### PR TITLE
chore(plugins): update everruns dev messaging

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,7 +1,7 @@
 {
   "name": "everruns-dev",
   "interface": {
-    "displayName": "Everruns Dev"
+    "displayName": "Everruns(Dev)"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "everruns-dev",
-  "description": "Everruns plugins for Claude Code — connect Claude to the Everruns dev agent platform over MCP to manage agents, harnesses, and sessions.",
+  "description": "Everruns plugins for Claude Code - connect Claude to the Everruns(Dev) managed harnesses platform to manage agents, harnesses, capabilities, sessions, and apps.",
   "owner": {
     "name": "Everruns",
     "url": "https://everruns.com"
@@ -9,8 +9,8 @@
     {
       "name": "everruns-dev",
       "source": "./plugins/everruns-dev",
-      "description": "Interact with the Everruns dev agent platform - create and run agents, manage harnesses and sessions, browse the API catalog.",
-      "version": "0.1.1",
+      "description": "Interact with the Everruns(Dev) managed harnesses platform. Manage harnesses, agents, and capabilities. Run agentic sessions. Create and deploy agentic applications.",
+      "version": "0.1.2",
       "author": {
         "name": "Everruns",
         "url": "https://everruns.com"

--- a/plugins/AGENTS.md
+++ b/plugins/AGENTS.md
@@ -1,0 +1,17 @@
+## Plugin changes
+
+When changing a shipped plugin, bump the plugin patch version unless the change
+is purely internal test code. Keep all plugin manifests and marketplace entries
+that carry the version in sync, then run the plugin metadata validation.
+
+For `plugins/everruns-dev`, update:
+
+- `plugins/everruns-dev/.codex-plugin/plugin.json`
+- `plugins/everruns-dev/.claude-plugin/plugin.json`
+- `.claude-plugin/marketplace.json`
+
+Validate with:
+
+```bash
+bash scripts/test-everruns-dev-plugin.sh
+```

--- a/plugins/everruns-dev/.claude-plugin/plugin.json
+++ b/plugins/everruns-dev/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "everruns-dev",
-  "version": "0.1.1",
-  "description": "Interact with the Everruns dev agent platform — inspect state with read-only queries, run side-effecting workflows, and manage agents, harnesses, and sessions.",
+  "version": "0.1.2",
+  "description": "Interact with the Everruns(Dev) managed harnesses platform. Manage harnesses, agents, and capabilities. Run agentic sessions. Create and deploy agentic applications.",
   "author": {
     "name": "Everruns",
     "url": "https://everruns.com"

--- a/plugins/everruns-dev/.codex-plugin/plugin.json
+++ b/plugins/everruns-dev/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "everruns-dev",
-  "version": "0.1.1",
-  "description": "Interact with the Everruns dev agent platform from Codex over MCP, with read-only `query` and full-access `execute` workflows.",
+  "version": "0.1.2",
+  "description": "Interact with the Everruns(Dev) managed harnesses platform from Codex. Manage harnesses, agents, and capabilities. Run agentic sessions. Create and deploy agentic applications.",
   "author": {
     "name": "Everruns",
     "url": "https://everruns.com"
@@ -19,9 +19,9 @@
   "skills": "./skills/",
   "mcpServers": "./.mcp.json",
   "interface": {
-    "displayName": "Everruns Dev",
-    "shortDescription": "Query or execute Everruns dev workflows from Codex over MCP",
-    "longDescription": "Bring the Everruns dev agent platform into Codex. Query Everruns dev state through the read-only `query` tool, use `execute` for workflows with side effects, manage harnesses and sessions, browse the API catalog, and drive the full platform through the bundled skill, slash commands, and MCP connection.",
+    "displayName": "Everruns(Dev)",
+    "shortDescription": "Manage harnesses, agents, capabilities, sessions, and apps on Everruns(Dev).",
+    "longDescription": "Use Everruns(Dev) from Codex to manage durable harnesses, configure agents and capabilities, run agentic sessions, and create deployable agentic applications. Useful for data analysis, customer support, operational workflows, research automation, and other agent-powered products.",
     "developerName": "Everruns",
     "category": "Agents",
     "capabilities": [
@@ -30,7 +30,7 @@
     ],
     "websiteURL": "https://everruns.com",
     "defaultPrompt": [
-      "Create an Everruns agent to summarize news from https://news.ycombinator.com/, pick the right harness and capabilities, and run it against this task"
+      "Create an Everruns(Dev) agent to summarize news from https://news.ycombinator.com/, pick the right harness and capabilities, and run it against this task"
     ],
     "brandColor": "#D4A43A",
     "composerIcon": "./assets/everruns-small.svg",

--- a/plugins/everruns-dev/.mcp.json
+++ b/plugins/everruns-dev/.mcp.json
@@ -4,7 +4,7 @@
       "type": "http",
       "url": "https://dev.everruns.com/mcp",
       "oauth_resource": "https://dev.everruns.com/mcp",
-      "note": "Everruns Dev MCP endpoint. Your MCP host will handle OAuth on first use."
+      "note": "Everruns(Dev) MCP endpoint. Your MCP host will handle OAuth on first use."
     }
   }
 }

--- a/plugins/everruns-dev/README.md
+++ b/plugins/everruns-dev/README.md
@@ -1,13 +1,11 @@
-# Everruns Dev Plugin
+# Everruns(Dev) Plugin
 
-This directory is the shared source of truth for the Everruns Dev plugin in both
+This directory is the shared source of truth for the Everruns(Dev) plugin in both
 Claude Code and Codex.
 
-It wires the [Everruns](https://everruns.com) dev agent platform into local
-agent tools over MCP. The shared payload is the Everruns Dev MCP server config,
-the `everruns-dev` skill, and the slash commands for common session workflows.
-Use `query` for read-only inspection and `execute` for workflows that create,
-update, delete, or otherwise have side effects.
+It wires the [Everruns](https://everruns.com) dev managed harnesses platform into
+local agent tools. The shared payload is the Everruns(Dev) MCP server config, the
+`everruns-dev` skill, and the slash commands for common session workflows.
 
 - Product: <https://everruns.com>
 - Docs: <https://docs.everruns.com>
@@ -17,9 +15,9 @@ update, delete, or otherwise have side effects.
 
 - `.claude-plugin/plugin.json` for Claude Code metadata
 - `.codex-plugin/plugin.json` for Codex metadata
-- `.mcp.json` for the Everruns Dev MCP server
-- `skills/everruns-dev/SKILL.md` for Everruns Dev concepts and workflows
-- `commands/` for the main Everruns Dev slash commands
+- `.mcp.json` for the Everruns(Dev) MCP server
+- `skills/everruns-dev/SKILL.md` for Everruns(Dev) concepts and workflows
+- `commands/` for the main Everruns(Dev) slash commands
 - `assets/` for Codex UI metadata
 
 ## Install
@@ -55,9 +53,9 @@ Codex discovers the plugin through the workspace marketplace at
 1. Install the plugin in Claude Code or expose it through the Codex marketplace.
 2. Run `/everruns-dev:whoami`.
 3. Complete the OAuth flow in the browser if prompted.
-4. Ask for an Everruns Dev task in natural language.
+4. Ask for an Everruns(Dev) task in natural language.
 
-## Pointing At Another Everruns Dev Deployment
+## Pointing At Another Everruns(Dev) Deployment
 
 Edit `plugins/everruns-dev/.mcp.json` and replace the `url` value with your
 deployment's `/mcp` endpoint.

--- a/plugins/everruns-dev/commands/agent-run.md
+++ b/plugins/everruns-dev/commands/agent-run.md
@@ -1,5 +1,5 @@
 ---
-description: Start a new session on an Everruns Dev agent and send the first message
+description: Start a new Everruns(Dev) agentic session and send the first message
 argument-hint: "<agent_id_or_name> <message>"
 ---
 

--- a/plugins/everruns-dev/commands/discover.md
+++ b/plugins/everruns-dev/commands/discover.md
@@ -1,5 +1,5 @@
 ---
-description: Search the Everruns Dev API catalog for operations
+description: Search the Everruns(Dev) API catalog for available operations
 argument-hint: "<query> | --all"
 ---
 

--- a/plugins/everruns-dev/commands/execute.md
+++ b/plugins/everruns-dev/commands/execute.md
@@ -1,10 +1,10 @@
 ---
-description: Run a bash script with full Everruns Dev API access, including side effects
+description: Run an Everruns(Dev) workflow that can modify platform state
 argument-hint: "<bash script>"
 ---
 
 Call the `execute` MCP tool with the provided script as `commands`. Every
-Everruns Dev API operation is a bash builtin; `jq` is available. Prefer `query`
+Everruns(Dev) API operation is a bash builtin; `jq` is available. Prefer `query`
 for read-only inspection and use `execute` when the script needs to create,
 update, delete, or trigger other side effects. See the `everruns-dev` skill for
 the command inventory, patterns, and examples.

--- a/plugins/everruns-dev/commands/query.md
+++ b/plugins/everruns-dev/commands/query.md
@@ -1,10 +1,10 @@
 ---
-description: Run a read-only bash script against the Everruns Dev API
+description: Inspect Everruns(Dev) platform data with a bash script
 argument-hint: "<bash script>"
 ---
 
 Call the `query` MCP tool with the provided script as `commands`. Only
-read-only Everruns Dev API operations are available as bash builtins; `jq` is
+read-only Everruns(Dev) API operations are available as bash builtins; `jq` is
 available. Use `execute` instead when the script needs side effects. See the
 `everruns-dev` skill for the command inventory, patterns, and examples. If the
 output shape is unclear, call `discover` first and check `output_shape`:

--- a/plugins/everruns-dev/commands/session-send.md
+++ b/plugins/everruns-dev/commands/session-send.md
@@ -1,5 +1,5 @@
 ---
-description: Send a follow-up message to an existing Everruns Dev session
+description: Send a follow-up message to an existing Everruns(Dev) session
 argument-hint: "<session_id> <message>"
 ---
 

--- a/plugins/everruns-dev/commands/session-status.md
+++ b/plugins/everruns-dev/commands/session-status.md
@@ -1,5 +1,5 @@
 ---
-description: Poll status and recent events for an Everruns Dev session
+description: Poll status and recent events for an Everruns(Dev) session
 argument-hint: "<session_id>"
 ---
 

--- a/plugins/everruns-dev/commands/whoami.md
+++ b/plugins/everruns-dev/commands/whoami.md
@@ -1,5 +1,5 @@
 ---
-description: Show the current Everruns Dev user and active organization
+description: Show the current Everruns(Dev) user and active organization
 ---
 
 Call the `me` MCP tool. If it fails with an auth error, tell the user to

--- a/plugins/everruns-dev/skills/everruns-dev/SKILL.md
+++ b/plugins/everruns-dev/skills/everruns-dev/SKILL.md
@@ -1,16 +1,16 @@
 ---
 name: everruns-dev
-description: Reference for working with the Everruns dev agent platform (https://dev.everruns.com) over MCP - core concepts, how to connect capabilities to agents and harnesses, and how to drive the API with the `discover`, `query`, and `execute` tools. Use whenever the user asks about Everruns Dev agents, harnesses, capabilities, sessions, models, or wants to call the Everruns Dev API.
+description: Reference for working with the Everruns(Dev) managed harnesses platform (https://dev.everruns.com) - core concepts, UI links, entity naming, and API workflows for agents, harnesses, capabilities, sessions, models, and apps.
 ---
 
-# Everruns Dev
+# Everruns(Dev)
 
-Everruns Dev is the dev deployment of the durable Everruns agentic harness engine. Docs:
-<https://docs.everruns.com>. This plugin talks to the Everruns dev deployment
-over MCP and exposes read-only API operations as bash builtins inside `query`
-and the full API surface inside `execute`.
+Everruns(Dev) is the dev deployment of the durable Everruns agentic harness
+engine. Docs: <https://docs.everruns.com>. This plugin talks to the
+Everruns(Dev) deployment over MCP and exposes both focused session tools and
+scriptable API access.
 
-If a user asks something Everruns Dev-related, prefer the MCP tools over guessing.
+If a user asks something Everruns(Dev)-related, prefer the MCP tools over guessing.
 When the exact shape of an operation is unclear, call `discover` first.
 
 ## Core concepts
@@ -45,7 +45,7 @@ Harness --has--> Capability
   `paused`. Sessions live indefinitely.
 - **Model** - an LLM like `gpt-4o` or `claude-sonnet-4`. Resolution priority:
   per-message controls -> session override -> agent default -> system default.
-- **MCP server** - a remote server exposing tools; integrated into Everruns Dev as
+- **MCP server** - a remote server exposing tools; integrated into Everruns(Dev) as
   a virtual capability (`mcp:{uuid}`).
 - **App** - binds a Harness + Agent to a channel (Slack, web widget, etc.) for
   external deployment.
@@ -60,13 +60,57 @@ Harness --has--> Capability
 3. Run the agent with `agent_run` - that creates a session (using the default
    harness), sends the first user message, and triggers the turn loop. To pin a
    specific harness, create the session directly via
-   `create_session --harness_id ...` and then call `send_message`.
+   `create_session --harness_id ...` and then call `create_message`.
 
 Capabilities are the answer to "how does my agent get tool X?" - attach the
 capability at the harness level for org-wide defaults, at the agent level for
 agent-specific tools, or at the session level for one-off additions.
 
-## MCP tools exposed by Everruns Dev
+## UI links
+
+All user-facing outputs should include links to the relevant Everruns(Dev) UI
+objects when an object is created, updated, inspected, or returned as a primary
+result. Use Markdown links. Default base URL: `https://dev.everruns.com` unless
+the user provides another deployment URL.
+
+Top-level UI paths:
+
+- Dashboard: `https://dev.everruns.com/dashboard`
+- Sessions list: `https://dev.everruns.com/sessions`
+- Session chat: `https://dev.everruns.com/sessions/{session_id}/chat`
+- Session events/files/resources/schedules/storage:
+  `https://dev.everruns.com/sessions/{session_id}/{tab}`
+- Agent: `https://dev.everruns.com/agents/{agent_id}`
+- Harness: `https://dev.everruns.com/harnesses/{harness_id}`
+- Capability: `https://dev.everruns.com/capabilities/{capability_id}`
+- App: `https://dev.everruns.com/apps/{app_id}`
+- MCP servers list: `https://dev.everruns.com/mcp-servers`
+- Models list: `https://dev.everruns.com/models`
+- Organization: `https://dev.everruns.com/orgs/{org_id}`
+
+Examples:
+
+- `[Support Triage](https://dev.everruns.com/agents/agent_01933b5a00007000800000000000001)`
+- `[Session](https://dev.everruns.com/sessions/session_01933b5a00007000800000000000003/chat)`
+- `[Base Harness](https://dev.everruns.com/harnesses/harness_01933b5a00007000800000000000002)`
+- `[Web Fetch](https://dev.everruns.com/capabilities/web_fetch)`
+
+## Names and IDs
+
+- `id` is the stable API and UI-link identifier. Use it for follow-up calls,
+  joins, and links. Core IDs are prefixed, such as `agent_...`, `harness_...`,
+  `session_...`, `app_...`, and `org_...`. Capability IDs are capability refs,
+  such as `web_fetch`, `session_storage`, `mcp:{uuid}`, or `skill:{id}`.
+- `name` is the addressable slug for agents and harnesses. It is lowercase,
+  URL-friendly, and good for search or operator-facing references, but `id` is
+  safer for exact operations.
+- `display_name` is the human-readable UI label for agents and harnesses.
+  Render entities as `display_name || name || id`. Apps use `name`; sessions use
+  `title || preview || id`; capabilities use `name || id`.
+- When returning a list, include both a readable label and the stable ID. Link
+  the readable label when possible.
+
+## MCP tools exposed by Everruns(Dev)
 
 | Tool | When to use |
 |---|---|
@@ -76,8 +120,8 @@ agent-specific tools, or at the session level for one-off additions.
 | `session_send_message` | Follow-up user message in an existing session. |
 | `session_get_status` | Poll session status + latest agent message + recent events. Supports `since_event_id` for incremental polling and `event_types` to filter. |
 | `discover` | Search the API catalog. Returns operation name, category, description, parameters. |
-| `query` | Run a bash script where only read-only Everruns Dev API operations are builtins. `jq` is available. Prefer this for inspection, search, preview, export, grep, and status checks. |
-| `execute` | Run a bash script where every Everruns Dev API operation is a builtin. `jq` is available. Use this when the workflow needs side effects. |
+| `query` | Run a bash script where only read-only Everruns(Dev) API operations are builtins. `jq` is available. Prefer this for inspection, search, preview, export, grep, and status checks. |
+| `execute` | Run a bash script where every Everruns(Dev) API operation is a builtin. `jq` is available. Use this when the workflow needs side effects. |
 
 Default to `query` for reads. Switch to `execute` only when the workflow needs
 to create, update, delete, or trigger actions.


### PR DESCRIPTION
## What
Update Everruns(Dev) plugin messaging across Codex, Claude, command metadata, README, and skill instructions. Bump the plugin version to 0.1.2 and add plugins/AGENTS.md guidance requiring version bumps for shipped plugin changes.

## Why
The plugin listing should describe user-facing outcomes instead of implementation details like query/execute. Agent-facing mechanics belong in the skill instructions.

## How
- Reworded Codex and Claude plugin descriptions around managed harnesses, agents, capabilities, sessions, and apps.
- Updated display name to Everruns(Dev) and removed query/execute language from user-facing descriptions.
- Added skill guidance for UI links and display_name/name/id rendering.
- Bumped plugin metadata version from 0.1.1 to 0.1.2.
- Added plugins/AGENTS.md with version bump instructions.

## Risk
- Low
- Plugin marketplace/listing text could display awkwardly if hosts have strict display-name expectations around parentheses.

## Security
- Threat categories reviewed: No security-relevant code changes. This changes plugin metadata, Markdown command descriptions, README/skill guidance, and an MCP note string only.
- Findings and resolutions: No auth, authorization, API, tool execution, filesystem, SQL, or web runtime behavior changed.

## Checklist
- [ ] Tests added or updated (not applicable: metadata and documentation only)
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

Validation:
- bash scripts/test-everruns-dev-plugin.sh
- python3 -m json.tool on plugin and marketplace JSON
- git diff --check
- just pre-push