### PR TITLE
fix(mcp): accept array and object flags in generated bashkit builtins

### DIFF
--- a/crates/server/src/api/mcp_endpoint/catalog.rs
+++ b/crates/server/src/api/mcp_endpoint/catalog.rs
@@ -158,6 +158,12 @@ fn bashkit_inventory_schema(mut schema: serde_json::Value) -> serde_json::Value 
 /// whose declared type is array or object back into structured JSON. Bashkit's
 /// flag parser keeps these as raw strings; the domain dispatcher expects the
 /// typed shape.
+///
+/// Empty / whitespace-only strings are left untouched so optional fields that
+/// rely on `deserialize_opt_json_value_lenient` (e.g. `channel_config`) keep
+/// their `--flag ''` → `None` behavior. The dispatcher applies the same trim
+/// rule for non-empty strings, so we only intervene when there is JSON to
+/// parse on the bash side.
 fn coerce_json_text_params(
     schema: &serde_json::Value,
     params: &mut serde_json::Value,
@@ -184,7 +190,10 @@ fn coerce_json_text_params(
         let serde_json::Value::String(text) = raw else {
             continue;
         };
-        let parsed = serde_json::from_str::<serde_json::Value>(text)
+        if text.trim().is_empty() {
+            continue;
+        }
+        let parsed = serde_json::from_str::<serde_json::Value>(text.trim())
             .map_err(|err| format!("--{name}: invalid JSON ({err})"))?;
         params_obj.insert(name.clone(), parsed);
     }
@@ -354,6 +363,28 @@ mod tests {
         let err = coerce_json_text_params(&schema, &mut params).unwrap_err();
         assert!(err.starts_with("--capabilities:"), "got: {err}");
         assert!(err.contains("invalid JSON"));
+    }
+
+    #[test]
+    fn coerce_leaves_empty_and_whitespace_strings_untouched() {
+        // Optional non-scalar fields like `channel_config` rely on
+        // `deserialize_opt_json_value_lenient`, which maps empty/whitespace
+        // strings to `None`. Eagerly parsing those would regress the bash
+        // ergonomics (`--channel_config ''` should still mean "unset").
+        let schema = serde_json::json!({
+            "properties": {
+                "channel_config": { "type": "object", "properties": {} }
+            }
+        });
+        for blank in ["", "   ", "\t\n"] {
+            let mut params = serde_json::json!({ "channel_config": blank });
+            coerce_json_text_params(&schema, &mut params).expect("coerce");
+            assert_eq!(
+                params["channel_config"],
+                serde_json::Value::String(blank.to_string()),
+                "blank input {blank:?} should pass through untouched",
+            );
+        }
     }
 
     #[test]

--- a/crates/server/src/api/mcp_endpoint/catalog.rs
+++ b/crates/server/src/api/mcp_endpoint/catalog.rs
@@ -113,17 +113,33 @@ fn bashkit_inventory_schema(mut schema: serde_json::Value) -> serde_json::Value 
         return schema;
     };
 
-    for (name, property) in properties.iter_mut() {
-        if name != "channel_config" {
-            continue;
-        }
+    // EVE-409: bashkit's flag parser only coerces scalar types and falls back
+    // to `string` for anything else, leaving array/object fields as raw strings
+    // by the time they reach the dispatcher. Generic operations (`update_agent
+    // --capabilities '[...]'`, `--tags '[...]'`, etc.) then fail to deserialize.
+    // Re-shape every non-scalar property to `type: string` with a JSON-text
+    // hint here, and let `make_inventory_callback` parse those JSON strings
+    // back into structured values before dispatch.
+    for (_name, property) in properties.iter_mut() {
         let Some(object) = property.as_object_mut() else {
             continue;
         };
+        let is_non_scalar = object
+            .get("type")
+            .and_then(|value| value.as_str())
+            .is_some_and(|value| matches!(value, "array" | "object"))
+            || object.contains_key("items")
+            || object.contains_key("properties");
+        if !is_non_scalar {
+            continue;
+        }
         object.insert(
             "type".to_string(),
             serde_json::Value::String("string".to_string()),
         );
+        // Drop array-only metadata that no longer applies after retyping; this
+        // keeps `tools/list` consumers from generating bogus item validators.
+        object.remove("items");
         let description = object
             .get("description")
             .and_then(|value| value.as_str())
@@ -138,6 +154,43 @@ fn bashkit_inventory_schema(mut schema: serde_json::Value) -> serde_json::Value 
     schema
 }
 
+/// Walk the original param schema and parse JSON-text values for properties
+/// whose declared type is array or object back into structured JSON. Bashkit's
+/// flag parser keeps these as raw strings; the domain dispatcher expects the
+/// typed shape.
+fn coerce_json_text_params(
+    schema: &serde_json::Value,
+    params: &mut serde_json::Value,
+) -> Result<(), String> {
+    let (Some(properties), Some(params_obj)) = (
+        schema.get("properties").and_then(|value| value.as_object()),
+        params.as_object_mut(),
+    ) else {
+        return Ok(());
+    };
+    for (name, property) in properties.iter() {
+        let needs_parse = property
+            .get("type")
+            .and_then(|value| value.as_str())
+            .is_some_and(|value| matches!(value, "array" | "object"))
+            || property.get("items").is_some()
+            || property.get("properties").is_some();
+        if !needs_parse {
+            continue;
+        }
+        let Some(raw) = params_obj.get(name) else {
+            continue;
+        };
+        let serde_json::Value::String(text) = raw else {
+            continue;
+        };
+        let parsed = serde_json::from_str::<serde_json::Value>(text)
+            .map_err(|err| format!("--{name}: invalid JSON ({err})"))?;
+        params_obj.insert(name.clone(), parsed);
+    }
+    Ok(())
+}
+
 fn make_inventory_callback(
     desc: &'static crate::domains::common::CommandDescriptor,
     ctx: CatalogContext,
@@ -146,10 +199,16 @@ fn make_inventory_callback(
 + Sync
 + 'static {
     move |args: ToolArgs| {
-        let params = args.params;
+        let mut params = args.params;
         let domain_ctx = ctx.to_domain_ctx();
         let link_builder = ctx.link_builder.clone();
         Box::pin(async move {
+            // Schema rewriting in `bashkit_inventory_schema` advertises array
+            // and object fields as `string` so bashkit's parser accepts JSON
+            // text on the command line. Translate them back here so the
+            // domain dispatcher sees the structured value it expects.
+            let original_schema = (desc.param_schema)();
+            coerce_json_text_params(&original_schema, &mut params)?;
             let result = (desc.dispatch)(params, &domain_ctx)
                 .await
                 .map_err(|error| error.to_string())?;
@@ -215,6 +274,101 @@ mod tests {
             value["ui_link"],
             "https://app.example/agents/agent_00000000000000000000000000000001"
         );
+    }
+
+    #[test]
+    fn bashkit_schema_retypes_array_and_object_fields_to_string() {
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "id": { "type": "string" },
+                "capabilities": {
+                    "type": "array",
+                    "items": { "type": "object" },
+                    "description": "List of capabilities"
+                },
+                "tags": {
+                    "type": "array",
+                    "items": { "type": "string" }
+                },
+                "channel_config": {
+                    "type": "object",
+                    "description": "Channel config"
+                }
+            }
+        });
+        let rewritten = bashkit_inventory_schema(schema);
+        let props = rewritten["properties"].as_object().unwrap();
+        // Scalars unchanged
+        assert_eq!(props["id"]["type"], "string");
+        // Arrays and objects retyped to string with JSON-text hint
+        for key in ["capabilities", "tags", "channel_config"] {
+            assert_eq!(
+                props[key]["type"], "string",
+                "{key} should be retyped to string",
+            );
+            assert!(
+                props[key]["description"]
+                    .as_str()
+                    .unwrap()
+                    .contains("JSON text in bash mode"),
+            );
+            assert!(
+                props[key].get("items").is_none(),
+                "items metadata should be dropped for {key}",
+            );
+        }
+    }
+
+    #[test]
+    fn coerce_parses_json_text_for_array_and_object_fields() {
+        let schema = serde_json::json!({
+            "properties": {
+                "id": { "type": "string" },
+                "capabilities": { "type": "array", "items": { "type": "object" } },
+                "tags": { "type": "array", "items": { "type": "string" } }
+            }
+        });
+        let mut params = serde_json::json!({
+            "id": "agent_1",
+            "capabilities": "[{\"ref\":\"current_time\"}]",
+            "tags": "[\"a\",\"b\"]"
+        });
+        coerce_json_text_params(&schema, &mut params).expect("coerce");
+        assert_eq!(params["id"], "agent_1");
+        assert_eq!(
+            params["capabilities"],
+            serde_json::json!([{"ref": "current_time"}]),
+        );
+        assert_eq!(params["tags"], serde_json::json!(["a", "b"]));
+    }
+
+    #[test]
+    fn coerce_surfaces_json_parse_errors_with_field_name() {
+        let schema = serde_json::json!({
+            "properties": {
+                "capabilities": { "type": "array", "items": {} }
+            }
+        });
+        let mut params = serde_json::json!({ "capabilities": "[not-json" });
+        let err = coerce_json_text_params(&schema, &mut params).unwrap_err();
+        assert!(err.starts_with("--capabilities:"), "got: {err}");
+        assert!(err.contains("invalid JSON"));
+    }
+
+    #[test]
+    fn coerce_passes_through_already_parsed_values() {
+        let schema = serde_json::json!({
+            "properties": {
+                "capabilities": { "type": "array", "items": {} }
+            }
+        });
+        // Non-bash MCP clients send the structured value directly; the coercer
+        // must leave it alone.
+        let original = serde_json::json!([{ "ref": "current_time" }]);
+        let mut params = serde_json::json!({ "capabilities": original.clone() });
+        coerce_json_text_params(&schema, &mut params).expect("coerce");
+        assert_eq!(params["capabilities"], original);
     }
 
     #[test]

--- a/specs/domains.md
+++ b/specs/domains.md
@@ -168,6 +168,21 @@ important for jq scripting should override both. Use `output_shape = "paginated"
 for `{data,total,offset,limit}` list responses and `output_shape = "array"` for
 bare array responses.
 
+### Array and object parameters in bashkit builtins
+
+`api/mcp_endpoint/catalog.rs::bashkit_inventory_schema` rewrites every
+non-scalar property (any field whose type is `array`/`object`, or that carries
+`items`/`properties`) into `type: "string"` with a "Pass JSON text in bash
+mode" hint, then `make_inventory_callback` runs `coerce_json_text_params` to
+parse those JSON strings back into structured values before dispatch. Without
+this, bashkit's flag parser falls through to `string` for every non-scalar
+type and the dispatcher fails to deserialise generic operations like
+`update_agent --capabilities '[{"ref":"current_time"}]'` or
+`update_agent --tags '["a","b"]'`. The translation is generic so every
+inventory-registered command gets the same treatment automatically; do not
+special-case individual fields. JSON parse errors surface a `--<field>:
+invalid JSON (...)` message instead of the opaque `callback failed`.
+
 ## Writing a Command
 
 Canonical pattern (see `domains/agents/commands.rs` for reference):


### PR DESCRIPTION
## What
Generalise the bashkit catalog so every non-scalar inventory-command field (arrays, objects, anything that previously had `items` / nested `properties`) is advertised to bashkit as `type: "string"` with a "Pass JSON text in bash mode" hint, and translate those JSON-text values back into structured arrays/objects right before dispatch. Surface JSON parse errors with the offending flag name instead of the opaque `callback failed`.

Fixes EVE-409.

## Why
Bashkit's flag parser only coerces `integer` / `number` / `boolean`; everything else falls through to `string`. Generated MCP builtins like `update_agent --capabilities '[{"ref":"current_time"}]'` and `update_agent --tags '["a","b"]'` therefore reached the dispatcher with the field still typed as a raw string, and `Vec<CapabilityRef>` / `Vec<String>` deserialisation failed. Bashkit then sanitised the failure to `callback failed`, which gave Codex/Everruns MCP users no actionable context.

The previous code only special-cased `channel_config`, leaving every other array/object flag broken. Per the issue, the fix has to be generic across all generated operations.

## How
- `bashkit_inventory_schema` (in `crates/server/src/api/mcp_endpoint/catalog.rs`) walks the schema's `properties` map and for any property whose declared type is `array` or `object`, or that carries `items` / nested `properties`, retypes it to `string`, drops the now-irrelevant `items`, and prepends a JSON-text hint to its description. Scalars are unchanged.
- New `coerce_json_text_params` reads the *original* (pre-rewrite) schema, finds the same non-scalar fields, and parses any string-valued `params[key]` as JSON before dispatch. Errors return `--<field>: invalid JSON (...)` so users can see what the dispatcher would have rejected.
- `make_inventory_callback` calls `coerce_json_text_params` before invoking the domain dispatch.
- Unit tests cover: schema rewriting (scalars untouched, arrays/objects retyped, items dropped, JSON-text hint appended), JSON-text parsing for array/object fields, parse-error surfacing with the field name, and pass-through of already-structured payloads from non-bash MCP clients (which still send native JSON values).
- `specs/domains.md` documents the new generic translation under "Array and object parameters in bashkit builtins".

## Risk
- Low / Medium.
- Behaviour change is additive: non-bash MCP clients keep sending structured values and `coerce_json_text_params` leaves those untouched (covered by `coerce_passes_through_already_parsed_values`). Bash callers gain support for any non-scalar flag.
- The schema rewrite only affects the inventory-built bashkit toolset (`build_toolset`), not domain types or HTTP shapes.

## Security
- Threat categories reviewed: **TM-MCP** / **TM-API** (input validation at the bashkit dispatch boundary), **TM-LLM** indirectly (the bashkit toolset is exposed to agent LLMs via `query` / `execute`).
- Findings and resolutions:
  - JSON parsing happens with `serde_json::from_str` and is bounded by bashkit's existing `max_input_bytes` limit; no new resource exhaustion vector.
  - Errors include the field name only, not the raw payload, so we don't echo attacker-controlled text back into LLM context.
  - Dispatch policy enforcement (`THREAT[TM-MCP-002]` read-only / mutating split) is unchanged; we only translate parameter values.
- No new dependencies, no migrations, no secrets.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SCGMufANbPDU3Y6PYbTXyt)_