### PR TITLE
chore(llm): log read failures with org/resource context

### DIFF
--- a/crates/server/src/domains/llm_models/service.rs
+++ b/crates/server/src/domains/llm_models/service.rs
@@ -15,6 +15,7 @@ use everruns_core::{
     LlmProviderType, Permission, Policy, Rule, get_model_profile,
 };
 use std::sync::Arc;
+use tracing::error;
 use uuid::Uuid;
 
 use crate::api::llm_models::{CreateLlmModelRequest, UpdateLlmModelRequest};
@@ -86,10 +87,21 @@ impl LlmModelService {
         caller: &Caller,
         id: Uuid,
     ) -> Result<Option<LlmModelWithProvider>> {
+        // EVE-417: log the underlying DB error with org/model context so
+        // operators can diagnose the org-scoped read failures that surface
+        // through MCP as `internal: <message>`. Error still propagates.
         let row = self
             .db
             .get_llm_model_with_provider(caller.org_id, id)
-            .await?;
+            .await
+            .inspect_err(|err| {
+                error!(
+                    org_id = caller.org_id,
+                    model_id = %id,
+                    error = %err,
+                    "Failed to read llm model"
+                );
+            })?;
         Ok(row.as_ref().map(Self::row_to_model_with_provider))
     }
 
@@ -101,12 +113,30 @@ impl LlmModelService {
         let rows = self
             .db
             .list_llm_models_for_provider(caller.org_id, provider_id)
-            .await?;
+            .await
+            .inspect_err(|err| {
+                error!(
+                    org_id = caller.org_id,
+                    provider_id = %provider_id,
+                    error = %err,
+                    "Failed to list llm models for provider"
+                );
+            })?;
         Ok(rows.iter().map(Self::row_to_model).collect())
     }
 
     pub async fn list_all(&self, caller: &Caller) -> Result<Vec<LlmModelWithProvider>> {
-        let rows = self.db.list_all_llm_models(caller.org_id).await?;
+        let rows = self
+            .db
+            .list_all_llm_models(caller.org_id)
+            .await
+            .inspect_err(|err| {
+                error!(
+                    org_id = caller.org_id,
+                    error = %err,
+                    "Failed to list llm models"
+                );
+            })?;
         Ok(rows.iter().map(Self::row_to_model_with_provider).collect())
     }
 
@@ -118,10 +148,31 @@ impl LlmModelService {
         include_stale: bool,
         favorites_only: bool,
     ) -> Result<Vec<LlmModelWithProvider>> {
-        let rows = self.db.list_all_llm_models(caller.org_id).await?;
+        // EVE-417: same diagnostic logging as `list_all`/`list_for_provider`.
+        let rows = self
+            .db
+            .list_all_llm_models(caller.org_id)
+            .await
+            .inspect_err(|err| {
+                error!(
+                    org_id = caller.org_id,
+                    error = %err,
+                    "Failed to list llm models for filtering"
+                );
+            })?;
 
         // Get provider last_synced_at timestamps for stale detection
-        let providers = self.db.list_llm_providers(caller.org_id).await?;
+        let providers = self
+            .db
+            .list_llm_providers(caller.org_id)
+            .await
+            .inspect_err(|err| {
+                error!(
+                    org_id = caller.org_id,
+                    error = %err,
+                    "Failed to list llm providers for stale detection"
+                );
+            })?;
         let provider_sync_times: std::collections::HashMap<
             Uuid,
             Option<chrono::DateTime<chrono::Utc>>,

--- a/crates/server/src/domains/llm_providers/service.rs
+++ b/crates/server/src/domains/llm_providers/service.rs
@@ -14,6 +14,7 @@ use everruns_core::url_validation::validate_safe_url;
 use everruns_core::{Caller, LlmProviderStatus, LlmProviderType, Permission, Policy, Rule};
 use reqwest::Url;
 use std::sync::Arc;
+use tracing::error;
 use uuid::Uuid;
 
 use crate::api::llm_providers::{CreateLlmProviderRequest, UpdateLlmProviderRequest};
@@ -93,12 +94,39 @@ impl LlmProviderService {
     }
 
     pub async fn get(&self, caller: &Caller, id: Uuid) -> Result<Option<LlmProvider>> {
-        let row = self.db.get_llm_provider(caller.org_id, id).await?;
+        // EVE-417: log the underlying DB error with org/provider context so
+        // operators can diagnose the org-scoped read failures that surface
+        // through MCP as a structured `internal: <message>` (and previously as
+        // an opaque `callback failed`). The error still propagates unchanged.
+        let row = self
+            .db
+            .get_llm_provider(caller.org_id, id)
+            .await
+            .inspect_err(|err| {
+                error!(
+                    org_id = caller.org_id,
+                    provider_id = %id,
+                    error = %err,
+                    "Failed to read llm provider"
+                );
+            })?;
         Ok(row.as_ref().map(Self::row_to_provider))
     }
 
     pub async fn list(&self, caller: &Caller) -> Result<Vec<LlmProvider>> {
-        let rows = self.db.list_llm_providers(caller.org_id).await?;
+        // EVE-417: same diagnostic logging as `get`. List failures here are
+        // the most common path for org-scoped MCP read regressions.
+        let rows = self
+            .db
+            .list_llm_providers(caller.org_id)
+            .await
+            .inspect_err(|err| {
+                error!(
+                    org_id = caller.org_id,
+                    error = %err,
+                    "Failed to list llm providers"
+                );
+            })?;
         Ok(rows.iter().map(Self::row_to_provider).collect())
     }
 


### PR DESCRIPTION
## What
Surface the underlying database/storage error whenever a read on `LlmProviderService::{get,list}` or `LlmModelService::{get_with_provider,list_for_provider,list_all,list_all_with_filters}` fails. Logs are structured with the `org_id` (and `provider_id`/`model_id` where applicable) so operators can correlate the new MCP `internal: <message>` errors (EVE-419) with concrete server-side storage failures.

## Why
EVE-417 reports that `list_providers`, `get_provider`, and related reads fail for one org (Personal) while succeeding for the Default org. The reproduction stays opaque without dev DB access: the catalog dispatch layer turns a `CommandError::Internal(anyhow)` into a string, but on the server side there is no log line tying the storage error to the calling org or to the failing operation. With this change, the server log shows e.g.

```
Failed to list llm providers org_id=42 error=column "settings" does not exist
```

at the moment of failure. Combined with the structured MCP error from EVE-419 (`list_providers: internal: …`), the next reproduction will localise the underlying cause without further code changes.

This is intentionally additive — I cannot reproduce EVE-417 without dev DB access, and a speculative code change to the read path would be unsafe. Logging buys us the diagnostics without changing behaviour.

## How
- `crates/server/src/domains/llm_providers/service.rs`:
  - Add `tracing::error` import.
  - Wrap `db.get_llm_provider` and `db.list_llm_providers` in `inspect_err`, logging `org_id`, `provider_id` (where applicable), and the underlying error.
- `crates/server/src/domains/llm_models/service.rs`:
  - Same treatment for `db.get_llm_model_with_provider`, `db.list_llm_models_for_provider`, `db.list_all_llm_models` (used by both `list_all` and `list_all_with_filters`), plus the secondary `list_llm_providers` call inside `list_all_with_filters` that backs stale-detection.

The error continues to propagate up the stack through `?` exactly as before, so `classify_anyhow` still returns `CommandError::Internal` and the MCP layer still emits the structured `internal: <message>` (EVE-419). Nothing about the call signature or success path changes.

## Risk
- Low.
- Pure observability addition. No success-path behaviour change. Existing tests on these services still pass (`cargo test -p everruns-server --lib -- domains::llm_providers domains::llm_models` — 25/25 pass on this branch).
- The log payload is the existing `anyhow::Error` display, which we already returned to callers via the dispatch path. No new sensitive data is logged.

## Security
- Threat categories reviewed: TM-AUTH (no auth surface change), TM-AUTHZ (caller/org gating untouched — `org_id` is whatever the dispatcher already passed in), TM-LLM (no provider, prompt, or key handling change), TM-API (read-only on already-authenticated paths).
- Findings: none. Logged fields (`org_id`, `provider_id`, `model_id`, error display) are the same data already round-tripping through the existing error path; nothing previously private is now exposed.

## Validation
- `cargo fmt --check` — clean.
- `cargo clippy -p everruns-server --tests -- -D warnings` — clean.
- `cargo test -p everruns-server --lib -- domains::llm_providers domains::llm_models` — 25/25 pass.

## What this does not do
- Does not fix the underlying Personal-org read failure. The actual cause (most likely a row-shape or schema mismatch specific to that org's data) requires inspecting dev DB state, which is outside what I can do from a coding agent. After this change ships and is deployed to dev, re-running `list_providers` against Personal should produce a self-diagnostic log line + a structured `internal: <message>` MCP response that pinpoints the failing column/row.

## Checklist
- [x] Tests added or updated (existing service tests still pass; the change is observability-only)
- [x] Backward compatibility considered (additive logging; error propagation unchanged)
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
