### PR TITLE
chore(ship): surface follow-ups explicitly in ship workflow

### DIFF
--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -46,7 +46,13 @@ Use this skill when the user asks to:
    - Use `just start-all --no-watch` when database, migration, infra, or API integration risk exists.
    - Stop any servers you started.
    - Docs-only or config-only changes that do not affect runtime behavior may skip smoke testing with explicit justification.
-6. The PR is mergeable and merged safely.
+6. Follow-ups are surfaced, not silently dropped.
+   - **Default to implementing everything in scope before merging.** Do not defer work just because the PR is "big enough".
+   - During diff review, security review, smoke testing, and review-comment handling, actively look for: TODOs you added, partial fixes, known edge cases not covered by tests, suggestions you chose not to apply, related bugs you noticed, spec/doc drift you did not fix, and threat-model items that warrant a separate change.
+   - For each candidate, decide explicitly: **implement now** (preferred) or **defer**. Prefer implementing now whenever the work is small, clearly in scope, or required for correctness.
+   - For anything deferred, list it under a **Follow-ups** section in the PR body with a one-line rationale per item (why it is safe to defer and what should happen later). File Linear issues for non-trivial follow-ups when appropriate (OSS project, EVE team).
+   - If there are no follow-ups, state "No follow-ups." in the PR body. Silence is not acceptable — readers must be able to tell the difference between "nothing left" and "agent forgot".
+7. The PR is mergeable and merged safely.
    - Push the branch.
    - Create or update the PR with `.github/pull_request_template.md`.
    - Check the PR conversation, review threads, and review state from all reviewers, including bots.
@@ -123,7 +129,7 @@ Pick only what matches the changed surface:
 ## PR And Merge
 
 - Use a conventional-commit style PR title.
-- In the PR body, explain what changed, why it changed, how it was validated, and notable risks or follow-ups.
+- In the PR body, explain what changed, why it changed, how it was validated, notable risks, and an explicit **Follow-ups** section (or "No follow-ups." if none). Prefer implementing follow-ups in this PR; only defer when the work is genuinely out of scope or too large, and say so per item.
 - Use `gh pr view --json url` to detect an existing PR.
 - Create a PR with `gh pr create` if needed.
 - Use `gh pr view --comments` to inspect the PR conversation, including bot comments.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,6 +15,9 @@ High-level approach.
 - Threat categories reviewed: (e.g. TM-AUTH, TM-API, or "No security-relevant code changes" with justification)
 - Findings and resolutions:
 
+## Follow-ups
+List anything intentionally deferred with a one-line rationale, or write "No follow-ups." Prefer implementing in-scope work in this PR over deferring it.
+
 ## Checklist
 - [ ] Tests added or updated
 - [ ] Backward compatibility considered

--- a/specs/shipping.md
+++ b/specs/shipping.md
@@ -37,7 +37,8 @@ Relevant references:
 3. Merge-ready code: touched code is reviewed for avoidable complexity and performance risk. A structured security review is performed against the relevant threat model categories from `specs/threat-model.md` (see the Security Review section in the ship skill). Issues found during review are addressed or explicitly blocked.
 4. Synced artifacts: only the affected artifacts are updated, including specs, threat model, docs, OpenAPI, test cases, and agent instructions when relevant. Specs touched by the change must not contain implementation details that duplicate code (struct fields, enum variants, exhaustive tables, code snippets) — replace with links to source files per the spec content principle in `AGENTS.md`.
 5. Smoke test impacted functionality: always smoke test the flows affected by the change end-to-end. This is mandatory, not conditional on risk assessment. Docs-only or config-only changes that do not affect runtime behavior may skip smoke testing with explicit justification.
-6. Safe merge: the PR uses the repo template, CI is green, **every** review comment from all reviewers (including async bot reviewers and low-confidence suggestions) is explicitly analyzed, reasoned about, and resolved — either with a code change or a written explanation — after a final post-green sweep, and merge happens with squash only.
+6. Follow-ups surfaced: the agent actively looks for in-scope work that risks being silently dropped (TODOs, partial fixes, declined suggestions, missed edge cases, spec/doc drift) and prefers to implement them in this PR. Anything deferred is listed under a **Follow-ups** section in the PR body with a one-line rationale; if nothing is deferred, the PR body must explicitly state "No follow-ups." so readers can distinguish completeness from omission.
+7. Safe merge: the PR uses the repo template, CI is green, **every** review comment from all reviewers (including async bot reviewers and low-confidence suggestions) is explicitly analyzed, reasoned about, and resolved — either with a code change or a written explanation — after a final post-green sweep, and merge happens with squash only.
 
 ## Constraints
 
@@ -59,4 +60,5 @@ Shipping output should make it easy to evaluate readiness:
 - security review: which threat categories were checked, any findings, and how they were resolved
 - what was skipped and why
 - review comments: how each comment was addressed (code change or written reasoning)
+- follow-ups: what was deferred and why (or an explicit "No follow-ups." statement)
 - what blockers or residual risks remain


### PR DESCRIPTION
## What
- Add a required outcome and PR-body section for **Follow-ups** in the ship skill (`.agents/skills/ship/SKILL.md`) and shipping spec (`specs/shipping.md`).
- Add a **Follow-ups** section to the repo PR template (`.github/pull_request_template.md`) so the discipline applies even outside the ship skill.

## Why
Agents (and humans) too often drop in-scope work — TODOs, declined suggestions, partial fixes, related bugs noticed during review — without recording it. The default should be to implement everything in scope; when work is genuinely deferred, that decision must be visible. Requiring an explicit "No follow-ups." statement otherwise also lets reviewers tell completeness from omission.

## How
- New required outcome #6 in the ship skill: actively look for follow-up candidates during diff review, security review, smoke testing, and review-comment handling. Decide explicitly per item: implement now (preferred) or defer with rationale.
- PR/Merge guidance updated to require a **Follow-ups** section in the PR body.
- `specs/shipping.md` success bar gains a matching outcome and the Reporting Standard now includes follow-ups.
- PR template gains a **Follow-ups** section between **Security** and **Checklist**.

## Risk
- Low / agent-process docs only. No code, schema, API, or UI surface.
- What can break: nothing runtime; agents may produce slightly longer PR bodies.

## Security
- Threat categories reviewed: No security-relevant code changes — this PR only edits agent workflow docs (skill, spec, PR template). No runtime code, configuration, infrastructure, dependencies, or trust boundaries are touched.
- Findings and resolutions: none.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated — N/A, docs-only
- [x] Backward compatibility considered — N/A, agent-process docs
- [x] Security review performed against relevant threat model categories — no security-relevant surface
- [x] All review comments addressed (code change or written reasoning)


---
_Generated by [Claude Code](https://claude.ai/code/session_01CJv8gyRkFnVoyX6tY3yigV)_