### PR TITLE
feat(harnesses): add harness examples gallery

### DIFF
--- a/apps/ui/src/app/(main)/harnesses/examples/page.tsx
+++ b/apps/ui/src/app/(main)/harnesses/examples/page.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useState, useCallback, useMemo } from "react";
+import { useHarnessExamples, useImportHarnessExample, useCapabilities } from "@/hooks";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { ArrowLeft, Search } from "lucide-react";
+import { QueryStateWrapper } from "@/components/query-state-wrapper";
+import { HarnessExampleCard } from "@/components/harnesses";
+
+export default function AllHarnessExamplesPage() {
+  const router = useRouter();
+  const [exampleSearch, setExampleSearch] = useState("");
+  const { data: allCapabilities } = useCapabilities();
+  const { data: examples, isLoading, error } = useHarnessExamples();
+  const importExample = useImportHarnessExample();
+  const [importingName, setImportingName] = useState<string | null>(null);
+
+  const handleImport = useCallback(
+    async (name: string) => {
+      setImportingName(name);
+      try {
+        const harness = await importExample.mutateAsync(name);
+        router.push(`/harnesses/${harness.id}`);
+      } catch (err) {
+        console.error("Failed to import harness example:", err);
+      } finally {
+        setImportingName(null);
+      }
+    },
+    [importExample, router],
+  );
+
+  const filteredExamples = useMemo(() => {
+    if (!examples || !exampleSearch.trim()) return examples;
+    const query = exampleSearch.toLowerCase();
+    return examples.filter(
+      (ex) =>
+        ex.display_name.toLowerCase().includes(query) ||
+        ex.name.toLowerCase().includes(query) ||
+        ex.description.toLowerCase().includes(query) ||
+        ex.tags.some((tag) => tag.toLowerCase().includes(query)),
+    );
+  }, [examples, exampleSearch]);
+
+  return (
+    <div className="container mx-auto p-6">
+      <div className="flex items-center justify-between mb-6">
+        <div className="flex items-center gap-3">
+          <Link href="/harnesses">
+            <Button variant="ghost" size="icon" className="h-8 w-8" aria-label="Back to harnesses">
+              <ArrowLeft className="w-4 h-4" />
+            </Button>
+          </Link>
+          <h1 className="text-2xl font-bold">Example Harnesses</h1>
+        </div>
+        <div className="relative">
+          <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+          <Input
+            placeholder="Search examples..."
+            value={exampleSearch}
+            onChange={(e) => setExampleSearch(e.target.value)}
+            className="pl-8 w-64"
+          />
+        </div>
+      </div>
+
+      <QueryStateWrapper
+        isLoading={isLoading}
+        error={error}
+        data={filteredExamples}
+        errorMessagePrefix="Failed to load examples"
+        emptyState={
+          <div className="text-center py-12">
+            <p className="text-muted-foreground">
+              {exampleSearch.trim() ? "No examples match your search" : "No examples available"}
+            </p>
+          </div>
+        }
+      >
+        {(items) => (
+          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+            {items.map((example, index) => (
+              <HarnessExampleCard
+                key={example.name ?? `example-${index}`}
+                example={example}
+                allCapabilities={allCapabilities}
+                onImport={handleImport}
+                adopting={importingName === example.name}
+              />
+            ))}
+          </div>
+        )}
+      </QueryStateWrapper>
+    </div>
+  );
+}

--- a/apps/ui/src/app/(main)/harnesses/harnesses-page-client.tsx
+++ b/apps/ui/src/app/(main)/harnesses/harnesses-page-client.tsx
@@ -1,22 +1,52 @@
 "use client";
 
-import { useState } from "react";
-import { useHarnesses, useCapabilities } from "@/hooks";
+import { useCallback, useState } from "react";
+import {
+  useCapabilities,
+  useHarnessExamples,
+  useHarnesses,
+  useImportHarnessExample,
+} from "@/hooks";
+import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
-import { Plus } from "lucide-react";
+import { ArrowRight, Plus } from "lucide-react";
 import { QueryStateWrapper } from "@/components/query-state-wrapper";
-import { HarnessCard } from "@/components/harnesses";
+import { HarnessCard, HarnessExampleCard } from "@/components/harnesses";
 import { ArchiveFilter } from "@/components/archive-filter";
 
+const PREVIEW_LIMIT = 6;
+
 export default function HarnessesPageClient() {
+  const router = useRouter();
   const [showArchived, setShowArchived] = useState(false);
   const { data: harnesses, isLoading, error } = useHarnesses({ includeArchived: showArchived });
   const { data: allCapabilities } = useCapabilities();
+  const { data: examples, isLoading: examplesLoading, error: examplesError } = useHarnessExamples();
+  const importExample = useImportHarnessExample();
+  const [importingName, setImportingName] = useState<string | null>(null);
+
+  const handleImport = useCallback(
+    async (name: string) => {
+      setImportingName(name);
+      try {
+        const harness = await importExample.mutateAsync(name);
+        router.push(`/harnesses/${harness.id}`);
+      } catch (err) {
+        console.error("Failed to import harness example:", err);
+      } finally {
+        setImportingName(null);
+      }
+    },
+    [importExample, router],
+  );
+
+  const previewExamples = examples?.slice(0, PREVIEW_LIMIT);
+  const hasMoreExamples = (examples?.length ?? 0) > PREVIEW_LIMIT;
 
   return (
-    <div className="container mx-auto p-6">
-      <div className="flex items-center justify-between mb-6">
+    <div className="container mx-auto p-6 space-y-10">
+      <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold">Harnesses</h1>
         <div className="flex items-center gap-2">
           <ArchiveFilter showArchived={showArchived} onShowArchivedChange={setShowArchived} />
@@ -29,36 +59,81 @@ export default function HarnessesPageClient() {
         </div>
       </div>
 
-      <QueryStateWrapper
-        isLoading={isLoading}
-        error={error}
-        data={harnesses}
-        errorMessagePrefix="Failed to load harnesses"
-        emptyState={
-          <div className="text-center py-12">
-            <p className="text-muted-foreground mb-4">No harnesses yet</p>
-            <Link href="/harnesses/new">
-              <Button>
-                <Plus className="w-4 h-4 mr-2" />
-                Create your first harness
+      <section>
+        <QueryStateWrapper
+          isLoading={isLoading}
+          error={error}
+          data={harnesses}
+          errorMessagePrefix="Failed to load harnesses"
+          emptyState={
+            <div className="text-center py-12">
+              <p className="text-muted-foreground mb-4">No harnesses yet</p>
+              <Link href="/harnesses/new">
+                <Button>
+                  <Plus className="w-4 h-4 mr-2" />
+                  Create your first harness
+                </Button>
+              </Link>
+            </div>
+          }
+        >
+          {(items) => (
+            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+              {items.map((harness) => (
+                <HarnessCard
+                  key={harness.id}
+                  harness={harness}
+                  allCapabilities={allCapabilities}
+                  showEditButton
+                />
+              ))}
+            </div>
+          )}
+        </QueryStateWrapper>
+      </section>
+
+      <hr className="border-border" />
+
+      <section>
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-xl font-semibold">Example harnesses</h2>
+        </div>
+        <QueryStateWrapper
+          isLoading={examplesLoading}
+          error={examplesError}
+          data={previewExamples}
+          errorMessagePrefix="Failed to load examples"
+          emptyState={
+            <div className="text-center py-12">
+              <p className="text-muted-foreground">No examples available</p>
+            </div>
+          }
+        >
+          {(items) => (
+            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+              {items.map((example, index) => (
+                <HarnessExampleCard
+                  key={example.name ?? `example-${index}`}
+                  example={example}
+                  allCapabilities={allCapabilities}
+                  onImport={handleImport}
+                  adopting={importingName === example.name}
+                />
+              ))}
+            </div>
+          )}
+        </QueryStateWrapper>
+        {hasMoreExamples && (
+          <div className="flex justify-end mt-4">
+            <Link href="/harnesses/examples">
+              <Button variant="outline">
+                All examples
+                <ArrowRight className="w-4 h-4 ml-2" />
               </Button>
             </Link>
           </div>
-        }
-      >
-        {(items) => (
-          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-            {items.map((harness) => (
-              <HarnessCard
-                key={harness.id}
-                harness={harness}
-                allCapabilities={allCapabilities}
-                showEditButton
-              />
-            ))}
-          </div>
         )}
-      </QueryStateWrapper>
+      </section>
     </div>
   );
 }

--- a/apps/ui/src/components/harnesses/example-card.tsx
+++ b/apps/ui/src/components/harnesses/example-card.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { Import } from "lucide-react";
+import type { Capability, CapabilityId, HarnessExample } from "@/lib/api/types";
+import { getCapabilityIcon } from "@/lib/capability-icons";
+
+interface HarnessExampleCardProps {
+  example: HarnessExample;
+  allCapabilities?: Capability[];
+  onImport: (name: string) => void;
+  adopting?: boolean;
+}
+
+export function HarnessExampleCard({
+  example,
+  allCapabilities,
+  onImport,
+  adopting = false,
+}: HarnessExampleCardProps) {
+  const getCapabilityInfo = (capabilityId: CapabilityId): Capability | undefined =>
+    allCapabilities?.find((c) => c.id === capabilityId);
+
+  return (
+    <Card className="bg-background transition-colors hover:bg-card">
+      <CardHeader className="flex flex-row items-start justify-between space-y-0">
+        <CardTitle className="text-lg">{example.display_name}</CardTitle>
+        {example.dev_only && (
+          <Badge variant="outline" className="text-xs">
+            dev
+          </Badge>
+        )}
+      </CardHeader>
+      <CardContent>
+        <p className="text-sm text-muted-foreground mb-3 line-clamp-2">{example.description}</p>
+
+        {example.capabilities.length > 0 && (
+          <div className="flex flex-wrap gap-1 mb-3">
+            <TooltipProvider>
+              {example.capabilities.map((capConfig) => {
+                const cap = getCapabilityInfo(capConfig.ref);
+                if (!cap) return null;
+                const IconComponent = getCapabilityIcon(cap.icon);
+
+                return (
+                  <Tooltip key={capConfig.ref}>
+                    <TooltipTrigger className="inline-flex cursor-default items-center gap-1 border bg-muted px-2 py-0.5 text-xs">
+                      <IconComponent className="icon-sharp h-3 w-3" />
+                      <span>{cap.name}</span>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <p className="font-medium">{cap.name}</p>
+                      <p className="text-xs text-muted-foreground">{cap.description}</p>
+                    </TooltipContent>
+                  </Tooltip>
+                );
+              })}
+            </TooltipProvider>
+          </div>
+        )}
+
+        {example.tags.length > 0 && (
+          <div className="flex flex-wrap gap-1 mb-3">
+            {example.tags.map((tag) => (
+              <Badge key={tag} variant="outline" className="text-xs">
+                {tag}
+              </Badge>
+            ))}
+          </div>
+        )}
+
+        <div className="flex items-center justify-end">
+          <Button
+            variant="accent"
+            size="sm"
+            onClick={() => onImport(example.name)}
+            disabled={adopting}
+          >
+            <Import className="w-4 h-4 mr-2" />
+            {adopting ? "Importing..." : "Import"}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/ui/src/components/harnesses/index.ts
+++ b/apps/ui/src/components/harnesses/index.ts
@@ -1,2 +1,3 @@
 export { HarnessCard } from "./harness-card";
+export { HarnessExampleCard } from "./example-card";
 export { HarnessPreview } from "./harness-preview";

--- a/apps/ui/src/hooks/index.ts
+++ b/apps/ui/src/hooks/index.ts
@@ -3,6 +3,7 @@ export * from "./use-agent-examples";
 export * from "./use-agents";
 export * from "./use-apps";
 export * from "./use-harnesses";
+export * from "./use-harness-examples";
 export * from "./use-capabilities";
 export * from "./use-sessions";
 export * from "./use-llm-providers";

--- a/apps/ui/src/hooks/use-harness-examples.ts
+++ b/apps/ui/src/hooks/use-harness-examples.ts
@@ -1,0 +1,34 @@
+// Harness example hooks
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { listHarnessExamples, importHarnessExample } from "@/lib/api/harness-examples";
+import { queryKeys } from "@/lib/query-keys";
+import { useOrg } from "@/providers/org-provider";
+
+export function useHarnessExamples() {
+  const { currentOrg, isLoading: orgLoading } = useOrg();
+  const org = currentOrg?.public_id;
+
+  const query = useQuery({
+    queryKey: [...queryKeys.harnessExamples.list(), org],
+    queryFn: () => listHarnessExamples(),
+    enabled: !!org,
+  });
+
+  return {
+    ...query,
+    isLoading: orgLoading || query.isLoading,
+  };
+}
+
+export function useImportHarnessExample() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (name: string) => importHarnessExample(name),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.harnesses.all });
+    },
+  });
+}

--- a/apps/ui/src/lib/api/harness-examples.ts
+++ b/apps/ui/src/lib/api/harness-examples.ts
@@ -1,0 +1,16 @@
+// Harness Examples API — read-only examples adoptable as real Harnesses
+
+import { api } from "./client";
+import type { Harness, HarnessExample } from "./types";
+
+export async function listHarnessExamples(): Promise<HarnessExample[]> {
+  const response = await api.get<HarnessExample[]>("/v1/harness-examples");
+  return response.data;
+}
+
+export async function importHarnessExample(name: string): Promise<Harness> {
+  const response = await api.post<Harness>(
+    `/v1/harnesses/import?from-example=${encodeURIComponent(name)}`,
+  );
+  return response.data;
+}

--- a/apps/ui/src/lib/api/types/agent-types.ts
+++ b/apps/ui/src/lib/api/types/agent-types.ts
@@ -171,6 +171,18 @@ export interface UpdateHarnessRequest {
   status?: HarnessStatus;
 }
 
+/** Read-only harness example defined in code, adoptable as a real Harness */
+export interface HarnessExample {
+  name: string;
+  display_name: string;
+  description: string;
+  tags: string[];
+  /** Name of the parent harness (e.g. `generic`) the example will inherit from when imported. */
+  parent_name?: string;
+  capabilities: AgentCapabilityConfig[];
+  dev_only: boolean;
+}
+
 /** Request to preview the final harness shape with capabilities applied */
 export interface PreviewHarnessRequest {
   /** The base system prompt (before capability additions) */

--- a/apps/ui/src/lib/query-keys.ts
+++ b/apps/ui/src/lib/query-keys.ts
@@ -32,6 +32,12 @@ export const queryKeys = {
     detail: (harnessId: string) => ["harness", harnessId] as const,
   },
 
+  // Harness example queries
+  harnessExamples: {
+    all: ["harness-examples"] as const,
+    list: () => ["harness-examples"] as const,
+  },
+
   // Session queries (sessions are org-level, with optional agent filter)
   sessions: {
     all: () => ["sessions"] as const,

--- a/crates/server/src/api/harness_examples.rs
+++ b/crates/server/src/api/harness_examples.rs
@@ -1,0 +1,135 @@
+// Harness Examples API — read-only catalogue of adoptable harness templates.
+//
+// Decision: Examples live in code (see `crate::harnesses::examples`), not in DB.
+// Decision: Adoption is handled by `POST /v1/harnesses/import?from-example={name}`
+// Decision: Examples are identified by their `name` (slug).
+// Decision: Examples are filtered at request time by capability registration so
+//   that capability-gated harnesses (e.g. `coding-container`) only appear when
+//   the corresponding capability plugin is registered for the deployment.
+
+use crate::auth::{AuthState, ResolvedOrg};
+use crate::harnesses::{HarnessExampleDef, harness_examples};
+use axum::{Json, Router, extract::State, routing::get};
+use everruns_core::{AgentCapabilityConfig, DeploymentGrade, PlatformDefinition};
+use serde::Serialize;
+use std::sync::Arc;
+use utoipa::ToSchema;
+
+use super::common::impl_auth_state;
+
+/// A read-only harness example defined in code.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct HarnessExample {
+    /// Unique slug (e.g. `data-analyst`).
+    pub name: String,
+    /// Human-readable display name (e.g. `Data Analyst`).
+    pub display_name: String,
+    /// Short description.
+    pub description: String,
+    /// Tags for categorization.
+    pub tags: Vec<String>,
+    /// Name of the parent harness this example inherits from when adopted
+    /// (e.g. `generic`). Resolved per-org at import time — no UUIDs are
+    /// hardcoded.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_name: Option<String>,
+    /// Capabilities the example will assign with their per-harness config.
+    pub capabilities: Vec<AgentCapabilityConfig>,
+    /// Whether this example is only available when experimental features are on.
+    pub dev_only: bool,
+}
+
+fn example_to_dto(ex: &HarnessExampleDef) -> HarnessExample {
+    HarnessExample {
+        name: ex.definition.name.clone(),
+        display_name: ex.definition.display_name.clone(),
+        description: ex.definition.description.clone(),
+        tags: ex.definition.tags.clone(),
+        parent_name: ex.definition.parent_name.clone(),
+        capabilities: ex
+            .definition
+            .capabilities
+            .iter()
+            .map(|cap| AgentCapabilityConfig::with_config(cap.id.clone(), cap.config.clone()))
+            .collect(),
+        dev_only: ex.dev_only,
+    }
+}
+
+/// App state for harness example routes.
+#[derive(Clone)]
+pub struct AppState {
+    pub auth: AuthState,
+    pub grade: DeploymentGrade,
+    pub platform_definition: Arc<PlatformDefinition>,
+}
+
+impl_auth_state!(AppState);
+
+/// Create harness example routes.
+pub fn routes(state: AppState) -> Router {
+    Router::new()
+        .route("/v1/harness-examples", get(list_examples))
+        .with_state(state)
+}
+
+/// GET /v1/harness-examples — list all available harness examples.
+#[utoipa::path(
+    get,
+    path = "/v1/harness-examples",
+    responses(
+        (status = 200, description = "List of harness examples", body = Vec<HarnessExample>),
+    ),
+    tag = "harness-examples"
+)]
+pub async fn list_examples(
+    _org: ResolvedOrg,
+    State(state): State<AppState>,
+) -> Json<Vec<HarnessExample>> {
+    let include_dev = state.grade.experimental_features_enabled();
+    let platform = &state.platform_definition;
+
+    let examples: Vec<HarnessExample> = harness_examples()
+        .iter()
+        .filter(|ex| {
+            if ex.dev_only && !include_dev {
+                return false;
+            }
+            // Only show examples whose capabilities are all registered.
+            ex.definition
+                .capabilities
+                .iter()
+                .all(|cap| platform.capability_registry().has(&cap.id))
+        })
+        .map(example_to_dto)
+        .collect();
+
+    Json(examples)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dto_round_trips_capabilities() {
+        let examples = harness_examples();
+        let dto = example_to_dto(&examples[0]);
+        assert!(!dto.capabilities.is_empty());
+        assert_eq!(dto.parent_name.as_deref(), Some("generic"));
+    }
+
+    #[test]
+    fn known_example_present_in_catalog() {
+        let names: Vec<String> = harness_examples()
+            .iter()
+            .map(|e| e.definition.name.clone())
+            .collect();
+        for expected in ["coding-daytona", "coding-container", "data-analyst"] {
+            assert!(
+                names.iter().any(|n| n == expected),
+                "expected {expected} in harness examples catalogue"
+            );
+        }
+    }
+}

--- a/crates/server/src/api/harnesses.rs
+++ b/crates/server/src/api/harnesses.rs
@@ -22,7 +22,7 @@ use everruns_core::{
 };
 
 use super::common::{
-    ApiResult, ErrorResponse, ListResponse, UrlBuilder, WithUrls, impl_auth_state,
+    ApiResult, ApiResultExt, ErrorResponse, ListResponse, UrlBuilder, WithUrls, impl_auth_state,
 };
 use serde::Deserialize;
 use std::sync::Arc;
@@ -103,8 +103,9 @@ pub fn routes(state: AppState) -> Router {
 #[derive(Debug, Clone, Deserialize, IntoParams, ToSchema)]
 pub struct ImportHarnessQuery {
     /// Import from a built-in harness example by name (e.g. `data-analyst`).
+    /// Required: the only currently supported import mode is from-example.
     #[serde(rename = "from-example")]
-    pub from_example: Option<String>,
+    pub from_example: String,
 }
 
 /// POST /v1/harnesses/import - Adopt a harness example as a regular org-owned harness.
@@ -134,10 +135,13 @@ pub async fn import_harness(
     State(state): State<AppState>,
     Query(query): Query<ImportHarnessQuery>,
 ) -> Result<(StatusCode, Json<WithUrls<Harness>>), (StatusCode, Json<ErrorResponse>)> {
-    let name = query.from_example.ok_or_else(|| {
-        ErrorResponse::new("missing required `from-example` query parameter")
-            .into_response(StatusCode::BAD_REQUEST)
-    })?;
+    let name = query.from_example.trim().to_string();
+    if name.is_empty() {
+        return Err(
+            ErrorResponse::new("`from-example` query parameter must not be empty")
+                .into_response(StatusCode::BAD_REQUEST),
+        );
+    }
 
     let example = crate::harnesses::find_harness_example(&name)
         .ok_or_else(|| ErrorResponse::not_found(&format!("harness example '{name}'")))?;
@@ -171,10 +175,7 @@ pub async fn import_harness(
             .db
             .get_harness_by_name(org.org_id, parent_name)
             .await
-            .map_err(|e| {
-                ErrorResponse::new(format!("failed to resolve parent harness: {e}"))
-                    .into_response(StatusCode::INTERNAL_SERVER_ERROR)
-            })?
+            .log_internal_error_json("resolve parent harness for example import")?
             .ok_or_else(|| {
                 ErrorResponse::new(format!(
                     "Required parent harness `{parent_name}` is not provisioned for this org"

--- a/crates/server/src/api/harnesses.rs
+++ b/crates/server/src/api/harnesses.rs
@@ -16,14 +16,17 @@ use axum::{
     http::StatusCode,
     routing::{get, post},
 };
-use everruns_core::{Caller, Harness, ResourceConfigResponse, evaluate_policies_with};
+use everruns_core::{
+    AgentCapabilityConfig, Caller, DeploymentGrade, Harness, PlatformDefinition,
+    ResourceConfigResponse, evaluate_policies_with,
+};
 
 use super::common::{
     ApiResult, ErrorResponse, ListResponse, UrlBuilder, WithUrls, impl_auth_state,
 };
 use serde::Deserialize;
 use std::sync::Arc;
-use utoipa::IntoParams;
+use utoipa::{IntoParams, ToSchema};
 
 use crate::services::CapabilityService;
 
@@ -42,6 +45,8 @@ pub struct AppState {
     pub db: Arc<StorageBackend>,
     pub capability_service: Arc<CapabilityService>,
     pub auth: AuthState,
+    pub grade: DeploymentGrade,
+    pub platform_definition: Arc<PlatformDefinition>,
 }
 
 impl AppState {
@@ -49,11 +54,15 @@ impl AppState {
         db: Arc<StorageBackend>,
         capability_service: Arc<CapabilityService>,
         auth: AuthState,
+        grade: DeploymentGrade,
+        platform_definition: Arc<PlatformDefinition>,
     ) -> Self {
         Self {
             db,
             capability_service,
             auth,
+            grade,
+            platform_definition,
         }
     }
 
@@ -71,13 +80,14 @@ impl AppState {
 
 impl_auth_state!(AppState);
 
-/// Create harness routes (no import/export)
+/// Create harness routes
 pub fn routes(state: AppState) -> Router {
     Router::new()
         .route("/v1/harnesses", post(create_harness).get(list_harnesses))
         .route("/v1/harnesses/check-name", get(check_harness_name))
         .route("/v1/harnesses/config", get(harness_config))
         .route("/v1/harnesses/preview", post(preview_harness))
+        .route("/v1/harnesses/import", post(import_harness))
         .route(
             "/v1/harnesses/{harness_id}",
             get(get_harness)
@@ -87,6 +97,156 @@ pub fn routes(state: AppState) -> Router {
         .route("/v1/harnesses/{harness_id}/delete", post(destroy_harness))
         .route("/v1/harnesses/{harness_id}/copy", post(copy_harness))
         .with_state(state)
+}
+
+/// Query parameters for `POST /v1/harnesses/import`.
+#[derive(Debug, Clone, Deserialize, IntoParams, ToSchema)]
+pub struct ImportHarnessQuery {
+    /// Import from a built-in harness example by name (e.g. `data-analyst`).
+    #[serde(rename = "from-example")]
+    pub from_example: Option<String>,
+}
+
+/// POST /v1/harnesses/import - Adopt a harness example as a regular org-owned harness.
+///
+/// Creates a normal harness (`is_built_in = false`) from a code-defined
+/// example. The new harness inherits from the org's `generic` harness by
+/// name — no UUIDs are hardcoded. Capabilities and other config flow through
+/// the same validation paths as `POST /v1/harnesses`.
+///
+/// Returns 201 on creation. If the example name collides with an existing
+/// harness in the org, a random alphanumeric suffix is appended (parity with
+/// agent example import).
+#[utoipa::path(
+    post,
+    path = "/v1/harnesses/import",
+    params(ImportHarnessQuery),
+    responses(
+        (status = 201, description = "Harness adopted from example", body = WithUrls<Harness>),
+        (status = 400, description = "Invalid input or missing capabilities", body = ErrorResponse),
+        (status = 404, description = "Example not found", body = ErrorResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse)
+    ),
+    tag = "harnesses"
+)]
+pub async fn import_harness(
+    org: ResolvedOrg,
+    State(state): State<AppState>,
+    Query(query): Query<ImportHarnessQuery>,
+) -> Result<(StatusCode, Json<WithUrls<Harness>>), (StatusCode, Json<ErrorResponse>)> {
+    let name = query.from_example.ok_or_else(|| {
+        ErrorResponse::new("missing required `from-example` query parameter")
+            .into_response(StatusCode::BAD_REQUEST)
+    })?;
+
+    let example = crate::harnesses::find_harness_example(&name)
+        .ok_or_else(|| ErrorResponse::not_found(&format!("harness example '{name}'")))?;
+
+    if example.dev_only && !state.grade.experimental_features_enabled() {
+        return Err(ErrorResponse::not_found(&format!(
+            "harness example '{name}'"
+        )));
+    }
+
+    let missing: Vec<&str> = example
+        .definition
+        .capabilities
+        .iter()
+        .map(|c| c.id.as_str())
+        .filter(|id| !state.platform_definition.capability_registry().has(id))
+        .collect();
+    if !missing.is_empty() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: format!("Example requires unregistered capabilities: {missing:?}"),
+            }),
+        ));
+    }
+
+    // Resolve parent harness ID by name within this org. Examples are required
+    // to inherit by name (no hardcoded UUIDs).
+    let parent_harness_id = if let Some(parent_name) = example.definition.parent_name.as_deref() {
+        let parent_row = state
+            .db
+            .get_harness_by_name(org.org_id, parent_name)
+            .await
+            .map_err(|e| {
+                ErrorResponse::new(format!("failed to resolve parent harness: {e}"))
+                    .into_response(StatusCode::INTERNAL_SERVER_ERROR)
+            })?
+            .ok_or_else(|| {
+                ErrorResponse::new(format!(
+                    "Required parent harness `{parent_name}` is not provisioned for this org"
+                ))
+                .into_response(StatusCode::INTERNAL_SERVER_ERROR)
+            })?;
+        Some(parent_row.id)
+    } else {
+        None
+    };
+
+    let capabilities: Vec<AgentCapabilityConfig> = example
+        .definition
+        .capabilities
+        .iter()
+        .map(|cap| AgentCapabilityConfig::with_config(cap.id.clone(), cap.config.clone()))
+        .collect();
+
+    // Pick a non-colliding name with random suffix retry — same strategy as
+    // agent example import. Concurrency-safe enough for a manual UI action.
+    let unique_name = {
+        use rand::Rng;
+        let base = example.definition.name.as_str();
+        let mut selected = None;
+
+        for attempt in 0..10 {
+            let candidate = if attempt == 0 {
+                base.to_string()
+            } else {
+                let suffix: String = rand::rng()
+                    .sample_iter(&rand::distr::Alphanumeric)
+                    .take(5)
+                    .map(|c| (c as char).to_ascii_lowercase())
+                    .collect();
+                format!("{base}-{suffix}")
+            };
+
+            let result = crate::domains::harnesses::CheckHarnessName {
+                name: candidate.clone(),
+                exclude_id: None,
+            }
+            .run(&state.ctx(&org))
+            .await?;
+
+            if result.available {
+                selected = Some(candidate);
+                break;
+            }
+        }
+
+        selected.ok_or_else(ErrorResponse::internal_error)?
+    };
+
+    let req = CreateHarnessRequest {
+        name: unique_name,
+        display_name: Some(example.definition.display_name.clone()),
+        description: Some(example.definition.description.clone()),
+        system_prompt: example.definition.system_prompt.clone(),
+        parent_harness_id,
+        default_model_id: None,
+        tags: example.definition.tags.clone(),
+        capabilities,
+        initial_files: vec![],
+        mcp_servers: Default::default(),
+        network_access: None,
+    };
+
+    let harness = crate::domains::harnesses::CreateHarness(req)
+        .run(&state.ctx(&org))
+        .await?;
+    let urls = UrlBuilder::from_auth_config(&state.auth.config);
+    Ok((StatusCode::CREATED, Json(urls.wrap(harness))))
 }
 
 /// GET /v1/harnesses/config

--- a/crates/server/src/api/mod.rs
+++ b/crates/server/src/api/mod.rs
@@ -19,6 +19,7 @@ pub mod durable;
 pub mod evals;
 pub mod events;
 pub mod feature_flags;
+pub mod harness_examples;
 pub mod harnesses;
 pub mod http_signing_keys;
 pub mod images;

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -762,11 +762,19 @@ impl ServerAppBuilder {
             capability_service.clone(),
             auth_state.clone(),
         );
+        let grade_for_harnesses = everruns_core::DeploymentGrade::from_env();
         let harnesses_state = api::harnesses::AppState::new(
             db.clone(),
             capability_service.clone(),
             auth_state.clone(),
+            grade_for_harnesses,
+            platform_definition.clone(),
         );
+        let harness_examples_state = api::harness_examples::AppState {
+            auth: auth_state.clone(),
+            grade: grade_for_harnesses,
+            platform_definition: platform_definition.clone(),
+        };
         let commands_state = api::commands::AppState::new(
             capability_service.clone(),
             command_service,
@@ -998,6 +1006,7 @@ impl ServerAppBuilder {
             ))
             .merge(api::apps::routes(apps_state))
             // Evals routes are conditionally merged below based on feature flag.
+            .merge(api::harness_examples::routes(harness_examples_state))
             .merge(api::harnesses::routes(harnesses_state))
             .merge(api::sessions::routes(sessions_state))
             .merge(api::messages::routes(messages_state))

--- a/crates/server/src/harnesses/examples.rs
+++ b/crates/server/src/harnesses/examples.rs
@@ -1,0 +1,113 @@
+//! Harness examples — adoptable templates analogous to agent examples.
+//!
+//! Decision: Examples live in code, not in DB. Mirrors `seed::SEED_AGENTS`.
+//! Decision: Listed via `GET /v1/harness-examples`; adopted via
+//!   `POST /v1/harnesses/import?from-example={name}` which creates a normal
+//!   org-owned harness (`is_built_in = false`) inheriting from the org's
+//!   `generic` harness by name.
+//! Decision: Examples are filtered at runtime by capability registration —
+//!   examples whose required capabilities are missing are hidden, matching
+//!   agent examples behaviour.
+
+use everruns_core::BuiltInHarnessDefinition;
+
+use super::{coding_container, coding_daytona, data_analyst};
+
+/// A harness example wrapping a `BuiltInHarnessDefinition` with adoption
+/// metadata (dev gating).
+pub struct HarnessExampleDef {
+    /// Underlying harness definition (name, prompt, capabilities, parent name…).
+    pub definition: BuiltInHarnessDefinition,
+    /// If true, only available when experimental features are enabled.
+    pub dev_only: bool,
+}
+
+impl HarnessExampleDef {
+    fn new(definition: BuiltInHarnessDefinition) -> Self {
+        Self {
+            definition,
+            dev_only: false,
+        }
+    }
+}
+
+/// Adoptable harness examples in display order.
+///
+/// Each example is filtered at request time by capability registration so that
+/// `coding-container` (and any future feature-gated capability) only appears
+/// when the corresponding capability plugin is registered for the deployment.
+pub fn harness_examples() -> Vec<HarnessExampleDef> {
+    vec![
+        HarnessExampleDef::new(coding_daytona::definition()),
+        HarnessExampleDef::new(coding_container::definition()),
+        HarnessExampleDef::new(data_analyst::definition()),
+    ]
+}
+
+/// Look up a harness example by its `name`.
+pub fn find_harness_example(name: &str) -> Option<HarnessExampleDef> {
+    harness_examples()
+        .into_iter()
+        .find(|ex| ex.definition.name == name)
+}
+
+/// Names of harnesses that used to be installed as built-ins for every org but
+/// are now opt-in examples. Used by reconciliation to release legacy
+/// `is_built_in = true` rows back to org ownership without breaking existing
+/// references.
+pub const LEGACY_BUILT_IN_NAMES: &[&str] = &["coding-container", "coding-daytona", "data-analyst"];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn examples_have_unique_names() {
+        let examples = harness_examples();
+        let names: Vec<&str> = examples
+            .iter()
+            .map(|e| e.definition.name.as_str())
+            .collect();
+        let mut unique = names.clone();
+        unique.sort();
+        unique.dedup();
+        assert_eq!(names.len(), unique.len(), "duplicate harness example names");
+    }
+
+    #[test]
+    fn examples_inherit_from_generic_by_name() {
+        for ex in harness_examples() {
+            assert_eq!(
+                ex.definition.parent_name.as_deref(),
+                Some("generic"),
+                "harness example {} must inherit from `generic` by name",
+                ex.definition.name
+            );
+        }
+    }
+
+    #[test]
+    fn legacy_names_match_examples() {
+        let example_names: Vec<String> = harness_examples()
+            .iter()
+            .map(|e| e.definition.name.clone())
+            .collect();
+        for name in LEGACY_BUILT_IN_NAMES {
+            assert!(
+                example_names.iter().any(|n| n == name),
+                "legacy built-in {name} must be re-exposed as a harness example"
+            );
+        }
+    }
+
+    #[test]
+    fn find_returns_none_for_unknown() {
+        assert!(find_harness_example("does-not-exist").is_none());
+    }
+
+    #[test]
+    fn find_returns_some_for_known() {
+        let ex = find_harness_example("data-analyst").expect("data-analyst is an example");
+        assert_eq!(ex.definition.display_name, "Data Analyst");
+    }
+}

--- a/crates/server/src/harnesses/mod.rs
+++ b/crates/server/src/harnesses/mod.rs
@@ -1,32 +1,42 @@
 //! Built-in harness definitions.
 //!
-//! Each submodule defines one built-in harness (system prompt, capabilities,
-//! tags, roles). The top-level `built_in_harnesses()` function collects them
-//! into the ordered list consumed by `oss_built_in_harnesses()` in platform.rs.
+//! Decision: Only platform-essential harnesses are auto-provisioned per org —
+//! `base`, `generic`, and `platform-chat`. Specialized harnesses
+//! (`coding-container`, `coding-daytona`, `data-analyst`) live in the
+//! `examples` module and are adopted on demand via `/v1/harness-examples`
+//! and `POST /v1/harnesses/import?from-example=…`.
+//!
+//! Each submodule still defines one harness (system prompt, capabilities,
+//! tags, roles). The top-level `built_in_harnesses()` function collects the
+//! always-installed ones into the ordered list consumed by
+//! `oss_built_in_harnesses()` in platform.rs.
 
 mod base;
 mod coding_container;
 mod coding_daytona;
 mod coding_session_sandbox;
 mod data_analyst;
+pub mod examples;
 mod generic;
 mod platform_chat;
 
 use everruns_core::BuiltInHarnessDefinition;
 
+pub use examples::{
+    HarnessExampleDef, LEGACY_BUILT_IN_NAMES, find_harness_example, harness_examples,
+};
+
 /// All built-in harness definitions in provisioning order.
+///
+/// Only platform-essential harnesses are listed here. Specialized harnesses
+/// (data analyst, coding sandboxes) are adopted from `harness_examples()`.
 pub fn built_in_harnesses() -> Vec<BuiltInHarnessDefinition> {
     let internal_flags = everruns_core::InternalFeatureFlags::from_env();
     let mut harnesses = vec![
         base::definition(),
         generic::definition(),
-        data_analyst::definition(),
-        coding_daytona::definition(),
+        platform_chat::definition(),
     ];
-    if internal_flags.container_sandbox {
-        harnesses.push(coding_container::definition());
-    }
-    harnesses.push(platform_chat::definition());
     if internal_flags.session_sandbox {
         harnesses.push(coding_session_sandbox::definition());
     }
@@ -70,25 +80,27 @@ mod tests {
     }
 
     #[test]
-    fn test_coding_container_preserves_previous_provisioning_order_when_enabled() {
+    fn built_in_list_excludes_example_harnesses() {
         let _lock = lock_env();
-        let _env_guard =
-            EnvVarGuard::capture(&["FEATURE_CONTAINER_SANDBOX", "FEATURE_DOCKER_CAPABILITY"]);
+        let _env_guard = EnvVarGuard::capture(&[
+            "FEATURE_CONTAINER_SANDBOX",
+            "FEATURE_DOCKER_CAPABILITY",
+            "FEATURE_SESSION_SANDBOX",
+        ]);
         unsafe { std::env::set_var("FEATURE_CONTAINER_SANDBOX", "true") };
         unsafe { std::env::remove_var("FEATURE_DOCKER_CAPABILITY") };
+        unsafe { std::env::remove_var("FEATURE_SESSION_SANDBOX") };
 
         let names: Vec<String> = built_in_harnesses().into_iter().map(|h| h.name).collect();
 
-        assert_eq!(
-            names,
-            vec![
-                "base",
-                "generic",
-                "data-analyst",
-                "coding-daytona",
-                "coding-container",
-                "platform-chat",
-            ]
-        );
+        // The default built-in list now contains only platform-essential
+        // harnesses. Specialized coding/data harnesses moved to examples.
+        assert_eq!(names, vec!["base", "generic", "platform-chat",]);
+        for legacy in LEGACY_BUILT_IN_NAMES {
+            assert!(
+                !names.iter().any(|n| n == legacy),
+                "{legacy} should no longer be a default built-in"
+            );
+        }
     }
 }

--- a/crates/server/src/openapi.rs
+++ b/crates/server/src/openapi.rs
@@ -114,6 +114,9 @@ use utoipa::OpenApi;
         api::harnesses::copy_harness,
         api::harnesses::preview_harness,
         api::harnesses::harness_config,
+        api::harnesses::import_harness,
+        // Harness examples
+        api::harness_examples::list_examples,
         // Agents - additional
         api::agents::preview_agent,
         api::agents::upsert_agent,
@@ -193,6 +196,7 @@ use utoipa::OpenApi;
             domains::harnesses::types::UpdateHarnessRequest,
             domains::harnesses::types::PreviewHarnessRequest,
             domains::harnesses::types::HarnessPreviewResponse,
+            api::harness_examples::HarnessExample,
             ListResponse<everruns_core::Harness>,
             api::users::User,
             api::users::ListUsersQuery,

--- a/crates/server/src/org_init.rs
+++ b/crates/server/src/org_init.rs
@@ -55,6 +55,12 @@ pub async fn initialize_org_harnesses_with_definitions(
 ) -> Result<InitResult> {
     let mut result = InitResult::default();
 
+    // Release legacy built-ins that were demoted to example harnesses.
+    // We keep the rows (so existing sessions/agents that reference them keep
+    // working) but flip `is_built_in` to false so they become editable, regular
+    // org-owned harnesses. New orgs are unaffected because no row exists.
+    release_legacy_built_ins(db, org_id).await?;
+
     for harness in harnesses {
         let parent_harness_id = resolve_built_in_parent_id(db, org_id, harnesses, harness)
             .await
@@ -121,6 +127,23 @@ pub async fn initialize_org_harnesses_with_definitions(
     sync_org_harness_settings_with_definitions(db, org_id, harnesses).await?;
 
     Ok(result)
+}
+
+/// Demote any rows for the legacy default built-ins (`coding-container`,
+/// `coding-daytona`, `data-analyst`) to regular org-owned harnesses. Idempotent
+/// — only flips rows that are still flagged `is_built_in = true`.
+async fn release_legacy_built_ins(db: &StorageBackend, org_id: i64) -> Result<()> {
+    for name in crate::harnesses::LEGACY_BUILT_IN_NAMES {
+        let flipped = db.release_built_in_harness(org_id, name).await?;
+        if flipped {
+            tracing::info!(
+                org_id,
+                name,
+                "Released legacy built-in harness; row preserved as org-owned"
+            );
+        }
+    }
+    Ok(())
 }
 
 async fn resolve_built_in_parent_id(
@@ -626,6 +649,55 @@ mod tests {
         let result2 = initialize_org_harnesses(&db, DEFAULT_ORG_ID).await.unwrap();
         assert_eq!(result2.created, 0, "should be idempotent");
         assert_eq!(result2.unchanged, harnesses().len());
+    }
+
+    #[tokio::test]
+    async fn test_legacy_built_ins_are_released_on_reconcile() {
+        // Simulates an org upgraded from a previous version where
+        // `data-analyst` was a default built-in. After reconciliation, the row
+        // must remain (so existing references keep working) but with
+        // `is_built_in = false` so the user can edit/manage it.
+        let db = make_db();
+        seed_default_org(&db).await;
+
+        // Provision today's built-ins first so generic/base exist for parents.
+        initialize_org_harnesses(&db, DEFAULT_ORG_ID).await.unwrap();
+
+        // Inject a stale `data-analyst` built-in row directly.
+        let row = db
+            .create_harness(
+                DEFAULT_ORG_ID,
+                crate::storage::models::CreateHarnessRow {
+                    name: "data-analyst".to_string(),
+                    display_name: Some("Data Analyst".to_string()),
+                    description: Some("legacy".to_string()),
+                    system_prompt: "legacy prompt".to_string(),
+                    parent_harness_id: None,
+                    default_model_id: None,
+                    tags: vec![],
+                    initial_files: serde_json::json!([]),
+                    mcp_servers: serde_json::json!({}),
+                    network_access: None,
+                    is_built_in: true,
+                },
+            )
+            .await
+            .unwrap();
+        assert!(row.is_built_in);
+
+        // Run reconciliation again — should release the legacy built-in.
+        initialize_org_harnesses(&db, DEFAULT_ORG_ID).await.unwrap();
+
+        let after = db
+            .get_harness_by_name(DEFAULT_ORG_ID, "data-analyst")
+            .await
+            .unwrap()
+            .expect("data-analyst row must still exist after reconcile");
+        assert!(
+            !after.is_built_in,
+            "legacy data-analyst row must no longer be flagged as built-in"
+        );
+        assert_eq!(after.id, row.id, "row identity preserved");
     }
 
     async fn seed_default_org(db: &StorageBackend) {

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -2389,7 +2389,7 @@ mod tests {
     }
 
     #[test]
-    fn test_coding_container_harness_capabilities_are_registered_when_flag_enabled() {
+    fn test_coding_container_example_capabilities_are_registered_when_flag_enabled() {
         let _lock = lock_env();
         let _env_guard =
             EnvVarGuard::capture(&["FEATURE_CONTAINER_SANDBOX", "FEATURE_DOCKER_CAPABILITY"]);
@@ -2400,35 +2400,47 @@ mod tests {
             everruns_core::DeploymentGrade::Dev,
         );
 
-        let built_in_harnesses = built_in_harnesses();
-        let coding_container = built_in_harnesses
-            .iter()
-            .find(|h| h.name == "coding-container")
-            .expect("Coding (Container) harness should exist when the feature is enabled");
+        // Container example is always present in the example catalogue but its
+        // capabilities only appear in `/v1/harness-examples` when registered.
+        let example = crate::harnesses::find_harness_example("coding-container")
+            .expect("coding-container should exist in the example catalogue");
 
-        for cap in &coding_container.capabilities {
+        for cap in &example.definition.capabilities {
             assert!(
                 registry.has(&cap.id),
-                "Capability '{}' referenced by Coding (Container) harness must be registered",
+                "Capability '{}' referenced by Coding (Container) example must be registered",
                 cap.id
             );
         }
     }
 
     #[test]
-    fn test_coding_container_harness_hidden_when_flag_disabled() {
+    fn test_coding_container_capability_unregistered_when_flag_disabled() {
         let _lock = lock_env();
         let _env_guard =
             EnvVarGuard::capture(&["FEATURE_CONTAINER_SANDBOX", "FEATURE_DOCKER_CAPABILITY"]);
         unsafe { std::env::remove_var("FEATURE_CONTAINER_SANDBOX") };
         unsafe { std::env::remove_var("FEATURE_DOCKER_CAPABILITY") };
 
+        let registry = everruns_core::capabilities::CapabilityRegistry::with_builtins_for_grade(
+            everruns_core::DeploymentGrade::Dev,
+        );
+
+        // The Coding (Container) example is filtered out of `/v1/harness-examples`
+        // when its `container_sandbox` capability isn't registered. We assert
+        // the registry-level fact that powers the filter.
+        assert!(
+            !registry.has("container_sandbox"),
+            "container_sandbox capability should not be registered when feature flag is off"
+        );
+
+        // Defensive: built-in list never contains coding-container by default.
         let built_in_harnesses = built_in_harnesses();
         assert!(
             built_in_harnesses
                 .iter()
                 .all(|h| h.name != "coding-container"),
-            "Coding (Container) harness should be hidden when container_sandbox is disabled"
+            "Coding (Container) is no longer a default built-in"
         );
     }
 

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -473,6 +473,10 @@ impl StorageBackend {
         dispatch!(self, list_child_harnesses, org_id, parent_id)
     }
 
+    pub async fn release_built_in_harness(&self, org_id: i64, name: &str) -> Result<bool> {
+        dispatch!(self, release_built_in_harness, org_id, name)
+    }
+
     pub async fn delete_harness(&self, org_id: i64, id: HarnessId) -> Result<bool> {
         dispatch!(self, delete_harness, org_id, id)
     }

--- a/crates/server/src/storage/memory/harnesses.rs
+++ b/crates/server/src/storage/memory/harnesses.rs
@@ -209,6 +209,20 @@ impl InMemoryDatabase {
         Ok(None)
     }
 
+    /// Release built-in flag for a named harness (in-memory backend variant).
+    pub async fn release_built_in_harness(&self, org_id: i64, name: &str) -> Result<bool> {
+        let mut harnesses = self.harnesses.write();
+        let target = harnesses
+            .values_mut()
+            .find(|h| h.org_id == org_id && h.name == name && h.is_built_in);
+        if let Some(h) = target {
+            h.is_built_in = false;
+            h.updated_at = Self::now();
+            return Ok(true);
+        }
+        Ok(false)
+    }
+
     pub async fn delete_harness(&self, org_id: i64, id: HarnessId) -> Result<bool> {
         let mut harnesses = self.harnesses.write();
         if let Some(harness) = harnesses.get_mut(&id) {

--- a/crates/server/src/storage/repositories/harnesses.rs
+++ b/crates/server/src/storage/repositories/harnesses.rs
@@ -223,6 +223,28 @@ impl Database {
         Ok(row)
     }
 
+    /// Release built-in flag on the harness with `name` in `org_id`, if it
+    /// exists and is currently flagged as built-in. Used during reconciliation
+    /// when a previously default-installed harness is moved to the example
+    /// catalogue: existing rows are kept (so sessions and agents that
+    /// reference them keep working) but become editable, org-owned harnesses.
+    /// Returns true when a row was actually flipped.
+    pub async fn release_built_in_harness(&self, org_id: i64, name: &str) -> Result<bool> {
+        let result = sqlx::query(
+            r#"
+            UPDATE harnesses
+            SET is_built_in = false, updated_at = NOW()
+            WHERE org_id = $1 AND name = $2 AND is_built_in = true
+            "#,
+        )
+        .bind(org_id)
+        .bind(name)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(result.rows_affected() > 0)
+    }
+
     pub async fn list_child_harnesses(
         &self,
         org_id: i64,

--- a/crates/server/tests/test_harness.rs
+++ b/crates/server/tests/test_harness.rs
@@ -318,6 +318,8 @@ impl TestServer {
             db.clone(),
             capability_service.clone(),
             auth_state.clone(),
+            grade,
+            platform_definition.clone(),
         );
         let commands_state = api::commands::AppState::new(
             capability_service.clone(),

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -1478,6 +1478,30 @@
         }
       }
     },
+    "/v1/harness-examples": {
+      "get": {
+        "tags": [
+          "harness-examples"
+        ],
+        "summary": "GET /v1/harness-examples — list all available harness examples.",
+        "operationId": "list_examples",
+        "responses": {
+          "200": {
+            "description": "List of harness examples",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/HarnessExample"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/harnesses": {
       "get": {
         "tags": [
@@ -1605,6 +1629,72 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ResourceConfigResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/harnesses/import": {
+      "post": {
+        "tags": [
+          "harnesses"
+        ],
+        "summary": "POST /v1/harnesses/import - Adopt a harness example as a regular org-owned harness.",
+        "description": "Creates a normal harness (`is_built_in = false`) from a code-defined\nexample. The new harness inherits from the org's `generic` harness by\nname — no UUIDs are hardcoded. Capabilities and other config flow through\nthe same validation paths as `POST /v1/harnesses`.\n\nReturns 201 on creation. If the example name collides with an existing\nharness in the org, a random alphanumeric suffix is appended (parity with\nagent example import).",
+        "operationId": "import_harness",
+        "parameters": [
+          {
+            "name": "from-example",
+            "in": "query",
+            "description": "Import from a built-in harness example by name (e.g. `data-analyst`).",
+            "required": false,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Harness adopted from example",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WithUrls_Harness"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid input or missing capabilities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Example not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -7951,6 +8041,57 @@
             "type": "string",
             "format": "date-time",
             "description": "Timestamp when the harness was last updated."
+          }
+        }
+      },
+      "HarnessExample": {
+        "type": "object",
+        "description": "A read-only harness example defined in code.",
+        "required": [
+          "name",
+          "display_name",
+          "description",
+          "tags",
+          "capabilities",
+          "dev_only"
+        ],
+        "properties": {
+          "capabilities": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AgentCapabilityConfig"
+            },
+            "description": "Capabilities the example will assign with their per-harness config."
+          },
+          "description": {
+            "type": "string",
+            "description": "Short description."
+          },
+          "dev_only": {
+            "type": "boolean",
+            "description": "Whether this example is only available when experimental features are on."
+          },
+          "display_name": {
+            "type": "string",
+            "description": "Human-readable display name (e.g. `Data Analyst`)."
+          },
+          "name": {
+            "type": "string",
+            "description": "Unique slug (e.g. `data-analyst`)."
+          },
+          "parent_name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Name of the parent harness this example inherits from when adopted\n(e.g. `generic`). Resolved per-org at import time — no UUIDs are\nhardcoded."
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Tags for categorization."
           }
         }
       },

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -1648,13 +1648,10 @@
           {
             "name": "from-example",
             "in": "query",
-            "description": "Import from a built-in harness example by name (e.g. `data-analyst`).",
-            "required": false,
+            "description": "Import from a built-in harness example by name (e.g. `data-analyst`).\nRequired: the only currently supported import mode is from-example.",
+            "required": true,
             "schema": {
-              "type": [
-                "string",
-                "null"
-              ]
+              "type": "string"
             }
           }
         ],

--- a/specs/coding-daytona-harness.md
+++ b/specs/coding-daytona-harness.md
@@ -1,6 +1,12 @@
 # Coding Daytona Harness
 
-Built-in harness for coding agents using Daytona cloud sandboxes.
+Adoptable harness example for coding agents using Daytona cloud sandboxes.
+
+This harness is no longer auto-installed into every org. It lives in the harness
+example catalogue (`crates/server/src/harnesses/examples.rs`) and is adopted on
+demand via `POST /v1/harnesses/import?from-example=coding-daytona`. See
+[`harness-types.md`](harness-types.md#harness-examples-adoptable-templates) for
+the default-built-ins-vs-examples split and migration behaviour.
 
 ## Design
 

--- a/specs/harness-types.md
+++ b/specs/harness-types.md
@@ -25,6 +25,29 @@ The `name` field works like a GitHub repository name: lowercase alphanumeric wit
 - **POST /v1/sessions** — Accepts `harness_name` as an alternative to `harness_id`. The two fields are mutually exclusive.
 - **CLI** — `everruns sessions create --harness generic` accepts both IDs and names. Non-ID values are resolved via `GET /v1/harnesses/{name}` before session creation.
 
+## Default Built-in Harnesses vs Harness Examples
+
+Two categories of code-defined harnesses exist:
+
+| Category | What it is | Where it lives | Adoption |
+|----------|-----------|----------------|----------|
+| **Default built-ins** | Platform-essential harnesses provisioned automatically into every org with `is_built_in = true`. | `crates/server/src/harnesses/{base,generic,platform_chat}.rs`, collected by `built_in_harnesses()`. | Created on org initialization. Read-only by default. |
+| **Harness examples** | Adoptable templates the user opts into when needed. Shown in the UI gallery. | `crates/server/src/harnesses/examples.rs` (catalogue) plus the per-harness module file (e.g. `data_analyst.rs`). | Listed via `GET /v1/harness-examples`; adopted via `POST /v1/harnesses/import?from-example={name}`, which creates a normal `is_built_in = false` row that the user can edit. |
+
+**Default built-ins are the minimum required for the platform to function:**
+
+- `base` — required as a fallback parent for sessions without an explicit harness.
+- `generic` — required as the default parent harness referenced by examples and most user harnesses.
+- `platform-chat` — required by the global chat path (singleton per-user session pattern).
+
+**Harness examples** today: `coding-daytona`, `coding-container`, `data-analyst`. Examples whose required capabilities are not registered for the deployment (for example, `coding-container` when the `container_sandbox` plugin is disabled) are filtered out of `/v1/harness-examples` automatically, mirroring the agent examples behaviour.
+
+**Why the split:** specialised harnesses like `data-analyst` were previously installed into every org by default, polluting fresh installs and creating reconciliation churn for orgs that never used them. Moving them to examples keeps fresh orgs lean while making the same templates discoverable from the UI gallery on demand.
+
+### Migration of legacy built-in rows
+
+Existing orgs that already had `data-analyst`, `coding-daytona`, or `coding-container` provisioned as `is_built_in = true` keep those rows during reconciliation. The reconciliation step demotes them to regular org-owned harnesses (`is_built_in = false`) so existing sessions and agents that reference them keep working, while users gain the ability to edit, archive, or delete them like any custom harness. The demotion is idempotent and only flips the `is_built_in` flag — no data is rewritten and no UUIDs change.
+
 ## Built-in Harness Types
 
 ### Base
@@ -127,6 +150,10 @@ Built-in harnesses are managed by `crates/server/src/org_init.rs`:
 
 Harness seed UUIDs occupy the `0x600-0x6FF` range. These fixed UUIDs exist solely so historical default-org rows stay stable across upgrades; they are an implementation detail of org seeding and are not addressable identity. New code, tests, and migrations must always use name-based lookups. See `crates/server/src/seed.rs` for seed harness definitions and capability assignments.
 
+## Harness Examples (adoptable templates)
+
+These templates are not auto-installed. They appear in the UI gallery (`/harnesses`, `/harnesses/examples`) and are adopted via `POST /v1/harnesses/import?from-example={name}`. Adoption creates a normal `is_built_in = false` row in the caller's org, inheriting from the org's `generic` harness by name (no hardcoded UUIDs). Required capabilities must be registered for the deployment, otherwise the example is filtered out of the listing and import returns 400.
+
 ### Data Analyst
 
 Data analysis harness with SQL databases, persistent memory, interactive charts via OpenUI, and a structured analysis pipeline inspired by OpenAI's Kepler data agent and the open-source [Dash](https://github.com/agno-agi/dash) project. Inherits from Generic.
@@ -154,6 +181,14 @@ Data analysis harness with SQL databases, persistent memory, interactive charts 
 - Interactive data exploration with visualization
 - Agents that learn from corrections across sessions
 - Analytics workflows with curated knowledge bases
+
+### Coding (Daytona)
+
+Coding harness with Daytona cloud sandboxes (real filesystem, full process execution, git integration). Inherits from Generic. Visible only when the `daytona` capability plugin is registered (the OSS deployment registers it whenever the integration is built in). See `crates/server/src/harnesses/coding_daytona.rs`.
+
+### Coding (Container)
+
+Coding harness backed by self-hosted Docker container sandboxes. Inherits from Generic. Visible only when the `container_sandbox` capability plugin is registered (gated by the `FEATURE_CONTAINER_SANDBOX` flag). See `crates/server/src/harnesses/coding_container.rs` and `specs/coding-daytona-harness.md`.
 
 ## Future Harness Types
 

--- a/specs/harness-types.md
+++ b/specs/harness-types.md
@@ -188,7 +188,7 @@ Coding harness with Daytona cloud sandboxes (real filesystem, full process execu
 
 ### Coding (Container)
 
-Coding harness backed by self-hosted Docker container sandboxes. Inherits from Generic. Visible only when the `container_sandbox` capability plugin is registered (gated by the `FEATURE_CONTAINER_SANDBOX` flag). See `crates/server/src/harnesses/coding_container.rs` and `specs/coding-daytona-harness.md`.
+Coding harness backed by self-hosted Docker container sandboxes. Inherits from Generic. Visible only when the `container_sandbox` capability plugin is registered (gated by the `FEATURE_CONTAINER_SANDBOX` flag). See `crates/server/src/harnesses/coding_container.rs` for the harness definition and [`crates/container-sandbox/SPEC.md`](../crates/container-sandbox/SPEC.md) for the underlying capability spec.
 
 ## Future Harness Types
 


### PR DESCRIPTION
## What

Move specialized harnesses (`coding-daytona`, `coding-container`, `data-analyst`) out of the always-installed built-in set and into a code-defined examples catalogue users can adopt on demand from the UI gallery, mirroring the existing agent-examples pattern.

New endpoints, types, and UI:

- `GET /v1/harness-examples` — read-only catalogue, filtered by capability registration and dev gating.
- `POST /v1/harnesses/import?from-example={name}` — adopts an example as a regular org-owned harness (`is_built_in = false`) inheriting from the org's `generic` harness by name (no hardcoded UUIDs). Random suffix on name collisions, matching agent example import.
- UI: `useHarnessExamples`, `useImportHarnessExample`, `HarnessExample` type, `harnessExamples` query keys, `HarnessExampleCard`, `/harnesses/examples` gallery page, and a preview section on `/harnesses`.

`built_in_harnesses()` now ships only platform-essential rows (`base`, `generic`, `platform-chat`); `coding-session-sandbox` stays feature-gated. Reconciliation demotes legacy `is_built_in = true` rows for the moved names to org-owned (`is_built_in = false`) so existing sessions/agents that reference them keep working but become editable.

Specs and OpenAPI updated. Resolves [EVE-406](https://linear.app/everruns/issue/EVE-406).

## Why

Specialized harnesses were installed into every org by default, polluting fresh installs and creating reconciliation churn for orgs that never used them. Agents already have a `/agent-examples` catalogue — extending the same pattern to harnesses keeps fresh orgs lean while making the same templates discoverable on demand.

## How

- New module `crates/server/src/harnesses/examples.rs` defines a `HarnessExampleDef` wrapper around `BuiltInHarnessDefinition` plus `dev_only`, and exposes `harness_examples()` plus `LEGACY_BUILT_IN_NAMES`.
- New API at `crates/server/src/api/harness_examples.rs` mirrors the agent-examples handler — read-only, filtered by `dev_only` (deployment grade) and capability registration.
- Import handler in `crates/server/src/api/harnesses.rs` resolves the example, validates capabilities, looks up the org's `generic` harness by name, picks a non-colliding name, and runs the standard `CreateHarness` command (so all existing validation and policy paths apply, including `HARNESS_MANAGE`).
- New storage method `release_built_in_harness(org_id, name)` (Postgres + in-memory + dispatcher) flips the flag without modifying any other field. `org_init::release_legacy_built_ins` calls it for each `LEGACY_BUILT_IN_NAMES` during initialization/reconciliation. Idempotent.
- Tests cover catalogue uniqueness, parent-by-name inheritance, the legacy release flow on reconcile, and the capability-filtering invariant.

## Risk

- Medium — touches provisioning, org reconciliation, and a new public API surface.
- Possible breakage path: an existing org sees its `data-analyst` row become editable. Existing references continue to resolve because the row is preserved with the same UUID. The flag flip is idempotent and only runs for the explicit `LEGACY_BUILT_IN_NAMES` list.
- Existing `coding-container` flag-gating still works: when `container_sandbox` capability isn't registered, the example is filtered out of `/v1/harness-examples` and `/v1/harnesses/import` returns 400 with the missing-capability error.

## Validation

- `cargo fmt --all -- --check` ✅
- `cargo clippy --all-targets --all-features -- -D warnings` ✅
- `cargo test -p everruns-server --lib` → 1106 passed ✅
- `cd apps/ui && npm run format:check && npm run lint && npm run build` ✅ (5 pre-existing warnings, 0 errors; new `/harnesses/examples` route present in the build manifest)
- `./scripts/export-openapi.sh` ✅ (only adds the two new paths and the `HarnessExample` schema)
- `./scripts/lib/pre-push.sh` ✅

Targeted unit tests:

- `harnesses::examples::tests::*` — catalogue uniqueness, parent-by-name, legacy-name coverage, lookup.
- `api::harness_examples::tests::*` — DTO round-trips, catalogue presence.
- `org_init::tests::test_legacy_built_ins_are_released_on_reconcile` — verifies a stale `data-analyst is_built_in=true` row is flipped to `is_built_in=false` while preserving the row identity.
- `seed::tests::test_coding_container_example_capabilities_are_registered_when_flag_enabled` and `test_coding_container_capability_unregistered_when_flag_disabled` — capability-gating invariants.

## Security

Threat categories reviewed against [`specs/threat-model.md`](../blob/main/specs/threat-model.md):

- **TM-API** — Two new authenticated endpoints. Both require `ResolvedOrg`. `from-example` is matched against a static, compile-time catalogue (404 on miss), so the parameter cannot drive arbitrary harness creation. The import handler delegates to the standard `CreateHarness` command, which performs the same input-size, capability-validation, and parent-validation steps as the existing `POST /v1/harnesses` route.
- **TM-AUTHZ** — Adoption goes through `CreateHarness`, which is gated by `HARNESS_MANAGE` via `#[policy]`. No new bypass surface.
- **TM-TENANT** — `get_harness_by_name(org_id, parent_name)`, `release_built_in_harness(org_id, name)`, and the `Ctx` used for the create command are all scoped to the caller's `ResolvedOrg.org_id`. The legacy release method only flips rows owned by the supplied org and does so per-org during that org's own initialization. No cross-tenant exposure.
- **TM-DOS** — Inputs come from a static catalogue plus a single short query parameter. The name-collision retry is bounded to 10 attempts. No new unbounded loops or allocations.
- **TM-WEB** — UI changes reuse existing `ExampleCard` patterns; no new XSS or unsafe rendering surface.

No new `THREAT[...]` mitigations required. No changes to `specs/threat-model.md`.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered (legacy built-in rows are preserved and released to org-owned)
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)


---
_Generated by [Claude Code](https://claude.ai/code/session_016jEd8UJePhdPKEuDxsF7Dj)_