### PR TITLE
feat(ui): group models by enabled, sort by recency, surface release date

### DIFF
--- a/apps/ui/src/__tests__/models-page.test.tsx
+++ b/apps/ui/src/__tests__/models-page.test.tsx
@@ -127,7 +127,98 @@ describe("ModelsPage", () => {
     render(<ModelsPage />, { wrapper });
 
     expect(screen.getAllByText("GPT-4").length).toBeGreaterThanOrEqual(1);
-    expect(screen.getByText("gpt-5.2 - OpenAI Production")).toBeInTheDocument();
+    expect(screen.getByText(/gpt-5\.2 - OpenAI Production/)).toBeInTheDocument();
+  });
+
+  it("groups models into Enabled and Available sections", () => {
+    mockUseLlmModels.mockReturnValue({
+      data: [
+        ...mockModels,
+        {
+          id: "model-2",
+          model_id: "gpt-3.5-turbo",
+          display_name: "GPT-3.5",
+          provider_id: "provider-1",
+          provider_name: "OpenAI Production",
+          provider_type: "openai",
+          status: "active",
+          enabled: false,
+          capabilities: ["chat"],
+          created_at: "2024-01-01T00:00:00Z",
+          updated_at: "2024-01-01T00:00:00Z",
+        },
+      ],
+      isLoading: false,
+      error: null,
+    });
+
+    render(<ModelsPage />, { wrapper });
+
+    expect(screen.getByRole("heading", { name: "Enabled models" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Available models" })).toBeInTheDocument();
+  });
+
+  it("sorts models within a section by release date descending", () => {
+    mockUseLlmModels.mockReturnValue({
+      data: [
+        {
+          id: "older",
+          model_id: "gpt-4",
+          display_name: "GPT-4 Older",
+          provider_id: "provider-1",
+          provider_name: "OpenAI Production",
+          provider_type: "openai",
+          status: "active",
+          enabled: true,
+          capabilities: [],
+          created_at: "2024-01-01T00:00:00Z",
+          updated_at: "2024-01-01T00:00:00Z",
+          profile: {
+            name: "GPT-4 Older",
+            family: "gpt-4",
+            attachment: false,
+            reasoning: false,
+            temperature: true,
+            tool_call: true,
+            structured_output: true,
+            open_weights: false,
+            release_date: "2024-01-01",
+          },
+        },
+        {
+          id: "newer",
+          model_id: "gpt-4.1",
+          display_name: "GPT-4.1 Newer",
+          provider_id: "provider-1",
+          provider_name: "OpenAI Production",
+          provider_type: "openai",
+          status: "active",
+          enabled: true,
+          capabilities: [],
+          created_at: "2024-01-01T00:00:00Z",
+          updated_at: "2024-01-01T00:00:00Z",
+          profile: {
+            name: "GPT-4.1 Newer",
+            family: "gpt-4.1",
+            attachment: false,
+            reasoning: false,
+            temperature: true,
+            tool_call: true,
+            structured_output: true,
+            open_weights: false,
+            release_date: "2025-04-14",
+          },
+        },
+      ],
+      isLoading: false,
+      error: null,
+    });
+
+    render(<ModelsPage />, { wrapper });
+
+    const newer = screen.getByText("GPT-4.1 Newer");
+    const older = screen.getByText("GPT-4 Older");
+    expect(newer.compareDocumentPosition(older) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
   it("shows empty state when no models exist", () => {

--- a/apps/ui/src/__tests__/models-page.test.tsx
+++ b/apps/ui/src/__tests__/models-page.test.tsx
@@ -221,6 +221,104 @@ describe("ModelsPage", () => {
     expect(newer.compareDocumentPosition(older) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
+  it("places models without a release_date below dated models in the same section", () => {
+    const baseModel = {
+      provider_id: "provider-1",
+      provider_name: "OpenAI Production",
+      provider_type: "openai" as const,
+      status: "active" as const,
+      enabled: true,
+      capabilities: [],
+      created_at: "2024-01-01T00:00:00Z",
+      updated_at: "2024-01-01T00:00:00Z",
+    };
+    const baseProfile = {
+      family: "gpt",
+      attachment: false,
+      reasoning: false,
+      temperature: true,
+      tool_call: true,
+      structured_output: true,
+      open_weights: false,
+    };
+    mockUseLlmModels.mockReturnValue({
+      data: [
+        {
+          ...baseModel,
+          id: "undated",
+          model_id: "gpt-undated",
+          display_name: "GPT Undated",
+          profile: { ...baseProfile, name: "GPT Undated" },
+        },
+        {
+          ...baseModel,
+          id: "dated",
+          model_id: "gpt-dated",
+          display_name: "GPT Dated",
+          profile: { ...baseProfile, name: "GPT Dated", release_date: "2024-01-01" },
+        },
+      ],
+      isLoading: false,
+      error: null,
+    });
+
+    render(<ModelsPage />, { wrapper });
+
+    const dated = screen.getByText("GPT Dated");
+    const undated = screen.getByText("GPT Undated");
+    expect(dated.compareDocumentPosition(undated) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it("breaks release_date ties using created_at descending", () => {
+    const baseModel = {
+      provider_id: "provider-1",
+      provider_name: "OpenAI Production",
+      provider_type: "openai" as const,
+      status: "active" as const,
+      enabled: true,
+      capabilities: [],
+      updated_at: "2024-01-01T00:00:00Z",
+    };
+    const baseProfile = {
+      family: "gpt",
+      attachment: false,
+      reasoning: false,
+      temperature: true,
+      tool_call: true,
+      structured_output: true,
+      open_weights: false,
+      release_date: "2025-04-14",
+    };
+    mockUseLlmModels.mockReturnValue({
+      data: [
+        {
+          ...baseModel,
+          id: "added-first",
+          model_id: "gpt-a",
+          display_name: "GPT Added First",
+          created_at: "2024-01-01T00:00:00Z",
+          profile: { ...baseProfile, name: "GPT Added First" },
+        },
+        {
+          ...baseModel,
+          id: "added-later",
+          model_id: "gpt-b",
+          display_name: "GPT Added Later",
+          created_at: "2024-06-01T00:00:00Z",
+          profile: { ...baseProfile, name: "GPT Added Later" },
+        },
+      ],
+      isLoading: false,
+      error: null,
+    });
+
+    render(<ModelsPage />, { wrapper });
+
+    const later = screen.getByText("GPT Added Later");
+    const first = screen.getByText("GPT Added First");
+    expect(later.compareDocumentPosition(first) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
   it("shows empty state when no models exist", () => {
     mockUseLlmModels.mockReturnValue({
       data: [],

--- a/apps/ui/src/app/(main)/models/page.tsx
+++ b/apps/ui/src/app/(main)/models/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { Cpu, Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -22,6 +22,18 @@ import { useLlmModels, useLlmProviders, useDeleteLlmModel } from "@/hooks/use-ll
 import { useOrganization, useUpdateOrganization } from "@/hooks/use-organizations";
 import { updateLlmModel } from "@/lib/api/llm-providers";
 import { queryKeys } from "@/lib/query-keys";
+import type { LlmModelWithProvider } from "@/lib/api/types";
+
+// Order models by release date desc (newest first), then by created_at desc.
+// Models without a release_date in their profile fall to the bottom; this works
+// uniformly across providers because release_date comes from the shared
+// models.dev profile.
+function compareByRecency(a: LlmModelWithProvider, b: LlmModelWithProvider): number {
+  const aDate = a.profile?.release_date ?? "";
+  const bDate = b.profile?.release_date ?? "";
+  if (aDate !== bDate) return bDate.localeCompare(aDate);
+  return (b.created_at ?? "").localeCompare(a.created_at ?? "");
+}
 
 export default function ModelsPage() {
   const queryClient = useQueryClient();
@@ -33,7 +45,11 @@ export default function ModelsPage() {
   const [addModelOpen, setAddModelOpen] = useState(false);
   const [togglingModelId, setTogglingModelId] = useState<string | null>(null);
 
-  const enabledModels = models.filter((model) => model.enabled);
+  const { enabledModels, availableModels } = useMemo(() => {
+    const enabled = models.filter((m) => m.enabled).sort(compareByRecency);
+    const available = models.filter((m) => !m.enabled).sort(compareByRecency);
+    return { enabledModels: enabled, availableModels: available };
+  }, [models]);
   const selectedDefaultModelName = org?.default_model_id
     ? (enabledModels.find((model) => model.id === org.default_model_id)?.display_name ??
       "Unknown model")
@@ -106,16 +122,54 @@ export default function ModelsPage() {
               )}
             </Card>
           ) : (
-            <div className="space-y-2">
-              {models.map((model) => (
-                <ModelRow
-                  key={model.id}
-                  model={model}
-                  onDelete={handleDeleteModel}
-                  onToggleEnabled={handleToggleEnabled}
-                  isTogglingEnabled={togglingModelId === model.id}
-                />
-              ))}
+            <div className="space-y-8">
+              {enabledModels.length > 0 && (
+                <div>
+                  <div className="flex items-center justify-between mb-3">
+                    <h2 className="text-xl font-semibold">Enabled models</h2>
+                    <span className="text-sm text-muted-foreground">
+                      {enabledModels.length} enabled
+                    </span>
+                  </div>
+                  <div className="space-y-2">
+                    {enabledModels.map((model) => (
+                      <ModelRow
+                        key={model.id}
+                        model={model}
+                        onDelete={handleDeleteModel}
+                        onToggleEnabled={handleToggleEnabled}
+                        isTogglingEnabled={togglingModelId === model.id}
+                      />
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {enabledModels.length > 0 && availableModels.length > 0 && (
+                <hr className="border-border" />
+              )}
+
+              {availableModels.length > 0 && (
+                <div>
+                  <div className="flex items-center justify-between mb-3">
+                    <h2 className="text-xl font-semibold">Available models</h2>
+                    <span className="text-sm text-muted-foreground">
+                      Enable a model to use it with agents
+                    </span>
+                  </div>
+                  <div className="space-y-2">
+                    {availableModels.map((model) => (
+                      <ModelRow
+                        key={model.id}
+                        model={model}
+                        onDelete={handleDeleteModel}
+                        onToggleEnabled={handleToggleEnabled}
+                        isTogglingEnabled={togglingModelId === model.id}
+                      />
+                    ))}
+                  </div>
+                </div>
+              )}
             </div>
           )}
         </section>

--- a/apps/ui/src/components/models/model-row.tsx
+++ b/apps/ui/src/components/models/model-row.tsx
@@ -31,6 +31,21 @@ function formatCost(cost: number): string {
 }
 
 function formatReleaseDate(value: string): string {
+  // Profile release dates are documented as YYYY-MM-DD. `new Date(value)` would
+  // parse that form as UTC midnight, which renders as the previous calendar day
+  // for users west of UTC — parse the components as a local date instead.
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (match) {
+    const [, y, m, d] = match;
+    const local = new Date(Number(y), Number(m) - 1, Number(d));
+    if (!Number.isNaN(local.getTime())) {
+      return local.toLocaleDateString(undefined, {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+      });
+    }
+  }
   const parsed = new Date(value);
   if (Number.isNaN(parsed.getTime())) return value;
   return parsed.toLocaleDateString(undefined, {

--- a/apps/ui/src/components/models/model-row.tsx
+++ b/apps/ui/src/components/models/model-row.tsx
@@ -30,6 +30,16 @@ function formatCost(cost: number): string {
   return `$${cost.toFixed(3)}`;
 }
 
+function formatReleaseDate(value: string): string {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return value;
+  return parsed.toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
 export function ModelRow({
   model,
   onDelete,
@@ -76,6 +86,14 @@ export function ModelRow({
             </div>
             <div className="text-sm text-muted-foreground">
               {model.model_id} - {model.provider_name}
+              {profile?.release_date && (
+                <>
+                  {" · "}
+                  <span title={`Released ${profile.release_date}`}>
+                    Released {formatReleaseDate(profile.release_date)}
+                  </span>
+                </>
+              )}
             </div>
           </div>
         </div>


### PR DESCRIPTION
## What
Redesign the Models page so newer and enabled models are easier to find:

- Split the list into two sections — **Enabled models** and **Available models** — separated by a divider, mirroring the Agents page treatment of example agents.
- Sort each section by `profile.release_date` desc (then `created_at`), so newer releases like `gpt-4.1-2025-04-14` appear above older ones. Models without `release_date` fall to the bottom.
- Surface the release date inline on each row (e.g. `gpt-4.1-2025-04-14 - OpenAI · Released Apr 14, 2025`) so users no longer need to expand a row to see when a model shipped.

## Why
The previous Models page rendered every model — enabled and disabled — in one undifferentiated list, with no grouping and no recency ordering. With many providers and dated model variants (`gpt-4.1` vs `gpt-4.1-2025-04-14`, dated and undated `mini` / `nano`, etc.), users had to scan the whole list to find the latest. Release dates were already in the profile but only visible after expanding a row.

## How
Sorting and grouping is done in `apps/ui/src/app/(main)/models/page.tsx` against the existing `useLlmModels()` payload — it works uniformly for all providers because the recency key (`release_date`) comes from the shared models.dev profile attached server-side.

`apps/ui/src/components/models/model-row.tsx` adds a small inline `Released <localized date>` segment after the existing `model_id - provider_name` line whenever `profile.release_date` is present. Falls back gracefully when missing.

## Risk
- Low.
- Pure UI: no API surface, no schema, no backend, no data fetching changes. Sorting/grouping is client-side over the same payload that already drives the page.

## Security
- Threat categories reviewed: TM-WEB. No other categories touched (no auth, no API, no tenant queries, no tool/LLM/sandbox surface, no new dependencies).
- Findings and resolutions:
  - `release_date`, `display_name`, `model_id` are rendered as React children (text), not via `dangerouslySetInnerHTML` — no XSS surface introduced.
  - `formatReleaseDate` parses with `new Date(value)` and falls back to the original string on `NaN`. The original string is also placed in the `title` attribute (HTML-attribute-escaped by React).
  - No new external links, no new dependencies, no env / config changes, no THREAT comments touched.

## Checklist
- [x] Tests added or updated (group sections + recency sort cases in `apps/ui/src/__tests__/models-page.test.tsx`)
- [x] Backward compatibility considered (UI-only)
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_012WQJWxHSTqMEjrDeLevtut)_