### PR TITLE
fix(ui): add shared page layout shell and apply to models page

### DIFF
--- a/apps/ui/src/app/(main)/models/page.tsx
+++ b/apps/ui/src/app/(main)/models/page.tsx
@@ -14,6 +14,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
+import { PageShell, PageHeader, PageBody } from "@/components/layout";
 import { AddModelDialog } from "@/components/models/add-model-dialog";
 import { ModelRow } from "@/components/models/model-row";
 import { ProviderIcon } from "@/components/providers/provider-icon";
@@ -62,114 +63,114 @@ export default function ModelsPage() {
   };
 
   return (
-    <div className="space-y-8">
-      <section>
-        <div className="flex items-center justify-between mb-4">
-          <div>
-            <h2 className="text-xl font-semibold">Models</h2>
-            <p className="text-sm text-muted-foreground">
-              Manage the models available from your configured providers.
-            </p>
-          </div>
+    <PageShell>
+      <PageHeader
+        title="Models"
+        description="Manage the models available from your configured providers."
+        actions={
           <Button onClick={() => setAddModelOpen(true)} disabled={providers.length === 0}>
             <Plus className="h-4 w-4 mr-2" />
             Add Model
           </Button>
-        </div>
+        }
+      />
 
-        {modelsError && (
-          <div className="bg-destructive/10 text-destructive p-4 mb-4">
-            Failed to load models: {modelsError.message}
-          </div>
-        )}
-
-        {modelsLoading ? (
-          <div className="space-y-2">
-            {[...Array(3)].map((_, index) => (
-              <Skeleton key={index} className="h-16 w-full" />
-            ))}
-          </div>
-        ) : models.length === 0 ? (
-          <Card className="p-8 text-center">
-            <Cpu className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
-            <h3 className="text-lg font-medium mb-2">No models configured</h3>
-            <p className="text-muted-foreground mb-4">
-              {providers.length === 0
-                ? "Add a provider first, then add models to it."
-                : "Add models to your providers to use them with agents."}
-            </p>
-            {providers.length > 0 && (
-              <Button onClick={() => setAddModelOpen(true)}>
-                <Plus className="h-4 w-4 mr-2" />
-                Add Model
-              </Button>
-            )}
-          </Card>
-        ) : (
-          <div className="space-y-2">
-            {models.map((model) => (
-              <ModelRow
-                key={model.id}
-                model={model}
-                onDelete={handleDeleteModel}
-                onToggleEnabled={handleToggleEnabled}
-                isTogglingEnabled={togglingModelId === model.id}
-              />
-            ))}
-          </div>
-        )}
-      </section>
-
-      {enabledModels.length > 0 && (
+      <PageBody>
         <section>
-          <div className="mb-4">
-            <h2 className="text-xl font-semibold">Organization Settings</h2>
-            <p className="text-sm text-muted-foreground">
-              Configure the default model for your organization. This is used when no model is
-              specified at the agent or session level.
-            </p>
-          </div>
-          <Card>
-            <CardContent className="pt-6">
-              <div className="flex items-center gap-4">
-                <Label htmlFor="default-model" className="whitespace-nowrap font-medium">
-                  Default Model
-                </Label>
-                <Select
-                  value={org?.default_model_id ?? "none"}
-                  onValueChange={(value) => handleSetDefaultModel(value === "none" ? "" : value)}
-                  disabled={updateOrg.isPending}
-                >
-                  <SelectTrigger className="w-full max-w-md" id="default-model">
-                    <SelectValue placeholder="No default model">
-                      {selectedDefaultModelName}
-                    </SelectValue>
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="none">No default model</SelectItem>
-                    {enabledModels.map((model) => (
-                      <SelectItem key={model.id} value={model.id}>
-                        <div className="flex items-center gap-2">
-                          <ProviderIcon
-                            providerType={model.provider_type}
-                            size="sm"
-                            showBackground={false}
-                          />
-                          <span>
-                            {model.display_name} ({model.provider_name})
-                          </span>
-                        </div>
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-            </CardContent>
-          </Card>
+          {modelsError && (
+            <div className="bg-destructive/10 text-destructive p-4 mb-4">
+              Failed to load models: {modelsError.message}
+            </div>
+          )}
+
+          {modelsLoading ? (
+            <div className="space-y-2">
+              {[...Array(3)].map((_, index) => (
+                <Skeleton key={index} className="h-16 w-full" />
+              ))}
+            </div>
+          ) : models.length === 0 ? (
+            <Card className="p-8 text-center">
+              <Cpu className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
+              <h3 className="text-lg font-medium mb-2">No models configured</h3>
+              <p className="text-muted-foreground mb-4">
+                {providers.length === 0
+                  ? "Add a provider first, then add models to it."
+                  : "Add models to your providers to use them with agents."}
+              </p>
+              {providers.length > 0 && (
+                <Button onClick={() => setAddModelOpen(true)}>
+                  <Plus className="h-4 w-4 mr-2" />
+                  Add Model
+                </Button>
+              )}
+            </Card>
+          ) : (
+            <div className="space-y-2">
+              {models.map((model) => (
+                <ModelRow
+                  key={model.id}
+                  model={model}
+                  onDelete={handleDeleteModel}
+                  onToggleEnabled={handleToggleEnabled}
+                  isTogglingEnabled={togglingModelId === model.id}
+                />
+              ))}
+            </div>
+          )}
         </section>
-      )}
+
+        {enabledModels.length > 0 && (
+          <section>
+            <div className="mb-4">
+              <h2 className="text-xl font-semibold">Organization Settings</h2>
+              <p className="text-sm text-muted-foreground">
+                Configure the default model for your organization. This is used when no model is
+                specified at the agent or session level.
+              </p>
+            </div>
+            <Card>
+              <CardContent className="pt-6">
+                <div className="flex items-center gap-4">
+                  <Label htmlFor="default-model" className="whitespace-nowrap font-medium">
+                    Default Model
+                  </Label>
+                  <Select
+                    value={org?.default_model_id ?? "none"}
+                    onValueChange={(value) => handleSetDefaultModel(value === "none" ? "" : value)}
+                    disabled={updateOrg.isPending}
+                  >
+                    <SelectTrigger className="w-full max-w-md" id="default-model">
+                      <SelectValue placeholder="No default model">
+                        {selectedDefaultModelName}
+                      </SelectValue>
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="none">No default model</SelectItem>
+                      {enabledModels.map((model) => (
+                        <SelectItem key={model.id} value={model.id}>
+                          <div className="flex items-center gap-2">
+                            <ProviderIcon
+                              providerType={model.provider_type}
+                              size="sm"
+                              showBackground={false}
+                            />
+                            <span>
+                              {model.display_name} ({model.provider_name})
+                            </span>
+                          </div>
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </CardContent>
+            </Card>
+          </section>
+        )}
+      </PageBody>
 
       <AddModelDialog providers={providers} open={addModelOpen} onOpenChange={setAddModelOpen} />
-    </div>
+    </PageShell>
   );
 }

--- a/apps/ui/src/components/layout/index.ts
+++ b/apps/ui/src/components/layout/index.ts
@@ -9,3 +9,4 @@ export {
   defaultDevNavigation,
 } from "./sidebar";
 export { MainLayout } from "./main-layout";
+export { PageShell, PageHeader, PageBody } from "./page-shell";

--- a/apps/ui/src/components/layout/page-shell.tsx
+++ b/apps/ui/src/components/layout/page-shell.tsx
@@ -1,0 +1,49 @@
+// Reusable layout primitives for standard app pages.
+// PageShell provides container padding (max-width by default; opt into full-width
+// for dense tool pages). PageHeader renders the title/description/actions row.
+// PageBody is a thin wrapper that vertically spaces content sections.
+
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+interface PageShellProps {
+  children: ReactNode;
+  fullWidth?: boolean;
+  className?: string;
+}
+
+export function PageShell({ children, fullWidth = false, className }: PageShellProps) {
+  return (
+    <div className={cn(fullWidth ? "w-full p-6" : "container mx-auto p-6", className)}>
+      {children}
+    </div>
+  );
+}
+
+interface PageHeaderProps {
+  title: ReactNode;
+  description?: ReactNode;
+  actions?: ReactNode;
+  className?: string;
+}
+
+export function PageHeader({ title, description, actions, className }: PageHeaderProps) {
+  return (
+    <div className={cn("flex items-start justify-between gap-4 mb-6", className)}>
+      <div className="min-w-0">
+        <h1 className="text-2xl font-bold flex items-center gap-3">{title}</h1>
+        {description && <p className="text-sm text-muted-foreground mt-1">{description}</p>}
+      </div>
+      {actions && <div className="flex items-center gap-2 shrink-0">{actions}</div>}
+    </div>
+  );
+}
+
+interface PageBodyProps {
+  children: ReactNode;
+  className?: string;
+}
+
+export function PageBody({ children, className }: PageBodyProps) {
+  return <div className={cn("space-y-8", className)}>{children}</div>;
+}


### PR DESCRIPTION
## What
- New `PageShell` / `PageHeader` / `PageBody` primitives in `apps/ui/src/components/layout/page-shell.tsx` for standard app pages.
- Re-exported from `@/components/layout`.
- `/models` page now uses these primitives (was rendering edge-to-edge with no container/padding).

## Why
The `/models` page rendered without surrounding page padding or max-width, so on SaaS dev (https://dev.everruns.com/models) the header and model rows collided with the sidebar boundary. The page-layout contract was implicit: every route author had to remember to wrap their content in `container mx-auto p-6` + a header row, and `/models` simply forgot. Adding a shared shell makes the default obvious.

Closes EVE-408.

## How
- `PageShell` defaults to `container mx-auto p-6`. Pass `fullWidth` for dense tool pages that intentionally fill the content area.
- `PageHeader` renders the standard `title` (`h1 text-2xl font-bold`) / optional `description` / right-aligned `actions` row used by the rest of the app.
- `PageBody` is a thin `space-y-8` wrapper for vertically stacked sections.
- The models page kept its two existing sections (model list + Organization Settings); only the outer wrapping changed. The section-level inner header for "Models" was promoted to the page-level `PageHeader`.

## Risk
- Low. Pure presentational refactor — no data, API, auth, or business-logic changes. The new primitives use the same Tailwind utilities (`container mx-auto p-6`, `flex items-start justify-between mb-6`) already in production on 12+ other pages (`/agents`, `/apps`, `/dashboard`, `/durable`, `/sessions`, `/skills`, `/harnesses`, etc.).
- SaaS pass-through (`apps/saas-ui/src/app/(main)/models/page.tsx`) re-exports the OSS page unchanged; no SaaS-only override required.

## Validation
- `npm run format:check` — clean.
- `npm run lint` — clean (5 pre-existing warnings in unrelated files; none from this change).
- `npm run build` — `✓ Compiled successfully in 28.2s`, all routes including `/models` generated.
- CI: UI Build/Lint/Test, UI Playwright Smoke, CodeQL, Migration Immutability, and Build Check all green; backend-only jobs correctly skipped (no Rust/migration changes).

## Security
- Threat categories reviewed: TM-WEB. The change adds presentational React components rendering `children`/`title`/`description`/`actions` props through standard React (auto-escaped). No `dangerouslySetInnerHTML`, no new auth/cookie handling, no CORS/CSP changes, no new endpoints, no data flow changes.
- Findings: none. No `THREAT[...]` markers touched; no new threat surface; no threat model update needed.

## Checklist
- [x] Tests added or updated — N/A (purely presentational layout primitives; existing models-page behavior unchanged).
- [x] Backward compatibility considered — internal-only UI components; SaaS pass-through still re-exports the OSS page.
- [x] Security review performed against relevant threat model categories.
- [x] All review comments addressed (code change or written reasoning).
