### PR TITLE
fix(deletion): block deleting app-backed entities

### DIFF
--- a/apps/ui/src/app/(main)/agent-identities/[identityId]/page.tsx
+++ b/apps/ui/src/app/(main)/agent-identities/[identityId]/page.tsx
@@ -11,6 +11,7 @@ import {
   useUpdateAgentIdentity,
 } from "@/hooks/use-agent-identities";
 import { ResourceNotFound } from "@/components/resource-not-found";
+import { EntityDeleteErrorNotice } from "@/components/entity-delete-error-notice";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -111,6 +112,8 @@ export default function AgentIdentityDetailPage({
 
   const isSaving = updateIdentity.isPending;
   const isReadOnly = isReadOnlyStatus(identity?.status);
+  const deleteError = deleteIdentity.error ?? destroyIdentity.error;
+  const deleteAction = identity?.status === "archived" ? "delete" : "archive";
 
   if (isLoading) {
     return (
@@ -272,6 +275,14 @@ export default function AgentIdentityDetailPage({
                     </Button>
                   )}
                 </div>
+                {deleteError && (
+                  <EntityDeleteErrorNotice
+                    entityKind="identity"
+                    action={deleteAction}
+                    message={deleteError.message}
+                    className="mt-4"
+                  />
+                )}
               </CardContent>
             </Card>
           </div>
@@ -337,6 +348,14 @@ export default function AgentIdentityDetailPage({
               Permanently delete the archived identity &quot;{identity.name}&quot;? Existing
               references will render as deleted tombstones.
             </DialogDescription>
+            {destroyIdentity.error && (
+              <EntityDeleteErrorNotice
+                entityKind="identity"
+                action="delete"
+                message={destroyIdentity.error.message}
+                className="mt-4"
+              />
+            )}
           </DialogHeader>
           <DialogFooter>
             <Button variant="outline" onClick={() => setShowDeleteDialog(false)}>

--- a/apps/ui/src/app/(main)/agents/[agentId]/edit/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/edit/page.tsx
@@ -31,6 +31,7 @@ import {
 } from "@/components/ui/dialog";
 import { CapabilitySelector } from "@/components/agents/capability-selector";
 import { AgentPreview } from "@/components/agents/agent-preview";
+import { EntityDeleteErrorNotice } from "@/components/entity-delete-error-notice";
 import { InitialFilesEditor } from "@/components/initial-files-editor";
 import { ModelPicker } from "@/components/models/model-picker";
 import { ArrowLeft, Save, Trash2, Eye, Edit2, Check, X, Loader2 } from "lucide-react";
@@ -194,6 +195,8 @@ export default function EditAgentPage({ params }: { params: Promise<{ agentId: s
   const isSaving = updateAgent.isPending;
   const isReadOnly = isReadOnlyStatus(agent?.status);
   const canDangerousDelete = canPolicies("agent.dangerous");
+  const deleteError = deleteAgent.error ?? destroyAgent.error;
+  const deleteAction = agent?.status === "archived" ? "delete" : "archive";
 
   if (isLoading) {
     return (
@@ -424,6 +427,14 @@ export default function EditAgentPage({ params }: { params: Promise<{ agentId: s
                         </Button>
                       )}
                     </div>
+                    {deleteError && (
+                      <EntityDeleteErrorNotice
+                        entityKind="agent"
+                        action={deleteAction}
+                        message={deleteError.message}
+                        className="mt-4"
+                      />
+                    )}
                   </CardContent>
                 </Card>
               </div>
@@ -535,6 +546,14 @@ export default function EditAgentPage({ params }: { params: Promise<{ agentId: s
               Permanently delete the archived agent &quot;{agentDisplayName}
               &quot;? Existing references will render as deleted tombstones.
             </DialogDescription>
+            {destroyAgent.error && (
+              <EntityDeleteErrorNotice
+                entityKind="agent"
+                action="delete"
+                message={destroyAgent.error.message}
+                className="mt-4"
+              />
+            )}
           </DialogHeader>
           <DialogFooter>
             <Button variant="outline" onClick={() => setShowDeleteDialog(false)}>

--- a/apps/ui/src/app/(main)/harnesses/[harnessId]/edit/page.tsx
+++ b/apps/ui/src/app/(main)/harnesses/[harnessId]/edit/page.tsx
@@ -31,6 +31,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { CapabilitySelector } from "@/components/agents/capability-selector";
+import { EntityDeleteErrorNotice } from "@/components/entity-delete-error-notice";
 import { HarnessSelect } from "@/components/harness/harness-select";
 import { HarnessPreview } from "@/components/harnesses/harness-preview";
 import { InitialFilesEditor } from "@/components/initial-files-editor";
@@ -192,6 +193,8 @@ export default function EditHarnessPage({ params }: { params: Promise<{ harnessI
   const isSaving = updateHarness.isPending;
   const isReadOnly = isReadOnlyStatus(harness?.status);
   const canDangerousDelete = canPolicies("harness.dangerous");
+  const deleteError = deleteHarness.error ?? destroyHarness.error;
+  const deleteAction = harness?.status === "archived" ? "delete" : "archive";
 
   // Built-in harnesses cannot be edited — redirect to detail page
   if (harness?.is_built_in) {
@@ -441,6 +444,14 @@ export default function EditHarnessPage({ params }: { params: Promise<{ harnessI
                         </Button>
                       )}
                     </div>
+                    {deleteError && (
+                      <EntityDeleteErrorNotice
+                        entityKind="harness"
+                        action={deleteAction}
+                        message={deleteError.message}
+                        className="mt-4"
+                      />
+                    )}
                   </CardContent>
                 </Card>
               </div>
@@ -560,6 +571,14 @@ export default function EditHarnessPage({ params }: { params: Promise<{ harnessI
               Permanently delete the archived harness &quot;{getDisplayName(harness)}&quot;?
               Existing references will render as deleted tombstones.
             </DialogDescription>
+            {destroyHarness.error && (
+              <EntityDeleteErrorNotice
+                entityKind="harness"
+                action="delete"
+                message={destroyHarness.error.message}
+                className="mt-4"
+              />
+            )}
           </DialogHeader>
           <DialogFooter>
             <Button variant="outline" onClick={() => setShowDeleteDialog(false)}>

--- a/apps/ui/src/app/(main)/harnesses/[harnessId]/page.tsx
+++ b/apps/ui/src/app/(main)/harnesses/[harnessId]/page.tsx
@@ -21,6 +21,7 @@ import { InlineStreamdownMessage } from "@/components/chat/streamdown-message";
 import { ProviderIcon } from "@/components/providers/provider-icon";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { HarnessPreview } from "@/components/harnesses/harness-preview";
+import { EntityDeleteErrorNotice } from "@/components/entity-delete-error-notice";
 import { ArrowLeft, Pencil, Copy, Trash2, Eye, LayoutDashboard } from "lucide-react";
 import { CopyButton } from "@/components/ui/copy-button";
 import type { Capability, LlmModelWithProvider } from "@/lib/api/types";
@@ -60,6 +61,7 @@ export default function HarnessDetailPage({ params }: { params: Promise<{ harnes
     allCapabilities?.find((c) => c.id === capabilityId);
 
   const harnessCapabilities = harness?.capabilities ?? [];
+  const deleteError = deleteHarness.error;
 
   const handleDelete = async () => {
     if (!confirm("Archive this harness? It will become read-only and stop being assignable.")) {
@@ -152,6 +154,14 @@ export default function HarnessDetailPage({ params }: { params: Promise<{ harnes
           )}
         </div>
       </div>
+      {deleteError && (
+        <EntityDeleteErrorNotice
+          entityKind="harness"
+          action="archive"
+          message={deleteError.message}
+          className="mb-4"
+        />
+      )}
 
       <Tabs value={activeTab} onValueChange={setActiveTab}>
         <TabsList className="mb-6">

--- a/apps/ui/src/components/entity-delete-error-notice.tsx
+++ b/apps/ui/src/components/entity-delete-error-notice.tsx
@@ -1,0 +1,70 @@
+import { AlertCircle } from "lucide-react";
+import { Notice, NoticeDescription, NoticeTitle } from "@/components/ui/notice";
+
+type DeleteAction = "archive" | "delete";
+
+interface EntityDeleteErrorNoticeProps {
+  entityKind: "agent" | "harness" | "identity";
+  action: DeleteAction;
+  message: string;
+  className?: string;
+}
+
+function titleFor(entityKind: EntityDeleteErrorNoticeProps["entityKind"], action: DeleteAction) {
+  const label = entityKind === "identity" ? "Agent Identity" : capitalize(entityKind);
+  return `Cannot ${capitalize(action)} ${label}`;
+}
+
+function capitalize(value: string) {
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+function formatDeleteErrorMessage(
+  entityKind: EntityDeleteErrorNoticeProps["entityKind"],
+  action: DeleteAction,
+  message: string,
+) {
+  const appReference = message.match(
+    /^Cannot archive or delete (agent|harness|agent identity) while apps still reference it: (.+)$/i,
+  );
+  if (appReference) {
+    const apps = appReference[2];
+    const label = entityKind === "identity" ? "agent identity" : entityKind;
+    const verb = action === "archive" ? "archiving" : "deleting";
+    return `This ${label} is still used by apps: ${apps}. Remove it from those apps before ${verb}.`;
+  }
+
+  const childHarnesses = message.match(
+    /^Cannot archive or delete harness while child harnesses still inherit from it: (.+)$/i,
+  );
+  if (childHarnesses) {
+    const verb = action === "archive" ? "archiving" : "deleting";
+    return `Other harnesses still inherit from this harness: ${childHarnesses[1]}. Move or remove those child harnesses before ${verb}.`;
+  }
+
+  if (message === "Cannot archive or delete harness while it is the organization default harness") {
+    const verb = action === "archive" ? "archiving" : "deleting";
+    return `This harness is the organization default harness. Choose a different default harness before ${verb}.`;
+  }
+
+  if (message === "Cannot archive or delete harness while it is the organization base harness") {
+    const verb = action === "archive" ? "archiving" : "deleting";
+    return `This harness is the organization base harness. Choose a different base harness before ${verb}.`;
+  }
+
+  return message;
+}
+
+export function EntityDeleteErrorNotice({
+  entityKind,
+  action,
+  message,
+  className,
+}: EntityDeleteErrorNoticeProps) {
+  return (
+    <Notice variant="destructive" className={className} icon={<AlertCircle className="size-4" />}>
+      <NoticeTitle>{titleFor(entityKind, action)}</NoticeTitle>
+      <NoticeDescription>{formatDeleteErrorMessage(entityKind, action, message)}</NoticeDescription>
+    </Notice>
+  );
+}

--- a/crates/server/src/domains/agent_identities/commands.rs
+++ b/crates/server/src/domains/agent_identities/commands.rs
@@ -317,6 +317,13 @@ impl Command for DeleteAgentIdentity {
             .parse()
             .map_err(|e| CommandError::bad_request(format!("Invalid identity ID: {e}")))?;
 
+        crate::domains::apps::queries::ensure_no_app_references_to_agent_identity(
+            &ctx.db,
+            ctx.org_id(),
+            identity_id.uuid(),
+        )
+        .await?;
+
         let deleted = ctx
             .db
             .delete_agent_identity(ctx.org_id(), identity_id)
@@ -373,6 +380,13 @@ impl Command for DestroyAgentIdentity {
             .id
             .parse()
             .map_err(|e| CommandError::bad_request(format!("Invalid identity ID: {e}")))?;
+
+        crate::domains::apps::queries::ensure_no_app_references_to_agent_identity(
+            &ctx.db,
+            ctx.org_id(),
+            identity_id.uuid(),
+        )
+        .await?;
 
         let destroyed = ctx
             .db

--- a/crates/server/src/domains/agents/commands.rs
+++ b/crates/server/src/domains/agents/commands.rs
@@ -545,6 +545,13 @@ impl Command for DeleteAgent {
             .map_err(classify_anyhow)?
             .ok_or_else(|| CommandError::not_found("Agent"))?;
 
+        crate::domains::apps::queries::ensure_no_app_references_to_agent(
+            &ctx.db,
+            ctx.org_id(),
+            row.id.uuid(),
+        )
+        .await?;
+
         ctx.db
             .delete_agent(ctx.org_id(), row.id)
             .await
@@ -995,6 +1002,13 @@ impl Command for DestroyAgent {
                 "Agent must be archived before deletion",
             ));
         }
+
+        crate::domains::apps::queries::ensure_no_app_references_to_agent(
+            &ctx.db,
+            ctx.org_id(),
+            row.id.uuid(),
+        )
+        .await?;
 
         ctx.db
             .destroy_agent(ctx.org_id(), row.id)

--- a/crates/server/src/domains/apps/queries.rs
+++ b/crates/server/src/domains/apps/queries.rs
@@ -2,6 +2,7 @@
 //
 // No policy checks, no input validation. Pure data access + mapping.
 
+use crate::domains::common::CommandError;
 use crate::services::row_to_principal;
 use crate::storage::StorageBackend;
 use crate::storage::encryption::EncryptionService;
@@ -267,6 +268,67 @@ pub async fn load_apps_list(
         apps.push(row_to_app(db, encryption, row, org_id).await);
     }
     Ok(apps)
+}
+
+// ============================================================================
+// Reference guards
+// ============================================================================
+
+fn referenced_app_names(apps: &[AppRow], predicate: impl Fn(&AppRow) -> bool) -> Option<String> {
+    let names = apps
+        .iter()
+        .filter(|app| predicate(app))
+        .map(|app| app.name.as_str())
+        .collect::<Vec<_>>();
+    if names.is_empty() {
+        None
+    } else {
+        Some(names.join(", "))
+    }
+}
+
+pub async fn ensure_no_app_references_to_agent(
+    db: &StorageBackend,
+    org_id: i64,
+    agent_id: Uuid,
+) -> Result<(), CommandError> {
+    let apps = db.list_apps(org_id, None, false).await?;
+    if let Some(names) = referenced_app_names(&apps, |app| app.agent_id == Some(agent_id)) {
+        return Err(CommandError::conflict(format!(
+            "Cannot archive or delete agent while apps still reference it: {names}"
+        )));
+    }
+    Ok(())
+}
+
+pub async fn ensure_no_app_references_to_harness(
+    db: &StorageBackend,
+    org_id: i64,
+    harness_id: Uuid,
+) -> Result<(), CommandError> {
+    let apps = db.list_apps(org_id, None, false).await?;
+    if let Some(names) = referenced_app_names(&apps, |app| app.harness_id == harness_id) {
+        return Err(CommandError::conflict(format!(
+            "Cannot archive or delete harness while apps still reference it: {names}"
+        )));
+    }
+    Ok(())
+}
+
+pub async fn ensure_no_app_references_to_agent_identity(
+    db: &StorageBackend,
+    org_id: i64,
+    identity_id: Uuid,
+) -> Result<(), CommandError> {
+    let apps = db.list_apps(org_id, None, false).await?;
+    if let Some(names) =
+        referenced_app_names(&apps, |app| app.agent_identity_id == Some(identity_id))
+    {
+        return Err(CommandError::conflict(format!(
+            "Cannot archive or delete agent identity while apps still reference it: {names}"
+        )));
+    }
+    Ok(())
 }
 
 /// Lookup app by public_id without org scoping (for unauthenticated webhooks).

--- a/crates/server/src/domains/harnesses/commands.rs
+++ b/crates/server/src/domains/harnesses/commands.rs
@@ -523,7 +523,14 @@ impl Command for DeleteHarness {
 
         q::ensure_no_child_harnesses(&ctx.db, ctx.org_id(), harness_id)
             .await
-            .map_err(classify_anyhow)?;
+            .map_err(|err| CommandError::conflict(err.to_string()))?;
+        q::ensure_not_org_default_harness(&ctx.db, ctx.org_id(), harness_id).await?;
+        crate::domains::apps::queries::ensure_no_app_references_to_harness(
+            &ctx.db,
+            ctx.org_id(),
+            harness_id.uuid(),
+        )
+        .await?;
 
         let deleted = ctx
             .db
@@ -588,7 +595,14 @@ impl Command for DestroyHarness {
 
         q::ensure_no_child_harnesses(&ctx.db, ctx.org_id(), harness_id)
             .await
-            .map_err(classify_anyhow)?;
+            .map_err(|err| CommandError::conflict(err.to_string()))?;
+        q::ensure_not_org_default_harness(&ctx.db, ctx.org_id(), harness_id).await?;
+        crate::domains::apps::queries::ensure_no_app_references_to_harness(
+            &ctx.db,
+            ctx.org_id(),
+            harness_id.uuid(),
+        )
+        .await?;
 
         let existing = ctx
             .db

--- a/crates/server/src/domains/harnesses/queries.rs
+++ b/crates/server/src/domains/harnesses/queries.rs
@@ -331,6 +331,29 @@ pub async fn ensure_no_child_harnesses(
     );
 }
 
+/// Ensure deleting/archiving won't break org-level default harness settings.
+pub async fn ensure_not_org_default_harness(
+    db: &StorageBackend,
+    org_id: i64,
+    harness_id: HarnessId,
+) -> Result<(), CommandError> {
+    let settings = db.get_organization_settings(org_id).await?;
+    let Some(settings) = settings else {
+        return Ok(());
+    };
+    if settings.default_harness_id == Some(harness_id) {
+        return Err(CommandError::conflict(
+            "Cannot archive or delete harness while it is the organization default harness",
+        ));
+    }
+    if settings.base_harness_id == Some(harness_id) {
+        return Err(CommandError::conflict(
+            "Cannot archive or delete harness while it is the organization base harness",
+        ));
+    }
+    Ok(())
+}
+
 async fn ensure_no_parent_cycle(
     db: &StorageBackend,
     org_id: i64,

--- a/crates/server/tests/api_integration_test.rs
+++ b/crates/server/tests/api_integration_test.rs
@@ -21,8 +21,9 @@ use test_harness::TestServer;
 use everruns_core::llm_models::LlmProvider;
 use everruns_core::typed_id::ScheduleId;
 use everruns_core::{Agent, DEFAULT_ORG_ID, Harness, LlmModel, PrincipalId, Session, SessionFile};
+use everruns_durable::UpdateField;
 use everruns_server::storage::models::{
-    CreatePrincipalRow, CreateSessionScheduleRow, UpdateSession,
+    CreatePrincipalRow, CreateSessionScheduleRow, UpdateOrganizationSettings, UpdateSession,
 };
 use uuid::Uuid;
 
@@ -3506,6 +3507,248 @@ async fn test_verify_connection_providers_listed() {
 // ============================================
 // App Reference Validation Tests
 // ============================================
+
+#[tokio::test]
+async fn test_delete_agent_referenced_by_app_returns_conflict() {
+    let server = TestServer::in_memory().await;
+
+    let agent: Value = server
+        .post(
+            "/v1/agents",
+            json!({
+                "name": "delete-app-agent",
+                "display_name": "Delete App Agent",
+                "system_prompt": "Test"
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    server
+        .post(
+            "/v1/apps",
+            json!({
+                "name": "Agent Delete Blocker",
+                "harness_id": server.seed_generic_harness_id,
+                "agent_id": agent["id"]
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED);
+
+    server
+        .delete(&format!("/v1/agents/{}", agent["id"].as_str().unwrap()))
+        .await
+        .assert_status(StatusCode::CONFLICT);
+}
+
+#[tokio::test]
+async fn test_delete_harness_referenced_by_app_returns_conflict() {
+    let server = TestServer::in_memory().await;
+
+    let harness: Harness = server
+        .post(
+            "/v1/harnesses",
+            json!({
+                "name": "delete-app-harness",
+                "display_name": "Delete App Harness",
+                "system_prompt": "Test"
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    server
+        .post(
+            "/v1/apps",
+            json!({
+                "name": "Harness Delete Blocker",
+                "harness_id": harness.id
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED);
+
+    server
+        .delete(&format!("/v1/harnesses/{}", harness.id))
+        .await
+        .assert_status(StatusCode::CONFLICT);
+}
+
+#[tokio::test]
+async fn test_delete_agent_identity_referenced_by_app_returns_conflict() {
+    let server = TestServer::in_memory().await;
+
+    let identity: Value = server
+        .post(
+            "/v1/agent-identities",
+            json!({"name": "Delete App Identity"}),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    server
+        .post(
+            "/v1/apps",
+            json!({
+                "name": "Identity Delete Blocker",
+                "harness_id": server.seed_generic_harness_id,
+                "agent_identity_id": identity["id"]
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED);
+
+    server
+        .delete(&format!(
+            "/v1/agent-identities/{}",
+            identity["id"].as_str().unwrap()
+        ))
+        .await
+        .assert_status(StatusCode::CONFLICT);
+}
+
+#[tokio::test]
+async fn test_delete_harness_with_child_returns_conflict() {
+    let server = TestServer::in_memory().await;
+
+    let parent: Harness = server
+        .post(
+            "/v1/harnesses",
+            json!({
+                "name": "parent-delete-blocker",
+                "display_name": "Parent Delete Blocker",
+                "system_prompt": "Parent"
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    server
+        .post(
+            "/v1/harnesses",
+            json!({
+                "name": "child-delete-blocker",
+                "display_name": "Child Delete Blocker",
+                "system_prompt": "Child",
+                "parent_harness_id": parent.id
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED);
+
+    server
+        .delete(&format!("/v1/harnesses/{}", parent.id))
+        .await
+        .assert_status(StatusCode::CONFLICT);
+}
+
+#[tokio::test]
+async fn test_delete_org_default_harness_returns_conflict() {
+    let server = TestServer::in_memory().await;
+
+    let harness: Harness = server
+        .post(
+            "/v1/harnesses",
+            json!({
+                "name": "org-default-delete-blocker",
+                "display_name": "Org Default Delete Blocker",
+                "system_prompt": "Test"
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    server
+        .db
+        .patch_organization_settings(
+            DEFAULT_ORG_ID,
+            UpdateOrganizationSettings {
+                default_model_id: UpdateField::Unchanged,
+                default_harness_id: UpdateField::Set(harness.id),
+                base_harness_id: UpdateField::Unchanged,
+            },
+        )
+        .await
+        .unwrap();
+
+    server
+        .delete(&format!("/v1/harnesses/{}", harness.id))
+        .await
+        .assert_status(StatusCode::CONFLICT);
+}
+
+#[tokio::test]
+async fn test_delete_entities_referenced_only_by_session_succeeds() {
+    let server = TestServer::in_memory().await;
+
+    let harness: Harness = server
+        .post(
+            "/v1/harnesses",
+            json!({
+                "name": "session-only-delete-harness",
+                "display_name": "Session Only Delete Harness",
+                "system_prompt": "Test"
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+    let agent: Value = server
+        .post(
+            "/v1/agents",
+            json!({
+                "name": "session-only-delete-agent",
+                "display_name": "Session Only Delete Agent",
+                "system_prompt": "Test"
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+    let identity: Value = server
+        .post(
+            "/v1/agent-identities",
+            json!({"name": "Session Only Delete Identity"}),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    server
+        .post(
+            "/v1/sessions",
+            json!({
+                "harness_id": harness.id,
+                "agent_id": agent["id"],
+                "agent_identity_id": identity["id"],
+                "title": "Session-only references"
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED);
+
+    server
+        .delete(&format!("/v1/agents/{}", agent["id"].as_str().unwrap()))
+        .await
+        .assert_status(StatusCode::NO_CONTENT);
+    server
+        .delete(&format!("/v1/harnesses/{}", harness.id))
+        .await
+        .assert_status(StatusCode::NO_CONTENT);
+    server
+        .delete(&format!(
+            "/v1/agent-identities/{}",
+            identity["id"].as_str().unwrap()
+        ))
+        .await
+        .assert_status(StatusCode::NO_CONTENT);
+}
 
 #[tokio::test]
 async fn test_create_app_missing_harness_returns_not_found() {


### PR DESCRIPTION
## What
- Block Agent, Harness, and Agent Identity archive/delete while active or draft Apps reference them.
- Block Harness archive/delete when child harnesses depend on it or when it is the organization default/base harness.
- Show delete-blocking conflicts as destructive notices in the UI danger zones, including the referencing App or Harness names.
- Add API regression tests for App references, child harness references, org default harnesses, and session-only references.

## Why
Deleting these entities while Apps or harness settings still depend on them can silently break active App configurations. Session history references are archival and should still tolerate deletion through tombstones.

## How
- Added org-scoped backend guards used by soft delete and permanent delete commands.
- Converted dependent-harness delete failures into 409 conflicts and added org default/base harness guards.
- Added a reusable `EntityDeleteErrorNotice` component that formats backend conflict messages into user-facing danger-zone notices.

## Risk
- Low
- Delete/archive operations now return 409 for live App, child harness, or org setting dependencies that were previously allowed; this is the intended behavior.
- Authorized users may see names of dependent Apps or Harnesses in delete-blocking errors.

## Security
- Threat categories reviewed: TM-AUTHZ, TM-API, TM-TENANT, TM-WEB, TM-DOS.
- Findings and resolutions: existing command policies still gate delete/archive actions; all dependency checks use `ctx.org_id()` scoped queries; React renders escaped text only; no new external dependency or unbounded user-controlled HTML. No threat-model update needed.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] All review comments addressed (code change or written reasoning)
