### PR TITLE
feat(models): default to gpt-5.5

### DIFF
--- a/crates/core/src/capabilities/openai_tool_search.rs
+++ b/crates/core/src/capabilities/openai_tool_search.rs
@@ -1,9 +1,9 @@
 // OpenAI Tool Search Capability
 //
 // When added to an agent, enables tool_search (deferred tool loading) for
-// models that support it (GPT-5.4+). Tools are grouped into namespaces
-// based on capability categories, and their full parameter schemas are
-// loaded on-demand by the model instead of sent upfront.
+// models with tool_search=true in their profile. Tools are grouped into
+// namespaces based on capability categories, and their full parameter schemas
+// are loaded on-demand by the model instead of sent upfront.
 //
 // This capability does not provide any tools itself — it configures the
 // LLM driver to use tool_search when constructing the API request.
@@ -68,7 +68,7 @@ impl Capability for OpenAiToolSearchCapability {
     }
 
     fn description(&self) -> &str {
-        "Enables deferred tool loading for models that support it (GPT-5.4+). \
+        "Enables deferred tool loading for models that support it (GPT-5.4 and newer). \
          Reduces token usage by loading tool schemas on-demand instead of upfront."
     }
 

--- a/crates/core/src/llm_models.rs
+++ b/crates/core/src/llm_models.rs
@@ -348,12 +348,12 @@ pub struct LlmModelProfile {
     pub reasoning_effort: Option<ReasoningEffortConfig>,
     /// Whether the model supports tool_search (deferred tool loading).
     /// When true, the driver can use namespaces and defer_loading to reduce
-    /// token usage for large tool sets. Currently supported by GPT-5.4+.
+    /// token usage for large tool sets. Currently supported by GPT-5.4 and newer.
     #[serde(default)]
     pub tool_search: bool,
     /// Whether the model supports native execution phases ("commentary" / "final_answer").
     /// When true, the driver sends the `phase` field on assistant messages in the wire format.
-    /// Currently supported by GPT-5.4+ via OpenAI Responses API.
+    /// Currently supported by GPT-5.4 and newer via OpenAI Responses API.
     #[serde(default)]
     pub supports_phases: bool,
 }

--- a/crates/core/src/openresponses_protocol.rs
+++ b/crates/core/src/openresponses_protocol.rs
@@ -583,7 +583,7 @@ impl LlmDriver for OpenResponsesProtocolLlmDriver {
         config: &LlmCallConfig,
     ) -> Result<LlmResponseStream> {
         // Check model profile to determine if phases should be sent in the wire format.
-        // Only GPT-5.4+ models support native execution phases.
+        // GPT-5.4 and newer models support native execution phases.
         let supports_phases = crate::llm_model_profiles::get_model_profile(
             &crate::llm_models::LlmProviderType::Openai,
             &config.model,

--- a/crates/core/src/runtime_agent.rs
+++ b/crates/core/src/runtime_agent.rs
@@ -392,7 +392,7 @@ impl RuntimeAgentBuilder {
     /// Build the runtime agent.
     ///
     /// Validates that tool_search is only enabled for models that support it
-    /// (currently GPT-5.4+). Clears tool_search for unsupported models to
+    /// (currently GPT-5.4 and newer). Clears tool_search for unsupported models to
     /// prevent 400 errors from the OpenAI API.
     ///
     /// tool_search is capability-driven: it is only set when the

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -1802,8 +1802,8 @@ const SEED_MODELS: &[SeedModel] = &[
     },
 ];
 
-/// Default model ID for org settings seeding (GPT-5.4)
-const DEFAULT_MODEL_ID: Uuid = seed_ids::GPT_5_4;
+/// Default model ID for org settings seeding (GPT-5.5)
+const DEFAULT_MODEL_ID: Uuid = seed_ids::GPT_5_5;
 
 /// Seed organization settings (default model, etc.)
 async fn seed_organization_settings(db: &StorageBackend) -> anyhow::Result<SeedResult> {
@@ -2603,6 +2603,10 @@ mod tests {
             .id;
         assert_eq!(settings.default_harness_id, Some(generic_id));
         assert_eq!(settings.base_harness_id, Some(base_id));
+        assert_eq!(
+            settings.default_model_id,
+            Some(everruns_core::ModelId::from_uuid(DEFAULT_MODEL_ID))
+        );
     }
 
     #[tokio::test]

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -10766,7 +10766,7 @@
           },
           "supports_phases": {
             "type": "boolean",
-            "description": "Whether the model supports native execution phases (\"commentary\" / \"final_answer\").\nWhen true, the driver sends the `phase` field on assistant messages in the wire format.\nCurrently supported by GPT-5.4+ via OpenAI Responses API."
+            "description": "Whether the model supports native execution phases (\"commentary\" / \"final_answer\").\nWhen true, the driver sends the `phase` field on assistant messages in the wire format.\nCurrently supported by GPT-5.4 and newer via OpenAI Responses API."
           },
           "temperature": {
             "type": "boolean",
@@ -10778,7 +10778,7 @@
           },
           "tool_search": {
             "type": "boolean",
-            "description": "Whether the model supports tool_search (deferred tool loading).\nWhen true, the driver can use namespaces and defer_loading to reduce\ntoken usage for large tool sets. Currently supported by GPT-5.4+."
+            "description": "Whether the model supports tool_search (deferred tool loading).\nWhen true, the driver can use namespaces and defer_loading to reduce\ntoken usage for large tool sets. Currently supported by GPT-5.4 and newer."
           }
         }
       },

--- a/docs/capabilities/openai-tool-search.md
+++ b/docs/capabilities/openai-tool-search.md
@@ -1,6 +1,6 @@
 ---
 title: OpenAI Tool Search
-description: Deferred tool loading for agents with many tools, reducing prompt token usage on OpenAI GPT-5.4+ models. Tools are loaded on demand based on semantic search.
+description: Deferred tool loading for agents with many tools, reducing prompt token usage on supported OpenAI models. Tools are loaded on demand based on semantic search.
 sidebar:
   order: 90
 ---
@@ -42,11 +42,11 @@ Each tool has a `deferrable` policy that controls whether its schema can be defe
 
 Tool search requires model-level support. Currently supported:
 
-| Model | Supported |
+| Model family | Supported |
 |---|---|
-| `gpt-5.4` | Yes |
-| `gpt-5.4-pro` | Yes |
-| All other models | No (capability is silently ignored) |
+| `gpt-5.5*` | Yes |
+| `gpt-5.4*` | Yes |
+| Models outside the `gpt-5.4*` and `gpt-5.5*` families | No (capability is silently ignored) |
 
 When the capability is enabled but the model doesn't support tool_search, the feature is silently skipped — no errors, no behavior change.
 
@@ -92,7 +92,7 @@ An agent with 20 tools and `openai_tool_search` enabled:
 ## Limitations
 
 - **OpenAI-only** — tool_search is an OpenAI Responses API feature; other providers (Anthropic, Gemini) ignore this capability
-- **GPT-5.4+ only** — earlier OpenAI models don't support tool_search
+- **Supported OpenAI reasoning models only** — earlier OpenAI models don't support tool_search
 - **No client-side tools** — currently only applies to built-in (server-executed) tools
 
 ## See Also

--- a/specs/tool-search.md
+++ b/specs/tool-search.md
@@ -20,7 +20,7 @@ OpenAI's implementation has two modes:
 
 ```json
 {
-  "model": "gpt-5.4",
+  "model": "gpt-5.5",
   "tools": [
     {
       "type": "namespace",
@@ -191,7 +191,7 @@ Track tool_search effectiveness via existing metadata:
 ### Phase 1: Model Profile + Driver (Low Risk)
 
 1. Add `tool_search: bool` to `LlmModelProfile` (default false)
-2. Set `tool_search: true` for GPT-5.4 family
+2. Set `tool_search: true` for supported GPT-5.4 and GPT-5.5 family models
 3. Add `category: Option<String>` to `BuiltinTool` / `ToolDefinition`
 4. Propagate capability category to tool definitions in `collect_capabilities()`
 5. Extend `ResponsesTool` enum with `Namespace` and `ToolSearch` variants
@@ -208,6 +208,6 @@ Track tool_search effectiveness via existing metadata:
 ## References
 
 - [OpenAI Tool Search Guide](https://developers.openai.com/api/docs/guides/tools-tool-search/)
-- [GPT-5.4 Announcement](https://openai.com/index/introducing-gpt-5-4/)
+- [Using GPT-5.5](https://developers.openai.com/api/docs/guides/latest-model)
 - [OpenAI Responses API](https://platform.openai.com/docs/api-reference/responses)
 - Internal: `specs/capabilities.md`, `specs/llm-drivers.md`


### PR DESCRIPTION
## What
- Set the seeded organization default model to GPT-5.5.
- Add seed-test coverage that verifies the default model ID points at the GPT-5.5 seed.
- Update tool_search docs/comments/spec examples to include GPT-5.5 support.
- Refresh generated OpenAPI after model-profile description changes.

## Why
GPT-5.5 is the current OpenAI target model. New default orgs should start on that model, and related tool_search documentation should reflect supported GPT-5.5 models.

## How
- Repointed `DEFAULT_MODEL_ID` from `seed_ids::GPT_5_4` to `seed_ids::GPT_5_5`.
- Kept existing GPT-5.5 profile and seed entries intact.
- Left historical/eval/comparison model references unchanged.

## Risk
- Low
- New in-memory/default-org seeds will prefer GPT-5.5; existing org settings with an explicit default are not overwritten by the seeder.

## Security
- Threat categories reviewed: TM-LLM.
- Findings and resolutions: No new secret handling, tool execution, auth, tenant, SQL, or external input surface. The change only updates seeded model selection, model metadata descriptions, generated OpenAPI, and docs/comments; no threat-model update needed.

## Validation
- `cargo fmt`
- `cargo clippy -p everruns-core -p everruns-server -- -D warnings`
- `just pre-push`
- `cargo test -p everruns-core test_gpt55`
- `cargo test -p everruns-server test_seed_all_first_run_creates_everything`
- `./scripts/export-openapi.sh`
- Smoke: dev-mode server startup on `127.0.0.1:13701`; `/health` returned ok, `/api/v1/llm-models` included enabled `gpt-5.5`, `/api/v1/orgs` returned default model `model_01933b5a000070008000000000000223`.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)