### PR TITLE
refactor(ui): rebuild dev showcases with real components

### DIFF
--- a/apps/ui/e2e/message-components.spec.ts
+++ b/apps/ui/e2e/message-components.spec.ts
@@ -13,34 +13,24 @@ test.describe("Chat Components Page", () => {
   });
 
   test("should render the page title", async ({ page }) => {
-    await expect(
-      page.getByRole("heading", { name: "Canonical component gallery" }),
-    ).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Chat UI" })).toBeVisible();
   });
 
   test("should render the shared chat primitives", async ({ page }) => {
-    await expect(page.getByText("Message Info", { exact: true })).toBeVisible();
-    await expect(page.getByText("Attachments", { exact: true })).toBeVisible();
+    await expect(page.getByText("Tool-heavy runtime scene", { exact: true })).toBeVisible();
     await expect(
-      page.getByText("Tool Activity", { exact: true }),
+      page.getByText("Transcript-focused runtime scene", { exact: true }),
     ).toBeVisible();
-    await expect(
-      page.getByText("Execution Plan", { exact: true }),
-    ).toBeVisible();
-    await expect(
-      page.getByText("Components now follow the canonical chat style."),
-    ).toBeVisible();
+    await expect(page.getByText("Empty state and composer", { exact: true })).toBeVisible();
+    await expect(page.getByText("/ship tighten the tool transcript UI")).toBeVisible();
     await expect(page.getByText("layout.png")).toBeVisible();
-    await expect(
-      page.getByText("Applying canonical styling").first(),
-    ).toBeVisible();
   });
 
   test("should use self-contained attachment previews in the gallery", async ({
     page,
   }) => {
     const uploadedPreview = page.locator('img[alt="layout.png"]');
-    const uploadingPreview = page.locator('img[alt="annotated.jpg"]');
+    const uploadingPreview = page.locator('img[alt="sandbox-daytona.jpg"]');
 
     await expect(uploadedPreview).toBeVisible();
     await expect(uploadedPreview).toHaveAttribute("src", /data:image\/svg\+xml/);
@@ -58,20 +48,15 @@ test.describe("Tool Activity Page", () => {
   });
 
   test("should render the transcript preview", async ({ page }) => {
-    await expect(
-      page.getByRole("heading", { name: "Minimal execution states" }),
-    ).toBeVisible();
-    await expect(
-      page.getByText(
-        "Can you inspect this project and sketch the rewrite steps?",
-      ),
-    ).toBeVisible();
-    await expect(
-      page.getByText("Rewrite it so it supports a rock collection instead."),
-    ).toBeVisible();
-    await expect(page.getByText("/ship")).toBeVisible();
-    await expect(page.getByText("Pick File")).toBeVisible();
-    await expect(page.getByText("Tool activity preview")).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Tool Outputs", exact: true })).toBeVisible();
+    await expect(page.getByText("Standalone tool outputs", { exact: true })).toBeVisible();
+    await expect(page.getByText("Bash output", { exact: true })).toBeVisible();
+    await expect(page.getByText("Todo plan output", { exact: true })).toBeVisible();
+    await expect(page.getByText("Grouped activity", { exact: true })).toBeVisible();
+    await expect(page.getByText("Narrated tool timeline", { exact: true })).toBeVisible();
+    await expect(page.getByText("Created Daytona sandbox")).toBeVisible();
+    await expect(page.getByText("hello from dev.everruns.com").first()).toBeVisible();
+    await expect(page.getByText("Combined transcript grouping", { exact: true })).toBeVisible();
   });
 });
 
@@ -92,11 +77,9 @@ test.describe("Dev Index Page", () => {
   test("should navigate to chat components page", async ({ page }) => {
     await page.goto("/dev");
 
-    await page.getByRole("link", { name: /Chat Components/i }).click();
+    await page.getByRole("link", { name: /Chat UI/i }).click();
 
     await expect(page).toHaveURL("/dev/chat-components");
-    await expect(
-      page.getByRole("heading", { name: "Canonical component gallery" }),
-    ).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Chat UI" })).toBeVisible();
   });
 });

--- a/apps/ui/src/app/(main)/sessions/[sessionId]/layout.tsx
+++ b/apps/ui/src/app/(main)/sessions/[sessionId]/layout.tsx
@@ -1,51 +1,15 @@
 "use client";
 
-import { use, useEffect, useMemo, useRef, useState } from "react";
-import { usePathname, useRouter } from "next/navigation";
-import Link from "next/link";
+import { use, useMemo } from "react";
+import { usePathname } from "next/navigation";
 import { ResourceNotFound } from "@/components/resource-not-found";
-import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { Input } from "@/components/ui/input";
-import { buttonVariants } from "@/components/ui/button";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuGroup,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuPositioner,
-  DropdownMenuShortcut,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import {
-  ArrowLeft,
-  Sparkles,
-  MessageSquare,
-  Folder,
-  Activity,
-  Zap,
-  Database,
-  Bot,
-  GitBranch,
-  Pencil,
-  Check,
-  X,
-  CalendarClock,
-  ChevronDown,
-  Wrench,
-} from "lucide-react";
-import { cn, shortenId } from "@/lib/utils";
-import { CopyButton } from "@/components/ui/copy-button";
-import { useUpdateSession } from "@/hooks/use-sessions";
 import { SessionProvider, useSessionContext } from "./session-context";
 import {
-  getDisplayName,
-  getEntityReferenceClassName,
-  getEntityReferenceLabel,
-} from "@/lib/entity-lifecycle";
-import { formatTokens } from "@/lib/formatting";
+  SessionHeader,
+  type SessionNavKey,
+  buildSessionNavigation,
+} from "@/components/session/session-header";
 
 interface SessionLayoutProps {
   children: React.ReactNode;
@@ -67,119 +31,10 @@ interface SessionLayoutContentProps {
   sessionId: string;
 }
 
-type SessionNavKey =
-  | "chat"
-  | "files"
-  | "storage"
-  | "resources"
-  | "schedules"
-  | "events"
-  | "trajectory";
-
-interface SessionNavItem {
-  key: SessionNavKey;
-  label: string;
-  href: string;
-  icon: React.ComponentType<{ className?: string }>;
-  badge?: string;
-}
-
-function EditableSessionTitle({
-  sessionId,
-  title,
-  fallback,
-}: {
-  sessionId: string;
-  title: string | null;
-  fallback: string;
-}) {
-  const [editing, setEditing] = useState(false);
-  const [value, setValue] = useState(title ?? "");
-  const inputRef = useRef<HTMLInputElement>(null);
-  const updateSession = useUpdateSession();
-
-  useEffect(() => {
-    if (editing) {
-      setValue(title ?? "");
-      // Wait for next frame so the input is mounted
-      requestAnimationFrame(() => inputRef.current?.select());
-    }
-  }, [editing, title]);
-
-  function save() {
-    const trimmed = value.trim();
-    // Skip if unchanged
-    if (trimmed === (title ?? "")) {
-      setEditing(false);
-      return;
-    }
-    updateSession.mutate(
-      { sessionId, request: { title: trimmed || undefined } },
-      { onSettled: () => setEditing(false) },
-    );
-  }
-
-  if (editing) {
-    return (
-      <div className="flex items-center gap-1">
-        <Input
-          ref={inputRef}
-          value={value}
-          onChange={(e: React.ChangeEvent<HTMLInputElement>) => setValue(e.target.value)}
-          onKeyDown={(e: React.KeyboardEvent) => {
-            if (e.key === "Enter") save();
-            if (e.key === "Escape") setEditing(false);
-          }}
-          className="h-8 text-xl font-bold w-64"
-          placeholder={fallback}
-        />
-        <button
-          onClick={save}
-          className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground"
-          aria-label="Save title"
-        >
-          <Check className="w-4 h-4" />
-        </button>
-        <button
-          onClick={() => setEditing(false)}
-          className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground"
-          aria-label="Cancel editing"
-        >
-          <X className="w-4 h-4" />
-        </button>
-      </div>
-    );
-  }
-
-  return (
-    <h1 className="text-xl font-bold flex items-center gap-2">
-      {title || fallback}
-      <button
-        onClick={() => setEditing(true)}
-        className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground"
-        aria-label="Edit session title"
-      >
-        <Pencil className="w-3.5 h-3.5" />
-      </button>
-      <CopyButton value={sessionId} />
-    </h1>
-  );
-}
-
-function SessionLayoutContent({ children, sessionId }: SessionLayoutContentProps) {
+export function SessionLayoutContent({ children, sessionId }: SessionLayoutContentProps) {
   const pathname = usePathname();
-  const router = useRouter();
   const { agent, session, llmModel, sessionLoading, effectiveStatus, liveUsage, agentId } =
     useSessionContext();
-  const agentReferenceLabel =
-    session?.agent_id != null
-      ? getEntityReferenceLabel({
-          kind: "Agent",
-          name: getDisplayName(agent),
-          status: agent?.status ?? "deleted",
-        })
-      : null;
-  const agentReferenceStatus = session?.agent_id != null ? (agent?.status ?? "deleted") : null;
 
   // Determine active tab from pathname
   const getActiveTab = (): SessionNavKey => {
@@ -194,82 +49,12 @@ function SessionLayoutContent({ children, sessionId }: SessionLayoutContentProps
   const activeTab = getActiveTab();
 
   const basePath = `/sessions/${sessionId}`;
-  const getNavigationClassName = (isActive: boolean) =>
-    cn(
-      buttonVariants({ variant: "outline", size: "sm" }),
-      isActive ? "border-primary bg-card text-foreground" : "text-muted-foreground",
-    );
-
-  // Compute active feature set from session capabilities
   const features = useMemo(() => new Set(session?.features ?? []), [session?.features]);
-  const hasFeature = (feature: string) => features.has(feature);
-  const navigationItems: SessionNavItem[] = [
-    {
-      key: "chat",
-      label: "Chat",
-      href: `${basePath}/chat`,
-      icon: MessageSquare,
-    },
-    ...(hasFeature("file_system")
-      ? [
-          {
-            key: "files" as const,
-            label: "Workspace",
-            href: `${basePath}/files`,
-            icon: Folder,
-          },
-        ]
-      : []),
-    ...(hasFeature("secrets") || hasFeature("key_value")
-      ? [
-          {
-            key: "storage" as const,
-            label: "Storage",
-            href: `${basePath}/storage`,
-            icon: Database,
-          },
-        ]
-      : []),
-    ...(hasFeature("leased_resources")
-      ? [
-          {
-            key: "resources" as const,
-            label: "Resources",
-            href: `${basePath}/resources`,
-            icon: Wrench,
-          },
-        ]
-      : []),
-    ...(hasFeature("schedules")
-      ? [
-          {
-            key: "schedules" as const,
-            label: "Schedules",
-            href: `${basePath}/schedules`,
-            icon: CalendarClock,
-            badge:
-              (session?.active_schedule_count ?? 0) > 0
-                ? String(session?.active_schedule_count ?? 0)
-                : undefined,
-          },
-        ]
-      : []),
-    {
-      key: "events",
-      label: "Events",
-      href: `${basePath}/events`,
-      icon: Activity,
-    },
-    {
-      key: "trajectory",
-      label: "Trajectory",
-      href: `${basePath}/trajectory`,
-      icon: GitBranch,
-    },
-  ];
-  const chatItem = navigationItems[0];
-  const advancedNavigationItems = navigationItems.slice(1);
-  const activeAdvancedItem = advancedNavigationItems.find((item) => item.key === activeTab);
+  const navigationItems = buildSessionNavigation({
+    basePath,
+    features,
+    activeScheduleCount: session?.active_schedule_count,
+  });
 
   if (sessionLoading) {
     return (
@@ -295,148 +80,22 @@ function SessionLayoutContent({ children, sessionId }: SessionLayoutContentProps
 
   return (
     <div className="flex flex-col h-full">
-      {/* Header */}
-      <div className="border-b border-border/70 bg-background/80 px-4 py-3 backdrop-blur-[1px]">
-        <Link
-          href="/sessions"
-          className="mb-1.5 inline-flex items-center text-sm text-muted-foreground hover:text-foreground"
-        >
-          <ArrowLeft className="icon-sharp mr-2 h-4 w-4" />
-          Back to Sessions
-        </Link>
-
-        <div className="flex items-center justify-between">
-          <div className="group/title">
-            <EditableSessionTitle
-              sessionId={sessionId}
-              title={session.title}
-              fallback={`Session ${shortenId(session.id)}`}
-            />
-            <div className="flex items-center gap-2 text-sm text-muted-foreground">
-              {agentReferenceLabel &&
-                (agent ? (
-                  <Link
-                    href={`/agents/${agentId}`}
-                    className="inline-flex items-center gap-1 hover:text-foreground"
-                  >
-                    <Bot className="icon-sharp h-3 w-3" />
-                    <span className={getEntityReferenceClassName(agentReferenceStatus)}>
-                      {agentReferenceLabel}
-                    </span>
-                  </Link>
-                ) : (
-                  <span className="inline-flex items-center gap-1">
-                    <Bot className="icon-sharp h-3 w-3" />
-                    <span className={getEntityReferenceClassName(agentReferenceStatus)}>
-                      {agentReferenceLabel}
-                    </span>
-                  </span>
-                ))}
-              <span>•</span>
-              <span>
-                {activeTab === "files"
-                  ? "Workspace: /workspace"
-                  : `Started ${new Date(session.created_at).toLocaleString()}`}
-              </span>
-            </div>
-          </div>
-          <div className="flex flex-wrap items-center justify-end gap-2">
-            {liveUsage && (
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger>
-                    <Badge variant="outline" className="gap-1 cursor-help">
-                      <Zap className="icon-sharp h-3 w-3" />
-                      {formatTokens(liveUsage.input_tokens)} /{" "}
-                      {formatTokens(liveUsage.output_tokens)}
-                    </Badge>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-xs">
-                      <dt className="text-muted-foreground">Input</dt>
-                      <dd>{liveUsage.input_tokens.toLocaleString()}</dd>
-                      <dt className="text-muted-foreground">Output</dt>
-                      <dd>{liveUsage.output_tokens.toLocaleString()}</dd>
-                      {(liveUsage.cache_read_tokens ?? 0) > 0 && (
-                        <>
-                          <dt className="text-muted-foreground">Cache read</dt>
-                          <dd>{liveUsage.cache_read_tokens!.toLocaleString()}</dd>
-                        </>
-                      )}
-                      {(liveUsage.cache_creation_tokens ?? 0) > 0 && (
-                        <>
-                          <dt className="text-muted-foreground">Cache created</dt>
-                          <dd>{liveUsage.cache_creation_tokens!.toLocaleString()}</dd>
-                        </>
-                      )}
-                    </dl>
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-            )}
-            {llmModel && (
-              <Badge variant="outline" className="gap-1">
-                <Sparkles className="icon-sharp h-3 w-3" />
-                {llmModel.display_name}
-              </Badge>
-            )}
-            {effectiveStatus === "active" && <Badge variant="default">Processing...</Badge>}
-            {effectiveStatus === "idle" && <Badge variant="secondary">Ready</Badge>}
-            {effectiveStatus === "started" && <Badge variant="outline">New</Badge>}
-            <Link
-              href={chatItem.href}
-              className={getNavigationClassName(activeTab === chatItem.key)}
-              aria-current={activeTab === chatItem.key ? "page" : undefined}
-            >
-              <chatItem.icon className="icon-sharp h-4 w-4" />
-              {chatItem.label}
-            </Link>
-            {advancedNavigationItems.length > 0 && (
-              <DropdownMenu>
-                <DropdownMenuTrigger
-                  className={getNavigationClassName(activeTab !== "chat")}
-                  aria-label="Advanced navigation"
-                >
-                  Advanced
-                  {activeAdvancedItem && (
-                    <span className="text-xs text-muted-foreground">
-                      {activeAdvancedItem.label}
-                    </span>
-                  )}
-                  <ChevronDown className="icon-sharp h-4 w-4 opacity-60" />
-                </DropdownMenuTrigger>
-                <DropdownMenuPositioner align="end">
-                  <DropdownMenuContent className="w-56">
-                    <DropdownMenuGroup>
-                      <DropdownMenuLabel>Advanced Views</DropdownMenuLabel>
-                      {advancedNavigationItems.map((item) => (
-                        <DropdownMenuItem
-                          key={item.key}
-                          onClick={() => router.push(item.href)}
-                          className="flex items-center justify-between gap-3"
-                        >
-                          <span className="flex min-w-0 items-center gap-2">
-                            <item.icon className="icon-sharp h-4 w-4" />
-                            <span>{item.label}</span>
-                          </span>
-                          <span className="flex items-center gap-2">
-                            {item.badge && (
-                              <DropdownMenuShortcut>{item.badge}</DropdownMenuShortcut>
-                            )}
-                            {activeTab === item.key && (
-                              <Check className="icon-sharp h-4 w-4 text-primary" />
-                            )}
-                          </span>
-                        </DropdownMenuItem>
-                      ))}
-                    </DropdownMenuGroup>
-                  </DropdownMenuContent>
-                </DropdownMenuPositioner>
-              </DropdownMenu>
-            )}
-          </div>
-        </div>
-      </div>
+      <SessionHeader
+        sessionId={sessionId}
+        session={session}
+        agent={agent}
+        agentId={agentId}
+        llmModel={llmModel}
+        effectiveStatus={effectiveStatus}
+        liveUsage={liveUsage}
+        activeTab={activeTab}
+        navigationItems={navigationItems}
+        secondaryMetaText={
+          activeTab === "files"
+            ? "Workspace: /workspace"
+            : `Started ${new Date(session.created_at).toLocaleString()}`
+        }
+      />
 
       {/* Tab content */}
       {children}

--- a/apps/ui/src/app/(main)/sessions/[sessionId]/session-context.tsx
+++ b/apps/ui/src/app/(main)/sessions/[sessionId]/session-context.tsx
@@ -40,7 +40,7 @@ export interface ToolOutputStreams {
   stderr: string;
 }
 
-interface SessionContextValue {
+export interface SessionContextValue {
   // IDs
   agentId: string | undefined;
   sessionId: string;
@@ -97,7 +97,7 @@ interface SessionContextValue {
   ) => Array<{ id: string; name: string; arguments: Record<string, unknown> }>;
 }
 
-const SessionContext = createContext<SessionContextValue | null>(null);
+export const SessionContext = createContext<SessionContextValue | null>(null);
 
 export function useSessionContext() {
   const context = useContext(SessionContext);

--- a/apps/ui/src/app/dev/_components/dev-chat-runtime-preview.tsx
+++ b/apps/ui/src/app/dev/_components/dev-chat-runtime-preview.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { ChatPanel } from "@/components/chat/chat-panel";
+import { type SessionContextValue } from "@/app/(main)/sessions/[sessionId]/session-context";
+import type { Agent, Event, LlmModelWithProvider, Message, Session } from "@/lib/api/types";
+import { getTextFromContent, getToolCallsFromContent } from "@/lib/api/types";
+import { getLocalizedOutputMessageText } from "@/lib/runtime-errors";
+import { getDevChatFixture } from "@/app/dev/_fixtures/chat-runtime-fixtures";
+import { useLocale } from "@/providers/locale-provider";
+import { DevSessionRuntimeFrame } from "@/app/dev/_components/dev-session-runtime-frame";
+
+function createNoopCancelMutation(): SessionContextValue["cancelCurrentTurn"] {
+  return {
+    mutate: () => undefined,
+    isPending: false,
+  } as SessionContextValue["cancelCurrentTurn"];
+}
+
+export function DevChatRuntimeScene({
+  scenario,
+}: {
+  scenario: "tool-activity" | "chat-components";
+}) {
+  const fixture = useMemo(() => getDevChatFixture(scenario), [scenario]);
+  const { locale } = useLocale();
+  const llmModels = useMemo<LlmModelWithProvider[]>(
+    () =>
+      fixture.llmModels.map((model) => ({
+        ...model,
+        provider_name: model.provider_id === "provider-openai" ? "OpenAI" : "OpenRouter",
+        provider_type: "openai",
+        profile: {
+          name: model.display_name,
+          family: "kimi",
+          attachment: true,
+          reasoning: true,
+          temperature: true,
+          tool_call: true,
+          structured_output: true,
+          open_weights: false,
+          reasoning_effort: {
+            default: "medium",
+            values: [
+              { value: "low", name: "Low" },
+              { value: "medium", name: "Medium" },
+              { value: "high", name: "High" },
+            ],
+          },
+        },
+      })),
+    [fixture.llmModels],
+  );
+  const [events, setEvents] = useState<Event[]>(fixture.events);
+  const [reasoningEffort, setReasoningEffort] = useState<SessionContextValue["reasoningEffort"]>(
+    fixture.initialReasoningEffort as SessionContextValue["reasoningEffort"],
+  );
+  const [isWaitingForResponse, setIsWaitingForResponse] = useState(false);
+
+  const agent: Agent = {
+    id: "agent_dev_preview",
+    name: "platform-chat",
+    display_name: "Platform Chat",
+    description: "Fixture agent for runtime chat previews.",
+    system_prompt: "You are a precise coding assistant.",
+    default_model_id: llmModels[0].id,
+    tags: [],
+    capabilities: [],
+    initial_files: [],
+    status: "active",
+    created_at: "2026-03-07T21:00:00Z",
+    updated_at: "2026-03-07T21:00:00Z",
+    archived_at: null,
+    deleted_at: null,
+  };
+
+  const session: Session = {
+    id: fixture.sessionId,
+    organization_id: "org_dev_preview",
+    harness_id: "harness_platform",
+    agent_id: agent.id,
+    owner_principal_id: "user_dev_preview",
+    title:
+      scenario === "tool-activity" ? "Daytona sandbox tool activity" : "Runtime chat components",
+    preview: null,
+    output_preview: null,
+    tags: [],
+    model_id: llmModels[0].id,
+    status: scenario === "tool-activity" ? "active" : "idle",
+    created_at: "2026-03-07T21:20:00Z",
+    updated_at: "2026-03-07T21:22:00Z",
+    started_at: "2026-03-07T21:20:00Z",
+    finished_at: null,
+    active_schedule_count: scenario === "tool-activity" ? 1 : 0,
+    features: ["file_system", "leased_resources", "schedules"],
+  };
+
+  const sendMessage = useMemo(() => {
+    const mutateAsync = async ({
+      sessionId,
+      content,
+    }: {
+      sessionId: string;
+      content: string;
+    }): Promise<Message> => {
+      const ts = new Date().toISOString();
+      const message: Message = {
+        id: `dev-msg-${Date.now()}`,
+        session_id: sessionId,
+        sequence: events.length + 10,
+        role: "user",
+        content: [{ type: "text", text: content }],
+        tool_call_id: null,
+        created_at: ts,
+      };
+
+      setEvents((current) => [
+        ...current,
+        {
+          id: `dev-event-${Date.now()}`,
+          type: "input.message",
+          ts,
+          session_id: sessionId,
+          context: {},
+          data: { message },
+        },
+      ]);
+
+      return message;
+    };
+
+    return {
+      mutateAsync,
+      isPending: false,
+    } as SessionContextValue["sendMessage"];
+  }, [events.length]);
+
+  const contextValue: SessionContextValue = {
+    agentId: "agent_dev_preview",
+    sessionId: fixture.sessionId,
+    agent,
+    session,
+    events,
+    llmModel: llmModels[0],
+    chatEvents: events,
+    toolResultsMap: fixture.toolResultsMap,
+    toolProgressMap: fixture.toolProgressMap,
+    toolOutputMap: fixture.toolOutputMap,
+    sessionLoading: false,
+    eventsLoading: false,
+    effectiveStatus: session.status,
+    liveUsage: { input_tokens: 1842, output_tokens: 326 },
+    isActive: scenario === "tool-activity",
+    shouldPoll: false,
+    supportsReasoning: true,
+    reasoningEffort,
+    setReasoningEffort,
+    getReasoningEffortName: (value: string) =>
+      value === "medium" ? "Medium" : value === "high" ? "High" : value === "low" ? "Low" : value,
+    defaultEffortName: "Medium",
+    isWaitingForResponse,
+    setIsWaitingForResponse,
+    isThinking: scenario === "chat-components",
+    streamingText:
+      scenario === "chat-components"
+        ? "Applying the runtime chat surface directly to this dev page."
+        : null,
+    streamingTurnId: scenario === "chat-components" ? "turn-dev-streaming" : null,
+    streamingIteration: scenario === "chat-components" ? 2 : null,
+    sendMessage,
+    cancelCurrentTurn: createNoopCancelMutation(),
+    hasMoreEvents: false,
+    loadingOlderEvents: false,
+    loadOlderEvents: async () => undefined,
+    totalNonDeltaCount: events.length,
+    getMessageText: (data) =>
+      data.message?.role === "agent"
+        ? getLocalizedOutputMessageText(locale, data)
+        : getTextFromContent(data.message?.content ?? []),
+    getToolCalls: (data) => getToolCallsFromContent(data.message?.content ?? []),
+  };
+
+  return (
+    <DevSessionRuntimeFrame contextValue={contextValue}>
+      <ChatPanel />
+    </DevSessionRuntimeFrame>
+  );
+}

--- a/apps/ui/src/app/dev/_components/dev-session-runtime-frame.tsx
+++ b/apps/ui/src/app/dev/_components/dev-session-runtime-frame.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import {
+  SessionContext,
+  type SessionContextValue,
+} from "@/app/(main)/sessions/[sessionId]/session-context";
+import { SessionLayoutContent } from "@/app/(main)/sessions/[sessionId]/layout";
+
+export function DevSessionRuntimeFrame({
+  contextValue,
+  children,
+}: {
+  contextValue: SessionContextValue;
+  children: React.ReactNode;
+}) {
+  return (
+    <SessionContext.Provider value={contextValue}>
+      <div className="overflow-hidden border border-border/70 bg-background shadow-[0_1px_0_hsl(var(--background)/0.92)]">
+        <div className="flex min-h-[760px] flex-col">
+          <SessionLayoutContent sessionId={contextValue.sessionId}>{children}</SessionLayoutContent>
+        </div>
+      </div>
+    </SessionContext.Provider>
+  );
+}

--- a/apps/ui/src/app/dev/_fixtures/chat-runtime-fixtures.ts
+++ b/apps/ui/src/app/dev/_fixtures/chat-runtime-fixtures.ts
@@ -1,0 +1,731 @@
+"use client";
+
+import type { PendingImage } from "@/lib/api/images";
+import type {
+  CommandDescriptor,
+  Event,
+  LlmModel,
+  ToolCompletedData,
+  ToolProgressData,
+} from "@/lib/api/types";
+import type { ToolOutputStreams } from "@/app/(main)/sessions/[sessionId]/session-context";
+
+export interface DevChatFixture {
+  sessionId: string;
+  events: Event[];
+  toolResultsMap: Map<string, ToolCompletedData>;
+  toolProgressMap: Map<string, ToolProgressData>;
+  toolOutputMap: Map<string, ToolOutputStreams>;
+  pendingImages: PendingImage[];
+  commands: CommandDescriptor[];
+  llmModels: LlmModel[];
+  initialInputValue: string;
+  initialModelId: string;
+  initialReasoningEffort: string;
+}
+
+function makeInputEvent({
+  id,
+  sequence,
+  sessionId,
+  text,
+  ts,
+  metadata,
+}: {
+  id: string;
+  sequence: number;
+  sessionId: string;
+  text: string;
+  ts: string;
+  metadata?: Record<string, unknown>;
+}): Event {
+  return {
+    id,
+    type: "input.message",
+    ts,
+    session_id: sessionId,
+    context: {},
+    data: {
+      message: {
+        id: `msg-${id}`,
+        session_id: sessionId,
+        sequence,
+        role: "user",
+        content: [{ type: "text", text }],
+        tool_call_id: null,
+        created_at: ts,
+        metadata,
+      },
+    },
+  };
+}
+
+function makeOutputEvent({
+  id,
+  sequence,
+  sessionId,
+  ts,
+  text,
+  toolCalls,
+  metadata,
+}: {
+  id: string;
+  sequence: number;
+  sessionId: string;
+  ts: string;
+  text?: string;
+  toolCalls?: Array<{
+    id: string;
+    name: string;
+    arguments: Record<string, unknown>;
+  }>;
+  metadata?: Record<string, unknown>;
+}): Event {
+  return {
+    id,
+    type: "output.message.completed",
+    ts,
+    session_id: sessionId,
+    context: {},
+    data: {
+      message: {
+        id: `msg-${id}`,
+        session_id: sessionId,
+        sequence,
+        role: "agent",
+        content: [
+          ...(text ? [{ type: "text" as const, text }] : []),
+          ...((toolCalls ?? []).map((toolCall) => ({
+            type: "tool_call" as const,
+            id: toolCall.id,
+            name: toolCall.name,
+            arguments: toolCall.arguments,
+          })) ?? []),
+        ],
+        tool_call_id: null,
+        created_at: ts,
+        metadata,
+      },
+      metadata: { model: "kimi-k2.5" },
+      usage: { input_tokens: 820, output_tokens: 140 },
+    },
+  };
+}
+
+function toolResult(
+  tool_call_id: string,
+  tool_name: string,
+  result: ToolCompletedData["result"],
+  extra?: Partial<ToolCompletedData>,
+): ToolCompletedData {
+  return {
+    tool_call_id,
+    tool_name,
+    success: true,
+    status: "success",
+    result,
+    ...extra,
+  };
+}
+
+function dataPreviewSvg(label: string, fill: string, text: string): string {
+  return `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='96' height='96' viewBox='0 0 96 96'%3E%3Crect fill='${fill}' width='96' height='96'/%3E%3Ctext x='50%25' y='44%25' dominant-baseline='middle' text-anchor='middle' fill='%230a1636' font-size='11'%3E${label}%3C/text%3E%3Ctext x='50%25' y='60%25' dominant-baseline='middle' text-anchor='middle' fill='%230a1636' font-size='8'%3E${text}%3C/text%3E%3C/svg%3E`;
+}
+
+export const devCommands: CommandDescriptor[] = [
+  {
+    name: "ship",
+    description: "Run the shipping workflow",
+    source: "system",
+  },
+  {
+    name: "process-issues",
+    description: "Batch-process open issues",
+    source: "skill",
+  },
+  {
+    name: "btw",
+    description: "Ask a side question without changing the main task",
+    source: "system",
+    args: [{ name: "question", description: "Question to answer", required: true }],
+  },
+];
+
+export const devModels: LlmModel[] = [
+  {
+    id: "model-kimi-k2.5",
+    provider_id: "provider-openrouter",
+    model_id: "openrouter/kimi-k2.5",
+    display_name: "Kimi K2.5",
+    capabilities: ["chat", "tools"],
+    enabled: true,
+    is_favorite: true,
+    status: "active",
+    created_at: "2026-03-07T21:00:00Z",
+    updated_at: "2026-03-07T21:00:00Z",
+  },
+  {
+    id: "model-gpt-5.4-mini",
+    provider_id: "provider-openai",
+    model_id: "gpt-5.4-mini",
+    display_name: "GPT-5.4 Mini",
+    capabilities: ["chat", "tools"],
+    enabled: true,
+    is_favorite: false,
+    status: "active",
+    created_at: "2026-03-07T21:00:00Z",
+    updated_at: "2026-03-07T21:00:00Z",
+  },
+];
+
+export function makePendingImages(): PendingImage[] {
+  return [
+    {
+      tempId: "pending-layout",
+      file: null,
+      uploadPromise: null,
+      imageId: null,
+      filename: "layout.png",
+      previewUrl: dataPreviewSvg("PNG", "%23ece7db", "layout"),
+      status: "uploaded",
+    },
+    {
+      tempId: "pending-sandbox",
+      file: null,
+      uploadPromise: null,
+      imageId: null,
+      filename: "sandbox-daytona.jpg",
+      previewUrl: dataPreviewSvg("JPG", "%23f6e7c1", "sandbox"),
+      status: "uploading",
+    },
+  ];
+}
+
+export function getDevChatFixture(kind: "tool-activity" | "chat-components"): DevChatFixture {
+  if (kind === "tool-activity") {
+    const sessionId = "session-dev-tool-activity";
+    const events: Event[] = [
+      makeInputEvent({
+        id: "tool-user-1",
+        sequence: 1,
+        sessionId,
+        text: "Inspect the repo and show me the path you took through the code.",
+        ts: "2026-03-07T21:20:00Z",
+        metadata: { source: "schedule" },
+      }),
+      makeOutputEvent({
+        id: "tool-agent-1",
+        sequence: 2,
+        sessionId,
+        ts: "2026-03-07T21:20:06Z",
+        text: "I’m reading the entry points first, then I’ll summarize the key edges.",
+        metadata: { model: "kimi-k2.5", reasoning_effort: "medium" },
+      }),
+      makeOutputEvent({
+        id: "tool-agent-2",
+        sequence: 3,
+        sessionId,
+        ts: "2026-03-07T21:20:10Z",
+        toolCalls: [
+          { id: "ta-list", name: "list_files", arguments: { path: "." } },
+          {
+            id: "ta-read",
+            name: "read_file",
+            arguments: { path: "/workspace/AGENTS.md" },
+          },
+          {
+            id: "ta-search",
+            name: "grep_files",
+            arguments: { pattern: "**/auth*" },
+          },
+          {
+            id: "ta-web",
+            name: "search_web",
+            arguments: { query: "daytona sandbox access issue" },
+          },
+          {
+            id: "ta-bash",
+            name: "daytona_exec",
+            arguments: { command: "pwd && uname -s" },
+          },
+        ],
+      }),
+      makeInputEvent({
+        id: "tool-user-2",
+        sequence: 4,
+        sessionId,
+        text: "Now run the Daytona check and tell me what broke.",
+        ts: "2026-03-07T21:21:00Z",
+      }),
+      {
+        id: "tool-act-1",
+        type: "act.started",
+        ts: "2026-03-07T21:21:05Z",
+        session_id: sessionId,
+        context: { exec_id: "exec-daytona" },
+        data: {
+          headline: "Running Daytona sandbox checks",
+          tool_calls: [
+            {
+              id: "tda-create",
+              name: "daytona_create_sandbox",
+              narration: "Created Daytona sandbox",
+            },
+            {
+              id: "tda-run",
+              name: "daytona_exec",
+              narration: "Ran `pwd; uname -s`",
+            },
+            {
+              id: "tda-write",
+              name: "daytona_exec",
+              narration: "Wrote `/home/daytona/hello-from-everruns.txt`",
+            },
+            {
+              id: "tda-read",
+              name: "daytona_exec",
+              narration: "Read the file back",
+            },
+          ],
+        },
+      },
+      {
+        id: "tool-completed-1",
+        type: "tool.completed",
+        ts: "2026-03-07T21:21:07Z",
+        session_id: sessionId,
+        context: { exec_id: "exec-daytona" },
+        data: {
+          tool_call_id: "tda-create",
+          tool_name: "daytona_create_sandbox",
+          success: true,
+          status: "success",
+          narration: "Created Daytona sandbox",
+          result: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                sandbox_id: "9beac0d5-ae4c-41e8-970f-f48e70a20395",
+                status: "running",
+                workspace_path: "/home/daytona",
+              }),
+            },
+          ],
+          duration_ms: 620,
+        },
+      },
+      {
+        id: "tool-completed-2",
+        type: "tool.completed",
+        ts: "2026-03-07T21:21:08Z",
+        session_id: sessionId,
+        context: { exec_id: "exec-daytona" },
+        data: {
+          tool_call_id: "tda-run",
+          tool_name: "daytona_exec",
+          success: false,
+          status: "error",
+          narration: "Ran `pwd; uname -s`",
+          error: "Resource was not created by this session",
+          result: [{ type: "text", text: "Resource was not created by this session" }],
+          duration_ms: 180,
+        },
+      },
+      {
+        id: "tool-completed-3",
+        type: "tool.completed",
+        ts: "2026-03-07T21:21:11Z",
+        session_id: sessionId,
+        context: { exec_id: "exec-daytona" },
+        data: {
+          tool_call_id: "tda-write",
+          tool_name: "daytona_exec",
+          success: true,
+          status: "success",
+          narration: "Wrote `/home/daytona/hello-from-everruns.txt`",
+          result: [{ type: "text", text: "file written" }],
+          duration_ms: 240,
+        },
+      },
+      {
+        id: "tool-completed-4",
+        type: "tool.completed",
+        ts: "2026-03-07T21:21:12Z",
+        session_id: sessionId,
+        context: { exec_id: "exec-daytona" },
+        data: {
+          tool_call_id: "tda-read",
+          tool_name: "daytona_exec",
+          success: true,
+          status: "success",
+          narration: "Read the file back",
+          result: [{ type: "text", text: "hello from dev.everruns.com" }],
+          duration_ms: 120,
+        },
+      },
+      {
+        id: "tool-act-1-done",
+        type: "act.completed",
+        ts: "2026-03-07T21:21:12Z",
+        session_id: sessionId,
+        context: { exec_id: "exec-daytona" },
+        data: {
+          completed: true,
+          success_count: 3,
+          error_count: 1,
+          duration_ms: 1820,
+          headline: "Ran Daytona sandbox checks",
+        },
+      },
+      {
+        id: "tool-client-wait",
+        type: "tool.call_requested",
+        ts: "2026-03-07T21:21:20Z",
+        session_id: sessionId,
+        context: {},
+        data: {
+          headline: "Waiting on tools",
+          tool_calls: [
+            {
+              id: "client-pick",
+              name: "pick_file",
+              arguments: { accept: ".png,.jpg" },
+            },
+          ],
+          tool_summaries: [
+            {
+              id: "client-pick",
+              name: "pick_file",
+              display_name: "Pick File",
+              narration: "Choose a screenshot",
+            },
+          ],
+        },
+      },
+      makeOutputEvent({
+        id: "tool-agent-3",
+        sequence: 5,
+        sessionId,
+        ts: "2026-03-07T21:21:25Z",
+        text: "The Daytona run succeeded after the first session-scoped command failed on resource ownership.",
+        metadata: { model: "kimi-k2.5", reasoning_effort: "medium" },
+      }),
+    ];
+
+    return {
+      sessionId,
+      events,
+      toolResultsMap: new Map([
+        [
+          "ta-list",
+          toolResult(
+            "ta-list",
+            "list_files",
+            [{ type: "text", text: "apps/\ncrates/\nscripts/\nAGENTS.md" }],
+            { duration_ms: 54 },
+          ),
+        ],
+        [
+          "ta-read",
+          toolResult(
+            "ta-read",
+            "read_file",
+            [
+              {
+                type: "text",
+                text: JSON.stringify({
+                  path: "/workspace/AGENTS.md",
+                  content: "Always make sure you are working on top of latest main from remote.",
+                  encoding: "text",
+                  size_bytes: 78,
+                }),
+              },
+            ],
+            { duration_ms: 36 },
+          ),
+        ],
+        [
+          "ta-search",
+          toolResult(
+            "ta-search",
+            "grep_files",
+            [
+              {
+                type: "text",
+                text: "crates/server/src/auth/config.rs\napps/ui/src/providers/auth-provider.tsx",
+              },
+            ],
+            { duration_ms: 44 },
+          ),
+        ],
+        [
+          "ta-web",
+          toolResult(
+            "ta-web",
+            "search_web",
+            [
+              {
+                type: "text",
+                text: "Auth bootstrap and middleware ordering can cause login redirects in dev.",
+              },
+            ],
+            { duration_ms: 260 },
+          ),
+        ],
+      ]),
+      toolProgressMap: new Map([
+        [
+          "ta-web",
+          {
+            tool_call_id: "ta-web",
+            tool_name: "search_web",
+            message: "Comparing docs and UI behavior",
+          },
+        ],
+      ]),
+      toolOutputMap: new Map([["ta-bash", { stdout: "/home/daytona\nLinux\n", stderr: "" }]]),
+      pendingImages: makePendingImages(),
+      commands: devCommands,
+      llmModels: devModels,
+      initialInputValue: "/ship",
+      initialModelId: "model-kimi-k2.5",
+      initialReasoningEffort: "medium",
+    };
+  }
+
+  const sessionId = "session-dev-chat-components";
+  const events: Event[] = [
+    makeInputEvent({
+      id: "components-user-1",
+      sequence: 1,
+      sessionId,
+      text: "Tighten the tool-call UI and show me the exact surfaces users will see.",
+      ts: "2026-03-07T21:45:00Z",
+    }),
+    makeOutputEvent({
+      id: "components-agent-1",
+      sequence: 2,
+      sessionId,
+      ts: "2026-03-07T21:45:04Z",
+      text: "I’m rendering the runtime chat stack directly so the preview matches production behavior.",
+      metadata: { model: "kimi-k2.5", reasoning_effort: "medium" },
+    }),
+    makeOutputEvent({
+      id: "components-agent-2",
+      sequence: 3,
+      sessionId,
+      ts: "2026-03-07T21:45:09Z",
+      text: "Here’s the current pass over transcript chrome, todo state, and file previews.",
+      toolCalls: [
+        {
+          id: "cc-todos",
+          name: "write_todos",
+          arguments: {
+            todos: [
+              {
+                content: "Audit current transcript components",
+                activeForm: "Auditing current transcript components",
+                status: "completed",
+              },
+              {
+                content: "Move dev routes onto real chat stack",
+                activeForm: "Moving dev routes onto real chat stack",
+                status: "in_progress",
+              },
+              {
+                content: "Verify the preview against main chat",
+                activeForm: "Verifying the preview against main chat",
+                status: "pending",
+              },
+            ],
+          },
+        },
+        {
+          id: "cc-read-image",
+          name: "read_file",
+          arguments: { path: "/workspace/mockups/tool-call-flow.png" },
+        },
+        {
+          id: "cc-write",
+          name: "write_file",
+          arguments: {
+            path: "/workspace/apps/ui/src/components/chat/tool-call-card.tsx",
+          },
+        },
+      ],
+      metadata: { model: "kimi-k2.5", reasoning_effort: "medium" },
+    }),
+    {
+      id: "components-tools-pending",
+      type: "tool.call_requested",
+      ts: "2026-03-07T21:45:13Z",
+      session_id: sessionId,
+      context: {},
+      data: {
+        headline: "Waiting on tools",
+        tool_calls: [
+          {
+            id: "cc-client-pick",
+            name: "pick_file",
+            arguments: { accept: ".png,.jpg" },
+          },
+        ],
+        tool_summaries: [
+          {
+            id: "cc-client-pick",
+            name: "pick_file",
+            display_name: "Pick File",
+            narration: "Choose a screenshot to annotate",
+          },
+        ],
+      },
+    },
+    {
+      id: "components-act",
+      type: "act.started",
+      ts: "2026-03-07T21:45:18Z",
+      session_id: sessionId,
+      context: { exec_id: "exec-components" },
+      data: {
+        headline: "Refining transcript chrome",
+        tool_calls: [
+          { id: "cc-shell", name: "bash", narration: "Ran UI tests" },
+          {
+            id: "cc-edit",
+            name: "edit_file",
+            narration: "Patched chat card styles",
+          },
+        ],
+      },
+    },
+    {
+      id: "components-shell-done",
+      type: "tool.completed",
+      ts: "2026-03-07T21:45:20Z",
+      session_id: sessionId,
+      context: { exec_id: "exec-components" },
+      data: {
+        tool_call_id: "cc-shell",
+        tool_name: "bash",
+        success: true,
+        status: "success",
+        narration: "Ran UI tests",
+        result: [
+          {
+            type: "text",
+            text: JSON.stringify({
+              stdout: "PASS src/__tests__/tool-activity-group.test.tsx",
+              stderr: "",
+              exit_code: 0,
+              success: true,
+            }),
+          },
+        ],
+        duration_ms: 410,
+      },
+    },
+    {
+      id: "components-edit-done",
+      type: "tool.completed",
+      ts: "2026-03-07T21:45:22Z",
+      session_id: sessionId,
+      context: { exec_id: "exec-components" },
+      data: {
+        tool_call_id: "cc-edit",
+        tool_name: "edit_file",
+        success: true,
+        status: "success",
+        narration: "Patched chat card styles",
+        result: [{ type: "text", text: "diff applied" }],
+        duration_ms: 130,
+      },
+    },
+    {
+      id: "components-act-done",
+      type: "act.completed",
+      ts: "2026-03-07T21:45:22Z",
+      session_id: sessionId,
+      context: { exec_id: "exec-components" },
+      data: {
+        completed: true,
+        success_count: 2,
+        error_count: 0,
+        duration_ms: 640,
+        headline: "Refined transcript chrome",
+      },
+    },
+    makeOutputEvent({
+      id: "components-agent-3",
+      sequence: 4,
+      sessionId,
+      ts: "2026-03-07T21:45:26Z",
+      text: "The preview now uses the same transcript list and composer components as the live session view.",
+      metadata: { model: "kimi-k2.5", reasoning_effort: "medium" },
+    }),
+  ];
+
+  return {
+    sessionId,
+    events,
+    toolResultsMap: new Map([
+      [
+        "cc-todos",
+        toolResult("cc-todos", "write_todos", [{ type: "text", text: "todo list updated" }], {
+          duration_ms: 28,
+        }),
+      ],
+      [
+        "cc-read-image",
+        toolResult(
+          "cc-read-image",
+          "read_file",
+          [
+            {
+              type: "text",
+              text: JSON.stringify({
+                path: "/workspace/mockups/tool-call-flow.png",
+                media_type: "image/png",
+                size_bytes: 68,
+              }),
+            },
+            {
+              type: "image",
+              base64:
+                "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO2pQwAAAABJRU5ErkJggg==",
+              media_type: "image/png",
+            },
+          ],
+          { duration_ms: 74 },
+        ),
+      ],
+      [
+        "cc-write",
+        toolResult(
+          "cc-write",
+          "write_file",
+          [
+            {
+              type: "text",
+              text: JSON.stringify({
+                path: "/workspace/apps/ui/src/components/chat/tool-call-card.tsx",
+                size_bytes: 2134,
+                created: false,
+                applied_edits: 3,
+                first_changed_line: 24,
+              }),
+            },
+          ],
+          { duration_ms: 92 },
+        ),
+      ],
+    ]),
+    toolProgressMap: new Map(),
+    toolOutputMap: new Map(),
+    pendingImages: makePendingImages(),
+    commands: devCommands,
+    llmModels: devModels,
+    initialInputValue: "/process-issues",
+    initialModelId: "model-kimi-k2.5",
+    initialReasoningEffort: "medium",
+  };
+}

--- a/apps/ui/src/app/dev/_fixtures/session-showcase-fixtures.ts
+++ b/apps/ui/src/app/dev/_fixtures/session-showcase-fixtures.ts
@@ -1,0 +1,192 @@
+"use client";
+
+import type {
+  Agent,
+  LlmModelWithProvider,
+  Session,
+  SessionStatus,
+  TokenUsage,
+} from "@/lib/api/types";
+import type { SessionNavKey } from "@/components/session/session-header";
+
+const agent: Agent = {
+  id: "agent_session_showcase",
+  name: "platform-chat",
+  display_name: "Platform Chat",
+  description: "Showcase agent for session UI states.",
+  system_prompt: "You are a precise coding assistant.",
+  default_model_id: "model-kimi-k2.5",
+  tags: [],
+  capabilities: [],
+  initial_files: [],
+  status: "active",
+  created_at: "2026-04-22T14:00:00Z",
+  updated_at: "2026-04-22T14:00:00Z",
+  archived_at: null,
+  deleted_at: null,
+};
+
+const model: LlmModelWithProvider = {
+  id: "model-kimi-k2.5",
+  provider_id: "provider-openrouter",
+  model_id: "openrouter/kimi-k2.5",
+  display_name: "Kimi K2.5",
+  capabilities: ["chat", "tools"],
+  enabled: true,
+  is_favorite: true,
+  status: "active",
+  created_at: "2026-04-22T14:00:00Z",
+  updated_at: "2026-04-22T14:00:00Z",
+  provider_name: "OpenRouter",
+  provider_type: "openai",
+};
+
+function createSession({
+  id,
+  title,
+  status,
+  features,
+  activeScheduleCount = 0,
+  usage,
+}: {
+  id: string;
+  title: string;
+  status: SessionStatus;
+  features: string[];
+  activeScheduleCount?: number;
+  usage?: TokenUsage;
+}): Session {
+  return {
+    id,
+    organization_id: "org_session_showcase",
+    harness_id: "harness_generic",
+    agent_id: agent.id,
+    owner_principal_id: "user_session_showcase",
+    title,
+    preview: "Make the tool transcript read like progress instead of raw logs.",
+    output_preview: "The preview now uses the same session chrome as the main view.",
+    tags: ["showcase"],
+    model_id: model.id,
+    status,
+    created_at: "2026-04-22T14:20:00Z",
+    updated_at: "2026-04-22T14:25:00Z",
+    started_at: "2026-04-22T14:20:00Z",
+    finished_at: null,
+    active_schedule_count: activeScheduleCount,
+    features,
+    usage,
+  };
+}
+
+export const sessionShowcaseAgent = agent;
+export const sessionShowcaseModel = model;
+
+export const sessionUsageSamples = {
+  light: {
+    input_tokens: 128,
+    output_tokens: 45,
+    cache_read_tokens: 0,
+    cache_creation_tokens: 0,
+  } satisfies TokenUsage,
+  medium: {
+    input_tokens: 1842,
+    output_tokens: 326,
+    cache_read_tokens: 512,
+    cache_creation_tokens: 0,
+  } satisfies TokenUsage,
+  heavy: {
+    input_tokens: 15234,
+    output_tokens: 8721,
+    cache_read_tokens: 5000,
+    cache_creation_tokens: 1200,
+  } satisfies TokenUsage,
+};
+
+export const sessionHeaderScenarios: Array<{
+  name: string;
+  session: Session;
+  activeTab: SessionNavKey;
+  effectiveStatus: SessionStatus;
+  liveUsage?: TokenUsage;
+  secondaryMetaText: string;
+}> = [
+  {
+    name: "Active chat session",
+    session: createSession({
+      id: "session_showcase_active",
+      title: "Tool transcript polish",
+      status: "active",
+      features: ["file_system", "leased_resources", "schedules"],
+      activeScheduleCount: 2,
+    }),
+    activeTab: "chat",
+    effectiveStatus: "active",
+    liveUsage: sessionUsageSamples.medium,
+    secondaryMetaText: "Started 4/22/2026, 9:20:00 AM",
+  },
+  {
+    name: "Workspace view",
+    session: createSession({
+      id: "session_showcase_workspace",
+      title: "Sandbox file inspection",
+      status: "idle",
+      features: ["file_system", "key_value"],
+      usage: sessionUsageSamples.light,
+    }),
+    activeTab: "files",
+    effectiveStatus: "idle",
+    liveUsage: sessionUsageSamples.light,
+    secondaryMetaText: "Workspace: /workspace",
+  },
+  {
+    name: "Waiting on client tools",
+    session: createSession({
+      id: "session_showcase_waiting",
+      title: "Annotate the screenshot",
+      status: "waiting_for_tool_results",
+      features: ["file_system", "leased_resources", "schedules"],
+      activeScheduleCount: 1,
+      usage: sessionUsageSamples.heavy,
+    }),
+    activeTab: "chat",
+    effectiveStatus: "waiting_for_tool_results",
+    liveUsage: sessionUsageSamples.heavy,
+    secondaryMetaText: "Started 4/22/2026, 9:20:00 AM",
+  },
+];
+
+export const sessionCardScenarios = [
+  {
+    name: "Running",
+    session: createSession({
+      id: "session_card_running",
+      title: "Daytona sandbox investigation",
+      status: "active",
+      features: ["file_system", "leased_resources"],
+      activeScheduleCount: 1,
+      usage: sessionUsageSamples.medium,
+    }),
+    summary: "Run the sandbox flow and show the exact tool transcript.",
+  },
+  {
+    name: "Idle",
+    session: createSession({
+      id: "session_card_idle",
+      title: "Chat UI review",
+      status: "idle",
+      features: ["file_system"],
+      usage: sessionUsageSamples.light,
+    }),
+    summary: "The chat UI preview now points at the production transcript stack.",
+  },
+  {
+    name: "New",
+    session: createSession({
+      id: "session_card_new",
+      title: "Session components",
+      status: "started",
+      features: ["file_system", "schedules"],
+    }),
+    summary: "Showcase headers, badges, and session cards in one place.",
+  },
+];

--- a/apps/ui/src/app/dev/_fixtures/tool-showcase-fixtures.ts
+++ b/apps/ui/src/app/dev/_fixtures/tool-showcase-fixtures.ts
@@ -1,0 +1,251 @@
+"use client";
+
+import type { ToolOutputStreams } from "@/app/(main)/sessions/[sessionId]/session-context";
+import type { ToolCallContent } from "@/components/chat/tool-call-utils";
+import type { TimelineToolRow } from "@/components/chat/tool-activity-timeline-group";
+import type { ToolCompletedData, ToolProgressData } from "@/lib/api/types";
+
+function textResult(text: string): ToolCompletedData["result"] {
+  return [{ type: "text", text }];
+}
+
+function makeCompletedResult({
+  toolCallId,
+  toolName,
+  text,
+  durationMs,
+  error,
+  success = true,
+}: {
+  toolCallId: string;
+  toolName: string;
+  text: string;
+  durationMs?: number;
+  error?: string;
+  success?: boolean;
+}): ToolCompletedData {
+  return {
+    tool_call_id: toolCallId,
+    tool_name: toolName,
+    success,
+    status: success ? "success" : "error",
+    result: textResult(text),
+    error,
+    duration_ms: durationMs,
+  };
+}
+
+export const bashToolCall: ToolCallContent = {
+  id: "tool-bash-showcase",
+  name: "bash",
+  arguments: { command: "pwd && uname -s" },
+};
+
+export const bashToolResult = makeCompletedResult({
+  toolCallId: bashToolCall.id,
+  toolName: bashToolCall.name,
+  text: JSON.stringify(
+    {
+      cwd: "/home/daytona",
+      stdout: "/home/daytona\nLinux\n",
+      stderr: "",
+      exit_code: 0,
+      success: true,
+    },
+    null,
+    2,
+  ),
+  durationMs: 180,
+});
+
+export const bashToolOutput: ToolOutputStreams = {
+  stdout: "/home/daytona\nLinux\n",
+  stderr: "",
+};
+
+export const readFileToolCall: ToolCallContent = {
+  id: "tool-read-showcase",
+  name: "read_file",
+  arguments: {
+    path: "/workspace/apps/ui/src/components/chat/tool-call-chrome.ts",
+  },
+};
+
+export const readFileToolResult = makeCompletedResult({
+  toolCallId: readFileToolCall.id,
+  toolName: readFileToolCall.name,
+  text: JSON.stringify(
+    {
+      path: "/workspace/apps/ui/src/components/chat/tool-call-chrome.ts",
+      encoding: "text",
+      size_bytes: 1240,
+      content: "export const toolCallChrome = { card: 'border border-border/70 bg-card/90', ... }",
+    },
+    null,
+    2,
+  ),
+  durationMs: 42,
+});
+
+export const writeFileToolCall: ToolCallContent = {
+  id: "tool-write-showcase",
+  name: "write_file",
+  arguments: {
+    path: "/workspace/apps/ui/src/components/chat/tool-call-card.tsx",
+  },
+};
+
+export const writeFileToolResult = makeCompletedResult({
+  toolCallId: writeFileToolCall.id,
+  toolName: writeFileToolCall.name,
+  text: JSON.stringify(
+    {
+      path: "/workspace/apps/ui/src/components/chat/tool-call-card.tsx",
+      created: false,
+      size_bytes: 2134,
+      applied_edits: 3,
+      first_changed_line: 24,
+    },
+    null,
+    2,
+  ),
+  durationMs: 94,
+});
+
+export const todoToolCall: ToolCallContent = {
+  id: "tool-todos-showcase",
+  name: "write_todos",
+  arguments: {
+    todos: [
+      {
+        content: "Audit current transcript components",
+        activeForm: "Auditing current transcript components",
+        status: "completed",
+      },
+      {
+        content: "Replace dev mocks with production session chrome",
+        activeForm: "Replacing dev mocks with production session chrome",
+        status: "in_progress",
+      },
+      {
+        content: "Verify the new showcase pages",
+        activeForm: "Verifying the new showcase pages",
+        status: "pending",
+      },
+    ],
+  },
+};
+
+export const todoToolResult = makeCompletedResult({
+  toolCallId: todoToolCall.id,
+  toolName: todoToolCall.name,
+  text: "todo list updated",
+  durationMs: 26,
+});
+
+export const groupedActivityToolCalls: ToolCallContent[] = [
+  {
+    id: "tool-list-files",
+    name: "list_files",
+    arguments: { path: "." },
+  },
+  {
+    id: "tool-search-web",
+    name: "search_web",
+    arguments: { query: "daytona sandbox auth issue" },
+  },
+  {
+    id: "tool-edit-file",
+    name: "edit_file",
+    arguments: {
+      path: "/workspace/apps/ui/src/components/chat/tool-call-card.tsx",
+    },
+  },
+];
+
+export const groupedActivityResults = new Map<string, ToolCompletedData>([
+  [
+    "tool-list-files",
+    makeCompletedResult({
+      toolCallId: "tool-list-files",
+      toolName: "list_files",
+      text: "apps/\ncrates/\nscripts/\nAGENTS.md",
+      durationMs: 54,
+    }),
+  ],
+  [
+    "tool-search-web",
+    makeCompletedResult({
+      toolCallId: "tool-search-web",
+      toolName: "search_web",
+      text: "Auth bootstrap and middleware ordering can cause login redirects in dev.",
+      durationMs: 260,
+    }),
+  ],
+  [
+    "tool-edit-file",
+    makeCompletedResult({
+      toolCallId: "tool-edit-file",
+      toolName: "edit_file",
+      text: "diff applied",
+      durationMs: 120,
+    }),
+  ],
+]);
+
+export const groupedActivityProgress = new Map<string, ToolProgressData>([
+  [
+    "tool-search-web",
+    {
+      tool_call_id: "tool-search-web",
+      tool_name: "search_web",
+      message: "Comparing docs and UI behavior",
+    },
+  ],
+]);
+
+export const timelineRows: TimelineToolRow[] = [
+  {
+    id: "timeline-create-sandbox",
+    label: "Created Daytona sandbox",
+    state: "completed",
+    result: makeCompletedResult({
+      toolCallId: "timeline-create-sandbox",
+      toolName: "daytona_create_sandbox",
+      text: JSON.stringify(
+        {
+          sandbox_id: "9beac0d5-ae4c-41e8-970f-f48e70a20395",
+          status: "running",
+          workspace_path: "/home/daytona",
+        },
+        null,
+        2,
+      ),
+      durationMs: 620,
+    }),
+  },
+  {
+    id: "timeline-run-check",
+    label: "Ran `pwd; uname -s`",
+    state: "error",
+    result: makeCompletedResult({
+      toolCallId: "timeline-run-check",
+      toolName: "daytona_exec",
+      text: "Resource was not created by this session",
+      durationMs: 180,
+      error: "Resource was not created by this session",
+      success: false,
+    }),
+  },
+  {
+    id: "timeline-read-file",
+    label: "Read the file back",
+    state: "completed",
+    result: makeCompletedResult({
+      toolCallId: "timeline-read-file",
+      toolName: "daytona_exec",
+      text: "hello from dev.everruns.com",
+      durationMs: 120,
+    }),
+  },
+];

--- a/apps/ui/src/app/dev/chat-components/page.tsx
+++ b/apps/ui/src/app/dev/chat-components/page.tsx
@@ -1,194 +1,145 @@
 "use client";
 
-import { ToolActivityGroup } from "@/components/chat/tool-activity-group";
-import { TodoListRenderer } from "@/components/chat/todo-list-renderer";
-import { MessageInfoIcon } from "@/components/chat/message-info-icon";
-import { ImageAttachments } from "@/components/chat/image-attachments";
-import { ChatErrorAlert } from "@/components/chat/chat-error-alert";
-import type { Event, ToolCompletedData } from "@/lib/api/types";
-import type { ToolCallContent } from "@/components/chat/tool-call-utils";
-import type { PendingImage } from "@/lib/api/images";
+import { useMemo, useRef, useState } from "react";
 import { DevPageShell } from "@/app/dev/_components/dev-page-shell";
+import { DevChatRuntimeScene } from "@/app/dev/_components/dev-chat-runtime-preview";
+import {
+  devCommands,
+  devModels,
+  makePendingImages,
+} from "@/app/dev/_fixtures/chat-runtime-fixtures";
+import { ChatComposer } from "@/components/chat/chat-composer";
+import { ChatMessageList } from "@/components/chat/chat-message-list";
+import { chatSurfaceStyles } from "@/components/chat/chat-surface";
+import type { PendingImage } from "@/lib/api/images";
+import type { ReasoningEffortConfig } from "@/lib/api/types";
 
-const infoEvent: Event = {
-  id: "evt-chat-components",
-  type: "output.message.completed",
-  ts: "2026-03-07T21:45:00Z",
-  session_id: "session-chat-components",
-  context: {},
-  data: {
-    message: {
-      id: "msg-chat-components",
-      session_id: "session-chat-components",
-      sequence: 1,
-      role: "agent",
-      content: [
-        {
-          type: "text",
-          text: "Components now follow the canonical chat style.",
-        },
-      ],
-      tool_call_id: null,
-      created_at: "2026-03-07T21:45:00Z",
-      metadata: { model: "kimi-k2.5", reasoning_effort: "medium" },
-    },
-    metadata: { model: "kimi-k2.5" },
-    usage: { input_tokens: 318, output_tokens: 52 },
-  },
+const reasoningEffortConfig: ReasoningEffortConfig = {
+  default: "medium",
+  values: [
+    { value: "low", name: "Low" },
+    { value: "medium", name: "Medium" },
+    { value: "high", name: "High" },
+  ],
 };
 
-const toolCalls: ToolCallContent[] = [
-  { id: "component-list", name: "list_files", arguments: { path: "." } },
-  {
-    id: "component-read",
-    name: "read_file",
-    arguments: { path: "/workspace/AGENTS.md" },
-  },
-  {
-    id: "component-search",
-    name: "search_web",
-    arguments: { query: "chat ui reference" },
-  },
-];
-
-const toolResults = new Map<string, ToolCompletedData>([
-  [
-    "component-list",
-    {
-      tool_call_id: "component-list",
-      tool_name: "list_files",
-      success: true,
-      status: "success",
-      result: [{ type: "text", text: "apps/\ncrates/\nscripts/\nAGENTS.md" }],
-    },
-  ],
-  [
-    "component-read",
-    {
-      tool_call_id: "component-read",
-      tool_name: "read_file",
-      success: true,
-      status: "success",
-      result: [{ type: "text", text: "Use a port prefix per worktree/session." }],
-    },
-  ],
-]);
-
-const pendingImages: PendingImage[] = [
-  {
-    tempId: "pending-1",
-    file: null,
-    uploadPromise: null,
-    // Dev fixtures stay self-contained: no backend image record exists here.
-    imageId: null,
-    filename: "layout.png",
-    previewUrl:
-      "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='80' height='80' viewBox='0 0 80 80'%3E%3Crect fill='%23ece7db' width='80' height='80'/%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' fill='%230a1636' font-size='10'%3EPNG%3C/text%3E%3C/svg%3E",
-    status: "uploaded",
-  },
-  {
-    tempId: "pending-2",
-    file: null,
-    uploadPromise: null,
-    imageId: null,
-    filename: "annotated.jpg",
-    previewUrl:
-      "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='80' height='80' viewBox='0 0 80 80'%3E%3Crect fill='%23f6e7c1' width='80' height='80'/%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' fill='%23d4a43a' font-size='10'%3EJPG%3C/text%3E%3C/svg%3E",
-    status: "uploading",
-  },
-];
-
-function Section({
-  title,
-  description,
-  children,
-}: {
-  title: string;
-  description: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <section className="border border-border bg-card">
-      <div className="border-b border-border px-4 py-4">
-        <div className="text-[10px] uppercase tracking-[0.24em] text-muted-foreground">{title}</div>
-        <p className="mt-1 text-sm text-muted-foreground">{description}</p>
-      </div>
-      <div className="p-4">{children}</div>
-    </section>
-  );
-}
-
 export default function DevChatComponentsPage() {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const [inputValue, setInputValue] = useState("/ship tighten the tool transcript UI");
+  const [selectedModelId, setSelectedModelId] = useState(devModels[0]?.id ?? "");
+  const [reasoningEffort, setReasoningEffort] = useState("medium");
+  const [pendingImages, setPendingImages] = useState<PendingImage[]>(() => makePendingImages());
+
+  const emptyToolResults = useMemo(() => new Map(), []);
+  const emptyToolProgress = useMemo(() => new Map(), []);
+  const emptyToolOutputs = useMemo(() => new Map(), []);
+
   return (
     <DevPageShell
-      eyebrow="Chat Components"
-      title="Canonical component gallery"
-      description="These are the chat-specific primitives used by the runtime chat surface."
+      eyebrow="Chat UI"
+      title="Chat UI"
+      description="Runtime chat surfaces driven by the real transcript and composer components."
+      widthClassName="max-w-7xl"
     >
-      <div className="grid gap-6 lg:grid-cols-2">
-        <Section
-          title="Message Info"
-          description="Metadata affordance for user and assistant messages."
-        >
-          <div className="flex items-center justify-between border border-border bg-background px-4 py-3">
-            <div className="text-sm text-foreground">
-              Components now follow the canonical chat style.
-            </div>
-            <MessageInfoIcon event={infoEvent} />
+      <div className="space-y-6">
+        <section className="space-y-3">
+          <div className="space-y-1">
+            <h2 className="text-lg font-semibold text-foreground">Tool-heavy runtime scene</h2>
+            <p className="text-sm text-muted-foreground">
+              Full session chrome plus the actual chat panel, using the Daytona-style transcript
+              flow.
+            </p>
           </div>
-        </Section>
+          <DevChatRuntimeScene scenario="tool-activity" />
+        </section>
 
-        <Section
-          title="Attachments"
-          description="Pending image attachments now use the same runtime treatment."
-        >
-          <ImageAttachments images={pendingImages} onRemove={() => undefined} />
-        </Section>
+        <section className="space-y-3">
+          <div className="space-y-1">
+            <h2 className="text-lg font-semibold text-foreground">
+              Transcript-focused runtime scene
+            </h2>
+            <p className="text-sm text-muted-foreground">
+              Same runtime stack, but tuned to text, todos, and file mutation output.
+            </p>
+          </div>
+          <DevChatRuntimeScene scenario="chat-components" />
+        </section>
 
-        <Section
-          title="Tool Activity"
-          description="Grouped execution cards used inline in transcripts."
-        >
-          <ToolActivityGroup toolCalls={toolCalls} toolResultsMap={toolResults} />
-        </Section>
+        <section className="space-y-3 border border-border/70 bg-card/90 p-4 shadow-[inset_0_1px_0_hsl(var(--background)/0.92)]">
+          <div className="space-y-1">
+            <h2 className="text-lg font-semibold text-foreground">Empty state and composer</h2>
+            <p className="text-sm text-muted-foreground">
+              Direct preview of the empty transcript state and the production composer controls.
+            </p>
+          </div>
 
-        <Section title="Execution Plan" description="Persistent todo card for long-running turns.">
-          <TodoListRenderer
-            arguments={{
-              todos: [
-                {
-                  content: "Read current implementation",
-                  activeForm: "Reading current implementation",
-                  status: "completed",
-                },
-                {
-                  content: "Apply canonical styling",
-                  activeForm: "Applying canonical styling",
-                  status: "in_progress",
-                },
-                {
-                  content: "Verify main routes",
-                  activeForm: "Verifying main routes",
-                  status: "pending",
-                },
-              ],
-            }}
-            isExecuting
-          />
-        </Section>
+          <div className="overflow-hidden border border-border/70 bg-background">
+            <div className="flex min-h-[720px] flex-col">
+              <div className="flex-1 px-4 py-4">
+                <ChatMessageList
+                  events={[]}
+                  chatEvents={[]}
+                  sessionId="session-chat-empty"
+                  toolResultsMap={emptyToolResults}
+                  toolProgressMap={emptyToolProgress}
+                  toolOutputMap={emptyToolOutputs}
+                  eventsLoading={false}
+                  hasMoreEvents={false}
+                  loadingOlderEvents={false}
+                  getMessageText={() => ""}
+                  getToolCalls={() => []}
+                />
+              </div>
 
-        <Section title="Error Handling" description="Failure treatment used by chat surfaces.">
-          <ChatErrorAlert
-            message="backend temporarily unavailable"
-            details={[
-              "event_id: evt-failed-1",
-              "event_type: turn.failed",
-              "turn_id: turn-1",
-              "error_code: dependency_unavailable",
-              "error: backend temporarily unavailable",
-            ].join("\n")}
-          />
-        </Section>
+              <div className={chatSurfaceStyles.composerSection}>
+                <ChatComposer
+                  commands={devCommands}
+                  llmModels={devModels}
+                  inputValue={inputValue}
+                  onInputChange={setInputValue}
+                  onSubmit={async () => undefined}
+                  onCommandSelect={async () => undefined}
+                  pendingImages={pendingImages}
+                  hasImages={pendingImages.length > 0}
+                  removeImage={(tempId) =>
+                    setPendingImages((current) =>
+                      current.filter((image) => image.tempId !== tempId),
+                    )
+                  }
+                  addFiles={() => undefined}
+                  isDraggingOver={false}
+                  dropZoneProps={{}}
+                  handlePaste={() => undefined}
+                  selectedModelId={selectedModelId}
+                  onModelChange={setSelectedModelId}
+                  modelTriggerLabel={
+                    devModels.find((model) => model.id === selectedModelId)?.display_name ??
+                    "Default model"
+                  }
+                  defaultModelOptionLabel="Default model"
+                  supportsReasoning
+                  reasoningEffort={reasoningEffort}
+                  reasoningEffortConfig={reasoningEffortConfig}
+                  defaultEffortName="Medium"
+                  getReasoningEffortName={(value) =>
+                    reasoningEffortConfig.values.find((effort) => effort.value === value)?.name ??
+                    value
+                  }
+                  onReasoningEffortChange={setReasoningEffort}
+                  isActive={false}
+                  cancelCurrentTurn={{
+                    mutate: () => undefined,
+                    isPending: false,
+                  }}
+                  canSubmit={inputValue.trim().length > 0 || pendingImages.length > 0}
+                  isUploading={pendingImages.some((image) => image.status === "uploading")}
+                  sendPending={false}
+                  textareaRef={textareaRef}
+                />
+              </div>
+            </div>
+          </div>
+        </section>
       </div>
     </DevPageShell>
   );

--- a/apps/ui/src/app/dev/page.tsx
+++ b/apps/ui/src/app/dev/page.tsx
@@ -18,20 +18,20 @@ const isDev = process.env.NODE_ENV === "development";
 
 const devPages = [
   {
-    title: "Chat Components",
-    description: "Chat-specific: messages, tool calls, todo lists, image attachments",
+    title: "Chat UI",
+    description: "Real chat runtime scenes plus empty-state and composer showcases",
     href: "/dev/chat-components",
     icon: MessageSquare,
   },
   {
-    title: "Tool Activity",
-    description: "Grouped tool execution with animations, summaries, and todo progress cards",
+    title: "Tool Outputs",
+    description: "Standalone, grouped, and narrated tool transcript components",
     href: "/dev/tool-activity",
     icon: MessageSquare,
   },
   {
     title: "Session Components",
-    description: "Session-level: token usage, status badges, session headers",
+    description: "Real session headers, badges, navigation, and session cards",
     href: "/dev/session-components",
     icon: Gauge,
   },

--- a/apps/ui/src/app/dev/session-components/page.tsx
+++ b/apps/ui/src/app/dev/session-components/page.tsx
@@ -1,285 +1,108 @@
 "use client";
 
-import Link from "next/link";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
-import { ScrollArea } from "@/components/ui/scroll-area";
-import { ArrowLeft, Zap } from "lucide-react";
-import type { TokenUsage } from "@/lib/api/types";
-import { formatTokens } from "@/lib/formatting";
-
-// Check if we're in development mode
-const isDev = process.env.NODE_ENV === "development";
-
-// ============================================
-// Showcase Section Components
-// ============================================
-
-function ShowcaseSection({
-  title,
-  description,
-  children,
-}: {
-  title: string;
-  description?: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <Card>
-      <CardHeader>
-        <CardTitle className="text-lg">{title}</CardTitle>
-        {description && <CardDescription>{description}</CardDescription>}
-      </CardHeader>
-      <CardContent className="space-y-4">{children}</CardContent>
-    </Card>
-  );
-}
-
-function ShowcaseItem({ label, children }: { label: string; children: React.ReactNode }) {
-  return (
-    <div className="space-y-2">
-      <div className="text-sm font-medium text-muted-foreground">{label}</div>
-      <div className="border p-4 bg-background">{children}</div>
-    </div>
-  );
-}
-
-// ============================================
-// Token Usage Display
-// ============================================
-
-// Helper function to calculate total tokens
-function totalTokens(usage: TokenUsage): number {
-  return usage.input_tokens + usage.output_tokens;
-}
-
-// Sample usage data
-const sampleUsageData = {
-  small: {
-    input_tokens: 128,
-    output_tokens: 45,
-    cache_read_tokens: 0,
-    cache_creation_tokens: 0,
-  } satisfies TokenUsage,
-  medium: {
-    input_tokens: 15234,
-    output_tokens: 8721,
-    cache_read_tokens: 5000,
-    cache_creation_tokens: 0,
-  } satisfies TokenUsage,
-  large: {
-    input_tokens: 1250000,
-    output_tokens: 875000,
-    cache_read_tokens: 500000,
-    cache_creation_tokens: 125000,
-  } satisfies TokenUsage,
-};
-
-// Token Usage Card component (matches agent detail page)
-function TokenUsageCard({ usage, title }: { usage: TokenUsage; title: string }) {
-  return (
-    <Card>
-      <CardHeader className="pb-2">
-        <CardTitle className="text-sm">{title}</CardTitle>
-      </CardHeader>
-      <CardContent>
-        <div className="flex items-center gap-2 p-2 border bg-muted/50">
-          <Zap className="w-4 h-4 text-yellow-500" />
-          <div className="flex-1">
-            <p className="text-sm font-medium">{formatTokens(totalTokens(usage))} total</p>
-            <p className="text-xs text-muted-foreground">
-              {formatTokens(usage.input_tokens)} input / {formatTokens(usage.output_tokens)} output
-              {usage.cache_read_tokens ? ` / ${formatTokens(usage.cache_read_tokens)} cached` : ""}
-            </p>
-          </div>
-        </div>
-      </CardContent>
-    </Card>
-  );
-}
-
-// Token Usage Badge component (matches session header)
-function TokenUsageBadge({ usage }: { usage: TokenUsage }) {
-  return (
-    <Badge variant="outline" className="gap-1" title="Token usage (input/output)">
-      <Zap className="w-3 h-3" />
-      {formatTokens(usage.input_tokens)} / {formatTokens(usage.output_tokens)}
-    </Badge>
-  );
-}
-
-// ============================================
-// Main Page Component
-// ============================================
+import { DevPageShell } from "@/app/dev/_components/dev-page-shell";
+import {
+  sessionCardScenarios,
+  sessionHeaderScenarios,
+  sessionShowcaseAgent,
+  sessionShowcaseModel,
+  sessionUsageSamples,
+} from "@/app/dev/_fixtures/session-showcase-fixtures";
+import {
+  SessionHeader,
+  SessionStatusBadge,
+  SessionUsageBadge,
+  buildSessionNavigation,
+} from "@/components/session/session-header";
+import { SessionCard } from "@/components/session/session-card";
 
 export default function DevSessionComponentsPage() {
-  // Show 404-like message in production
-  if (!isDev) {
-    return (
-      <div className="flex items-center justify-center min-h-screen">
-        <div className="text-center">
-          <h1 className="text-4xl font-bold text-muted-foreground">404</h1>
-          <p className="text-muted-foreground mt-2">Page not found</p>
-        </div>
-      </div>
-    );
-  }
-
   return (
-    <div className="min-h-screen bg-muted/30">
-      <div className="container mx-auto py-8 px-4">
-        <div className="mb-8">
-          <Link
-            href="/dev"
-            className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground mb-4"
-          >
-            <ArrowLeft className="w-4 h-4 mr-2" />
-            Back to Developer Tools
-          </Link>
-          <h1 className="text-3xl font-bold">Session Components</h1>
-          <p className="text-muted-foreground mt-2">
-            Components for session-level UI: token usage, status badges, and headers
-          </p>
-          <Badge variant="outline" className="mt-2">
-            Development Mode
-          </Badge>
-        </div>
-
-        <ScrollArea className="h-[calc(100vh-12rem)]">
-          <div className="space-y-8 pr-4">
-            {/* Token Usage Display Section */}
-            <ShowcaseSection
-              title="Token Usage Display"
-              description="Components showing LLM token usage statistics for agents and sessions"
-            >
-              <ShowcaseItem label="Usage Card (Agent Detail Page)">
-                <div className="grid grid-cols-3 gap-4">
-                  <TokenUsageCard usage={sampleUsageData.small} title="Small Usage" />
-                  <TokenUsageCard usage={sampleUsageData.medium} title="Medium Usage" />
-                  <TokenUsageCard usage={sampleUsageData.large} title="Large Usage" />
-                </div>
-              </ShowcaseItem>
-
-              <ShowcaseItem label="Usage Badge (Session Header)">
-                <div className="flex items-center gap-4">
-                  <div className="flex items-center gap-2">
-                    <span className="text-sm text-muted-foreground">Small:</span>
-                    <TokenUsageBadge usage={sampleUsageData.small} />
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <span className="text-sm text-muted-foreground">Medium:</span>
-                    <TokenUsageBadge usage={sampleUsageData.medium} />
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <span className="text-sm text-muted-foreground">Large:</span>
-                    <TokenUsageBadge usage={sampleUsageData.large} />
-                  </div>
-                </div>
-              </ShowcaseItem>
-
-              <ShowcaseItem label="Session Header with Usage">
-                <div className="border p-4">
-                  <div className="flex items-center justify-between">
-                    <div>
-                      <h2 className="text-lg font-bold">Example Session</h2>
-                      <p className="text-sm text-muted-foreground">
-                        Started Jan 15, 2026, 10:30 AM
-                      </p>
-                    </div>
-                    <div className="flex items-center gap-2">
-                      <TokenUsageBadge usage={sampleUsageData.medium} />
-                      <Badge variant="outline" className="gap-1">
-                        claude-sonnet-4
-                      </Badge>
-                      <Badge variant="secondary">Ready</Badge>
-                    </div>
-                  </div>
-                </div>
-              </ShowcaseItem>
-            </ShowcaseSection>
-
-            {/* Status Badges Section */}
-            <ShowcaseSection
-              title="Status Badges"
-              description="Session and agent status indicators"
-            >
-              <ShowcaseItem label="Session Status">
-                <div className="flex items-center gap-4">
-                  <Badge variant="secondary">pending</Badge>
-                  <Badge variant="default" className="bg-blue-500">
-                    running
-                  </Badge>
-                  <Badge variant="outline" className="border-green-500 text-green-600">
-                    completed
-                  </Badge>
-                  <Badge variant="destructive">failed</Badge>
-                  <Badge variant="outline" className="border-yellow-500 text-yellow-600">
-                    cancelled
-                  </Badge>
-                </div>
-              </ShowcaseItem>
-
-              <ShowcaseItem label="Agent Status">
-                <div className="flex items-center gap-4">
-                  <Badge variant="outline" className="border-green-500 text-green-600">
-                    active
-                  </Badge>
-                  <Badge variant="secondary">inactive</Badge>
-                  <Badge variant="destructive">error</Badge>
-                </div>
-              </ShowcaseItem>
-
-              <ShowcaseItem label="Model Badges">
-                <div className="flex items-center gap-4">
-                  <Badge variant="outline">claude-sonnet-4</Badge>
-                  <Badge variant="outline">gpt-4o</Badge>
-                  <Badge variant="outline">o1-preview</Badge>
-                </div>
-              </ShowcaseItem>
-            </ShowcaseSection>
-
-            {/* Session Header Examples */}
-            <ShowcaseSection
-              title="Session Header Layouts"
-              description="Different configurations of session headers"
-            >
-              <ShowcaseItem label="Minimal Header">
-                <div className="border p-4">
-                  <div className="flex items-center justify-between">
-                    <h2 className="text-lg font-semibold">Session #1234</h2>
-                    <Badge variant="secondary">pending</Badge>
-                  </div>
-                </div>
-              </ShowcaseItem>
-
-              <ShowcaseItem label="Full Header with All Metadata">
-                <div className="border p-4">
-                  <div className="flex items-center justify-between">
-                    <div>
-                      <h2 className="text-lg font-bold">Production Debug Session</h2>
-                      <p className="text-sm text-muted-foreground">
-                        Created 2 hours ago by user@example.com
-                      </p>
-                    </div>
-                    <div className="flex items-center gap-2">
-                      <TokenUsageBadge usage={sampleUsageData.large} />
-                      <Badge variant="outline">o1-preview</Badge>
-                      <Badge variant="default" className="bg-blue-500">
-                        running
-                      </Badge>
-                    </div>
-                  </div>
-                  <div className="mt-3 pt-3 border-t flex items-center gap-4 text-sm text-muted-foreground">
-                    <span>Turn: 15</span>
-                    <span>Messages: 47</span>
-                    <span>Duration: 1h 23m</span>
-                  </div>
-                </div>
-              </ShowcaseItem>
-            </ShowcaseSection>
+    <DevPageShell
+      eyebrow="Session UI"
+      title="Session Components"
+      description="Real session-page chrome and list components in the states the main UI uses."
+      widthClassName="max-w-7xl"
+    >
+      <div className="space-y-6">
+        <section className="space-y-4 border border-border/70 bg-card/90 p-4 shadow-[inset_0_1px_0_hsl(var(--background)/0.92)]">
+          <div className="space-y-1">
+            <h2 className="text-lg font-semibold text-foreground">Session header states</h2>
+            <p className="text-sm text-muted-foreground">
+              Extracted from the real session layout so the showcase matches main.
+            </p>
           </div>
-        </ScrollArea>
+
+          <div className="space-y-4">
+            {sessionHeaderScenarios.map((scenario) => (
+              <div key={scenario.session.id} className="space-y-2">
+                <p className="text-sm font-medium text-foreground">{scenario.name}</p>
+                <div className="overflow-hidden border border-border/70 bg-background">
+                  <SessionHeader
+                    sessionId={scenario.session.id}
+                    session={scenario.session}
+                    agent={sessionShowcaseAgent}
+                    agentId={sessionShowcaseAgent.id}
+                    llmModel={sessionShowcaseModel}
+                    effectiveStatus={scenario.effectiveStatus}
+                    liveUsage={scenario.liveUsage}
+                    activeTab={scenario.activeTab}
+                    navigationItems={buildSessionNavigation({
+                      basePath: `/sessions/${scenario.session.id}`,
+                      features: new Set(scenario.session.features ?? []),
+                      activeScheduleCount: scenario.session.active_schedule_count,
+                    })}
+                    secondaryMetaText={scenario.secondaryMetaText}
+                    allowTitleEditing={false}
+                  />
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="space-y-4 border border-border/70 bg-card/90 p-4 shadow-[inset_0_1px_0_hsl(var(--background)/0.92)]">
+          <div className="space-y-1">
+            <h2 className="text-lg font-semibold text-foreground">Header badges</h2>
+            <p className="text-sm text-muted-foreground">
+              These are the exact badge components used inside the session header.
+            </p>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-3">
+            <SessionUsageBadge usage={sessionUsageSamples.light} />
+            <SessionUsageBadge usage={sessionUsageSamples.medium} />
+            <SessionStatusBadge status="started" />
+            <SessionStatusBadge status="active" />
+            <SessionStatusBadge status="idle" />
+            <SessionStatusBadge status="waiting_for_tool_results" />
+          </div>
+        </section>
+
+        <section className="space-y-4 border border-border/70 bg-card/90 p-4 shadow-[inset_0_1px_0_hsl(var(--background)/0.92)]">
+          <div className="space-y-1">
+            <h2 className="text-lg font-semibold text-foreground">Session cards</h2>
+            <p className="text-sm text-muted-foreground">
+              The same list cards used on the sessions index, shown in running, idle, and new
+              states.
+            </p>
+          </div>
+
+          <div className="grid gap-3 lg:grid-cols-3">
+            {sessionCardScenarios.map((scenario) => (
+              <div key={scenario.session.id} className="overflow-hidden border border-border/70">
+                <SessionCard
+                  session={scenario.session}
+                  agentName={sessionShowcaseAgent.display_name ?? sessionShowcaseAgent.name}
+                  agentStatus={sessionShowcaseAgent.status}
+                  model={sessionShowcaseModel}
+                  summary={scenario.summary}
+                />
+              </div>
+            ))}
+          </div>
+        </section>
       </div>
-    </div>
+    </DevPageShell>
   );
 }

--- a/apps/ui/src/app/dev/tool-activity/page.tsx
+++ b/apps/ui/src/app/dev/tool-activity/page.tsx
@@ -1,623 +1,136 @@
 "use client";
 
-import {
-  Bot,
-  Brain,
-  CalendarClock,
-  ImagePlus,
-  Send,
-  Sparkles,
-  StopCircle,
-  Terminal,
-} from "lucide-react";
-import { MessageInfoIcon } from "@/components/chat/message-info-icon";
-import { ChatMessageList } from "@/components/chat/chat-message-list";
-import { ToolActivityGroup } from "@/components/chat/tool-activity-group";
-import { TodoListRenderer } from "@/components/chat/todo-list-renderer";
-import type { Event, ToolCompletedData, ToolProgressData } from "@/lib/api/types";
-import type { ToolCallContent } from "@/components/chat/tool-call-utils";
-import type { ToolOutputStreams } from "@/app/(main)/sessions/[sessionId]/session-context";
 import { DevPageShell } from "@/app/dev/_components/dev-page-shell";
-import { chatSurfaceStyles } from "@/components/chat/chat-surface";
-
-const activeToolCalls: ToolCallContent[] = [
-  {
-    id: "tool-list",
-    name: "list_files",
-    arguments: { path: "." },
-  },
-  {
-    id: "tool-read",
-    name: "read_file",
-    arguments: { path: "/workspace/README.md" },
-  },
-  {
-    id: "tool-grep",
-    name: "grep_files",
-    arguments: { pattern: "**/package.json" },
-  },
-  {
-    id: "tool-search",
-    name: "search_web",
-    arguments: { query: "next.js structured tool activity ui" },
-  },
-];
-
-const activeToolResults = new Map<string, ToolCompletedData>([
-  [
-    "tool-list",
-    {
-      tool_call_id: "tool-list",
-      tool_name: "list_files",
-      success: true,
-      status: "success",
-      result: [
-        {
-          type: "text",
-          text: "README.md\npackage.json\nsrc/\napps/\ncrates/",
-        },
-      ],
-    },
-  ],
-  [
-    "tool-read",
-    {
-      tool_call_id: "tool-read",
-      tool_name: "read_file",
-      success: true,
-      status: "success",
-      result: [
-        {
-          type: "text",
-          text: JSON.stringify({
-            path: "/workspace/README.md",
-            content: "# Everruns\nDurable agent runtime and UI for long-running tasks.",
-            encoding: "text",
-            size_bytes: 63,
-          }),
-        },
-      ],
-    },
-  ],
-]);
-
-const completedToolCalls: ToolCallContent[] = [
-  {
-    id: "tool-shell",
-    name: "bash",
-    arguments: { command: "cargo test -p everruns-ui" },
-  },
-  {
-    id: "tool-edit",
-    name: "write_file",
-    arguments: { path: "/workspace/README.md" },
-  },
-];
-
-const completedToolResults = new Map<string, ToolCompletedData>([
-  [
-    "tool-shell",
-    {
-      tool_call_id: "tool-shell",
-      tool_name: "bash",
-      success: false,
-      status: "error",
-      result: [
-        {
-          type: "text",
-          text: JSON.stringify({
-            stdout: "running 4 tests\n3 passed",
-            stderr: "thread 'tool_activity' panicked at assertion failed: left == right",
-            exit_code: 101,
-            success: false,
-          }),
-        },
-      ],
-      duration_ms: 910,
-    },
-  ],
-  [
-    "tool-edit",
-    {
-      tool_call_id: "tool-edit",
-      tool_name: "write_file",
-      success: true,
-      status: "success",
-      result: [
-        {
-          type: "text",
-          text: JSON.stringify({
-            path: "/workspace/README.md",
-            size_bytes: 1584,
-            created: true,
-          }),
-        },
-      ],
-      duration_ms: 95,
-    },
-  ],
-]);
-
-const clientToolCalls: ToolCallContent[] = [
-  {
-    id: "tool-picker",
-    name: "pick_file",
-    display_name: "Pick File",
-    arguments: { accept: ".png,.jpg" },
-  },
-];
-
-const monitorToolCalls: ToolCallContent[] = [
-  {
-    id: "tool-monitor-create",
-    name: "spawn_background",
-    arguments: {
-      tool: "github_watch_pr",
-      title: "Watch PR 1319",
-      schedule: {
-        cron_expression: "*/10 * * * *",
-        timezone: "America/Chicago",
-      },
-    },
-  },
-  {
-    id: "tool-monitor-delete",
-    name: "cancel_schedule",
-    arguments: {
-      schedule_id: "sched_0195monitor",
-    },
-  },
-];
-
-const monitorToolResults = new Map<string, ToolCompletedData>([
-  [
-    "tool-monitor-create",
-    {
-      tool_call_id: "tool-monitor-create",
-      tool_name: "spawn_background",
-      success: true,
-      status: "success",
-      result: [
-        {
-          type: "text",
-          text: JSON.stringify({
-            created: true,
-            status: "scheduled",
-            title: "Watch PR 1319",
-            cron_expression: "*/10 * * * *",
-            timezone: "America/Chicago",
-          }),
-        },
-      ],
-      duration_ms: 84,
-    },
-  ],
-  [
-    "tool-monitor-delete",
-    {
-      tool_call_id: "tool-monitor-delete",
-      tool_name: "cancel_schedule",
-      success: true,
-      status: "success",
-      result: [
-        {
-          type: "text",
-          text: JSON.stringify({
-            cancelled: true,
-            description: `Monitor: Watch PR 1319
-
-This scheduled monitor fired. Start the background run now.
-
-spawn_background payload:
-{"tool":"github_watch_pr","title":"Watch PR 1319","signal_on_completion":true,"args":{"pull_request":1319}}`,
-          }),
-        },
-      ],
-      duration_ms: 41,
-    },
-  ],
-]);
-
-const planTodos = [
-  {
-    content: "Update schema for rock collection domain",
-    activeForm: "Updating schema for rock collection domain",
-    status: "completed" as const,
-  },
-  {
-    content: "Rename Convex functions and routes",
-    activeForm: "Renaming Convex functions and routes",
-    status: "completed" as const,
-  },
-  {
-    content: "Update UI copy for rock collection",
-    activeForm: "Updating UI copy for rock collection",
-    status: "in_progress" as const,
-  },
-  {
-    content: "Refresh README examples",
-    activeForm: "Refreshing README examples",
-    status: "pending" as const,
-  },
-];
-
-const scheduledInputEvent: Event = {
-  id: "evt-user-1",
-  type: "input.message",
-  ts: "2026-03-07T21:20:00Z",
-  session_id: "session-dev-tool-activity",
-  context: {},
-  data: {
-    message: {
-      id: "msg-user-1",
-      session_id: "session-dev-tool-activity",
-      sequence: 1,
-      role: "user",
-      content: [
-        {
-          type: "text",
-          text: "Can you inspect this project and sketch the rewrite steps?",
-        },
-      ],
-      tool_call_id: null,
-      created_at: "2026-03-07T21:20:00Z",
-      metadata: { source: "schedule" },
-    },
-  },
-};
-
-const rewriteInputEvent: Event = {
-  id: "evt-user-2",
-  type: "input.message",
-  ts: "2026-03-07T21:21:00Z",
-  session_id: "session-dev-tool-activity",
-  context: {},
-  data: {
-    message: {
-      id: "msg-user-2",
-      session_id: "session-dev-tool-activity",
-      sequence: 2,
-      role: "user",
-      content: [
-        {
-          type: "text",
-          text: "Rewrite it so it supports a rock collection instead.",
-        },
-      ],
-      tool_call_id: null,
-      created_at: "2026-03-07T21:21:00Z",
-    },
-  },
-};
-
-const agentPlanningEvent: Event = {
-  id: "evt-agent-1",
-  type: "output.message.completed",
-  ts: "2026-03-07T21:20:08Z",
-  session_id: "session-dev-tool-activity",
-  context: {},
-  data: {
-    message: {
-      id: "msg-agent-1",
-      session_id: "session-dev-tool-activity",
-      sequence: 3,
-      role: "agent",
-      content: [
-        {
-          type: "text",
-          text: "I'm checking the codebase shape first, then I'll summarize the likely rewrite path.",
-        },
-      ],
-      tool_call_id: null,
-      created_at: "2026-03-07T21:20:08Z",
-      metadata: {
-        model: "kimi-k2.5",
-        reasoning_effort: "medium",
-      },
-    },
-    metadata: { model: "kimi-k2.5" },
-    usage: { input_tokens: 1220, output_tokens: 188 },
-  },
-};
-
-const narratedRuntimeEvents: Event[] = [
-  {
-    id: "evt-human-intent-act-started",
-    type: "act.started",
-    ts: "2026-03-07T21:20:09Z",
-    session_id: "session-dev-tool-activity",
-    context: {
-      turn_id: "turn-human-intent",
-      input_message_id: "msg-user-1",
-      exec_id: "exec-human-intent",
-    },
-    data: {
-      tool_calls: [
-        {
-          id: "call-list-harnesses",
-          name: "platform_management",
-          display_name: "Platform Management",
-          narration: "Listing all harnesses",
-        },
-      ],
-      headline: "Listing all harnesses",
-    },
-  },
-  {
-    id: "evt-human-intent-tool-started",
-    type: "tool.started",
-    ts: "2026-03-07T21:20:10Z",
-    session_id: "session-dev-tool-activity",
-    context: {
-      turn_id: "turn-human-intent",
-      input_message_id: "msg-user-1",
-      exec_id: "exec-human-intent",
-    },
-    data: {
-      tool_call: {
-        id: "call-list-harnesses",
-        name: "platform_management",
-        arguments: {
-          operation: "list",
-          resource: "harnesses",
-          human_intent: "Listing all harnesses",
-        },
-      },
-      display_name: "Platform Management",
-      narration: "Listing all harnesses",
-    },
-  },
-  {
-    id: "evt-human-intent-tool-completed",
-    type: "tool.completed",
-    ts: "2026-03-07T21:20:11Z",
-    session_id: "session-dev-tool-activity",
-    context: {
-      turn_id: "turn-human-intent",
-      input_message_id: "msg-user-1",
-      exec_id: "exec-human-intent",
-    },
-    data: {
-      tool_call_id: "call-list-harnesses",
-      tool_name: "platform_management",
-      display_name: "Platform Management",
-      success: true,
-      status: "success",
-      result: [{ type: "text", text: "Base\nGeneric\nData Analyst" }],
-      duration_ms: 74,
-      narration: "Listing all harnesses",
-    },
-  },
-  {
-    id: "evt-human-intent-act-completed",
-    type: "act.completed",
-    ts: "2026-03-07T21:20:11Z",
-    session_id: "session-dev-tool-activity",
-    context: {
-      turn_id: "turn-human-intent",
-      input_message_id: "msg-user-1",
-      exec_id: "exec-human-intent",
-    },
-    data: {
-      completed: true,
-      success_count: 1,
-      error_count: 0,
-      duration_ms: 74,
-      headline: "Listing all harnesses",
-    },
-  },
-];
-
-const emptyToolResultsMap = new Map<string, ToolCompletedData>();
-const emptyToolProgressMap = new Map<string, ToolProgressData>();
-const emptyToolOutputMap = new Map<string, ToolOutputStreams>();
+import {
+  bashToolCall,
+  bashToolOutput,
+  bashToolResult,
+  groupedActivityProgress,
+  groupedActivityResults,
+  groupedActivityToolCalls,
+  readFileToolCall,
+  readFileToolResult,
+  timelineRows,
+  todoToolCall,
+  todoToolResult,
+  writeFileToolCall,
+  writeFileToolResult,
+} from "@/app/dev/_fixtures/tool-showcase-fixtures";
+import { BashToolCallCard } from "@/components/chat/bash-tool-call-card";
+import { GroupedActivityCard } from "@/components/chat/grouped-activity-card";
+import { ReadFileToolCallCard } from "@/components/chat/read-file-tool-call-card";
+import { TodoListRenderer } from "@/components/chat/todo-list-renderer";
+import { ToolActivityGroup } from "@/components/chat/tool-activity-group";
+import { ToolActivityTimelineGroup } from "@/components/chat/tool-activity-timeline-group";
+import { WriteFileToolCallCard } from "@/components/chat/write-file-tool-call-card";
 
 export default function ToolActivityDevPage() {
   return (
     <DevPageShell
-      eyebrow="Tool Activity"
-      title="Minimal execution states"
-      description="Preview the same quieter transcript treatment used by the runtime chat."
-      widthClassName="max-w-6xl"
+      eyebrow="Tool Outputs"
+      title="Tool Outputs"
+      description="A section-per-output reference page built entirely from the production tool transcript components."
+      widthClassName="max-w-7xl"
     >
-      <div className="mx-auto max-w-5xl">
-        <div className="overflow-hidden border border-border bg-card">
-          <div className="flex flex-wrap items-center justify-between gap-3 border-b border-border px-5 py-4">
-            <div>
-              <div className="text-[10px] uppercase tracking-[0.24em] text-muted-foreground">
-                Everruns Chat
-              </div>
-              <div className="mt-1 text-sm font-medium text-foreground">Tool activity preview</div>
-            </div>
-            <div className="flex items-center gap-2 text-[10px] uppercase tracking-[0.22em] text-muted-foreground">
-              <span className="inline-flex h-2 w-2 bg-accent" />
-              Preview
-            </div>
+      <div className="space-y-6">
+        <section className="space-y-4 border border-border/70 bg-card/90 p-4 shadow-[inset_0_1px_0_hsl(var(--background)/0.92)]">
+          <div className="space-y-1">
+            <h2 className="text-lg font-semibold text-foreground">Standalone tool outputs</h2>
+            <p className="text-sm text-muted-foreground">
+              Bash, file reads, file writes, and todo plans as they appear in the transcript.
+            </p>
           </div>
 
-          <div className="min-h-[760px] bg-background/80">
-            <div className="flex flex-col">
-              <div className="flex-1 space-y-6 px-4 py-5 sm:px-6">
-                <div className="flex justify-end">
-                  <div className={chatSurfaceStyles.userMessage}>
-                    <div className="mb-1 flex items-center justify-between gap-2">
-                      <div className="flex items-center gap-1 text-[10px] uppercase tracking-[0.22em] text-muted-foreground">
-                        <CalendarClock className="h-3 w-3" />
-                        Scheduled
-                      </div>
-                      <MessageInfoIcon event={scheduledInputEvent} />
-                    </div>
-                    Can you inspect this project and sketch the rewrite steps?
-                  </div>
-                </div>
+          <div className="grid gap-4 xl:grid-cols-2">
+            <div className="space-y-2">
+              <p className="text-sm font-medium text-foreground">Bash output</p>
+              <BashToolCallCard
+                toolCall={bashToolCall}
+                toolResult={bashToolResult}
+                streamedOutput={bashToolOutput}
+              />
+            </div>
 
-                <div className={chatSurfaceStyles.agentMessageRow}>
-                  <div className={chatSurfaceStyles.agentIcon}>
-                    <Bot className="h-3.5 w-3.5" />
-                  </div>
-                  <div className="flex-1 space-y-3">
-                    <div className="flex items-start gap-2">
-                      <p className={chatSurfaceStyles.agentMessage}>
-                        I&apos;m checking the codebase shape first, then I&apos;ll summarize the
-                        likely rewrite path.
-                      </p>
-                      <MessageInfoIcon event={agentPlanningEvent} />
-                    </div>
-                    <ChatMessageList
-                      events={narratedRuntimeEvents}
-                      chatEvents={narratedRuntimeEvents}
-                      sessionId="session-dev-tool-activity"
-                      toolResultsMap={emptyToolResultsMap}
-                      toolProgressMap={emptyToolProgressMap}
-                      toolOutputMap={emptyToolOutputMap}
-                      eventsLoading={false}
-                      hasMoreEvents={false}
-                      loadingOlderEvents={false}
-                      getMessageText={() => ""}
-                      getToolCalls={() => []}
-                    />
-                    <ToolActivityGroup
-                      toolCalls={activeToolCalls}
-                      toolResultsMap={activeToolResults}
-                    />
-                  </div>
-                </div>
+            <div className="space-y-2">
+              <p className="text-sm font-medium text-foreground">Read file output</p>
+              <ReadFileToolCallCard toolCall={readFileToolCall} toolResult={readFileToolResult} />
+            </div>
 
-                <div className="flex justify-end">
-                  <div className={chatSurfaceStyles.userMessage}>
-                    <div className="mb-1 flex items-center justify-end">
-                      <MessageInfoIcon event={rewriteInputEvent} />
-                    </div>
-                    Rewrite it so it supports a rock collection instead.
-                  </div>
-                </div>
+            <div className="space-y-2">
+              <p className="text-sm font-medium text-foreground">Write file output</p>
+              <WriteFileToolCallCard
+                toolCall={writeFileToolCall}
+                toolResult={writeFileToolResult}
+              />
+            </div>
 
-                <div className={chatSurfaceStyles.agentMessageRow}>
-                  <div className={chatSurfaceStyles.agentIcon}>
-                    <Bot className="h-3.5 w-3.5" />
-                  </div>
-                  <div className="flex-1 space-y-3">
-                    <ToolActivityGroup
-                      toolCalls={completedToolCalls}
-                      toolResultsMap={completedToolResults}
-                    />
-                    <TodoListRenderer arguments={{ todos: planTodos }} isExecuting />
-                  </div>
-                </div>
-
-                <div className={chatSurfaceStyles.agentMessageRow}>
-                  <div className={chatSurfaceStyles.agentIcon}>
-                    <Bot className="h-3.5 w-3.5" />
-                  </div>
-                  <div className="flex-1 space-y-3">
-                    <p className={chatSurfaceStyles.agentMessage}>
-                      I set a monitor for the PR and removed it after merge.
-                    </p>
-                    <ToolActivityGroup
-                      toolCalls={monitorToolCalls}
-                      toolResultsMap={monitorToolResults}
-                    />
-                  </div>
-                </div>
-
-                <div className={chatSurfaceStyles.agentMessageRow}>
-                  <div className={chatSurfaceStyles.agentIcon}>
-                    <Bot className="h-3.5 w-3.5" />
-                  </div>
-                  <div className="flex-1">
-                    <ToolActivityGroup
-                      toolCalls={clientToolCalls}
-                      toolResultsMap={new Map()}
-                      mode="client"
-                    />
-                  </div>
-                </div>
-              </div>
-
-              <div className={chatSurfaceStyles.composerSection}>
-                <div className="mb-3 flex flex-wrap gap-2">
-                  <div className="border border-border/70 bg-card/85 px-2 py-1 text-xs text-muted-foreground shadow-[inset_0_1px_0_hsl(var(--background)/0.92)]">
-                    architecture.png
-                  </div>
-                  <div className="border border-border/70 bg-card/85 px-2 py-1 text-xs text-muted-foreground shadow-[inset_0_1px_0_hsl(var(--background)/0.92)]">
-                    schema-draft.png
-                  </div>
-                </div>
-
-                <div className={chatSurfaceStyles.composerInputShell}>
-                  <div className="absolute bottom-full left-0 right-0 border border-border/70 bg-card/95 p-1 shadow-[0_1px_0_hsl(var(--background)/0.9)]">
-                    <button
-                      type="button"
-                      className="flex w-full items-center gap-2 px-2 py-1.5 text-left text-sm text-foreground"
-                    >
-                      <Terminal className="h-3.5 w-3.5 text-muted-foreground" />
-                      <span className="font-mono text-xs">/ship</span>
-                      <span className="truncate text-xs text-muted-foreground">
-                        Run the shipping workflow
-                      </span>
-                    </button>
-                    <button
-                      type="button"
-                      className="flex w-full items-center gap-2 px-2 py-1.5 text-left text-sm text-muted-foreground"
-                    >
-                      <Sparkles className="h-3.5 w-3.5 text-muted-foreground" />
-                      <span className="font-mono text-xs">/process-issues</span>
-                      <span className="truncate text-xs text-muted-foreground">
-                        Batch-process open issues
-                      </span>
-                    </button>
-                  </div>
-
-                  <div className="px-4 py-3.5 text-sm text-foreground">
-                    Type a message or <span className="font-mono">/</span> for commands...
-                  </div>
-                </div>
-
-                <div className="mt-3 flex flex-wrap items-center justify-between gap-3">
-                  <div className="flex flex-wrap items-center gap-2 text-[11px] text-muted-foreground">
-                    <button
-                      type="button"
-                      className={`inline-flex items-center justify-center ${chatSurfaceStyles.composerIconButton}`}
-                      aria-label="Attach images"
-                    >
-                      <ImagePlus className="icon-sharp h-4 w-4" />
-                    </button>
-                    <div className={chatSurfaceStyles.composerControlChip}>
-                      <span className="text-[10px] uppercase tracking-[0.22em] text-muted-foreground">
-                        Model
-                      </span>
-                      <span className="text-sm text-foreground">Kimi K2.5</span>
-                    </div>
-                    <div className={chatSurfaceStyles.composerControlChip}>
-                      <Brain className="icon-sharp h-3.5 w-3.5" />
-                      <span className="text-[10px] uppercase tracking-[0.22em] text-muted-foreground">
-                        Reasoning
-                      </span>
-                      <span className="text-sm text-foreground">Default</span>
-                    </div>
-                  </div>
-
-                  <div className="flex items-center gap-2">
-                    <button
-                      type="button"
-                      className={`inline-flex items-center justify-center ${chatSurfaceStyles.composerDangerButton}`}
-                      aria-label="Cancel current turn"
-                    >
-                      <StopCircle className="icon-sharp h-4 w-4" />
-                    </button>
-                    <button
-                      type="button"
-                      className={`inline-flex items-center justify-center ${chatSurfaceStyles.composerSubmitButton} bg-primary text-primary-foreground`}
-                      aria-label="Send message"
-                    >
-                      <Send className="icon-sharp h-4 w-4" />
-                    </button>
-                  </div>
-                </div>
-              </div>
+            <div className="space-y-2">
+              <p className="text-sm font-medium text-foreground">Todo plan output</p>
+              <TodoListRenderer
+                arguments={todoToolCall.arguments}
+                result={todoToolResult.result}
+                isExecuting={false}
+              />
             </div>
           </div>
-        </div>
+        </section>
+
+        <section className="space-y-4 border border-border/70 bg-card/90 p-4 shadow-[inset_0_1px_0_hsl(var(--background)/0.92)]">
+          <div className="space-y-1">
+            <h2 className="text-lg font-semibold text-foreground">Grouped activity</h2>
+            <p className="text-sm text-muted-foreground">
+              The shared multi-tool execution card used when a turn batches several non-shell tool
+              calls.
+            </p>
+          </div>
+
+          <GroupedActivityCard
+            toolCalls={groupedActivityToolCalls}
+            toolResultsMap={groupedActivityResults}
+            toolProgressMap={groupedActivityProgress}
+            mode="server"
+          />
+        </section>
+
+        <section className="space-y-4 border border-border/70 bg-card/90 p-4 shadow-[inset_0_1px_0_hsl(var(--background)/0.92)]">
+          <div className="space-y-1">
+            <h2 className="text-lg font-semibold text-foreground">Narrated tool timeline</h2>
+            <p className="text-sm text-muted-foreground">
+              The Daytona-style narrated activity block that tracks an execution across several tool
+              steps.
+            </p>
+          </div>
+
+          <ToolActivityTimelineGroup
+            headline="Running Daytona sandbox checks"
+            completedHeadline="Ran Daytona sandbox checks"
+            rows={timelineRows}
+          />
+        </section>
+
+        <section className="space-y-4 border border-border/70 bg-card/90 p-4 shadow-[inset_0_1px_0_hsl(var(--background)/0.92)]">
+          <div className="space-y-1">
+            <h2 className="text-lg font-semibold text-foreground">Combined transcript grouping</h2>
+            <p className="text-sm text-muted-foreground">
+              The router component that decides when to render standalone rows, grouped activity, or
+              todo cards.
+            </p>
+          </div>
+
+          <ToolActivityGroup
+            toolCalls={[bashToolCall, ...groupedActivityToolCalls, todoToolCall]}
+            toolResultsMap={
+              new Map([
+                [bashToolCall.id, bashToolResult],
+                ...groupedActivityResults,
+                [todoToolCall.id, todoToolResult],
+              ])
+            }
+            toolProgressMap={groupedActivityProgress}
+            toolOutputMap={new Map([[bashToolCall.id, bashToolOutput]])}
+            mode="server"
+          />
+        </section>
       </div>
     </DevPageShell>
   );

--- a/apps/ui/src/components/session/session-header.tsx
+++ b/apps/ui/src/components/session/session-header.tsx
@@ -1,0 +1,451 @@
+"use client";
+
+import {
+  useEffect,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type ComponentType,
+  type KeyboardEvent,
+} from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import type {
+  Agent,
+  LlmModelWithProvider,
+  Session,
+  SessionStatus,
+  TokenUsage,
+} from "@/lib/api/types";
+import { buttonVariants } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { CopyButton } from "@/components/ui/copy-button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuPositioner,
+  DropdownMenuShortcut,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { useUpdateSession } from "@/hooks/use-sessions";
+import {
+  getDisplayName,
+  getEntityReferenceClassName,
+  getEntityReferenceLabel,
+} from "@/lib/entity-lifecycle";
+import { formatTokens } from "@/lib/formatting";
+import { cn, shortenId } from "@/lib/utils";
+import {
+  ArrowLeft,
+  Bot,
+  CalendarClock,
+  Check,
+  ChevronDown,
+  Database,
+  Folder,
+  GitBranch,
+  Activity,
+  MessageSquare,
+  Pencil,
+  Sparkles,
+  Wrench,
+  X,
+  Zap,
+} from "lucide-react";
+
+export type SessionNavKey =
+  | "chat"
+  | "files"
+  | "storage"
+  | "resources"
+  | "schedules"
+  | "events"
+  | "trajectory";
+
+export interface SessionNavItem {
+  key: SessionNavKey;
+  label: string;
+  href: string;
+  icon: ComponentType<{ className?: string }>;
+  badge?: string;
+}
+
+function EditableSessionTitle({
+  sessionId,
+  title,
+  fallback,
+  editable,
+}: {
+  sessionId: string;
+  title: string | null;
+  fallback: string;
+  editable: boolean;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [value, setValue] = useState(title ?? "");
+  const inputRef = useRef<HTMLInputElement>(null);
+  const updateSession = useUpdateSession();
+
+  useEffect(() => {
+    if (editing) {
+      setValue(title ?? "");
+      requestAnimationFrame(() => inputRef.current?.select());
+    }
+  }, [editing, title]);
+
+  function save() {
+    const trimmed = value.trim();
+    if (trimmed === (title ?? "")) {
+      setEditing(false);
+      return;
+    }
+    updateSession.mutate(
+      { sessionId, request: { title: trimmed || undefined } },
+      { onSettled: () => setEditing(false) },
+    );
+  }
+
+  if (editing) {
+    return (
+      <div className="flex items-center gap-1">
+        <Input
+          ref={inputRef}
+          value={value}
+          onChange={(e: ChangeEvent<HTMLInputElement>) => setValue(e.target.value)}
+          onKeyDown={(e: KeyboardEvent) => {
+            if (e.key === "Enter") save();
+            if (e.key === "Escape") setEditing(false);
+          }}
+          className="h-8 w-64 text-xl font-bold"
+          placeholder={fallback}
+        />
+        <button
+          onClick={save}
+          className="rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+          aria-label="Save title"
+        >
+          <Check className="h-4 w-4" />
+        </button>
+        <button
+          onClick={() => setEditing(false)}
+          className="rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+          aria-label="Cancel editing"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <h1 className="flex items-center gap-2 text-xl font-bold">
+      {title || fallback}
+      {editable && (
+        <button
+          onClick={() => setEditing(true)}
+          className="rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+          aria-label="Edit session title"
+        >
+          <Pencil className="h-3.5 w-3.5" />
+        </button>
+      )}
+      <CopyButton value={sessionId} />
+    </h1>
+  );
+}
+
+export function SessionUsageBadge({ usage }: { usage: TokenUsage }) {
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger>
+          <Badge variant="outline" className="cursor-help gap-1">
+            <Zap className="icon-sharp h-3 w-3" />
+            {formatTokens(usage.input_tokens)} / {formatTokens(usage.output_tokens)}
+          </Badge>
+        </TooltipTrigger>
+        <TooltipContent>
+          <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-xs">
+            <dt className="text-muted-foreground">Input</dt>
+            <dd>{usage.input_tokens.toLocaleString()}</dd>
+            <dt className="text-muted-foreground">Output</dt>
+            <dd>{usage.output_tokens.toLocaleString()}</dd>
+            {(usage.cache_read_tokens ?? 0) > 0 && (
+              <>
+                <dt className="text-muted-foreground">Cache read</dt>
+                <dd>{usage.cache_read_tokens!.toLocaleString()}</dd>
+              </>
+            )}
+            {(usage.cache_creation_tokens ?? 0) > 0 && (
+              <>
+                <dt className="text-muted-foreground">Cache created</dt>
+                <dd>{usage.cache_creation_tokens!.toLocaleString()}</dd>
+              </>
+            )}
+          </dl>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
+export function SessionStatusBadge({ status }: { status: SessionStatus | undefined }) {
+  if (status === "active") {
+    return <Badge variant="default">Processing...</Badge>;
+  }
+
+  if (status === "idle") {
+    return <Badge variant="secondary">Ready</Badge>;
+  }
+
+  if (status === "waiting_for_tool_results") {
+    return <Badge variant="outline">Waiting on tools</Badge>;
+  }
+
+  if (status === "started") {
+    return <Badge variant="outline">New</Badge>;
+  }
+
+  return null;
+}
+
+export function buildSessionNavigation({
+  basePath,
+  features,
+  activeScheduleCount,
+}: {
+  basePath: string;
+  features: Set<string>;
+  activeScheduleCount?: number;
+}): SessionNavItem[] {
+  const hasFeature = (feature: string) => features.has(feature);
+
+  return [
+    {
+      key: "chat",
+      label: "Chat",
+      href: `${basePath}/chat`,
+      icon: MessageSquare,
+    },
+    ...(hasFeature("file_system")
+      ? [
+          {
+            key: "files" as const,
+            label: "Workspace",
+            href: `${basePath}/files`,
+            icon: Folder,
+          },
+        ]
+      : []),
+    ...(hasFeature("secrets") || hasFeature("key_value")
+      ? [
+          {
+            key: "storage" as const,
+            label: "Storage",
+            href: `${basePath}/storage`,
+            icon: Database,
+          },
+        ]
+      : []),
+    ...(hasFeature("leased_resources")
+      ? [
+          {
+            key: "resources" as const,
+            label: "Resources",
+            href: `${basePath}/resources`,
+            icon: Wrench,
+          },
+        ]
+      : []),
+    ...(hasFeature("schedules")
+      ? [
+          {
+            key: "schedules" as const,
+            label: "Schedules",
+            href: `${basePath}/schedules`,
+            icon: CalendarClock,
+            badge:
+              activeScheduleCount && activeScheduleCount > 0
+                ? String(activeScheduleCount)
+                : undefined,
+          },
+        ]
+      : []),
+    {
+      key: "events",
+      label: "Events",
+      href: `${basePath}/events`,
+      icon: Activity,
+    },
+    {
+      key: "trajectory",
+      label: "Trajectory",
+      href: `${basePath}/trajectory`,
+      icon: GitBranch,
+    },
+  ];
+}
+
+export function SessionHeader({
+  sessionId,
+  session,
+  agent,
+  agentId,
+  llmModel,
+  effectiveStatus,
+  liveUsage,
+  activeTab,
+  navigationItems,
+  secondaryMetaText,
+  backHref = "/sessions",
+  backLabel = "Back to Sessions",
+  allowTitleEditing = true,
+}: {
+  sessionId: string;
+  session: Session;
+  agent?: Agent;
+  agentId?: string;
+  llmModel?: LlmModelWithProvider;
+  effectiveStatus?: SessionStatus;
+  liveUsage?: TokenUsage;
+  activeTab: SessionNavKey;
+  navigationItems: SessionNavItem[];
+  secondaryMetaText: string;
+  backHref?: string;
+  backLabel?: string;
+  allowTitleEditing?: boolean;
+}) {
+  const router = useRouter();
+  const agentReferenceLabel =
+    session.agent_id != null
+      ? getEntityReferenceLabel({
+          kind: "Agent",
+          name: getDisplayName(agent),
+          status: agent?.status ?? "deleted",
+        })
+      : null;
+  const agentReferenceStatus = session.agent_id != null ? (agent?.status ?? "deleted") : null;
+  const getNavigationClassName = (isActive: boolean) =>
+    cn(
+      buttonVariants({ variant: "outline", size: "sm" }),
+      isActive ? "border-primary bg-card text-foreground" : "text-muted-foreground",
+    );
+  const chatItem = navigationItems[0];
+  const advancedNavigationItems = navigationItems.slice(1);
+  const activeAdvancedItem = advancedNavigationItems.find((item) => item.key === activeTab);
+
+  return (
+    <div className="border-b border-border/70 bg-background/80 px-4 py-3 backdrop-blur-[1px]">
+      <Link
+        href={backHref}
+        className="mb-1.5 inline-flex items-center text-sm text-muted-foreground hover:text-foreground"
+      >
+        <ArrowLeft className="icon-sharp mr-2 h-4 w-4" />
+        {backLabel}
+      </Link>
+
+      <div className="flex items-center justify-between gap-4">
+        <div className="group/title min-w-0">
+          <EditableSessionTitle
+            sessionId={sessionId}
+            title={session.title}
+            fallback={`Session ${shortenId(session.id)}`}
+            editable={allowTitleEditing}
+          />
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            {agentReferenceLabel &&
+              (agent && agentId ? (
+                <Link
+                  href={`/agents/${agentId}`}
+                  className="inline-flex items-center gap-1 hover:text-foreground"
+                >
+                  <Bot className="icon-sharp h-3 w-3" />
+                  <span className={getEntityReferenceClassName(agentReferenceStatus)}>
+                    {agentReferenceLabel}
+                  </span>
+                </Link>
+              ) : (
+                <span className="inline-flex items-center gap-1">
+                  <Bot className="icon-sharp h-3 w-3" />
+                  <span className={getEntityReferenceClassName(agentReferenceStatus)}>
+                    {agentReferenceLabel}
+                  </span>
+                </span>
+              ))}
+            <span>•</span>
+            <span>{secondaryMetaText}</span>
+          </div>
+        </div>
+
+        <div className="flex flex-wrap items-center justify-end gap-2">
+          {liveUsage && <SessionUsageBadge usage={liveUsage} />}
+
+          {llmModel && (
+            <Badge variant="outline" className="gap-1">
+              <Sparkles className="icon-sharp h-3 w-3" />
+              {llmModel.display_name}
+            </Badge>
+          )}
+
+          <SessionStatusBadge status={effectiveStatus} />
+
+          {chatItem && (
+            <Link
+              href={chatItem.href}
+              className={getNavigationClassName(activeTab === chatItem.key)}
+              aria-current={activeTab === chatItem.key ? "page" : undefined}
+            >
+              <chatItem.icon className="icon-sharp h-4 w-4" />
+              {chatItem.label}
+            </Link>
+          )}
+
+          {advancedNavigationItems.length > 0 && (
+            <DropdownMenu>
+              <DropdownMenuTrigger
+                className={getNavigationClassName(activeTab !== "chat")}
+                aria-label="Advanced navigation"
+              >
+                Advanced
+                {activeAdvancedItem && (
+                  <span className="text-xs text-muted-foreground">{activeAdvancedItem.label}</span>
+                )}
+                <ChevronDown className="icon-sharp h-4 w-4 opacity-60" />
+              </DropdownMenuTrigger>
+              <DropdownMenuPositioner align="end">
+                <DropdownMenuContent className="w-56">
+                  <DropdownMenuGroup>
+                    <DropdownMenuLabel>Advanced Views</DropdownMenuLabel>
+                    {advancedNavigationItems.map((item) => (
+                      <DropdownMenuItem
+                        key={item.key}
+                        onClick={() => router.push(item.href)}
+                        className="flex items-center justify-between gap-3"
+                      >
+                        <span className="flex min-w-0 items-center gap-2">
+                          <item.icon className="icon-sharp h-4 w-4" />
+                          <span>{item.label}</span>
+                        </span>
+                        <span className="flex items-center gap-2">
+                          {item.badge && <DropdownMenuShortcut>{item.badge}</DropdownMenuShortcut>}
+                          {activeTab === item.key && (
+                            <Check className="icon-sharp h-4 w-4 text-primary" />
+                          )}
+                        </span>
+                      </DropdownMenuItem>
+                    ))}
+                  </DropdownMenuGroup>
+                </DropdownMenuContent>
+              </DropdownMenuPositioner>
+            </DropdownMenu>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## What
Refactor the dev showcase pages to reuse real session and chat UI components instead of bespoke mock layouts.

## Why
The existing `/dev` pages diverged from the main product UI, which made them poor references for tool activity, chat transcript, and session chrome work.

## How
- extract the session header/navigation into a reusable `SessionHeader` component and switch the main session layout to use it
- rebuild `/dev/chat-components`, `/dev/session-components`, and `/dev/tool-activity` around production chat/session/tool components plus shared fixture data
- export the session context symbols needed for the dev runtime preview wrappers

## Risk
- Low
- The main risk is visual regression in session header chrome or drift between dev fixtures and backend event shapes.

## Security
- Threat categories reviewed: No security-relevant code changes. UI-only refactor and dev showcase pages; no auth, data access, or server-side behavior changes.
- Findings and resolutions:
  - No new trust boundaries or sensitive-data flows introduced.

## Checklist
- [ ] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
