### PR TITLE
fix(ui): smooth cross-org entity links

### DIFF
--- a/apps/ui/src/__tests__/use-resource-org-fallback.test.tsx
+++ b/apps/ui/src/__tests__/use-resource-org-fallback.test.tsx
@@ -1,0 +1,89 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { ApiError } from "@/lib/api/client";
+import { resolveOrgForResource } from "@/lib/api/resolver";
+import { useResourceOrgFallback } from "@/hooks/use-resource-org-fallback";
+
+const mockUseOrg = jest.fn();
+jest.mock("@/providers/org-provider", () => ({
+  useOrg: () => mockUseOrg(),
+}));
+
+jest.mock("@/lib/api/resolver", () => ({
+  resolveOrgForResource: jest.fn(),
+}));
+
+const mockResolveOrgForResource = resolveOrgForResource as jest.MockedFunction<
+  typeof resolveOrgForResource
+>;
+
+describe("useResourceOrgFallback", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("switches to the owning organization and stays on the entity page after a detail 404", async () => {
+    const setCurrentOrg = jest.fn();
+    const targetOrg = { public_id: "org_target", name: "Target Org", role: "member" };
+
+    mockUseOrg.mockReturnValue({
+      currentOrg: { public_id: "org_current", name: "Current Org", role: "member" },
+      organizations: [{ public_id: "org_current", name: "Current Org", role: "member" }, targetOrg],
+      setCurrentOrg,
+      isSwitching: false,
+    });
+    mockResolveOrgForResource.mockResolvedValue({
+      org_id: "org_target",
+      org_name: "Target Org",
+    });
+
+    const { result } = renderHook(() =>
+      useResourceOrgFallback({
+        resourceId: "agent_00000000000000000000000000000042",
+        error: new ApiError(404, "Not Found"),
+        isLoading: false,
+      }),
+    );
+
+    expect(result.current.isCheckingOtherOrgs).toBe(true);
+
+    await waitFor(() => {
+      expect(mockResolveOrgForResource).toHaveBeenCalledWith(
+        "agent_00000000000000000000000000000042",
+      );
+      expect(setCurrentOrg).toHaveBeenCalledWith(targetOrg, { stayOnPage: true });
+    });
+  });
+
+  it("does nothing when the resolved organization is not in the user's org list", async () => {
+    const setCurrentOrg = jest.fn();
+
+    mockUseOrg.mockReturnValue({
+      currentOrg: { public_id: "org_current", name: "Current Org", role: "member" },
+      organizations: [{ public_id: "org_current", name: "Current Org", role: "member" }],
+      setCurrentOrg,
+      isSwitching: false,
+    });
+    mockResolveOrgForResource.mockResolvedValue({
+      org_id: "org_missing",
+      org_name: "Missing Org",
+    });
+
+    const { result } = renderHook(() =>
+      useResourceOrgFallback({
+        resourceId: "agent_00000000000000000000000000000042",
+        error: new ApiError(404, "Not Found"),
+        isLoading: false,
+      }),
+    );
+
+    expect(result.current.isCheckingOtherOrgs).toBe(true);
+
+    await waitFor(() => {
+      expect(mockResolveOrgForResource).toHaveBeenCalledWith(
+        "agent_00000000000000000000000000000042",
+      );
+      expect(result.current.isCheckingOtherOrgs).toBe(false);
+    });
+    expect(setCurrentOrg).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ui/src/hooks/create-crud-hooks.ts
+++ b/apps/ui/src/hooks/create-crud-hooks.ts
@@ -98,12 +98,15 @@ export function createCrudHooks<TItem, TCreate, TUpdate>({
     // Cross-org fallback: if the current org doesn't own this resource but
     // another org the caller belongs to does, switch and retry transparently.
     // See specs/multitenancy.md (Cross-Org Resource Resolution).
-    useResourceOrgFallback({
+    const fallback = useResourceOrgFallback({
       resourceId: id,
       error: query.error,
       isLoading: query.isLoading,
     });
-    return query;
+    return {
+      ...query,
+      isLoading: query.isLoading || fallback.isCheckingOtherOrgs,
+    };
   }
 
   function useCreate(): UseMutationResult<TItem, Error, TCreate> {

--- a/apps/ui/src/hooks/use-agent-identities.ts
+++ b/apps/ui/src/hooks/use-agent-identities.ts
@@ -39,12 +39,15 @@ export function useAgentIdentity(identityId: string | undefined) {
     queryFn: () => getAgentIdentity(identityId!),
     enabled: !!org && !!identityId,
   });
-  useResourceOrgFallback({
+  const fallback = useResourceOrgFallback({
     resourceId: identityId,
     error: query.error,
     isLoading: orgLoading || query.isLoading,
   });
-  return { ...query, isLoading: orgLoading || query.isLoading };
+  return {
+    ...query,
+    isLoading: orgLoading || query.isLoading || fallback.isCheckingOtherOrgs,
+  };
 }
 
 export function useCreateAgentIdentity() {

--- a/apps/ui/src/hooks/use-capabilities.ts
+++ b/apps/ui/src/hooks/use-capabilities.ts
@@ -8,6 +8,7 @@ import { useQuery } from "@tanstack/react-query";
 import { getCapability, listCapabilities } from "@/lib/api/capabilities";
 import type { CapabilityId } from "@/lib/api/types";
 import { useOrg } from "@/providers/org-provider";
+import { useResourceOrgFallback } from "./use-resource-org-fallback";
 
 export function useCapabilities() {
   const { currentOrg, isLoading: orgLoading } = useOrg();
@@ -36,9 +37,15 @@ export function useCapability(capabilityId: CapabilityId | undefined) {
     enabled: !!org && !!capabilityId,
   });
 
+  const fallback = useResourceOrgFallback({
+    resourceId: capabilityId,
+    error: query.error,
+    isLoading: orgLoading || query.isLoading,
+  });
+
   // Include org loading state so pages show skeleton while org initializes
   return {
     ...query,
-    isLoading: orgLoading || query.isLoading,
+    isLoading: orgLoading || query.isLoading || fallback.isCheckingOtherOrgs,
   };
 }

--- a/apps/ui/src/hooks/use-resource-org-fallback.ts
+++ b/apps/ui/src/hooks/use-resource-org-fallback.ts
@@ -10,7 +10,7 @@
 
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ApiError } from "@/lib/api/client";
 import { resolveOrgForResource } from "@/lib/api/resolver";
 import { useOrg } from "@/providers/org-provider";
@@ -31,6 +31,14 @@ function is404(error: unknown): boolean {
   return error instanceof ApiError && error.status === 404;
 }
 
+export interface ResourceOrgFallbackState {
+  /**
+   * True while a 404 might still be recoverable by switching to another org.
+   * Detail pages should hide final "not found" UI while this is true.
+   */
+  isCheckingOtherOrgs: boolean;
+}
+
 /**
  * Attempt to recover from a 404 on an entity detail route by switching to the
  * owning org (if the caller is a member of it).
@@ -40,28 +48,61 @@ function is404(error: unknown): boolean {
  * `stayOnPage: true`, React Query invalidates, and the detail query re-runs
  * in the new org context.
  */
-export function useResourceOrgFallback({ resourceId, error, isLoading }: Options): void {
-  const { currentOrg, organizations, setCurrentOrg, isSwitching } = useOrg();
-  const attemptedRef = useRef<string | null>(null);
+export function useResourceOrgFallback({
+  resourceId,
+  error,
+  isLoading,
+}: Options): ResourceOrgFallbackState {
+  const { currentOrg, organizations = [], setCurrentOrg, isSwitching } = useOrg();
+  const attemptedKeysRef = useRef<Set<string>>(new Set());
+  const [exhaustedKeys, setExhaustedKeys] = useState<Set<string>>(() => new Set());
+
+  const lookupKey = resourceId && currentOrg ? `${resourceId}:${currentOrg.public_id}` : undefined;
+  const shouldCheck =
+    !!lookupKey && !isLoading && !isSwitching && is404(error) && !exhaustedKeys.has(lookupKey);
+
+  const organizationsById = useMemo(
+    () => new Map(organizations.map((org) => [org.public_id, org])),
+    [organizations],
+  );
+
+  const markExhausted = useCallback((key: string) => {
+    setExhaustedKeys((prev) => {
+      if (prev.has(key)) return prev;
+      const next = new Set(prev);
+      next.add(key);
+      return next;
+    });
+  }, []);
 
   useEffect(() => {
-    if (!resourceId || !currentOrg || isLoading || isSwitching) return;
-    if (!is404(error)) return;
-    // Only try once per resource id per mount to avoid ping-pong if the
-    // target org also returns 404.
-    if (attemptedRef.current === resourceId) return;
-    attemptedRef.current = resourceId;
+    if (!resourceId || !currentOrg || !lookupKey || !shouldCheck) return;
+    // Only try once per resource+org pair. If switching succeeds but the
+    // target org still 404s, the key changes and we can mark that final state
+    // exhausted instead of hiding the error forever.
+    if (attemptedKeysRef.current.has(lookupKey)) return;
+    attemptedKeysRef.current.add(lookupKey);
 
     let cancelled = false;
     (async () => {
       try {
         const result = await resolveOrgForResource(resourceId);
-        if (cancelled || !result) return;
-        if (result.org_id === currentOrg.public_id) return;
-        const target = organizations.find((o) => o.public_id === result.org_id);
-        if (!target) return;
+        if (cancelled) return;
+        if (!result || result.org_id === currentOrg.public_id) {
+          markExhausted(lookupKey);
+          return;
+        }
+        const target = organizationsById.get(result.org_id);
+        if (!target) {
+          markExhausted(lookupKey);
+          return;
+        }
         setCurrentOrg(target, { stayOnPage: true });
+        markExhausted(lookupKey);
       } catch (e) {
+        if (!cancelled) {
+          markExhausted(lookupKey);
+        }
         console.warn("Failed to resolve owning org for resource:", e);
       }
     })();
@@ -69,5 +110,15 @@ export function useResourceOrgFallback({ resourceId, error, isLoading }: Options
     return () => {
       cancelled = true;
     };
-  }, [resourceId, error, isLoading, isSwitching, currentOrg, organizations, setCurrentOrg]);
+  }, [
+    resourceId,
+    currentOrg,
+    lookupKey,
+    shouldCheck,
+    organizationsById,
+    markExhausted,
+    setCurrentOrg,
+  ]);
+
+  return { isCheckingOtherOrgs: shouldCheck || (isSwitching && is404(error)) };
 }

--- a/apps/ui/src/hooks/use-sessions.ts
+++ b/apps/ui/src/hooks/use-sessions.ts
@@ -85,7 +85,7 @@ export function useSession(
   // Cross-org fallback: auto-switch to the owning org when the user follows a
   // direct link to a session in another org they are a member of.
   // See specs/multitenancy.md (Cross-Org Resource Resolution).
-  useResourceOrgFallback({
+  const fallback = useResourceOrgFallback({
     resourceId: sessionId,
     error: query.error,
     isLoading: orgLoading || query.isLoading,
@@ -94,7 +94,7 @@ export function useSession(
   // Include org loading state so pages show skeleton while org initializes
   return {
     ...query,
-    isLoading: orgLoading || query.isLoading,
+    isLoading: orgLoading || query.isLoading || fallback.isCheckingOtherOrgs,
   };
 }
 

--- a/crates/server/src/domains/org_resolver.rs
+++ b/crates/server/src/domains/org_resolver.rs
@@ -17,7 +17,10 @@ use std::future::Future;
 use std::pin::Pin;
 
 use anyhow::Result;
-use everruns_core::typed_id::SessionId;
+use everruns_core::{
+    CapabilityId,
+    typed_id::{McpServerId, SessionId, SkillId},
+};
 
 use crate::storage::StorageBackend;
 
@@ -49,6 +52,16 @@ inventory::collect!(ResourceOrgResolver);
 /// exist. Callers MUST filter the returned `org_id` against the user's
 /// memberships before revealing it to the client.
 pub async fn resolve_resource_org(db: &StorageBackend, id: &str) -> Result<Option<i64>> {
+    let capability_id = CapabilityId::new(id);
+    if let Some(server_id) = capability_id.mcp_server_id() {
+        let public_id = McpServerId::from_uuid(server_id).to_string();
+        return db.get_mcp_server_organization_id(&public_id).await;
+    }
+    if let Some(skill_id) = capability_id.skill_id() {
+        let public_id = SkillId::from_uuid(skill_id).to_string();
+        return db.get_skill_organization_id(&public_id).await;
+    }
+
     let prefix = match id.split_once('_') {
         Some((p, _)) if !p.is_empty() => p,
         _ => return Ok(None),
@@ -218,5 +231,62 @@ mod tests {
             .await
             .unwrap();
         assert!(org.is_none());
+    }
+
+    #[tokio::test]
+    async fn resolve_virtual_capability_returns_underlying_resource_org_id() {
+        use crate::storage::models::{CreateMcpServerRow, CreateSkillRow};
+        use everruns_core::{
+            capabilities::{mcp_capability_id, skill_capability_id},
+            typed_id::SkillId,
+        };
+
+        let db = StorageBackend::in_memory();
+
+        let mcp = db
+            .create_mcp_server(
+                42,
+                CreateMcpServerRow {
+                    name: "tools".to_string(),
+                    description: None,
+                    url: "https://mcp.example.test".to_string(),
+                    transport_type: "streamable_http".to_string(),
+                    api_key_encrypted: None,
+                    headers: None,
+                    settings: None,
+                },
+            )
+            .await
+            .unwrap();
+        let mcp_capability_id = mcp_capability_id(mcp.id.uuid());
+
+        let skill_id = SkillId::new();
+        db.create_skill(
+            43,
+            CreateSkillRow {
+                public_id: skill_id.to_string(),
+                name: "helper".to_string(),
+                description: "Helper skill".to_string(),
+                license: None,
+                compatibility: None,
+                metadata: serde_json::json!({}),
+                allowed_tools: None,
+                instructions: "Do useful things.".to_string(),
+                source_type: "manual".to_string(),
+                archive_data: None,
+                version: "1.0.0".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+        let skill_capability_id = skill_capability_id(skill_id.uuid());
+
+        let org = resolve_resource_org(&db, &mcp_capability_id).await.unwrap();
+        assert_eq!(org, Some(42));
+
+        let org = resolve_resource_org(&db, &skill_capability_id)
+            .await
+            .unwrap();
+        assert_eq!(org, Some(43));
     }
 }

--- a/specs/domains.md
+++ b/specs/domains.md
@@ -337,6 +337,9 @@ contract. When introducing a new such entity, add:
 1. A storage method `get_<entity>_organization_id(public_id: &str) -> Result<Option<i64>>`
    (PG + in-memory).
 2. One `inventory::submit!` block in `domains/org_resolver.rs`.
+3. A UI detail hook that uses `hooks/create-crud-hooks.ts::useDetail`, or a
+   bespoke hook that calls `hooks/use-resource-org-fallback.ts` and folds
+   `isCheckingOtherOrgs` into its loading state.
 
 ### Shared services (`crates/server/src/services/`)
 

--- a/specs/multitenancy.md
+++ b/specs/multitenancy.md
@@ -607,7 +607,7 @@ resource and the UI shows a "not found" screen — a recurring papercut.
 |----------------------|--------------------------------------------------------------------------------------------------------------------------|
 | Entity APIs          | UNCHANGED — still return 404 for resources in other orgs. Preserves the enumeration guarantee on lines 127–128.          |
 | `GET /v1/resolve-org`| Authenticated endpoint. Given a prefixed public ID, returns the owning org ONLY when the caller is a member of that org. |
-| UI                   | On 404 from an entity detail fetch, calls the resolver and, if a member-owned org is returned, switches and retries.     |
+| UI                   | On 404 from an entity detail fetch, suppresses final "not found" UI while checking the resolver; if a member-owned org is returned, switches and retries. |
 
 Because the resolver reveals only orgs the caller already belongs to, the
 set of answers it can produce is a subset of the information the caller can
@@ -633,12 +633,12 @@ endpoint dispatches by prefix; adding a new top entity requires:
 1. A storage method `get_<entity>_organization_id(public_id: &str) -> Result<Option<i64>>`
    on the PG and in-memory backends (no caller-side org scoping).
 2. One `inventory::submit!` block in `domains/org_resolver.rs`.
-3. Nothing else — the resolver endpoint picks up the new prefix on startup,
-   and any entity-detail React hook built on `useDetail` automatically gets
-   the fallback.
+3. Nothing else on the backend — the resolver endpoint picks up the new
+   prefix on startup.
 
 Existing registrations cover: `session`, `agent`, `harness`, `app`,
-`skill`, `mcp`, `identity`, `eval`.
+`skill`, `mcp`, `identity`, `eval`. Virtual capability IDs (`mcp:<uuid>` and
+`skill:<uuid>`) resolve through their underlying MCP server or skill rows.
 
 ### UI integration
 
@@ -648,14 +648,23 @@ Existing registrations cover: `session`, `agent`, `harness`, `app`,
   `setCurrentOrg(target, { stayOnPage: true })` when the owner is a
   membership. The `stayOnPage` option skips the default org-switch redirect
   that would otherwise send the user back to the list page.
-- It is wired into `useDetail` (shared CRUD factory) and the bespoke
-  `useSession` / `useAgentIdentity` hooks so every top-level detail route
-  gets the fallback for free.
+- While the resolver check or resulting org switch is pending, the hook
+  exposes `isCheckingOtherOrgs`. Detail hooks MUST fold that into their
+  loading state so users see loading/checking UI instead of a brief red 404.
+  Render final "not found" only after the fallback is exhausted.
+- For ordinary CRUD-style entities, `hooks/create-crud-hooks.ts::useDetail`
+  is the generic integration point. Agents, harnesses, apps, skills, MCP
+  servers, and evals inherit the fallback through this helper.
+- Bespoke detail hooks that do not use `createCrudHooks` MUST call
+  `useResourceOrgFallback` themselves and include `isCheckingOtherOrgs` in
+  their returned loading state. Current bespoke integrations: `useSession`,
+  `useAgentIdentity`, and `useCapability`.
 
 ### Invariants
 
-- The fallback fires **at most once per resource id per mount** (tracked
-  via a ref inside the hook) to avoid ping-pong when the new org also 404s.
+- The fallback fires **at most once per resource id + current org pair**
+  (tracked via a ref inside the hook) to avoid ping-pong when the new org
+  also 404s.
 - The entity API's 404 behaviour is never relaxed. The only cross-org
   information disclosure happens through `GET /v1/resolve-org`, which is
   membership-gated.


### PR DESCRIPTION
## What
- Suppress transient 404/not-found UI while entity detail hooks check whether a direct link belongs to another organization the user can access.
- Extend org resolution for virtual capability IDs backed by MCP servers or skills.
- Document the generic UI fallback contract and add regression tests.

## Why
Direct links to agents, harnesses, sessions, and related entity detail pages could briefly render a red 404 before the UI switched to the owning organization.

## How
- `useResourceOrgFallback` now exposes `isCheckingOtherOrgs` until resolution is exhausted or an org switch completes.
- Shared CRUD detail hooks and bespoke session/identity/capability hooks fold that state into loading.
- `domains/org_resolver` resolves `mcp:<uuid>` and `skill:<uuid>` capability IDs through their underlying org-owned rows.

## Risk
- Low / Medium / High: Low
- What can break: Entity detail pages could stay in loading longer for unresolved 404s if fallback exhaustion regresses. Tests cover successful switch and unrecoverable resolution.

## Security
- Threat categories reviewed: TM-TENANT, TM-API, TM-WEB, TM-TOOL.
- Findings and resolutions: The existing `/v1/resolve-org` membership gate remains the only disclosure path. Entity APIs still return 404 across org boundaries. Virtual capability IDs are mapped to underlying MCP/skill rows, then still pass through the same endpoint membership gate before any org identity is returned. No new endpoint, auth path, dependency, or secret handling was added. Existing TM-TENANT-010 mitigation remains accurate; no threat-model update needed beyond the multitenancy/spec contract text.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

Validation:
- `npm run test -- use-resource-org-fallback.test.tsx create-crud-hooks.test.tsx --runInBand`
- `npm run build`
- `npm run format:check && npm run lint`
- `cargo test -p everruns-server domains::org_resolver::tests::resolve_virtual_capability_returns_underlying_resource_org_id`
- `just pre-push`
- Smoke: `PORT_PREFIX=478 just start-dev --no-watch`, then checked `/`, `/api/v1/auth/config`, `/health`, and `/api/v1/resolve-org?id=agent_00000000000000000000000000000001`.