### PR TITLE
chore(release): prepare v0.8.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- New changes go here. Use `/prepare-release X.Y.Z` to generate draft from commits. -->
 
+## [0.8.25] - 2026-05-04
+
+### Highlights
+
+- **App lifecycle deepens** - Apps gain configurable AG-UI thread expiration ([#1646](https://github.com/everruns/everruns/pull/1646)), per-app rate limits on the public AG-UI endpoint ([#1647](https://github.com/everruns/everruns/pull/1647)), app/channel-scoped budgets with periodic resets ([#1649](https://github.com/everruns/everruns/pull/1649)), session provenance tracking, and a guard that blocks deletion of app-backed entities so live channels stay consistent.
+- **Streaming output guardrails + prompt canary capability** - New core capability lets agents validate streaming output and surface prompt canaries for safer model interactions ([#1651](https://github.com/everruns/everruns/pull/1651)).
+- **Agent and harness usage stats** - UI now surfaces per-agent and per-harness usage counts so operators can see where activity actually concentrates.
+- **AG-UI public-endpoint hardening** - Public AG-UI errors are sanitized and now follow the defined public-endpoint contract ([#1645](https://github.com/everruns/everruns/pull/1645)), privileged message roles are rejected in AG-UI requests ([#1653](https://github.com/everruns/everruns/pull/1653)), and unsafe redirect URI schemes are rejected during MCP OAuth registration ([#1652](https://github.com/everruns/everruns/pull/1652)).
+- **bashkit bumped to v0.4.1 from crates.io** - Picks up the latest sandbox capabilities and hardening, and switches the dependency to crates.io ([#1650](https://github.com/everruns/everruns/pull/1650), [#1656](https://github.com/everruns/everruns/pull/1656)).
+
+### What's Changed
+
+- fix(ui): handle missing initial_files in agent and harness preview ([#1634](https://github.com/everruns/everruns/pull/1634)) by [@chaliy](https://github.com/chaliy)
+- fix(ui): improve app 404 resource states ([#1638](https://github.com/everruns/everruns/pull/1638)) by [@chaliy](https://github.com/chaliy)
+- fix(ui): add shared page layout shell and apply to models page ([#1635](https://github.com/everruns/everruns/pull/1635)) by [@chaliy](https://github.com/chaliy)
+- fix(ui): simplify organisations settings by [@chaliy](https://github.com/chaliy)
+- fix(ui): smooth cross-org entity links by [@chaliy](https://github.com/chaliy)
+- fix(api): add UI links to command outputs by [@chaliy](https://github.com/chaliy)
+- fix(worker): notify initial durable tasks via active backend by [@chaliy](https://github.com/chaliy)
+- test(mcp): add adversarial org-scope coverage by [@chaliy](https://github.com/chaliy)
+- fix(deletion): block deleting app-backed entities by [@chaliy](https://github.com/chaliy)
+- feat(ui): show agent and harness usage counts by [@chaliy](https://github.com/chaliy)
+- fix(core): cap infinity context prompt window by [@chaliy](https://github.com/chaliy)
+- feat(apps): add configurable AG-UI thread expiration ([#1646](https://github.com/everruns/everruns/pull/1646)) by [@chaliy](https://github.com/chaliy)
+- chore(deps): bump bashkit to v0.4.0 ([#1650](https://github.com/everruns/everruns/pull/1650)) by [@chaliy](https://github.com/chaliy)
+- fix(server): reject unsafe redirect URI schemes in MCP OAuth registration ([#1652](https://github.com/everruns/everruns/pull/1652)) by [@chaliy](https://github.com/chaliy)
+- fix(server): reject privileged message roles in AG-UI request body ([#1653](https://github.com/everruns/everruns/pull/1653)) by [@chaliy](https://github.com/chaliy)
+- fix(mcp): accept array and object flags in generated bashkit builtins ([#1654](https://github.com/everruns/everruns/pull/1654)) by [@chaliy](https://github.com/chaliy)
+- fix(ui): show display names in selects, never internal values ([#1648](https://github.com/everruns/everruns/pull/1648)) by [@chaliy](https://github.com/chaliy)
+- fix(server): sanitize AG-UI public errors + define public-endpoint contract ([#1645](https://github.com/everruns/everruns/pull/1645)) by [@chaliy](https://github.com/chaliy)
+- feat(ag-ui): configurable per-app rate limit on public endpoint ([#1647](https://github.com/everruns/everruns/pull/1647)) by [@chaliy](https://github.com/chaliy)
+- feat(budgets): app/channel scoped budgets with periodic resets ([#1649](https://github.com/everruns/everruns/pull/1649)) by [@chaliy](https://github.com/chaliy)
+- feat(stats): add agent and harness usage stats by [@chaliy](https://github.com/chaliy)
+- chore(deps): bump bashkit to v0.4.1 from crates.io ([#1656](https://github.com/everruns/everruns/pull/1656)) by [@chaliy](https://github.com/chaliy)
+- feat(apps): track app session provenance by [@chaliy](https://github.com/chaliy)
+- fix(ui): show chat error alerts by [@chaliy](https://github.com/chaliy)
+- feat(core): streaming output guardrails + prompt canary capability ([#1651](https://github.com/everruns/everruns/pull/1651)) by [@chaliy](https://github.com/chaliy)
+- refactor(ui): rebuild dev showcases with real components ([#1657](https://github.com/everruns/everruns/pull/1657)) by [@chaliy](https://github.com/chaliy)
+- chore(ship): validate migration ordering after rebase and pre-merge ([#1659](https://github.com/everruns/everruns/pull/1659)) by [@chaliy](https://github.com/chaliy)
+
 ## [0.8.24] - 2026-05-03
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -691,12 +691,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
-
-[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1369,9 +1363,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
  "const-oid 0.10.2",
@@ -1579,11 +1573,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-a2ui"
-version = "0.8.24"
+version = "0.8.25"
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1591,7 +1585,7 @@ dependencies = [
  "eventsource-stream",
  "everruns-core",
  "futures",
- "reqwest 0.13.2",
+ "reqwest 0.13.3",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -1602,7 +1596,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-cli"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "anyhow",
  "base64",
@@ -1615,7 +1609,7 @@ dependencies = [
  "hostname",
  "ignore",
  "notify",
- "reqwest 0.13.2",
+ "reqwest 0.13.3",
  "rustls",
  "serde",
  "serde_json",
@@ -1629,14 +1623,14 @@ dependencies = [
 
 [[package]]
 name = "everruns-config"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "everruns-container-sandbox"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "async-trait",
  "base64",
@@ -1644,7 +1638,7 @@ dependencies = [
  "everruns-core",
  "hex",
  "inventory",
- "reqwest 0.13.2",
+ "reqwest 0.13.3",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -1657,7 +1651,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1683,7 +1677,7 @@ dependencies = [
  "opentelemetry_sdk",
  "rand 0.9.4",
  "regex",
- "reqwest 0.13.2",
+ "reqwest 0.13.3",
  "rstest",
  "rustls",
  "serde",
@@ -1710,7 +1704,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-durable"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1745,14 +1739,14 @@ dependencies = [
 
 [[package]]
 name = "everruns-gemini"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
  "everruns-core",
  "futures",
- "reqwest 0.13.2",
+ "reqwest 0.13.3",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -1763,13 +1757,13 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-brave-search"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "async-trait",
  "chrono",
  "everruns-core",
  "inventory",
- "reqwest 0.13.2",
+ "reqwest 0.13.3",
  "serde",
  "serde_json",
  "tokio",
@@ -1779,7 +1773,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-browserless"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "async-trait",
  "base64",
@@ -1787,7 +1781,7 @@ dependencies = [
  "everruns-core",
  "futures-util",
  "inventory",
- "reqwest 0.13.2",
+ "reqwest 0.13.3",
  "rustls",
  "rustls-native-certs 0.8.3",
  "serde",
@@ -1800,13 +1794,13 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "async-trait",
  "chrono",
  "everruns-core",
  "inventory",
- "reqwest 0.13.2",
+ "reqwest 0.13.3",
  "serde",
  "serde_json",
  "tokio",
@@ -1816,7 +1810,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-deno"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "async-trait",
  "base64",
@@ -1826,7 +1820,7 @@ dependencies = [
  "hickory-resolver",
  "http",
  "inventory",
- "reqwest 0.13.2",
+ "reqwest 0.13.3",
  "rustls",
  "rustls-native-certs 0.8.3",
  "serde",
@@ -1840,7 +1834,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-docker"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "async-trait",
  "base64",
@@ -1855,12 +1849,12 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "async-trait",
  "everruns-core",
  "inventory",
- "reqwest 0.13.2",
+ "reqwest 0.13.3",
  "serde",
  "serde_json",
  "tokio",
@@ -1870,7 +1864,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-e2b"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1885,7 +1879,7 @@ dependencies = [
  "inventory",
  "prost",
  "protox",
- "reqwest 0.13.2",
+ "reqwest 0.13.3",
  "rustls",
  "rustls-native-certs 0.8.3",
  "serde",
@@ -1899,19 +1893,19 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-parallel"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "async-trait",
  "everruns-core",
  "inventory",
- "reqwest 0.13.2",
+ "reqwest 0.13.3",
  "serde_json",
  "tokio",
 ]
 
 [[package]]
 name = "everruns-integrations-pi"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1926,13 +1920,13 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-sprites"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "async-trait",
  "chrono",
  "everruns-core",
  "inventory",
- "reqwest 0.13.2",
+ "reqwest 0.13.3",
  "serde",
  "serde_json",
  "tokio",
@@ -1942,7 +1936,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-internal-protocol"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "chrono",
  "everruns-core",
@@ -1959,7 +1953,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-macros"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1969,7 +1963,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1979,7 +1973,7 @@ dependencies = [
  "everruns-core",
  "futures",
  "inventory",
- "reqwest 0.13.2",
+ "reqwest 0.13.3",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -1991,11 +1985,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-openui"
-version = "0.8.24"
+version = "0.8.25"
 
 [[package]]
 name = "everruns-runtime"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2029,7 +2023,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-server"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "aes-gcm",
  "ag-ui-core",
@@ -2085,7 +2079,7 @@ dependencies = [
  "prost-types",
  "rand 0.9.4",
  "regex",
- "reqwest 0.13.2",
+ "reqwest 0.13.3",
  "serde",
  "serde_html_form",
  "serde_json",
@@ -2113,7 +2107,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-session-sqldb"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2132,7 +2126,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-worker"
-version = "0.8.24"
+version = "0.8.25"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2160,7 +2154,7 @@ dependencies = [
  "futures",
  "hex",
  "prost-types",
- "reqwest 0.13.2",
+ "reqwest 0.13.3",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -2256,7 +2250,7 @@ dependencies = [
  "ed25519-dalek",
  "futures",
  "rand 0.8.6",
- "reqwest 0.13.2",
+ "reqwest 0.13.3",
  "schemars",
  "serde",
  "serde_json",
@@ -2673,9 +2667,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2766,9 +2760,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hickory-net"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c61c8db47fae51ba9f8f2a2748bd87542acfbe22f2ec9cf9c8ec72d1ee6e9a6"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -2779,7 +2773,7 @@ dependencies = [
  "hickory-proto",
  "idna",
  "ipnet",
- "jni 0.22.4",
+ "jni",
  "rand 0.10.1",
  "thiserror 2.0.18",
  "tinyvec",
@@ -2790,14 +2784,14 @@ dependencies = [
 
 [[package]]
 name = "hickory-proto"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a916d0494600d99ecb15aadfab677ad97c4de559e8f1af0c129353a733ac1fcc"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
 dependencies = [
  "data-encoding",
  "idna",
  "ipnet",
- "jni 0.22.4",
+ "jni",
  "once_cell",
  "prefix-trie",
  "rand 0.10.1",
@@ -2810,9 +2804,9 @@ dependencies = [
 
 [[package]]
 name = "hickory-resolver"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a10bd64d950b4d38ca21e25c8ae230712e4955fb8290cfcb29a5e5dc6017e544"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2820,7 +2814,7 @@ dependencies = [
  "hickory-proto",
  "ipconfig",
  "ipnet",
- "jni 0.22.4",
+ "jni",
  "moka",
  "ndk-context",
  "once_cell",
@@ -2864,7 +2858,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3163,9 +3157,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -3477,22 +3471,6 @@ dependencies = [
 
 [[package]]
 name = "jni"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
-dependencies = [
- "cesu8",
- "cfg-if",
- "combine",
- "jni-sys 0.3.1",
- "log",
- "thiserror 1.0.69",
- "walkdir",
- "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "jni"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
@@ -3500,7 +3478,7 @@ dependencies = [
  "cfg-if",
  "combine",
  "jni-macros",
- "jni-sys 0.4.1",
+ "jni-sys",
  "log",
  "simd_cesu8",
  "thiserror 2.0.18",
@@ -3519,15 +3497,6 @@ dependencies = [
  "rustc_version",
  "simd_cesu8",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "jni-sys"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
-dependencies = [
- "jni-sys 0.4.1",
 ]
 
 [[package]]
@@ -3561,9 +3530,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -3611,11 +3580,11 @@ dependencies = [
 
 [[package]]
 name = "kqueue-sys"
-version = "1.0.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+checksum = "a7b65860415f949f23fa882e669f2dbd4a0f0eeb1acdd56790b30494afd7da2f"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.11.1",
  "libc",
 ]
 
@@ -3675,7 +3644,7 @@ dependencies = [
  "bitflags 2.11.1",
  "libc",
  "plain",
- "redox_syscall 0.7.4",
+ "redox_syscall 0.7.5",
 ]
 
 [[package]]
@@ -3757,7 +3726,7 @@ dependencies = [
  "rand 0.9.4",
  "rand_distr",
  "ratatui",
- "reqwest 0.13.2",
+ "reqwest 0.13.3",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -3877,7 +3846,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
  "cfg-if",
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3909,12 +3878,12 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.24.3"
+version = "0.24.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d5312e9ba3771cfa961b585728215e3d972c950a3eed9252aa093d6301277e8"
+checksum = "ff56c2e7dce6bd462e3b8919986a617027481b1dcc703175b58cf9dd98a2f071"
 dependencies = [
- "ahash",
  "portable-atomic",
+ "rapidhash",
 ]
 
 [[package]]
@@ -4362,15 +4331,14 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.78"
+version = "0.10.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
+checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -4400,9 +4368,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.114"
+version = "0.9.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
+checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
 dependencies = [
  "cc",
  "libc",
@@ -4795,9 +4763,9 @@ dependencies = [
 
 [[package]]
 name = "prefix-trie"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23370be78b7e5bcbb0cab4a02047eb040279a693c78daad04c2c5f1c24a83503"
+checksum = "90f561214012d3fc240a1f9c817cc4d57f5310910d066069c1b093f766bb5966"
 dependencies = [
  "either",
  "ipnet",
@@ -5144,6 +5112,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rapidhash"
+version = "4.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "ratatui"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5282,9 +5259,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
+checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
 dependencies = [
  "bitflags 2.11.1",
 ]
@@ -5407,9 +5384,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
 dependencies = [
  "base64",
  "bytes",
@@ -5587,9 +5564,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.39"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -5647,13 +5624,13 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
- "jni 0.21.1",
+ "jni",
  "log",
  "once_cell",
  "rustls",
@@ -5964,7 +5941,7 @@ checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -5992,7 +5969,7 @@ checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -6111,9 +6088,9 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "sketches-ddsketch"
@@ -6784,9 +6761,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
 dependencies = [
  "bytes",
  "libc",
@@ -7574,9 +7551,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -7587,9 +7564,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -7597,9 +7574,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -7607,9 +7584,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -7620,9 +7597,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
 dependencies = [
  "unicode-ident",
 ]
@@ -7689,9 +7666,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -7714,7 +7691,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fc95580916af1e68ff6a7be07446fc5db73ebf71cf092de939bbf5f7e189f72"
 dependencies = [
  "core-foundation 0.10.1",
- "jni 0.22.4",
+ "jni",
  "log",
  "ndk-context",
  "objc2",
@@ -8042,15 +8019,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -8083,21 +8051,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -8159,12 +8112,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -8183,12 +8130,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -8204,12 +8145,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -8243,12 +8178,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -8264,12 +8193,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -8291,12 +8214,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -8312,12 +8229,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.8.24"
+version = "0.8.25"
 edition = "2024"
 license = "MIT"
 authors = ["Everruns Contributors"]

--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "everruns-ui",
-  "version": "0.8.24",
+  "version": "0.8.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "everruns-ui",
-      "version": "0.8.24",
+      "version": "0.8.25",
       "dependencies": {
         "@base-ui/react": "^1.2.0",
         "@openuidev/react-lang": "^0.1.3",

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "everruns-ui",
-  "version": "0.8.24",
+  "version": "0.8.25",
   "private": true,
   "exports": {
     "./route-manifest": "./src/lib/ui-route-manifest.ts",


### PR DESCRIPTION
## Release v0.8.25

This PR prepares the v0.8.25 release.

### Highlights

- **App lifecycle deepens** - Apps gain configurable AG-UI thread expiration (#1646), per-app rate limits on the public AG-UI endpoint (#1647), app/channel-scoped budgets with periodic resets (#1649), session provenance tracking, and a guard that blocks deletion of app-backed entities so live channels stay consistent.
- **Streaming output guardrails + prompt canary capability** - New core capability lets agents validate streaming output and surface prompt canaries for safer model interactions (#1651).
- **Agent and harness usage stats** - UI now surfaces per-agent and per-harness usage counts so operators can see where activity actually concentrates.
- **AG-UI public-endpoint hardening** - Public AG-UI errors are sanitized and now follow the defined public-endpoint contract (#1645), privileged message roles are rejected in AG-UI requests (#1653), and unsafe redirect URI schemes are rejected during MCP OAuth registration (#1652).
- **bashkit bumped to v0.4.1 from crates.io** - Picks up the latest sandbox capabilities and hardening, and switches the dependency to crates.io (#1650, #1656).

### Checklist
- [ ] Review CHANGELOG.md entries
- [ ] Add highlights/screenshots if needed
- [ ] Verify version numbers updated
- [ ] CI passes

### Post-merge
After merging, the release workflow will automatically:
- Create git tag `v0.8.25`
- Create GitHub Release with notes from CHANGELOG.md
- Trigger Docker image build with version tag
