### PR TITLE
fix(core): cap infinity context prompt window

### DIFF
--- a/crates/core/src/capabilities/infinity_context.rs
+++ b/crates/core/src/capabilities/infinity_context.rs
@@ -84,6 +84,13 @@ struct InfinityContextConfig {
     /// Minimum number of recent messages to keep even when the budget is tight.
     #[serde(default = "default_min_recent_messages")]
     min_recent_messages: usize,
+
+    /// Optional hard cap on recent messages kept in the live prompt.
+    ///
+    /// Useful for public support chats where the prompt must stay small even
+    /// when the token-budget estimate would allow more messages.
+    #[serde(default)]
+    max_recent_messages: Option<usize>,
 }
 
 fn default_context_budget_tokens() -> usize {
@@ -99,6 +106,7 @@ impl Default for InfinityContextConfig {
         Self {
             context_budget_tokens: default_context_budget_tokens(),
             min_recent_messages: default_min_recent_messages(),
+            max_recent_messages: None,
         }
     }
 }
@@ -109,6 +117,15 @@ fn calculate_message_limit(budget_tokens: usize, min_recent_messages: usize) -> 
     (budget_tokens / AVG_TOKENS_PER_MESSAGE).max(min_recent_messages)
 }
 
+fn resolve_message_limit(config: &InfinityContextConfig) -> usize {
+    let estimated =
+        calculate_message_limit(config.context_budget_tokens, config.min_recent_messages);
+    config
+        .max_recent_messages
+        .map(|max| estimated.min(max.max(1)))
+        .unwrap_or(estimated)
+}
+
 struct InfinityContextFilterProvider;
 
 impl MessageFilterProvider for InfinityContextFilterProvider {
@@ -116,10 +133,7 @@ impl MessageFilterProvider for InfinityContextFilterProvider {
         let config: InfinityContextConfig =
             serde_json::from_value(config.clone()).unwrap_or_default();
 
-        query.limit = Some(calculate_message_limit(
-            config.context_budget_tokens,
-            config.min_recent_messages,
-        ) as i64);
+        query.limit = Some(resolve_message_limit(&config) as i64);
         query.prepend_transform = Some(Arc::new(ExcludedNoticeTransform::infinity_context()));
     }
 
@@ -423,6 +437,17 @@ mod tests {
     }
 
     #[test]
+    fn test_resolve_message_limit_respects_hard_cap() {
+        let config = InfinityContextConfig {
+            context_budget_tokens: 10_000,
+            min_recent_messages: 10,
+            max_recent_messages: Some(30),
+        };
+
+        assert_eq!(resolve_message_limit(&config), 30);
+    }
+
+    #[test]
     fn test_capability_metadata() {
         let capability = InfinityContextCapability;
 
@@ -444,6 +469,23 @@ mod tests {
         );
 
         assert_eq!(query.limit, Some(4));
+        assert!(query.prepend_transform.is_some());
+    }
+
+    #[test]
+    fn test_filter_provider_allows_small_public_chat_window() {
+        let mut query = MessageQuery::new(SessionId::new());
+        let provider = InfinityContextFilterProvider;
+        provider.apply_filters(
+            &mut query,
+            &json!({
+                "context_budget_tokens": 10_000,
+                "min_recent_messages": 10,
+                "max_recent_messages": 30
+            }),
+        );
+
+        assert_eq!(query.limit, Some(30));
         assert!(query.prepend_transform.is_some());
     }
 

--- a/crates/core/src/memory.rs
+++ b/crates/core/src/memory.rs
@@ -163,49 +163,7 @@ impl MessageRetriever for InMemoryMessageRetriever {
             }
         }
 
-        // Apply offset
-        if let Some(offset) = query.offset {
-            let offset = offset.max(0i64) as usize;
-            if offset < messages.len() {
-                messages = messages.into_iter().skip(offset).collect();
-            } else {
-                messages.clear();
-            }
-        }
-
-        // Track count before limit for prepend transform
-        let count_before_limit = messages.len();
-
-        // Apply limit - keep the most RECENT messages (drop oldest)
-        if let Some(limit) = query.limit {
-            let limit = limit.max(0i64) as usize;
-            if messages.len() > limit {
-                let skip_count = messages.len() - limit;
-                messages = messages.into_iter().skip(skip_count).collect();
-            }
-        }
-
-        // Apply prepend transform if set
-        if let Some(ref transform) = query.prepend_transform {
-            let ctx = crate::message_filter::FilterContext {
-                total_count: count_before_limit,
-                filtered_count: messages.len(),
-                excluded_count: count_before_limit.saturating_sub(messages.len()),
-            };
-            tracing::debug!(
-                total = count_before_limit,
-                filtered = messages.len(),
-                excluded = ctx.excluded_count,
-                "PrependTransform context"
-            );
-            if let Some(prepend_msg) = transform.transform(&ctx) {
-                tracing::info!(
-                    excluded = ctx.excluded_count,
-                    "Prepending excluded messages notice"
-                );
-                messages.insert(0, prepend_msg);
-            }
-        }
+        query.apply_windowing(&mut messages);
 
         // Apply injections
         if query.has_injections() {

--- a/crates/core/src/message_filter.rs
+++ b/crates/core/src/message_filter.rs
@@ -418,6 +418,51 @@ impl MessageQuery {
         // Insert end injections
         messages.extend(end_injections);
     }
+
+    /// Apply offset and latest-message limiting.
+    ///
+    /// `limit` means "keep the latest N messages" while preserving chronological
+    /// order in the returned slice. This is the prompt-window behavior expected
+    /// by long-context capabilities such as `infinity_context`.
+    pub fn apply_window_bounds(&self, messages: &mut Vec<Message>) {
+        if let Some(offset) = self.offset {
+            let offset = offset.max(0) as usize;
+            if offset < messages.len() {
+                messages.drain(0..offset);
+            } else {
+                messages.clear();
+            }
+        }
+
+        if let Some(limit) = self.limit {
+            let limit = limit.max(0) as usize;
+            if messages.len() > limit {
+                let skip_count = messages.len() - limit;
+                messages.drain(0..skip_count);
+            }
+        }
+    }
+
+    /// Prepend the dynamic hidden-history notice, if configured.
+    pub fn prepend_excluded_notice(&self, messages: &mut Vec<Message>, count_before_limit: usize) {
+        if let Some(ref transform) = self.prepend_transform {
+            let ctx = FilterContext {
+                total_count: count_before_limit,
+                filtered_count: messages.len(),
+                excluded_count: count_before_limit.saturating_sub(messages.len()),
+            };
+            if let Some(prepend_msg) = transform.transform(&ctx) {
+                messages.insert(0, prepend_msg);
+            }
+        }
+    }
+
+    /// Apply offset, latest-message limiting, and optional prepend notice.
+    pub fn apply_windowing(&self, messages: &mut Vec<Message>) {
+        let count_before_limit = messages.len();
+        self.apply_window_bounds(messages);
+        self.prepend_excluded_notice(messages, count_before_limit);
+    }
 }
 
 // ============================================================================
@@ -542,6 +587,38 @@ mod tests {
 
         assert_eq!(messages.len(), 3);
         assert_eq!(messages[2].text(), Some("Injected at end"));
+    }
+
+    #[test]
+    fn test_apply_windowing_keeps_latest_messages_chronological() {
+        let session_id: SessionId = Uuid::now_v7().into();
+        let query = MessageQuery::new(session_id).with_limit(2);
+        let mut messages = vec![
+            Message::user("oldest"),
+            Message::user("middle"),
+            Message::user("newest"),
+        ];
+
+        query.apply_windowing(&mut messages);
+
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].text(), Some("middle"));
+        assert_eq!(messages[1].text(), Some("newest"));
+    }
+
+    #[test]
+    fn test_apply_windowing_prepends_excluded_notice() {
+        let session_id: SessionId = Uuid::now_v7().into();
+        let query = MessageQuery::new(session_id)
+            .with_limit(1)
+            .with_prepend_transform(Arc::new(ExcludedNoticeTransform::new("{} hidden")));
+        let mut messages = vec![Message::user("first"), Message::user("second")];
+
+        query.apply_windowing(&mut messages);
+
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].text(), Some("1 hidden"));
+        assert_eq!(messages[1].text(), Some("second"));
     }
 
     #[test]

--- a/crates/internal-protocol/proto/worker.proto
+++ b/crates/internal-protocol/proto/worker.proto
@@ -468,10 +468,12 @@ message GetMessageResponse {
 
 message LoadMessagesRequest {
     Uuid session_id = 1;
+    optional int32 message_limit = 2;
 }
 
 message LoadMessagesResponse {
     repeated Message messages = 1;
+    int32 total_count = 2;
 }
 
 message AddMessageRequest {

--- a/crates/server/src/grpc_service/worker_service_impl.rs
+++ b/crates/server/src/grpc_service/worker_service_impl.rs
@@ -514,13 +514,20 @@ impl WorkerService for WorkerServiceImpl {
     ) -> Result<Response<LoadMessagesResponse>, Status> {
         let req = request.into_inner();
         let session_id = parse_uuid(req.session_id.as_ref())?;
+        let message_limit = req.message_limit.map(|limit| limit.max(0));
 
         // Query events for message-related event types using EventService
         let events = self
             .event_service
-            .list_message_events(session_id)
+            .list_message_events_limited(session_id, message_limit)
             .await
             .map_err(|e| Status::internal(format!("Failed to list messages: {}", e)))?;
+        let total_count = self
+            .db
+            .count_message_events(everruns_core::SessionId::from_uuid(session_id))
+            .await
+            .map_err(|e| Status::internal(format!("Failed to count messages: {}", e)))?
+            .min(i32::MAX as i64) as i32;
 
         let mut proto_messages: Vec<proto::Message> = Vec::with_capacity(events.len());
 
@@ -543,6 +550,7 @@ impl WorkerService for WorkerServiceImpl {
 
         Ok(Response::new(LoadMessagesResponse {
             messages: proto_messages,
+            total_count,
         }))
     }
 

--- a/crates/server/src/storage/memory/events.rs
+++ b/crates/server/src/storage/memory/events.rs
@@ -349,7 +349,11 @@ impl InMemoryDatabase {
             result = result.into_iter().skip(offset as usize).collect();
         }
         if let Some(limit) = query.limit {
-            result.truncate(limit as usize);
+            let limit = limit.max(0) as usize;
+            if result.len() > limit {
+                let skip_count = result.len() - limit;
+                result.drain(0..skip_count);
+            }
         }
 
         Ok(result)

--- a/crates/server/src/storage/memory/tests.rs
+++ b/crates/server/src/storage/memory/tests.rs
@@ -2560,6 +2560,20 @@ async fn test_search_filter_empty_string_matches_all() {
 }
 
 #[tokio::test]
+async fn test_filtered_message_limit_keeps_latest_events_chronological() {
+    let db = InMemoryDatabase::new();
+    let session_id = create_session_with_content_events(&db).await;
+
+    let query = MessageQuery::new(session_id).with_limit(2);
+
+    let events = db.list_message_events_filtered(&query).await.unwrap();
+
+    assert_eq!(events.len(), 2);
+    assert_eq!(events[0].event_type, "tool.completed");
+    assert_eq!(events[1].event_type, "output.message.completed");
+}
+
+#[tokio::test]
 async fn test_session_system_prompt_and_initial_files_round_trip() {
     let db = InMemoryDatabase::new();
 

--- a/crates/server/src/storage/message_store.rs
+++ b/crates/server/src/storage/message_store.rs
@@ -121,20 +121,20 @@ impl MessageRetriever for DbMessageRetriever {
     async fn load_filtered(&self, query: MessageQuery) -> Result<Vec<Message>> {
         // Check if we have any custom filters that need in-memory processing
         let has_custom_filters = query.has_custom_filters();
+        let needs_exact_filtered_count =
+            query.prepend_transform.is_some() && !query.filters.is_empty();
+        let needs_unbounded_candidates = has_custom_filters || needs_exact_filtered_count;
+        let mut db_query = query.clone();
 
-        let count_before_limit = if query.prepend_transform.is_some() {
-            self.db
-                .count_message_events(query.session_id)
-                .await
-                .store_err()? as usize
-        } else {
-            0
-        };
+        if needs_unbounded_candidates {
+            db_query.limit = None;
+            db_query.offset = None;
+        }
 
         // Load events using the filtered query
         let events = self
             .db
-            .list_message_events_filtered(&query)
+            .list_message_events_filtered(&db_query)
             .await
             .store_err()?;
 
@@ -158,6 +158,17 @@ impl MessageRetriever for DbMessageRetriever {
                 })
             });
         }
+
+        let count_before_limit = if query.prepend_transform.is_none() {
+            0
+        } else if needs_unbounded_candidates {
+            messages.len()
+        } else {
+            self.db
+                .count_message_events(query.session_id)
+                .await
+                .store_err()? as usize
+        };
 
         query.apply_window_bounds(&mut messages);
         query.prepend_excluded_notice(&mut messages, count_before_limit);
@@ -285,10 +296,79 @@ pub fn create_db_message_retriever(db: Arc<StorageBackend>) -> DbMessageRetrieve
 mod tests {
     use everruns_core::events::EventContext;
     use everruns_core::typed_id::SessionId;
-    use everruns_core::{ContentPart, Event, ToolCall};
+    use everruns_core::{ContentPart, Event, ExcludedNoticeTransform, MessageRetriever, ToolCall};
     use serde_json::json;
 
     use super::*;
+
+    async fn add_user_messages(
+        retriever: &DbMessageRetriever,
+        session_id: SessionId,
+        texts: &[&str],
+    ) {
+        for text in texts {
+            retriever
+                .add(session_id.uuid(), InputMessage::user(*text))
+                .await
+                .unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn load_filtered_applies_custom_filter_before_latest_limit() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let retriever = DbMessageRetriever::new(db);
+        let session_id = SessionId::new();
+
+        add_user_messages(
+            &retriever,
+            session_id,
+            &["keep 1", "drop 1", "keep 2", "drop 2", "keep 3"],
+        )
+        .await;
+
+        let query = MessageQuery::new(session_id)
+            .with_filter(MessageFilter::Custom(Arc::new(|message| {
+                message.text().is_some_and(|text| text.starts_with("keep"))
+            })))
+            .with_limit(2);
+
+        let messages = retriever.load_filtered(query).await.unwrap();
+
+        let texts: Vec<_> = messages.iter().filter_map(Message::text).collect();
+        assert_eq!(texts, vec!["keep 2", "keep 3"]);
+    }
+
+    #[tokio::test]
+    async fn load_filtered_notice_counts_filtered_candidates_before_limit() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let retriever = DbMessageRetriever::new(db);
+        let session_id = SessionId::new();
+
+        add_user_messages(
+            &retriever,
+            session_id,
+            &["rust 1", "go 1", "rust 2", "go 2", "rust 3"],
+        )
+        .await;
+
+        let query = MessageQuery::new(session_id)
+            .with_filter(MessageFilter::Search("rust".to_string()))
+            .with_limit(2)
+            .with_prepend_transform(Arc::new(ExcludedNoticeTransform::infinity_context()));
+
+        let messages = retriever.load_filtered(query).await.unwrap();
+
+        assert_eq!(messages.len(), 3);
+        assert!(
+            messages[0]
+                .text()
+                .is_some_and(|text| text.contains("1 earlier messages"))
+        );
+
+        let visible_texts: Vec<_> = messages[1..].iter().filter_map(Message::text).collect();
+        assert_eq!(visible_texts, vec!["rust 2", "rust 3"]);
+    }
 
     // ========================================================================
     // Test: Message constructors

--- a/crates/server/src/storage/message_store.rs
+++ b/crates/server/src/storage/message_store.rs
@@ -122,6 +122,15 @@ impl MessageRetriever for DbMessageRetriever {
         // Check if we have any custom filters that need in-memory processing
         let has_custom_filters = query.has_custom_filters();
 
+        let count_before_limit = if query.prepend_transform.is_some() {
+            self.db
+                .count_message_events(query.session_id)
+                .await
+                .store_err()? as usize
+        } else {
+            0
+        };
+
         // Load events using the filtered query
         let events = self
             .db
@@ -149,6 +158,9 @@ impl MessageRetriever for DbMessageRetriever {
                 })
             });
         }
+
+        query.apply_window_bounds(&mut messages);
+        query.prepend_excluded_notice(&mut messages, count_before_limit);
 
         // Apply injections
         if query.has_injections() {

--- a/crates/server/src/storage/repositories/events.rs
+++ b/crates/server/src/storage/repositories/events.rs
@@ -431,7 +431,12 @@ impl Database {
             }
         }
 
-        sql.push_str(" ORDER BY sequence ASC");
+        let latest_window = query.limit.is_some() && query.offset.is_none();
+        if latest_window {
+            sql.push_str(" ORDER BY sequence DESC");
+        } else {
+            sql.push_str(" ORDER BY sequence ASC");
+        }
 
         // Apply limit/offset
         if let Some(limit) = query.limit {
@@ -467,8 +472,10 @@ impl Database {
         if include_ids.is_some() {
             db_query = db_query.bind(include_ids);
         }
-
-        let rows = db_query.fetch_all(&self.pool).await?;
+        let mut rows = db_query.fetch_all(&self.pool).await?;
+        if latest_window {
+            rows.reverse();
+        }
 
         Ok(rows)
     }

--- a/crates/worker/src/grpc_adapters.rs
+++ b/crates/worker/src/grpc_adapters.rs
@@ -817,30 +817,26 @@ impl MessageRetriever for GrpcAdapter {
     }
 
     async fn load(&self, session_id: SessionId) -> Result<Vec<Message>> {
-        let mut client = self.client.inner.lock().await;
-
-        let request = proto::LoadMessagesRequest {
-            session_id: Some(uuid_to_proto(session_id.uuid())),
-        };
-
-        let response = client
-            .load_messages(request)
-            .await
-            .map_err(grpc_status_to_error)?;
-
-        response
-            .into_inner()
-            .messages
-            .into_iter()
-            .map(proto_message_to_message)
-            .collect()
+        let (messages, _) = self.load_with_message_limit(session_id, None).await?;
+        Ok(messages)
     }
 
     async fn load_filtered(
         &self,
         query: everruns_core::message_filter::MessageQuery,
     ) -> Result<Vec<Message>> {
-        let mut messages = self.load(query.session_id).await?;
+        let simple_window_query =
+            query.filters.is_empty() && query.offset.is_none() && query.limit.is_some();
+        let message_limit = if simple_window_query {
+            query
+                .limit
+                .map(|limit| limit.clamp(0, i32::MAX as i64) as i32)
+        } else {
+            None
+        };
+        let (mut messages, total_count) = self
+            .load_with_message_limit(query.session_id, message_limit)
+            .await?;
 
         for filter in &query.filters {
             match filter {
@@ -863,27 +859,68 @@ impl MessageRetriever for GrpcAdapter {
                 }
                 MessageFilter::Search(q) => {
                     let q_lower = q.to_lowercase();
-                    messages.retain(|m| {
-                        m.text()
-                            .is_some_and(|t| t.to_lowercase().contains(&q_lower))
-                    });
+                    messages
+                        .retain(|m| m.content_to_llm_string().to_lowercase().contains(&q_lower));
                 }
                 MessageFilter::Custom(predicate) => {
                     messages.retain(|m| predicate(m));
                 }
                 MessageFilter::ToolName(_)
                 | MessageFilter::ExcludeIds(_)
-                | MessageFilter::IncludeIds(_) => {}
+                | MessageFilter::IncludeIds(_) => {
+                    return Err(AgentLoopError::store(format!(
+                        "gRPC MessageRetriever does not support filter: {filter:?}"
+                    )));
+                }
             }
         }
 
-        query.apply_windowing(&mut messages);
+        if simple_window_query {
+            query.apply_window_bounds(&mut messages);
+            query.prepend_excluded_notice(&mut messages, total_count);
+        } else {
+            query.apply_windowing(&mut messages);
+        }
 
         if query.has_injections() {
             query.apply_injections(&mut messages);
         }
 
         Ok(messages)
+    }
+}
+
+impl GrpcAdapter {
+    async fn load_with_message_limit(
+        &self,
+        session_id: SessionId,
+        message_limit: Option<i32>,
+    ) -> Result<(Vec<Message>, usize)> {
+        let mut client = self.client.inner.lock().await;
+
+        let request = proto::LoadMessagesRequest {
+            session_id: Some(uuid_to_proto(session_id.uuid())),
+            message_limit,
+        };
+
+        let response = client
+            .load_messages(request)
+            .await
+            .map_err(grpc_status_to_error)?;
+        let response = response.into_inner();
+        let total_count = if response.total_count > 0 {
+            response.total_count as usize
+        } else {
+            response.messages.len()
+        };
+
+        let messages = response
+            .messages
+            .into_iter()
+            .map(proto_message_to_message)
+            .collect::<Result<Vec<_>>>()?;
+
+        Ok((messages, total_count))
     }
 }
 

--- a/crates/worker/src/grpc_adapters.rs
+++ b/crates/worker/src/grpc_adapters.rs
@@ -22,7 +22,9 @@ use everruns_core::traits::{
     StoredImageInfo,
 };
 use everruns_core::typed_id::{AgentId, LeasedResourceId, MessageId, ModelId, SessionId};
-use everruns_core::{Agent, Harness, HarnessStatus, Message, Session, SessionStatus};
+use everruns_core::{
+    Agent, Harness, HarnessStatus, Message, MessageFilter, MessageRole, Session, SessionStatus,
+};
 use everruns_internal_protocol::proto;
 use everruns_internal_protocol::{
     WorkerServiceClient, json_to_proto_list, json_to_proto_struct, proto_list_to_json,
@@ -832,6 +834,56 @@ impl MessageRetriever for GrpcAdapter {
             .into_iter()
             .map(proto_message_to_message)
             .collect()
+    }
+
+    async fn load_filtered(
+        &self,
+        query: everruns_core::message_filter::MessageQuery,
+    ) -> Result<Vec<Message>> {
+        let mut messages = self.load(query.session_id).await?;
+
+        for filter in &query.filters {
+            match filter {
+                MessageFilter::TimeRange { from, to } => {
+                    messages.retain(|m| {
+                        let after_from = from.is_none_or(|t| m.created_at >= t);
+                        let before_to = to.is_none_or(|t| m.created_at <= t);
+                        after_from && before_to
+                    });
+                }
+                MessageFilter::EventTypes(types) => {
+                    messages.retain(|m| {
+                        types.iter().any(|event_type| match event_type.as_str() {
+                            "input.message" => m.role == MessageRole::User,
+                            "output.message.completed" => m.role == MessageRole::Agent,
+                            "tool.completed" => m.role == MessageRole::ToolResult,
+                            _ => false,
+                        })
+                    });
+                }
+                MessageFilter::Search(q) => {
+                    let q_lower = q.to_lowercase();
+                    messages.retain(|m| {
+                        m.text()
+                            .is_some_and(|t| t.to_lowercase().contains(&q_lower))
+                    });
+                }
+                MessageFilter::Custom(predicate) => {
+                    messages.retain(|m| predicate(m));
+                }
+                MessageFilter::ToolName(_)
+                | MessageFilter::ExcludeIds(_)
+                | MessageFilter::IncludeIds(_) => {}
+            }
+        }
+
+        query.apply_windowing(&mut messages);
+
+        if query.has_injections() {
+            query.apply_injections(&mut messages);
+        }
+
+        Ok(messages)
     }
 }
 

--- a/specs/infinity-context.md
+++ b/specs/infinity-context.md
@@ -76,7 +76,8 @@ When searching history:
   ```json
   {
     "context_budget_tokens": 100000,
-    "min_recent_messages": 10
+    "min_recent_messages": 10,
+    "max_recent_messages": null
   }
   ```
 
@@ -142,6 +143,13 @@ def select_messages(all_messages, budget_tokens, min_recent):
     excluded = [m for m in all_messages if m not in selected]
     return selected, excluded
 ```
+
+Implementations MAY expose `max_recent_messages` as a hard cap for constrained
+surfaces such as public support chat. When set, the live prompt keeps no more
+than that many persisted messages, even if `context_budget_tokens` would allow
+more. Message limits always mean the latest N messages, returned in
+chronological order; older excluded messages remain available through
+`query_history`.
 
 ### History Notice Format
 


### PR DESCRIPTION
## What
Adds a hard `max_recent_messages` cap to `infinity_context` and fixes message-window retrieval so limits keep the latest N messages in chronological order.

## Why
Public support chat needs a much smaller live context window, and the existing limit behavior was inconsistent across storage paths.

## How
- Resolves `infinity_context` limits from token budget plus optional hard message cap.
- Centralizes message windowing in `MessageQuery`.
- Applies latest-window semantics in in-memory, DB, and gRPC retrieval paths.
- Updates the infinity-context spec and adds focused tests.

## Risk
- Medium
- Changes prompt history selection semantics for `MessageQuery.limit`; older messages are intentionally hidden from the live prompt but remain queryable through `query_history`.

## Security
- Threat categories reviewed: TM-LLM, TM-DOS, TM-TENANT, TM-SQL.
- Findings and resolutions: Prompt construction now has an explicit hard cap for constrained support surfaces. DB retrieval keeps limits in SQL for latest-window queries, avoiding unbounded history materialization. Session scoping and bound SQL parameters are unchanged; no new threat-model entry needed.

## Validation
- `cargo fmt --check`
- `cargo test -p everruns-core message_filter::tests::test_apply_windowing`
- `cargo test -p everruns-core capabilities::infinity_context::tests::test_filter_provider_allows_small_public_chat_window`
- `cargo test -p everruns-server storage::memory::tests::test_filtered_message_limit_keeps_latest_events_chronological`
- `CARGO_INCREMENTAL=0 cargo check -p everruns-server -p everruns-worker`
- Backend smoke: `everruns-server` dev/in-memory mode + `GET /health` returned OK
- `CARGO_INCREMENTAL=0 just pre-push`

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] All review comments addressed (code change or written reasoning)