### PR TITLE
chore(deps): bump bashkit to v0.4.1 from crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -457,8 +457,9 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bashkit"
-version = "0.4.0"
-source = "git+https://github.com/everruns/bashkit?tag=v0.4.0#2d87a82ff743fef8a24388251ad89ee27a0611f4"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd73187decb067c0df19d2a7e042d05b481d711d048ad3169162196e2489b7db"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3023,7 +3024,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4983,7 +4984,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5021,7 +5022,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -7865,7 +7866,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -66,7 +66,7 @@ fetchkit = { version = "0.2.0", features = ["bot-auth"] }
 ed25519-dalek = { version = "2", features = ["rand_core"] }
 
 # Virtual bash interpreter
-bashkit = { git = "https://github.com/everruns/bashkit", tag = "v0.4.0", features = ["jq"] }
+bashkit = { version = "0.4.1", features = ["jq"] }
 
 # Tree-sitter for structural outlines (EVE-248)
 tree-sitter = { version = "0.24", optional = true }

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -66,7 +66,7 @@ urlencoding = "2"
 git2.workspace = true
 mime_guess = "2"
 
-bashkit = { git = "https://github.com/everruns/bashkit", tag = "v0.4.0", features = ["scripted_tool", "jq"] }
+bashkit = { version = "0.4.1", features = ["scripted_tool", "jq"] }
 
 everruns-config = { path = "../config" }
 everruns-core = { path = "../core", features = ["openapi", "sqlx", "tree-sitter-outlines"] }


### PR DESCRIPTION
## What
Bump `bashkit` from `v0.4.0` (git tag) to `v0.4.1` and switch the dependency source from the `everruns/bashkit` git repo to the crates.io registry.

## Why
Picks up the latest published bashkit release. Switching to crates.io aligns bashkit with `fetchkit` (already on crates.io) and matches the toolkit-library-contract pattern.

## How
- `crates/core/Cargo.toml`: `bashkit = { version = "0.4.1", features = ["jq"] }`
- `crates/server/Cargo.toml`: `bashkit = { version = "0.4.1", features = ["scripted_tool", "jq"] }`
- `cargo update -p bashkit` to refresh `Cargo.lock`

## Risk
- Low
- Patch-level bashkit bump; same major.minor. Workspace `cargo check --all-features` passes.

## Security
- Threat categories reviewed: No security-relevant code changes (dependency patch bump from a trusted upstream; source moved from git tag to crates.io registry checksum-pinned in `Cargo.lock`).
- Findings and resolutions: None.

## Checklist
- [ ] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
