### PR TITLE
fix(mcp): expose command output schemas in discover

### DIFF
--- a/crates/server/src/api/mcp_endpoint/mod.rs
+++ b/crates/server/src/api/mcp_endpoint/mod.rs
@@ -6,7 +6,7 @@
 //   → Direct service calls, first-class support for the agent conversation loop
 // - Tier 2 tools: discover, query, execute
 //   → Backed by bashkit ScriptedTool with API operations exposed as builtins
-//   → discover: uses ScriptedTool's built-in `discover` command
+//   → discover: reads inventory descriptors and returns schema-bearing JSON
 //   → query: runs bash scripts with the read-only subset of API ops
 //   → execute: runs bash scripts with the full API surface, including writes
 // - Tier 0 tools: me, list_organizations, switch_organization
@@ -1140,30 +1140,121 @@ async fn tool_session_get_status(
 }
 
 // ============================================================================
-// Tier 2: discover — delegates to ScriptedTool's built-in discover command
+// Tier 2: discover — structured catalog from inventory descriptors
 // ============================================================================
 
 async fn tool_discover(
     args: &Value,
-    org: &ResolvedOrg,
-    state: &AppState,
+    _org: &ResolvedOrg,
+    _state: &AppState,
 ) -> Result<String, String> {
     let show_all = args.get("all").and_then(|v| v.as_bool()).unwrap_or(false);
+    let include_schemas = args
+        .get("include_schemas")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(!show_all);
 
-    let command = if show_all {
-        "discover --categories".to_string()
-    } else {
-        let query = args.get("query").and_then(|v| v.as_str()).unwrap_or("");
+    let mut entries = crate::domains::common::catalog_entries_with_schemas(include_schemas);
+    entries.sort_by_key(|entry| (entry.category, entry.name));
+
+    if !show_all {
+        let query = args
+            .get("query")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .trim();
         if query.is_empty() {
             return Err(
                 "Provide a 'query' to search or set 'all: true' to list everything.".into(),
             );
         }
-        format!("discover --search '{}'", query.replace('\'', "'\\''"))
+
+        entries.retain(|entry| catalog_entry_matches(entry, query));
+    }
+
+    let operation_json = |entry: &crate::domains::common::CommandCatalogEntry| {
+        let mut value = json!({
+            "name": entry.name,
+            "category": entry.category,
+            "description": entry.description,
+            "method": entry.method,
+            "path": entry.path,
+            "read_only": entry.read_only,
+            "output_shape": entry.output_shape,
+        });
+        if let Some(positional_arg) = entry.positional_arg {
+            value["positional_arg"] = json!(positional_arg);
+        }
+        if include_schemas {
+            value["input_schema"] = entry.input_schema.clone();
+            value["output_schema"] = entry.output_schema.clone();
+        }
+        value
     };
 
-    let toolset = build_toolset(org, state, catalog::ToolsetMode::Full);
-    execute_script(&toolset, &command, 10_000).await
+    if show_all {
+        let mut by_category: std::collections::BTreeMap<&str, Vec<Value>> =
+            std::collections::BTreeMap::new();
+        for entry in &entries {
+            by_category
+                .entry(entry.category)
+                .or_default()
+                .push(operation_json(entry));
+        }
+
+        let categories: Vec<Value> = by_category
+            .into_iter()
+            .map(|(category, operations)| {
+                json!({
+                    "category": category,
+                    "count": operations.len(),
+                    "operations": operations,
+                })
+            })
+            .collect();
+
+        pretty_json(&json!({
+            "count": entries.len(),
+            "include_schemas": include_schemas,
+            "categories": categories,
+            "shape_hints": output_shape_hints(),
+        }))
+    } else {
+        pretty_json(&json!({
+            "count": entries.len(),
+            "include_schemas": include_schemas,
+            "operations": entries.iter().map(operation_json).collect::<Vec<_>>(),
+            "shape_hints": output_shape_hints(),
+        }))
+    }
+}
+
+fn catalog_entry_matches(entry: &crate::domains::common::CommandCatalogEntry, query: &str) -> bool {
+    let haystack = format!(
+        "{} {} {} {}",
+        entry.name,
+        entry.name.replace('_', " "),
+        entry.category,
+        entry.description
+    )
+    .to_lowercase();
+
+    let normalized_query = query.replace('_', " ").to_lowercase();
+    query
+        .to_lowercase()
+        .split_whitespace()
+        .all(|term| haystack.contains(term))
+        || normalized_query
+            .split_whitespace()
+            .all(|term| haystack.contains(term))
+}
+
+fn output_shape_hints() -> Value {
+    json!({
+        "array": "Root JSON value is an array. Use jq '.[]'.",
+        "paginated": "Root JSON value is an object with data/total/offset/limit. Use jq '.data[]'.",
+        "unknown": "Inspect output_schema or run a small sample before choosing a jq path."
+    })
 }
 
 // ============================================================================
@@ -1262,12 +1353,29 @@ async fn execute_script(
                         response.exit_code
                     ))
                 } else {
-                    Err(trimmed.to_string())
+                    Err(sanitize_script_error(trimmed))
                 }
             }
         }
         Err(_) => Err(format!("Command timed out after {timeout_ms}ms")),
     }
+}
+
+fn sanitize_script_error(message: &str) -> String {
+    if message.contains("jq: runtime error")
+        || (message.contains("jq: error") && message.contains("Cannot index"))
+    {
+        let cause = if message.to_lowercase().contains("cannot index") {
+            "cannot index input with requested path"
+        } else {
+            "filter failed against input value"
+        };
+        return format!(
+            "jq: runtime error: {cause}. Input value omitted; use discover output_shape/output_schema to choose the jq path."
+        );
+    }
+
+    message.to_string()
 }
 
 #[cfg(test)]

--- a/crates/server/src/api/mcp_endpoint/tool_registry.rs
+++ b/crates/server/src/api/mcp_endpoint/tool_registry.rs
@@ -366,7 +366,7 @@ fn discover_tool(protocol_version: &str, org_id_description: &str) -> McpEndpoin
         protocol_version,
         "discover",
         "Discover Operations",
-        "Search the Everruns API catalog to find available operations. Returns matching operations with description and parameters. Use all: true to list every operation grouped by category. Read-only operations are available as bash builtins in query; the full catalog is available in execute.",
+        "Search the Everruns API catalog to find available operations. Returns matching operations with input/output schemas and jq-oriented output shape hints. Use all: true to list every operation grouped by category. Read-only operations are available as bash builtins in query; the full catalog is available in execute.",
         object_schema(
             vec![
                 (
@@ -384,6 +384,13 @@ fn discover_tool(protocol_version: &str, org_id_description: &str) -> McpEndpoin
                     }),
                 ),
                 (
+                    "include_schemas",
+                    json!({
+                        "type": "boolean",
+                        "description": "Include input_schema and output_schema in results. Defaults to true for search and false for all."
+                    }),
+                ),
+                (
                     "organization_id",
                     json!({
                         "type": "string",
@@ -394,7 +401,7 @@ fn discover_tool(protocol_version: &str, org_id_description: &str) -> McpEndpoin
             ],
             vec![],
         ),
-        None,
+        Some(discover_output_schema()),
         Some(read_only_annotations()),
         10_000,
     )
@@ -593,5 +600,62 @@ fn me_output_schema() -> Value {
             }
         },
         "required": ["user", "current_organization", "organizations"]
+    })
+}
+
+fn discover_output_schema() -> Value {
+    let operation_schema = json!({
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+            "name": { "type": "string" },
+            "category": { "type": "string" },
+            "description": { "type": "string" },
+            "method": { "type": "string" },
+            "path": { "type": "string" },
+            "read_only": { "type": "boolean" },
+            "positional_arg": { "type": "string" },
+            "input_schema": { "type": "object", "additionalProperties": true },
+            "output_schema": { "type": "object", "additionalProperties": true },
+            "output_shape": {
+                "type": "string",
+                "enum": ["array", "paginated", "unknown"]
+            }
+        },
+        "required": ["name", "category", "description", "method", "path", "read_only", "output_shape"]
+    });
+
+    json!({
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+            "count": { "type": "integer" },
+            "include_schemas": { "type": "boolean" },
+            "operations": {
+                "type": "array",
+                "items": operation_schema
+            },
+            "categories": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "category": { "type": "string" },
+                        "count": { "type": "integer" },
+                        "operations": {
+                            "type": "array",
+                            "items": operation_schema
+                        }
+                    },
+                    "required": ["category", "count", "operations"]
+                }
+            },
+            "shape_hints": {
+                "type": "object",
+                "additionalProperties": { "type": "string" }
+            }
+        },
+        "required": ["count", "include_schemas", "shape_hints"]
     })
 }

--- a/crates/server/src/domains/agents/commands.rs
+++ b/crates/server/src/domains/agents/commands.rs
@@ -265,6 +265,14 @@ impl Command for ListAgents {
         Some(&AGENT_VIEW)
     }
 
+    fn output_schema() -> serde_json::Value {
+        paginated_output_schema(output_schema_for::<Agent>())
+    }
+
+    fn output_shape() -> &'static str {
+        "paginated"
+    }
+
     async fn execute(self, ctx: &Ctx) -> Result<Paginated<Agent>, CommandError> {
         let pg = pagination(self.offset, self.limit);
         let (rows, total) = ctx

--- a/crates/server/src/domains/capabilities/commands.rs
+++ b/crates/server/src/domains/capabilities/commands.rs
@@ -42,6 +42,14 @@ impl Command for ListCapabilities {
         }
     }
 
+    fn output_schema() -> serde_json::Value {
+        paginated_output_schema(output_schema_for::<CapabilityInfo>())
+    }
+
+    fn output_shape() -> &'static str {
+        "paginated"
+    }
+
     async fn execute(self, ctx: &Ctx) -> Result<Paginated<CapabilityInfo>, CommandError> {
         let mut capabilities = ctx
             .capability_service

--- a/crates/server/src/domains/common.rs
+++ b/crates/server/src/domains/common.rs
@@ -425,6 +425,24 @@ pub trait Command: DeserializeOwned + Send + 'static + CommandSchema {
         json_schema_for_command::<Self>()
     }
 
+    /// JSON Schema for the command output surfaced in MCP discovery.
+    ///
+    /// Commands should override this when the output shape is important for
+    /// scripting. The default remains a valid open schema so discovery can
+    /// always report an output contract without blocking command migration.
+    fn output_schema() -> Value {
+        serde_json::json!({
+            "type": "object",
+            "additionalProperties": true,
+            "description": "Output schema is not declared for this command yet."
+        })
+    }
+
+    /// Short jq-oriented output shape hint for MCP scripting callers.
+    fn output_shape() -> &'static str {
+        "unknown"
+    }
+
     /// Execute the command. Validation + business logic + persistence.
     ///
     /// SECURITY: Do not call this directly from HTTP/MCP/gRPC adapters —
@@ -479,6 +497,37 @@ where
     T: ToSchema,
 {
     json_schema_for::<T>()
+}
+
+pub fn output_schema_for<T>() -> Value
+where
+    T: ToSchema,
+{
+    json_schema_for::<T>()
+}
+
+pub fn array_output_schema(item_schema: Value) -> Value {
+    serde_json::json!({
+        "type": "array",
+        "items": item_schema
+    })
+}
+
+pub fn paginated_output_schema(item_schema: Value) -> Value {
+    serde_json::json!({
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+            "data": {
+                "type": "array",
+                "items": item_schema
+            },
+            "total": { "type": "integer" },
+            "offset": { "type": "integer" },
+            "limit": { "type": "integer" }
+        },
+        "required": ["data", "total", "offset", "limit"]
+    })
 }
 
 fn json_schema_for<T>() -> Value
@@ -584,6 +633,8 @@ pub struct CommandDescriptor {
     pub read_only: fn() -> bool,
     pub positional_arg: fn() -> Option<&'static str>,
     pub param_schema: fn() -> Value,
+    pub output_schema: fn() -> Value,
+    pub output_shape: fn() -> &'static str,
     // SECURITY: Exposed so the policy-coverage test can assert every
     // mutating command declares a policy; do not drop.
     pub policy: fn() -> Option<&'static Policy>,
@@ -600,6 +651,8 @@ impl CommandDescriptor {
             read_only: C::read_only,
             positional_arg: C::positional_arg,
             param_schema: <C as Command>::param_schema,
+            output_schema: C::output_schema,
+            output_shape: C::output_shape,
             policy: C::policy,
             dispatch: dispatch_for::<C>,
         }
@@ -653,6 +706,50 @@ pub fn catalog_entries() -> Vec<CommandMeta> {
     inventory::iter::<CommandDescriptor>
         .into_iter()
         .map(|desc| (desc.meta)())
+        .collect()
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CommandCatalogEntry {
+    pub name: &'static str,
+    pub category: &'static str,
+    pub description: &'static str,
+    pub method: &'static str,
+    pub path: &'static str,
+    pub read_only: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub positional_arg: Option<&'static str>,
+    pub input_schema: Value,
+    pub output_schema: Value,
+    pub output_shape: &'static str,
+}
+
+pub fn catalog_entries_with_schemas(include_schemas: bool) -> Vec<CommandCatalogEntry> {
+    inventory::iter::<CommandDescriptor>
+        .into_iter()
+        .map(|desc| {
+            let meta = (desc.meta)();
+            CommandCatalogEntry {
+                name: meta.name,
+                category: meta.category,
+                description: meta.description,
+                method: meta.method,
+                path: meta.path,
+                read_only: (desc.read_only)(),
+                positional_arg: (desc.positional_arg)(),
+                input_schema: if include_schemas {
+                    (desc.param_schema)()
+                } else {
+                    Value::Null
+                },
+                output_schema: if include_schemas {
+                    (desc.output_schema)()
+                } else {
+                    Value::Null
+                },
+                output_shape: (desc.output_shape)(),
+            }
+        })
         .collect()
 }
 

--- a/crates/server/src/domains/harnesses/commands.rs
+++ b/crates/server/src/domains/harnesses/commands.rs
@@ -227,6 +227,14 @@ impl Command for ListHarnesses {
         Some(&HARNESS_VIEW)
     }
 
+    fn output_schema() -> serde_json::Value {
+        array_output_schema(output_schema_for::<Harness>())
+    }
+
+    fn output_shape() -> &'static str {
+        "array"
+    }
+
     async fn execute(self, ctx: &Ctx) -> Result<Vec<Harness>, CommandError> {
         let rows = ctx
             .db

--- a/crates/server/tests/mcp_endpoint_test.rs
+++ b/crates/server/tests/mcp_endpoint_test.rs
@@ -355,7 +355,7 @@ async fn test_mcp_tools_list() {
         discover["inputSchema"]["properties"]["organization_id"]["pattern"],
         "^org_[0-9a-f]{32}$"
     );
-    assert!(discover.as_object().unwrap().get("outputSchema").is_none());
+    assert_eq!(discover["outputSchema"]["type"], "object");
     assert!(discover.as_object().unwrap().get("_meta").is_none());
 
     let query = tools.iter().find(|tool| tool["name"] == "query").unwrap();
@@ -873,7 +873,7 @@ async fn test_mcp_session_get_status_nonexistent() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_mcp_discover_agents() {
-    let server = TestServer::new().await;
+    let server = TestServer::in_memory().await;
     let resp = mcp_tool_call(&server, "discover", json!({ "query": "agents" })).await;
 
     assert!(
@@ -881,16 +881,28 @@ async fn test_mcp_discover_agents() {
         "discover failed: {}",
         tool_text(&resp)
     );
-    let text = tool_text(&resp);
+    let payload = tool_json(&resp);
+    let text = payload.to_string();
     assert!(
         text.contains("list_agents"),
         "discover should find list_agents, got: {text}"
+    );
+    let list_agents = payload["operations"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|op| op["name"] == "list_agents")
+        .expect("list_agents operation");
+    assert_eq!(list_agents["output_shape"], "paginated");
+    assert_eq!(
+        list_agents["output_schema"]["properties"]["data"]["type"],
+        "array"
     );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_mcp_discover_sessions() {
-    let server = TestServer::new().await;
+    let server = TestServer::in_memory().await;
     let resp = mcp_tool_call(&server, "discover", json!({ "query": "sessions" })).await;
 
     assert!(
@@ -898,7 +910,8 @@ async fn test_mcp_discover_sessions() {
         "discover failed: {}",
         tool_text(&resp)
     );
-    let text = tool_text(&resp);
+    let payload = tool_json(&resp);
+    let text = payload.to_string();
     // "sessions" matches list_sessions, create_session, get_session, etc.
     assert!(
         text.contains("list_sessions"),
@@ -908,7 +921,7 @@ async fn test_mcp_discover_sessions() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_mcp_discover_harnesses() {
-    let server = TestServer::new().await;
+    let server = TestServer::in_memory().await;
     let resp = mcp_tool_call(&server, "discover", json!({ "query": "harnesses" })).await;
 
     assert!(
@@ -916,16 +929,25 @@ async fn test_mcp_discover_harnesses() {
         "discover failed: {}",
         tool_text(&resp)
     );
-    let text = tool_text(&resp);
+    let payload = tool_json(&resp);
+    let text = payload.to_string();
     assert!(
         text.contains("list_harnesses"),
         "discover should find list_harnesses"
     );
+    let list_harnesses = payload["operations"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|op| op["name"] == "list_harnesses")
+        .expect("list_harnesses operation");
+    assert_eq!(list_harnesses["output_shape"], "array");
+    assert_eq!(list_harnesses["output_schema"]["type"], "array");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_mcp_discover_mcp_servers() {
-    let server = TestServer::new().await;
+    let server = TestServer::in_memory().await;
     let resp = mcp_tool_call(&server, "discover", json!({ "query": "mcp" })).await;
 
     assert!(
@@ -933,7 +955,8 @@ async fn test_mcp_discover_mcp_servers() {
         "discover failed: {}",
         tool_text(&resp)
     );
-    let text = tool_text(&resp);
+    let payload = tool_json(&resp);
+    let text = payload.to_string();
     assert!(
         text.contains("mcp"),
         "discover should find MCP-related operations"
@@ -942,14 +965,31 @@ async fn test_mcp_discover_mcp_servers() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_mcp_discover_missing_query() {
-    let server = TestServer::new().await;
+    let server = TestServer::in_memory().await;
     let resp = mcp_tool_call(&server, "discover", json!({})).await;
     assert!(tool_is_error(&resp), "Expected error for missing query");
+    assert!(
+        tool_text(&resp).contains("query"),
+        "Expected query guidance, got: {}",
+        tool_text(&resp)
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_discover_empty_query() {
+    let server = TestServer::in_memory().await;
+    let resp = mcp_tool_call(&server, "discover", json!({ "query": "" })).await;
+    assert!(tool_is_error(&resp), "Expected error for empty query");
+    assert!(
+        tool_text(&resp).contains("all: true"),
+        "Expected all:true guidance, got: {}",
+        tool_text(&resp)
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_mcp_discover_all() {
-    let server = TestServer::new().await;
+    let server = TestServer::in_memory().await;
     let resp = mcp_tool_call(&server, "discover", json!({ "all": true })).await;
 
     assert!(
@@ -957,21 +997,37 @@ async fn test_mcp_discover_all() {
         "discover --all failed: {}",
         tool_text(&resp)
     );
-    let text = tool_text(&resp);
+    let payload = tool_json(&resp);
+    let categories = payload["categories"].as_array().expect("categories array");
     assert!(
-        text.contains("## agents"),
-        "Should list agents category heading"
+        categories.iter().any(|cat| cat["category"] == "agents"),
+        "Should list agents category"
     );
     assert!(
-        text.contains("## sessions"),
-        "Should list sessions category heading"
+        categories.iter().any(|cat| cat["category"] == "sessions"),
+        "Should list sessions category"
     );
-    assert!(text.contains("create_agent"), "Should include create_agent");
+    assert!(
+        payload.to_string().contains("create_agent"),
+        "Should include create_agent"
+    );
+    assert_eq!(payload["include_schemas"], false);
+    let first_operation = payload["categories"][0]["operations"][0]
+        .as_object()
+        .expect("operation object");
+    assert!(
+        !first_operation.contains_key("input_schema"),
+        "discover --all should omit input schemas by default"
+    );
+    assert!(
+        !first_operation.contains_key("output_schema"),
+        "discover --all should omit output schemas by default"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_mcp_discover_fuzzy_search() {
-    let server = TestServer::new().await;
+    let server = TestServer::in_memory().await;
     // "create agent" should match "create_agent" via token matching
     let resp = mcp_tool_call(&server, "discover", json!({ "query": "create agent" })).await;
 
@@ -980,7 +1036,8 @@ async fn test_mcp_discover_fuzzy_search() {
         "discover fuzzy search failed: {}",
         tool_text(&resp)
     );
-    let text = tool_text(&resp);
+    let payload = tool_json(&resp);
+    let text = payload.to_string();
     assert!(
         text.contains("create_agent"),
         "fuzzy search 'create agent' should find create_agent, got: {text}"
@@ -989,7 +1046,7 @@ async fn test_mcp_discover_fuzzy_search() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_mcp_discover_capabilities() {
-    let server = TestServer::new().await;
+    let server = TestServer::in_memory().await;
     let resp = mcp_tool_call(&server, "discover", json!({ "query": "capabilities" })).await;
 
     assert!(
@@ -997,7 +1054,8 @@ async fn test_mcp_discover_capabilities() {
         "discover capabilities failed: {}",
         tool_text(&resp)
     );
-    let text = tool_text(&resp);
+    let payload = tool_json(&resp);
+    let text = payload.to_string();
     assert!(
         text.contains("list_capabilities"),
         "Should find list_capabilities, got: {text}"
@@ -1006,6 +1064,13 @@ async fn test_mcp_discover_capabilities() {
         text.contains("get_capability"),
         "Should find get_capability, got: {text}"
     );
+    let list_capabilities = payload["operations"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|op| op["name"] == "list_capabilities")
+        .expect("list_capabilities operation");
+    assert_eq!(list_capabilities["output_shape"], "paginated");
 }
 
 // ============================================================================
@@ -1025,6 +1090,67 @@ async fn test_mcp_query_list_harnesses() {
     let result = tool_json(&resp);
     let harnesses = result.as_array().expect("Expected harnesses array");
     assert!(!harnesses.is_empty(), "Should have seed harnesses");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_query_missing_commands() {
+    let server = TestServer::in_memory().await;
+    let resp = mcp_tool_call(&server, "query", json!({})).await;
+    assert!(tool_is_error(&resp), "Expected error for missing commands");
+    assert!(
+        tool_text(&resp).contains("commands"),
+        "Expected commands guidance, got: {}",
+        tool_text(&resp)
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_execute_missing_commands() {
+    let server = TestServer::in_memory().await;
+    let resp = mcp_tool_call(&server, "execute", json!({})).await;
+    assert!(tool_is_error(&resp), "Expected error for missing commands");
+    assert!(
+        tool_text(&resp).contains("commands"),
+        "Expected commands guidance, got: {}",
+        tool_text(&resp)
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_query_list_harnesses_wrong_jq_shape_is_concise() {
+    let server = TestServer::in_memory().await;
+    let resp = mcp_tool_call(
+        &server,
+        "query",
+        json!({
+            "commands": "list_harnesses --limit 100 | jq -c '.data[] | {id, name, system_prompt}'"
+        }),
+    )
+    .await;
+
+    assert!(tool_is_error(&resp), "Expected jq shape mismatch error");
+    let text = tool_text(&resp);
+    assert!(
+        text.contains("jq: runtime error") || text.contains("jq: error"),
+        "Expected jq error, got: {text}"
+    );
+    assert!(
+        text.contains("output_shape"),
+        "Expected discover guidance, got: {text}"
+    );
+    assert!(
+        !text.contains("system_prompt"),
+        "Error must not dump harness fields: {text}"
+    );
+    assert!(
+        !text.contains("You are"),
+        "Error must not dump prompt content: {text}"
+    );
+    assert!(
+        text.len() < 240,
+        "Error should be concise, got {} chars: {text}",
+        text.len()
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/plugins/everruns-dev/commands/discover.md
+++ b/plugins/everruns-dev/commands/discover.md
@@ -4,7 +4,9 @@ argument-hint: "<query> | --all"
 ---
 
 Call the `discover` MCP tool. With `--all`, pass `all: true`; otherwise pass
-the text as `query`. Use `query` for read-only operations and `execute` for
-mutating workflows. See the `everruns-dev` skill for examples.
+the text as `query`. Focused discovery returns `input_schema`, `output_schema`,
+and `output_shape`; use `output_shape` to choose `.data[]` for paginated
+outputs or `.[]` for bare arrays. Use `query` for read-only operations and
+`execute` for mutating workflows. See the `everruns-dev` skill for examples.
 
 Arguments: `$ARGUMENTS`

--- a/plugins/everruns-dev/commands/query.md
+++ b/plugins/everruns-dev/commands/query.md
@@ -6,6 +6,8 @@ argument-hint: "<bash script>"
 Call the `query` MCP tool with the provided script as `commands`. Only
 read-only Everruns Dev API operations are available as bash builtins; `jq` is
 available. Use `execute` instead when the script needs side effects. See the
-`everruns-dev` skill for the command inventory, patterns, and examples.
+`everruns-dev` skill for the command inventory, patterns, and examples. If the
+output shape is unclear, call `discover` first and check `output_shape`:
+`paginated` uses `.data[]`; `array` uses `.[]`.
 
 Arguments: `$ARGUMENTS`

--- a/plugins/everruns-dev/skills/everruns-dev/SKILL.md
+++ b/plugins/everruns-dev/skills/everruns-dev/SKILL.md
@@ -88,6 +88,15 @@ to create, update, delete, or trigger actions.
 `execute` runs the full catalog. Always use `discover` if you are unsure which
 builtin to call.
 
+`discover` returns JSON. Focused searches include each operation's
+`input_schema`, `output_schema`, and `output_shape`. Use `output_shape` before
+writing jq:
+
+- `paginated` means the root is `{data,total,offset,limit}`; iterate with
+  `.data[]`.
+- `array` means the root is a bare array; iterate with `.[]`.
+- `unknown` means inspect `output_schema` or run a small sample first.
+
 ### Finding operations
 
 ```text
@@ -119,6 +128,14 @@ Rules of thumb:
 
 ```bash
 query { "commands": "list_agents | jq '.data[] | {id, name, default_model_id}'" }
+```
+
+**List harnesses.**
+
+`list_harnesses` returns a bare array, not a paginated object:
+
+```bash
+query { "commands": "list_harnesses | jq '.[] | {id, name, display_name, description, status, parent_harness_id}'" }
 ```
 
 **Create a harness and an agent, then run the agent.**

--- a/specs/domains.md
+++ b/specs/domains.md
@@ -162,6 +162,12 @@ command has exactly one required primary-key-like parameter. See EVE-323.
 read-only MCP `query` tool. The default is GET-only; override it for safe
 POST-style commands such as previews or structured search helpers.
 
+`Command::output_schema()` and `Command::output_shape()` feed MCP `discover`.
+Every command reports a valid output schema; commands whose output shape is
+important for jq scripting should override both. Use `output_shape = "paginated"`
+for `{data,total,offset,limit}` list responses and `output_shape = "array"` for
+bare array responses.
+
 ## Writing a Command
 
 Canonical pattern (see `domains/agents/commands.rs` for reference):
@@ -254,6 +260,10 @@ descriptors:
   true; `execute` exposes the full catalog.
 - `CatalogContext::to_domain_ctx()` constructs the domain `Ctx` from the
   MCP `AppState` (db, capability_service, encryption).
+- The top-level MCP `discover` tool reads inventory descriptors directly and
+  returns JSON with `input_schema`, `output_schema`, and `output_shape` for
+  focused searches. This avoids guessing whether a list command should be
+  consumed with jq `.data[]` or `.[]`.
 - Adding `inventory::submit! { CommandDescriptor::of::<Cmd>() }` makes the
   command immediately discoverable in MCP — no other wiring needed.
 

--- a/specs/toolkit-library-contract.md
+++ b/specs/toolkit-library-contract.md
@@ -293,6 +293,14 @@ Fetch content from a URL and return it as text or markdown.
 
 The exact sections vary by tool — the contract is that `help()` is comprehensive enough to use the tool without reading source code.
 
+#### Runtime error hygiene
+
+Toolkit-owned interpreters must format runtime errors as concise user-facing
+messages. Errors should name the failing builtin and cause, but must not dump
+entire structured input values or prompt-sized fields. Consumers can add
+defense-in-depth truncation, but the toolkit owns avoiding verbose `Debug`
+renders from embedded engines such as jq.
+
 #### Locale affects
 
 Locale controls the language of human-readable text:


### PR DESCRIPTION
## What
Expose command output metadata through MCP `discover` and add jq shape guidance for Everruns Dev plugin users.

## Why
`list_harnesses` returns a bare array, but callers reasonably tried `.data[]` because other list commands are paginated. The resulting jq mismatch could produce noisy errors and previously risked dumping prompt-sized fields.

## How
- Add `Command::output_schema()` and `Command::output_shape()` metadata to the inventory catalog.
- Make MCP `discover` return structured JSON with input/output schemas and shape hints.
- Declare output shapes for `list_harnesses`, `list_agents`, and `list_capabilities`.
- Sanitize jq index-shape errors from scripted query/execute output.
- Update Everruns Dev plugin steering and domain/toolkit specs.
- Add negative and EVE-405 regression tests for discover/query/execute.

## Risk
- Low
- Changes are scoped to MCP discovery metadata and scripted-tool error presentation. The main compatibility risk is clients expecting human-readable `discover` text; plugin guidance and tests now treat `discover` as JSON.

## Security
- Threat categories reviewed: TM-TOOL, TM-BASH, TM-API, TM-DOS
- Findings and resolutions: The relevant risk is data exposure through scripted jq errors. The sanitizer omits input values for jq index/runtime errors, and regression coverage asserts prompt fields are not dumped. No auth, authorization, tenant scoping, or command execution permissions changed.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] All review comments addressed (code change or written reasoning)

Validation:
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -p everruns-server --test mcp_endpoint_test mcp_query -- --test-threads=1`
- `cargo test -p everruns-server --test mcp_endpoint_test mcp_discover -- --test-threads=1`
- `cargo test -p everruns-server --test mcp_endpoint_test test_mcp_execute_missing_commands -- --test-threads=1`
- `cargo test -p everruns-server --test mcp_endpoint_test test_mcp_tools_list -- --test-threads=1`
- `just pre-push`