### PR TITLE
fix(plugin): add Everruns Dev MCP OAuth resource

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "everruns-dev",
       "source": "./plugins/everruns-dev",
       "description": "Interact with the Everruns dev agent platform - create and run agents, manage harnesses and sessions, browse the API catalog.",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "author": {
         "name": "Everruns",
         "url": "https://everruns.com"

--- a/plugins/everruns-dev/.claude-plugin/plugin.json
+++ b/plugins/everruns-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "everruns-dev",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Interact with the Everruns dev agent platform — inspect state with read-only queries, run side-effecting workflows, and manage agents, harnesses, and sessions.",
   "author": {
     "name": "Everruns",

--- a/plugins/everruns-dev/.codex-plugin/plugin.json
+++ b/plugins/everruns-dev/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "everruns-dev",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Interact with the Everruns dev agent platform from Codex over MCP, with read-only `query` and full-access `execute` workflows.",
   "author": {
     "name": "Everruns",

--- a/plugins/everruns-dev/.mcp.json
+++ b/plugins/everruns-dev/.mcp.json
@@ -3,6 +3,7 @@
     "everruns-dev": {
       "type": "http",
       "url": "https://dev.everruns.com/mcp",
+      "oauth_resource": "https://dev.everruns.com/mcp",
       "note": "Everruns Dev MCP endpoint. Your MCP host will handle OAuth on first use."
     }
   }

--- a/scripts/test-everruns-dev-plugin.sh
+++ b/scripts/test-everruns-dev-plugin.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+python3 - <<'PY' "$PROJECT_ROOT"
+import json
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+plugin_dir = root / "plugins" / "everruns-dev"
+expected_url = "https://dev.everruns.com/mcp"
+
+mcp = json.loads((plugin_dir / ".mcp.json").read_text())
+server = mcp["mcpServers"]["everruns-dev"]
+
+if server["url"] != expected_url:
+    raise SystemExit(f"Everruns Dev MCP URL changed unexpectedly: {server['url']}")
+
+if server.get("oauth_resource") != expected_url:
+    raise SystemExit(
+        "Everruns Dev plugin must declare oauth_resource so Codex MCP login "
+        "includes the RFC 8707 resource parameter without user config."
+    )
+
+if server.get("scopes"):
+    raise SystemExit(
+        "Everruns Dev plugin must not request OAuth scopes; "
+        "PropelAuth rejects them for this MCP resource."
+    )
+
+codex = json.loads((plugin_dir / ".codex-plugin" / "plugin.json").read_text())
+claude = json.loads((plugin_dir / ".claude-plugin" / "plugin.json").read_text())
+marketplace = json.loads((root / ".claude-plugin" / "marketplace.json").read_text())
+marketplace_plugin = marketplace["plugins"][0]
+
+versions = {
+    "codex": codex["version"],
+    "claude": claude["version"],
+    "marketplace": marketplace_plugin["version"],
+}
+
+if len(set(versions.values())) != 1:
+    raise SystemExit(f"Everruns Dev plugin versions diverged: {versions}")
+
+print("everruns-dev plugin metadata checks passed")
+PY


### PR DESCRIPTION
## What
Add `oauth_resource` to the Everruns Dev plugin MCP config and bump the plugin metadata to `0.1.1`.

## Why
Codex MCP OAuth login must include the RFC 8707 `resource` parameter for `https://dev.everruns.com/mcp`; without it PropelAuth rejects login with `Missing or invalid resource`.

## How
- Declare `oauth_resource` in `plugins/everruns-dev/.mcp.json`
- Keep Codex/Claude/marketplace plugin versions aligned at `0.1.1`
- Add a repo shell test guarding the MCP URL, OAuth resource, no scopes, and version alignment

## Risk
- Low
- Plugin metadata only; main risk is marketplace packaging/import compatibility.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
