### PR TITLE
feat(volumes): add workspace volume CRUD APIs

### DIFF
--- a/crates/server/migrations/031_volume_case_insensitive_names.sql
+++ b/crates/server/migrations/031_volume_case_insensitive_names.sql
@@ -1,0 +1,6 @@
+-- Enforce the Workspace Volume name semantics used by the API and in-memory
+-- backend: non-deleted volume names are unique per org regardless of case.
+
+CREATE UNIQUE INDEX idx_volumes_org_lower_name_active
+    ON volumes(org_id, LOWER(name))
+    WHERE status != 'deleted';

--- a/crates/server/src/api/mod.rs
+++ b/crates/server/src/api/mod.rs
@@ -51,6 +51,7 @@ pub mod tool_results;
 pub mod user_connections;
 pub mod users;
 pub mod validation;
+pub mod volumes;
 
 // Re-export common types
 pub use common::{ErrorResponse, ListResponse, PaginatedResponse};

--- a/crates/server/src/api/volumes.rs
+++ b/crates/server/src/api/volumes.rs
@@ -1,0 +1,155 @@
+// Workspace Volume CRUD HTTP routes.
+
+use crate::auth::{AuthState, ResolvedOrg};
+use crate::domains::common::{Command, Ctx};
+pub use crate::domains::volumes::types::{
+    CreateVolumeRequest, ListVolumesQuery, UpdateVolumeRequest, VolumeResponse,
+};
+use crate::domains::volumes::{
+    CreateVolume, DeleteVolume, GetVolume, ListVolumes, UpdateVolumeCmd,
+};
+use crate::storage::StorageBackend;
+use axum::{
+    Json, Router,
+    extract::{Path, Query, State},
+    http::StatusCode,
+    routing::{get, post},
+};
+use everruns_core::Caller;
+use std::sync::Arc;
+
+use super::common::{ApiResult, ErrorResponse, ListResponse, impl_auth_state};
+
+#[derive(Clone)]
+pub struct AppState {
+    pub db: Arc<StorageBackend>,
+    pub auth: AuthState,
+}
+
+impl AppState {
+    pub fn new(db: Arc<StorageBackend>, auth: AuthState) -> Self {
+        Self { db, auth }
+    }
+
+    fn ctx(&self, org: &ResolvedOrg) -> Ctx {
+        Ctx::minimal(
+            Caller::from(org),
+            self.db.clone(),
+            None,
+            self.auth.permission_resolver.clone(),
+        )
+    }
+}
+
+impl_auth_state!(AppState);
+
+pub fn routes(state: AppState) -> Router {
+    Router::new()
+        .route("/v1/volumes", post(create_volume).get(list_volumes))
+        .route(
+            "/v1/volumes/{volume_id}",
+            get(get_volume).patch(update_volume).delete(delete_volume),
+        )
+        .with_state(state)
+}
+
+#[utoipa::path(
+    post,
+    path = "/v1/volumes",
+    request_body = CreateVolumeRequest,
+    responses(
+        (status = 201, description = "Volume created", body = VolumeResponse),
+        (status = 400, description = "Invalid input", body = ErrorResponse),
+        (status = 409, description = "Duplicate volume name", body = ErrorResponse)
+    ),
+    tag = "volumes"
+)]
+pub async fn create_volume(
+    org: ResolvedOrg,
+    State(state): State<AppState>,
+    Json(req): Json<CreateVolumeRequest>,
+) -> Result<(StatusCode, Json<VolumeResponse>), (StatusCode, Json<ErrorResponse>)> {
+    let volume = CreateVolume::from(req).run(&state.ctx(&org)).await?;
+    Ok((StatusCode::CREATED, Json(volume)))
+}
+
+#[utoipa::path(
+    get,
+    path = "/v1/volumes",
+    params(ListVolumesQuery),
+    responses(
+        (status = 200, description = "List volumes", body = ListResponse<VolumeResponse>)
+    ),
+    tag = "volumes"
+)]
+pub async fn list_volumes(
+    org: ResolvedOrg,
+    State(state): State<AppState>,
+    Query(query): Query<ListVolumesQuery>,
+) -> ApiResult<ListResponse<VolumeResponse>> {
+    let volumes = ListVolumes::from(query).run(&state.ctx(&org)).await?;
+    Ok(Json(ListResponse::new(volumes)))
+}
+
+#[utoipa::path(
+    get,
+    path = "/v1/volumes/{volume_id}",
+    params(("volume_id" = String, Path, description = "Volume ID")),
+    responses(
+        (status = 200, description = "Volume found", body = VolumeResponse),
+        (status = 404, description = "Volume not found", body = ErrorResponse)
+    ),
+    tag = "volumes"
+)]
+pub async fn get_volume(
+    org: ResolvedOrg,
+    State(state): State<AppState>,
+    Path(volume_id): Path<String>,
+) -> ApiResult<VolumeResponse> {
+    Ok(Json(GetVolume { volume_id }.run(&state.ctx(&org)).await?))
+}
+
+#[utoipa::path(
+    patch,
+    path = "/v1/volumes/{volume_id}",
+    params(("volume_id" = String, Path, description = "Volume ID")),
+    request_body = UpdateVolumeRequest,
+    responses(
+        (status = 200, description = "Volume updated", body = VolumeResponse),
+        (status = 400, description = "Invalid input", body = ErrorResponse),
+        (status = 404, description = "Volume not found", body = ErrorResponse),
+        (status = 409, description = "Duplicate volume name", body = ErrorResponse)
+    ),
+    tag = "volumes"
+)]
+pub async fn update_volume(
+    org: ResolvedOrg,
+    State(state): State<AppState>,
+    Path(volume_id): Path<String>,
+    Json(request): Json<UpdateVolumeRequest>,
+) -> ApiResult<VolumeResponse> {
+    Ok(Json(
+        UpdateVolumeCmd { volume_id, request }
+            .run(&state.ctx(&org))
+            .await?,
+    ))
+}
+
+#[utoipa::path(
+    delete,
+    path = "/v1/volumes/{volume_id}",
+    params(("volume_id" = String, Path, description = "Volume ID")),
+    responses(
+        (status = 204, description = "Volume archived"),
+        (status = 404, description = "Volume not found", body = ErrorResponse)
+    ),
+    tag = "volumes"
+)]
+pub async fn delete_volume(
+    org: ResolvedOrg,
+    State(state): State<AppState>,
+    Path(volume_id): Path<String>,
+) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
+    DeleteVolume { volume_id }.run(&state.ctx(&org)).await?;
+    Ok(StatusCode::NO_CONTENT)
+}

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -946,6 +946,7 @@ impl ServerAppBuilder {
             auth_state.clone(),
             platform_definition.built_in_harnesses().to_vec(),
         );
+        let volumes_state = api::volumes::AppState::new(db.clone(), auth_state.clone());
         let audit_logs_state = api::audit_logs::AppState::new(
             db.clone(),
             capability_service.clone(),
@@ -1070,6 +1071,7 @@ impl ServerAppBuilder {
             })
             .merge(api::skills::routes(skills_state))
             .merge(api::organizations::routes(organizations_state))
+            .merge(api::volumes::routes(volumes_state))
             .merge(api::user_connections::routes(user_connections_state))
             .merge(api::session_schedules::routes(session_schedules_state))
             .merge(api::audit_logs::routes(audit_logs_state))

--- a/crates/server/src/domains/mod.rs
+++ b/crates/server/src/domains/mod.rs
@@ -36,3 +36,4 @@ pub mod skills;
 pub mod system;
 pub mod tool_results;
 pub mod users;
+pub mod volumes;

--- a/crates/server/src/domains/volumes/commands.rs
+++ b/crates/server/src/domains/volumes/commands.rs
@@ -1,0 +1,460 @@
+use super::types::{
+    CreateVolumeRequest, CreateVolumeRow, ListVolumesQuery, UpdateVolume, UpdateVolumeRequest,
+    VolumeResponse, volume_response,
+};
+use super::{VOLUME_MANAGE, VOLUME_VIEW};
+use crate::domains::common::*;
+use everruns_core::Policy;
+use everruns_core::typed_id::VolumeId;
+use everruns_durable::UpdateField;
+use serde::Deserialize;
+use utoipa::ToSchema;
+
+fn validate_name(name: &str) -> Result<String, CommandError> {
+    let trimmed = name.trim();
+    if trimmed.is_empty() {
+        return Err(CommandError::bad_request("Volume name cannot be empty"));
+    }
+    if trimmed.chars().count() > 255 {
+        return Err(CommandError::bad_request(
+            "Volume name must be at most 255 characters",
+        ));
+    }
+    Ok(trimmed.to_string())
+}
+
+fn parse_volume_id(volume_id: &str) -> Result<VolumeId, CommandError> {
+    volume_id
+        .parse()
+        .map_err(|_| CommandError::not_found("Volume"))
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct ListVolumes {
+    #[serde(default)]
+    pub search: Option<String>,
+    #[serde(default)]
+    pub include_archived: Option<bool>,
+}
+
+impl From<ListVolumesQuery> for ListVolumes {
+    fn from(query: ListVolumesQuery) -> Self {
+        Self {
+            search: query.search,
+            include_archived: query.include_archived,
+        }
+    }
+}
+
+impl Command for ListVolumes {
+    type Output = Vec<VolumeResponse>;
+
+    fn meta() -> CommandMeta {
+        CommandMeta {
+            name: "list_volumes",
+            category: "volumes",
+            description: "List workspace volumes in the current organization.",
+            method: "GET",
+            path: "/v1/volumes",
+        }
+    }
+
+    fn policy() -> Option<&'static Policy> {
+        Some(&VOLUME_VIEW)
+    }
+
+    fn output_schema() -> serde_json::Value {
+        array_output_schema(output_schema_for::<VolumeResponse>())
+    }
+
+    async fn execute(self, ctx: &Ctx) -> Result<Vec<VolumeResponse>, CommandError> {
+        let rows = ctx
+            .db
+            .list_volumes(
+                ctx.org_id(),
+                self.search.as_deref(),
+                self.include_archived.unwrap_or(false),
+            )
+            .await
+            .map_err(classify_anyhow)?;
+        rows.into_iter()
+            .map(|row| volume_response(row).map_err(classify_anyhow))
+            .collect()
+    }
+}
+
+inventory::submit! { CommandDescriptor::of::<ListVolumes>() }
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct CreateVolume {
+    pub name: String,
+    #[serde(default)]
+    pub description: Option<String>,
+}
+
+impl From<CreateVolumeRequest> for CreateVolume {
+    fn from(request: CreateVolumeRequest) -> Self {
+        Self {
+            name: request.name,
+            description: request.description,
+        }
+    }
+}
+
+impl Command for CreateVolume {
+    type Output = VolumeResponse;
+
+    fn meta() -> CommandMeta {
+        CommandMeta {
+            name: "create_volume",
+            category: "volumes",
+            description: "Create a workspace volume in the current organization.",
+            method: "POST",
+            path: "/v1/volumes",
+        }
+    }
+
+    fn policy() -> Option<&'static Policy> {
+        Some(&VOLUME_MANAGE)
+    }
+
+    fn output_schema() -> serde_json::Value {
+        output_schema_for::<VolumeResponse>()
+    }
+
+    async fn execute(self, ctx: &Ctx) -> Result<VolumeResponse, CommandError> {
+        let name = validate_name(&self.name)?;
+        let input = CreateVolumeRow {
+            public_id: VolumeId::new().to_string(),
+            name,
+            description: self.description,
+            owner_principal_id: None,
+            resolved_owner_user_id: ctx.caller.user_id,
+        };
+        let row = ctx
+            .db
+            .create_volume(ctx.org_id(), input)
+            .await
+            .map_err(classify_anyhow)?;
+        volume_response(row).map_err(classify_anyhow)
+    }
+}
+
+inventory::submit! { CommandDescriptor::of::<CreateVolume>() }
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct GetVolume {
+    pub volume_id: String,
+}
+
+impl Command for GetVolume {
+    type Output = VolumeResponse;
+
+    fn meta() -> CommandMeta {
+        CommandMeta {
+            name: "get_volume",
+            category: "volumes",
+            description: "Get a workspace volume by ID.",
+            method: "GET",
+            path: "/v1/volumes/{volume_id}",
+        }
+    }
+
+    fn positional_arg() -> Option<&'static str> {
+        Some("volume_id")
+    }
+
+    fn policy() -> Option<&'static Policy> {
+        Some(&VOLUME_VIEW)
+    }
+
+    fn output_schema() -> serde_json::Value {
+        output_schema_for::<VolumeResponse>()
+    }
+
+    async fn execute(self, ctx: &Ctx) -> Result<VolumeResponse, CommandError> {
+        let id = parse_volume_id(&self.volume_id)?;
+        let row = ctx
+            .db
+            .get_volume(ctx.org_id(), id)
+            .await
+            .map_err(classify_anyhow)?
+            .ok_or_else(|| CommandError::not_found("Volume"))?;
+        volume_response(row).map_err(classify_anyhow)
+    }
+}
+
+inventory::submit! { CommandDescriptor::of::<GetVolume>() }
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct UpdateVolumeCmd {
+    pub volume_id: String,
+    #[serde(flatten)]
+    pub request: UpdateVolumeRequest,
+}
+
+impl Command for UpdateVolumeCmd {
+    type Output = VolumeResponse;
+
+    fn meta() -> CommandMeta {
+        CommandMeta {
+            name: "update_volume",
+            category: "volumes",
+            description: "Update a workspace volume.",
+            method: "PATCH",
+            path: "/v1/volumes/{volume_id}",
+        }
+    }
+
+    fn policy() -> Option<&'static Policy> {
+        Some(&VOLUME_MANAGE)
+    }
+
+    fn output_schema() -> serde_json::Value {
+        output_schema_for::<VolumeResponse>()
+    }
+
+    async fn execute(self, ctx: &Ctx) -> Result<VolumeResponse, CommandError> {
+        let id = parse_volume_id(&self.volume_id)?;
+        let existing = ctx
+            .db
+            .get_volume(ctx.org_id(), id)
+            .await
+            .map_err(classify_anyhow)?
+            .ok_or_else(|| CommandError::not_found("Volume"))?;
+        let name = self
+            .request
+            .name
+            .as_deref()
+            .map(validate_name)
+            .transpose()?;
+        let row = ctx
+            .db
+            .update_volume(
+                ctx.org_id(),
+                existing.id,
+                UpdateVolume {
+                    name,
+                    description: match self.request.description {
+                        UpdateField::Set(description) => Some(Some(description)),
+                        UpdateField::Clear => Some(None),
+                        UpdateField::Unchanged => None,
+                    },
+                    status: None,
+                },
+            )
+            .await
+            .map_err(classify_anyhow)?
+            .ok_or_else(|| CommandError::not_found("Volume"))?;
+        volume_response(row).map_err(classify_anyhow)
+    }
+}
+
+inventory::submit! { CommandDescriptor::of::<UpdateVolumeCmd>() }
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct DeleteVolume {
+    pub volume_id: String,
+}
+
+impl Command for DeleteVolume {
+    type Output = ();
+
+    fn meta() -> CommandMeta {
+        CommandMeta {
+            name: "delete_volume",
+            category: "volumes",
+            description: "Archive a workspace volume.",
+            method: "DELETE",
+            path: "/v1/volumes/{volume_id}",
+        }
+    }
+
+    fn policy() -> Option<&'static Policy> {
+        Some(&VOLUME_MANAGE)
+    }
+
+    async fn execute(self, ctx: &Ctx) -> Result<(), CommandError> {
+        let id = parse_volume_id(&self.volume_id)?;
+        let existing = ctx
+            .db
+            .get_volume(ctx.org_id(), id)
+            .await
+            .map_err(classify_anyhow)?
+            .ok_or_else(|| CommandError::not_found("Volume"))?;
+        let archived = ctx
+            .db
+            .archive_volume(ctx.org_id(), existing.id)
+            .await
+            .map_err(classify_anyhow)?;
+        if archived {
+            Ok(())
+        } else {
+            Err(CommandError::not_found("Volume"))
+        }
+    }
+}
+
+inventory::submit! { CommandDescriptor::of::<DeleteVolume>() }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domains::common::Ctx;
+    use crate::storage::StorageBackend;
+    use everruns_core::{Caller, DEFAULT_ORG_ID, OrgRole};
+    use std::sync::Arc;
+
+    fn ctx_for_org(org_id: i64) -> Ctx {
+        Ctx::minimal_for_test(
+            Caller {
+                org_id,
+                org_public_id: everruns_core::organization::org_public_id_from_internal(org_id),
+                user_id: None,
+                role: OrgRole::Owner,
+                is_platform_user: false,
+                is_internal: false,
+            },
+            Arc::new(StorageBackend::in_memory()),
+            None,
+        )
+    }
+
+    fn ctx_with_db(org_id: i64, db: Arc<StorageBackend>) -> Ctx {
+        Ctx::minimal_for_test(
+            Caller {
+                org_id,
+                org_public_id: everruns_core::organization::org_public_id_from_internal(org_id),
+                user_id: None,
+                role: OrgRole::Owner,
+                is_platform_user: false,
+                is_internal: false,
+            },
+            db,
+            None,
+        )
+    }
+
+    #[tokio::test]
+    async fn volume_lifecycle_round_trip() {
+        let ctx = ctx_for_org(DEFAULT_ORG_ID);
+
+        let created = CreateVolume {
+            name: "Team Memory".into(),
+            description: Some("Shared working files".into()),
+        }
+        .run(&ctx)
+        .await
+        .expect("create volume");
+
+        assert!(created.id.to_string().starts_with("vol_"));
+        assert_eq!(created.name, "Team Memory");
+        assert_eq!(created.status, "active");
+
+        let listed = ListVolumes {
+            search: Some("memory".into()),
+            include_archived: None,
+        }
+        .run(&ctx)
+        .await
+        .expect("list volumes");
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].id, created.id);
+
+        let updated = UpdateVolumeCmd {
+            volume_id: created.id.to_string(),
+            request: UpdateVolumeRequest {
+                name: Some("Team Files".into()),
+                description: UpdateField::Set("Shared files".into()),
+            },
+        }
+        .run(&ctx)
+        .await
+        .expect("update volume");
+        assert_eq!(updated.name, "Team Files");
+        assert_eq!(updated.description.as_deref(), Some("Shared files"));
+
+        let cleared = UpdateVolumeCmd {
+            volume_id: created.id.to_string(),
+            request: UpdateVolumeRequest {
+                name: None,
+                description: UpdateField::Clear,
+            },
+        }
+        .run(&ctx)
+        .await
+        .expect("clear volume description");
+        assert_eq!(cleared.name, "Team Files");
+        assert_eq!(cleared.description, None);
+
+        DeleteVolume {
+            volume_id: created.id.to_string(),
+        }
+        .run(&ctx)
+        .await
+        .expect("archive volume");
+
+        let active = ListVolumes {
+            search: None,
+            include_archived: None,
+        }
+        .run(&ctx)
+        .await
+        .expect("list active volumes");
+        assert!(active.is_empty());
+
+        let archived = ListVolumes {
+            search: None,
+            include_archived: Some(true),
+        }
+        .run(&ctx)
+        .await
+        .expect("list archived volumes");
+        assert_eq!(archived.len(), 1);
+        assert_eq!(archived[0].status, "archived");
+    }
+
+    #[tokio::test]
+    async fn volume_ids_do_not_cross_orgs() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let org_one = ctx_with_db(1, db.clone());
+        let org_two = ctx_with_db(2, db);
+
+        let created = CreateVolume {
+            name: "Private".into(),
+            description: None,
+        }
+        .run(&org_one)
+        .await
+        .expect("create volume");
+
+        let err = GetVolume {
+            volume_id: created.id.to_string(),
+        }
+        .run(&org_two)
+        .await
+        .expect_err("other org should not read volume");
+        assert!(matches!(err, CommandError::NotFound(_)));
+    }
+
+    #[tokio::test]
+    async fn duplicate_active_volume_names_conflict() {
+        let ctx = ctx_for_org(DEFAULT_ORG_ID);
+        CreateVolume {
+            name: "Research".into(),
+            description: None,
+        }
+        .run(&ctx)
+        .await
+        .expect("create volume");
+
+        let err = CreateVolume {
+            name: "research".into(),
+            description: None,
+        }
+        .run(&ctx)
+        .await
+        .expect_err("duplicate name should fail");
+        assert!(matches!(err, CommandError::Conflict(_)));
+    }
+}

--- a/crates/server/src/domains/volumes/mod.rs
+++ b/crates/server/src/domains/volumes/mod.rs
@@ -1,0 +1,18 @@
+// Workspace Volumes domain.
+
+use everruns_core::{Permission, Policy, Rule};
+
+pub mod commands;
+pub mod types;
+
+pub use commands::*;
+
+pub const VOLUME_VIEW: Policy = Policy {
+    id: "volume.view",
+    rules: &[Rule::UserHasPermission(Permission::OrgSettingsView)],
+};
+
+pub const VOLUME_MANAGE: Policy = Policy {
+    id: "volume.manage",
+    rules: &[Rule::UserHasPermission(Permission::OrgSettingsManage)],
+};

--- a/crates/server/src/domains/volumes/types.rs
+++ b/crates/server/src/domains/volumes/types.rs
@@ -1,0 +1,65 @@
+use crate::api::common::deserialize_nullable_update_field;
+use chrono::{DateTime, Utc};
+use everruns_core::typed_id::VolumeId;
+use everruns_durable::UpdateField;
+use serde::{Deserialize, Serialize};
+use utoipa::{IntoParams, ToSchema};
+use uuid::Uuid;
+
+pub use crate::storage::models::{CreateVolumeRow, UpdateVolume, VolumeRow};
+
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct VolumeResponse {
+    #[schema(value_type = String, example = "vol_01933b5a000070008000000000000001")]
+    pub id: VolumeId,
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip)]
+    pub internal_id: Uuid,
+    pub status: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub archived_at: Option<DateTime<Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deleted_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, Deserialize, ToSchema)]
+pub struct CreateVolumeRequest {
+    pub name: String,
+    #[serde(default)]
+    pub description: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, ToSchema)]
+pub struct UpdateVolumeRequest {
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_nullable_update_field")]
+    #[schema(value_type = Option<String>, nullable = true)]
+    pub description: UpdateField<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, IntoParams, ToSchema)]
+pub struct ListVolumesQuery {
+    #[serde(default)]
+    pub search: Option<String>,
+    #[serde(default)]
+    pub include_archived: Option<bool>,
+}
+
+pub fn volume_response(row: VolumeRow) -> anyhow::Result<VolumeResponse> {
+    Ok(VolumeResponse {
+        id: row.public_id.parse()?,
+        name: row.name,
+        description: row.description,
+        internal_id: row.id,
+        status: row.status,
+        created_at: row.created_at,
+        updated_at: row.updated_at,
+        archived_at: row.archived_at,
+        deleted_at: row.deleted_at,
+    })
+}

--- a/crates/server/src/openapi.rs
+++ b/crates/server/src/openapi.rs
@@ -132,6 +132,12 @@ use utoipa::OpenApi;
         api::organizations::list_organizations,
         api::organizations::get_organization,
         api::organizations::update_organization,
+        // Workspace Volumes
+        api::volumes::create_volume,
+        api::volumes::list_volumes,
+        api::volumes::get_volume,
+        api::volumes::update_volume,
+        api::volumes::delete_volume,
         // Images
         api::images::upload_image,
         api::images::list_images,
@@ -258,6 +264,10 @@ use utoipa::OpenApi;
             domains::skills::types::UpdateSkillRequest,
             api::skills::ValidateSkillRequest,
             ListResponse<Skill>,
+            api::volumes::CreateVolumeRequest,
+            api::volumes::UpdateVolumeRequest,
+            api::volumes::ListVolumesQuery,
+            api::volumes::VolumeResponse,
         )
     ),
     tags(
@@ -275,6 +285,7 @@ use utoipa::OpenApi;
         (name = "mcp-servers", description = "MCP Server management endpoints"),
         (name = "durable-schedules", description = "Durable scheduled tasks management endpoints"),
         (name = "organizations", description = "Organization management endpoints"),
+        (name = "volumes", description = "Workspace volume management endpoints"),
         (name = "images", description = "Image upload and management endpoints"),
         (name = "session-databases", description = "Session-scoped SQL database endpoints"),
         (name = "session-storage", description = "Session key-value storage endpoints"),

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -9,7 +9,7 @@ use chrono::{DateTime, Utc};
 use everruns_core::message_filter::MessageQuery;
 use everruns_core::typed_id::{
     AgentId, AgentIdentityId, EventId, HarnessId, LeasedResourceId, MessageId, NotificationId,
-    PrincipalId, ScheduleId, SessionId,
+    PrincipalId, ScheduleId, SessionId, VolumeId,
 };
 use sqlx::PgPool;
 use uuid::Uuid;
@@ -699,6 +699,49 @@ impl StorageBackend {
 
     pub async fn delete_session(&self, org_id: i64, id: SessionId) -> Result<bool> {
         dispatch!(self, delete_session, org_id, id)
+    }
+
+    // ============================================
+    // Workspace Volumes
+    // ============================================
+
+    pub async fn create_volume(&self, org_id: i64, input: CreateVolumeRow) -> Result<VolumeRow> {
+        dispatch!(self, create_volume, org_id, input)
+    }
+
+    pub async fn get_volume(&self, org_id: i64, volume_id: VolumeId) -> Result<Option<VolumeRow>> {
+        dispatch!(
+            self,
+            get_volume_by_public_id,
+            org_id,
+            &volume_id.to_string()
+        )
+    }
+
+    pub async fn get_volume_by_id(&self, org_id: i64, id: Uuid) -> Result<Option<VolumeRow>> {
+        dispatch!(self, get_volume_by_id, org_id, id)
+    }
+
+    pub async fn list_volumes(
+        &self,
+        org_id: i64,
+        search: Option<&str>,
+        include_archived: bool,
+    ) -> Result<Vec<VolumeRow>> {
+        dispatch!(self, list_volumes, org_id, search, include_archived)
+    }
+
+    pub async fn update_volume(
+        &self,
+        org_id: i64,
+        id: Uuid,
+        input: UpdateVolume,
+    ) -> Result<Option<VolumeRow>> {
+        dispatch!(self, update_volume, org_id, id, input)
+    }
+
+    pub async fn archive_volume(&self, org_id: i64, id: Uuid) -> Result<bool> {
+        dispatch!(self, archive_volume, org_id, id)
     }
 
     // ============================================

--- a/crates/server/src/storage/memory/mod.rs
+++ b/crates/server/src/storage/memory/mod.rs
@@ -32,6 +32,7 @@ mod sessions;
 mod skills;
 mod user_connections;
 mod users;
+mod volumes;
 
 #[cfg(test)]
 mod tests;
@@ -141,6 +142,8 @@ pub struct InMemoryDatabase {
     budgets: RwLock<HashMap<Uuid, BudgetRow>>,
     usage_journal: RwLock<HashMap<Uuid, UsageJournalRow>>,
     usage_ledger: RwLock<Vec<UsageLedgerRow>>,
+    // Workspace volumes
+    volumes: RwLock<HashMap<Uuid, VolumeRow>>,
     // OAuth clients (MCP OAuth 2.1)
     oauth_clients: RwLock<HashMap<Uuid, OAuthClientRow>>,
     oauth_authorization_codes: RwLock<HashMap<Uuid, OAuthAuthorizationCodeRow>>,
@@ -212,6 +215,7 @@ impl Default for InMemoryDatabase {
             budgets: RwLock::new(HashMap::new()),
             usage_journal: RwLock::new(HashMap::new()),
             usage_ledger: RwLock::new(Vec::new()),
+            volumes: RwLock::new(HashMap::new()),
             oauth_clients: RwLock::new(HashMap::new()),
             oauth_authorization_codes: RwLock::new(HashMap::new()),
             oauth_refresh_tokens: RwLock::new(HashMap::new()),

--- a/crates/server/src/storage/memory/volumes.rs
+++ b/crates/server/src/storage/memory/volumes.rs
@@ -1,0 +1,153 @@
+// In-memory storage: Workspace Volume CRUD
+
+use super::super::models::*;
+use super::{InMemoryDatabase, matches_search_tokens};
+use anyhow::{Result, bail};
+use uuid::Uuid;
+
+impl InMemoryDatabase {
+    pub async fn create_volume(&self, org_id: i64, input: CreateVolumeRow) -> Result<VolumeRow> {
+        let now = Self::now();
+        let mut volumes = self.volumes.write();
+
+        if volumes.values().any(|volume| {
+            volume.org_id == org_id
+                && volume.status != "deleted"
+                && volume.name.eq_ignore_ascii_case(&input.name)
+        }) {
+            bail!("volume name already exists");
+        }
+
+        let id = Uuid::now_v7();
+        let row = VolumeRow {
+            id,
+            org_id,
+            public_id: input.public_id,
+            name: input.name,
+            description: input.description,
+            owner_principal_id: input.owner_principal_id,
+            resolved_owner_user_id: input.resolved_owner_user_id,
+            status: "active".to_string(),
+            created_at: now,
+            updated_at: now,
+            archived_at: None,
+            deleted_at: None,
+        };
+        volumes.insert(id, row.clone());
+        Ok(row)
+    }
+
+    pub async fn get_volume_by_public_id(
+        &self,
+        org_id: i64,
+        public_id: &str,
+    ) -> Result<Option<VolumeRow>> {
+        Ok(self
+            .volumes
+            .read()
+            .values()
+            .find(|volume| {
+                volume.org_id == org_id
+                    && volume.public_id == public_id
+                    && volume.status != "deleted"
+            })
+            .cloned())
+    }
+
+    pub async fn get_volume_by_id(&self, org_id: i64, id: Uuid) -> Result<Option<VolumeRow>> {
+        Ok(self
+            .volumes
+            .read()
+            .get(&id)
+            .filter(|volume| volume.org_id == org_id && volume.status != "deleted")
+            .cloned())
+    }
+
+    pub async fn list_volumes(
+        &self,
+        org_id: i64,
+        search: Option<&str>,
+        include_archived: bool,
+    ) -> Result<Vec<VolumeRow>> {
+        let mut result: Vec<_> = self
+            .volumes
+            .read()
+            .values()
+            .filter(|volume| {
+                volume.org_id == org_id
+                    && if include_archived {
+                        volume.status != "deleted"
+                    } else {
+                        volume.status == "active"
+                    }
+            })
+            .filter(|volume| {
+                matches_search_tokens(
+                    search,
+                    &[&volume.name, volume.description.as_deref().unwrap_or("")],
+                )
+            })
+            .cloned()
+            .collect();
+        result.sort_by_key(|volume| std::cmp::Reverse(volume.created_at));
+        Ok(result)
+    }
+
+    pub async fn update_volume(
+        &self,
+        org_id: i64,
+        id: Uuid,
+        input: UpdateVolume,
+    ) -> Result<Option<VolumeRow>> {
+        let mut volumes = self.volumes.write();
+        if let Some(name) = input.name.as_ref()
+            && volumes.values().any(|volume| {
+                volume.org_id == org_id
+                    && volume.id != id
+                    && volume.status != "deleted"
+                    && volume.name.eq_ignore_ascii_case(name)
+            })
+        {
+            bail!("volume name already exists");
+        }
+
+        let Some(volume) = volumes.get_mut(&id) else {
+            return Ok(None);
+        };
+        if volume.org_id != org_id || volume.status == "deleted" {
+            return Ok(None);
+        }
+
+        if let Some(name) = input.name {
+            volume.name = name;
+        }
+        if let Some(description) = input.description {
+            volume.description = description;
+        }
+        if let Some(status) = input.status {
+            volume.status = status.clone();
+            match status.as_str() {
+                "active" => volume.archived_at = None,
+                "archived" => volume.archived_at = Some(Self::now()),
+                "deleted" => volume.deleted_at = Some(Self::now()),
+                _ => {}
+            }
+        }
+        volume.updated_at = Self::now();
+        Ok(Some(volume.clone()))
+    }
+
+    pub async fn archive_volume(&self, org_id: i64, id: Uuid) -> Result<bool> {
+        let mut volumes = self.volumes.write();
+        let Some(volume) = volumes.get_mut(&id) else {
+            return Ok(false);
+        };
+        if volume.org_id != org_id || volume.status != "active" {
+            return Ok(false);
+        }
+        volume.status = "archived".to_string();
+        volume.archived_at = Some(Self::now());
+        volume.updated_at = Self::now();
+        Ok(true)
+    }
+}

--- a/crates/server/src/storage/models.rs
+++ b/crates/server/src/storage/models.rs
@@ -866,6 +866,42 @@ pub struct SessionFileInfoRow {
 }
 
 // ============================================
+// Workspace Volume models
+// ============================================
+
+#[derive(Debug, Clone, FromRow, serde::Serialize)]
+pub struct VolumeRow {
+    pub id: Uuid,
+    pub org_id: i64,
+    pub public_id: String,
+    pub name: String,
+    pub description: Option<String>,
+    pub owner_principal_id: Option<String>,
+    pub resolved_owner_user_id: Option<Uuid>,
+    pub status: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub archived_at: Option<DateTime<Utc>>,
+    pub deleted_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CreateVolumeRow {
+    pub public_id: String,
+    pub name: String,
+    pub description: Option<String>,
+    pub owner_principal_id: Option<String>,
+    pub resolved_owner_user_id: Option<Uuid>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct UpdateVolume {
+    pub name: Option<String>,
+    pub description: Option<Option<String>>,
+    pub status: Option<String>,
+}
+
+// ============================================
 // Session Git models (libgit2 custom ODB/refdb over PostgreSQL)
 // ============================================
 

--- a/crates/server/src/storage/repositories/mod.rs
+++ b/crates/server/src/storage/repositories/mod.rs
@@ -27,6 +27,7 @@ mod sessions;
 mod skills;
 mod user_connections;
 mod users;
+mod volumes;
 
 #[cfg(test)]
 mod tests;

--- a/crates/server/src/storage/repositories/volumes.rs
+++ b/crates/server/src/storage/repositories/volumes.rs
@@ -1,0 +1,148 @@
+// PostgreSQL repository: Workspace Volume CRUD
+
+use super::super::models::*;
+use super::{Database, build_search_sql};
+use anyhow::Result;
+use uuid::Uuid;
+
+impl Database {
+    pub async fn create_volume(&self, org_id: i64, input: CreateVolumeRow) -> Result<VolumeRow> {
+        let row = sqlx::query_as::<_, VolumeRow>(
+            r#"
+            INSERT INTO volumes (org_id, public_id, name, description, owner_principal_id, resolved_owner_user_id)
+            VALUES ($1, $2, $3, $4, $5, $6)
+            RETURNING id, org_id, public_id, name, description, owner_principal_id, resolved_owner_user_id, status, created_at, updated_at, archived_at, deleted_at
+            "#,
+        )
+        .bind(org_id)
+        .bind(&input.public_id)
+        .bind(&input.name)
+        .bind(&input.description)
+        .bind(&input.owner_principal_id)
+        .bind(input.resolved_owner_user_id)
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(row)
+    }
+
+    pub async fn get_volume_by_public_id(
+        &self,
+        org_id: i64,
+        public_id: &str,
+    ) -> Result<Option<VolumeRow>> {
+        let row = sqlx::query_as::<_, VolumeRow>(
+            r#"
+            SELECT id, org_id, public_id, name, description, owner_principal_id, resolved_owner_user_id, status, created_at, updated_at, archived_at, deleted_at
+            FROM volumes
+            WHERE org_id = $1 AND public_id = $2 AND status != 'deleted'
+            "#,
+        )
+        .bind(org_id)
+        .bind(public_id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row)
+    }
+
+    pub async fn get_volume_by_id(&self, org_id: i64, id: Uuid) -> Result<Option<VolumeRow>> {
+        let row = sqlx::query_as::<_, VolumeRow>(
+            r#"
+            SELECT id, org_id, public_id, name, description, owner_principal_id, resolved_owner_user_id, status, created_at, updated_at, archived_at, deleted_at
+            FROM volumes
+            WHERE org_id = $1 AND id = $2 AND status != 'deleted'
+            "#,
+        )
+        .bind(org_id)
+        .bind(id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row)
+    }
+
+    pub async fn list_volumes(
+        &self,
+        org_id: i64,
+        search: Option<&str>,
+        include_archived: bool,
+    ) -> Result<Vec<VolumeRow>> {
+        let (search_sql, patterns) =
+            build_search_sql(search, "LOWER(name || ' ' || COALESCE(description, ''))", 2);
+        let status_sql = if include_archived {
+            " AND status != 'deleted'"
+        } else {
+            " AND status = 'active'"
+        };
+        let sql = format!(
+            r#"
+            SELECT id, org_id, public_id, name, description, owner_principal_id, resolved_owner_user_id, status, created_at, updated_at, archived_at, deleted_at
+            FROM volumes
+            WHERE org_id = $1{status_sql}{search_sql}
+            ORDER BY created_at DESC
+            "#
+        );
+        let mut query = sqlx::query_as::<_, VolumeRow>(&sql).bind(org_id);
+        for pattern in &patterns {
+            query = query.bind(pattern);
+        }
+
+        Ok(query.fetch_all(&self.pool).await?)
+    }
+
+    pub async fn update_volume(
+        &self,
+        org_id: i64,
+        id: Uuid,
+        input: UpdateVolume,
+    ) -> Result<Option<VolumeRow>> {
+        let row = sqlx::query_as::<_, VolumeRow>(
+            r#"
+            UPDATE volumes
+            SET
+                name = COALESCE($3, name),
+                description = CASE WHEN $4 THEN $5 ELSE description END,
+                status = COALESCE($6, status),
+                archived_at = CASE
+                    WHEN $6 = 'archived' THEN COALESCE(archived_at, NOW())
+                    WHEN $6 = 'active' THEN NULL
+                    ELSE archived_at
+                END,
+                deleted_at = CASE
+                    WHEN $6 = 'deleted' THEN COALESCE(deleted_at, NOW())
+                    ELSE deleted_at
+                END,
+                updated_at = NOW()
+            WHERE org_id = $1 AND id = $2 AND status != 'deleted'
+            RETURNING id, org_id, public_id, name, description, owner_principal_id, resolved_owner_user_id, status, created_at, updated_at, archived_at, deleted_at
+            "#,
+        )
+        .bind(org_id)
+        .bind(id)
+        .bind(&input.name)
+        .bind(input.description.is_some())
+        .bind(input.description.flatten())
+        .bind(&input.status)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row)
+    }
+
+    pub async fn archive_volume(&self, org_id: i64, id: Uuid) -> Result<bool> {
+        let result = sqlx::query(
+            r#"
+            UPDATE volumes
+            SET status = 'archived', archived_at = COALESCE(archived_at, NOW()), updated_at = NOW()
+            WHERE org_id = $1 AND id = $2 AND status = 'active'
+            "#,
+        )
+        .bind(org_id)
+        .bind(id)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(result.rows_affected() > 0)
+    }
+}

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -5598,6 +5598,240 @@
           }
         }
       }
+    },
+    "/v1/volumes": {
+      "get": {
+        "tags": [
+          "volumes"
+        ],
+        "operationId": "list_volumes",
+        "parameters": [
+          {
+            "name": "search",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          {
+            "name": "include_archived",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List volumes",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListResponse_VolumeResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "volumes"
+        ],
+        "operationId": "create_volume",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateVolumeRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Volume created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VolumeResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid input",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Duplicate volume name",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/volumes/{volume_id}": {
+      "get": {
+        "tags": [
+          "volumes"
+        ],
+        "operationId": "get_volume",
+        "parameters": [
+          {
+            "name": "volume_id",
+            "in": "path",
+            "description": "Volume ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Volume found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VolumeResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Volume not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "volumes"
+        ],
+        "operationId": "delete_volume",
+        "parameters": [
+          {
+            "name": "volume_id",
+            "in": "path",
+            "description": "Volume ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Volume archived"
+          },
+          "404": {
+            "description": "Volume not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "volumes"
+        ],
+        "operationId": "update_volume",
+        "parameters": [
+          {
+            "name": "volume_id",
+            "in": "path",
+            "description": "Volume ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateVolumeRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Volume updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VolumeResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid input",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Volume not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Duplicate volume name",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -7261,6 +7495,23 @@
             "type": "string",
             "description": "Full SKILL.md content (YAML frontmatter + markdown body)",
             "example": "---\nname: pdf-processing\ndescription: Extract text from PDFs.\n---\n\n# PDF Processing\n\nUse pdfplumber..."
+          }
+        }
+      },
+      "CreateVolumeRequest": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "name": {
+            "type": "string"
           }
         }
       },
@@ -9815,6 +10066,69 @@
           }
         }
       },
+      "ListResponse_VolumeResponse": {
+        "type": "object",
+        "description": "Response wrapper for list endpoints.\nAll list endpoints return responses wrapped in a `data` field.",
+        "required": [
+          "data"
+        ],
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "id",
+                "name",
+                "status",
+                "created_at",
+                "updated_at"
+              ],
+              "properties": {
+                "archived_at": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "format": "date-time"
+                },
+                "created_at": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "deleted_at": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "format": "date-time"
+                },
+                "description": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "id": {
+                  "type": "string",
+                  "example": "vol_01933b5a000070008000000000000001"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "status": {
+                  "type": "string"
+                },
+                "updated_at": {
+                  "type": "string",
+                  "format": "date-time"
+                }
+              }
+            },
+            "description": "Array of items returned by the list operation."
+          }
+        }
+      },
       "ListResponse_WithUrls_LlmModel": {
         "type": "object",
         "description": "Response wrapper for list endpoints.\nAll list endpoints return responses wrapped in a `data` field.",
@@ -10637,6 +10951,23 @@
               "null"
             ],
             "description": "Search query to filter by name or email"
+          }
+        }
+      },
+      "ListVolumesQuery": {
+        "type": "object",
+        "properties": {
+          "include_archived": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "search": {
+            "type": [
+              "string",
+              "null"
+            ]
           }
         }
       },
@@ -16032,6 +16363,23 @@
           }
         }
       },
+      "UpdateVolumeRequest": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      },
       "User": {
         "type": "object",
         "description": "User response for listing",
@@ -16086,6 +16434,56 @@
           "skill_md": {
             "type": "string",
             "description": "SKILL.md content to validate"
+          }
+        }
+      },
+      "VolumeResponse": {
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "status",
+          "created_at",
+          "updated_at"
+        ],
+        "properties": {
+          "archived_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "deleted_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "id": {
+            "type": "string",
+            "example": "vol_01933b5a000070008000000000000001"
+          },
+          "name": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
           }
         }
       },
@@ -17834,6 +18232,10 @@
     {
       "name": "organizations",
       "description": "Organization management endpoints"
+    },
+    {
+      "name": "volumes",
+      "description": "Workspace volume management endpoints"
     },
     {
       "name": "images",


### PR DESCRIPTION
## What
Adds org-scoped Workspace Volume CRUD APIs for EVE-420:
- `POST /api/v1/volumes`
- `GET /api/v1/volumes`
- `GET /api/v1/volumes/{volume_id}`
- `PATCH /api/v1/volumes/{volume_id}`
- `DELETE /api/v1/volumes/{volume_id}` soft-archives volumes

## Why
Workspace volumes are the server-side foundation for org-shared storage, knowledge-base-style files, and later UI/runtime volume mounting work.

Linear: https://linear.app/everruns/issue/EVE-420/featvolumes-implement-workspace-volume-apis

## How
- Adds volume domain commands with `OrgSettingsView` / `OrgSettingsManage` policy checks.
- Adds Postgres and in-memory storage repositories with org scoping, search, archive filtering, and duplicate active-name protection.
- Registers Axum routes and OpenAPI schemas/paths.
- Adds focused domain tests for lifecycle, cross-org isolation, and duplicate active-name conflicts.

## Risk
- Medium
- New org-scoped API metadata could leak across orgs if storage scoping regresses. Storage lookups and list queries require `org_id`, and tests cover cross-org isolation.
- Name validation and duplicate checks could reject valid future naming patterns. Current validation only rejects empty names and names over 255 characters.

## Security
- Threat categories reviewed: TM-API, TM-AUTHZ, TM-TENANT, TM-DOS
- Findings and resolutions: authorization goes through domain policies, HTTP routes resolve org context before command execution, storage operations bind `org_id` for tenant isolation, SQL queries use bound parameters/static fragments, and search token handling reuses the existing bounded search helper. No new secrets, external calls, or filesystem path operations are introduced.

## Validation
- `cargo test -p everruns-server domains::volumes`
- `cargo check -p everruns-server`
- `./scripts/export-openapi.sh`
- `PORT_PREFIX=79 just start-dev --no-watch --no-ui` API smoke: list, create, read, patch, duplicate-name 409, delete/archive, include archived
- `just pre-push`

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)