### PR TITLE
feat(ui): show agent and harness usage counts

### DIFF
--- a/apps/ui/src/app/(main)/agents/[agentId]/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/page.tsx
@@ -34,7 +34,7 @@ import {
   getEntityStatusBadgeVariant,
 } from "@/lib/entity-lifecycle";
 import { useOrganization } from "@/hooks/use-organizations";
-import { formatTokens } from "@/lib/formatting";
+import { formatTokens, pluralize } from "@/lib/formatting";
 import { normalizeTags } from "@/lib/tags";
 
 // Helper function to calculate total tokens
@@ -118,6 +118,8 @@ export default function AgentDetailPage({ params }: { params: Promise<{ agentId:
 
   // Capabilities are now part of the agent resource
   const agentCapabilities = agent?.capabilities ?? [];
+  const agentSessionCount = agent?.session_count ?? totalSessions;
+  const agentAppCount = agent?.app_count ?? 0;
 
   if (agentLoading) {
     return (
@@ -334,6 +336,27 @@ export default function AgentDetailPage({ params }: { params: Promise<{ agentId:
                       </div>
                     </div>
                   )}
+
+                  <div>
+                    <p className="text-sm font-medium mb-2">Usage</p>
+                    <div className="grid grid-cols-2 gap-2">
+                      <Link
+                        href={`/agents/${agentId}/sessions`}
+                        className="border bg-muted/50 p-2 hover:bg-muted"
+                      >
+                        <p className="text-sm font-medium">{agentSessionCount}</p>
+                        <p className="text-xs text-muted-foreground">
+                          {pluralize(agentSessionCount, "session")}
+                        </p>
+                      </Link>
+                      <div className="border bg-muted/50 p-2">
+                        <p className="text-sm font-medium">{agentAppCount}</p>
+                        <p className="text-xs text-muted-foreground">
+                          {pluralize(agentAppCount, "app")}
+                        </p>
+                      </div>
+                    </div>
+                  </div>
 
                   {agent.usage && (
                     <div>

--- a/apps/ui/src/app/(main)/harnesses/[harnessId]/page.tsx
+++ b/apps/ui/src/app/(main)/harnesses/[harnessId]/page.tsx
@@ -31,6 +31,7 @@ import {
   getEntityNameClassName,
   getEntityStatusBadgeVariant,
 } from "@/lib/entity-lifecycle";
+import { pluralize } from "@/lib/formatting";
 import { normalizeTags } from "@/lib/tags";
 
 export default function HarnessDetailPage({ params }: { params: Promise<{ harnessId: string }> }) {
@@ -62,6 +63,8 @@ export default function HarnessDetailPage({ params }: { params: Promise<{ harnes
 
   const harnessCapabilities = harness?.capabilities ?? [];
   const deleteError = deleteHarness.error;
+  const harnessSessionCount = harness?.session_count ?? 0;
+  const harnessAppCount = harness?.app_count ?? 0;
 
   const handleDelete = async () => {
     if (!confirm("Archive this harness? It will become read-only and stop being assignable.")) {
@@ -285,6 +288,24 @@ export default function HarnessDetailPage({ params }: { params: Promise<{ harnes
                       </div>
                     </div>
                   )}
+
+                  <div>
+                    <p className="text-sm font-medium mb-2">Usage</p>
+                    <div className="grid grid-cols-2 gap-2">
+                      <div className="border bg-muted/50 p-2">
+                        <p className="text-sm font-medium">{harnessSessionCount}</p>
+                        <p className="text-xs text-muted-foreground">
+                          {pluralize(harnessSessionCount, "session")}
+                        </p>
+                      </div>
+                      <div className="border bg-muted/50 p-2">
+                        <p className="text-sm font-medium">{harnessAppCount}</p>
+                        <p className="text-xs text-muted-foreground">
+                          {pluralize(harnessAppCount, "app")}
+                        </p>
+                      </div>
+                    </div>
+                  </div>
 
                   <div>
                     <p className="text-sm font-medium">Created</p>

--- a/apps/ui/src/components/agents/agent-card.tsx
+++ b/apps/ui/src/components/agents/agent-card.tsx
@@ -15,6 +15,7 @@ import {
   getEntityNameClassName,
   getEntityStatusBadgeVariant,
 } from "@/lib/entity-lifecycle";
+import { formatCountLabel } from "@/lib/formatting";
 import { normalizeTags } from "@/lib/tags";
 
 interface AgentCardProps {
@@ -37,6 +38,8 @@ export function AgentCard({
   // Capabilities are now directly on the agent
   const agentCapabilities = agent.capabilities ?? [];
   const tags = normalizeTags(agent.tags);
+  const sessionCount = agent.session_count ?? 0;
+  const appCount = agent.app_count ?? 0;
 
   return (
     <Card className="bg-background transition-colors hover:bg-card">
@@ -102,9 +105,13 @@ export function AgentCard({
 
         {/* Footer */}
         <div className="flex items-center justify-between">
-          <span className="text-xs text-muted-foreground">
-            Created {new Date(agent.created_at).toLocaleDateString()}
-          </span>
+          <div className="min-w-0 text-xs text-muted-foreground">
+            <span>Created {new Date(agent.created_at).toLocaleDateString()}</span>
+            <span className="mx-2">·</span>
+            <span>
+              {formatCountLabel(sessionCount, "session")} · {formatCountLabel(appCount, "app")}
+            </span>
+          </div>
           {showEditButton && agent.status === "active" && (
             <Link href={`/agents/${agent.id}/edit`}>
               <Button variant="ghost" size="icon" className="h-8 w-8">

--- a/apps/ui/src/components/harnesses/harness-card.tsx
+++ b/apps/ui/src/components/harnesses/harness-card.tsx
@@ -15,6 +15,7 @@ import {
   getEntityNameClassName,
   getEntityStatusBadgeVariant,
 } from "@/lib/entity-lifecycle";
+import { formatCountLabel } from "@/lib/formatting";
 import { normalizeTags } from "@/lib/tags";
 
 interface HarnessCardProps {
@@ -35,6 +36,8 @@ export function HarnessCard({
 
   const harnessCapabilities = harness.capabilities ?? [];
   const tags = normalizeTags(harness.tags);
+  const sessionCount = harness.session_count ?? 0;
+  const appCount = harness.app_count ?? 0;
 
   return (
     <Card className="bg-background transition-colors hover:bg-card">
@@ -104,9 +107,13 @@ export function HarnessCard({
 
         {/* Footer */}
         <div className="flex items-center justify-between">
-          <span className="text-xs text-muted-foreground">
-            Created {new Date(harness.created_at).toLocaleDateString()}
-          </span>
+          <div className="min-w-0 text-xs text-muted-foreground">
+            <span>Created {new Date(harness.created_at).toLocaleDateString()}</span>
+            <span className="mx-2">·</span>
+            <span>
+              {formatCountLabel(sessionCount, "session")} · {formatCountLabel(appCount, "app")}
+            </span>
+          </div>
           {showEditButton && !harness.is_built_in && harness.status === "active" && (
             <Link href={`/harnesses/${harness.id}/edit`}>
               <Button variant="ghost" size="icon" className="h-8 w-8">

--- a/apps/ui/src/lib/api/types/agent-types.ts
+++ b/apps/ui/src/lib/api/types/agent-types.ts
@@ -39,6 +39,10 @@ export interface Agent {
   deleted_at: string | null;
   /** Cumulative token usage across all sessions for this agent */
   usage?: TokenUsage;
+  /** Number of sessions using this agent. Present on list/detail API responses. */
+  session_count?: number;
+  /** Number of non-deleted apps using this agent. Present on list/detail API responses. */
+  app_count?: number;
 }
 
 export interface CreateAgentRequest {
@@ -136,6 +140,10 @@ export interface Harness {
   updated_at: string;
   archived_at: string | null;
   deleted_at: string | null;
+  /** Number of sessions using this harness. Present on list/detail API responses. */
+  session_count?: number;
+  /** Number of non-deleted apps using this harness. Present on list/detail API responses. */
+  app_count?: number;
 }
 
 export interface CreateHarnessRequest {

--- a/apps/ui/src/lib/formatting.ts
+++ b/apps/ui/src/lib/formatting.ts
@@ -12,6 +12,14 @@ export function formatCompactNumber(value: number): string {
   return value.toString();
 }
 
+export function pluralize(count: number, singular: string): string {
+  return `${singular}${count === 1 ? "" : "s"}`;
+}
+
+export function formatCountLabel(count: number, singular: string): string {
+  return `${count} ${pluralize(count, singular)}`;
+}
+
 /**
  * Format token count in compact form
  * @alias formatCompactNumber - provided for semantic clarity

--- a/crates/server/src/api/agents.rs
+++ b/crates/server/src/api/agents.rs
@@ -17,9 +17,11 @@ use everruns_core::{
     Agent, AgentCapabilityConfig, Caller, DeploymentGrade, InitialFile, OrgRole,
     PlatformDefinition, ResourceConfigResponse, ScopedMcpServers, evaluate_policies_with,
 };
+use futures::future::try_join_all;
 
 use super::common::{
-    ApiResult, ErrorResponse, PaginatedResponse, UrlBuilder, WithUrls, impl_auth_state,
+    ApiResult, ApiResultExt, ErrorResponse, PaginatedResponse, ResourceWithCounts, UrlBuilder,
+    WithUrls, impl_auth_state,
 };
 use super::validation::{
     validate_agent_name_format, validate_create_agent_input, validate_import_file_size,
@@ -155,6 +157,44 @@ impl AppState {
 
 impl_auth_state!(AppState);
 
+async fn add_agent_counts(
+    db: &StorageBackend,
+    org_id: i64,
+    agent: Agent,
+) -> Result<ResourceWithCounts<Agent>, (StatusCode, Json<ErrorResponse>)> {
+    let agent_id = AgentId::from_uuid(agent.internal_id);
+    let session_count = async {
+        db.count_sessions_for_agent(org_id, agent_id)
+            .await
+            .log_internal_error_json("count agent sessions")
+    };
+    let app_count = async {
+        db.count_apps_for_agent(org_id, agent_id)
+            .await
+            .log_internal_error_json("count agent apps")
+    };
+    let (session_count, app_count) = tokio::try_join!(session_count, app_count)?;
+
+    Ok(ResourceWithCounts {
+        session_count,
+        app_count,
+        inner: agent,
+    })
+}
+
+async fn add_agents_counts(
+    db: &StorageBackend,
+    org_id: i64,
+    agents: Vec<Agent>,
+) -> Result<Vec<ResourceWithCounts<Agent>>, (StatusCode, Json<ErrorResponse>)> {
+    try_join_all(
+        agents
+            .into_iter()
+            .map(|agent| add_agent_counts(db, org_id, agent)),
+    )
+    .await
+}
+
 /// GET /v1/agents/check-name
 ///
 /// Returns whether an agent name is available for use. Optionally excludes
@@ -285,7 +325,7 @@ pub async fn create_agent(
     path = "/v1/agents",
     params(ListAgentsQuery),
     responses(
-        (status = 200, description = "Paginated list of agents", body = PaginatedResponse<WithUrls<Agent>>),
+        (status = 200, description = "Paginated list of agents", body = PaginatedResponse<WithUrls<ResourceWithCounts<Agent>>>),
         (status = 500, description = "Internal server error")
     ),
     tag = "agents"
@@ -294,7 +334,7 @@ pub async fn list_agents(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Query(query): Query<ListAgentsQuery>,
-) -> ApiResult<PaginatedResponse<WithUrls<Agent>>> {
+) -> ApiResult<PaginatedResponse<WithUrls<ResourceWithCounts<Agent>>>> {
     let result = crate::domains::agents::ListAgents {
         search: query.search,
         include_archived: query.include_archived.unwrap_or(false),
@@ -304,10 +344,10 @@ pub async fn list_agents(
     .run(&state.ctx(&org))
     .await?;
 
+    let data = add_agents_counts(&state.db, org.org_id, result.data).await?;
     let builder = UrlBuilder::from_auth_config(&state.auth.config);
     Ok(Json(
-        PaginatedResponse::new(result.data, result.total, result.offset, result.limit)
-            .with_urls(&builder),
+        PaginatedResponse::new(data, result.total, result.offset, result.limit).with_urls(&builder),
     ))
 }
 
@@ -322,7 +362,7 @@ pub async fn list_agents(
         ("agent_id" = String, Path, description = "Agent ID (prefixed) or name")
     ),
     responses(
-        (status = 200, description = "Agent found", body = WithUrls<Agent>),
+        (status = 200, description = "Agent found", body = WithUrls<ResourceWithCounts<Agent>>),
         (status = 400, description = "Invalid agent ID"),
         (status = 404, description = "Agent not found"),
         (status = 500, description = "Internal server error")
@@ -333,12 +373,13 @@ pub async fn get_agent(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Path(agent_id_or_name): Path<String>,
-) -> ApiResult<WithUrls<Agent>> {
+) -> ApiResult<WithUrls<ResourceWithCounts<Agent>>> {
     let agent = crate::domains::agents::GetAgent {
         id: agent_id_or_name,
     }
     .run(&state.ctx(&org))
     .await?;
+    let agent = add_agent_counts(&state.db, org.org_id, agent).await?;
     let builder = UrlBuilder::from_auth_config(&state.auth.config);
     Ok(Json(builder.wrap(agent)))
 }

--- a/crates/server/src/api/common.rs
+++ b/crates/server/src/api/common.rs
@@ -665,6 +665,32 @@ pub struct WithUrls<T: Serialize> {
     pub inner: T,
 }
 
+/// Wrapper that flattens lightweight relationship counts into resource responses.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct ResourceWithCounts<T: Serialize> {
+    /// Number of sessions using this resource.
+    pub session_count: u64,
+    /// Number of non-deleted apps using this resource.
+    pub app_count: u64,
+    /// The resource itself (fields are flattened into the parent object).
+    #[serde(flatten)]
+    pub inner: T,
+}
+
+impl<T: ResourceUrlable + Serialize> ResourceUrlable for ResourceWithCounts<T> {
+    fn api_path() -> &'static str {
+        T::api_path()
+    }
+
+    fn ui_path() -> &'static str {
+        T::ui_path()
+    }
+
+    fn resource_id(&self) -> String {
+        self.inner.resource_id()
+    }
+}
+
 impl<T: ResourceUrlable + Serialize> PaginatedResponse<T> {
     /// Map all items through `UrlBuilder::wrap`.
     pub fn with_urls(self, builder: &UrlBuilder) -> PaginatedResponse<WithUrls<T>> {

--- a/crates/server/src/api/harnesses.rs
+++ b/crates/server/src/api/harnesses.rs
@@ -20,9 +20,11 @@ use everruns_core::{
     AgentCapabilityConfig, Caller, DeploymentGrade, Harness, PlatformDefinition,
     ResourceConfigResponse, evaluate_policies_with,
 };
+use futures::future::try_join_all;
 
 use super::common::{
-    ApiResult, ApiResultExt, ErrorResponse, ListResponse, UrlBuilder, WithUrls, impl_auth_state,
+    ApiResult, ApiResultExt, ErrorResponse, ListResponse, ResourceWithCounts, UrlBuilder, WithUrls,
+    impl_auth_state,
 };
 use serde::Deserialize;
 use std::sync::Arc;
@@ -79,6 +81,43 @@ impl AppState {
 }
 
 impl_auth_state!(AppState);
+
+async fn add_harness_counts(
+    db: &StorageBackend,
+    org_id: i64,
+    harness: Harness,
+) -> Result<ResourceWithCounts<Harness>, (StatusCode, Json<ErrorResponse>)> {
+    let session_count = async {
+        db.count_sessions_for_harness(org_id, harness.id)
+            .await
+            .log_internal_error_json("count harness sessions")
+    };
+    let app_count = async {
+        db.count_apps_for_harness(org_id, harness.id)
+            .await
+            .log_internal_error_json("count harness apps")
+    };
+    let (session_count, app_count) = tokio::try_join!(session_count, app_count)?;
+
+    Ok(ResourceWithCounts {
+        session_count,
+        app_count,
+        inner: harness,
+    })
+}
+
+async fn add_harnesses_counts(
+    db: &StorageBackend,
+    org_id: i64,
+    harnesses: Vec<Harness>,
+) -> Result<Vec<ResourceWithCounts<Harness>>, (StatusCode, Json<ErrorResponse>)> {
+    try_join_all(
+        harnesses
+            .into_iter()
+            .map(|harness| add_harness_counts(db, org_id, harness)),
+    )
+    .await
+}
 
 /// Create harness routes
 pub fn routes(state: AppState) -> Router {
@@ -336,7 +375,7 @@ pub async fn create_harness(
     get,
     path = "/v1/harnesses",
     responses(
-        (status = 200, description = "List of harnesses", body = ListResponse<WithUrls<Harness>>),
+        (status = 200, description = "List of harnesses", body = ListResponse<WithUrls<ResourceWithCounts<Harness>>>),
         (status = 403, description = "Forbidden"),
         (status = 500, description = "Internal server error")
     ),
@@ -347,7 +386,7 @@ pub async fn list_harnesses(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Query(query): Query<ListHarnessesQuery>,
-) -> ApiResult<ListResponse<WithUrls<Harness>>> {
+) -> ApiResult<ListResponse<WithUrls<ResourceWithCounts<Harness>>>> {
     let harnesses = crate::domains::harnesses::ListHarnesses {
         search: query.search,
         include_archived: query.include_archived.unwrap_or(false),
@@ -355,6 +394,7 @@ pub async fn list_harnesses(
     .run(&state.ctx(&org))
     .await?;
 
+    let harnesses = add_harnesses_counts(&state.db, org.org_id, harnesses).await?;
     let urls = UrlBuilder::from_auth_config(&state.auth.config);
     Ok(Json(ListResponse::new(harnesses).with_urls(&urls)))
 }
@@ -371,7 +411,7 @@ pub async fn list_harnesses(
         ("harness_id" = String, Path, description = "Harness ID (prefixed) or name")
     ),
     responses(
-        (status = 200, description = "Harness found", body = WithUrls<Harness>),
+        (status = 200, description = "Harness found", body = WithUrls<ResourceWithCounts<Harness>>),
         (status = 403, description = "Forbidden"),
         (status = 404, description = "Harness not found"),
         (status = 500, description = "Internal server error")
@@ -382,12 +422,13 @@ pub async fn get_harness(
     org: ResolvedOrg,
     State(state): State<AppState>,
     Path(harness_id_or_name): Path<String>,
-) -> ApiResult<WithUrls<Harness>> {
+) -> ApiResult<WithUrls<ResourceWithCounts<Harness>>> {
     let harness = crate::domains::harnesses::GetHarness {
         id: harness_id_or_name,
     }
     .run(&state.ctx(&org))
     .await?;
+    let harness = add_harness_counts(&state.db, org.org_id, harness).await?;
     let urls = UrlBuilder::from_auth_config(&state.auth.config);
     Ok(Json(urls.wrap(harness)))
 }

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -381,6 +381,10 @@ impl StorageBackend {
         )
     }
 
+    pub async fn count_sessions_for_agent(&self, org_id: i64, agent_id: AgentId) -> Result<u64> {
+        dispatch!(self, count_sessions_for_agent, org_id, agent_id)
+    }
+
     pub async fn get_agent_by_name(&self, org_id: i64, name: &str) -> Result<Option<AgentRow>> {
         dispatch!(self, get_agent_by_name, org_id, name)
     }
@@ -454,6 +458,14 @@ impl StorageBackend {
         include_archived: bool,
     ) -> Result<Vec<HarnessRow>> {
         dispatch!(self, list_harnesses, org_id, search, include_archived)
+    }
+
+    pub async fn count_sessions_for_harness(
+        &self,
+        org_id: i64,
+        harness_id: HarnessId,
+    ) -> Result<u64> {
+        dispatch!(self, count_sessions_for_harness, org_id, harness_id)
     }
 
     pub async fn update_harness(
@@ -2127,6 +2139,14 @@ impl StorageBackend {
         include_archived: bool,
     ) -> Result<Vec<AppRow>> {
         dispatch!(self, list_apps, org_id, search, include_archived)
+    }
+
+    pub async fn count_apps_for_agent(&self, org_id: i64, agent_id: AgentId) -> Result<u64> {
+        dispatch!(self, count_apps_for_agent, org_id, agent_id)
+    }
+
+    pub async fn count_apps_for_harness(&self, org_id: i64, harness_id: HarnessId) -> Result<u64> {
+        dispatch!(self, count_apps_for_harness, org_id, harness_id)
     }
 
     pub async fn update_app(

--- a/crates/server/src/storage/memory/apps.rs
+++ b/crates/server/src/storage/memory/apps.rs
@@ -4,6 +4,7 @@ use super::super::models::*;
 use super::InMemoryDatabase;
 use super::matches_search_tokens;
 use anyhow::Result;
+use everruns_core::typed_id::{AgentId, HarnessId};
 use uuid::Uuid;
 
 impl InMemoryDatabase {
@@ -91,6 +92,28 @@ impl InMemoryDatabase {
             .collect();
         result.sort_by_key(|app| std::cmp::Reverse(app.created_at));
         Ok(result)
+    }
+
+    pub async fn count_apps_for_agent(&self, org_id: i64, agent_id: AgentId) -> Result<u64> {
+        Ok(self
+            .apps
+            .read()
+            .values()
+            .filter(|a| {
+                a.org_id == org_id && a.agent_id == Some(agent_id.uuid()) && a.status != "deleted"
+            })
+            .count() as u64)
+    }
+
+    pub async fn count_apps_for_harness(&self, org_id: i64, harness_id: HarnessId) -> Result<u64> {
+        Ok(self
+            .apps
+            .read()
+            .values()
+            .filter(|a| {
+                a.org_id == org_id && a.harness_id == harness_id.uuid() && a.status != "deleted"
+            })
+            .count() as u64)
     }
 
     pub async fn update_app(

--- a/crates/server/src/storage/memory/sessions.rs
+++ b/crates/server/src/storage/memory/sessions.rs
@@ -5,7 +5,7 @@ use super::InMemoryDatabase;
 use super::matches_search_tokens;
 use anyhow::Result;
 use chrono::{DateTime, Utc};
-use everruns_core::{AgentId, EventId, PrincipalId, SessionId};
+use everruns_core::{AgentId, EventId, HarnessId, PrincipalId, SessionId};
 use uuid::Uuid;
 
 impl InMemoryDatabase {
@@ -135,6 +135,28 @@ impl InMemoryDatabase {
         let paginated = result.into_iter().skip(offset).take(limit).collect();
 
         Ok((paginated, total))
+    }
+
+    pub async fn count_sessions_for_agent(&self, org_id: i64, agent_id: AgentId) -> Result<u64> {
+        Ok(self
+            .sessions
+            .read()
+            .values()
+            .filter(|s| s.org_id == org_id && s.agent_id == Some(agent_id))
+            .count() as u64)
+    }
+
+    pub async fn count_sessions_for_harness(
+        &self,
+        org_id: i64,
+        harness_id: HarnessId,
+    ) -> Result<u64> {
+        Ok(self
+            .sessions
+            .read()
+            .values()
+            .filter(|s| s.org_id == org_id && s.harness_id == Some(harness_id))
+            .count() as u64)
     }
 
     /// List child sessions (subagents) for a parent session.

--- a/crates/server/src/storage/repositories/apps.rs
+++ b/crates/server/src/storage/repositories/apps.rs
@@ -4,6 +4,7 @@ use super::super::models::*;
 use super::Database;
 use super::build_search_sql;
 use anyhow::Result;
+use everruns_core::typed_id::{AgentId, HarnessId};
 use uuid::Uuid;
 
 impl Database {
@@ -108,6 +109,30 @@ impl Database {
             query = query.bind(pat);
         }
         Ok(query.fetch_all(&self.pool).await?)
+    }
+
+    pub async fn count_apps_for_agent(&self, org_id: i64, agent_id: AgentId) -> Result<u64> {
+        let (count,): (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM apps WHERE org_id = $1 AND agent_id = $2 AND status != 'deleted'",
+        )
+        .bind(org_id)
+        .bind(agent_id.uuid())
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(count as u64)
+    }
+
+    pub async fn count_apps_for_harness(&self, org_id: i64, harness_id: HarnessId) -> Result<u64> {
+        let (count,): (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM apps WHERE org_id = $1 AND harness_id = $2 AND status != 'deleted'",
+        )
+        .bind(org_id)
+        .bind(harness_id.uuid())
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(count as u64)
     }
 
     pub async fn update_app(

--- a/crates/server/src/storage/repositories/sessions.rs
+++ b/crates/server/src/storage/repositories/sessions.rs
@@ -7,7 +7,7 @@ use anyhow::Result;
 use chrono::{DateTime, Utc};
 use everruns_core::AgentIdentityId;
 use everruns_core::PrincipalId;
-use everruns_core::typed_id::{AgentId, SessionId};
+use everruns_core::typed_id::{AgentId, HarnessId, SessionId};
 use uuid::Uuid;
 
 impl Database {
@@ -183,6 +183,32 @@ impl Database {
             .await?;
 
         Ok((rows, total.0 as u32))
+    }
+
+    pub async fn count_sessions_for_agent(&self, org_id: i64, agent_id: AgentId) -> Result<u64> {
+        let (count,): (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM sessions WHERE org_id = $1 AND agent_id = $2")
+                .bind(org_id)
+                .bind(agent_id)
+                .fetch_one(&self.pool)
+                .await?;
+
+        Ok(count as u64)
+    }
+
+    pub async fn count_sessions_for_harness(
+        &self,
+        org_id: i64,
+        harness_id: HarnessId,
+    ) -> Result<u64> {
+        let (count,): (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM sessions WHERE org_id = $1 AND harness_id = $2")
+                .bind(org_id)
+                .bind(harness_id)
+                .fetch_one(&self.pool)
+                .await?;
+
+        Ok(count as u64)
     }
 
     /// List child sessions (subagents) for a parent session.

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -86,7 +86,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PaginatedResponse_WithUrls_Agent"
+                  "$ref": "#/components/schemas/PaginatedResponse_WithUrls_ResourceWithCounts_Agent"
                 }
               }
             }
@@ -306,7 +306,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/WithUrls_Agent"
+                  "$ref": "#/components/schemas/WithUrls_ResourceWithCounts_Agent"
                 }
               }
             }
@@ -1541,7 +1541,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ListResponse_WithUrls_Harness"
+                  "$ref": "#/components/schemas/ListResponse_WithUrls_ResourceWithCounts_Harness"
                 }
               }
             }
@@ -1765,7 +1765,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/WithUrls_Harness"
+                  "$ref": "#/components/schemas/WithUrls_ResourceWithCounts_Harness"
                 }
               }
             }
@@ -9660,173 +9660,6 @@
           }
         }
       },
-      "ListResponse_WithUrls_Harness": {
-        "type": "object",
-        "description": "Response wrapper for list endpoints.\nAll list endpoints return responses wrapped in a `data` field.",
-        "required": [
-          "data"
-        ],
-        "properties": {
-          "data": {
-            "type": "array",
-            "items": {
-              "allOf": [
-                {
-                  "type": "object",
-                  "description": "Harness configuration for sessions.\nA harness defines the base behavior and capabilities that apply to all sessions.",
-                  "required": [
-                    "id",
-                    "name",
-                    "system_prompt",
-                    "status",
-                    "created_at",
-                    "updated_at"
-                  ],
-                  "properties": {
-                    "archived_at": {
-                      "type": [
-                        "string",
-                        "null"
-                      ],
-                      "format": "date-time",
-                      "description": "Timestamp when the harness was archived."
-                    },
-                    "capabilities": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/AgentCapabilityConfig"
-                      },
-                      "description": "Capabilities enabled for this harness with per-harness configuration."
-                    },
-                    "created_at": {
-                      "type": "string",
-                      "format": "date-time",
-                      "description": "Timestamp when the harness was created."
-                    },
-                    "default_model_id": {
-                      "type": [
-                        "string",
-                        "null"
-                      ],
-                      "description": "Default LLM model ID for this harness.\nLowest priority in chain: controls > session > agent > harness.",
-                      "example": "model_01933b5a00007000800000000000001"
-                    },
-                    "deleted_at": {
-                      "type": [
-                        "string",
-                        "null"
-                      ],
-                      "format": "date-time",
-                      "description": "Timestamp when the harness was deleted."
-                    },
-                    "description": {
-                      "type": [
-                        "string",
-                        "null"
-                      ],
-                      "description": "Human-readable description of what the harness does."
-                    },
-                    "display_name": {
-                      "type": [
-                        "string",
-                        "null"
-                      ],
-                      "description": "Human-readable display name shown in UI."
-                    },
-                    "id": {
-                      "type": "string",
-                      "description": "Unique identifier for the harness (format: harness_{32-hex}).",
-                      "example": "harness_01933b5a00007000800000000000001"
-                    },
-                    "initial_files": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/InitialFile"
-                      },
-                      "description": "Starter files copied into each new session for this harness."
-                    },
-                    "is_built_in": {
-                      "type": "boolean",
-                      "description": "Whether this harness is built-in (system-managed, readonly).\nBuilt-in harnesses are provisioned during org initialization and\ncannot be modified or deleted via the API. Users can copy them."
-                    },
-                    "mcpServers": {
-                      "$ref": "#/components/schemas/BTreeMap",
-                      "description": "Remote MCP servers scoped to this harness and inherited by descendant layers."
-                    },
-                    "name": {
-                      "type": "string",
-                      "description": "Name, unique per org (e.g. \"generic\")."
-                    },
-                    "network_access": {
-                      "oneOf": [
-                        {
-                          "type": "null"
-                        },
-                        {
-                          "$ref": "#/components/schemas/NetworkAccessList",
-                          "description": "Network access list controlling which hosts/URLs sessions can reach.\nMerged with agent and session layers (allowed: intersect, blocked: union)."
-                        }
-                      ]
-                    },
-                    "parent_harness_id": {
-                      "type": [
-                        "string",
-                        "null"
-                      ],
-                      "description": "Optional parent harness that this harness inherits from.",
-                      "example": "harness_01933b5a000070008000000000000602"
-                    },
-                    "status": {
-                      "$ref": "#/components/schemas/HarnessStatus",
-                      "description": "Current lifecycle status of the harness."
-                    },
-                    "system_prompt": {
-                      "type": "string",
-                      "description": "System prompt that defines the harness's base behavior.\nForms the foundation of the prompt stack."
-                    },
-                    "tags": {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      },
-                      "description": "Tags for organizing and filtering harnesses."
-                    },
-                    "updated_at": {
-                      "type": "string",
-                      "format": "date-time",
-                      "description": "Timestamp when the harness was last updated."
-                    }
-                  }
-                },
-                {
-                  "type": "object",
-                  "required": [
-                    "self_url",
-                    "view_url",
-                    "ui_link"
-                  ],
-                  "properties": {
-                    "self_url": {
-                      "type": "string",
-                      "description": "Full API endpoint URL for this resource."
-                    },
-                    "ui_link": {
-                      "type": "string",
-                      "description": "Alias for `view_url`, used by command and MCP outputs."
-                    },
-                    "view_url": {
-                      "type": "string",
-                      "description": "Full UI URL for viewing this resource."
-                    }
-                  }
-                }
-              ],
-              "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
-            },
-            "description": "Array of items returned by the list operation."
-          }
-        }
-      },
       "ListResponse_WithUrls_LlmModel": {
         "type": "object",
         "description": "Response wrapper for list endpoints.\nAll list endpoints return responses wrapped in a `data` field.",
@@ -10250,6 +10083,199 @@
                       "example": "https://mcp.atlassian.com/v1/mcp"
                     }
                   }
+                },
+                {
+                  "type": "object",
+                  "required": [
+                    "self_url",
+                    "view_url",
+                    "ui_link"
+                  ],
+                  "properties": {
+                    "self_url": {
+                      "type": "string",
+                      "description": "Full API endpoint URL for this resource."
+                    },
+                    "ui_link": {
+                      "type": "string",
+                      "description": "Alias for `view_url`, used by command and MCP outputs."
+                    },
+                    "view_url": {
+                      "type": "string",
+                      "description": "Full UI URL for viewing this resource."
+                    }
+                  }
+                }
+              ],
+              "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
+            },
+            "description": "Array of items returned by the list operation."
+          }
+        }
+      },
+      "ListResponse_WithUrls_ResourceWithCounts_Harness": {
+        "type": "object",
+        "description": "Response wrapper for list endpoints.\nAll list endpoints return responses wrapped in a `data` field.",
+        "required": [
+          "data"
+        ],
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "allOf": [
+                {
+                  "allOf": [
+                    {
+                      "type": "object",
+                      "description": "Harness configuration for sessions.\nA harness defines the base behavior and capabilities that apply to all sessions.",
+                      "required": [
+                        "id",
+                        "name",
+                        "system_prompt",
+                        "status",
+                        "created_at",
+                        "updated_at"
+                      ],
+                      "properties": {
+                        "archived_at": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "format": "date-time",
+                          "description": "Timestamp when the harness was archived."
+                        },
+                        "capabilities": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/AgentCapabilityConfig"
+                          },
+                          "description": "Capabilities enabled for this harness with per-harness configuration."
+                        },
+                        "created_at": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "Timestamp when the harness was created."
+                        },
+                        "default_model_id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "description": "Default LLM model ID for this harness.\nLowest priority in chain: controls > session > agent > harness.",
+                          "example": "model_01933b5a00007000800000000000001"
+                        },
+                        "deleted_at": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "format": "date-time",
+                          "description": "Timestamp when the harness was deleted."
+                        },
+                        "description": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "description": "Human-readable description of what the harness does."
+                        },
+                        "display_name": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "description": "Human-readable display name shown in UI."
+                        },
+                        "id": {
+                          "type": "string",
+                          "description": "Unique identifier for the harness (format: harness_{32-hex}).",
+                          "example": "harness_01933b5a00007000800000000000001"
+                        },
+                        "initial_files": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/InitialFile"
+                          },
+                          "description": "Starter files copied into each new session for this harness."
+                        },
+                        "is_built_in": {
+                          "type": "boolean",
+                          "description": "Whether this harness is built-in (system-managed, readonly).\nBuilt-in harnesses are provisioned during org initialization and\ncannot be modified or deleted via the API. Users can copy them."
+                        },
+                        "mcpServers": {
+                          "$ref": "#/components/schemas/BTreeMap",
+                          "description": "Remote MCP servers scoped to this harness and inherited by descendant layers."
+                        },
+                        "name": {
+                          "type": "string",
+                          "description": "Name, unique per org (e.g. \"generic\")."
+                        },
+                        "network_access": {
+                          "oneOf": [
+                            {
+                              "type": "null"
+                            },
+                            {
+                              "$ref": "#/components/schemas/NetworkAccessList",
+                              "description": "Network access list controlling which hosts/URLs sessions can reach.\nMerged with agent and session layers (allowed: intersect, blocked: union)."
+                            }
+                          ]
+                        },
+                        "parent_harness_id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "description": "Optional parent harness that this harness inherits from.",
+                          "example": "harness_01933b5a000070008000000000000602"
+                        },
+                        "status": {
+                          "$ref": "#/components/schemas/HarnessStatus",
+                          "description": "Current lifecycle status of the harness."
+                        },
+                        "system_prompt": {
+                          "type": "string",
+                          "description": "System prompt that defines the harness's base behavior.\nForms the foundation of the prompt stack."
+                        },
+                        "tags": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "description": "Tags for organizing and filtering harnesses."
+                        },
+                        "updated_at": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "Timestamp when the harness was last updated."
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "required": [
+                        "session_count",
+                        "app_count"
+                      ],
+                      "properties": {
+                        "app_count": {
+                          "type": "integer",
+                          "format": "int64",
+                          "description": "Number of non-deleted apps using this resource.",
+                          "minimum": 0
+                        },
+                        "session_count": {
+                          "type": "integer",
+                          "format": "int64",
+                          "description": "Number of sessions using this resource.",
+                          "minimum": 0
+                        }
+                      }
+                    }
+                  ],
+                  "description": "Wrapper that flattens lightweight relationship counts into resource responses."
                 },
                 {
                   "type": "object",
@@ -12117,208 +12143,6 @@
           }
         }
       },
-      "PaginatedResponse_WithUrls_Agent": {
-        "type": "object",
-        "description": "Response wrapper for paginated list endpoints.\nIncludes pagination metadata along with the data array.",
-        "required": [
-          "data",
-          "total",
-          "offset",
-          "limit"
-        ],
-        "properties": {
-          "data": {
-            "type": "array",
-            "items": {
-              "allOf": [
-                {
-                  "type": "object",
-                  "description": "Agent configuration for agentic loop.\nAn agent defines the behavior and capabilities of an AI assistant.",
-                  "required": [
-                    "id",
-                    "name",
-                    "system_prompt",
-                    "status",
-                    "created_at",
-                    "updated_at"
-                  ],
-                  "properties": {
-                    "archived_at": {
-                      "type": [
-                        "string",
-                        "null"
-                      ],
-                      "format": "date-time",
-                      "description": "Timestamp when the agent was archived."
-                    },
-                    "capabilities": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/AgentCapabilityConfig"
-                      },
-                      "description": "Capabilities enabled for this agent with per-agent configuration.\nCapabilities add tools and system prompt modifications."
-                    },
-                    "created_at": {
-                      "type": "string",
-                      "format": "date-time",
-                      "description": "Timestamp when the agent was created."
-                    },
-                    "default_model_id": {
-                      "type": [
-                        "string",
-                        "null"
-                      ],
-                      "description": "Default LLM model ID for this agent.\nCan be overridden at the session level.",
-                      "example": "model_01933b5a00007000800000000000001"
-                    },
-                    "deleted_at": {
-                      "type": [
-                        "string",
-                        "null"
-                      ],
-                      "format": "date-time",
-                      "description": "Timestamp when the agent was deleted."
-                    },
-                    "description": {
-                      "type": [
-                        "string",
-                        "null"
-                      ],
-                      "description": "Human-readable description of what the agent does."
-                    },
-                    "display_name": {
-                      "type": [
-                        "string",
-                        "null"
-                      ],
-                      "description": "Human-readable display name shown in UI (e.g. \"Customer Support Agent\").\nFalls back to `name` when absent."
-                    },
-                    "id": {
-                      "type": "string",
-                      "description": "External identifier (agent_<32-hex>). Shown as \"id\" in API.\nClient-supplied or auto-generated.",
-                      "example": "agent_01933b5a000070008000000000000001"
-                    },
-                    "initial_files": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/InitialFile"
-                      },
-                      "description": "Starter files copied into each new session for this agent."
-                    },
-                    "max_iterations": {
-                      "type": [
-                        "integer",
-                        "null"
-                      ],
-                      "description": "Maximum number of LLM iterations per turn for this agent.",
-                      "minimum": 0
-                    },
-                    "mcpServers": {
-                      "$ref": "#/components/schemas/BTreeMap",
-                      "description": "Remote MCP servers scoped to this agent and inherited by its sessions."
-                    },
-                    "name": {
-                      "type": "string",
-                      "description": "Name, unique per org (e.g. \"customer-support\")."
-                    },
-                    "network_access": {
-                      "oneOf": [
-                        {
-                          "type": "null"
-                        },
-                        {
-                          "$ref": "#/components/schemas/NetworkAccessList",
-                          "description": "Network access list controlling which hosts/URLs agent sessions can reach.\nMerged with harness and session layers (allowed: intersect, blocked: union)."
-                        }
-                      ]
-                    },
-                    "status": {
-                      "$ref": "#/components/schemas/AgentStatus",
-                      "description": "Current lifecycle status of the agent."
-                    },
-                    "system_prompt": {
-                      "type": "string",
-                      "description": "System prompt that defines the agent's behavior.\nSent as the first message in every conversation."
-                    },
-                    "tags": {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      },
-                      "description": "Tags for organizing and filtering agents."
-                    },
-                    "tools": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/ToolDefinition"
-                      },
-                      "description": "Client-side tools registered for this agent.\nThese tools are executed by the client, not the server."
-                    },
-                    "updated_at": {
-                      "type": "string",
-                      "format": "date-time",
-                      "description": "Timestamp when the agent was last updated."
-                    },
-                    "usage": {
-                      "oneOf": [
-                        {
-                          "type": "null"
-                        },
-                        {
-                          "$ref": "#/components/schemas/TokenUsage",
-                          "description": "Cumulative token usage across all sessions for this agent."
-                        }
-                      ]
-                    }
-                  }
-                },
-                {
-                  "type": "object",
-                  "required": [
-                    "self_url",
-                    "view_url",
-                    "ui_link"
-                  ],
-                  "properties": {
-                    "self_url": {
-                      "type": "string",
-                      "description": "Full API endpoint URL for this resource."
-                    },
-                    "ui_link": {
-                      "type": "string",
-                      "description": "Alias for `view_url`, used by command and MCP outputs."
-                    },
-                    "view_url": {
-                      "type": "string",
-                      "description": "Full UI URL for viewing this resource."
-                    }
-                  }
-                }
-              ],
-              "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
-            },
-            "description": "Array of items returned by the list operation."
-          },
-          "limit": {
-            "type": "integer",
-            "format": "int32",
-            "description": "Maximum number of items per page.",
-            "minimum": 0
-          },
-          "offset": {
-            "type": "integer",
-            "format": "int32",
-            "description": "Current offset (starting position).",
-            "minimum": 0
-          },
-          "total": {
-            "type": "integer",
-            "format": "int32",
-            "description": "Total number of items matching the query (across all pages).",
-            "minimum": 0
-          }
-        }
-      },
       "PaginatedResponse_WithUrls_CapabilityInfo": {
         "type": "object",
         "description": "Response wrapper for paginated list endpoints.\nIncludes pagination metadata along with the data array.",
@@ -12422,6 +12246,234 @@
                       "description": "Tool definitions provided by this capability"
                     }
                   }
+                },
+                {
+                  "type": "object",
+                  "required": [
+                    "self_url",
+                    "view_url",
+                    "ui_link"
+                  ],
+                  "properties": {
+                    "self_url": {
+                      "type": "string",
+                      "description": "Full API endpoint URL for this resource."
+                    },
+                    "ui_link": {
+                      "type": "string",
+                      "description": "Alias for `view_url`, used by command and MCP outputs."
+                    },
+                    "view_url": {
+                      "type": "string",
+                      "description": "Full UI URL for viewing this resource."
+                    }
+                  }
+                }
+              ],
+              "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
+            },
+            "description": "Array of items returned by the list operation."
+          },
+          "limit": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Maximum number of items per page.",
+            "minimum": 0
+          },
+          "offset": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Current offset (starting position).",
+            "minimum": 0
+          },
+          "total": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Total number of items matching the query (across all pages).",
+            "minimum": 0
+          }
+        }
+      },
+      "PaginatedResponse_WithUrls_ResourceWithCounts_Agent": {
+        "type": "object",
+        "description": "Response wrapper for paginated list endpoints.\nIncludes pagination metadata along with the data array.",
+        "required": [
+          "data",
+          "total",
+          "offset",
+          "limit"
+        ],
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "allOf": [
+                {
+                  "allOf": [
+                    {
+                      "type": "object",
+                      "description": "Agent configuration for agentic loop.\nAn agent defines the behavior and capabilities of an AI assistant.",
+                      "required": [
+                        "id",
+                        "name",
+                        "system_prompt",
+                        "status",
+                        "created_at",
+                        "updated_at"
+                      ],
+                      "properties": {
+                        "archived_at": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "format": "date-time",
+                          "description": "Timestamp when the agent was archived."
+                        },
+                        "capabilities": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/AgentCapabilityConfig"
+                          },
+                          "description": "Capabilities enabled for this agent with per-agent configuration.\nCapabilities add tools and system prompt modifications."
+                        },
+                        "created_at": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "Timestamp when the agent was created."
+                        },
+                        "default_model_id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "description": "Default LLM model ID for this agent.\nCan be overridden at the session level.",
+                          "example": "model_01933b5a00007000800000000000001"
+                        },
+                        "deleted_at": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "format": "date-time",
+                          "description": "Timestamp when the agent was deleted."
+                        },
+                        "description": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "description": "Human-readable description of what the agent does."
+                        },
+                        "display_name": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "description": "Human-readable display name shown in UI (e.g. \"Customer Support Agent\").\nFalls back to `name` when absent."
+                        },
+                        "id": {
+                          "type": "string",
+                          "description": "External identifier (agent_<32-hex>). Shown as \"id\" in API.\nClient-supplied or auto-generated.",
+                          "example": "agent_01933b5a000070008000000000000001"
+                        },
+                        "initial_files": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/InitialFile"
+                          },
+                          "description": "Starter files copied into each new session for this agent."
+                        },
+                        "max_iterations": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ],
+                          "description": "Maximum number of LLM iterations per turn for this agent.",
+                          "minimum": 0
+                        },
+                        "mcpServers": {
+                          "$ref": "#/components/schemas/BTreeMap",
+                          "description": "Remote MCP servers scoped to this agent and inherited by its sessions."
+                        },
+                        "name": {
+                          "type": "string",
+                          "description": "Name, unique per org (e.g. \"customer-support\")."
+                        },
+                        "network_access": {
+                          "oneOf": [
+                            {
+                              "type": "null"
+                            },
+                            {
+                              "$ref": "#/components/schemas/NetworkAccessList",
+                              "description": "Network access list controlling which hosts/URLs agent sessions can reach.\nMerged with harness and session layers (allowed: intersect, blocked: union)."
+                            }
+                          ]
+                        },
+                        "status": {
+                          "$ref": "#/components/schemas/AgentStatus",
+                          "description": "Current lifecycle status of the agent."
+                        },
+                        "system_prompt": {
+                          "type": "string",
+                          "description": "System prompt that defines the agent's behavior.\nSent as the first message in every conversation."
+                        },
+                        "tags": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "description": "Tags for organizing and filtering agents."
+                        },
+                        "tools": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/ToolDefinition"
+                          },
+                          "description": "Client-side tools registered for this agent.\nThese tools are executed by the client, not the server."
+                        },
+                        "updated_at": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "Timestamp when the agent was last updated."
+                        },
+                        "usage": {
+                          "oneOf": [
+                            {
+                              "type": "null"
+                            },
+                            {
+                              "$ref": "#/components/schemas/TokenUsage",
+                              "description": "Cumulative token usage across all sessions for this agent."
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "required": [
+                        "session_count",
+                        "app_count"
+                      ],
+                      "properties": {
+                        "app_count": {
+                          "type": "integer",
+                          "format": "int64",
+                          "description": "Number of non-deleted apps using this resource.",
+                          "minimum": 0
+                        },
+                        "session_count": {
+                          "type": "integer",
+                          "format": "int64",
+                          "description": "Number of sessions using this resource.",
+                          "minimum": 0
+                        }
+                      }
+                    }
+                  ],
+                  "description": "Wrapper that flattens lightweight relationship counts into resource responses."
                 },
                 {
                   "type": "object",
@@ -16585,6 +16637,380 @@
                 "example": "https://mcp.atlassian.com/v1/mcp"
               }
             }
+          },
+          {
+            "type": "object",
+            "required": [
+              "self_url",
+              "view_url",
+              "ui_link"
+            ],
+            "properties": {
+              "self_url": {
+                "type": "string",
+                "description": "Full API endpoint URL for this resource."
+              },
+              "ui_link": {
+                "type": "string",
+                "description": "Alias for `view_url`, used by command and MCP outputs."
+              },
+              "view_url": {
+                "type": "string",
+                "description": "Full UI URL for viewing this resource."
+              }
+            }
+          }
+        ],
+        "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
+      },
+      "WithUrls_ResourceWithCounts_Agent": {
+        "allOf": [
+          {
+            "allOf": [
+              {
+                "type": "object",
+                "description": "Agent configuration for agentic loop.\nAn agent defines the behavior and capabilities of an AI assistant.",
+                "required": [
+                  "id",
+                  "name",
+                  "system_prompt",
+                  "status",
+                  "created_at",
+                  "updated_at"
+                ],
+                "properties": {
+                  "archived_at": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "format": "date-time",
+                    "description": "Timestamp when the agent was archived."
+                  },
+                  "capabilities": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/AgentCapabilityConfig"
+                    },
+                    "description": "Capabilities enabled for this agent with per-agent configuration.\nCapabilities add tools and system prompt modifications."
+                  },
+                  "created_at": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "Timestamp when the agent was created."
+                  },
+                  "default_model_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Default LLM model ID for this agent.\nCan be overridden at the session level.",
+                    "example": "model_01933b5a00007000800000000000001"
+                  },
+                  "deleted_at": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "format": "date-time",
+                    "description": "Timestamp when the agent was deleted."
+                  },
+                  "description": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Human-readable description of what the agent does."
+                  },
+                  "display_name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Human-readable display name shown in UI (e.g. \"Customer Support Agent\").\nFalls back to `name` when absent."
+                  },
+                  "id": {
+                    "type": "string",
+                    "description": "External identifier (agent_<32-hex>). Shown as \"id\" in API.\nClient-supplied or auto-generated.",
+                    "example": "agent_01933b5a000070008000000000000001"
+                  },
+                  "initial_files": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/InitialFile"
+                    },
+                    "description": "Starter files copied into each new session for this agent."
+                  },
+                  "max_iterations": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
+                    "description": "Maximum number of LLM iterations per turn for this agent.",
+                    "minimum": 0
+                  },
+                  "mcpServers": {
+                    "$ref": "#/components/schemas/BTreeMap",
+                    "description": "Remote MCP servers scoped to this agent and inherited by its sessions."
+                  },
+                  "name": {
+                    "type": "string",
+                    "description": "Name, unique per org (e.g. \"customer-support\")."
+                  },
+                  "network_access": {
+                    "oneOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "$ref": "#/components/schemas/NetworkAccessList",
+                        "description": "Network access list controlling which hosts/URLs agent sessions can reach.\nMerged with harness and session layers (allowed: intersect, blocked: union)."
+                      }
+                    ]
+                  },
+                  "status": {
+                    "$ref": "#/components/schemas/AgentStatus",
+                    "description": "Current lifecycle status of the agent."
+                  },
+                  "system_prompt": {
+                    "type": "string",
+                    "description": "System prompt that defines the agent's behavior.\nSent as the first message in every conversation."
+                  },
+                  "tags": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Tags for organizing and filtering agents."
+                  },
+                  "tools": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/ToolDefinition"
+                    },
+                    "description": "Client-side tools registered for this agent.\nThese tools are executed by the client, not the server."
+                  },
+                  "updated_at": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "Timestamp when the agent was last updated."
+                  },
+                  "usage": {
+                    "oneOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "$ref": "#/components/schemas/TokenUsage",
+                        "description": "Cumulative token usage across all sessions for this agent."
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "type": "object",
+                "required": [
+                  "session_count",
+                  "app_count"
+                ],
+                "properties": {
+                  "app_count": {
+                    "type": "integer",
+                    "format": "int64",
+                    "description": "Number of non-deleted apps using this resource.",
+                    "minimum": 0
+                  },
+                  "session_count": {
+                    "type": "integer",
+                    "format": "int64",
+                    "description": "Number of sessions using this resource.",
+                    "minimum": 0
+                  }
+                }
+              }
+            ],
+            "description": "Wrapper that flattens lightweight relationship counts into resource responses."
+          },
+          {
+            "type": "object",
+            "required": [
+              "self_url",
+              "view_url",
+              "ui_link"
+            ],
+            "properties": {
+              "self_url": {
+                "type": "string",
+                "description": "Full API endpoint URL for this resource."
+              },
+              "ui_link": {
+                "type": "string",
+                "description": "Alias for `view_url`, used by command and MCP outputs."
+              },
+              "view_url": {
+                "type": "string",
+                "description": "Full UI URL for viewing this resource."
+              }
+            }
+          }
+        ],
+        "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
+      },
+      "WithUrls_ResourceWithCounts_Harness": {
+        "allOf": [
+          {
+            "allOf": [
+              {
+                "type": "object",
+                "description": "Harness configuration for sessions.\nA harness defines the base behavior and capabilities that apply to all sessions.",
+                "required": [
+                  "id",
+                  "name",
+                  "system_prompt",
+                  "status",
+                  "created_at",
+                  "updated_at"
+                ],
+                "properties": {
+                  "archived_at": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "format": "date-time",
+                    "description": "Timestamp when the harness was archived."
+                  },
+                  "capabilities": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/AgentCapabilityConfig"
+                    },
+                    "description": "Capabilities enabled for this harness with per-harness configuration."
+                  },
+                  "created_at": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "Timestamp when the harness was created."
+                  },
+                  "default_model_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Default LLM model ID for this harness.\nLowest priority in chain: controls > session > agent > harness.",
+                    "example": "model_01933b5a00007000800000000000001"
+                  },
+                  "deleted_at": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "format": "date-time",
+                    "description": "Timestamp when the harness was deleted."
+                  },
+                  "description": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Human-readable description of what the harness does."
+                  },
+                  "display_name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Human-readable display name shown in UI."
+                  },
+                  "id": {
+                    "type": "string",
+                    "description": "Unique identifier for the harness (format: harness_{32-hex}).",
+                    "example": "harness_01933b5a00007000800000000000001"
+                  },
+                  "initial_files": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/InitialFile"
+                    },
+                    "description": "Starter files copied into each new session for this harness."
+                  },
+                  "is_built_in": {
+                    "type": "boolean",
+                    "description": "Whether this harness is built-in (system-managed, readonly).\nBuilt-in harnesses are provisioned during org initialization and\ncannot be modified or deleted via the API. Users can copy them."
+                  },
+                  "mcpServers": {
+                    "$ref": "#/components/schemas/BTreeMap",
+                    "description": "Remote MCP servers scoped to this harness and inherited by descendant layers."
+                  },
+                  "name": {
+                    "type": "string",
+                    "description": "Name, unique per org (e.g. \"generic\")."
+                  },
+                  "network_access": {
+                    "oneOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "$ref": "#/components/schemas/NetworkAccessList",
+                        "description": "Network access list controlling which hosts/URLs sessions can reach.\nMerged with agent and session layers (allowed: intersect, blocked: union)."
+                      }
+                    ]
+                  },
+                  "parent_harness_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Optional parent harness that this harness inherits from.",
+                    "example": "harness_01933b5a000070008000000000000602"
+                  },
+                  "status": {
+                    "$ref": "#/components/schemas/HarnessStatus",
+                    "description": "Current lifecycle status of the harness."
+                  },
+                  "system_prompt": {
+                    "type": "string",
+                    "description": "System prompt that defines the harness's base behavior.\nForms the foundation of the prompt stack."
+                  },
+                  "tags": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Tags for organizing and filtering harnesses."
+                  },
+                  "updated_at": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "Timestamp when the harness was last updated."
+                  }
+                }
+              },
+              {
+                "type": "object",
+                "required": [
+                  "session_count",
+                  "app_count"
+                ],
+                "properties": {
+                  "app_count": {
+                    "type": "integer",
+                    "format": "int64",
+                    "description": "Number of non-deleted apps using this resource.",
+                    "minimum": 0
+                  },
+                  "session_count": {
+                    "type": "integer",
+                    "format": "int64",
+                    "description": "Number of sessions using this resource.",
+                    "minimum": 0
+                  }
+                }
+              }
+            ],
+            "description": "Wrapper that flattens lightweight relationship counts into resource responses."
           },
           {
             "type": "object",


### PR DESCRIPTION
## What
- Adds session_count and app_count to agent and harness list/detail API responses.
- Shows compact usage counts on agent and harness cards.
- Adds Usage counts on agent and harness detail pages.
- Updates generated OpenAPI schema.

## Why
Agent and harness surfaces should show how many sessions and apps are using each resource without making users drill into separate pages.

## How
- Adds org-scoped storage count helpers for sessions and non-deleted apps.
- Wraps agent and harness API responses with flattened count metadata.
- Renders counts in minimal card footers and detail Usage blocks.

## Risk
- Low
- Adds extra count queries to agent/harness list and detail endpoints. Counts are org-scoped and parameterized; card/detail rendering only consumes numeric fields.

## Security
- Threat categories reviewed: TM-API, TM-TENANT, TM-WEB, TM-DOS
- Findings and resolutions: count queries include org_id filters and use bound parameters; UI renders numeric values only; no auth, secret, tenant-resolution, or tool-execution changes; no threat-model update needed.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

Validation:
- cargo fmt --check
- cargo check -p everruns-server
- cargo build -p everruns-server
- cargo clippy --all-targets --all-features -- -D warnings
- targeted UI oxlint for changed files
- ./scripts/export-openapi.sh
- PORT_PREFIX=271 just start-dev --no-watch smoke: /api/v1/agents list/detail and /api/v1/harnesses list/detail include session_count and app_count
- just pre-push