### PR TITLE
test(memory): add UI test cases for memory stores

### DIFF
--- a/test_cases/ui/memory_stores/MANUAL_TEST_RESULTS_2026-05-06.md
+++ b/test_cases/ui/memory_stores/MANUAL_TEST_RESULTS_2026-05-06.md
@@ -25,7 +25,7 @@
 ## Detailed Notes
 
 ### TC001 — PASS
-Empty-state CTA opens the dialog, name `team-knowledge` accepted, **Create** transitions back to the populated layout. Card shows `mst_019dfeb5d6f976d3ba1463b4fdd290e2`, `0 active memories`, no Default badge. Right pane shows the "No memories yet…" empty state. Screenshot: `/tmp/memory_after_create.png`.
+Empty-state CTA opens the dialog, name `team-knowledge` accepted, **Create** transitions back to the populated layout. Card shows `mst_019dfeb5d6f976d3ba1463b4fdd290e2`, `0 active memories`, no Default badge. Right pane shows the memories empty state: "No memories yet. Agents using the memory capability will populate this store as they learn." Screenshot: `/tmp/memory_after_create.png`.
 
 ### TC002 — PASS
 Created `org-default` with the Default checkbox ticked. Card now shows the **Default** star badge; `team-knowledge` no longer has one. Both stores listed in the sidebar. Screenshot: `/tmp/memory_default_created.png`.

--- a/test_cases/ui/memory_stores/MANUAL_TEST_RESULTS_2026-05-06.md
+++ b/test_cases/ui/memory_stores/MANUAL_TEST_RESULTS_2026-05-06.md
@@ -1,0 +1,54 @@
+# Manual UI Test Results — memory_stores — 2026-05-06
+
+## Environment
+
+- **Auth Mode**: dev (in-memory storage, anonymous user, soft auth)
+- **Stack**: `just start-dev --no-watch` (server + in-process worker + Caddy at :27100, Next.js dev at :27105)
+- **PORT_PREFIX**: 271
+- **Build**: `target/debug/everruns-server` (everruns 0.8.26)
+- **UI**: `apps/ui` Next.js 16.2.4 (Turbopack)
+- **Browser**: agent-browser (Chromium)
+
+## Test Summary
+
+| Test | Result | Notes |
+|------|--------|-------|
+| TC001 Create Memory Store | PASS | New store auto-selected, `mst_<32-hex>` ID, `0 active memories` shown |
+| TC002 Create Default Memory Store | PASS | Default badge appears on new store; previously default cleared |
+| TC003 Duplicate Store Name Validation | PARTIAL | Server returns the correct 409 with body `memory store name already exists`; the UI does not surface this error to the user — the failed mutation is only visible in the Next.js dev "1 issue" overlay. Dialog stays open and the duplicate is not created. |
+| TC004 Search and Filter Memories | NOT RUN | Requires seeded memories (agent `remember` calls). Out of scope for a smoke pass without provider keys configured. |
+| TC005 Forget a Memory | NOT RUN | Same as TC004. |
+| TC006 Capability Config Store Picker | NOT RUN | `/agents/new` and `/agents` redirect to `/login` in dev mode (anonymous-user flow doesn't satisfy the agents page auth guard). Memory page itself works because its layout tolerates the in-flight auth state. Needs `just start-all` with a real signed-in user. |
+| TC007 Cross-Org Memory Store Isolation | NOT RUN | Requires multi-org auth (full mode). |
+| TC008 Memory Page Empty State | PASS | Brain icon, "No memory stores" heading, explanatory text, and CTA all render; two-column layout is suppressed. |
+
+## Detailed Notes
+
+### TC001 — PASS
+Empty-state CTA opens the dialog, name `team-knowledge` accepted, **Create** transitions back to the populated layout. Card shows `mst_019dfeb5d6f976d3ba1463b4fdd290e2`, `0 active memories`, no Default badge. Right pane shows the "No memories yet…" empty state. Screenshot: `/tmp/memory_after_create.png`.
+
+### TC002 — PASS
+Created `org-default` with the Default checkbox ticked. Card now shows the **Default** star badge; `team-knowledge` no longer has one. Both stores listed in the sidebar. Screenshot: `/tmp/memory_default_created.png`.
+
+### TC003 — PARTIAL (UI gap)
+Submitting `TEAM-KNOWLEDGE` (existing name in different casing) hits the server, which correctly returns `memory store name already exists`. The dialog stays open with the typed value, and the store list is unchanged (confirming the server-side uniqueness check). However, no toast / inline error is rendered for the user — the failure is only visible because Next.js dev surfaces the unhandled `ApiError` in the "1 issue" overlay. In production builds this would be silent. Worth a follow-up to wrap `useCreateMemoryStore` with toast-on-error in `apps/ui/src/app/(main)/memory-stores/page.tsx`. Screenshot: `/tmp/dup_error_overlay.png`.
+
+### TC008 — PASS
+Fresh dev DB has zero stores and `/memory-stores` renders the centered empty state with the brain icon, "No memory stores" heading, paragraph mentioning the auto-default-on-first-use, and the **New Store** call-to-action. Two-column layout is correctly suppressed. Screenshot: `/tmp/memory_empty.png`.
+
+## Issues Found
+
+### Issue #1 (Low): Duplicate-name error not surfaced to user
+- **Severity**: Low (server-side enforcement is correct, no data integrity risk)
+- **Steps**: Create store with a name; open New Store dialog again and re-enter the same name (any casing); click Create.
+- **Expected**: A user-visible toast / inline error such as "A memory store with that name already exists." Dialog stays open.
+- **Actual**: API correctly returns 409 `memory store name already exists`, but the UI swallows the rejection silently. Only Next.js dev mode shows it via the issues overlay; in production the user would see no feedback at all.
+- **Fix sketch**: Wire `onError` on `useCreateMemoryStore` (or surround `mutateAsync` in the dialog) to render a toast / inline message; clear it on successful create.
+- **File**: `apps/ui/src/app/(main)/memory-stores/page.tsx` (`CreateStoreDialog`).
+
+## Skipped — environmental gaps
+
+- TC004 / TC005 need seeded memories. The minimum to seed is a running agent that uses the `memory` capability with provider keys configured. The dev stack doesn't expose a "manual remember" UI, so a seed script or agent run is required.
+- TC006 / TC007 need a real signed-in user (full auth mode). The dev anonymous-user flow loads `/memory-stores` but bounces `/agents*` to `/login`; the agent capability-config picker therefore can't be reached without `just start-all` plus a login.
+
+These test cases are documented and ready to run against a `just start-all` deployment; they're listed here as not-run rather than failed.

--- a/test_cases/ui/memory_stores/TC001_create_memory_store.md
+++ b/test_cases/ui/memory_stores/TC001_create_memory_store.md
@@ -1,0 +1,36 @@
+# TC001: Create Memory Store
+
+## Description
+
+Verify that a new org-scoped memory store can be created from the Memory page and is selected immediately after creation.
+
+## Preconditions
+
+- UI running (`just start-dev` or `just start-all`)
+- User is authenticated and has access to an organization
+- The current organization may have zero or more existing stores
+
+## Test Data
+
+| Field | Value |
+|-------|-------|
+| Store Name | team-knowledge |
+| Make Default | unchecked |
+
+## Steps
+
+1. Sign in and navigate to the sidebar entry **Memory** (`/memory-stores`)
+2. Click the **New Store** button in the page header
+3. In the **New memory store** dialog, enter Name: `team-knowledge`
+4. Leave "Make this the default store for the organization" **unchecked**
+5. Click **Create**
+
+## Expected Result
+
+- Dialog closes after a successful create
+- A new store card titled `team-knowledge` appears in the left store list
+- The new store is auto-selected (its card has the active border)
+- The card shows the store ID in the format `mst_<32-hex>` with a copy button
+- The card shows `0 active memories`
+- No `Default` badge is shown on the card (because the box was unchecked)
+- The right pane shows the memories empty state: "No memories yet…"

--- a/test_cases/ui/memory_stores/TC001_create_memory_store.md
+++ b/test_cases/ui/memory_stores/TC001_create_memory_store.md
@@ -33,4 +33,4 @@ Verify that a new org-scoped memory store can be created from the Memory page an
 - The card shows the store ID in the format `mst_<32-hex>` with a copy button
 - The card shows `0 active memories`
 - No `Default` badge is shown on the card (because the box was unchecked)
-- The right pane shows the memories empty state: "No memories yet…"
+- The right pane shows the memories empty state: "No memories yet. Agents using the memory capability will populate this store as they learn."

--- a/test_cases/ui/memory_stores/TC002_create_default_store.md
+++ b/test_cases/ui/memory_stores/TC002_create_default_store.md
@@ -1,0 +1,35 @@
+# TC002: Create Default Memory Store
+
+## Description
+
+Verify that creating a store with "Make this the default store" checked sets it as the org default and clears the default flag from any previously default store.
+
+## Preconditions
+
+- UI running and user authenticated
+- TC001 has been executed so at least one non-default store (`team-knowledge`) exists
+- Optionally another store may already be marked default
+
+## Test Data
+
+| Field | Value |
+|-------|-------|
+| Store Name | org-default |
+| Make Default | checked |
+
+## Steps
+
+1. Navigate to **Memory** (`/memory-stores`)
+2. Note which store currently shows the **Default** badge (if any)
+3. Click **New Store**
+4. Enter Name: `org-default`
+5. Check "Make this the default store for the organization"
+6. Click **Create**
+7. Reload the page
+
+## Expected Result
+
+- After step 6, the dialog closes and the new `org-default` card appears with a **Default** badge (star icon)
+- The previously default store no longer shows the **Default** badge
+- After step 7 (reload), `org-default` still shows the **Default** badge — i.e. the default flag is persisted server-side
+- When the page reloads with no explicit selection, the default store is the one shown selected by default

--- a/test_cases/ui/memory_stores/TC003_validation_duplicate_name.md
+++ b/test_cases/ui/memory_stores/TC003_validation_duplicate_name.md
@@ -1,0 +1,30 @@
+# TC003: Duplicate Store Name Validation
+
+## Description
+
+Verify that creating a store with a name that already exists in the organization (case-insensitive) surfaces a non-disclosing error and does not create a duplicate.
+
+## Preconditions
+
+- UI running and user authenticated
+- A store named `team-knowledge` already exists (from TC001)
+
+## Test Data
+
+| Field | Value |
+|-------|-------|
+| Store Name | TEAM-KNOWLEDGE |
+
+## Steps
+
+1. Navigate to **Memory** (`/memory-stores`)
+2. Click **New Store**
+3. Enter Name: `TEAM-KNOWLEDGE` (different casing of the existing store)
+4. Click **Create**
+
+## Expected Result
+
+- Server returns a 409 Conflict and the UI shows a toast / inline error indicating the name is already in use
+- The dialog stays open with the typed value preserved
+- The store list does not gain a duplicate entry
+- The existing `team-knowledge` card retains its previous memory count and ID

--- a/test_cases/ui/memory_stores/TC004_search_and_filter_memories.md
+++ b/test_cases/ui/memory_stores/TC004_search_and_filter_memories.md
@@ -1,0 +1,42 @@
+# TC004: Search and Filter Memories
+
+## Description
+
+Verify that the memory list supports text search across memory content and filtering by kind, and that the result count updates accordingly.
+
+## Preconditions
+
+- UI running and user authenticated
+- A store exists that has at least 3 memories of different kinds. The easiest setup:
+  - Run an agent with the `memory` capability that calls `remember` a few times, e.g. one `fact`, one `preference`, one `correction`
+  - Or seed via API: `POST /v1/memory-stores/{store_id}/memories` is not exposed; use the `remember` tool from an agent session against the target store
+- Memories should have distinguishable content (e.g. one mentioning "espresso", one mentioning "dark mode", one mentioning "PostgreSQL")
+
+## Test Data
+
+| Field | Value |
+|-------|-------|
+| Search query 1 | espresso |
+| Search query 2 | nonexistent-substring-xyz |
+| Kind filter 1 | All kinds |
+| Kind filter 2 | Preference |
+
+## Steps
+
+1. Navigate to **Memory** and select the seeded store from the left list
+2. Confirm the right pane shows the count "N memories" matching the seed count
+3. Type `espresso` in the search input
+4. Observe the filtered list and counter
+5. Clear the search input
+6. Open the **Kind** dropdown and pick **Preference**
+7. Observe the filtered list and counter
+8. Set **Kind** back to **All kinds**
+9. Type `nonexistent-substring-xyz` in the search input
+
+## Expected Result
+
+- Step 2: All seeded memories are listed; the counter shows "N memories"
+- Step 4: Only memories whose content contains "espresso" are listed; the counter updates; non-matching memories are hidden
+- Step 6/7: Only memories with `kind = preference` are listed; each card shows a `preference` outline badge
+- Step 9: The list is empty; the empty-state placeholder ("No memories yet…") is shown; the counter is `0 memories`
+- Search and filter persist across each other while both are set (intersection of both filters)

--- a/test_cases/ui/memory_stores/TC004_search_and_filter_memories.md
+++ b/test_cases/ui/memory_stores/TC004_search_and_filter_memories.md
@@ -38,5 +38,5 @@ Verify that the memory list supports text search across memory content and filte
 - Step 2: All seeded memories are listed; the counter shows "N memories"
 - Step 4: Only memories whose content contains "espresso" are listed; the counter updates; non-matching memories are hidden
 - Step 6/7: Only memories with `kind = preference` are listed; each card shows a `preference` outline badge
-- Step 9: The list is empty; the empty-state placeholder ("No memories yet…") is shown; the counter is `0 memories`
+- Step 9: The list is empty; the memories empty-state placeholder ("No memories yet. Agents using the memory capability will populate this store as they learn.") is shown; the counter is `0 memories`
 - Search and filter persist across each other while both are set (intersection of both filters)

--- a/test_cases/ui/memory_stores/TC005_forget_memory.md
+++ b/test_cases/ui/memory_stores/TC005_forget_memory.md
@@ -1,0 +1,34 @@
+# TC005: Forget a Memory
+
+## Description
+
+Verify that the **Forget** action on a memory card deactivates the memory: it disappears from the default list, the store's active memory count decreases, and the memory remains visible only when including inactive entries.
+
+## Preconditions
+
+- UI running and user authenticated
+- A store exists with at least 2 active memories (see TC004 for seeding)
+- User has the `OrgSettingsManage` permission (the role used to sign in must be permitted to call `DELETE /v1/memory-stores/{store_id}/memories/{memory_id}`)
+
+## Test Data
+
+| Field | Value |
+|-------|-------|
+| Target memory | First card in the active list |
+
+## Steps
+
+1. Navigate to **Memory** and select the target store
+2. Note the **active memory count** displayed on the store card (call it `N`)
+3. Note the memories counter in the right pane (call it `M`)
+4. Click the **Forget** button (trash icon) on the first memory card
+5. Wait for the request to settle
+
+## Expected Result
+
+- The forgotten memory disappears from the list
+- The right-pane memory counter decreases to `M - 1`
+- The store card's active memory count decreases to `N - 1`
+- A success toast or in-place state confirms forget succeeded
+- Re-running the same forget call against an already-forgotten memory ID via the API returns 404 (existence is not re-disclosed)
+- Calling `GET /v1/memory-stores/{store_id}/memories?include_inactive=true` returns the forgotten memory with `active: false` (and the UI would render the `forgotten` destructive badge if the memory were displayed)

--- a/test_cases/ui/memory_stores/TC006_capability_config_store_picker.md
+++ b/test_cases/ui/memory_stores/TC006_capability_config_store_picker.md
@@ -1,0 +1,41 @@
+# TC006: Memory Capability Config Store Picker
+
+## Description
+
+Verify that the Agent capability configuration replaces the raw `mst_…` text input for the `memory` capability with a structured store picker populated from the org's stores, and that the selected store is persisted as the capability config.
+
+## Preconditions
+
+- UI running and user authenticated
+- At least two memory stores exist in the org (e.g. `team-knowledge` from TC001 and `org-default` from TC002)
+- An agent exists that the user can edit, or a new agent can be created
+
+## Test Data
+
+| Field | Value |
+|-------|-------|
+| Capability | memory |
+| Store selection 1 | Default store (empty value) |
+| Store selection 2 | `team-knowledge` |
+| Passive recall count | 3 |
+
+## Steps
+
+1. Navigate to an agent's edit page (Agents → pick an agent → Edit) or create a new agent
+2. Open the **Capabilities** section and enable the **memory** capability if not already enabled
+3. Open the memory capability's settings panel
+4. Confirm a **Memory store** combobox is shown (not a free-text input) with placeholder "Default store"
+5. Open the combobox and verify it lists at least: `Default store`, `team-knowledge`, `org-default (default)`
+6. Pick `team-knowledge`
+7. Set **Passive recall count** to `3`
+8. Save the agent
+9. Reload the agent edit page
+
+## Expected Result
+
+- Step 4: The memory capability uses the structured editor (combobox + numeric input), not the generic JSON form
+- Step 5: All org stores are listed; the org's default store has a `(default)` suffix; a `Default store` option (sentinel) is the first choice
+- Step 6: After picking `team-knowledge`, the trigger shows `team-knowledge` (without `(default)` suffix)
+- Step 8: Save succeeds. Inspecting the agent's stored config (e.g. via API `GET /v1/agents/{id}`) shows `capabilities.memory.config = { "store": "mst_<id-of-team-knowledge>", "passive_recall_count": 3 }`
+- Step 9: The reloaded form shows `team-knowledge` selected and `Passive recall count = 3`
+- If the store is later deleted/archived from outside the form, the picker shows the destructive message "Selected store is no longer available in this organization."

--- a/test_cases/ui/memory_stores/TC007_org_isolation.md
+++ b/test_cases/ui/memory_stores/TC007_org_isolation.md
@@ -1,0 +1,40 @@
+# TC007: Cross-Org Memory Store Isolation
+
+## Description
+
+Verify that memory stores and memories are strictly scoped to the active organization: switching orgs hides the other org's stores, and direct access to a foreign store ID returns a non-disclosing 404 (not 403).
+
+## Preconditions
+
+- Server running with full mode (`just start-all`) and authentication enabled
+- User belongs to two organizations: **Org A** and **Org B**
+- Org A has at least one store (e.g. `team-knowledge`); note its ID `mst_<A>`
+- Org B has at least one store with a different name; note its ID `mst_<B>`
+
+## Test Data
+
+| Field | Value |
+|-------|-------|
+| Org A store ID | `mst_<A>` (from Org A) |
+| Org B store ID | `mst_<B>` (from Org B) |
+
+## Steps
+
+1. Sign in and switch the active organization to **Org A** via the org switcher
+2. Navigate to **Memory** (`/memory-stores`)
+3. Capture the list of stores shown
+4. Switch the active organization to **Org B**
+5. Navigate to **Memory**
+6. Capture the list of stores shown
+7. While in Org B, hit `GET /v1/memory-stores/<mst_A>` (Org A's store ID) using the user's session, with `X-Org-Id: <org-b-public-id>`
+8. While in Org B, hit `GET /v1/memory-stores/<mst_A>/memories` with the same headers
+9. While in Org B, hit `DELETE /v1/memory-stores/<mst_A>/memories/<mem_id_from_A>`
+
+## Expected Result
+
+- Step 3: Only Org A's stores are listed; `mst_<B>` is not present
+- Step 6: Only Org B's stores are listed; `mst_<A>` is not present
+- Step 7: Returns `404 Not Found` with a generic not-found error body — never `403 Forbidden` and never any field that confirms the store exists in another org
+- Step 8: Returns `404 Not Found` with the same non-disclosing shape
+- Step 9: Returns `404 Not Found`. The memory remains active when re-checked from Org A (active count unchanged)
+- The capability-config store picker, when shown for an agent in Org B, never lists Org A's stores even if the agent JSON is hand-edited to reference `mst_<A>`; instead the picker displays "Selected store is no longer available in this organization."

--- a/test_cases/ui/memory_stores/TC007_org_isolation.md
+++ b/test_cases/ui/memory_stores/TC007_org_isolation.md
@@ -26,9 +26,9 @@ Verify that memory stores and memories are strictly scoped to the active organiz
 4. Switch the active organization to **Org B**
 5. Navigate to **Memory**
 6. Capture the list of stores shown
-7. While in Org B, hit `GET /v1/memory-stores/<mst_A>` (Org A's store ID) using the user's session, with `X-Org-Id: <org-b-public-id>`
-8. While in Org B, hit `GET /v1/memory-stores/<mst_A>/memories` with the same headers
-9. While in Org B, hit `DELETE /v1/memory-stores/<mst_A>/memories/<mem_id_from_A>`
+7. While in Org B, hit `GET /v1/memory-stores/mst_<A>` (Org A's store ID) using the user's session, with `X-Org-Id: <org-b-public-id>`
+8. While in Org B, hit `GET /v1/memory-stores/mst_<A>/memories` with the same headers
+9. While in Org B, hit `DELETE /v1/memory-stores/mst_<A>/memories/<mem_id_from_A>`
 
 ## Expected Result
 
@@ -37,4 +37,4 @@ Verify that memory stores and memories are strictly scoped to the active organiz
 - Step 7: Returns `404 Not Found` with a generic not-found error body — never `403 Forbidden` and never any field that confirms the store exists in another org
 - Step 8: Returns `404 Not Found` with the same non-disclosing shape
 - Step 9: Returns `404 Not Found`. The memory remains active when re-checked from Org A (active count unchanged)
-- The capability-config store picker, when shown for an agent in Org B, never lists Org A's stores even if the agent JSON is hand-edited to reference `mst_<A>`; instead the picker displays "Selected store is no longer available in this organization."
+- The capability-config store picker, when shown for an agent in Org B, never lists Org A's stores even if the agent JSON is hand-edited to reference `mst_<A>` (the Org A store ID); instead the picker displays "Selected store is no longer available in this organization."

--- a/test_cases/ui/memory_stores/TC008_empty_state.md
+++ b/test_cases/ui/memory_stores/TC008_empty_state.md
@@ -1,0 +1,29 @@
+# TC008: Memory Page Empty State
+
+## Description
+
+Verify that visiting the Memory page in an org with zero memory stores shows the empty-state with a call-to-action that opens the create dialog, and creating a store from the empty state transitions the page into the populated layout.
+
+## Preconditions
+
+- UI running and user authenticated
+- Active org has **no** memory stores yet (use a freshly created org, or sign in with a user whose default org has none)
+
+## Test Data
+
+| Field | Value |
+|-------|-------|
+| Store Name | first-store |
+
+## Steps
+
+1. Navigate to **Memory** (`/memory-stores`)
+2. Observe the page contents
+3. Click the empty-state **New Store** button
+4. Enter Name: `first-store`
+5. Click **Create**
+
+## Expected Result
+
+- Step 2: A centered empty state is shown with the brain icon, the heading "No memory stores", explanatory text mentioning that the default store is created on first agent use, and a **New Store** call-to-action button. The two-column layout (sidebar + memories pane) is **not** rendered.
+- Step 5: After creation, the page transitions to the two-column layout. The `first-store` card is visible in the sidebar and selected. The right pane shows the "No memories yet…" memories empty state.

--- a/test_cases/ui/memory_stores/TC008_empty_state.md
+++ b/test_cases/ui/memory_stores/TC008_empty_state.md
@@ -26,4 +26,4 @@ Verify that visiting the Memory page in an org with zero memory stores shows the
 ## Expected Result
 
 - Step 2: A centered empty state is shown with the brain icon, the heading "No memory stores", explanatory text mentioning that the default store is created on first agent use, and a **New Store** call-to-action button. The two-column layout (sidebar + memories pane) is **not** rendered.
-- Step 5: After creation, the page transitions to the two-column layout. The `first-store` card is visible in the sidebar and selected. The right pane shows the "No memories yet…" memories empty state.
+- Step 5: After creation, the page transitions to the two-column layout. The `first-store` card is visible in the sidebar and selected. The right pane shows the memories empty state: "No memories yet. Agents using the memory capability will populate this store as they learn."


### PR DESCRIPTION
## What
Adds eight manual UI test cases under `test_cases/ui/memory_stores/` covering the org memory stores feature delivered in EVE-422 / #1687, plus a results file from a local dev-mode smoke run.

Test cases:
- TC001 create memory store
- TC002 create default memory store (default badge transfer)
- TC003 duplicate name validation (case-insensitive)
- TC004 search + kind filter on memories
- TC005 forget a memory (active count drop, `include_inactive` parity)
- TC006 capability config store picker (combobox replaces raw `mst_…` input)
- TC007 cross-org isolation (404, no `Forbidden`)
- TC008 memory page empty state

`MANUAL_TEST_RESULTS_2026-05-06.md` records the dev-mode pass: TC001/TC002/TC008 PASS, TC003 PARTIAL (server returns 409 correctly but UI does not surface the error to the user — flagged as Issue #1 in the results file). TC004/TC005 require seeded memories, TC006/TC007 require full auth and were intentionally not run in dev mode.

## Why
The feature spec (`specs/memory.md`) and the delivery PR mention storage parity, API isolation, and forget behavior, but `test_cases/ui/` had no entries for it. New features require corresponding test cases per `specs/test-cases.md`.

## How
Followed the existing `test_cases/ui/` format (Description / Preconditions / Test Data / Steps / Expected Result), per-feature folder, TC001+ numbering. No code changes.

Smoke testing setup: `PORT_PREFIX=271 doppler run -- just start-dev --no-watch`, browser via `agent-browser`. `apps/ui` deps installed manually because the start-dev script just warns when `node_modules` is missing.

## Risk
- Low. Documentation-only change under `test_cases/`. No runtime, build, or schema impact.

## Security
- Threat categories reviewed: **No security-relevant code changes** — this PR adds Markdown test-case docs and a results report under `test_cases/ui/memory_stores/` only. The TC007 case itself documents the existing org-isolation mitigations (404-not-403, `mst_…` not disclosed), which align with the threat model entries already covered by the EVE-422 PR.
- Findings and resolutions: None; no production code or configuration is touched.

## Checklist
- [x] Tests added or updated — manual UI test cases for an already-shipped feature
- [x] Backward compatibility considered — N/A (docs only)
- [x] Security review performed against relevant threat model categories
- [ ] All review comments addressed — pending review


---
_Generated by [Claude Code](https://claude.ai/code/session_01Da95xBTQ7r7V6pWTr6446z)_