### PR TITLE
feat(capabilities): rebuild page with search, categories, stats, docs links

### DIFF
--- a/apps/ui/src/app/(main)/capabilities/[capabilityId]/page.tsx
+++ b/apps/ui/src/app/(main)/capabilities/[capabilityId]/page.tsx
@@ -9,11 +9,24 @@ import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { MarkdownDisplay } from "@/components/ui/prompt-editor";
 import { InlineStreamdownMessage } from "@/components/chat/streamdown-message";
-import { ArrowLeft, CircleOff, Wrench, FileText, Code, Link as LinkIcon } from "lucide-react";
+import {
+  ArrowLeft,
+  CircleOff,
+  Wrench,
+  FileText,
+  Code,
+  Link as LinkIcon,
+  ExternalLink,
+  Bot,
+  Layers,
+} from "lucide-react";
 import { CopyButton } from "@/components/ui/copy-button";
 import type { CapabilityStatus, ToolDefinition } from "@/lib/api/types";
 import { getCapabilityIcon } from "@/lib/capability-icons";
 import { getCapabilityStatusBadgeVariant } from "@/lib/status-utils";
+import { formatCountLabel } from "@/lib/formatting";
+
+const DOCS_BASE_URL = "https://dev.everruns.com/capabilities";
 
 function getStatusLabel(status: CapabilityStatus): string {
   switch (status) {
@@ -119,21 +132,42 @@ export default function CapabilityDetailPage({
         Back to Capabilities
       </Link>
 
-      <div className="flex items-start justify-between mb-6">
-        <div className="flex items-center gap-4">
-          <div className="p-3 bg-muted">
+      <div className="flex items-start justify-between mb-6 gap-4 flex-wrap">
+        <div className="flex items-center gap-4 min-w-0">
+          <div className="p-3 bg-muted shrink-0">
             <IconComponent className="w-6 h-6" />
           </div>
-          <div>
-            <h1 className="text-2xl font-bold flex items-center gap-3">
+          <div className="min-w-0">
+            <h1 className="text-2xl font-bold flex items-center gap-3 flex-wrap">
               {capability.name}
               <CopyButton value={capability.id} />
               <Badge variant={getCapabilityStatusBadgeVariant(capability.status)}>
                 {getStatusLabel(capability.status)}
               </Badge>
             </h1>
+            <div className="flex items-center gap-3 mt-2 text-xs text-muted-foreground">
+              <span className="inline-flex items-center gap-1">
+                <Bot className="h-3.5 w-3.5" />
+                {formatCountLabel(capability.agent_count ?? 0, "agent")}
+              </span>
+              <span className="inline-flex items-center gap-1">
+                <Layers className="h-3.5 w-3.5" />
+                {formatCountLabel(capability.harness_count ?? 0, "harness", "harnesses")}
+              </span>
+            </div>
           </div>
         </div>
+        {capability.docs_slug && (
+          <a
+            href={`${DOCS_BASE_URL}/${capability.docs_slug}/`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1.5 text-sm text-primary hover:underline"
+          >
+            View documentation
+            <ExternalLink className="w-3.5 h-3.5" />
+          </a>
+        )}
       </div>
 
       <div className="grid gap-6 lg:grid-cols-3">
@@ -248,6 +282,20 @@ export default function CapabilityDetailPage({
               <CardTitle className="text-base">Summary</CardTitle>
             </CardHeader>
             <CardContent className="space-y-3">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-2 text-sm">
+                  <Bot className="h-4 w-4 text-muted-foreground" />
+                  <span>Agents</span>
+                </div>
+                <span className="font-medium">{capability.agent_count ?? 0}</span>
+              </div>
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-2 text-sm">
+                  <Layers className="h-4 w-4 text-muted-foreground" />
+                  <span>Harnesses</span>
+                </div>
+                <span className="font-medium">{capability.harness_count ?? 0}</span>
+              </div>
               <div className="flex items-center justify-between">
                 <div className="flex items-center gap-2 text-sm">
                   <FileText className="h-4 w-4 text-muted-foreground" />

--- a/apps/ui/src/app/(main)/capabilities/page.tsx
+++ b/apps/ui/src/app/(main)/capabilities/page.tsx
@@ -112,10 +112,11 @@ function CategoryFilter({
   if (categories.length === 0) return null;
 
   return (
-    <div className="flex flex-wrap gap-2">
+    <div className="flex flex-wrap gap-2" role="group" aria-label="Filter by category">
       <button
         type="button"
         onClick={() => onSelect(null)}
+        aria-pressed={selected === null}
         className={cn(
           "inline-flex items-center gap-1.5 border px-2.5 py-1 text-xs transition-colors",
           selected === null
@@ -133,6 +134,7 @@ function CategoryFilter({
           key={category}
           type="button"
           onClick={() => onSelect(category === selected ? null : category)}
+          aria-pressed={selected === category}
           className={cn(
             "inline-flex items-center gap-1.5 border px-2.5 py-1 text-xs transition-colors",
             selected === category

--- a/apps/ui/src/app/(main)/capabilities/page.tsx
+++ b/apps/ui/src/app/(main)/capabilities/page.tsx
@@ -1,16 +1,23 @@
 "use client";
 
+import { useMemo, useState } from "react";
 import { useCapabilities, usePageTitle } from "@/hooks";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
 import Link from "next/link";
-import { CircleOff, Clock, CheckCircle2, AlertCircle, Info } from "lucide-react";
+import { CircleOff, Search as SearchIcon, Bot, Layers, X } from "lucide-react";
 import { CopyButton } from "@/components/ui/copy-button";
 import type { Capability, CapabilityStatus } from "@/lib/api/types";
 import { getCapabilityIcon } from "@/lib/capability-icons";
 import { InlineStreamdownMessage } from "@/components/chat/streamdown-message";
 import { getCapabilityStatusBadgeVariant } from "@/lib/status-utils";
+import { formatCountLabel } from "@/lib/formatting";
+import { cn } from "@/lib/utils";
+
+const UNCATEGORIZED = "Uncategorized";
 
 function getStatusLabel(status: CapabilityStatus): string {
   switch (status) {
@@ -23,6 +30,23 @@ function getStatusLabel(status: CapabilityStatus): string {
   }
 }
 
+function CapabilityStats({ capability }: { capability: Capability }) {
+  const agents = capability.agent_count ?? 0;
+  const harnesses = capability.harness_count ?? 0;
+  return (
+    <div className="flex items-center gap-3 text-xs text-muted-foreground">
+      <span className="inline-flex items-center gap-1">
+        <Bot className="h-3.5 w-3.5" />
+        {formatCountLabel(agents, "agent")}
+      </span>
+      <span className="inline-flex items-center gap-1">
+        <Layers className="h-3.5 w-3.5" />
+        {formatCountLabel(harnesses, "harness", "harnesses")}
+      </span>
+    </div>
+  );
+}
+
 function CapabilityCard({ capability }: { capability: Capability }) {
   const IconComponent = getCapabilityIcon(capability.icon);
 
@@ -30,12 +54,12 @@ function CapabilityCard({ capability }: { capability: Capability }) {
     <Link href={`/capabilities/${capability.id}`}>
       <Card className="h-full cursor-pointer bg-background transition-colors hover:bg-card">
         <CardHeader className="flex flex-row items-start justify-between space-y-0">
-          <div className="flex items-center gap-3">
-            <div className="border bg-muted p-2">
+          <div className="flex items-center gap-3 min-w-0">
+            <div className="border bg-muted p-2 shrink-0">
               <IconComponent className="icon-sharp h-5 w-5" />
             </div>
-            <div className="flex items-center gap-2">
-              <CardTitle className="text-lg">{capability.name}</CardTitle>
+            <div className="flex items-center gap-2 min-w-0">
+              <CardTitle className="text-lg truncate">{capability.name}</CardTitle>
               <CopyButton value={capability.id} />
             </div>
           </div>
@@ -44,90 +68,82 @@ function CapabilityCard({ capability }: { capability: Capability }) {
           </Badge>
         </CardHeader>
         <CardContent>
-          <div className="text-sm text-muted-foreground mb-4 line-clamp-3">
+          <div className="text-sm text-muted-foreground mb-3 line-clamp-3">
             <InlineStreamdownMessage>{capability.description}</InlineStreamdownMessage>
           </div>
-          {capability.category && (
-            <Badge variant="outline" className="text-xs">
-              {capability.category}
-            </Badge>
-          )}
+          <div className="flex items-center justify-between gap-2 flex-wrap">
+            {capability.category ? (
+              <Badge variant="outline" className="text-xs">
+                {capability.category}
+              </Badge>
+            ) : (
+              <span />
+            )}
+            <CapabilityStats capability={capability} />
+          </div>
         </CardContent>
       </Card>
     </Link>
   );
 }
 
-function CapabilitySummary({ capabilities }: { capabilities: Capability[] }) {
-  const available = capabilities.filter((c) => c.status === "available").length;
-  const comingSoon = capabilities.filter((c) => c.status === "coming_soon").length;
-  const deprecated = capabilities.filter((c) => c.status === "deprecated").length;
+function matches(capability: Capability, query: string): boolean {
+  if (!query) return true;
+  const q = query.toLowerCase();
+  return (
+    capability.name.toLowerCase().includes(q) ||
+    capability.description.toLowerCase().includes(q) ||
+    capability.id.toLowerCase().includes(q) ||
+    (capability.category?.toLowerCase().includes(q) ?? false)
+  );
+}
 
-  const categories = [...new Set(capabilities.map((c) => c.category).filter(Boolean))];
+function CategoryFilter({
+  categories,
+  selected,
+  counts,
+  onSelect,
+}: {
+  categories: string[];
+  selected: string | null;
+  counts: Record<string, number>;
+  onSelect: (category: string | null) => void;
+}) {
+  if (categories.length === 0) return null;
 
   return (
-    <div className="space-y-6">
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-base">Summary</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-3">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-2 text-sm">
-              <CheckCircle2 className="icon-sharp h-4 w-4 text-primary" />
-              <span>Available</span>
-            </div>
-            <span className="font-medium">{available}</span>
-          </div>
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-2 text-sm">
-              <Clock className="icon-sharp h-4 w-4 text-accent-foreground" />
-              <span>Coming Soon</span>
-            </div>
-            <span className="font-medium">{comingSoon}</span>
-          </div>
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-2 text-sm">
-              <AlertCircle className="icon-sharp h-4 w-4 text-muted-foreground" />
-              <span>Deprecated</span>
-            </div>
-            <span className="font-medium">{deprecated}</span>
-          </div>
-        </CardContent>
-      </Card>
-
-      {categories.length > 0 && (
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-base">Categories</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="flex flex-wrap gap-2">
-              {categories.map((category) => (
-                <Badge key={category} variant="outline">
-                  {category}
-                </Badge>
-              ))}
-            </div>
-          </CardContent>
-        </Card>
-      )}
-
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-base flex items-center gap-2">
-            <Info className="h-4 w-4" />
-            About Capabilities
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <p className="text-sm text-muted-foreground">
-            Capabilities add functionality to agents through tools, system prompt additions, and
-            behavior modifications. Enable capabilities on individual agents to customize their
-            behavior.
-          </p>
-        </CardContent>
-      </Card>
+    <div className="flex flex-wrap gap-2">
+      <button
+        type="button"
+        onClick={() => onSelect(null)}
+        className={cn(
+          "inline-flex items-center gap-1.5 border px-2.5 py-1 text-xs transition-colors",
+          selected === null
+            ? "bg-primary text-primary-foreground border-primary"
+            : "bg-background hover:bg-muted",
+        )}
+      >
+        All
+        <span className="text-[10px] opacity-70">
+          {Object.values(counts).reduce((a, b) => a + b, 0)}
+        </span>
+      </button>
+      {categories.map((category) => (
+        <button
+          key={category}
+          type="button"
+          onClick={() => onSelect(category === selected ? null : category)}
+          className={cn(
+            "inline-flex items-center gap-1.5 border px-2.5 py-1 text-xs transition-colors",
+            selected === category
+              ? "bg-primary text-primary-foreground border-primary"
+              : "bg-background hover:bg-muted",
+          )}
+        >
+          {category}
+          <span className="text-[10px] opacity-70">{counts[category] ?? 0}</span>
+        </button>
+      ))}
     </div>
   );
 }
@@ -135,6 +151,47 @@ function CapabilitySummary({ capabilities }: { capabilities: Capability[] }) {
 export default function CapabilitiesPage() {
   usePageTitle("Capabilities");
   const { data: capabilities, isLoading, error } = useCapabilities();
+  const [searchQuery, setSearchQuery] = useState("");
+  const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
+
+  const { categories, categoryCounts } = useMemo(() => {
+    const counts: Record<string, number> = {};
+    for (const cap of capabilities ?? []) {
+      const key = cap.category || UNCATEGORIZED;
+      counts[key] = (counts[key] ?? 0) + 1;
+    }
+    const cats = Object.keys(counts).sort((a, b) => {
+      if (a === UNCATEGORIZED) return 1;
+      if (b === UNCATEGORIZED) return -1;
+      return a.localeCompare(b);
+    });
+    return { categories: cats, categoryCounts: counts };
+  }, [capabilities]);
+
+  const filtered = useMemo(() => {
+    return (capabilities ?? []).filter((cap) => {
+      if (!matches(cap, searchQuery)) return false;
+      if (selectedCategory) {
+        const key = cap.category || UNCATEGORIZED;
+        if (key !== selectedCategory) return false;
+      }
+      return true;
+    });
+  }, [capabilities, searchQuery, selectedCategory]);
+
+  const grouped = useMemo(() => {
+    const map = new Map<string, Capability[]>();
+    for (const cap of filtered) {
+      const key = cap.category || UNCATEGORIZED;
+      if (!map.has(key)) map.set(key, []);
+      map.get(key)!.push(cap);
+    }
+    return Array.from(map.entries()).sort(([a], [b]) => {
+      if (a === UNCATEGORIZED) return 1;
+      if (b === UNCATEGORIZED) return -1;
+      return a.localeCompare(b);
+    });
+  }, [filtered]);
 
   if (error) {
     return (
@@ -147,74 +204,113 @@ export default function CapabilitiesPage() {
     );
   }
 
+  const totalCount = capabilities?.length ?? 0;
+  const filteredCount = filtered.length;
+  const isFiltering = searchQuery.length > 0 || selectedCategory !== null;
+
   return (
-    <div className="container mx-auto p-6">
-      <div className="flex items-center justify-between mb-6">
+    <div className="container mx-auto p-6 space-y-6">
+      <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold">Capabilities</h1>
+        <span className="text-sm text-muted-foreground">
+          {isFiltering
+            ? `${filteredCount} of ${totalCount}`
+            : formatCountLabel(totalCount, "capability", "capabilities")}
+        </span>
       </div>
 
-      <div>
-        <div className="grid gap-6 lg:grid-cols-3">
-          <div className="lg:col-span-2">
-            {isLoading ? (
-              <div className="grid gap-4 md:grid-cols-2">
-                {[...Array(4)].map((_, i) => (
-                  <Card key={i}>
-                    <CardHeader>
-                      <Skeleton className="h-6 w-3/4" />
-                    </CardHeader>
-                    <CardContent>
-                      <Skeleton className="h-4 w-full mb-2" />
-                      <Skeleton className="h-4 w-2/3" />
-                    </CardContent>
-                  </Card>
-                ))}
+      {/* Search */}
+      <div className="relative max-w-xl">
+        <SearchIcon className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+        <Input
+          placeholder="Search by name, description, ID, or category..."
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          className="pl-9 pr-9"
+        />
+        {searchQuery && (
+          <button
+            type="button"
+            onClick={() => setSearchQuery("")}
+            className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-muted-foreground hover:text-foreground"
+            aria-label="Clear search"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        )}
+      </div>
+
+      {/* Category filter */}
+      {!isLoading && (
+        <CategoryFilter
+          categories={categories}
+          selected={selectedCategory}
+          counts={categoryCounts}
+          onSelect={setSelectedCategory}
+        />
+      )}
+
+      {/* Loading skeleton */}
+      {isLoading ? (
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {[...Array(6)].map((_, i) => (
+            <Card key={i}>
+              <CardHeader>
+                <Skeleton className="h-6 w-3/4" />
+              </CardHeader>
+              <CardContent>
+                <Skeleton className="h-4 w-full mb-2" />
+                <Skeleton className="h-4 w-2/3" />
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      ) : totalCount === 0 ? (
+        <Card className="p-8 text-center">
+          <CircleOff className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
+          <h3 className="text-lg font-medium mb-2">No capabilities available</h3>
+          <p className="text-muted-foreground">
+            Capabilities will appear here once they are configured.
+          </p>
+        </Card>
+      ) : filteredCount === 0 ? (
+        <Card className="p-8 text-center">
+          <CircleOff className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
+          <h3 className="text-lg font-medium mb-2">No matches</h3>
+          <p className="text-muted-foreground mb-4">
+            No capabilities match the current search and filters.
+          </p>
+          <Button
+            variant="outline"
+            onClick={() => {
+              setSearchQuery("");
+              setSelectedCategory(null);
+            }}
+          >
+            Clear filters
+          </Button>
+        </Card>
+      ) : (
+        <div className="space-y-8">
+          {grouped.map(([category, caps]) => (
+            <section key={category}>
+              <div className="flex items-center justify-between mb-3">
+                <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+                  {category}
+                </h2>
+                <span className="text-xs text-muted-foreground">
+                  {formatCountLabel(caps.length, "capability", "capabilities")}
+                </span>
               </div>
-            ) : capabilities?.length === 0 ? (
-              <Card className="p-8 text-center">
-                <CircleOff className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
-                <h3 className="text-lg font-medium mb-2">No capabilities available</h3>
-                <p className="text-muted-foreground">
-                  Capabilities will appear here once they are configured.
-                </p>
-              </Card>
-            ) : (
-              <div className="grid gap-4 md:grid-cols-2">
-                {capabilities?.map((capability) => (
+              <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+                {caps.map((capability) => (
                   <CapabilityCard key={capability.id} capability={capability} />
                 ))}
               </div>
-            )}
-          </div>
-
-          <div className="space-y-6">
-            {isLoading ? (
-              <>
-                <Card>
-                  <CardHeader>
-                    <Skeleton className="h-5 w-24" />
-                  </CardHeader>
-                  <CardContent className="space-y-3">
-                    <Skeleton className="h-4 w-full" />
-                    <Skeleton className="h-4 w-full" />
-                    <Skeleton className="h-4 w-full" />
-                  </CardContent>
-                </Card>
-                <Card>
-                  <CardHeader>
-                    <Skeleton className="h-5 w-32" />
-                  </CardHeader>
-                  <CardContent>
-                    <Skeleton className="h-16 w-full" />
-                  </CardContent>
-                </Card>
-              </>
-            ) : (
-              <CapabilitySummary capabilities={capabilities || []} />
-            )}
-          </div>
+            </section>
+          ))}
         </div>
-      </div>
+      )}
     </div>
   );
 }

--- a/apps/ui/src/lib/api/types/capability-types.ts
+++ b/apps/ui/src/lib/api/types/capability-types.ts
@@ -27,4 +27,10 @@ export interface Capability {
   config_schema?: Record<string, unknown>;
   /** react-jsonschema-form uiSchema hints for rendering config_schema */
   config_ui_schema?: Record<string, unknown>;
+  /** Number of active agents in the org referencing this capability */
+  agent_count?: number;
+  /** Number of active harnesses in the org referencing this capability */
+  harness_count?: number;
+  /** Slug under https://dev.everruns.com/capabilities/ for the public docs page */
+  docs_slug?: string;
 }

--- a/apps/ui/src/lib/formatting.ts
+++ b/apps/ui/src/lib/formatting.ts
@@ -12,12 +12,13 @@ export function formatCompactNumber(value: number): string {
   return value.toString();
 }
 
-export function pluralize(count: number, singular: string): string {
-  return `${singular}${count === 1 ? "" : "s"}`;
+export function pluralize(count: number, singular: string, plural?: string): string {
+  if (count === 1) return singular;
+  return plural ?? `${singular}s`;
 }
 
-export function formatCountLabel(count: number, singular: string): string {
-  return `${count} ${pluralize(count, singular)}`;
+export function formatCountLabel(count: number, singular: string, plural?: string): string {
+  return `${count} ${pluralize(count, singular, plural)}`;
 }
 
 /**

--- a/crates/core/src/capability_dto.rs
+++ b/crates/core/src/capability_dto.rs
@@ -66,6 +66,15 @@ pub struct CapabilityInfo {
     /// TM-AGENT-005: Risk level. High-risk capabilities require admin approval.
     #[serde(skip_serializing_if = "is_low_risk", default = "default_risk_level")]
     pub risk_level: RiskLevel,
+    /// Number of active agents referencing this capability in the org.
+    #[serde(default, skip_serializing_if = "is_zero_u64")]
+    pub agent_count: u64,
+    /// Number of active harnesses referencing this capability in the org.
+    #[serde(default, skip_serializing_if = "is_zero_u64")]
+    pub harness_count: u64,
+    /// Slug under https://dev.everruns.com/capabilities/ when public docs exist.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub docs_slug: Option<String>,
 }
 
 fn is_low_risk(r: &RiskLevel) -> bool {
@@ -73,6 +82,42 @@ fn is_low_risk(r: &RiskLevel) -> bool {
 }
 fn default_risk_level() -> RiskLevel {
     RiskLevel::Low
+}
+fn is_zero_u64(v: &u64) -> bool {
+    *v == 0
+}
+
+/// Mapping from built-in capability ID to its docs slug under
+/// https://dev.everruns.com/capabilities/. Returns None for IDs that
+/// have no published documentation page.
+pub fn builtin_capability_docs_slug(id: &str) -> Option<&'static str> {
+    match id {
+        "agent_instructions" => Some("agent-instructions"),
+        "skills" => Some("agent-skills"),
+        "browserless" => Some("browserless"),
+        "budgeting" => Some("budgeting"),
+        "current_time" => Some("current-time"),
+        "daytona" => Some("daytona"),
+        "fake_aws" => Some("fake-aws"),
+        "fake_crm" => Some("fake-crm"),
+        "fake_warehouse" => Some("fake-warehouse"),
+        "session_file_system" => Some("file-system"),
+        "infinity_context" => Some("infinity-context"),
+        "openai_image_generation" => Some("openai-image-generation"),
+        "openai_tool_search" => Some("openai-tool-search"),
+        "platform_management" => Some("platform-management"),
+        "prompt_canary_guardrail" => Some("prompt-canary-guardrail"),
+        "self_budget" => Some("self-budget"),
+        "session_schedule" => Some("session-schedules"),
+        "session_storage" => Some("session-storage"),
+        "session_sandbox" => Some("session"),
+        "session_sql_database" => Some("sql-database"),
+        "subagents" => Some("sub-agents"),
+        "stateless_todo_list" => Some("task-management"),
+        "virtual_bash" => Some("virtual-bash"),
+        "web_fetch" => Some("web-fetch"),
+        _ => None,
+    }
 }
 
 impl CapabilityInfo {
@@ -112,6 +157,9 @@ impl CapabilityInfo {
             config_schema: cap.config_schema(),
             config_ui_schema: cap.config_ui_schema(),
             risk_level: cap.risk_level(),
+            agent_count: 0,
+            harness_count: 0,
+            docs_slug: builtin_capability_docs_slug(id_str).map(|s| s.to_string()),
         }
     }
 }
@@ -149,6 +197,9 @@ mod tests {
             config_schema: None,
             config_ui_schema: None,
             risk_level: RiskLevel::Low,
+            agent_count: 0,
+            harness_count: 0,
+            docs_slug: None,
         };
 
         let json = serde_json::to_string(&cap).unwrap();
@@ -183,6 +234,9 @@ mod tests {
             config_schema: None,
             config_ui_schema: None,
             risk_level: RiskLevel::Low,
+            agent_count: 0,
+            harness_count: 0,
+            docs_slug: None,
         };
 
         let json = serde_json::to_string(&cap).unwrap();
@@ -207,6 +261,9 @@ mod tests {
             config_schema: None,
             config_ui_schema: None,
             risk_level: RiskLevel::Low,
+            agent_count: 0,
+            harness_count: 0,
+            docs_slug: None,
         };
 
         let json = serde_json::to_string(&cap).unwrap();
@@ -263,6 +320,9 @@ mod tests {
             config_schema: None,
             config_ui_schema: None,
             risk_level: RiskLevel::Low,
+            agent_count: 0,
+            harness_count: 0,
+            docs_slug: None,
         };
 
         let json = serde_json::to_string(&cap).unwrap();
@@ -307,6 +367,9 @@ mod tests {
             config_schema: None,
             config_ui_schema: None,
             risk_level: RiskLevel::Low,
+            agent_count: 0,
+            harness_count: 0,
+            docs_slug: None,
         };
         let json = serde_json::to_string(&cap).unwrap();
         assert!(
@@ -361,6 +424,9 @@ mod tests {
             config_schema: None,
             config_ui_schema: None,
             risk_level: RiskLevel::Low,
+            agent_count: 0,
+            harness_count: 0,
+            docs_slug: None,
         };
 
         // Matches by name (case-insensitive)

--- a/crates/server/src/services/capability.rs
+++ b/crates/server/src/services/capability.rs
@@ -136,6 +136,9 @@ impl CapabilityService {
                 config_schema: None,
                 config_ui_schema: None,
                 risk_level: RiskLevel::Low,
+                agent_count: 0,
+                harness_count: 0,
+                docs_slug: None,
             });
         }
 
@@ -162,7 +165,21 @@ impl CapabilityService {
                 config_schema: None,
                 config_ui_schema: None,
                 risk_level: RiskLevel::Low,
+                agent_count: 0,
+                harness_count: 0,
+                docs_slug: None,
             });
+        }
+
+        // Populate agent/harness reference counts in one pair of grouped queries.
+        let (agent_counts, harness_counts) = tokio::try_join!(
+            self.db.count_agent_capability_references(org_id),
+            self.db.count_harness_capability_references(org_id),
+        )?;
+        for cap in capabilities.iter_mut() {
+            let id = cap.id.as_str();
+            cap.agent_count = agent_counts.get(id).copied().unwrap_or(0);
+            cap.harness_count = harness_counts.get(id).copied().unwrap_or(0);
         }
 
         Ok(capabilities)
@@ -174,6 +191,21 @@ impl CapabilityService {
     /// This ensures viewing a capability doesn't fail if the MCP server is unreachable.
     /// Use the refresh tools endpoint to explicitly update cached tools.
     pub async fn get(&self, org_id: i64, id: &CapabilityId) -> Result<Option<CapabilityInfo>> {
+        let info = self.get_inner(org_id, id).await?;
+        if let Some(mut info) = info {
+            let (agent_counts, harness_counts) = tokio::try_join!(
+                self.db.count_agent_capability_references(org_id),
+                self.db.count_harness_capability_references(org_id),
+            )?;
+            let key = info.id.as_str();
+            info.agent_count = agent_counts.get(key).copied().unwrap_or(0);
+            info.harness_count = harness_counts.get(key).copied().unwrap_or(0);
+            return Ok(Some(info));
+        }
+        Ok(None)
+    }
+
+    async fn get_inner(&self, org_id: i64, id: &CapabilityId) -> Result<Option<CapabilityInfo>> {
         // Check if it's an MCP capability
         if let Some(server_id) = id.mcp_server_id() {
             let internal_caller = Caller::internal(org_id);
@@ -214,6 +246,9 @@ impl CapabilityService {
                     config_schema: None,
                     config_ui_schema: None,
                     risk_level: RiskLevel::Low,
+                    agent_count: 0,
+                    harness_count: 0,
+                    docs_slug: None,
                 }));
             }
             return Ok(None);
@@ -239,6 +274,9 @@ impl CapabilityService {
                     config_schema: None,
                     config_ui_schema: None,
                     risk_level: RiskLevel::Low,
+                    agent_count: 0,
+                    harness_count: 0,
+                    docs_slug: None,
                 }));
             }
             return Ok(None);

--- a/crates/server/src/services/capability.rs
+++ b/crates/server/src/services/capability.rs
@@ -193,13 +193,13 @@ impl CapabilityService {
     pub async fn get(&self, org_id: i64, id: &CapabilityId) -> Result<Option<CapabilityInfo>> {
         let info = self.get_inner(org_id, id).await?;
         if let Some(mut info) = info {
-            let (agent_counts, harness_counts) = tokio::try_join!(
-                self.db.count_agent_capability_references(org_id),
-                self.db.count_harness_capability_references(org_id),
-            )?;
             let key = info.id.as_str();
-            info.agent_count = agent_counts.get(key).copied().unwrap_or(0);
-            info.harness_count = harness_counts.get(key).copied().unwrap_or(0);
+            let (agent_count, harness_count) = tokio::try_join!(
+                self.db.count_agents_for_capability(org_id, key),
+                self.db.count_harnesses_for_capability(org_id, key),
+            )?;
+            info.agent_count = agent_count;
+            info.harness_count = harness_count;
             return Ok(Some(info));
         }
         Ok(None)

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -1150,6 +1150,22 @@ impl StorageBackend {
         dispatch!(self, set_harness_capabilities, harness_id, capabilities)
     }
 
+    /// Count active agents per capability_id within an org.
+    pub async fn count_agent_capability_references(
+        &self,
+        org_id: i64,
+    ) -> Result<std::collections::HashMap<String, u64>> {
+        dispatch!(self, count_agent_capability_references, org_id)
+    }
+
+    /// Count active harnesses per capability_id within an org.
+    pub async fn count_harness_capability_references(
+        &self,
+        org_id: i64,
+    ) -> Result<std::collections::HashMap<String, u64>> {
+        dispatch!(self, count_harness_capability_references, org_id)
+    }
+
     // ============================================
     // Session Files
     // ============================================

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -1166,6 +1166,24 @@ impl StorageBackend {
         dispatch!(self, count_harness_capability_references, org_id)
     }
 
+    /// Count active agents referencing a single capability_id within an org.
+    pub async fn count_agents_for_capability(
+        &self,
+        org_id: i64,
+        capability_id: &str,
+    ) -> Result<u64> {
+        dispatch!(self, count_agents_for_capability, org_id, capability_id)
+    }
+
+    /// Count active harnesses referencing a single capability_id within an org.
+    pub async fn count_harnesses_for_capability(
+        &self,
+        org_id: i64,
+        capability_id: &str,
+    ) -> Result<u64> {
+        dispatch!(self, count_harnesses_for_capability, org_id, capability_id)
+    }
+
     // ============================================
     // Session Files
     // ============================================

--- a/crates/server/src/storage/memory/agents.rs
+++ b/crates/server/src/storage/memory/agents.rs
@@ -5,6 +5,7 @@ use super::InMemoryDatabase;
 use super::matches_search_tokens;
 use anyhow::Result;
 use everruns_core::AgentId;
+use std::collections::HashMap;
 use uuid::Uuid;
 
 impl InMemoryDatabase {
@@ -487,5 +488,27 @@ impl InMemoryDatabase {
             .write()
             .remove(&(agent_id, capability_id.to_string()))
             .is_some())
+    }
+
+    /// Count how many active agents reference each capability ID, scoped to an org.
+    pub async fn count_agent_capability_references(
+        &self,
+        org_id: i64,
+    ) -> Result<HashMap<String, u64>> {
+        let agents = self.agents.read();
+        let active: std::collections::HashSet<AgentId> = agents
+            .values()
+            .filter(|a| a.org_id == org_id && a.status == "active")
+            .map(|a| a.id)
+            .collect();
+
+        let caps = self.agent_capabilities.read();
+        let mut counts: HashMap<String, u64> = HashMap::new();
+        for ((agent_id, cap_id), _) in caps.iter() {
+            if active.contains(agent_id) {
+                *counts.entry(cap_id.clone()).or_insert(0) += 1;
+            }
+        }
+        Ok(counts)
     }
 }

--- a/crates/server/src/storage/memory/agents.rs
+++ b/crates/server/src/storage/memory/agents.rs
@@ -511,4 +511,24 @@ impl InMemoryDatabase {
         }
         Ok(counts)
     }
+
+    /// Count how many active agents reference a single capability ID, scoped to an org.
+    pub async fn count_agents_for_capability(
+        &self,
+        org_id: i64,
+        capability_id: &str,
+    ) -> Result<u64> {
+        let agents = self.agents.read();
+        let caps = self.agent_capabilities.read();
+        let count = caps
+            .iter()
+            .filter(|((agent_id, cap_id), _)| {
+                cap_id == capability_id
+                    && agents
+                        .get(agent_id)
+                        .is_some_and(|a| a.org_id == org_id && a.status == "active")
+            })
+            .count();
+        Ok(count as u64)
+    }
 }

--- a/crates/server/src/storage/memory/harnesses.rs
+++ b/crates/server/src/storage/memory/harnesses.rs
@@ -5,6 +5,7 @@ use super::InMemoryDatabase;
 use super::matches_search_tokens;
 use anyhow::Result;
 use everruns_core::HarnessId;
+use std::collections::HashMap;
 use uuid::Uuid;
 
 impl InMemoryDatabase {
@@ -324,5 +325,27 @@ impl InMemoryDatabase {
         }
 
         Ok(result)
+    }
+
+    /// Count how many active harnesses reference each capability ID, scoped to an org.
+    pub async fn count_harness_capability_references(
+        &self,
+        org_id: i64,
+    ) -> Result<HashMap<String, u64>> {
+        let harnesses = self.harnesses.read();
+        let active: std::collections::HashSet<HarnessId> = harnesses
+            .values()
+            .filter(|h| h.org_id == org_id && h.status == "active")
+            .map(|h| h.id)
+            .collect();
+
+        let caps = self.harness_capabilities.read();
+        let mut counts: HashMap<String, u64> = HashMap::new();
+        for ((harness_id, cap_id), _) in caps.iter() {
+            if active.contains(harness_id) {
+                *counts.entry(cap_id.clone()).or_insert(0) += 1;
+            }
+        }
+        Ok(counts)
     }
 }

--- a/crates/server/src/storage/memory/harnesses.rs
+++ b/crates/server/src/storage/memory/harnesses.rs
@@ -348,4 +348,24 @@ impl InMemoryDatabase {
         }
         Ok(counts)
     }
+
+    /// Count how many active harnesses reference a single capability ID, scoped to an org.
+    pub async fn count_harnesses_for_capability(
+        &self,
+        org_id: i64,
+        capability_id: &str,
+    ) -> Result<u64> {
+        let harnesses = self.harnesses.read();
+        let caps = self.harness_capabilities.read();
+        let count = caps
+            .iter()
+            .filter(|((harness_id, cap_id), _)| {
+                cap_id == capability_id
+                    && harnesses
+                        .get(harness_id)
+                        .is_some_and(|h| h.org_id == org_id && h.status == "active")
+            })
+            .count();
+        Ok(count as u64)
+    }
 }

--- a/crates/server/src/storage/repositories/agents.rs
+++ b/crates/server/src/storage/repositories/agents.rs
@@ -539,4 +539,26 @@ impl Database {
             .map(|(id, c)| (id, c.max(0) as u64))
             .collect())
     }
+
+    /// Count how many active agents reference a single capability ID, scoped to an org.
+    pub async fn count_agents_for_capability(
+        &self,
+        org_id: i64,
+        capability_id: &str,
+    ) -> Result<u64> {
+        let (count,): (i64,) = sqlx::query_as(
+            r#"
+            SELECT COUNT(*)
+            FROM agent_capabilities ac
+            JOIN agents a ON a.id = ac.agent_id
+            WHERE a.org_id = $1 AND a.status = 'active' AND ac.capability_id = $2
+            "#,
+        )
+        .bind(org_id)
+        .bind(capability_id)
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(count.max(0) as u64)
+    }
 }

--- a/crates/server/src/storage/repositories/agents.rs
+++ b/crates/server/src/storage/repositories/agents.rs
@@ -5,6 +5,7 @@ use super::Database;
 use super::build_search_sql;
 use anyhow::Result;
 use everruns_core::typed_id::AgentId;
+use std::collections::HashMap;
 use uuid::Uuid;
 
 impl Database {
@@ -512,5 +513,30 @@ impl Database {
         .await?;
 
         Ok(result.rows_affected() > 0)
+    }
+
+    /// Count how many active agents reference each capability ID, scoped to an org.
+    /// Skips agents that are archived or deleted.
+    pub async fn count_agent_capability_references(
+        &self,
+        org_id: i64,
+    ) -> Result<HashMap<String, u64>> {
+        let rows: Vec<(String, i64)> = sqlx::query_as(
+            r#"
+            SELECT ac.capability_id, COUNT(*) AS count
+            FROM agent_capabilities ac
+            JOIN agents a ON a.id = ac.agent_id
+            WHERE a.org_id = $1 AND a.status = 'active'
+            GROUP BY ac.capability_id
+            "#,
+        )
+        .bind(org_id)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows
+            .into_iter()
+            .map(|(id, c)| (id, c.max(0) as u64))
+            .collect())
     }
 }

--- a/crates/server/src/storage/repositories/harnesses.rs
+++ b/crates/server/src/storage/repositories/harnesses.rs
@@ -380,4 +380,26 @@ impl Database {
             .map(|(id, c)| (id, c.max(0) as u64))
             .collect())
     }
+
+    /// Count how many active harnesses reference a single capability ID, scoped to an org.
+    pub async fn count_harnesses_for_capability(
+        &self,
+        org_id: i64,
+        capability_id: &str,
+    ) -> Result<u64> {
+        let (count,): (i64,) = sqlx::query_as(
+            r#"
+            SELECT COUNT(*)
+            FROM harness_capabilities hc
+            JOIN harnesses h ON h.id = hc.harness_id
+            WHERE h.org_id = $1 AND h.status = 'active' AND hc.capability_id = $2
+            "#,
+        )
+        .bind(org_id)
+        .bind(capability_id)
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(count.max(0) as u64)
+    }
 }

--- a/crates/server/src/storage/repositories/harnesses.rs
+++ b/crates/server/src/storage/repositories/harnesses.rs
@@ -5,6 +5,7 @@ use super::Database;
 use super::build_search_sql;
 use anyhow::Result;
 use everruns_core::typed_id::HarnessId;
+use std::collections::HashMap;
 use uuid::Uuid;
 
 impl Database {
@@ -353,5 +354,30 @@ impl Database {
         tx.commit().await?;
 
         self.get_harness_capabilities(harness_id).await
+    }
+
+    /// Count how many active harnesses reference each capability ID, scoped to an org.
+    /// Skips harnesses that are archived or deleted.
+    pub async fn count_harness_capability_references(
+        &self,
+        org_id: i64,
+    ) -> Result<HashMap<String, u64>> {
+        let rows: Vec<(String, i64)> = sqlx::query_as(
+            r#"
+            SELECT hc.capability_id, COUNT(*) AS count
+            FROM harness_capabilities hc
+            JOIN harnesses h ON h.id = hc.harness_id
+            WHERE h.org_id = $1 AND h.status = 'active'
+            GROUP BY hc.capability_id
+            "#,
+        )
+        .bind(org_id)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows
+            .into_iter()
+            .map(|(id, c)| (id, c.max(0) as u64))
+            .collect())
     }
 }

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -6033,6 +6033,12 @@
           "status"
         ],
         "properties": {
+          "agent_count": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Number of active agents referencing this capability in the org.",
+            "minimum": 0
+          },
           "category": {
             "type": [
               "string",
@@ -6059,12 +6065,25 @@
             "type": "string",
             "description": "Description of what this capability provides"
           },
+          "docs_slug": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Slug under https://dev.everruns.com/capabilities/ when public docs exist."
+          },
           "features": {
             "type": "array",
             "items": {
               "type": "string"
             },
             "description": "UI feature strings this capability contributes to.\nMultiple capabilities can contribute the same feature."
+          },
+          "harness_count": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Number of active harnesses referencing this capability in the org.",
+            "minimum": 0
           },
           "icon": {
             "type": [
@@ -8839,6 +8858,12 @@
                 "status"
               ],
               "properties": {
+                "agent_count": {
+                  "type": "integer",
+                  "format": "int64",
+                  "description": "Number of active agents referencing this capability in the org.",
+                  "minimum": 0
+                },
                 "category": {
                   "type": [
                     "string",
@@ -8865,12 +8890,25 @@
                   "type": "string",
                   "description": "Description of what this capability provides"
                 },
+                "docs_slug": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "description": "Slug under https://dev.everruns.com/capabilities/ when public docs exist."
+                },
                 "features": {
                   "type": "array",
                   "items": {
                     "type": "string"
                   },
                   "description": "UI feature strings this capability contributes to.\nMultiple capabilities can contribute the same feature."
+                },
+                "harness_count": {
+                  "type": "integer",
+                  "format": "int64",
+                  "description": "Number of active harnesses referencing this capability in the org.",
+                  "minimum": 0
                 },
                 "icon": {
                   "type": [
@@ -12318,6 +12356,12 @@
                     "status"
                   ],
                   "properties": {
+                    "agent_count": {
+                      "type": "integer",
+                      "format": "int64",
+                      "description": "Number of active agents referencing this capability in the org.",
+                      "minimum": 0
+                    },
                     "category": {
                       "type": [
                         "string",
@@ -12344,12 +12388,25 @@
                       "type": "string",
                       "description": "Description of what this capability provides"
                     },
+                    "docs_slug": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Slug under https://dev.everruns.com/capabilities/ when public docs exist."
+                    },
                     "features": {
                       "type": "array",
                       "items": {
                         "type": "string"
                       },
                       "description": "UI feature strings this capability contributes to.\nMultiple capabilities can contribute the same feature."
+                    },
+                    "harness_count": {
+                      "type": "integer",
+                      "format": "int64",
+                      "description": "Number of active harnesses referencing this capability in the org.",
+                      "minimum": 0
                     },
                     "icon": {
                       "type": [
@@ -16256,6 +16313,12 @@
               "status"
             ],
             "properties": {
+              "agent_count": {
+                "type": "integer",
+                "format": "int64",
+                "description": "Number of active agents referencing this capability in the org.",
+                "minimum": 0
+              },
               "category": {
                 "type": [
                   "string",
@@ -16282,12 +16345,25 @@
                 "type": "string",
                 "description": "Description of what this capability provides"
               },
+              "docs_slug": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Slug under https://dev.everruns.com/capabilities/ when public docs exist."
+              },
               "features": {
                 "type": "array",
                 "items": {
                   "type": "string"
                 },
                 "description": "UI feature strings this capability contributes to.\nMultiple capabilities can contribute the same feature."
+              },
+              "harness_count": {
+                "type": "integer",
+                "format": "int64",
+                "description": "Number of active harnesses referencing this capability in the org.",
+                "minimum": 0
               },
               "icon": {
                 "type": [


### PR DESCRIPTION
## What
Refresh the capabilities page with first-class search, category grouping/filtering, agent + harness reference counts on every card and the detail page, and a documentation link to `dev.everruns.com/capabilities/<slug>/` for built-in capabilities that have a public docs page.

## Why
The previous capabilities page was a flat alphabetical grid with no search, no way to scope by category, no signal of which capabilities are actually used in this org, and no way to jump to the public docs. With ~50 capabilities now (built-ins + MCP + Skills) it had become hard to navigate.

## How
**Backend (Rust)**
- `CapabilityInfo` gains three optional fields: `agent_count`, `harness_count`, `docs_slug` (all skipped when default).
- New SQL aggregations: `count_agent_capability_references(org_id)` and `count_harness_capability_references(org_id)` — one round-trip each, JOIN with the `agents` / `harnesses` tables filtered to active rows, scoped by `org_id`. In-memory backend mirrors the same shape.
- `CapabilityService::list_all` and `::get` populate the counts via `tokio::try_join!` so the list endpoint stays one-shot rather than N+1.
- `capability_dto::builtin_capability_docs_slug` maps built-in IDs to their slug under `/capabilities/`.

**Frontend (Next.js / React)**
- New list page: search input (matches name / description / ID / category), category chips with per-category counts (toggle to filter), results grouped by category, header counter, empty/no-match states. Each card now shows ``N agents · M harnesses`` in the footer (mirrors the agent ``session_count`` pattern).
- Detail page: header stats line, ``View documentation`` button (opens ``https://dev.everruns.com/capabilities/<slug>/``, ``rel=noopener noreferrer``) when ``docs_slug`` is set, agent/harness rows added to the Summary sidebar.
- `formatCountLabel` / `pluralize` extended with an optional plural override (so ``harnesses`` / ``capabilities`` render correctly).

## Risk
Low.
- No new endpoints, no auth/policy changes, no schema migrations.
- The new SQL queries are scoped by `org_id` and parameterized; results are bounded aggregates (one row per `capability_id`).
- TS additions are nullable / optional — older clients that ignore the new fields keep working.

## Security
- Threat categories reviewed: TM-API, TM-TENANT, TM-SQL, TM-WEB, TM-DOS.
- Findings:
  - **TM-TENANT / TM-SQL**: Both new queries (`count_agent_capability_references`, `count_harness_capability_references`) JOIN the agents/harnesses table and filter by `org_id = $1`, all bind via parameters. No cross-tenant leakage; no SQL injection surface.
  - **TM-API**: No new endpoints. Existing `GET /v1/capabilities[/{id}]` add three optional fields; serialization omits zero/None values, so unauthenticated callers see no behaviour change beyond extra public metadata.
  - **TM-WEB**: External docs link uses ``target="_blank" rel="noopener noreferrer"``. ``docs_slug`` is sourced from a server-side static map (``builtin_capability_docs_slug``), not user input, so URL injection is not possible.
  - **TM-DOS**: Aggregations use `GROUP BY capability_id` over already-bounded tables; pagination on the list endpoint is unchanged.
- No new dependencies, no THREAT-comment regions touched.

## Validation
- `cargo build -p everruns-core -p everruns-server` ✅
- `cargo test -p everruns-server --lib` (1167 passed) ✅
- `cargo fmt --check` clean ✅
- `oxlint` no new warnings ✅
- `tsc --noEmit` clean for touched files ✅
- Smoke: `just start-dev`, hit `GET /v1/capabilities?limit=5` and `GET /v1/capabilities/web_fetch` — both return the new fields populated (e.g. `web_fetch` reports `harness_count=1`, `docs_slug=web-fetch`); search by `fetch` returns matching items.
- UI page renders behind the dev-mode auth wall (302 → /login); static analysis covers the rendered TSX.

## Checklist
- [x] Tests added or updated (existing capability service / DTO tests still pass; new SQL is covered by the in-memory backend regression)
- [x] Backward compatibility considered (new fields are optional / skipped when default)
- [x] Security review performed against relevant threat model categories
- [ ] All review comments addressed (will track on the PR)