### PR TITLE
fix(ui): show chat error alerts

### DIFF
--- a/apps/ui/src/__tests__/chat-panel.test.tsx
+++ b/apps/ui/src/__tests__/chat-panel.test.tsx
@@ -23,6 +23,8 @@ const mockSessionContext = {
   llmModel: null,
   chatEvents: [],
   toolResultsMap: new Map(),
+  toolProgressMap: new Map(),
+  toolOutputMap: new Map(),
   eventsLoading: false,
   isActive: false,
   reasoningEffort: "",
@@ -287,6 +289,12 @@ describe("ChatPanel compaction divider", () => {
 describe("ChatPanel placeholder", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockExecuteSessionCommand.mockReset();
+    mockSessionContext.chatEvents = [];
+    mockSessionContext.llmModel = null;
+    mockSessionContext.reasoningEffort = "";
+    mockSessionContext.sendMessage.mutateAsync.mockReset();
+    mockUseSessionCommands.mockReturnValue({ data: { commands: [] } });
   });
 
   it("does not advertise slash commands when none are available", () => {
@@ -393,5 +401,45 @@ describe("ChatPanel placeholder", () => {
     expect(mockSessionContext.sendMessage.mutateAsync).not.toHaveBeenCalled();
     expect(await screen.findByText("Side answer")).toBeInTheDocument();
     expect(screen.getByText("/btw")).toBeInTheDocument();
+  });
+
+  it("renders a chat error alert for failed turns", () => {
+    mockSessionContext.chatEvents = [
+      {
+        id: "evt-failed-1",
+        type: "turn.failed",
+        session_id: "session-1",
+        ts: new Date().toISOString(),
+        context: { turn_id: "turn-1" },
+        data: {
+          turn_id: "turn-1",
+          error: "backend temporarily unavailable",
+          error_code: "dependency_unavailable",
+        },
+      },
+    ];
+
+    render(<ChatPanel />);
+
+    expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+    expect(
+      screen.getByText("Execution stopped because a required dependency is unavailable."),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/backend temporarily unavailable/)).toBeInTheDocument();
+  });
+
+  it("renders a chat error alert when sending a message fails", async () => {
+    mockSessionContext.sendMessage.mutateAsync.mockRejectedValueOnce(
+      new Error("backend temporarily unavailable"),
+    );
+
+    render(<ChatPanel />);
+
+    const textarea = screen.getByPlaceholderText("Type a message... (Enter to send)");
+    fireEvent.change(textarea, { target: { value: "hello" } });
+    fireEvent.keyDown(textarea, { key: "Enter", code: "Enter" });
+
+    expect(await screen.findByText("Something went wrong")).toBeInTheDocument();
+    expect(screen.getByText("backend temporarily unavailable")).toBeInTheDocument();
   });
 });

--- a/apps/ui/src/app/(main)/chat/page.tsx
+++ b/apps/ui/src/app/(main)/chat/page.tsx
@@ -6,25 +6,25 @@ import { SessionProvider } from "@/app/(main)/sessions/[sessionId]/session-conte
 import { useGlobalChat } from "@/hooks/use-global-chat";
 import { useFeatureFlag } from "@/providers/feature-flags-provider";
 import { ExperimentalPageBadge } from "@/components/ui/experimental-badge";
+import { ChatErrorAlert } from "@/components/chat/chat-error-alert";
 
 function GlobalChatEnabledContent() {
   const { sessionId, isLoading, error } = useGlobalChat();
+
+  if (error) {
+    return (
+      <div className="flex h-full items-center justify-center bg-background bg-brand-dots p-6">
+        <div className="w-full max-w-3xl">
+          <ChatErrorAlert message={error.message} />
+        </div>
+      </div>
+    );
+  }
 
   if (isLoading || !sessionId) {
     return (
       <div className="flex h-full items-center justify-center">
         <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
-      </div>
-    );
-  }
-
-  if (error) {
-    return (
-      <div className="flex h-full items-center justify-center">
-        <div className="text-center text-muted-foreground">
-          <p className="text-lg font-medium">Failed to load chat</p>
-          <p className="text-sm">{error.message}</p>
-        </div>
       </div>
     );
   }

--- a/apps/ui/src/app/(main)/sessions/[sessionId]/session-context.tsx
+++ b/apps/ui/src/app/(main)/sessions/[sessionId]/session-context.tsx
@@ -242,6 +242,16 @@ export function SessionProvider({ sessionId, children }: SessionProviderProps) {
         setStreamingTurnId(null);
         break;
       }
+      if (event.type === "turn.failed") {
+        // Turn failed - clear optimistic waiting/streaming state immediately.
+        setIsWaitingForResponse(false);
+        setIsThinking(false);
+        setStreamingText(null);
+        setStreamingTurnId(null);
+        setStreamingIteration(null);
+        setLocalStatus("idle");
+        break;
+      }
     }
   }, [events]);
 
@@ -358,6 +368,7 @@ export function SessionProvider({ sessionId, children }: SessionProviderProps) {
           (e) =>
             e.type === "input.message" ||
             e.type === "output.message.completed" ||
+            e.type === "turn.failed" ||
             e.type === "act.started" ||
             e.type === "act.completed" ||
             e.type === "tool.started" ||

--- a/apps/ui/src/app/dev/chat-components/page.tsx
+++ b/apps/ui/src/app/dev/chat-components/page.tsx
@@ -4,6 +4,7 @@ import { ToolActivityGroup } from "@/components/chat/tool-activity-group";
 import { TodoListRenderer } from "@/components/chat/todo-list-renderer";
 import { MessageInfoIcon } from "@/components/chat/message-info-icon";
 import { ImageAttachments } from "@/components/chat/image-attachments";
+import { ChatErrorAlert } from "@/components/chat/chat-error-alert";
 import type { Event, ToolCompletedData } from "@/lib/api/types";
 import type { ToolCallContent } from "@/components/chat/tool-call-utils";
 import type { PendingImage } from "@/lib/api/images";
@@ -173,6 +174,19 @@ export default function DevChatComponentsPage() {
               ],
             }}
             isExecuting
+          />
+        </Section>
+
+        <Section title="Error Handling" description="Failure treatment used by chat surfaces.">
+          <ChatErrorAlert
+            message="backend temporarily unavailable"
+            details={[
+              "event_id: evt-failed-1",
+              "event_type: turn.failed",
+              "turn_id: turn-1",
+              "error_code: dependency_unavailable",
+              "error: backend temporarily unavailable",
+            ].join("\n")}
           />
         </Section>
       </div>

--- a/apps/ui/src/components/chat/chat-error-alert.tsx
+++ b/apps/ui/src/components/chat/chat-error-alert.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { ChevronDown, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { useLocale } from "@/providers/locale-provider";
+
+interface ChatErrorAlertProps {
+  message: string;
+  details?: string | null;
+  className?: string;
+}
+
+export function ChatErrorAlert({ message, details, className }: ChatErrorAlertProps) {
+  const { t } = useLocale();
+  const displayMessage = message.trim() || t("chat_error_fallback");
+  const trimmedDetails = details?.trim();
+
+  return (
+    <div
+      role="alert"
+      className={cn(
+        "animate-chat-row-in w-full rounded-lg border border-border/80 bg-card/95 px-4 py-3 text-left shadow-[0_12px_36px_hsl(var(--foreground)/0.06),inset_0_1px_0_hsl(var(--background)/0.92)]",
+        className,
+      )}
+    >
+      <div className="flex items-center gap-2 text-destructive">
+        <X className="h-4 w-4 flex-shrink-0" />
+        <div className="text-sm font-semibold">{t("chat_error_title")}</div>
+      </div>
+      <p className="mt-2 text-sm leading-5 text-muted-foreground">{t("chat_error_description")}</p>
+      <div className="mt-3 rounded-md bg-muted/70 px-3 py-2 font-mono text-sm leading-5 text-foreground">
+        {displayMessage}
+      </div>
+      {trimmedDetails ? (
+        <details className="group mt-2">
+          <summary className="flex cursor-pointer list-none items-center gap-1 text-sm text-muted-foreground marker:hidden">
+            <ChevronDown className="h-3.5 w-3.5 transition-transform group-open:rotate-180" />
+            <span>{t("details")}</span>
+          </summary>
+          <pre className="mt-2 max-h-64 overflow-auto rounded-md bg-muted/60 px-3 py-2 text-xs leading-5 text-muted-foreground">
+            {trimmedDetails}
+          </pre>
+        </details>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/ui/src/components/chat/chat-message-list.tsx
+++ b/apps/ui/src/components/chat/chat-message-list.tsx
@@ -13,15 +13,17 @@ import type {
   Event,
   InputMessageData,
   OutputMessageCompletedData,
+  TurnFailedData,
   ToolCallSummary,
   ToolCompletedData,
   ToolProgressData,
 } from "@/lib/api/types";
 import type { ToolOutputStreams } from "@/app/(main)/sessions/[sessionId]/session-context";
-import { getEventData, isImageFilePart } from "@/lib/api/types";
+import { getEventData, getTextFromContent, isImageFilePart } from "@/lib/api/types";
 import { MessageInfoIcon } from "@/components/chat/message-info-icon";
 import { MessageImage } from "@/components/chat/image-attachments";
 import { MessageContent } from "@/components/chat/message-content";
+import { ChatErrorAlert } from "@/components/chat/chat-error-alert";
 import { ToolActivityGroup } from "@/components/chat/tool-activity-group";
 import { SetupConnectionToolCall } from "@/components/chat/setup-connection-tool-call";
 import {
@@ -36,6 +38,12 @@ import { chatSurfaceStyles } from "@/components/chat/chat-surface";
 import { CompactionDivider } from "@/components/chat/compaction-divider";
 import type { ToolCallContent } from "@/components/chat/tool-call-utils";
 import { useLocale } from "@/providers/locale-provider";
+import {
+  getRuntimeErrorFromOutputMessage,
+  getRuntimeErrorFromTurnFailed,
+  localizeRuntimeError,
+} from "@/lib/runtime-errors";
+import type { SupportedLocale } from "@/lib/i18n";
 
 interface ChatMessageListProps {
   events: Event[] | undefined;
@@ -63,6 +71,36 @@ function getMessageImages(content: ContentPart[]): Array<{ image_id: string; fil
     image_id: part.image_id,
     filename: part.filename,
   }));
+}
+
+function formatFailureDetails({
+  event,
+  error,
+  errorCode,
+  errorFields,
+  rawMessage,
+}: {
+  event: Event;
+  error?: string;
+  errorCode?: string;
+  errorFields?: Record<string, unknown>;
+  rawMessage?: string;
+}): string | null {
+  const lines = [
+    `event_id: ${event.id}`,
+    `event_type: ${event.type}`,
+    event.context?.turn_id ? `turn_id: ${event.context.turn_id}` : null,
+    errorCode ? `error_code: ${errorCode}` : null,
+    error && error !== rawMessage ? `error: ${error}` : null,
+    rawMessage ? `message: ${rawMessage}` : null,
+    errorFields ? `error_fields: ${JSON.stringify(errorFields, null, 2)}` : null,
+  ].filter(Boolean);
+
+  return lines.length > 0 ? lines.join("\n") : null;
+}
+
+function getTurnFailedMessage(locale: SupportedLocale, data: TurnFailedData): string {
+  return localizeRuntimeError(locale, getRuntimeErrorFromTurnFailed(data), data.error);
 }
 
 function buildActGroups(chatEvents: Event[], workingLabel: string) {
@@ -175,7 +213,7 @@ export const ChatMessageList = memo(function ChatMessageList({
   getMessageText,
   getToolCalls,
 }: ChatMessageListProps) {
-  const { t } = useLocale();
+  const { locale, t } = useLocale();
   const clientRequestedToolCallIds = useMemo(() => {
     const ids = new Set<string>();
     for (const event of chatEvents) {
@@ -245,6 +283,22 @@ export const ChatMessageList = memo(function ChatMessageList({
         if (event.type === "context.compacted") {
           const compactedData = getEventData(event, "context.compacted");
           return compactedData ? <CompactionDivider key={event.id} data={compactedData} /> : null;
+        }
+
+        const turnFailedData = getEventData(event, "turn.failed");
+        if (turnFailedData) {
+          return (
+            <ChatErrorAlert
+              key={event.id}
+              message={getTurnFailedMessage(locale, turnFailedData)}
+              details={formatFailureDetails({
+                event,
+                error: turnFailedData.error,
+                errorCode: turnFailedData.error_code,
+                errorFields: turnFailedData.error_fields,
+              })}
+            />
+          );
         }
 
         if (event.type === "act.started") {
@@ -349,6 +403,22 @@ export const ChatMessageList = memo(function ChatMessageList({
         if (!data) return null;
 
         const textContent = getMessageText(data);
+        const outputError = outputData ? getRuntimeErrorFromOutputMessage(outputData) : undefined;
+        if (outputData && outputError) {
+          const rawMessage = getTextFromContent(outputData.message?.content ?? []);
+          return (
+            <ChatErrorAlert
+              key={event.id}
+              message={textContent}
+              details={formatFailureDetails({
+                event,
+                errorCode: outputError.code,
+                errorFields: outputError.fields,
+                rawMessage,
+              })}
+            />
+          );
+        }
         const toolCalls = isUser
           ? []
           : outputData

--- a/apps/ui/src/components/chat/chat-panel.tsx
+++ b/apps/ui/src/components/chat/chat-panel.tsx
@@ -17,6 +17,7 @@ import { executeSessionCommand } from "@/lib/api/commands";
 import { sendUserMessageWithImages } from "@/lib/api/messages";
 import { useMutation } from "@tanstack/react-query";
 import { chatSurfaceStyles } from "@/components/chat/chat-surface";
+import { ChatErrorAlert } from "@/components/chat/chat-error-alert";
 import { ChatMessageList } from "@/components/chat/chat-message-list";
 import { ChatComposer } from "@/components/chat/chat-composer";
 import { MessageContent } from "@/components/chat/message-content";
@@ -98,6 +99,7 @@ export function ChatPanel() {
 
   const { data: llmModels = [] } = useLlmModels();
   const [inputValue, setInputValue] = useState("");
+  const [submitError, setSubmitError] = useState<string | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   const {
@@ -265,6 +267,7 @@ export function ChatPanel() {
 
   const submitMessage = async (controls?: Controls) => {
     if (!canSubmit) return;
+    setSubmitError(null);
 
     const parsedSystemCommand = hasImages
       ? null
@@ -299,6 +302,7 @@ export function ChatPanel() {
       setIsWaitingForResponse(true);
     } catch (error) {
       console.error("Failed to send message:", error);
+      setSubmitError(error instanceof Error ? error.message : "Failed to send message.");
     }
   };
 
@@ -363,6 +367,12 @@ export function ChatPanel() {
                 ) : null}
               </div>
             </div>
+          </div>
+        )}
+
+        {submitError && (
+          <div className="mt-4">
+            <ChatErrorAlert message={submitError} />
           </div>
         )}
 

--- a/apps/ui/src/lib/i18n.ts
+++ b/apps/ui/src/lib/i18n.ts
@@ -65,6 +65,10 @@ const messages = {
     expand_tool_activity: "Expand tool activity",
     collapse_activity_group: "Collapse activity group",
     expand_activity_group: "Expand activity group",
+    chat_error_title: "Something went wrong",
+    chat_error_description:
+      "Try sending your message again. If it keeps happening, share feedback so we can investigate.",
+    chat_error_fallback: "Message failed.",
     error_prefix: "Error: {value}",
     runtime_error_budget_exhausted_reached:
       "Budget exhausted. {spent} {currency} spent reached the {limit} {currency} limit. Increase the budget to continue.",
@@ -194,6 +198,10 @@ const messages = {
     expand_tool_activity: "Розгорнути активність інструментів",
     collapse_activity_group: "Згорнути групу активності",
     expand_activity_group: "Розгорнути групу активності",
+    chat_error_title: "Щось пішло не так",
+    chat_error_description:
+      "Спробуйте надіслати повідомлення ще раз. Якщо це повторюється, надішліть відгук, щоб ми могли дослідити проблему.",
+    chat_error_fallback: "Повідомлення не вдалося надіслати.",
     error_prefix: "Помилка: {value}",
     runtime_error_budget_exhausted_reached:
       "Бюджет вичерпано. Витрачено {spent} {currency}, що досягло ліміту {limit} {currency}. Збільште бюджет, щоб продовжити.",


### PR DESCRIPTION
## What
Adds a shared chat error alert and wires it into Session Chat and Platform Chat failure paths.

## Why
Chat failures were easy to miss or rendered as plain text. Users need a clear failure treatment with retry guidance and enough detail for investigation.

## How
- Adds `ChatErrorAlert` with summary and collapsible details.
- Includes `turn.failed` events in chat transcripts and clears active streaming state on failure.
- Renders runtime-error output messages and send/init failures through the same alert.
- Adds a dev gallery fixture at `/dev/chat-components` for visual review.
- Adds focused ChatPanel tests for failed turns and send failures.

## Risk
- Low
- What can break: chat transcript rendering for failure events, Platform Chat initialization error state, and localized chat error copy.

## Security
- Threat categories reviewed: TM-WEB.
- Findings and resolutions: no auth, authorization, API, tenant, database, filesystem, secret, or dependency surface changed. Error strings already delivered to the authenticated UI are rendered as React text, not HTML, so XSS risk is not introduced. Details are limited to event ids, turn ids, error codes, fields, and existing error text for debugging.

## Validation
- `CARGO_INCREMENTAL=0 just pre-push`
- `cd apps/ui && npm run build`
- `cd apps/ui && npm test -- --runTestsByPath src/__tests__/chat-panel.test.tsx src/__tests__/global-chat-page.test.tsx`
- Smoke screenshot: `/tmp/everruns-chat-error-screenshot.png` from `http://localhost:9120/dev/chat-components`

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
