### PR TITLE
test(volumes): add UI test cases for workspace volumes

### DIFF
--- a/test_cases/ui/volumes/MANUAL_TEST_RESULTS_2026-05-06.md
+++ b/test_cases/ui/volumes/MANUAL_TEST_RESULTS_2026-05-06.md
@@ -1,0 +1,46 @@
+# Manual UI Test Results - 2026-05-06
+
+## Environment
+
+- **Auth Mode**: none (`AUTH_MODE` unset, dev defaults)
+- **Stack**: `just start-dev --no-watch` (in-memory storage), API + Caddy + Next.js dev
+- **PORT_PREFIX**: 271
+- **Browser**: Chromium 1194 (headless, via agent-browser 0.26.0)
+
+## Test Summary
+
+| Category | Tests | Pass | Fail/Partial | Issues |
+|----------|-------|------|-------------|--------|
+| volumes  | 6     | 6    | 0           | 0      |
+| **Total** | **6** | **6** | **0**       | **0**  |
+
+## Detailed Results
+
+### volumes (6/6 PASS)
+
+- **TC001 Create Volume**: PASS — `tc001-research` created with description, `vol_` prefixed ID, `active` badge, "just now" timestamps.
+- **TC002 Create Volume - Required Name Validation**: PASS — empty name blocked by HTML5 required validation; whitespace-only name blocked with inline `Name is required` error; no volume created on cancel.
+- **TC003 Edit Volume Name and Description**: PASS — `tc003-source` renamed to `tc003-renamed`, description updated to `Renamed in TC003`, list and detail views both reflect the new values.
+- **TC004 Archive Volume and Toggle Archived Filter**: PASS — confirmation dialog references `tc004-archive-me`; archived card hidden by default; `Show archived` filter reveals it with `archived` badge, disabled Edit, no Archive; detail page shows `archived` badge with Archived activity timestamp and disabled Edit.
+- **TC005 Search Volumes by Name**: PASS — `alpha` search filtered list to `tc005-alpha`; clearing restored all three; `zzz-no-match` showed `No volumes found` without an in-state `New Volume` button.
+- **TC006 Workspace Volumes Capability Mount Editor**: PASS — Workspace Volumes capability auto-added File System dependency; volume picker listed only active volumes (archived `tc004-archive-me` not selectable); `/etc/passwd` rejected with `Path must be /workspace or start with /workspace/`; two-row save persisted both mounts via API; `/workspace/research/docs` triggered overlap error on both affected rows; duplicate `/workspace/research` triggered `Duplicate mount path` error on both rows; trash icon removed the row.
+
+## Issues Found
+
+None.
+
+## Evidence
+
+Screenshots captured locally during the run (excluded from the repo):
+
+- `/tmp/tc001_created.png`
+- `/tmp/tc002_whitespace.png`
+- `/tmp/tc003_renamed.png`
+- `/tmp/tc004_confirm.png`, `/tmp/tc004_archived_filter.png`, `/tmp/tc004_detail.png`
+- `/tmp/tc005_alpha.png`, `/tmp/tc005_nomatch.png`
+- `/tmp/tc006_invalid_path.png`, `/tmp/tc006_two_mounts.png`, `/tmp/tc006_overlap.png`, `/tmp/tc006_duplicate.png`
+
+## Notes
+
+- Combobox volume selection in the mount editor required typing into the search input and pressing Enter to commit the selection (mouse-clicking the option in the listbox was also possible from the UI but was easier to drive deterministically via search + Enter under headless Chromium).
+- Save Changes had to be invoked while the button was scrolled into view; clicking it from above the fold did not trigger the form submit reliably under headless Chromium. Manual users do not see this.

--- a/test_cases/ui/volumes/TC001_create_volume.md
+++ b/test_cases/ui/volumes/TC001_create_volume.md
@@ -1,0 +1,41 @@
+# TC001: Create Volume
+
+## Description
+
+Verify that a new workspace volume can be created from the Volumes page and appears in the list with `active` status and a `vol_` prefixed ID.
+
+## Preconditions
+
+- Server running (`just start-all`)
+- User logged in with an org selected
+
+## Test Data
+
+| Field | Value |
+|-------|-------|
+| Volume name | `tc001-research` |
+| Description | `Test volume for TC001` |
+
+## Steps
+
+1. Navigate to `/volumes` (sidebar entry "Volumes")
+2. Click the **New Volume** button in the page header
+3. In the dialog, enter `tc001-research` in the **Name** field
+4. Enter `Test volume for TC001` in the **Description** field
+5. Click **Create Volume**
+6. Observe the volume list
+
+## Expected Result
+
+| Check | Expected |
+|-------|----------|
+| Dialog closes | Dialog closes without error after submit |
+| Card appears | A card titled `tc001-research` appears in the grid |
+| Status badge | Card shows an `active` status badge |
+| ID format | Card ID matches `vol_` followed by 32 hex characters |
+| Description | Card displays `Test volume for TC001` |
+| Created timestamp | Card shows a recent "Created" relative time |
+
+## Cleanup
+
+- Archive the volume via the **Archive** button on the card to leave a clean list.

--- a/test_cases/ui/volumes/TC002_create_volume_validation.md
+++ b/test_cases/ui/volumes/TC002_create_volume_validation.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-Verify that the New Volume dialog rejects an empty or whitespace-only name and surfaces an inline field error without submitting the form.
+Verify that the New Volume dialog rejects a whitespace-only name with an inline field error and does not create a volume.
 
 ## Preconditions
 
@@ -13,24 +13,23 @@ Verify that the New Volume dialog rejects an empty or whitespace-only name and s
 
 | Field | Value |
 |-------|-------|
-| Volume name (attempt 1) | (empty) |
-| Volume name (attempt 2) | `   ` (whitespace only) |
+| Volume name | `   ` (three spaces) |
 
 ## Steps
 
 1. Navigate to `/volumes`
 2. Click **New Volume**
-3. Leave the **Name** field empty and click **Create Volume**
-4. Observe the dialog
-5. Type three spaces into the **Name** field and click **Create Volume**
-6. Observe the dialog
-7. Click **Cancel**
+3. Type three spaces into the **Name** field
+4. Click **Create Volume**
+5. Observe the dialog
+6. Click **Cancel**
+7. Reload the volumes list
 
 ## Expected Result
 
 | Check | Expected |
 |-------|----------|
-| Empty name rejected | Browser/HTML5 required validation prevents submit, OR an inline `Name is required` error renders |
-| Whitespace name rejected | Inline `Name is required` error renders below the Name input; dialog stays open |
-| No volume created | Returning to the list shows no new volume |
-| Cancel | Dialog closes without creating any volume |
+| Inline error | `Name is required` is rendered below the Name input |
+| Submit blocked | The dialog stays open and no network request to create a volume is made |
+| Cancel | Dialog closes without creating a volume |
+| No volume created | Reloaded volumes list contains no new volume from this attempt |

--- a/test_cases/ui/volumes/TC002_create_volume_validation.md
+++ b/test_cases/ui/volumes/TC002_create_volume_validation.md
@@ -1,0 +1,36 @@
+# TC002: Create Volume - Required Name Validation
+
+## Description
+
+Verify that the New Volume dialog rejects an empty or whitespace-only name and surfaces an inline field error without submitting the form.
+
+## Preconditions
+
+- Server running (`just start-all`)
+- User logged in with an org selected
+
+## Test Data
+
+| Field | Value |
+|-------|-------|
+| Volume name (attempt 1) | (empty) |
+| Volume name (attempt 2) | `   ` (whitespace only) |
+
+## Steps
+
+1. Navigate to `/volumes`
+2. Click **New Volume**
+3. Leave the **Name** field empty and click **Create Volume**
+4. Observe the dialog
+5. Type three spaces into the **Name** field and click **Create Volume**
+6. Observe the dialog
+7. Click **Cancel**
+
+## Expected Result
+
+| Check | Expected |
+|-------|----------|
+| Empty name rejected | Browser/HTML5 required validation prevents submit, OR an inline `Name is required` error renders |
+| Whitespace name rejected | Inline `Name is required` error renders below the Name input; dialog stays open |
+| No volume created | Returning to the list shows no new volume |
+| Cancel | Dialog closes without creating any volume |

--- a/test_cases/ui/volumes/TC003_edit_volume.md
+++ b/test_cases/ui/volumes/TC003_edit_volume.md
@@ -1,0 +1,46 @@
+# TC003: Edit Volume Name and Description
+
+## Description
+
+Verify that an existing active volume's name and description can be edited from the volume card and that changes are reflected in both the list and detail views.
+
+## Preconditions
+
+- Server running (`just start-all`)
+- User logged in
+- At least one active volume exists (create one via TC001 if needed)
+
+## Test Data
+
+| Field | Value |
+|-------|-------|
+| Original name | `tc003-source` |
+| New name | `tc003-renamed` |
+| New description | `Renamed in TC003` |
+
+## Steps
+
+1. Create a volume named `tc003-source` (via the New Volume dialog) if one is not already present
+2. Navigate to `/volumes`
+3. Locate the `tc003-source` card and click its **Edit** button
+4. In the dialog, change the **Name** to `tc003-renamed`
+5. Set the **Description** to `Renamed in TC003`
+6. Click **Save Changes**
+7. Observe the card in the list
+8. Click **Open** on the renamed card to navigate to the detail page
+
+## Expected Result
+
+| Check | Expected |
+|-------|----------|
+| Dialog closes | Dialog closes after save with no error |
+| Card name updates | Card title now reads `tc003-renamed` |
+| Card description updates | Card body now reads `Renamed in TC003` |
+| Updated timestamp | Card "Updated" relative time refreshes to a recent value |
+| Detail page header | `/volumes/<id>` page heading reads `tc003-renamed` |
+| Detail description | Overview section shows `Renamed in TC003` |
+| Page title | Browser tab title contains `tc003-renamed` |
+
+## Cleanup
+
+- Archive `tc003-renamed` from the detail page or list.

--- a/test_cases/ui/volumes/TC004_archive_and_filter_volume.md
+++ b/test_cases/ui/volumes/TC004_archive_and_filter_volume.md
@@ -1,0 +1,40 @@
+# TC004: Archive Volume and Toggle Archived Filter
+
+## Description
+
+Verify that a volume can be archived from the list, that archived volumes are hidden by default, and that the archive filter toggle reveals them with a read-only `archived` badge and disabled write actions.
+
+## Preconditions
+
+- Server running (`just start-all`)
+- User logged in
+- At least one active volume named `tc004-archive-me` exists
+
+## Test Data
+
+| Field | Value |
+|-------|-------|
+| Volume name | `tc004-archive-me` |
+
+## Steps
+
+1. Navigate to `/volumes`
+2. Locate the `tc004-archive-me` card and click **Archive**
+3. In the **Archive Volume** confirmation dialog, click **Archive**
+4. Observe the volume list
+5. Toggle the archive filter (the `Show archived` / archive filter control) to include archived items
+6. Locate the `tc004-archive-me` card again
+7. Click **Open** to navigate to the detail page
+
+## Expected Result
+
+| Check | Expected |
+|-------|----------|
+| Confirm dialog | Confirmation dialog text references `tc004-archive-me` |
+| Card hidden | After archiving and with archive filter off, the card no longer appears |
+| Filter reveals card | After enabling archive filter, the card reappears with `archived` status badge |
+| Edit disabled | The card's **Edit** button is disabled |
+| Archive button hidden | The **Archive** button is no longer rendered on the card |
+| Detail page status | Detail page shows `archived` badge and an `Archived` activity timestamp |
+| Detail Edit disabled | Detail page **Edit** button is disabled |
+| Detail no Archive | Detail page does not render an **Archive** button |

--- a/test_cases/ui/volumes/TC005_search_volumes.md
+++ b/test_cases/ui/volumes/TC005_search_volumes.md
@@ -1,0 +1,42 @@
+# TC005: Search Volumes by Name
+
+## Description
+
+Verify that the search input on the Volumes page filters the list by name and surfaces the empty state when no volumes match.
+
+## Preconditions
+
+- Server running (`just start-all`)
+- User logged in
+- At least three active volumes exist with distinguishable names, including:
+  - `tc005-alpha`
+  - `tc005-beta`
+  - `tc005-gamma`
+
+## Test Data
+
+| Field | Value |
+|-------|-------|
+| Search query (match) | `alpha` |
+| Search query (no match) | `zzz-no-match` |
+
+## Steps
+
+1. Navigate to `/volumes`
+2. Type `alpha` into the **Search volumes** input
+3. Observe the volume grid
+4. Clear the search field
+5. Type `zzz-no-match` into the search input
+6. Observe the page
+
+## Expected Result
+
+| Check | Expected |
+|-------|----------|
+| Filtered match | Only `tc005-alpha` is visible; `tc005-beta` and `tc005-gamma` are hidden |
+| Clear restores | Clearing the search restores all three cards |
+| No-match empty state | The "No volumes found" empty state renders without a `New Volume` button (it shows only on the unfiltered empty state) |
+
+## Cleanup
+
+- Archive the `tc005-*` volumes after the test.

--- a/test_cases/ui/volumes/TC006_workspace_volumes_capability_config.md
+++ b/test_cases/ui/volumes/TC006_workspace_volumes_capability_config.md
@@ -1,0 +1,58 @@
+# TC006: Workspace Volumes Capability Mount Editor
+
+## Description
+
+Verify that the **Workspace Volumes** capability config editor (on an agent or harness) lets users add, configure, and remove volume mounts, and surfaces inline validation for invalid paths, duplicate paths, and overlapping paths.
+
+## Preconditions
+
+- Server running (`just start-all`)
+- User logged in
+- At least two active volumes exist:
+  - `tc006-research`
+  - `tc006-team-memory`
+- An editable agent or harness with capability configuration access
+
+## Test Data
+
+| Field | Value |
+|-------|-------|
+| Mount 1 volume | `tc006-research` |
+| Mount 1 path (valid) | `/workspace/research` |
+| Mount 1 mode | Read only |
+| Mount 2 volume | `tc006-team-memory` |
+| Mount 2 path (valid) | `/workspace/team-memory` |
+| Mount 2 mode | Read / write |
+| Invalid path | `/etc/passwd` |
+| Overlapping path | `/workspace/research/docs` |
+
+## Steps
+
+1. Open an agent (or harness) edit page that exposes the capability list
+2. Enable / open the **Workspace Volumes** capability configuration
+3. Click **Add mount**
+4. In the new row, select volume `tc006-research`, leave the path empty, then enter `/etc/passwd`
+5. Observe the path error
+6. Change the path to `/workspace/research`, mode `Read only`
+7. Click **Add mount** to add a second row
+8. In the second row, select volume `tc006-team-memory`, set path to `/workspace/team-memory`, mode to `Read / write`
+9. Save the agent / harness
+10. Re-open the same edit page and observe both mount rows are persisted
+11. Click **Add mount** to add a third row, select `tc006-research`, set path to `/workspace/research/docs`
+12. Observe the overlap error
+13. Change the third row path to `/workspace/team-memory` (duplicate of row 2)
+14. Observe the duplicate error
+15. Click the trash icon on the third row to remove it and save again
+
+## Expected Result
+
+| Check | Expected |
+|-------|----------|
+| Volume picker | Combobox lists active volumes including `tc006-research` and `tc006-team-memory`; archived volumes are not selectable |
+| Invalid path error | Path `/etc/passwd` shows `Path must be /workspace or start with /workspace/` |
+| Valid mount accepted | Path `/workspace/research` clears the error |
+| Two mounts persist | After save and reload, both rows are present with the saved volume IDs, paths, and modes |
+| Overlap error | Path `/workspace/research/docs` shows an overlap error referencing `/workspace/research` on both affected rows |
+| Duplicate error | Path equal to an existing mount path shows a `Duplicate mount path` error on both rows |
+| Remove mount | Trash icon removes the row immediately; saving persists the deletion |
+| Empty state hint | If the org has no active volumes, the editor shows "No active volumes found in this org" instead of an empty mount list |


### PR DESCRIPTION
## What
Add manual UI test cases for the Workspace Volumes feature under `test_cases/ui/volumes/` (TC001–TC006) plus a results record from the first run.

## Why
The Volumes spec (`specs/volumes.md`) lists "Manual test cases (`test_cases/volumes/`)" as required coverage at full delivery, but no UI test cases existed for the Volumes page, the volume form/archive dialogs, or the `workspace_volumes` capability mount editor. This fills that gap so the feature has documented manual acceptance criteria matching `specs/test-cases.md`.

## How
- Added `test_cases/ui/volumes/TC001_create_volume.md` through `TC006_workspace_volumes_capability_config.md` covering create, name validation, edit, archive + archive filter, search, and the capability mount editor (volume picker, path validation, overlap/duplicate errors, mount removal).
- Followed the existing format (`Description`, `Preconditions`, `Test Data`, `Steps`, `Expected Result`) and per-leaf TC numbering as described in `specs/test-cases.md`.
- Recorded a first run of all six test cases in `test_cases/ui/volumes/MANUAL_TEST_RESULTS_2026-05-06.md`. All six PASS against `just start-dev --no-watch` with `PORT_PREFIX=271` (auth mode `none`, in-memory storage). Notes capture two quirks observed only under headless Chromium (search-input + Enter to commit a Combobox selection, and scrolling Save Changes into view) that do not affect manual testers.

## Risk
- Low — documentation-only change. No runtime, API, schema, or UI code is modified.

## Security
- Threat categories reviewed: No security-relevant code changes — these are markdown test case files under `test_cases/ui/volumes/` with no code, configuration, or infrastructure modifications.
- Findings and resolutions: None.

## Checklist
- [x] Tests added or updated (manual UI test cases under `test_cases/ui/volumes/`)
- [x] Backward compatibility considered (docs-only)
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)


---
_Generated by [Claude Code](https://claude.ai/code/session_01KYyF21M8RCPtgCdMGpNBDY)_