### PR TITLE
chore(release): tighten highlights guidance for maintenance releases

### DIFF
--- a/.agents/commands/prepare-release.md
+++ b/.agents/commands/prepare-release.md
@@ -33,10 +33,11 @@ See `specs/release-process.md` for the full release process specification.
    ```
 
 3. **Analyze commits and suggest highlights**:
-   - Review the commit list and identify the 3-5 most impactful **user-facing** features and changes
+   - Review the commit list and identify only the genuinely impactful **user-facing** features and changes
    - Prioritize: new capabilities users can interact with, new integrations, significant UX improvements, security/reliability improvements that affect users
-   - Deprioritize: internal refactors, CI changes, spec/docs updates, test additions (unless they enable a user-facing feature)
-   - Present the commit list and your suggested highlights to the user
+   - Exclude: internal refactors, CI changes, dependency bumps, spec/docs updates, test additions, minor fixes (unless they directly resolve a user-visible regression)
+   - Do not pad the list to hit a target count. Maintenance releases (mostly fixes and internal work) may have one or two highlights, or none at all — in which case omit the Highlights section entirely
+   - Present the commit list and your suggested highlights (or a recommendation to skip the section) to the user
    - Ask the user to confirm, adjust, or replace the highlights
    - Note: Add markdown links for PRs `([#123](url))` and usernames `[@user](url))`
 
@@ -136,7 +137,7 @@ See `specs/release-process.md` for the full release process specification.
 ## Notes
 
 - Always preserve the CHANGELOG.md header and versioning policy section
-- The Highlights section is optional but recommended for minor/major releases
+- The Highlights section is optional. Recommended for minor/major releases that ship genuinely noteworthy user-facing changes; omit entirely for maintenance releases
 - Include screenshots for UI changes (can be added as links in CHANGELOG.md)
 - Do not add a "Migration Notes" section to release entries unless it is necessary for user-facing upgrade guidance
 - The `chore(release): prepare vX.Y.Z` commit message triggers auto-tagging on merge

--- a/.agents/commands/prepare-release.md
+++ b/.agents/commands/prepare-release.md
@@ -39,7 +39,7 @@ See `specs/release-process.md` for the full release process specification.
    - Do not pad the list to hit a target count. Maintenance releases (mostly fixes and internal work) may have one or two highlights, or none at all — in which case omit the Highlights section entirely
    - Present the commit list and your suggested highlights (or a recommendation to skip the section) to the user
    - Ask the user to confirm, adjust, or replace the highlights
-   - Note: Add markdown links for PRs `([#123](url))` and usernames `[@user](url))`
+   - Note: Add markdown links for PRs `([#123](url))` and usernames `[@user](url)`
 
 4. **After user approval**, update these files:
 

--- a/specs/release-process.md
+++ b/specs/release-process.md
@@ -22,7 +22,7 @@ Release readiness also includes the integration backstops that are intentionally
 1. CHANGELOG.md is the canonical source for release notes
 2. GitHub Release notes are extracted from the corresponding version section in CHANGELOG.md
 3. Each version section includes:
-   - **Highlights** - Key features (user-written, 5-10 items with PR links)
+   - **Highlights** - Significant user-facing features and changes (user-written, with PR links). Include only items that are genuinely noteworthy on their own. Do not pad the list to hit a target count: maintenance releases may have few highlights, or omit the section entirely. Internal refactors, CI changes, dependency bumps, spec/docs updates, and minor fixes belong in **What's Changed**, not here.
    - **What's Changed** - List of commits: `- <message> ([#PR](url))`
 
 Release notes should not normally include a dedicated "Migration Notes" section. Migration-specific engineering detail belongs in the migration files and migration spec, which remain the source of truth for upgrade and database-migration behavior. If a release has any operator-visible migration caveat, compatibility limitation, or exceptional upgrade requirement, call it out explicitly in the release PR and release notes.

--- a/specs/release-process.md
+++ b/specs/release-process.md
@@ -21,9 +21,9 @@ Release readiness also includes the integration backstops that are intentionally
 
 1. CHANGELOG.md is the canonical source for release notes
 2. GitHub Release notes are extracted from the corresponding version section in CHANGELOG.md
-3. Each version section includes:
-   - **Highlights** - Significant user-facing features and changes (user-written, with PR links). Include only items that are genuinely noteworthy on their own. Do not pad the list to hit a target count: maintenance releases may have few highlights, or omit the section entirely. Internal refactors, CI changes, dependency bumps, spec/docs updates, and minor fixes belong in **What's Changed**, not here.
-   - **What's Changed** - List of commits: `- <message> ([#PR](url))`
+3. Each version section contains:
+   - **What's Changed** (required) - List of commits: `- <message> ([#PR](url))`
+   - **Highlights** (optional) - Significant user-facing features and changes (user-written, with PR links). Include only items that are genuinely noteworthy on their own. Do not pad the list to hit a target count: maintenance releases may have few highlights, or omit the section entirely. Internal refactors, CI changes, dependency bumps, spec/docs updates, and minor fixes belong in **What's Changed**, not here.
 
 Release notes should not normally include a dedicated "Migration Notes" section. Migration-specific engineering detail belongs in the migration files and migration spec, which remain the source of truth for upgrade and database-migration behavior. If a release has any operator-visible migration caveat, compatibility limitation, or exceptional upgrade requirement, call it out explicitly in the release PR and release notes.
 


### PR DESCRIPTION
## What
Tighten the Highlights contract in the release spec and the `/prepare-release` command so that maintenance releases don't get padded with insignificant items.

- `specs/release-process.md`: Drop the "5-10 items" floor. Highlights are now defined as significant user-facing changes only, with explicit permission to keep the section short or omit it entirely. Internal refactors, CI changes, dependency bumps, spec/docs updates, and minor fixes are explicitly redirected to **What's Changed**.
- `.agents/commands/prepare-release.md`: Drop "3-5 most impactful" target, expand the exclusion list, and instruct the agent to recommend skipping Highlights for maintenance releases instead of padding the list.

## Why
Current guidance pushed the agent to find 5-10 highlights for every release. For maintenance releases (mostly fixes and internal work) that means surfacing trivia as "highlights", which dilutes the section and misleads readers about what actually shipped.

## How
Two text-only edits to the spec and the command. No code, no configuration, no runtime behavior change.

## Risk
- Low.
- Affects how future release PRs are drafted by the agent. Reviewers always have final say on CHANGELOG content.

## Security
- Threat categories reviewed: No security-relevant code changes — docs/spec-only edits with no code, configuration, or infrastructure surface.
- Findings and resolutions: None.

## Checklist
- [x] Tests added or updated — N/A (docs-only)
- [x] Backward compatibility considered — N/A (guidance change)
- [x] Security review performed against relevant threat model categories
- [ ] All review comments addressed (code change or written reasoning)


---
_Generated by [Claude Code](https://claude.ai/code/session_017upd8iUw38H7hxr5HysEqN)_