### PR TITLE
docs(plugin): align everruns-dev with Claude Code spec and surface in README

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,6 @@
 {
   "name": "everruns-dev",
+  "description": "Everruns plugins for Claude Code — connect Claude to the Everruns dev agent platform over MCP to manage agents, harnesses, and sessions.",
   "owner": {
     "name": "Everruns",
     "url": "https://everruns.com"

--- a/README.md
+++ b/README.md
@@ -74,6 +74,17 @@ curl -X POST http://localhost:9300/api/v1/sessions/{session_id}/messages \
   -d '{"message": {"content": [{"type": "text", "text": "Hello!"}]}}'
 ```
 
+## Use from Claude Code
+
+This repo is also a [Claude Code plugin marketplace](https://code.claude.com/docs/en/plugin-marketplaces) that ships the `everruns-dev` plugin. Connect Claude Code to the Everruns dev platform over MCP:
+
+```text
+/plugin marketplace add everruns/everruns
+/plugin install everruns-dev@everruns-dev
+```
+
+Then run `/everruns-dev:whoami` and complete the OAuth flow on first use. See [`plugins/everruns-dev/README.md`](./plugins/everruns-dev/README.md) for full install options (local clone, Codex, custom deployments).
+
 ## Contributing
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for local development setup and guidelines.

--- a/plugins/everruns-dev/.claude-plugin/plugin.json
+++ b/plugins/everruns-dev/.claude-plugin/plugin.json
@@ -9,7 +9,6 @@
   "homepage": "https://everruns.com",
   "repository": "https://github.com/everruns/everruns",
   "license": "MIT",
-  "category": "Agents",
   "keywords": [
     "agents",
     "everruns-dev",

--- a/scripts/test-everruns-dev-plugin.sh
+++ b/scripts/test-everruns-dev-plugin.sh
@@ -75,5 +75,18 @@ if codex_source.get("source") != "local" or codex_source.get("path") != "./plugi
         "Codex marketplace must point at local ./plugins/everruns-dev"
     )
 
+if "category" in claude:
+    raise SystemExit(
+        "Claude plugin.json must not declare 'category' — it is not part of "
+        "the Claude Code plugin manifest schema. Put it on the marketplace "
+        "plugin entry instead."
+    )
+
+if not claude_marketplace.get("description"):
+    raise SystemExit(
+        "marketplace.json must declare a top-level 'description' so the "
+        "marketplace renders correctly in Claude Code's plugin browser."
+    )
+
 print("everruns-dev plugin metadata checks passed")
 PY


### PR DESCRIPTION
## What
- Remove the non-spec `category` field from `plugins/everruns-dev/.claude-plugin/plugin.json`.
- Add a top-level `description` to `.claude-plugin/marketplace.json`.
- Add a "Use from Claude Code" section to the root `README.md` with the `/plugin marketplace add` and `/plugin install` commands and a link to the plugin README.

## Why
A spec audit against the official Claude Code plugin docs flagged two issues:

- `category` is **not** a documented field in the `plugin.json` schema (it is only valid on marketplace plugin entries — where we already have it). See https://code.claude.com/docs/en/plugins-reference.md#plugin-manifest-schema.
- `marketplace.json` supports an optional top-level `description` for browse UX. See https://code.claude.com/docs/en/plugin-marketplaces.md#marketplace-schema.

The plugin install flow was previously only documented inside `plugins/everruns-dev/README.md`. Surfacing it from the repo root makes the marketplace discoverable to Claude Code users landing on the GitHub page.

`oauth_resource` in `.mcp.json` is intentionally kept — it is required by Codex MCP OAuth (RFC 8707 `resource` parameter, PropelAuth requirement; see commit b3b92b2) and is ignored by Claude Code. The shared `.mcp.json` serves both hosts.

## How
- Edit two JSON files and one README section.
- No code changes.
- The existing guard `scripts/test-everruns-dev-plugin.sh` continues to pass (URL, `oauth_resource`, no-scopes, version alignment).

## Risk
- Low.
- Plugin metadata only, plus one new README section. No runtime, API, or schema impact.

## Security
- Threat categories reviewed: **No security-relevant code changes.** Diff is limited to two JSON metadata fields and a new documentation section linking to the existing plugin README and the public Anthropic docs URL. No code paths, no auth/authz, no input handling, no dependencies.
- Findings and resolutions: none.

## Checklist
- [x] Tests added or updated (existing `scripts/test-everruns-dev-plugin.sh` covers the touched files; passes)
- [x] Backward compatibility considered (removing `category` from `plugin.json` is safe — Claude Code ignores unknown fields and the field is preserved on the marketplace entry where the spec puts it)
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)