### PR TITLE
feat(memory): add PATCH endpoint to rename memory store and toggle default

### DIFF
--- a/apps/ui/src/app/(main)/memory-stores/page.tsx
+++ b/apps/ui/src/app/(main)/memory-stores/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { Brain, ChevronRight, Plus, Search, Star, Trash2, X } from "lucide-react";
+import { Brain, ChevronRight, Pencil, Plus, Search, Star, Trash2, X } from "lucide-react";
 import { QueryStateWrapper } from "@/components/query-state-wrapper";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -37,12 +37,14 @@ import {
   useMemories,
   useMemoryStores,
   usePageTitle,
+  useUpdateMemoryStore,
 } from "@/hooks";
 import type {
   CreateMemoryStoreRequest,
   Memory,
   MemoryContentPart,
   MemoryStore,
+  UpdateMemoryStoreRequest,
 } from "@/lib/api/types";
 import { formatRelativeTime } from "@/lib/formatting";
 
@@ -58,6 +60,7 @@ const KIND_OPTIONS = [
 export default function MemoryStoresPage() {
   usePageTitle("Memory");
   const [createOpen, setCreateOpen] = useState(false);
+  const [editStoreId, setEditStoreId] = useState<string | null>(null);
   const [selectedStoreId, setSelectedStoreId] = useState<string | null>(null);
   const [search, setSearch] = useState("");
   const [kind, setKind] = useState<string>("all");
@@ -70,9 +73,11 @@ export default function MemoryStoresPage() {
   const activeStore = stores?.find((s) => s.id === activeStoreId) ?? null;
 
   const createStore = useCreateMemoryStore();
+  const updateStore = useUpdateMemoryStore();
   const forgetMemory = useForgetMemory(activeStoreId ?? undefined);
 
   const trimmedSearch = search.trim();
+  const editStore = editStoreId ? (stores?.find((s) => s.id === editStoreId) ?? null) : null;
   const memoriesQuery = useMemories(activeStoreId ?? undefined, {
     query: trimmedSearch,
     kind: kind === "all" ? undefined : kind,
@@ -146,6 +151,7 @@ export default function MemoryStoresPage() {
                   store={store}
                   active={store.id === activeStoreId}
                   onSelect={() => setSelectedStoreId(store.id)}
+                  onEdit={() => setEditStoreId(store.id)}
                 />
               ))}
             </aside>
@@ -234,6 +240,20 @@ export default function MemoryStoresPage() {
         }}
       />
 
+      <EditStoreDialog
+        store={editStore}
+        open={editStore !== null}
+        isPending={updateStore.isPending}
+        onOpenChange={(open) => {
+          if (!open) setEditStoreId(null);
+        }}
+        onSubmit={async (request) => {
+          if (!editStore) return;
+          await updateStore.mutateAsync({ storeId: editStore.id, request });
+          setEditStoreId(null);
+        }}
+      />
+
       <MemoryDetailDrawer
         memory={
           detailMemoryId
@@ -260,40 +280,54 @@ function StoreCard({
   store,
   active,
   onSelect,
+  onEdit,
 }: {
   store: MemoryStore;
   active: boolean;
   onSelect: () => void;
+  onEdit: () => void;
 }) {
   return (
-    <button
-      type="button"
-      onClick={onSelect}
+    <div
       aria-current={active ? "true" : undefined}
-      className={`flex w-full items-center gap-3 rounded-md border px-3 py-2.5 text-left transition hover:bg-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
+      className={`flex w-full items-center rounded-md border transition ${
         active ? "border-primary bg-accent/60 shadow-sm" : "border-border bg-card"
       }`}
     >
-      <div className="min-w-0 flex-1">
-        <div className="flex items-center gap-2">
-          <span className="truncate text-sm font-semibold">{store.name}</span>
-          {store.is_default && (
-            <Badge variant="secondary" className="shrink-0 px-1.5 py-0 text-[10px]">
-              <Star className="h-3 w-3" /> Default
-            </Badge>
-          )}
+      <button
+        type="button"
+        onClick={onSelect}
+        className="flex min-w-0 flex-1 items-center gap-3 rounded-l-md px-3 py-2.5 text-left transition hover:bg-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <span className="truncate text-sm font-semibold">{store.name}</span>
+            {store.is_default && (
+              <Badge variant="secondary" className="shrink-0 px-1.5 py-0 text-[10px]">
+                <Star className="h-3 w-3" /> Default
+              </Badge>
+            )}
+          </div>
+          <div className="mt-0.5 text-xs text-muted-foreground">
+            {store.active_memory_count} active{" "}
+            {store.active_memory_count === 1 ? "memory" : "memories"}
+          </div>
         </div>
-        <div className="mt-0.5 text-xs text-muted-foreground">
-          {store.active_memory_count} active{" "}
-          {store.active_memory_count === 1 ? "memory" : "memories"}
-        </div>
-      </div>
-      <ChevronRight
-        className={`h-4 w-4 shrink-0 transition ${
-          active ? "text-primary" : "text-muted-foreground/40"
-        }`}
-      />
-    </button>
+        <ChevronRight
+          className={`h-4 w-4 shrink-0 transition ${
+            active ? "text-primary" : "text-muted-foreground/40"
+          }`}
+        />
+      </button>
+      <button
+        type="button"
+        onClick={onEdit}
+        aria-label={`Edit ${store.name}`}
+        className="mr-2 inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition hover:bg-background hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        <Pencil className="h-3.5 w-3.5" />
+      </button>
+    </div>
   );
 }
 
@@ -739,6 +773,106 @@ function CreateStoreDialog({
             }}
           >
             Create
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function EditStoreDialog({
+  store,
+  open,
+  isPending,
+  onOpenChange,
+  onSubmit,
+}: {
+  store: MemoryStore | null;
+  open: boolean;
+  isPending: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: (request: UpdateMemoryStoreRequest) => Promise<void>;
+}) {
+  const [name, setName] = useState("");
+  const [isDefault, setIsDefault] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (store) {
+      setName(store.name);
+      setIsDefault(store.is_default);
+      setError(null);
+    }
+  }, [store?.id, store?.name, store?.is_default, store]);
+
+  if (!store) return null;
+
+  const trimmed = name.trim();
+  const nameChanged = trimmed.length > 0 && trimmed !== store.name;
+  const defaultChanged = isDefault !== store.is_default;
+  const dirty = nameChanged || defaultChanged;
+  // Demoting the only default is rejected server-side. Disable the toggle
+  // when the store is currently the default — the supported way to move the
+  // default is to promote a different store, which demotes this one.
+  const disableDefaultToggle = store.is_default;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Edit memory store</DialogTitle>
+          <DialogDescription>
+            Rename the store or change which one is the org default.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-3">
+          <div className="space-y-1">
+            <label className="text-sm font-medium" htmlFor="memory-store-edit-name">
+              Name
+            </label>
+            <Input
+              id="memory-store-edit-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="team-knowledge"
+            />
+          </div>
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              checked={isDefault}
+              disabled={disableDefaultToggle}
+              onChange={(e) => setIsDefault(e.target.checked)}
+            />
+            Make this the default store for the organization
+            {disableDefaultToggle && (
+              <span className="text-xs text-muted-foreground">
+                — promote another store to demote this one
+              </span>
+            )}
+          </label>
+          {error && <p className="text-sm text-destructive">{error}</p>}
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isPending}>
+            Cancel
+          </Button>
+          <Button
+            variant="accent"
+            disabled={!dirty || isPending || trimmed.length === 0}
+            onClick={async () => {
+              setError(null);
+              const request: UpdateMemoryStoreRequest = {};
+              if (nameChanged) request.name = trimmed;
+              if (defaultChanged) request.is_default = isDefault;
+              try {
+                await onSubmit(request);
+              } catch (e) {
+                setError(e instanceof Error ? e.message : "Failed to update memory store");
+              }
+            }}
+          >
+            Save
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/apps/ui/src/app/(main)/memory-stores/page.tsx
+++ b/apps/ui/src/app/(main)/memory-stores/page.tsx
@@ -797,13 +797,17 @@ function EditStoreDialog({
   const [isDefault, setIsDefault] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  // Initialize form state only when the dialog opens onto a different store
+  // (or onto a store at all). Re-running on every store-object identity change
+  // would clobber in-progress edits whenever the underlying query refetches.
   useEffect(() => {
     if (store) {
       setName(store.name);
       setIsDefault(store.is_default);
       setError(null);
     }
-  }, [store?.id, store?.name, store?.is_default, store]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [store?.id]);
 
   if (!store) return null;
 

--- a/apps/ui/src/hooks/use-memory-stores.ts
+++ b/apps/ui/src/hooks/use-memory-stores.ts
@@ -7,8 +7,14 @@ import {
   getMemoryStore,
   listMemories,
   listMemoryStores,
+  updateMemoryStore,
 } from "@/lib/api/memory-stores";
-import type { CreateMemoryStoreRequest, ListMemoriesParams, MemoryStore } from "@/lib/api/types";
+import type {
+  CreateMemoryStoreRequest,
+  ListMemoriesParams,
+  MemoryStore,
+  UpdateMemoryStoreRequest,
+} from "@/lib/api/types";
 import { queryKeys } from "@/lib/query-keys";
 import { useOrgScopedQuery } from "./create-crud-hooks";
 
@@ -39,6 +45,17 @@ export function useCreateMemoryStore() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (request: CreateMemoryStoreRequest) => createMemoryStore(request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.memoryStores.all });
+    },
+  });
+}
+
+export function useUpdateMemoryStore() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ storeId, request }: { storeId: string; request: UpdateMemoryStoreRequest }) =>
+      updateMemoryStore(storeId, request),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.memoryStores.all });
     },

--- a/apps/ui/src/lib/api/memory-stores.ts
+++ b/apps/ui/src/lib/api/memory-stores.ts
@@ -7,6 +7,7 @@ import type {
   ListMemoriesResponse,
   ListResponse,
   MemoryStore,
+  UpdateMemoryStoreRequest,
 } from "./types";
 
 export async function listMemoryStores(): Promise<MemoryStore[]> {
@@ -21,6 +22,14 @@ export async function getMemoryStore(storeId: string): Promise<MemoryStore> {
 
 export async function createMemoryStore(request: CreateMemoryStoreRequest): Promise<MemoryStore> {
   const response = await api.post<MemoryStore>("/v1/memory-stores", request);
+  return response.data;
+}
+
+export async function updateMemoryStore(
+  storeId: string,
+  request: UpdateMemoryStoreRequest,
+): Promise<MemoryStore> {
+  const response = await api.patch<MemoryStore>(`/v1/memory-stores/${storeId}`, request);
   return response.data;
 }
 

--- a/apps/ui/src/lib/api/types/memory-store-types.ts
+++ b/apps/ui/src/lib/api/types/memory-store-types.ts
@@ -33,6 +33,11 @@ export interface CreateMemoryStoreRequest {
   is_default?: boolean;
 }
 
+export interface UpdateMemoryStoreRequest {
+  name?: string;
+  is_default?: boolean;
+}
+
 export interface ListMemoriesParams {
   query?: string;
   kind?: string;

--- a/crates/server/src/api/memory_stores.rs
+++ b/crates/server/src/api/memory_stores.rs
@@ -5,10 +5,11 @@ use crate::auth::{AuthState, ResolvedOrg};
 use crate::domains::common::{Command, Ctx};
 pub use crate::domains::memory_stores::types::{
     CreateMemoryStoreRequest, ListMemoriesQuery, ListMemoriesResponse, MemoryResponse,
-    MemoryStoreResponse,
+    MemoryStoreResponse, UpdateMemoryStoreRequest,
 };
 use crate::domains::memory_stores::{
     CreateMemoryStore, ForgetMemoryCmd, GetMemoryStore, ListMemoriesCmd, ListMemoryStores,
+    UpdateMemoryStore,
 };
 use crate::storage::StorageBackend;
 use axum::{
@@ -51,7 +52,10 @@ pub fn routes(state: AppState) -> Router {
             "/v1/memory-stores",
             post(create_memory_store).get(list_memory_stores),
         )
-        .route("/v1/memory-stores/{store_id}", get(get_memory_store))
+        .route(
+            "/v1/memory-stores/{store_id}",
+            get(get_memory_store).patch(update_memory_store),
+        )
         .route("/v1/memory-stores/{store_id}/memories", get(list_memories))
         .route(
             "/v1/memory-stores/{store_id}/memories/{memory_id}",
@@ -114,6 +118,32 @@ pub async fn get_memory_store(
 ) -> ApiResult<MemoryStoreResponse> {
     Ok(Json(
         GetMemoryStore { store_id }.run(&state.ctx(&org)).await?,
+    ))
+}
+
+#[utoipa::path(
+    patch,
+    path = "/v1/memory-stores/{store_id}",
+    params(("store_id" = String, Path, description = "Memory store ID")),
+    request_body = UpdateMemoryStoreRequest,
+    responses(
+        (status = 200, description = "Memory store updated", body = MemoryStoreResponse),
+        (status = 400, description = "Invalid input", body = ErrorResponse),
+        (status = 404, description = "Not found", body = ErrorResponse),
+        (status = 409, description = "Duplicate name", body = ErrorResponse)
+    ),
+    tag = "memory_stores"
+)]
+pub async fn update_memory_store(
+    org: ResolvedOrg,
+    State(state): State<AppState>,
+    Path(store_id): Path<String>,
+    Json(req): Json<UpdateMemoryStoreRequest>,
+) -> ApiResult<MemoryStoreResponse> {
+    Ok(Json(
+        UpdateMemoryStore::from_request(store_id, req)
+            .run(&state.ctx(&org))
+            .await?,
     ))
 }
 

--- a/crates/server/src/api/memory_stores.rs
+++ b/crates/server/src/api/memory_stores.rs
@@ -130,7 +130,7 @@ pub async fn get_memory_store(
         (status = 200, description = "Memory store updated", body = MemoryStoreResponse),
         (status = 400, description = "Invalid input", body = ErrorResponse),
         (status = 404, description = "Not found", body = ErrorResponse),
-        (status = 409, description = "Duplicate name", body = ErrorResponse)
+        (status = 409, description = "Conflict (duplicate name or concurrent default reassignment)", body = ErrorResponse)
     ),
     tag = "memory_stores"
 )]

--- a/crates/server/src/domains/memory_stores/commands.rs
+++ b/crates/server/src/domains/memory_stores/commands.rs
@@ -218,9 +218,8 @@ impl Command for UpdateMemoryStore {
             None => None,
         };
 
-        // Look up the existing store first so we can reject a no-op demotion
-        // of the only default store and avoid issuing UPDATE SQL when nothing
-        // would actually change. This also returns 404 before any write.
+        // Look up the existing store first so we can reject a demotion of the
+        // only default store with a clear error and return 404 before any write.
         let existing = ctx
             .db
             .get_memory_store_by_public_id(ctx.org_id(), &id.to_string())

--- a/crates/server/src/domains/memory_stores/commands.rs
+++ b/crates/server/src/domains/memory_stores/commands.rs
@@ -1,10 +1,10 @@
 use super::types::{
     CreateMemoryStoreRequest, ListMemoriesQuery, ListMemoriesResponse, MemoryResponse,
-    MemoryStoreResponse, memory_response, store_response,
+    MemoryStoreResponse, UpdateMemoryStoreRequest, memory_response, store_response,
 };
 use super::{MEMORY_STORE_MANAGE, MEMORY_STORE_VIEW};
 use crate::domains::common::*;
-use crate::storage::models::{CreateMemoryStoreRow, ListMemoriesFilter};
+use crate::storage::models::{CreateMemoryStoreRow, ListMemoriesFilter, UpdateMemoryStoreRow};
 use everruns_core::Policy;
 use everruns_core::memory_store::MemoryLimits;
 use everruns_core::typed_id::{MemoryId, MemoryStoreId};
@@ -159,6 +159,112 @@ impl Command for CreateMemoryStore {
 }
 
 inventory::submit! { CommandDescriptor::of::<CreateMemoryStore>() }
+
+#[derive(Debug, Default, Deserialize, ToSchema)]
+pub struct UpdateMemoryStore {
+    pub store_id: String,
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub is_default: Option<bool>,
+}
+
+impl UpdateMemoryStore {
+    pub fn from_request(store_id: String, req: UpdateMemoryStoreRequest) -> Self {
+        Self {
+            store_id,
+            name: req.name,
+            is_default: req.is_default,
+        }
+    }
+}
+
+impl Command for UpdateMemoryStore {
+    type Output = MemoryStoreResponse;
+
+    fn meta() -> CommandMeta {
+        CommandMeta {
+            name: "update_memory_store",
+            category: "memory_stores",
+            description: "Rename a memory store and/or change which one is the org default.",
+            method: "PATCH",
+            path: "/v1/memory-stores/{store_id}",
+        }
+    }
+
+    fn positional_arg() -> Option<&'static str> {
+        Some("store_id")
+    }
+
+    fn policy() -> Option<&'static Policy> {
+        Some(&MEMORY_STORE_MANAGE)
+    }
+
+    fn output_schema() -> serde_json::Value {
+        output_schema_for::<MemoryStoreResponse>()
+    }
+
+    async fn execute(self, ctx: &Ctx) -> Result<MemoryStoreResponse, CommandError> {
+        let id = parse_store_id(&self.store_id)?;
+
+        if self.name.is_none() && self.is_default.is_none() {
+            return Err(CommandError::bad_request(
+                "Provide at least one of `name` or `is_default`.",
+            ));
+        }
+
+        let validated_name = match self.name.as_deref() {
+            Some(n) => Some(validate_store_name(n)?),
+            None => None,
+        };
+
+        // Look up the existing store first so we can reject a no-op demotion
+        // of the only default store and avoid issuing UPDATE SQL when nothing
+        // would actually change. This also returns 404 before any write.
+        let existing = ctx
+            .db
+            .get_memory_store_by_public_id(ctx.org_id(), &id.to_string())
+            .await
+            .map_err(classify_anyhow)?
+            .ok_or_else(|| CommandError::not_found("Memory store"))?;
+
+        // Demoting the only default would leave the org without a default
+        // store. Reject with a clear error; promoting another store first
+        // (or PATCHing a different store with `is_default=true`, which
+        // demotes this one in the same transaction) is the supported way to
+        // move the default.
+        if matches!(self.is_default, Some(false)) && existing.is_default {
+            return Err(CommandError::bad_request(
+                "Cannot unset is_default on the only default memory store. \
+                 Promote another store instead — setting is_default=true on \
+                 it will demote this one atomically.",
+            ));
+        }
+
+        let row = ctx
+            .db
+            .update_memory_store(
+                ctx.org_id(),
+                &id.to_string(),
+                UpdateMemoryStoreRow {
+                    name: validated_name,
+                    is_default: self.is_default,
+                },
+            )
+            .await
+            .map_err(classify_anyhow)?
+            .ok_or_else(|| CommandError::not_found("Memory store"))?;
+
+        let count = ctx
+            .db
+            .count_active_memories(row.id)
+            .await
+            .map_err(classify_anyhow)?;
+        store_response(row, count).map_err(classify_anyhow)
+    }
+}
+
+inventory::submit! { CommandDescriptor::of::<UpdateMemoryStore>() }
 
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct GetMemoryStore {
@@ -587,5 +693,152 @@ mod tests {
         // ListMemoryStores in other org should be empty.
         let listed = ListMemoryStores.run(&org_b).await.expect("list stores");
         assert!(listed.is_empty());
+    }
+
+    #[tokio::test]
+    async fn rename_store_updates_name() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let ctx = ctx_with_db(DEFAULT_ORG_ID, db);
+
+        let created = CreateMemoryStore {
+            name: "old-name".into(),
+            is_default: true,
+        }
+        .run(&ctx)
+        .await
+        .expect("create store");
+
+        let updated = UpdateMemoryStore {
+            store_id: created.id.to_string(),
+            name: Some("new-name".into()),
+            is_default: None,
+        }
+        .run(&ctx)
+        .await
+        .expect("rename store");
+
+        assert_eq!(updated.id, created.id);
+        assert_eq!(updated.name, "new-name");
+        assert!(updated.is_default);
+    }
+
+    #[tokio::test]
+    async fn promoting_default_demotes_previous_default() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let ctx = ctx_with_db(DEFAULT_ORG_ID, db);
+
+        let first = CreateMemoryStore {
+            name: "first".into(),
+            is_default: true,
+        }
+        .run(&ctx)
+        .await
+        .expect("create first store");
+        let second = CreateMemoryStore {
+            name: "second".into(),
+            is_default: false,
+        }
+        .run(&ctx)
+        .await
+        .expect("create second store");
+
+        let promoted = UpdateMemoryStore {
+            store_id: second.id.to_string(),
+            name: None,
+            is_default: Some(true),
+        }
+        .run(&ctx)
+        .await
+        .expect("promote second");
+        assert!(promoted.is_default);
+
+        let listed = ListMemoryStores.run(&ctx).await.expect("list stores");
+        let by_id: std::collections::HashMap<_, _> =
+            listed.iter().map(|s| (s.id, s.is_default)).collect();
+        assert_eq!(by_id.get(&first.id), Some(&false));
+        assert_eq!(by_id.get(&second.id), Some(&true));
+    }
+
+    #[tokio::test]
+    async fn rename_to_existing_name_returns_conflict() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let ctx = ctx_with_db(DEFAULT_ORG_ID, db);
+
+        let _ = CreateMemoryStore {
+            name: "team-a".into(),
+            is_default: true,
+        }
+        .run(&ctx)
+        .await
+        .expect("create team-a");
+        let team_b = CreateMemoryStore {
+            name: "team-b".into(),
+            is_default: false,
+        }
+        .run(&ctx)
+        .await
+        .expect("create team-b");
+
+        // Case-insensitive collision: "TEAM-A" should clash with "team-a".
+        let err = UpdateMemoryStore {
+            store_id: team_b.id.to_string(),
+            name: Some("TEAM-A".into()),
+            is_default: None,
+        }
+        .run(&ctx)
+        .await
+        .expect_err("rename should conflict");
+        assert!(matches!(err, CommandError::Conflict(_)));
+    }
+
+    #[tokio::test]
+    async fn demoting_only_default_is_rejected() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let ctx = ctx_with_db(DEFAULT_ORG_ID, db);
+
+        let only = CreateMemoryStore {
+            name: "only".into(),
+            is_default: true,
+        }
+        .run(&ctx)
+        .await
+        .expect("create only store");
+
+        let err = UpdateMemoryStore {
+            store_id: only.id.to_string(),
+            name: None,
+            is_default: Some(false),
+        }
+        .run(&ctx)
+        .await
+        .expect_err("demote-only-default should be rejected");
+        assert!(matches!(err, CommandError::BadRequest(_)));
+
+        let listed = ListMemoryStores.run(&ctx).await.expect("list stores");
+        assert!(listed.iter().any(|s| s.id == only.id && s.is_default));
+    }
+
+    #[tokio::test]
+    async fn update_with_no_fields_is_bad_request() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let ctx = ctx_with_db(DEFAULT_ORG_ID, db);
+
+        let store = CreateMemoryStore {
+            name: "store".into(),
+            is_default: true,
+        }
+        .run(&ctx)
+        .await
+        .expect("create store");
+
+        let err = UpdateMemoryStore {
+            store_id: store.id.to_string(),
+            name: None,
+            is_default: None,
+        }
+        .run(&ctx)
+        .await
+        .expect_err("empty update should fail");
+        assert!(matches!(err, CommandError::BadRequest(_)));
     }
 }

--- a/crates/server/src/domains/memory_stores/types.rs
+++ b/crates/server/src/domains/memory_stores/types.rs
@@ -23,6 +23,14 @@ pub struct CreateMemoryStoreRequest {
     pub is_default: bool,
 }
 
+#[derive(Debug, Clone, Default, Deserialize, ToSchema)]
+pub struct UpdateMemoryStoreRequest {
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub is_default: Option<bool>,
+}
+
 #[derive(Debug, Clone, Serialize, ToSchema)]
 pub struct MemoryResponse {
     #[schema(value_type = String, example = "mem_01933b5a000070008000000000000001")]

--- a/crates/server/src/openapi.rs
+++ b/crates/server/src/openapi.rs
@@ -165,6 +165,7 @@ use utoipa::OpenApi;
         api::memory_stores::list_memory_stores,
         api::memory_stores::create_memory_store,
         api::memory_stores::get_memory_store,
+        api::memory_stores::update_memory_store,
         api::memory_stores::list_memories,
         api::memory_stores::forget_memory,
         // Knowledge Bases
@@ -335,6 +336,7 @@ use utoipa::OpenApi;
             api::volumes::ListVolumesQuery,
             api::volumes::VolumeResponse,
             api::memory_stores::CreateMemoryStoreRequest,
+            api::memory_stores::UpdateMemoryStoreRequest,
             api::memory_stores::ListMemoriesQuery,
             api::memory_stores::ListMemoriesResponse,
             api::memory_stores::MemoryResponse,

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -823,6 +823,15 @@ impl StorageBackend {
         dispatch!(self, count_memory_stores, org_id)
     }
 
+    pub async fn update_memory_store(
+        &self,
+        org_id: i64,
+        public_id: &str,
+        input: UpdateMemoryStoreRow,
+    ) -> Result<Option<MemoryStoreDbRow>> {
+        dispatch!(self, update_memory_store, org_id, public_id, input)
+    }
+
     pub async fn create_memory(&self, input: CreateMemoryRow) -> Result<MemoryDbRow> {
         dispatch!(self, create_memory, input)
     }

--- a/crates/server/src/storage/memory/memories.rs
+++ b/crates/server/src/storage/memory/memories.rs
@@ -108,6 +108,58 @@ impl InMemoryDatabase {
         Ok(result)
     }
 
+    pub async fn update_memory_store(
+        &self,
+        org_id: i64,
+        public_id: &str,
+        input: UpdateMemoryStoreRow,
+    ) -> Result<Option<MemoryStoreDbRow>> {
+        let now = Self::now();
+        let mut stores = self.memory_stores.write();
+
+        let target_id = stores
+            .values()
+            .find(|s| s.org_id == org_id && s.public_id == public_id)
+            .map(|s| s.id);
+        let Some(target_id) = target_id else {
+            return Ok(None);
+        };
+
+        // Validate case-insensitive name uniqueness within the org. The
+        // Postgres backend gets this for free from the unique partial index;
+        // mirror it here so dev mode (in-memory) matches production behaviour.
+        if let Some(ref new_name) = input.name {
+            let collision = stores.values().any(|s| {
+                s.org_id == org_id && s.id != target_id && s.name.eq_ignore_ascii_case(new_name)
+            });
+            if collision {
+                bail!("memory store name already exists");
+            }
+        }
+
+        // Promote: demote the previous default first.
+        if matches!(input.is_default, Some(true)) {
+            for s in stores.values_mut() {
+                if s.org_id == org_id && s.id != target_id && s.is_default {
+                    s.is_default = false;
+                    s.updated_at = now;
+                }
+            }
+        }
+
+        let target = stores
+            .get_mut(&target_id)
+            .expect("memory store row must exist after id lookup");
+        if let Some(ref new_name) = input.name {
+            target.name = new_name.clone();
+        }
+        if let Some(new_default) = input.is_default {
+            target.is_default = new_default;
+        }
+        target.updated_at = now;
+        Ok(Some(target.clone()))
+    }
+
     pub async fn count_memory_stores(&self, org_id: i64) -> Result<i64> {
         Ok(self
             .memory_stores

--- a/crates/server/src/storage/models.rs
+++ b/crates/server/src/storage/models.rs
@@ -1059,6 +1059,12 @@ pub struct CreateMemoryStoreRow {
     pub is_default: bool,
 }
 
+#[derive(Debug, Clone, Default)]
+pub struct UpdateMemoryStoreRow {
+    pub name: Option<String>,
+    pub is_default: Option<bool>,
+}
+
 #[derive(Debug, Clone, FromRow, serde::Serialize)]
 pub struct MemoryDbRow {
     pub id: Uuid,

--- a/crates/server/src/storage/repositories/memories.rs
+++ b/crates/server/src/storage/repositories/memories.rs
@@ -114,6 +114,76 @@ impl Database {
         Ok(rows)
     }
 
+    /// Atomically rename a memory store and/or change its default flag.
+    ///
+    /// When `is_default = Some(true)` is requested the previous default in the
+    /// same org is demoted in the same transaction so the unique partial index
+    /// `idx_memory_stores_org_default` stays satisfied. The case-insensitive
+    /// unique index `idx_memory_stores_org_lower_name` enforces name uniqueness;
+    /// a duplicate is surfaced as an `anyhow` error containing the Postgres
+    /// "duplicate key" message and is mapped to `Conflict` upstream.
+    pub async fn update_memory_store(
+        &self,
+        org_id: i64,
+        public_id: &str,
+        input: UpdateMemoryStoreRow,
+    ) -> Result<Option<MemoryStoreDbRow>> {
+        let mut tx = self.pool.begin().await?;
+
+        let existing: Option<MemoryStoreDbRow> = sqlx::query_as(
+            r#"
+            SELECT id, org_id, public_id, name, is_default, created_at, updated_at
+            FROM memory_stores
+            WHERE org_id = $1 AND public_id = $2
+            FOR UPDATE
+            "#,
+        )
+        .bind(org_id)
+        .bind(public_id)
+        .fetch_optional(&mut *tx)
+        .await?;
+
+        let Some(existing) = existing else {
+            tx.rollback().await?;
+            return Ok(None);
+        };
+
+        // Promote: demote any other default in this org first.
+        if matches!(input.is_default, Some(true)) && !existing.is_default {
+            sqlx::query(
+                r#"
+                UPDATE memory_stores
+                SET is_default = FALSE, updated_at = NOW()
+                WHERE org_id = $1 AND id <> $2 AND is_default
+                "#,
+            )
+            .bind(org_id)
+            .bind(existing.id)
+            .execute(&mut *tx)
+            .await?;
+        }
+
+        let row: MemoryStoreDbRow = sqlx::query_as(
+            r#"
+            UPDATE memory_stores
+            SET name = COALESCE($3, name),
+                is_default = COALESCE($4, is_default),
+                updated_at = NOW()
+            WHERE org_id = $1 AND id = $2
+            RETURNING id, org_id, public_id, name, is_default, created_at, updated_at
+            "#,
+        )
+        .bind(org_id)
+        .bind(existing.id)
+        .bind(input.name.as_deref())
+        .bind(input.is_default)
+        .fetch_one(&mut *tx)
+        .await?;
+
+        tx.commit().await?;
+        Ok(Some(row))
+    }
+
     pub async fn count_memory_stores(&self, org_id: i64) -> Result<i64> {
         let row: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM memory_stores WHERE org_id = $1")
             .bind(org_id)

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -4458,6 +4458,75 @@
             }
           }
         }
+      },
+      "patch": {
+        "tags": [
+          "memory_stores"
+        ],
+        "operationId": "update_memory_store",
+        "parameters": [
+          {
+            "name": "store_id",
+            "in": "path",
+            "description": "Memory store ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateMemoryStoreRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Memory store updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MemoryStoreResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid input",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Duplicate name",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/v1/memory-stores/{store_id}/memories": {
@@ -20316,6 +20385,23 @@
             ],
             "description": "The URL of the MCP server endpoint.",
             "example": "https://mcp.example.com/v1/mcp"
+          }
+        }
+      },
+      "UpdateMemoryStoreRequest": {
+        "type": "object",
+        "properties": {
+          "is_default": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "name": {
+            "type": [
+              "string",
+              "null"
+            ]
           }
         }
       },

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -4517,7 +4517,7 @@
             }
           },
           "409": {
-            "description": "Duplicate name",
+            "description": "Conflict (duplicate name or concurrent default reassignment)",
             "content": {
               "application/json": {
                 "schema": {

--- a/specs/memory.md
+++ b/specs/memory.md
@@ -163,8 +163,18 @@ Org-scoped CRUD lives at `/v1/memory-stores`:
 | `GET` | `/v1/memory-stores` | List org memory stores |
 | `POST` | `/v1/memory-stores` | Create a new store |
 | `GET` | `/v1/memory-stores/{store_id}` | Get a store with active memory count |
+| `PATCH` | `/v1/memory-stores/{store_id}` | Rename and/or change the org default (optional `name`, `is_default`) |
 | `GET` | `/v1/memory-stores/{store_id}/memories` | Search memories (`query`, `kind`, `tag[]`, `include_inactive`, `limit`) |
 | `DELETE` | `/v1/memory-stores/{store_id}/memories/{memory_id}` | Forget (soft-delete) a memory |
+
+`PATCH` accepts a partial body — supply `name`, `is_default`, or both. Names
+are unique per org case-insensitively (`idx_memory_stores_org_lower_name`); a
+duplicate returns `409`. Promoting a store to default
+(`is_default = true`) atomically demotes the previous default within the
+same transaction so the unique partial index `idx_memory_stores_org_default`
+stays satisfied. **Demoting the only default store is rejected** with `400`
+— move the default by promoting another store instead, which demotes the
+current one in the same transaction.
 
 All routes resolve org from the authenticated request; cross-org access
 returns `404` rather than disclosing existence. Full handlers in


### PR DESCRIPTION
## What
Memory stores are now editable beyond capability config. Adds `PATCH /v1/memory-stores/{store_id}` (optional `name`, `is_default`) and a corresponding edit dialog on the Memory page. Promoting a store to default atomically demotes the previous default in the same transaction so the unique partial index `idx_memory_stores_org_default` stays satisfied.

## Why
Memory stores were create-only after first use. Users had no way to rename them or move the org default. Resolves EVE-428.

## How

### Backend
- New `UpdateMemoryStore` command (policy `MEMORY_STORE_MANAGE`) and a matching `update_memory_store` storage method on both Postgres and the in-memory backend.
- The Postgres path locks the target row, demotes any other default in the same org when `is_default = true` is requested, then updates and commits in one transaction.
- Case-insensitive name uniqueness is enforced by `idx_memory_stores_org_lower_name`; duplicate names map to 409. The in-memory backend mirrors the same constraint.
- Demoting the only default store is rejected with 400; the supported workflow is to promote another store, which demotes the previous default atomically.
- PATCH route and OpenAPI registration added; `docs/api/openapi.json` regenerated.

### UI
- Added `updateMemoryStore`, `useUpdateMemoryStore`, and `UpdateMemoryStoreRequest`.
- Store rows now include an edit button that opens a dialog with name input and a “Make default” checkbox.
- The dialog sends only changed fields and disables unsetting the current default, matching the server rule.

## Risk
- Low/Medium.
- New writes touch `memory_stores`; default reassignment is transactional and org-scoped.
- No schema change; existing migration 032 already provides the needed unique indexes.

## Security
- Reviewed threat categories: TM-AUTHZ, TM-API, TM-TENANT, TM-SQL.
- TM-AUTHZ: update uses `MEMORY_STORE_MANAGE`, same manage policy family as create/forget.
- TM-API: request accepts only optional `name` and `is_default`; empty patch and invalid names are rejected.
- TM-TENANT: every read/write is scoped by `org_id`; cross-org PATCH returns 404.
- TM-SQL: all queries are parameterized; default move runs in one transaction.
- No new secret logging or external network calls.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed
- [x] Review comments addressed

## Validation
- `cargo test -p everruns-server --lib memory_stores` — 9 passed.
- `cargo clippy -p everruns-server --all-targets -- -D warnings` — passed.
- `cargo fmt --check` — passed.
- `cd apps/ui && npm run lint` — passed with existing warnings outside this change.
- `cd apps/ui && npm run format:check` — passed.
- `cd apps/ui && npm run build` — passed.
- `CARGO_INCREMENTAL=0 ./scripts/export-openapi.sh` — regenerated cleanly; no diff after re-run.
- `bash scripts/lib/check-migration-ordering.sh` — migrations sequential.
- `PORT_PREFIX=271 CARGO_INCREMENTAL=0 just start-dev --no-watch` smoke: created two memory stores, renamed/promoted the second, verified previous default demotion, duplicate rename returned 409, and demoting current default returned 400.
- Browser check on `http://localhost:27100/memory-stores`: edit buttons render, edit dialog opens with existing name, and current default checkbox is disabled with explanatory text.
- `CARGO_INCREMENTAL=0 just pre-push` — all 8 checks passed.

Resolves EVE-428.
