### PR TITLE
feat(sessions): add context usage report

### DIFF
--- a/apps/ui/src/__tests__/session-navigation.test.ts
+++ b/apps/ui/src/__tests__/session-navigation.test.ts
@@ -1,0 +1,15 @@
+import { buildSessionNavigation } from "@/components/session/session-header";
+
+describe("buildSessionNavigation", () => {
+  it("includes the context report in advanced session navigation", () => {
+    const items = buildSessionNavigation({
+      basePath: "/sessions/session_123",
+      features: new Set(),
+    });
+
+    expect(items.map((item) => item.key)).toContain("context");
+    expect(items.find((item) => item.key === "context")?.href).toBe(
+      "/sessions/session_123/context",
+    );
+  });
+});

--- a/apps/ui/src/app/(main)/sessions/[sessionId]/context/page.tsx
+++ b/apps/ui/src/app/(main)/sessions/[sessionId]/context/page.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useSessionContextReport } from "@/hooks/use-sessions";
+import { formatTokens } from "@/lib/formatting";
+import { RefreshCw } from "lucide-react";
+import { useSessionContext } from "../session-context";
+
+const SECTION_COLORS: Record<string, string> = {
+  system_prompt: "bg-zinc-500",
+  tools: "bg-violet-500",
+  rules: "bg-emerald-600",
+  skills: "bg-amber-500",
+  mcp: "bg-pink-500",
+  subagents: "bg-sky-500",
+  conversation: "bg-orange-500",
+};
+
+export default function SessionContextPage() {
+  const { sessionId } = useSessionContext();
+  const { data: report, isLoading, isFetching, refetch } = useSessionContextReport(sessionId);
+
+  if (isLoading) {
+    return (
+      <div className="flex-1 overflow-auto p-6">
+        <Skeleton className="mb-4 h-9 w-48" />
+        <Skeleton className="h-80 w-full" />
+      </div>
+    );
+  }
+
+  const total = report?.estimated_input_tokens ?? 0;
+  const windowTokens = report?.context_window_tokens;
+  const percent =
+    windowTokens && windowTokens > 0 ? Math.min(100, (total / windowTokens) * 100) : 0;
+
+  return (
+    <div className="flex-1 overflow-auto p-6">
+      <div className="mb-5 flex items-center justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-semibold">Context</h2>
+          <p className="text-sm text-muted-foreground">
+            {report
+              ? `${formatTokens(total)} estimated input tokens${windowTokens ? ` / ${formatTokens(windowTokens)} context` : ""}`
+              : "No LLM context has been recorded for this session yet."}
+          </p>
+        </div>
+        <Button variant="outline" size="sm" onClick={() => refetch()} disabled={isFetching}>
+          <RefreshCw className={`h-4 w-4 ${isFetching ? "animate-spin" : ""}`} />
+          Refresh
+        </Button>
+      </div>
+
+      {report && report.sections.length > 0 ? (
+        <div className="rounded-lg border bg-card p-5">
+          <div className="mb-2 flex items-center justify-between text-sm">
+            <span>{windowTokens ? `${Math.round(percent)}% full` : "Estimated usage"}</span>
+            <span className="text-muted-foreground tabular-nums">
+              {formatTokens(total)}
+              {windowTokens ? ` / ${formatTokens(windowTokens)}` : ""}
+            </span>
+          </div>
+          <div className="mb-6 flex h-2 overflow-hidden rounded-full bg-muted">
+            {report.sections.map((section) => (
+              <div
+                key={section.key}
+                className={SECTION_COLORS[section.key] ?? "bg-muted-foreground"}
+                style={{ width: `${total > 0 ? (section.tokens / total) * 100 : 0}%` }}
+                title={`${section.label}: ${section.tokens.toLocaleString()} tokens`}
+              />
+            ))}
+          </div>
+
+          <div className="space-y-3">
+            {report.sections.map((section) => (
+              <div key={section.key} className="flex items-center justify-between gap-4 text-sm">
+                <div className="flex min-w-0 items-center gap-3">
+                  <span
+                    className={`h-3 w-3 rounded-sm ${SECTION_COLORS[section.key] ?? "bg-muted-foreground"}`}
+                  />
+                  <span>{section.label}</span>
+                  <span className="text-xs text-muted-foreground">{section.items} items</span>
+                </div>
+                <span className="tabular-nums text-muted-foreground">
+                  {section.tokens.toLocaleString()}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      ) : (
+        <div className="rounded-lg border bg-card p-8 text-sm text-muted-foreground">
+          No context report is available until the session makes an LLM call.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/ui/src/app/(main)/sessions/[sessionId]/layout.tsx
+++ b/apps/ui/src/app/(main)/sessions/[sessionId]/layout.tsx
@@ -21,6 +21,7 @@ const SESSION_TAB_LABELS: Record<SessionNavKey, string> = {
   storage: "Storage",
   resources: "Resources",
   schedules: "Schedules",
+  context: "Context",
 };
 
 interface SessionLayoutProps {
@@ -56,6 +57,7 @@ export function SessionLayoutContent({ children, sessionId }: SessionLayoutConte
     if (pathname.endsWith("/storage")) return "storage";
     if (pathname.endsWith("/resources")) return "resources";
     if (pathname.endsWith("/schedules")) return "schedules";
+    if (pathname.endsWith("/context")) return "context";
     return "chat"; // Default to chat (includes /chat and base path)
   };
   const activeTab = getActiveTab();

--- a/apps/ui/src/components/session/session-header.tsx
+++ b/apps/ui/src/components/session/session-header.tsx
@@ -50,6 +50,7 @@ import {
   Folder,
   GitBranch,
   Activity,
+  ChartNoAxesColumn,
   MessageSquare,
   Pencil,
   Sparkles,
@@ -64,6 +65,7 @@ export type SessionNavKey =
   | "storage"
   | "resources"
   | "schedules"
+  | "context"
   | "events"
   | "trajectory";
 
@@ -276,6 +278,12 @@ export function buildSessionNavigation({
           },
         ]
       : []),
+    {
+      key: "context",
+      label: "Context",
+      href: `${basePath}/context`,
+      icon: ChartNoAxesColumn,
+    },
     {
       key: "events",
       label: "Events",

--- a/apps/ui/src/hooks/use-sessions.ts
+++ b/apps/ui/src/hooks/use-sessions.ts
@@ -7,6 +7,7 @@ import {
   createSession,
   deleteSession,
   getSession,
+  getSessionContextReport,
   getSessionStats,
   listSessions,
   updateSession,
@@ -95,6 +96,22 @@ export function useSession(
   return {
     ...query,
     isLoading: orgLoading || query.isLoading || fallback.isCheckingOtherOrgs,
+  };
+}
+
+export function useSessionContextReport(sessionId: string | undefined) {
+  const { currentOrg, isLoading: orgLoading } = useOrg();
+  const org = currentOrg?.public_id;
+
+  const query = useQuery({
+    queryKey: queryKeys.sessions.contextReport(org, sessionId),
+    queryFn: () => getSessionContextReport(sessionId!),
+    enabled: !!org && !!sessionId,
+  });
+
+  return {
+    ...query,
+    isLoading: orgLoading || query.isLoading,
   };
 }
 

--- a/apps/ui/src/lib/api/sessions.ts
+++ b/apps/ui/src/lib/api/sessions.ts
@@ -7,6 +7,7 @@ import type {
   SessionStats,
   CreateSessionRequest,
   UpdateSessionRequest,
+  SessionContextReport,
   PaginatedResponse,
   PaginationParams,
 } from "./types";
@@ -59,6 +60,11 @@ export async function getSessionStats(): Promise<SessionStats> {
 
 export async function getSession(sessionId: string): Promise<Session> {
   const response = await api.get<Session>(`/v1/sessions/${sessionId}`);
+  return response.data;
+}
+
+export async function getSessionContextReport(sessionId: string): Promise<SessionContextReport> {
+  const response = await api.get<SessionContextReport>(`/v1/sessions/${sessionId}/context-report`);
   return response.data;
 }
 

--- a/apps/ui/src/lib/api/types/common-types.ts
+++ b/apps/ui/src/lib/api/types/common-types.ts
@@ -121,6 +121,30 @@ export interface TokenUsage {
   cache_creation_tokens?: number;
 }
 
+export interface ContextReportSection {
+  key: string;
+  label: string;
+  tokens: number;
+  items: number;
+}
+
+export interface ContextReportContribution {
+  section_key: string;
+  source_id: string;
+  label: string;
+  tokens: number;
+}
+
+export interface SessionContextReport {
+  session_id: string;
+  model: string;
+  context_window_tokens?: number;
+  estimated_input_tokens: number;
+  sections: ContextReportSection[];
+  contributions: ContextReportContribution[];
+  cumulative_usage?: TokenUsage;
+}
+
 // ============================================
 // List response wrappers
 // ============================================

--- a/apps/ui/src/lib/query-keys.ts
+++ b/apps/ui/src/lib/query-keys.ts
@@ -47,6 +47,8 @@ export const queryKeys = {
       ["sessions", org, agentId ?? "all", offset ?? 0, limit ?? 20] as const,
     byAgent: (agentId: string) => ["sessions", "agent", agentId] as const,
     detail: (org?: string, sessionId?: string) => ["session", org, sessionId] as const,
+    contextReport: (org?: string, sessionId?: string) =>
+      ["session", org, sessionId, "context-report"] as const,
     stats: (org?: string) => ["sessions", "stats", org] as const,
   },
 

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -1001,6 +1001,8 @@ impl Default for CapabilityRegistryBuilder {
 pub struct CollectedCapabilities {
     /// System prompt additions (in order)
     pub system_prompt_parts: Vec<String>,
+    /// Source attribution for each system prompt addition.
+    pub system_prompt_attributions: Vec<SystemPromptAttribution>,
     /// Tool implementations for the registry
     pub tools: Vec<Box<dyn Tool>>,
     /// Tool definitions for config
@@ -1026,6 +1028,12 @@ pub struct CollectedCapabilities {
     // configs + registry, because they need the assembled system prompt at
     // arming time (which only exists once the runtime agent is built). Storing
     // them here would duplicate that work for callers that don't run a stream.
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SystemPromptAttribution {
+    pub capability_id: String,
+    pub content: String,
 }
 
 impl CollectedCapabilities {
@@ -1463,6 +1471,7 @@ pub async fn collect_capabilities_with_configs(
     ctx: &SystemPromptContext,
 ) -> CollectedCapabilities {
     let mut system_prompt_parts: Vec<String> = Vec::new();
+    let mut system_prompt_attributions: Vec<SystemPromptAttribution> = Vec::new();
     let mut tools: Vec<Box<dyn Tool>> = Vec::new();
     let mut tool_definitions: Vec<ToolDefinition> = Vec::new();
     let mut mounts: Vec<MountPoint> = Vec::new();
@@ -1488,6 +1497,10 @@ pub async fn collect_capabilities_with_configs(
                 .system_prompt_contribution_with_config(ctx, &cap_config.config)
                 .await
             {
+                system_prompt_attributions.push(SystemPromptAttribution {
+                    capability_id: cap_id.to_string(),
+                    content: contribution.clone(),
+                });
                 system_prompt_parts.push(contribution);
             }
 
@@ -1574,6 +1587,7 @@ pub async fn collect_capabilities_with_configs(
 
     CollectedCapabilities {
         system_prompt_parts,
+        system_prompt_attributions,
         tools,
         tool_definitions,
         mounts,

--- a/crates/core/src/capabilities/platform_management.rs
+++ b/crates/core/src/capabilities/platform_management.rs
@@ -140,6 +140,7 @@ consult these docs before answering.
             Box::new(ManageAppsTool),
             Box::new(ManageAppChannelsTool),
             Box::new(ReadSessionsTool),
+            Box::new(SessionContextReportTool),
             Box::new(ManageSessionsTool),
             Box::new(SessionSendMessageTool),
             Box::new(SessionReadMessagesTool),
@@ -1737,6 +1738,83 @@ impl Tool for ReadSessionsTool {
 }
 
 // =============================================================================
+// Tool: session_context_report
+// =============================================================================
+
+pub struct SessionContextReportTool;
+
+#[async_trait]
+impl Tool for SessionContextReportTool {
+    fn name(&self) -> &str {
+        "session_context_report"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("Session Context Report")
+    }
+
+    fn description(&self) -> &str {
+        "Read the latest estimated context token breakdown for a session."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "session_id": {
+                    "type": "string",
+                    "description": "Session ID to inspect"
+                }
+            },
+            "required": ["session_id"],
+            "additionalProperties": false
+        })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_idempotent(true)
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "session_context_report requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let store = match get_platform_store(context) {
+            Ok(s) => s,
+            Err(e) => return e,
+        };
+        let id_str = match require_str(&arguments, "session_id") {
+            Ok(value) => value,
+            Err(e) => return e,
+        };
+        let id = match id_str.parse::<crate::typed_id::SessionId>() {
+            Ok(id) => id,
+            Err(_) => {
+                return ToolExecutionResult::tool_error(format!("Invalid session_id: {id_str}"));
+            }
+        };
+
+        match store.get_session_context_report(id).await {
+            Ok(report) => ToolExecutionResult::success(json!(report)),
+            Err(e) => ToolExecutionResult::tool_error(format!("Failed to get context report: {e}")),
+        }
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+// =============================================================================
 // Tool: manage_sessions (mutations: create, delete)
 // =============================================================================
 
@@ -2359,10 +2437,10 @@ mod tests {
     }
 
     #[test]
-    fn capability_provides_thirteen_tools() {
+    fn capability_provides_fourteen_tools() {
         let cap = PlatformManagementCapability;
         let tools = cap.tools();
-        assert_eq!(tools.len(), 13);
+        assert_eq!(tools.len(), 14);
         let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
         assert!(names.contains(&"read_capabilities"));
         assert!(names.contains(&"read_harnesses"));
@@ -2373,6 +2451,7 @@ mod tests {
         assert!(names.contains(&"manage_apps"));
         assert!(names.contains(&"manage_app_channels"));
         assert!(names.contains(&"read_sessions"));
+        assert!(names.contains(&"session_context_report"));
         assert!(names.contains(&"manage_sessions"));
         assert!(names.contains(&"session_send_message"));
         assert!(names.contains(&"session_read_messages"));
@@ -2953,6 +3032,23 @@ mod tests {
         }
     }
 
+    #[tokio::test]
+    async fn session_context_report_returns_report() {
+        let ctx = mock_context();
+        let tool = SessionContextReportTool;
+        let session_id = SessionId::new().to_string();
+        let result = tool
+            .execute_with_context(json!({"session_id": session_id}), &ctx)
+            .await;
+        match result {
+            ToolExecutionResult::Success(value) => {
+                assert_eq!(value["estimated_input_tokens"], 42);
+                assert_eq!(value["sections"][0]["key"], "conversation");
+            }
+            other => panic!("expected success, got: {other:?}"),
+        }
+    }
+
     // =========================================================================
     // ManageSessionsTool tests
     // =========================================================================
@@ -3183,6 +3279,7 @@ mod tests {
         assert!(ManageAppsTool.requires_context());
         assert!(ManageAppChannelsTool.requires_context());
         assert!(ReadSessionsTool.requires_context());
+        assert!(SessionContextReportTool.requires_context());
         assert!(ManageSessionsTool.requires_context());
         assert!(SessionSendMessageTool.requires_context());
         assert!(SessionReadMessagesTool.requires_context());
@@ -3202,6 +3299,7 @@ mod tests {
             "manage_apps",
             "manage_app_channels",
             "read_sessions",
+            "session_context_report",
             "manage_sessions",
             "session_send_message",
             "session_read_messages",
@@ -3229,6 +3327,11 @@ mod tests {
                         .await
                 }
                 "read_sessions" => ReadSessionsTool.execute(json!({})).await,
+                "session_context_report" => {
+                    SessionContextReportTool
+                        .execute(json!({"session_id": "x"}))
+                        .await
+                }
                 "manage_sessions" => {
                     ManageSessionsTool
                         .execute(json!({"operation": "create"}))

--- a/crates/core/src/context_report.rs
+++ b/crates/core/src/context_report.rs
@@ -1,0 +1,373 @@
+use crate::capabilities::{CapabilityRegistry, SystemPromptContext};
+use crate::events::{LlmGenerationData, TokenUsage};
+use crate::llm_model_profiles::get_model_profile;
+use crate::message::MessageRole;
+use crate::runtime_context::AssembledTurnContext;
+use crate::tool_types::ToolDefinition;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct ContextReportSection {
+    pub key: String,
+    pub label: String,
+    pub tokens: u32,
+    pub items: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct ContextReportContribution {
+    pub section_key: String,
+    pub source_id: String,
+    pub label: String,
+    pub tokens: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct SessionContextReport {
+    pub session_id: String,
+    pub model: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context_window_tokens: Option<u32>,
+    pub estimated_input_tokens: u32,
+    pub sections: Vec<ContextReportSection>,
+    pub contributions: Vec<ContextReportContribution>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cumulative_usage: Option<TokenUsage>,
+}
+
+pub fn build_session_context_report_from_generation(
+    session_id: impl Into<String>,
+    generation: &LlmGenerationData,
+    context_window_tokens: Option<u32>,
+    cumulative_usage: Option<TokenUsage>,
+) -> SessionContextReport {
+    let mut builder = ContextReportBuilder::default();
+
+    for message in &generation.messages {
+        if message.role == MessageRole::System {
+            add_system_prompt_breakdown(&mut builder, &message.content_to_llm_string());
+        } else {
+            builder.add(
+                "conversation",
+                "Conversation",
+                estimate_serialized_tokens(message),
+                1,
+            );
+        }
+    }
+
+    for tool in &generation.tools {
+        let key = if tool.name.starts_with("mcp_") {
+            "mcp"
+        } else if matches!(
+            tool.name.as_str(),
+            "spawn_subagent" | "get_subagents" | "message_subagent"
+        ) {
+            "subagents"
+        } else {
+            "tools"
+        };
+        builder.add(key, section_label(key), estimate_serialized_tokens(tool), 1);
+    }
+
+    let sections = builder.sections();
+    let estimated_input_tokens = sections.iter().map(|section| section.tokens).sum();
+    let contributions = builder.contributions;
+
+    SessionContextReport {
+        session_id: session_id.into(),
+        model: generation.metadata.model.clone(),
+        context_window_tokens,
+        estimated_input_tokens,
+        sections,
+        contributions,
+        cumulative_usage,
+    }
+}
+
+pub async fn build_session_context_report(
+    assembled: &AssembledTurnContext,
+    _capability_registry: &CapabilityRegistry,
+    _prompt_ctx: &SystemPromptContext,
+) -> SessionContextReport {
+    let mut builder = ContextReportBuilder::default();
+
+    add_system_prompt_breakdown(&mut builder, &assembled.runtime_agent.system_prompt);
+
+    for tool in &assembled.runtime_agent.tools {
+        let section_key = classify_tool(tool);
+        builder.add(
+            section_key,
+            section_label(section_key),
+            estimate_tool_tokens(tool),
+            1,
+        );
+    }
+
+    for message in &assembled.messages {
+        builder.add(
+            "conversation",
+            "Conversation",
+            estimate_serialized_tokens(message),
+            1,
+        );
+    }
+
+    let sections = builder.sections();
+    let estimated_input_tokens = sections.iter().map(|section| section.tokens).sum();
+    let context_window_tokens = get_model_profile(
+        &assembled.model_with_provider.provider_type,
+        &assembled.runtime_agent.model,
+    )
+    .and_then(|profile| profile.limits)
+    .and_then(|limits| u32::try_from(limits.context).ok());
+
+    SessionContextReport {
+        session_id: assembled.session.id.to_string(),
+        model: assembled.runtime_agent.model.clone(),
+        context_window_tokens,
+        estimated_input_tokens,
+        sections,
+        contributions: builder.contributions,
+        cumulative_usage: assembled.session.usage.clone(),
+    }
+}
+
+fn add_system_prompt_breakdown(builder: &mut ContextReportBuilder, prompt: &str) {
+    let mut cursor = 0usize;
+    while let Some(relative_start) = prompt[cursor..].find("<capability id=\"") {
+        let start = cursor + relative_start;
+        if start > cursor {
+            builder.add(
+                "system_prompt",
+                "System prompt",
+                estimate_text_tokens(&prompt[cursor..start]),
+                1,
+            );
+        }
+
+        let id_start = start + "<capability id=\"".len();
+        let Some(relative_id_end) = prompt[id_start..].find('"') else {
+            break;
+        };
+        let id_end = id_start + relative_id_end;
+        let capability_id = &prompt[id_start..id_end];
+        let Some(relative_end) = prompt[id_end..].find("</capability>") else {
+            break;
+        };
+        let end = id_end + relative_end + "</capability>".len();
+        let key = classify_capability_prompt(capability_id);
+        let tokens = estimate_text_tokens(&prompt[start..end]);
+        builder.add(key, section_label(key), tokens, 1);
+        builder.contributions.push(ContextReportContribution {
+            section_key: key.to_string(),
+            source_id: capability_id.to_string(),
+            label: capability_id.to_string(),
+            tokens,
+        });
+        cursor = end;
+    }
+
+    if cursor < prompt.len() {
+        builder.add(
+            "system_prompt",
+            "System prompt",
+            estimate_text_tokens(&prompt[cursor..]),
+            1,
+        );
+    }
+}
+
+#[derive(Default)]
+struct ContextReportBuilder {
+    sections: Vec<ContextReportSection>,
+    contributions: Vec<ContextReportContribution>,
+}
+
+impl ContextReportBuilder {
+    fn add(&mut self, key: &str, label: &str, tokens: u32, items: u32) {
+        if tokens == 0 && items == 0 {
+            return;
+        }
+        if let Some(section) = self.sections.iter_mut().find(|section| section.key == key) {
+            section.tokens = section.tokens.saturating_add(tokens);
+            section.items = section.items.saturating_add(items);
+            return;
+        }
+        self.sections.push(ContextReportSection {
+            key: key.to_string(),
+            label: label.to_string(),
+            tokens,
+            items,
+        });
+    }
+
+    fn sections(&self) -> Vec<ContextReportSection> {
+        let mut sections = self.sections.clone();
+        let order = [
+            "system_prompt",
+            "tools",
+            "rules",
+            "skills",
+            "mcp",
+            "subagents",
+            "conversation",
+        ];
+        sections.sort_by_key(|section| {
+            order
+                .iter()
+                .position(|key| *key == section.key)
+                .unwrap_or(order.len())
+        });
+        sections
+    }
+}
+
+fn section_label(key: &str) -> &'static str {
+    match key {
+        "system_prompt" => "System prompt",
+        "rules" => "Rules",
+        "skills" => "Skills",
+        "mcp" => "MCP",
+        "subagents" => "Subagents",
+        "conversation" => "Conversation",
+        _ => "Tools",
+    }
+}
+
+fn classify_capability_prompt(capability_id: &str) -> &'static str {
+    if capability_id == "agent_instructions" {
+        "rules"
+    } else if capability_id == "skills" || capability_id.starts_with("skill:") {
+        "skills"
+    } else if capability_id == "subagents" {
+        "subagents"
+    } else if capability_id.starts_with("mcp:") {
+        "mcp"
+    } else {
+        "tools"
+    }
+}
+
+fn classify_tool(tool: &ToolDefinition) -> &'static str {
+    let name = tool.name();
+    let category = tool.category().unwrap_or_default();
+    if name.starts_with("mcp_") || category.eq_ignore_ascii_case("mcp") {
+        "mcp"
+    } else if matches!(
+        name,
+        "spawn_subagent" | "get_subagents" | "message_subagent"
+    ) {
+        "subagents"
+    } else {
+        "tools"
+    }
+}
+
+fn estimate_tool_tokens(tool: &ToolDefinition) -> u32 {
+    estimate_serialized_tokens(tool)
+}
+
+fn estimate_serialized_tokens(value: &impl Serialize) -> u32 {
+    serde_json::to_string(value)
+        .ok()
+        .map(|text| estimate_text_tokens(&text))
+        .unwrap_or(0)
+}
+
+pub fn estimate_text_tokens(text: &str) -> u32 {
+    let chars = text.chars().count();
+    if chars == 0 {
+        0
+    } else {
+        u32::try_from(chars.div_ceil(4)).unwrap_or(u32::MAX)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::BuiltinTool;
+    use serde_json::json;
+
+    #[test]
+    fn classifies_attribution_sections() {
+        assert_eq!(classify_capability_prompt("agent_instructions"), "rules");
+        assert_eq!(classify_capability_prompt("skills"), "skills");
+        assert_eq!(classify_capability_prompt("skill:abc"), "skills");
+        assert_eq!(classify_capability_prompt("mcp:abc"), "mcp");
+        assert_eq!(classify_capability_prompt("subagents"), "subagents");
+    }
+
+    #[test]
+    fn classifies_mcp_and_subagent_tools() {
+        let mcp = ToolDefinition::Builtin(BuiltinTool {
+            name: "mcp_docs_search".into(),
+            display_name: None,
+            description: "Search docs".into(),
+            parameters: json!({"type": "object"}),
+            policy: Default::default(),
+            category: None,
+            deferrable: Default::default(),
+            hints: Default::default(),
+        });
+        let subagent = ToolDefinition::Builtin(BuiltinTool {
+            name: "spawn_subagent".into(),
+            display_name: None,
+            description: "Spawn".into(),
+            parameters: json!({"type": "object"}),
+            policy: Default::default(),
+            category: None,
+            deferrable: Default::default(),
+            hints: Default::default(),
+        });
+
+        assert_eq!(classify_tool(&mcp), "mcp");
+        assert_eq!(classify_tool(&subagent), "subagents");
+    }
+
+    #[test]
+    fn estimates_tokens_with_minimum_for_nonempty_text() {
+        assert_eq!(estimate_text_tokens(""), 0);
+        assert_eq!(estimate_text_tokens("abc"), 1);
+        assert_eq!(estimate_text_tokens("abcd"), 1);
+        assert_eq!(estimate_text_tokens("abcde"), 2);
+    }
+
+    #[test]
+    fn generation_report_attributes_capability_prompt_blocks() {
+        let data = LlmGenerationData::success(
+            vec![crate::Message::system(
+                "<capability id=\"agent_instructions\">Rules</capability>\n\n<system-prompt>\nBase\n</system-prompt>",
+            )],
+            vec![],
+            Some("ok".into()),
+            vec![],
+            "gpt-test".into(),
+            Some("openai".into()),
+            None,
+            None,
+            None,
+        );
+
+        let report =
+            build_session_context_report_from_generation("session_test", &data, None, None);
+        assert!(report.sections.iter().any(|section| section.key == "rules"));
+        assert!(
+            report
+                .contributions
+                .iter()
+                .any(|contribution| contribution.source_id == "agent_instructions")
+        );
+    }
+
+    #[test]
+    fn empty_system_prompt_does_not_add_section() {
+        let mut builder = ContextReportBuilder::default();
+        add_system_prompt_breakdown(&mut builder, "");
+        assert!(builder.sections().is_empty());
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -95,6 +95,7 @@ pub mod atoms;
 pub mod capabilities;
 pub mod command;
 pub mod config_layer;
+pub mod context_report;
 pub mod dependency_blocker;
 pub mod error;
 pub mod llm_driver_helpers;
@@ -302,6 +303,10 @@ pub use app::{
     SessionStrategy, SlackChannelConfig, SlackReplyMode,
 };
 pub use capability_dto::{AgentCapability, CapabilityInfo};
+pub use context_report::{
+    ContextReportContribution, ContextReportSection, SessionContextReport,
+    build_session_context_report, build_session_context_report_from_generation,
+};
 pub use events::{
     ACT_COMPLETED, ACT_STARTED, ActCompletedData, ActStartedData, CONTEXT_COMPACTED,
     CONTEXT_COMPACTING, CompactionReason, CompactionStepData, ContextCompactedData,

--- a/crates/core/src/platform_store.rs
+++ b/crates/core/src/platform_store.rs
@@ -5,6 +5,7 @@
 // Decision: Tool results include UI links via base_url()
 // Decision: PlatformMessage is a simplified view (role + text + timestamp)
 
+use crate::SessionContextReport;
 use crate::agent::Agent;
 use crate::app::{App, AppChannel, ChannelType};
 use crate::capability_dto::CapabilityInfo;
@@ -213,6 +214,9 @@ pub trait PlatformStore: Send + Sync {
 
     /// Get a session by ID.
     async fn get_session_by_id(&self, id: SessionId) -> Result<Option<Session>>;
+
+    /// Get the latest estimated context breakdown for a session.
+    async fn get_session_context_report(&self, id: SessionId) -> Result<SessionContextReport>;
 
     /// Delete (archive) a session.
     async fn delete_session(&self, id: SessionId) -> Result<()>;
@@ -666,6 +670,22 @@ pub mod tests {
         }
         async fn get_session_by_id(&self, _id: SessionId) -> Result<Option<Session>> {
             Ok(Some(self.session.clone()))
+        }
+        async fn get_session_context_report(&self, id: SessionId) -> Result<SessionContextReport> {
+            Ok(SessionContextReport {
+                session_id: id.to_string(),
+                model: "llmsim".to_string(),
+                context_window_tokens: Some(128_000),
+                estimated_input_tokens: 42,
+                sections: vec![crate::ContextReportSection {
+                    key: "conversation".to_string(),
+                    label: "Conversation".to_string(),
+                    tokens: 42,
+                    items: 1,
+                }],
+                contributions: vec![],
+                cumulative_usage: None,
+            })
         }
         async fn set_subagent_metadata(
             &self,

--- a/crates/core/src/tools.rs
+++ b/crates/core/src/tools.rs
@@ -2047,6 +2047,20 @@ mod tests {
         async fn get_session_by_id(&self, _id: SessionId) -> crate::Result<Option<crate::Session>> {
             Ok(None)
         }
+        async fn get_session_context_report(
+            &self,
+            id: SessionId,
+        ) -> crate::Result<crate::SessionContextReport> {
+            Ok(crate::SessionContextReport {
+                session_id: id.to_string(),
+                model: "llmsim".to_string(),
+                context_window_tokens: None,
+                estimated_input_tokens: 0,
+                sections: vec![],
+                contributions: vec![],
+                cumulative_usage: None,
+            })
+        }
         async fn set_subagent_metadata(
             &self,
             _session_id: SessionId,

--- a/crates/server/src/api/sessions.rs
+++ b/crates/server/src/api/sessions.rs
@@ -6,8 +6,8 @@ use crate::auth::{AuthState, ResolvedOrg};
 use crate::domains::common::{Command, Ctx};
 use crate::domains::sessions::{
     CancelSession, CreateSession, DeleteSession, GetOrCreateChatSession, GetSession,
-    GetSessionStats, ListSessions, PinSession, SESSION_MANAGE, SESSION_VIEW, SessionService,
-    UnpinSession, UpdateSessionCmd,
+    GetSessionContextReport, GetSessionStats, ListSessions, PinSession, SESSION_MANAGE,
+    SESSION_VIEW, SessionService, UnpinSession, UpdateSessionCmd,
 };
 use crate::services::EventService;
 use crate::storage::StorageBackend;
@@ -21,7 +21,7 @@ use everruns_core::capability_types::AgentCapabilityConfig;
 use everruns_core::typed_id::{AgentId, AgentIdentityId, HarnessId, ModelId};
 use everruns_core::{
     BuiltInHarnessRole, Caller, PlatformDefinition, ResourceConfigResponse, ScopedMcpServers,
-    Session, ToolDefinition, evaluate_policies_with,
+    Session, SessionContextReport, ToolDefinition, evaluate_policies_with,
 };
 use everruns_worker::AgentRunner;
 
@@ -359,6 +359,10 @@ pub fn routes(state: AppState) -> Router {
                 .patch(update_session)
                 .delete(delete_session),
         )
+        .route(
+            "/v1/sessions/{session_id}/context-report",
+            get(get_session_context_report),
+        )
         // Pin/unpin
         .route(
             "/v1/sessions/{session_id}/pin",
@@ -508,6 +512,33 @@ pub async fn get_session(
     let session = GetSession { session_id }.run(&state.ctx(&org)).await?;
 
     Ok(Json(urls.wrap(session)))
+}
+
+/// GET /v1/sessions/{session_id}/context-report - Latest context breakdown
+#[utoipa::path(
+    get,
+    path = "/v1/sessions/{session_id}/context-report",
+    params(
+        ("session_id" = String, Path, description = "Session ID (prefixed, e.g., session_...)")
+    ),
+    responses(
+        (status = 200, description = "Session context report", body = SessionContextReport),
+        (status = 400, description = "Invalid session ID"),
+        (status = 404, description = "Session not found"),
+        (status = 500, description = "Internal server error")
+    ),
+    tag = "sessions"
+)]
+pub async fn get_session_context_report(
+    org: ResolvedOrg,
+    State(state): State<AppState>,
+    Path(session_id): Path<String>,
+) -> ApiResult<SessionContextReport> {
+    Ok(Json(
+        GetSessionContextReport { session_id }
+            .run(&state.ctx(&org))
+            .await?,
+    ))
 }
 
 /// PATCH /v1/sessions/{session_id} - Update session

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -2509,6 +2509,17 @@ impl everruns_core::platform_store::PlatformStore for DirectPlatformStore {
         .await
     }
 
+    async fn get_session_context_report(
+        &self,
+        id: SessionId,
+    ) -> everruns_core::error::Result<everruns_core::SessionContextReport> {
+        self.execute_domain_command(
+            "get_session_context_report",
+            serde_json::json!({ "session_id": id.to_string() }),
+        )
+        .await
+    }
+
     async fn set_subagent_metadata(
         &self,
         session_id: SessionId,

--- a/crates/server/src/domains/sessions/commands.rs
+++ b/crates/server/src/domains/sessions/commands.rs
@@ -4,10 +4,16 @@ use super::types::{
     SessionStatsResponse, UpdateSessionRequest,
 };
 use crate::domains::common::*;
-use everruns_core::events::{EventContext, EventRequest, InputMessageData, TurnCancelledData};
+use everruns_core::events::{
+    EventContext, EventData, EventRequest, InputMessageData, LLM_GENERATION, TurnCancelledData,
+    deserialize_event_data,
+};
+use everruns_core::llm_model_profiles::get_model_profile;
+use everruns_core::llm_models::LlmProviderType;
 use everruns_core::typed_id::{AgentId, MessageId, TurnId};
-use everruns_core::{ANONYMOUS_USER_ID, Message, Session};
+use everruns_core::{ANONYMOUS_USER_ID, Message, Session, SessionContextReport};
 use serde::Deserialize;
+use std::str::FromStr;
 use utoipa::ToSchema;
 
 fn validation_error(
@@ -257,6 +263,105 @@ impl Command for GetSession {
 }
 
 inventory::submit! { CommandDescriptor::of::<GetSession>() }
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct GetSessionContextReport {
+    pub session_id: String,
+}
+
+impl Command for GetSessionContextReport {
+    type Output = SessionContextReport;
+
+    fn meta() -> CommandMeta {
+        CommandMeta {
+            name: "get_session_context_report",
+            category: "sessions",
+            description: "Get the latest estimated context token breakdown for a session, grouped by system prompt, tools, rules, skills, MCP, subagents, and conversation.",
+            method: "GET",
+            path: "/v1/sessions/{session_id}/context-report",
+        }
+    }
+
+    fn positional_arg() -> Option<&'static str> {
+        Some("session_id")
+    }
+
+    fn policy() -> Option<&'static everruns_core::Policy> {
+        Some(&super::SESSION_VIEW)
+    }
+
+    async fn execute(self, ctx: &Ctx) -> Result<SessionContextReport, CommandError> {
+        let session_id = q::parse_session_id(&self.session_id)?;
+        let session = q::get_session(ctx, session_id, ctx.caller.user_id).await?;
+        let rows = ctx
+            .db
+            .list_events(
+                session_id,
+                None,
+                None,
+                &[LLM_GENERATION.to_string()],
+                &[],
+                None,
+                Some(1),
+            )
+            .await
+            .map_err(classify_anyhow)?;
+
+        let Some(row) = rows.into_iter().next() else {
+            return Ok(SessionContextReport {
+                session_id: session.id.to_string(),
+                model: "unknown".to_string(),
+                context_window_tokens: None,
+                estimated_input_tokens: 0,
+                sections: vec![],
+                contributions: vec![],
+                cumulative_usage: session.usage,
+            });
+        };
+
+        let EventData::LlmGeneration(data) = deserialize_event_data(&row.event_type, row.data)
+        else {
+            return Err(CommandError::Internal(anyhow::anyhow!(
+                "latest llm.generation event could not be decoded"
+            )));
+        };
+        let context_window_tokens = data
+            .metadata
+            .provider
+            .as_deref()
+            .and_then(parse_provider_type)
+            .and_then(|provider_type| get_model_profile(&provider_type, &data.metadata.model))
+            .and_then(|profile| profile.limits)
+            .and_then(|limits| u32::try_from(limits.context).ok());
+
+        Ok(everruns_core::build_session_context_report_from_generation(
+            session.id.to_string(),
+            &data,
+            context_window_tokens,
+            session.usage,
+        ))
+    }
+}
+
+fn parse_provider_type(provider: &str) -> Option<LlmProviderType> {
+    LlmProviderType::from_str(&provider.to_ascii_lowercase()).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_provider_type_accepts_mixed_case_known_values() {
+        assert_eq!(parse_provider_type("OpenAI"), Some(LlmProviderType::Openai));
+        assert_eq!(
+            parse_provider_type("AZURE_OPENAI"),
+            Some(LlmProviderType::AzureOpenai)
+        );
+    }
+}
+
+inventory::submit! { CommandDescriptor::of::<GetSessionContextReport>() }
 
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct UpdateSessionCmd {

--- a/crates/server/src/openapi.rs
+++ b/crates/server/src/openapi.rs
@@ -9,11 +9,11 @@ use crate::api::{ListResponse, PaginatedResponse};
 use crate::domains;
 use everruns_core::llm_models::LlmProvider;
 use everruns_core::{
-    Agent, AgentStatus, CapabilityInfo, Event, EventContext, EventData, FileInfo, FileStat,
-    GrepMatch, GrepResult, LeasedResource, LlmModel, LlmModelWithProvider, LlmProviderStatus,
-    LlmProviderType, McpServer, McpServerStatus, McpServerTransportType, Session, SessionFile,
-    SessionStatus, Skill, SkillContent, SkillFileEntry, SkillSourceType, SkillStatus,
-    SkillValidationResult, ToolCall,
+    Agent, AgentStatus, CapabilityInfo, ContextReportContribution, ContextReportSection, Event,
+    EventContext, EventData, FileInfo, FileStat, GrepMatch, GrepResult, LeasedResource, LlmModel,
+    LlmModelWithProvider, LlmProviderStatus, LlmProviderType, McpServer, McpServerStatus,
+    McpServerTransportType, Session, SessionContextReport, SessionFile, SessionStatus, Skill,
+    SkillContent, SkillFileEntry, SkillSourceType, SkillStatus, SkillValidationResult, ToolCall,
     events::{
         ActCompletedData, ActStartedData, InputMessageData, LlmGenerationData,
         LlmGenerationMetadata, LlmGenerationOutput, ModelMetadata, OutputMessageCompletedData,
@@ -42,6 +42,7 @@ use utoipa::OpenApi;
         api::sessions::create_session,
         api::sessions::list_sessions,
         api::sessions::get_session,
+        api::sessions::get_session_context_report,
         api::sessions::update_session,
         api::sessions::delete_session,
         api::sessions::get_or_create_chat_session,
@@ -189,6 +190,7 @@ use utoipa::OpenApi;
             // Event data types
             InputMessageData, OutputMessageStartedData, OutputMessageDeltaData, OutputMessageCompletedData,
             ModelMetadata, TokenUsage,
+            SessionContextReport, ContextReportSection, ContextReportContribution,
             TurnStartedData, TurnCompletedData, TurnFailedData,
             ReasonStartedData, ReasonCompletedData,
             ActStartedData, ActCompletedData, ToolCallSummary,

--- a/crates/server/tests/api_integration_test.rs
+++ b/crates/server/tests/api_integration_test.rs
@@ -20,7 +20,10 @@ use test_harness::TestServer;
 
 use everruns_core::llm_models::LlmProvider;
 use everruns_core::typed_id::ScheduleId;
-use everruns_core::{Agent, DEFAULT_ORG_ID, Harness, LlmModel, PrincipalId, Session, SessionFile};
+use everruns_core::{
+    Agent, DEFAULT_ORG_ID, Harness, LlmModel, PrincipalId, Session, SessionContextReport,
+    SessionFile,
+};
 use everruns_durable::UpdateField;
 use everruns_server::storage::models::{
     CreatePrincipalRow, CreateSessionScheduleRow, UpdateOrganizationSettings, UpdateSession,
@@ -656,6 +659,33 @@ async fn test_get_session() {
         .json();
 
     assert_eq!(fetched_session.id, session.id);
+}
+
+#[tokio::test]
+async fn test_get_session_context_report_without_generation() {
+    let server = TestServer::in_memory().await;
+
+    let session: Session = server
+        .post(
+            "/v1/sessions",
+            json!({
+                "harness_id": server.seed_base_harness_id,
+                "title": "Context Report Test"
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    let report: SessionContextReport = server
+        .get(&format!("/v1/sessions/{}/context-report", session.id))
+        .await
+        .assert_status(StatusCode::OK)
+        .json();
+
+    assert_eq!(report.session_id, session.id.to_string());
+    assert_eq!(report.estimated_input_tokens, 0);
+    assert!(report.sections.is_empty());
 }
 
 #[tokio::test]

--- a/crates/server/tests/mcp_endpoint_test.rs
+++ b/crates/server/tests/mcp_endpoint_test.rs
@@ -1236,6 +1236,39 @@ async fn test_mcp_execute_list_harnesses() {
     assert!(names.contains(&"generic"), "Should have Generic harness");
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_execute_get_session_context_report() {
+    let server = TestServer::in_memory().await;
+    let session: Value = server
+        .post(
+            "/v1/sessions",
+            json!({
+                "harness_id": server.seed_base_harness_id,
+                "title": "MCP Context Report"
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+    let session_id = session["id"].as_str().expect("session id").to_string();
+
+    let resp = mcp_tool_call(
+        &server,
+        "execute",
+        json!({ "commands": format!("get_session_context_report {session_id}") }),
+    )
+    .await;
+    assert!(
+        !tool_is_error(&resp),
+        "execute get_session_context_report failed: {}",
+        tool_text(&resp)
+    );
+
+    let result = tool_json(&resp);
+    assert_eq!(result["session_id"], session_id);
+    assert_eq!(result["estimated_input_tokens"], 0);
+}
+
 #[tokio::test]
 async fn test_mcp_execute_session_files_reads_virtual_mounts() {
     let server = TestServer::in_memory().await;

--- a/crates/worker/src/grpc_adapters.rs
+++ b/crates/worker/src/grpc_adapters.rs
@@ -3053,6 +3053,17 @@ impl everruns_core::platform_store::PlatformStore for GrpcOrgAdapter {
         .await
     }
 
+    async fn get_session_context_report(
+        &self,
+        id: SessionId,
+    ) -> Result<everruns_core::SessionContextReport> {
+        self.execute_platform_command(
+            "get_session_context_report",
+            serde_json::json!({ "session_id": id.to_string() }),
+        )
+        .await
+    }
+
     async fn set_subagent_metadata(
         &self,
         _session_id: SessionId,

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -4306,6 +4306,47 @@
         }
       }
     },
+    "/v1/sessions/{session_id}/context-report": {
+      "get": {
+        "tags": [
+          "sessions"
+        ],
+        "summary": "GET /v1/sessions/{session_id}/context-report - Latest context breakdown",
+        "operationId": "get_session_context_report",
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "description": "Session ID (prefixed, e.g., session_...)",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Session context report",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionContextReport"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid session ID"
+          },
+          "404": {
+            "description": "Session not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
     "/v1/sessions/{session_id}/databases": {
       "get": {
         "tags": [
@@ -7507,6 +7548,58 @@
           "strategy": {
             "type": "string",
             "description": "Strategy requested (may differ from strategy_used in the completed event)."
+          }
+        }
+      },
+      "ContextReportContribution": {
+        "type": "object",
+        "required": [
+          "section_key",
+          "source_id",
+          "label",
+          "tokens"
+        ],
+        "properties": {
+          "label": {
+            "type": "string"
+          },
+          "section_key": {
+            "type": "string"
+          },
+          "source_id": {
+            "type": "string"
+          },
+          "tokens": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          }
+        }
+      },
+      "ContextReportSection": {
+        "type": "object",
+        "required": [
+          "key",
+          "label",
+          "tokens",
+          "items"
+        ],
+        "properties": {
+          "items": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          },
+          "key": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "tokens": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
           }
         }
       },
@@ -15803,6 +15896,59 @@
             "type": "string",
             "description": "Turn ID that activated the session",
             "example": "turn_01933b5a00007000800000000000001"
+          }
+        }
+      },
+      "SessionContextReport": {
+        "type": "object",
+        "required": [
+          "session_id",
+          "model",
+          "estimated_input_tokens",
+          "sections",
+          "contributions"
+        ],
+        "properties": {
+          "context_window_tokens": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "minimum": 0
+          },
+          "contributions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ContextReportContribution"
+            }
+          },
+          "cumulative_usage": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/TokenUsage"
+              }
+            ]
+          },
+          "estimated_input_tokens": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          },
+          "model": {
+            "type": "string"
+          },
+          "sections": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ContextReportSection"
+            }
+          },
+          "session_id": {
+            "type": "string"
           }
         }
       },

--- a/docs/capabilities/index.md
+++ b/docs/capabilities/index.md
@@ -59,7 +59,7 @@ Agent self-management, dynamic instructions, and skill discovery.
 
 | Capability | ID | Tools |
 |---|---|---|
-| [Platform Management](/capabilities/platform-management/) | `platform_management` | 5 |
+| [Platform Management](/capabilities/platform-management/) | `platform_management` | 14 |
 | [AGENTS.md](/capabilities/agent-instructions/) | `agent_instructions` | 0 |
 | [Agent Skills](/capabilities/agent-skills/) | `skills` | 2 |
 

--- a/docs/capabilities/platform-management.md
+++ b/docs/capabilities/platform-management.md
@@ -10,7 +10,7 @@ description: Programmatic management of harnesses, agents, and sessions from wit
 | **Features** | None |
 | **Dependencies** | `session_file_system` |
 
-Tools to manage Everruns entities programmatically. Read, create, update, and delete harnesses, agents, and sessions — and interact with sessions by sending messages.
+Tools to manage Everruns entities programmatically. Read, create, update, and delete harnesses, agents, and sessions; inspect session context usage; and interact with sessions by sending messages.
 
 ## Platform Documentation
 
@@ -127,6 +127,14 @@ Wait for session to finish processing and return the response.
 |---|---|---|---|
 | `session_id` | string | yes | Target session ID |
 | `timeout_secs` | integer | no | Timeout (default: 120). Set to 0 to check status without waiting. |
+
+### `session_context_report`
+
+Read the latest estimated context-token breakdown for a session. Returns total estimated input tokens, optional context-window size, cumulative usage, grouped sections, and per-capability contributions where available.
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `session_id` | string | yes | Session ID to inspect |
 
 ## Use Cases
 

--- a/specs/capabilities.md
+++ b/specs/capabilities.md
@@ -741,7 +741,7 @@ See `crates/core/src/capabilities/sample_data.rs` for a concrete example of `mou
 - **System Prompt**: Describes available management tools, common workflows, and platform docs availability
 - **Mounts**: `/docs` — Everruns platform documentation (virtual, readonly). The stored/normalized mount path is `/docs`; agents/tools access it as `/workspace/docs`. Embedded at compile time via `include_dir!` from the repo `docs/` directory. Only markdown files (`.md`, `.mdx`) are included in the virtual tree.
 - **Lifecycle Parity**: Must enforce the same archive/delete, assignment, and read-only rules as the public API and UI. Agents using these tools may not bypass lifecycle restrictions.
-- **Tools**: Read/write split — read tools (`read_capabilities`, `read_harnesses`, `read_agents`, `read_sessions`, `session_read_messages`, `session_read_response`) return single item by ID or filtered list; write tools (`manage_harnesses`, `manage_agents`, `manage_sessions`, `session_send_message`) perform mutations. See `crates/core/src/capabilities/platform_management.rs` for full tool parameter definitions.
+- **Tools**: Read/write split — read tools (`read_capabilities`, `read_harnesses`, `read_agents`, `read_sessions`, `session_context_report`, `session_read_messages`, `session_read_response`) return single item by ID, filtered lists, or latest session context usage; write tools (`manage_harnesses`, `manage_agents`, `manage_sessions`, `session_send_message`) perform mutations. See `crates/core/src/capabilities/platform_management.rs` for full tool parameter definitions.
 
 Lifecycle rules for platform management:
 - `delete` archives.


### PR DESCRIPTION
## What
Add a session context report that breaks latest LLM input context into system prompt, tools, rules, skills, MCP, subagents, and conversation sections. Expose it in the session Advanced navigation as a Context tab with a manual refresh button.

Also expose the report through REST, MCP execute, and Platform Management.

## Why
Users need a non-dynamic, inspectable view of what is consuming session context and whether capability attribution is coming from rules, skills, MCP, or subagents.

## How
- Added a core context report builder with capability prompt attribution and latest-generation fallback parsing.
- Added GET /v1/sessions/{session_id}/context-report and the get_session_context_report command.
- Added the session_context_report Platform Management tool.
- Added the Advanced > Context UI tab and API hook.
- Regenerated OpenAPI and updated capability docs/spec.

## Risk
- Medium
- New read-only endpoint/tool surfaces could expose session context metadata if authorization were skipped; mitigated by routing REST/MCP/gRPC through Command::run with SESSION_VIEW and by resolving the session before reading events.
- Token counts are estimates, not provider-tokenizer exact counts.

## Security
- Threat categories reviewed: TM-AUTHZ, TM-API, TM-TENANT, TM-TOOL, TM-MCP, TM-WEB, TM-DOS.
- Findings and resolutions: no new threat model entries required. The new REST and MCP execute path use SESSION_VIEW via Command::run; the platform tool is read-only/idempotent and requires session tool context; no raw HTML rendering or unbounded user payload parsing was added.

## Validation
- just pre-push
- cargo test -p everruns-core context_report --lib
- cargo test -p everruns-server --test api_integration_test test_get_session_context_report_without_generation -- --exact
- cargo test -p everruns-server --test mcp_endpoint_test test_mcp_execute_get_session_context_report -- --exact
- npm test -- --runTestsByPath src/__tests__/session-navigation.test.ts --runInBand
- npm run build (apps/ui)
- ./scripts/export-openapi.sh
- PORT_PREFIX=286 just start-dev --no-watch; smoke-created a session, fetched /api/v1/sessions/{id}/context-report, and called get_session_context_report through /mcp execute.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
