### PR TITLE
fix(ui): improve app 404 resource states

### DIFF
--- a/apps/ui/src/__tests__/resource-not-found.test.tsx
+++ b/apps/ui/src/__tests__/resource-not-found.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from "@testing-library/react";
+
+import { ResourceNotFound } from "@/components/resource-not-found";
+
+describe("ResourceNotFound", () => {
+  it("renders resource-specific copy, actions, and id", () => {
+    render(
+      <ResourceNotFound
+        title="Harness not found"
+        description="This harness may have been deleted, moved to another organization, or the URL may be wrong."
+        backHref="/harnesses"
+        backLabel="Back to harnesses"
+        resourceId="harness_019defa39e937b0c999ef870e8ded53b23"
+      />,
+    );
+
+    expect(screen.getByText("404 / Resource not found")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Harness not found" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Back to harnesses/ })).toHaveAttribute(
+      "href",
+      "/harnesses",
+    );
+    expect(screen.getByRole("link", { name: /Go to dashboard/ })).toHaveAttribute(
+      "href",
+      "/dashboard",
+    );
+    expect(screen.getByText("harness_019defa39e937b0c999ef870e8ded53b23")).toBeInTheDocument();
+  });
+});

--- a/apps/ui/src/app/(main)/agent-identities/[identityId]/page.tsx
+++ b/apps/ui/src/app/(main)/agent-identities/[identityId]/page.tsx
@@ -10,6 +10,7 @@ import {
   useDestroyAgentIdentity,
   useUpdateAgentIdentity,
 } from "@/hooks/use-agent-identities";
+import { ResourceNotFound } from "@/components/resource-not-found";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -122,12 +123,13 @@ export default function AgentIdentityDetailPage({
 
   if (!identity) {
     return (
-      <div className="container mx-auto p-6">
-        <div className="text-red-500">Identity not found</div>
-        <Link href="/agent-identities" className="text-blue-500 hover:underline">
-          Back to Agent Identities
-        </Link>
-      </div>
+      <ResourceNotFound
+        title="Identity not found"
+        description="This agent identity may have been deleted, moved to another organization, or the URL may be wrong."
+        backHref="/agent-identities"
+        backLabel="Back to agent identities"
+        resourceId={identityId}
+      />
     );
   }
 

--- a/apps/ui/src/app/(main)/agents/[agentId]/edit/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/edit/page.tsx
@@ -12,6 +12,7 @@ import {
   useAgentNameAvailability,
 } from "@/hooks";
 import { usePolicies } from "@/hooks/use-policies";
+import { ResourceNotFound } from "@/components/resource-not-found";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -212,12 +213,13 @@ export default function EditAgentPage({ params }: { params: Promise<{ agentId: s
 
   if (!agent) {
     return (
-      <div className="container mx-auto p-6">
-        <div className="text-red-500">Agent not found</div>
-        <Link href="/agents" className="text-blue-500 hover:underline">
-          Back to agents
-        </Link>
-      </div>
+      <ResourceNotFound
+        title="Agent not found"
+        description="This agent may have been deleted, moved to another organization, or the URL may be wrong."
+        backHref="/agents"
+        backLabel="Back to agents"
+        resourceId={agentId}
+      />
     );
   }
 

--- a/apps/ui/src/app/(main)/agents/[agentId]/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/page.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/hooks";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
+import { ResourceNotFound } from "@/components/resource-not-found";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -130,12 +131,13 @@ export default function AgentDetailPage({ params }: { params: Promise<{ agentId:
 
   if (!agent) {
     return (
-      <div className="container mx-auto p-6">
-        <div className="text-red-500">Agent not found</div>
-        <Link href="/agents" className="text-blue-500 hover:underline">
-          Back to agents
-        </Link>
-      </div>
+      <ResourceNotFound
+        title="Agent not found"
+        description="This agent may have been deleted, moved to another organization, or the URL may be wrong."
+        backHref="/agents"
+        backLabel="Back to agents"
+        resourceId={agentId}
+      />
     );
   }
 

--- a/apps/ui/src/app/(main)/agents/[agentId]/sessions/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/sessions/page.tsx
@@ -4,6 +4,7 @@ import { use, useState, useMemo } from "react";
 import { useAgent, useHarnesses, useSessions, useCreateSession, useLlmModels } from "@/hooks";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
+import { ResourceNotFound } from "@/components/resource-not-found";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -74,12 +75,13 @@ export default function SessionsListPage({ params }: { params: Promise<{ agentId
 
   if (!agent) {
     return (
-      <div className="container mx-auto p-6">
-        <div className="text-red-500">Agent not found</div>
-        <Link href="/agents" className="text-blue-500 hover:underline">
-          Back to agents
-        </Link>
-      </div>
+      <ResourceNotFound
+        title="Agent not found"
+        description="This agent may have been deleted, moved to another organization, or the URL may be wrong."
+        backHref="/agents"
+        backLabel="Back to agents"
+        resourceId={agentId}
+      />
     );
   }
 

--- a/apps/ui/src/app/(main)/apps/[appId]/page.tsx
+++ b/apps/ui/src/app/(main)/apps/[appId]/page.tsx
@@ -22,6 +22,7 @@ import { useRouter } from "next/navigation";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { queryKeys } from "@/lib/query-keys";
 import Link from "next/link";
+import { ResourceNotFound } from "@/components/resource-not-found";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -187,11 +188,6 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
   );
   const slackConfig = slackChannel?.channel_config as SlackChannelConfig | undefined;
   const hasSlackConfig = slackConfig?.signing_secret && slackConfig?.bot_token;
-  const agUiChannel = app?.channels?.find(
-    (ch: AppChannel) => ch.channel_type === "ag_ui" && ch.enabled,
-  );
-  const agUiConfig = agUiChannel?.channel_config as AgUiChannelConfig | undefined;
-  const hasAgUiConfig = agUiConfig?.anonymous ?? !!agUiChannel;
   const canPublishApp =
     app?.channels?.some((channel) => {
       if (!channel.enabled) {
@@ -400,12 +396,13 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
 
   if (!app) {
     return (
-      <div className="container mx-auto p-6">
-        <div className="text-red-500">App not found</div>
-        <Link href="/apps" className="text-blue-500 hover:underline">
-          Back to Apps
-        </Link>
-      </div>
+      <ResourceNotFound
+        title="App not found"
+        description="This app may have been deleted, moved to another organization, or the URL may be wrong."
+        backHref="/apps"
+        backLabel="Back to apps"
+        resourceId={appId}
+      />
     );
   }
 

--- a/apps/ui/src/app/(main)/capabilities/[capabilityId]/page.tsx
+++ b/apps/ui/src/app/(main)/capabilities/[capabilityId]/page.tsx
@@ -3,6 +3,7 @@
 import { use } from "react";
 import { useCapability, useCapabilities } from "@/hooks";
 import Link from "next/link";
+import { ResourceNotFound } from "@/components/resource-not-found";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -89,14 +90,17 @@ export default function CapabilityDetailPage({
 
   if (error || !capability) {
     return (
-      <div className="container mx-auto p-6">
-        <div className="text-red-500 mb-4">
-          {error ? `Error loading capability: ${error.message}` : "Capability not found"}
-        </div>
-        <Link href="/capabilities" className="text-blue-500 hover:underline">
-          Back to capabilities
-        </Link>
-      </div>
+      <ResourceNotFound
+        title={error ? "Capability unavailable" : "Capability not found"}
+        description={
+          error
+            ? `The capability could not be loaded: ${error.message}`
+            : "This capability may have been deleted, moved to another organization, or the URL may be wrong."
+        }
+        backHref="/capabilities"
+        backLabel="Back to capabilities"
+        resourceId={capabilityId}
+      />
     );
   }
 

--- a/apps/ui/src/app/(main)/evals/[evalId]/page.tsx
+++ b/apps/ui/src/app/(main)/evals/[evalId]/page.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/hooks";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
+import { ResourceNotFound } from "@/components/resource-not-found";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -357,12 +358,13 @@ export default function EvalDetailPage({ params }: { params: Promise<{ evalId: s
 
   if (!ev) {
     return (
-      <div className="container mx-auto p-6">
-        <div className="text-red-500">Eval not found</div>
-        <Link href="/evals" className="text-blue-500 hover:underline">
-          Back to evals
-        </Link>
-      </div>
+      <ResourceNotFound
+        title="Eval not found"
+        description="This eval may have been deleted, moved to another organization, or the URL may be wrong."
+        backHref="/evals"
+        backLabel="Back to evals"
+        resourceId={evalId}
+      />
     );
   }
 

--- a/apps/ui/src/app/(main)/evals/[evalId]/runs/[runId]/page.tsx
+++ b/apps/ui/src/app/(main)/evals/[evalId]/runs/[runId]/page.tsx
@@ -3,6 +3,7 @@
 import { use, useCallback } from "react";
 import { useEval, useEvalRun, useCancelEvalRun } from "@/hooks";
 import Link from "next/link";
+import { ResourceNotFound } from "@/components/resource-not-found";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -151,12 +152,13 @@ export default function EvalRunDetailPage({
 
   if (!run) {
     return (
-      <div className="container mx-auto p-6">
-        <div className="text-red-500">Run not found</div>
-        <Link href={`/evals/${evalId}`} className="text-blue-500 hover:underline">
-          Back to eval
-        </Link>
-      </div>
+      <ResourceNotFound
+        title="Run not found"
+        description="This eval run may have been deleted, moved to another organization, or the URL may be wrong."
+        backHref={`/evals/${evalId}`}
+        backLabel="Back to eval"
+        resourceId={runId}
+      />
     );
   }
 

--- a/apps/ui/src/app/(main)/harnesses/[harnessId]/edit/page.tsx
+++ b/apps/ui/src/app/(main)/harnesses/[harnessId]/edit/page.tsx
@@ -13,6 +13,7 @@ import {
   useHarnessNameAvailability,
 } from "@/hooks";
 import { usePolicies } from "@/hooks/use-policies";
+import { ResourceNotFound } from "@/components/resource-not-found";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -216,12 +217,13 @@ export default function EditHarnessPage({ params }: { params: Promise<{ harnessI
 
   if (!harness) {
     return (
-      <div className="container mx-auto p-6">
-        <div className="text-red-500">Harness not found</div>
-        <Link href="/harnesses" className="text-blue-500 hover:underline">
-          Back to harnesses
-        </Link>
-      </div>
+      <ResourceNotFound
+        title="Harness not found"
+        description="This harness may have been deleted, moved to another organization, or the URL may be wrong."
+        backHref="/harnesses"
+        backLabel="Back to harnesses"
+        resourceId={harnessId}
+      />
     );
   }
 

--- a/apps/ui/src/app/(main)/harnesses/[harnessId]/page.tsx
+++ b/apps/ui/src/app/(main)/harnesses/[harnessId]/page.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/hooks";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
+import { ResourceNotFound } from "@/components/resource-not-found";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -93,12 +94,13 @@ export default function HarnessDetailPage({ params }: { params: Promise<{ harnes
 
   if (!harness) {
     return (
-      <div className="container mx-auto p-6">
-        <div className="text-red-500">Harness not found</div>
-        <Link href="/harnesses" className="text-blue-500 hover:underline">
-          Back to harnesses
-        </Link>
-      </div>
+      <ResourceNotFound
+        title="Harness not found"
+        description="This harness may have been deleted, moved to another organization, or the URL may be wrong."
+        backHref="/harnesses"
+        backLabel="Back to harnesses"
+        resourceId={harnessId}
+      />
     );
   }
 

--- a/apps/ui/src/app/(main)/sessions/[sessionId]/layout.tsx
+++ b/apps/ui/src/app/(main)/sessions/[sessionId]/layout.tsx
@@ -3,6 +3,7 @@
 import { use, useEffect, useMemo, useRef, useState } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import Link from "next/link";
+import { ResourceNotFound } from "@/components/resource-not-found";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
@@ -282,12 +283,13 @@ function SessionLayoutContent({ children, sessionId }: SessionLayoutContentProps
 
   if (!session) {
     return (
-      <div className="container mx-auto p-6">
-        <div className="text-destructive">Session not found</div>
-        <Link href="/sessions" className="text-sm text-muted-foreground hover:text-foreground">
-          Back to sessions
-        </Link>
-      </div>
+      <ResourceNotFound
+        title="Session not found"
+        description="This session may have been deleted, moved to another organization, or the URL may be wrong."
+        backHref="/sessions"
+        backLabel="Back to sessions"
+        resourceId={sessionId}
+      />
     );
   }
 

--- a/apps/ui/src/app/not-found.tsx
+++ b/apps/ui/src/app/not-found.tsx
@@ -1,23 +1,13 @@
-import Link from "next/link";
+import { ResourceNotFound } from "@/components/resource-not-found";
 
 export default function NotFound() {
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center bg-background px-4">
-      <div className="w-full max-w-md text-center">
-        <p className="text-6xl font-bold text-muted-foreground">404</p>
-        <h1 className="mt-4 text-2xl font-semibold tracking-tight">Page not found</h1>
-        <p className="mt-2 text-muted-foreground">
-          The page you&apos;re looking for doesn&apos;t exist or has been moved.
-        </p>
-        <div className="mt-6">
-          <Link
-            href="/dashboard"
-            className="inline-flex h-10 items-center justify-center bg-primary px-6 text-sm font-medium text-primary-foreground shadow-sm hover:bg-primary/90 transition-colors"
-          >
-            Back to dashboard
-          </Link>
-        </div>
-      </div>
-    </div>
+    <ResourceNotFound
+      title="Page not found"
+      description="This page does not exist in the current workspace."
+      backHref="/dashboard"
+      backLabel="Back to dashboard"
+      className="min-h-screen bg-background bg-brand-dots"
+    />
   );
 }

--- a/apps/ui/src/components/resource-not-found.tsx
+++ b/apps/ui/src/components/resource-not-found.tsx
@@ -1,0 +1,71 @@
+import Link from "next/link";
+import { ArrowLeft, LayoutDashboard, SearchX } from "lucide-react";
+
+import { buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+interface ResourceNotFoundProps {
+  title: string;
+  description: string;
+  backHref: string;
+  backLabel: string;
+  resourceId?: string;
+  className?: string;
+}
+
+export function ResourceNotFound({
+  title,
+  description,
+  backHref,
+  backLabel,
+  resourceId,
+  className,
+}: ResourceNotFoundProps) {
+  return (
+    <div className={cn("flex min-h-[calc(100vh-2rem)] items-center justify-center p-6", className)}>
+      <section
+        aria-labelledby="resource-not-found-title"
+        className="w-full max-w-xl border border-l-2 border-border border-l-accent bg-background/95 p-6 shadow-sm"
+      >
+        <div className="flex items-start gap-4">
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center border border-border bg-muted text-muted-foreground">
+            <SearchX className="h-5 w-5" aria-hidden="true" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <p className="text-xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+              404 / Resource not found
+            </p>
+            <h1
+              id="resource-not-found-title"
+              className="mt-2 text-2xl font-semibold tracking-tight"
+            >
+              {title}
+            </h1>
+            <p className="mt-2 max-w-prose text-sm leading-6 text-muted-foreground">
+              {description}
+            </p>
+          </div>
+        </div>
+
+        <div className="mt-6 flex flex-wrap gap-2">
+          <Link href={backHref} className={buttonVariants({ variant: "default" })}>
+            <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+            {backLabel}
+          </Link>
+          {backHref !== "/dashboard" && (
+            <Link href="/dashboard" className={buttonVariants({ variant: "outline" })}>
+              <LayoutDashboard className="h-4 w-4" aria-hidden="true" />
+              Go to dashboard
+            </Link>
+          )}
+        </div>
+
+        {resourceId && (
+          <p className="mt-5 border-t border-border pt-4 font-mono text-xs text-muted-foreground break-all">
+            {resourceId}
+          </p>
+        )}
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
## What
Add a shared app-side `ResourceNotFound` state and use it for missing resource/detail pages across harnesses, agents, apps, capabilities, evals, sessions, identities, and the generic app 404.

## Why
Current missing-resource pages render sparse red text and blue links, which clashes with the Everruns operator-console UI and leaves the main workspace mostly empty.

## How
- Introduced a reusable sharp-corner resource 404 panel with muted icon, gold left accent, primary back action, dashboard action, and optional resource ID.
- Replaced existing detail-page red-text fallbacks with resource-specific copy.
- Updated the generic app `not-found.tsx` to reuse the same visual language.
- Added a focused render test for the shared component.

## Risk
- Low
- Can break missing-resource fallback rendering or route-level navigation labels, but does not change data fetching or API behavior.

## Security
- Threat categories reviewed: TM-WEB
- Findings and resolutions: No new trust boundary, dependency, or backend behavior. Resource IDs are rendered as React text, so they remain escaped. Links are static internal routes supplied by call sites.

## Validation
- `cd apps/ui && npm test -- --runTestsByPath src/__tests__/resource-not-found.test.tsx --runInBand`
- `cd apps/ui && npm run lint` (passes with existing warnings in unrelated files)
- `cd apps/ui && npm run build`
- `PORT_PREFIX=271 just start-dev --no-watch`
- Playwright smoke: `/harnesses/harness_019defa39e937b0c999ef870e8ded53b23` renders the sidebar, `Harness not found`, both actions, and the resource ID.
- `just pre-push`

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
