### PR TITLE
fix(ui): simplify organisations settings

### DIFF
--- a/apps/ui/src/__tests__/settings-layout.test.tsx
+++ b/apps/ui/src/__tests__/settings-layout.test.tsx
@@ -29,7 +29,7 @@ describe("SettingsLayout", () => {
       </SettingsLayout>,
     );
 
-    expect(screen.getByText("General")).toBeInTheDocument();
+    expect(screen.queryByText("General")).not.toBeInTheDocument();
     expect(screen.getByText("Organisations")).toBeInTheDocument();
     expect(screen.getByText("LLM Providers")).toBeInTheDocument();
     expect(screen.getByText("Members")).toBeInTheDocument();
@@ -56,7 +56,6 @@ describe("SettingsLayout", () => {
       </SettingsLayout>,
     );
 
-    const generalLink = screen.getByRole("link", { name: /General/i });
     const organisationsLink = screen.getByRole("link", { name: /Organisations/i });
     const providersLink = screen.getByRole("link", { name: /LLM Providers/i });
     const membersLink = screen.getByRole("link", { name: /Members/i });
@@ -64,7 +63,6 @@ describe("SettingsLayout", () => {
     const connectionsLink = screen.getByRole("link", { name: /Connections/i });
     const apiKeysLink = screen.getByRole("link", { name: /API Keys/i });
 
-    expect(generalLink).toHaveAttribute("href", "/settings/organisation");
     expect(organisationsLink).toHaveAttribute("href", "/settings/organisations");
     expect(providersLink).toHaveAttribute("href", "/settings/providers");
     expect(membersLink).toHaveAttribute("href", "/settings/members");
@@ -120,7 +118,7 @@ describe("SettingsLayout", () => {
     expect(membersLink).toHaveClass("border-accent");
   });
 
-  it("has exactly 7 navigation items", () => {
+  it("has exactly 6 navigation items", () => {
     render(
       <SettingsLayout>
         <div>Test Content</div>
@@ -128,7 +126,7 @@ describe("SettingsLayout", () => {
     );
 
     const navLinks = screen.getAllByRole("link");
-    expect(navLinks).toHaveLength(7);
+    expect(navLinks).toHaveLength(6);
   });
 
   it("groups items under correct sections", () => {
@@ -143,7 +141,7 @@ describe("SettingsLayout", () => {
 
     // Organisation section contains its items
     const orgSection = orgLabel.closest("div[class]")!.parentElement!;
-    expect(orgSection).toHaveTextContent("General");
+    expect(orgSection).not.toHaveTextContent("General");
     expect(orgSection).toHaveTextContent("Organisations");
     expect(orgSection).toHaveTextContent("LLM Providers");
     expect(orgSection).toHaveTextContent("Members");
@@ -155,7 +153,6 @@ describe("SettingsLayout", () => {
     expect(personalSection).toHaveTextContent("Profile");
     expect(personalSection).toHaveTextContent("Connections");
     expect(personalSection).toHaveTextContent("API Keys");
-    expect(personalSection).not.toHaveTextContent("General");
     expect(personalSection).not.toHaveTextContent("Organisations");
     expect(personalSection).not.toHaveTextContent("Members");
   });
@@ -187,28 +184,13 @@ describe("SettingsLayout", () => {
       </SettingsLayout>,
     );
 
-    const generalLink = screen.getByRole("link", { name: /General/i });
     const organisationsLink = screen.getByRole("link", { name: /Organisations/i });
     const membersLink = screen.getByRole("link", { name: /Members/i });
     const apiKeysLink = screen.getByRole("link", { name: /API Keys/i });
 
-    expect(generalLink).toHaveClass("border-transparent");
-    expect(generalLink).not.toHaveClass("border-accent");
     expect(organisationsLink).toHaveClass("border-transparent");
     expect(membersLink).toHaveClass("border-transparent");
     expect(apiKeysLink).toHaveClass("border-transparent");
-  });
-
-  it("highlights active item for General page", () => {
-    mockPathname.mockReturnValue("/settings/organisation");
-    render(
-      <SettingsLayout>
-        <div>Test Content</div>
-      </SettingsLayout>,
-    );
-
-    const generalLink = screen.getByRole("link", { name: /General/i });
-    expect(generalLink).toHaveClass("border-accent");
   });
 
   it("highlights active item for Organisations page", () => {

--- a/apps/ui/src/__tests__/settings-organisations.test.tsx
+++ b/apps/ui/src/__tests__/settings-organisations.test.tsx
@@ -42,6 +42,12 @@ describe("OrganisationsPage", () => {
     render(<OrganisationsPage />);
 
     expect(screen.getByRole("heading", { name: "Organisations" })).toBeInTheDocument();
+    expect(screen.getByRole("table", { name: "Organisations" })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "Organisation" })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "ID" })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "Role" })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "Status" })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "Actions" })).toBeInTheDocument();
     expect(screen.getByText("Current Org")).toBeInTheDocument();
     expect(screen.getByText("Second Org")).toBeInTheDocument();
     expect(screen.getByText("org-1")).toBeInTheDocument();
@@ -52,7 +58,7 @@ describe("OrganisationsPage", () => {
   it("switches to another organisation", () => {
     render(<OrganisationsPage />);
 
-    fireEvent.click(screen.getByRole("button", { name: "Switch" }));
+    fireEvent.click(screen.getByRole("button", { name: "Switch to Second Org" }));
 
     expect(mockSetCurrentOrg).toHaveBeenCalledWith({
       public_id: "org-2",

--- a/apps/ui/src/app/(main)/settings/layout.tsx
+++ b/apps/ui/src/app/(main)/settings/layout.tsx
@@ -22,12 +22,6 @@ const settingsSections: NavSection[] = [
     label: "Organisation",
     items: [
       {
-        name: "General",
-        href: "/settings/organisation",
-        icon: Building2,
-        description: "Manage organisation settings",
-      },
-      {
         name: "Organisations",
         href: "/settings/organisations",
         icon: Building2,

--- a/apps/ui/src/app/(main)/settings/organisations/page.tsx
+++ b/apps/ui/src/app/(main)/settings/organisations/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { Building2, Check, Plus } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import {
@@ -15,8 +16,23 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
 import { useCreateOrganization } from "@/hooks/use-organizations";
 import { useOrg } from "@/providers/org-provider";
+import type { OrgRole } from "@/lib/api/types";
+
+const ROLE_LABELS: Record<OrgRole, string> = {
+  owner: "Owner",
+  admin: "Admin",
+  member: "Member",
+};
 
 export default function OrganisationsPage() {
   const router = useRouter();
@@ -61,43 +77,54 @@ export default function OrganisationsPage() {
             </p>
           </Card>
         ) : (
-          <div className="space-y-3">
-            {organizations.map((org) => {
-              const isCurrent = currentOrg?.public_id === org.public_id;
-              return (
-                <Card
-                  key={org.public_id}
-                  className={`p-4 flex items-center justify-between gap-4 ${isCurrent ? "border-primary/50" : ""}`}
-                >
-                  <div className="flex min-w-0 items-center gap-3">
-                    <div className={`p-2 ${isCurrent ? "bg-primary/10" : "bg-muted"}`}>
-                      <Building2
-                        className={`h-4 w-4 ${isCurrent ? "text-primary" : "text-muted-foreground"}`}
-                      />
-                    </div>
-                    <div className="min-w-0">
-                      <p className="truncate font-medium">{org.name}</p>
-                      <p className="truncate text-xs text-muted-foreground font-mono">
+          <Card className="overflow-hidden">
+            <Table aria-label="Organisations">
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Organisation</TableHead>
+                  <TableHead>ID</TableHead>
+                  <TableHead>Role</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead className="text-right">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {organizations.map((org) => {
+                  const isCurrent = currentOrg?.public_id === org.public_id;
+                  return (
+                    <TableRow key={org.public_id} data-state={isCurrent ? "selected" : undefined}>
+                      <TableCell className="font-medium">{org.name}</TableCell>
+                      <TableCell className="font-mono text-xs text-muted-foreground">
                         {org.public_id}
-                      </p>
-                    </div>
-                  </div>
-                  <div className="flex shrink-0 items-center gap-2">
-                    {isCurrent ? (
-                      <span className="flex items-center gap-1 text-sm text-primary">
-                        <Check className="h-4 w-4" />
-                        Current
-                      </span>
-                    ) : (
-                      <Button variant="outline" size="sm" onClick={() => setCurrentOrg(org)}>
-                        Switch
-                      </Button>
-                    )}
-                  </div>
-                </Card>
-              );
-            })}
-          </div>
+                      </TableCell>
+                      <TableCell>{ROLE_LABELS[org.role]}</TableCell>
+                      <TableCell>
+                        {isCurrent ? (
+                          <Badge variant="accent">
+                            <Check className="h-3 w-3" />
+                            Current
+                          </Badge>
+                        ) : (
+                          <span className="text-muted-foreground">Available</span>
+                        )}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          disabled={isCurrent}
+                          aria-label={`Switch to ${org.name}`}
+                          onClick={() => setCurrentOrg(org)}
+                        >
+                          Switch
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          </Card>
         )}
       </section>
 

--- a/apps/ui/src/hooks/use-global-search.ts
+++ b/apps/ui/src/hooks/use-global-search.ts
@@ -180,12 +180,6 @@ const NAVIGATION_PAGES: NavigationPage[] = [
     keywords: ["openai", "anthropic", "credentials"],
   },
   {
-    title: "Settings > Organisation",
-    href: "/settings/organisation",
-    icon: Settings,
-    keywords: ["org", "organization", "team"],
-  },
-  {
     title: "Settings > Organisations",
     href: "/settings/organisations",
     icon: Settings,


### PR DESCRIPTION
## What
Remove the organisation General settings entry from Settings navigation and global search, and render Settings / Organisations as a table.

## Why
Organisations should not be listed under Settings / General, and the organisations list should scan like structured settings data rather than separate cards.

## How
- Removed the General organisation nav/search destination from the user-facing settings surfaces.
- Replaced organisation cards with a table showing organisation name, ID, role, status, and actions.
- Updated tests for settings layout and organisations page behavior.

## Risk
- Low
- Settings navigation and the organisations settings page could regress visually or lose expected table/action labels.

## Security
- Threat categories reviewed: TM-WEB.
- Findings and resolutions: Client-only settings navigation/rendering change. No new inputs, auth/authz behavior, data access, API calls, dependencies, or sensitive data exposure introduced.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)