### PR TITLE
fix(ui): show display names in selects, never internal values

### DIFF
--- a/apps/ui/src/__tests__/select-display-name.test.tsx
+++ b/apps/ui/src/__tests__/select-display-name.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen } from "@testing-library/react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+// Real-DOM integration test (no base-ui mock) covering the Add Channel
+// dropdown bug: <Select> must show the human-readable label of the selected
+// item, never the raw internal value. base-ui's <Select.Value> resolves the
+// label from the items map our wrapper auto-collects from <SelectItem>
+// children. See specs/code-organization.md "Dropdowns Must Show Display
+// Names".
+describe("Select trigger displays human-readable labels by default", () => {
+  it("shows 'Webhook' (label) when value is 'webhook' (internal)", () => {
+    render(
+      <Select value="webhook" onValueChange={() => {}}>
+        <SelectTrigger data-testid="trigger">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="slack">Slack</SelectItem>
+          <SelectItem value="ag_ui">AG-UI</SelectItem>
+          <SelectItem value="schedule">Schedule</SelectItem>
+          <SelectItem value="webhook">Webhook</SelectItem>
+        </SelectContent>
+      </Select>,
+    );
+
+    const trigger = screen.getByTestId("trigger");
+    expect(trigger).toHaveTextContent("Webhook");
+    expect(trigger).not.toHaveTextContent("webhook");
+  });
+
+  it("shows 'Shared Session' (label) when value is 'shared_session' (internal)", () => {
+    render(
+      <Select value="shared_session" onValueChange={() => {}}>
+        <SelectTrigger data-testid="trigger">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="shared_session">Shared Session</SelectItem>
+          <SelectItem value="session_per_invocation">Session Per Invocation</SelectItem>
+        </SelectContent>
+      </Select>,
+    );
+
+    const trigger = screen.getByTestId("trigger");
+    expect(trigger).toHaveTextContent("Shared Session");
+    expect(trigger).not.toHaveTextContent("shared_session");
+  });
+
+  it("shows the placeholder when no value is selected", () => {
+    render(
+      <Select value="" onValueChange={() => {}}>
+        <SelectTrigger data-testid="trigger">
+          <SelectValue placeholder="Choose later" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="slack">Slack</SelectItem>
+        </SelectContent>
+      </Select>,
+    );
+
+    expect(screen.getByTestId("trigger")).toHaveTextContent("Choose later");
+  });
+
+  it("explicit children on SelectValue still win over the auto-resolved label", () => {
+    render(
+      <Select value="agent_123" onValueChange={() => {}}>
+        <SelectTrigger data-testid="trigger">
+          <SelectValue>Custom display</SelectValue>
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="agent_123">Default Label</SelectItem>
+        </SelectContent>
+      </Select>,
+    );
+
+    expect(screen.getByTestId("trigger")).toHaveTextContent("Custom display");
+  });
+});

--- a/apps/ui/src/__tests__/select.test.tsx
+++ b/apps/ui/src/__tests__/select.test.tsx
@@ -1,6 +1,14 @@
 import { render, screen } from "@testing-library/react";
 import React from "react";
-import { SelectTrigger } from "@/components/ui/select";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+const rootItemsCalls: Array<Record<string, React.ReactNode> | undefined> = [];
 
 jest.mock("@base-ui/react/select", () => {
   const passthrough = React.forwardRef(function Passthrough(
@@ -23,9 +31,21 @@ jest.mock("@base-ui/react/select", () => {
     );
   });
 
+  const Root = ({
+    items,
+    children,
+  }: {
+    items?: Record<string, React.ReactNode>;
+    children?: React.ReactNode;
+    [key: string]: unknown;
+  }) => {
+    rootItemsCalls.push(items);
+    return <div data-testid="select-root">{children}</div>;
+  };
+
   return {
     Select: {
-      Root: passthrough,
+      Root,
       Group: passthrough,
       Value: passthrough,
       Trigger: React.forwardRef(function Trigger(
@@ -51,10 +71,83 @@ jest.mock("@base-ui/react/select", () => {
   };
 });
 
+beforeEach(() => {
+  rootItemsCalls.length = 0;
+});
+
 describe("SelectTrigger", () => {
   it("resets native button appearance for shared pickers", () => {
     render(<SelectTrigger>Default</SelectTrigger>);
 
     expect(screen.getByRole("button")).toHaveClass("appearance-none");
+  });
+});
+
+describe("Select wrapper auto-collects display labels", () => {
+  // The bug: <SelectValue> showed the raw internal value (e.g. "shared_session")
+  // because no items map was forwarded to base-ui. The wrapper now walks
+  // <SelectItem> children and forwards a value→label map, so display labels
+  // are the default. See specs/code-organization.md.
+  it("forwards a value→label map collected from SelectItem children", () => {
+    render(
+      <Select value="webhook" onValueChange={() => {}}>
+        <SelectTrigger>
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="slack">Slack</SelectItem>
+          <SelectItem value="webhook">Webhook</SelectItem>
+        </SelectContent>
+      </Select>,
+    );
+
+    const items = rootItemsCalls.at(-1);
+    expect(items).toBeDefined();
+    expect(items?.slack).toBe("Slack");
+    expect(items?.webhook).toBe("Webhook");
+  });
+
+  it("explicit items prop entries take precedence over collected labels", () => {
+    render(
+      <Select
+        value="shared_session"
+        onValueChange={() => {}}
+        items={{ shared_session: "Override" }}
+      >
+        <SelectTrigger>
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="shared_session">Shared Session</SelectItem>
+        </SelectContent>
+      </Select>,
+    );
+
+    const items = rootItemsCalls.at(-1);
+    expect(items?.shared_session).toBe("Override");
+  });
+
+  it("descends through wrapper components to find SelectItem children", () => {
+    function CustomGroup({ children }: { children: React.ReactNode }) {
+      return <>{children}</>;
+    }
+
+    render(
+      <Select value="a" onValueChange={() => {}}>
+        <SelectTrigger>
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <CustomGroup>
+            <SelectItem value="a">Alpha</SelectItem>
+            <SelectItem value="b">Beta</SelectItem>
+          </CustomGroup>
+        </SelectContent>
+      </Select>,
+    );
+
+    const items = rootItemsCalls.at(-1);
+    expect(items?.a).toBe("Alpha");
+    expect(items?.b).toBe("Beta");
   });
 });

--- a/apps/ui/src/components/ui/select.tsx
+++ b/apps/ui/src/components/ui/select.tsx
@@ -61,18 +61,19 @@ function Select({ onValueChange, items, children, ...props }: SelectProps) {
     [onValueChange],
   );
 
-  const itemsMap = React.useMemo<SelectItemsMap>(() => {
-    const acc: SelectItemsMap = {};
-    if (items) {
-      if (Array.isArray(items)) {
-        for (const item of items) acc[item.value] = item.label;
-      } else {
-        Object.assign(acc, items as SelectItemsMap);
-      }
+  // Computed inline on every render: children is a fresh ReactNode tree each
+  // render, so memoizing on [items, children] would invalidate every time.
+  // The traversal is bounded by the number of <SelectItem> children — tiny
+  // for typical selects.
+  const itemsMap: SelectItemsMap = {};
+  if (items) {
+    if (Array.isArray(items)) {
+      for (const item of items) itemsMap[item.value] = item.label;
+    } else {
+      Object.assign(itemsMap, items as SelectItemsMap);
     }
-    collectSelectItemLabels(children, acc, new WeakSet());
-    return acc;
-  }, [items, children]);
+  }
+  collectSelectItemLabels(children, itemsMap, new WeakSet());
 
   return (
     <SelectPrimitive.Root<string> onValueChange={handleValueChange} items={itemsMap} {...props}>

--- a/apps/ui/src/components/ui/select.tsx
+++ b/apps/ui/src/components/ui/select.tsx
@@ -6,12 +6,52 @@ import { CheckIcon, ChevronDownIcon } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 
-// Wrapper to provide backwards-compatible onValueChange API
-interface SelectProps extends Omit<SelectPrimitive.Root.Props<string>, "onValueChange"> {
-  onValueChange?: (value: string) => void;
+// Select must always show the human-readable label of the selected item, never
+// the raw internal value (e.g. show "Webhook", not "webhook"). base-ui resolves
+// labels from <Select.Value> using its `items` prop, so the wrapper auto-walks
+// <SelectItem> children and forwards a value→label map by default.
+// Spec: specs/code-organization.md "Dropdowns must show display names".
+type SelectItemsMap = Record<string, React.ReactNode>;
+
+function collectSelectItemLabels(
+  node: React.ReactNode,
+  acc: SelectItemsMap,
+  visited: WeakSet<object>,
+): void {
+  React.Children.forEach(node, (child) => {
+    if (!React.isValidElement(child)) return;
+    if (visited.has(child)) return;
+    visited.add(child);
+
+    if (child.type === SelectItem) {
+      const props = child.props as { value?: unknown; children?: React.ReactNode };
+      if (props.value !== undefined && props.value !== null) {
+        const key = String(props.value);
+        if (!(key in acc)) {
+          acc[key] = props.children;
+        }
+      }
+      // SelectItem children are the label content — don't descend further.
+      return;
+    }
+
+    const grandChildren = (child.props as { children?: React.ReactNode } | null)?.children;
+    if (grandChildren !== undefined && grandChildren !== null) {
+      collectSelectItemLabels(grandChildren, acc, visited);
+    }
+  });
 }
 
-function Select({ onValueChange, ...props }: SelectProps) {
+interface SelectProps extends Omit<SelectPrimitive.Root.Props<string>, "onValueChange" | "items"> {
+  onValueChange?: (value: string) => void;
+  /**
+   * Optional explicit value→label map. When omitted, labels are auto-collected
+   * from <SelectItem> children so <SelectValue> always shows the display name.
+   */
+  items?: SelectItemsMap | ReadonlyArray<{ value: string; label: React.ReactNode }>;
+}
+
+function Select({ onValueChange, items, children, ...props }: SelectProps) {
   const handleValueChange = React.useCallback(
     (value: string | null) => {
       if (value !== null && onValueChange) {
@@ -21,66 +61,45 @@ function Select({ onValueChange, ...props }: SelectProps) {
     [onValueChange],
   );
 
-  return <SelectPrimitive.Root<string> onValueChange={handleValueChange} {...props} />;
+  const itemsMap = React.useMemo<SelectItemsMap>(() => {
+    const acc: SelectItemsMap = {};
+    if (items) {
+      if (Array.isArray(items)) {
+        for (const item of items) acc[item.value] = item.label;
+      } else {
+        Object.assign(acc, items as SelectItemsMap);
+      }
+    }
+    collectSelectItemLabels(children, acc, new WeakSet());
+    return acc;
+  }, [items, children]);
+
+  return (
+    <SelectPrimitive.Root<string> onValueChange={handleValueChange} items={itemsMap} {...props}>
+      {children}
+    </SelectPrimitive.Root>
+  );
 }
 
 function SelectGroup({ ...props }: SelectPrimitive.Group.Props) {
   return <SelectPrimitive.Group data-slot="select-group" {...props} />;
 }
 
-// Children override the default display text (which may show raw IDs from
-// base-ui's Value when portal items haven't mounted). Always pass children
-// when the select value is an ID or otherwise not human-readable.
+// Renders the label of the selected item. base-ui resolves the label from the
+// `items` map provided by <Select> above. Pass children only when overriding
+// the default lookup (e.g. compose icon + label in the trigger).
 function SelectValue({
   placeholder,
   children,
   ...props
 }: SelectPrimitive.Value.Props & {
-  placeholder?: string;
-  children?: React.ReactNode;
+  placeholder?: React.ReactNode;
+  children?: React.ReactNode | ((value: unknown) => React.ReactNode);
 }) {
-  if (children !== undefined && children !== null) {
-    return (
-      <SelectPrimitive.Value
-        render={(_, { value }) => {
-          // Show children when we have a value, placeholder otherwise
-          if (value && children) {
-            return <span data-slot="select-value">{children}</span>;
-          }
-          if (placeholder) {
-            return (
-              <span data-slot="select-value" className="text-muted-foreground">
-                {placeholder}
-              </span>
-            );
-          }
-          return <span data-slot="select-value">{children}</span>;
-        }}
-        {...props}
-      />
-    );
-  }
-
-  if (!placeholder) {
-    return <SelectPrimitive.Value data-slot="select-value" {...props} />;
-  }
-
   return (
-    <SelectPrimitive.Value
-      render={(_, { value }) => {
-        if (value) {
-          return <SelectPrimitive.Value data-slot="select-value" {...props} />;
-        }
-
-        // Placeholder
-        return (
-          <span data-slot="select-value" className="text-muted-foreground">
-            {placeholder}
-          </span>
-        );
-      }}
-      {...props}
-    />
+    <SelectPrimitive.Value data-slot="select-value" placeholder={placeholder} {...props}>
+      {children}
+    </SelectPrimitive.Value>
   );
 }
 

--- a/specs/code-organization.md
+++ b/specs/code-organization.md
@@ -408,7 +408,7 @@ Uses `Swatinem/rust-cache@v2` with shared keys for cross-job cache reuse:
 - Always put a human-readable label in `<SelectItem>` children — never just the raw value.
 - Use `<SelectValue />` (no children, no manual lookup) for the common case. The wrapper resolves the label.
 - Pass an explicit `<SelectValue>{node}</SelectValue>` only when composing extra trigger content (e.g. icon + label).
-- For dynamic options that aren't rendered as static JSX children of `<Select>`, pass an `items={{ ... }}` prop on `<Select>`.
+- Auto-collection traverses the JSX tree passed as `<Select>` children — it does **not** render custom wrapper components that internally return a `<SelectItem>` (e.g. `<MySelectItem />`). For such cases, or for options that aren't visible as static JSX children of `<Select>` (lists built far from the root, portals, async loads), pass an explicit `items={{ value: label, ... }}` prop on `<Select>`.
 - For combobox/autocomplete, options must be `{ value, label }` pairs and the trigger must show `label`.
 
 **Why:** Internal values like `shared_session` or `webhook` leak implementation details into the UI and look unprofessional. Centralising the resolution in the shared wrapper makes "display name" the default and prevents the bug from recurring.

--- a/specs/code-organization.md
+++ b/specs/code-organization.md
@@ -398,6 +398,21 @@ Uses `Swatinem/rust-cache@v2` with shared keys for cross-job cache reuse:
 
 ## UI Patterns
 
+### Dropdowns Must Show Display Names
+
+**Rule:** Every dropdown (Select/Combobox) must show the human-readable display name of the selected option, never the raw internal value (e.g. `"Webhook"`, not `"webhook"`; `"Shared Session"`, not `"shared_session"`).
+
+**How it works:** The shared `<Select>` wrapper at `components/ui/select.tsx` walks its `<SelectItem>` children at render time and forwards a `value → label` map to base-ui's `items` prop. base-ui's `<SelectValue>` then resolves the label automatically. Callers do not need to do anything special — just render `<SelectItem value="..."><Label/></SelectItem>` and `<SelectValue />`.
+
+**Authoring rules:**
+- Always put a human-readable label in `<SelectItem>` children — never just the raw value.
+- Use `<SelectValue />` (no children, no manual lookup) for the common case. The wrapper resolves the label.
+- Pass an explicit `<SelectValue>{node}</SelectValue>` only when composing extra trigger content (e.g. icon + label).
+- For dynamic options that aren't rendered as static JSX children of `<Select>`, pass an `items={{ ... }}` prop on `<Select>`.
+- For combobox/autocomplete, options must be `{ value, label }` pairs and the trigger must show `label`.
+
+**Why:** Internal values like `shared_session` or `webhook` leak implementation details into the UI and look unprofessional. Centralising the resolution in the shared wrapper makes "display name" the default and prevents the bug from recurring.
+
 ### Entity Select Components
 
 Most entities have an ID (used as value) and a display name. When creating dropdowns for entity selection, create dedicated `{Entity}Select` components that handle the ID-to-name mapping internally.


### PR DESCRIPTION
## What
Make the shared `<Select>` wrapper render the human-readable label of the selected item by default, never the raw internal value. The Add Channel form was showing `webhook` (lowercase) and `shared_session` in the trigger; it now shows `Webhook` and `Shared Session`.

## Why
base-ui's `<Select.Value>` resolves labels from the `Select.Root` `items` prop. Our wrapper never forwarded one, so the trigger fell back to stringifying the raw value. Internal codes like `shared_session` leaked into the UI on every static-options select. Reported via screenshot of `apps/[appId]` Add Channel form.

## How
- `apps/ui/src/components/ui/select.tsx`: `<Select>` now walks its JSX children at render time, collects `<SelectItem value=... children=...>` pairs into a `value → label` map, and forwards it to `SelectPrimitive.Root` as the `items` prop. base-ui then renders the label automatically. An optional `items={...}` prop lets callers pass dynamic options not visible in JSX (e.g. portal-rendered).
- `<SelectValue>` is now a thin pass-through to `SelectPrimitive.Value`. Explicit children still win for callers that compose icon + label trigger content (AgentSelect, ModelPicker, chat-composer, etc.).
- `specs/code-organization.md`: new "Dropdowns Must Show Display Names" rule with authoring contract.
- Tests:
  - `__tests__/select.test.tsx`: 3 wrapper-level cases asserting items map collection (auto-collected, explicit-prop precedence, descent through nested wrapper components).
  - `__tests__/select-display-name.test.tsx`: 4 real-DOM cases (no base-ui mock) that render the actual component and assert the trigger text — `Webhook` for `value="webhook"`, `Shared Session` for `value="shared_session"`, placeholder, and explicit-children override.

All 16 audited `<SelectValue>` call sites already render display labels in their `<SelectItem>` children, so they all benefit automatically with no further changes. Wrappers that pass explicit `<SelectValue>{label}</SelectValue>` (`AgentSelect`, `HarnessSelect`, `ModelPicker`, `chat-composer`, `settings/members`) continue to work — explicit children still win.

## Risk
- Low. Pure UI render-prop change confined to the shared `<Select>` wrapper. Behavior for callers passing explicit `<SelectValue>` children is unchanged. No API, DB, migration, or auth surface touched.
- Edge case considered: `collectSelectItemLabels` walks `child.props.children` recursively with a `WeakSet` to short-circuit shared element references and avoid descending into `<SelectItem>` children themselves.

## Validation
- `just pre-push` ✅
- `cd apps/ui && npm run build` ✅ (Next.js prod build)
- `cd apps/ui && npx jest src/__tests__/select.test.tsx src/__tests__/select-display-name.test.tsx src/__tests__/chat-panel.test.tsx` ✅ (16 tests)
- `cd apps/ui && npm run lint` ✅
- Smoke evidence: real-DOM jest tests render the actual base-ui Select and assert the visible trigger text matches the labels (equivalent to the user's screenshot scenario).

## Security
- Threat categories reviewed: `TM-WEB` (frontend rendering).
- Findings and resolutions: None. Labels are rendered as React text nodes (no `dangerouslySetInnerHTML`), the data is developer-authored JSX, no untrusted input is processed by the new traversal helper. The wrapper does not change any auth, API, DB, FS, bash, or tenancy boundary. The label content was already rendered inside the `<SelectContent>` popup — we are not exposing new information, only displaying it consistently in the trigger.
- No threat model update required.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (explicit `<SelectValue>` children still take precedence)
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01V8Qf4Ew3LZ33t9NfnAzKjG)_