### PR TITLE
feat(apps): add configurable AG-UI thread expiration

### DIFF
--- a/apps/ui/src/__tests__/ag-ui-setup-guidance.test.tsx
+++ b/apps/ui/src/__tests__/ag-ui-setup-guidance.test.tsx
@@ -18,7 +18,7 @@ describe("AgUiSetupGuidance", () => {
     expect(screen.getByText("Responses stream back as AG-UI SSE events.")).toBeInTheDocument();
     expect(screen.getByText("Thread expiration")).toBeInTheDocument();
     expect(
-      screen.getByText(/6 hours.*after this, the same threadId starts a new session/),
+      screen.getByText(/6 hours.*requests reusing the same threadId are rejected with 410 Gone/),
     ).toBeInTheDocument();
   });
 

--- a/apps/ui/src/__tests__/ag-ui-setup-guidance.test.tsx
+++ b/apps/ui/src/__tests__/ag-ui-setup-guidance.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import { AgUiSetupGuidance } from "@/components/apps/ag-ui-setup-guidance";
+import { AgUiSetupGuidance, formatSessionExpiration } from "@/components/apps/ag-ui-setup-guidance";
 
 describe("AgUiSetupGuidance", () => {
   it("renders the endpoint and anonymous status", () => {
@@ -8,6 +8,7 @@ describe("AgUiSetupGuidance", () => {
         endpointUrl="https://example.com/api/v1/apps/app-123/ag-ui"
         isPublished={true}
         anonymousEnabled={true}
+        sessionExpirationSeconds={6 * 60 * 60}
       />,
     );
 
@@ -15,5 +16,48 @@ describe("AgUiSetupGuidance", () => {
     expect(screen.getByText("Ready for AG-UI clients")).toBeInTheDocument();
     expect(screen.getByText("https://example.com/api/v1/apps/app-123/ag-ui")).toBeInTheDocument();
     expect(screen.getByText("Responses stream back as AG-UI SSE events.")).toBeInTheDocument();
+    expect(screen.getByText("Thread expiration")).toBeInTheDocument();
+    expect(
+      screen.getByText(/6 hours.*after this, the same threadId starts a new session/),
+    ).toBeInTheDocument();
+  });
+
+  it("renders 'Never' when expiration is disabled", () => {
+    render(
+      <AgUiSetupGuidance
+        endpointUrl="https://example.com/api/v1/apps/app-123/ag-ui"
+        isPublished={true}
+        anonymousEnabled={true}
+        sessionExpirationSeconds={0}
+      />,
+    );
+
+    expect(screen.getByText(/Never.*threads can be resumed indefinitely/)).toBeInTheDocument();
+  });
+});
+
+describe("formatSessionExpiration", () => {
+  it("formats whole hours", () => {
+    expect(formatSessionExpiration(6 * 60 * 60)).toBe("6 hours");
+    expect(formatSessionExpiration(60 * 60)).toBe("1 hour");
+  });
+
+  it("formats fractional hours", () => {
+    expect(formatSessionExpiration(90 * 60)).toBe("1.5 hours");
+  });
+
+  it("formats minutes", () => {
+    expect(formatSessionExpiration(5 * 60)).toBe("5 minutes");
+    expect(formatSessionExpiration(60)).toBe("1 minute");
+  });
+
+  it("formats seconds for short values", () => {
+    expect(formatSessionExpiration(30)).toBe("30 seconds");
+    expect(formatSessionExpiration(1)).toBe("1 second");
+  });
+
+  it("returns 'Never' for zero or negative", () => {
+    expect(formatSessionExpiration(0)).toBe("Never");
+    expect(formatSessionExpiration(-1)).toBe("Never");
   });
 });

--- a/apps/ui/src/app/(main)/apps/[appId]/page.tsx
+++ b/apps/ui/src/app/(main)/apps/[appId]/page.tsx
@@ -125,7 +125,6 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
     useState<InvocationSessionMode>("shared_session");
   const [editChannelMessage, setEditChannelMessage] = useState("");
   const [editWebhookToken, setEditWebhookToken] = useState("");
-  const [editAgUiAnonymous, setEditAgUiAnonymous] = useState(true);
   const [editAgUiExpirationHours, setEditAgUiExpirationHours] = useState(
     DEFAULT_AG_UI_SESSION_EXPIRATION_SECONDS / 3600,
   );
@@ -281,7 +280,6 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
     setEditInvocationSessionMode("shared_session");
     setEditChannelMessage("");
     setEditWebhookToken("");
-    setEditAgUiAnonymous(true);
     setEditAgUiExpirationHours(DEFAULT_AG_UI_SESSION_EXPIRATION_SECONDS / 3600);
     setEditChannelEnabled(true);
   };
@@ -293,7 +291,7 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
           ? Math.max(0, editAgUiExpirationHours)
           : DEFAULT_AG_UI_SESSION_EXPIRATION_SECONDS / 3600;
         return {
-          anonymous: editAgUiAnonymous,
+          anonymous: true,
           session_expiration_seconds: Math.round(hours * 3600),
         };
       }
@@ -340,7 +338,6 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
     setEditChannelEnabled(channel.enabled);
     if (channel.channel_type === "ag_ui") {
       const config = channel.channel_config as AgUiChannelConfig;
-      setEditAgUiAnonymous(config?.anonymous ?? true);
       const expSeconds =
         config?.session_expiration_seconds ?? DEFAULT_AG_UI_SESSION_EXPIRATION_SECONDS;
       setEditAgUiExpirationHours(expSeconds / 3600);
@@ -463,15 +460,9 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
 
         {formChannelType === "ag_ui" && (
           <>
-            <div className="flex items-center justify-between rounded-md border p-3">
-              <div className="space-y-1">
-                <p className="text-sm font-medium">Anonymous access</p>
-                <p className="text-xs text-muted-foreground">
-                  When enabled, anyone with the endpoint URL can start a thread without
-                  authentication.
-                </p>
-              </div>
-              <Switch checked={editAgUiAnonymous} onCheckedChange={setEditAgUiAnonymous} />
+            <div className="rounded-md border p-3 text-sm text-muted-foreground">
+              AG-UI requests are accepted anonymously for now. Publish the app, then point an AG-UI
+              client at the endpoint shown on this page.
             </div>
 
             <div>
@@ -486,8 +477,9 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
                 placeholder="6"
               />
               <p className="mt-1 text-xs text-muted-foreground">
-                After this window the same `threadId` cannot resume the existing session and a new
-                one is started. Set to `0` to allow resumption indefinitely. Default is 6 hours.
+                After this window, requests reusing the same `threadId` are rejected with{" "}
+                <code>410 Gone</code> and the client must start a new thread. Set to `0` to allow
+                resumption indefinitely. Default is 6 hours.
               </p>
             </div>
           </>

--- a/apps/ui/src/app/(main)/apps/[appId]/page.tsx
+++ b/apps/ui/src/app/(main)/apps/[appId]/page.tsx
@@ -67,6 +67,7 @@ import type {
   SlackReplyMode,
   WebhookChannelConfig,
 } from "@/lib/api/types";
+import { DEFAULT_AG_UI_SESSION_EXPIRATION_SECONDS } from "@/lib/api/types/app-types";
 import {
   getDisplayName,
   getEntityNameClassName,
@@ -124,6 +125,10 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
     useState<InvocationSessionMode>("shared_session");
   const [editChannelMessage, setEditChannelMessage] = useState("");
   const [editWebhookToken, setEditWebhookToken] = useState("");
+  const [editAgUiAnonymous, setEditAgUiAnonymous] = useState(true);
+  const [editAgUiExpirationHours, setEditAgUiExpirationHours] = useState(
+    DEFAULT_AG_UI_SESSION_EXPIRATION_SECONDS / 3600,
+  );
   const [editChannelEnabled, setEditChannelEnabled] = useState(true);
 
   const [creatingSlackApp, setCreatingSlackApp] = useState(false);
@@ -276,13 +281,22 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
     setEditInvocationSessionMode("shared_session");
     setEditChannelMessage("");
     setEditWebhookToken("");
+    setEditAgUiAnonymous(true);
+    setEditAgUiExpirationHours(DEFAULT_AG_UI_SESSION_EXPIRATION_SECONDS / 3600);
     setEditChannelEnabled(true);
   };
 
   const buildChannelConfig = (channelType: ChannelType): ChannelConfigInput => {
     switch (channelType) {
-      case "ag_ui":
-        return { anonymous: true };
+      case "ag_ui": {
+        const hours = Number.isFinite(editAgUiExpirationHours)
+          ? Math.max(0, editAgUiExpirationHours)
+          : DEFAULT_AG_UI_SESSION_EXPIRATION_SECONDS / 3600;
+        return {
+          anonymous: editAgUiAnonymous,
+          session_expiration_seconds: Math.round(hours * 3600),
+        };
+      }
       case "schedule":
         return {
           cron_expression: editScheduleCronExpression,
@@ -311,7 +325,7 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
   const isChannelConfigValid = (channelType: ChannelType) => {
     switch (channelType) {
       case "ag_ui":
-        return true;
+        return Number.isFinite(editAgUiExpirationHours) && editAgUiExpirationHours >= 0;
       case "schedule":
         return !!editScheduleCronExpression && !!editChannelMessage;
       case "webhook":
@@ -324,7 +338,13 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
   const startEditChannel = (channel: AppChannel) => {
     resetChannelForm(channel.channel_type);
     setEditChannelEnabled(channel.enabled);
-    if (channel.channel_type === "slack") {
+    if (channel.channel_type === "ag_ui") {
+      const config = channel.channel_config as AgUiChannelConfig;
+      setEditAgUiAnonymous(config?.anonymous ?? true);
+      const expSeconds =
+        config?.session_expiration_seconds ?? DEFAULT_AG_UI_SESSION_EXPIRATION_SECONDS;
+      setEditAgUiExpirationHours(expSeconds / 3600);
+    } else if (channel.channel_type === "slack") {
       const config = channel.channel_config as SlackChannelConfig;
       setEditSigningSecret(config?.signing_secret ?? "");
       setEditBotToken(config?.bot_token ?? "");
@@ -442,10 +462,35 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
         </div>
 
         {formChannelType === "ag_ui" && (
-          <div className="rounded-md border p-3 text-sm text-muted-foreground">
-            AG-UI requests are accepted anonymously for now. Publish the app, then point an AG-UI
-            client at the endpoint shown on this page.
-          </div>
+          <>
+            <div className="flex items-center justify-between rounded-md border p-3">
+              <div className="space-y-1">
+                <p className="text-sm font-medium">Anonymous access</p>
+                <p className="text-xs text-muted-foreground">
+                  When enabled, anyone with the endpoint URL can start a thread without
+                  authentication.
+                </p>
+              </div>
+              <Switch checked={editAgUiAnonymous} onCheckedChange={setEditAgUiAnonymous} />
+            </div>
+
+            <div>
+              <Label htmlFor={`ag_ui_expiration_${formId}`}>Thread expiration (hours)</Label>
+              <Input
+                id={`ag_ui_expiration_${formId}`}
+                type="number"
+                min="0"
+                step="0.25"
+                value={editAgUiExpirationHours}
+                onChange={(e) => setEditAgUiExpirationHours(Number(e.target.value))}
+                placeholder="6"
+              />
+              <p className="mt-1 text-xs text-muted-foreground">
+                After this window the same `threadId` cannot resume the existing session and a new
+                one is started. Set to `0` to allow resumption indefinitely. Default is 6 hours.
+              </p>
+            </div>
+          </>
         )}
 
         {formChannelType === "slack" && (
@@ -670,6 +715,9 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
             endpointUrl={agUiEndpointUrl}
             isPublished={isPublished}
             anonymousEnabled={config?.anonymous ?? true}
+            sessionExpirationSeconds={
+              config?.session_expiration_seconds ?? DEFAULT_AG_UI_SESSION_EXPIRATION_SECONDS
+            }
             onConfigure={() => startEditChannel(channel)}
           />
         </div>

--- a/apps/ui/src/components/apps/ag-ui-setup-guidance.tsx
+++ b/apps/ui/src/components/apps/ag-ui-setup-guidance.tsx
@@ -7,13 +7,33 @@ interface AgUiSetupGuidanceProps {
   endpointUrl: string;
   isPublished: boolean;
   anonymousEnabled: boolean;
+  sessionExpirationSeconds: number;
   onConfigure?: () => void;
+}
+
+export function formatSessionExpiration(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds <= 0) {
+    return "Never";
+  }
+  const hours = seconds / 3600;
+  if (hours >= 1 && Number.isInteger(hours)) {
+    return `${hours} ${hours === 1 ? "hour" : "hours"}`;
+  }
+  if (hours >= 1) {
+    return `${hours.toFixed(1)} hours`;
+  }
+  const minutes = seconds / 60;
+  if (minutes >= 1 && Number.isInteger(minutes)) {
+    return `${minutes} ${minutes === 1 ? "minute" : "minutes"}`;
+  }
+  return `${seconds} ${seconds === 1 ? "second" : "seconds"}`;
 }
 
 export function AgUiSetupGuidance({
   endpointUrl,
   isPublished,
   anonymousEnabled,
+  sessionExpirationSeconds,
   onConfigure,
 }: AgUiSetupGuidanceProps) {
   return (
@@ -34,6 +54,16 @@ export function AgUiSetupGuidance({
           <code className="flex-1 truncate text-sm">{endpointUrl}</code>
           <CopyButton value={endpointUrl} />
         </div>
+      </div>
+
+      <div>
+        <p className="text-sm font-medium">Thread expiration</p>
+        <p className="text-sm text-muted-foreground">
+          {formatSessionExpiration(sessionExpirationSeconds)}
+          {sessionExpirationSeconds > 0
+            ? " — after this, the same threadId starts a new session"
+            : " — threads can be resumed indefinitely"}
+        </p>
       </div>
 
       <div className="space-y-1 text-sm text-muted-foreground">

--- a/apps/ui/src/components/apps/ag-ui-setup-guidance.tsx
+++ b/apps/ui/src/components/apps/ag-ui-setup-guidance.tsx
@@ -61,7 +61,7 @@ export function AgUiSetupGuidance({
         <p className="text-sm text-muted-foreground">
           {formatSessionExpiration(sessionExpirationSeconds)}
           {sessionExpirationSeconds > 0
-            ? " — after this, the same threadId starts a new session"
+            ? " — after this, requests reusing the same threadId are rejected with 410 Gone and the client must start a new thread"
             : " — threads can be resumed indefinitely"}
         </p>
       </div>

--- a/apps/ui/src/lib/api/types/app-types.ts
+++ b/apps/ui/src/lib/api/types/app-types.ts
@@ -19,8 +19,18 @@ export interface SlackChannelConfig {
   first_message_received_at?: string | null;
 }
 
+/** Default thread expiration window for AG-UI (6 hours, in seconds). */
+export const DEFAULT_AG_UI_SESSION_EXPIRATION_SECONDS = 6 * 60 * 60;
+
 export interface AgUiChannelConfig {
   anonymous?: boolean;
+  /**
+   * How long an AG-UI thread can be resumed (in seconds) after the underlying
+   * session was created. After this elapses the same `thread_id` cannot reuse
+   * the existing session and must start a new one. `0` disables expiration.
+   * Defaults to 6 hours.
+   */
+  session_expiration_seconds?: number;
 }
 
 export interface ScheduleChannelConfig {

--- a/crates/core/src/app.rs
+++ b/crates/core/src/app.rs
@@ -357,6 +357,9 @@ pub struct SlackChannelConfig {
     pub first_message_received_at: Option<DateTime<Utc>>,
 }
 
+/// Default session expiration for public channel threads (6 hours).
+pub const DEFAULT_SESSION_EXPIRATION_SECONDS: u32 = 6 * 60 * 60;
+
 /// Typed AG-UI channel configuration.
 ///
 /// Parsed from the `channel_config` JSON field on App.
@@ -367,6 +370,16 @@ pub struct AgUiChannelConfig {
     /// Enabled by default for the initial AG-UI rollout.
     #[serde(default = "default_true")]
     pub anonymous: bool,
+    /// How long (in seconds) a thread can be resumed after its session was
+    /// created. Once this elapses, the same `thread_id` cannot reuse the
+    /// existing session and must start a new one. `0` disables expiration.
+    /// Defaults to 6 hours.
+    #[serde(default = "default_session_expiration_seconds")]
+    pub session_expiration_seconds: u32,
+}
+
+fn default_session_expiration_seconds() -> u32 {
+    DEFAULT_SESSION_EXPIRATION_SECONDS
 }
 
 /// How app-triggered invocations route into sessions.
@@ -597,14 +610,29 @@ mod tests {
     fn test_ag_ui_channel_config_defaults_to_anonymous() {
         let config: AgUiChannelConfig = serde_json::from_str("{}").unwrap();
         assert!(config.anonymous);
+        assert_eq!(
+            config.session_expiration_seconds,
+            DEFAULT_SESSION_EXPIRATION_SECONDS
+        );
     }
 
     #[test]
     fn test_ag_ui_channel_config_roundtrip() {
-        let config = AgUiChannelConfig { anonymous: true };
+        let config = AgUiChannelConfig {
+            anonymous: true,
+            session_expiration_seconds: 3600,
+        };
         let json = serde_json::to_string(&config).unwrap();
         let parsed: AgUiChannelConfig = serde_json::from_str(&json).unwrap();
         assert!(parsed.anonymous);
+        assert_eq!(parsed.session_expiration_seconds, 3600);
+    }
+
+    #[test]
+    fn test_ag_ui_channel_config_zero_disables_expiration() {
+        let config: AgUiChannelConfig =
+            serde_json::from_str(r#"{"session_expiration_seconds": 0}"#).unwrap();
+        assert_eq!(config.session_expiration_seconds, 0);
     }
 
     #[test]

--- a/crates/server/src/api/ag_ui.rs
+++ b/crates/server/src/api/ag_ui.rs
@@ -50,7 +50,9 @@ use everruns_core::events::{
     ReasonThinkingDeltaData, ReasonThinkingStartedData, ToolCompletedData, ToolStartedData,
 };
 use everruns_core::message_retriever::InputMessage as StoredInputMessage;
-use everruns_core::{App, AppStatus, Caller, ContentPart, ExternalActor, MessageRole};
+use everruns_core::{
+    AgUiChannelConfig, App, AppStatus, Caller, ContentPart, ExternalActor, MessageRole,
+};
 use futures::{
     StreamExt,
     stream::{self, Stream},
@@ -170,9 +172,16 @@ async fn run_agent(
         format!("ag_ui:app:{}", app.public_id),
         format!("ag_ui:thread:{}", thread_tag),
     ];
-    let session = find_or_create_session(&state, &app, &routing_tags, &thread_tag, &req)
-        .await
-        .map_err(internal_error)?;
+    let session = find_or_create_session(
+        &state,
+        &app,
+        &channel_config,
+        &routing_tags,
+        &thread_tag,
+        &req,
+    )
+    .await
+    .map_err(SessionError::into_response)?;
 
     // THREAT[TM-DOS-010]: Anonymous AG-UI streams must still respect server-wide
     // SSE connection limits.
@@ -347,13 +356,47 @@ struct SessionResolution {
     is_new: bool,
 }
 
+/// Errors that can come back from `find_or_create_session`. Distinguishes
+/// expected client failures (expired threads) from internal errors so the
+/// caller can return the right HTTP status.
+enum SessionError {
+    Expired { age_seconds: i64, max_seconds: u32 },
+    Internal(anyhow::Error),
+}
+
+impl SessionError {
+    fn into_response(self) -> (StatusCode, Json<ErrorResponse>) {
+        match self {
+            SessionError::Expired {
+                age_seconds,
+                max_seconds,
+            } => (
+                StatusCode::GONE,
+                Json(ErrorResponse {
+                    error: format!(
+                        "AG-UI thread expired after {age_seconds}s (limit {max_seconds}s); start a new thread"
+                    ),
+                }),
+            ),
+            SessionError::Internal(err) => internal_error(err),
+        }
+    }
+}
+
+impl From<anyhow::Error> for SessionError {
+    fn from(err: anyhow::Error) -> Self {
+        SessionError::Internal(err)
+    }
+}
+
 async fn find_or_create_session(
     state: &AgUiState,
     app: &App,
+    config: &AgUiChannelConfig,
     routing_tags: &[String],
     thread_id: &str,
     req: &AgUiRunAgentInput,
-) -> anyhow::Result<SessionResolution> {
+) -> Result<SessionResolution, SessionError> {
     let org_row = state
         .db
         .get_organization(app.org_id)
@@ -367,6 +410,27 @@ async fn find_or_create_session(
         .await?
     {
         Some(row) => {
+            // THREAT[TM-AUTHZ-005]: Public AG-UI threads must not be resumable
+            // forever. After the configured expiration the thread_id can no
+            // longer carry forward an existing conversation.
+            if let Some(age) = expired_age_seconds(
+                row.created_at,
+                config.session_expiration_seconds,
+                chrono::Utc::now(),
+            ) {
+                tracing::info!(
+                    app_id = %app.public_id,
+                    session_id = %row.id,
+                    age_seconds = age,
+                    max_seconds = config.session_expiration_seconds,
+                    "Rejecting AG-UI resume on expired thread"
+                );
+                return Err(SessionError::Expired {
+                    age_seconds: age,
+                    max_seconds: config.session_expiration_seconds,
+                });
+            }
+
             let fallback = if row.harness_id.is_none() {
                 Some(crate::org_init::base_harness_id(&state.db, app.org_id).await?)
             } else {
@@ -792,6 +856,21 @@ fn translate_event(state: &mut AgUiStreamState, event: &everruns_core::Event) {
     }
 }
 
+/// Returns the age of a session (in seconds) when it has exceeded the
+/// configured expiration. Returns `None` when expiration is disabled
+/// (`max_seconds == 0`) or when the session is still within the window.
+fn expired_age_seconds(
+    created_at: chrono::DateTime<chrono::Utc>,
+    max_seconds: u32,
+    now: chrono::DateTime<chrono::Utc>,
+) -> Option<i64> {
+    if max_seconds == 0 {
+        return None;
+    }
+    let age = now.signed_duration_since(created_at).num_seconds().max(0);
+    (age > max_seconds as i64).then_some(age)
+}
+
 fn agui_base_event() -> AgUiBaseEvent {
     AgUiBaseEvent {
         timestamp: None,
@@ -863,10 +942,39 @@ fn not_found() -> (StatusCode, Json<ErrorResponse>) {
 mod tests {
     use super::*;
     use ag_ui_core::event::EventType as AgUiEventType;
+    use chrono::Duration as ChronoDuration;
     use everruns_core::{
         Event, EventContext, Message, MessageId, OutputMessageCompletedData,
         OutputMessageDeltaData, SessionId, ToolCall, ToolCompletedData, ToolStartedData, TurnId,
     };
+
+    #[test]
+    fn test_expired_age_seconds_within_window() {
+        let now = chrono::Utc::now();
+        let created = now - ChronoDuration::seconds(100);
+        assert_eq!(expired_age_seconds(created, 200, now), None);
+    }
+
+    #[test]
+    fn test_expired_age_seconds_past_window() {
+        let now = chrono::Utc::now();
+        let created = now - ChronoDuration::seconds(300);
+        assert_eq!(expired_age_seconds(created, 200, now), Some(300));
+    }
+
+    #[test]
+    fn test_expired_age_seconds_zero_disables_expiration() {
+        let now = chrono::Utc::now();
+        let created = now - ChronoDuration::days(30);
+        assert_eq!(expired_age_seconds(created, 0, now), None);
+    }
+
+    #[test]
+    fn test_expired_age_seconds_clock_skew() {
+        let now = chrono::Utc::now();
+        let created = now + ChronoDuration::seconds(5);
+        assert_eq!(expired_age_seconds(created, 60, now), None);
+    }
 
     async fn test_stream_state() -> AgUiStreamState {
         let session_id = SessionId::new();

--- a/specs/apps.md
+++ b/specs/apps.md
@@ -49,7 +49,8 @@ Channel config is stored as JSONB and validated at the application layer per cha
 **AG-UI channel config example:**
 ```json
 {
-  "anonymous": true
+  "anonymous": true,
+  "session_expiration_seconds": 21600
 }
 ```
 
@@ -60,6 +61,10 @@ AG-UI uses an app-scoped anonymous ingress for the initial rollout:
 - Responses stream back as AG-UI SSE events translated from the durable runtime
 - Anonymous access is currently required when the channel is enabled
 - Session routing is per `threadId`, with sessions tagged by app and thread
+- `session_expiration_seconds` caps how long a `threadId` can resume the
+  underlying session. After the window elapses, AG-UI requests with that
+  `threadId` are rejected with `410 Gone` and the client must start a new
+  thread. Defaults to `21600` (6 hours). Set to `0` to disable expiration.
 
 `schedule` and `webhook` are app invocation channels, not interactive messaging adapters:
 


### PR DESCRIPTION
## What
Adds a configurable thread expiration window to the AG-UI app channel. After the window elapses, requests reusing the same `threadId` are rejected with `410 Gone` and the client must start a new thread. Default is 6 hours; `0` disables enforcement.

## Why
AG-UI is the public, anonymous app channel. Today, any client that reuses an old `threadId` lands in the original session indefinitely — there is zero age check on `find_session_by_tags`. That lets stale or guessed `threadId`s attach to old conversations on a public endpoint.

## How
- New field `session_expiration_seconds` on `AgUiChannelConfig` (Rust + TypeScript), defaulting to `21600` (6 hours). Stored in the existing `app_channels.channel_config` JSONB — no migration.
- `crates/server/src/api/ag_ui.rs::find_or_create_session` now consults the channel config when reusing a session by tag and returns `410 Gone` with a clear message once the session is older than the configured window. Pure helper `expired_age_seconds` is unit-tested and handles clock skew + the `0` disabled case.
- App detail UI (`apps/[appId]/page.tsx`) gets a thread-expiration input on the AG-UI channel form. The setup-guidance card displays the configured window or "Never" and explains the `410 Gone` behavior.
- Spec (`specs/apps.md`) documents the new field and the `410 Gone` behavior.

## Risk
- Low.
- Existing AG-UI channels load with `serde(default)` → 6 h expiration applied automatically. The only behavior change visible to existing clients is that requests reusing a `threadId` older than 6 h start getting `410 Gone` instead of resuming. Clients must regenerate the `threadId` on `410`.
- Channel config is JSONB so no schema migration.

## Security
- Threat categories reviewed: TM-AUTHZ-005 (anonymous AG-UI session reuse). Existing comment in `ag_ui.rs` already flagged this; expiration enforcement is the mitigation. No new auth surface, no new endpoint.
- Findings and resolutions: previously, a leaked or guessed `threadId` granted indefinite access to the original session's history on a published, anonymous app. Now bounded by the channel's `session_expiration_seconds`.

## Checklist
- [x] Tests added or updated (Rust unit tests for `expired_age_seconds` + serde defaults; UI tests for `formatSessionExpiration` and the guidance card).
- [x] Backward compatibility considered (serde default keeps existing channels working; semantically, threads older than 6 h now require a new `threadId` — documented).
- [x] Security review performed against relevant threat model categories.
- [x] All review comments addressed (code change or written reasoning).