### PR TITLE
chore(release): prepare v0.8.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- New changes go here. Use `/prepare-release X.Y.Z` to generate draft from commits. -->
 
+## [0.8.23] - 2026-04-30
+
+### Highlights
+
+- **Default model bumped to `gpt-5.5`** - The out-of-the-box default model is now `gpt-5.5`, replacing the previous default. Existing agents and sessions with explicit `default_model_id` are unaffected.
+- **Embeddable auth & search MCP integration** - New `ServerAppBuilder` hook lets embedders wrap the API key CRUD router ([#1617](https://github.com/everruns/everruns/pull/1617)), and the parallel-search MCP integration adds a first-class search backend that capabilities can consume.
+- **Human-intent tool hooks** - Core gains explicit hooks for human-intent tool flows, giving capabilities a structured place to participate in user-driven tool execution.
+- **Per-request HTTP access logs** - Server now emits one `INFO` log per HTTP request with `request_id`, status, and latency ([#1614](https://github.com/everruns/everruns/pull/1614)), so operators get a uniform request audit trail without enabling debug-level logs.
+- **Auth hardening** - External OAuth misconfiguration now fails fast at startup, the signup harness-seed safety net is restored via `platform_definition`, and `/btw` LLM errors are classified instead of returning `500` ([#1613](https://github.com/everruns/everruns/pull/1613)).
+
+### What's Changed
+
+- fix(commands): classify /btw LLM errors instead of returning 500 ([#1613](https://github.com/everruns/everruns/pull/1613)) by [@chaliy](https://github.com/chaliy)
+- feat(server): emit one INFO log per HTTP request with request_id, status, latency ([#1614](https://github.com/everruns/everruns/pull/1614)) by [@chaliy](https://github.com/chaliy)
+- feat(core): add human intent tool hooks by [@chaliy](https://github.com/chaliy)
+- fix(discovery): add homepage link headers by [@chaliy](https://github.com/chaliy)
+- feat(auth): add ServerAppBuilder hook to wrap API key CRUD router ([#1617](https://github.com/everruns/everruns/pull/1617)) by [@chaliy](https://github.com/chaliy)
+- feat(parallel): add search mcp integration by [@chaliy](https://github.com/chaliy)
+- chore(agents): make agents dirs source of truth ([#1618](https://github.com/everruns/everruns/pull/1618)) by [@chaliy](https://github.com/chaliy)
+- chore(docs): keep proposals out of public docs by [@chaliy](https://github.com/chaliy)
+- fix(auth): restore signup harness-seed safety net via platform_definition by [@chaliy](https://github.com/chaliy)
+- fix(auth): fail fast on external OAuth config by [@chaliy](https://github.com/chaliy)
+- chore(plugins): update everruns dev metadata by [@chaliy](https://github.com/chaliy)
+- feat(models): default to gpt-5.5 by [@chaliy](https://github.com/chaliy)
+
 ## [0.8.22] - 2026-04-27
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1577,11 +1577,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-a2ui"
-version = "0.8.22"
+version = "0.8.23"
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.8.22"
+version = "0.8.23"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1600,7 +1600,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-cli"
-version = "0.8.22"
+version = "0.8.23"
 dependencies = [
  "anyhow",
  "base64",
@@ -1627,14 +1627,14 @@ dependencies = [
 
 [[package]]
 name = "everruns-config"
-version = "0.8.22"
+version = "0.8.23"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "everruns-container-sandbox"
-version = "0.8.22"
+version = "0.8.23"
 dependencies = [
  "async-trait",
  "base64",
@@ -1655,7 +1655,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.8.22"
+version = "0.8.23"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1708,7 +1708,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-durable"
-version = "0.8.22"
+version = "0.8.23"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1743,7 +1743,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-gemini"
-version = "0.8.22"
+version = "0.8.23"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1761,7 +1761,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-brave-search"
-version = "0.8.22"
+version = "0.8.23"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1777,7 +1777,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-browserless"
-version = "0.8.22"
+version = "0.8.23"
 dependencies = [
  "async-trait",
  "base64",
@@ -1798,7 +1798,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.8.22"
+version = "0.8.23"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1814,7 +1814,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-deno"
-version = "0.8.22"
+version = "0.8.23"
 dependencies = [
  "async-trait",
  "base64",
@@ -1838,7 +1838,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-docker"
-version = "0.8.22"
+version = "0.8.23"
 dependencies = [
  "async-trait",
  "base64",
@@ -1853,7 +1853,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.8.22"
+version = "0.8.23"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-e2b"
-version = "0.8.22"
+version = "0.8.23"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1897,7 +1897,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-parallel"
-version = "0.8.22"
+version = "0.8.23"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -1909,7 +1909,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-pi"
-version = "0.8.22"
+version = "0.8.23"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1924,7 +1924,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-sprites"
-version = "0.8.22"
+version = "0.8.23"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1940,7 +1940,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-internal-protocol"
-version = "0.8.22"
+version = "0.8.23"
 dependencies = [
  "chrono",
  "everruns-core",
@@ -1957,7 +1957,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-macros"
-version = "0.8.22"
+version = "0.8.23"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1967,7 +1967,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.8.22"
+version = "0.8.23"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1989,11 +1989,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-openui"
-version = "0.8.22"
+version = "0.8.23"
 
 [[package]]
 name = "everruns-runtime"
-version = "0.8.22"
+version = "0.8.23"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2027,7 +2027,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-server"
-version = "0.8.22"
+version = "0.8.23"
 dependencies = [
  "aes-gcm",
  "ag-ui-core",
@@ -2111,7 +2111,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-session-sqldb"
-version = "0.8.22"
+version = "0.8.23"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2130,7 +2130,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-worker"
-version = "0.8.22"
+version = "0.8.23"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.8.22"
+version = "0.8.23"
 edition = "2024"
 license = "MIT"
 authors = ["Everruns Contributors"]

--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "everruns-ui",
-  "version": "0.8.22",
+  "version": "0.8.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "everruns-ui",
-      "version": "0.8.22",
+      "version": "0.8.23",
       "dependencies": {
         "@base-ui/react": "^1.2.0",
         "@openuidev/react-lang": "^0.1.3",

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "everruns-ui",
-  "version": "0.8.22",
+  "version": "0.8.23",
   "private": true,
   "exports": {
     "./route-manifest": "./src/lib/ui-route-manifest.ts",


### PR DESCRIPTION
## What

Patch release v0.8.23 — bumps `workspace.package.version` and `apps/ui/package.json` to `0.8.23`, regenerates lockfiles, and adds the v0.8.23 entry to `CHANGELOG.md` covering the 12 commits that landed on `main` since v0.8.22.

## Why

Routine patch on top of v0.8.22 collecting feat/fix/chore work that has merged since the last tag and shipping it as a normal patch release so SaaS can pick it up.

### Highlights

- **Default model bumped to `gpt-5.5`** — out-of-the-box default model is now `gpt-5.5`; agents/sessions with explicit `default_model_id` are unaffected.
- **Embeddable auth & search MCP integration** — new `ServerAppBuilder` hook to wrap the API key CRUD router ([#1617](https://github.com/everruns/everruns/pull/1617)); parallel-search MCP integration adds a first-class search backend.
- **Human-intent tool hooks** — core gains explicit hooks for human-intent tool flows so capabilities can participate in user-driven tool execution.
- **Per-request HTTP access logs** — server emits one `INFO` log per HTTP request with `request_id`, status, and latency ([#1614](https://github.com/everruns/everruns/pull/1614)).
- **Auth hardening** — external OAuth misconfiguration fails fast at startup, signup harness-seed safety net restored via `platform_definition`, and `/btw` LLM errors are classified instead of returning `500` ([#1613](https://github.com/everruns/everruns/pull/1613)).

## How

Followed `/prepare-release` (`specs/release-process.md`):

- `Cargo.toml` — `workspace.package.version` `0.8.22` → `0.8.23`
- `apps/ui/package.json` — `version` `0.8.22` → `0.8.23`
- `Cargo.lock` regenerated via `cargo update --workspace`
- `apps/ui/package-lock.json` regenerated via `npm install --package-lock-only`
- `CHANGELOG.md` — new `## [0.8.23]` section with Highlights and What's Changed

No migration changes; sequence `001..026` remains contiguous.

## Risk

- Low — no source code changes; version-bump + changelog only. Auto-tagging triggers off the `chore(release): prepare v0.8.23` commit message on merge.
- What can break: nothing direct; downstream SaaS adoption follows in a separate bump PR.

## Security

- Threat categories reviewed: No security-relevant code changes — version bump and changelog only.
- Findings and resolutions: None.

## Checklist
- [x] Tests added or updated (n/a — release prep)
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] All review comments addressed (code change or written reasoning)

### Post-merge

After merging, the release workflow will automatically:
- Create git tag `v0.8.23`
- Create GitHub Release with notes from CHANGELOG.md
- Trigger Docker image build with version tag

---
_Generated by [Claude Code](https://claude.ai/code/session_018XEKrBT9KxVA6V3QpdecN9)_