### PR TITLE
feat(memory): add tag filter UI on Memory page

### DIFF
--- a/apps/ui/src/app/(main)/memory-stores/page.tsx
+++ b/apps/ui/src/app/(main)/memory-stores/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { Brain, Plus, Search, Star, Trash2 } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { Brain, Plus, Search, Star, Trash2, X } from "lucide-react";
 import { QueryStateWrapper } from "@/components/query-state-wrapper";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -61,6 +61,7 @@ export default function MemoryStoresPage() {
   const [selectedStoreId, setSelectedStoreId] = useState<string | null>(null);
   const [search, setSearch] = useState("");
   const [kind, setKind] = useState<string>("all");
+  const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const [detailMemoryId, setDetailMemoryId] = useState<string | null>(null);
 
   const { data: stores, isLoading, error } = useMemoryStores();
@@ -74,14 +75,37 @@ export default function MemoryStoresPage() {
   const memoriesQuery = useMemories(activeStoreId ?? undefined, {
     query: search,
     kind: kind === "all" ? undefined : kind,
+    tag: selectedTags.length > 0 ? selectedTags : undefined,
     limit: 200,
   });
+
+  // Tag chip set: union of tags present in the current results and tags
+  // already selected, so a chip you picked doesn't disappear when the
+  // narrowed result no longer contains it (you can still deselect it).
+  const availableTags = useMemo(() => {
+    const set = new Set<string>(selectedTags);
+    for (const m of memoriesQuery.data?.data ?? []) {
+      for (const t of m.tags) set.add(t);
+    }
+    return Array.from(set).sort();
+  }, [memoriesQuery.data?.data, selectedTags]);
+
+  const toggleTag = (tag: string) => {
+    setSelectedTags((prev) =>
+      prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag],
+    );
+  };
 
   // Close the detail drawer when the memory list it was selected from changes,
   // so a previously-selected memory can't render against the wrong store/forget mutation.
   useEffect(() => {
     setDetailMemoryId(null);
-  }, [activeStoreId, search, kind]);
+  }, [activeStoreId, search, kind, selectedTags]);
+
+  // Reset tag selection on store switch — tags are scoped to a store.
+  useEffect(() => {
+    setSelectedTags([]);
+  }, [activeStoreId]);
 
   return (
     <div className="container mx-auto p-6">
@@ -141,6 +165,15 @@ export default function MemoryStoresPage() {
                 </Select>
               </div>
 
+              {availableTags.length > 0 && (
+                <TagFilter
+                  tags={availableTags}
+                  selected={selectedTags}
+                  onToggle={toggleTag}
+                  onClear={() => setSelectedTags([])}
+                />
+              )}
+
               <QueryStateWrapper
                 isLoading={memoriesQuery.isLoading}
                 error={memoriesQuery.error}
@@ -163,6 +196,8 @@ export default function MemoryStoresPage() {
                           onForget={() => forgetMemory.mutate(memory.id)}
                           forgetting={forgetMemory.isPending}
                           onSelect={() => setDetailMemoryId(memory.id)}
+                          selectedTags={selectedTags}
+                          onToggleTag={toggleTag}
                         />
                       ))}
                     </div>
@@ -255,11 +290,15 @@ function MemoryCard({
   onForget,
   forgetting,
   onSelect,
+  selectedTags,
+  onToggleTag,
 }: {
   memory: Memory;
   onForget: () => void;
   forgetting: boolean;
   onSelect: () => void;
+  selectedTags: string[];
+  onToggleTag: (tag: string) => void;
 }) {
   return (
     <Card
@@ -279,11 +318,34 @@ function MemoryCard({
           <Badge variant="outline">{memory.kind}</Badge>
           <Badge variant="secondary">importance {memory.importance}</Badge>
           {!memory.active && <Badge variant="destructive">forgotten</Badge>}
-          {memory.tags.map((tag) => (
-            <Badge key={tag} variant="outline" className="text-xs">
-              {tag}
-            </Badge>
-          ))}
+          {memory.tags.map((tag) => {
+            const active = selectedTags.includes(tag);
+            return (
+              <button
+                key={tag}
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onToggleTag(tag);
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.stopPropagation();
+                  }
+                }}
+                aria-pressed={active}
+                aria-label={`${active ? "Remove" : "Add"} tag filter ${tag}`}
+                className="cursor-pointer"
+              >
+                <Badge
+                  variant={active ? "default" : "outline"}
+                  className="text-xs hover:border-primary"
+                >
+                  {tag}
+                </Badge>
+              </button>
+            );
+          })}
         </div>
         <Button
           variant="outline"
@@ -453,6 +515,56 @@ function MemoryContentPartView({ part }: { part: MemoryContentPart }) {
   }
   return (
     <pre className="rounded-md border bg-muted/30 p-2 text-xs">{JSON.stringify(part, null, 2)}</pre>
+  );
+}
+
+function TagFilter({
+  tags,
+  selected,
+  onToggle,
+  onClear,
+}: {
+  tags: string[];
+  selected: string[];
+  onToggle: (tag: string) => void;
+  onClear: () => void;
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-1.5">
+      <span className="text-xs font-medium text-muted-foreground">Tags:</span>
+      {tags.map((tag) => {
+        const active = selected.includes(tag);
+        return (
+          <button
+            key={tag}
+            type="button"
+            onClick={() => onToggle(tag)}
+            aria-pressed={active}
+            aria-label={`${active ? "Remove" : "Add"} tag filter ${tag}`}
+            className="cursor-pointer"
+          >
+            <Badge
+              variant={active ? "default" : "outline"}
+              className="text-xs hover:border-primary"
+            >
+              {tag}
+            </Badge>
+          </button>
+        );
+      })}
+      {selected.length > 0 && (
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={onClear}
+          aria-label="Clear tag filters"
+          className="h-6 gap-1 px-2 text-xs"
+        >
+          <X className="h-3 w-3" />
+          Clear
+        </Button>
+      )}
+    </div>
   );
 }
 

--- a/apps/ui/src/app/(main)/memory-stores/page.tsx
+++ b/apps/ui/src/app/(main)/memory-stores/page.tsx
@@ -92,7 +92,7 @@ export default function MemoryStoresPage() {
 
   const toggleTag = (tag: string) => {
     setSelectedTags((prev) =>
-      prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag],
+      prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag].sort(),
     );
   };
 


### PR DESCRIPTION
## What
Multi-select tag filter on `/memory-stores`. Tags from the currently loaded memory set are rendered as chips above the memory list. Selecting one or more chips narrows the visible memories to those that contain all selected tags (server already AND-matches repeated `tag` params). Tag badges on each memory card are now buttons that toggle the tag in the filter without opening the detail drawer. A "Clear" button resets the filter. Switching stores also resets the selection.

## Why
`GET /v1/memory-stores/{id}/memories` accepts repeated `tag` parameters but the page only exposed search and kind filters. Resolves EVE-427.

## How
- New `selectedTags: string[]` state plus a `toggleTag` helper.
- `availableTags` computed as the union of (tags in current results, currently selected tags) and sorted, so a picked chip doesn't disappear when narrowing removes the only memory that has it.
- New `TagFilter` component renders the chip row plus a "Clear" button (visible only when something is selected). Chips use `aria-pressed` to expose toggle state to screen readers.
- `MemoryCard` tag badges are now `<button>` elements that call `onToggleTag` and stop click/keydown propagation so they don't also open the detail drawer added in #1689.
- `useMemories` is invoked with `tag: selectedTags` only when non-empty (to keep the param off the URL otherwise). The existing API client already serializes the array as repeated `tag=...` params.
- The drawer-close `useEffect` now also depends on `selectedTags` so a previously-selected memory can't render against a result it has dropped out of.

## Risk
- Low.
- UI-only; no API, schema, or auth changes.
- Drawer/forget flow re-uses the same staleness guard from #1689; new dependency `selectedTags` extends it.

## Security
- Threat categories reviewed: TM-WEB.
- Findings: none. Tag values are derived solely from server-returned `Memory.tags` payloads (already authorized via `MEMORY_STORE_VIEW`) and rendered through React's escaping. They flow back to the server only as `tag=` query params on the same authorized endpoint. No new endpoints, no new auth surface.

## Checklist
- [x] Tests added or updated — n/a; behavioural change covered by `npm run build` typecheck and lint pass; tag chip toggle and clear are pure state with no asynchronous edges.
- [x] Backward compatibility considered — internal feature, no external consumers.
- [x] Security review performed against relevant threat model categories — TM-WEB, no findings.
- [x] All review comments addressed — none yet.

## Validation
- `npm run lint` — clean (no new warnings on touched files).
- `npm run format:check` — clean.
- `npm run build` — clean.
- `bash scripts/lib/check-migration-ordering.sh` — sequential.
- `just pre-push` — all 8 checks pass.
- Smoke: skipped live stack run; build + types + lint cover the changed surface (UI-only state + chip rendering, no runtime side effects beyond passing tags into an existing query).

Resolves EVE-427.


---
_Generated by [Claude Code](https://claude.ai/code/session_015BYbYvipV68CVZ1KyGBQRy)_