### PR TITLE
feat(ui): add markdown link icons

### DIFF
--- a/apps/ui/src/__tests__/file-previews.test.tsx
+++ b/apps/ui/src/__tests__/file-previews.test.tsx
@@ -1,10 +1,13 @@
 import { render, screen } from "@testing-library/react";
 
+let capturedStreamdownProps: Record<string, unknown> = {};
+
 // Mock streamdown to avoid ESM issues in Jest
 jest.mock("streamdown", () => ({
-  Streamdown: ({ children }: { children: string }) => (
-    <pre data-testid="streamdown-mock">{children}</pre>
-  ),
+  Streamdown: (props: Record<string, unknown>) => {
+    capturedStreamdownProps = props;
+    return <pre data-testid="streamdown-mock">{props.children as string}</pre>;
+  },
 }));
 
 jest.mock("@streamdown/code", () => ({
@@ -428,9 +431,20 @@ describe("parseFrontmatter", () => {
 // ============================================
 
 describe("MarkdownPreview", () => {
+  beforeEach(() => {
+    capturedStreamdownProps = {};
+  });
+
   it("renders markdown content without frontmatter", () => {
     render(<MarkdownPreview content="# Hello World" />);
     expect(screen.getByTestId("streamdown-mock")).toHaveTextContent("# Hello World");
+  });
+
+  it("passes the icon link renderer to readme markdown links", () => {
+    render(<MarkdownPreview content="[PR](https://github.com/everruns/everruns/pull/44)" />);
+
+    const components = capturedStreamdownProps.components as Record<string, unknown>;
+    expect(components.a).toBeDefined();
   });
 
   it("strips frontmatter and renders body", () => {

--- a/apps/ui/src/__tests__/streamdown-message.test.tsx
+++ b/apps/ui/src/__tests__/streamdown-message.test.tsx
@@ -31,6 +31,7 @@ jest.mock("remark-gfm", () => jest.fn());
 jest.mock("remark-github-blockquote-alert", () => jest.fn());
 
 import { StreamdownMessage, InlineStreamdownMessage } from "@/components/chat/streamdown-message";
+import { getMarkdownLinkKind } from "@/components/markdown/markdown-link";
 
 describe("StreamdownMessage", () => {
   beforeEach(() => {
@@ -45,7 +46,7 @@ describe("StreamdownMessage", () => {
     expect(components.a).toBeDefined();
   });
 
-  it("ExternalLink component renders links with target=_blank", () => {
+  it("MarkdownLink component renders links with target=_blank", () => {
     render(<StreamdownMessage>test</StreamdownMessage>);
 
     const components = capturedStreamdownProps.components as Record<
@@ -64,9 +65,10 @@ describe("StreamdownMessage", () => {
     expect(link).toHaveAttribute("rel", "noopener noreferrer");
     expect(link).toHaveAttribute("href", "https://example.com");
     expect(link).toHaveTextContent("Click me");
+    expect(link.querySelector("svg")).not.toBeNull();
   });
 
-  it("ExternalLink preserves additional attributes", () => {
+  it("MarkdownLink preserves additional attributes", () => {
     render(<StreamdownMessage>test</StreamdownMessage>);
 
     const components = capturedStreamdownProps.components as Record<
@@ -82,9 +84,24 @@ describe("StreamdownMessage", () => {
     );
     const link = container.querySelector("a")!;
 
-    expect(link).toHaveAttribute("class", "custom-link");
+    expect(link).toHaveClass("custom-link");
     expect(link).toHaveAttribute("title", "Example");
     expect(link).toHaveAttribute("target", "_blank");
+  });
+
+  it("MarkdownLink renders Everruns logo for internal links", () => {
+    render(<StreamdownMessage>test</StreamdownMessage>);
+
+    const components = capturedStreamdownProps.components as Record<
+      string,
+      React.ComponentType<React.AnchorHTMLAttributes<HTMLAnchorElement>>
+    >;
+    const AnchorComponent = components.a;
+
+    const { container } = render(<AnchorComponent href="/sessions/123">Session</AnchorComponent>);
+    const logo = container.querySelector(".markdown-link-everruns-icon");
+
+    expect(logo).toHaveAttribute("aria-hidden", "true");
   });
 
   it("renders with default variant (bg-muted p-4)", () => {
@@ -180,10 +197,26 @@ describe("InlineStreamdownMessage", () => {
     expect(wrapper?.className).toContain("text-muted-foreground");
   });
 
-  it("inherits ExternalLink component for links", () => {
+  it("inherits MarkdownLink component for links", () => {
     render(<InlineStreamdownMessage>Content</InlineStreamdownMessage>);
 
     const components = capturedStreamdownProps.components as Record<string, unknown>;
     expect(components.a).toBeDefined();
+  });
+});
+
+describe("getMarkdownLinkKind", () => {
+  it.each([
+    ["https://github.com/everruns/everruns/pull/44", "github"],
+    ["https://twitter.com/everruns_ai", "twitter"],
+    ["https://x.com/everruns_ai", "twitter"],
+    ["https://docs.everruns.com/api", "everruns"],
+    ["/sessions/session_123", "everruns"],
+    ["docs/setup.md", "everruns"],
+    ["https://example.com/docs", "web"],
+    ["#local-section", null],
+    ["mailto:hello@everruns.com", null],
+  ] as const)("classifies %s as %s", (href, expected) => {
+    expect(getMarkdownLinkKind(href)).toBe(expected);
   });
 });

--- a/apps/ui/src/components/chat/streamdown-message.css
+++ b/apps/ui/src/components/chat/streamdown-message.css
@@ -58,6 +58,22 @@
   color: var(--color-primary);
   text-decoration: underline;
 }
+.streamdown a.markdown-link-with-icon {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.3em;
+}
+.streamdown .markdown-link-icon {
+  width: 1em;
+  height: 1em;
+  flex: 0 0 auto;
+  position: relative;
+  top: 0.125em;
+  stroke-width: 2.25;
+}
+.streamdown .markdown-link-everruns-icon {
+  background: url("/logo.svg") center / contain no-repeat;
+}
 .streamdown strong {
   font-weight: 600;
 }

--- a/apps/ui/src/components/chat/streamdown-message.tsx
+++ b/apps/ui/src/components/chat/streamdown-message.tsx
@@ -14,8 +14,9 @@ import { code as baseCodePlugin } from "@streamdown/code";
 import remarkGfm from "remark-gfm";
 import remarkGithubAlerts from "remark-github-blockquote-alert";
 import { cn } from "@/lib/utils";
-import { useState, useEffect, type ComponentType, type AnchorHTMLAttributes } from "react";
+import { useState, useEffect } from "react";
 import type { DiagramPlugin } from "@streamdown/mermaid";
+import { MarkdownLink } from "@/components/markdown/markdown-link";
 import "./streamdown-message.css";
 
 // Lazy-load the mermaid plugin to avoid pulling the full mermaid dependency
@@ -55,17 +56,7 @@ const code = {
     lang === "openui" ? false : baseCodePlugin.supportsLanguage(lang),
 };
 
-/** Opens all markdown links in a new tab with noopener noreferrer. */
-const ExternalLink: ComponentType<AnchorHTMLAttributes<HTMLAnchorElement>> = ({
-  children,
-  ...props
-}) => (
-  <a {...props} target="_blank" rel="noopener noreferrer">
-    {children}
-  </a>
-);
-
-const markdownComponents = { a: ExternalLink };
+const markdownComponents = { a: MarkdownLink };
 
 // Streamdown styles loaded from streamdown-message.css
 

--- a/apps/ui/src/components/files/file-previews.css
+++ b/apps/ui/src/components/files/file-previews.css
@@ -46,6 +46,22 @@
   color: var(--color-primary);
   text-decoration: underline;
 }
+.file-preview-streamdown a.markdown-link-with-icon {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.3em;
+}
+.file-preview-streamdown .markdown-link-icon {
+  width: 1em;
+  height: 1em;
+  flex: 0 0 auto;
+  position: relative;
+  top: 0.125em;
+  stroke-width: 2.25;
+}
+.file-preview-streamdown .markdown-link-everruns-icon {
+  background: url("/logo.svg") center / contain no-repeat;
+}
 .file-preview-streamdown strong {
   font-weight: 600;
 }

--- a/apps/ui/src/components/files/file-previews.tsx
+++ b/apps/ui/src/components/files/file-previews.tsx
@@ -40,6 +40,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { AlertCircle } from "lucide-react";
+import { MarkdownLink } from "@/components/markdown/markdown-link";
 import "./file-previews.css";
 
 // File extension categorization
@@ -76,6 +77,7 @@ const CODE_EXTENSIONS = new Set([
 ]);
 
 const IMAGE_EXTENSIONS = new Set(["png", "jpg", "jpeg", "gif", "webp", "bmp", "ico"]);
+const markdownComponents = { a: MarkdownLink };
 
 // Map file extensions to Shiki language identifiers
 const EXTENSION_TO_LANG: Record<string, string> = {
@@ -359,7 +361,9 @@ export function MarkdownPreview({ content }: { content: string }) {
     <ScrollArea className="h-full">
       <div className="file-preview-streamdown text-sm p-4">
         {entries.length > 0 && <FrontmatterBlock entries={entries} />}
-        <Streamdown plugins={{ code }}>{body}</Streamdown>
+        <Streamdown plugins={{ code }} components={markdownComponents}>
+          {body}
+        </Streamdown>
       </div>
     </ScrollArea>
   );

--- a/apps/ui/src/components/markdown/markdown-link.tsx
+++ b/apps/ui/src/components/markdown/markdown-link.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { Github, Globe2, Twitter, type LucideIcon } from "lucide-react";
+import { type AnchorHTMLAttributes, type ComponentType } from "react";
+import { cn } from "@/lib/utils";
+
+export type MarkdownLinkKind = "everruns" | "github" | "twitter" | "web";
+
+const EVERRUNS_HOSTS = new Set([
+  "everruns.com",
+  "app.everruns.com",
+  "dev.everruns.com",
+  "docs.everruns.com",
+  "staging.everruns.com",
+]);
+
+function normalizeHostname(hostname: string): string {
+  return hostname.toLowerCase().replace(/^www\./, "");
+}
+
+function isEverrunsHost(hostname: string): boolean {
+  const normalized = normalizeHostname(hostname);
+  return EVERRUNS_HOSTS.has(normalized) || normalized.endsWith(".everruns.com");
+}
+
+function getCurrentOrigin(): string | undefined {
+  return typeof window === "undefined" ? undefined : window.location.origin;
+}
+
+export function getMarkdownLinkKind(href?: string): MarkdownLinkKind | null {
+  if (!href) return null;
+
+  const trimmed = href.trim();
+  const lower = trimmed.toLowerCase();
+  if (
+    lower.startsWith("#") ||
+    lower.startsWith("mailto:") ||
+    lower.startsWith("tel:") ||
+    lower.startsWith("javascript:")
+  ) {
+    return null;
+  }
+
+  if (trimmed.startsWith("/") && !trimmed.startsWith("//")) {
+    return "everruns";
+  }
+  if (!/^[a-z][a-z0-9+.-]*:/i.test(trimmed) && !trimmed.startsWith("//")) {
+    return "everruns";
+  }
+
+  try {
+    const url = new URL(trimmed, getCurrentOrigin());
+    const host = normalizeHostname(url.hostname);
+
+    if (host === "github.com" || host.endsWith(".github.com")) return "github";
+    if (host === "twitter.com" || host.endsWith(".twitter.com")) return "twitter";
+    if (host === "x.com" || host.endsWith(".x.com")) return "twitter";
+    if (isEverrunsHost(host) || url.origin === getCurrentOrigin()) return "everruns";
+    if (url.protocol === "http:" || url.protocol === "https:") return "web";
+  } catch {
+    return null;
+  }
+
+  return null;
+}
+
+function LinkIcon({ kind }: { kind: MarkdownLinkKind }) {
+  if (kind === "everruns") {
+    return <span aria-hidden="true" className="markdown-link-icon markdown-link-everruns-icon" />;
+  }
+
+  const Icon: LucideIcon = kind === "github" ? Github : kind === "twitter" ? Twitter : Globe2;
+  return <Icon aria-hidden="true" className="markdown-link-icon" />;
+}
+
+/** Opens markdown links in a new tab and prefixes external links with source icons. */
+export const MarkdownLink: ComponentType<AnchorHTMLAttributes<HTMLAnchorElement>> = ({
+  children,
+  className,
+  href,
+  ...props
+}) => {
+  const kind = getMarkdownLinkKind(href);
+
+  return (
+    <a
+      {...props}
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={cn(kind && "markdown-link-with-icon", className)}
+    >
+      {kind && <LinkIcon kind={kind} />}
+      {children}
+    </a>
+  );
+};


### PR DESCRIPTION
## What
Add source icons to markdown links rendered in chat messages and README/file markdown previews.

## Why
Markdown links should visually communicate their destination type, matching the GitHub-link style shown in chat: web links get a globe, Everruns/internal links get the Everruns logo, GitHub links get a GitHub icon, and Twitter/X links get a Twitter icon.

## How
- Added a shared `MarkdownLink` renderer for Streamdown anchor components.
- Classifies relative/internal/Everruns, GitHub, Twitter/X, and generic web links.
- Reused the shared renderer in chat markdown and markdown file previews.
- Added focused tests for link classification and README preview wiring.

## Risk
- Low
- Markdown link rendering could show an unexpected icon for an uncommon URL shape.

## Security
- Threat categories reviewed: TM-WEB
- Findings and resolutions: The change only adds React-rendered icon elements around existing markdown links. Link content remains escaped by React/Streamdown. Existing `target="_blank"` and `rel="noopener noreferrer"` behavior is preserved. `javascript:`, `mailto:`, `tel:`, and hash links are not iconified. No new dependencies or raw HTML rendering were added.

## Validation
- `npm test -- --runTestsByPath src/__tests__/streamdown-message.test.tsx src/__tests__/file-previews.test.tsx`
- `npm run build` in `apps/ui`
- `just pre-push`
- Browser smoke test on `http://localhost:9120/dev/markdown`: GitHub markdown link renders an icon and keeps `_blank`/`noopener noreferrer`.
- Browser smoke test on `http://localhost:9120/dev/file-previews`: markdown preview links render icons and keep `_blank`/`noopener noreferrer`.
- `bash scripts/lib/check-migration-ordering.sh`

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
