### PR TITLE
feat(parallel): add search mcp integration

### DIFF
--- a/.github/workflows/integration-live-sweep.yml
+++ b/.github/workflows/integration-live-sweep.yml
@@ -72,9 +72,17 @@ jobs:
         run: doppler run -- ${{ matrix.command }}
 
   duckduckgo-integration-test:
-    name: DuckDuckGo API Tests
+    name: ${{ matrix.name }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: DuckDuckGo API Tests
+            command: cargo test -p everruns-integrations-duckduckgo --features integration
+          - name: Parallel MCP Tests
+            command: cargo test -p everruns-integrations-parallel --features integration
 
     steps:
       - uses: actions/checkout@v4
@@ -88,7 +96,7 @@ jobs:
           shared-key: "debug"
 
       - name: Run integration tests
-        run: cargo test -p everruns-integrations-duckduckgo --features integration
+        run: ${{ matrix.command }}
 
   container-sandbox-live-test:
     name: Container Sandbox Live API Tests

--- a/.github/workflows/parallel-integration.yml
+++ b/.github/workflows/parallel-integration.yml
@@ -1,0 +1,43 @@
+name: Parallel Integration
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'integrations/parallel/**'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'integrations/parallel/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+  CARGO_INCREMENTAL: 0
+
+jobs:
+  integration-test:
+    name: Parallel MCP Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "debug"
+
+      - name: Run integration tests
+        run: cargo test -p everruns-integrations-parallel --features integration

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1896,6 +1896,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "everruns-integrations-parallel"
+version = "0.8.22"
+dependencies = [
+ "async-trait",
+ "everruns-core",
+ "inventory",
+ "reqwest 0.13.2",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "everruns-integrations-pi"
 version = "0.8.22"
 dependencies = [
@@ -2042,6 +2054,7 @@ dependencies = [
  "everruns-integrations-docker",
  "everruns-integrations-duckduckgo",
  "everruns-integrations-e2b",
+ "everruns-integrations-parallel",
  "everruns-integrations-pi",
  "everruns-integrations-sprites",
  "everruns-internal-protocol",
@@ -2136,6 +2149,7 @@ dependencies = [
  "everruns-integrations-docker",
  "everruns-integrations-duckduckgo",
  "everruns-integrations-e2b",
+ "everruns-integrations-parallel",
  "everruns-integrations-pi",
  "everruns-integrations-sprites",
  "everruns-internal-protocol",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ members = [
     "integrations/daytona",
     "integrations/deno",
     "integrations/brave-search",
+    "integrations/parallel",
     "integrations/duckduckgo",
     "integrations/browserless",
     "integrations/e2b",

--- a/apps/ui/src/__tests__/capability-settings-editor.test.tsx
+++ b/apps/ui/src/__tests__/capability-settings-editor.test.tsx
@@ -66,6 +66,43 @@ function imageGenerationCapability(): Capability {
   });
 }
 
+function parallelCapability(): Capability {
+  return capability({
+    id: "parallel_search",
+    config_schema: {
+      type: "object",
+      properties: {
+        auth: {
+          type: "string",
+          title: "Authentication",
+          description: "Free works without setup. API key uses Settings > Connections > Parallel.",
+          default: "free",
+          oneOf: [
+            { const: "free", title: "Free" },
+            { const: "connection", title: "Parallel API Key" },
+          ],
+        },
+        endpoint: {
+          type: "string",
+          title: "MCP Endpoint",
+          description:
+            "OAuth MCP uses https://search.parallel.ai/mcp-oauth and requires a Parallel API key.",
+          default: "free",
+          oneOf: [
+            { const: "free", title: "Free MCP" },
+            { const: "oauth", title: "OAuth MCP" },
+          ],
+        },
+      },
+    },
+    config_ui_schema: {
+      "ui:order": ["auth", "endpoint"],
+      auth: { "ui:widget": "select" },
+      endpoint: { "ui:widget": "select" },
+    },
+  });
+}
+
 describe("CapabilitySettingsEditor", () => {
   it("exposes settings when a capability provides config schema", () => {
     expect(hasCapabilitySettings(capability({ id: "gpt_image_gen" }))).toBe(false);
@@ -122,5 +159,21 @@ describe("CapabilitySettingsEditor", () => {
 
     expect(screen.getByLabelText("Endpoint URL")).toHaveValue("https://example.com");
     expect(screen.getByText("Base URL used by the capability.")).toBeInTheDocument();
+  });
+
+  it("renders Parallel settings from schema metadata", () => {
+    render(
+      <CapabilitySettingsEditor
+        capability={parallelCapability()}
+        config={{}}
+        onChange={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Authentication")).toBeInTheDocument();
+    expect(screen.getByText("Free")).toBeInTheDocument();
+    expect(screen.getByText("MCP Endpoint")).toBeInTheDocument();
+    expect(screen.getByText("Free MCP")).toBeInTheDocument();
+    expect(screen.getByText(/works without setup/i)).toBeInTheDocument();
   });
 });

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -20,6 +20,7 @@
 
 use crate::command::CommandDescriptor;
 use crate::deployment::DeploymentGrade;
+use crate::mcp_server::{ScopedMcpServers, merge_scoped_mcp_servers};
 use crate::message_filter::MessageFilterProvider;
 use crate::runtime_agent::RuntimeAgent;
 use crate::tool_types::{ToolCall, ToolDefinition};
@@ -473,6 +474,20 @@ pub trait Capability: Send + Sync {
     /// MCP write paths share the same server-side guardrail.
     fn validate_config(&self, _config: &serde_json::Value) -> Result<(), String> {
         Ok(())
+    }
+
+    /// Returns remote MCP servers contributed by this capability.
+    ///
+    /// These are merged into harness/agent/session scoped MCP config at runtime.
+    /// Explicit scoped MCP config overrides capability-contributed defaults by
+    /// logical server name.
+    fn mcp_servers(&self) -> ScopedMcpServers {
+        ScopedMcpServers::default()
+    }
+
+    /// Returns config-aware remote MCP server contributions.
+    fn mcp_servers_with_config(&self, _config: &serde_json::Value) -> ScopedMcpServers {
+        self.mcp_servers()
     }
 
     /// Returns a message filter provider if this capability modifies message retrieval.
@@ -972,6 +987,8 @@ pub struct CollectedCapabilities {
     pub tool_definition_hooks: Vec<Arc<dyn ToolDefinitionHook>>,
     /// Hooks that inspect or transform model-produced tool calls.
     pub tool_call_hooks: Vec<Arc<dyn ToolCallHook>>,
+    /// Scoped remote MCP servers contributed by capabilities.
+    pub mcp_servers: ScopedMcpServers,
 }
 
 impl CollectedCapabilities {
@@ -1070,6 +1087,28 @@ pub fn collect_message_filters_only(
     CollectedMessageFilters {
         message_filter_providers,
     }
+}
+
+pub fn collect_capability_mcp_servers(
+    capability_configs: &[AgentCapabilityConfig],
+    registry: &CapabilityRegistry,
+) -> ScopedMcpServers {
+    let mut servers = ScopedMcpServers::default();
+
+    for cap_config in capability_configs {
+        let cap_id = cap_config.capability_ref.as_str();
+        if let Some(capability) = registry.get(cap_id) {
+            if capability.status() != CapabilityStatus::Available {
+                continue;
+            }
+            servers = merge_scoped_mcp_servers(
+                &servers,
+                &capability.mcp_servers_with_config(&cap_config.config),
+            );
+        }
+    }
+
+    servers
 }
 
 // ============================================================================
@@ -1397,6 +1436,7 @@ pub async fn collect_capabilities_with_configs(
     let mut prompt_cache: Option<crate::llm_driver_registry::PromptCacheConfig> = None;
     let mut tool_definition_hooks: Vec<Arc<dyn ToolDefinitionHook>> = Vec::new();
     let mut tool_call_hooks: Vec<Arc<dyn ToolCallHook>> = Vec::new();
+    let mut mcp_servers = ScopedMcpServers::default();
 
     for cap_config in capability_configs {
         let cap_id = cap_config.capability_ref.as_str();
@@ -1469,6 +1509,11 @@ pub async fn collect_capabilities_with_configs(
             // Collect mount points
             mounts.extend(capability.mounts());
 
+            mcp_servers = merge_scoped_mcp_servers(
+                &mcp_servers,
+                &capability.mcp_servers_with_config(&cap_config.config),
+            );
+
             // Normalize capability-contributed skills into mount points under
             // `/.agents/skills/{name}/`. Discovery/activation stays with the
             // built-in `skills` capability — see specs/skills-registry.md.
@@ -1499,6 +1544,7 @@ pub async fn collect_capabilities_with_configs(
         prompt_cache,
         tool_definition_hooks,
         tool_call_hooks,
+        mcp_servers,
     }
 }
 

--- a/crates/core/src/config_layer.rs
+++ b/crates/core/src/config_layer.rs
@@ -464,6 +464,9 @@ mod tests {
                 transport_type: McpServerTransportType::Http,
                 url: "https://base.example.com/mcp".to_string(),
                 headers: Default::default(),
+                auth_mode: crate::McpServerAuthMode::None,
+                oauth_provider_id: None,
+                tool_discovery: true,
             },
         );
 
@@ -474,6 +477,9 @@ mod tests {
                 transport_type: McpServerTransportType::Http,
                 url: "https://overlay.example.com/mcp".to_string(),
                 headers: Default::default(),
+                auth_mode: crate::McpServerAuthMode::None,
+                oauth_provider_id: None,
+                tool_discovery: true,
             },
         );
         overlay_servers.insert(
@@ -482,6 +488,9 @@ mod tests {
                 transport_type: McpServerTransportType::Http,
                 url: "https://search.example.com/mcp".to_string(),
                 headers: Default::default(),
+                auth_mode: crate::McpServerAuthMode::None,
+                oauth_provider_id: None,
+                tool_discovery: true,
             },
         );
 

--- a/crates/core/src/mcp_server.rs
+++ b/crates/core/src/mcp_server.rs
@@ -62,6 +62,12 @@ impl From<&str> for McpServerAuthMode {
     }
 }
 
+impl McpServerAuthMode {
+    pub fn is_none(&self) -> bool {
+        matches!(self, McpServerAuthMode::None)
+    }
+}
+
 impl std::fmt::Display for McpServerTransportType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -192,12 +198,32 @@ pub struct ScopedMcpServer {
     /// Additional HTTP headers sent on MCP requests.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub headers: HashMap<String, String>,
+    /// Authentication mode used when executing tools from this scoped server.
+    #[serde(default, skip_serializing_if = "McpServerAuthMode::is_none")]
+    pub auth_mode: McpServerAuthMode,
+    /// Provider id used to resolve a user-scoped bearer token.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub oauth_provider_id: Option<String>,
+    /// Whether to discover tool definitions live from this server.
+    #[serde(
+        default = "default_scoped_tool_discovery",
+        skip_serializing_if = "is_true"
+    )]
+    pub tool_discovery: bool,
 }
 
 pub type ScopedMcpServers = BTreeMap<String, ScopedMcpServer>;
 
 fn default_scoped_transport_type() -> McpServerTransportType {
     McpServerTransportType::Http
+}
+
+fn default_scoped_tool_discovery() -> bool {
+    true
+}
+
+fn is_true(value: &bool) -> bool {
+    *value
 }
 
 pub fn scoped_mcp_servers_is_empty(servers: &ScopedMcpServers) -> bool {

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -73,6 +73,7 @@ everruns-core = { path = "../core", features = ["openapi", "sqlx", "tree-sitter-
 everruns-macros = { path = "../macros" }
 everruns-integrations-docker = { path = "../../integrations/docker" }
 everruns-integrations-brave-search = { path = "../../integrations/brave-search" }
+everruns-integrations-parallel = { path = "../../integrations/parallel" }
 everruns-integrations-duckduckgo = { path = "../../integrations/duckduckgo" }
 everruns-integrations-daytona = { path = "../../integrations/daytona" }
 everruns-integrations-deno = { path = "../../integrations/deno" }

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -33,7 +33,8 @@ use uuid::Uuid;
 use crate::domains::budgets::BudgetService;
 use crate::domains::mcp_servers::McpServerService;
 use crate::domains::mcp_servers::scoped_mcp::{
-    build_scoped_mcp_tool_definitions, resolve_scoped_mcp_server, validate_scoped_mcp_servers,
+    build_scoped_mcp_tool_definitions, merge_effective_scoped_mcp_servers_with_capabilities,
+    resolve_scoped_mcp_server_with_capabilities, validate_scoped_mcp_servers,
 };
 use crate::domains::messages::MessageService;
 use crate::domains::sessions::SessionService;
@@ -1158,9 +1159,13 @@ impl WorkerAdapters for DirectWorkerAdapters {
                 None => None,
             };
 
-            if let Some(resolved) =
-                resolve_scoped_mcp_server(&harness, agent.as_ref(), &session, server_prefix)
-            {
+            if let Some(resolved) = resolve_scoped_mcp_server_with_capabilities(
+                &harness,
+                agent.as_ref(),
+                &session,
+                server_prefix,
+                &self.capability_registry,
+            ) {
                 return Ok(McpServerInfo {
                     id: resolved.id,
                     name: resolved.name,
@@ -1241,23 +1246,27 @@ impl WorkerAdapters for DirectWorkerAdapters {
             .await?;
 
         let local_mcp_tool_definitions = if let Some(ref harness) = harness {
-            let effective =
-                crate::domains::mcp_servers::scoped_mcp::merge_effective_scoped_mcp_servers(
-                    harness,
-                    agent.as_ref(),
-                    &session,
-                );
+            let effective = merge_effective_scoped_mcp_servers_with_capabilities(
+                harness,
+                agent.as_ref(),
+                &session,
+                &self.capability_registry,
+            );
 
             if let Err(error) = validate_scoped_mcp_servers(&effective) {
                 tracing::warn!(error = %error, "Invalid scoped MCP server config, skipping");
                 vec![]
             } else {
-                build_scoped_mcp_tool_definitions(&effective)
-                    .await
-                    .unwrap_or_else(|error| {
-                        tracing::warn!(error = %error, "Failed to build scoped MCP tool definitions");
-                        vec![]
-                    })
+                build_scoped_mcp_tool_definitions(
+                    &effective,
+                    Some(session.id),
+                    self.connection_resolver.as_ref(),
+                )
+                .await
+                .unwrap_or_else(|error| {
+                    tracing::warn!(error = %error, "Failed to build scoped MCP tool definitions");
+                    vec![]
+                })
             }
         } else {
             vec![]

--- a/crates/server/src/domains/agents/commands.rs
+++ b/crates/server/src/domains/agents/commands.rs
@@ -859,6 +859,8 @@ impl Command for PreviewAgent {
         tools.extend(
             crate::domains::mcp_servers::scoped_mcp::build_scoped_mcp_tool_definitions(
                 &self.mcp_servers,
+                None,
+                None,
             )
             .await
             .map_err(classify_anyhow)?,

--- a/crates/server/src/domains/harnesses/commands.rs
+++ b/crates/server/src/domains/harnesses/commands.rs
@@ -749,6 +749,8 @@ impl Command for PreviewHarness {
         tools.extend(
             crate::domains::mcp_servers::scoped_mcp::build_scoped_mcp_tool_definitions(
                 &effective_mcp_servers,
+                None,
+                None,
             )
             .await
             .map_err(classify_anyhow)?,

--- a/crates/server/src/domains/mcp_servers/scoped_mcp.rs
+++ b/crates/server/src/domains/mcp_servers/scoped_mcp.rs
@@ -6,12 +6,16 @@
 // narrowly scoped and avoid mutating config rows during runtime.
 
 use anyhow::{Result, anyhow};
+use everruns_core::capabilities::{CapabilityRegistry, collect_capability_mcp_servers};
 use everruns_core::mcp_server::sanitize_mcp_server_name;
+use everruns_core::traits::UserConnectionResolver;
 use everruns_core::{
     Agent, Capability, Harness, McpCapability, McpServerAuthMode, ScopedMcpServers, Session,
-    ToolDefinition, merge_scoped_mcp_servers, validate_safe_url,
+    SessionId, ToolDefinition, merge_scoped_mcp_servers, resolve_runtime_capabilities,
+    validate_safe_url,
 };
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 use uuid::Uuid;
 
 use crate::domains::mcp_servers::McpServerResolved;
@@ -28,6 +32,25 @@ pub fn merge_effective_scoped_mcp_servers(
     }
     layers.push(&session.mcp_servers);
     merge_scoped_mcp_server_layers(layers)
+}
+
+pub fn merge_effective_scoped_mcp_servers_with_capabilities(
+    harness: &Harness,
+    agent: Option<&Agent>,
+    session: &Session,
+    capability_registry: &CapabilityRegistry,
+) -> ScopedMcpServers {
+    let explicit = merge_effective_scoped_mcp_servers(harness, agent, session);
+    let resolved = resolve_runtime_capabilities(
+        std::slice::from_ref(harness),
+        agent,
+        session,
+        capability_registry,
+    );
+    let contributed =
+        collect_capability_mcp_servers(&resolved.resolved_capability_configs, capability_registry);
+
+    merge_scoped_mcp_servers(&contributed, &explicit)
 }
 
 pub fn merge_scoped_mcp_server_layers<'a, I>(layers: I) -> ScopedMcpServers
@@ -62,8 +85,34 @@ pub fn resolve_scoped_mcp_server(
             id: scoped_mcp_server_uuid(session.id.uuid(), &name),
             name,
             url: server.url,
-            auth_mode: McpServerAuthMode::None,
-            oauth_provider_id: None,
+            auth_mode: server.auth_mode,
+            oauth_provider_id: server.oauth_provider_id,
+            api_key: None,
+            headers: server.headers,
+        })
+    })
+}
+
+pub fn resolve_scoped_mcp_server_with_capabilities(
+    harness: &Harness,
+    agent: Option<&Agent>,
+    session: &Session,
+    server_prefix: &str,
+    capability_registry: &CapabilityRegistry,
+) -> Option<McpServerResolved> {
+    let effective = merge_effective_scoped_mcp_servers_with_capabilities(
+        harness,
+        agent,
+        session,
+        capability_registry,
+    );
+    effective.into_iter().find_map(|(name, server)| {
+        (sanitize_mcp_server_name(&name) == server_prefix).then(|| McpServerResolved {
+            id: scoped_mcp_server_uuid(session.id.uuid(), &name),
+            name,
+            url: server.url,
+            auth_mode: server.auth_mode,
+            oauth_provider_id: server.oauth_provider_id,
             api_key: None,
             headers: server.headers,
         })
@@ -72,16 +121,109 @@ pub fn resolve_scoped_mcp_server(
 
 pub async fn build_scoped_mcp_tool_definitions(
     servers: &ScopedMcpServers,
+    session_id: Option<SessionId>,
+    connection_resolver: Option<&Arc<dyn UserConnectionResolver>>,
 ) -> Result<Vec<ToolDefinition>> {
     let mut definitions = Vec::new();
 
     for (name, server) in servers {
-        let tools = fetch_mcp_tools(&server.url, None, &server.headers).await?;
+        if !server.tool_discovery {
+            tracing::debug!(
+                server_name = %name,
+                "Skipping scoped MCP tool discovery by server config"
+            );
+            continue;
+        }
+
+        let bearer_token =
+            match resolve_scoped_mcp_discovery_token(name, server, session_id, connection_resolver)
+                .await
+            {
+                Ok(bearer_token) => bearer_token,
+                Err(error) => {
+                    tracing::warn!(
+                        server_name = %name,
+                        error = %error,
+                        "Failed to resolve scoped MCP discovery token, skipping server"
+                    );
+                    continue;
+                }
+            };
+        let has_authorization_header = has_authorization_header(&server.headers);
+        if server.auth_mode == McpServerAuthMode::OAuth
+            && !has_authorization_header
+            && bearer_token.is_none()
+        {
+            tracing::debug!(
+                server_name = %name,
+                "Skipping scoped MCP tool discovery because no user connection token is available"
+            );
+            continue;
+        }
+
+        let tools =
+            match fetch_mcp_tools(&server.url, bearer_token.as_deref(), &server.headers).await {
+                Ok(tools) => tools,
+                Err(error) => {
+                    tracing::warn!(
+                        server_name = %name,
+                        error = %error,
+                        "Failed to discover scoped MCP tools, skipping server"
+                    );
+                    continue;
+                }
+            };
         let capability = McpCapability::new(Uuid::nil(), name.clone(), None, tools);
         definitions.extend(capability.tool_definitions());
     }
 
     Ok(definitions)
+}
+
+async fn resolve_scoped_mcp_discovery_token(
+    server_name: &str,
+    server: &everruns_core::ScopedMcpServer,
+    session_id: Option<SessionId>,
+    connection_resolver: Option<&Arc<dyn UserConnectionResolver>>,
+) -> Result<Option<String>> {
+    if server.auth_mode != McpServerAuthMode::OAuth || has_authorization_header(&server.headers) {
+        return Ok(None);
+    }
+
+    let Some(provider) = server.oauth_provider_id.as_deref() else {
+        tracing::debug!(
+            server_name,
+            "Skipping scoped MCP discovery token lookup because oauth_provider_id is missing"
+        );
+        return Ok(None);
+    };
+    let Some(session_id) = session_id else {
+        tracing::debug!(
+            server_name,
+            provider,
+            "Skipping scoped MCP discovery token lookup because session_id is unavailable"
+        );
+        return Ok(None);
+    };
+    let Some(resolver) = connection_resolver else {
+        tracing::debug!(
+            server_name,
+            provider,
+            "Skipping scoped MCP discovery token lookup because connection resolver is unavailable"
+        );
+        return Ok(None);
+    };
+
+    resolver
+        .get_connection_token(session_id, provider)
+        .await
+        .map_err(|error| anyhow!("Failed to resolve scoped MCP discovery token: {error}"))
+}
+
+fn has_authorization_header(headers: &HashMap<String, String>) -> bool {
+    headers
+        .keys()
+        .any(|header_name| header_name.eq_ignore_ascii_case("Authorization"))
 }
 
 pub fn validate_scoped_mcp_servers(servers: &ScopedMcpServers) -> Result<()> {
@@ -128,7 +270,19 @@ mod tests {
             transport_type: everruns_core::McpServerTransportType::Http,
             url: url.to_string(),
             headers: Default::default(),
+            auth_mode: McpServerAuthMode::None,
+            oauth_provider_id: None,
+            tool_discovery: true,
         }
+    }
+
+    #[test]
+    fn detects_authorization_header_case_insensitively() {
+        let mut headers = HashMap::new();
+        assert!(!has_authorization_header(&headers));
+
+        headers.insert("authorization".to_string(), "Bearer token".to_string());
+        assert!(has_authorization_header(&headers));
     }
 
     fn test_harness() -> Harness {

--- a/crates/server/src/grpc_service/worker_service_impl.rs
+++ b/crates/server/src/grpc_service/worker_service_impl.rs
@@ -225,12 +225,12 @@ impl WorkerService for WorkerServiceImpl {
         // Append org-scoped tool definitions first so scoped definitions win on
         // name collisions when RuntimeAgentBuilder deduplicates with last-wins.
         let local_mcp_tool_definitions = if let Some(ref harness) = harness {
-            let effective =
-                crate::domains::mcp_servers::scoped_mcp::merge_effective_scoped_mcp_servers(
-                    harness,
-                    agent.as_ref(),
-                    &session,
-                );
+            let effective = crate::domains::mcp_servers::scoped_mcp::merge_effective_scoped_mcp_servers_with_capabilities(
+                harness,
+                agent.as_ref(),
+                &session,
+                self.capability_service.registry(),
+            );
 
             if let Err(error) =
                 crate::domains::mcp_servers::scoped_mcp::validate_scoped_mcp_servers(&effective)
@@ -240,6 +240,8 @@ impl WorkerService for WorkerServiceImpl {
             } else {
                 crate::domains::mcp_servers::scoped_mcp::build_scoped_mcp_tool_definitions(
                     &effective,
+                    Some(session.id),
+                    self.connection_resolver.as_ref(),
                 )
                 .await
                 .map(|defs| {
@@ -2186,11 +2188,12 @@ impl WorkerService for WorkerServiceImpl {
                     None
                 };
 
-                if let Some(r) = crate::domains::mcp_servers::scoped_mcp::resolve_scoped_mcp_server(
+                if let Some(r) = crate::domains::mcp_servers::scoped_mcp::resolve_scoped_mcp_server_with_capabilities(
                     &harness,
                     agent.as_ref(),
                     &session,
                     &req.server_prefix,
+                    self.capability_service.registry(),
                 ) {
                     return Ok(Response::new(GetMcpServerByPrefixResponse {
                         server: Some(McpServerInfo {

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -12,6 +12,7 @@ extern crate everruns_integrations_deno;
 extern crate everruns_integrations_docker;
 extern crate everruns_integrations_duckduckgo;
 extern crate everruns_integrations_e2b;
+extern crate everruns_integrations_parallel;
 extern crate everruns_integrations_sprites;
 
 // API routes and types (shared for OpenAPI generation)

--- a/crates/server/src/services/capability.rs
+++ b/crates/server/src/services/capability.rs
@@ -63,6 +63,10 @@ impl CapabilityService {
         }
     }
 
+    pub fn registry(&self) -> &CapabilityRegistry {
+        &self.registry
+    }
+
     /// Invalidate the cached skill list for an org. Called by skill mutation
     /// commands after create/update/delete.
     pub async fn invalidate_skills_cache(&self, org_id: i64) {
@@ -356,6 +360,14 @@ impl CapabilityService {
             system_prompt_parts.push(prefix);
         }
         tool_definitions.extend(collected.tool_definitions);
+        tool_definitions.extend(
+            crate::domains::mcp_servers::scoped_mcp::build_scoped_mcp_tool_definitions(
+                &collected.mcp_servers,
+                None,
+                None,
+            )
+            .await?,
+        );
 
         // Collect from MCP capabilities using cached tools only (no refresh)
         // Note: MCP capabilities don't have dependencies

--- a/crates/worker/Cargo.toml
+++ b/crates/worker/Cargo.toml
@@ -18,6 +18,7 @@ everruns-config = { path = "../config" }
 everruns-core = { path = "../core", features = ["tree-sitter-outlines"] }
 everruns-integrations-docker = { path = "../../integrations/docker" }
 everruns-integrations-brave-search = { path = "../../integrations/brave-search" }
+everruns-integrations-parallel = { path = "../../integrations/parallel" }
 everruns-integrations-duckduckgo = { path = "../../integrations/duckduckgo" }
 everruns-integrations-daytona = { path = "../../integrations/daytona" }
 everruns-integrations-deno = { path = "../../integrations/deno" }

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -7,6 +7,7 @@ extern crate everruns_integrations_deno;
 extern crate everruns_integrations_docker;
 extern crate everruns_integrations_duckduckgo;
 extern crate everruns_integrations_e2b;
+extern crate everruns_integrations_parallel;
 extern crate everruns_integrations_sprites;
 
 pub mod activities;

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -5663,6 +5663,10 @@
             "url"
           ],
           "properties": {
+            "auth_mode": {
+              "$ref": "#/components/schemas/McpServerAuthMode",
+              "description": "Authentication mode used when executing tools from this scoped server."
+            },
             "headers": {
               "type": "object",
               "description": "Additional HTTP headers sent on MCP requests.",
@@ -5672,6 +5676,17 @@
               "propertyNames": {
                 "type": "string"
               }
+            },
+            "oauth_provider_id": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Provider id used to resolve a user-scoped bearer token."
+            },
+            "tool_discovery": {
+              "type": "boolean",
+              "description": "Whether to discover tool definitions live from this server."
             },
             "type": {
               "$ref": "#/components/schemas/McpServerTransportType",

--- a/docs/integrations/parallel.md
+++ b/docs/integrations/parallel.md
@@ -1,0 +1,25 @@
+---
+title: Parallel
+description: Use Parallel's hosted MCP server for free web search and URL fetching, with optional API-key authentication and OAuth-compatible endpoint selection.
+---
+
+# Parallel
+
+Parallel provides hosted MCP tools for web search and URL fetching.
+
+## Setup
+
+Add the `parallel_search` capability to an agent or harness. It works for free without any connection.
+
+To use a Parallel API key, add a `Parallel` connection in Settings > Connections, then configure the capability with `auth: "connection"`.
+
+To use Parallel's OAuth-compatible MCP endpoint, configure the capability with `endpoint: "oauth"`. This mode requires the `Parallel` connection because the endpoint rejects anonymous requests.
+
+## Tools
+
+| Tool | Purpose |
+|---|---|
+| `mcp_parallel__web_search` | Search the web and return ranked URLs with excerpts. |
+| `mcp_parallel__web_fetch` | Fetch and extract focused content from known URLs. |
+
+Agents should reuse one stable `session_id` across Parallel tool calls in the same conversation.

--- a/integrations/parallel/Cargo.toml
+++ b/integrations/parallel/Cargo.toml
@@ -1,0 +1,24 @@
+# Parallel MCP Integration
+# Decision: Capability contributes a remote MCP server rather than reimplementing search tools.
+# Decision: Free by default; optional user connection supplies a Parallel API key as bearer auth.
+
+[package]
+name = "everruns-integrations-parallel"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "Parallel MCP integration for Everruns"
+
+[dependencies]
+everruns-core = { path = "../../crates/core" }
+inventory.workspace = true
+reqwest.workspace = true
+serde_json.workspace = true
+async-trait.workspace = true
+
+[features]
+integration = []
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["full", "test-util"] }

--- a/integrations/parallel/SPEC.md
+++ b/integrations/parallel/SPEC.md
@@ -1,0 +1,35 @@
+# Parallel MCP Integration
+
+Parallel exposes hosted MCP tools for real-time web search and URL fetching.
+
+## Capability
+
+The `parallel_search` capability contributes one scoped remote MCP server named `Parallel`.
+Tools are discovered from the contributed MCP server so agents see a single MCP-backed tool surface.
+
+Default mode uses `https://search.parallel.ai/mcp` without authentication. Optional config:
+
+- `auth: "connection"` sends the user-scoped `parallel` connection token as a bearer token.
+- `endpoint: "oauth"` switches the server URL to `https://search.parallel.ai/mcp-oauth` and requires the same user-scoped connection token.
+
+## Connection
+
+The `parallel` connection provider stores an optional Parallel API key. Validation calls `tools/list` on the free MCP endpoint with bearer auth; `401`/`403` means the key is invalid.
+
+## Tools
+
+Parallel currently exposes:
+
+- `web_search` for ranked web search with dense excerpts.
+- `web_fetch` for extracting focused markdown from known URLs.
+
+The Everruns-visible tool names use the normal MCP prefix: `mcp_parallel__web_search` and `mcp_parallel__web_fetch`.
+
+## Tests
+
+- `tests/plugin_registration.rs` verifies capability and connection-provider inventory registration.
+- `tests/live_api_test.rs` runs live no-secret MCP smoke tests against the free endpoint with `--features integration`.
+
+## Security
+
+The integration uses the shared MCP URL validation path before discovery and execution. API keys are user-scoped connections, encrypted by the existing connection storage, and only sent as bearer auth when capability config opts into authenticated mode or the OAuth-compatible endpoint.

--- a/integrations/parallel/src/connection.rs
+++ b/integrations/parallel/src/connection.rs
@@ -1,0 +1,120 @@
+// Parallel Connection Provider
+//
+// Decision: API-key connection. Parallel's MCP accepts the key as a bearer
+// token on both /mcp and /mcp-oauth, and the free mode remains usable without
+// storing any credential.
+
+use async_trait::async_trait;
+use everruns_core::connection_provider::{
+    ConnectionFormSchema, ConnectionProvider, ConnectionType, ConnectionValidation, FieldType,
+    FormField,
+};
+use everruns_core::{McpToolsListRequest, McpToolsListResponse};
+
+use crate::{PARALLEL_MCP_URL, PARALLEL_PROVIDER_ID};
+
+pub struct ParallelConnectionProvider;
+
+#[async_trait]
+impl ConnectionProvider for ParallelConnectionProvider {
+    fn provider_id(&self) -> &str {
+        PARALLEL_PROVIDER_ID
+    }
+
+    fn display_name(&self) -> &str {
+        "Parallel"
+    }
+
+    fn description(&self) -> &str {
+        "Optional Parallel API key for higher Search MCP limits and authenticated MCP endpoints"
+    }
+
+    fn icon(&self) -> &str {
+        "search"
+    }
+
+    fn connection_type(&self) -> ConnectionType {
+        ConnectionType::ApiKey
+    }
+
+    fn form_schema(&self) -> Option<ConnectionFormSchema> {
+        Some(ConnectionFormSchema {
+            fields: vec![FormField {
+                name: "api_key".to_string(),
+                label: "API Key".to_string(),
+                field_type: FieldType::Password,
+                required: true,
+                placeholder: Some("parallel_api_key".to_string()),
+                help_text: Some(
+                    "Parallel is free without a key; add one for authenticated usage.".to_string(),
+                ),
+            }],
+            instructions_markdown: "\
+Parallel MCP works without a key by default.\n\n\
+To use authenticated mode:\n\
+1. Go to [Parallel Platform](https://platform.parallel.ai)\n\
+2. Create or copy your API key\n\
+3. Paste it below"
+                .to_string(),
+        })
+    }
+
+    async fn validate(&self, credential: &str) -> Result<ConnectionValidation, String> {
+        let response = reqwest::Client::new()
+            .post(PARALLEL_MCP_URL)
+            .bearer_auth(credential)
+            .json(&McpToolsListRequest::default())
+            .send()
+            .await
+            .map_err(|e| format!("Failed to reach Parallel MCP: {e}"))?;
+
+        match response.status().as_u16() {
+            200 => {
+                let mcp_response: McpToolsListResponse = response
+                    .json()
+                    .await
+                    .map_err(|e| format!("Invalid Parallel MCP response: {e}"))?;
+                if let Some(error) = mcp_response.error {
+                    return Err(format!("Parallel MCP error: {}", error.message));
+                }
+                Ok(ConnectionValidation {
+                    provider_username: None,
+                    provider_metadata: None,
+                })
+            }
+            401 | 403 => Err("Invalid Parallel API key.".to_string()),
+            429 => Err("Parallel API key is valid but rate-limited. Try again later.".to_string()),
+            status => Err(format!(
+                "Unexpected response from Parallel MCP (HTTP {status})"
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn provider_metadata() {
+        let p = ParallelConnectionProvider;
+        assert_eq!(p.provider_id(), "parallel");
+        assert_eq!(p.display_name(), "Parallel");
+        assert_eq!(p.connection_type(), ConnectionType::ApiKey);
+        assert_eq!(p.icon(), "search");
+    }
+
+    #[test]
+    fn form_schema_describes_optional_key() {
+        let p = ParallelConnectionProvider;
+        let schema = p.form_schema().expect("should have form schema");
+        assert_eq!(schema.fields.len(), 1);
+        assert_eq!(schema.fields[0].name, "api_key");
+        assert!(schema.instructions_markdown.contains("without a key"));
+        assert!(
+            schema
+                .instructions_markdown
+                .contains("platform.parallel.ai")
+        );
+    }
+}

--- a/integrations/parallel/src/lib.rs
+++ b/integrations/parallel/src/lib.rs
@@ -1,0 +1,323 @@
+//! Parallel MCP Integration.
+//!
+//! Decision: Use Parallel's hosted MCP server directly so Everruns gets the
+//! provider-owned `web_search` and `web_fetch` behavior without proxying or
+//! reimplementing it.
+//! Decision: Default to the free unauthenticated endpoint. Per-capability config
+//! can require a user-scoped Parallel API-key connection and can switch to the
+//! OAuth-compatible MCP endpoint.
+
+pub mod connection;
+
+use everruns_core::capabilities::{Capability, CapabilityStatus, IntegrationPlugin};
+use everruns_core::connection_provider::ConnectionProviderPlugin;
+use everruns_core::{McpServerAuthMode, McpServerTransportType, ScopedMcpServer, ScopedMcpServers};
+use serde_json::{Value, json};
+use std::collections::HashMap;
+
+use connection::ParallelConnectionProvider;
+
+inventory::submit! {
+    IntegrationPlugin {
+        experimental_only: true,
+        feature_flag: None,
+        factory: || Box::new(ParallelCapability),
+    }
+}
+
+inventory::submit! {
+    ConnectionProviderPlugin {
+        experimental_only: true,
+        factory: || Box::new(ParallelConnectionProvider),
+    }
+}
+
+pub const PARALLEL_CAPABILITY_ID: &str = "parallel_search";
+pub const PARALLEL_PROVIDER_ID: &str = "parallel";
+pub const PARALLEL_SERVER_NAME: &str = "Parallel";
+pub const PARALLEL_MCP_URL: &str = "https://search.parallel.ai/mcp";
+pub const PARALLEL_MCP_OAUTH_URL: &str = "https://search.parallel.ai/mcp-oauth";
+
+const CONFIG_AUTH_CONNECTION: &str = "connection";
+const CONFIG_ENDPOINT_OAUTH: &str = "oauth";
+
+pub struct ParallelCapability;
+
+impl ParallelCapability {
+    fn use_connection(config: &serde_json::Value) -> bool {
+        config
+            .get("auth")
+            .and_then(|value| value.as_str())
+            .is_some_and(|auth| auth == CONFIG_AUTH_CONNECTION)
+            || Self::use_oauth_endpoint(config)
+    }
+
+    fn use_oauth_endpoint(config: &serde_json::Value) -> bool {
+        config
+            .get("endpoint")
+            .and_then(|value| value.as_str())
+            .is_some_and(|endpoint| endpoint == CONFIG_ENDPOINT_OAUTH)
+    }
+
+    fn mcp_url(config: &serde_json::Value) -> &'static str {
+        if Self::use_oauth_endpoint(config) {
+            PARALLEL_MCP_OAUTH_URL
+        } else {
+            PARALLEL_MCP_URL
+        }
+    }
+}
+
+impl Capability for ParallelCapability {
+    fn id(&self) -> &str {
+        PARALLEL_CAPABILITY_ID
+    }
+
+    fn name(&self) -> &str {
+        "[Experimental] Parallel"
+    }
+
+    fn description(&self) -> &str {
+        "Search and fetch web content through Parallel MCP. Free by default, with optional Parallel API-key connection for authenticated usage."
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+
+    fn icon(&self) -> Option<&str> {
+        Some("search")
+    }
+
+    fn category(&self) -> Option<&str> {
+        Some("Network")
+    }
+
+    fn system_prompt_addition(&self) -> Option<&str> {
+        Some(
+            r#"## Parallel
+
+Use Parallel for current web search and focused URL extraction.
+
+For Parallel tool calls, generate one stable `session_id` for the conversation and reuse it for both search and fetch calls."#,
+        )
+    }
+
+    fn config_schema(&self) -> Option<Value> {
+        Some(json!({
+            "type": "object",
+            "title": "Parallel Settings",
+            "properties": {
+                "auth": {
+                    "type": "string",
+                    "title": "Authentication",
+                    "description": "Free works without setup. API key uses Settings > Connections > Parallel.",
+                    "default": "free",
+                    "oneOf": [
+                        { "const": "free", "title": "Free" },
+                        { "const": "connection", "title": "Parallel API Key" }
+                    ]
+                },
+                "endpoint": {
+                    "type": "string",
+                    "title": "MCP Endpoint",
+                    "description": "OAuth MCP uses https://search.parallel.ai/mcp-oauth and requires a Parallel API key.",
+                    "default": "free",
+                    "oneOf": [
+                        { "const": "free", "title": "Free MCP" },
+                        { "const": "oauth", "title": "OAuth MCP" }
+                    ]
+                }
+            },
+            "allOf": [
+                {
+                    "if": {
+                        "properties": {
+                            "endpoint": { "const": "oauth" }
+                        },
+                        "required": ["endpoint"]
+                    },
+                    "then": {
+                        "properties": {
+                            "auth": { "const": "connection" }
+                        },
+                        "required": ["auth"]
+                    }
+                }
+            ]
+        }))
+    }
+
+    fn config_ui_schema(&self) -> Option<Value> {
+        Some(json!({
+            "ui:submitButtonOptions": { "norender": true },
+            "ui:order": ["auth", "endpoint"],
+            "auth": { "ui:widget": "select" },
+            "endpoint": { "ui:widget": "select" }
+        }))
+    }
+
+    fn validate_config(&self, config: &Value) -> Result<(), String> {
+        if config.is_null() {
+            return Ok(());
+        }
+
+        let object = config
+            .as_object()
+            .ok_or_else(|| "Invalid parallel_search config: expected object".to_string())?;
+
+        for field in object.keys() {
+            if field != "auth" && field != "endpoint" {
+                return Err(format!(
+                    "Invalid parallel_search config: unknown field `{field}`"
+                ));
+            }
+        }
+
+        if let Some(auth) = object.get("auth") {
+            match auth.as_str() {
+                Some("free" | CONFIG_AUTH_CONNECTION) => {}
+                Some(other) => {
+                    return Err(format!(
+                        "Invalid parallel_search config: unsupported auth `{other}`"
+                    ));
+                }
+                None => return Err("Invalid parallel_search config: auth must be a string".into()),
+            }
+        }
+
+        if let Some(endpoint) = object.get("endpoint") {
+            match endpoint.as_str() {
+                Some("free" | CONFIG_ENDPOINT_OAUTH) => {}
+                Some(other) => {
+                    return Err(format!(
+                        "Invalid parallel_search config: unsupported endpoint `{other}`"
+                    ));
+                }
+                None => {
+                    return Err("Invalid parallel_search config: endpoint must be a string".into());
+                }
+            }
+        }
+
+        let auth = object.get("auth").and_then(Value::as_str).unwrap_or("free");
+        let endpoint = object
+            .get("endpoint")
+            .and_then(Value::as_str)
+            .unwrap_or("free");
+        if endpoint == CONFIG_ENDPOINT_OAUTH && auth != CONFIG_AUTH_CONNECTION {
+            return Err(
+                "Invalid parallel_search config: endpoint `oauth` requires auth `connection`"
+                    .into(),
+            );
+        }
+
+        Ok(())
+    }
+
+    fn mcp_servers_with_config(&self, config: &serde_json::Value) -> ScopedMcpServers {
+        let mut servers = ScopedMcpServers::default();
+        servers.insert(
+            PARALLEL_SERVER_NAME.to_string(),
+            ScopedMcpServer {
+                transport_type: McpServerTransportType::Http,
+                url: Self::mcp_url(config).to_string(),
+                headers: HashMap::new(),
+                auth_mode: if Self::use_connection(config) {
+                    McpServerAuthMode::OAuth
+                } else {
+                    McpServerAuthMode::None
+                },
+                oauth_provider_id: Self::use_connection(config)
+                    .then(|| PARALLEL_PROVIDER_ID.to_string()),
+                tool_discovery: true,
+            },
+        );
+        servers
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use everruns_core::capabilities::{Capability, collect_capability_mcp_servers};
+    use everruns_core::capability_types::AgentCapabilityConfig;
+    use serde_json::json;
+
+    #[test]
+    fn metadata() {
+        let cap = ParallelCapability;
+        assert_eq!(cap.id(), "parallel_search");
+        assert_eq!(cap.icon(), Some("search"));
+        assert_eq!(cap.category(), Some("Network"));
+        assert!(cap.tools().is_empty());
+        assert!(cap.tool_definitions().is_empty());
+    }
+
+    #[test]
+    fn contributes_free_mcp_server_by_default() {
+        let cap = ParallelCapability;
+        let servers = cap.mcp_servers_with_config(&json!({}));
+        let server = servers.get(PARALLEL_SERVER_NAME).unwrap();
+        assert_eq!(server.url, PARALLEL_MCP_URL);
+        assert_eq!(server.auth_mode, McpServerAuthMode::None);
+        assert_eq!(server.oauth_provider_id, None);
+    }
+
+    #[test]
+    fn config_can_use_connection_on_default_endpoint() {
+        let cap = ParallelCapability;
+        let servers = cap.mcp_servers_with_config(&json!({ "auth": "connection" }));
+        let server = servers.get(PARALLEL_SERVER_NAME).unwrap();
+        assert_eq!(server.url, PARALLEL_MCP_URL);
+        assert_eq!(server.auth_mode, McpServerAuthMode::OAuth);
+        assert_eq!(
+            server.oauth_provider_id.as_deref(),
+            Some(PARALLEL_PROVIDER_ID)
+        );
+    }
+
+    #[test]
+    fn config_can_use_oauth_endpoint() {
+        let cap = ParallelCapability;
+        let servers =
+            cap.mcp_servers_with_config(&json!({ "auth": "connection", "endpoint": "oauth" }));
+        let server = servers.get(PARALLEL_SERVER_NAME).unwrap();
+        assert_eq!(server.url, PARALLEL_MCP_OAUTH_URL);
+        assert_eq!(server.auth_mode, McpServerAuthMode::OAuth);
+        assert_eq!(
+            server.oauth_provider_id.as_deref(),
+            Some(PARALLEL_PROVIDER_ID)
+        );
+    }
+
+    #[test]
+    fn validates_config_values() {
+        let cap = ParallelCapability;
+
+        assert!(
+            cap.validate_config(&json!({ "auth": "connection", "endpoint": "oauth" }))
+                .is_ok()
+        );
+        assert!(
+            cap.validate_config(&json!({ "endpoint": "oauth" }))
+                .is_err()
+        );
+        assert!(
+            cap.validate_config(&json!({ "auth": "free", "endpoint": "oauth" }))
+                .is_err()
+        );
+        assert!(cap.validate_config(&json!({ "auth": "invalid" })).is_err());
+        assert!(cap.validate_config(&json!({ "extra": true })).is_err());
+    }
+
+    #[test]
+    fn collection_merges_contributed_mcp_servers() {
+        let mut registry = everruns_core::CapabilityRegistry::new();
+        registry.register(ParallelCapability);
+        let configs = vec![AgentCapabilityConfig::new(PARALLEL_CAPABILITY_ID)];
+
+        let servers = collect_capability_mcp_servers(&configs, &registry);
+        assert!(servers.contains_key(PARALLEL_SERVER_NAME));
+    }
+}

--- a/integrations/parallel/tests/live_api_test.rs
+++ b/integrations/parallel/tests/live_api_test.rs
@@ -1,0 +1,68 @@
+//! Live Parallel MCP tests.
+//!
+//! Gated behind:
+//!   cargo test -p everruns-integrations-parallel --features integration
+//!
+//! Parallel MCP is free by default, so these tests require no secrets.
+
+#![cfg(feature = "integration")]
+
+use everruns_core::{McpToolCallRequest, McpToolCallResponse, McpToolsListRequest};
+use everruns_integrations_parallel::PARALLEL_MCP_URL;
+use serde_json::json;
+
+#[tokio::test]
+async fn smoke_tools_list_free_mcp() {
+    let response = reqwest::Client::new()
+        .post(PARALLEL_MCP_URL)
+        .json(&McpToolsListRequest::default())
+        .send()
+        .await
+        .expect("tools/list request");
+
+    assert!(
+        response.status().is_success(),
+        "status: {}",
+        response.status()
+    );
+
+    let body: everruns_core::McpToolsListResponse = response
+        .json()
+        .await
+        .expect("valid MCP tools/list response");
+    let result = body.result.expect("tools/list result");
+    let names: Vec<_> = result.tools.iter().map(|tool| tool.name.as_str()).collect();
+    assert!(names.contains(&"web_search"));
+    assert!(names.contains(&"web_fetch"));
+}
+
+#[tokio::test]
+async fn smoke_web_search_free_mcp() {
+    let request = McpToolCallRequest::new(
+        1,
+        "web_search".to_string(),
+        Some(json!({
+            "objective": "Find the official Everruns GitHub organization URL.",
+            "search_queries": ["Everruns GitHub"],
+            "session_id": "everruns-parallel-live-test-0123456789abcdef"
+        })),
+    );
+
+    let response = reqwest::Client::new()
+        .post(PARALLEL_MCP_URL)
+        .json(&request)
+        .send()
+        .await
+        .expect("tools/call request");
+
+    assert!(
+        response.status().is_success(),
+        "status: {}",
+        response.status()
+    );
+
+    let body: McpToolCallResponse = response.json().await.expect("valid MCP call response");
+    assert!(body.error.is_none(), "MCP error: {:?}", body.error);
+    let result = body.result.expect("tool call result");
+    assert!(!result.content.is_empty());
+}

--- a/integrations/parallel/tests/plugin_registration.rs
+++ b/integrations/parallel/tests/plugin_registration.rs
@@ -1,0 +1,76 @@
+//! Integration test: verify Parallel plugin registers via inventory.
+
+use everruns_core::capabilities::{CapabilityRegistry, IntegrationPlugin};
+use everruns_core::connection_provider::ConnectionProviderPlugin;
+use everruns_core::deployment::DeploymentGrade;
+
+use everruns_integrations_parallel as _;
+
+#[test]
+fn parallel_plugin_is_submitted() {
+    let plugins: Vec<&IntegrationPlugin> = inventory::iter::<IntegrationPlugin>().collect();
+    assert!(
+        plugins.iter().any(|p| {
+            let cap = (p.factory)();
+            cap.id() == "parallel_search"
+        }),
+        "Parallel IntegrationPlugin should be submitted via inventory"
+    );
+}
+
+#[test]
+fn parallel_plugin_is_experimental() {
+    let plugins: Vec<&IntegrationPlugin> = inventory::iter::<IntegrationPlugin>().collect();
+    let plugin = plugins
+        .iter()
+        .find(|p| {
+            let cap = (p.factory)();
+            cap.id() == "parallel_search"
+        })
+        .expect("Parallel plugin not found");
+
+    assert!(plugin.experimental_only);
+}
+
+#[test]
+fn parallel_registered_in_dev_registry() {
+    let registry = CapabilityRegistry::with_builtins_for_grade(DeploymentGrade::Dev);
+    assert!(registry.has("parallel_search"));
+}
+
+#[test]
+fn parallel_not_registered_in_prod_registry() {
+    let registry = CapabilityRegistry::with_builtins_for_grade(DeploymentGrade::Prod);
+    assert!(!registry.has("parallel_search"));
+}
+
+#[test]
+fn connection_provider_is_submitted() {
+    let plugins: Vec<&ConnectionProviderPlugin> =
+        inventory::iter::<ConnectionProviderPlugin>().collect();
+    assert!(
+        plugins.iter().any(|p| {
+            let provider = (p.factory)();
+            provider.provider_id() == "parallel"
+        }),
+        "Parallel ConnectionProviderPlugin should be submitted via inventory"
+    );
+}
+
+#[test]
+fn connection_provider_has_api_key_form() {
+    let plugins: Vec<&ConnectionProviderPlugin> =
+        inventory::iter::<ConnectionProviderPlugin>().collect();
+    let plugin = plugins
+        .iter()
+        .find(|p| {
+            let provider = (p.factory)();
+            provider.provider_id() == "parallel"
+        })
+        .expect("Parallel connection plugin not found");
+
+    let provider = (plugin.factory)();
+    let schema = provider.form_schema().expect("should have form schema");
+    assert_eq!(schema.fields.len(), 1);
+    assert_eq!(schema.fields[0].name, "api_key");
+}

--- a/specs/integrations.md
+++ b/specs/integrations.md
@@ -40,6 +40,7 @@ Auto-registered via `inventory` plugin system. Each crate has a `SPEC.md`.
 | Integration | Spec | Summary |
 |---|---|---|
 | Brave Search | [`integrations/brave-search/SPEC.md`](../integrations/brave-search/SPEC.md) | Web search via Brave Search API. Experimental (Dev only). |
+| Parallel | [`integrations/parallel/SPEC.md`](../integrations/parallel/SPEC.md) | Web search and URL fetch through Parallel MCP. Experimental (Dev only). |
 | DuckDuckGo | [`integrations/duckduckgo/SPEC.md`](../integrations/duckduckgo/SPEC.md) | Instant answers via DuckDuckGo API. Experimental (Dev only). |
 | Browserless | [`integrations/browserless/SPEC.md`](../integrations/browserless/SPEC.md) | Cloud browser automation — screenshots, DOM, scraping, multi-step interactions. REST and CDP modes. |
 | E2B | [`integrations/e2b/SPEC.md`](../integrations/e2b/SPEC.md) | Cloud sandbox environments via E2B management API + envd runtime endpoints. Platform-owned token, multiple sandboxes per session. |


### PR DESCRIPTION
## What
Add an experimental `parallel_search` capability backed by Parallel's hosted MCP server, plus a `parallel` connection provider for optional API-key authenticated usage.

## Why
Agents need a provider-owned Parallel Search integration that supports free unauthenticated MCP search/fetch, optional Parallel API keys, and the OAuth-compatible MCP endpoint without duplicating MCP tools as built-ins.

## How
- Add `integrations/parallel` with capability ID `parallel_search`, provider ID `parallel`, config schema/UI schema, config validation, plugin registration, docs, and live MCP tests.
- Extend capabilities so they can contribute scoped remote MCP servers and merge those servers into preview/runtime tool discovery.
- Resolve authenticated contributed MCP discovery through user-scoped connection tokens when configured.
- Adopt schema-rendered capability settings for Parallel instead of hard-coded UI settings.
- Add Parallel integration workflow coverage and weekly live sweep coverage.

## Risk
- Medium
- Can break capability collection, scoped MCP tool discovery, or agent preview/runtime tool lists if contributed MCP servers are merged incorrectly.
- Can break Parallel authenticated mode if connection token lookup fails or OAuth endpoint discovery semantics change.

## Security
- Threat categories reviewed: TM-TOOL, TM-LLM, TM-AUTH, TM-API, TM-WEB, TM-DOS
- Findings and resolutions:
  - TM-TOOL/TM-LLM: Parallel is exposed only as MCP-discovered tools; removed duplicated static built-ins to avoid two tool surfaces for the same remote actions.
  - TM-AUTH: Parallel API keys remain user-scoped connections and are only sent as bearer tokens when config opts into connection/OAuth mode.
  - TM-API: Capability config is schema-rendered and server-validated; invalid auth/endpoint values and unknown fields are rejected.
  - TM-WEB: UI uses the generic schema renderer adopted from main, with a focused rendering test for Parallel settings.
  - TM-DOS: Live discovery uses the shared MCP client path and existing remote MCP validation; no new unbounded user-controlled loops or persistence paths were added.

## Validation
- `cargo test -p everruns-integrations-parallel`
- `cargo test -p everruns-integrations-parallel --features integration --test live_api_test`
- `cargo check -p everruns-server`
- `npm test -- --runTestsByPath src/__tests__/capability-settings-editor.test.tsx`
- `PORT_PREFIX=168 RUST_LOG=info just start-dev --no-watch`
- Smoke: `/api/v1/capabilities?limit=200` returned `parallel_search` with config schema.
- Smoke: `/api/v1/agents/preview` with `parallel_search` returned `mcp_parallel__web_search` and `mcp_parallel__web_fetch`.
- Smoke: created llmsim-backed agent/session/message with `parallel_search`; run completed and logs showed `mcp_tools_count=2`.
- `just pre-push`

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
