### PR TITLE
feat(ag-ui): support public image uploads

### DIFF
--- a/apps/ui/src/__tests__/ag-ui-setup-guidance.test.tsx
+++ b/apps/ui/src/__tests__/ag-ui-setup-guidance.test.tsx
@@ -6,6 +6,7 @@ describe("AgUiSetupGuidance", () => {
     render(
       <AgUiSetupGuidance
         endpointUrl="https://example.com/api/v1/apps/app-123/ag-ui"
+        imageUploadUrl="https://example.com/api/v1/apps/app-123/ag-ui/images"
         isPublished={true}
         anonymousEnabled={true}
         sessionExpirationSeconds={6 * 60 * 60}
@@ -15,6 +16,10 @@ describe("AgUiSetupGuidance", () => {
     expect(screen.getByText("Anonymous")).toBeInTheDocument();
     expect(screen.getByText("Ready for AG-UI clients")).toBeInTheDocument();
     expect(screen.getByText("https://example.com/api/v1/apps/app-123/ag-ui")).toBeInTheDocument();
+    expect(
+      screen.getByText("https://example.com/api/v1/apps/app-123/ag-ui/images"),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/forwardedProps.imageIds/)).toBeInTheDocument();
     expect(screen.getByText("Responses stream back as AG-UI SSE events.")).toBeInTheDocument();
     expect(screen.getByText("Thread expiration")).toBeInTheDocument();
     expect(

--- a/apps/ui/src/app/(main)/apps/[appId]/page.tsx
+++ b/apps/ui/src/app/(main)/apps/[appId]/page.tsx
@@ -256,6 +256,7 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
     typeof window !== "undefined"
       ? `${window.location.origin}/api/v1/apps/${appId}/ag-ui`
       : `/api/v1/apps/${appId}/ag-ui`;
+  const agUiImageUploadUrl = `${agUiEndpointUrl}/images`;
 
   const isLocalhost =
     typeof window !== "undefined" &&
@@ -877,6 +878,7 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
         <div key={channel.id} className="space-y-4">
           <AgUiSetupGuidance
             endpointUrl={agUiEndpointUrl}
+            imageUploadUrl={agUiImageUploadUrl}
             isPublished={isPublished}
             anonymousEnabled={config?.anonymous ?? true}
             sessionExpirationSeconds={

--- a/apps/ui/src/components/apps/ag-ui-setup-guidance.tsx
+++ b/apps/ui/src/components/apps/ag-ui-setup-guidance.tsx
@@ -7,6 +7,7 @@ import { Globe } from "lucide-react";
 
 interface AgUiSetupGuidanceProps {
   endpointUrl: string;
+  imageUploadUrl?: string;
   isPublished: boolean;
   anonymousEnabled: boolean;
   sessionExpirationSeconds: number;
@@ -37,6 +38,7 @@ export function formatSessionExpiration(seconds: number): string {
 
 export function AgUiSetupGuidance({
   endpointUrl,
+  imageUploadUrl,
   isPublished,
   anonymousEnabled,
   sessionExpirationSeconds,
@@ -66,6 +68,17 @@ export function AgUiSetupGuidance({
           <CopyButton value={endpointUrl} />
         </div>
       </div>
+
+      {imageUploadUrl && (
+        <div>
+          <p className="text-sm font-medium">Image upload</p>
+          <div className="mt-2 flex items-center gap-2 bg-muted p-3">
+            <Globe className="h-4 w-4 shrink-0 text-muted-foreground" />
+            <code className="flex-1 truncate text-sm">{imageUploadUrl}</code>
+            <CopyButton value={imageUploadUrl} />
+          </div>
+        </div>
+      )}
 
       <div>
         <p className="text-sm font-medium">Token</p>
@@ -108,6 +121,11 @@ export function AgUiSetupGuidance({
 
       <div className="space-y-1 text-sm text-muted-foreground">
         <p>Send AG-UI `RunAgentInput` JSON to this endpoint.</p>
+        {imageUploadUrl && (
+          <p>
+            Upload images as multipart `file`, then pass returned IDs in `forwardedProps.imageIds`.
+          </p>
+        )}
         {hasToken && (
           <p>Include `Authorization: Bearer &lt;token&gt;` or `X-Everruns-AG-UI-Token`.</p>
         )}

--- a/crates/cli/src/commands/files/sync_engine.rs
+++ b/crates/cli/src/commands/files/sync_engine.rs
@@ -685,7 +685,10 @@ mod tests {
     fn test_safe_local_path_normal() {
         let dir = tempfile::tempdir().unwrap();
         let result = safe_local_path(dir.path(), "src/main.rs").unwrap();
-        assert_eq!(result, dir.path().join("src/main.rs"));
+        assert_eq!(
+            result,
+            dir.path().canonicalize().unwrap().join("src/main.rs")
+        );
     }
 
     #[test]

--- a/crates/server/src/api/ag_ui.rs
+++ b/crates/server/src/api/ag_ui.rs
@@ -36,7 +36,7 @@ use ag_ui_core::types::{
 };
 use axum::{
     Extension, Json, Router,
-    extract::{ConnectInfo, Path, State},
+    extract::{ConnectInfo, DefaultBodyLimit, Path, State},
     http::{HeaderMap, StatusCode, header::AUTHORIZATION},
     response::{
         IntoResponse, Response,
@@ -44,6 +44,7 @@ use axum::{
     },
     routing::post,
 };
+use axum_extra::extract::Multipart;
 use everruns_core::events::{
     OutputMessageCompletedData, OutputMessageDeltaData, ReasonThinkingCompletedData,
     ReasonThinkingDeltaData, ReasonThinkingStartedData, ToolCompletedData, ToolStartedData,
@@ -52,7 +53,7 @@ use everruns_core::events::{
 use everruns_core::message_retriever::InputMessage as StoredInputMessage;
 use everruns_core::{
     AgUiChannelConfig, AgUiToolVisibility, App, AppStatus, Caller, ContentPart, ExternalActor,
-    MessageRole,
+    MessageRole, typed_id::ImageId,
 };
 use futures::{
     StreamExt,
@@ -64,6 +65,9 @@ use uuid::Uuid;
 
 use crate::api::ag_ui_rate_limit::AgUiRateLimiter;
 use crate::api::common::ErrorResponse;
+use crate::api::images::{
+    ImageUploadResponse, MAX_IMAGE_SIZE, generate_thumbnail, is_valid_content_type,
+};
 use crate::api::messages::{
     CreateMessageRequest, InputContentPart, InputMessage, MessageRole as ApiMessageRole,
 };
@@ -76,9 +80,12 @@ use crate::domains::sessions::SessionService;
 use crate::execution_metadata;
 use crate::middleware::RequestId;
 use crate::services::EventService;
-use crate::storage::{DbMessageRetriever, EncryptionService, StorageBackend};
+use crate::storage::{
+    DbMessageRetriever, EncryptionService, StorageBackend, models::CreateImageRow,
+};
 
 const AG_UI_TOKEN_HEADER: &str = "x-everruns-ag-ui-token";
+const MAX_AG_UI_IMAGES_PER_RUN: usize = 10;
 
 #[derive(Clone)]
 pub struct AgUiState {
@@ -121,7 +128,162 @@ impl AgUiState {
 pub fn routes(state: AgUiState) -> Router {
     Router::new()
         .route("/v1/apps/{app_id}/ag-ui", post(run_agent))
+        .route(
+            "/v1/apps/{app_id}/ag-ui/images",
+            post(upload_image).layer(DefaultBodyLimit::max(MAX_IMAGE_SIZE + 1024 * 1024)),
+        )
         .with_state(state)
+}
+
+struct AuthorizedAgUiRequest {
+    app: App,
+    channel_config: AgUiChannelConfig,
+}
+
+async fn authorize_ag_ui_request(
+    state: &AgUiState,
+    app_id: &str,
+    headers: &HeaderMap,
+    peer_addr: Option<std::net::SocketAddr>,
+) -> Result<AuthorizedAgUiRequest, Response> {
+    let app = crate::domains::apps::queries::get_by_public_id_unscoped(
+        &state.db,
+        state.encryption.as_ref(),
+        app_id,
+    )
+    .await
+    .map_err(internal_error)?
+    .ok_or_else(not_found)?;
+
+    // THREAT[TM-AUTHZ-005]: Anonymous AG-UI requests must not reach draft or
+    // private app configurations.
+    // Mitigation: Require a published app, an enabled AG-UI channel, and
+    // `anonymous=true` before accepting unauthenticated traffic.
+    if app.status != AppStatus::Published {
+        return Err(forbidden("App is not published"));
+    }
+
+    let channel = app
+        .ag_ui_channel()
+        .ok_or_else(|| bad_request("App does not have an enabled AG-UI channel"))?;
+    let channel_config = channel
+        .ag_ui_config()
+        .ok_or_else(|| bad_request("Invalid AG-UI channel configuration"))?;
+    if !channel_config.anonymous {
+        return Err(forbidden("Anonymous AG-UI access is disabled"));
+    }
+    if let Some(expected_token) = channel_config.token.as_deref()
+        && !expected_token.is_empty()
+    {
+        let provided_token = extract_ag_ui_token(headers).ok_or_else(unauthorized)?;
+        if !constant_time_eq(provided_token.as_bytes(), expected_token.as_bytes()) {
+            return Err(unauthorized());
+        }
+    }
+
+    // THREAT[TM-DOS-010]: Anonymous AG-UI traffic must respect a configurable
+    // per-app, per-IP cap in addition to the global API limit. App owners
+    // tune `rate_limit_per_minute` based on expected client traffic.
+    if let Some(limit) = channel_config.rate_limit_per_minute
+        && limit > 0
+    {
+        let client_ip = extract_client_ip_from_parts(peer_addr, headers);
+        if state
+            .rate_limiter
+            .check(&app.public_id.to_string(), client_ip, limit)
+            .await
+            .is_err()
+        {
+            return Err(too_many_requests("AG-UI rate limit exceeded for this app"));
+        }
+    }
+
+    Ok(AuthorizedAgUiRequest {
+        app,
+        channel_config,
+    })
+}
+
+async fn upload_image(
+    State(state): State<AgUiState>,
+    Path(app_id): Path<String>,
+    connect_info: Option<Extension<ConnectInfo<std::net::SocketAddr>>>,
+    headers: HeaderMap,
+    mut multipart: Multipart,
+) -> Result<(StatusCode, Json<ImageUploadResponse>), Response> {
+    let peer_addr = connect_info.map(|Extension(ConnectInfo(addr))| addr);
+    let AuthorizedAgUiRequest { app, .. } =
+        authorize_ag_ui_request(&state, &app_id, &headers, peer_addr).await?;
+
+    // THREAT[TM-DOS-010]: Public AG-UI image uploads are anonymous ingress.
+    // Mitigation: reuse the per-app public AG-UI gate/rate limit above, cap the
+    // multipart body at the router, and validate MIME type plus byte length
+    // before writing image bytes to storage.
+    let mut file_data: Option<(String, String, Vec<u8>)> = None;
+    while let Some(field) = multipart
+        .next_field()
+        .await
+        .map_err(|_| bad_request("invalid_request"))?
+    {
+        if field.name().unwrap_or("") != "file" {
+            continue;
+        }
+
+        let filename = field.file_name().unwrap_or("upload").to_string();
+        let content_type = field
+            .content_type()
+            .unwrap_or("application/octet-stream")
+            .to_string();
+        if !is_valid_content_type(&content_type) {
+            return Err(bad_request("invalid_request"));
+        }
+
+        let data = field
+            .bytes()
+            .await
+            .map_err(|_| bad_request("invalid_request"))?;
+        if data.len() > MAX_IMAGE_SIZE {
+            return Err(bad_request("invalid_request"));
+        }
+
+        file_data = Some((filename, content_type, data.to_vec()));
+        break;
+    }
+
+    let (filename, content_type, data) =
+        file_data.ok_or_else(|| bad_request("No 'file' field in request"))?;
+    let (thumbnail_data, thumbnail_content_type) = generate_thumbnail(&data, &content_type)
+        .map(|(data, content_type)| (Some(data), Some(content_type)))
+        .unwrap_or((None, None));
+    let size_bytes = data.len() as i64;
+    let row = state
+        .db
+        .create_image(
+            app.org_id,
+            CreateImageRow {
+                org_id: app.org_id,
+                filename,
+                content_type,
+                size_bytes,
+                data,
+                thumbnail_data,
+                thumbnail_content_type,
+                metadata: ag_ui_image_metadata(&app),
+            },
+        )
+        .await
+        .map_err(internal_error)?;
+
+    Ok((
+        StatusCode::CREATED,
+        Json(ImageUploadResponse {
+            id: row.id,
+            filename: row.filename,
+            content_type: row.content_type,
+            size_bytes: row.size_bytes,
+            created_at: row.created_at,
+        }),
+    ))
 }
 
 async fn run_agent(
@@ -150,57 +312,10 @@ async fn run_agent(
 
     let request_id = req_id.map(|Extension(r)| r.0);
     let peer_addr = connect_info.map(|Extension(ConnectInfo(addr))| addr);
-    let app = crate::domains::apps::queries::get_by_public_id_unscoped(
-        &state.db,
-        state.encryption.as_ref(),
-        &app_id,
-    )
-    .await
-    .map_err(internal_error)?
-    .ok_or_else(not_found)?;
-
-    // THREAT[TM-AUTHZ-005]: Anonymous AG-UI requests must not reach draft or
-    // private app configurations.
-    // Mitigation: Require a published app, an enabled AG-UI channel, and
-    // `anonymous=true` before accepting unauthenticated traffic.
-    if app.status != AppStatus::Published {
-        return Err(forbidden("App is not published"));
-    }
-
-    let channel = app
-        .ag_ui_channel()
-        .ok_or_else(|| bad_request("App does not have an enabled AG-UI channel"))?;
-    let channel_config = channel
-        .ag_ui_config()
-        .ok_or_else(|| bad_request("Invalid AG-UI channel configuration"))?;
-    if !channel_config.anonymous {
-        return Err(forbidden("Anonymous AG-UI access is disabled"));
-    }
-    if let Some(expected_token) = channel_config.token.as_deref()
-        && !expected_token.is_empty()
-    {
-        let provided_token = extract_ag_ui_token(&headers).ok_or_else(unauthorized)?;
-        if !constant_time_eq(provided_token.as_bytes(), expected_token.as_bytes()) {
-            return Err(unauthorized());
-        }
-    }
-
-    // THREAT[TM-DOS-010]: Anonymous AG-UI traffic must respect a configurable
-    // per-app, per-IP cap in addition to the global API limit. App owners
-    // tune `rate_limit_per_minute` based on expected client traffic.
-    if let Some(limit) = channel_config.rate_limit_per_minute
-        && limit > 0
-    {
-        let client_ip = extract_client_ip_from_parts(peer_addr, &headers);
-        if state
-            .rate_limiter
-            .check(&app.public_id.to_string(), client_ip, limit)
-            .await
-            .is_err()
-        {
-            return Err(too_many_requests("AG-UI rate limit exceeded for this app"));
-        }
-    }
+    let AuthorizedAgUiRequest {
+        app,
+        channel_config,
+    } = authorize_ag_ui_request(&state, &app_id, &headers, peer_addr).await?;
 
     let trigger_message = req
         .messages
@@ -268,6 +383,12 @@ async fn run_agent(
         .await
         .map_err(internal_error)?;
 
+    let trigger_image_parts = ag_ui_image_content_parts(&state, &app, &req.forwarded_props)
+        .await
+        .map_err(|err| *err)?;
+    let mut trigger_parts = vec![InputContentPart::text(trigger_content)];
+    trigger_parts.extend(trigger_image_parts);
+
     let message = state
         .message_service
         .create(
@@ -287,7 +408,7 @@ async fn run_agent(
             CreateMessageRequest {
                 message: InputMessage {
                     role: ApiMessageRole::User,
-                    content: vec![InputContentPart::text(trigger_content)],
+                    content: trigger_parts,
                 },
                 controls: None,
                 metadata: Some(ag_ui_message_metadata(&app, thread_tag, run_tag)),
@@ -431,6 +552,82 @@ fn ag_ui_message_metadata(
     ]
     .into_iter()
     .collect()
+}
+
+fn ag_ui_image_metadata(app: &App) -> Value {
+    serde_json::json!({
+        "_app_id": app.public_id.to_string(),
+        "source": "ag_ui",
+    })
+}
+
+fn is_ag_ui_app_image(metadata: &Value, app_public_id: &str) -> bool {
+    metadata
+        .get("_app_id")
+        .and_then(Value::as_str)
+        .is_some_and(|id| id == app_public_id)
+        && metadata.get("source").and_then(Value::as_str) == Some("ag_ui")
+}
+
+async fn ag_ui_image_content_parts(
+    state: &AgUiState,
+    app: &App,
+    forwarded_props: &Value,
+) -> Result<Vec<InputContentPart>, Box<Response>> {
+    let image_ids = forwarded_ag_ui_image_ids(forwarded_props)?;
+    if image_ids.is_empty() {
+        return Ok(vec![]);
+    }
+
+    // THREAT[TM-TENANT-009]: Public clients must not attach arbitrary org
+    // images to an app run. Mitigation: resolve by org and require AG-UI image
+    // metadata for the same public app before constructing ImageFile parts.
+    let app_public_id = app.public_id.to_string();
+    let mut parts = Vec::with_capacity(image_ids.len());
+    for image_id in image_ids {
+        let row = state
+            .db
+            .get_image(app.org_id, image_id.uuid())
+            .await
+            .map_err(|err| Box::new(internal_error(err)))?
+            .ok_or_else(|| Box::new(bad_request("invalid_request")))?;
+        if !is_ag_ui_app_image(&row.metadata, &app_public_id) {
+            return Err(Box::new(bad_request("invalid_request")));
+        }
+        parts.push(InputContentPart::ImageFile(
+            everruns_core::ImageFileContentPart::with_filename(row.id, row.filename),
+        ));
+    }
+    Ok(parts)
+}
+
+fn forwarded_ag_ui_image_ids(forwarded_props: &Value) -> Result<Vec<ImageId>, Box<Response>> {
+    let Some(raw_images) = forwarded_props
+        .get("imageIds")
+        .or_else(|| forwarded_props.get("image_ids"))
+        .or_else(|| forwarded_props.get("agUiImageIds"))
+        .or_else(|| forwarded_props.get("ag_ui_image_ids"))
+    else {
+        return Ok(vec![]);
+    };
+
+    let images = raw_images
+        .as_array()
+        .ok_or_else(|| Box::new(bad_request("invalid_request")))?;
+    if images.len() > MAX_AG_UI_IMAGES_PER_RUN {
+        return Err(Box::new(bad_request("invalid_request")));
+    }
+
+    images
+        .iter()
+        .map(|value| {
+            let id = value
+                .as_str()
+                .ok_or_else(|| Box::new(bad_request("invalid_request")))?;
+            id.parse::<ImageId>()
+                .map_err(|_| Box::new(bad_request("invalid_request")))
+        })
+        .collect()
 }
 
 struct SessionResolution {
@@ -1241,6 +1438,33 @@ mod tests {
             metadata.get("ag_ui_thread_id"),
             Some(&Value::String("thread-1".to_string()))
         );
+    }
+
+    #[test]
+    fn ag_ui_image_metadata_scopes_upload_to_app() {
+        let app = test_app();
+        let metadata = ag_ui_image_metadata(&app);
+        let app_public_id = app.public_id.to_string();
+
+        assert!(is_ag_ui_app_image(&metadata, &app_public_id));
+        assert!(!is_ag_ui_app_image(
+            &serde_json::json!({"source": "ag_ui"}),
+            &app_public_id
+        ));
+    }
+
+    #[test]
+    fn forwarded_ag_ui_image_ids_parse_camel_case_ids() {
+        let image_id = ImageId::from_seed(42);
+        let props = serde_json::json!({ "imageIds": [image_id.to_string()] });
+
+        assert_eq!(forwarded_ag_ui_image_ids(&props).unwrap(), vec![image_id]);
+    }
+
+    #[test]
+    fn forwarded_ag_ui_image_ids_reject_bad_shape() {
+        assert!(forwarded_ag_ui_image_ids(&serde_json::json!({ "imageIds": "img_bad" })).is_err());
+        assert!(forwarded_ag_ui_image_ids(&serde_json::json!({ "imageIds": [42] })).is_err());
     }
 
     #[tokio::test]

--- a/crates/server/src/api/images.rs
+++ b/crates/server/src/api/images.rs
@@ -36,7 +36,8 @@ pub(crate) const MAX_IMAGE_SIZE: usize = 100 * 1024 * 1024;
 const THUMBNAIL_MAX_DIM: u32 = 200;
 
 /// Allowed MIME types
-const ALLOWED_CONTENT_TYPES: &[&str] = &["image/png", "image/jpeg", "image/gif", "image/webp"];
+pub(crate) const ALLOWED_CONTENT_TYPES: &[&str] =
+    &["image/png", "image/jpeg", "image/gif", "image/webp"];
 
 // ============================================
 // API Types
@@ -124,7 +125,7 @@ pub fn routes(state: AppState) -> Router {
 // ============================================
 
 /// Validate content type is allowed
-fn is_valid_content_type(content_type: &str) -> bool {
+pub(crate) fn is_valid_content_type(content_type: &str) -> bool {
     ALLOWED_CONTENT_TYPES.contains(&content_type)
 }
 

--- a/crates/server/tests/ag_ui_integration_test.rs
+++ b/crates/server/tests/ag_ui_integration_test.rs
@@ -145,6 +145,38 @@ async fn send_ag_ui_run_with_headers(
         .await
 }
 
+async fn upload_ag_ui_image(
+    server: &TestServer,
+    app_id: impl std::fmt::Display,
+    headers: Vec<(&str, &str)>,
+) -> test_harness::TestResponse {
+    let boundary = "agui-test-boundary";
+    let body = format!(
+        concat!(
+            "--{boundary}\r\n",
+            "Content-Disposition: form-data; name=\"file\"; filename=\"photo.png\"\r\n",
+            "Content-Type: image/png\r\n\r\n",
+            "fake-png-bytes\r\n",
+            "--{boundary}--\r\n",
+        ),
+        boundary = boundary
+    );
+    let mut request_headers = vec![(
+        "content-type",
+        "multipart/form-data; boundary=agui-test-boundary",
+    )];
+    request_headers.extend(headers);
+
+    server
+        .request_raw(
+            Method::POST,
+            &format!("/v1/apps/{}/ag-ui/images", app_id),
+            request_headers,
+            body.into_bytes(),
+        )
+        .await
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_ag_ui_rejects_missing_messages() {
     let server = TestServer::in_memory().await;
@@ -255,6 +287,89 @@ async fn test_ag_ui_rejects_empty_token_config() {
                 }
             }),
         )
+        .await
+        .assert_status(StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_ag_ui_public_image_upload_requires_published_app() {
+    let server = TestServer::in_memory().await;
+    let agent_id = create_llmsim_agent(&server).await;
+
+    let app: App = server
+        .post(
+            "/v1/apps",
+            json!({
+                "name": unique_id("Draft Image Upload AG-UI App"),
+                "harness_id": server.seed_base_harness_id,
+                "agent_id": agent_id,
+                "channel_type": "ag_ui",
+                "channel_config": { "anonymous": true }
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    upload_ag_ui_image(&server, &app.public_id, vec![])
+        .await
+        .assert_status(StatusCode::FORBIDDEN);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_ag_ui_public_image_upload_returns_image_id() {
+    let server = TestServer::in_memory().await;
+    let app = create_published_ag_ui_app(&server).await;
+
+    let body: Value = upload_ag_ui_image(&server, &app.public_id, vec![])
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    assert!(body["id"].as_str().unwrap().starts_with("img_"));
+    assert_eq!(body["filename"], "photo.png");
+    assert_eq!(body["content_type"], "image/png");
+
+    let image_id = body["id"]
+        .as_str()
+        .unwrap()
+        .parse::<everruns_core::typed_id::ImageId>()
+        .unwrap();
+    let image = server
+        .db
+        .get_image(everruns_core::DEFAULT_ORG_ID, image_id.uuid())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(image.metadata["_app_id"], app.public_id.to_string());
+    assert_eq!(image.metadata["source"], "ag_ui");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_ag_ui_run_rejects_image_uploaded_for_other_app() {
+    let server = TestServer::in_memory().await;
+    let first_app = create_published_ag_ui_app(&server).await;
+    let second_app = create_published_ag_ui_app(&server).await;
+    let upload: Value = upload_ag_ui_image(&server, &first_app.public_id, vec![])
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    let payload = json!({
+        "threadId": raw_uuid(),
+        "runId": raw_uuid(),
+        "state": {},
+        "messages": [
+            { "id": raw_uuid(), "role": "user", "content": "Describe this image" }
+        ],
+        "tools": [],
+        "context": [],
+        "forwardedProps": {
+            "imageIds": [upload["id"].as_str().unwrap()]
+        }
+    });
+
+    send_ag_ui_run(&server, &second_app.public_id, &payload)
         .await
         .assert_status(StatusCode::BAD_REQUEST);
 }

--- a/specs/apps.md
+++ b/specs/apps.md
@@ -63,6 +63,11 @@ AG-UI uses an app-scoped anonymous ingress for the initial rollout:
 - Endpoint: `POST /v1/apps/{app_id}/ag-ui`
 - Requests use AG-UI `RunAgentInput` JSON
 - Responses stream back as AG-UI SSE events translated from the durable runtime
+- Images may be uploaded through `POST /v1/apps/{app_id}/ag-ui/images`
+  as multipart form field `file`. The route uses the same published-app,
+  anonymous, token, and rate-limit gates as the stream endpoint. The returned
+  image IDs may be passed on a run in `forwardedProps.imageIds`; the handler
+  attaches only images uploaded through the same app's public AG-UI route.
 - Anonymous access is currently required when the channel is enabled
 - If `token` is set, requests must include either `Authorization: Bearer <token>` or `X-Everruns-AG-UI-Token: <token>`.
 - Session routing is per `threadId`, with sessions tagged by app and thread

--- a/specs/public-endpoints.md
+++ b/specs/public-endpoints.md
@@ -7,6 +7,7 @@ A **public endpoint** is an HTTP endpoint that accepts unauthenticated traffic a
 | Endpoint | Route | Source | Notes |
 |---|---|---|---|
 | AG-UI | `POST /v1/apps/{app_id}/ag-ui` | `crates/server/src/api/ag_ui.rs` | Public, app-scoped SSE stream; optional channel token |
+| AG-UI image upload | `POST /v1/apps/{app_id}/ag-ui/images` | `crates/server/src/api/ag_ui.rs` | Public, app-scoped multipart image upload; optional channel token |
 | Slack events | `POST /v1/apps/{app_id}/slack/events` | `crates/server/src/api/slack_events.rs` | Anonymous Slack webhook (signature-verified) |
 | Slack manifest | `GET /v1/apps/{app_id}/slack/manifest` | `crates/server/src/api/slack_events.rs` | Anonymous YAML manifest fetch |
 


### PR DESCRIPTION
## What
Add a public AG-UI image upload endpoint at `POST /v1/apps/{app_id}/ag-ui/images` and document the returned IDs for use in `forwardedProps.imageIds`.

## Why
Public AG-UI clients need a way to attach user-uploaded images without requiring owner-authenticated API access.

## How
Reuse the existing public AG-UI published-app, anonymous, token, and per-app rate-limit gate for uploads. Store uploaded images with AG-UI app metadata, then only attach image file parts when the run references images uploaded through the same app. Surface the upload URL in the app setup guidance and keep the specs/public endpoint registry in sync.

Validation:
- `cargo test -p everruns-server --test ag_ui_integration_test`
- `cargo test -p everruns-server api::ag_ui::tests::`
- `cargo test -p everruns-cli --bin everruns commands::files::sync_engine::tests::test_safe_local_path_normal`
- `cd apps/ui && npm test -- --runTestsByPath src/__tests__/ag-ui-setup-guidance.test.tsx`
- `cd apps/ui && npm run lint`
- `cd apps/ui && npm run build`
- `./scripts/export-openapi.sh`
- `bash scripts/lib/check-migration-ordering.sh`
- `just pre-pr`
- `just pre-push`
- Live smoke on `PORT_PREFIX=284 just start-dev --no-watch`: created AG-UI apps, uploaded a PNG through the public endpoint, and verified another app cannot reference that image.

## Risk
- Medium
- Public anonymous multipart upload can affect storage and runtime ingress if gating, limits, or app scoping regress. The implementation reuses AG-UI channel authorization/rate limiting, caps request size, validates image content type and byte length, and verifies same-app metadata before attaching images to runs.

## Security
- Threat categories reviewed: TM-AUTHZ, TM-API, TM-TENANT, TM-DOS, TM-LLM, TM-INFO.
- Findings and resolutions: upload uses the existing published-app/anonymous/token gate; multipart inputs are bounded and MIME-checked; run attachment is limited to 10 image IDs and requires same-app AG-UI metadata; public stream payload errors still use the existing `PublicError` adapter; no new dependency or secret-handling surface was added.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)