### PR TITLE
fix(billing): omit event_id FK for ephemeral llm.generation events

### DIFF
--- a/crates/core/src/events.rs
+++ b/crates/core/src/events.rs
@@ -68,6 +68,16 @@ pub const TOOL_CALL_REQUESTED: &str = "tool.call_requested";
 // LLM events
 pub const LLM_GENERATION: &str = "llm.generation";
 
+/// Single source of truth for which event types are ephemeral. Both
+/// `EventRequest::is_ephemeral` and `Event::is_ephemeral` delegate here so the
+/// match set cannot drift between the input and persisted forms.
+fn is_ephemeral_event_type(event_type: &str) -> bool {
+    matches!(
+        event_type,
+        OUTPUT_MESSAGE_DELTA | REASON_THINKING_DELTA | TOOL_OUTPUT_DELTA | LLM_GENERATION
+    )
+}
+
 // Reasoning/thinking events (extended thinking from models like Claude)
 pub const REASON_THINKING_STARTED: &str = "reason.thinking.started";
 pub const REASON_THINKING_DELTA: &str = "reason.thinking.delta";
@@ -361,14 +371,10 @@ impl Event {
     /// downstream storage that holds an FK to `events.id` must treat the
     /// reference as best-effort and skip it for ephemeral sources.
     ///
-    /// See [`EventRequest::is_ephemeral`] for the canonical match set; this
-    /// mirror exists so listeners holding `Event` (post-construction) can ask
-    /// the same question without rebuilding a request.
+    /// Mirror of [`EventRequest::is_ephemeral`]; both delegate to
+    /// `is_ephemeral_event_type` so the match set stays in lockstep.
     pub fn is_ephemeral(&self) -> bool {
-        matches!(
-            self.event_type.as_str(),
-            OUTPUT_MESSAGE_DELTA | REASON_THINKING_DELTA | TOOL_OUTPUT_DELTA | LLM_GENERATION
-        )
+        is_ephemeral_event_type(&self.event_type)
     }
 
     /// Check if this is an input event
@@ -2248,10 +2254,7 @@ impl EventRequest {
     /// (e.g. `output.message.completed` has the full text), so missing a delta
     /// on reconnect is acceptable.
     pub fn is_ephemeral(&self) -> bool {
-        matches!(
-            self.event_type.as_str(),
-            OUTPUT_MESSAGE_DELTA | REASON_THINKING_DELTA | TOOL_OUTPUT_DELTA | LLM_GENERATION
-        )
+        is_ephemeral_event_type(&self.event_type)
     }
 
     /// Convert to an Event with the given id and sequence

--- a/crates/core/src/events.rs
+++ b/crates/core/src/events.rs
@@ -356,6 +356,21 @@ impl Event {
         self.event_type == INPUT_MESSAGE || self.event_type == OUTPUT_MESSAGE_COMPLETED
     }
 
+    /// Whether this event is ephemeral. Ephemeral events may be delivered to
+    /// listeners without ever being inserted into the `events` table, so any
+    /// downstream storage that holds an FK to `events.id` must treat the
+    /// reference as best-effort and skip it for ephemeral sources.
+    ///
+    /// See [`EventRequest::is_ephemeral`] for the canonical match set; this
+    /// mirror exists so listeners holding `Event` (post-construction) can ask
+    /// the same question without rebuilding a request.
+    pub fn is_ephemeral(&self) -> bool {
+        matches!(
+            self.event_type.as_str(),
+            OUTPUT_MESSAGE_DELTA | REASON_THINKING_DELTA | TOOL_OUTPUT_DELTA | LLM_GENERATION
+        )
+    }
+
     /// Check if this is an input event
     pub fn is_input_event(&self) -> bool {
         self.event_type.starts_with("input.")

--- a/crates/server/src/domains/budgets/service.rs
+++ b/crates/server/src/domains/budgets/service.rs
@@ -289,6 +289,12 @@ impl BudgetService {
         }
 
         let total_tokens = input_tokens + output_tokens;
+        // Ephemeral events (e.g. `llm.generation`) may not be persisted to the
+        // `events` table when the ephemeral-skip delivery path is active (NATS),
+        // so storing their id in `usage_journal.event_id` would violate the FK.
+        // The public id is still preserved via `source_type`/`source_id` for
+        // traceability — `event_id` is the durable FK reference only.
+        let event_id = (!event.is_ephemeral()).then(|| event.id.uuid());
         let journal = match self
             .db
             .create_usage_journal_entry(CreateUsageJournalRow {
@@ -296,7 +302,7 @@ impl BudgetService {
                 kind: "llm_generation".to_string(),
                 source_type: Some("event".to_string()),
                 source_id: Some(event.id.to_string()),
-                event_id: Some(event.id.uuid()),
+                event_id,
                 session_id: scope.session_id,
                 turn_id: event.context.turn_id.as_ref().map(|id| id.uuid()),
                 user_id: scope.user_id,

--- a/crates/server/src/domains/budgets/tests.rs
+++ b/crates/server/src/domains/budgets/tests.rs
@@ -6,7 +6,9 @@
 use crate::domains::budgets::BudgetService;
 use crate::storage::StorageBackend;
 use crate::storage::models::*;
+use everruns_core::EventListener;
 use everruns_core::budget::BudgetAction;
+use everruns_core::events::{Event, EventContext, LlmGenerationData, TokenUsage};
 use everruns_core::{AgentId, PrincipalId, org_public_id_from_internal};
 use std::sync::Arc;
 use uuid::Uuid;
@@ -1181,4 +1183,84 @@ fn test_row_to_ledger_entry_dto() {
     assert_eq!(dto.amount, 5.5);
     assert_eq!(dto.meter_source, "llm_tokens");
     assert_eq!(dto.description, Some("test".into()));
+}
+
+// ========================================================================
+// Listener: ephemeral llm.generation event journaling (regression: EVE-416)
+// ========================================================================
+
+#[tokio::test]
+async fn test_llm_generation_listener_omits_event_id_for_ephemeral_events() {
+    // Regression for EVE-416: `llm.generation` is ephemeral and may skip the
+    // `events` table insert when NATS-backed delivery is active. The budget
+    // listener used to write `usage_journal.event_id = <ephemeral event id>`,
+    // which violated the FK on `events(id)`. The listener must now omit the
+    // FK reference for ephemeral source events while still journaling the
+    // generation. The public id is preserved via `source_type`/`source_id`.
+    let db = make_db();
+    let svc = BudgetService::new(db.clone());
+
+    let session = create_session_with_owner(&db, 1, None, None).await;
+    let session_id = session.id;
+    let session_subject_id = session_id.to_string();
+
+    let budget = db
+        .create_budget(CreateBudgetRow {
+            org_id: session.org_id,
+            subject_type: "session".into(),
+            subject_id: session_subject_id.clone(),
+            currency: "tokens".into(),
+            limit: 10_000.0,
+            soft_limit: None,
+            period: None,
+            metadata: None,
+        })
+        .await
+        .unwrap();
+
+    let data = LlmGenerationData::success(
+        vec![],
+        vec![],
+        Some("hello".into()),
+        vec![],
+        "gpt-5.4-mini".into(),
+        Some("openai".into()),
+        Some(TokenUsage::new(100, 50)),
+        Some(42),
+        Some(10),
+    );
+    let event = Event::new(session_id, EventContext::empty(), data);
+    let public_event_id = event.id.to_string();
+
+    assert!(
+        event.is_ephemeral(),
+        "llm.generation must remain ephemeral for this regression to apply"
+    );
+
+    svc.on_event(&event).await;
+
+    // The journal should be created via the ledger entry attached to the budget.
+    let ledger_entries = db
+        .list_usage_ledger_for_budget(budget.id, 10, 0)
+        .await
+        .unwrap();
+    assert_eq!(
+        ledger_entries.len(),
+        1,
+        "expected exactly one ledger entry for the llm generation"
+    );
+    let journal = db
+        .get_usage_journal(ledger_entries[0].journal_id)
+        .await
+        .unwrap()
+        .expect("journal row should exist for the ledger entry");
+
+    assert!(
+        journal.event_id.is_none(),
+        "usage_journal.event_id must be NULL for ephemeral source events to avoid FK violation, got {:?}",
+        journal.event_id
+    );
+    assert_eq!(journal.kind, "llm_generation");
+    assert_eq!(journal.source_type.as_deref(), Some("event"));
+    assert_eq!(journal.source_id.as_deref(), Some(public_event_id.as_str()));
 }


### PR DESCRIPTION
## What
Stop writing the ephemeral `llm.generation` event id into `usage_journal.event_id`. The journal row keeps the public id via `source_type`/`source_id`, but the durable FK column is now `NULL` for ephemeral source events. Adds `Event::is_ephemeral` mirroring `EventRequest::is_ephemeral` so listeners holding `Event` can ask the same question without rebuilding a request.

## Why
`llm.generation` is in `Event::is_ephemeral()`'s match set, so under NATS-backed delivery it skips the `events` table insert. The budget listener was still inserting `usage_journal` rows with `event_id = <ephemeral event id>`, which the `usage_journal_event_id_fkey -> events(id)` foreign key rejected. Every public AG-UI turn produced:

```
ERROR everruns_server::domains::budgets::service:
  Failed to create usage journal row for llm generation
  error=insert or update on table "usage_journal" violates
  foreign key constraint "usage_journal_event_id_fkey"
```

Effect: usage accounting and budget metering silently dropped LLM generations whenever NATS was available. Fixes EVE-416.

## How
- `crates/core/src/events.rs`: add `Event::is_ephemeral` mirroring the existing helper on `EventRequest`. Same match set (`OUTPUT_MESSAGE_DELTA | REASON_THINKING_DELTA | TOOL_OUTPUT_DELTA | LLM_GENERATION`). Doc comment links the two so the contract stays explicit.
- `crates/server/src/domains/budgets/service.rs`: in `process_llm_generation`, set `event_id` to `Some(event.id.uuid())` only for non-ephemeral source events. Ephemeral events still get journaled — the public id is preserved via `source_type: "event"` + `source_id: event.id.to_string()` for traceability.

This keeps the FK as a real referential check for durable sources and avoids the violation entirely for ephemeral ones, regardless of whether the deployment runs with or without NATS.

## Risk
- Low.
- Surface: a single FK column value swap in one listener, plus a pure-read helper on `Event`.
- Behavioral change limited to `usage_journal.event_id` for ephemeral source events — that column already accepted `NULL` (the migration declares `event_id UUID REFERENCES events(id) ON DELETE SET NULL`), and the journal row's identity / metering / ledger linking does not depend on it.
- No API, schema, auth, or tenant-boundary changes.

## Security
- Threat categories reviewed: TM-API (no endpoint changes), TM-AUTHZ (no policy changes), TM-TENANT (org_id flow unchanged in `CreateUsageJournalRow`), TM-DOS (no new unbounded paths), TM-LLM (no prompt or key handling change).
- Findings: none. The fix narrows what we write into a durable column; it does not relax any check or expose new data. Source event id is still recorded as a string under `source_id` exactly as before for non-ephemeral events.

## Validation
- New regression test `test_llm_generation_listener_omits_event_id_for_ephemeral_events` (`crates/server/src/domains/budgets/tests.rs`) wires up a session + budget, fires an `llm.generation` `Event` through `BudgetService::on_event`, and asserts the resulting `usage_journal` row has `event_id = None` while keeping `kind = "llm_generation"` and `source_id = <public event id>`. The assertion `event.is_ephemeral()` is also checked so the test fails loudly if the ephemeral classification ever changes.
- `cargo test -p everruns-server --lib domains::budgets` — 53/53 pass.
- `cargo test -p everruns-core --lib` — 1744/1744 pass.
- `cargo fmt --check` — clean.
- `cargo clippy -p everruns-core -p everruns-server --tests -- -D warnings` — clean.

Smoke test against a running stack was not run: the bug only manifests under PostgreSQL FK + NATS ephemeral-skip delivery, which the in-memory `just start-dev` mode does not exercise. The regression test drives the same `EventListener` path that the worker uses in production, so it is the higher-signal evidence.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (internal-only column write; `event_id` already nullable)
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_018dEoqsrBrk2ThceRnDszRK)_