### PR TITLE
fix(server): reject unsafe redirect URI schemes in MCP OAuth registration

### DIFF
--- a/crates/server/src/auth/mcp_oauth.rs
+++ b/crates/server/src/auth/mcp_oauth.rs
@@ -71,8 +71,9 @@ fn verify_pkce_s256(verifier: &str, challenge: &str) -> bool {
 ///
 /// Policy (per spec/threat-model OAuth open-redirect prevention):
 /// - Allow `https://` to any host (with absolute URL form, no fragment).
-/// - Allow `http://` only for native loopback callbacks: `127.0.0.1`, `[::1]`,
-///   and the literal `localhost` host. Any port is fine.
+/// - Allow `http://` only for native loopback callbacks: any IPv4 address in
+///   `127.0.0.0/8`, the IPv6 `[::1]` address, and the literal `localhost`
+///   host. Any port is fine.
 /// - Reject every other scheme — explicitly including `javascript:`, `data:`,
 ///   `file:`, `vbscript:`, custom app schemes, and unparseable/relative URIs.
 /// - Reject URIs with a fragment component (RFC 6749 §3.1.2).
@@ -598,12 +599,18 @@ async fn issue_authorization_code(
     );
 
     tracing::info!(user_id = %user.id, client_id = %query.client_id, redirect_uri = %query.redirect_uri, "MCP OAuth: auth code issued, redirecting");
-    Ok(format!(
-        "{}?code={}&state={}",
-        query.redirect_uri,
-        urlencoding::encode(&code),
-        urlencoding::encode(&query.state)
-    ))
+    // RFC 6749 §3.1.2 — the registered redirect URI MAY contain a query
+    // component, which must be retained when appending `code` and `state`.
+    // Use `Url::query_pairs_mut` so a redirect like `https://app/cb?next=1`
+    // becomes `https://app/cb?next=1&code=...&state=...`, not the malformed
+    // `...?next=1?code=...` that naive string concatenation would produce.
+    let mut redirect = url::Url::parse(&query.redirect_uri)
+        .map_err(|_| AuthError::unauthorized("Invalid redirect_uri"))?;
+    redirect
+        .query_pairs_mut()
+        .append_pair("code", &code)
+        .append_pair("state", &query.state);
+    Ok(redirect.into())
 }
 
 fn render_authorize_confirm_page(query: &OAuthAuthorizeQuery, csrf_token: &str) -> String {
@@ -1038,6 +1045,22 @@ mod tests {
                 "expected {uri} to be accepted",
             );
         }
+    }
+
+    #[test]
+    fn test_redirect_url_with_existing_query_preserves_pairs() {
+        // Simulate the URL builder from `issue_authorization_code` to make
+        // sure a registered redirect URI with an existing query keeps it.
+        let mut url = url::Url::parse("https://app.example.com/cb?next=1").unwrap();
+        url.query_pairs_mut()
+            .append_pair("code", "C&D")
+            .append_pair("state", "x y");
+        let s: String = url.into();
+        assert!(s.starts_with("https://app.example.com/cb?next=1&"));
+        assert!(s.contains("code=C%26D"));
+        assert!(s.contains("state=x+y"));
+        // No double `?` or naive concatenation.
+        assert_eq!(s.matches('?').count(), 1);
     }
 
     #[test]

--- a/crates/server/src/auth/mcp_oauth.rs
+++ b/crates/server/src/auth/mcp_oauth.rs
@@ -67,6 +67,37 @@ fn verify_pkce_s256(verifier: &str, challenge: &str) -> bool {
     computed == challenge
 }
 
+/// Validate a registered redirect URI for an MCP OAuth client.
+///
+/// Policy (per spec/threat-model OAuth open-redirect prevention):
+/// - Allow `https://` to any host (with absolute URL form, no fragment).
+/// - Allow `http://` only for native loopback callbacks: `127.0.0.1`, `[::1]`,
+///   and the literal `localhost` host. Any port is fine.
+/// - Reject every other scheme — explicitly including `javascript:`, `data:`,
+///   `file:`, `vbscript:`, custom app schemes, and unparseable/relative URIs.
+/// - Reject URIs with a fragment component (RFC 6749 §3.1.2).
+fn validate_redirect_uri(raw: &str) -> Result<(), &'static str> {
+    let parsed = url::Url::parse(raw).map_err(|_| "redirect_uri must be an absolute URL")?;
+    if parsed.fragment().is_some() {
+        return Err("redirect_uri must not contain a fragment");
+    }
+    match parsed.scheme() {
+        "https" => {
+            if parsed.host().is_none() {
+                return Err("https redirect_uri must include a host");
+            }
+            Ok(())
+        }
+        "http" => match parsed.host() {
+            Some(url::Host::Domain("localhost")) => Ok(()),
+            Some(url::Host::Ipv4(ip)) if ip.is_loopback() => Ok(()),
+            Some(url::Host::Ipv6(ip)) if ip.is_loopback() => Ok(()),
+            _ => Err("http redirect_uri is only allowed for loopback hosts"),
+        },
+        _ => Err("redirect_uri scheme is not allowed"),
+    }
+}
+
 // ============================================
 // Request/Response types
 // ============================================
@@ -310,6 +341,15 @@ async fn oauth_register(
             error_description: Some("At least one redirect_uri is required".to_string()),
         });
     }
+    for uri in &req.redirect_uris {
+        if let Err(reason) = validate_redirect_uri(uri) {
+            tracing::warn!(client_name = %req.client_name, reason, "MCP OAuth: rejected redirect_uri");
+            return Err(OAuthErrorResponse {
+                error: "invalid_redirect_uri".to_string(),
+                error_description: Some(reason.to_string()),
+            });
+        }
+    }
 
     // Generate client credentials
     let client_id = format!("mcp_client_{}", generate_random_hex());
@@ -414,6 +454,11 @@ async fn oauth_authorize(
     if !registered_uris.contains(&query.redirect_uri) {
         return Err(AuthError::unauthorized("Invalid redirect_uri"));
     }
+    // Defense-in-depth: reject unsafe schemes even if a legacy client managed to
+    // register one before scheme validation existed.
+    if validate_redirect_uri(&query.redirect_uri).is_err() {
+        return Err(AuthError::unauthorized("Invalid redirect_uri"));
+    }
 
     let csrf_token = generate_random_hex();
     let csrf_cookie = Cookie::build((OAUTH_AUTHORIZE_CSRF_COOKIE, csrf_token.clone()))
@@ -500,6 +545,9 @@ async fn validate_authorize_client(
     let registered_uris: Vec<String> =
         serde_json::from_value(client.redirect_uris).unwrap_or_default();
     if !registered_uris.contains(&query.redirect_uri) {
+        return Err(AuthError::unauthorized("Invalid redirect_uri"));
+    }
+    if validate_redirect_uri(&query.redirect_uri).is_err() {
         return Err(AuthError::unauthorized("Invalid redirect_uri"));
     }
     Ok(())
@@ -973,6 +1021,48 @@ mod tests {
 
         assert!(verify_pkce_s256(verifier, &challenge));
         assert!(!verify_pkce_s256("wrong-verifier", &challenge));
+    }
+
+    #[test]
+    fn test_validate_redirect_uri_accepts_safe_schemes() {
+        for uri in [
+            "https://example.com/cb",
+            "https://example.com:8443/cb?next=1",
+            "http://localhost/cb",
+            "http://localhost:9999/cb",
+            "http://127.0.0.1:9999/cb",
+            "http://[::1]:9999/cb",
+        ] {
+            assert!(
+                validate_redirect_uri(uri).is_ok(),
+                "expected {uri} to be accepted",
+            );
+        }
+    }
+
+    #[test]
+    fn test_validate_redirect_uri_rejects_unsafe_schemes() {
+        for uri in [
+            "javascript:alert(1)",
+            "data:text/html,<script>alert(1)</script>",
+            "file:///tmp/cb",
+            "vbscript:msgbox(1)",
+            "myapp://callback",
+            "http://example.com/cb",     // non-loopback http
+            "http://10.0.0.1:9999/cb",   // non-loopback IPv4
+            "http://[2001:db8::1]/cb",   // non-loopback IPv6
+            "http://localhost.evil.com", // suffix attack
+            "//example.com/cb",          // protocol-relative
+            "/relative",
+            "",
+            "https://example.com/cb#frag", // fragment forbidden
+            "not a url",
+        ] {
+            assert!(
+                validate_redirect_uri(uri).is_err(),
+                "expected {uri} to be rejected",
+            );
+        }
     }
 
     #[test]

--- a/crates/server/tests/mcp_endpoint_test.rs
+++ b/crates/server/tests/mcp_endpoint_test.rs
@@ -2273,6 +2273,38 @@ async fn test_oauth_token_invalid_content_type_falls_back_to_form() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_oauth_register_rejects_unsafe_redirect_uris() {
+    let server = TestServer::in_memory().await;
+    for uri in [
+        "javascript:alert(1)",
+        "data:text/html,<script>alert(1)</script>",
+        "file:///tmp/cb",
+        "http://example.com/cb",
+        "myapp://callback",
+        "//example.com/cb",
+        "/relative",
+        "",
+    ] {
+        let resp = server
+            .post(
+                "/oauth/register",
+                json!({
+                    "client_name": "unsafe-client",
+                    "redirect_uris": [uri],
+                }),
+            )
+            .await;
+        assert_eq!(
+            resp.status(),
+            axum::http::StatusCode::BAD_REQUEST,
+            "expected register to reject {uri}",
+        );
+        let body: Value = resp.json();
+        assert_eq!(body["error"], "invalid_redirect_uri");
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_oauth_register_and_metadata() {
     let server = TestServer::new().await;
     // Test dynamic client registration

--- a/specs/mcp.md
+++ b/specs/mcp.md
@@ -164,6 +164,13 @@ Dynamic Client Registration (RFC 7591). No auth required.
 }
 ```
 
+**Redirect URI policy.** Each `redirect_uris[*]` must parse as an absolute URL with no fragment and use one of the allowed schemes:
+
+- `https://` to any host.
+- `http://` only when the host is loopback: `localhost`, an IPv4 in `127.0.0.0/8`, or `[::1]`.
+
+All other schemes — including `javascript:`, `data:`, `file:`, `vbscript:`, custom app schemes, protocol-relative `//host/...`, and unparseable/relative URIs — are rejected with `400 invalid_redirect_uri`. The same check is enforced again at `GET /oauth/authorize` and `POST /oauth/authorize` confirmation as defense in depth, so a previously registered unsafe URI cannot become an open-redirect target. See `crates/server/src/auth/mcp_oauth.rs::validate_redirect_uri` for the canonical policy.
+
 #### GET /oauth/authorize
 
 Authorization endpoint. Redirects to login when no session cookie is present.


### PR DESCRIPTION
## What
Validate redirect URIs at MCP OAuth dynamic client registration. Reject `javascript:`, `data:`, `file:`, custom schemes, non-loopback `http://`, protocol-relative, fragmented, and unparseable URIs. Apply the same check at `GET/POST /oauth/authorize` as defense in depth so any pre-existing unsafe registration cannot become a redirect target.

## Why
`oauth_register` previously accepted any non-empty `redirect_uris` strings. The authorize endpoint then formatted the registered URI into the post-consent `Location:` header verbatim, turning the consent endpoint into an open redirect to arbitrary schemes (e.g. `Location: javascript:alert(1)?code=...`). A malicious or compromised MCP client could induce a browser navigation to a non-HTTP scheme.

Fixes EVE-411.

## How
- New `validate_redirect_uri` in `crates/server/src/auth/mcp_oauth.rs` parses the URI with `url::Url` and enforces:
  - `https://` to any host (no fragment, must include host)
  - `http://` only when host is `localhost`, an IPv4 in `127.0.0.0/8`, or `[::1]`
  - Anything else rejected
- Called from `oauth_register` for every registered URI (`400 invalid_redirect_uri`).
- Called as defense in depth in `oauth_authorize` and `validate_authorize_client` so legacy unsafe registrations cannot become redirect targets.
- Unit tests cover accept/reject vectors (https, loopback http, javascript:, data:, file:, vbscript:, custom schemes, non-loopback hosts, suffix attacks like `localhost.evil.com`, protocol-relative, relative, empty, fragmented, malformed).
- Integration test `test_oauth_register_rejects_unsafe_redirect_uris` exercises `/oauth/register` with a mix of unsafe values and asserts `400 invalid_redirect_uri`.
- `specs/mcp.md` documents the policy with a link to the canonical implementation.

## Risk
- Low.
- Behavior change is strictly tightening: existing legitimate clients (https or loopback http) keep working. Any legacy client that was registered with an unsafe URI will start failing at authorize, which is the intended outcome.

## Security
- Threat categories reviewed: **TM-AUTH** (OAuth dynamic client registration trust boundary, authorize redirect target) and **TM-WEB** (open redirect / `javascript:` navigation from a first-party origin).
- Findings and resolutions:
  - Open redirect via attacker-supplied redirect URI scheme — fixed by allowlisting `https://` and loopback-`http://` only at registration, plus defense-in-depth at the authorize handler.
  - Suffix host attack (`http://localhost.evil.com`) explicitly covered by tests; `url::Host::Domain("localhost")` exact-match prevents it.
  - URI fragments rejected per RFC 6749 §3.1.2.
- No secrets, no new dependencies, no new endpoints, no migration changes.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SCGMufANbPDU3Y6PYbTXyt)_