### PR TITLE
chore(plugins): update everruns dev metadata

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -14,7 +14,7 @@
         "installation": "AVAILABLE",
         "authentication": "ON_INSTALL"
       },
-      "category": "Coding"
+      "category": "Agents"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -17,7 +17,7 @@
       "homepage": "https://everruns.com",
       "repository": "https://github.com/everruns/everruns",
       "license": "MIT",
-      "category": "agents",
+      "category": "Agents",
       "keywords": [
         "agents",
         "everruns-dev",

--- a/plugins/everruns-dev/.claude-plugin/plugin.json
+++ b/plugins/everruns-dev/.claude-plugin/plugin.json
@@ -9,6 +9,7 @@
   "homepage": "https://everruns.com",
   "repository": "https://github.com/everruns/everruns",
   "license": "MIT",
+  "category": "Agents",
   "keywords": [
     "agents",
     "everruns-dev",

--- a/plugins/everruns-dev/.codex-plugin/plugin.json
+++ b/plugins/everruns-dev/.codex-plugin/plugin.json
@@ -30,7 +30,7 @@
     ],
     "websiteURL": "https://everruns.com",
     "defaultPrompt": [
-      "Create an Everruns agent summarize news from https://news.ycombinator.com/ , pick the right harness and capabilities, and run it against this task"
+      "Create an Everruns agent to summarize news from https://news.ycombinator.com/, pick the right harness and capabilities, and run it against this task"
     ],
     "brandColor": "#D4A43A",
     "composerIcon": "./assets/everruns-small.svg",

--- a/plugins/everruns-dev/.codex-plugin/plugin.json
+++ b/plugins/everruns-dev/.codex-plugin/plugin.json
@@ -23,14 +23,14 @@
     "shortDescription": "Query or execute Everruns dev workflows from Codex over MCP",
     "longDescription": "Bring the Everruns dev agent platform into Codex. Query Everruns dev state through the read-only `query` tool, use `execute` for workflows with side effects, manage harnesses and sessions, browse the API catalog, and drive the full platform through the bundled skill, slash commands, and MCP connection.",
     "developerName": "Everruns",
-    "category": "Coding",
+    "category": "Agents",
     "capabilities": [
       "Interactive",
       "Write"
     ],
     "websiteURL": "https://everruns.com",
     "defaultPrompt": [
-      "Create an Everruns dev agent, pick the right harness and capabilities, and run it against this task"
+      "Create an Everruns agent summarize news from https://news.ycombinator.com/ , pick the right harness and capabilities, and run it against this task"
     ],
     "brandColor": "#D4A43A",
     "composerIcon": "./assets/everruns-small.svg",


### PR DESCRIPTION
## What
Update the Everruns Dev plugin metadata for public release positioning.

## Why
Everruns Dev is an agents and harness platform, not a coding plugin. The default prompt should also demonstrate a concrete agent workflow.

## How
- Set Codex and Claude marketplace categories to `Agents`
- Add `category` to the Claude plugin definition
- Replace the Codex default prompt with the Hacker News summarization agent example

## Risk
- Low
- Metadata display and starter prompt text could render differently in plugin listings; no runtime behavior changes.

## Security
- Threat categories reviewed: No security-relevant code changes. This only changes static plugin metadata and a starter prompt string; it does not modify MCP server execution, auth, authorization, data access, or tool runtime behavior.
- Findings and resolutions: No findings.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

Validation: `jq empty .agents/plugins/marketplace.json .claude-plugin/marketplace.json plugins/everruns-dev/.claude-plugin/plugin.json plugins/everruns-dev/.codex-plugin/plugin.json plugins/everruns-dev/.mcp.json`; `just pre-push`.
