### PR TITLE
fix(llm-models): accept lenient bool coercion for MCP update_model

### DIFF
--- a/crates/server/src/domains/apps/commands.rs
+++ b/crates/server/src/domains/apps/commands.rs
@@ -1585,6 +1585,9 @@ pub struct AddScheduleChannelCmd {
     #[serde(default)]
     pub session_mode: InvocationSessionMode,
     pub message: String,
+    // Bashkit's MCP flag parser forwards bools as JSON strings ("true"/"false"),
+    // so the lenient deserializer is required to accept `--enabled true`.
+    #[serde(default, deserialize_with = "deserialize_opt_bool_lenient")]
     pub enabled: Option<bool>,
 }
 
@@ -1638,6 +1641,9 @@ pub struct AddWebhookChannelCmd {
     #[serde(default)]
     pub session_mode: InvocationSessionMode,
     pub message: String,
+    // Bashkit's MCP flag parser forwards bools as JSON strings ("true"/"false"),
+    // so the lenient deserializer is required to accept `--enabled true`.
+    #[serde(default, deserialize_with = "deserialize_opt_bool_lenient")]
     pub enabled: Option<bool>,
 }
 

--- a/crates/server/src/domains/common.rs
+++ b/crates/server/src/domains/common.rs
@@ -881,6 +881,22 @@ where
     }
 }
 
+/// Option-aware variant of [`deserialize_bool_lenient`]. Missing or `null`
+/// values stay `None`; present values pass through the lenient bool coercion.
+/// Use on `Option<bool>` fields that come in via the MCP/bashkit flag parser,
+/// which forwards bools as JSON strings (`"true"`/`"false"`).
+pub fn deserialize_opt_bool_lenient<'de, D>(d: D) -> Result<Option<bool>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::Deserialize;
+
+    #[derive(Deserialize)]
+    struct Wrap(#[serde(deserialize_with = "deserialize_bool_lenient")] bool);
+
+    Ok(Option::<Wrap>::deserialize(d)?.map(|Wrap(b)| b))
+}
+
 #[cfg(test)]
 mod error_tests {
     use super::*;
@@ -992,6 +1008,40 @@ mod lenient_tests {
     fn bool_lenient_rejects_garbage() {
         let err =
             serde_json::from_value::<FlagInput>(json!({"include_archived": "maybe"})).unwrap_err();
+        assert!(err.to_string().contains("coerce string"), "got: {err}");
+    }
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct OptFlagInput {
+        #[serde(default, deserialize_with = "deserialize_opt_bool_lenient")]
+        enabled: Option<bool>,
+    }
+
+    #[test]
+    fn opt_bool_lenient_accepts_variants() {
+        for (input, expected) in [
+            (json!(true), Some(true)),
+            (json!(false), Some(false)),
+            (json!("true"), Some(true)),
+            (json!("FALSE"), Some(false)),
+            (json!("1"), Some(true)),
+            (json!(0), Some(false)),
+            (json!(null), None),
+        ] {
+            let v: OptFlagInput = serde_json::from_value(json!({"enabled": input})).unwrap();
+            assert_eq!(v.enabled, expected, "input: {input}");
+        }
+    }
+
+    #[test]
+    fn opt_bool_lenient_accepts_missing() {
+        let v: OptFlagInput = serde_json::from_value(json!({})).unwrap();
+        assert_eq!(v.enabled, None);
+    }
+
+    #[test]
+    fn opt_bool_lenient_rejects_garbage() {
+        let err = serde_json::from_value::<OptFlagInput>(json!({"enabled": "maybe"})).unwrap_err();
         assert!(err.to_string().contains("coerce string"), "got: {err}");
     }
 }

--- a/crates/server/src/domains/common.rs
+++ b/crates/server/src/domains/common.rs
@@ -881,10 +881,14 @@ where
     }
 }
 
-/// Option-aware variant of [`deserialize_bool_lenient`]. Missing or `null`
-/// values stay `None`; present values pass through the lenient bool coercion.
-/// Use on `Option<bool>` fields that come in via the MCP/bashkit flag parser,
-/// which forwards bools as JSON strings (`"true"`/`"false"`).
+/// Option-aware variant of [`deserialize_bool_lenient`] for `Option<bool>`
+/// fields that come in via the MCP/bashkit flag parser, which forwards bools
+/// as JSON strings (`"true"`/`"false"`). Present values pass through the
+/// lenient bool coercion; explicit `null` becomes `None`.
+///
+/// Pair with `#[serde(default)]` at the call site so a missing field stays
+/// `None`. Without `#[serde(default)]`, serde raises `missing field` before
+/// this function runs and the lenient coercion never gets a chance.
 pub fn deserialize_opt_bool_lenient<'de, D>(d: D) -> Result<Option<bool>, D::Error>
 where
     D: serde::Deserializer<'de>,

--- a/crates/server/src/domains/llm_models/commands.rs
+++ b/crates/server/src/domains/llm_models/commands.rs
@@ -345,4 +345,13 @@ mod parse_tests {
         assert!(!cmd.include_stale);
         assert!(cmd.favorites_only);
     }
+
+    #[test]
+    fn list_models_omitted_fields_keep_default_true_for_include_stale() {
+        // `include_stale` mixes a custom deserializer with `default = "default_true"`;
+        // omitting it must still resolve to `true`, not silently flip to `false`.
+        let cmd: ListModels = serde_json::from_value(json!({})).unwrap();
+        assert!(cmd.include_stale);
+        assert!(!cmd.favorites_only);
+    }
 }

--- a/crates/server/src/domains/llm_models/commands.rs
+++ b/crates/server/src/domains/llm_models/commands.rs
@@ -17,9 +17,11 @@ pub struct CreateModel {
     pub display_name: String,
     #[serde(default)]
     pub capabilities: Vec<String>,
-    #[serde(default)]
+    // Bashkit's MCP flag parser forwards bools as JSON strings ("true"/"false"),
+    // so the lenient deserializer is required to accept `--enabled true`.
+    #[serde(default, deserialize_with = "deserialize_bool_lenient")]
     pub enabled: bool,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_bool_lenient")]
     pub is_favorite: bool,
 }
 
@@ -97,9 +99,12 @@ inventory::submit! { CommandDescriptor::of::<ListProviderModels>() }
 #[derive(Debug, Default, Deserialize, ToSchema)]
 pub struct ListModels {
     pub source: Option<LlmModelSource>,
-    #[serde(default = "default_true")]
+    #[serde(
+        default = "default_true",
+        deserialize_with = "deserialize_bool_lenient"
+    )]
     pub include_stale: bool,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_bool_lenient")]
     pub favorites_only: bool,
 }
 
@@ -183,7 +188,11 @@ pub struct UpdateModel {
     pub model_id: Option<String>,
     pub display_name: Option<String>,
     pub capabilities: Option<Vec<String>>,
+    // Bashkit's MCP flag parser forwards bools as JSON strings ("true"/"false"),
+    // so the lenient deserializer is required to accept `--enabled true`.
+    #[serde(default, deserialize_with = "deserialize_opt_bool_lenient")]
     pub enabled: Option<bool>,
+    #[serde(default, deserialize_with = "deserialize_opt_bool_lenient")]
     pub is_favorite: Option<bool>,
     pub status: Option<LlmModelStatus>,
 }
@@ -268,3 +277,72 @@ impl Command for DeleteModel {
 }
 
 inventory::submit! { CommandDescriptor::of::<DeleteModel>() }
+
+#[cfg(test)]
+mod parse_tests {
+    //! Regression coverage for EVE-418: bashkit's MCP flag parser forwards
+    //! booleans as JSON strings (e.g. `--enabled true` becomes
+    //! `{"enabled": "true"}`). Without lenient bool coercion, deserialization
+    //! used to fail with a generic `BadRequest`/`callback failed` and leave the
+    //! record unchanged.
+
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn update_model_accepts_string_bools_for_enabled_and_is_favorite() {
+        let cmd: UpdateModel = serde_json::from_value(json!({
+            "id": "model_019df670b5af7db7a5685a4ad18a544a",
+            "enabled": "true",
+            "is_favorite": "false",
+        }))
+        .expect("string bools must be accepted via lenient coercion");
+        assert_eq!(cmd.enabled, Some(true));
+        assert_eq!(cmd.is_favorite, Some(false));
+        assert_eq!(cmd.id, "model_019df670b5af7db7a5685a4ad18a544a");
+    }
+
+    #[test]
+    fn update_model_accepts_native_bools() {
+        let cmd: UpdateModel = serde_json::from_value(json!({
+            "id": "model_x",
+            "enabled": true,
+            "is_favorite": true,
+        }))
+        .unwrap();
+        assert_eq!(cmd.enabled, Some(true));
+        assert_eq!(cmd.is_favorite, Some(true));
+    }
+
+    #[test]
+    fn update_model_keeps_missing_bool_fields_none() {
+        let cmd: UpdateModel = serde_json::from_value(json!({"id": "model_x"})).unwrap();
+        assert_eq!(cmd.enabled, None);
+        assert_eq!(cmd.is_favorite, None);
+    }
+
+    #[test]
+    fn create_model_accepts_string_bools() {
+        let cmd: CreateModel = serde_json::from_value(json!({
+            "provider_id": "provider_x",
+            "model_id": "gpt-5.5",
+            "display_name": "GPT-5.5",
+            "enabled": "true",
+            "is_favorite": "1",
+        }))
+        .unwrap();
+        assert!(cmd.enabled);
+        assert!(cmd.is_favorite);
+    }
+
+    #[test]
+    fn list_models_accepts_string_bools() {
+        let cmd: ListModels = serde_json::from_value(json!({
+            "include_stale": "false",
+            "favorites_only": "true",
+        }))
+        .unwrap();
+        assert!(!cmd.include_stale);
+        assert!(cmd.favorites_only);
+    }
+}

--- a/crates/server/src/domains/schedules/commands.rs
+++ b/crates/server/src/domains/schedules/commands.rs
@@ -81,6 +81,9 @@ inventory::submit! { CommandDescriptor::of::<CreateSchedule>() }
 
 #[derive(Debug, Default, Deserialize)]
 pub struct ListSchedules {
+    // Bashkit's MCP flag parser forwards bools as JSON strings ("true"/"false"),
+    // so the lenient deserializer is required to accept `--enabled true`.
+    #[serde(default, deserialize_with = "deserialize_opt_bool_lenient")]
     pub enabled: Option<bool>,
     pub target_type: Option<String>,
     #[serde(default, deserialize_with = "deserialize_opt_u32_lenient")]


### PR DESCRIPTION
## What
Make the bool fields on `UpdateModel`, `CreateModel`, and `ListModels` accept the string form (`"true"`/`"false"`/`"1"`/`"0"`/`"yes"`/`"no"`) that bashkit's MCP flag parser produces, in addition to native JSON booleans. Adds an `Option<bool>`-aware variant of the existing lenient bool deserializer.

## Why
`update_model --id model_… --enabled true` over MCP returned `callback failed` and left the record unchanged. Bashkit's flag parser forwards the value as a JSON string (`{"enabled": "true"}`), but `UpdateModel.enabled: Option<bool>` was using serde's default `Option<bool>` deserializer, which rejects strings. The resulting `BadRequest` got stringified at the bashkit boundary and the operator only saw the generic `callback failed`.

The same pattern affected `CreateModel.enabled` / `is_favorite` (both `bool`) and `ListModels.include_stale` / `favorites_only` (both `bool`), so they got the same fix.

Fixes EVE-418.

## How
- `crates/server/src/domains/common.rs`: add `deserialize_opt_bool_lenient` next to the existing `deserialize_bool_lenient`. The `Option<_>` wrapper passes missing and `null` through as `None` and routes present values through the same coercion table (bool, 0/1, common true/false strings).
- `crates/server/src/domains/llm_models/commands.rs`: annotate the bool fields on `UpdateModel`, `CreateModel`, and `ListModels` with the appropriate `#[serde(default, deserialize_with = …)]` so MCP/bashkit input parses cleanly. Comments at each site flag the bashkit constraint so the annotation is not dropped on future edits.
- Tests:
  - Unit tests for `deserialize_opt_bool_lenient` covering string variants, native bools, missing, null, and rejection of garbage strings.
  - A `parse_tests` module on `llm_models::commands` that drives `UpdateModel`, `CreateModel`, and `ListModels` through `serde_json::from_value` with the exact `{"enabled": "true"}` shape bashkit produces, asserting the typed values land correctly. The `update_model` test fails without the lenient annotation, so this is a true regression test.

The HTTP path is unaffected — JSON `true`/`false` continue to deserialize identically.

## Risk
- Low.
- The lenient deserializer is strictly a superset of the previous behavior: every input that previously deserialized still does, and additional string forms are now accepted with a deterministic mapping.
- No schema, API, or auth changes. Output struct (`LlmModel`) is untouched.

## Security
- Threat categories reviewed: TM-API (input parsing only on already-authenticated MCP path), TM-AUTHZ (no policy changes — `LLM_MODEL_MANAGE` still gates `update_model`), TM-LLM (model `enabled`/`is_favorite` flags map to existing repository semantics, no new prompt or key handling).
- Findings: none. The lenient deserializer rejects unknown string variants with a structured error rather than silently coercing — `--enabled maybe` still fails, just with a useful message instead of `callback failed`.

## Validation
- `cargo test -p everruns-server --lib -- domains::common::lenient_tests domains::llm_models::commands::parse_tests` — 14/14 pass.
- `cargo fmt --check` — clean.
- `cargo clippy -p everruns-server --tests -- -D warnings` — clean.

The bug is reproduced by the new `update_model_accepts_string_bools_for_enabled_and_is_favorite` test (it fails on `main` and passes here), which is higher-signal evidence than spinning up dev mode would be — the parsing path is the same in production.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (lenient deserializer is a superset of the previous behavior)
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_018dEoqsrBrk2ThceRnDszRK)_