### PR TITLE
chore(release): prepare v0.8.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- New changes go here. Use `/prepare-release X.Y.Z` to generate draft from commits. -->
 
+## [0.8.26] - 2026-05-06
+
+### Highlights
+
+- **Workspace volumes** - Sessions can now declare reusable workspace volumes through new CRUD APIs, a dedicated UI for managing them, and a capability mount picker that lets agents bind volumes via `workspace_volumes` ([#1682](https://github.com/everruns/everruns/pull/1682)).
+- **AG-UI public surface hardening** - Public AG-UI now supports per-channel tokens for scoped access, redacts public tool activity to keep internal details private, and emits structured ingress timing so operators can attribute pre-LLM latency ([#1672](https://github.com/everruns/everruns/pull/1672)).
+- **Capabilities catalog rebuild** - The capabilities page now ships search, categories, usage stats, and direct documentation links so operators can discover and adopt capabilities faster ([#1668](https://github.com/everruns/everruns/pull/1668)).
+- **MCP robustness** - MCP dispatch now emits structured errors with broader bool coercion ([#1670](https://github.com/everruns/everruns/pull/1670)) and walks `allOf`/`$ref` to coerce JSON aggregate flags for flatten commands ([#1678](https://github.com/everruns/everruns/pull/1678)), tightening the contract for generated bashkit builtins.
+- **UI polish** - Per-page document titles ([#1665](https://github.com/everruns/everruns/pull/1665)), models grouped by enabled state with recency sorting and release dates ([#1664](https://github.com/everruns/everruns/pull/1664)), markdown link icons, and improved SEO titles & descriptions across the app.
+
+### What's Changed
+
+- chore(release): tighten highlights guidance for maintenance releases ([#1661](https://github.com/everruns/everruns/pull/1661)) by [@chaliy](https://github.com/chaliy)
+- feat(ag-ui): add channel token support by [@chaliy](https://github.com/chaliy)
+- feat(ui): group models by enabled, sort by recency, surface release date ([#1664](https://github.com/everruns/everruns/pull/1664)) by [@chaliy](https://github.com/chaliy)
+- feat(ui): set per-page document titles ([#1665](https://github.com/everruns/everruns/pull/1665)) by [@chaliy](https://github.com/chaliy)
+- fix(billing): omit event_id FK for ephemeral llm.generation events ([#1666](https://github.com/everruns/everruns/pull/1666)) by [@chaliy](https://github.com/chaliy)
+- docs(plugin): clarify everruns-dev skill by [@chaliy](https://github.com/chaliy)
+- fix(llm-models): accept lenient bool coercion for MCP update_model ([#1667](https://github.com/everruns/everruns/pull/1667)) by [@chaliy](https://github.com/chaliy)
+- feat(mcp): structured dispatch errors and broader bool coercion sweep ([#1670](https://github.com/everruns/everruns/pull/1670)) by [@chaliy](https://github.com/chaliy)
+- feat(ag-ui): redact public tool activity by [@chaliy](https://github.com/chaliy)
+- feat(capabilities): rebuild page with search, categories, stats, docs links ([#1668](https://github.com/everruns/everruns/pull/1668)) by [@chaliy](https://github.com/chaliy)
+- chore(llm): log read failures with org/resource context ([#1671](https://github.com/everruns/everruns/pull/1671)) by [@chaliy](https://github.com/chaliy)
+- feat(ag-ui): emit structured ingress timing for pre-LLM latency budget ([#1672](https://github.com/everruns/everruns/pull/1672)) by [@chaliy](https://github.com/chaliy)
+- docs(getting-started): add Codex plugin setup guide by [@chaliy](https://github.com/chaliy)
+- docs(seo): improve page titles and descriptions by [@chaliy](https://github.com/chaliy)
+- refactor(llm-models): derive `healthy` from provider, drop status ([#1674](https://github.com/everruns/everruns/pull/1674)) by [@chaliy](https://github.com/chaliy)
+- feat(ui): add markdown link icons by [@chaliy](https://github.com/chaliy)
+- feat(volumes): add workspace volume CRUD APIs by [@chaliy](https://github.com/chaliy)
+- refactor(api): introduce Dispatcher chokepoint and instrument Command::run ([#1679](https://github.com/everruns/everruns/pull/1679)) by [@chaliy](https://github.com/chaliy)
+- feat(volumes): add workspace volumes UI by [@chaliy](https://github.com/chaliy)
+- fix(mcp): walk allOf/$ref to coerce JSON aggregate flags for flatten cmds ([#1678](https://github.com/everruns/everruns/pull/1678)) by [@chaliy](https://github.com/chaliy)
+- fix(deps): clear dependency security alerts by [@chaliy](https://github.com/chaliy)
+- feat(capabilities): add volume mount picker for workspace_volumes ([#1682](https://github.com/everruns/everruns/pull/1682)) by [@chaliy](https://github.com/chaliy)
+- chore(deps): bump oxfmt + document cargo-outdated gap ([#1683](https://github.com/everruns/everruns/pull/1683)) by [@chaliy](https://github.com/chaliy)
+
 ## [0.8.25] - 2026-05-04
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1572,11 +1572,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-a2ui"
-version = "0.8.25"
+version = "0.8.26"
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.8.25"
+version = "0.8.26"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1595,7 +1595,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-cli"
-version = "0.8.25"
+version = "0.8.26"
 dependencies = [
  "anyhow",
  "base64",
@@ -1622,14 +1622,14 @@ dependencies = [
 
 [[package]]
 name = "everruns-config"
-version = "0.8.25"
+version = "0.8.26"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "everruns-container-sandbox"
-version = "0.8.25"
+version = "0.8.26"
 dependencies = [
  "async-trait",
  "base64",
@@ -1650,7 +1650,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.8.25"
+version = "0.8.26"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1703,7 +1703,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-durable"
-version = "0.8.25"
+version = "0.8.26"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1738,7 +1738,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-gemini"
-version = "0.8.25"
+version = "0.8.26"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1756,7 +1756,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-brave-search"
-version = "0.8.25"
+version = "0.8.26"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1772,7 +1772,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-browserless"
-version = "0.8.25"
+version = "0.8.26"
 dependencies = [
  "async-trait",
  "base64",
@@ -1793,7 +1793,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.8.25"
+version = "0.8.26"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1809,7 +1809,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-deno"
-version = "0.8.25"
+version = "0.8.26"
 dependencies = [
  "async-trait",
  "base64",
@@ -1833,7 +1833,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-docker"
-version = "0.8.25"
+version = "0.8.26"
 dependencies = [
  "async-trait",
  "base64",
@@ -1848,7 +1848,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.8.25"
+version = "0.8.26"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -1863,7 +1863,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-e2b"
-version = "0.8.25"
+version = "0.8.26"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1892,7 +1892,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-parallel"
-version = "0.8.25"
+version = "0.8.26"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -1904,7 +1904,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-pi"
-version = "0.8.25"
+version = "0.8.26"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1919,7 +1919,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-sprites"
-version = "0.8.25"
+version = "0.8.26"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1935,7 +1935,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-internal-protocol"
-version = "0.8.25"
+version = "0.8.26"
 dependencies = [
  "chrono",
  "everruns-core",
@@ -1952,7 +1952,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-macros"
-version = "0.8.25"
+version = "0.8.26"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1962,7 +1962,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.8.25"
+version = "0.8.26"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1984,11 +1984,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-openui"
-version = "0.8.25"
+version = "0.8.26"
 
 [[package]]
 name = "everruns-runtime"
-version = "0.8.25"
+version = "0.8.26"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2022,7 +2022,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-server"
-version = "0.8.25"
+version = "0.8.26"
 dependencies = [
  "aes-gcm",
  "ag-ui-core",
@@ -2106,7 +2106,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-session-sqldb"
-version = "0.8.25"
+version = "0.8.26"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2125,7 +2125,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-worker"
-version = "0.8.25"
+version = "0.8.26"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3346,16 +3346,6 @@ version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 dependencies = [
- "serde",
-]
-
-[[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
  "serde",
 ]
 
@@ -4639,18 +4629,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.11"
+version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+checksum = "cbf0d9e68100b3a7989b4901972f265cd542e560a3a8a724e1e20322f4d06ce9"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.11"
+version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+checksum = "a990e22f43e84855daf260dded30524ef4a9021cc7541c26540500a50b624389"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7007,9 +6997,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "a28f0d049ccfaa566e14e9663d304d8577427b368cb4710a20528690287a738b"
 dependencies = [
  "async-compression",
  "bitflags 2.11.1",
@@ -7019,7 +7009,6 @@ dependencies = [
  "http",
  "http-body",
  "http-body-util",
- "iri-string",
  "pin-project-lite",
  "tokio",
  "tokio-util",
@@ -7027,6 +7016,7 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+ "url",
 ]
 
 [[package]]
@@ -7390,9 +7380,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "utoipa"
-version = "5.4.0"
+version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fcc29c80c21c31608227e0912b2d7fddba57ad76b606890627ba8ee7964e993"
+checksum = "8bde15df68e80b16c7d16b9616e80770ad158988daa56a27dccd1e55558b0160"
 dependencies = [
  "indexmap",
  "serde",
@@ -7402,9 +7392,9 @@ dependencies = [
 
 [[package]]
 name = "utoipa-gen"
-version = "5.4.0"
+version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d79d08d92ab8af4c5e8a6da20c47ae3f61a0f1dabc1997cdf2d082b757ca08b"
+checksum = "6ba0b99ee52df3028635d93840c797102da61f8a7bb3cf751032455895b52ef8"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.8.25"
+version = "0.8.26"
 edition = "2024"
 license = "MIT"
 authors = ["Everruns Contributors"]

--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "everruns-ui",
-  "version": "0.8.25",
+  "version": "0.8.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "everruns-ui",
-      "version": "0.8.25",
+      "version": "0.8.26",
       "dependencies": {
         "@base-ui/react": "^1.2.0",
         "@openuidev/react-lang": "^0.1.3",

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "everruns-ui",
-  "version": "0.8.25",
+  "version": "0.8.26",
   "private": true,
   "exports": {
     "./route-manifest": "./src/lib/ui-route-manifest.ts",


### PR DESCRIPTION
## What
Patch release v0.8.26.

- Bumps `workspace.package.version` and `apps/ui/package.json` from 0.8.25 to 0.8.26.
- Regenerates `Cargo.lock` and `apps/ui/package-lock.json`.
- Adds `## [0.8.26] - 2026-05-06` section to `CHANGELOG.md` with highlights and the full commit list since v0.8.25.

## Why
Release the work that has accumulated on `main` since v0.8.25 (workspace volumes feature, AG-UI hardening, capabilities catalog rebuild, MCP robustness improvements, UI polish, and dependency / security updates) so it can be picked up downstream (saas, dev.everruns.com).

## How
Followed `/prepare-release`:

1. Bumped versions in `Cargo.toml` and `apps/ui/package.json`.
2. Drafted CHANGELOG entry from `git log v0.8.25..origin/main`.
3. Regenerated lockfiles via `cargo generate-lockfile` and `npm install --package-lock-only`.
4. Verified migration ordering is untouched (no migrations rewritten/renumbered in this release).

## Risk
- Low. Release-prep only — no code changes, only version + lockfile + changelog.

## Security
- Threat categories reviewed: No security-relevant code changes — release-prep only (version, lockfile, changelog).
- Findings and resolutions: None.

## Checklist
- [ ] Tests added or updated — N/A (release prep)
- [x] Backward compatibility considered — patch release
- [x] Security review performed against relevant threat model categories
- [ ] All review comments addressed (code change or written reasoning)

### Post-merge
The release workflow will:
- Create git tag `v0.8.26`
- Create a GitHub Release using the new CHANGELOG entry
- Trigger Docker, CLI, and server/worker binary publish workflows for the tag

---
_Generated by [Claude Code](https://claude.ai/code/session_01HRPzHkjkDShLfY5FwFBFCK)_