### PR TITLE
fix(mcp): walk allOf/$ref to coerce JSON aggregate flags for flatten cmds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -457,9 +457,9 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bashkit"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd73187decb067c0df19d2a7e042d05b481d711d048ad3169162196e2489b7db"
+checksum = "ac1e824b4d156642e3ff4cd365af83eca1e90c62a09d8059cb05f26af1bf5d09"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -66,7 +66,7 @@ fetchkit = { version = "0.2.0", features = ["bot-auth"] }
 ed25519-dalek = { version = "2", features = ["rand_core"] }
 
 # Virtual bash interpreter
-bashkit = { version = "0.4.1", features = ["jq"] }
+bashkit = { version = "0.5.0", features = ["jq"] }
 
 # Tree-sitter for structural outlines (EVE-248)
 tree-sitter = { version = "0.24", optional = true }

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -66,7 +66,7 @@ urlencoding = "2"
 git2.workspace = true
 mime_guess = "2"
 
-bashkit = { version = "0.4.1", features = ["scripted_tool", "jq"] }
+bashkit = { version = "0.5.0", features = ["scripted_tool", "jq"] }
 
 everruns-config = { path = "../config" }
 everruns-core = { path = "../core", features = ["openapi", "sqlx", "tree-sitter-outlines"] }

--- a/crates/server/src/api/mcp_endpoint/catalog.rs
+++ b/crates/server/src/api/mcp_endpoint/catalog.rs
@@ -106,53 +106,101 @@ fn command_descriptor_to_def(desc: &crate::domains::common::CommandDescriptor) -
         })
 }
 
+// EVE-409: bashkit's flag parser only coerces scalar types (integer, number,
+// boolean) and treats everything else as raw `string`. So array/object fields
+// like `--capabilities '[...]'` or `--tags '[...]'` arrive at dispatch as JSON
+// strings. We bridge this in two complementary passes:
+//
+// 1. `bashkit_inventory_schema` rewrites every aggregate property to
+//    `type: "string"` so bashkit's `tools/list` advertises a flat string flag
+//    and `parse_flags` accepts the raw JSON text without typed coercion
+//    attempts (which still don't reach into `allOf`/`$ref` composition;
+//    bashkit#1516/#1527 only coerces top-level array/object schemas).
+// 2. `coerce_json_text_params` parses those JSON strings back into typed
+//    values before the domain dispatcher sees them.
+//
+// Both passes walk `$ref` into `$defs`/`definitions`, traverse `allOf`,
+// `oneOf`, `anyOf` branches, and recurse into nested `$defs` entries — this
+// is what makes the `#[serde(flatten)]` shape used by `UpdateAgentCmd`
+// (`allOf: [{$ref: ".../UpdateAgentRequest"}, {properties: {id}}]`) work the
+// same as the simpler `CreateAgentCmd` shape with direct top-level
+// properties.
+const SCHEMA_WALK_MAX_DEPTH: u8 = 8;
+
 fn bashkit_inventory_schema(mut schema: serde_json::Value) -> serde_json::Value {
-    let Some(properties) = schema
+    let defs_snapshot = schema
+        .get("$defs")
+        .or_else(|| schema.get("definitions"))
+        .and_then(|value| value.as_object())
+        .cloned();
+    retype_aggregate_properties_in_place(&mut schema, defs_snapshot.as_ref(), 0);
+    schema
+}
+
+fn retype_aggregate_properties_in_place(
+    schema: &mut serde_json::Value,
+    defs: Option<&serde_json::Map<String, serde_json::Value>>,
+    depth: u8,
+) {
+    if depth >= SCHEMA_WALK_MAX_DEPTH {
+        return;
+    }
+    if let Some(properties) = schema
         .get_mut("properties")
         .and_then(|value| value.as_object_mut())
-    else {
-        return schema;
-    };
-
-    // EVE-409: bashkit's flag parser only coerces scalar types and falls back
-    // to `string` for anything else, leaving array/object fields as raw strings
-    // by the time they reach the dispatcher. Generic operations (`update_agent
-    // --capabilities '[...]'`, `--tags '[...]'`, etc.) then fail to deserialize.
-    // Re-shape every non-scalar property to `type: string` with a JSON-text
-    // hint here, and let `make_inventory_callback` parse those JSON strings
-    // back into structured values before dispatch.
-    for (_name, property) in properties.iter_mut() {
-        let Some(object) = property.as_object_mut() else {
-            continue;
-        };
-        let is_non_scalar = object
-            .get("type")
-            .and_then(|value| value.as_str())
-            .is_some_and(|value| matches!(value, "array" | "object"))
-            || object.contains_key("items")
-            || object.contains_key("properties");
-        if !is_non_scalar {
-            continue;
+    {
+        for (_name, property) in properties.iter_mut() {
+            if !property_is_aggregate(property, defs, 0) {
+                continue;
+            }
+            let Some(object) = property.as_object_mut() else {
+                continue;
+            };
+            object.insert(
+                "type".to_string(),
+                serde_json::Value::String("string".to_string()),
+            );
+            // Drop type-discriminating constructs that no longer apply after
+            // retyping; this keeps `tools/list` consumers from generating
+            // bogus item validators or following stale composition branches.
+            object.remove("items");
+            object.remove("properties");
+            object.remove("oneOf");
+            object.remove("anyOf");
+            object.remove("allOf");
+            object.remove("$ref");
+            let description = object
+                .get("description")
+                .and_then(|value| value.as_str())
+                .map(|value| format!("{value} Pass JSON text in bash mode."))
+                .unwrap_or_else(|| "Pass JSON text in bash mode.".to_string());
+            object.insert(
+                "description".to_string(),
+                serde_json::Value::String(description),
+            );
         }
-        object.insert(
-            "type".to_string(),
-            serde_json::Value::String("string".to_string()),
-        );
-        // Drop array-only metadata that no longer applies after retyping; this
-        // keeps `tools/list` consumers from generating bogus item validators.
-        object.remove("items");
-        let description = object
-            .get("description")
-            .and_then(|value| value.as_str())
-            .map(|value| format!("{value} Pass JSON text in bash mode."))
-            .unwrap_or_else(|| "Pass JSON text in bash mode.".to_string());
-        object.insert(
-            "description".to_string(),
-            serde_json::Value::String(description),
-        );
     }
-
-    schema
+    let defs_key = if schema.get("$defs").is_some() {
+        Some("$defs")
+    } else if schema.get("definitions").is_some() {
+        Some("definitions")
+    } else {
+        None
+    };
+    if let Some(key) = defs_key
+        && let Some(defs_obj) = schema.get_mut(key).and_then(|value| value.as_object_mut())
+    {
+        for (_, def) in defs_obj.iter_mut() {
+            retype_aggregate_properties_in_place(def, defs, depth + 1);
+        }
+    }
+    for key in ["allOf", "oneOf", "anyOf"] {
+        if let Some(branches) = schema.get_mut(key).and_then(|value| value.as_array_mut()) {
+            for branch in branches.iter_mut() {
+                retype_aggregate_properties_in_place(branch, defs, depth + 1);
+            }
+        }
+    }
 }
 
 /// Walk the original param schema and parse JSON-text values for properties
@@ -169,26 +217,23 @@ fn coerce_json_text_params(
     schema: &serde_json::Value,
     params: &mut serde_json::Value,
 ) -> Result<(), String> {
-    let (Some(properties), Some(params_obj)) = (
-        schema.get("properties").and_then(|value| value.as_object()),
-        params.as_object_mut(),
-    ) else {
+    let Some(params_obj) = params.as_object_mut() else {
         return Ok(());
     };
-    for (name, property) in properties.iter() {
-        let needs_parse = property
-            .get("type")
-            .and_then(|value| value.as_str())
-            .is_some_and(|value| matches!(value, "array" | "object"))
-            || property.get("items").is_some()
-            || property.get("properties").is_some();
-        if !needs_parse {
-            continue;
-        }
-        let Some(raw) = params_obj.get(name) else {
+    let defs = schema
+        .get("$defs")
+        .or_else(|| schema.get("definitions"))
+        .and_then(|value| value.as_object());
+    let mut all_properties = serde_json::Map::new();
+    collect_all_properties(schema, defs, &mut all_properties, 0);
+    for (name, value) in params_obj.iter_mut() {
+        let Some(property) = all_properties.get(name) else {
             continue;
         };
-        let serde_json::Value::String(text) = raw else {
+        if !property_is_aggregate(property, defs, 0) {
+            continue;
+        }
+        let serde_json::Value::String(text) = value else {
             continue;
         };
         if text.trim().is_empty() {
@@ -196,9 +241,99 @@ fn coerce_json_text_params(
         }
         let parsed = serde_json::from_str::<serde_json::Value>(text.trim())
             .map_err(|err| format!("--{name}: invalid JSON ({err})"))?;
-        params_obj.insert(name.clone(), parsed);
+        *value = parsed;
     }
     Ok(())
+}
+
+/// Merge property maps across `$ref`, `allOf`, `oneOf`, and `anyOf` branches
+/// so composed command schemas surface every declared field. The outermost
+/// schema's own `properties` are visited first, then `$ref` resolution and
+/// composition branches; combined with `or_insert_with` this gives outer
+/// declarations precedence over nested copies on key conflicts.
+fn collect_all_properties(
+    schema: &serde_json::Value,
+    defs: Option<&serde_json::Map<String, serde_json::Value>>,
+    out: &mut serde_json::Map<String, serde_json::Value>,
+    depth: u8,
+) {
+    if depth >= SCHEMA_WALK_MAX_DEPTH {
+        return;
+    }
+    if let Some(properties) = schema.get("properties").and_then(|value| value.as_object()) {
+        for (name, property) in properties {
+            out.entry(name.clone()).or_insert_with(|| property.clone());
+        }
+    }
+    if let Some(reference) = schema.get("$ref").and_then(|value| value.as_str())
+        && let Some(name) = reference
+            .strip_prefix("#/$defs/")
+            .or_else(|| reference.strip_prefix("#/definitions/"))
+        && let Some(defs) = defs
+        && let Some(resolved) = defs.get(name)
+    {
+        collect_all_properties(resolved, Some(defs), out, depth + 1);
+    }
+    for key in ["allOf", "oneOf", "anyOf"] {
+        if let Some(branches) = schema.get(key).and_then(|value| value.as_array()) {
+            for branch in branches {
+                collect_all_properties(branch, defs, out, depth + 1);
+            }
+        }
+    }
+}
+
+/// Decide whether a property's declared schema represents an array or object
+/// aggregate, including the utoipa-style nullable shapes (`type: ["array",
+/// "null"]`, `oneOf` with a `null` branch + array branch) and `$ref` chains
+/// into `$defs`.
+fn property_is_aggregate(
+    schema: &serde_json::Value,
+    defs: Option<&serde_json::Map<String, serde_json::Value>>,
+    depth: u8,
+) -> bool {
+    if depth >= SCHEMA_WALK_MAX_DEPTH {
+        return false;
+    }
+    if let Some(value) = schema.get("type") {
+        if let Some(name) = value.as_str()
+            && matches!(name, "array" | "object")
+        {
+            return true;
+        }
+        if let Some(types) = value.as_array()
+            && types.iter().any(|entry| {
+                entry
+                    .as_str()
+                    .is_some_and(|name| matches!(name, "array" | "object"))
+            })
+        {
+            return true;
+        }
+    }
+    if schema.get("items").is_some() || schema.get("properties").is_some() {
+        return true;
+    }
+    if let Some(reference) = schema.get("$ref").and_then(|value| value.as_str())
+        && let Some(name) = reference
+            .strip_prefix("#/$defs/")
+            .or_else(|| reference.strip_prefix("#/definitions/"))
+        && let Some(defs) = defs
+        && let Some(resolved) = defs.get(name)
+        && property_is_aggregate(resolved, Some(defs), depth + 1)
+    {
+        return true;
+    }
+    for key in ["allOf", "oneOf", "anyOf"] {
+        if let Some(branches) = schema.get(key).and_then(|value| value.as_array())
+            && branches
+                .iter()
+                .any(|branch| property_is_aggregate(branch, defs, depth + 1))
+        {
+            return true;
+        }
+    }
+    false
 }
 
 /// Stable, lower_snake_case label for a `CommandError` variant. Surfaced as
@@ -410,6 +545,110 @@ mod tests {
                 "blank input {blank:?} should pass through untouched",
             );
         }
+    }
+
+    #[test]
+    fn bashkit_schema_retypes_aggregate_fields_buried_under_allof_and_ref() {
+        // `UpdateAgentCmd` shape: `#[serde(flatten)]` projects the wrapped
+        // request's properties into an `allOf: [{$ref}, {properties: {id}}]`
+        // composition. Top-level `properties` is empty; aggregate flags
+        // (`capabilities`, `tags`, `mcpServers`) live under
+        // `$defs.UpdateAgentRequest.properties`. The retyper must reach them
+        // so bashkit advertises plain `string` flags instead of typed
+        // arrays/objects (which bashkit#1516/#1527 still does not coerce
+        // through `allOf`/`$ref`).
+        let schema = serde_json::json!({
+            "type": "object",
+            "$defs": {
+                "UpdateAgentRequest": {
+                    "type": "object",
+                    "properties": {
+                        "tags": {
+                            "type": ["array", "null"],
+                            "items": { "type": "string" }
+                        },
+                        "capabilities": {
+                            "type": ["array", "null"],
+                            "items": { "$ref": "#/$defs/AgentCapabilityConfig" }
+                        },
+                        "mcpServers": {
+                            "oneOf": [
+                                { "type": "null" },
+                                { "$ref": "#/$defs/ScopedMcpServers" }
+                            ]
+                        }
+                    }
+                },
+                "AgentCapabilityConfig": { "type": "object", "properties": {} },
+                "ScopedMcpServers": { "type": "object", "properties": {} }
+            },
+            "allOf": [
+                { "$ref": "#/$defs/UpdateAgentRequest" },
+                {
+                    "type": "object",
+                    "properties": { "id": { "type": "string" } },
+                    "required": ["id"]
+                }
+            ]
+        });
+        let rewritten = bashkit_inventory_schema(schema);
+        let req_props = rewritten["$defs"]["UpdateAgentRequest"]["properties"]
+            .as_object()
+            .expect("UpdateAgentRequest properties");
+        for key in ["tags", "capabilities", "mcpServers"] {
+            assert_eq!(
+                req_props[key]["type"], "string",
+                "{key} should be retyped to string under $defs"
+            );
+            assert!(
+                req_props[key].get("items").is_none(),
+                "{key} items metadata should be dropped"
+            );
+            assert!(
+                req_props[key].get("oneOf").is_none(),
+                "{key} oneOf branches should be dropped"
+            );
+        }
+        // Top-level allOf id flag remains a plain string.
+        let id_props = rewritten["allOf"][1]["properties"].as_object().unwrap();
+        assert_eq!(id_props["id"]["type"], "string");
+    }
+
+    #[test]
+    fn coerce_walks_allof_ref_to_parse_flatten_aggregate_fields() {
+        // Same `UpdateAgentCmd` shape as above. Bashkit hands us the
+        // string-typed value because we advertised the field as `string`;
+        // the coercer must walk into `$defs` via the `allOf` `$ref` to
+        // discover that `capabilities` was originally an array and parse it.
+        let schema = serde_json::json!({
+            "$defs": {
+                "UpdateAgentRequest": {
+                    "properties": {
+                        "tags": { "type": ["array", "null"], "items": {} },
+                        "capabilities": {
+                            "type": ["array", "null"],
+                            "items": { "type": "object" }
+                        }
+                    }
+                }
+            },
+            "allOf": [
+                { "$ref": "#/$defs/UpdateAgentRequest" },
+                { "properties": { "id": { "type": "string" } } }
+            ]
+        });
+        let mut params = serde_json::json!({
+            "id": "agent_x",
+            "capabilities": "[{\"ref\":\"current_time\"}]",
+            "tags": "[\"a\",\"b\"]"
+        });
+        coerce_json_text_params(&schema, &mut params).expect("coerce");
+        assert_eq!(params["id"], "agent_x");
+        assert_eq!(
+            params["capabilities"],
+            serde_json::json!([{ "ref": "current_time" }])
+        );
+        assert_eq!(params["tags"], serde_json::json!(["a", "b"]));
     }
 
     #[test]

--- a/crates/server/tests/mcp_endpoint_test.rs
+++ b/crates/server/tests/mcp_endpoint_test.rs
@@ -2092,6 +2092,105 @@ async fn test_mcp_execute_agent_crud_workflow() {
     );
 }
 
+// EVE-409: bashkit's flag parser stringifies any flag whose schema is not a
+// scalar, so JSON arrays/objects passed to generated builtins arrive at the
+// MCP catalog callback as strings. `coerce_json_text_params` parses them
+// back into structured JSON before the domain dispatcher sees them. These
+// tests exercise both `create_agent` and `update_agent` end-to-end through
+// the bashkit pipeline to make sure the fix works for every typed-aggregate
+// field on every generated operation, including the `#[serde(flatten)]`
+// shape used by `UpdateAgentCmd`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_execute_array_flags_create_and_update_agent() {
+    let (_server, url) = TestServer::serving().await;
+
+    // create_agent with --capabilities and --tags as JSON-stringified arrays.
+    let suffix = unique_suffix();
+    let create_cmd = format!(
+        "create_agent --name 'eve409-arr-{suffix}' --display_name 'EVE-409 Array Flags' \
+         --system_prompt 'Test array flags.' \
+         --tags '[\"alpha\",\"beta\"]' \
+         --capabilities '[{{\"ref\":\"current_time\"}}]'"
+    );
+    let resp = execute_http_command(&url, create_cmd).await;
+    assert!(
+        !tool_is_error(&resp),
+        "create_agent with array flags failed: {}",
+        tool_text(&resp)
+    );
+    let created = tool_json(&resp);
+    let agent_id = created["id"].as_str().unwrap().to_string();
+    assert_eq!(
+        created["tags"],
+        json!(["alpha", "beta"]),
+        "tags should round-trip as an array"
+    );
+    let cap_refs: Vec<String> = created["capabilities"]
+        .as_array()
+        .expect("capabilities array")
+        .iter()
+        .map(|c| c["ref"].as_str().unwrap_or_default().to_string())
+        .collect();
+    assert!(
+        cap_refs.iter().any(|r| r == "current_time"),
+        "expected current_time capability, got: {cap_refs:?}"
+    );
+
+    // update_agent --capabilities '[{"ref":"current_time"}]' — the exact
+    // failing case from EVE-409.
+    let update_resp = execute_http_command(
+        &url,
+        format!("update_agent --id {agent_id} --capabilities '[{{\"ref\":\"current_time\"}}]'"),
+    )
+    .await;
+    assert!(
+        !tool_is_error(&update_resp),
+        "update_agent --capabilities failed: {}",
+        tool_text(&update_resp)
+    );
+    let updated_caps: Vec<String> = tool_json(&update_resp)["capabilities"]
+        .as_array()
+        .expect("capabilities array")
+        .iter()
+        .map(|c| c["ref"].as_str().unwrap_or_default().to_string())
+        .collect();
+    assert!(
+        updated_caps.iter().any(|r| r == "current_time"),
+        "update_agent should persist capabilities, got: {updated_caps:?}"
+    );
+
+    // update_agent --tags '["a","b"]'
+    let tags_resp = execute_http_command(
+        &url,
+        format!("update_agent --id {agent_id} --tags '[\"codex-created\",\"joke\"]'"),
+    )
+    .await;
+    assert!(
+        !tool_is_error(&tags_resp),
+        "update_agent --tags failed: {}",
+        tool_text(&tags_resp)
+    );
+    assert_eq!(
+        tool_json(&tags_resp)["tags"],
+        json!(["codex-created", "joke"]),
+        "update_agent --tags should round-trip"
+    );
+
+    // Malformed JSON in an array flag must still fail loudly so the user
+    // gets a non-zero exit. Bashkit sanitizes the callback message itself
+    // (THREAT[TM-INF-030]) so we only assert that the call errors out and
+    // that we did not silently coerce garbage into success.
+    let bad_resp = execute_http_command(
+        &url,
+        format!("update_agent --id {agent_id} --tags '[not, valid'"),
+    )
+    .await;
+    assert!(
+        tool_is_error(&bad_resp),
+        "expected error for malformed --tags JSON"
+    );
+}
+
 // ============================================================================
 // Tier 1 + Tier 2 combined: full flow via MCP
 // ============================================================================


### PR DESCRIPTION
## What

Make MCP `update_*` commands (and any other inventory command that uses `#[serde(flatten)]`) accept JSON-text aggregate flags (`--capabilities '[…]'`, `--tags '[…]'`, `--mcpServers '{…}'`, …) the same way `create_*` commands already do. Bumps `bashkit` to `v0.5.0` along the way.

## Why

EVE-409: `update_agent --capabilities '[{"ref":"current_time"}]'` (the canonical failing case from the original issue) hit `update_agent: callback failed`. Bashkit's flag parser only coerces scalar types and falls back to `string` for arrays/objects, so the JSON text arrived at the dispatcher as a serde-rejected raw string.

The catalog already worked around this for top-level command schemas: it advertises every aggregate flag as `string` to bashkit and parses the JSON back before dispatch. But the existing walker only mutated `schema.properties` at the top level. Commands shaped like `UpdateAgentCmd` flatten a wrapped request via `#[serde(flatten)]`, which utoipa emits as `allOf: [{ $ref: "#/$defs/UpdateAgentRequest" }, …]`. Their aggregate flags live under `$defs.<Type>.properties` and were never visited.

Bashkit `v0.5.0` (everruns/bashkit#1527, #1528) ships its own JSON-coercion + `--flag key=value` sugar, but its `parse_flags` does not traverse `allOf`/`$ref` to discover flattened aggregates either. So we still need to bridge this on the everruns side.

The previous attempt at the fix (a duplicate walker living in `dispatch_for`) was a belt-and-suspenders second pass at the wrong architectural layer.

## How

- Bumps `bashkit` to `0.5.0` in both `crates/core/Cargo.toml` and `crates/server/Cargo.toml` and refreshes the lockfile. v0.5.0's coercion helps every other bashkit consumer and unlocks the new `--flag key=value` shorthand for downstream tools, even though it does not by itself solve the flatten case for everruns.
- Hoists the schema walker into `crates/server/src/api/mcp_endpoint/catalog.rs` (the architectural layer that owns the bashkit ↔ domain schema translation) and removes the `dispatch_for` workaround introduced in `crates/server/src/domains/common.rs`.
- `bashkit_inventory_schema` now retypes every reachable aggregate property to `type: "string"` — top-level, every entry under `$defs`/`definitions`, and every branch of `allOf`/`oneOf`/`anyOf`. Type-discriminating constructs (`items`, `properties`, `oneOf`, `anyOf`, `allOf`, `$ref`) are dropped on the rewritten property so `tools/list` consumers no longer follow stale composition branches or build bogus item validators.
- `coerce_json_text_params` collects all reachable property declarations the same way before parsing JSON text back into structured values for the domain dispatcher. Both walkers handle `$ref` chains into `$defs`/`definitions`, `type: ["array","null"]`, and the `oneOf: [{type:"null"}, {$ref}]` shape utoipa emits for nullable sub-objects, with a depth bound (`SCHEMA_WALK_MAX_DEPTH = 8`) to prevent pathological cycles.
- Adds two regression unit tests pinned on the `UpdateAgentRequest` shape: `bashkit_schema_retypes_aggregate_fields_buried_under_allof_and_ref` and `coerce_walks_allof_ref_to_parse_flatten_aggregate_fields`.
- Keeps the existing `mcp_endpoint_test::test_mcp_execute_array_flags_create_and_update_agent` end-to-end check, which now exercises the catalog-layer walker through the live MCP execute path for both `create_agent` and `update_agent`.

## Risk

- **Low.** The schema walker is internal plumbing for the bashkit↔domain translation. The functional contract is unchanged for the cases that already worked (top-level aggregate flags); it now additionally covers the `#[serde(flatten)]` shape. Final type validation still happens in `serde_json::from_value::<C>(params)` inside `dispatch_for`, so invalid input is still rejected; we only widen which fields are eligible for JSON-string-→typed-JSON coercion.
- Depth bound (`SCHEMA_WALK_MAX_DEPTH = 8`) prevents unbounded recursion through pathological schemas.
- Bashkit `v0.5.0` is already on crates.io and main is on `v0.4.1`; no behavioral surprises beyond the new top-level coercion + comma-split shorthands documented in everruns/bashkit#1527/#1528.

## Security

- Threat categories reviewed: **TM-MCP**.
- TM-MCP-002 (mutating command exposed through read-only `query`) is preserved: the `read_only` filter at `catalog.rs:86` is unchanged, and the existing `THREAT[TM-MCP-002]` comment is intact. Inventory tests in `crates/server/tests/command_policy_enforcement_test.rs` still gate the read-only override allowlist.
- TM-MCP-001 (tenant escape) is unaffected: org scoping happens via `Caller` and `Command::run`'s policy check, downstream of `dispatch_for`. The walker only translates JSON-string→typed JSON before serde validation; it does not influence org resolution, policy evaluation, or any data access path.
- Injection: `serde_json::from_str` is used to parse the JSON text — no string interpolation, no `eval`-style execution. Parse failures surface as `--{name}: invalid JSON ({err})` and short-circuit dispatch.
- Resource exhaustion: both walkers (`collect_all_properties`, `property_is_aggregate`) have explicit depth bounds at `SCHEMA_WALK_MAX_DEPTH = 8`.
- No new threat surface; `specs/threat-model.md` does not require an update.

## Checklist

- [x] Tests added or updated (2 new catalog unit tests; existing e2e test retained)
- [x] Backward compatibility considered (catalog functional contract unchanged for existing working cases)
- [x] Security review performed against relevant threat model categories (TM-MCP)
- [ ] All review comments addressed (code change or written reasoning) — pending review

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mm9PCuwxhL5YeLfivKKiod)_