### PR TITLE
fix(mcp): use path-specific OAuth protected-resource metadata URL

### DIFF
--- a/crates/server/src/api/mcp_endpoint/mod.rs
+++ b/crates/server/src/api/mcp_endpoint/mod.rs
@@ -197,9 +197,10 @@ pub struct AppState {
     pub chat_harness_name: Option<String>,
     pub chat_session_title: Option<String>,
     pub sqldb_store: Option<Arc<dyn SessionSqlDbStore>>,
-    /// Absolute URL of `/.well-known/oauth-protected-resource`, used to
+    /// Absolute URL of `/.well-known/oauth-protected-resource/mcp`, used to
     /// populate the `WWW-Authenticate: Bearer resource_metadata="..."` header
     /// on 401 responses per RFC 9728 §5.1 and the MCP 2025-06-18 auth spec.
+    /// Path-derived per RFC 9728 §3.1 for the `/mcp` resource.
     /// `None` disables the header (e.g. tests without an issuer configured).
     pub resource_metadata_url: Option<String>,
 }
@@ -1340,7 +1341,7 @@ mod www_authenticate_tests {
     use axum::routing::any;
     use tower::ServiceExt;
 
-    const METADATA_URL: &str = "https://example.com/.well-known/oauth-protected-resource";
+    const METADATA_URL: &str = "https://example.com/.well-known/oauth-protected-resource/mcp";
 
     fn app_with_layer(status: StatusCode) -> Router {
         let header_value = parse_www_authenticate_value(METADATA_URL).expect("valid header");

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -935,9 +935,10 @@ impl ServerAppBuilder {
             api::session_resources::AppState::new(db.clone(), auth_state.clone());
 
         // MCP endpoint: derive the protected-resource metadata URL from
-        // auth_config.base_url so it matches `/.well-known/oauth-protected-resource`.
+        // auth_config.base_url. Path-derived per RFC 9728 §3.1 for resource
+        // `{root}/mcp` → `{root}/.well-known/oauth-protected-resource/mcp`.
         let mcp_resource_metadata_url = format!(
-            "{}/.well-known/oauth-protected-resource",
+            "{}/.well-known/oauth-protected-resource/mcp",
             auth::builtin::root_url_from_api_base(&auth_config.base_url)
         );
         let mcp_endpoint_state = api::mcp_endpoint::AppState::new(

--- a/crates/server/src/auth/builtin.rs
+++ b/crates/server/src/auth/builtin.rs
@@ -72,7 +72,8 @@ fn build_api_key_cache() -> Cache<String, AuthUser> {
 
 /// Strip the API prefix from the base URL to recover the public root origin.
 /// Used by MCP metadata endpoints and the MCP 401 `WWW-Authenticate` header
-/// so clients can locate `/.well-known/oauth-protected-resource`.
+/// so clients can locate `/.well-known/oauth-protected-resource/mcp` (RFC 9728
+/// §3.1 path-derived for the `/mcp` resource).
 pub(crate) fn root_url_from_api_base(api_base_url: &str) -> String {
     let trimmed = api_base_url.trim_end_matches('/');
     if let Ok(api_prefix) = std::env::var("API_PREFIX") {

--- a/crates/server/src/auth/mcp_oauth.rs
+++ b/crates/server/src/auth/mcp_oauth.rs
@@ -212,8 +212,12 @@ impl FromRef<McpOAuthState> for AuthState {
 /// discovers them via `/.well-known/oauth-authorization-server`.
 pub fn mcp_oauth_routes(state: McpOAuthState) -> Router {
     Router::new()
+        // RFC 9728 §3.1 path-derived discovery: resource `{root}/mcp` →
+        // PRM at `{root}/.well-known/oauth-protected-resource/mcp`. Real MCP
+        // providers (Atlassian, etc.) only serve the path-specific URL, so
+        // OSS canonicalises on it too and SaaS no longer needs a root alias.
         .route(
-            "/.well-known/oauth-protected-resource",
+            "/.well-known/oauth-protected-resource/mcp",
             get(oauth_protected_resource_metadata),
         )
         .route(
@@ -248,10 +252,10 @@ async fn try_resolve_user(state: &McpOAuthState, jar: &CookieJar) -> Option<Auth
 // Handlers
 // ============================================
 
-/// GET /.well-known/oauth-protected-resource — Protected resource metadata (RFC 9728)
+/// GET /.well-known/oauth-protected-resource/mcp — Protected resource metadata (RFC 9728)
 ///
 /// MCP clients fetch this first to discover which authorization server protects
-/// the resource. Points to the authorization server metadata URL.
+/// the resource. Path-derived per RFC 9728 §3.1 for the `/mcp` resource.
 async fn oauth_protected_resource_metadata(
     State(state): State<McpOAuthState>,
 ) -> Json<OAuthProtectedResourceMetadata> {

--- a/crates/server/tests/mcp_endpoint_test.rs
+++ b/crates/server/tests/mcp_endpoint_test.rs
@@ -1851,11 +1851,17 @@ async fn test_oauth_register_and_metadata() {
             .ends_with("/oauth/token")
     );
 
-    // Test protected resource metadata endpoint
+    // Test path-specific protected resource metadata endpoint (RFC 9728 §3.1).
     let resource: Value = server
-        .get("/.well-known/oauth-protected-resource")
+        .get("/.well-known/oauth-protected-resource/mcp")
         .await
         .assert_success()
         .json();
     assert!(resource["resource"].as_str().unwrap().ends_with("/mcp"));
+
+    // Root PRM URL is no longer served — clients must use the path-derived URL.
+    server
+        .get("/.well-known/oauth-protected-resource")
+        .await
+        .assert_status(StatusCode::NOT_FOUND);
 }

--- a/specs/mcp.md
+++ b/specs/mcp.md
@@ -10,7 +10,7 @@ Routing is intentionally split:
 - MCP OAuth lives at `/oauth/*` (authorize, token, register)
 - MCP JSON-RPC lives at `/mcp`
 - OAuth discovery metadata lives at `/.well-known/oauth-authorization-server`
-- Protected-resource metadata lives at `/.well-known/oauth-protected-resource`
+- Protected-resource metadata lives at `/.well-known/oauth-protected-resource/mcp` (RFC 9728 §3.1 path-derived for the `/mcp` resource)
 
 Everruns also acts as an **MCP client** (connecting to remote MCP servers). That side is covered in [`specs/mcp-servers.md`](mcp-servers.md).
 
@@ -124,9 +124,11 @@ The `issuer` is the backend root URL (e.g. `https://app.example.com`). OAuth end
 }
 ```
 
-#### GET /.well-known/oauth-protected-resource
+#### GET /.well-known/oauth-protected-resource/mcp
 
 Protected Resource Metadata for MCP-aware OAuth clients. No auth required.
+
+The path-specific URL is derived per [RFC 9728 §3.1](https://datatracker.ietf.org/doc/html/rfc9728#section-3.1) for the `/mcp` resource: `{root}/mcp` → `{root}/.well-known/oauth-protected-resource/mcp`. The root `/.well-known/oauth-protected-resource` URL is intentionally **not** served — it would be the PRM for a resource at `/`, which Everruns does not expose. Real MCP providers (e.g. Atlassian) only serve the path-specific URL, so OSS canonicalises on the same shape.
 
 Everruns advertises `/mcp` as the protected resource and points clients at the same OAuth issuer and token endpoints used by the rest of the MCP flow.
 
@@ -135,10 +137,10 @@ Everruns advertises `/mcp` as the protected resource and points clients at the s
 Per [RFC 9728 §5.1](https://datatracker.ietf.org/doc/html/rfc9728#section-5.1) and the MCP 2025-06-18 auth spec, unauthenticated requests to `/mcp` return `401 Unauthorized` with a `WWW-Authenticate` header pointing at the protected-resource metadata document:
 
 ```
-WWW-Authenticate: Bearer realm="mcp", resource_metadata="https://app.example.com/.well-known/oauth-protected-resource"
+WWW-Authenticate: Bearer realm="mcp", resource_metadata="https://app.example.com/.well-known/oauth-protected-resource/mcp"
 ```
 
-The `resource_metadata` URL is derived from the configured API base URL (stripping `/api` or `$API_PREFIX`) so it matches the origin of the `.well-known` endpoints. Implementation: `crates/server/src/api/mcp_endpoint/mod.rs` attaches a tower layer to the MCP router that injects the header on 401 responses and leaves other status codes untouched.
+The `resource_metadata` URL is derived from the configured API base URL (stripping `/api` or `$API_PREFIX`) and uses the path-specific PRM URL for the `/mcp` resource. Implementation: `crates/server/src/api/mcp_endpoint/mod.rs` attaches a tower layer to the MCP router that injects the header on 401 responses and leaves other status codes untouched.
 
 #### POST /oauth/register
 


### PR DESCRIPTION
## What

Switch the OSS MCP `/mcp` endpoint's protected-resource metadata (PRM) URL from the root form to the **path-specific** form per RFC 9728 §3.1:

- Route: `/.well-known/oauth-protected-resource` → `/.well-known/oauth-protected-resource/mcp`
- `WWW-Authenticate` header on `/mcp` 401 responses now advertises the path-specific URL.
- Root PRM URL is no longer served (regression-tested).

## Why

[RFC 9728 §3.1](https://datatracker.ietf.org/doc/html/rfc9728#section-3.1) path-derived discovery: for a resource at `{root}/mcp`, the well-known PRM URL is `{root}/.well-known/oauth-protected-resource/mcp`, not the root path. Real MCP providers (e.g. Atlassian) only serve the path-specific URL and may 404 on the root, so RFC-conformant MCP clients construct the path-specific URL from the resource. The OSS server previously hard-coded the root URL in `ServerAppBuilder`, which forced SaaS to maintain a root-URL compatibility bridge. With this change OSS canonicalises on the same shape and SaaS can drop the bridge once it consumes this OSS version.

Closes EVE-404.

## How

- `crates/server/src/auth/mcp_oauth.rs`: move PRM route to `/.well-known/oauth-protected-resource/mcp` and refresh the docstring.
- `crates/server/src/app_builder.rs`: derive `mcp_resource_metadata_url` with the `/mcp` suffix so the `WWW-Authenticate: Bearer ... resource_metadata="..."` header matches.
- `crates/server/src/api/mcp_endpoint/mod.rs`: doc comment + unit-test `METADATA_URL` constant updated.
- `crates/server/tests/mcp_endpoint_test.rs`: integration test now asserts the path-specific URL serves the metadata and the root URL returns 404.
- `crates/server/src/auth/builtin.rs`: doc comment refreshed.
- `specs/mcp.md`: routing list, endpoint section, and 401 example now show the path-specific URL with rationale.

The existing `with_resource_metadata_url(...)` embedding hook on `mcp_endpoint::AppState` is unchanged, so wrappers can still override the URL when embedding the OSS server with a non-default routing layout.

## Risk

- **Low**.
- The endpoint is unauthenticated and read-only; only the URL path changed, the response shape is identical.
- Any client still hitting the root URL gets a clear 404 rather than wrong metadata.
- No SaaS coordination required up-front: SaaS already serves a root compatibility bridge, so it keeps working until SaaS opts in by removing it.

## Validation

- `cargo fmt --check` ✅
- `cargo clippy -p everruns-server --tests --all-features -- -D warnings` ✅
- `cargo test -p everruns-server --lib mcp_endpoint::www_authenticate_tests` — 4 passed (header format, 401 injection, non-401 skip, preserve existing) ✅
- `cargo test -p everruns-server --test mcp_endpoint_test test_oauth_register_and_metadata` — passed ✅
- `just pre-push` — all checks ✅
- Manual smoke test against `just start-dev`:
  - `GET /.well-known/oauth-protected-resource/mcp` → `200` with `{"resource":".../mcp", "authorization_servers":[...], "bearer_methods_supported":["header"]}`
  - `GET /.well-known/oauth-protected-resource` → `404`

Pre-existing `test_mcp_discover_*` and `test_mcp_execute_*` failures on `main` were verified to be unrelated to this change (they fail on a clean `main` checkout in the same environment).

## Security

- Threat categories reviewed: **TM-AUTH**, **TM-API**.
- **TM-AUTH** — OAuth metadata endpoint: handler logic, response shape, authentication requirements, and trust boundaries are unchanged. Only the route path is canonicalised to RFC 9728 §3.1. No tokens, secrets, or session state are introduced or changed.
- **TM-API** — Public unauthenticated GET route: no new query/body inputs; the `WWW-Authenticate` header value is built once at router construction time from a server-derived URL and parsed via `HeaderValue::parse` (header-injection safe). No SSRF, injection, or data-exposure surface is added.
- No `THREAT[…]` comments needed adjustment; no new `specs/threat-model.md` entries required.

## Checklist

- [x] Tests added or updated (unit + integration, including a 404 regression for the old root URL)
- [x] Backward compatibility considered (internal code; SaaS bridge still works during rollout)
- [x] Security review performed against relevant threat model categories (TM-AUTH, TM-API)
- [x] All review comments addressed (none yet — will sweep after open)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XUJUFiQ5kAX2bmU8mcdazJ)_