### PR TITLE
fix(worker): notify initial durable tasks via active backend

### DIFF
--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -22,6 +22,7 @@ use crate::{api, seed, services};
 use crate::middleware::RequestIdLayer;
 use crate::middleware::request_id::RequestId;
 use anyhow::{Context, Result};
+use async_trait::async_trait;
 use axum::http::{Method, header};
 use axum::{Json, Router, extract::State, routing::get};
 use everruns_core::{
@@ -32,7 +33,8 @@ use everruns_durable::{
     InMemoryWorkflowEventStore, PostgresWorkflowEventStore, WorkflowEventStore,
 };
 use everruns_worker::{
-    AgentRunner, RunnerBackend, TaskWorker, TaskWorkerConfig, create_runner_with_backend,
+    AgentRunner, DurableTaskNotifier, RunnerBackend, TaskWorker, TaskWorkerConfig,
+    create_runner_with_backend,
 };
 use serde::Serialize;
 use sqlx::PgPool;
@@ -58,6 +60,17 @@ type BackgroundTaskFn =
     Box<dyn FnOnce(ServerContext) -> Pin<Box<dyn Future<Output = ()> + Send>> + Send>;
 
 type ApiKeyRoutesWrapFn = Box<dyn FnOnce(Router) -> Router + Send>;
+
+struct ServerTaskNotifier {
+    broadcaster: Arc<crate::task_notifications::TaskBroadcaster>,
+}
+
+#[async_trait]
+impl DurableTaskNotifier for ServerTaskNotifier {
+    async fn notify_task_available(&self, activity_type: &str) {
+        self.broadcaster.notify_task_available(activity_type).await;
+    }
+}
 
 /// Apply the optional API-key-routes wrap closure to the api-key router.
 /// Identity when no wrap is configured.
@@ -279,6 +292,8 @@ impl ServerAppBuilder {
         // =====================================================================
         // Phase 1: Storage backend & runner
         // =====================================================================
+        let database_unpooled_url = std::env::var("DATABASE_UNPOOLED_URL").ok();
+        let task_broadcaster: Option<Arc<crate::task_notifications::TaskBroadcaster>>;
         let (db, runner, shared_durable_store, database_url) = if self.config.dev_mode {
             tracing::info!("Starting in DEV MODE (in-memory storage, no PostgreSQL required)");
 
@@ -288,6 +303,7 @@ impl ServerAppBuilder {
                 create_runner_with_backend(RunnerBackend::SharedInMemory(shared_store.clone()))
                     .await
                     .context("Failed to create in-memory agent runner")?;
+            task_broadcaster = None;
 
             tracing::info!(
                 "Using in-memory storage and durable execution engine with in-process worker"
@@ -345,7 +361,21 @@ impl ServerAppBuilder {
                 .pool()
                 .expect("PostgreSQL backend should have pool")
                 .clone();
-            let runner = create_runner_with_backend(RunnerBackend::Postgres(pool))
+            task_broadcaster = crate::task_notifications::TaskBroadcaster::from_env(
+                Some(&database_url),
+                database_unpooled_url.as_deref(),
+            )
+            .await
+            .map(Arc::new);
+            let runner_backend = if let Some(broadcaster) = task_broadcaster.clone() {
+                RunnerBackend::PostgresWithNotifier {
+                    pool,
+                    task_notifier: Arc::new(ServerTaskNotifier { broadcaster }),
+                }
+            } else {
+                RunnerBackend::Postgres(pool)
+            };
+            let runner = create_runner_with_backend(runner_backend)
                 .await
                 .context("Failed to create agent runner")?;
 
@@ -572,7 +602,6 @@ impl ServerAppBuilder {
         } else {
             crate::event_delivery::EventDelivery::from_env().await
         };
-        let database_unpooled_url = std::env::var("DATABASE_UNPOOLED_URL").ok();
         let resolve_listener_database_url = || {
             database_url
                 .as_deref()
@@ -874,18 +903,6 @@ impl ServerAppBuilder {
                         as Arc<dyn WorkflowEventStore + Send + Sync>
                 })
             };
-        // Create TaskBroadcaster early so it can be shared between durable_state and gRPC service
-        let task_broadcaster = if !self.config.dev_mode {
-            crate::task_notifications::TaskBroadcaster::from_env(
-                database_url.as_deref(),
-                database_unpooled_url.as_deref(),
-            )
-            .await
-            .map(Arc::new)
-        } else {
-            None
-        };
-
         // TM-DURABLE-010: All durable endpoints require admin role
         let durable_state = api::durable::AppState::new(
             durable_store.clone(),

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -362,7 +362,7 @@ impl ServerAppBuilder {
                 .expect("PostgreSQL backend should have pool")
                 .clone();
             task_broadcaster = crate::task_notifications::TaskBroadcaster::from_env(
-                Some(&database_url),
+                Some(database_url.as_str()),
                 database_unpooled_url.as_deref(),
             )
             .await

--- a/crates/worker/src/durable_runner.rs
+++ b/crates/worker/src/durable_runner.rs
@@ -528,100 +528,116 @@ impl AgentRunner for DurableRunner {
         };
         let workflow_id = session_id.uuid();
         let input_json = serde_json::to_value(&input)?;
-        let mut store = self.store.lock().await;
+        let notify_activity = {
+            let mut store = self.store.lock().await;
 
-        match store.try_claim_workflow_for_new_turn(workflow_id).await {
-            Ok(true) => {
-                if let Err(error) = store
-                    .enqueue_task(
-                        workflow_id,
-                        format!("input_{}", Uuid::now_v7()),
-                        "process_input".to_string(),
-                        input_json,
-                    )
-                    .await
-                {
-                    let _ = store
-                        .update_workflow_status(workflow_id, WorkflowStatus::Completed, None, None)
-                        .await;
-                    return Err(anyhow::anyhow!("Failed to enqueue task: {error}"));
+            match store.try_claim_workflow_for_new_turn(workflow_id).await {
+                Ok(true) => {
+                    if let Err(error) = store
+                        .enqueue_task(
+                            workflow_id,
+                            format!("input_{}", Uuid::now_v7()),
+                            "process_input".to_string(),
+                            input_json,
+                        )
+                        .await
+                    {
+                        let _ = store
+                            .update_workflow_status(
+                                workflow_id,
+                                WorkflowStatus::Completed,
+                                None,
+                                None,
+                            )
+                            .await;
+                        return Err(anyhow::anyhow!("Failed to enqueue task: {error}"));
+                    }
+                    Some("process_input")
                 }
-                self.notify_task_available("process_input").await;
-            }
-            Ok(false) => {
-                let signal = WorkflowSignal::new(
-                    everruns_durable::signal_types::USER_MESSAGE,
-                    serde_json::json!({
-                        "input_message_id": input_message_id.to_string(),
-                        "org_id": org_id,
-                        "harness_id": harness_id.to_string(),
-                        "agent_id": agent_id.map(|id| id.to_string()),
-                    }),
-                );
-                if let Err(error) = store.send_signal(workflow_id, signal).await {
-                    tracing::warn!(
-                        session_id = %session_id,
-                        %error,
-                        "failed to send steering signal"
+                Ok(false) => {
+                    let signal = WorkflowSignal::new(
+                        everruns_durable::signal_types::USER_MESSAGE,
+                        serde_json::json!({
+                            "input_message_id": input_message_id.to_string(),
+                            "org_id": org_id,
+                            "harness_id": harness_id.to_string(),
+                            "agent_id": agent_id.map(|id| id.to_string()),
+                        }),
                     );
+                    if let Err(error) = store.send_signal(workflow_id, signal).await {
+                        tracing::warn!(
+                            session_id = %session_id,
+                            %error,
+                            "failed to send steering signal"
+                        );
+                    }
+                    None
                 }
-                return Ok(());
-            }
-            Err(error) => {
-                let err = error.to_string();
-                if !err.contains("not found") && !err.contains("NOT_FOUND") {
-                    return Err(anyhow::anyhow!("Failed to check workflow status: {error}"));
+                Err(error) => {
+                    let err = error.to_string();
+                    if !err.contains("not found") && !err.contains("NOT_FOUND") {
+                        return Err(anyhow::anyhow!("Failed to check workflow status: {error}"));
+                    }
+
+                    store
+                        .create_workflow(workflow_id, "turn_workflow", input_json.clone())
+                        .await
+                        .map_err(|e| anyhow::anyhow!("Failed to create workflow: {e}"))?;
+
+                    let activity_id = format!("input_{}", Uuid::now_v7());
+                    let sequence = store
+                        .append_events(
+                            workflow_id,
+                            0,
+                            vec![WorkflowEvent::WorkflowStarted {
+                                input: input_json.clone(),
+                            }],
+                        )
+                        .await
+                        .map_err(|e| {
+                            anyhow::anyhow!("Failed to append WorkflowStarted event: {e}")
+                        })?;
+
+                    store
+                        .enqueue_task(
+                            workflow_id,
+                            activity_id.clone(),
+                            "process_input".to_string(),
+                            input_json.clone(),
+                        )
+                        .await
+                        .map_err(|e| anyhow::anyhow!("Failed to enqueue task: {e}"))?;
+
+                    store
+                        .update_workflow_status(workflow_id, WorkflowStatus::Running, None, None)
+                        .await
+                        .map_err(|e| {
+                            anyhow::anyhow!("Failed to set new workflow to Running: {e}")
+                        })?;
+
+                    let _ = store
+                        .append_events(
+                            workflow_id,
+                            sequence,
+                            vec![WorkflowEvent::ActivityScheduled {
+                                activity_id,
+                                activity_type: "process_input".to_string(),
+                                input: input_json,
+                                options: everruns_durable::ActivityOptions::default(),
+                            }],
+                        )
+                        .await
+                        .map_err(|e| {
+                            anyhow::anyhow!("Failed to append ActivityScheduled event: {e}")
+                        })?;
+
+                    Some("process_input")
                 }
-
-                store
-                    .create_workflow(workflow_id, "turn_workflow", input_json.clone())
-                    .await
-                    .map_err(|e| anyhow::anyhow!("Failed to create workflow: {e}"))?;
-
-                let activity_id = format!("input_{}", Uuid::now_v7());
-                let sequence = store
-                    .append_events(
-                        workflow_id,
-                        0,
-                        vec![WorkflowEvent::WorkflowStarted {
-                            input: input_json.clone(),
-                        }],
-                    )
-                    .await
-                    .map_err(|e| anyhow::anyhow!("Failed to append WorkflowStarted event: {e}"))?;
-
-                store
-                    .enqueue_task(
-                        workflow_id,
-                        activity_id.clone(),
-                        "process_input".to_string(),
-                        input_json.clone(),
-                    )
-                    .await
-                    .map_err(|e| anyhow::anyhow!("Failed to enqueue task: {e}"))?;
-                self.notify_task_available("process_input").await;
-
-                store
-                    .update_workflow_status(workflow_id, WorkflowStatus::Running, None, None)
-                    .await
-                    .map_err(|e| anyhow::anyhow!("Failed to set new workflow to Running: {e}"))?;
-
-                let _ = store
-                    .append_events(
-                        workflow_id,
-                        sequence,
-                        vec![WorkflowEvent::ActivityScheduled {
-                            activity_id,
-                            activity_type: "process_input".to_string(),
-                            input: input_json,
-                            options: everruns_durable::ActivityOptions::default(),
-                        }],
-                    )
-                    .await
-                    .map_err(|e| {
-                        anyhow::anyhow!("Failed to append ActivityScheduled event: {e}")
-                    })?;
             }
+        };
+
+        if let Some(activity_type) = notify_activity {
+            self.notify_task_available(activity_type).await;
         }
 
         Ok(())
@@ -674,6 +690,7 @@ impl AgentRunner for DurableRunner {
                 .await;
             return Err(anyhow::anyhow!("Failed to enqueue reason task: {error}"));
         }
+        drop(store);
         self.notify_task_available("reason").await;
 
         Ok(())

--- a/crates/worker/src/durable_runner.rs
+++ b/crates/worker/src/durable_runner.rs
@@ -18,6 +18,11 @@ use uuid::Uuid;
 use crate::grpc_durable_store::{GrpcDurableStore, WorkflowStatus as GrpcWorkflowStatus};
 use crate::runner::AgentRunner;
 
+#[async_trait]
+pub trait DurableTaskNotifier: Send + Sync {
+    async fn notify_task_available(&self, activity_type: &str);
+}
+
 /// Output metadata for durable turns.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct DurableTurnOutput {
@@ -416,6 +421,7 @@ impl DurableStoreBackend for InMemoryDurableStore {
 /// This runner maps runtime turn state onto the durable engine.
 pub struct DurableRunner {
     store: Arc<Mutex<dyn DurableStoreBackend>>,
+    task_notifier: Option<Arc<dyn DurableTaskNotifier>>,
 }
 
 impl DurableRunner {
@@ -428,6 +434,7 @@ impl DurableRunner {
         let store = GrpcDurableStore::connect(grpc_address).await?;
         Ok(Self {
             store: Arc::new(Mutex::new(store)),
+            task_notifier: None,
         })
     }
 
@@ -436,6 +443,19 @@ impl DurableRunner {
         let store = DirectDurableStore::new(pool);
         Self {
             store: Arc::new(Mutex::new(store)),
+            task_notifier: None,
+        }
+    }
+
+    pub fn new_with_pool_and_task_notifier(
+        pool: sqlx::PgPool,
+        task_notifier: Arc<dyn DurableTaskNotifier>,
+    ) -> Self {
+        info!("Initializing durable runner (direct DB mode with task notifier)");
+        let store = DirectDurableStore::new(pool);
+        Self {
+            store: Arc::new(Mutex::new(store)),
+            task_notifier: Some(task_notifier),
         }
     }
 
@@ -444,6 +464,7 @@ impl DurableRunner {
         let store = InMemoryDurableStore::new();
         Self {
             store: Arc::new(Mutex::new(store)),
+            task_notifier: None,
         }
     }
 
@@ -452,13 +473,25 @@ impl DurableRunner {
         let store = InMemoryDurableStore::from_shared(shared_store);
         Self {
             store: Arc::new(Mutex::new(store)),
+            task_notifier: None,
         }
+    }
+
+    pub fn with_task_notifier(mut self, task_notifier: Arc<dyn DurableTaskNotifier>) -> Self {
+        self.task_notifier = Some(task_notifier);
+        self
     }
 
     pub async fn from_env() -> Result<Self> {
         let grpc_address =
             std::env::var("WORKER_GRPC_ADDRESS").unwrap_or_else(|_| "127.0.0.1:9001".to_string());
         Self::new(&grpc_address).await
+    }
+
+    async fn notify_task_available(&self, activity_type: &str) {
+        if let Some(task_notifier) = &self.task_notifier {
+            task_notifier.notify_task_available(activity_type).await;
+        }
     }
 }
 
@@ -513,6 +546,7 @@ impl AgentRunner for DurableRunner {
                         .await;
                     return Err(anyhow::anyhow!("Failed to enqueue task: {error}"));
                 }
+                self.notify_task_available("process_input").await;
             }
             Ok(false) => {
                 let signal = WorkflowSignal::new(
@@ -565,6 +599,7 @@ impl AgentRunner for DurableRunner {
                     )
                     .await
                     .map_err(|e| anyhow::anyhow!("Failed to enqueue task: {e}"))?;
+                self.notify_task_available("process_input").await;
 
                 store
                     .update_workflow_status(workflow_id, WorkflowStatus::Running, None, None)
@@ -639,6 +674,7 @@ impl AgentRunner for DurableRunner {
                 .await;
             return Err(anyhow::anyhow!("Failed to enqueue reason task: {error}"));
         }
+        self.notify_task_available("reason").await;
 
         Ok(())
     }
@@ -698,6 +734,30 @@ fn runtime_to_grpc_status(status: WorkflowStatus) -> GrpcWorkflowStatus {
 mod tests {
     use super::*;
 
+    #[derive(Default)]
+    struct RecordingTaskNotifier {
+        activity_types: std::sync::Mutex<Vec<String>>,
+    }
+
+    impl RecordingTaskNotifier {
+        fn activity_types(&self) -> Vec<String> {
+            self.activity_types
+                .lock()
+                .expect("recorded activity types lock poisoned")
+                .clone()
+        }
+    }
+
+    #[async_trait]
+    impl DurableTaskNotifier for RecordingTaskNotifier {
+        async fn notify_task_available(&self, activity_type: &str) {
+            self.activity_types
+                .lock()
+                .expect("recorded activity types lock poisoned")
+                .push(activity_type.to_string());
+        }
+    }
+
     #[tokio::test]
     async fn start_run_creates_new_workflow_and_input_task() {
         let shared = Arc::new(InMemoryWorkflowEventStore::new());
@@ -723,6 +783,28 @@ mod tests {
             .expect("task should be claimable");
         assert_eq!(claimed.len(), 1);
         assert_eq!(claimed[0].activity_type, "process_input");
+    }
+
+    #[tokio::test]
+    async fn start_run_notifies_initial_process_input_task() {
+        let shared = Arc::new(InMemoryWorkflowEventStore::new());
+        let notifier = Arc::new(RecordingTaskNotifier::default());
+        let runner = DurableRunner::new_with_shared_store(shared.clone())
+            .with_task_notifier(notifier.clone());
+
+        runner
+            .start_run(
+                1,
+                SessionId::new(),
+                HarnessId::new(),
+                None,
+                MessageId::new(),
+                None,
+            )
+            .await
+            .expect("start_run should create workflow");
+
+        assert_eq!(notifier.activity_types(), vec!["process_input"]);
     }
 
     #[tokio::test]
@@ -873,5 +955,50 @@ mod tests {
             .expect("reason task should be claimable");
         assert_eq!(claimed.len(), 1);
         assert_eq!(claimed[0].activity_type, "reason");
+    }
+
+    #[tokio::test]
+    async fn resume_after_tool_results_notifies_reason_task() {
+        let shared = Arc::new(InMemoryWorkflowEventStore::new());
+        let notifier = Arc::new(RecordingTaskNotifier::default());
+        let session_id = SessionId::new();
+        let saved_input = DurableTurnInput {
+            org_id: 1,
+            session_id,
+            harness_id: HarnessId::new(),
+            agent_id: Some(AgentId::new()),
+            input_message_id: MessageId::new(),
+            turn_id: None,
+            previous_response_id: Some("resp_123".to_string()),
+            iteration: 3,
+            request_id: None,
+        };
+        shared
+            .create_workflow(
+                session_id.uuid(),
+                "turn_workflow",
+                serde_json::to_value(&saved_input).expect("serialize input"),
+                None,
+            )
+            .await
+            .expect("create workflow");
+        shared
+            .update_workflow_status(
+                session_id.uuid(),
+                WorkflowStatus::Completed,
+                Some(serde_json::to_value(&saved_input).expect("serialize result")),
+                None,
+            )
+            .await
+            .expect("mark completed");
+
+        let runner = DurableRunner::new_with_shared_store(shared.clone())
+            .with_task_notifier(notifier.clone());
+        runner
+            .resume_after_tool_results(session_id)
+            .await
+            .expect("resume should enqueue reason");
+
+        assert_eq!(notifier.activity_types(), vec!["reason"]);
     }
 }

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -30,8 +30,8 @@ pub mod worker_adapters;
 
 // Re-export main types
 pub use durable_runner::{
-    DirectDurableStore, DurableRunner, DurableStoreBackend, DurableTurnInput, DurableTurnOutput,
-    InMemoryDurableStore,
+    DirectDurableStore, DurableRunner, DurableStoreBackend, DurableTaskNotifier, DurableTurnInput,
+    DurableTurnOutput, InMemoryDurableStore,
 };
 pub use durable_worker::{DurableWorker, DurableWorkerConfig, ShutdownHandle};
 pub use grpc_durable_store::{

--- a/crates/worker/src/runner.rs
+++ b/crates/worker/src/runner.rs
@@ -19,7 +19,7 @@ use everruns_core::typed_id::{AgentId, HarnessId, MessageId, SessionId};
 use everruns_durable::InMemoryWorkflowEventStore;
 use std::sync::Arc;
 
-use crate::durable_runner::DurableRunner;
+use crate::durable_runner::{DurableRunner, DurableTaskNotifier};
 
 // =============================================================================
 // AgentRunner Trait
@@ -71,6 +71,11 @@ pub trait AgentRunner: Send + Sync {
 pub enum RunnerBackend {
     /// Use PostgreSQL for workflow persistence (production)
     Postgres(sqlx::PgPool),
+    /// Use PostgreSQL and publish task availability through the control-plane notifier.
+    PostgresWithNotifier {
+        pool: sqlx::PgPool,
+        task_notifier: Arc<dyn DurableTaskNotifier>,
+    },
     /// Use in-memory storage (dev mode, no database required)
     InMemory,
     /// Use shared in-memory storage (dev mode with in-process worker)
@@ -107,6 +112,16 @@ pub async fn create_runner_with_backend(backend: RunnerBackend) -> Result<Arc<dy
         RunnerBackend::Postgres(pool) => {
             tracing::info!("Creating Durable execution engine runner (PostgreSQL mode)");
             let runner = DurableRunner::new_with_pool(pool);
+            Ok(Arc::new(runner))
+        }
+        RunnerBackend::PostgresWithNotifier {
+            pool,
+            task_notifier,
+        } => {
+            tracing::info!(
+                "Creating Durable execution engine runner (PostgreSQL mode with task notifier)"
+            );
+            let runner = DurableRunner::new_with_pool_and_task_notifier(pool, task_notifier);
             Ok(Arc::new(runner))
         }
         RunnerBackend::InMemory => {


### PR DESCRIPTION
## What
Fixes EVE-410 by making direct durable runner task scheduling publish through the active task notification backend.

## Why
When `NATS_URL` was enabled, the first `process_input` task for a user message was inserted directly through the Postgres durable store. That path relied on PG NOTIFY triggers, but workers were listening through the NATS task notification stream, so the initial task waited for fallback polling before `session.activated`.

## How
- Added a worker-owned `DurableTaskNotifier` interface.
- Wired the Postgres-backed control-plane runner with the server's selected `TaskBroadcaster`.
- Notify after direct `process_input` and direct `reason` task enqueues.
- Kept PG behavior intact: `TaskBroadcaster::notify_task_available` is a no-op for PG because DB triggers already publish PG NOTIFY.
- Added runner-level regression tests for the initial `process_input` notification and direct `reason` resume notification.

## Risk
- Low / Medium / High: Low
- What can break: duplicate task availability notifications could cause extra claim attempts, but task claiming remains guarded by durable queue status and `SKIP LOCKED`; PG backend stays trigger-driven/no-op through the broadcaster.

## Security
- Threat categories reviewed: TM-DOS, TM-TENANT, TM-API
- Findings and resolutions: No new external input, authz boundary, tenant query, or secret handling was added. The change only publishes task availability for already-authorized durable tasks. Resource risk from duplicate notifications is bounded because workers claim through existing durable queue locking and status checks.

## Validation
- `cargo test -p everruns-worker durable_runner --lib`
- `cargo check -p everruns-server`
- `just pre-push`
- Prod-like smoke with local Postgres + NATS + server + worker:
  - `process_input` claim delay: 3.250ms
  - `reason` claim delay: 5.948ms
  - `input.message` to `session.activated`: ~39.568ms

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
