### PR TITLE
fix(api): add UI links to command outputs

### DIFF
--- a/crates/core/src/capabilities/platform_management.rs
+++ b/crates/core/src/capabilities/platform_management.rs
@@ -577,6 +577,7 @@ impl Tool for ManageHarnessesTool {
                 match store.delete_harness(id).await {
                     Ok(()) => ToolExecutionResult::success(json!({
                         "harness_id": id_str,
+                        "ui_link": format!("{}/harnesses/{}", base_url, id_str),
                         "message": "Harness archived successfully"
                     })),
                     Err(e) => {
@@ -927,6 +928,7 @@ impl Tool for ManageAgentsTool {
                 match store.delete_agent(id).await {
                     Ok(()) => ToolExecutionResult::success(json!({
                         "agent_id": id_str,
+                        "ui_link": format!("{}/agents/{}", base_url, id_str),
                         "message": "Agent archived successfully"
                     })),
                     Err(e) => {
@@ -1314,6 +1316,7 @@ impl Tool for ManageAppsTool {
                 match store.delete_app(app_id).await {
                     Ok(()) => ToolExecutionResult::success(json!({
                         "app_id": app_id_str,
+                        "ui_link": format!("{}/apps/{}", base_url, app_id_str),
                         "message": "App archived successfully"
                     })),
                     Err(e) => {
@@ -1338,6 +1341,7 @@ impl Tool for ManageAppsTool {
                 match store.destroy_app(app_id).await {
                     Ok(()) => ToolExecutionResult::success(json!({
                         "app_id": app_id_str,
+                        "ui_link": format!("{}/apps", base_url),
                         "message": "App destroyed successfully"
                     })),
                     Err(e) => {
@@ -1585,6 +1589,7 @@ impl Tool for ManageAppChannelsTool {
                     Ok(()) => ToolExecutionResult::success(json!({
                         "app_id": app_id_str,
                         "channel_id": channel_id_str,
+                        "ui_link": format!("{}/apps/{}", base_url, app_id),
                         "message": "App channel deleted successfully"
                     })),
                     Err(e) => ToolExecutionResult::tool_error(format!(
@@ -1888,6 +1893,7 @@ impl Tool for ManageSessionsTool {
                 match store.delete_session(id).await {
                     Ok(()) => ToolExecutionResult::success(json!({
                         "session_id": id_str,
+                        "ui_link": format!("{}/sessions/{}/chat", base_url, id_str),
                         "message": "Session archived successfully"
                     })),
                     Err(e) => {
@@ -2257,6 +2263,7 @@ impl Tool for ReadCapabilitiesTool {
             Ok(s) => s,
             Err(e) => return e,
         };
+        let base_url = store.base_url();
 
         let id_filter = get_str(&arguments, "id");
         let search = get_str(&arguments, "search");
@@ -2274,6 +2281,7 @@ impl Tool for ReadCapabilitiesTool {
                             "name": c.name,
                             "description": c.description,
                             "status": c.status.to_string(),
+                            "ui_link": format!("{}/capabilities/{}", base_url, c.id.as_str()),
                         });
                         if let Some(cat) = &c.category {
                             item["category"] = json!(cat);
@@ -3270,6 +3278,7 @@ mod tests {
                     assert!(cap["id"].is_string());
                     assert!(cap["name"].is_string());
                     assert!(cap["type"].is_string());
+                    assert!(cap["ui_link"].as_str().unwrap().contains("/capabilities/"));
                 }
                 assert!(v["hint"].as_str().unwrap().contains("capability IDs"));
             }

--- a/crates/server/src/api/common.rs
+++ b/crates/server/src/api/common.rs
@@ -5,17 +5,24 @@
 // impl_auth_state!: macro to eliminate repeated FromRef<AppState> for AuthState impls
 
 use axum::Json;
-use axum::http::StatusCode;
+use axum::body::{Body, to_bytes};
+use axum::extract::Request;
+use axum::http::{StatusCode, header};
+use axum::middleware::Next;
+use axum::response::{IntoResponse, Response};
 use everruns_core::typed_id::SessionId;
 use everruns_durable::UpdateField;
 use serde::{
     Deserialize, Deserializer, Serialize,
     de::{DeserializeOwned, Error as DeError},
 };
+use serde_json::Value;
 use std::sync::Arc;
 use utoipa::ToSchema;
 
 use crate::storage::StorageBackend;
+
+const LINK_DECORATION_MAX_RESPONSE_BYTES: u64 = 16 * 1024 * 1024;
 
 /// Standard return type for API handlers that return JSON with error responses.
 ///
@@ -363,14 +370,15 @@ impl UrlBuilder {
         Self::new(&config.base_url, &config.frontend_url)
     }
 
-    /// Wrap a single resource with `self_url` and `view_url`.
+    /// Wrap a single resource with API and UI links.
     pub fn wrap<T: ResourceUrlable + Serialize>(&self, item: T) -> WithUrls<T> {
-        let id = item.resource_id();
-        let api_path = T::api_path();
-        let ui_path = T::ui_path();
+        let api_path = item.api_url_path();
+        let ui_path = item.ui_url_path();
+        let view_url = format!("{}/{}", self.ui_base, ui_path);
         WithUrls {
-            self_url: format!("{}/{}/{}", self.api_base, api_path, id),
-            view_url: format!("{}/{}/{}", self.ui_base, ui_path, id),
+            self_url: format!("{}/{}", self.api_base, api_path),
+            view_url: view_url.clone(),
+            ui_link: view_url,
             inner: item,
         }
     }
@@ -379,6 +387,247 @@ impl UrlBuilder {
     pub fn wrap_vec<T: ResourceUrlable + Serialize>(&self, items: Vec<T>) -> Vec<WithUrls<T>> {
         items.into_iter().map(|item| self.wrap(item)).collect()
     }
+
+    /// Add resource links to any recognizable entity objects in a JSON value.
+    ///
+    /// This is the protocol-agnostic link aspect used for command/MCP output
+    /// and final API responses. It is additive only: existing link fields win.
+    pub fn decorate_value_links(&self, value: &mut Value) -> bool {
+        decorate_value_links(value, self)
+    }
+}
+
+/// Middleware that enriches successful JSON API responses with entity links.
+///
+/// This covers endpoints that return command/domain DTOs directly instead of
+/// using `WithUrls`, while preserving non-JSON, streaming, and error responses.
+pub async fn decorate_json_response_links(
+    builder: UrlBuilder,
+    req: Request,
+    next: Next,
+) -> Response {
+    let response = next.run(req).await;
+    if !response.status().is_success()
+        || !response_is_json(&response)
+        || !response_within_link_decoration_limit(&response)
+    {
+        return response;
+    }
+
+    let (mut parts, body) = response.into_parts();
+    let bytes = match to_bytes(body, LINK_DECORATION_MAX_RESPONSE_BYTES as usize).await {
+        Ok(bytes) => bytes,
+        Err(err) => {
+            tracing::warn!(error = %err, "failed to read JSON response body for link decoration");
+            return ErrorResponse::internal_error().into_response();
+        }
+    };
+    if bytes.is_empty() {
+        return Response::from_parts(parts, Body::from(bytes));
+    }
+
+    let mut value = match serde_json::from_slice::<Value>(&bytes) {
+        Ok(value) => value,
+        Err(_) => return Response::from_parts(parts, Body::from(bytes)),
+    };
+    if !builder.decorate_value_links(&mut value) {
+        return Response::from_parts(parts, Body::from(bytes));
+    }
+
+    match serde_json::to_vec(&value) {
+        Ok(body) => {
+            parts.headers.remove(header::CONTENT_LENGTH);
+            Response::from_parts(parts, Body::from(body))
+        }
+        Err(err) => {
+            tracing::warn!(error = %err, "failed to serialize link-decorated JSON response");
+            Response::from_parts(parts, Body::from(bytes))
+        }
+    }
+}
+
+fn response_within_link_decoration_limit(response: &Response) -> bool {
+    response
+        .headers()
+        .get(header::CONTENT_LENGTH)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.parse::<u64>().ok())
+        .is_some_and(|length| length <= LINK_DECORATION_MAX_RESPONSE_BYTES)
+}
+
+fn response_is_json(response: &Response) -> bool {
+    response
+        .headers()
+        .get(header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| {
+            value
+                .split(';')
+                .next()
+                .is_some_and(|mime| mime.trim().eq_ignore_ascii_case("application/json"))
+        })
+}
+
+fn decorate_value_links(value: &mut Value, builder: &UrlBuilder) -> bool {
+    match value {
+        Value::Object(map) => {
+            let mut changed = false;
+            if !map.contains_key("ui_link")
+                && let Some(view_url) = map.get("view_url").and_then(Value::as_str)
+            {
+                map.insert("ui_link".to_string(), Value::String(view_url.to_string()));
+                changed = true;
+            }
+            if let Some(route) = route_for_object(map) {
+                if !map.contains_key("self_url")
+                    && let Some(api_path) = route.api_path
+                {
+                    map.insert(
+                        "self_url".to_string(),
+                        Value::String(format!("{}/{}", builder.api_base, api_path)),
+                    );
+                    changed = true;
+                }
+                if !map.contains_key("view_url") {
+                    let view_url = format!("{}/{}", builder.ui_base, route.ui_path);
+                    map.insert("view_url".to_string(), Value::String(view_url.clone()));
+                    changed = true;
+                    if !map.contains_key("ui_link") {
+                        map.insert("ui_link".to_string(), Value::String(view_url));
+                        changed = true;
+                    }
+                } else if !map.contains_key("ui_link")
+                    && let Some(view_url) = map.get("view_url").and_then(Value::as_str)
+                {
+                    map.insert("ui_link".to_string(), Value::String(view_url.to_string()));
+                    changed = true;
+                }
+            }
+
+            for child in map.values_mut() {
+                changed |= decorate_value_links(child, builder);
+            }
+            changed
+        }
+        Value::Array(items) => {
+            let mut changed = false;
+            for item in items {
+                changed |= decorate_value_links(item, builder);
+            }
+            changed
+        }
+        _ => false,
+    }
+}
+
+struct LinkRoute {
+    api_path: Option<String>,
+    ui_path: String,
+}
+
+struct ResourceId {
+    value: String,
+    include_self_url: bool,
+}
+
+fn route_for_object(map: &serde_json::Map<String, Value>) -> Option<LinkRoute> {
+    let id = own_resource_id(map)?;
+    let mut route = route_for_id(&id.value, map)?;
+    if !id.include_self_url {
+        route.api_path = None;
+    }
+    Some(route)
+}
+
+fn own_resource_id(map: &serde_json::Map<String, Value>) -> Option<ResourceId> {
+    for key in ["id", "public_id"] {
+        if let Some(id) = map.get(key).and_then(Value::as_str)
+            && route_for_id(id, map).is_some()
+        {
+            return Some(ResourceId {
+                value: id.to_string(),
+                include_self_url: true,
+            });
+        }
+    }
+
+    for key in [
+        "session_id",
+        "agent_id",
+        "harness_id",
+        "app_id",
+        "identity_id",
+        "mcp_server_id",
+        "skill_id",
+        "provider_id",
+        "model_id",
+        "eval_id",
+        "budget_id",
+    ] {
+        if let Some(id) = map.get(key).and_then(Value::as_str)
+            && route_for_id(id, map).is_some()
+        {
+            return Some(ResourceId {
+                value: id.to_string(),
+                include_self_url: false,
+            });
+        }
+    }
+
+    None
+}
+
+fn route_for_id(id: &str, map: &serde_json::Map<String, Value>) -> Option<LinkRoute> {
+    let Some((prefix, _)) = id.split_once('_') else {
+        return looks_like_capability(map).then(|| LinkRoute {
+            api_path: Some(format!("v1/capabilities/{id}")),
+            ui_path: format!("capabilities/{id}"),
+        });
+    };
+    let route = match prefix {
+        "agent" => ("v1/agents", format!("agents/{id}")),
+        "harness" => ("v1/harnesses", format!("harnesses/{id}")),
+        "session" => ("v1/sessions", format!("sessions/{id}/chat")),
+        "app" => ("v1/apps", format!("apps/{id}")),
+        "identity" => ("v1/agent-identities", format!("agent-identities/{id}")),
+        "mcp" => ("v1/mcp-servers", "mcp-servers".to_string()),
+        "skill" => ("v1/skills", "skills".to_string()),
+        "provider" => ("v1/llm-providers", "settings/providers".to_string()),
+        "model" => ("v1/llm-models", "models".to_string()),
+        "eval" => ("v1/evals", format!("evals/{id}")),
+        "bdgt" => ("v1/budgets", "budgets".to_string()),
+        "sched" => {
+            let session_id = map.get("session_id").and_then(Value::as_str)?;
+            return Some(LinkRoute {
+                api_path: Some(format!("v1/sessions/{session_id}/schedules/{id}")),
+                ui_path: format!("sessions/{session_id}/schedules"),
+            });
+        }
+        _ if looks_like_capability(map) => {
+            return Some(LinkRoute {
+                api_path: Some(format!("v1/capabilities/{id}")),
+                ui_path: format!("capabilities/{id}"),
+            });
+        }
+        _ => return None,
+    };
+    Some(LinkRoute {
+        api_path: Some(format!("{}/{id}", route.0)),
+        ui_path: route.1,
+    })
+}
+
+fn looks_like_capability(map: &serde_json::Map<String, Value>) -> bool {
+    map.contains_key("tool_definitions")
+        || map.contains_key("tool_count")
+        || map.contains_key("dependencies")
+        || map.contains_key("config_schema")
+        || map
+            .get("type")
+            .and_then(Value::as_str)
+            .is_some_and(|value| matches!(value, "builtin" | "mcp_server" | "skill"))
+        || map.contains_key("is_mcp")
+        || map.contains_key("is_skill")
 }
 
 /// Trait for resources that can have `url` and `view_url` generated.
@@ -389,9 +638,17 @@ pub trait ResourceUrlable {
     fn ui_path() -> &'static str;
     /// The resource's public ID as a string.
     fn resource_id(&self) -> String;
+    /// API path for this concrete resource, including its ID.
+    fn api_url_path(&self) -> String {
+        format!("{}/{}", Self::api_path(), self.resource_id())
+    }
+    /// UI path for this concrete resource.
+    fn ui_url_path(&self) -> String {
+        format!("{}/{}", Self::ui_path(), self.resource_id())
+    }
 }
 
-/// Wrapper that adds `self_url` and `view_url` to a serialized resource.
+/// Wrapper that adds API and UI links to a serialized resource.
 ///
 /// Uses `self_url` (not `url`) for the API link to avoid collision with
 /// resources that already have a `url` field (e.g. McpServer).
@@ -401,6 +658,8 @@ pub struct WithUrls<T: Serialize> {
     pub self_url: String,
     /// Full UI URL for viewing this resource.
     pub view_url: String,
+    /// Alias for `view_url`, used by command and MCP outputs.
+    pub ui_link: String,
     /// The resource itself (fields are flattened into the parent object).
     #[serde(flatten)]
     pub inner: T,
@@ -446,35 +705,138 @@ macro_rules! impl_resource_urlable {
 }
 
 impl_resource_urlable!(everruns_core::Agent, "v1/agents", "agents", public_id);
-impl_resource_urlable!(everruns_core::Session, "v1/sessions", "sessions", id);
 impl_resource_urlable!(everruns_core::Harness, "v1/harnesses", "harnesses", id);
-impl_resource_urlable!(everruns_core::Skill, "v1/skills", "skills", id);
-impl_resource_urlable!(everruns_core::budget::Budget, "v1/budgets", "budgets", id);
-impl_resource_urlable!(
-    everruns_core::McpServer,
-    "v1/mcp-servers",
-    "mcp-servers",
-    id
-);
 impl_resource_urlable!(everruns_core::App, "v1/apps", "apps", public_id);
-impl_resource_urlable!(
-    everruns_core::llm_models::LlmProvider,
-    "v1/llm-providers",
-    "llm-providers",
-    id
-);
-impl_resource_urlable!(
-    everruns_core::llm_models::LlmModel,
-    "v1/llm-models",
-    "llm-models",
-    id
-);
-impl_resource_urlable!(
-    everruns_core::LlmModelWithProvider,
-    "v1/llm-models",
-    "llm-models",
-    id
-);
+
+impl ResourceUrlable for everruns_core::budget::Budget {
+    fn api_path() -> &'static str {
+        "v1/budgets"
+    }
+    fn ui_path() -> &'static str {
+        "budgets"
+    }
+    fn resource_id(&self) -> String {
+        self.id.to_string()
+    }
+    fn ui_url_path(&self) -> String {
+        "budgets".to_string()
+    }
+}
+
+impl ResourceUrlable for everruns_core::Session {
+    fn api_path() -> &'static str {
+        "v1/sessions"
+    }
+    fn ui_path() -> &'static str {
+        "sessions"
+    }
+    fn resource_id(&self) -> String {
+        self.id.to_string()
+    }
+    fn ui_url_path(&self) -> String {
+        format!("sessions/{}/chat", self.id)
+    }
+}
+
+impl ResourceUrlable for everruns_core::AgentIdentity {
+    fn api_path() -> &'static str {
+        "v1/agent-identities"
+    }
+    fn ui_path() -> &'static str {
+        "agent-identities"
+    }
+    fn resource_id(&self) -> String {
+        self.id.to_string()
+    }
+}
+
+impl ResourceUrlable for everruns_core::eval::Eval {
+    fn api_path() -> &'static str {
+        "v1/evals"
+    }
+    fn ui_path() -> &'static str {
+        "evals"
+    }
+    fn resource_id(&self) -> String {
+        self.public_id.to_string()
+    }
+}
+
+impl ResourceUrlable for everruns_core::McpServer {
+    fn api_path() -> &'static str {
+        "v1/mcp-servers"
+    }
+    fn ui_path() -> &'static str {
+        "mcp-servers"
+    }
+    fn resource_id(&self) -> String {
+        self.id.to_string()
+    }
+    fn ui_url_path(&self) -> String {
+        "mcp-servers".to_string()
+    }
+}
+
+impl ResourceUrlable for everruns_core::Skill {
+    fn api_path() -> &'static str {
+        "v1/skills"
+    }
+    fn ui_path() -> &'static str {
+        "skills"
+    }
+    fn resource_id(&self) -> String {
+        self.id.to_string()
+    }
+    fn ui_url_path(&self) -> String {
+        "skills".to_string()
+    }
+}
+
+impl ResourceUrlable for everruns_core::llm_models::LlmProvider {
+    fn api_path() -> &'static str {
+        "v1/llm-providers"
+    }
+    fn ui_path() -> &'static str {
+        "settings/providers"
+    }
+    fn resource_id(&self) -> String {
+        self.id.to_string()
+    }
+    fn ui_url_path(&self) -> String {
+        "settings/providers".to_string()
+    }
+}
+
+impl ResourceUrlable for everruns_core::llm_models::LlmModel {
+    fn api_path() -> &'static str {
+        "v1/llm-models"
+    }
+    fn ui_path() -> &'static str {
+        "models"
+    }
+    fn resource_id(&self) -> String {
+        self.id.to_string()
+    }
+    fn ui_url_path(&self) -> String {
+        "models".to_string()
+    }
+}
+
+impl ResourceUrlable for everruns_core::LlmModelWithProvider {
+    fn api_path() -> &'static str {
+        "v1/llm-models"
+    }
+    fn ui_path() -> &'static str {
+        "models"
+    }
+    fn resource_id(&self) -> String {
+        self.id.to_string()
+    }
+    fn ui_url_path(&self) -> String {
+        "models".to_string()
+    }
+}
+
 impl ResourceUrlable for everruns_core::session_schedule::SessionSchedule {
     fn api_path() -> &'static str {
         "v1/sessions"
@@ -484,6 +846,9 @@ impl ResourceUrlable for everruns_core::session_schedule::SessionSchedule {
     }
     fn resource_id(&self) -> String {
         format!("{}/schedules/{}", self.session_id, self.id)
+    }
+    fn ui_url_path(&self) -> String {
+        format!("sessions/{}/schedules", self.session_id)
     }
 }
 
@@ -519,6 +884,25 @@ pub async fn verify_session_ownership(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[derive(Serialize)]
+    struct TestResource {
+        id: String,
+    }
+
+    impl ResourceUrlable for TestResource {
+        fn api_path() -> &'static str {
+            "v1/test-resources"
+        }
+
+        fn ui_path() -> &'static str {
+            "test-resources"
+        }
+
+        fn resource_id(&self) -> String {
+            self.id.clone()
+        }
+    }
 
     #[test]
     fn test_error_response_new() {
@@ -614,6 +998,128 @@ mod tests {
         assert_eq!(parsed["total"], 50);
         assert_eq!(parsed["offset"], 10);
         assert_eq!(parsed["limit"], 5);
+    }
+
+    #[test]
+    fn test_url_builder_wrap_includes_ui_link_alias() {
+        let builder = UrlBuilder::new("https://api.example/api", "https://app.example");
+        let wrapped = builder.wrap(TestResource {
+            id: "resource_1".to_string(),
+        });
+
+        assert_eq!(
+            wrapped.self_url,
+            "https://api.example/api/v1/test-resources/resource_1"
+        );
+        assert_eq!(
+            wrapped.view_url,
+            "https://app.example/test-resources/resource_1"
+        );
+        assert_eq!(wrapped.ui_link, wrapped.view_url);
+    }
+
+    #[test]
+    fn test_link_decoration_requires_bounded_content_length() {
+        let missing_length = Response::builder()
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::empty())
+            .unwrap();
+        assert!(!response_within_link_decoration_limit(&missing_length));
+
+        let large_response = Response::builder()
+            .header(header::CONTENT_TYPE, "application/json")
+            .header(
+                header::CONTENT_LENGTH,
+                (LINK_DECORATION_MAX_RESPONSE_BYTES + 1).to_string(),
+            )
+            .body(Body::empty())
+            .unwrap();
+        assert!(!response_within_link_decoration_limit(&large_response));
+
+        let bounded_response = Response::builder()
+            .header(header::CONTENT_TYPE, "application/json")
+            .header(header::CONTENT_LENGTH, "128")
+            .body(Body::empty())
+            .unwrap();
+        assert!(response_within_link_decoration_limit(&bounded_response));
+    }
+
+    #[test]
+    fn test_decorate_value_links_adds_command_session_link() {
+        let builder = UrlBuilder::new("https://api.example/api", "https://app.example");
+        let mut value = serde_json::json!({
+            "session_id": "session_00000000000000000000000000000001",
+            "message_id": "message_00000000000000000000000000000002"
+        });
+
+        assert!(builder.decorate_value_links(&mut value));
+        assert!(value.get("self_url").is_none());
+        assert_eq!(
+            value["ui_link"],
+            "https://app.example/sessions/session_00000000000000000000000000000001/chat"
+        );
+    }
+
+    #[test]
+    fn test_decorate_value_links_adds_nested_capability_link() {
+        let builder = UrlBuilder::new("https://api.example/api", "https://app.example");
+        let mut value = serde_json::json!({
+            "data": [{
+                "id": "platform_management",
+                "name": "Platform Management",
+                "type": "builtin"
+            }]
+        });
+
+        assert!(builder.decorate_value_links(&mut value));
+        assert_eq!(
+            value["data"][0]["view_url"],
+            "https://app.example/capabilities/platform_management"
+        );
+    }
+
+    #[test]
+    fn test_decorate_value_links_aligns_budget_ui_link() {
+        let builder = UrlBuilder::new("https://api.example/api", "https://app.example");
+        let mut value = serde_json::json!({
+            "id": "bdgt_00000000000000000000000000000001",
+            "subject_type": "session"
+        });
+
+        assert!(builder.decorate_value_links(&mut value));
+        assert_eq!(value["view_url"], "https://app.example/budgets");
+        assert_eq!(value["ui_link"], value["view_url"]);
+    }
+
+    #[test]
+    fn test_decorate_value_links_preserves_existing_links() {
+        let builder = UrlBuilder::new("https://api.example/api", "https://app.example");
+        let mut value = serde_json::json!({
+            "id": "agent_00000000000000000000000000000001",
+            "self_url": "https://custom.example/api",
+            "view_url": "https://custom.example/view"
+        });
+
+        assert!(builder.decorate_value_links(&mut value));
+        assert_eq!(value["self_url"], "https://custom.example/api");
+        assert_eq!(value["view_url"], "https://custom.example/view");
+        assert_eq!(value["ui_link"], "https://custom.example/view");
+    }
+
+    #[test]
+    fn test_decorate_value_links_aliases_existing_view_url() {
+        let builder = UrlBuilder::new("https://api.example/api", "https://app.example");
+        let mut value = serde_json::json!({
+            "id": "compaction",
+            "name": "Compaction",
+            "view_url": "https://app.example/capabilities/compaction"
+        });
+
+        assert!(builder.decorate_value_links(&mut value));
+        assert_eq!(
+            value["ui_link"],
+            "https://app.example/capabilities/compaction"
+        );
     }
 
     #[test]

--- a/crates/server/src/api/mcp_endpoint/catalog.rs
+++ b/crates/server/src/api/mcp_endpoint/catalog.rs
@@ -11,6 +11,7 @@ use std::sync::LazyLock;
 pub struct CatalogContext {
     pub state: super::AppState,
     pub caller: everruns_core::permissions::Caller,
+    pub link_builder: crate::api::common::UrlBuilder,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -145,12 +146,26 @@ fn make_inventory_callback(
     move |args: ToolArgs| {
         let params = args.params;
         let domain_ctx = ctx.to_domain_ctx();
+        let link_builder = ctx.link_builder.clone();
         Box::pin(async move {
-            (desc.dispatch)(params, &domain_ctx)
+            let result = (desc.dispatch)(params, &domain_ctx)
                 .await
-                .map_err(|error| error.to_string())
+                .map_err(|error| error.to_string())?;
+            decorate_command_output(&result, &link_builder)
         })
     }
+}
+
+fn decorate_command_output(
+    result: &str,
+    link_builder: &crate::api::common::UrlBuilder,
+) -> Result<String, String> {
+    let mut value = match serde_json::from_str::<serde_json::Value>(result) {
+        Ok(value) => value,
+        Err(_) => return Ok(result.to_string()),
+    };
+    link_builder.decorate_value_links(&mut value);
+    serde_json::to_string(&value).map_err(|error| format!("Internal error: {error}"))
 }
 
 #[cfg(test)]
@@ -176,6 +191,38 @@ mod tests {
         assert_ne!(
             def.input_schema.get("additionalProperties"),
             Some(&serde_json::Value::Bool(true))
+        );
+    }
+
+    #[test]
+    fn command_output_decoration_adds_ui_link_for_mcp_execute_results() {
+        let builder =
+            crate::api::common::UrlBuilder::new("https://api.example/api", "https://app.example");
+        let result = decorate_command_output(
+            r#"{"id":"agent_00000000000000000000000000000001","name":"demo"}"#,
+            &builder,
+        )
+        .expect("decorated output");
+        let value: serde_json::Value = serde_json::from_str(&result).unwrap();
+
+        assert_eq!(
+            value["self_url"],
+            "https://api.example/api/v1/agents/agent_00000000000000000000000000000001"
+        );
+        assert_eq!(
+            value["ui_link"],
+            "https://app.example/agents/agent_00000000000000000000000000000001"
+        );
+    }
+
+    #[test]
+    fn command_output_decoration_preserves_non_json_results() {
+        let builder =
+            crate::api::common::UrlBuilder::new("https://api.example/api", "https://app.example");
+
+        assert_eq!(
+            decorate_command_output("plain result", &builder).expect("decorated output"),
+            "plain result"
         );
     }
 }

--- a/crates/server/src/api/mcp_endpoint/mod.rs
+++ b/crates/server/src/api/mcp_endpoint/mod.rs
@@ -555,7 +555,9 @@ async fn read_capabilities(org: &ResolvedOrg, state: &AppState) -> Result<String
         })
         .collect();
 
-    serde_json::to_string(&summary).map_err(|e| format!("Serialization error: {e}"))
+    let mut value = Value::Array(summary);
+    link_builder(state).decorate_value_links(&mut value);
+    serde_json::to_string(&value).map_err(|e| format!("Serialization error: {e}"))
 }
 
 async fn read_harnesses(org: &ResolvedOrg, state: &AppState) -> Result<String, String> {
@@ -580,7 +582,9 @@ async fn read_harnesses(org: &ResolvedOrg, state: &AppState) -> Result<String, S
         })
         .collect();
 
-    serde_json::to_string(&summary).map_err(|e| format!("Serialization error: {e}"))
+    let mut value = Value::Array(summary);
+    link_builder(state).decorate_value_links(&mut value);
+    serde_json::to_string(&value).map_err(|e| format!("Serialization error: {e}"))
 }
 
 async fn read_models(org: &ResolvedOrg, state: &AppState) -> Result<String, String> {
@@ -601,7 +605,9 @@ async fn read_models(org: &ResolvedOrg, state: &AppState) -> Result<String, Stri
         })
         .collect();
 
-    serde_json::to_string(&summary).map_err(|e| format!("Serialization error: {e}"))
+    let mut value = Value::Array(summary);
+    link_builder(state).decorate_value_links(&mut value);
+    serde_json::to_string(&value).map_err(|e| format!("Serialization error: {e}"))
 }
 
 async fn read_agents(org: &ResolvedOrg, state: &AppState) -> Result<String, String> {
@@ -628,7 +634,9 @@ async fn read_agents(org: &ResolvedOrg, state: &AppState) -> Result<String, Stri
         })
         .collect();
 
-    serde_json::to_string(&summary).map_err(|e| format!("Serialization error: {e}"))
+    let mut value = Value::Array(summary);
+    link_builder(state).decorate_value_links(&mut value);
+    serde_json::to_string(&value).map_err(|e| format!("Serialization error: {e}"))
 }
 
 async fn handle_tools_call(
@@ -937,6 +945,10 @@ fn pretty_json(value: &Value) -> Result<String, String> {
     serde_json::to_string_pretty(value).map_err(|e| format!("Internal error: {e}"))
 }
 
+fn link_builder(state: &AppState) -> crate::api::common::UrlBuilder {
+    crate::api::common::UrlBuilder::from_auth_config(&state.auth.config)
+}
+
 // ============================================================================
 // Tier 1: agent_run
 // ============================================================================
@@ -1007,6 +1019,7 @@ async fn tool_agent_run(
     if let Some(bid) = budget_id {
         result["budget_id"] = json!(bid);
     }
+    link_builder(state).decorate_value_links(&mut result);
 
     pretty_json(&result)
 }
@@ -1043,11 +1056,14 @@ async fn tool_session_send_message(
     let session_params = json!({ "session_id": session_id });
     let session = dispatch_command("get_session", session_params, org, state).await?;
 
-    pretty_json(&json!({
+    let mut result = json!({
         "message_id": msg["id"],
         "session_status": session["status"],
+        "session_id": session_id,
         "hint": "Use session_get_status to poll for completion"
-    }))
+    });
+    link_builder(state).decorate_value_links(&mut result);
+    pretty_json(&result)
 }
 
 // ============================================================================
@@ -1123,7 +1139,7 @@ async fn tool_session_get_status(
         .last()
         .and_then(|e| e.get("id").and_then(|v| v.as_str()));
 
-    pretty_json(&json!({
+    let mut result = json!({
         "session_id": session_id,
         "status": session["status"],
         "agent_id": session["agent_id"],
@@ -1136,7 +1152,9 @@ async fn tool_session_get_status(
             "type": e["event_type"],
             "ts": e["ts"],
         })).collect::<Vec<_>>()
-    }))
+    });
+    link_builder(state).decorate_value_links(&mut result);
+    pretty_json(&result)
 }
 
 // ============================================================================
@@ -1303,6 +1321,7 @@ fn catalog_context(org: &ResolvedOrg, state: &AppState) -> catalog::CatalogConte
     catalog::CatalogContext {
         state: state.clone(),
         caller: Caller::from(org),
+        link_builder: link_builder(state),
     }
 }
 

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -1096,6 +1096,12 @@ impl ServerAppBuilder {
 
         // TM-DOS: Global per-IP API rate limiting (applied to API routes only,
         // not /health or /metrics). Set RATE_LIMIT_API_REQUESTS_PER_MINUTE=0 to disable.
+        let link_builder = api::common::UrlBuilder::from_auth_config(&auth_state.config);
+        let api_routes = api_routes.layer(axum::middleware::from_fn(move |req, next| {
+            let link_builder = link_builder.clone();
+            api::common::decorate_json_response_links(link_builder, req, next)
+        }));
+
         let api_routes = if crate::auth::rate_limit::ApiRateLimiter::is_disabled() {
             tracing::info!("API rate limiting disabled via RATE_LIMIT_API_REQUESTS_PER_MINUTE=0");
             api_routes

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -9802,12 +9802,17 @@
                   "type": "object",
                   "required": [
                     "self_url",
-                    "view_url"
+                    "view_url",
+                    "ui_link"
                   ],
                   "properties": {
                     "self_url": {
                       "type": "string",
                       "description": "Full API endpoint URL for this resource."
+                    },
+                    "ui_link": {
+                      "type": "string",
+                      "description": "Alias for `view_url`, used by command and MCP outputs."
                     },
                     "view_url": {
                       "type": "string",
@@ -9816,7 +9821,7 @@
                   }
                 }
               ],
-              "description": "Wrapper that adds `self_url` and `view_url` to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
+              "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
             },
             "description": "Array of items returned by the list operation."
           }
@@ -9898,12 +9903,17 @@
                   "type": "object",
                   "required": [
                     "self_url",
-                    "view_url"
+                    "view_url",
+                    "ui_link"
                   ],
                   "properties": {
                     "self_url": {
                       "type": "string",
                       "description": "Full API endpoint URL for this resource."
+                    },
+                    "ui_link": {
+                      "type": "string",
+                      "description": "Alias for `view_url`, used by command and MCP outputs."
                     },
                     "view_url": {
                       "type": "string",
@@ -9912,7 +9922,7 @@
                   }
                 }
               ],
-              "description": "Wrapper that adds `self_url` and `view_url` to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
+              "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
             },
             "description": "Array of items returned by the list operation."
           }
@@ -10013,12 +10023,17 @@
                   "type": "object",
                   "required": [
                     "self_url",
-                    "view_url"
+                    "view_url",
+                    "ui_link"
                   ],
                   "properties": {
                     "self_url": {
                       "type": "string",
                       "description": "Full API endpoint URL for this resource."
+                    },
+                    "ui_link": {
+                      "type": "string",
+                      "description": "Alias for `view_url`, used by command and MCP outputs."
                     },
                     "view_url": {
                       "type": "string",
@@ -10027,7 +10042,7 @@
                   }
                 }
               ],
-              "description": "Wrapper that adds `self_url` and `view_url` to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
+              "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
             },
             "description": "Array of items returned by the list operation."
           }
@@ -10102,12 +10117,17 @@
                   "type": "object",
                   "required": [
                     "self_url",
-                    "view_url"
+                    "view_url",
+                    "ui_link"
                   ],
                   "properties": {
                     "self_url": {
                       "type": "string",
                       "description": "Full API endpoint URL for this resource."
+                    },
+                    "ui_link": {
+                      "type": "string",
+                      "description": "Alias for `view_url`, used by command and MCP outputs."
                     },
                     "view_url": {
                       "type": "string",
@@ -10116,7 +10136,7 @@
                   }
                 }
               ],
-              "description": "Wrapper that adds `self_url` and `view_url` to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
+              "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
             },
             "description": "Array of items returned by the list operation."
           }
@@ -10235,12 +10255,17 @@
                   "type": "object",
                   "required": [
                     "self_url",
-                    "view_url"
+                    "view_url",
+                    "ui_link"
                   ],
                   "properties": {
                     "self_url": {
                       "type": "string",
                       "description": "Full API endpoint URL for this resource."
+                    },
+                    "ui_link": {
+                      "type": "string",
+                      "description": "Alias for `view_url`, used by command and MCP outputs."
                     },
                     "view_url": {
                       "type": "string",
@@ -10249,7 +10274,7 @@
                   }
                 }
               ],
-              "description": "Wrapper that adds `self_url` and `view_url` to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
+              "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
             },
             "description": "Array of items returned by the list operation."
           }
@@ -10362,12 +10387,17 @@
                   "type": "object",
                   "required": [
                     "self_url",
-                    "view_url"
+                    "view_url",
+                    "ui_link"
                   ],
                   "properties": {
                     "self_url": {
                       "type": "string",
                       "description": "Full API endpoint URL for this resource."
+                    },
+                    "ui_link": {
+                      "type": "string",
+                      "description": "Alias for `view_url`, used by command and MCP outputs."
                     },
                     "view_url": {
                       "type": "string",
@@ -10376,7 +10406,7 @@
                   }
                 }
               ],
-              "description": "Wrapper that adds `self_url` and `view_url` to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
+              "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
             },
             "description": "Array of items returned by the list operation."
           }
@@ -12246,12 +12276,17 @@
                   "type": "object",
                   "required": [
                     "self_url",
-                    "view_url"
+                    "view_url",
+                    "ui_link"
                   ],
                   "properties": {
                     "self_url": {
                       "type": "string",
                       "description": "Full API endpoint URL for this resource."
+                    },
+                    "ui_link": {
+                      "type": "string",
+                      "description": "Alias for `view_url`, used by command and MCP outputs."
                     },
                     "view_url": {
                       "type": "string",
@@ -12260,7 +12295,7 @@
                   }
                 }
               ],
-              "description": "Wrapper that adds `self_url` and `view_url` to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
+              "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
             },
             "description": "Array of items returned by the list operation."
           },
@@ -12392,12 +12427,17 @@
                   "type": "object",
                   "required": [
                     "self_url",
-                    "view_url"
+                    "view_url",
+                    "ui_link"
                   ],
                   "properties": {
                     "self_url": {
                       "type": "string",
                       "description": "Full API endpoint URL for this resource."
+                    },
+                    "ui_link": {
+                      "type": "string",
+                      "description": "Alias for `view_url`, used by command and MCP outputs."
                     },
                     "view_url": {
                       "type": "string",
@@ -12406,7 +12446,7 @@
                   }
                 }
               ],
-              "description": "Wrapper that adds `self_url` and `view_url` to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
+              "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
             },
             "description": "Array of items returned by the list operation."
           },
@@ -12740,12 +12780,17 @@
                   "type": "object",
                   "required": [
                     "self_url",
-                    "view_url"
+                    "view_url",
+                    "ui_link"
                   ],
                   "properties": {
                     "self_url": {
                       "type": "string",
                       "description": "Full API endpoint URL for this resource."
+                    },
+                    "ui_link": {
+                      "type": "string",
+                      "description": "Alias for `view_url`, used by command and MCP outputs."
                     },
                     "view_url": {
                       "type": "string",
@@ -12754,7 +12799,7 @@
                   }
                 }
               ],
-              "description": "Wrapper that adds `self_url` and `view_url` to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
+              "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
             },
             "description": "Array of items returned by the list operation."
           },
@@ -15873,12 +15918,17 @@
             "type": "object",
             "required": [
               "self_url",
-              "view_url"
+              "view_url",
+              "ui_link"
             ],
             "properties": {
               "self_url": {
                 "type": "string",
                 "description": "Full API endpoint URL for this resource."
+              },
+              "ui_link": {
+                "type": "string",
+                "description": "Alias for `view_url`, used by command and MCP outputs."
               },
               "view_url": {
                 "type": "string",
@@ -15887,7 +15937,7 @@
             }
           }
         ],
-        "description": "Wrapper that adds `self_url` and `view_url` to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
+        "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
       },
       "WithUrls_CapabilityInfo": {
         "allOf": [
@@ -15985,12 +16035,17 @@
             "type": "object",
             "required": [
               "self_url",
-              "view_url"
+              "view_url",
+              "ui_link"
             ],
             "properties": {
               "self_url": {
                 "type": "string",
                 "description": "Full API endpoint URL for this resource."
+              },
+              "ui_link": {
+                "type": "string",
+                "description": "Alias for `view_url`, used by command and MCP outputs."
               },
               "view_url": {
                 "type": "string",
@@ -15999,7 +16054,7 @@
             }
           }
         ],
-        "description": "Wrapper that adds `self_url` and `view_url` to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
+        "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
       },
       "WithUrls_Harness": {
         "allOf": [
@@ -16134,12 +16189,17 @@
             "type": "object",
             "required": [
               "self_url",
-              "view_url"
+              "view_url",
+              "ui_link"
             ],
             "properties": {
               "self_url": {
                 "type": "string",
                 "description": "Full API endpoint URL for this resource."
+              },
+              "ui_link": {
+                "type": "string",
+                "description": "Alias for `view_url`, used by command and MCP outputs."
               },
               "view_url": {
                 "type": "string",
@@ -16148,7 +16208,7 @@
             }
           }
         ],
-        "description": "Wrapper that adds `self_url` and `view_url` to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
+        "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
       },
       "WithUrls_LlmModel": {
         "allOf": [
@@ -16217,12 +16277,17 @@
             "type": "object",
             "required": [
               "self_url",
-              "view_url"
+              "view_url",
+              "ui_link"
             ],
             "properties": {
               "self_url": {
                 "type": "string",
                 "description": "Full API endpoint URL for this resource."
+              },
+              "ui_link": {
+                "type": "string",
+                "description": "Alias for `view_url`, used by command and MCP outputs."
               },
               "view_url": {
                 "type": "string",
@@ -16231,7 +16296,7 @@
             }
           }
         ],
-        "description": "Wrapper that adds `self_url` and `view_url` to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
+        "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
       },
       "WithUrls_LlmModelWithProvider": {
         "allOf": [
@@ -16319,12 +16384,17 @@
             "type": "object",
             "required": [
               "self_url",
-              "view_url"
+              "view_url",
+              "ui_link"
             ],
             "properties": {
               "self_url": {
                 "type": "string",
                 "description": "Full API endpoint URL for this resource."
+              },
+              "ui_link": {
+                "type": "string",
+                "description": "Alias for `view_url`, used by command and MCP outputs."
               },
               "view_url": {
                 "type": "string",
@@ -16333,7 +16403,7 @@
             }
           }
         ],
-        "description": "Wrapper that adds `self_url` and `view_url` to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
+        "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
       },
       "WithUrls_LlmProvider": {
         "allOf": [
@@ -16395,12 +16465,17 @@
             "type": "object",
             "required": [
               "self_url",
-              "view_url"
+              "view_url",
+              "ui_link"
             ],
             "properties": {
               "self_url": {
                 "type": "string",
                 "description": "Full API endpoint URL for this resource."
+              },
+              "ui_link": {
+                "type": "string",
+                "description": "Alias for `view_url`, used by command and MCP outputs."
               },
               "view_url": {
                 "type": "string",
@@ -16409,7 +16484,7 @@
             }
           }
         ],
-        "description": "Wrapper that adds `self_url` and `view_url` to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
+        "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
       },
       "WithUrls_McpServer": {
         "allOf": [
@@ -16515,12 +16590,17 @@
             "type": "object",
             "required": [
               "self_url",
-              "view_url"
+              "view_url",
+              "ui_link"
             ],
             "properties": {
               "self_url": {
                 "type": "string",
                 "description": "Full API endpoint URL for this resource."
+              },
+              "ui_link": {
+                "type": "string",
+                "description": "Alias for `view_url`, used by command and MCP outputs."
               },
               "view_url": {
                 "type": "string",
@@ -16529,7 +16609,7 @@
             }
           }
         ],
-        "description": "Wrapper that adds `self_url` and `view_url` to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
+        "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
       },
       "WithUrls_Session": {
         "allOf": [
@@ -16829,12 +16909,17 @@
             "type": "object",
             "required": [
               "self_url",
-              "view_url"
+              "view_url",
+              "ui_link"
             ],
             "properties": {
               "self_url": {
                 "type": "string",
                 "description": "Full API endpoint URL for this resource."
+              },
+              "ui_link": {
+                "type": "string",
+                "description": "Alias for `view_url`, used by command and MCP outputs."
               },
               "view_url": {
                 "type": "string",
@@ -16843,7 +16928,7 @@
             }
           }
         ],
-        "description": "Wrapper that adds `self_url` and `view_url` to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
+        "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
       },
       "WithUrls_Skill": {
         "allOf": [
@@ -16943,12 +17028,17 @@
             "type": "object",
             "required": [
               "self_url",
-              "view_url"
+              "view_url",
+              "ui_link"
             ],
             "properties": {
               "self_url": {
                 "type": "string",
                 "description": "Full API endpoint URL for this resource."
+              },
+              "ui_link": {
+                "type": "string",
+                "description": "Alias for `view_url`, used by command and MCP outputs."
               },
               "view_url": {
                 "type": "string",
@@ -16957,7 +17047,7 @@
             }
           }
         ],
-        "description": "Wrapper that adds `self_url` and `view_url` to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
+        "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
       }
     }
   },


### PR DESCRIPTION
## What
Add a shared link-decoration path so REST API responses, MCP command outputs, first-class MCP tools, and platform_management tool results expose UI links for recognized entities.

## Why
Agents and API/MCP clients need a stable `ui_link` to send users directly to the relevant web UI instead of returning only IDs or API URLs.

## How
- Extend `UrlBuilder`/`WithUrls` with `ui_link` and protocol-agnostic JSON link decoration.
- Apply the decorator as API response middleware and to MCP resources/tools/command catalog output.
- Add explicit `ui_link` fields to platform_management delete/read capability results.
- Refresh `docs/api/openapi.json` so typed REST wrappers document `ui_link`.

## Risk
- Low / Medium / High: Medium
- What can break: JSON response bodies now pass through additive decoration on successful API responses; malformed/non-JSON bodies are preserved, and existing `self_url`/`view_url`/`ui_link` fields are not overwritten.

## Security
- Threat categories reviewed: TM-API, TM-TOOL, TM-DOS, TM-AUTHZ
- Findings and resolutions: No new permissions, data sources, or DB queries. Links are derived only from IDs already present in authorized responses. Non-JSON command output is preserved. Middleware only decorates successful JSON responses and leaves errors/streams/non-JSON responses untouched.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

Validation:
- `cargo test -p everruns-server api::common::tests::test_decorate_value_links --lib`
- `cargo test -p everruns-server api::common::tests::test_url_builder_wrap_includes_ui_link_alias --lib`
- `cargo test -p everruns-server api::mcp_endpoint::catalog::tests::command_output_decoration --lib`
- `cargo test -p everruns-core capabilities::platform_management::tests::read_capabilities_returns_all --lib`
- `cargo check -p everruns-server`
- `./scripts/export-openapi.sh`
- `git diff --check`
- `just pre-push`
- Smoke: `PORT_PREFIX=274 just start-dev --no-watch`, `/health`, `/api/v1/capabilities` returned `self_url`, `view_url`, `ui_link`, and `/api-doc/openapi.json` included `ui_link` schemas.
