### PR TITLE
test(mcp): add adversarial org-scope coverage

### DIFF
--- a/crates/server/src/api/mcp_endpoint/catalog.rs
+++ b/crates/server/src/api/mcp_endpoint/catalog.rs
@@ -80,6 +80,8 @@ pub fn build_toolset(ctx: CatalogContext, mode: ToolsetMode) -> ScriptingToolSet
         );
 
     for desc in inventory::iter::<crate::domains::common::CommandDescriptor> {
+        // THREAT[TM-MCP-002]: MCP `query` must not expose mutating server
+        // tools. Read-only classification is backed by inventory tests.
         if mode == ToolsetMode::ReadOnly && !(desc.read_only)() {
             continue;
         }

--- a/crates/server/src/api/mcp_endpoint/mod.rs
+++ b/crates/server/src/api/mcp_endpoint/mod.rs
@@ -760,6 +760,8 @@ async fn resolve_org_override(
     default_org: &ResolvedOrg,
     state: &AppState,
 ) -> Result<ResolvedOrg, String> {
+    // THREAT[TM-MCP-001]: External MCP clients can pass organization_id on
+    // server tools; resolve it through fresh membership before dispatch.
     let org_public_id = match args.get("organization_id").and_then(|v| v.as_str()) {
         Some(id) => id,
         None => return Ok(default_org.clone()),

--- a/crates/server/tests/command_policy_enforcement_test.rs
+++ b/crates/server/tests/command_policy_enforcement_test.rs
@@ -13,6 +13,7 @@
 //!     role map (including denying an Owner) — the SaaS enforcement contract.
 //!  4. `dispatch()` (MCP + gRPC `ExecuteCommand`) enforces identically.
 //!  5. Inventory coverage: every mutating command declares `policy()`.
+//!  6. MCP `query` exposes only reviewed non-GET read-only helpers.
 //!
 //! Run with: cargo test -p everruns-server --test command_policy_enforcement_test
 
@@ -247,8 +248,40 @@ fn every_non_readonly_command_declares_policy() {
     );
 }
 
+#[test]
+fn mcp_query_read_only_overrides_are_allowlisted() {
+    use everruns_server::domains::common::CommandDescriptor;
+
+    let mut non_get_read_only: Vec<&'static str> = inventory::iter::<CommandDescriptor>
+        .into_iter()
+        .filter_map(|desc| {
+            let meta = (desc.meta)();
+            ((desc.read_only)() && meta.method != "GET").then_some(meta.name)
+        })
+        .collect();
+    non_get_read_only.sort_unstable();
+
+    let mut allowed = ALLOWED_NON_GET_READ_ONLY.to_vec();
+    allowed.sort_unstable();
+
+    assert_eq!(
+        non_get_read_only, allowed,
+        "MCP query exposes every read_only() command. Non-GET read-only overrides \
+         must stay intentionally reviewed so mutating commands do not drift into query."
+    );
+}
+
 /// Commands intentionally exposed without a policy (public reads, probes).
 /// Keep tiny; justify every entry in a comment.
 const ALLOWED_PUBLIC: &[&str] = &[
     // (none today)
+];
+
+/// POST-style helpers intentionally available through MCP `query`.
+/// They do not persist state and each still declares a view policy.
+const ALLOWED_NON_GET_READ_ONLY: &[&str] = &[
+    "grep_session_files",
+    "preview_agent",
+    "preview_harness",
+    "stat_session_file",
 ];

--- a/crates/server/tests/mcp_endpoint_test.rs
+++ b/crates/server/tests/mcp_endpoint_test.rs
@@ -13,10 +13,11 @@
 mod test_harness;
 
 use axum::http::{Method, StatusCode};
+use everruns_core::DEFAULT_ORG_PUBLIC_ID;
 use everruns_core::capability_types::VirtualFileTree;
 use everruns_core::typed_id::SessionId;
 use serde_json::{Value, json};
-use test_harness::TestServer;
+use test_harness::{TestServer, extract_cookie};
 
 // ============================================================================
 // Helpers
@@ -1610,6 +1611,327 @@ async fn test_mcp_execute_create_mcp_server() {
     let created = tool_json(&resp);
     assert_eq!(created["name"], unique_name);
     assert!(created["id"].as_str().unwrap().starts_with("mcp_"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_adversarial_tool_chain_cannot_escape_org_scope() {
+    let server = TestServer::in_memory().await;
+    let marker = format!("org2-agent-marker-{}", unique_suffix());
+    let escaped_name = format!("mcp-escape-success-{}", unique_suffix());
+
+    let org2: Value = server
+        .post(
+            "/v1/orgs",
+            json!({ "name": format!("MCP Escape Target {}", unique_suffix()) }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+    let org2_id = org2["id"].as_str().expect("org2 id").to_string();
+
+    let switch_resp = server
+        .post("/v1/users/me/switch-org", json!({ "org_id": org2_id }))
+        .await
+        .assert_status(StatusCode::OK);
+    let org2_cookie = extract_cookie(switch_resp.headers(), "everruns_org");
+
+    let create_agent_resp = mcp_tool_call_with_headers(
+        &server,
+        "execute",
+        json!({
+            "commands": format!(
+                "create_agent --name '{marker}' --display_name 'Org 2 Marker' --system_prompt 'tenant marker'"
+            )
+        }),
+        vec![("cookie", org2_cookie.as_str())],
+    )
+    .await;
+    assert!(
+        !tool_is_error(&create_agent_resp),
+        "org2 setup create_agent failed: {}",
+        tool_text(&create_agent_resp)
+    );
+    let org2_agent = tool_json(&create_agent_resp);
+    let org2_agent_id = org2_agent["id"].as_str().expect("org2 agent id");
+
+    let run_org2_resp = mcp_tool_call_with_headers(
+        &server,
+        "agent_run",
+        json!({
+            "agent_id": org2_agent_id,
+            "message": "seed cross-org session",
+            "title": "org2 adversarial session",
+        }),
+        vec![("cookie", org2_cookie.as_str())],
+    )
+    .await;
+    assert!(
+        !tool_is_error(&run_org2_resp),
+        "org2 setup agent_run failed: {}",
+        tool_text(&run_org2_resp)
+    );
+    let org2_session = tool_json(&run_org2_resp);
+    let org2_session_id = org2_session["session_id"]
+        .as_str()
+        .expect("org2 session id");
+
+    let discover_agents = mcp_tool_call(
+        &server,
+        "discover",
+        json!({ "query": "agent", "include_schemas": true }),
+    )
+    .await;
+    assert!(
+        !tool_is_error(&discover_agents),
+        "discover agent failed: {}",
+        tool_text(&discover_agents)
+    );
+    let discover_agent_text = tool_text(&discover_agents);
+    assert!(discover_agent_text.contains("get_agent"));
+    assert!(discover_agent_text.contains("update_agent"));
+
+    let discover_sessions = mcp_tool_call(
+        &server,
+        "discover",
+        json!({ "query": "session", "include_schemas": true }),
+    )
+    .await;
+    assert!(
+        !tool_is_error(&discover_sessions),
+        "discover session failed: {}",
+        tool_text(&discover_sessions)
+    );
+    let discover_session_text = tool_text(&discover_sessions);
+    assert!(discover_session_text.contains("get_session"));
+    assert!(discover_session_text.contains("create_message"));
+
+    let wrong_org_query = mcp_tool_call(
+        &server,
+        "query",
+        json!({ "commands": format!("get_agent {org2_agent_id}") }),
+    )
+    .await;
+    assert!(
+        tool_is_error(&wrong_org_query),
+        "default org query unexpectedly read org2 agent: {}",
+        tool_text(&wrong_org_query)
+    );
+    assert!(
+        !tool_text(&wrong_org_query).contains(&marker),
+        "cross-org query leaked org2 marker: {}",
+        tool_text(&wrong_org_query)
+    );
+
+    let wrong_org_probe = mcp_tool_call(
+        &server,
+        "query",
+        json!({
+            "commands": format!(
+                "list_agents --limit 200 | jq -e --arg id '{org2_agent_id}' '.data[] | select(.id == $id)'"
+            )
+        }),
+    )
+    .await;
+    assert!(
+        tool_is_error(&wrong_org_probe),
+        "default org query unexpectedly found org2 agent: {}",
+        tool_text(&wrong_org_probe)
+    );
+    assert!(
+        !tool_text(&wrong_org_probe).contains(&marker),
+        "cross-org list probe leaked org2 marker: {}",
+        tool_text(&wrong_org_probe)
+    );
+
+    let wrong_org_execute = mcp_tool_call(
+        &server,
+        "execute",
+        json!({
+            "commands": format!("update_agent --id {org2_agent_id} --name '{escaped_name}'")
+        }),
+    )
+    .await;
+    assert!(
+        tool_is_error(&wrong_org_execute),
+        "default org execute unexpectedly mutated org2 agent: {}",
+        tool_text(&wrong_org_execute)
+    );
+
+    let wrong_org_agent_run = mcp_tool_call(
+        &server,
+        "agent_run",
+        json!({
+            "agent_id": org2_agent_id,
+            "message": "run the other tenant's agent",
+            "title": "cross-org run attempt",
+        }),
+    )
+    .await;
+    assert!(
+        tool_is_error(&wrong_org_agent_run),
+        "default org agent_run unexpectedly used org2 agent: {}",
+        tool_text(&wrong_org_agent_run)
+    );
+
+    let wrong_org_status = mcp_tool_call(
+        &server,
+        "session_get_status",
+        json!({ "session_id": org2_session_id }),
+    )
+    .await;
+    assert!(
+        tool_is_error(&wrong_org_status),
+        "default org session_get_status unexpectedly read org2 session: {}",
+        tool_text(&wrong_org_status)
+    );
+
+    let wrong_org_send = mcp_tool_call(
+        &server,
+        "session_send_message",
+        json!({
+            "session_id": org2_session_id,
+            "message": "write into the other tenant session",
+        }),
+    )
+    .await;
+    assert!(
+        tool_is_error(&wrong_org_send),
+        "default org session_send_message unexpectedly wrote org2 session: {}",
+        tool_text(&wrong_org_send)
+    );
+
+    let fake_org_override = mcp_tool_call(
+        &server,
+        "execute",
+        json!({
+            "organization_id": "org_ffffffffffffffffffffffffffffffff",
+            "commands": format!("update_agent --id {org2_agent_id} --name '{escaped_name}'"),
+        }),
+    )
+    .await;
+    assert!(
+        tool_is_error(&fake_org_override),
+        "non-member organization_id override unexpectedly executed: {}",
+        tool_text(&fake_org_override)
+    );
+    assert!(
+        tool_text(&fake_org_override).contains("Organization not found")
+            || tool_text(&fake_org_override).contains("not a member"),
+        "expected membership failure, got: {}",
+        tool_text(&fake_org_override)
+    );
+
+    let default_org_override = mcp_tool_call(
+        &server,
+        "query",
+        json!({
+            "organization_id": DEFAULT_ORG_PUBLIC_ID,
+            "commands": "list_agents --limit 5",
+        }),
+    )
+    .await;
+    assert!(
+        !tool_is_error(&default_org_override),
+        "default org override should remain usable: {}",
+        tool_text(&default_org_override)
+    );
+    assert!(
+        !tool_text(&default_org_override).contains(&marker),
+        "default org override leaked org2 marker: {}",
+        tool_text(&default_org_override)
+    );
+
+    let org2_after_attack = mcp_tool_call_with_headers(
+        &server,
+        "query",
+        json!({ "commands": format!("get_agent {org2_agent_id}") }),
+        vec![("cookie", org2_cookie.as_str())],
+    )
+    .await;
+    assert!(
+        !tool_is_error(&org2_after_attack),
+        "org2 verification get_agent failed: {}",
+        tool_text(&org2_after_attack)
+    );
+    let org2_agent_after_attack = tool_json(&org2_after_attack);
+    assert_eq!(org2_agent_after_attack["name"], marker);
+    assert_ne!(org2_agent_after_attack["name"], escaped_name);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_resources_read_cannot_escape_org_scope() {
+    let server = TestServer::in_memory().await;
+    let marker = format!("org2-resource-marker-{}", unique_suffix());
+
+    let org2: Value = server
+        .post(
+            "/v1/orgs",
+            json!({ "name": format!("MCP Resource Target {}", unique_suffix()) }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+    let org2_id = org2["id"].as_str().expect("org2 id").to_string();
+
+    let switch_resp = server
+        .post("/v1/users/me/switch-org", json!({ "org_id": org2_id }))
+        .await
+        .assert_status(StatusCode::OK);
+    let org2_cookie = extract_cookie(switch_resp.headers(), "everruns_org");
+
+    let create_agent_resp = mcp_tool_call_with_headers(
+        &server,
+        "execute",
+        json!({
+            "commands": format!(
+                "create_agent --name '{marker}' --display_name 'Org 2 Resource Marker' --system_prompt 'tenant marker'"
+            )
+        }),
+        vec![("cookie", org2_cookie.as_str())],
+    )
+    .await;
+    assert!(
+        !tool_is_error(&create_agent_resp),
+        "org2 setup create_agent failed: {}",
+        tool_text(&create_agent_resp)
+    );
+
+    let default_resources = mcp_call(
+        &server,
+        "resources/read",
+        json!({ "uri": "everruns://agents" }),
+    )
+    .await;
+    assert!(
+        default_resources["error"].is_null(),
+        "default resources/read failed: {default_resources}"
+    );
+    let default_text = default_resources["result"]["contents"][0]["text"]
+        .as_str()
+        .expect("default resource text");
+    assert!(
+        !default_text.contains(&marker),
+        "default org resources/read leaked org2 marker: {default_text}"
+    );
+
+    let org2_resources = mcp_call_with_headers(
+        &server,
+        "resources/read",
+        json!({ "uri": "everruns://agents" }),
+        vec![("cookie", org2_cookie.as_str())],
+    )
+    .await;
+    assert!(
+        org2_resources["error"].is_null(),
+        "org2 resources/read failed: {org2_resources}"
+    );
+    let org2_text = org2_resources["result"]["contents"][0]["text"]
+        .as_str()
+        .expect("org2 resource text");
+    assert!(
+        org2_text.contains(&marker),
+        "org2 resources/read should see its own marker: {org2_text}"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/server/tests/test_harness.rs
+++ b/crates/server/tests/test_harness.rs
@@ -209,7 +209,8 @@ impl TestServer {
             db.clone(),
             platform_definition.clone(),
         );
-        let auth_state = auth::AuthState::new(auth_config.clone(), Arc::new(auth_backend.clone()));
+        let auth_state = auth::AuthState::new(auth_config.clone(), Arc::new(auth_backend.clone()))
+            .with_db(db.clone());
 
         // Create runner with PostgreSQL backend
         let runner = match mode {

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -27,6 +27,7 @@ Format: `TM-<CATEGORY>-<NNN>`
 | TM-BASH | Bash Sandbox | Bashkit sandbox escape, resource exhaustion, VFS boundary |
 | TM-DOS | Denial of Service | Resource exhaustion, large payloads |
 | TM-CLIENT | Client-Side Tools | Tool ID spoofing, timeout abuse |
+| TM-MCP | MCP Server | First-party `/mcp` endpoint, MCP OAuth, external MCP clients, MCP server tool discovery/execution |
 | TM-SLACK | Slack Integration | Webhook forgery, signing secret leak, bot loops |
 
 ### Managing Threat IDs
@@ -460,6 +461,33 @@ ZIP archive extraction in `SkillService::create_from_archive()` enforces:
 3. Per-file size limit: 1 MB per individual file
 4. Total decompressed size limit: 10 MB
 5. Files extracted into `skill_files` table as individual rows (no runtime ZIP extraction)
+
+## 7b. MCP Server (TM-MCP)
+
+This section covers Everruns acting as an MCP server for external MCP clients. It does not cover harness/session tool execution or Everruns acting as an MCP client to remote MCP servers; those belong under `TM-TOOL`, `TM-AGENT`, and integration-specific categories.
+
+| ID | Threat | Severity | Mitigation | Status |
+|----|--------|----------|------------|--------|
+| TM-MCP-001 | Everruns MCP server tenant escape | Critical | The first-party `/mcp` endpoint resolves org context before every tool call; `query` exposes only read-only inventory commands; `execute` and tier-1 agent/session tools dispatch through org-scoped domain commands and `Command::run` policy checks. Regression coverage in `crates/server/tests/mcp_endpoint_test.rs` chains `discover`, `query`, `execute`, `agent_run`, `session_get_status`, and `session_send_message` against cross-org bait and verifies no read/write escape; resources/read is also covered against cross-org bait. | MITIGATED |
+| TM-MCP-002 | Mutating command exposed through read-only `query` | High | `query` builds a read-only command toolset from `Command::read_only()`. Inventory coverage in `crates/server/tests/command_policy_enforcement_test.rs` allows only a small reviewed set of POST-style read helpers to override `read_only() == true`. | MITIGATED |
+
+### Mitigation Details
+
+**TM-MCP-001 — Everruns MCP Server Tenant Escape:**
+The first-party MCP endpoint is both a discovery surface and an execution surface: `discover` publishes the command catalog, `query` runs bashkit scripts over read-only builtins, `execute` runs scripts over the full command set, and tier-1 tools (`agent_run`, `session_send_message`, `session_get_status`) compose session and message commands directly. The threat is a caller using catalog discovery plus scripted control flow, guessed IDs, or `organization_id` overrides to read or mutate another organization.
+
+Mitigations are layered:
+- The request `ResolvedOrg` is derived from authenticated org membership; per-tool `organization_id` overrides are resolved against fresh membership before dispatch.
+- API-key callers cannot use per-tool org overrides to switch away from the org selected by request auth.
+- `query` receives a read-only toolset built from inventory descriptors whose `read_only()` flag is true.
+- `execute` and tier-1 tools dispatch through domain commands, preserving repository org filters and `Command::run` policy checks.
+- MCP `resources/read` routes through policy-gated list commands instead of raw storage reads.
+- Bashkit runs the scripted surface with parser, input, command-count, loop, function-depth, AST-depth, and timeout limits.
+
+Regression coverage: `test_mcp_adversarial_tool_chain_cannot_escape_org_scope` creates real cross-org bait, discovers the relevant agent/session operations, then attacks the wrong org with `query`, `execute`, `agent_run`, `session_get_status`, `session_send_message`, and a non-member `organization_id` override. `test_mcp_resources_read_cannot_escape_org_scope` verifies resource reads do not leak cross-org agent summaries. Both tests assert no data leak and no mutation.
+
+**TM-MCP-002 — Read-Only Query Catalog Drift:**
+The MCP `query` tool is intentionally safer than `execute`, but that safety depends on the inventory metadata for every command. By default, only `GET` commands are read-only. POST-style helpers must explicitly override `read_only() == true`; each such override is reviewed in `mcp_query_read_only_overrides_are_allowlisted` to prevent a future mutating command from becoming available through `query`.
 
 **TM-TOOL-015 — Browserless URL Validation (MITIGATED):**
 Browserless tools now reuse the shared `validate_safe_url()` policy from core. This blocks:


### PR DESCRIPTION
## What
Add adversarial MCP server coverage for org-scope enforcement across first-party `/mcp` tools.

## Why
External MCP clients can combine discovery, scripted `query`/`execute`, tier-1 agent/session tools, guessed IDs, and `organization_id` overrides. The test suite should prove those paths cannot read or mutate resources outside the caller's organization.

## How
- Added black-box MCP tests that create cross-org bait and attack it through `discover`, `query`, `execute`, `agent_run`, `session_get_status`, `session_send_message`, and `resources/read`.
- Added a command inventory guard so MCP `query` only exposes reviewed non-GET read-only helpers.
- Updated the MCP threat-model category and added mitigation comments near the org override and read-only catalog boundaries.
- Fixed the in-memory test harness auth state to resolve org switch cookies through the DB, matching production setup.

## Risk
- Low / Medium / High: Medium
- What can break: MCP endpoint tests and command inventory expectations may fail if new commands are added without correct read-only/policy metadata. The harness auth-state change affects tests only and matches production behavior.

## Security
- Threat categories reviewed: `TM-MCP`, `TM-TENANT`, `TM-AUTHZ`, `TM-BASH`.
- Findings and resolutions: Added regression coverage for MCP cross-org read/write escape attempts and catalog drift where mutating commands could become available through read-only `query`. Live security probing also found unsafe MCP OAuth redirect URI validation; tracked separately as Linear `EVE-411` because this PR is test/threat-model coverage only.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

Validation:
- `cargo fmt --check`
- `cargo test -p everruns-server --test mcp_endpoint_test cannot_escape_org_scope`
- `cargo test -p everruns-server --test command_policy_enforcement_test mcp_query_read_only_overrides_are_allowlisted`
- `cargo test -p everruns-server --test command_policy_enforcement_test`
- `cargo clippy -p everruns-server --tests -- -D warnings`
- `just pre-push`
- Smoke: `PORT_PREFIX=395 just start-dev --no-watch`, then `/mcp tools/list` returned 9 tools and MCP `query` ran `list_harnesses | jq length` successfully.