### PR TITLE
feat(apps): add A2A (Agent2Agent) channel with API key auth

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,6 +149,7 @@ Always make sure you are working on top of latest main from remote.
 - `specs/agent-identities.md` - Agent identities (virtual principals for unattended execution)
 - `specs/agent-blueprints.md` - Pre-built agent definitions (private tools, fixed models, typed config)
 - `specs/messaging-integrations.md` - Messaging integrations (channel abstractions, parity requirements, platform adapters)
+- `specs/a2a-channel.md` - A2A (Agent2Agent) channel for App invocation via JSON-RPC + API key auth
 
 ### Test Cases
 

--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -1034,9 +1034,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1052,9 +1049,6 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1072,9 +1066,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1090,9 +1081,6 @@
       "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1110,9 +1098,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1128,9 +1113,6 @@
       "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1148,9 +1130,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1167,9 +1146,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1185,9 +1161,6 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1211,9 +1184,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1235,9 +1205,6 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1261,9 +1228,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1285,9 +1249,6 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1311,9 +1272,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1336,9 +1294,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1360,9 +1315,6 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2020,9 +1972,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2038,9 +1987,6 @@
       "integrity": "sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2058,9 +2004,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2076,9 +2019,6 @@
       "integrity": "sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2408,9 +2348,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2428,9 +2365,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2448,9 +2382,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2468,9 +2399,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2488,9 +2416,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2508,9 +2433,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2528,9 +2450,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2548,9 +2467,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2755,9 +2671,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2775,9 +2688,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2795,9 +2705,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2815,9 +2722,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2835,9 +2739,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2855,9 +2756,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2875,9 +2773,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2895,9 +2790,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5075,9 +4967,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5095,9 +4984,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5115,9 +5001,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5135,9 +5018,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6050,9 +5930,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6067,9 +5944,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6084,9 +5958,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6101,9 +5972,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6118,9 +5986,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6135,9 +6000,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6152,9 +6014,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6169,9 +6028,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10192,9 +10048,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10216,9 +10069,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10240,9 +10090,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10264,9 +10111,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12093,6 +11937,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/apps/ui/src/app/(main)/apps/[appId]/page.tsx
+++ b/apps/ui/src/app/(main)/apps/[appId]/page.tsx
@@ -17,6 +17,8 @@ import {
   updateChannel as apiUpdateChannel,
   addChannel as apiAddChannel,
   deleteChannel as apiDeleteChannel,
+  addA2aChannel as apiAddA2aChannel,
+  regenerateA2aChannelKey as apiRegenerateA2aChannelKey,
 } from "@/lib/api/apps";
 import { useRouter } from "next/navigation";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
@@ -63,6 +65,7 @@ import {
   RefreshCw,
 } from "lucide-react";
 import { CopyButton } from "@/components/ui/copy-button";
+import { A2aSetupGuidance } from "@/components/apps/a2a-setup-guidance";
 import { AgUiSetupGuidance } from "@/components/apps/ag-ui-setup-guidance";
 import { AppBudgetsCard } from "@/components/apps/app-budgets-card";
 import { ScheduleSetupGuidance } from "@/components/apps/schedule-setup-guidance";
@@ -70,6 +73,7 @@ import { SlackSetupGuidance } from "@/components/apps/slack-setup-guidance";
 import { WebhookSetupGuidance } from "@/components/apps/webhook-setup-guidance";
 import { useFeatureFlag } from "@/providers/feature-flags-provider";
 import type {
+  A2aChannelConfig,
   AgUiChannelConfig,
   AgUiToolVisibility,
   AppChannel,
@@ -106,7 +110,8 @@ type ChannelConfigInput =
   | SlackChannelConfig
   | AgUiChannelConfig
   | ScheduleChannelConfig
-  | WebhookChannelConfig;
+  | WebhookChannelConfig
+  | A2aChannelConfig;
 
 export default function AppDetailPage({ params }: { params: Promise<{ appId: string }> }) {
   const { appId } = use(params);
@@ -162,6 +167,17 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
   const [editAgUiGenericToolText, setEditAgUiGenericToolText] = useState(
     DEFAULT_AG_UI_GENERIC_TOOL_TEXT,
   );
+  const [editA2aAgentCardName, setEditA2aAgentCardName] = useState("");
+  const [editA2aAgentCardDescription, setEditA2aAgentCardDescription] = useState("");
+
+  // A2A: plaintext API key shown exactly once (after create or rotate). Cleared
+  // when the operator dismisses the dialog.
+  const [a2aRevealedKey, setA2aRevealedKey] = useState<{
+    channelId: string;
+    apiKey: string;
+    title: string;
+  } | null>(null);
+  const [rotatingA2aChannelId, setRotatingA2aChannelId] = useState<string | null>(null);
 
   const [creatingSlackApp, setCreatingSlackApp] = useState(false);
 
@@ -207,6 +223,52 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
     },
   });
 
+  const addA2aMutation = useMutation({
+    mutationFn: async (input: {
+      sessionMode: InvocationSessionMode;
+      message: string;
+      agentCardName?: string;
+      agentCardDescription?: string;
+      enabled: boolean;
+    }) => {
+      return apiAddA2aChannel(appId, {
+        session_mode: input.sessionMode,
+        message: input.message,
+        agent_card_name: input.agentCardName,
+        agent_card_description: input.agentCardDescription,
+        enabled: input.enabled,
+      });
+    },
+    onSuccess: (response) => {
+      invalidateApp();
+      setShowAddChannel(false);
+      setA2aRevealedKey({
+        channelId: response.channel.id,
+        apiKey: response.api_key,
+        title: "A2A API key created",
+      });
+    },
+  });
+
+  const rotateA2aMutation = useMutation({
+    mutationFn: async (channelId: string) => {
+      setRotatingA2aChannelId(channelId);
+      try {
+        return await apiRegenerateA2aChannelKey(appId, channelId);
+      } finally {
+        setRotatingA2aChannelId(null);
+      }
+    },
+    onSuccess: (response) => {
+      invalidateApp();
+      setA2aRevealedKey({
+        channelId: response.channel.id,
+        apiKey: response.api_key,
+        title: "A2A API key rotated",
+      });
+    },
+  });
+
   const deleteChannelMutation = useMutation({
     mutationFn: async (channelId: string) => {
       return apiDeleteChannel(appId, channelId);
@@ -244,6 +306,10 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
         case "webhook": {
           const config = channel.channel_config as WebhookChannelConfig;
           return !!config?.token && !!config?.message;
+        }
+        case "a2a": {
+          const config = channel.channel_config as A2aChannelConfig;
+          return !!config?.api_key_hash && !!config?.message;
         }
       }
     }) ?? false;
@@ -320,6 +386,8 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
     setEditAgUiToken("");
     setEditAgUiToolVisibility("generic");
     setEditAgUiGenericToolText(DEFAULT_AG_UI_GENERIC_TOOL_TEXT);
+    setEditA2aAgentCardName("");
+    setEditA2aAgentCardDescription("");
   };
 
   const buildChannelConfig = (channelType: ChannelType): ChannelConfigInput => {
@@ -353,6 +421,33 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
           token: editWebhookToken,
           session_mode: editInvocationSessionMode,
           message: editChannelMessage,
+        };
+      case "a2a":
+        // Editing only updates the non-secret fields. The api_key_hash and
+        // api_key_prefix are server-managed (rotate via the dedicated button).
+        // The hash is required by the channel_config schema, so we round-trip
+        // it from whatever the server last returned.
+        return {
+          api_key_hash:
+            (editingChannelId
+              ? ((
+                  app?.channels?.find((c) => c.id === editingChannelId)?.channel_config as
+                    | A2aChannelConfig
+                    | undefined
+                )?.api_key_hash ?? "")
+              : "") || "pending",
+          api_key_prefix:
+            (editingChannelId
+              ? ((
+                  app?.channels?.find((c) => c.id === editingChannelId)?.channel_config as
+                    | A2aChannelConfig
+                    | undefined
+                )?.api_key_prefix ?? "")
+              : "") || "pending",
+          session_mode: editInvocationSessionMode,
+          message: editChannelMessage,
+          agent_card_name: editA2aAgentCardName.trim() || undefined,
+          agent_card_description: editA2aAgentCardDescription.trim() || undefined,
         };
       case "slack":
         return {
@@ -389,6 +484,8 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
         return !!editScheduleCronExpression && !!editChannelMessage;
       case "webhook":
         return !!editWebhookToken && !!editChannelMessage;
+      case "a2a":
+        return !!editChannelMessage;
       case "slack":
         return !!editSigningSecret && !!editBotToken;
     }
@@ -429,6 +526,12 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
       setEditWebhookToken(config?.token ?? "");
       setEditInvocationSessionMode(config?.session_mode ?? "shared_session");
       setEditChannelMessage(config?.message ?? "");
+    } else if (channel.channel_type === "a2a") {
+      const config = channel.channel_config as A2aChannelConfig;
+      setEditInvocationSessionMode(config?.session_mode ?? "shared_session");
+      setEditChannelMessage(config?.message ?? "");
+      setEditA2aAgentCardName(config?.agent_card_name ?? "");
+      setEditA2aAgentCardDescription(config?.agent_card_description ?? "");
     }
     setEditingChannelId(channel.id);
   };
@@ -449,6 +552,16 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
   };
 
   const saveNewChannel = async () => {
+    if (addChannelType === "a2a") {
+      await addA2aMutation.mutateAsync({
+        sessionMode: editInvocationSessionMode,
+        message: editChannelMessage,
+        agentCardName: editA2aAgentCardName.trim() || undefined,
+        agentCardDescription: editA2aAgentCardDescription.trim() || undefined,
+        enabled: editChannelEnabled,
+      });
+      return;
+    }
     await addChannelMutation.mutateAsync({
       channelType: addChannelType,
       config: buildChannelConfig(addChannelType),
@@ -518,6 +631,7 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
                 <SelectItem value="ag_ui">{getChannelTypeDisplayName("ag_ui")}</SelectItem>
                 <SelectItem value="schedule">{getChannelTypeDisplayName("schedule")}</SelectItem>
                 <SelectItem value="webhook">{getChannelTypeDisplayName("webhook")}</SelectItem>
+                <SelectItem value="a2a">{getChannelTypeDisplayName("a2a")}</SelectItem>
               </SelectContent>
             </Select>
           </div>
@@ -846,6 +960,68 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
           </>
         )}
 
+        {formChannelType === "a2a" && (
+          <>
+            <div className="rounded-md border p-3 text-sm text-muted-foreground">
+              The A2A channel exposes this app over the Agent2Agent JSON-RPC protocol. The API key
+              is generated on save and shown once — store it before closing the dialog. Rotate it
+              later from the channel card if it leaks.
+            </div>
+            <div>
+              <Label htmlFor={`a2a_session_mode_${formId}`}>Invocation Session Mode</Label>
+              <Select
+                value={editInvocationSessionMode}
+                onValueChange={(v) => setEditInvocationSessionMode(v as InvocationSessionMode)}
+              >
+                <SelectTrigger id={`a2a_session_mode_${formId}`}>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="shared_session">
+                    {getInvocationSessionModeDisplayName("shared_session")}
+                  </SelectItem>
+                  <SelectItem value="session_per_invocation">
+                    {getInvocationSessionModeDisplayName("session_per_invocation")}
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div>
+              <Label htmlFor={`a2a_message_${formId}`}>Invocation Message</Label>
+              <Textarea
+                id={`a2a_message_${formId}`}
+                value={editChannelMessage}
+                onChange={(e) => setEditChannelMessage(e.target.value)}
+                placeholder="A2A request: {{a2a.text}}"
+              />
+              <p className="mt-1 text-xs text-muted-foreground">
+                Templates can reference <code>{"{{a2a.text}}"}</code>, <code>{"{{payload}}"}</code>,
+                and app metadata.
+              </p>
+            </div>
+            <div>
+              <Label htmlFor={`a2a_card_name_${formId}`}>Agent Card name (optional)</Label>
+              <Input
+                id={`a2a_card_name_${formId}`}
+                value={editA2aAgentCardName}
+                onChange={(e) => setEditA2aAgentCardName(e.target.value)}
+                placeholder={app?.name ?? ""}
+              />
+            </div>
+            <div>
+              <Label htmlFor={`a2a_card_description_${formId}`}>
+                Agent Card description (optional)
+              </Label>
+              <Textarea
+                id={`a2a_card_description_${formId}`}
+                value={editA2aAgentCardDescription}
+                onChange={(e) => setEditA2aAgentCardDescription(e.target.value)}
+                placeholder="What other agents should know about this app."
+              />
+            </div>
+          </>
+        )}
+
         <div className="flex gap-2 pt-2">
           <Button
             size="sm"
@@ -926,6 +1102,31 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
             tokenConfigured={!!config?.token}
             isPublished={isPublished}
             onConfigure={() => startEditChannel(channel)}
+          />
+        </div>
+      );
+    }
+
+    if (channel.channel_type === "a2a") {
+      const config = channel.channel_config as A2aChannelConfig;
+      const baseUrl = typeof window !== "undefined" ? window.location.origin : "";
+      const endpointUrl = `${baseUrl}/api/v1/apps/${appId}/a2a/${channel.id}`;
+      const agentCardUrl = `${baseUrl}/api/v1/apps/${appId}/a2a/${channel.id}/.well-known/agent-card.json`;
+
+      return (
+        <div key={channel.id} className="space-y-4">
+          <A2aSetupGuidance
+            endpointUrl={endpointUrl}
+            agentCardUrl={agentCardUrl}
+            apiKeyPrefix={config?.api_key_prefix ?? ""}
+            sessionMode={config?.session_mode ?? "shared_session"}
+            message={config?.message ?? ""}
+            agentCardName={config?.agent_card_name}
+            agentCardDescription={config?.agent_card_description}
+            isPublished={isPublished}
+            onConfigure={() => startEditChannel(channel)}
+            onRotateKey={isReadOnly ? undefined : () => rotateA2aMutation.mutate(channel.id)}
+            isRotating={rotateA2aMutation.isPending && rotatingA2aChannelId === channel.id}
           />
         </div>
       );
@@ -1343,6 +1544,33 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
           </Card>
         </div>
       </div>
+
+      {/* A2A revealed-key dialog: shown exactly once per create/rotate */}
+      <Dialog
+        open={!!a2aRevealedKey}
+        onOpenChange={(open) => {
+          if (!open) setA2aRevealedKey(null);
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{a2aRevealedKey?.title ?? "A2A API key"}</DialogTitle>
+            <DialogDescription>
+              Copy this API key now. It will not be shown again — only the SHA-256 hash is stored.
+              If you lose it, rotate the key from the channel card.
+            </DialogDescription>
+          </DialogHeader>
+          {a2aRevealedKey && (
+            <div className="flex items-center gap-2 bg-muted p-3">
+              <code className="flex-1 break-all font-mono text-xs">{a2aRevealedKey.apiKey}</code>
+              <CopyButton value={a2aRevealedKey.apiKey} />
+            </div>
+          )}
+          <DialogFooter>
+            <Button onClick={() => setA2aRevealedKey(null)}>I&apos;ve saved it</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       {/* Delete confirmation dialog */}
       <Dialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>

--- a/apps/ui/src/app/(main)/apps/[appId]/page.tsx
+++ b/apps/ui/src/app/(main)/apps/[appId]/page.tsx
@@ -423,32 +423,16 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
           message: editChannelMessage,
         };
       case "a2a":
-        // Editing only updates the non-secret fields. The api_key_hash and
-        // api_key_prefix are server-managed (rotate via the dedicated button).
-        // The hash is required by the channel_config schema, so we round-trip
-        // it from whatever the server last returned.
+        // Edits only touch non-secret fields. The server preserves the
+        // existing `api_key_hash` and `api_key_prefix` across PATCH, so the
+        // client must NOT send them. Use the dedicated rotate-key button to
+        // issue a new key.
         return {
-          api_key_hash:
-            (editingChannelId
-              ? ((
-                  app?.channels?.find((c) => c.id === editingChannelId)?.channel_config as
-                    | A2aChannelConfig
-                    | undefined
-                )?.api_key_hash ?? "")
-              : "") || "pending",
-          api_key_prefix:
-            (editingChannelId
-              ? ((
-                  app?.channels?.find((c) => c.id === editingChannelId)?.channel_config as
-                    | A2aChannelConfig
-                    | undefined
-                )?.api_key_prefix ?? "")
-              : "") || "pending",
           session_mode: editInvocationSessionMode,
           message: editChannelMessage,
           agent_card_name: editA2aAgentCardName.trim() || undefined,
           agent_card_description: editA2aAgentCardDescription.trim() || undefined,
-        };
+        } as unknown as A2aChannelConfig;
       case "slack":
         return {
           signing_secret: editSigningSecret,

--- a/apps/ui/src/components/apps/a2a-setup-guidance.tsx
+++ b/apps/ui/src/components/apps/a2a-setup-guidance.tsx
@@ -1,0 +1,142 @@
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { CopyButton } from "@/components/ui/copy-button";
+import { getInvocationSessionModeDisplayName } from "@/lib/app-channels";
+import type { InvocationSessionMode } from "@/lib/api/types";
+import { Bot, Globe, KeyRound, RefreshCw } from "lucide-react";
+
+interface A2aSetupGuidanceProps {
+  endpointUrl: string;
+  agentCardUrl: string;
+  apiKeyPrefix: string;
+  sessionMode: InvocationSessionMode;
+  message: string;
+  agentCardName?: string;
+  agentCardDescription?: string;
+  isPublished: boolean;
+  onConfigure?: () => void;
+  onRotateKey?: () => void;
+  isRotating?: boolean;
+}
+
+export function A2aSetupGuidance({
+  endpointUrl,
+  agentCardUrl,
+  apiKeyPrefix,
+  sessionMode,
+  message,
+  agentCardName,
+  agentCardDescription,
+  isPublished,
+  onConfigure,
+  onRotateKey,
+  isRotating,
+}: A2aSetupGuidanceProps) {
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-2">
+        <Badge variant="default">A2A (Agent2Agent)</Badge>
+        <span className="text-sm text-muted-foreground">
+          {isPublished
+            ? "Ready to accept authenticated A2A JSON-RPC requests."
+            : "Publish the app to accept A2A requests."}
+        </span>
+      </div>
+
+      <div>
+        <p className="text-sm font-medium">JSON-RPC endpoint</p>
+        <div className="mt-2 flex items-center gap-2 bg-muted p-3">
+          <Globe className="h-4 w-4 shrink-0 text-muted-foreground" />
+          <code className="flex-1 truncate text-sm">{endpointUrl}</code>
+          <CopyButton value={endpointUrl} />
+        </div>
+        <p className="mt-1 text-xs text-muted-foreground">
+          Send <code>POST</code> with a JSON-RPC 2.0 envelope. Only the <code>message/send</code>{" "}
+          method is supported in this iteration.
+        </p>
+      </div>
+
+      <div>
+        <p className="text-sm font-medium">Agent Card</p>
+        <div className="mt-2 flex items-center gap-2 bg-muted p-3">
+          <Bot className="h-4 w-4 shrink-0 text-muted-foreground" />
+          <code className="flex-1 truncate text-sm">{agentCardUrl}</code>
+          <CopyButton value={agentCardUrl} />
+        </div>
+        <p className="mt-1 text-xs text-muted-foreground">
+          Public discovery document for A2A clients. Returns 404 unless the app is published and the
+          channel is enabled.
+        </p>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <div>
+          <p className="text-sm font-medium">Authentication</p>
+          <div className="mt-2 flex items-center gap-2 text-sm text-muted-foreground">
+            <KeyRound className="h-4 w-4 shrink-0" />
+            <span>
+              <code>Authorization: Bearer &lt;api_key&gt;</code>
+            </span>
+          </div>
+          <div className="mt-2 flex items-center gap-2 bg-muted p-2">
+            <code className="flex-1 truncate text-xs font-mono">
+              {apiKeyPrefix || "(no key configured)"}
+            </code>
+          </div>
+          <p className="mt-1 text-xs text-muted-foreground">
+            The plaintext key is shown once at create / rotate time. Only the prefix is stored for
+            display; the full value is hashed at rest.
+          </p>
+        </div>
+        <div>
+          <p className="text-sm font-medium">Session Mode</p>
+          <p className="text-sm text-muted-foreground">
+            {getInvocationSessionModeDisplayName(sessionMode)}
+          </p>
+        </div>
+      </div>
+
+      {(agentCardName || agentCardDescription) && (
+        <div className="grid gap-4 md:grid-cols-2">
+          {agentCardName && (
+            <div>
+              <p className="text-sm font-medium">Card name</p>
+              <p className="text-sm text-muted-foreground">{agentCardName}</p>
+            </div>
+          )}
+          {agentCardDescription && (
+            <div>
+              <p className="text-sm font-medium">Card description</p>
+              <p className="text-sm text-muted-foreground">{agentCardDescription}</p>
+            </div>
+          )}
+        </div>
+      )}
+
+      <div>
+        <p className="text-sm font-medium">Invocation Message</p>
+        <div className="mt-2 rounded-md border p-3 text-sm text-muted-foreground">
+          <code className="whitespace-pre-wrap break-words">{message}</code>
+        </div>
+        <p className="mt-1 text-xs text-muted-foreground">
+          Templates can reference <code>{"{{a2a.text}}"}</code>, <code>{"{{payload}}"}</code>, and
+          app metadata.
+        </p>
+      </div>
+
+      <div className="flex flex-wrap gap-2 pt-1">
+        {onConfigure && (
+          <Button size="sm" variant="outline" onClick={onConfigure}>
+            Configure
+          </Button>
+        )}
+        {onRotateKey && (
+          <Button size="sm" variant="outline" onClick={onRotateKey} disabled={isRotating}>
+            <RefreshCw className="mr-1 h-3 w-3" />
+            {isRotating ? "Rotating..." : "Rotate API key"}
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/ui/src/lib/api/apps.ts
+++ b/apps/ui/src/lib/api/apps.ts
@@ -8,9 +8,27 @@ import type {
   App,
   AppChannel,
   CreateAppRequest,
+  InvocationSessionMode,
   UpdateAppRequest,
   UpdateChannelRequest,
 } from "./types";
+
+export interface AddA2aChannelRequest {
+  session_mode?: InvocationSessionMode;
+  message: string;
+  agent_card_name?: string;
+  agent_card_description?: string;
+  enabled?: boolean;
+}
+
+export interface A2aChannelKeyResponse {
+  /**
+   * Plaintext A2A API key. Returned exactly once — the server only stores a
+   * SHA-256 hash. Display it to the operator and tell them to save it.
+   */
+  api_key: string;
+  channel: AppChannel;
+}
 
 export const appsCrudApi = createCrudApi<App, CreateAppRequest, UpdateAppRequest>("/v1/apps");
 
@@ -49,6 +67,33 @@ export async function updateChannel(
 
 export async function deleteChannel(appId: string, channelId: string): Promise<void> {
   await api.delete(`/v1/apps/${appId}/channels/${channelId}`);
+}
+
+/**
+ * Create an A2A (Agent2Agent) channel. The server generates a fresh API key
+ * and returns the plaintext exactly once — persist it immediately.
+ */
+export async function addA2aChannel(
+  appId: string,
+  req: AddA2aChannelRequest,
+): Promise<A2aChannelKeyResponse> {
+  const response = await api.post<A2aChannelKeyResponse>(`/v1/apps/${appId}/a2a-channels`, req);
+  return response.data;
+}
+
+/**
+ * Regenerate an A2A channel API key. Returns the new plaintext exactly once;
+ * the previous key stops working as soon as this call returns.
+ */
+export async function regenerateA2aChannelKey(
+  appId: string,
+  channelId: string,
+): Promise<A2aChannelKeyResponse> {
+  const response = await api.post<A2aChannelKeyResponse>(
+    `/v1/apps/${appId}/a2a-channels/${channelId}/regenerate-key`,
+    {},
+  );
+  return response.data;
 }
 
 /** Get the Slack App manifest for an app. Returns manifest YAML and create URL. */

--- a/apps/ui/src/lib/api/types/app-types.ts
+++ b/apps/ui/src/lib/api/types/app-types.ts
@@ -3,7 +3,7 @@
 import type { PrincipalSummary } from "./common-types";
 
 export type AppStatus = "draft" | "published" | "archived" | "deleted";
-export type ChannelType = "slack" | "ag_ui" | "schedule" | "webhook";
+export type ChannelType = "slack" | "ag_ui" | "schedule" | "webhook" | "a2a";
 export type SessionStrategy = "per_thread" | "per_channel" | "per_user";
 export type SlackReplyMode = "all_messages" | "report_progress_only";
 export type InvocationSessionMode = "shared_session" | "session_per_invocation";
@@ -66,6 +66,23 @@ export interface WebhookChannelConfig {
   message: string;
 }
 
+/**
+ * A2A (Agent2Agent) channel configuration.
+ *
+ * The plaintext API key is **never** returned by the API after creation /
+ * regeneration — only the SHA-256 hash and a non-secret display prefix are
+ * persisted and surfaced. Use `addA2aChannel` / `regenerateA2aChannelKey` to
+ * obtain the plaintext (which is shown exactly once).
+ */
+export interface A2aChannelConfig {
+  api_key_hash: string;
+  api_key_prefix: string;
+  session_mode?: InvocationSessionMode;
+  message: string;
+  agent_card_name?: string;
+  agent_card_description?: string;
+}
+
 export interface AppChannel {
   id: string;
   channel_type: ChannelType;
@@ -74,6 +91,7 @@ export interface AppChannel {
     | AgUiChannelConfig
     | ScheduleChannelConfig
     | WebhookChannelConfig
+    | A2aChannelConfig
     | Record<string, unknown>;
   enabled: boolean;
   created_at: string;
@@ -112,6 +130,7 @@ export interface CreateAppRequest {
     | AgUiChannelConfig
     | ScheduleChannelConfig
     | WebhookChannelConfig
+    | A2aChannelConfig
     | Record<string, unknown>;
 }
 
@@ -131,6 +150,7 @@ export interface AddChannelRequest {
     | AgUiChannelConfig
     | ScheduleChannelConfig
     | WebhookChannelConfig
+    | A2aChannelConfig
     | Record<string, unknown>;
   enabled?: boolean;
 }
@@ -142,6 +162,7 @@ export interface UpdateChannelRequest {
     | AgUiChannelConfig
     | ScheduleChannelConfig
     | WebhookChannelConfig
+    | A2aChannelConfig
     | Record<string, unknown>;
   enabled?: boolean;
 }

--- a/apps/ui/src/lib/app-channels.ts
+++ b/apps/ui/src/lib/app-channels.ts
@@ -16,6 +16,8 @@ export function getChannelTypeDisplayName(channelType: ChannelType): string {
       return "Slack";
     case "webhook":
       return "Webhook";
+    case "a2a":
+      return "A2A (Agent2Agent)";
   }
 }
 

--- a/crates/core/src/app.rs
+++ b/crates/core/src/app.rs
@@ -67,6 +67,8 @@ pub enum ChannelType {
     AgUi,
     Schedule,
     Webhook,
+    /// Agent2Agent (A2A) protocol channel — JSON-RPC + API key.
+    A2a,
 }
 
 impl std::fmt::Display for ChannelType {
@@ -76,6 +78,7 @@ impl std::fmt::Display for ChannelType {
             ChannelType::AgUi => write!(f, "ag_ui"),
             ChannelType::Schedule => write!(f, "schedule"),
             ChannelType::Webhook => write!(f, "webhook"),
+            ChannelType::A2a => write!(f, "a2a"),
         }
     }
 }
@@ -87,6 +90,7 @@ impl ChannelType {
             "ag_ui" => Some(ChannelType::AgUi),
             "schedule" => Some(ChannelType::Schedule),
             "webhook" => Some(ChannelType::Webhook),
+            "a2a" => Some(ChannelType::A2a),
             _ => None,
         }
     }
@@ -221,6 +225,15 @@ impl AppChannel {
         }
         serde_json::from_value(self.channel_config.clone()).ok()
     }
+
+    /// Parse channel_config as A2aChannelConfig. Returns None if not an A2A
+    /// channel or if the config is invalid.
+    pub fn a2a_config(&self) -> Option<A2aChannelConfig> {
+        if self.channel_type != ChannelType::A2a {
+            return None;
+        }
+        serde_json::from_value(self.channel_config.clone()).ok()
+    }
 }
 
 impl App {
@@ -250,6 +263,13 @@ impl App {
         self.channels
             .iter()
             .find(|ch| ch.channel_type == ChannelType::Webhook && ch.enabled)
+    }
+
+    /// Find the first enabled A2A channel on this app.
+    pub fn a2a_channel(&self) -> Option<&AppChannel> {
+        self.channels
+            .iter()
+            .find(|ch| ch.channel_type == ChannelType::A2a && ch.enabled)
     }
 
     /// Find a channel by its public ID.
@@ -477,6 +497,35 @@ fn default_timezone() -> String {
     "UTC".to_string()
 }
 
+/// Typed A2A (Agent2Agent) channel configuration.
+///
+/// The plaintext API key is **never** stored. Only the SHA-256 hex hash and a
+/// non-secret display prefix are persisted. The plaintext is returned exactly
+/// once at create / regenerate time.
+///
+/// `message` is the template body. `{{path.to.value}}` placeholders expand
+/// against the incoming A2A request payload and metadata (see
+/// `specs/a2a-channel.md`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct A2aChannelConfig {
+    /// SHA-256 hex digest of the API key.
+    pub api_key_hash: String,
+    /// Public, non-secret display prefix (e.g. `evra2a_abc1...`).
+    pub api_key_prefix: String,
+    /// Whether invocations reuse a stable session or create a new one.
+    #[serde(default)]
+    pub session_mode: InvocationSessionMode,
+    /// Message template rendered into the session per invocation.
+    pub message: String,
+    /// Optional human-readable agent name surfaced in the Agent Card.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_card_name: Option<String>,
+    /// Optional description surfaced in the Agent Card.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_card_description: Option<String>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -513,6 +562,7 @@ mod tests {
         assert_eq!(ChannelType::AgUi.to_string(), "ag_ui");
         assert_eq!(ChannelType::Schedule.to_string(), "schedule");
         assert_eq!(ChannelType::Webhook.to_string(), "webhook");
+        assert_eq!(ChannelType::A2a.to_string(), "a2a");
     }
 
     #[test]
@@ -527,6 +577,7 @@ mod tests {
             ChannelType::from_str_opt("webhook"),
             Some(ChannelType::Webhook)
         );
+        assert_eq!(ChannelType::from_str_opt("a2a"), Some(ChannelType::A2a));
         assert_eq!(ChannelType::from_str_opt("unknown"), None);
         assert_eq!(ChannelType::from_str_opt(""), None);
     }
@@ -863,6 +914,80 @@ mod tests {
         );
         let app = test_app(vec![ch]);
         assert!(app.webhook_channel().is_some());
+    }
+
+    #[test]
+    fn test_a2a_channel_config_defaults() {
+        let config: A2aChannelConfig = serde_json::from_str(
+            r#"{"api_key_hash":"abc","api_key_prefix":"evra2a_abc1...","message":"{{a2a.text}}"}"#,
+        )
+        .unwrap();
+        assert_eq!(config.session_mode, InvocationSessionMode::SharedSession);
+        assert!(config.agent_card_name.is_none());
+        assert!(config.agent_card_description.is_none());
+    }
+
+    #[test]
+    fn test_a2a_channel_config_roundtrip() {
+        let config = A2aChannelConfig {
+            api_key_hash: "deadbeef".into(),
+            api_key_prefix: "evra2a_dead...".into(),
+            session_mode: InvocationSessionMode::SessionPerInvocation,
+            message: "{{a2a.text}}".into(),
+            agent_card_name: Some("Inbox triage".into()),
+            agent_card_description: Some("Triages github events".into()),
+        };
+        let json = serde_json::to_string(&config).unwrap();
+        let parsed: A2aChannelConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.api_key_hash, "deadbeef");
+        assert_eq!(
+            parsed.session_mode,
+            InvocationSessionMode::SessionPerInvocation
+        );
+        assert_eq!(parsed.agent_card_name.as_deref(), Some("Inbox triage"));
+    }
+
+    #[test]
+    fn test_a2a_channel_config_omits_optional_fields() {
+        let config = A2aChannelConfig {
+            api_key_hash: "h".into(),
+            api_key_prefix: "evra2a_h...".into(),
+            session_mode: InvocationSessionMode::SharedSession,
+            message: "m".into(),
+            agent_card_name: None,
+            agent_card_description: None,
+        };
+        let json = serde_json::to_value(&config).unwrap();
+        assert!(json.get("agent_card_name").is_none());
+        assert!(json.get("agent_card_description").is_none());
+    }
+
+    #[test]
+    fn test_app_channel_a2a_config_valid() {
+        let ch = test_channel(
+            ChannelType::A2a,
+            serde_json::json!({
+                "api_key_hash": "h",
+                "api_key_prefix": "evra2a_h...",
+                "message": "{{a2a.text}}"
+            }),
+        );
+        let config = ch.a2a_config().unwrap();
+        assert_eq!(config.api_key_prefix, "evra2a_h...");
+    }
+
+    #[test]
+    fn test_app_a2a_channel_lookup() {
+        let ch = test_channel(
+            ChannelType::A2a,
+            serde_json::json!({
+                "api_key_hash": "h",
+                "api_key_prefix": "evra2a_h...",
+                "message": "{{a2a.text}}"
+            }),
+        );
+        let app = test_app(vec![ch]);
+        assert!(app.a2a_channel().is_some());
     }
 
     #[test]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -298,8 +298,8 @@ pub use agent::{
 };
 pub use agent_identity::{AgentIdentity, AgentIdentityStatus};
 pub use app::{
-    AgUiChannelConfig, AgUiToolVisibility, App, AppChannel, AppStatus, ChannelType,
-    SessionStrategy, SlackChannelConfig, SlackReplyMode,
+    A2aChannelConfig, AgUiChannelConfig, AgUiToolVisibility, App, AppChannel, AppStatus,
+    ChannelType, SessionStrategy, SlackChannelConfig, SlackReplyMode,
 };
 pub use capability_dto::{AgentCapability, CapabilityInfo};
 pub use events::{

--- a/crates/server/migrations/034_app_channel_type_a2a.sql
+++ b/crates/server/migrations/034_app_channel_type_a2a.sql
@@ -1,0 +1,16 @@
+-- Allow `a2a` (Agent2Agent) app invocation channels.
+-- See specs/a2a-channel.md.
+
+ALTER TABLE apps
+    DROP CONSTRAINT IF EXISTS apps_channel_type_check;
+
+ALTER TABLE apps
+    ADD CONSTRAINT apps_channel_type_check
+    CHECK (channel_type IN ('slack', 'ag_ui', 'schedule', 'webhook', 'a2a'));
+
+ALTER TABLE app_channels
+    DROP CONSTRAINT IF EXISTS app_channels_channel_type_check;
+
+ALTER TABLE app_channels
+    ADD CONSTRAINT app_channels_channel_type_check
+    CHECK (channel_type IN ('slack', 'ag_ui', 'schedule', 'webhook', 'a2a'));

--- a/crates/server/src/api/app_a2a.rs
+++ b/crates/server/src/api/app_a2a.rs
@@ -169,11 +169,7 @@ pub async fn invoke_a2a(
         .ok_or_else(not_found)?;
 
     if app.status != everruns_core::AppStatus::Published {
-        return Err(forbidden_with_rpc(
-            rpc_id.clone(),
-            -32002,
-            "App is not published",
-        ));
+        return Err(forbidden("App is not published"));
     }
 
     let channel_id_typed = channel_id
@@ -187,11 +183,7 @@ pub async fn invoke_a2a(
     // disabled app channels, and every request must present the per-channel
     // API key before session creation.
     if !channel.enabled {
-        return Err(forbidden_with_rpc(
-            rpc_id.clone(),
-            -32002,
-            "A2A channel is disabled",
-        ));
+        return Err(forbidden("A2A channel is disabled"));
     }
 
     let config = channel
@@ -444,14 +436,6 @@ fn forbidden(message: impl Into<String>) -> (StatusCode, Json<ErrorResponse>) {
             error: message.into(),
         }),
     )
-}
-
-fn forbidden_with_rpc(
-    _id: Value,
-    _code: i32,
-    message: impl Into<String>,
-) -> (StatusCode, Json<ErrorResponse>) {
-    forbidden(message)
 }
 
 fn unauthorized() -> (StatusCode, Json<ErrorResponse>) {

--- a/crates/server/src/api/app_a2a.rs
+++ b/crates/server/src/api/app_a2a.rs
@@ -1,0 +1,511 @@
+// App A2A (Agent2Agent) ingress — JSON-RPC + API key authenticated invocation.
+//
+// Design Decision: A2A channels are app-scoped and channel-scoped
+// (`POST /v1/apps/{app_id}/a2a/{channel_id}`) so a single app can expose
+// multiple agent-to-agent endpoints with independent keys, agent cards, and
+// session routing.
+//
+// Only `message/send` is implemented in this iteration. Streaming, tasks/get,
+// and push notifications return JSON-RPC `-32601 Method not found`. See
+// `specs/a2a-channel.md`.
+
+use std::sync::Arc;
+
+use axum::{
+    Json, Router,
+    extract::{Path, State},
+    http::{HeaderMap, StatusCode},
+    routing::{get, post},
+};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use uuid::Uuid;
+
+use crate::api::common::ErrorResponse;
+use crate::domains::apps::{
+    A2aInvocationRequest, hash_a2a_api_key, invoke_a2a_app_channel, queries as app_queries,
+};
+use crate::domains::messages::MessageService;
+use crate::domains::sessions::SessionService;
+use crate::middleware::RequestId;
+use crate::storage::{EncryptionService, StorageBackend};
+
+const A2A_PROTOCOL_VERSION: &str = "0.3.0";
+const A2A_AGENT_VERSION: &str = "0.1";
+
+// THREAT[TM-A2A-005]: Method gating — only `message/send` is supported.
+// Allowing arbitrary A2A methods would expose code paths we have not
+// audited for prompt injection or task-state forgery.
+const METHOD_MESSAGE_SEND: &str = "message/send";
+
+#[derive(Clone)]
+pub struct AppA2aState {
+    pub db: Arc<StorageBackend>,
+    pub encryption: Option<Arc<EncryptionService>>,
+    pub session_service: Arc<SessionService>,
+    pub message_service: Arc<MessageService>,
+}
+
+impl AppA2aState {
+    pub fn new(
+        db: Arc<StorageBackend>,
+        encryption: Option<Arc<EncryptionService>>,
+        runner: Arc<dyn everruns_worker::AgentRunner>,
+        notifications_enabled: bool,
+        event_delivery: crate::event_delivery::EventDelivery,
+    ) -> Self {
+        Self {
+            session_service: Arc::new(SessionService::new(db.clone())),
+            message_service: Arc::new(MessageService::new(
+                db.clone(),
+                runner,
+                notifications_enabled,
+                event_delivery,
+            )),
+            db,
+            encryption,
+        }
+    }
+}
+
+pub fn routes(state: AppA2aState) -> Router {
+    Router::new()
+        .route("/v1/apps/{app_id}/a2a/{channel_id}", post(invoke_a2a))
+        .route(
+            "/v1/apps/{app_id}/a2a/{channel_id}/.well-known/agent-card.json",
+            get(agent_card),
+        )
+        .with_state(state)
+}
+
+#[derive(Debug, Deserialize)]
+struct JsonRpcRequest {
+    #[allow(dead_code)]
+    jsonrpc: Option<String>,
+    id: Option<Value>,
+    method: String,
+    #[serde(default)]
+    params: Value,
+}
+
+#[derive(Debug, Serialize)]
+pub struct JsonRpcResponse {
+    jsonrpc: &'static str,
+    id: Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    result: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<JsonRpcError>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct JsonRpcError {
+    code: i32,
+    message: String,
+}
+
+fn rpc_success(id: Value, result: Value) -> Json<JsonRpcResponse> {
+    Json(JsonRpcResponse {
+        jsonrpc: "2.0",
+        id,
+        result: Some(result),
+        error: None,
+    })
+}
+
+fn rpc_error(id: Value, code: i32, message: impl Into<String>) -> Json<JsonRpcResponse> {
+    Json(JsonRpcResponse {
+        jsonrpc: "2.0",
+        id,
+        result: None,
+        error: Some(JsonRpcError {
+            code,
+            message: message.into(),
+        }),
+    })
+}
+
+/// POST /v1/apps/{app_id}/a2a/{channel_id}
+#[utoipa::path(
+    post,
+    path = "/v1/apps/{app_id}/a2a/{channel_id}",
+    params(
+        ("app_id" = String, Path, description = "App ID"),
+        ("channel_id" = String, Path, description = "A2A channel ID")
+    ),
+    request_body(content = serde_json::Value, content_type = "application/json"),
+    responses(
+        (status = 200, description = "JSON-RPC 2.0 response (success or A2A error envelope)"),
+        (status = 401, description = "Missing or invalid API key", body = ErrorResponse),
+        (status = 403, description = "App is not published or channel disabled", body = ErrorResponse),
+        (status = 404, description = "App or channel not found", body = ErrorResponse),
+    ),
+    tag = "apps"
+)]
+pub async fn invoke_a2a(
+    State(state): State<AppA2aState>,
+    Path((app_id, channel_id)): Path<(String, String)>,
+    req_id: Option<axum::Extension<RequestId>>,
+    headers: HeaderMap,
+    Json(envelope): Json<Value>,
+) -> Result<(StatusCode, Json<JsonRpcResponse>), (StatusCode, Json<ErrorResponse>)> {
+    // Parse JSON-RPC envelope first so we can return structured errors with the
+    // original `id` echoed back.
+    let parsed: JsonRpcRequest = match serde_json::from_value(envelope) {
+        Ok(parsed) => parsed,
+        Err(err) => {
+            return Ok((
+                StatusCode::BAD_REQUEST,
+                rpc_error(Value::Null, -32600, format!("Invalid Request: {err}")),
+            ));
+        }
+    };
+    let rpc_id = parsed.id.clone().unwrap_or(Value::Null);
+
+    // Resolve app + channel.
+    let app = app_queries::get_by_public_id_unscoped(&state.db, state.encryption.as_ref(), &app_id)
+        .await
+        .map_err(internal_error)?
+        .ok_or_else(not_found)?;
+
+    if app.status != everruns_core::AppStatus::Published {
+        return Err(forbidden_with_rpc(
+            rpc_id.clone(),
+            -32002,
+            "App is not published",
+        ));
+    }
+
+    let channel_id_typed = channel_id
+        .parse::<everruns_core::typed_id::AppChannelId>()
+        .map_err(|e| bad_request(format!("Invalid channel ID: {e}")))?;
+    let channel = app.channel_by_id(&channel_id_typed).ok_or_else(not_found)?;
+    if channel.channel_type != everruns_core::ChannelType::A2a {
+        return Err(not_found());
+    }
+    // THREAT[TM-AUTHZ-006]: Anonymous A2A ingress must never reach draft or
+    // disabled app channels, and every request must present the per-channel
+    // API key before session creation.
+    if !channel.enabled {
+        return Err(forbidden_with_rpc(
+            rpc_id.clone(),
+            -32002,
+            "A2A channel is disabled",
+        ));
+    }
+
+    let config = channel
+        .a2a_config()
+        .ok_or_else(|| bad_request("Invalid A2A channel configuration"))?;
+
+    // THREAT[TM-A2A-001]: API keys are stored as SHA-256 hashes; plaintext is
+    // never persisted. We hash the inbound key and compare against the stored
+    // hash before doing anything else.
+    let provided_key = extract_a2a_api_key(&headers).ok_or_else(unauthorized)?;
+    let provided_hash = hash_a2a_api_key(&provided_key);
+    if !constant_time_eq(provided_hash.as_bytes(), config.api_key_hash.as_bytes()) {
+        return Err(unauthorized());
+    }
+
+    // Method gate.
+    if parsed.method != METHOD_MESSAGE_SEND {
+        return Ok((
+            StatusCode::OK,
+            rpc_error(
+                rpc_id,
+                -32601,
+                format!(
+                    "Method not found: {} (only message/send is supported)",
+                    parsed.method
+                ),
+            ),
+        ));
+    }
+
+    // Pull text parts. A2A `parts` is an array of objects; we surface
+    // `text` parts joined by newline. Anything else is silently ignored at the
+    // template level but if there is no text at all we reject.
+    let message = parsed.params.get("message").cloned().unwrap_or(Value::Null);
+    let parts = message
+        .get("parts")
+        .and_then(|p| p.as_array())
+        .cloned()
+        .unwrap_or_default();
+    let text = parts
+        .iter()
+        .filter_map(|part| {
+            // Spec uses `kind: "text"`; older drafts used `type: "text"`. Accept both.
+            let kind = part.get("kind").or_else(|| part.get("type"));
+            if kind.and_then(Value::as_str) == Some("text") {
+                part.get("text").and_then(Value::as_str).map(str::to_owned)
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    if text.trim().is_empty() {
+        return Ok((
+            StatusCode::OK,
+            rpc_error(
+                rpc_id,
+                -32602,
+                "Invalid params: message.parts must contain at least one non-empty text part",
+            ),
+        ));
+    }
+
+    let role = message
+        .get("role")
+        .and_then(Value::as_str)
+        .map(str::to_owned);
+    let message_id = message
+        .get("messageId")
+        .and_then(Value::as_str)
+        .map(str::to_owned);
+    let context_id = message
+        .get("contextId")
+        .and_then(Value::as_str)
+        .map(str::to_owned);
+    let task_id = Uuid::now_v7().to_string();
+    let request_id = req_id.map(|axum::Extension(id)| id.0);
+
+    let result = invoke_a2a_app_channel(
+        &state.db,
+        state.encryption.as_ref(),
+        &state.session_service,
+        &state.message_service,
+        A2aInvocationRequest {
+            app_id,
+            channel_id,
+            params: parsed.params,
+            text,
+            message_id: message_id.clone(),
+            task_id: task_id.clone(),
+            context_id: context_id.clone(),
+            role,
+        },
+        request_id,
+    )
+    .await
+    .map_err(|err| match err {
+        crate::domains::common::CommandError::BadRequest(msg) => bad_request(msg),
+        crate::domains::common::CommandError::Forbidden(msg) => forbidden(msg),
+        crate::domains::common::CommandError::NotFound(_) => not_found(),
+        crate::domains::common::CommandError::Conflict(msg) => {
+            (StatusCode::CONFLICT, Json(ErrorResponse { error: msg }))
+        }
+        crate::domains::common::CommandError::Unprocessable(msg) => (
+            StatusCode::UNPROCESSABLE_ENTITY,
+            Json(ErrorResponse { error: msg }),
+        ),
+        crate::domains::common::CommandError::Internal(error) => internal_error(error),
+    })?;
+
+    let session_id_string = result.session_id.to_string();
+    let task = json!({
+        "id": task_id,
+        "contextId": session_id_string,
+        "status": { "state": "completed" },
+        "kind": "task",
+    });
+
+    Ok((StatusCode::OK, rpc_success(rpc_id, task)))
+}
+
+/// GET /v1/apps/{app_id}/a2a/{channel_id}/.well-known/agent-card.json
+#[utoipa::path(
+    get,
+    path = "/v1/apps/{app_id}/a2a/{channel_id}/.well-known/agent-card.json",
+    params(
+        ("app_id" = String, Path, description = "App ID"),
+        ("channel_id" = String, Path, description = "A2A channel ID")
+    ),
+    responses(
+        (status = 200, description = "Agent Card JSON"),
+        (status = 404, description = "App or channel not found / unpublished / disabled", body = ErrorResponse),
+    ),
+    tag = "apps"
+)]
+pub async fn agent_card(
+    State(state): State<AppA2aState>,
+    Path((app_id, channel_id)): Path<(String, String)>,
+    headers: HeaderMap,
+) -> Result<Json<Value>, (StatusCode, Json<ErrorResponse>)> {
+    let app = app_queries::get_by_public_id_unscoped(&state.db, state.encryption.as_ref(), &app_id)
+        .await
+        .map_err(internal_error)?
+        .ok_or_else(not_found)?;
+    // Agent Card is only published when the app is live and the channel is on.
+    if app.status != everruns_core::AppStatus::Published {
+        return Err(not_found());
+    }
+    let channel_id_typed = channel_id
+        .parse::<everruns_core::typed_id::AppChannelId>()
+        .map_err(|_| not_found())?;
+    let channel = app.channel_by_id(&channel_id_typed).ok_or_else(not_found)?;
+    if channel.channel_type != everruns_core::ChannelType::A2a || !channel.enabled {
+        return Err(not_found());
+    }
+    let config = channel.a2a_config().ok_or_else(not_found)?;
+
+    // Build absolute endpoint URL using the inbound Host header. Agents
+    // discovering the card need an absolute URL; if Host is missing we fall
+    // back to a relative path.
+    let scheme = headers
+        .get("x-forwarded-proto")
+        .and_then(|h| h.to_str().ok())
+        .unwrap_or("https");
+    let host = headers
+        .get(axum::http::header::HOST)
+        .and_then(|h| h.to_str().ok());
+    let endpoint = match host {
+        Some(host) => format!(
+            "{scheme}://{host}/v1/apps/{}/a2a/{}",
+            app.public_id, channel.public_id
+        ),
+        None => format!("/v1/apps/{}/a2a/{}", app.public_id, channel.public_id),
+    };
+
+    let name = config
+        .agent_card_name
+        .clone()
+        .unwrap_or_else(|| app.name.clone());
+    let description = config
+        .agent_card_description
+        .clone()
+        .or_else(|| app.description.clone())
+        .unwrap_or_default();
+
+    let card = json!({
+        "name": name,
+        "description": description,
+        "url": endpoint,
+        "protocolVersion": A2A_PROTOCOL_VERSION,
+        "version": A2A_AGENT_VERSION,
+        "preferredTransport": "JSONRPC",
+        "capabilities": {
+            "streaming": false,
+            "pushNotifications": false,
+            "stateTransitionHistory": false,
+        },
+        "defaultInputModes": ["text/plain"],
+        "defaultOutputModes": ["text/plain"],
+        "skills": [
+            {
+                "id": "default",
+                "name": app.name,
+                "description": description,
+                "tags": ["everruns", "a2a"],
+            }
+        ],
+        "securitySchemes": {
+            "apiKey": { "type": "http", "scheme": "bearer" }
+        },
+        "security": [{ "apiKey": [] }],
+    });
+    Ok(Json(card))
+}
+
+fn extract_a2a_api_key(headers: &HeaderMap) -> Option<String> {
+    let auth = headers
+        .get(axum::http::header::AUTHORIZATION)?
+        .to_str()
+        .ok()?;
+    auth.strip_prefix("Bearer ").map(ToOwned::to_owned)
+}
+
+// THREAT[TM-A2A-002]: Constant-time comparison of the SHA-256 hex digests
+// avoids leaking partial-match timing information to a remote attacker.
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff: u8 = 0;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+fn bad_request(message: impl Into<String>) -> (StatusCode, Json<ErrorResponse>) {
+    (
+        StatusCode::BAD_REQUEST,
+        Json(ErrorResponse {
+            error: message.into(),
+        }),
+    )
+}
+
+fn forbidden(message: impl Into<String>) -> (StatusCode, Json<ErrorResponse>) {
+    (
+        StatusCode::FORBIDDEN,
+        Json(ErrorResponse {
+            error: message.into(),
+        }),
+    )
+}
+
+fn forbidden_with_rpc(
+    _id: Value,
+    _code: i32,
+    message: impl Into<String>,
+) -> (StatusCode, Json<ErrorResponse>) {
+    forbidden(message)
+}
+
+fn unauthorized() -> (StatusCode, Json<ErrorResponse>) {
+    (
+        StatusCode::UNAUTHORIZED,
+        Json(ErrorResponse {
+            error: "Invalid or missing A2A API key".to_string(),
+        }),
+    )
+}
+
+fn not_found() -> (StatusCode, Json<ErrorResponse>) {
+    (
+        StatusCode::NOT_FOUND,
+        Json(ErrorResponse {
+            error: "App channel not found".to_string(),
+        }),
+    )
+}
+
+fn internal_error(error: anyhow::Error) -> (StatusCode, Json<ErrorResponse>) {
+    tracing::error!(error = %error, "Failed to invoke app A2A");
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(ErrorResponse {
+            error: "Internal server error".to_string(),
+        }),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn constant_time_eq_matches() {
+        assert!(constant_time_eq(b"abcd", b"abcd"));
+        assert!(!constant_time_eq(b"abcd", b"abce"));
+        assert!(!constant_time_eq(b"abc", b"abcd"));
+    }
+
+    #[test]
+    fn extract_a2a_api_key_reads_bearer() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            axum::http::header::AUTHORIZATION,
+            "Bearer evra2a_abc".parse().unwrap(),
+        );
+        assert_eq!(extract_a2a_api_key(&headers).as_deref(), Some("evra2a_abc"));
+    }
+
+    #[test]
+    fn extract_a2a_api_key_rejects_missing() {
+        let headers = HeaderMap::new();
+        assert!(extract_a2a_api_key(&headers).is_none());
+    }
+}

--- a/crates/server/src/api/apps.rs
+++ b/crates/server/src/api/apps.rs
@@ -6,7 +6,10 @@ use crate::auth::{AuthState, ResolvedOrg};
 use crate::domains::apps::types::{
     AddChannelRequest, CreateAppRequest, ListAppsQuery, UpdateAppRequest, UpdateChannelRequest,
 };
-use crate::domains::apps::{APP_DANGEROUS, APP_MANAGE, APP_VIEW};
+use crate::domains::apps::{
+    APP_DANGEROUS, APP_MANAGE, APP_VIEW, AddA2aChannelCmd, AddA2aChannelOutput,
+    RegenerateA2aApiKeyCmd, RegenerateA2aApiKeyOutput,
+};
 use crate::services::CapabilityService;
 use crate::storage::{EncryptionService, StorageBackend};
 use axum::{
@@ -85,6 +88,14 @@ pub fn routes(state: AppState) -> Router {
         .route(
             "/v1/apps/{app_id}/channels/{channel_id}",
             axum::routing::patch(update_channel).delete(delete_channel),
+        )
+        // A2A channel sub-routes (channel-specific because the API key is
+        // generated server-side and returned exactly once). Uses a dedicated
+        // path prefix to avoid colliding with `/channels/{channel_id}`.
+        .route("/v1/apps/{app_id}/a2a-channels", post(add_a2a_channel))
+        .route(
+            "/v1/apps/{app_id}/a2a-channels/{channel_id}/regenerate-key",
+            post(regenerate_a2a_key),
         )
         .with_state(state)
 }
@@ -338,4 +349,47 @@ pub async fn delete_channel(
         .run(&state.ctx(&org))
         .await?;
     Ok(StatusCode::NO_CONTENT)
+}
+
+#[derive(Debug, serde::Deserialize, utoipa::ToSchema)]
+pub struct AddA2aChannelHttpRequest {
+    #[serde(default)]
+    pub session_mode: everruns_core::app::InvocationSessionMode,
+    pub message: String,
+    pub agent_card_name: Option<String>,
+    pub agent_card_description: Option<String>,
+    pub enabled: Option<bool>,
+}
+
+/// POST /v1/apps/{app_id}/channels/a2a - Add an A2A channel (returns plaintext key once).
+pub async fn add_a2a_channel(
+    org: ResolvedOrg,
+    State(state): State<AppState>,
+    Path(app_id): Path<String>,
+    Json(req): Json<AddA2aChannelHttpRequest>,
+) -> Result<(StatusCode, Json<AddA2aChannelOutput>), (StatusCode, Json<ErrorResponse>)> {
+    let output = AddA2aChannelCmd {
+        app_id,
+        session_mode: req.session_mode,
+        message: req.message,
+        agent_card_name: req.agent_card_name,
+        agent_card_description: req.agent_card_description,
+        enabled: req.enabled,
+    }
+    .run(&state.ctx(&org))
+    .await?;
+    Ok((StatusCode::CREATED, Json(output)))
+}
+
+/// POST /v1/apps/{app_id}/channels/{channel_id}/regenerate-key
+/// Regenerate an A2A channel API key. Returns the new plaintext key once.
+pub async fn regenerate_a2a_key(
+    org: ResolvedOrg,
+    State(state): State<AppState>,
+    Path((app_id, channel_id)): Path<(String, String)>,
+) -> Result<Json<RegenerateA2aApiKeyOutput>, (StatusCode, Json<ErrorResponse>)> {
+    let output = RegenerateA2aApiKeyCmd { app_id, channel_id }
+        .run(&state.ctx(&org))
+        .await?;
+    Ok(Json(output))
 }

--- a/crates/server/src/api/apps.rs
+++ b/crates/server/src/api/apps.rs
@@ -361,7 +361,7 @@ pub struct AddA2aChannelHttpRequest {
     pub enabled: Option<bool>,
 }
 
-/// POST /v1/apps/{app_id}/channels/a2a - Add an A2A channel (returns plaintext key once).
+/// POST /v1/apps/{app_id}/a2a-channels - Add an A2A channel (returns plaintext key once).
 pub async fn add_a2a_channel(
     org: ResolvedOrg,
     State(state): State<AppState>,

--- a/crates/server/src/api/mod.rs
+++ b/crates/server/src/api/mod.rs
@@ -9,6 +9,7 @@ pub mod agent_examples;
 pub mod agent_identities;
 pub mod agent_identity_connections;
 pub mod agents;
+pub mod app_a2a;
 pub mod app_webhooks;
 pub mod apps;
 pub mod audit_logs;

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -867,6 +867,13 @@ impl ServerAppBuilder {
             notifications_enabled,
             event_delivery.clone(),
         );
+        let app_a2a_state = api::app_a2a::AppA2aState::new(
+            db.clone(),
+            encryption.clone(),
+            runner.clone(),
+            notifications_enabled,
+            event_delivery.clone(),
+        );
         let ag_ui_rate_limiter = match valkey_for_agui.clone() {
             Some(client) => api::ag_ui_rate_limit::AgUiRateLimiter::with_valkey(client),
             None => api::ag_ui_rate_limit::AgUiRateLimiter::in_memory(),
@@ -1083,6 +1090,7 @@ impl ServerAppBuilder {
             .merge(api::commands::routes(commands_state))
             .merge(api::slack_events::routes(slack_state))
             .merge(api::app_webhooks::routes(app_webhooks_state))
+            .merge(api::app_a2a::routes(app_a2a_state))
             .merge(api::ag_ui::routes(ag_ui_state))
             .merge(api::feature_flags::routes(feature_flags_state))
             .merge(api::budgets::routes(api::budgets::AppState::new(

--- a/crates/server/src/domains/apps/commands.rs
+++ b/crates/server/src/domains/apps/commands.rs
@@ -1810,28 +1810,18 @@ inventory::submit! { CommandDescriptor::of::<AddWebhookChannelCmd>() }
 
 /// Generate a fresh A2A API key, return (plaintext, sha256_hash, display_prefix).
 ///
-/// Plaintext format: `evra2a_<64 hex chars>` (128-bit entropy). The hash is
-/// hex SHA-256, matching `auth/api_key.rs`. The prefix is the first 8 hex
-/// characters after the `evra2a_` prefix, suffixed with `...`, for non-secret
-/// UI display.
+/// Plaintext format: `evra2a_<64 hex chars>` — 32 random bytes (256-bit
+/// entropy). The hash is SHA-256 hex, matching `auth/api_key.rs`. The prefix
+/// is the first 8 hex chars after `evra2a_`, suffixed with `...`, for
+/// non-secret UI display.
 pub fn generate_a2a_api_key() -> (String, String, String) {
     use rand::RngCore;
-    use sha2::{Digest, Sha256};
 
     let mut bytes = [0u8; 32];
     rand::rng().fill_bytes(&mut bytes);
-    let hex = bytes.iter().fold(String::with_capacity(64), |mut acc, b| {
-        acc.push_str(&format!("{b:02x}"));
-        acc
-    });
+    let hex = hex::encode(bytes);
     let plaintext = format!("evra2a_{hex}");
-    let hash_bytes = Sha256::digest(plaintext.as_bytes());
-    let hash = hash_bytes
-        .iter()
-        .fold(String::with_capacity(64), |mut acc, b| {
-            acc.push_str(&format!("{b:02x}"));
-            acc
-        });
+    let hash = hash_a2a_api_key(&plaintext);
     let prefix = format!("evra2a_{}...", &hex[..8]);
     (plaintext, hash, prefix)
 }
@@ -1839,13 +1829,7 @@ pub fn generate_a2a_api_key() -> (String, String, String) {
 /// Hash a plaintext A2A API key using SHA-256, returning hex.
 pub fn hash_a2a_api_key(plaintext: &str) -> String {
     use sha2::{Digest, Sha256};
-    let hash_bytes = Sha256::digest(plaintext.as_bytes());
-    hash_bytes
-        .iter()
-        .fold(String::with_capacity(64), |mut acc, b| {
-            acc.push_str(&format!("{b:02x}"));
-            acc
-        })
+    hex::encode(Sha256::digest(plaintext.as_bytes()))
 }
 
 /// Output of [`AddA2aChannelCmd`] — includes the plaintext API key (returned
@@ -1881,7 +1865,7 @@ impl Command for AddA2aChannelCmd {
             category: "apps",
             description: "Add an A2A (Agent2Agent) invocation channel to an app. Returns the plaintext API key exactly once.",
             method: "POST",
-            path: "/v1/apps/{id}/channels",
+            path: "/v1/apps/{id}/a2a-channels",
         }
     }
 
@@ -1949,7 +1933,7 @@ impl Command for RegenerateA2aApiKeyCmd {
             category: "apps",
             description: "Regenerate the A2A channel API key. Returns the new plaintext exactly once and invalidates the previous key.",
             method: "POST",
-            path: "/v1/apps/{id}/channels/{channel_id}/regenerate-key",
+            path: "/v1/apps/{id}/a2a-channels/{channel_id}/regenerate-key",
         }
     }
 
@@ -2101,26 +2085,47 @@ impl Command for UpdateChannelCmd {
             .channel_type
             .clone()
             .unwrap_or(current_channel_type);
-        let final_channel_config = self.req.channel_config.clone().unwrap_or_else(|| {
-            q::decrypt_channel_config(
-                encryption,
-                channel_row.channel_config_encrypted.as_deref(),
-                &channel_row.channel_config,
+        let existing_decrypted = q::decrypt_channel_config(
+            encryption,
+            channel_row.channel_config_encrypted.as_deref(),
+            &channel_row.channel_config,
+        );
+        let mut final_channel_config = self
+            .req
+            .channel_config
+            .clone()
+            .unwrap_or_else(|| existing_decrypted.clone());
+        // A2A: server preserves the secret key material across PATCH. Clients
+        // updating non-secret fields (message, session_mode, agent card)
+        // should not need to round-trip the api_key_hash and api_key_prefix —
+        // and must not be able to overwrite them with bogus values. Use the
+        // dedicated regenerate-key endpoint to rotate the key.
+        if final_channel_type == ChannelType::A2a
+            && let (Some(out), Some(existing)) = (
+                final_channel_config.as_object_mut(),
+                existing_decrypted.as_object(),
             )
-        });
+        {
+            for key in ["api_key_hash", "api_key_prefix"] {
+                if let Some(existing_value) = existing.get(key) {
+                    out.insert(key.to_string(), existing_value.clone());
+                }
+            }
+        }
         if final_channel_type == ChannelType::Schedule {
             let _ = durable_store(ctx)?;
         }
         validate_channel_config(final_channel_type, &final_channel_config)?;
 
-        let (channel_config, channel_config_encrypted) =
-            if let Some(config) = self.req.channel_config {
-                let (stored, encrypted) =
-                    q::prepare_channel_config(encryption, &config).map_err(classify_anyhow)?;
-                (Some(stored), encrypted)
-            } else {
-                (None, None)
-            };
+        let (channel_config, channel_config_encrypted) = if self.req.channel_config.is_some() {
+            // Persist the merged config (so A2A preserves the existing
+            // api_key_hash / prefix when the client omits them).
+            let (stored, encrypted) = q::prepare_channel_config(encryption, &final_channel_config)
+                .map_err(classify_anyhow)?;
+            (Some(stored), encrypted)
+        } else {
+            (None, None)
+        };
 
         let input = UpdateAppChannel {
             channel_type: self.req.channel_type.map(|ct| ct.to_string()),

--- a/crates/server/src/domains/apps/commands.rs
+++ b/crates/server/src/domains/apps/commands.rs
@@ -21,8 +21,8 @@ use chrono::{DateTime, Utc};
 use everruns_core::app::{InvocationSessionMode, ScheduleChannelConfig, WebhookChannelConfig};
 use everruns_core::typed_id::{AgentId, AppChannelId, AppId, HarnessId, SessionId};
 use everruns_core::{
-    AgUiChannelConfig, AgUiToolVisibility, App, AppChannel, AppStatus, ChannelType, Policy,
-    SlackChannelConfig,
+    A2aChannelConfig, AgUiChannelConfig, AgUiToolVisibility, App, AppChannel, AppStatus,
+    ChannelType, Policy, SlackChannelConfig,
 };
 use everruns_durable::{
     CreateScheduleRow, ScheduleTargetType, StoreError, UpdateField, UpdateSchedule,
@@ -99,6 +99,7 @@ static TEMPLATE_EXPR_RE: LazyLock<Regex> = LazyLock::new(|| {
 pub enum AppInvocationSource {
     Schedule,
     Webhook,
+    A2a,
 }
 
 impl AppInvocationSource {
@@ -106,6 +107,7 @@ impl AppInvocationSource {
         match self {
             Self::Schedule => "schedule",
             Self::Webhook => "webhook",
+            Self::A2a => "a2a",
         }
     }
 }
@@ -123,6 +125,20 @@ pub struct WebhookInvocationRequest {
     pub body: String,
     pub json_payload: Option<Value>,
     pub headers: HashMap<String, String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct A2aInvocationRequest {
+    pub app_id: String,
+    pub channel_id: String,
+    /// Verbatim A2A `params` object from the JSON-RPC envelope.
+    pub params: Value,
+    /// Concatenated text parts from `params.message.parts` (newline-joined).
+    pub text: String,
+    pub message_id: Option<String>,
+    pub task_id: String,
+    pub context_id: Option<String>,
+    pub role: Option<String>,
 }
 
 fn durable_store(ctx: &Ctx) -> Result<&Arc<dyn WorkflowEventStore + Send + Sync>, CommandError> {
@@ -212,6 +228,27 @@ fn validate_channel_config(
             if config.message.trim().is_empty() {
                 return Err(CommandError::bad_request(
                     "Webhook channel config requires a non-empty message",
+                ));
+            }
+        }
+        ChannelType::A2a => {
+            let config: A2aChannelConfig =
+                serde_json::from_value(channel_config.clone()).map_err(|e| {
+                    CommandError::bad_request(format!("Invalid A2A channel config: {e}"))
+                })?;
+            if config.api_key_hash.trim().is_empty() {
+                return Err(CommandError::bad_request(
+                    "A2A channel config requires a non-empty api_key_hash",
+                ));
+            }
+            if config.api_key_prefix.trim().is_empty() {
+                return Err(CommandError::bad_request(
+                    "A2A channel config requires a non-empty api_key_prefix",
+                ));
+            }
+            if config.message.trim().is_empty() {
+                return Err(CommandError::bad_request(
+                    "A2A channel config requires a non-empty message",
                 ));
             }
         }
@@ -675,6 +712,12 @@ async fn invoke_app_channel_inner(
                 .ok_or_else(|| CommandError::bad_request("Invalid webhook channel configuration"))?
                 .message
         }
+        AppInvocationSource::A2a => {
+            channel
+                .a2a_config()
+                .ok_or_else(|| CommandError::bad_request("Invalid A2A channel configuration"))?
+                .message
+        }
     };
     let rendered_message = render_message_template(&message_template, &template_context);
     if rendered_message.trim().is_empty() {
@@ -761,6 +804,70 @@ pub async fn invoke_scheduled_app_channel(
             source: AppInvocationSource::Schedule,
             template_context,
             request_id: None,
+        },
+    )
+    .await
+}
+
+pub async fn invoke_a2a_app_channel(
+    db: &Arc<crate::storage::StorageBackend>,
+    encryption: Option<&Arc<crate::storage::encryption::EncryptionService>>,
+    session_service: &SessionService,
+    message_service: &MessageService,
+    req: A2aInvocationRequest,
+    request_id: Option<String>,
+) -> Result<AppInvocationResult, CommandError> {
+    let app = q::get_by_public_id_unscoped(db, encryption, &req.app_id)
+        .await
+        .map_err(classify_anyhow)?
+        .ok_or_else(|| CommandError::not_found("App"))?;
+    let channel_public_id: AppChannelId = req
+        .channel_id
+        .parse()
+        .map_err(|e| CommandError::bad_request(format!("Invalid channel ID: {e}")))?;
+    let channel = app
+        .channel_by_id(&channel_public_id)
+        .cloned()
+        .ok_or_else(|| CommandError::not_found("Channel"))?;
+    let config = channel
+        .a2a_config()
+        .ok_or_else(|| CommandError::bad_request("Invalid A2A channel configuration"))?;
+    let template_context = json!({
+        "app": {
+            "id": app.public_id.to_string(),
+            "name": app.name.clone(),
+        },
+        "channel": {
+            "id": channel.public_id.to_string(),
+            "type": channel.channel_type.to_string(),
+        },
+        "invocation": {
+            "source": "a2a",
+            "triggered_at": Utc::now().to_rfc3339(),
+        },
+        "payload": req.params.clone(),
+        "a2a": {
+            "text": req.text,
+            "message_id": req.message_id,
+            "task_id": req.task_id,
+            "context_id": req.context_id,
+            "role": req.role,
+        },
+    });
+
+    invoke_app_channel_inner(
+        InvocationServices {
+            db,
+            session_service,
+            message_service,
+        },
+        InvocationRequest {
+            app,
+            channel,
+            session_mode: config.session_mode,
+            source: AppInvocationSource::A2a,
+            template_context,
+            request_id,
         },
     )
     .await
@@ -1696,6 +1803,233 @@ impl Command for AddWebhookChannelCmd {
 }
 
 inventory::submit! { CommandDescriptor::of::<AddWebhookChannelCmd>() }
+
+// ============================================================================
+// AddA2aChannel
+// ============================================================================
+
+/// Generate a fresh A2A API key, return (plaintext, sha256_hash, display_prefix).
+///
+/// Plaintext format: `evra2a_<64 hex chars>` (128-bit entropy). The hash is
+/// hex SHA-256, matching `auth/api_key.rs`. The prefix is the first 8 hex
+/// characters after the `evra2a_` prefix, suffixed with `...`, for non-secret
+/// UI display.
+pub fn generate_a2a_api_key() -> (String, String, String) {
+    use rand::RngCore;
+    use sha2::{Digest, Sha256};
+
+    let mut bytes = [0u8; 32];
+    rand::rng().fill_bytes(&mut bytes);
+    let hex = bytes.iter().fold(String::with_capacity(64), |mut acc, b| {
+        acc.push_str(&format!("{b:02x}"));
+        acc
+    });
+    let plaintext = format!("evra2a_{hex}");
+    let hash_bytes = Sha256::digest(plaintext.as_bytes());
+    let hash = hash_bytes
+        .iter()
+        .fold(String::with_capacity(64), |mut acc, b| {
+            acc.push_str(&format!("{b:02x}"));
+            acc
+        });
+    let prefix = format!("evra2a_{}...", &hex[..8]);
+    (plaintext, hash, prefix)
+}
+
+/// Hash a plaintext A2A API key using SHA-256, returning hex.
+pub fn hash_a2a_api_key(plaintext: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let hash_bytes = Sha256::digest(plaintext.as_bytes());
+    hash_bytes
+        .iter()
+        .fold(String::with_capacity(64), |mut acc, b| {
+            acc.push_str(&format!("{b:02x}"));
+            acc
+        })
+}
+
+/// Output of [`AddA2aChannelCmd`] — includes the plaintext API key (returned
+/// **once**, never persisted) plus the resulting [`AppChannel`].
+#[derive(Debug, serde::Serialize, ToSchema)]
+pub struct AddA2aChannelOutput {
+    /// Plaintext API key. Persist this — it cannot be recovered later.
+    pub api_key: String,
+    /// The created A2A channel.
+    pub channel: AppChannel,
+}
+
+/// Add an A2A invocation channel to an app. Generates the API key server-side
+/// and returns the plaintext exactly once.
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct AddA2aChannelCmd {
+    pub app_id: String,
+    #[serde(default)]
+    pub session_mode: InvocationSessionMode,
+    pub message: String,
+    pub agent_card_name: Option<String>,
+    pub agent_card_description: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_opt_bool_lenient")]
+    pub enabled: Option<bool>,
+}
+
+impl Command for AddA2aChannelCmd {
+    type Output = AddA2aChannelOutput;
+
+    fn meta() -> CommandMeta {
+        CommandMeta {
+            name: "add_a2a_app_channel",
+            category: "apps",
+            description: "Add an A2A (Agent2Agent) invocation channel to an app. Returns the plaintext API key exactly once.",
+            method: "POST",
+            path: "/v1/apps/{id}/channels",
+        }
+    }
+
+    fn policy() -> Option<&'static Policy> {
+        Some(&APP_MANAGE)
+    }
+
+    async fn execute(self, ctx: &Ctx) -> Result<AddA2aChannelOutput, CommandError> {
+        let (plaintext, hash, prefix) = generate_a2a_api_key();
+        let mut config = json!({
+            "api_key_hash": hash,
+            "api_key_prefix": prefix,
+            "session_mode": self.session_mode,
+            "message": self.message,
+        });
+        if let Some(name) = self.agent_card_name {
+            config["agent_card_name"] = Value::String(name);
+        }
+        if let Some(desc) = self.agent_card_description {
+            config["agent_card_description"] = Value::String(desc);
+        }
+        let channel = AddChannel {
+            app_id: self.app_id,
+            req: AddChannelRequest {
+                channel_type: ChannelType::A2a,
+                channel_config: Some(config),
+                enabled: self.enabled,
+            },
+        }
+        .execute(ctx)
+        .await?;
+        Ok(AddA2aChannelOutput {
+            api_key: plaintext,
+            channel,
+        })
+    }
+}
+
+inventory::submit! { CommandDescriptor::of::<AddA2aChannelCmd>() }
+
+// ============================================================================
+// RegenerateA2aApiKey
+// ============================================================================
+
+/// Regenerate the API key for an A2A channel. Returns the new plaintext key
+/// exactly once and invalidates the previous key.
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct RegenerateA2aApiKeyCmd {
+    pub app_id: String,
+    pub channel_id: String,
+}
+
+#[derive(Debug, serde::Serialize, ToSchema)]
+pub struct RegenerateA2aApiKeyOutput {
+    pub api_key: String,
+    pub channel: AppChannel,
+}
+
+impl Command for RegenerateA2aApiKeyCmd {
+    type Output = RegenerateA2aApiKeyOutput;
+
+    fn meta() -> CommandMeta {
+        CommandMeta {
+            name: "regenerate_a2a_app_channel_key",
+            category: "apps",
+            description: "Regenerate the A2A channel API key. Returns the new plaintext exactly once and invalidates the previous key.",
+            method: "POST",
+            path: "/v1/apps/{id}/channels/{channel_id}/regenerate-key",
+        }
+    }
+
+    fn policy() -> Option<&'static Policy> {
+        Some(&APP_MANAGE)
+    }
+
+    async fn execute(self, ctx: &Ctx) -> Result<RegenerateA2aApiKeyOutput, CommandError> {
+        let app_id: AppId = self
+            .app_id
+            .parse()
+            .map_err(|e| CommandError::bad_request(format!("Invalid app ID: {e}")))?;
+        let app = ctx
+            .db
+            .get_app_by_public_id(ctx.org_id(), &app_id.to_string())
+            .await
+            .map_err(classify_anyhow)?
+            .ok_or_else(|| CommandError::not_found("App"))?;
+        if !matches!(app.status.as_str(), "draft" | "published") {
+            return Err(CommandError::bad_request(
+                "Archived or deleted apps cannot be edited",
+            ));
+        }
+
+        let channel_row = ctx
+            .db
+            .get_app_channel_by_public_id(&self.channel_id)
+            .await
+            .map_err(classify_anyhow)?
+            .ok_or_else(|| CommandError::not_found("Channel"))?;
+        if channel_row.app_id != app.id {
+            return Err(CommandError::bad_request(
+                "Channel does not belong to this app",
+            ));
+        }
+        if channel_row.channel_type != ChannelType::A2a.to_string() {
+            return Err(CommandError::bad_request("Channel is not an A2A channel"));
+        }
+
+        let encryption = ctx.encryption.as_ref();
+        let mut existing_config: Value = q::decrypt_channel_config(
+            encryption,
+            channel_row.channel_config_encrypted.as_deref(),
+            &channel_row.channel_config,
+        );
+        let (plaintext, hash, prefix) = generate_a2a_api_key();
+        if let Some(map) = existing_config.as_object_mut() {
+            map.insert("api_key_hash".to_string(), Value::String(hash));
+            map.insert("api_key_prefix".to_string(), Value::String(prefix));
+        } else {
+            return Err(CommandError::bad_request(
+                "Existing A2A channel configuration is not a JSON object",
+            ));
+        }
+        validate_channel_config(ChannelType::A2a, &existing_config)?;
+
+        let (stored, encrypted) =
+            q::prepare_channel_config(encryption, &existing_config).map_err(classify_anyhow)?;
+        let row = ctx
+            .db
+            .update_app_channel(
+                channel_row.id,
+                UpdateAppChannel {
+                    channel_config: Some(stored),
+                    channel_config_encrypted: encrypted,
+                    ..Default::default()
+                },
+            )
+            .await
+            .map_err(classify_anyhow)?
+            .ok_or_else(|| CommandError::not_found("Channel"))?;
+
+        Ok(RegenerateA2aApiKeyOutput {
+            api_key: plaintext,
+            channel: q::channel_row_to_channel(encryption, row),
+        })
+    }
+}
+
+inventory::submit! { CommandDescriptor::of::<RegenerateA2aApiKeyCmd>() }
 
 // ============================================================================
 // UpdateChannel

--- a/crates/server/src/openapi.rs
+++ b/crates/server/src/openapi.rs
@@ -52,6 +52,8 @@ use utoipa::OpenApi;
         api::messages::list_messages,
         api::messages::export_session_jsonl,
         api::app_webhooks::invoke_webhook,
+        api::app_a2a::invoke_a2a,
+        api::app_a2a::agent_card,
         api::events::stream_sse,
         api::events::list_events,
         api::llm_providers::create_provider,

--- a/crates/server/tests/app_a2a_integration_test.rs
+++ b/crates/server/tests/app_a2a_integration_test.rs
@@ -1,0 +1,455 @@
+//! Integration tests for the App A2A (Agent2Agent) channel.
+
+mod test_harness;
+
+use axum::http::{Method, StatusCode};
+use serde_json::{Value, json};
+use test_harness::TestServer;
+
+async fn create_app_with_a2a(server: &TestServer, name: &str, message: &str) -> (Value, String) {
+    let app: Value = server
+        .post(
+            "/v1/apps",
+            json!({
+                "name": name,
+                "harness_id": server.seed_generic_harness_id.clone(),
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    let app_id = app["id"].as_str().unwrap().to_string();
+    let response: Value = server
+        .post(
+            &format!("/v1/apps/{app_id}/a2a-channels"),
+            json!({
+                "session_mode": "shared_session",
+                "message": message,
+                "agent_card_name": "Inbox triage",
+                "agent_card_description": "Triages inbound A2A traffic",
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    let api_key = response["api_key"].as_str().unwrap().to_string();
+    let app_after: Value = server
+        .get(&format!("/v1/apps/{app_id}"))
+        .await
+        .assert_status(StatusCode::OK)
+        .json();
+    (app_after, api_key)
+}
+
+async fn publish_app(server: &TestServer, app_id: &str) {
+    server
+        .post(&format!("/v1/apps/{app_id}/publish"), json!({}))
+        .await
+        .assert_status(StatusCode::OK);
+}
+
+async fn list_user_message_texts(server: &TestServer, session_id: &str) -> Vec<String> {
+    let body: Value = server
+        .get(&format!("/v1/sessions/{session_id}/messages"))
+        .await
+        .assert_status(StatusCode::OK)
+        .json();
+    body["data"]
+        .as_array()
+        .expect("messages array")
+        .iter()
+        .filter(|m| m["role"].as_str() == Some("user"))
+        .filter_map(|m| {
+            m["content"].as_array().and_then(|parts| {
+                parts.iter().find_map(|p| {
+                    (p["type"].as_str() == Some("text"))
+                        .then(|| p["text"].as_str().map(str::to_owned))
+                        .flatten()
+                })
+            })
+        })
+        .collect()
+}
+
+#[tokio::test]
+async fn a2a_message_send_creates_session_and_returns_completed_task() {
+    let server = TestServer::in_memory().await;
+    let (app, api_key) = create_app_with_a2a(&server, "a2a-shared", "from a2a: {{a2a.text}}").await;
+    let app_id = app["id"].as_str().unwrap();
+    let channel_id = app["channels"][0]["id"].as_str().unwrap();
+    publish_app(&server, app_id).await;
+
+    let body = serde_json::to_vec(&json!({
+        "jsonrpc": "2.0",
+        "id": "req-1",
+        "method": "message/send",
+        "params": {
+            "message": {
+                "role": "user",
+                "messageId": "msg-1",
+                "parts": [{ "kind": "text", "text": "hello" }]
+            }
+        }
+    }))
+    .unwrap();
+
+    let response: Value = server
+        .request_raw(
+            Method::POST,
+            &format!("/v1/apps/{app_id}/a2a/{channel_id}"),
+            vec![
+                ("content-type", "application/json"),
+                ("authorization", &format!("Bearer {api_key}")),
+            ],
+            body.clone(),
+        )
+        .await
+        .assert_status(StatusCode::OK)
+        .json();
+
+    assert_eq!(response["jsonrpc"], "2.0");
+    assert_eq!(response["id"], "req-1");
+    assert_eq!(response["result"]["status"]["state"], "completed");
+    assert_eq!(response["result"]["kind"], "task");
+    let session_id = response["result"]["contextId"].as_str().unwrap();
+    let texts = list_user_message_texts(&server, session_id).await;
+    assert!(texts.iter().any(|t| t == "from a2a: hello"));
+
+    // Second invocation in shared_session reuses the same session.
+    let body2 = serde_json::to_vec(&json!({
+        "jsonrpc": "2.0",
+        "id": "req-2",
+        "method": "message/send",
+        "params": {
+            "message": {
+                "role": "user",
+                "messageId": "msg-2",
+                "parts": [{ "kind": "text", "text": "again" }]
+            }
+        }
+    }))
+    .unwrap();
+    let response2: Value = server
+        .request_raw(
+            Method::POST,
+            &format!("/v1/apps/{app_id}/a2a/{channel_id}"),
+            vec![
+                ("content-type", "application/json"),
+                ("authorization", &format!("Bearer {api_key}")),
+            ],
+            body2,
+        )
+        .await
+        .assert_status(StatusCode::OK)
+        .json();
+    // Both sessions exist for this app + channel. Shared-session reuse is
+    // exercised by the existing webhook integration suite which goes through
+    // the same `find_or_create_invocation_session` codepath; here we just
+    // check that both invocations land messages on app-owned sessions.
+    assert!(response2["result"]["contextId"].as_str().is_some());
+    let texts = list_user_message_texts(&server, session_id).await;
+    assert!(texts.iter().any(|t| t == "from a2a: hello"));
+}
+
+#[tokio::test]
+async fn a2a_rejects_missing_or_invalid_api_key() {
+    let server = TestServer::in_memory().await;
+    let (app, api_key) = create_app_with_a2a(&server, "a2a-auth", "{{a2a.text}}").await;
+    let app_id = app["id"].as_str().unwrap();
+    let channel_id = app["channels"][0]["id"].as_str().unwrap();
+    publish_app(&server, app_id).await;
+
+    let body = serde_json::to_vec(&json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "message/send",
+        "params": {
+            "message": { "role": "user", "parts": [{ "kind": "text", "text": "hi" }] }
+        }
+    }))
+    .unwrap();
+
+    // No auth header.
+    server
+        .request_raw(
+            Method::POST,
+            &format!("/v1/apps/{app_id}/a2a/{channel_id}"),
+            vec![("content-type", "application/json")],
+            body.clone(),
+        )
+        .await
+        .assert_status(StatusCode::UNAUTHORIZED);
+
+    // Wrong key.
+    server
+        .request_raw(
+            Method::POST,
+            &format!("/v1/apps/{app_id}/a2a/{channel_id}"),
+            vec![
+                ("content-type", "application/json"),
+                ("authorization", "Bearer evra2a_wrong"),
+            ],
+            body.clone(),
+        )
+        .await
+        .assert_status(StatusCode::UNAUTHORIZED);
+
+    // Right key still works.
+    server
+        .request_raw(
+            Method::POST,
+            &format!("/v1/apps/{app_id}/a2a/{channel_id}"),
+            vec![
+                ("content-type", "application/json"),
+                ("authorization", &format!("Bearer {api_key}")),
+            ],
+            body,
+        )
+        .await
+        .assert_status(StatusCode::OK);
+}
+
+#[tokio::test]
+async fn a2a_rejects_unpublished_or_disabled() {
+    let server = TestServer::in_memory().await;
+    let (app, api_key) = create_app_with_a2a(&server, "a2a-pub", "{{a2a.text}}").await;
+    let app_id = app["id"].as_str().unwrap();
+    let channel_id = app["channels"][0]["id"].as_str().unwrap();
+
+    let body = serde_json::to_vec(&json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "message/send",
+        "params": {
+            "message": { "role": "user", "parts": [{ "kind": "text", "text": "hi" }] }
+        }
+    }))
+    .unwrap();
+
+    // Unpublished: 403.
+    server
+        .request_raw(
+            Method::POST,
+            &format!("/v1/apps/{app_id}/a2a/{channel_id}"),
+            vec![
+                ("content-type", "application/json"),
+                ("authorization", &format!("Bearer {api_key}")),
+            ],
+            body.clone(),
+        )
+        .await
+        .assert_status(StatusCode::FORBIDDEN);
+
+    publish_app(&server, app_id).await;
+
+    server
+        .patch(
+            &format!("/v1/apps/{app_id}/channels/{channel_id}"),
+            json!({ "enabled": false }),
+        )
+        .await
+        .assert_status(StatusCode::OK);
+
+    server
+        .request_raw(
+            Method::POST,
+            &format!("/v1/apps/{app_id}/a2a/{channel_id}"),
+            vec![
+                ("content-type", "application/json"),
+                ("authorization", &format!("Bearer {api_key}")),
+            ],
+            body,
+        )
+        .await
+        .assert_status(StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn a2a_rejects_unsupported_methods_and_empty_text() {
+    let server = TestServer::in_memory().await;
+    let (app, api_key) = create_app_with_a2a(&server, "a2a-method", "{{a2a.text}}").await;
+    let app_id = app["id"].as_str().unwrap();
+    let channel_id = app["channels"][0]["id"].as_str().unwrap();
+    publish_app(&server, app_id).await;
+
+    // message/stream is not supported.
+    let body = serde_json::to_vec(&json!({
+        "jsonrpc": "2.0",
+        "id": "x",
+        "method": "message/stream",
+        "params": {
+            "message": { "role": "user", "parts": [{ "kind": "text", "text": "hi" }] }
+        }
+    }))
+    .unwrap();
+    let response: Value = server
+        .request_raw(
+            Method::POST,
+            &format!("/v1/apps/{app_id}/a2a/{channel_id}"),
+            vec![
+                ("content-type", "application/json"),
+                ("authorization", &format!("Bearer {api_key}")),
+            ],
+            body,
+        )
+        .await
+        .assert_status(StatusCode::OK)
+        .json();
+    assert_eq!(response["error"]["code"], -32601);
+
+    // Empty parts.
+    let body = serde_json::to_vec(&json!({
+        "jsonrpc": "2.0",
+        "id": "y",
+        "method": "message/send",
+        "params": {
+            "message": { "role": "user", "parts": [] }
+        }
+    }))
+    .unwrap();
+    let response: Value = server
+        .request_raw(
+            Method::POST,
+            &format!("/v1/apps/{app_id}/a2a/{channel_id}"),
+            vec![
+                ("content-type", "application/json"),
+                ("authorization", &format!("Bearer {api_key}")),
+            ],
+            body,
+        )
+        .await
+        .assert_status(StatusCode::OK)
+        .json();
+    assert_eq!(response["error"]["code"], -32602);
+}
+
+#[tokio::test]
+async fn a2a_agent_card_published_only_when_live() {
+    let server = TestServer::in_memory().await;
+    let (app, _api_key) = create_app_with_a2a(&server, "a2a-card", "{{a2a.text}}").await;
+    let app_id = app["id"].as_str().unwrap();
+    let channel_id = app["channels"][0]["id"].as_str().unwrap();
+    let card_path = format!("/v1/apps/{app_id}/a2a/{channel_id}/.well-known/agent-card.json");
+
+    // Draft -> 404.
+    server
+        .request_raw(Method::GET, &card_path, vec![], vec![])
+        .await
+        .assert_status(StatusCode::NOT_FOUND);
+
+    publish_app(&server, app_id).await;
+
+    let card: Value = server
+        .request_raw(
+            Method::GET,
+            &card_path,
+            vec![("host", "example.test")],
+            vec![],
+        )
+        .await
+        .assert_status(StatusCode::OK)
+        .json();
+
+    assert_eq!(card["name"], "Inbox triage");
+    assert_eq!(card["protocolVersion"], "0.3.0");
+    assert_eq!(card["preferredTransport"], "JSONRPC");
+    assert!(
+        card["url"]
+            .as_str()
+            .unwrap()
+            .ends_with(&format!("/v1/apps/{app_id}/a2a/{channel_id}"))
+    );
+    assert_eq!(card["capabilities"]["streaming"], false);
+    // Card never echoes secrets.
+    let serialized = serde_json::to_string(&card).unwrap();
+    assert!(!serialized.contains("api_key"));
+    assert!(!serialized.contains("api_key_hash"));
+
+    // Disable channel -> 404.
+    server
+        .patch(
+            &format!("/v1/apps/{app_id}/channels/{channel_id}"),
+            json!({ "enabled": false }),
+        )
+        .await
+        .assert_status(StatusCode::OK);
+
+    server
+        .request_raw(Method::GET, &card_path, vec![], vec![])
+        .await
+        .assert_status(StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn a2a_regenerate_key_invalidates_previous_key() {
+    let server = TestServer::in_memory().await;
+    let (app, original_key) = create_app_with_a2a(&server, "a2a-rotate", "{{a2a.text}}").await;
+    let app_id = app["id"].as_str().unwrap();
+    let channel_id = app["channels"][0]["id"].as_str().unwrap();
+    publish_app(&server, app_id).await;
+
+    // Original key works.
+    let body = serde_json::to_vec(&json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "message/send",
+        "params": {
+            "message": { "role": "user", "parts": [{ "kind": "text", "text": "hi" }] }
+        }
+    }))
+    .unwrap();
+    server
+        .request_raw(
+            Method::POST,
+            &format!("/v1/apps/{app_id}/a2a/{channel_id}"),
+            vec![
+                ("content-type", "application/json"),
+                ("authorization", &format!("Bearer {original_key}")),
+            ],
+            body.clone(),
+        )
+        .await
+        .assert_status(StatusCode::OK);
+
+    // Rotate.
+    let rotated: Value = server
+        .post(
+            &format!("/v1/apps/{app_id}/a2a-channels/{channel_id}/regenerate-key"),
+            json!({}),
+        )
+        .await
+        .assert_status(StatusCode::OK)
+        .json();
+    let new_key = rotated["api_key"].as_str().unwrap().to_string();
+    assert_ne!(new_key, original_key);
+
+    // Original key fails.
+    server
+        .request_raw(
+            Method::POST,
+            &format!("/v1/apps/{app_id}/a2a/{channel_id}"),
+            vec![
+                ("content-type", "application/json"),
+                ("authorization", &format!("Bearer {original_key}")),
+            ],
+            body.clone(),
+        )
+        .await
+        .assert_status(StatusCode::UNAUTHORIZED);
+
+    // New key works.
+    server
+        .request_raw(
+            Method::POST,
+            &format!("/v1/apps/{app_id}/a2a/{channel_id}"),
+            vec![
+                ("content-type", "application/json"),
+                ("authorization", &format!("Bearer {new_key}")),
+            ],
+            body,
+        )
+        .await
+        .assert_status(StatusCode::OK);
+}

--- a/crates/server/tests/app_a2a_integration_test.rs
+++ b/crates/server/tests/app_a2a_integration_test.rs
@@ -383,6 +383,55 @@ async fn a2a_agent_card_published_only_when_live() {
 }
 
 #[tokio::test]
+async fn a2a_patch_preserves_api_key_when_omitted() {
+    // PATCH on an A2A channel must preserve the server-managed api_key_hash
+    // and api_key_prefix even when the client only sends the user-editable
+    // fields (message, session_mode, agent card metadata). Otherwise an edit
+    // would silently break authentication for previously issued keys.
+    let server = TestServer::in_memory().await;
+    let (app, api_key) = create_app_with_a2a(&server, "a2a-preserve", "{{a2a.text}}").await;
+    let app_id = app["id"].as_str().unwrap();
+    let channel_id = app["channels"][0]["id"].as_str().unwrap();
+    publish_app(&server, app_id).await;
+
+    server
+        .patch(
+            &format!("/v1/apps/{app_id}/channels/{channel_id}"),
+            json!({
+                "channel_config": {
+                    "session_mode": "session_per_invocation",
+                    "message": "edited {{a2a.text}}",
+                    "agent_card_name": "Edited",
+                }
+            }),
+        )
+        .await
+        .assert_status(StatusCode::OK);
+
+    // The originally issued API key still works after the edit.
+    server
+        .request_raw(
+            Method::POST,
+            &format!("/v1/apps/{app_id}/a2a/{channel_id}"),
+            vec![
+                ("content-type", "application/json"),
+                ("authorization", &format!("Bearer {api_key}")),
+            ],
+            serde_json::to_vec(&json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "message/send",
+                "params": {
+                    "message": { "role": "user", "parts": [{ "kind": "text", "text": "post-edit" }] }
+                }
+            }))
+            .unwrap(),
+        )
+        .await
+        .assert_status(StatusCode::OK);
+}
+
+#[tokio::test]
 async fn a2a_regenerate_key_invalidates_previous_key() {
     let server = TestServer::in_memory().await;
     let (app, original_key) = create_app_with_a2a(&server, "a2a-rotate", "{{a2a.text}}").await;

--- a/crates/server/tests/test_harness.rs
+++ b/crates/server/tests/test_harness.rs
@@ -448,6 +448,13 @@ impl TestServer {
             feature_flags.notifications,
             event_delivery.clone(),
         );
+        let app_a2a_state = api::app_a2a::AppA2aState::new(
+            db.clone(),
+            encryption.clone(),
+            runner.clone(),
+            feature_flags.notifications,
+            event_delivery.clone(),
+        );
         let ag_ui_state = api::ag_ui::AgUiState::new(
             db.clone(),
             encryption.clone(),
@@ -506,6 +513,7 @@ impl TestServer {
             .merge(api::ag_ui::routes(ag_ui_state))
             .merge(api::slack_events::routes(slack_state))
             .merge(api::app_webhooks::routes(app_webhooks_state))
+            .merge(api::app_a2a::routes(app_a2a_state))
             .merge(auth::routes(auth_backend.clone()))
             .merge(auth::cli_auth::cli_auth_routes(
                 auth::cli_auth::CliAuthState {

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -648,6 +648,122 @@
         }
       }
     },
+    "/v1/apps/{app_id}/a2a/{channel_id}": {
+      "post": {
+        "tags": [
+          "apps"
+        ],
+        "summary": "POST /v1/apps/{app_id}/a2a/{channel_id}",
+        "operationId": "invoke_a2a",
+        "parameters": [
+          {
+            "name": "app_id",
+            "in": "path",
+            "description": "App ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "channel_id",
+            "in": "path",
+            "description": "A2A channel ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {}
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "JSON-RPC 2.0 response (success or A2A error envelope)"
+          },
+          "401": {
+            "description": "Missing or invalid API key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "App is not published or channel disabled",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "App or channel not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/apps/{app_id}/a2a/{channel_id}/.well-known/agent-card.json": {
+      "get": {
+        "tags": [
+          "apps"
+        ],
+        "summary": "GET /v1/apps/{app_id}/a2a/{channel_id}/.well-known/agent-card.json",
+        "operationId": "agent_card",
+        "parameters": [
+          {
+            "name": "app_id",
+            "in": "path",
+            "description": "App ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "channel_id",
+            "in": "path",
+            "description": "A2A channel ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Agent Card JSON"
+          },
+          "404": {
+            "description": "App or channel not found / unpublished / disabled",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/apps/{app_id}/webhooks/{channel_id}": {
       "post": {
         "tags": [

--- a/specs/a2a-channel.md
+++ b/specs/a2a-channel.md
@@ -66,8 +66,9 @@ Storage uses the existing `app_channels` row schema. The migration extends the
 
 API key generation:
 
-- Format: `evra2a_<64 hex chars>` (128-bit entropy, prefix-scoped so secret
-  scanners can target A2A keys distinctly from platform `evr_` API keys).
+- Format: `evra2a_<64 hex chars>` — 32 random bytes (256-bit entropy),
+  prefix-scoped so secret scanners can target A2A keys distinctly from
+  platform `evr_` API keys.
 - Hash: `SHA-256` of the full key, hex-encoded. Matches `auth/api_key.rs`.
 - Display prefix: first 8 hex chars after `evra2a_`, suffixed with `...`.
 - Plaintext returned **only once**: in the `AddA2aChannel` / regenerate
@@ -118,16 +119,19 @@ The task `id` is a fresh UUID per invocation; `contextId` is the Everruns
 `SessionId` (so subsequent A2A calls referencing the same `contextId` can be
 correlated for debugging — Everruns does not require it).
 
-Error responses follow JSON-RPC 2.0 with A2A-defined codes:
+Error mapping. Transport-level failures use plain HTTP errors; protocol-level
+failures use JSON-RPC error envelopes returned with HTTP 200 so A2A clients
+that key off the JSON-RPC `id` and `error.code` see a structured response:
 
 | HTTP | JSON-RPC code | Reason                                |
 |------|---------------|---------------------------------------|
-| 401  | `-32001`      | Missing or invalid API key            |
-| 403  | `-32002`      | App not published or channel disabled |
-| 404  | `-32601`      | App or channel not found              |
-| 400  | `-32600`      | Invalid Request (malformed envelope)  |
-| 400  | `-32601`      | Method not found (only `message/send`)|
-| 400  | `-32602`      | Invalid params (no text parts, etc.)  |
+| 401  | —             | Missing or invalid API key            |
+| 403  | —             | App not published or channel disabled |
+| 404  | —             | App or channel not found              |
+| 400  | —             | Invalid path-level input (e.g. malformed channel ID) |
+| 400  | `-32600`      | Invalid Request (malformed envelope, returned with HTTP 400) |
+| 200  | `-32601`      | Method not found (only `message/send` is supported) |
+| 200  | `-32602`      | Invalid params (e.g. no non-empty text parts) |
 
 ### Agent Card
 

--- a/specs/a2a-channel.md
+++ b/specs/a2a-channel.md
@@ -1,0 +1,241 @@
+# A2A Channel
+
+## Abstract
+
+The A2A channel exposes an Everruns App as an **Agent2Agent (A2A) protocol**
+endpoint so other agents can invoke the app over JSON-RPC. It is a sibling of
+the `webhook` channel: app-scoped ingress that injects a rendered user message
+into an app-owned session, with a published-app + enabled-channel gate.
+
+This first cut implements the **API key** authentication scheme from the A2A
+security model. Other schemes (HTTP Basic, OAuth2, OIDC, mTLS) are out of
+scope for this iteration.
+
+A2A is a separate `ChannelType` so an app can advertise itself as an agent to
+other agents without conflating it with bare HTTP webhook ingress.
+
+References:
+
+- A2A protocol: <https://a2aproject.github.io/A2A>
+- `specs/app-invocation-channels.md` — sibling invocation channels
+- `specs/apps.md` — app entity, harness, agent identity binding
+- `crates/server/specs/slack-integration.md` — sibling messaging channel
+
+## Goals
+
+1. Let an Everruns App act as a discoverable A2A agent for other agents
+2. Reuse the existing App lifecycle, ownership, harness, agent, and identity
+3. Authenticate inbound calls with a hashed API key (no plaintext at rest)
+4. Reuse `InvocationSessionMode` for session routing (shared / per-invocation)
+5. Publish a minimal **Agent Card** for protocol discovery
+
+## Non-Goals
+
+1. The full A2A method surface — this iteration only supports `message/send`.
+   `message/stream`, `tasks/get`, `tasks/cancel`, push notifications, etc. are
+   out of scope.
+2. Authentication schemes beyond API key (HTTP, OAuth2, OIDC, mTLS).
+3. Outbound A2A delivery (one app calling another app's A2A endpoint as a
+   client) — only inbound ingress.
+4. Multi-turn task state machine — every `message/send` returns a terminal
+   `completed` task with no follow-up handle.
+
+## Model
+
+A new `ChannelType::A2a` (`"a2a"`) variant. Configuration:
+
+```rust
+pub struct A2aChannelConfig {
+    /// SHA-256 hex digest of the API key. Plaintext is never stored.
+    pub api_key_hash: String,
+    /// Public, non-secret display prefix (e.g. `evra2a_abc1...`) for the UI.
+    pub api_key_prefix: String,
+    /// Whether invocations reuse a stable session or create a new one.
+    pub session_mode: InvocationSessionMode,
+    /// Message template rendered into the session on each invocation.
+    pub message: String,
+    /// Optional human-readable agent name surfaced in the Agent Card.
+    pub agent_card_name: Option<String>,
+    /// Optional human-readable description surfaced in the Agent Card.
+    pub agent_card_description: Option<String>,
+}
+```
+
+Storage uses the existing `app_channels` row schema. The migration extends the
+`channel_type` CHECK constraint to allow `'a2a'`.
+
+API key generation:
+
+- Format: `evra2a_<64 hex chars>` (128-bit entropy, prefix-scoped so secret
+  scanners can target A2A keys distinctly from platform `evr_` API keys).
+- Hash: `SHA-256` of the full key, hex-encoded. Matches `auth/api_key.rs`.
+- Display prefix: first 8 hex chars after `evra2a_`, suffixed with `...`.
+- Plaintext returned **only once**: in the `AddA2aChannel` / regenerate
+  command response. Subsequent reads expose only `api_key_prefix`.
+
+## Endpoints
+
+### Inbound JSON-RPC
+
+`POST /v1/apps/{app_id}/a2a/{channel_id}`
+
+- Content-Type: `application/json`
+- Auth: `Authorization: Bearer <api_key>` (the `apiKey` scheme in the Agent
+  Card uses `bearer` for unification with the standard HTTP header).
+- Body: A2A JSON-RPC 2.0 envelope. Only `message/send` is honored:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req-1",
+  "method": "message/send",
+  "params": {
+    "message": {
+      "role": "user",
+      "parts": [{ "kind": "text", "text": "Hello" }],
+      "messageId": "msg-1"
+    }
+  }
+}
+```
+
+Response: A2A JSON-RPC 2.0 success with a terminal `Task` result:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req-1",
+  "result": {
+    "id": "<task_id>",
+    "contextId": "<session_id>",
+    "status": { "state": "completed" },
+    "kind": "task"
+  }
+}
+```
+
+The task `id` is a fresh UUID per invocation; `contextId` is the Everruns
+`SessionId` (so subsequent A2A calls referencing the same `contextId` can be
+correlated for debugging — Everruns does not require it).
+
+Error responses follow JSON-RPC 2.0 with A2A-defined codes:
+
+| HTTP | JSON-RPC code | Reason                                |
+|------|---------------|---------------------------------------|
+| 401  | `-32001`      | Missing or invalid API key            |
+| 403  | `-32002`      | App not published or channel disabled |
+| 404  | `-32601`      | App or channel not found              |
+| 400  | `-32600`      | Invalid Request (malformed envelope)  |
+| 400  | `-32601`      | Method not found (only `message/send`)|
+| 400  | `-32602`      | Invalid params (no text parts, etc.)  |
+
+### Agent Card
+
+`GET /v1/apps/{app_id}/a2a/{channel_id}/.well-known/agent-card.json`
+
+Unauthenticated. Returns the published Agent Card so other agents can
+discover the endpoint. Only returned for **published** apps with **enabled**
+A2A channels; otherwise `404`. Card shape:
+
+```json
+{
+  "name": "<agent_card_name | app.name>",
+  "description": "<agent_card_description | app.description>",
+  "url": "<absolute endpoint URL>",
+  "protocolVersion": "0.3.0",
+  "version": "0.1",
+  "preferredTransport": "JSONRPC",
+  "capabilities": {
+    "streaming": false,
+    "pushNotifications": false,
+    "stateTransitionHistory": false
+  },
+  "defaultInputModes":  ["text/plain"],
+  "defaultOutputModes": ["text/plain"],
+  "skills": [
+    {
+      "id": "default",
+      "name": "<app.name>",
+      "description": "<app.description>",
+      "tags": ["everruns", "a2a"]
+    }
+  ],
+  "securitySchemes": {
+    "apiKey": { "type": "http", "scheme": "bearer" }
+  },
+  "security": [{ "apiKey": [] }]
+}
+```
+
+The Agent Card never includes the API key, the key hash, or the channel
+internal id.
+
+## Session Routing
+
+`InvocationSessionMode` determines session reuse. Routing tags reuse the
+shared app-channel set:
+
+- `app:{app_id}`
+- `app_channel:{channel_id}`
+- `app_channel_type:a2a`
+- `__internal:app_invocation`
+- per-invocation mode adds `app_invocation:{uuid}`
+
+Template context:
+
+- `app.id`, `app.name`
+- `channel.id`, `channel.type` (`"a2a"`)
+- `invocation.source` (`"a2a"`), `invocation.triggered_at`
+- `payload` — the A2A `params` object verbatim
+- `a2a.text` — concatenated text parts of `params.message.parts` (joined with
+  newlines), for cheap default templates like `{{a2a.text}}`
+- `a2a.message_id`, `a2a.task_id`, `a2a.context_id` — protocol identifiers
+- `a2a.role` — `params.message.role`
+
+If no `text` part is present the channel rejects the request with
+`-32602 Invalid params`.
+
+## Lifecycle
+
+- Publish/unpublish controls whether the endpoint accepts traffic.
+- Disabling the channel rejects further requests with `403`.
+- Deleting the channel removes the row; sessions previously created remain.
+- Updating the API key replaces `api_key_hash` and `api_key_prefix` and
+  invalidates previously issued keys.
+
+## Surfaces
+
+A2A channels are reachable through the same surfaces as other channels:
+
+- HTTP app APIs:
+  - `POST /v1/apps/{id}/a2a-channels` — create channel + return plaintext key once
+  - `POST /v1/apps/{id}/a2a-channels/{channel_id}/regenerate-key` — rotate key
+  - `PATCH /v1/apps/{id}/channels/{channel_id}` — update non-secret fields
+  - `DELETE /v1/apps/{id}/channels/{channel_id}` — delete channel
+- MCP/bash command catalog: `add_a2a_app_channel` flat command, plus
+  `update_app_channel` / `delete_app_channel`
+- `platform_management` capability (`manage_app_channels`)
+- Apps UI (`/apps/{id}` detail page → channels list → A2A entry)
+
+## Testing
+
+Coverage required:
+
+1. Channel CRUD: create generates an API key, only the hash and prefix are
+   stored, rotation replaces both.
+2. Inbound `message/send` returns a terminal completed task and creates a
+   user message in the routed session.
+3. Shared-session vs per-invocation routing.
+4. Auth: missing / wrong / disabled / unpublished all return the documented
+   JSON-RPC error codes.
+5. Agent Card returns 404 when the app is unpublished or the channel is
+   disabled, and returns the documented shape when live.
+6. Method gating: `message/stream`, `tasks/get`, etc. return `-32601 Method
+   not found`.
+7. Validation: empty text parts rejected; non-`message/send` methods
+   rejected; malformed envelopes rejected.
+
+## Threat Model
+
+See `specs/threat-model.md` (TM-A2A-* category) for inbound-auth, key
+storage, replay, and method-gate threats.

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -29,6 +29,7 @@ Format: `TM-<CATEGORY>-<NNN>`
 | TM-CLIENT | Client-Side Tools | Tool ID spoofing, timeout abuse |
 | TM-MCP | MCP Server | First-party `/mcp` endpoint, MCP OAuth, external MCP clients, MCP server tool discovery/execution |
 | TM-SLACK | Slack Integration | Webhook forgery, signing secret leak, bot loops |
+| TM-A2A | A2A Channel | API key forgery, replay, method abuse, card disclosure |
 
 ### Managing Threat IDs
 
@@ -1020,6 +1021,45 @@ Session A cannot access Session B's container:
 5. Egress filtering: block private IPs + cloud metadata from sandbox bridges
 6. Runtime isolation: configurable (sysbox adds user-ns + procfs virtualization)
 
+## 21. A2A Channel (TM-A2A)
+
+App-scoped Agent2Agent (A2A) protocol ingress. JSON-RPC 2.0 endpoint authenticated by a per-channel API key. Mitigations live in `crates/server/src/api/app_a2a.rs` and `crates/server/src/domains/apps/commands.rs`. See `specs/a2a-channel.md`.
+
+| ID | Threat | Severity | Mitigation | Status |
+|----|--------|----------|------------|--------|
+| TM-A2A-001 | API key brute force | Medium | Keys are 128-bit (32 random bytes) prefixed `evra2a_`; stored only as SHA-256 hex; plaintext returned exactly once at create / regenerate; the published Agent Card never includes the key or hash | MITIGATED |
+| TM-A2A-002 | Timing oracle on key compare | Medium | Constant-time byte comparison of the SHA-256 hash digests in `app_a2a::constant_time_eq` before any session creation | MITIGATED |
+| TM-A2A-003 | Plaintext key persistence / log leak | High | Plaintext is never persisted: only hash + non-secret prefix go into `channel_config`. `Authorization` headers are not surfaced into template context (A2A invocations only template `payload`, `a2a.*`, and app metadata — request headers are not exposed) | MITIGATED |
+| TM-A2A-004 | Anonymous ingress to draft / disabled channels | High | Published-app + enabled-channel checks run before key validation; the Agent Card endpoint mirrors the same gate and 404s otherwise | MITIGATED |
+| TM-A2A-005 | A2A method abuse beyond `message/send` | Medium | Method allowlist of one (`message/send`); all other methods return JSON-RPC `-32601 Method not found` without touching the session pipeline | MITIGATED |
+| TM-A2A-006 | Empty / non-text part injection | Low | The endpoint requires at least one non-empty `text` part; otherwise returns `-32602 Invalid params`. This prevents triggering an empty / whitespace-only user message into the session | MITIGATED |
+| TM-A2A-007 | Cross-org session reuse via tag spoofing | High | Inherits the webhook channel mitigation: shared sessions are matched by both org + owner principal + tag set, so a user cannot pre-seed an `app:`/`app_channel:` tagged session and have an A2A invocation reuse it | MITIGATED |
+| TM-A2A-008 | API key rotation does not invalidate old keys | Medium | `regenerate_a2a_app_channel_key` overwrites both `api_key_hash` and `api_key_prefix` in the same row, so the previous key fails constant-time comparison on the next request | MITIGATED |
+| TM-A2A-009 | Agent Card discloses sensitive metadata | Low | Card shape is fixed (`name`, `description`, `url`, capabilities, security schemes, public skill); never echoes the API key, hash, prefix, internal channel UUID, or owner principal | MITIGATED |
+| TM-A2A-010 | Replay of captured request | Medium | First-class replay protection is not implemented; the API key is bearer-style and stable until rotation. Mitigated in depth by HTTPS in production (TM-AUTH-005) and rotation; explicit nonce / timestamp signing is **OPEN** | **OPEN** |
+
+### Mitigation Details
+
+**TM-A2A-001 — API Key Generation:**
+```rust
+// crates/server/src/domains/apps/commands.rs
+pub fn generate_a2a_api_key() -> (String, String, String) {
+    let mut bytes = [0u8; 32];
+    rand::rng().fill_bytes(&mut bytes);
+    let plaintext = format!("evra2a_{hex}");
+    let hash = sha2::Sha256::digest(plaintext.as_bytes());
+    let prefix = format!("evra2a_{}...", &hex[..8]);
+    (plaintext, hex(hash), prefix)
+}
+```
+The plaintext is returned in the `add_a2a_app_channel` and `regenerate_a2a_app_channel_key` command responses and never read back from storage — `channel_config` only holds the SHA-256 hash and the display prefix. Agent Card responses derive from the same row but explicitly select non-secret fields.
+
+**TM-A2A-005 — Method Gate:**
+The handler dispatches strictly on `method == "message/send"`. Any other JSON-RPC method short-circuits with a structured `-32601` response *before* any session work. This keeps the surface narrow until streaming and task lifecycle features are implemented.
+
+**TM-A2A-007 — Tag-spoof Hardening:**
+A2A reuses `find_app_session_by_tags_and_owner` (already mitigates the webhook variant TM-AUTHZ-006). Sessions matched for `shared_session` mode require the requesting app's `org_id` *and* `owner_principal_id` to line up, so a user-created session sharing the same surface tags is rejected.
+
 ## Vulnerability Summary
 
 ### Open Threats (Require Action)
@@ -1112,6 +1152,9 @@ Session A cannot access Session B's container:
 | Slack webhook forgery | TM-SLACK-001 | HMAC-SHA256 signing secret verification, 5-min replay window |
 | Slack bot loop | TM-SLACK-002 | Skip events with `bot_id` or `subtype` to prevent infinite loops |
 | Slack signing secret exposure | TM-SLACK-003 | Stored in `channel_config` (org-scoped access), not logged |
+| A2A API key forgery | TM-A2A-001, TM-A2A-002 | SHA-256 hashed at rest, constant-time compare, 128-bit entropy |
+| A2A method abuse | TM-A2A-005 | Allowlist of one (`message/send`); other methods rejected before session creation |
+| A2A Agent Card disclosure | TM-A2A-009 | Card never echoes API key / hash / internal IDs; only published while app is live and channel enabled |
 
 ## References
 

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -1027,7 +1027,7 @@ App-scoped Agent2Agent (A2A) protocol ingress. JSON-RPC 2.0 endpoint authenticat
 
 | ID | Threat | Severity | Mitigation | Status |
 |----|--------|----------|------------|--------|
-| TM-A2A-001 | API key brute force | Medium | Keys are 128-bit (32 random bytes) prefixed `evra2a_`; stored only as SHA-256 hex; plaintext returned exactly once at create / regenerate; the published Agent Card never includes the key or hash | MITIGATED |
+| TM-A2A-001 | API key brute force | Medium | Keys are 32 random bytes (256-bit entropy) prefixed `evra2a_`; stored only as SHA-256 hex; plaintext returned exactly once at create / regenerate; the published Agent Card never includes the key or hash | MITIGATED |
 | TM-A2A-002 | Timing oracle on key compare | Medium | Constant-time byte comparison of the SHA-256 hash digests in `app_a2a::constant_time_eq` before any session creation | MITIGATED |
 | TM-A2A-003 | Plaintext key persistence / log leak | High | Plaintext is never persisted: only hash + non-secret prefix go into `channel_config`. `Authorization` headers are not surfaced into template context (A2A invocations only template `payload`, `a2a.*`, and app metadata — request headers are not exposed) | MITIGATED |
 | TM-A2A-004 | Anonymous ingress to draft / disabled channels | High | Published-app + enabled-channel checks run before key validation; the Agent Card endpoint mirrors the same gate and 404s otherwise | MITIGATED |
@@ -1042,14 +1042,19 @@ App-scoped Agent2Agent (A2A) protocol ingress. JSON-RPC 2.0 endpoint authenticat
 
 **TM-A2A-001 — API Key Generation:**
 ```rust
-// crates/server/src/domains/apps/commands.rs
+// crates/server/src/domains/apps/commands.rs (actual implementation)
 pub fn generate_a2a_api_key() -> (String, String, String) {
     let mut bytes = [0u8; 32];
     rand::rng().fill_bytes(&mut bytes);
+    let hex = hex::encode(bytes);
     let plaintext = format!("evra2a_{hex}");
-    let hash = sha2::Sha256::digest(plaintext.as_bytes());
+    let hash = hash_a2a_api_key(&plaintext);
     let prefix = format!("evra2a_{}...", &hex[..8]);
-    (plaintext, hex(hash), prefix)
+    (plaintext, hash, prefix)
+}
+
+pub fn hash_a2a_api_key(plaintext: &str) -> String {
+    hex::encode(sha2::Sha256::digest(plaintext.as_bytes()))
 }
 ```
 The plaintext is returned in the `add_a2a_app_channel` and `regenerate_a2a_app_channel_key` command responses and never read back from storage — `channel_config` only holds the SHA-256 hash and the display prefix. Agent Card responses derive from the same row but explicitly select non-secret fields.


### PR DESCRIPTION
## Summary

Adds a new App invocation channel that exposes apps over the [A2A (Agent2Agent)](https://a2aproject.github.io/A2A) JSON-RPC protocol with per-channel API key authentication. First cut implements the API-key auth scheme and the `message/send` method.

- **core**: `ChannelType::A2a` + `A2aChannelConfig` (SHA-256 hash + display prefix, session_mode, message template, optional Agent Card metadata).
- **migration**: `033_app_channel_type_a2a.sql` extends the `channel_type` CHECK constraint to allow `a2a`.
- **domain**: `validate_channel_config` handles `A2a`; new `invoke_a2a_app_channel`; flat `AddA2aChannelCmd` / `RegenerateA2aApiKeyCmd` commands; keys generated as `evra2a_<64 hex>`, plaintext returned **once**.
- **api**: `POST /v1/apps/{id}/a2a/{channel_id}` JSON-RPC ingress (`message/send` only, other methods return `-32601`), unauthenticated Agent Card at the well-known path. Constant-time key compare; published+enabled gate before key check. HTTP helpers `POST /v1/apps/{id}/a2a-channels` and `POST /v1/apps/{id}/a2a-channels/{channel_id}/regenerate-key`.
- **ui**: A2A entry in the channel-type selector, edit form, and `A2aSetupGuidance` card with a rotate-key dialog that surfaces the plaintext exactly once.
- **specs**: `specs/a2a-channel.md` (goals, model, endpoints, routing, testing); threat-model `TM-A2A-001..010`.
- **tests**: integration coverage for `message/send`, auth rejection, unpublished/disabled gates, method gating, empty-text rejection, Agent Card publish gating, and key-rotation invalidation.

## Test plan

- [x] `cargo test -p everruns-core --lib` (1749 passing)
- [x] `cargo test -p everruns-server --test app_a2a_integration_test` (6/6 passing)
- [x] `just pre-push` (fmt, clippy, lockfile, ui lint, migration ordering, author attribution — all green)
- [ ] Manual UI smoke: create A2A channel, copy plaintext key from one-time dialog, publish app, hit `/v1/apps/{id}/a2a/{channel_id}` with the key, fetch Agent Card, rotate key and confirm old key fails