### PR TITLE
fix(ui): handle missing initial_files in agent and harness preview

### DIFF
--- a/apps/ui/src/__tests__/agent-preview.test.tsx
+++ b/apps/ui/src/__tests__/agent-preview.test.tsx
@@ -27,10 +27,7 @@ function makeMutationStub(opts: {
   // We invoke onSuccess synchronously when data is supplied to drive the success path.
   return {
     mutate: jest.fn(
-      (
-        _req: unknown,
-        callbacks?: { onSuccess?: (d: AgentPreviewResponse) => void },
-      ) => {
+      (_req: unknown, callbacks?: { onSuccess?: (d: AgentPreviewResponse) => void }) => {
         if (opts.data && callbacks?.onSuccess) callbacks.onSuccess(opts.data);
       },
     ),
@@ -59,13 +56,7 @@ describe("AgentPreview", () => {
   it("shows skeletons while the preview request is pending", () => {
     mockUsePreviewAgent.mockReturnValue(makeMutationStub({ isPending: true }));
 
-    render(
-      <AgentPreview
-        systemPrompt="hi"
-        capabilities={[]}
-        initialFiles={[]}
-      />,
-    );
+    render(<AgentPreview systemPrompt="hi" capabilities={[]} initialFiles={[]} />);
 
     expect(screen.queryByText("Full System Prompt")).not.toBeInTheDocument();
   });
@@ -98,17 +89,9 @@ describe("AgentPreview", () => {
   });
 
   it("shows the error card when the preview mutation fails", () => {
-    mockUsePreviewAgent.mockReturnValue(
-      makeMutationStub({ error: new Error("boom") }),
-    );
+    mockUsePreviewAgent.mockReturnValue(makeMutationStub({ error: new Error("boom") }));
 
-    render(
-      <AgentPreview
-        systemPrompt="hi"
-        capabilities={[]}
-        initialFiles={[]}
-      />,
-    );
+    render(<AgentPreview systemPrompt="hi" capabilities={[]} initialFiles={[]} />);
 
     expect(screen.getByText("Preview Error")).toBeInTheDocument();
     expect(screen.getByText(/boom/)).toBeInTheDocument();
@@ -116,21 +99,14 @@ describe("AgentPreview", () => {
 
   // Regression for "TypeError: t is not iterable" in the agent preview tab when an
   // older agent record arrives without the `initial_files` field.
-  it.each([undefined, null])(
-    "does not crash when agent.initial_files is %p",
-    (initialFiles) => {
-      mockUsePreviewAgent.mockReturnValue(makeMutationStub({ data: sampleResponse }));
+  it.each([undefined, null])("does not crash when agent.initial_files is %p", (initialFiles) => {
+    mockUsePreviewAgent.mockReturnValue(makeMutationStub({ data: sampleResponse }));
 
-      render(
-        <AgentPreview
-          systemPrompt="hi"
-          capabilities={[]}
-          initialFiles={initialFiles as never}
-        />,
-      );
+    render(
+      <AgentPreview systemPrompt="hi" capabilities={[]} initialFiles={initialFiles as never} />,
+    );
 
-      expect(screen.getByText("Initial Files")).toBeInTheDocument();
-      expect(screen.getByText("No initial files configured.")).toBeInTheDocument();
-    },
-  );
+    expect(screen.getByText("Initial Files")).toBeInTheDocument();
+    expect(screen.getByText("No initial files configured.")).toBeInTheDocument();
+  });
 });

--- a/apps/ui/src/__tests__/agent-preview.test.tsx
+++ b/apps/ui/src/__tests__/agent-preview.test.tsx
@@ -1,0 +1,136 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { AgentPreview } from "@/components/agents/agent-preview";
+import type { AgentPreviewResponse } from "@/lib/api/types";
+
+jest.mock("streamdown", () => ({
+  Streamdown: ({ children }: { children: string }) => (
+    <pre data-testid="streamdown-mock">{children}</pre>
+  ),
+}));
+
+jest.mock("@streamdown/code", () => ({
+  code: {},
+}));
+
+const mockUsePreviewAgent = jest.fn();
+
+jest.mock("@/hooks/use-agents", () => ({
+  usePreviewAgent: () => mockUsePreviewAgent(),
+}));
+
+function makeMutationStub(opts: {
+  data?: AgentPreviewResponse | null;
+  isPending?: boolean;
+  error?: Error | null;
+}) {
+  // The component calls `previewMutation.mutate(req, { onSuccess })` from useEffect.
+  // We invoke onSuccess synchronously when data is supplied to drive the success path.
+  return {
+    mutate: jest.fn(
+      (
+        _req: unknown,
+        callbacks?: { onSuccess?: (d: AgentPreviewResponse) => void },
+      ) => {
+        if (opts.data && callbacks?.onSuccess) callbacks.onSuccess(opts.data);
+      },
+    ),
+    isPending: opts.isPending ?? false,
+    error: opts.error ?? null,
+  };
+}
+
+const sampleResponse: AgentPreviewResponse = {
+  system_prompt: "## System prompt\n\nYou are helpful.",
+  tools: [
+    {
+      type: "builtin",
+      name: "search_web",
+      description: "Search the web",
+      parameters: { type: "object", properties: {} },
+    },
+  ],
+};
+
+describe("AgentPreview", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("shows skeletons while the preview request is pending", () => {
+    mockUsePreviewAgent.mockReturnValue(makeMutationStub({ isPending: true }));
+
+    render(
+      <AgentPreview
+        systemPrompt="hi"
+        capabilities={[]}
+        initialFiles={[]}
+      />,
+    );
+
+    expect(screen.queryByText("Full System Prompt")).not.toBeInTheDocument();
+  });
+
+  it("renders system prompt, tools, and initial files preview on success", async () => {
+    mockUsePreviewAgent.mockReturnValue(makeMutationStub({ data: sampleResponse }));
+
+    render(
+      <AgentPreview
+        systemPrompt="base prompt"
+        capabilities={[]}
+        initialFiles={[
+          {
+            path: "/notes.txt",
+            content: "hello",
+            encoding: "text",
+            is_readonly: false,
+          },
+        ]}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByText("Full System Prompt")).toBeInTheDocument());
+    expect(screen.getByText(/You are helpful\./)).toBeInTheDocument();
+    expect(screen.getByText("Available Tools")).toBeInTheDocument();
+    expect(screen.getByText("search_web")).toBeInTheDocument();
+    // The InitialFilesPreview header is "Initial Files".
+    expect(screen.getByText("Initial Files")).toBeInTheDocument();
+    expect(screen.getByText("hello")).toBeInTheDocument();
+  });
+
+  it("shows the error card when the preview mutation fails", () => {
+    mockUsePreviewAgent.mockReturnValue(
+      makeMutationStub({ error: new Error("boom") }),
+    );
+
+    render(
+      <AgentPreview
+        systemPrompt="hi"
+        capabilities={[]}
+        initialFiles={[]}
+      />,
+    );
+
+    expect(screen.getByText("Preview Error")).toBeInTheDocument();
+    expect(screen.getByText(/boom/)).toBeInTheDocument();
+  });
+
+  // Regression for "TypeError: t is not iterable" in the agent preview tab when an
+  // older agent record arrives without the `initial_files` field.
+  it.each([undefined, null])(
+    "does not crash when agent.initial_files is %p",
+    (initialFiles) => {
+      mockUsePreviewAgent.mockReturnValue(makeMutationStub({ data: sampleResponse }));
+
+      render(
+        <AgentPreview
+          systemPrompt="hi"
+          capabilities={[]}
+          initialFiles={initialFiles as never}
+        />,
+      );
+
+      expect(screen.getByText("Initial Files")).toBeInTheDocument();
+      expect(screen.getByText("No initial files configured.")).toBeInTheDocument();
+    },
+  );
+});

--- a/apps/ui/src/__tests__/agent-preview.test.tsx
+++ b/apps/ui/src/__tests__/agent-preview.test.tsx
@@ -102,9 +102,7 @@ describe("AgentPreview", () => {
   it.each([undefined, null])("does not crash when agent.initial_files is %p", (initialFiles) => {
     mockUsePreviewAgent.mockReturnValue(makeMutationStub({ data: sampleResponse }));
 
-    render(
-      <AgentPreview systemPrompt="hi" capabilities={[]} initialFiles={initialFiles as never} />,
-    );
+    render(<AgentPreview systemPrompt="hi" capabilities={[]} initialFiles={initialFiles} />);
 
     expect(screen.getByText("Initial Files")).toBeInTheDocument();
     expect(screen.getByText("No initial files configured.")).toBeInTheDocument();

--- a/apps/ui/src/__tests__/harness-preview.test.tsx
+++ b/apps/ui/src/__tests__/harness-preview.test.tsx
@@ -25,10 +25,7 @@ function makeMutationStub(opts: {
 }) {
   return {
     mutate: jest.fn(
-      (
-        _req: unknown,
-        callbacks?: { onSuccess?: (d: AgentPreviewResponse) => void },
-      ) => {
+      (_req: unknown, callbacks?: { onSuccess?: (d: AgentPreviewResponse) => void }) => {
         if (opts.data && callbacks?.onSuccess) callbacks.onSuccess(opts.data);
       },
     ),
@@ -57,13 +54,7 @@ describe("HarnessPreview", () => {
   it("shows skeletons while the preview request is pending", () => {
     mockUsePreviewHarness.mockReturnValue(makeMutationStub({ isPending: true }));
 
-    render(
-      <HarnessPreview
-        systemPrompt="hi"
-        capabilities={[]}
-        initialFiles={[]}
-      />,
-    );
+    render(<HarnessPreview systemPrompt="hi" capabilities={[]} initialFiles={[]} />);
 
     expect(screen.queryByText("Full System Prompt")).not.toBeInTheDocument();
   });
@@ -96,17 +87,9 @@ describe("HarnessPreview", () => {
   });
 
   it("shows the error card when the preview mutation fails", () => {
-    mockUsePreviewHarness.mockReturnValue(
-      makeMutationStub({ error: new Error("boom") }),
-    );
+    mockUsePreviewHarness.mockReturnValue(makeMutationStub({ error: new Error("boom") }));
 
-    render(
-      <HarnessPreview
-        systemPrompt="hi"
-        capabilities={[]}
-        initialFiles={[]}
-      />,
-    );
+    render(<HarnessPreview systemPrompt="hi" capabilities={[]} initialFiles={[]} />);
 
     expect(screen.getByText("Preview Error")).toBeInTheDocument();
     expect(screen.getByText(/boom/)).toBeInTheDocument();
@@ -114,23 +97,16 @@ describe("HarnessPreview", () => {
 
   // Regression for "TypeError: t is not iterable" in the harness preview tab when an
   // older harness record arrives without the `initial_files` field.
-  it.each([undefined, null])(
-    "does not crash when harness.initial_files is %p",
-    (initialFiles) => {
-      mockUsePreviewHarness.mockReturnValue(makeMutationStub({ data: sampleResponse }));
+  it.each([undefined, null])("does not crash when harness.initial_files is %p", (initialFiles) => {
+    mockUsePreviewHarness.mockReturnValue(makeMutationStub({ data: sampleResponse }));
 
-      render(
-        <HarnessPreview
-          systemPrompt="hi"
-          capabilities={[]}
-          initialFiles={initialFiles as never}
-        />,
-      );
+    render(
+      <HarnessPreview systemPrompt="hi" capabilities={[]} initialFiles={initialFiles as never} />,
+    );
 
-      expect(screen.getByText("Initial Files")).toBeInTheDocument();
-      expect(screen.getByText("No initial files configured.")).toBeInTheDocument();
-    },
-  );
+    expect(screen.getByText("Initial Files")).toBeInTheDocument();
+    expect(screen.getByText("No initial files configured.")).toBeInTheDocument();
+  });
 
   it("passes parent_harness_id through to the preview mutation", () => {
     const stub = makeMutationStub({ data: sampleResponse });

--- a/apps/ui/src/__tests__/harness-preview.test.tsx
+++ b/apps/ui/src/__tests__/harness-preview.test.tsx
@@ -100,9 +100,7 @@ describe("HarnessPreview", () => {
   it.each([undefined, null])("does not crash when harness.initial_files is %p", (initialFiles) => {
     mockUsePreviewHarness.mockReturnValue(makeMutationStub({ data: sampleResponse }));
 
-    render(
-      <HarnessPreview systemPrompt="hi" capabilities={[]} initialFiles={initialFiles as never} />,
-    );
+    render(<HarnessPreview systemPrompt="hi" capabilities={[]} initialFiles={initialFiles} />);
 
     expect(screen.getByText("Initial Files")).toBeInTheDocument();
     expect(screen.getByText("No initial files configured.")).toBeInTheDocument();

--- a/apps/ui/src/__tests__/harness-preview.test.tsx
+++ b/apps/ui/src/__tests__/harness-preview.test.tsx
@@ -1,0 +1,153 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { HarnessPreview } from "@/components/harnesses/harness-preview";
+import type { AgentPreviewResponse } from "@/lib/api/types";
+
+jest.mock("streamdown", () => ({
+  Streamdown: ({ children }: { children: string }) => (
+    <pre data-testid="streamdown-mock">{children}</pre>
+  ),
+}));
+
+jest.mock("@streamdown/code", () => ({
+  code: {},
+}));
+
+const mockUsePreviewHarness = jest.fn();
+
+jest.mock("@/hooks/use-harnesses", () => ({
+  usePreviewHarness: () => mockUsePreviewHarness(),
+}));
+
+function makeMutationStub(opts: {
+  data?: AgentPreviewResponse | null;
+  isPending?: boolean;
+  error?: Error | null;
+}) {
+  return {
+    mutate: jest.fn(
+      (
+        _req: unknown,
+        callbacks?: { onSuccess?: (d: AgentPreviewResponse) => void },
+      ) => {
+        if (opts.data && callbacks?.onSuccess) callbacks.onSuccess(opts.data);
+      },
+    ),
+    isPending: opts.isPending ?? false,
+    error: opts.error ?? null,
+  };
+}
+
+const sampleResponse: AgentPreviewResponse = {
+  system_prompt: "## Harness prompt\n\nDo good things.",
+  tools: [
+    {
+      type: "builtin",
+      name: "shell",
+      description: "Run a shell command",
+      parameters: { type: "object", properties: {} },
+    },
+  ],
+};
+
+describe("HarnessPreview", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("shows skeletons while the preview request is pending", () => {
+    mockUsePreviewHarness.mockReturnValue(makeMutationStub({ isPending: true }));
+
+    render(
+      <HarnessPreview
+        systemPrompt="hi"
+        capabilities={[]}
+        initialFiles={[]}
+      />,
+    );
+
+    expect(screen.queryByText("Full System Prompt")).not.toBeInTheDocument();
+  });
+
+  it("renders system prompt, tools, and initial files preview on success", async () => {
+    mockUsePreviewHarness.mockReturnValue(makeMutationStub({ data: sampleResponse }));
+
+    render(
+      <HarnessPreview
+        systemPrompt="base prompt"
+        capabilities={[]}
+        initialFiles={[
+          {
+            path: "/welcome.md",
+            content: "welcome to the harness",
+            encoding: "text",
+            is_readonly: true,
+          },
+        ]}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByText("Full System Prompt")).toBeInTheDocument());
+    expect(screen.getByText(/Do good things\./)).toBeInTheDocument();
+    expect(screen.getByText("Available Tools")).toBeInTheDocument();
+    expect(screen.getByText("shell")).toBeInTheDocument();
+    expect(screen.getByText("Initial Files")).toBeInTheDocument();
+    expect(screen.getByText("welcome to the harness")).toBeInTheDocument();
+    expect(screen.getByText("read-only")).toBeInTheDocument();
+  });
+
+  it("shows the error card when the preview mutation fails", () => {
+    mockUsePreviewHarness.mockReturnValue(
+      makeMutationStub({ error: new Error("boom") }),
+    );
+
+    render(
+      <HarnessPreview
+        systemPrompt="hi"
+        capabilities={[]}
+        initialFiles={[]}
+      />,
+    );
+
+    expect(screen.getByText("Preview Error")).toBeInTheDocument();
+    expect(screen.getByText(/boom/)).toBeInTheDocument();
+  });
+
+  // Regression for "TypeError: t is not iterable" in the harness preview tab when an
+  // older harness record arrives without the `initial_files` field.
+  it.each([undefined, null])(
+    "does not crash when harness.initial_files is %p",
+    (initialFiles) => {
+      mockUsePreviewHarness.mockReturnValue(makeMutationStub({ data: sampleResponse }));
+
+      render(
+        <HarnessPreview
+          systemPrompt="hi"
+          capabilities={[]}
+          initialFiles={initialFiles as never}
+        />,
+      );
+
+      expect(screen.getByText("Initial Files")).toBeInTheDocument();
+      expect(screen.getByText("No initial files configured.")).toBeInTheDocument();
+    },
+  );
+
+  it("passes parent_harness_id through to the preview mutation", () => {
+    const stub = makeMutationStub({ data: sampleResponse });
+    mockUsePreviewHarness.mockReturnValue(stub);
+
+    render(
+      <HarnessPreview
+        systemPrompt="hi"
+        capabilities={[]}
+        initialFiles={[]}
+        parentHarnessId="harness-parent-1"
+      />,
+    );
+
+    expect(stub.mutate).toHaveBeenCalledWith(
+      expect.objectContaining({ parent_harness_id: "harness-parent-1" }),
+      expect.any(Object),
+    );
+  });
+});

--- a/apps/ui/src/__tests__/initial-files-preview.test.tsx
+++ b/apps/ui/src/__tests__/initial-files-preview.test.tsx
@@ -19,6 +19,14 @@ describe("InitialFilesPreview", () => {
     expect(screen.getByText("No initial files configured.")).toBeInTheDocument();
   });
 
+  // Regression: agents/harnesses persisted before `initial_files` existed (or stripped
+  // by serializers) hand the component `undefined`. It must not throw "t is not iterable".
+  it.each([undefined, null])("renders empty state when files prop is %p", (files) => {
+    render(<InitialFilesPreview files={files as InitialFile[] | null | undefined} />);
+
+    expect(screen.getByText("No initial files configured.")).toBeInTheDocument();
+  });
+
   it("shows text file contents inline and lets the user switch files", () => {
     const files: InitialFile[] = [
       {

--- a/apps/ui/src/components/agents/agent-preview.tsx
+++ b/apps/ui/src/components/agents/agent-preview.tsx
@@ -18,7 +18,8 @@ import { Wrench, FileText, AlertCircle } from "lucide-react";
 interface AgentPreviewProps {
   systemPrompt: string;
   capabilities: AgentCapabilityConfig[];
-  initialFiles: InitialFile[];
+  // Accept missing `initial_files` from agents persisted before that field existed.
+  initialFiles: InitialFile[] | null | undefined;
   tools?: ToolDefinition[];
 }
 

--- a/apps/ui/src/components/files/initial-files-preview.tsx
+++ b/apps/ui/src/components/files/initial-files-preview.tsx
@@ -24,7 +24,9 @@ import {
 } from "lucide-react";
 
 interface InitialFilesPreviewProps {
-  files: InitialFile[];
+  // Accept undefined/null so older API responses that omit `initial_files`
+  // do not crash the preview surface with `TypeError: t is not iterable`.
+  files: InitialFile[] | null | undefined;
   title?: string;
   description?: string;
 }
@@ -35,7 +37,10 @@ export function InitialFilesPreview({
   description = "Files configured on this item. New sessions may merge files from other layers, with later layers overriding earlier files by path.",
 }: InitialFilesPreviewProps) {
   const sortedFiles = useMemo(
-    () => [...files].sort((left, right) => left.path.localeCompare(right.path)),
+    () =>
+      Array.isArray(files)
+        ? [...files].sort((left, right) => left.path.localeCompare(right.path))
+        : [],
     [files],
   );
   const [selectedPath, setSelectedPath] = useState<string | null>(sortedFiles[0]?.path ?? null);

--- a/apps/ui/src/components/harnesses/harness-preview.tsx
+++ b/apps/ui/src/components/harnesses/harness-preview.tsx
@@ -18,7 +18,8 @@ import { Wrench, FileText, AlertCircle } from "lucide-react";
 interface HarnessPreviewProps {
   systemPrompt: string;
   capabilities: AgentCapabilityConfig[];
-  initialFiles: InitialFile[];
+  // Accept missing `initial_files` from harnesses persisted before that field existed.
+  initialFiles: InitialFile[] | null | undefined;
   parentHarnessId?: string;
 }
 

--- a/apps/ui/src/lib/api/types/agent-types.ts
+++ b/apps/ui/src/lib/api/types/agent-types.ts
@@ -26,7 +26,8 @@ export interface Agent {
   tags: string[];
   /** Capabilities with per-agent configuration */
   capabilities: AgentCapabilityConfig[];
-  initial_files: InitialFile[];
+  /** Initial files. Optional: older records and serializers that strip empty arrays may omit this field. */
+  initial_files?: InitialFile[];
   /** Tool definitions (including client-side tools), defaults to [] */
   tools?: ToolDefinition[];
   /** Network access list for URL filtering */
@@ -124,7 +125,8 @@ export interface Harness {
   tags: string[];
   /** Capabilities with per-harness configuration */
   capabilities: AgentCapabilityConfig[];
-  initial_files: InitialFile[];
+  /** Initial files. Optional: older records and serializers that strip empty arrays may omit this field. */
+  initial_files?: InitialFile[];
   /** Network access list for URL filtering */
   network_access?: NetworkAccessList | null;
   /** Whether this harness is built-in (system-managed, readonly) */


### PR DESCRIPTION
## What
The Preview tab on the agent detail page (`/agents/<id>`) crashes with the global error boundary ("Something went wrong — An unexpected error occurred"). The same crash affects the harness Preview tab.

This PR makes `InitialFilesPreview` and the two preview wrappers (`AgentPreview`, `HarnessPreview`) tolerate a missing `initial_files` field, and adds regression + happy/error path coverage for both preview surfaces.

## Why
`InitialFilesPreview` (shared by agent and harness preview) called `[...files].sort(...)` inside a `useMemo` callback. If the API response omitted `initial_files` — which happens for older records or when serializers strip empty arrays — `files` is `undefined` at runtime and the spread throws `TypeError: t is not iterable` (minified). The throw inside `useMemo` propagates up to the page-level error boundary, so the whole Preview tab renders "Something went wrong".

The TypeScript prop type was `InitialFile[]`, which masked the runtime risk.

## How
- `apps/ui/src/components/files/initial-files-preview.tsx`: widen `files` prop to `InitialFile[] | null | undefined` and guard the memo with `Array.isArray(files)`. The empty-state branch already handles the rendered output.
- `apps/ui/src/components/agents/agent-preview.tsx` and `apps/ui/src/components/harnesses/harness-preview.tsx`: widen the `initialFiles` prop type to match, so callers stay honest about the contract.
- Tests:
  - `initial-files-preview.test.tsx`: regression `it.each([undefined, null])` for the empty-state path.
  - `agent-preview.test.tsx` (new): pending skeleton, success path (system prompt / tools / initial files), error card, and `it.each([undefined, null])` regression for missing `initial_files`.
  - `harness-preview.test.tsx` (new): same coverage as agent, plus assertion that `parent_harness_id` is forwarded into the preview mutation.

## Risk
- **Low.** UI-only defensive change. The patch narrows runtime behavior (replaces a throw with an empty array) — no new rendering paths, no new data exposure, no API or schema changes.
- Worst case: an agent that legitimately has `null`/`undefined` files now shows "No initial files configured." instead of crashing. That is the desired behavior.

## Validation
- `npm run lint` — clean (5 pre-existing warnings unrelated to this change).
- `npm run format:check` — clean.
- `npm run build` — passes.
- `jest` (full UI suite) — **693/693 pass**, including 16 new/updated tests in `initial-files-preview.test.tsx`, `agent-preview.test.tsx`, `harness-preview.test.tsx`. The new tests render the real `InitialFilesPreview` through `AgentPreview` / `HarnessPreview` with `null` and `undefined` files, exercising the exact `useMemo` callback that previously threw.
- `./scripts/lib/pre-push.sh` — clean.
- Full-stack smoke test was not possible in this sandbox (`caddy` is not installed and `start-dev` needs the proxy). The unit-test reproduction is the highest-signal proof for a `useMemo` rendering defect — it runs the real component against the exact runtime shape that triggered the crash. CI will run the full UI suite.

## Security
- **Threat categories reviewed:** TM-WEB only.
- **Findings:** None. The change touches React components and Jest tests; no new rendering of user-controlled data, no new endpoints, auth flows, SQL, shell, MCP, or dependencies. The fix narrows behavior (avoids throw → renders empty state) so it cannot introduce new exposure. No `THREAT` comments adjacent; no threat-model entry needed.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (component now accepts `null`/`undefined`; existing array callers unaffected)
- [x] Security review performed against relevant threat model categories
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UUXEqVJcTRC9XtHqhbrA99)_