### PR TITLE
feat(memory): add org memory stores API and UI

### DIFF
--- a/apps/ui/src/app/(main)/memory-stores/page.tsx
+++ b/apps/ui/src/app/(main)/memory-stores/page.tsx
@@ -137,9 +137,7 @@ export default function MemoryStoresPage() {
                       <MemoryCard
                         key={memory.id}
                         memory={memory}
-                        onForget={() =>
-                          forgetMemory.mutate(memory.id)
-                        }
+                        onForget={() => forgetMemory.mutate(memory.id)}
                         forgetting={forgetMemory.isPending}
                       />
                     ))}
@@ -202,8 +200,7 @@ function StoreCard({
         </div>
       </CardHeader>
       <CardContent className="text-xs text-muted-foreground">
-        {store.active_memory_count} active{" "}
-        {store.active_memory_count === 1 ? "memory" : "memories"}
+        {store.active_memory_count} active {store.active_memory_count === 1 ? "memory" : "memories"}
       </CardContent>
     </Card>
   );
@@ -214,7 +211,15 @@ function MemoryCard({
   onForget,
   forgetting,
 }: {
-  memory: { id: string; content: string; kind: string; importance: number; tags: string[]; active: boolean; created_at: string };
+  memory: {
+    id: string;
+    content: string;
+    kind: string;
+    importance: number;
+    tags: string[];
+    active: boolean;
+    created_at: string;
+  };
   onForget: () => void;
   forgetting: boolean;
 }) {
@@ -274,8 +279,8 @@ function EmptyState({ onCreate }: { onCreate: () => void }) {
 function MemoriesEmptyState() {
   return (
     <div className="flex flex-col items-center justify-center py-10 text-center text-sm text-muted-foreground">
-      No memories yet. Agents using the <code className="font-mono">memory</code> capability
-      will populate this store as they learn.
+      No memories yet. Agents using the <code className="font-mono">memory</code> capability will
+      populate this store as they learn.
     </div>
   );
 }
@@ -300,8 +305,8 @@ function CreateStoreDialog({
         <DialogHeader>
           <DialogTitle>New memory store</DialogTitle>
           <DialogDescription>
-            Create a named container for agent memories. Use distinct stores to scope memory by
-            team or project.
+            Create a named container for agent memories. Use distinct stores to scope memory by team
+            or project.
           </DialogDescription>
         </DialogHeader>
         <div className="space-y-3">

--- a/apps/ui/src/app/(main)/memory-stores/page.tsx
+++ b/apps/ui/src/app/(main)/memory-stores/page.tsx
@@ -1,0 +1,347 @@
+"use client";
+
+import { useState } from "react";
+import { Brain, Plus, Search, Star, Trash2 } from "lucide-react";
+import { QueryStateWrapper } from "@/components/query-state-wrapper";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { CopyButton } from "@/components/ui/copy-button";
+import { Input } from "@/components/ui/input";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  useCreateMemoryStore,
+  useForgetMemory,
+  useMemories,
+  useMemoryStores,
+  usePageTitle,
+} from "@/hooks";
+import type { CreateMemoryStoreRequest, MemoryStore } from "@/lib/api/types";
+import { formatRelativeTime } from "@/lib/formatting";
+
+const KIND_OPTIONS = [
+  { value: "all", label: "All kinds" },
+  { value: "fact", label: "Fact" },
+  { value: "preference", label: "Preference" },
+  { value: "correction", label: "Correction" },
+  { value: "procedure", label: "Procedure" },
+  { value: "context", label: "Context" },
+];
+
+export default function MemoryStoresPage() {
+  usePageTitle("Memory");
+  const [createOpen, setCreateOpen] = useState(false);
+  const [selectedStoreId, setSelectedStoreId] = useState<string | null>(null);
+  const [search, setSearch] = useState("");
+  const [kind, setKind] = useState<string>("all");
+
+  const { data: stores, isLoading, error } = useMemoryStores();
+  const activeStoreId =
+    selectedStoreId ?? stores?.find((s) => s.is_default)?.id ?? stores?.[0]?.id ?? null;
+
+  const createStore = useCreateMemoryStore();
+  const forgetMemory = useForgetMemory(activeStoreId ?? undefined);
+
+  const memoriesQuery = useMemories(activeStoreId ?? undefined, {
+    query: search,
+    kind: kind === "all" ? undefined : kind,
+    limit: 200,
+  });
+
+  return (
+    <div className="container mx-auto p-6">
+      <div className="mb-6 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <h1 className="flex items-center gap-3 text-2xl font-bold">
+          <Brain className="h-6 w-6" /> Memory
+        </h1>
+        <Button variant="accent" onClick={() => setCreateOpen(true)}>
+          <Plus className="h-4 w-4" />
+          New Store
+        </Button>
+      </div>
+
+      <QueryStateWrapper
+        isLoading={isLoading}
+        error={error}
+        data={stores}
+        errorMessagePrefix="Failed to load memory stores"
+        skeletonCount={3}
+        emptyState={<EmptyState onCreate={() => setCreateOpen(true)} />}
+      >
+        {(items) => (
+          <div className="grid gap-6 lg:grid-cols-[18rem_1fr]">
+            <aside className="flex flex-col gap-2">
+              {items.map((store) => (
+                <StoreCard
+                  key={store.id}
+                  store={store}
+                  active={store.id === activeStoreId}
+                  onSelect={() => setSelectedStoreId(store.id)}
+                />
+              ))}
+            </aside>
+            <section className="space-y-4">
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                <div className="relative sm:w-72">
+                  <Search className="pointer-events-none absolute left-2.5 top-2 h-4 w-4 text-muted-foreground" />
+                  <Input
+                    value={search}
+                    onChange={(event) => setSearch(event.target.value)}
+                    placeholder="Search memory content"
+                    className="pl-8"
+                    aria-label="Search memories"
+                  />
+                </div>
+                <Select value={kind} onValueChange={setKind}>
+                  <SelectTrigger className="w-full sm:w-44">
+                    <SelectValue placeholder="Kind" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {KIND_OPTIONS.map((option) => (
+                      <SelectItem key={option.value} value={option.value}>
+                        {option.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <QueryStateWrapper
+                isLoading={memoriesQuery.isLoading}
+                error={memoriesQuery.error}
+                data={memoriesQuery.data}
+                errorMessagePrefix="Failed to load memories"
+                skeletonCount={4}
+                emptyState={<MemoriesEmptyState />}
+              >
+                {(response) => (
+                  <div className="space-y-3">
+                    <p className="text-xs text-muted-foreground">
+                      {response.total} {response.total === 1 ? "memory" : "memories"}
+                    </p>
+                    {response.data.map((memory) => (
+                      <MemoryCard
+                        key={memory.id}
+                        memory={memory}
+                        onForget={() =>
+                          forgetMemory.mutate(memory.id)
+                        }
+                        forgetting={forgetMemory.isPending}
+                      />
+                    ))}
+                  </div>
+                )}
+              </QueryStateWrapper>
+            </section>
+          </div>
+        )}
+      </QueryStateWrapper>
+
+      <CreateStoreDialog
+        open={createOpen}
+        isPending={createStore.isPending}
+        onOpenChange={setCreateOpen}
+        onSubmit={async (request) => {
+          const created = await createStore.mutateAsync(request);
+          setSelectedStoreId(created.id);
+          setCreateOpen(false);
+        }}
+      />
+    </div>
+  );
+}
+
+function StoreCard({
+  store,
+  active,
+  onSelect,
+}: {
+  store: MemoryStore;
+  active: boolean;
+  onSelect: () => void;
+}) {
+  return (
+    <Card
+      role="button"
+      tabIndex={0}
+      onClick={onSelect}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onSelect();
+        }
+      }}
+      className={`cursor-pointer transition ${active ? "border-primary" : ""}`}
+    >
+      <CardHeader className="space-y-2">
+        <div className="flex items-start justify-between gap-2">
+          <CardTitle className="truncate text-base">{store.name}</CardTitle>
+          {store.is_default && (
+            <Badge variant="secondary">
+              <Star className="h-3 w-3" /> Default
+            </Badge>
+          )}
+        </div>
+        <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+          <span className="truncate font-mono">{store.id}</span>
+          <CopyButton value={store.id} />
+        </div>
+      </CardHeader>
+      <CardContent className="text-xs text-muted-foreground">
+        {store.active_memory_count} active{" "}
+        {store.active_memory_count === 1 ? "memory" : "memories"}
+      </CardContent>
+    </Card>
+  );
+}
+
+function MemoryCard({
+  memory,
+  onForget,
+  forgetting,
+}: {
+  memory: { id: string; content: string; kind: string; importance: number; tags: string[]; active: boolean; created_at: string };
+  onForget: () => void;
+  forgetting: boolean;
+}) {
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-start justify-between gap-3 space-y-0">
+        <div className="flex flex-wrap items-center gap-2">
+          <Badge variant="outline">{memory.kind}</Badge>
+          <Badge variant="secondary">importance {memory.importance}</Badge>
+          {!memory.active && <Badge variant="destructive">forgotten</Badge>}
+          {memory.tags.map((tag) => (
+            <Badge key={tag} variant="outline" className="text-xs">
+              {tag}
+            </Badge>
+          ))}
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={onForget}
+          disabled={!memory.active || forgetting}
+          aria-label="Forget memory"
+        >
+          <Trash2 className="h-4 w-4" />
+          Forget
+        </Button>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <p className="text-sm">{memory.content}</p>
+        <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+          <span className="truncate font-mono">{memory.id}</span>
+          <CopyButton value={memory.id} />
+          <span className="ml-auto">{formatRelativeTime(memory.created_at)}</span>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function EmptyState({ onCreate }: { onCreate: () => void }) {
+  return (
+    <div className="flex flex-col items-center justify-center py-12 text-center">
+      <Brain className="mb-4 h-12 w-12 text-muted-foreground" />
+      <h3 className="mb-2 text-lg font-semibold">No memory stores</h3>
+      <p className="mb-4 max-w-sm text-sm text-muted-foreground">
+        Memory stores hold facts, preferences, and corrections that agents can recall across
+        sessions. The default store is created on first agent use.
+      </p>
+      <Button variant="accent" onClick={onCreate}>
+        <Plus className="h-4 w-4" />
+        New Store
+      </Button>
+    </div>
+  );
+}
+
+function MemoriesEmptyState() {
+  return (
+    <div className="flex flex-col items-center justify-center py-10 text-center text-sm text-muted-foreground">
+      No memories yet. Agents using the <code className="font-mono">memory</code> capability
+      will populate this store as they learn.
+    </div>
+  );
+}
+
+function CreateStoreDialog({
+  open,
+  isPending,
+  onOpenChange,
+  onSubmit,
+}: {
+  open: boolean;
+  isPending: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: (request: CreateMemoryStoreRequest) => Promise<void>;
+}) {
+  const [name, setName] = useState("");
+  const [isDefault, setIsDefault] = useState(false);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>New memory store</DialogTitle>
+          <DialogDescription>
+            Create a named container for agent memories. Use distinct stores to scope memory by
+            team or project.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-3">
+          <div className="space-y-1">
+            <label className="text-sm font-medium" htmlFor="memory-store-name">
+              Name
+            </label>
+            <Input
+              id="memory-store-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="team-knowledge"
+            />
+          </div>
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              checked={isDefault}
+              onChange={(e) => setIsDefault(e.target.checked)}
+            />
+            Make this the default store for the organization
+          </label>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isPending}>
+            Cancel
+          </Button>
+          <Button
+            variant="accent"
+            disabled={!name.trim() || isPending}
+            onClick={async () => {
+              await onSubmit({ name: name.trim(), is_default: isDefault });
+              setName("");
+              setIsDefault(false);
+            }}
+          >
+            Create
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/ui/src/app/(main)/memory-stores/page.tsx
+++ b/apps/ui/src/app/(main)/memory-stores/page.tsx
@@ -123,26 +123,29 @@ export default function MemoryStoresPage() {
               <QueryStateWrapper
                 isLoading={memoriesQuery.isLoading}
                 error={memoriesQuery.error}
-                data={memoriesQuery.data}
+                data={memoriesQuery.data?.data}
                 errorMessagePrefix="Failed to load memories"
                 skeletonCount={4}
                 emptyState={<MemoriesEmptyState />}
               >
-                {(response) => (
-                  <div className="space-y-3">
-                    <p className="text-xs text-muted-foreground">
-                      {response.total} {response.total === 1 ? "memory" : "memories"}
-                    </p>
-                    {response.data.map((memory) => (
-                      <MemoryCard
-                        key={memory.id}
-                        memory={memory}
-                        onForget={() => forgetMemory.mutate(memory.id)}
-                        forgetting={forgetMemory.isPending}
-                      />
-                    ))}
-                  </div>
-                )}
+                {(items) => {
+                  const total = memoriesQuery.data?.total ?? items.length;
+                  return (
+                    <div className="space-y-3">
+                      <p className="text-xs text-muted-foreground">
+                        {total} {total === 1 ? "memory" : "memories"}
+                      </p>
+                      {items.map((memory) => (
+                        <MemoryCard
+                          key={memory.id}
+                          memory={memory}
+                          onForget={() => forgetMemory.mutate(memory.id)}
+                          forgetting={forgetMemory.isPending}
+                        />
+                      ))}
+                    </div>
+                  );
+                }}
               </QueryStateWrapper>
             </section>
           </div>

--- a/apps/ui/src/components/agents/capability-settings-editor.tsx
+++ b/apps/ui/src/components/agents/capability-settings-editor.tsx
@@ -15,11 +15,13 @@ import {
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import type { Capability } from "@/lib/api/types";
+import { MemoryCapabilityConfigEditor } from "./memory-capability-config-editor";
 import { WorkspaceVolumesConfigEditor } from "./workspace-volumes-config-editor";
 
 // Capability IDs with purpose-built editors. Mirrors the constants exported
 // from crates/core/src/capabilities/*.
 const WORKSPACE_VOLUMES_CAPABILITY_ID = "workspace_volumes";
+const MEMORY_CAPABILITY_ID = "memory";
 
 interface CapabilitySettingsEditorProps {
   /** Full capability metadata, including optional config schema */
@@ -40,6 +42,9 @@ export function CapabilitySettingsEditor({
 }: CapabilitySettingsEditorProps) {
   if (capability.id === WORKSPACE_VOLUMES_CAPABILITY_ID) {
     return <WorkspaceVolumesConfigEditor config={config} onChange={onChange} disabled={disabled} />;
+  }
+  if (capability.id === MEMORY_CAPABILITY_ID) {
+    return <MemoryCapabilityConfigEditor config={config} onChange={onChange} disabled={disabled} />;
   }
   return (
     <SchemaCapabilityEditor

--- a/apps/ui/src/components/agents/memory-capability-config-editor.tsx
+++ b/apps/ui/src/components/agents/memory-capability-config-editor.tsx
@@ -71,9 +71,7 @@ export function MemoryCapabilityConfigEditor({
             Selected store is no longer available in this organization.
           </p>
         )}
-        {error && (
-          <p className="text-xs text-destructive">Failed to load memory stores.</p>
-        )}
+        {error && <p className="text-xs text-destructive">Failed to load memory stores.</p>}
         <p className="text-xs text-muted-foreground">
           When unset, the agent uses the org&apos;s default store, created on first use.
         </p>

--- a/apps/ui/src/components/agents/memory-capability-config-editor.tsx
+++ b/apps/ui/src/components/agents/memory-capability-config-editor.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { useMemo } from "react";
+import { Combobox, type ComboboxOption } from "@/components/ui/combobox";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useMemoryStores } from "@/hooks/use-memory-stores";
+
+interface MemoryConfig {
+  store?: string;
+  passive_recall_count?: number;
+}
+
+interface MemoryCapabilityConfigEditorProps {
+  config: Record<string, unknown>;
+  onChange: (config: Record<string, unknown>) => void;
+  disabled?: boolean;
+}
+
+const STORE_ID_PATTERN = /^mst_[0-9a-f]{32}$/;
+
+export function MemoryCapabilityConfigEditor({
+  config,
+  onChange,
+  disabled,
+}: MemoryCapabilityConfigEditorProps) {
+  const typed = config as MemoryConfig;
+  const { data: stores, isLoading, error } = useMemoryStores();
+
+  const storeOptions = useMemo<ComboboxOption[]>(() => {
+    const options: ComboboxOption[] = [{ value: "", label: "Default store" }];
+    for (const store of stores ?? []) {
+      const suffix = store.is_default ? " (default)" : "";
+      options.push({ value: store.id, label: `${store.name}${suffix}` });
+    }
+    return options;
+  }, [stores]);
+
+  const isUnknownStore =
+    !isLoading &&
+    !error &&
+    typed.store &&
+    STORE_ID_PATTERN.test(typed.store) &&
+    !(stores ?? []).some((s) => s.id === typed.store);
+
+  const passiveCount = typed.passive_recall_count ?? 5;
+
+  const update = (patch: Partial<MemoryConfig>) => {
+    const next: MemoryConfig = { ...typed, ...patch };
+    if (!next.store) delete next.store;
+    if (next.passive_recall_count === undefined || next.passive_recall_count === 5) {
+      delete next.passive_recall_count;
+    }
+    onChange(next as Record<string, unknown>);
+  };
+
+  return (
+    <div className="space-y-3 pt-2">
+      <div className="space-y-1">
+        <Label className="text-xs font-normal text-muted-foreground">Memory store</Label>
+        <Combobox
+          options={storeOptions}
+          value={typed.store ?? ""}
+          onValueChange={(value) => update({ store: value || undefined })}
+          placeholder={isLoading ? "Loading..." : "Default store"}
+          searchPlaceholder="Search stores..."
+          disabled={disabled || isLoading}
+        />
+        {isUnknownStore && (
+          <p className="text-xs text-destructive">
+            Selected store is no longer available in this organization.
+          </p>
+        )}
+        {error && (
+          <p className="text-xs text-destructive">Failed to load memory stores.</p>
+        )}
+        <p className="text-xs text-muted-foreground">
+          When unset, the agent uses the org&apos;s default store, created on first use.
+        </p>
+      </div>
+
+      <div className="space-y-1">
+        <Label
+          htmlFor="memory-passive-recall-count"
+          className="text-xs font-normal text-muted-foreground"
+        >
+          Passive recall count
+        </Label>
+        <Input
+          id="memory-passive-recall-count"
+          type="number"
+          min={0}
+          max={50}
+          value={passiveCount}
+          disabled={disabled}
+          className="h-8 w-32 text-sm"
+          onChange={(event) => {
+            const value = event.target.value;
+            const parsed = Number(value);
+            if (value === "" || !Number.isFinite(parsed)) {
+              update({ passive_recall_count: undefined });
+              return;
+            }
+            update({ passive_recall_count: Math.max(0, Math.min(50, Math.round(parsed))) });
+          }}
+        />
+        <p className="text-xs text-muted-foreground">
+          Memories auto-injected per turn. Set to 0 to disable passive recall.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/ui/src/components/layout/sidebar.tsx
+++ b/apps/ui/src/components/layout/sidebar.tsx
@@ -21,6 +21,7 @@ import { usePathname } from "next/navigation";
 import {
   Boxes,
   BookOpen,
+  Brain,
   Calendar,
   ClipboardCheck,
   FlaskConical,
@@ -94,6 +95,7 @@ export const defaultBuildingBlocksNavigation: NavigationItem[] = [
   { name: "Agent Identities", href: "/agent-identities", icon: UserRound },
   { name: "Skills", href: "/skills", icon: BookOpen },
   { name: "Volumes", href: "/volumes", icon: HardDrive },
+  { name: "Memory", href: "/memory-stores", icon: Brain },
   { name: "Models", href: "/models", icon: Cpu },
   { name: "Capabilities", href: "/capabilities", icon: Puzzle },
   { name: "MCP Servers", href: "/mcp-servers", icon: capabilityIconMap.mcp },

--- a/apps/ui/src/hooks/index.ts
+++ b/apps/ui/src/hooks/index.ts
@@ -25,3 +25,4 @@ export * from "./use-evals";
 export * from "./use-name-availability";
 export * from "./use-page-title";
 export * from "./use-volumes";
+export * from "./use-memory-stores";

--- a/apps/ui/src/hooks/use-memory-stores.ts
+++ b/apps/ui/src/hooks/use-memory-stores.ts
@@ -1,0 +1,68 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  createMemoryStore,
+  forgetMemory,
+  getMemoryStore,
+  listMemories,
+  listMemoryStores,
+} from "@/lib/api/memory-stores";
+import type {
+  CreateMemoryStoreRequest,
+  ListMemoriesParams,
+  MemoryStore,
+} from "@/lib/api/types";
+import { queryKeys } from "@/lib/query-keys";
+import { useOrgScopedQuery } from "./create-crud-hooks";
+
+export function useMemoryStores() {
+  return useOrgScopedQuery<MemoryStore[]>({
+    queryKey: queryKeys.memoryStores.list(),
+    queryFn: () => listMemoryStores(),
+  });
+}
+
+export function useMemoryStore(storeId: string | undefined) {
+  return useOrgScopedQuery<MemoryStore>({
+    queryKey: queryKeys.memoryStores.detail(storeId ?? ""),
+    queryFn: () => getMemoryStore(storeId!),
+    enabled: !!storeId,
+  });
+}
+
+export function useMemories(storeId: string | undefined, params: ListMemoriesParams = {}) {
+  return useOrgScopedQuery({
+    queryKey: queryKeys.memoryStores.memories(storeId ?? "", params as Record<string, unknown>),
+    queryFn: () => listMemories(storeId!, params),
+    enabled: !!storeId,
+  });
+}
+
+export function useCreateMemoryStore() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (request: CreateMemoryStoreRequest) => createMemoryStore(request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.memoryStores.all });
+    },
+  });
+}
+
+export function useForgetMemory(storeId: string | undefined) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (memoryId: string) => forgetMemory(storeId!, memoryId),
+    onSuccess: () => {
+      if (storeId) {
+        queryClient.invalidateQueries({
+          queryKey: ["memory-store", storeId, "memories"],
+        });
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.memoryStores.detail(storeId),
+        });
+        queryClient.invalidateQueries({ queryKey: queryKeys.memoryStores.all });
+      }
+    },
+  });
+}

--- a/apps/ui/src/hooks/use-memory-stores.ts
+++ b/apps/ui/src/hooks/use-memory-stores.ts
@@ -8,11 +8,7 @@ import {
   listMemories,
   listMemoryStores,
 } from "@/lib/api/memory-stores";
-import type {
-  CreateMemoryStoreRequest,
-  ListMemoriesParams,
-  MemoryStore,
-} from "@/lib/api/types";
+import type { CreateMemoryStoreRequest, ListMemoriesParams, MemoryStore } from "@/lib/api/types";
 import { queryKeys } from "@/lib/query-keys";
 import { useOrgScopedQuery } from "./create-crud-hooks";
 

--- a/apps/ui/src/lib/api/index.ts
+++ b/apps/ui/src/lib/api/index.ts
@@ -13,3 +13,4 @@ export * from "./auth";
 export * from "./durable";
 export * from "./agent-identities";
 export * from "./volumes";
+export * from "./memory-stores";

--- a/apps/ui/src/lib/api/memory-stores.ts
+++ b/apps/ui/src/lib/api/memory-stores.ts
@@ -1,0 +1,57 @@
+// Org-scoped memory store API client (see specs/memory.md)
+
+import { api } from "./client";
+import type {
+  CreateMemoryStoreRequest,
+  ListMemoriesParams,
+  ListMemoriesResponse,
+  ListResponse,
+  MemoryStore,
+} from "./types";
+
+export async function listMemoryStores(): Promise<MemoryStore[]> {
+  const response = await api.get<ListResponse<MemoryStore>>("/v1/memory-stores");
+  return response.data.data;
+}
+
+export async function getMemoryStore(storeId: string): Promise<MemoryStore> {
+  const response = await api.get<MemoryStore>(`/v1/memory-stores/${storeId}`);
+  return response.data;
+}
+
+export async function createMemoryStore(
+  request: CreateMemoryStoreRequest,
+): Promise<MemoryStore> {
+  const response = await api.post<MemoryStore>("/v1/memory-stores", request);
+  return response.data;
+}
+
+function memoriesQuery(params: ListMemoriesParams = {}): string {
+  const query = new URLSearchParams();
+  if (params.query?.trim()) query.set("query", params.query.trim());
+  if (params.kind) query.set("kind", params.kind);
+  if (params.tag) {
+    for (const t of params.tag) {
+      query.append("tag", t);
+    }
+  }
+  if (params.includeInactive) query.set("include_inactive", "true");
+  if (params.limit) query.set("limit", String(params.limit));
+  return query.toString();
+}
+
+export async function listMemories(
+  storeId: string,
+  params: ListMemoriesParams = {},
+): Promise<ListMemoriesResponse> {
+  const suffix = memoriesQuery(params);
+  const url = suffix
+    ? `/v1/memory-stores/${storeId}/memories?${suffix}`
+    : `/v1/memory-stores/${storeId}/memories`;
+  const response = await api.get<ListMemoriesResponse>(url);
+  return response.data;
+}
+
+export async function forgetMemory(storeId: string, memoryId: string): Promise<void> {
+  await api.delete(`/v1/memory-stores/${storeId}/memories/${memoryId}`);
+}

--- a/apps/ui/src/lib/api/memory-stores.ts
+++ b/apps/ui/src/lib/api/memory-stores.ts
@@ -19,9 +19,7 @@ export async function getMemoryStore(storeId: string): Promise<MemoryStore> {
   return response.data;
 }
 
-export async function createMemoryStore(
-  request: CreateMemoryStoreRequest,
-): Promise<MemoryStore> {
+export async function createMemoryStore(request: CreateMemoryStoreRequest): Promise<MemoryStore> {
   const response = await api.post<MemoryStore>("/v1/memory-stores", request);
   return response.data;
 }

--- a/apps/ui/src/lib/api/types/index.ts
+++ b/apps/ui/src/lib/api/types/index.ts
@@ -20,3 +20,4 @@ export * from "./command-types";
 export * from "./eval-types";
 export * from "./budget-types";
 export * from "./volume-types";
+export * from "./memory-store-types";

--- a/apps/ui/src/lib/api/types/memory-store-types.ts
+++ b/apps/ui/src/lib/api/types/memory-store-types.ts
@@ -1,0 +1,43 @@
+// Org-scoped memory store types (see specs/memory.md)
+
+export type MemoryKind = "fact" | "preference" | "correction" | "procedure" | "context";
+
+export interface MemoryStore {
+  id: string;
+  name: string;
+  is_default: boolean;
+  active_memory_count: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface Memory {
+  id: string;
+  store_id: string;
+  content: string;
+  content_parts: unknown;
+  kind: string;
+  importance: number;
+  tags: string[];
+  active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CreateMemoryStoreRequest {
+  name: string;
+  is_default?: boolean;
+}
+
+export interface ListMemoriesParams {
+  query?: string;
+  kind?: string;
+  tag?: string[];
+  includeInactive?: boolean;
+  limit?: number;
+}
+
+export interface ListMemoriesResponse {
+  data: Memory[];
+  total: number;
+}

--- a/apps/ui/src/lib/query-keys.ts
+++ b/apps/ui/src/lib/query-keys.ts
@@ -182,6 +182,15 @@ export const queryKeys = {
     detail: (volumeId: string) => ["volume", volumeId] as const,
   },
 
+  // Memory store queries
+  memoryStores: {
+    all: ["memory-stores"] as const,
+    list: () => ["memory-stores"] as const,
+    detail: (storeId: string) => ["memory-store", storeId] as const,
+    memories: (storeId: string, params: Record<string, unknown> = {}) =>
+      ["memory-store", storeId, "memories", params] as const,
+  },
+
   // Eval queries
   evals: {
     all: ["evals"] as const,

--- a/crates/core/src/capabilities/persistent_memory.rs
+++ b/crates/core/src/capabilities/persistent_memory.rs
@@ -61,6 +61,28 @@ impl Capability for MemoryCapability {
             Box::new(ForgetTool),
         ]
     }
+
+    fn config_schema(&self) -> Option<Value> {
+        Some(json!({
+            "type": "object",
+            "properties": {
+                "store": {
+                    "type": ["string", "null"],
+                    "title": "Memory store",
+                    "description": "Memory store ID (mst_<32-hex>) to read and write. Leave empty to use the org default store, created on first use.",
+                    "pattern": "^mst_[0-9a-f]{32}$"
+                },
+                "passive_recall_count": {
+                    "type": "integer",
+                    "title": "Passive recall count",
+                    "description": "Number of memories auto-injected per turn. Set to 0 to disable passive recall.",
+                    "minimum": 0,
+                    "maximum": 50,
+                    "default": 5
+                }
+            }
+        }))
+    }
 }
 
 const MEMORY_SYSTEM_PROMPT: &str = r#"## Persistent Memory

--- a/crates/runtime/src/host.rs
+++ b/crates/runtime/src/host.rs
@@ -218,7 +218,7 @@ pub trait RuntimeHostAdapter: Send + Sync + Clone + 'static {
         None
     }
 
-    fn memory_store(&self) -> Option<Arc<dyn everruns_core::MemoryStoreBackend>> {
+    fn memory_store(&self, _org_id: i64) -> Option<Arc<dyn everruns_core::MemoryStoreBackend>> {
         None
     }
 
@@ -769,7 +769,7 @@ pub async fn execute_act_activity<A: RuntimeHostAdapter>(
     if let Some(provider_credential_store) = adapter.provider_credential_store(org_id) {
         atom = atom.with_provider_credential_store(provider_credential_store);
     }
-    if let Some(memory_store) = adapter.memory_store() {
+    if let Some(memory_store) = adapter.memory_store(org_id) {
         atom = atom.with_memory_store(memory_store);
     }
     if let Some(connection_resolver) = adapter.connection_resolver() {

--- a/crates/runtime/tests/runtime_host_test.rs
+++ b/crates/runtime/tests/runtime_host_test.rs
@@ -183,7 +183,7 @@ impl RuntimeHostAdapter for MockHostAdapter {
         self.file_store.clone()
     }
 
-    fn memory_store(&self) -> Option<Arc<dyn MemoryStoreBackend>> {
+    fn memory_store(&self, _org_id: i64) -> Option<Arc<dyn MemoryStoreBackend>> {
         self.memory_store.clone()
     }
 }

--- a/crates/server/migrations/032_memory_stores.sql
+++ b/crates/server/migrations/032_memory_stores.sql
@@ -24,6 +24,8 @@ CREATE UNIQUE INDEX idx_memory_stores_org_public_id ON memory_stores(org_id, pub
 CREATE UNIQUE INDEX idx_memory_stores_org_lower_name ON memory_stores(org_id, LOWER(name));
 -- Only one default store per org.
 CREATE UNIQUE INDEX idx_memory_stores_org_default ON memory_stores(org_id) WHERE is_default;
+-- Supports the composite FK on memories(store_id, org_id) below.
+CREATE UNIQUE INDEX idx_memory_stores_id_org ON memory_stores(id, org_id);
 
 CREATE TRIGGER update_memory_stores_updated_at BEFORE UPDATE ON memory_stores
     FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
@@ -33,7 +35,7 @@ COMMENT ON TABLE memory_stores IS 'Org-scoped containers for agent memories. See
 CREATE TABLE memories (
     id UUID PRIMARY KEY DEFAULT uuidv7(),
     public_id TEXT NOT NULL,
-    store_id UUID NOT NULL REFERENCES memory_stores(id) ON DELETE CASCADE,
+    store_id UUID NOT NULL,
     -- org_id duplicated from store for fast org-scoped queries and isolation checks.
     org_id BIGINT NOT NULL REFERENCES organizations(org_id),
     content TEXT NOT NULL,
@@ -51,7 +53,16 @@ CREATE TABLE memories (
 
     CONSTRAINT memories_public_id_format
         CHECK (public_id ~ '^mem_[0-9a-f]{32}$'),
-    CONSTRAINT memories_content_length CHECK (char_length(content) <= 2000)
+    CONSTRAINT memories_content_length CHECK (char_length(content) <= 2000),
+
+    -- Composite FK pins (store_id, org_id) to a real memory_stores(id, org_id)
+    -- pair so a memory cannot be inserted with an org_id that disagrees with
+    -- its store's org. Defense-in-depth on top of the application-level org
+    -- check in DbMemoryStore.
+    CONSTRAINT memories_store_org_match
+        FOREIGN KEY (store_id, org_id)
+        REFERENCES memory_stores(id, org_id)
+        ON DELETE CASCADE
 );
 
 CREATE INDEX idx_memories_store_active ON memories(store_id) WHERE active;

--- a/crates/server/migrations/032_memory_stores.sql
+++ b/crates/server/migrations/032_memory_stores.sql
@@ -1,0 +1,66 @@
+-- Org-scoped persistent memory stores (EVE-422).
+-- See specs/memory.md for full design intent.
+--
+-- A MemoryStore is an org-scoped named container for Memory entries that
+-- agents create and recall via the `memory` capability (remember/recall/forget
+-- tools). Each org has at most one default store, automatically created on
+-- first use. Capability config can target a specific store ID.
+
+CREATE TABLE memory_stores (
+    id UUID PRIMARY KEY DEFAULT uuidv7(),
+    org_id BIGINT NOT NULL REFERENCES organizations(org_id) DEFAULT 1,
+    public_id TEXT NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    is_default BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT memory_stores_public_id_format
+        CHECK (public_id ~ '^mst_[0-9a-f]{32}$')
+);
+
+CREATE INDEX idx_memory_stores_org_id ON memory_stores(org_id);
+CREATE UNIQUE INDEX idx_memory_stores_org_public_id ON memory_stores(org_id, public_id);
+CREATE UNIQUE INDEX idx_memory_stores_org_lower_name ON memory_stores(org_id, LOWER(name));
+-- Only one default store per org.
+CREATE UNIQUE INDEX idx_memory_stores_org_default ON memory_stores(org_id) WHERE is_default;
+
+CREATE TRIGGER update_memory_stores_updated_at BEFORE UPDATE ON memory_stores
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+COMMENT ON TABLE memory_stores IS 'Org-scoped containers for agent memories. See specs/memory.md.';
+
+CREATE TABLE memories (
+    id UUID PRIMARY KEY DEFAULT uuidv7(),
+    public_id TEXT NOT NULL,
+    store_id UUID NOT NULL REFERENCES memory_stores(id) ON DELETE CASCADE,
+    -- org_id duplicated from store for fast org-scoped queries and isolation checks.
+    org_id BIGINT NOT NULL REFERENCES organizations(org_id),
+    content TEXT NOT NULL,
+    -- Multicontent parts (text + image variants) as JSON array. Empty array if
+    -- the memory only carries the plain `content` field.
+    content_parts JSONB NOT NULL DEFAULT '[]'::jsonb,
+    kind VARCHAR(32) NOT NULL DEFAULT 'fact'
+        CHECK (kind IN ('fact', 'preference', 'correction', 'procedure', 'context')),
+    importance SMALLINT NOT NULL DEFAULT 5
+        CHECK (importance BETWEEN 1 AND 10),
+    tags TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+    active BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT memories_public_id_format
+        CHECK (public_id ~ '^mem_[0-9a-f]{32}$'),
+    CONSTRAINT memories_content_length CHECK (char_length(content) <= 2000)
+);
+
+CREATE INDEX idx_memories_store_active ON memories(store_id) WHERE active;
+CREATE INDEX idx_memories_org_id ON memories(org_id);
+CREATE UNIQUE INDEX idx_memories_public_id ON memories(public_id);
+CREATE INDEX idx_memories_store_kind_active ON memories(store_id, kind) WHERE active;
+CREATE INDEX idx_memories_tags_gin ON memories USING GIN (tags);
+
+CREATE TRIGGER update_memories_updated_at BEFORE UPDATE ON memories
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+COMMENT ON TABLE memories IS 'Memory entries inside a memory_store. Soft-deleted via active=false.';

--- a/crates/server/src/api/memory_stores.rs
+++ b/crates/server/src/api/memory_stores.rs
@@ -1,0 +1,171 @@
+// Memory store CRUD HTTP routes.
+// See specs/memory.md.
+
+use crate::auth::{AuthState, ResolvedOrg};
+use crate::domains::common::{Command, Ctx};
+pub use crate::domains::memory_stores::types::{
+    CreateMemoryStoreRequest, ListMemoriesQuery, ListMemoriesResponse, MemoryResponse,
+    MemoryStoreResponse,
+};
+use crate::domains::memory_stores::{
+    CreateMemoryStore, ForgetMemoryCmd, GetMemoryStore, ListMemoriesCmd, ListMemoryStores,
+};
+use crate::storage::StorageBackend;
+use axum::{
+    Json, Router,
+    extract::{Path, Query, State},
+    http::StatusCode,
+    routing::{delete, get, post},
+};
+use everruns_core::Caller;
+use std::sync::Arc;
+
+use super::common::{ApiResult, ErrorResponse, ListResponse, impl_auth_state};
+
+#[derive(Clone)]
+pub struct AppState {
+    pub db: Arc<StorageBackend>,
+    pub auth: AuthState,
+}
+
+impl AppState {
+    pub fn new(db: Arc<StorageBackend>, auth: AuthState) -> Self {
+        Self { db, auth }
+    }
+
+    fn ctx(&self, org: &ResolvedOrg) -> Ctx {
+        Ctx::minimal(
+            Caller::from(org),
+            self.db.clone(),
+            None,
+            self.auth.permission_resolver.clone(),
+        )
+    }
+}
+
+impl_auth_state!(AppState);
+
+pub fn routes(state: AppState) -> Router {
+    Router::new()
+        .route(
+            "/v1/memory-stores",
+            post(create_memory_store).get(list_memory_stores),
+        )
+        .route("/v1/memory-stores/{store_id}", get(get_memory_store))
+        .route("/v1/memory-stores/{store_id}/memories", get(list_memories))
+        .route(
+            "/v1/memory-stores/{store_id}/memories/{memory_id}",
+            delete(forget_memory),
+        )
+        .with_state(state)
+}
+
+#[utoipa::path(
+    get,
+    path = "/v1/memory-stores",
+    responses(
+        (status = 200, description = "List org memory stores",
+            body = ListResponse<MemoryStoreResponse>)
+    ),
+    tag = "memory_stores"
+)]
+pub async fn list_memory_stores(
+    org: ResolvedOrg,
+    State(state): State<AppState>,
+) -> ApiResult<ListResponse<MemoryStoreResponse>> {
+    let stores = ListMemoryStores.run(&state.ctx(&org)).await?;
+    Ok(Json(ListResponse::new(stores)))
+}
+
+#[utoipa::path(
+    post,
+    path = "/v1/memory-stores",
+    request_body = CreateMemoryStoreRequest,
+    responses(
+        (status = 201, description = "Memory store created", body = MemoryStoreResponse),
+        (status = 400, description = "Invalid input", body = ErrorResponse),
+        (status = 409, description = "Duplicate name or default conflict", body = ErrorResponse)
+    ),
+    tag = "memory_stores"
+)]
+pub async fn create_memory_store(
+    org: ResolvedOrg,
+    State(state): State<AppState>,
+    Json(req): Json<CreateMemoryStoreRequest>,
+) -> Result<(StatusCode, Json<MemoryStoreResponse>), (StatusCode, Json<ErrorResponse>)> {
+    let store = CreateMemoryStore::from(req).run(&state.ctx(&org)).await?;
+    Ok((StatusCode::CREATED, Json(store)))
+}
+
+#[utoipa::path(
+    get,
+    path = "/v1/memory-stores/{store_id}",
+    params(("store_id" = String, Path, description = "Memory store ID")),
+    responses(
+        (status = 200, description = "Memory store", body = MemoryStoreResponse),
+        (status = 404, description = "Not found", body = ErrorResponse)
+    ),
+    tag = "memory_stores"
+)]
+pub async fn get_memory_store(
+    org: ResolvedOrg,
+    State(state): State<AppState>,
+    Path(store_id): Path<String>,
+) -> ApiResult<MemoryStoreResponse> {
+    Ok(Json(
+        GetMemoryStore { store_id }.run(&state.ctx(&org)).await?,
+    ))
+}
+
+#[utoipa::path(
+    get,
+    path = "/v1/memory-stores/{store_id}/memories",
+    params(
+        ("store_id" = String, Path, description = "Memory store ID"),
+        ListMemoriesQuery
+    ),
+    responses(
+        (status = 200, description = "Memories", body = ListMemoriesResponse),
+        (status = 404, description = "Store not found", body = ErrorResponse)
+    ),
+    tag = "memory_stores"
+)]
+pub async fn list_memories(
+    org: ResolvedOrg,
+    State(state): State<AppState>,
+    Path(store_id): Path<String>,
+    Query(query): Query<ListMemoriesQuery>,
+) -> ApiResult<ListMemoriesResponse> {
+    Ok(Json(
+        ListMemoriesCmd::from_query(store_id, query)
+            .run(&state.ctx(&org))
+            .await?,
+    ))
+}
+
+#[utoipa::path(
+    delete,
+    path = "/v1/memory-stores/{store_id}/memories/{memory_id}",
+    params(
+        ("store_id" = String, Path, description = "Memory store ID"),
+        ("memory_id" = String, Path, description = "Memory ID")
+    ),
+    responses(
+        (status = 204, description = "Memory deactivated"),
+        (status = 404, description = "Not found", body = ErrorResponse)
+    ),
+    tag = "memory_stores"
+)]
+pub async fn forget_memory(
+    org: ResolvedOrg,
+    State(state): State<AppState>,
+    Path((store_id, memory_id)): Path<(String, String)>,
+) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
+    ForgetMemoryCmd {
+        store_id,
+        memory_id,
+    }
+    .run(&state.ctx(&org))
+    .await?;
+    Ok(StatusCode::NO_CONTENT)
+}

--- a/crates/server/src/api/mod.rs
+++ b/crates/server/src/api/mod.rs
@@ -30,6 +30,7 @@ pub mod llm_models;
 pub mod llm_providers;
 pub mod mcp_endpoint;
 pub mod mcp_servers;
+pub mod memory_stores;
 pub mod messages;
 pub mod notifications;
 pub mod organizations;

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -947,6 +947,7 @@ impl ServerAppBuilder {
             platform_definition.built_in_harnesses().to_vec(),
         );
         let volumes_state = api::volumes::AppState::new(db.clone(), auth_state.clone());
+        let memory_stores_state = api::memory_stores::AppState::new(db.clone(), auth_state.clone());
         let audit_logs_state = api::audit_logs::AppState::new(
             db.clone(),
             capability_service.clone(),
@@ -1072,6 +1073,7 @@ impl ServerAppBuilder {
             .merge(api::skills::routes(skills_state))
             .merge(api::organizations::routes(organizations_state))
             .merge(api::volumes::routes(volumes_state))
+            .merge(api::memory_stores::routes(memory_stores_state))
             .merge(api::user_connections::routes(user_connections_state))
             .merge(api::session_schedules::routes(session_schedules_state))
             .merge(api::audit_logs::routes(audit_logs_state))

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -1381,6 +1381,16 @@ impl WorkerAdapters for DirectWorkerAdapters {
         ))
     }
 
+    fn memory_store(
+        &self,
+        org_id: i64,
+    ) -> Option<Arc<dyn everruns_core::memory_store::MemoryStoreBackend>> {
+        Some(Arc::new(crate::storage::DbMemoryStore::new(
+            self.db.clone(),
+            org_id,
+        )))
+    }
+
     fn budget_checker(
         &self,
         org_id: i64,

--- a/crates/server/src/domains/memory_stores/commands.rs
+++ b/crates/server/src/domains/memory_stores/commands.rs
@@ -1,0 +1,586 @@
+use super::types::{
+    CreateMemoryStoreRequest, ListMemoriesQuery, ListMemoriesResponse, MemoryResponse,
+    MemoryStoreResponse, memory_response, store_response,
+};
+use super::{MEMORY_STORE_MANAGE, MEMORY_STORE_VIEW};
+use crate::domains::common::*;
+use crate::storage::models::{CreateMemoryStoreRow, ListMemoriesFilter};
+use everruns_core::Policy;
+use everruns_core::memory_store::MemoryLimits;
+use everruns_core::typed_id::{MemoryId, MemoryStoreId};
+use serde::Deserialize;
+use utoipa::ToSchema;
+
+fn validate_store_name(name: &str) -> Result<String, CommandError> {
+    let trimmed = name.trim();
+    if trimmed.is_empty() {
+        return Err(CommandError::bad_request(
+            "Memory store name cannot be empty",
+        ));
+    }
+    if trimmed.chars().count() > 255 {
+        return Err(CommandError::bad_request(
+            "Memory store name must be at most 255 characters",
+        ));
+    }
+    Ok(trimmed.to_string())
+}
+
+fn parse_store_id(store_id: &str) -> Result<MemoryStoreId, CommandError> {
+    store_id
+        .parse()
+        .map_err(|_| CommandError::not_found("Memory store"))
+}
+
+fn parse_memory_id(memory_id: &str) -> Result<MemoryId, CommandError> {
+    memory_id
+        .parse()
+        .map_err(|_| CommandError::not_found("Memory"))
+}
+
+#[derive(Debug, Default, Deserialize, ToSchema)]
+pub struct ListMemoryStores;
+
+impl Command for ListMemoryStores {
+    type Output = Vec<MemoryStoreResponse>;
+
+    fn meta() -> CommandMeta {
+        CommandMeta {
+            name: "list_memory_stores",
+            category: "memory_stores",
+            description: "List org-scoped memory stores.",
+            method: "GET",
+            path: "/v1/memory-stores",
+        }
+    }
+
+    fn policy() -> Option<&'static Policy> {
+        Some(&MEMORY_STORE_VIEW)
+    }
+
+    fn output_schema() -> serde_json::Value {
+        array_output_schema(output_schema_for::<MemoryStoreResponse>())
+    }
+
+    async fn execute(self, ctx: &Ctx) -> Result<Vec<MemoryStoreResponse>, CommandError> {
+        let rows = ctx
+            .db
+            .list_memory_stores(ctx.org_id())
+            .await
+            .map_err(classify_anyhow)?;
+
+        let mut out = Vec::with_capacity(rows.len());
+        for row in rows {
+            let count = ctx
+                .db
+                .count_active_memories(row.id)
+                .await
+                .map_err(classify_anyhow)?;
+            out.push(store_response(row, count).map_err(classify_anyhow)?);
+        }
+        Ok(out)
+    }
+}
+
+inventory::submit! { CommandDescriptor::of::<ListMemoryStores>() }
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct CreateMemoryStore {
+    pub name: String,
+    #[serde(default)]
+    pub is_default: bool,
+}
+
+impl From<CreateMemoryStoreRequest> for CreateMemoryStore {
+    fn from(req: CreateMemoryStoreRequest) -> Self {
+        Self {
+            name: req.name,
+            is_default: req.is_default,
+        }
+    }
+}
+
+impl Command for CreateMemoryStore {
+    type Output = MemoryStoreResponse;
+
+    fn meta() -> CommandMeta {
+        CommandMeta {
+            name: "create_memory_store",
+            category: "memory_stores",
+            description: "Create an org-scoped memory store.",
+            method: "POST",
+            path: "/v1/memory-stores",
+        }
+    }
+
+    fn policy() -> Option<&'static Policy> {
+        Some(&MEMORY_STORE_MANAGE)
+    }
+
+    fn output_schema() -> serde_json::Value {
+        output_schema_for::<MemoryStoreResponse>()
+    }
+
+    async fn execute(self, ctx: &Ctx) -> Result<MemoryStoreResponse, CommandError> {
+        let name = validate_store_name(&self.name)?;
+
+        let existing_count = ctx
+            .db
+            .count_memory_stores(ctx.org_id())
+            .await
+            .map_err(classify_anyhow)?;
+        if existing_count as usize >= MemoryLimits::MAX_STORES_PER_ORG {
+            return Err(CommandError::bad_request(format!(
+                "memory store limit reached ({} stores per org)",
+                MemoryLimits::MAX_STORES_PER_ORG
+            )));
+        }
+
+        let public_id = MemoryStoreId::new().to_string();
+        let row = ctx
+            .db
+            .create_memory_store(
+                ctx.org_id(),
+                CreateMemoryStoreRow {
+                    public_id,
+                    name,
+                    is_default: self.is_default,
+                },
+            )
+            .await
+            .map_err(classify_anyhow)?;
+        store_response(row, 0).map_err(classify_anyhow)
+    }
+}
+
+inventory::submit! { CommandDescriptor::of::<CreateMemoryStore>() }
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct GetMemoryStore {
+    pub store_id: String,
+}
+
+impl Command for GetMemoryStore {
+    type Output = MemoryStoreResponse;
+
+    fn meta() -> CommandMeta {
+        CommandMeta {
+            name: "get_memory_store",
+            category: "memory_stores",
+            description: "Get a memory store by ID.",
+            method: "GET",
+            path: "/v1/memory-stores/{store_id}",
+        }
+    }
+
+    fn positional_arg() -> Option<&'static str> {
+        Some("store_id")
+    }
+
+    fn policy() -> Option<&'static Policy> {
+        Some(&MEMORY_STORE_VIEW)
+    }
+
+    fn output_schema() -> serde_json::Value {
+        output_schema_for::<MemoryStoreResponse>()
+    }
+
+    async fn execute(self, ctx: &Ctx) -> Result<MemoryStoreResponse, CommandError> {
+        let id = parse_store_id(&self.store_id)?;
+        let row = ctx
+            .db
+            .get_memory_store_by_public_id(ctx.org_id(), &id.to_string())
+            .await
+            .map_err(classify_anyhow)?
+            .ok_or_else(|| CommandError::not_found("Memory store"))?;
+        let count = ctx
+            .db
+            .count_active_memories(row.id)
+            .await
+            .map_err(classify_anyhow)?;
+        store_response(row, count).map_err(classify_anyhow)
+    }
+}
+
+inventory::submit! { CommandDescriptor::of::<GetMemoryStore>() }
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct ListMemoriesCmd {
+    pub store_id: String,
+    #[serde(default)]
+    pub query: Option<String>,
+    #[serde(default)]
+    pub kind: Option<String>,
+    #[serde(default)]
+    pub tag: Option<Vec<String>>,
+    #[serde(default)]
+    pub include_inactive: Option<bool>,
+    #[serde(default)]
+    pub limit: Option<usize>,
+}
+
+impl ListMemoriesCmd {
+    pub fn from_query(store_id: String, query: ListMemoriesQuery) -> Self {
+        Self {
+            store_id,
+            query: query.query,
+            kind: query.kind,
+            tag: query.tag,
+            include_inactive: query.include_inactive,
+            limit: query.limit,
+        }
+    }
+}
+
+impl Command for ListMemoriesCmd {
+    type Output = ListMemoriesResponse;
+
+    fn meta() -> CommandMeta {
+        CommandMeta {
+            name: "list_memories",
+            category: "memory_stores",
+            description: "List/search memories in a store.",
+            method: "GET",
+            path: "/v1/memory-stores/{store_id}/memories",
+        }
+    }
+
+    fn policy() -> Option<&'static Policy> {
+        Some(&MEMORY_STORE_VIEW)
+    }
+
+    fn output_schema() -> serde_json::Value {
+        output_schema_for::<ListMemoriesResponse>()
+    }
+
+    async fn execute(self, ctx: &Ctx) -> Result<ListMemoriesResponse, CommandError> {
+        let store_id = parse_store_id(&self.store_id)?;
+        let store = ctx
+            .db
+            .get_memory_store_by_public_id(ctx.org_id(), &store_id.to_string())
+            .await
+            .map_err(classify_anyhow)?
+            .ok_or_else(|| CommandError::not_found("Memory store"))?;
+        let filter = ListMemoriesFilter {
+            query: self.query,
+            kind: self.kind,
+            tags: self.tag,
+            include_inactive: self.include_inactive.unwrap_or(false),
+            limit: self.limit.unwrap_or(50),
+        };
+        let (rows, total) = ctx
+            .db
+            .list_memories(ctx.org_id(), Some(store.id), filter)
+            .await
+            .map_err(classify_anyhow)?;
+        let data: Vec<MemoryResponse> = rows
+            .into_iter()
+            .map(|r| memory_response(r).map_err(classify_anyhow))
+            .collect::<Result<_, _>>()?;
+        Ok(ListMemoriesResponse { data, total })
+    }
+}
+
+inventory::submit! { CommandDescriptor::of::<ListMemoriesCmd>() }
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct ForgetMemoryCmd {
+    pub store_id: String,
+    pub memory_id: String,
+}
+
+impl Command for ForgetMemoryCmd {
+    type Output = ();
+
+    fn meta() -> CommandMeta {
+        CommandMeta {
+            name: "forget_memory",
+            category: "memory_stores",
+            description: "Soft-delete (deactivate) a memory.",
+            method: "DELETE",
+            path: "/v1/memory-stores/{store_id}/memories/{memory_id}",
+        }
+    }
+
+    fn policy() -> Option<&'static Policy> {
+        Some(&MEMORY_STORE_MANAGE)
+    }
+
+    async fn execute(self, ctx: &Ctx) -> Result<(), CommandError> {
+        let store_id = parse_store_id(&self.store_id)?;
+        let memory_id = parse_memory_id(&self.memory_id)?;
+        let store = ctx
+            .db
+            .get_memory_store_by_public_id(ctx.org_id(), &store_id.to_string())
+            .await
+            .map_err(classify_anyhow)?
+            .ok_or_else(|| CommandError::not_found("Memory store"))?;
+        let removed = ctx
+            .db
+            .deactivate_memory(ctx.org_id(), store.id, &memory_id.to_string())
+            .await
+            .map_err(classify_anyhow)?;
+        if removed {
+            Ok(())
+        } else {
+            Err(CommandError::not_found("Memory"))
+        }
+    }
+}
+
+inventory::submit! { CommandDescriptor::of::<ForgetMemoryCmd>() }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::StorageBackend;
+    use everruns_core::{Caller, DEFAULT_ORG_ID, OrgRole};
+    use std::sync::Arc;
+
+    fn ctx_with_db(org_id: i64, db: Arc<StorageBackend>) -> Ctx {
+        Ctx::minimal_for_test(
+            Caller {
+                org_id,
+                org_public_id: everruns_core::organization::org_public_id_from_internal(org_id),
+                user_id: None,
+                role: OrgRole::Owner,
+                is_platform_user: false,
+                is_internal: false,
+            },
+            db,
+            None,
+        )
+    }
+
+    #[tokio::test]
+    async fn create_and_list_stores_round_trip() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let ctx = ctx_with_db(DEFAULT_ORG_ID, db);
+
+        let created = CreateMemoryStore {
+            name: "Team Knowledge".into(),
+            is_default: true,
+        }
+        .run(&ctx)
+        .await
+        .expect("create store");
+
+        assert!(created.id.to_string().starts_with("mst_"));
+        assert!(created.is_default);
+        assert_eq!(created.active_memory_count, 0);
+
+        let listed = ListMemoryStores.run(&ctx).await.expect("list stores");
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].id, created.id);
+    }
+
+    #[tokio::test]
+    async fn search_and_forget_via_backend_then_api() {
+        use crate::storage::DbMemoryStore;
+        use everruns_core::memory_store::{MemoryKind, MemoryQuery, MemoryStoreBackend};
+
+        let db = Arc::new(StorageBackend::in_memory());
+        let ctx = ctx_with_db(DEFAULT_ORG_ID, db.clone());
+
+        let store = CreateMemoryStore {
+            name: "Default".into(),
+            is_default: true,
+        }
+        .run(&ctx)
+        .await
+        .expect("create default store");
+
+        // Use the bridge backend to write memories the way the agent tools do.
+        let backend = DbMemoryStore::new(db.clone(), DEFAULT_ORG_ID);
+        let store_id = store.id;
+
+        for (content, kind, importance, tags) in [
+            (
+                "Rust never use unwrap in prod",
+                MemoryKind::Correction,
+                9u8,
+                vec!["rust".to_string(), "errors".to_string()],
+            ),
+            (
+                "User prefers concise replies",
+                MemoryKind::Preference,
+                6u8,
+                vec!["user".to_string()],
+            ),
+            (
+                "OpenAI rate limits reset hourly",
+                MemoryKind::Fact,
+                4u8,
+                vec!["openai".to_string()],
+            ),
+        ] {
+            backend
+                .create_memory(store_id, content.into(), Vec::new(), kind, importance, tags)
+                .await
+                .expect("create memory");
+        }
+
+        // Search by keyword.
+        let listed = ListMemoriesCmd::from_query(
+            store_id.to_string(),
+            ListMemoriesQuery {
+                query: Some("rust".into()),
+                ..Default::default()
+            },
+        )
+        .run(&ctx)
+        .await
+        .expect("list memories");
+        assert_eq!(listed.data.len(), 1);
+        assert_eq!(listed.total, 1);
+        assert!(listed.data[0].content.contains("Rust"));
+
+        // Filter by kind.
+        let listed = ListMemoriesCmd::from_query(
+            store_id.to_string(),
+            ListMemoriesQuery {
+                kind: Some("preference".into()),
+                ..Default::default()
+            },
+        )
+        .run(&ctx)
+        .await
+        .expect("list by kind");
+        assert_eq!(listed.data.len(), 1);
+        assert_eq!(listed.data[0].kind, "preference");
+
+        // Filter by tag.
+        let listed = ListMemoriesCmd::from_query(
+            store_id.to_string(),
+            ListMemoriesQuery {
+                tag: Some(vec!["openai".into()]),
+                ..Default::default()
+            },
+        )
+        .run(&ctx)
+        .await
+        .expect("list by tag");
+        assert_eq!(listed.data.len(), 1);
+        assert!(listed.data[0].tags.contains(&"openai".to_string()));
+
+        // Recall via the backend trait sees only active memories.
+        let (recalled, total) = backend
+            .recall(MemoryQuery {
+                store_id: Some(store_id),
+                query: None,
+                tags: None,
+                kind: None,
+                limit: 50,
+            })
+            .await
+            .expect("recall");
+        assert_eq!(total, 3);
+        assert_eq!(recalled.len(), 3);
+        assert_eq!(recalled[0].importance, 9);
+
+        // Forget via the API; the recalled set drops to 2.
+        let target = listed.data[0].id;
+        ForgetMemoryCmd {
+            store_id: store_id.to_string(),
+            memory_id: target.to_string(),
+        }
+        .run(&ctx)
+        .await
+        .expect("forget");
+
+        let (after_forget, total) = backend
+            .recall(MemoryQuery {
+                store_id: Some(store_id),
+                query: None,
+                tags: None,
+                kind: None,
+                limit: 50,
+            })
+            .await
+            .expect("recall after forget");
+        assert_eq!(total, 2);
+        assert!(after_forget.iter().all(|m| m.id != target));
+    }
+
+    #[tokio::test]
+    async fn memories_isolated_across_orgs() {
+        use crate::storage::DbMemoryStore;
+        use everruns_core::memory_store::{MemoryKind, MemoryQuery, MemoryStoreBackend};
+
+        let db = Arc::new(StorageBackend::in_memory());
+        let org_a = ctx_with_db(1, db.clone());
+        let org_b = ctx_with_db(2, db.clone());
+
+        let store_a = CreateMemoryStore {
+            name: "A".into(),
+            is_default: true,
+        }
+        .run(&org_a)
+        .await
+        .expect("create store A");
+
+        let backend_a = DbMemoryStore::new(db.clone(), 1);
+        let backend_b = DbMemoryStore::new(db.clone(), 2);
+
+        backend_a
+            .create_memory(
+                store_a.id,
+                "secret-a".into(),
+                Vec::new(),
+                MemoryKind::Fact,
+                5,
+                vec![],
+            )
+            .await
+            .expect("create memory");
+
+        // Org B cannot list memories in org A's store.
+        let err = ListMemoriesCmd::from_query(store_a.id.to_string(), ListMemoriesQuery::default())
+            .run(&org_b)
+            .await
+            .expect_err("org B should not see store A");
+        assert!(matches!(err, CommandError::NotFound(_)));
+
+        // Org B's backend recall returns nothing for org A's store_id.
+        let (recalled, total) = backend_b
+            .recall(MemoryQuery {
+                store_id: Some(store_a.id),
+                query: None,
+                tags: None,
+                kind: None,
+                limit: 50,
+            })
+            .await
+            .expect("recall");
+        assert_eq!(total, 0);
+        assert!(recalled.is_empty());
+    }
+
+    #[tokio::test]
+    async fn stores_isolated_across_orgs() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let org_a = ctx_with_db(1, db.clone());
+        let org_b = ctx_with_db(2, db);
+
+        let created = CreateMemoryStore {
+            name: "Private".into(),
+            is_default: false,
+        }
+        .run(&org_a)
+        .await
+        .expect("create store");
+
+        // Other org cannot read it.
+        let err = GetMemoryStore {
+            store_id: created.id.to_string(),
+        }
+        .run(&org_b)
+        .await
+        .expect_err("other org should not see the store");
+        assert!(matches!(err, CommandError::NotFound(_)));
+
+        // ListMemoryStores in other org should be empty.
+        let listed = ListMemoryStores.run(&org_b).await.expect("list stores");
+        assert!(listed.is_empty());
+    }
+}

--- a/crates/server/src/domains/memory_stores/commands.rs
+++ b/crates/server/src/domains/memory_stores/commands.rs
@@ -65,20 +65,25 @@ impl Command for ListMemoryStores {
     async fn execute(self, ctx: &Ctx) -> Result<Vec<MemoryStoreResponse>, CommandError> {
         let rows = ctx
             .db
-            .list_memory_stores(ctx.org_id())
+            .list_memory_stores_with_counts(ctx.org_id())
             .await
             .map_err(classify_anyhow)?;
 
-        let mut out = Vec::with_capacity(rows.len());
-        for row in rows {
-            let count = ctx
-                .db
-                .count_active_memories(row.id)
-                .await
-                .map_err(classify_anyhow)?;
-            out.push(store_response(row, count).map_err(classify_anyhow)?);
-        }
-        Ok(out)
+        rows.into_iter()
+            .map(|row| {
+                let count = row.active_count;
+                let store_row = crate::storage::models::MemoryStoreDbRow {
+                    id: row.id,
+                    org_id: row.org_id,
+                    public_id: row.public_id,
+                    name: row.name,
+                    is_default: row.is_default,
+                    created_at: row.created_at,
+                    updated_at: row.updated_at,
+                };
+                store_response(store_row, count).map_err(classify_anyhow)
+            })
+            .collect()
     }
 }
 

--- a/crates/server/src/domains/memory_stores/mod.rs
+++ b/crates/server/src/domains/memory_stores/mod.rs
@@ -1,0 +1,19 @@
+// Org-scoped memory stores domain.
+// See specs/memory.md.
+
+use everruns_core::{Permission, Policy, Rule};
+
+pub mod commands;
+pub mod types;
+
+pub use commands::*;
+
+pub const MEMORY_STORE_VIEW: Policy = Policy {
+    id: "memory_store.view",
+    rules: &[Rule::UserHasPermission(Permission::OrgSettingsView)],
+};
+
+pub const MEMORY_STORE_MANAGE: Policy = Policy {
+    id: "memory_store.manage",
+    rules: &[Rule::UserHasPermission(Permission::OrgSettingsManage)],
+};

--- a/crates/server/src/domains/memory_stores/types.rs
+++ b/crates/server/src/domains/memory_stores/types.rs
@@ -1,0 +1,89 @@
+use chrono::{DateTime, Utc};
+use everruns_core::typed_id::{MemoryId, MemoryStoreId};
+use serde::{Deserialize, Serialize};
+use utoipa::{IntoParams, ToSchema};
+
+pub use crate::storage::models::{MemoryDbRow, MemoryStoreDbRow};
+
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct MemoryStoreResponse {
+    #[schema(value_type = String, example = "mst_01933b5a000070008000000000000001")]
+    pub id: MemoryStoreId,
+    pub name: String,
+    pub is_default: bool,
+    pub active_memory_count: i64,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Deserialize, ToSchema)]
+pub struct CreateMemoryStoreRequest {
+    pub name: String,
+    #[serde(default)]
+    pub is_default: bool,
+}
+
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct MemoryResponse {
+    #[schema(value_type = String, example = "mem_01933b5a000070008000000000000001")]
+    pub id: MemoryId,
+    #[schema(value_type = String, example = "mst_01933b5a000070008000000000000001")]
+    pub store_id: MemoryStoreId,
+    pub content: String,
+    pub content_parts: serde_json::Value,
+    pub kind: String,
+    pub importance: i16,
+    pub tags: Vec<String>,
+    pub active: bool,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct ListMemoriesResponse {
+    pub data: Vec<MemoryResponse>,
+    pub total: i64,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, IntoParams, ToSchema)]
+pub struct ListMemoriesQuery {
+    #[serde(default)]
+    pub query: Option<String>,
+    #[serde(default)]
+    pub kind: Option<String>,
+    #[serde(default)]
+    pub tag: Option<Vec<String>>,
+    #[serde(default)]
+    pub include_inactive: Option<bool>,
+    #[serde(default)]
+    pub limit: Option<usize>,
+}
+
+pub fn store_response(
+    row: MemoryStoreDbRow,
+    active_memory_count: i64,
+) -> anyhow::Result<MemoryStoreResponse> {
+    Ok(MemoryStoreResponse {
+        id: row.public_id.parse()?,
+        name: row.name,
+        is_default: row.is_default,
+        active_memory_count,
+        created_at: row.created_at,
+        updated_at: row.updated_at,
+    })
+}
+
+pub fn memory_response(row: MemoryDbRow) -> anyhow::Result<MemoryResponse> {
+    Ok(MemoryResponse {
+        id: row.public_id.parse()?,
+        store_id: row.store_public_id.parse()?,
+        content: row.content,
+        content_parts: row.content_parts,
+        kind: row.kind,
+        importance: row.importance,
+        tags: row.tags,
+        active: row.active,
+        created_at: row.created_at,
+        updated_at: row.updated_at,
+    })
+}

--- a/crates/server/src/domains/mod.rs
+++ b/crates/server/src/domains/mod.rs
@@ -18,6 +18,7 @@ pub mod images;
 pub mod llm_models;
 pub mod llm_providers;
 pub mod mcp_servers;
+pub mod memory_stores;
 pub mod messages;
 pub mod notifications;
 pub mod org_resolver;

--- a/crates/server/src/openapi.rs
+++ b/crates/server/src/openapi.rs
@@ -138,6 +138,12 @@ use utoipa::OpenApi;
         api::volumes::get_volume,
         api::volumes::update_volume,
         api::volumes::delete_volume,
+        // Memory Stores
+        api::memory_stores::list_memory_stores,
+        api::memory_stores::create_memory_store,
+        api::memory_stores::get_memory_store,
+        api::memory_stores::list_memories,
+        api::memory_stores::forget_memory,
         // Images
         api::images::upload_image,
         api::images::list_images,
@@ -268,6 +274,11 @@ use utoipa::OpenApi;
             api::volumes::UpdateVolumeRequest,
             api::volumes::ListVolumesQuery,
             api::volumes::VolumeResponse,
+            api::memory_stores::CreateMemoryStoreRequest,
+            api::memory_stores::ListMemoriesQuery,
+            api::memory_stores::ListMemoriesResponse,
+            api::memory_stores::MemoryResponse,
+            api::memory_stores::MemoryStoreResponse,
         )
     ),
     tags(
@@ -286,6 +297,7 @@ use utoipa::OpenApi;
         (name = "durable-schedules", description = "Durable scheduled tasks management endpoints"),
         (name = "organizations", description = "Organization management endpoints"),
         (name = "volumes", description = "Workspace volume management endpoints"),
+        (name = "memory_stores", description = "Org-scoped persistent memory stores"),
         (name = "images", description = "Image upload and management endpoints"),
         (name = "session-databases", description = "Session-scoped SQL database endpoints"),
         (name = "session-storage", description = "Session key-value storage endpoints"),

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -772,12 +772,27 @@ impl StorageBackend {
         dispatch!(self, list_memory_stores, org_id)
     }
 
+    pub async fn list_memory_stores_with_counts(
+        &self,
+        org_id: i64,
+    ) -> Result<Vec<MemoryStoreWithCount>> {
+        dispatch!(self, list_memory_stores_with_counts, org_id)
+    }
+
     pub async fn count_memory_stores(&self, org_id: i64) -> Result<i64> {
         dispatch!(self, count_memory_stores, org_id)
     }
 
     pub async fn create_memory(&self, input: CreateMemoryRow) -> Result<MemoryDbRow> {
         dispatch!(self, create_memory, input)
+    }
+
+    pub async fn create_memory_with_cap(
+        &self,
+        input: CreateMemoryRow,
+        cap_limit: i64,
+    ) -> Result<Option<MemoryDbRow>> {
+        dispatch!(self, create_memory_with_cap, input, cap_limit)
     }
 
     pub async fn get_memory_by_public_id(

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -745,6 +745,72 @@ impl StorageBackend {
     }
 
     // ============================================
+    // Memory Stores
+    // ============================================
+
+    pub async fn create_memory_store(
+        &self,
+        org_id: i64,
+        input: CreateMemoryStoreRow,
+    ) -> Result<MemoryStoreDbRow> {
+        dispatch!(self, create_memory_store, org_id, input)
+    }
+
+    pub async fn get_memory_store_by_public_id(
+        &self,
+        org_id: i64,
+        public_id: &str,
+    ) -> Result<Option<MemoryStoreDbRow>> {
+        dispatch!(self, get_memory_store_by_public_id, org_id, public_id)
+    }
+
+    pub async fn get_default_memory_store(&self, org_id: i64) -> Result<Option<MemoryStoreDbRow>> {
+        dispatch!(self, get_default_memory_store, org_id)
+    }
+
+    pub async fn list_memory_stores(&self, org_id: i64) -> Result<Vec<MemoryStoreDbRow>> {
+        dispatch!(self, list_memory_stores, org_id)
+    }
+
+    pub async fn count_memory_stores(&self, org_id: i64) -> Result<i64> {
+        dispatch!(self, count_memory_stores, org_id)
+    }
+
+    pub async fn create_memory(&self, input: CreateMemoryRow) -> Result<MemoryDbRow> {
+        dispatch!(self, create_memory, input)
+    }
+
+    pub async fn get_memory_by_public_id(
+        &self,
+        org_id: i64,
+        public_id: &str,
+    ) -> Result<Option<MemoryDbRow>> {
+        dispatch!(self, get_memory_by_public_id, org_id, public_id)
+    }
+
+    pub async fn list_memories(
+        &self,
+        org_id: i64,
+        store_id: Option<Uuid>,
+        filter: ListMemoriesFilter,
+    ) -> Result<(Vec<MemoryDbRow>, i64)> {
+        dispatch!(self, list_memories, org_id, store_id, filter)
+    }
+
+    pub async fn count_active_memories(&self, store_id: Uuid) -> Result<i64> {
+        dispatch!(self, count_active_memories, store_id)
+    }
+
+    pub async fn deactivate_memory(
+        &self,
+        org_id: i64,
+        store_id: Uuid,
+        memory_public_id: &str,
+    ) -> Result<bool> {
+        dispatch!(self, deactivate_memory, org_id, store_id, memory_public_id)
+    }
+
+    // ============================================
     // Pinned Sessions
     // ============================================
 

--- a/crates/server/src/storage/memory/memories.rs
+++ b/crates/server/src/storage/memory/memories.rs
@@ -1,0 +1,219 @@
+// In-memory storage: org-scoped memory stores and memories.
+
+use super::super::models::*;
+use super::InMemoryDatabase;
+use anyhow::{Result, bail};
+use uuid::Uuid;
+
+impl InMemoryDatabase {
+    // ============================================
+    // Memory Stores
+    // ============================================
+
+    pub async fn create_memory_store(
+        &self,
+        org_id: i64,
+        input: CreateMemoryStoreRow,
+    ) -> Result<MemoryStoreDbRow> {
+        let now = Self::now();
+        let mut stores = self.memory_stores.write();
+
+        if stores
+            .values()
+            .any(|s| s.org_id == org_id && s.name.eq_ignore_ascii_case(&input.name))
+        {
+            bail!("memory store name already exists");
+        }
+        if input.is_default && stores.values().any(|s| s.org_id == org_id && s.is_default) {
+            bail!("org already has a default memory store");
+        }
+
+        let id = Uuid::now_v7();
+        let row = MemoryStoreDbRow {
+            id,
+            org_id,
+            public_id: input.public_id,
+            name: input.name,
+            is_default: input.is_default,
+            created_at: now,
+            updated_at: now,
+        };
+        stores.insert(id, row.clone());
+        Ok(row)
+    }
+
+    pub async fn get_memory_store_by_public_id(
+        &self,
+        org_id: i64,
+        public_id: &str,
+    ) -> Result<Option<MemoryStoreDbRow>> {
+        Ok(self
+            .memory_stores
+            .read()
+            .values()
+            .find(|s| s.org_id == org_id && s.public_id == public_id)
+            .cloned())
+    }
+
+    pub async fn get_default_memory_store(&self, org_id: i64) -> Result<Option<MemoryStoreDbRow>> {
+        Ok(self
+            .memory_stores
+            .read()
+            .values()
+            .find(|s| s.org_id == org_id && s.is_default)
+            .cloned())
+    }
+
+    pub async fn list_memory_stores(&self, org_id: i64) -> Result<Vec<MemoryStoreDbRow>> {
+        let mut rows: Vec<_> = self
+            .memory_stores
+            .read()
+            .values()
+            .filter(|s| s.org_id == org_id)
+            .cloned()
+            .collect();
+        rows.sort_by(|a, b| {
+            b.is_default
+                .cmp(&a.is_default)
+                .then_with(|| a.created_at.cmp(&b.created_at))
+        });
+        Ok(rows)
+    }
+
+    pub async fn count_memory_stores(&self, org_id: i64) -> Result<i64> {
+        Ok(self
+            .memory_stores
+            .read()
+            .values()
+            .filter(|s| s.org_id == org_id)
+            .count() as i64)
+    }
+
+    // ============================================
+    // Memories
+    // ============================================
+
+    pub async fn create_memory(&self, input: CreateMemoryRow) -> Result<MemoryDbRow> {
+        // Verify store exists in this org.
+        let stores = self.memory_stores.read();
+        let Some(store) = stores
+            .values()
+            .find(|s| s.id == input.store_id && s.org_id == input.org_id)
+            .cloned()
+        else {
+            bail!("memory store not found in this org");
+        };
+        drop(stores);
+
+        let now = Self::now();
+        let id = Uuid::now_v7();
+        let row = MemoryDbRow {
+            id,
+            public_id: input.public_id,
+            store_id: input.store_id,
+            store_public_id: store.public_id,
+            org_id: input.org_id,
+            content: input.content,
+            content_parts: input.content_parts,
+            kind: input.kind,
+            importance: input.importance.clamp(1, 10),
+            tags: input.tags,
+            active: true,
+            created_at: now,
+            updated_at: now,
+        };
+        self.memories.write().insert(id, row.clone());
+        Ok(row)
+    }
+
+    pub async fn get_memory_by_public_id(
+        &self,
+        org_id: i64,
+        public_id: &str,
+    ) -> Result<Option<MemoryDbRow>> {
+        Ok(self
+            .memories
+            .read()
+            .values()
+            .find(|m| m.org_id == org_id && m.public_id == public_id)
+            .cloned())
+    }
+
+    pub async fn list_memories(
+        &self,
+        org_id: i64,
+        store_id: Option<Uuid>,
+        filter: ListMemoriesFilter,
+    ) -> Result<(Vec<MemoryDbRow>, i64)> {
+        let memories = self.memories.read();
+        let q_lower = filter
+            .query
+            .as_ref()
+            .map(|q| q.trim().to_lowercase())
+            .filter(|q| !q.is_empty());
+
+        let mut matches: Vec<MemoryDbRow> = memories
+            .values()
+            .filter(|m| m.org_id == org_id)
+            .filter(|m| store_id.is_none_or(|sid| m.store_id == sid))
+            .filter(|m| filter.include_inactive || m.active)
+            .filter(|m| filter.kind.as_deref().is_none_or(|k| m.kind == k))
+            .filter(|m| {
+                filter
+                    .tags
+                    .as_ref()
+                    .is_none_or(|tags| tags.iter().all(|t| m.tags.contains(t)))
+            })
+            .filter(|m| {
+                q_lower
+                    .as_ref()
+                    .is_none_or(|q| m.content.to_lowercase().contains(q))
+            })
+            .cloned()
+            .collect();
+        matches.sort_by(|a, b| {
+            b.importance
+                .cmp(&a.importance)
+                .then_with(|| b.created_at.cmp(&a.created_at))
+        });
+
+        let total = matches.len() as i64;
+        let limit = if filter.limit == 0 {
+            10
+        } else {
+            filter.limit.min(200)
+        };
+        matches.truncate(limit);
+        Ok((matches, total))
+    }
+
+    pub async fn count_active_memories(&self, store_id: Uuid) -> Result<i64> {
+        Ok(self
+            .memories
+            .read()
+            .values()
+            .filter(|m| m.store_id == store_id && m.active)
+            .count() as i64)
+    }
+
+    pub async fn deactivate_memory(
+        &self,
+        org_id: i64,
+        store_id: Uuid,
+        memory_public_id: &str,
+    ) -> Result<bool> {
+        let mut memories = self.memories.write();
+        if let Some(m) = memories.values_mut().find(|m| {
+            m.org_id == org_id
+                && m.store_id == store_id
+                && m.public_id == memory_public_id
+                && m.active
+        }) {
+            m.active = false;
+            m.updated_at = Self::now();
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+}

--- a/crates/server/src/storage/memory/memories.rs
+++ b/crates/server/src/storage/memory/memories.rs
@@ -80,6 +80,34 @@ impl InMemoryDatabase {
         Ok(rows)
     }
 
+    pub async fn list_memory_stores_with_counts(
+        &self,
+        org_id: i64,
+    ) -> Result<Vec<MemoryStoreWithCount>> {
+        let stores = self.list_memory_stores(org_id).await?;
+        let memories = self.memories.read();
+        let result = stores
+            .into_iter()
+            .map(|s| {
+                let active_count = memories
+                    .values()
+                    .filter(|m| m.store_id == s.id && m.active)
+                    .count() as i64;
+                MemoryStoreWithCount {
+                    id: s.id,
+                    org_id: s.org_id,
+                    public_id: s.public_id,
+                    name: s.name,
+                    is_default: s.is_default,
+                    created_at: s.created_at,
+                    updated_at: s.updated_at,
+                    active_count,
+                }
+            })
+            .collect();
+        Ok(result)
+    }
+
     pub async fn count_memory_stores(&self, org_id: i64) -> Result<i64> {
         Ok(self
             .memory_stores
@@ -92,6 +120,53 @@ impl InMemoryDatabase {
     // ============================================
     // Memories
     // ============================================
+
+    /// Atomic capacity-checked create. The in-memory backend already serialises
+    /// creates through the `memories` `RwLock`, so a plain count + insert under
+    /// a single write lock is enough.
+    pub async fn create_memory_with_cap(
+        &self,
+        input: CreateMemoryRow,
+        cap_limit: i64,
+    ) -> Result<Option<MemoryDbRow>> {
+        let stores = self.memory_stores.read();
+        let Some(store) = stores
+            .values()
+            .find(|s| s.id == input.store_id && s.org_id == input.org_id)
+            .cloned()
+        else {
+            bail!("memory store not found in this org");
+        };
+        drop(stores);
+
+        let now = Self::now();
+        let id = Uuid::now_v7();
+        let mut memories = self.memories.write();
+        let active = memories
+            .values()
+            .filter(|m| m.store_id == input.store_id && m.active)
+            .count() as i64;
+        if active >= cap_limit {
+            return Ok(None);
+        }
+        let row = MemoryDbRow {
+            id,
+            public_id: input.public_id,
+            store_id: input.store_id,
+            store_public_id: store.public_id,
+            org_id: input.org_id,
+            content: input.content,
+            content_parts: input.content_parts,
+            kind: input.kind,
+            importance: input.importance.clamp(1, 10),
+            tags: input.tags,
+            active: true,
+            created_at: now,
+            updated_at: now,
+        };
+        memories.insert(id, row.clone());
+        Ok(Some(row))
+    }
 
     pub async fn create_memory(&self, input: CreateMemoryRow) -> Result<MemoryDbRow> {
         // Verify store exists in this org.
@@ -146,11 +221,23 @@ impl InMemoryDatabase {
         filter: ListMemoriesFilter,
     ) -> Result<(Vec<MemoryDbRow>, i64)> {
         let memories = self.memories.read();
-        let q_lower = filter
+        // Multi-token AND search: each whitespace-separated token must appear
+        // somewhere in `content` (lowercased). Tokens are capped to match the
+        // SQL repo's MAX_SEARCH_TOKENS so behavior stays consistent across
+        // backends.
+        let tokens: Vec<String> = filter
             .query
             .as_ref()
-            .map(|q| q.trim().to_lowercase())
-            .filter(|q| !q.is_empty());
+            .filter(|q| !q.trim().is_empty())
+            .map(|q| {
+                q.trim()
+                    .to_lowercase()
+                    .split_whitespace()
+                    .take(super::MAX_SEARCH_TOKENS)
+                    .map(|t| t.to_string())
+                    .collect()
+            })
+            .unwrap_or_default();
 
         let mut matches: Vec<MemoryDbRow> = memories
             .values()
@@ -165,9 +252,11 @@ impl InMemoryDatabase {
                     .is_none_or(|tags| tags.iter().all(|t| m.tags.contains(t)))
             })
             .filter(|m| {
-                q_lower
-                    .as_ref()
-                    .is_none_or(|q| m.content.to_lowercase().contains(q))
+                if tokens.is_empty() {
+                    return true;
+                }
+                let content_lower = m.content.to_lowercase();
+                tokens.iter().all(|t| content_lower.contains(t))
             })
             .cloned()
             .collect();

--- a/crates/server/src/storage/memory/mod.rs
+++ b/crates/server/src/storage/memory/mod.rs
@@ -20,6 +20,7 @@ mod events;
 mod harnesses;
 mod llm;
 mod mcp_servers;
+mod memories;
 mod notifications;
 mod organizations;
 mod principals;
@@ -144,6 +145,9 @@ pub struct InMemoryDatabase {
     usage_ledger: RwLock<Vec<UsageLedgerRow>>,
     // Workspace volumes
     volumes: RwLock<HashMap<Uuid, VolumeRow>>,
+    // Memory stores and memories (org-scoped agent memory)
+    memory_stores: RwLock<HashMap<Uuid, MemoryStoreDbRow>>,
+    memories: RwLock<HashMap<Uuid, MemoryDbRow>>,
     // OAuth clients (MCP OAuth 2.1)
     oauth_clients: RwLock<HashMap<Uuid, OAuthClientRow>>,
     oauth_authorization_codes: RwLock<HashMap<Uuid, OAuthAuthorizationCodeRow>>,
@@ -216,6 +220,8 @@ impl Default for InMemoryDatabase {
             usage_journal: RwLock::new(HashMap::new()),
             usage_ledger: RwLock::new(Vec::new()),
             volumes: RwLock::new(HashMap::new()),
+            memory_stores: RwLock::new(HashMap::new()),
+            memories: RwLock::new(HashMap::new()),
             oauth_clients: RwLock::new(HashMap::new()),
             oauth_authorization_codes: RwLock::new(HashMap::new()),
             oauth_refresh_tokens: RwLock::new(HashMap::new()),

--- a/crates/server/src/storage/memory_store_backend.rs
+++ b/crates/server/src/storage/memory_store_backend.rs
@@ -103,20 +103,46 @@ impl MemoryStoreBackend for DbMemoryStore {
             return store_row_to_entity(existing);
         }
 
+        // Pick a name that won't collide with an existing user-created store
+        // named "default" (store names are unique per org). The first attempt
+        // uses the friendly "default"; on conflict we fall back to a name
+        // suffixed with a short hex slice of the new store ID.
         let public_id = MemoryStoreId::new().to_string();
-        let row = self
+        let primary_input = CreateMemoryStoreRow {
+            public_id: public_id.clone(),
+            name: "default".to_string(),
+            is_default: true,
+        };
+        match self
             .db
-            .create_memory_store(
-                self.org_id,
-                CreateMemoryStoreRow {
-                    public_id,
-                    name: "default".to_string(),
-                    is_default: true,
-                },
-            )
+            .create_memory_store(self.org_id, primary_input)
             .await
-            .map_err(store_err)?;
-        store_row_to_entity(row)
+        {
+            Ok(row) => store_row_to_entity(row),
+            Err(_) => {
+                // Likely a uniqueness conflict on the "default" name. Retry
+                // with a unique name derived from the store's public_id so
+                // initialisation cannot get stuck on a user-created collision.
+                let suffix = public_id
+                    .strip_prefix("mst_")
+                    .map(|s| &s[..8.min(s.len())])
+                    .unwrap_or("0")
+                    .to_string();
+                let row = self
+                    .db
+                    .create_memory_store(
+                        self.org_id,
+                        CreateMemoryStoreRow {
+                            public_id,
+                            name: format!("default-{suffix}"),
+                            is_default: true,
+                        },
+                    )
+                    .await
+                    .map_err(store_err)?;
+                store_row_to_entity(row)
+            }
+        }
     }
 
     async fn get_store(&self, store_id: MemoryStoreId) -> Result<Option<MemoryStoreEntity>> {
@@ -147,34 +173,31 @@ impl MemoryStoreBackend for DbMemoryStore {
             .map_err(store_err)?
             .ok_or_else(|| AgentLoopError::tool("memory store not found"))?;
 
-        let count = self
-            .db
-            .count_active_memories(store.id)
-            .await
-            .map_err(store_err)?;
-        if count as usize >= everruns_core::memory_store::MemoryLimits::MAX_MEMORIES_PER_STORE {
-            return Err(AgentLoopError::tool(format!(
-                "memory store full ({} active memories)",
-                count
-            )));
-        }
-
         let parts_json = serde_json::to_value(&content_parts).map_err(store_err)?;
         let public_id = MemoryId::new().to_string();
+        let cap = everruns_core::memory_store::MemoryLimits::MAX_MEMORIES_PER_STORE as i64;
+        // Atomic check+insert: serialises against concurrent creates targeting
+        // the same store so the per-store cap cannot be exceeded under load.
         let row = self
             .db
-            .create_memory(CreateMemoryRow {
-                public_id,
-                store_id: store.id,
-                org_id: self.org_id,
-                content,
-                content_parts: parts_json,
-                kind: kind.to_string(),
-                importance: importance.clamp(1, 10) as i16,
-                tags,
-            })
+            .create_memory_with_cap(
+                CreateMemoryRow {
+                    public_id,
+                    store_id: store.id,
+                    org_id: self.org_id,
+                    content,
+                    content_parts: parts_json,
+                    kind: kind.to_string(),
+                    importance: importance.clamp(1, 10) as i16,
+                    tags,
+                },
+                cap,
+            )
             .await
-            .map_err(store_err)?;
+            .map_err(store_err)?
+            .ok_or_else(|| {
+                AgentLoopError::tool(format!("memory store full ({cap} active memories)"))
+            })?;
         row_to_memory(row)
     }
 

--- a/crates/server/src/storage/memory_store_backend.rs
+++ b/crates/server/src/storage/memory_store_backend.rs
@@ -1,0 +1,246 @@
+// Database-backed `MemoryStoreBackend` implementation.
+//
+// Bridges the core `MemoryStoreBackend` trait (used by `remember`, `recall`,
+// and `forget` tools in `crates/core/src/capabilities/persistent_memory.rs`)
+// to the `StorageBackend` (Postgres or in-memory dev mode).
+//
+// Org-scoped: each instance is bound to a specific org_id at construction time.
+// All operations enforce that store_id and memory_id belong to that org;
+// foreign rows surface as `Ok(None)` or `Ok(false)` (non-disclosing).
+
+use super::backend::StorageBackend;
+use super::models::{CreateMemoryRow, CreateMemoryStoreRow, ListMemoriesFilter, MemoryDbRow};
+use async_trait::async_trait;
+use everruns_core::error::{AgentLoopError, Result};
+use everruns_core::memory_store::{
+    Memory, MemoryContentPart, MemoryKind, MemoryQuery, MemoryStoreBackend, MemoryStoreEntity,
+};
+use everruns_core::organization::org_public_id_from_internal;
+use everruns_core::typed_id::{MemoryId, MemoryStoreId, OrgId};
+use std::str::FromStr;
+use std::sync::Arc;
+
+fn org_id_to_public(internal: i64) -> Result<OrgId> {
+    org_public_id_from_internal(internal)
+        .parse()
+        .map_err(|e: everruns_core::typed_id::IdParseError| AgentLoopError::store(e.to_string()))
+}
+
+#[derive(Clone)]
+pub struct DbMemoryStore {
+    db: Arc<StorageBackend>,
+    org_id: i64,
+}
+
+impl DbMemoryStore {
+    pub fn new(db: Arc<StorageBackend>, org_id: i64) -> Self {
+        Self { db, org_id }
+    }
+}
+
+fn store_err<E: std::fmt::Display>(e: E) -> AgentLoopError {
+    AgentLoopError::store(e.to_string())
+}
+
+fn parse_kind(s: &str) -> MemoryKind {
+    match s {
+        "preference" => MemoryKind::Preference,
+        "correction" => MemoryKind::Correction,
+        "procedure" => MemoryKind::Procedure,
+        "context" => MemoryKind::Context,
+        _ => MemoryKind::Fact,
+    }
+}
+
+fn row_to_memory(row: MemoryDbRow) -> Result<Memory> {
+    let id = MemoryId::from_str(&row.public_id).map_err(store_err)?;
+    let store_id = MemoryStoreId::from_str(&row.store_public_id).map_err(store_err)?;
+    let content_parts: Vec<MemoryContentPart> = if row.content_parts.is_null() {
+        Vec::new()
+    } else {
+        serde_json::from_value(row.content_parts).map_err(store_err)?
+    };
+    Ok(Memory {
+        id,
+        store_id,
+        content: row.content,
+        content_parts,
+        kind: parse_kind(&row.kind),
+        importance: row.importance.clamp(1, 10) as u8,
+        tags: row.tags,
+        active: row.active,
+        created_at: row.created_at,
+        updated_at: row.updated_at,
+    })
+}
+
+fn store_row_to_entity(row: super::models::MemoryStoreDbRow) -> Result<MemoryStoreEntity> {
+    Ok(MemoryStoreEntity {
+        id: MemoryStoreId::from_str(&row.public_id).map_err(store_err)?,
+        org_id: org_id_to_public(row.org_id)?,
+        name: row.name,
+        is_default: row.is_default,
+        created_at: row.created_at,
+    })
+}
+
+#[async_trait]
+impl MemoryStoreBackend for DbMemoryStore {
+    async fn get_or_create_default_store(&self, org_id: OrgId) -> Result<MemoryStoreEntity> {
+        let expected = org_id_to_public(self.org_id)?;
+        if org_id != expected {
+            return Err(AgentLoopError::tool(
+                "Memory store backend is scoped to a different org",
+            ));
+        }
+
+        if let Some(existing) = self
+            .db
+            .get_default_memory_store(self.org_id)
+            .await
+            .map_err(store_err)?
+        {
+            return store_row_to_entity(existing);
+        }
+
+        let public_id = MemoryStoreId::new().to_string();
+        let row = self
+            .db
+            .create_memory_store(
+                self.org_id,
+                CreateMemoryStoreRow {
+                    public_id,
+                    name: "default".to_string(),
+                    is_default: true,
+                },
+            )
+            .await
+            .map_err(store_err)?;
+        store_row_to_entity(row)
+    }
+
+    async fn get_store(&self, store_id: MemoryStoreId) -> Result<Option<MemoryStoreEntity>> {
+        let Some(row) = self
+            .db
+            .get_memory_store_by_public_id(self.org_id, &store_id.to_string())
+            .await
+            .map_err(store_err)?
+        else {
+            return Ok(None);
+        };
+        Ok(Some(store_row_to_entity(row)?))
+    }
+
+    async fn create_memory(
+        &self,
+        store_id: MemoryStoreId,
+        content: String,
+        content_parts: Vec<MemoryContentPart>,
+        kind: MemoryKind,
+        importance: u8,
+        tags: Vec<String>,
+    ) -> Result<Memory> {
+        let store = self
+            .db
+            .get_memory_store_by_public_id(self.org_id, &store_id.to_string())
+            .await
+            .map_err(store_err)?
+            .ok_or_else(|| AgentLoopError::tool("memory store not found"))?;
+
+        let count = self
+            .db
+            .count_active_memories(store.id)
+            .await
+            .map_err(store_err)?;
+        if count as usize >= everruns_core::memory_store::MemoryLimits::MAX_MEMORIES_PER_STORE {
+            return Err(AgentLoopError::tool(format!(
+                "memory store full ({} active memories)",
+                count
+            )));
+        }
+
+        let parts_json = serde_json::to_value(&content_parts).map_err(store_err)?;
+        let public_id = MemoryId::new().to_string();
+        let row = self
+            .db
+            .create_memory(CreateMemoryRow {
+                public_id,
+                store_id: store.id,
+                org_id: self.org_id,
+                content,
+                content_parts: parts_json,
+                kind: kind.to_string(),
+                importance: importance.clamp(1, 10) as i16,
+                tags,
+            })
+            .await
+            .map_err(store_err)?;
+        row_to_memory(row)
+    }
+
+    async fn recall(&self, query: MemoryQuery) -> Result<(Vec<Memory>, usize)> {
+        let store_uuid = if let Some(sid) = query.store_id {
+            let Some(store) = self
+                .db
+                .get_memory_store_by_public_id(self.org_id, &sid.to_string())
+                .await
+                .map_err(store_err)?
+            else {
+                return Ok((Vec::new(), 0));
+            };
+            Some(store.id)
+        } else {
+            None
+        };
+
+        let filter = ListMemoriesFilter {
+            query: query.query.clone(),
+            kind: query.kind.map(|k| k.to_string()),
+            tags: query.tags.clone(),
+            include_inactive: false,
+            limit: query.limit,
+        };
+        let (rows, total) = self
+            .db
+            .list_memories(self.org_id, store_uuid, filter)
+            .await
+            .map_err(store_err)?;
+
+        let memories = rows
+            .into_iter()
+            .map(row_to_memory)
+            .collect::<Result<Vec<_>>>()?;
+        Ok((memories, total as usize))
+    }
+
+    async fn forget(&self, store_id: MemoryStoreId, memory_id: MemoryId) -> Result<bool> {
+        let Some(store) = self
+            .db
+            .get_memory_store_by_public_id(self.org_id, &store_id.to_string())
+            .await
+            .map_err(store_err)?
+        else {
+            return Ok(false);
+        };
+        self.db
+            .deactivate_memory(self.org_id, store.id, &memory_id.to_string())
+            .await
+            .map_err(store_err)
+    }
+
+    async fn count_active(&self, store_id: MemoryStoreId) -> Result<usize> {
+        let Some(store) = self
+            .db
+            .get_memory_store_by_public_id(self.org_id, &store_id.to_string())
+            .await
+            .map_err(store_err)?
+        else {
+            return Ok(0);
+        };
+        Ok(self
+            .db
+            .count_active_memories(store.id)
+            .await
+            .map_err(store_err)? as usize)
+    }
+}

--- a/crates/server/src/storage/mod.rs
+++ b/crates/server/src/storage/mod.rs
@@ -17,6 +17,7 @@ pub mod harness_store;
 pub mod leased_resource_store;
 pub mod llm_provider_store;
 pub mod memory;
+pub mod memory_store_backend;
 pub mod message_store;
 pub mod models;
 pub mod password;
@@ -43,6 +44,7 @@ pub use leased_resource_store::{
 };
 pub use llm_provider_store::{DbLlmProviderStore, create_db_llm_provider_store};
 pub use memory::InMemoryDatabase;
+pub use memory_store_backend::DbMemoryStore;
 pub use message_store::{DbMessageRetriever, create_db_message_retriever};
 pub use models::*;
 pub use repositories::*;

--- a/crates/server/src/storage/models.rs
+++ b/crates/server/src/storage/models.rs
@@ -902,6 +902,66 @@ pub struct UpdateVolume {
 }
 
 // ============================================
+// Memory Store models (org-scoped persistent memories — see specs/memory.md)
+// ============================================
+
+#[derive(Debug, Clone, FromRow, serde::Serialize)]
+pub struct MemoryStoreDbRow {
+    pub id: Uuid,
+    pub org_id: i64,
+    pub public_id: String,
+    pub name: String,
+    pub is_default: bool,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CreateMemoryStoreRow {
+    pub public_id: String,
+    pub name: String,
+    pub is_default: bool,
+}
+
+#[derive(Debug, Clone, FromRow, serde::Serialize)]
+pub struct MemoryDbRow {
+    pub id: Uuid,
+    pub public_id: String,
+    pub store_id: Uuid,
+    pub store_public_id: String,
+    pub org_id: i64,
+    pub content: String,
+    pub content_parts: serde_json::Value,
+    pub kind: String,
+    pub importance: i16,
+    pub tags: Vec<String>,
+    pub active: bool,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CreateMemoryRow {
+    pub public_id: String,
+    pub store_id: Uuid,
+    pub org_id: i64,
+    pub content: String,
+    pub content_parts: serde_json::Value,
+    pub kind: String,
+    pub importance: i16,
+    pub tags: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ListMemoriesFilter {
+    pub query: Option<String>,
+    pub kind: Option<String>,
+    pub tags: Option<Vec<String>>,
+    pub include_inactive: bool,
+    pub limit: usize,
+}
+
+// ============================================
 // Session Git models (libgit2 custom ODB/refdb over PostgreSQL)
 // ============================================
 

--- a/crates/server/src/storage/models.rs
+++ b/crates/server/src/storage/models.rs
@@ -916,6 +916,18 @@ pub struct MemoryStoreDbRow {
     pub updated_at: DateTime<Utc>,
 }
 
+#[derive(Debug, Clone, FromRow, serde::Serialize)]
+pub struct MemoryStoreWithCount {
+    pub id: Uuid,
+    pub org_id: i64,
+    pub public_id: String,
+    pub name: String,
+    pub is_default: bool,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub active_count: i64,
+}
+
 #[derive(Debug, Clone)]
 pub struct CreateMemoryStoreRow {
     pub public_id: String,

--- a/crates/server/src/storage/repositories/memories.rs
+++ b/crates/server/src/storage/repositories/memories.rs
@@ -2,7 +2,7 @@
 // See specs/memory.md.
 
 use super::super::models::*;
-use super::Database;
+use super::{Database, escape_like};
 use anyhow::Result;
 use uuid::Uuid;
 
@@ -193,7 +193,7 @@ impl Database {
             idx += 1;
         }
         if filter.query.as_ref().is_some_and(|q| !q.trim().is_empty()) {
-            sql.push_str(&format!(" AND LOWER(m.content) LIKE ${idx}"));
+            sql.push_str(&format!(" AND LOWER(m.content) LIKE ${idx} ESCAPE '\\'"));
             idx += 1;
         }
         sql.push_str(&format!(
@@ -215,7 +215,7 @@ impl Database {
         if let Some(ref query) = filter.query
             && !query.trim().is_empty()
         {
-            q = q.bind(format!("%{}%", query.trim().to_lowercase()));
+            q = q.bind(format!("%{}%", escape_like(&query.trim().to_lowercase())));
         }
         q = q.bind(limit);
 

--- a/crates/server/src/storage/repositories/memories.rs
+++ b/crates/server/src/storage/repositories/memories.rs
@@ -1,0 +1,294 @@
+// PostgreSQL repository: org-scoped memory stores and memories.
+// See specs/memory.md.
+
+use super::super::models::*;
+use super::Database;
+use anyhow::Result;
+use uuid::Uuid;
+
+impl Database {
+    // ============================================
+    // Memory Stores
+    // ============================================
+
+    pub async fn create_memory_store(
+        &self,
+        org_id: i64,
+        input: CreateMemoryStoreRow,
+    ) -> Result<MemoryStoreDbRow> {
+        let row = sqlx::query_as::<_, MemoryStoreDbRow>(
+            r#"
+            INSERT INTO memory_stores (org_id, public_id, name, is_default)
+            VALUES ($1, $2, $3, $4)
+            RETURNING id, org_id, public_id, name, is_default, created_at, updated_at
+            "#,
+        )
+        .bind(org_id)
+        .bind(&input.public_id)
+        .bind(&input.name)
+        .bind(input.is_default)
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(row)
+    }
+
+    pub async fn get_memory_store_by_public_id(
+        &self,
+        org_id: i64,
+        public_id: &str,
+    ) -> Result<Option<MemoryStoreDbRow>> {
+        let row = sqlx::query_as::<_, MemoryStoreDbRow>(
+            r#"
+            SELECT id, org_id, public_id, name, is_default, created_at, updated_at
+            FROM memory_stores
+            WHERE org_id = $1 AND public_id = $2
+            "#,
+        )
+        .bind(org_id)
+        .bind(public_id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row)
+    }
+
+    pub async fn get_default_memory_store(&self, org_id: i64) -> Result<Option<MemoryStoreDbRow>> {
+        let row = sqlx::query_as::<_, MemoryStoreDbRow>(
+            r#"
+            SELECT id, org_id, public_id, name, is_default, created_at, updated_at
+            FROM memory_stores
+            WHERE org_id = $1 AND is_default
+            LIMIT 1
+            "#,
+        )
+        .bind(org_id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row)
+    }
+
+    pub async fn list_memory_stores(&self, org_id: i64) -> Result<Vec<MemoryStoreDbRow>> {
+        let rows = sqlx::query_as::<_, MemoryStoreDbRow>(
+            r#"
+            SELECT id, org_id, public_id, name, is_default, created_at, updated_at
+            FROM memory_stores
+            WHERE org_id = $1
+            ORDER BY is_default DESC, created_at ASC
+            "#,
+        )
+        .bind(org_id)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows)
+    }
+
+    pub async fn count_memory_stores(&self, org_id: i64) -> Result<i64> {
+        let row: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM memory_stores WHERE org_id = $1")
+            .bind(org_id)
+            .fetch_one(&self.pool)
+            .await?;
+        Ok(row.0)
+    }
+
+    // ============================================
+    // Memories
+    // ============================================
+
+    pub async fn create_memory(&self, input: CreateMemoryRow) -> Result<MemoryDbRow> {
+        let row = sqlx::query_as::<_, MemoryDbRow>(
+            r#"
+            WITH inserted AS (
+                INSERT INTO memories (
+                    public_id, store_id, org_id, content, content_parts,
+                    kind, importance, tags, active
+                )
+                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, TRUE)
+                RETURNING *
+            )
+            SELECT i.id, i.public_id, i.store_id, s.public_id AS store_public_id,
+                   i.org_id, i.content, i.content_parts, i.kind, i.importance,
+                   i.tags, i.active, i.created_at, i.updated_at
+            FROM inserted i
+            JOIN memory_stores s ON s.id = i.store_id
+            "#,
+        )
+        .bind(&input.public_id)
+        .bind(input.store_id)
+        .bind(input.org_id)
+        .bind(&input.content)
+        .bind(&input.content_parts)
+        .bind(&input.kind)
+        .bind(input.importance)
+        .bind(&input.tags)
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(row)
+    }
+
+    pub async fn get_memory_by_public_id(
+        &self,
+        org_id: i64,
+        public_id: &str,
+    ) -> Result<Option<MemoryDbRow>> {
+        let row = sqlx::query_as::<_, MemoryDbRow>(
+            r#"
+            SELECT m.id, m.public_id, m.store_id, s.public_id AS store_public_id,
+                   m.org_id, m.content, m.content_parts, m.kind, m.importance,
+                   m.tags, m.active, m.created_at, m.updated_at
+            FROM memories m
+            JOIN memory_stores s ON s.id = m.store_id
+            WHERE m.org_id = $1 AND m.public_id = $2
+            "#,
+        )
+        .bind(org_id)
+        .bind(public_id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row)
+    }
+
+    pub async fn list_memories(
+        &self,
+        org_id: i64,
+        store_id: Option<Uuid>,
+        filter: ListMemoriesFilter,
+    ) -> Result<(Vec<MemoryDbRow>, i64)> {
+        let limit = if filter.limit == 0 {
+            10
+        } else {
+            filter.limit.min(200)
+        } as i64;
+
+        let mut sql = String::from(
+            r#"
+            SELECT m.id, m.public_id, m.store_id, s.public_id AS store_public_id,
+                   m.org_id, m.content, m.content_parts, m.kind, m.importance,
+                   m.tags, m.active, m.created_at, m.updated_at,
+                   COUNT(*) OVER() AS total_count
+            FROM memories m
+            JOIN memory_stores s ON s.id = m.store_id
+            WHERE m.org_id = $1
+            "#,
+        );
+
+        let mut idx = 2;
+        if store_id.is_some() {
+            sql.push_str(&format!(" AND m.store_id = ${idx}"));
+            idx += 1;
+        }
+        if !filter.include_inactive {
+            sql.push_str(" AND m.active = TRUE");
+        }
+        if filter.kind.is_some() {
+            sql.push_str(&format!(" AND m.kind = ${idx}"));
+            idx += 1;
+        }
+        if filter.tags.as_ref().is_some_and(|t| !t.is_empty()) {
+            sql.push_str(&format!(" AND m.tags @> ${idx}"));
+            idx += 1;
+        }
+        if filter.query.as_ref().is_some_and(|q| !q.trim().is_empty()) {
+            sql.push_str(&format!(" AND LOWER(m.content) LIKE ${idx}"));
+            idx += 1;
+        }
+        sql.push_str(&format!(
+            " ORDER BY m.importance DESC, m.created_at DESC LIMIT ${idx}"
+        ));
+
+        let mut q = sqlx::query_as::<_, MemoryWithTotalRow>(&sql).bind(org_id);
+        if let Some(sid) = store_id {
+            q = q.bind(sid);
+        }
+        if let Some(ref kind) = filter.kind {
+            q = q.bind(kind);
+        }
+        if let Some(ref tags) = filter.tags
+            && !tags.is_empty()
+        {
+            q = q.bind(tags);
+        }
+        if let Some(ref query) = filter.query
+            && !query.trim().is_empty()
+        {
+            q = q.bind(format!("%{}%", query.trim().to_lowercase()));
+        }
+        q = q.bind(limit);
+
+        let rows = q.fetch_all(&self.pool).await?;
+
+        let total = rows.first().map(|r| r.total_count).unwrap_or(0);
+        let memories = rows
+            .into_iter()
+            .map(|r| MemoryDbRow {
+                id: r.id,
+                public_id: r.public_id,
+                store_id: r.store_id,
+                store_public_id: r.store_public_id,
+                org_id: r.org_id,
+                content: r.content,
+                content_parts: r.content_parts,
+                kind: r.kind,
+                importance: r.importance,
+                tags: r.tags,
+                active: r.active,
+                created_at: r.created_at,
+                updated_at: r.updated_at,
+            })
+            .collect();
+        Ok((memories, total))
+    }
+
+    pub async fn count_active_memories(&self, store_id: Uuid) -> Result<i64> {
+        let row: (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM memories WHERE store_id = $1 AND active = TRUE")
+                .bind(store_id)
+                .fetch_one(&self.pool)
+                .await?;
+        Ok(row.0)
+    }
+
+    pub async fn deactivate_memory(
+        &self,
+        org_id: i64,
+        store_id: Uuid,
+        memory_public_id: &str,
+    ) -> Result<bool> {
+        let result = sqlx::query(
+            r#"
+            UPDATE memories
+            SET active = FALSE, updated_at = NOW()
+            WHERE org_id = $1 AND store_id = $2 AND public_id = $3 AND active = TRUE
+            "#,
+        )
+        .bind(org_id)
+        .bind(store_id)
+        .bind(memory_public_id)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(result.rows_affected() > 0)
+    }
+}
+
+#[derive(sqlx::FromRow)]
+struct MemoryWithTotalRow {
+    id: Uuid,
+    public_id: String,
+    store_id: Uuid,
+    store_public_id: String,
+    org_id: i64,
+    content: String,
+    content_parts: serde_json::Value,
+    kind: String,
+    importance: i16,
+    tags: Vec<String>,
+    active: bool,
+    created_at: chrono::DateTime<chrono::Utc>,
+    updated_at: chrono::DateTime<chrono::Utc>,
+    total_count: i64,
+}

--- a/crates/server/src/storage/repositories/memories.rs
+++ b/crates/server/src/storage/repositories/memories.rs
@@ -2,7 +2,7 @@
 // See specs/memory.md.
 
 use super::super::models::*;
-use super::{Database, escape_like};
+use super::{Database, build_search_sql};
 use anyhow::Result;
 use uuid::Uuid;
 
@@ -85,6 +85,35 @@ impl Database {
         Ok(rows)
     }
 
+    /// List memory stores joined with their active-memory counts. Single
+    /// roundtrip — preferred over list + per-store count_active_memories.
+    pub async fn list_memory_stores_with_counts(
+        &self,
+        org_id: i64,
+    ) -> Result<Vec<MemoryStoreWithCount>> {
+        let rows = sqlx::query_as::<_, MemoryStoreWithCount>(
+            r#"
+            SELECT s.id, s.org_id, s.public_id, s.name, s.is_default,
+                   s.created_at, s.updated_at,
+                   COALESCE(c.active_count, 0) AS active_count
+            FROM memory_stores s
+            LEFT JOIN (
+                SELECT store_id, COUNT(*) AS active_count
+                FROM memories
+                WHERE active = TRUE
+                GROUP BY store_id
+            ) c ON c.store_id = s.id
+            WHERE s.org_id = $1
+            ORDER BY s.is_default DESC, s.created_at ASC
+            "#,
+        )
+        .bind(org_id)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows)
+    }
+
     pub async fn count_memory_stores(&self, org_id: i64) -> Result<i64> {
         let row: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM memory_stores WHERE org_id = $1")
             .bind(org_id)
@@ -96,6 +125,75 @@ impl Database {
     // ============================================
     // Memories
     // ============================================
+
+    /// Insert a memory with an atomic per-store capacity check.
+    ///
+    /// `SELECT … FOR UPDATE` on the store row serialises concurrent creates
+    /// targeting the same store so the count and the insert observe a
+    /// consistent snapshot; without this two callers can both pass a 9999 →
+    /// 10000 transition and exceed `MAX_MEMORIES_PER_STORE`.
+    ///
+    /// Returns `Ok(None)` when the store is at or above `cap_limit`; the
+    /// caller maps that to a tool-error message that is safe to surface to
+    /// agents and other org members.
+    pub async fn create_memory_with_cap(
+        &self,
+        input: CreateMemoryRow,
+        cap_limit: i64,
+    ) -> Result<Option<MemoryDbRow>> {
+        let mut tx = self.pool.begin().await?;
+
+        // Serialise creates for this store. The lock is released when `tx`
+        // commits or rolls back, and the row's payload doesn't matter here.
+        let _store_lock: (uuid::Uuid,) =
+            sqlx::query_as("SELECT id FROM memory_stores WHERE id = $1 AND org_id = $2 FOR UPDATE")
+                .bind(input.store_id)
+                .bind(input.org_id)
+                .fetch_one(&mut *tx)
+                .await?;
+
+        let count: (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM memories WHERE store_id = $1 AND active = TRUE")
+                .bind(input.store_id)
+                .fetch_one(&mut *tx)
+                .await?;
+
+        if count.0 >= cap_limit {
+            tx.rollback().await?;
+            return Ok(None);
+        }
+
+        let row = sqlx::query_as::<_, MemoryDbRow>(
+            r#"
+            WITH inserted AS (
+                INSERT INTO memories (
+                    public_id, store_id, org_id, content, content_parts,
+                    kind, importance, tags, active
+                )
+                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, TRUE)
+                RETURNING *
+            )
+            SELECT i.id, i.public_id, i.store_id, s.public_id AS store_public_id,
+                   i.org_id, i.content, i.content_parts, i.kind, i.importance,
+                   i.tags, i.active, i.created_at, i.updated_at
+            FROM inserted i
+            JOIN memory_stores s ON s.id = i.store_id
+            "#,
+        )
+        .bind(&input.public_id)
+        .bind(input.store_id)
+        .bind(input.org_id)
+        .bind(&input.content)
+        .bind(&input.content_parts)
+        .bind(&input.kind)
+        .bind(input.importance)
+        .bind(&input.tags)
+        .fetch_one(&mut *tx)
+        .await?;
+
+        tx.commit().await?;
+        Ok(Some(row))
+    }
 
     pub async fn create_memory(&self, input: CreateMemoryRow) -> Result<MemoryDbRow> {
         let row = sqlx::query_as::<_, MemoryDbRow>(
@@ -192,10 +290,14 @@ impl Database {
             sql.push_str(&format!(" AND m.tags @> ${idx}"));
             idx += 1;
         }
-        if filter.query.as_ref().is_some_and(|q| !q.trim().is_empty()) {
-            sql.push_str(&format!(" AND LOWER(m.content) LIKE ${idx} ESCAPE '\\'"));
-            idx += 1;
-        }
+        // Multi-token AND search using the shared escape/cap helper. Each
+        // whitespace-separated token must match `LOWER(content)` with `%`/`_`
+        // wildcards escaped (TM-API-014). Tokens beyond MAX_SEARCH_TOKENS are
+        // ignored to bound query cost.
+        let (search_sql, search_patterns) =
+            build_search_sql(filter.query.as_deref(), "LOWER(m.content)", idx);
+        sql.push_str(&search_sql);
+        idx += search_patterns.len();
         sql.push_str(&format!(
             " ORDER BY m.importance DESC, m.created_at DESC LIMIT ${idx}"
         ));
@@ -212,10 +314,8 @@ impl Database {
         {
             q = q.bind(tags);
         }
-        if let Some(ref query) = filter.query
-            && !query.trim().is_empty()
-        {
-            q = q.bind(format!("%{}%", escape_like(&query.trim().to_lowercase())));
+        for pattern in &search_patterns {
+            q = q.bind(pattern);
         }
         q = q.bind(limit);
 

--- a/crates/server/src/storage/repositories/mod.rs
+++ b/crates/server/src/storage/repositories/mod.rs
@@ -15,6 +15,7 @@ mod events;
 mod harnesses;
 mod llm;
 mod mcp_servers;
+mod memories;
 mod notifications;
 mod organizations;
 mod principals;

--- a/crates/worker/src/runtime_host.rs
+++ b/crates/worker/src/runtime_host.rs
@@ -169,6 +169,10 @@ impl<A: WorkerAdapters> RuntimeHostAdapter for WorkerRuntimeHost<A> {
         Some(self.adapters.schedule_store(org_id))
     }
 
+    fn memory_store(&self, org_id: i64) -> Option<Arc<dyn everruns_core::MemoryStoreBackend>> {
+        self.adapters.memory_store(org_id)
+    }
+
     fn platform_store(
         &self,
         org_id: i64,

--- a/crates/worker/src/worker_adapters.rs
+++ b/crates/worker/src/worker_adapters.rs
@@ -265,6 +265,14 @@ pub trait WorkerAdapters: Send + Sync + Clone + 'static {
     /// Takes org_id so the store is scoped to the current session's organization.
     fn schedule_store(&self, org_id: i64) -> Arc<dyn everruns_core::traits::SessionScheduleStore>;
 
+    /// Get the org-scoped memory store for `remember`/`recall`/`forget` tools.
+    /// Returns `None` when the worker cannot reach a backing store (e.g. gRPC
+    /// workers without the corresponding RPC); callers fall through to a
+    /// non-disclosing tool error.
+    fn memory_store(&self, _org_id: i64) -> Option<Arc<dyn everruns_core::MemoryStoreBackend>> {
+        None
+    }
+
     /// Get the budget checker for the current turn, if available.
     ///
     /// gRPC workers provide this through the control-plane API. Direct dev-mode

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -3030,6 +3030,258 @@
         }
       }
     },
+    "/v1/memory-stores": {
+      "get": {
+        "tags": [
+          "memory_stores"
+        ],
+        "operationId": "list_memory_stores",
+        "responses": {
+          "200": {
+            "description": "List org memory stores",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListResponse_MemoryStoreResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "memory_stores"
+        ],
+        "operationId": "create_memory_store",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateMemoryStoreRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Memory store created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MemoryStoreResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid input",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Duplicate name or default conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/memory-stores/{store_id}": {
+      "get": {
+        "tags": [
+          "memory_stores"
+        ],
+        "operationId": "get_memory_store",
+        "parameters": [
+          {
+            "name": "store_id",
+            "in": "path",
+            "description": "Memory store ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Memory store",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MemoryStoreResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/memory-stores/{store_id}/memories": {
+      "get": {
+        "tags": [
+          "memory_stores"
+        ],
+        "operationId": "list_memories",
+        "parameters": [
+          {
+            "name": "store_id",
+            "in": "path",
+            "description": "Memory store ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "query",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          {
+            "name": "kind",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          {
+            "name": "tag",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "include_inactive",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "minimum": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Memories",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListMemoriesResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Store not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/memory-stores/{store_id}/memories/{memory_id}": {
+      "delete": {
+        "tags": [
+          "memory_stores"
+        ],
+        "operationId": "forget_memory",
+        "parameters": [
+          {
+            "name": "store_id",
+            "in": "path",
+            "description": "Memory store ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "memory_id",
+            "in": "path",
+            "description": "Memory ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Memory deactivated"
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/orgs": {
       "get": {
         "tags": [
@@ -7257,6 +7509,20 @@
           }
         }
       },
+      "CreateMemoryStoreRequest": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "is_default": {
+            "type": "boolean"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
       "CreateMessageRequest": {
         "type": "object",
         "description": "Request to create a message",
@@ -8973,6 +9239,64 @@
           }
         }
       },
+      "ListMemoriesQuery": {
+        "type": "object",
+        "properties": {
+          "include_inactive": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "kind": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "limit": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "minimum": 0
+          },
+          "query": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "tag": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "ListMemoriesResponse": {
+        "type": "object",
+        "required": [
+          "data",
+          "total"
+        ],
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MemoryResponse"
+            }
+          },
+          "total": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      },
       "ListResponse_Agent": {
         "type": "object",
         "description": "Response wrapper for list endpoints.\nAll list endpoints return responses wrapped in a `data` field.",
@@ -9746,6 +10070,54 @@
                   "type": "string",
                   "description": "URL of the MCP server endpoint.",
                   "example": "https://mcp.atlassian.com/v1/mcp"
+                }
+              }
+            },
+            "description": "Array of items returned by the list operation."
+          }
+        }
+      },
+      "ListResponse_MemoryStoreResponse": {
+        "type": "object",
+        "description": "Response wrapper for list endpoints.\nAll list endpoints return responses wrapped in a `data` field.",
+        "required": [
+          "data"
+        ],
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "id",
+                "name",
+                "is_default",
+                "active_memory_count",
+                "created_at",
+                "updated_at"
+              ],
+              "properties": {
+                "active_memory_count": {
+                  "type": "integer",
+                  "format": "int64"
+                },
+                "created_at": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "id": {
+                  "type": "string",
+                  "example": "mst_01933b5a000070008000000000000001"
+                },
+                "is_default": {
+                  "type": "boolean"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "updated_at": {
+                  "type": "string",
+                  "format": "date-time"
                 }
               }
             },
@@ -11994,6 +12366,94 @@
               "boolean",
               "null"
             ]
+          }
+        }
+      },
+      "MemoryResponse": {
+        "type": "object",
+        "required": [
+          "id",
+          "store_id",
+          "content",
+          "content_parts",
+          "kind",
+          "importance",
+          "tags",
+          "active",
+          "created_at",
+          "updated_at"
+        ],
+        "properties": {
+          "active": {
+            "type": "boolean"
+          },
+          "content": {
+            "type": "string"
+          },
+          "content_parts": {},
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "id": {
+            "type": "string",
+            "example": "mem_01933b5a000070008000000000000001"
+          },
+          "importance": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "kind": {
+            "type": "string"
+          },
+          "store_id": {
+            "type": "string",
+            "example": "mst_01933b5a000070008000000000000001"
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "MemoryStoreResponse": {
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "is_default",
+          "active_memory_count",
+          "created_at",
+          "updated_at"
+        ],
+        "properties": {
+          "active_memory_count": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "id": {
+            "type": "string",
+            "example": "mst_01933b5a000070008000000000000001"
+          },
+          "is_default": {
+            "type": "boolean"
+          },
+          "name": {
+            "type": "string"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
           }
         }
       },
@@ -18273,6 +18733,10 @@
     {
       "name": "volumes",
       "description": "Workspace volume management endpoints"
+    },
+    {
+      "name": "memory_stores",
+      "description": "Org-scoped persistent memory stores"
     },
     {
       "name": "images",

--- a/specs/memory.md
+++ b/specs/memory.md
@@ -140,8 +140,36 @@ Enforcement: checked on write (`remember` tool + REST API). Returns clear
 
 ## Storage
 
-In-memory implementation for dev mode (`InMemoryMemoryStore`).
-PostgreSQL implementation for production (future migration `012_memory.sql`).
+In-memory implementation for dev mode (`InMemoryMemoryStore`) — used by
+embedded runtimes and tests; see `crates/core/src/memory.rs`.
+
+PostgreSQL implementation for production (`crates/server/migrations/032_memory_stores.sql`):
+
+- `memory_stores` — org-scoped containers with one default store per org.
+- `memories` — soft-delete via `active = FALSE`; carries `org_id` for fast
+  org-scoped queries and isolation checks.
+
+The server bridges the trait via `DbMemoryStore`
+(`crates/server/src/storage/memory_store_backend.rs`), which is an org-scoped
+adapter wired into `DirectWorkerAdapters::memory_store(org_id)` so the
+`remember`/`recall`/`forget` tools persist through the configured backend.
+
+## REST API
+
+Org-scoped CRUD lives at `/v1/memory-stores`:
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/v1/memory-stores` | List org memory stores |
+| `POST` | `/v1/memory-stores` | Create a new store |
+| `GET` | `/v1/memory-stores/{store_id}` | Get a store with active memory count |
+| `GET` | `/v1/memory-stores/{store_id}/memories` | Search memories (`query`, `kind`, `tag[]`, `include_inactive`, `limit`) |
+| `DELETE` | `/v1/memory-stores/{store_id}/memories/{memory_id}` | Forget (soft-delete) a memory |
+
+All routes resolve org from the authenticated request; cross-org access
+returns `404` rather than disclosing existence. Full handlers in
+`crates/server/src/api/memory_stores.rs` and the Command implementations in
+`crates/server/src/domains/memory_stores/commands.rs`.
 
 ## System Prompt
 


### PR DESCRIPTION
Closes EVE-422.

## What
Make the org-scoped memory capability fully functional in production: durable Postgres-backed storage for stores and memories, an org-scoped REST API, a Memory page in the UI, and a structured store picker in the agent capability config editor.

## Why
The `memory` capability already shipped `remember`/`recall`/`forget` tools and the spec described `mst_…`-scoped stores, but production had no durable backend, no API for org members to inspect what agents had stored, and the capability config required pasting raw store IDs.

## How
- **Migration `032_memory_stores.sql`**: `memory_stores` (org-scoped, unique-default-per-org index, name unique per org case-insensitive) and `memories` (soft-delete via `active=false`, `org_id` denormalised for fast org-scoped queries, GIN tag index, 2k content cap).
- **Storage layer**: `MemoryStoreDbRow` / `MemoryDbRow` / `ListMemoriesFilter`, Postgres + in-memory parity, dispatched through `StorageBackend`.
- **`DbMemoryStore`** (`crates/server/src/storage/memory_store_backend.rs`): bridges core's `MemoryStoreBackend` trait to `StorageBackend`. Org-scoped at construction; cross-org store/memory IDs surface as `Ok(None)` / `Ok(false)` rather than disclosing existence.
- **Wiring**: added `memory_store(org_id)` to `WorkerAdapters` (default `None`), threaded through `RuntimeHostWorkerAdapter` and `RuntimeHostAdapter` so the `remember`/`recall`/`forget` tools persist through the configured backend in both in-process and gRPC workers. `DirectWorkerAdapters` returns the DB-backed implementation.
- **REST API** (`/v1/memory-stores`, OpenAPI tagged): list/create stores, get store with active count, list/search memories (`query`, `kind`, `tag[]`, `include_inactive`, `limit`), forget memory.
- **UI**: new sidebar entry → `/memory-stores` page with store list, search, kind filter, and per-memory forget. New `MemoryCapabilityConfigEditor` replaces the free-text store ID with a populated picker; the memory capability now exposes `config_schema` so the picker shows by default.

## Risk
- **Medium**. New SQL tables and a new tool-context wire. Cross-org isolation is the primary risk surface; covered by tests and by the org-scoped `DbMemoryStore` constructor.
- Existing in-memory dev path is unchanged for embedded runtimes (`InMemoryMemoryStore` still used by tests and `runtime`); the server now ignores it and returns the DB-backed adapter.

## Security
- Threat categories reviewed: **TM-AUTH** (org isolation), **TM-API** (input validation, error sanitisation).
- `DbMemoryStore` enforces `org_id` on every read/write; the REST handlers all derive `org_id` from `ResolvedOrg`. Cross-org reads return `404 Not Found` (`CommandError::not_found`) rather than `Forbidden` so the existence of foreign IDs is not disclosed. `recall` over a foreign `store_id` returns an empty result.
- `forget` is gated by `OrgSettingsManage`; list/get by `OrgSettingsView`.
- Postgres-side: `CHECK (importance BETWEEN 1 AND 10)`, content length capped (`char_length(content) <= 2000`), public_id format constraints `mst_/mem_<32-hex>`. App-side enforces the per-store memory cap (`MemoryLimits::MAX_MEMORIES_PER_STORE`) and per-org store cap (`MAX_STORES_PER_ORG`) on writes.
- Image content stays inside the existing `MemoryLimits::validate` path used by the `remember` tool.

## Checklist
- [x] Tests added or updated — storage parity (in-memory + Postgres dispatch), org isolation across stores and memories, search/kind/tag filters, forget end-to-end through API + backend.
- [x] Backward compatibility considered — internal-only types; no public API removals; `MemoryStoreBackend` trait unchanged.
- [x] Security review performed against relevant threat model categories.
- [x] All review comments addressed (n/a — initial PR).

---
_Generated by [Claude Code](https://claude.ai/code/session_01B39PWrSoM16qxrcpN827aK)_