### PR TITLE
chore(release): prepare v0.8.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- New changes go here. Use `/prepare-release X.Y.Z` to generate draft from commits. -->
 
+## [0.8.24] - 2026-05-03
+
+### Highlights
+
+- **Harness examples gallery** - New gallery surfaces built-in harness examples so users can browse and adopt them more easily ([#1629](https://github.com/everruns/everruns/pull/1629)).
+- **MCP discover exposes output schemas** - `discover` now includes command output schemas, giving MCP clients richer typing information ([#1627](https://github.com/everruns/everruns/pull/1627)).
+- **MCP OAuth metadata reliability** - Path-specific OAuth protected-resource metadata URL fixes resource discovery for clients that probe per-endpoint metadata ([#1623](https://github.com/everruns/everruns/pull/1623)), and the Everruns Dev plugin declares its `oauth_resource` so Codex MCP login satisfies RFC 8707 ([#1624](https://github.com/everruns/everruns/pull/1624)).
+- **bashkit bumped to v0.3.0** - Picks up the latest sandbox capabilities and hardening from upstream bashkit ([#1630](https://github.com/everruns/everruns/pull/1630), [#1625](https://github.com/everruns/everruns/pull/1625)).
+- **Everruns Dev plugin docs** - Plugin README and metadata aligned with the Claude Code spec for clearer surfacing in marketplaces ([#1628](https://github.com/everruns/everruns/pull/1628)).
+
+### What's Changed
+
+- fix(plugin): add Everruns Dev MCP OAuth resource ([#1624](https://github.com/everruns/everruns/pull/1624)) by [@chaliy](https://github.com/chaliy)
+- fix(mcp): use path-specific OAuth protected-resource metadata URL ([#1623](https://github.com/everruns/everruns/pull/1623)) by [@chaliy](https://github.com/chaliy)
+- chore(deps): bump bashkit to v0.2.1 ([#1625](https://github.com/everruns/everruns/pull/1625)) by [@chaliy](https://github.com/chaliy)
+- chore(plugins): enforce maintenance parity checks by [@chaliy](https://github.com/chaliy)
+- fix(mcp): expose command output schemas in discover ([#1627](https://github.com/everruns/everruns/pull/1627)) by [@chaliy](https://github.com/chaliy)
+- docs(plugin): align everruns-dev with Claude Code spec and surface in README ([#1628](https://github.com/everruns/everruns/pull/1628)) by [@chaliy](https://github.com/chaliy)
+- feat(harnesses): add harness examples gallery ([#1629](https://github.com/everruns/everruns/pull/1629)) by [@chaliy](https://github.com/chaliy)
+- chore(deps): bump bashkit to v0.3.0 ([#1630](https://github.com/everruns/everruns/pull/1630)) by [@chaliy](https://github.com/chaliy)
+
 ## [0.8.23] - 2026-04-30
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1577,11 +1577,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-a2ui"
-version = "0.8.23"
+version = "0.8.24"
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.8.23"
+version = "0.8.24"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1600,7 +1600,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-cli"
-version = "0.8.23"
+version = "0.8.24"
 dependencies = [
  "anyhow",
  "base64",
@@ -1627,14 +1627,14 @@ dependencies = [
 
 [[package]]
 name = "everruns-config"
-version = "0.8.23"
+version = "0.8.24"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "everruns-container-sandbox"
-version = "0.8.23"
+version = "0.8.24"
 dependencies = [
  "async-trait",
  "base64",
@@ -1655,7 +1655,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.8.23"
+version = "0.8.24"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1708,7 +1708,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-durable"
-version = "0.8.23"
+version = "0.8.24"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1743,7 +1743,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-gemini"
-version = "0.8.23"
+version = "0.8.24"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1761,7 +1761,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-brave-search"
-version = "0.8.23"
+version = "0.8.24"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1777,7 +1777,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-browserless"
-version = "0.8.23"
+version = "0.8.24"
 dependencies = [
  "async-trait",
  "base64",
@@ -1798,7 +1798,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.8.23"
+version = "0.8.24"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1814,7 +1814,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-deno"
-version = "0.8.23"
+version = "0.8.24"
 dependencies = [
  "async-trait",
  "base64",
@@ -1838,7 +1838,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-docker"
-version = "0.8.23"
+version = "0.8.24"
 dependencies = [
  "async-trait",
  "base64",
@@ -1853,7 +1853,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.8.23"
+version = "0.8.24"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-e2b"
-version = "0.8.23"
+version = "0.8.24"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1897,7 +1897,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-parallel"
-version = "0.8.23"
+version = "0.8.24"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -1909,7 +1909,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-pi"
-version = "0.8.23"
+version = "0.8.24"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1924,7 +1924,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-sprites"
-version = "0.8.23"
+version = "0.8.24"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1940,7 +1940,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-internal-protocol"
-version = "0.8.23"
+version = "0.8.24"
 dependencies = [
  "chrono",
  "everruns-core",
@@ -1957,7 +1957,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-macros"
-version = "0.8.23"
+version = "0.8.24"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1967,7 +1967,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.8.23"
+version = "0.8.24"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1989,11 +1989,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-openui"
-version = "0.8.23"
+version = "0.8.24"
 
 [[package]]
 name = "everruns-runtime"
-version = "0.8.23"
+version = "0.8.24"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2027,7 +2027,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-server"
-version = "0.8.23"
+version = "0.8.24"
 dependencies = [
  "aes-gcm",
  "ag-ui-core",
@@ -2111,7 +2111,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-session-sqldb"
-version = "0.8.23"
+version = "0.8.24"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2130,7 +2130,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-worker"
-version = "0.8.23"
+version = "0.8.24"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.8.23"
+version = "0.8.24"
 edition = "2024"
 license = "MIT"
 authors = ["Everruns Contributors"]

--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "everruns-ui",
-  "version": "0.8.23",
+  "version": "0.8.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "everruns-ui",
-      "version": "0.8.23",
+      "version": "0.8.24",
       "dependencies": {
         "@base-ui/react": "^1.2.0",
         "@openuidev/react-lang": "^0.1.3",

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "everruns-ui",
-  "version": "0.8.23",
+  "version": "0.8.24",
   "private": true,
   "exports": {
     "./route-manifest": "./src/lib/ui-route-manifest.ts",


### PR DESCRIPTION
## Release v0.8.24

Patch release rolling up the changes that landed on `main` since v0.8.23 (and the v0.8.23.1 OAuth-resource hotfix).

### Highlights

- **Harness examples gallery** — built-in examples are now surfaced in a gallery (#1629).
- **MCP discover output schemas** — discover responses now expose command output schemas (#1627).
- **MCP OAuth metadata reliability** — path-specific protected-resource metadata URL (#1623); Everruns Dev plugin declares its `oauth_resource` for RFC 8707 compliance (#1624).
- **bashkit v0.3.0** — picks up upstream sandbox capabilities and hardening (#1630, #1625).
- **Plugin docs alignment** — Everruns Dev plugin README/metadata aligned with Claude Code spec (#1628).

See `CHANGELOG.md` for the full list.

### Checklist
- [x] `Cargo.toml` workspace version bumped to `0.8.24`
- [x] `apps/ui/package.json` version bumped to `0.8.24`
- [x] `Cargo.lock` and `apps/ui/package-lock.json` refreshed
- [x] `CHANGELOG.md` updated with highlights and changes
- [x] Migrations sequential (001..026) and unchanged
- [x] `pre-push` checks pass locally
- [ ] CI green

### Post-merge
The auto-tagging workflow will:
- Create git tag `v0.8.24`
- Create GitHub Release with notes from `CHANGELOG.md`
- Trigger Docker image build with version tag
- Trigger CLI binary publishing + Homebrew formula update


---
_Generated by [Claude Code](https://claude.ai/code/session_01SvuKqSU26P8XqFdC9HHaoV)_