### PR TITLE
docs(seo): improve page titles and descriptions

### DIFF
--- a/apps/docs/src/routeData.ts
+++ b/apps/docs/src/routeData.ts
@@ -30,25 +30,12 @@ export const onRequest = defineRouteMiddleware((context) => {
   // Update both entry.data.title (affects h1) and the <title> head entry.
   if (isApiOperation) {
     const cleanTitle = route.entry.data.title.replace(methodPathPrefix, "");
-    route.entry.data.title = cleanTitle;
+    updateRouteTitle(route, cleanTitle);
+  }
 
-    // Update the <title> head entry
-    const titleEntry = route.head.find((e) => e.tag === "title");
-    if (titleEntry) {
-      titleEntry.content = titleEntry.content?.replace(methodPathPrefix, "");
-    }
-
-    // Update og:title
-    const ogTitle = route.head.find(
-      (e) =>
-        e.tag === "meta" &&
-        e.attrs &&
-        "property" in e.attrs &&
-        e.attrs.property === "og:title",
-    );
-    if (ogTitle?.attrs) {
-      ogTitle.attrs.content = cleanTitle;
-    }
+  // Give the generated API overview page a search-friendly title.
+  if (slug === "api") {
+    updateRouteTitle(route, "REST API Endpoints and Schemas");
   }
 
   // Generate meta description for pages without one.
@@ -61,7 +48,12 @@ export const onRequest = defineRouteMiddleware((context) => {
       e.attrs.name === "description",
   );
 
-  if (!hasDescription || !route.entry.data.description) {
+  if (
+    !hasDescription ||
+    !route.entry.data.description ||
+    isApiOperation ||
+    slug === "api"
+  ) {
     const description = deriveDescription(slug, route.entry.data.title);
     route.entry.data.description = description;
 
@@ -129,6 +121,31 @@ export const onRequest = defineRouteMiddleware((context) => {
   }
 });
 
+function updateRouteTitle(
+  route: NonNullable<Parameters<Parameters<typeof defineRouteMiddleware>[0]>[0]["locals"]["starlightRoute"]>,
+  title: string,
+): void {
+  route.entry.data.title = title;
+
+  // Update the <title> head entry.
+  const titleEntry = route.head.find((e) => e.tag === "title");
+  if (titleEntry) {
+    titleEntry.content = `${title} | Everruns`;
+  }
+
+  // Update og:title.
+  const ogTitle = route.head.find(
+    (e) =>
+      e.tag === "meta" &&
+      e.attrs &&
+      "property" in e.attrs &&
+      e.attrs.property === "og:title",
+  );
+  if (ogTitle?.attrs) {
+    ogTitle.attrs.content = title;
+  }
+}
+
 function deriveDescription(slug: string, title: string): string {
   // API tag group pages: derive tag name from slug (e.g. "api/operations/tags/agents" → "agents")
   if (slug.startsWith("api/operations/tags/")) {
@@ -138,12 +155,12 @@ function deriveDescription(slug: string, title: string): string {
 
   // API operation pages (title is already cleaned of method+path prefix)
   if (slug.startsWith("api/operations/")) {
-    return `${title} — Everruns REST API reference. View request parameters, response schema, and example payloads for this endpoint.`;
+    return `${title} in the Everruns REST API reference, with endpoint details, request parameters, response schemas, status codes, and example payloads for integration.`;
   }
 
   // API overview page
   if (slug === "api") {
-    return "Complete REST API reference for Everruns, including all endpoints, request and response schemas, authentication, and interactive usage examples.";
+    return "Explore the complete Everruns REST API reference, including agent, session, message, app, auth, schema, streaming, platform management, and integration examples.";
   }
 
   // API schema pages

--- a/docs/capabilities/daytona.md
+++ b/docs/capabilities/daytona.md
@@ -1,6 +1,8 @@
 ---
-title: Daytona
-description: Run code in isolated Daytona cloud sandboxes with secure command execution, file access, and session-scoped environments for safe multi-tenant agent workloads.
+title: Daytona Sandboxes for Agent Code Execution
+description: Run agent code in isolated Daytona cloud sandboxes with command execution, file access, workspace downloads, lifecycle controls, and session-scoped environments.
+sidebar:
+  label: Daytona
 ---
 
 | | |

--- a/docs/capabilities/fake-aws.md
+++ b/docs/capabilities/fake-aws.md
@@ -1,6 +1,8 @@
 ---
-title: Fake AWS
-description: Demo capability with simulated AWS infrastructure management tools. Use this built-in demo to test agent workflows with mock EC2, S3, and Lambda operations.
+title: Fake AWS Tools for Cloud Agent Demos
+description: Demo cloud-operations agents with simulated AWS tools for EC2, RDS, S3, IAM, security groups, and CloudWatch without using real infrastructure or cloud cost.
+sidebar:
+  label: Fake AWS
 ---
 
 | | |

--- a/docs/capabilities/fake-crm.md
+++ b/docs/capabilities/fake-crm.md
@@ -1,6 +1,8 @@
 ---
-title: Fake CRM
-description: Demo capability with simulated CRM and customer support tools. Use this built-in demo to test agent workflows with mock contacts, tickets, and customer data.
+title: Fake CRM Tools for Agent Workflow Demos
+description: Test support-agent workflows with a simulated CRM capability for mock customers, tickets, interactions, customer search, and session-persisted demo data.
+sidebar:
+  label: Fake CRM
 ---
 
 | | |

--- a/docs/capabilities/session-storage.md
+++ b/docs/capabilities/session-storage.md
@@ -1,6 +1,8 @@
 ---
-title: Storage
-description: Key/value storage and encrypted secret storage scoped to a session. Agents can persist state, cache results, and store sensitive data securely across turns.
+title: Session Storage for Agent State and Secrets
+description: Persist agent state with session-scoped key/value storage and encrypted secret storage for API keys, preferences, cached results, and multi-turn workflows.
+sidebar:
+  label: Storage
 ---
 
 | | |

--- a/docs/capabilities/session.md
+++ b/docs/capabilities/session.md
@@ -1,6 +1,8 @@
 ---
-title: Session
-description: Read and update current session metadata — titles, agent information, and session-scoped context. Agents can inspect and modify their own session during execution.
+title: Session Metadata Tools for Agents
+description: Let agents inspect and update current session metadata, including session IDs, titles, agent names, and context used for logging or conversation organization.
+sidebar:
+  label: Session
 ---
 
 | | |

--- a/docs/ecosystem/bashkit.md
+++ b/docs/ecosystem/bashkit.md
@@ -1,6 +1,8 @@
 ---
-title: Bashkit
-description: Sandboxed virtual Bash interpreter for multi-tenant agent environments. Run shell commands safely with process isolation, filesystem limits, and timeouts.
+title: Bashkit Virtual Bash Sandbox for Agents
+description: Use Bashkit to run agent shell commands inside a virtual Bash interpreter with sandboxed filesystems, resource limits, network controls, and async execution.
+sidebar:
+  label: Bashkit
 ---
 
 [Bashkit](https://github.com/everruns/bashkit) is a virtual Bash interpreter written in Rust. It provides sandboxed, in-process execution with no real filesystem access by default — purpose-built for running untrusted bash scripts in multi-tenant agent environments.

--- a/docs/features/apps.md
+++ b/docs/features/apps.md
@@ -1,6 +1,8 @@
 ---
-title: Apps
-description: Deploy Everruns agents to external channels like Slack, WhatsApp, and custom webhooks. Configure distribution, authentication, and message routing per app.
+title: Apps for Agent Distribution Channels
+description: Deploy Everruns agents to Slack, webhooks, and other channels with app publishing, channel authentication, session routing strategies, and lifecycle controls.
+sidebar:
+  label: Apps
 ---
 
 An App binds a Harness and Agent to a distribution channel, turning your agent into a deployed service that responds to external messages. Apps provide a publish/unpublish lifecycle — only published apps accept incoming requests.

--- a/docs/features/cli.md
+++ b/docs/features/cli.md
@@ -1,6 +1,8 @@
 ---
-title: CLI
-description: Command-line interface for managing agents, creating sessions, streaming real-time events, and running interactive conversations with the Everruns platform.
+title: CLI for Agents and Sessions
+description: Use the Everruns command-line interface to create agents, manage sessions, stream real-time events, import configuration files, and automate platform workflows.
+sidebar:
+  label: CLI
 ---
 
 The `everruns` CLI provides a command-line interface for managing agents, sessions, and conversations. It's useful for scripting, automation, and quick interactions without using the web UI.

--- a/docs/features/sdk.mdx
+++ b/docs/features/sdk.mdx
@@ -1,6 +1,8 @@
 ---
-title: SDK
-description: Official Everruns SDK client libraries for Rust, Python, and TypeScript with async/await, SSE streaming, typed models, and consistent cross-platform APIs.
+title: SDKs for Agent Applications
+description: Build agent applications with official Everruns SDKs for Rust, Python, and TypeScript, including typed clients, async APIs, sessions, messages, and SSE streams.
+sidebar:
+  label: SDK
 ---
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';

--- a/docs/features/ui.md
+++ b/docs/features/ui.md
@@ -1,6 +1,8 @@
 ---
-title: Management UI
-description: Optional web interface for managing agents, creating sessions, monitoring real-time events, and viewing conversation history in the Everruns platform.
+title: Management UI for Agents and Sessions
+description: Manage Everruns agents, sessions, capabilities, settings, files, and real-time event streams through the optional web interface for platform operators.
+sidebar:
+  label: Management UI
 ---
 
 While Everruns is a headless agent platform designed for API-first integration, it provides an optional management UI for administrative tasks and session monitoring.

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -1,6 +1,8 @@
 ---
-title: Concepts
-description: Learn the core Everruns entities and execution model — harnesses, agents, sessions, turns, events, and capabilities, and how they all relate at runtime.
+title: Core Concepts and Execution Model
+description: Learn how Everruns harnesses, agents, sessions, turns, events, capabilities, tools, apps, files, and runtime state fit together in the execution model.
+sidebar:
+  label: Concepts
 ---
 
 This page describes the core entities in Everruns and how they relate to each other, organized into three layers: the high-level execution model, session internals, and settings.

--- a/docs/sre/runbooks/authentication.md
+++ b/docs/sre/runbooks/authentication.md
@@ -1,6 +1,8 @@
 ---
-title: Authentication Configuration
-description: Configure authentication for Everruns, including API key setup, OAuth integration, token validation, and multi-tenant access control for production deployments.
+title: Authentication Configuration Runbook
+description: Configure Everruns authentication modes, API keys, OAuth providers, JWT secrets, token lifetimes, sign-up controls, and production access settings for operators.
+sidebar:
+  label: Authentication
 ---
 
 ## Overview


### PR DESCRIPTION
## What
Improve SEO titles and meta descriptions for docs pages flagged as too short. Preserve compact sidebar labels while making generated search metadata more descriptive.

## Why
Bing Webmaster Tools flagged several docs and API pages with short titles or descriptions. Better metadata should make search snippets clearer without disrupting docs navigation.

## How
- Expanded frontmatter titles/descriptions for the affected docs pages.
- Added explicit sidebar labels where the visible navigation should remain short.
- Updated docs route middleware so generated API pages and the API overview get stronger titles/descriptions in rendered HTML.

## Risk
- Low
- Could affect docs page headings, browser titles, social metadata, or generated search snippets. Runtime product behavior is unchanged.

## Security
- Threat categories reviewed: TM-WEB.
- Findings and resolutions: Static docs metadata generation only. No new user input, authentication, data access, dynamic script execution, or server runtime behavior. Existing head rendering path remains in use; no threat model update needed.

## Validation
- `npm run check` in `apps/docs`
- `npm run build` in `apps/docs`
- `just pre-push`
- `bash scripts/lib/check-migration-ordering.sh`
- Scraped generated HTML for representative flagged pages to confirm title/description lengths.
- Smoke test: skipped because this is docs-only static metadata; `npm run build` exercises the affected generated pages end to end.

## Checklist
- [x] Tests added or updated (docs check/build validation; no product tests needed)
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (none yet)
