### PR TITLE
chore(deps): bump bashkit to v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,7 +142,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -153,7 +153,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -457,13 +457,14 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bashkit"
-version = "0.3.0"
-source = "git+https://github.com/everruns/bashkit?tag=v0.3.0#7f3d9f67959af2e9d26b54d19d70cf6b41ad4ba5"
+version = "0.4.0"
+source = "git+https://github.com/everruns/bashkit?tag=v0.4.0#2d87a82ff743fef8a24388251ad89ee27a0611f4"
 dependencies = [
  "anyhow",
  "async-trait",
  "base64",
  "chrono",
+ "clap",
  "fancy-regex 0.18.0",
  "flate2",
  "futures-core",
@@ -1395,7 +1396,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1520,7 +1521,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3042,7 +3043,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.57.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -3444,7 +3445,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4188,7 +4189,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5580,7 +5581,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5661,7 +5662,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6151,7 +6152,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6560,7 +6561,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -66,7 +66,7 @@ fetchkit = { version = "0.2.0", features = ["bot-auth"] }
 ed25519-dalek = { version = "2", features = ["rand_core"] }
 
 # Virtual bash interpreter
-bashkit = { git = "https://github.com/everruns/bashkit", tag = "v0.3.0", features = ["jq"] }
+bashkit = { git = "https://github.com/everruns/bashkit", tag = "v0.4.0", features = ["jq"] }
 
 # Tree-sitter for structural outlines (EVE-248)
 tree-sitter = { version = "0.24", optional = true }

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -66,7 +66,7 @@ urlencoding = "2"
 git2.workspace = true
 mime_guess = "2"
 
-bashkit = { git = "https://github.com/everruns/bashkit", tag = "v0.3.0", features = ["scripted_tool", "jq"] }
+bashkit = { git = "https://github.com/everruns/bashkit", tag = "v0.4.0", features = ["scripted_tool", "jq"] }
 
 everruns-config = { path = "../config" }
 everruns-core = { path = "../core", features = ["openapi", "sqlx", "tree-sitter-outlines"] }


### PR DESCRIPTION
## What
Bump `bashkit` from `v0.3.0` to `v0.4.0` in `crates/core` and `crates/server`, and refresh `Cargo.lock`.

## Why
Pull in upstream improvements:
- New public `Extension` trait for grouping related builtins (additive).
- `clap`-backed builtins for declarative argument parsing (additive).
- `sqlite` builtin gains session-scoped engine across `exec()` calls (additive; not used by everruns).
- **SQLite security hardening**: PRAGMA policy parser now correctly handles SQL comments and quoted identifiers (closes a `PRAGMA main."cache_size"` bypass), and `max_db_bytes` enforcement is consistent across VFS operations.
- Embedded Python (monty) bumped to 0.0.17, upstream Rust toolchain bumped to 1.95.0.

## How
- `crates/core/Cargo.toml` and `crates/server/Cargo.toml`: tag bumped from `v0.3.0` to `v0.4.0`. Feature sets unchanged (`jq` for core; `scripted_tool, jq` for server).
- `cargo update -p bashkit` to refresh `Cargo.lock`. Side-effect: a few transitive `windows-sys` versions consolidate to `0.61.2` — no behavioural impact on Linux/macOS targets.

## Risk
- Low.
- API surface we consume (`bashkit::ScriptingToolSet`, `ToolArgs`, `ToolDef`, `hooks::*`, the bash interpreter) is unchanged — `cargo check` and our existing tests compile and pass without source changes.
- We do not enable nor consume the bashkit `sqlite` builtin (`grep -rn "sqlite" crates/core/src/capabilities/ crates/server/src/` returns nothing relevant), so the session-caching behaviour change cannot affect us.

## Validation
- `./scripts/lib/pre-push.sh` — all 8 checks pass (`cargo fmt`, `clippy`, lockfile freshness, migration ordering/immutability, attribution).
- `cargo check -p everruns-core -p everruns-server` — clean.
- `cargo test -p everruns-core --lib virtual_bash` — 79 passed.
- `cargo test -p everruns-server --lib mcp_endpoint` — 44 passed.
- Full-stack smoke test skipped: cloud agent environment lacks `caddy` (required by `just start-dev`). Risk is bounded by the unit test coverage above plus the unchanged consumer-side API surface.
- One pre-existing test failure (`everruns-core --test subagent_test::test_subagent_capability_registration`) reproduces against `origin/main` with the same Cargo.toml — unrelated to this bump.

## Security
- Threat categories reviewed: **TM-BASH** (bash sandbox), **TM-SQL** (SQL sandbox).
- Findings and resolutions:
  - **TM-BASH**: positive change — bashkit v0.4.0 strengthens its own internal SQLite PRAGMA policy parser. No widening of sandbox boundaries, network allowlist, or filesystem boundaries. Hooks contract used by `virtual_bash` (`HookAction::Continue` only) is unchanged.
  - **TM-SQL**: not exposed — everruns does not enable bashkit's `sqlite` feature/builtin, so the session-cached SQLite engine is not reachable from any agent.
  - No new dependencies added at our level. Transitive `windows-sys` consolidation is not security-relevant for our supported targets.
  - No `THREAT[...]` comments touched and no new threat surface introduced; `specs/threat-model.md` requires no changes.

## Checklist
- [x] Tests added or updated (existing bashkit-consuming tests run green)
- [x] Backward compatibility considered (internal-only; consumer API unchanged)
- [x] Security review performed against relevant threat model categories
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XsERJjr5y3nupambqDUpZY)_