### PR TITLE
feat(memory): add memory detail drawer on Memory page

### DIFF
--- a/apps/ui/src/app/(main)/memory-stores/page.tsx
+++ b/apps/ui/src/app/(main)/memory-stores/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Brain, Plus, Search, Star, Trash2 } from "lucide-react";
 import { QueryStateWrapper } from "@/components/query-state-wrapper";
 import { Badge } from "@/components/ui/badge";
@@ -76,6 +76,12 @@ export default function MemoryStoresPage() {
     kind: kind === "all" ? undefined : kind,
     limit: 200,
   });
+
+  // Close the detail drawer when the memory list it was selected from changes,
+  // so a previously-selected memory can't render against the wrong store/forget mutation.
+  useEffect(() => {
+    setDetailMemoryId(null);
+  }, [activeStoreId, search, kind]);
 
   return (
     <div className="container mx-auto p-6">
@@ -286,6 +292,11 @@ function MemoryCard({
             e.stopPropagation();
             onForget();
           }}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.stopPropagation();
+            }
+          }}
           disabled={!memory.active || forgetting}
           aria-label="Forget memory"
         >
@@ -431,7 +442,11 @@ function MemoryContentPartView({ part }: { part: MemoryContentPart }) {
     return (
       <div className="rounded-md border bg-muted/30 p-2">
         {/* eslint-disable-next-line @next/next/no-img-element */}
-        <img src={src} alt="" className="max-h-80 max-w-full rounded object-contain" />
+        <img
+          src={src}
+          alt={`Memory attachment (${part.media_type})`}
+          className="max-h-80 max-w-full rounded object-contain"
+        />
         <p className="mt-1 text-xs text-muted-foreground">{part.media_type}</p>
       </div>
     );

--- a/apps/ui/src/app/(main)/memory-stores/page.tsx
+++ b/apps/ui/src/app/(main)/memory-stores/page.tsx
@@ -17,6 +17,14 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import {
+  Drawer,
+  DrawerContent,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerTitle,
+} from "@/components/ui/drawer";
+import {
   Select,
   SelectContent,
   SelectItem,
@@ -30,7 +38,12 @@ import {
   useMemoryStores,
   usePageTitle,
 } from "@/hooks";
-import type { CreateMemoryStoreRequest, MemoryStore } from "@/lib/api/types";
+import type {
+  CreateMemoryStoreRequest,
+  Memory,
+  MemoryContentPart,
+  MemoryStore,
+} from "@/lib/api/types";
 import { formatRelativeTime } from "@/lib/formatting";
 
 const KIND_OPTIONS = [
@@ -48,10 +61,12 @@ export default function MemoryStoresPage() {
   const [selectedStoreId, setSelectedStoreId] = useState<string | null>(null);
   const [search, setSearch] = useState("");
   const [kind, setKind] = useState<string>("all");
+  const [detailMemoryId, setDetailMemoryId] = useState<string | null>(null);
 
   const { data: stores, isLoading, error } = useMemoryStores();
   const activeStoreId =
     selectedStoreId ?? stores?.find((s) => s.is_default)?.id ?? stores?.[0]?.id ?? null;
+  const activeStore = stores?.find((s) => s.id === activeStoreId) ?? null;
 
   const createStore = useCreateMemoryStore();
   const forgetMemory = useForgetMemory(activeStoreId ?? undefined);
@@ -141,6 +156,7 @@ export default function MemoryStoresPage() {
                           memory={memory}
                           onForget={() => forgetMemory.mutate(memory.id)}
                           forgetting={forgetMemory.isPending}
+                          onSelect={() => setDetailMemoryId(memory.id)}
                         />
                       ))}
                     </div>
@@ -161,6 +177,25 @@ export default function MemoryStoresPage() {
           setSelectedStoreId(created.id);
           setCreateOpen(false);
         }}
+      />
+
+      <MemoryDetailDrawer
+        memory={
+          detailMemoryId
+            ? (memoriesQuery.data?.data.find((m) => m.id === detailMemoryId) ?? null)
+            : null
+        }
+        store={activeStore}
+        open={detailMemoryId !== null}
+        onOpenChange={(open) => {
+          if (!open) setDetailMemoryId(null);
+        }}
+        onForget={(id) => {
+          forgetMemory.mutate(id, {
+            onSuccess: () => setDetailMemoryId(null),
+          });
+        }}
+        forgetting={forgetMemory.isPending}
       />
     </div>
   );
@@ -213,21 +248,26 @@ function MemoryCard({
   memory,
   onForget,
   forgetting,
+  onSelect,
 }: {
-  memory: {
-    id: string;
-    content: string;
-    kind: string;
-    importance: number;
-    tags: string[];
-    active: boolean;
-    created_at: string;
-  };
+  memory: Memory;
   onForget: () => void;
   forgetting: boolean;
+  onSelect: () => void;
 }) {
   return (
-    <Card>
+    <Card
+      role="button"
+      tabIndex={0}
+      onClick={onSelect}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onSelect();
+        }
+      }}
+      className="cursor-pointer transition hover:border-primary"
+    >
       <CardHeader className="flex flex-row items-start justify-between gap-3 space-y-0">
         <div className="flex flex-wrap items-center gap-2">
           <Badge variant="outline">{memory.kind}</Badge>
@@ -242,7 +282,10 @@ function MemoryCard({
         <Button
           variant="outline"
           size="sm"
-          onClick={onForget}
+          onClick={(e) => {
+            e.stopPropagation();
+            onForget();
+          }}
           disabled={!memory.active || forgetting}
           aria-label="Forget memory"
         >
@@ -252,13 +295,149 @@ function MemoryCard({
       </CardHeader>
       <CardContent className="space-y-2">
         <p className="text-sm">{memory.content}</p>
-        <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+        <div
+          role="presentation"
+          onClick={(e) => e.stopPropagation()}
+          onKeyDown={(e) => e.stopPropagation()}
+          className="flex items-center gap-1.5 text-xs text-muted-foreground"
+        >
           <span className="truncate font-mono">{memory.id}</span>
           <CopyButton value={memory.id} />
           <span className="ml-auto">{formatRelativeTime(memory.created_at)}</span>
         </div>
       </CardContent>
     </Card>
+  );
+}
+
+function MemoryDetailDrawer({
+  memory,
+  store,
+  open,
+  onOpenChange,
+  onForget,
+  forgetting,
+}: {
+  memory: Memory | null;
+  store: MemoryStore | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onForget: (memoryId: string) => void;
+  forgetting: boolean;
+}) {
+  return (
+    <Drawer open={open} onOpenChange={onOpenChange}>
+      <DrawerContent>
+        {memory ? (
+          <>
+            <DrawerHeader>
+              <DrawerTitle>Memory detail</DrawerTitle>
+              <DrawerDescription>Full content, metadata, and attached parts.</DrawerDescription>
+            </DrawerHeader>
+            <div className="flex flex-1 flex-col gap-4 overflow-y-auto">
+              <div className="flex flex-wrap items-center gap-2">
+                <Badge variant="outline">{memory.kind}</Badge>
+                <Badge variant="secondary">importance {memory.importance}</Badge>
+                {!memory.active && <Badge variant="destructive">forgotten</Badge>}
+                {memory.tags.map((tag) => (
+                  <Badge key={tag} variant="outline" className="text-xs">
+                    {tag}
+                  </Badge>
+                ))}
+              </div>
+
+              <section className="space-y-1">
+                <h4 className="text-xs font-medium uppercase text-muted-foreground">Content</h4>
+                <p className="whitespace-pre-wrap text-sm">{memory.content}</p>
+              </section>
+
+              {Array.isArray(memory.content_parts) && memory.content_parts.length > 0 && (
+                <section className="space-y-2">
+                  <h4 className="text-xs font-medium uppercase text-muted-foreground">
+                    Content parts
+                  </h4>
+                  <div className="space-y-2">
+                    {memory.content_parts.map((part, index) => (
+                      <MemoryContentPartView key={`${memory.id}-part-${index}`} part={part} />
+                    ))}
+                  </div>
+                </section>
+              )}
+
+              <section className="space-y-1">
+                <h4 className="text-xs font-medium uppercase text-muted-foreground">Memory ID</h4>
+                <div className="flex items-center gap-1.5 text-xs">
+                  <span className="truncate font-mono">{memory.id}</span>
+                  <CopyButton value={memory.id} />
+                </div>
+              </section>
+
+              {store && (
+                <section className="space-y-1">
+                  <h4 className="text-xs font-medium uppercase text-muted-foreground">Store</h4>
+                  <div className="flex items-center gap-2 text-sm">
+                    <span>{store.name}</span>
+                    {store.is_default && (
+                      <Badge variant="secondary">
+                        <Star className="h-3 w-3" /> Default
+                      </Badge>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                    <span className="truncate font-mono">{store.id}</span>
+                    <CopyButton value={store.id} />
+                  </div>
+                </section>
+              )}
+
+              <section className="grid grid-cols-2 gap-4 text-xs text-muted-foreground">
+                <div>
+                  <h4 className="text-xs font-medium uppercase">Created</h4>
+                  <p>{formatRelativeTime(memory.created_at)}</p>
+                </div>
+                <div>
+                  <h4 className="text-xs font-medium uppercase">Updated</h4>
+                  <p>{formatRelativeTime(memory.updated_at)}</p>
+                </div>
+              </section>
+            </div>
+            <DrawerFooter>
+              <Button
+                variant="outline"
+                onClick={() => onForget(memory.id)}
+                disabled={!memory.active || forgetting}
+              >
+                <Trash2 className="h-4 w-4" />
+                Forget memory
+              </Button>
+            </DrawerFooter>
+          </>
+        ) : null}
+      </DrawerContent>
+    </Drawer>
+  );
+}
+
+function MemoryContentPartView({ part }: { part: MemoryContentPart }) {
+  if (part.type === "text") {
+    return (
+      <div className="rounded-md border bg-muted/30 p-3 text-sm whitespace-pre-wrap">
+        {part.text}
+      </div>
+    );
+  }
+  if (part.type === "image") {
+    const src = `data:${part.media_type};base64,${part.base64}`;
+    return (
+      <div className="rounded-md border bg-muted/30 p-2">
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img src={src} alt="" className="max-h-80 max-w-full rounded object-contain" />
+        <p className="mt-1 text-xs text-muted-foreground">{part.media_type}</p>
+      </div>
+    );
+  }
+  return (
+    <pre className="rounded-md border bg-muted/30 p-2 text-xs">{JSON.stringify(part, null, 2)}</pre>
   );
 }
 

--- a/apps/ui/src/components/ui/drawer.tsx
+++ b/apps/ui/src/components/ui/drawer.tsx
@@ -1,0 +1,111 @@
+import * as React from "react";
+import { Dialog as DialogPrimitive } from "@base-ui/react/dialog";
+import { XIcon } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+function Drawer({ ...props }: DialogPrimitive.Root.Props) {
+  return <DialogPrimitive.Root data-slot="drawer" {...props} />;
+}
+
+function DrawerPortal({ ...props }: DialogPrimitive.Portal.Props) {
+  return <DialogPrimitive.Portal data-slot="drawer-portal" {...props} />;
+}
+
+function DrawerOverlay({ className, ...props }: DialogPrimitive.Backdrop.Props) {
+  return (
+    <DialogPrimitive.Backdrop
+      data-slot="drawer-overlay"
+      className={cn(
+        "data-[open]:animate-in data-[closed]:animate-out data-[closed]:fade-out-0 data-[open]:fade-in-0 data-[closed]:animation-duration-[200ms] fixed inset-0 z-50 bg-black/50",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DrawerContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: DialogPrimitive.Popup.Props & {
+  showCloseButton?: boolean;
+}) {
+  return (
+    <DrawerPortal data-slot="drawer-portal">
+      <DrawerOverlay />
+      <DialogPrimitive.Popup
+        data-slot="drawer-content"
+        className={cn(
+          "bg-background data-[open]:animate-in data-[open]:slide-in-from-right-8 data-[closed]:animate-out data-[closed]:slide-out-to-right-8 data-[open]:fade-in-0 data-[closed]:fade-out-0 fixed inset-y-0 right-0 z-50 flex h-full w-full max-w-md flex-col gap-4 border-l p-6 shadow-lg duration-200 sm:max-w-lg",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            data-slot="drawer-close"
+            className="ring-offset-background focus:ring-ring data-[open]:bg-muted data-[open]:text-muted-foreground absolute top-4 right-4 opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+          >
+            <XIcon />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Popup>
+    </DrawerPortal>
+  );
+}
+
+function DrawerHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="drawer-header"
+      className={cn("flex flex-col gap-2 text-left", className)}
+      {...props}
+    />
+  );
+}
+
+function DrawerFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="drawer-footer"
+      className={cn("mt-auto flex flex-col gap-2 sm:flex-row sm:justify-end", className)}
+      {...props}
+    />
+  );
+}
+
+function DrawerTitle({ className, ...props }: DialogPrimitive.Title.Props) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="drawer-title"
+      className={cn("text-lg leading-none font-semibold", className)}
+      {...props}
+    />
+  );
+}
+
+function DrawerDescription({ className, ...props }: DialogPrimitive.Description.Props) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="drawer-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Drawer,
+  DrawerContent,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerOverlay,
+  DrawerPortal,
+  DrawerTitle,
+};

--- a/apps/ui/src/lib/api/types/memory-store-types.ts
+++ b/apps/ui/src/lib/api/types/memory-store-types.ts
@@ -11,11 +11,15 @@ export interface MemoryStore {
   updated_at: string;
 }
 
+export type MemoryContentPart =
+  | { type: "text"; text: string }
+  | { type: "image"; base64: string; media_type: string };
+
 export interface Memory {
   id: string;
   store_id: string;
   content: string;
-  content_parts: unknown;
+  content_parts: MemoryContentPart[];
   kind: string;
   importance: number;
   tags: string[];


### PR DESCRIPTION
## What
Click any memory card on `/memory-stores` to open a side drawer showing full content, all metadata (kind, importance, tags, store, created/updated), and rendered `content_parts` (text + image). The Forget action is available from inside the drawer and dismisses it on success; the inline quick-forget button on each card is preserved.

## Why
The Memory page (EVE-422) currently truncates memory metadata to what fits on a card. Users couldn't read full content, see all tags/timestamps, or review attached image parts without leaving the page. Resolves EVE-426.

## How
- New `Drawer` UI primitive (`apps/ui/src/components/ui/drawer.tsx`) using base-ui Dialog primitives with right-side slide-in styling.
- New `MemoryDetailDrawer` component on the page renders content, content_parts (text + base64 image via `<img src="data:...">`), tags, timestamps, store, and a Forget button.
- Card now also acts as a button (Enter/Space/click) that opens the drawer; the existing quick-forget button stops propagation.
- `MemoryContentPart` discriminated-union type added to `memory-store-types.ts` matching the backend `MemoryContentPart` enum (`text` | `image`). `Memory.content_parts` typed accordingly.

## Risk
- Low.
- Pure UI; no API, auth, or data-model changes.
- Drawer is a new primitive but only consumed by the Memory page in this PR.

## Security
- Threat categories reviewed: TM-WEB.
- Findings: none. Memory data shown in the drawer is the same payload already returned by `GET /v1/memory-stores/{id}/memories` under existing `MEMORY_STORE_VIEW` policy. Image rendering uses `<img src="data:{media_type};base64,{data}">`; HTML `<img>` does not execute scripts (including for SVG-typed data URIs), and React escapes all string interpolations into the DOM. No new endpoints, no new auth/permission code.

## Checklist
- [x] Tests added or updated — n/a; behavioural change is covered by `npm run build` typecheck and lint pass; no unit-test surface for the drawer beyond what's covered already.
- [x] Backward compatibility considered — internal feature, no external consumers.
- [x] Security review performed against relevant threat model categories — TM-WEB, no findings.
- [x] All review comments addressed — none yet.

## Validation
- `npm run lint` — clean (no new warnings on touched files).
- `npm run format:check` — clean.
- `npm run build` — clean.
- `bash scripts/lib/check-migration-ordering.sh` — sequential.
- `just pre-push` — all 8 checks pass.
- Smoke: skipped live stack run; build + types + lint cover the changed surface (UI-only, no runtime side effects beyond DOM rendering of already-authorized data).

Resolves EVE-426.


---
_Generated by [Claude Code](https://claude.ai/code/session_015BYbYvipV68CVZ1KyGBQRy)_