### PR TITLE
chore(release): prepare v0.8.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- New changes go here. Use `/prepare-release X.Y.Z` to generate draft from commits. -->
 
+## [0.8.27] - 2026-05-07
+
+### Highlights
+
+- **A2A (Agent2Agent) channel** - Apps can now expose agents over the A2A JSON-RPC protocol with API key auth, and agents can delegate outbound to other A2A agents ([#1695](https://github.com/everruns/everruns/pull/1695)).
+- **Knowledge Bases foundation** - New first-class Knowledge Bases entity with curated entries and an agent-facing `search_knowledge` capability ([#1688](https://github.com/everruns/everruns/pull/1688)).
+- **Org memory stores** - Persistent cross-session memory now ships with org-scoped stores (API + UI), a memory detail drawer, and tag filtering on the Memory page ([#1687](https://github.com/everruns/everruns/pull/1687), [#1689](https://github.com/everruns/everruns/pull/1689), [#1693](https://github.com/everruns/everruns/pull/1693)).
+- **MCP Apps entity-card standard** - New `agent_get_card` tool plus the MCP Apps entity-card spec gives clients a standard way to render rich agent cards from MCP responses ([#1691](https://github.com/everruns/everruns/pull/1691)).
+- **Session context usage report** - Sessions now expose a structured context usage report so operators and agents can see token budget consumption ([#1694](https://github.com/everruns/everruns/pull/1694)).
+
+### What's Changed
+
+- chore(maintenance): refresh docs and dependency locks by [@chaliy](https://github.com/chaliy)
+- feat(ag-ui): support public image uploads by [@chaliy](https://github.com/chaliy)
+- feat(memory): add org memory stores API and UI ([#1687](https://github.com/everruns/everruns/pull/1687)) by [@chaliy](https://github.com/chaliy)
+- feat(knowledge): add Knowledge Bases foundation (EVE-423) ([#1688](https://github.com/everruns/everruns/pull/1688)) by [@chaliy](https://github.com/chaliy)
+- chore(specs): add reporting design by [@chaliy](https://github.com/chaliy)
+- feat(memory): add memory detail drawer on Memory page ([#1689](https://github.com/everruns/everruns/pull/1689)) by [@chaliy](https://github.com/chaliy)
+- feat(memory): add tag filter UI on Memory page ([#1693](https://github.com/everruns/everruns/pull/1693)) by [@chaliy](https://github.com/chaliy)
+- test(volumes): add UI test cases for workspace volumes ([#1692](https://github.com/everruns/everruns/pull/1692)) by [@chaliy](https://github.com/chaliy)
+- feat(sessions): add context usage report ([#1694](https://github.com/everruns/everruns/pull/1694)) by [@chaliy](https://github.com/chaliy)
+- feat(apps): add A2A (Agent2Agent) channel with API key auth ([#1695](https://github.com/everruns/everruns/pull/1695)) by [@chaliy](https://github.com/chaliy)
+- feat(core): add outbound A2A delegation by [@chaliy](https://github.com/chaliy)
+- feat(mcp): add MCP Apps entity-card standard with agent_get_card tool ([#1691](https://github.com/everruns/everruns/pull/1691)) by [@chaliy](https://github.com/chaliy)
+- test(memory): add UI test cases for memory stores ([#1697](https://github.com/everruns/everruns/pull/1697)) by [@chaliy](https://github.com/chaliy)
+- chore(ship): surface follow-ups explicitly in ship workflow ([#1698](https://github.com/everruns/everruns/pull/1698)) by [@chaliy](https://github.com/chaliy)
+
 ## [0.8.26] - 2026-05-06
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1667,11 +1667,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-a2ui"
-version = "0.8.26"
+version = "0.8.27"
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.8.26"
+version = "0.8.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1690,7 +1690,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-cli"
-version = "0.8.26"
+version = "0.8.27"
 dependencies = [
  "anyhow",
  "base64",
@@ -1717,14 +1717,14 @@ dependencies = [
 
 [[package]]
 name = "everruns-config"
-version = "0.8.26"
+version = "0.8.27"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "everruns-container-sandbox"
-version = "0.8.26"
+version = "0.8.27"
 dependencies = [
  "async-trait",
  "base64",
@@ -1745,7 +1745,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.8.26"
+version = "0.8.27"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -1802,7 +1802,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-durable"
-version = "0.8.26"
+version = "0.8.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1837,7 +1837,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-gemini"
-version = "0.8.26"
+version = "0.8.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1855,7 +1855,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-brave-search"
-version = "0.8.26"
+version = "0.8.27"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1871,7 +1871,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-browserless"
-version = "0.8.26"
+version = "0.8.27"
 dependencies = [
  "async-trait",
  "base64",
@@ -1892,7 +1892,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.8.26"
+version = "0.8.27"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1908,7 +1908,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-deno"
-version = "0.8.26"
+version = "0.8.27"
 dependencies = [
  "async-trait",
  "base64",
@@ -1932,7 +1932,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-docker"
-version = "0.8.26"
+version = "0.8.27"
 dependencies = [
  "async-trait",
  "base64",
@@ -1947,7 +1947,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.8.26"
+version = "0.8.27"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -1962,7 +1962,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-e2b"
-version = "0.8.26"
+version = "0.8.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1991,7 +1991,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-parallel"
-version = "0.8.26"
+version = "0.8.27"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2003,7 +2003,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-pi"
-version = "0.8.26"
+version = "0.8.27"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2018,7 +2018,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-sprites"
-version = "0.8.26"
+version = "0.8.27"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2034,7 +2034,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-internal-protocol"
-version = "0.8.26"
+version = "0.8.27"
 dependencies = [
  "chrono",
  "everruns-core",
@@ -2051,7 +2051,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-macros"
-version = "0.8.26"
+version = "0.8.27"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2061,7 +2061,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.8.26"
+version = "0.8.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2083,11 +2083,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-openui"
-version = "0.8.26"
+version = "0.8.27"
 
 [[package]]
 name = "everruns-runtime"
-version = "0.8.26"
+version = "0.8.27"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2121,7 +2121,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-server"
-version = "0.8.26"
+version = "0.8.27"
 dependencies = [
  "aes-gcm",
  "ag-ui-core",
@@ -2205,7 +2205,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-session-sqldb"
-version = "0.8.26"
+version = "0.8.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2224,7 +2224,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-worker"
-version = "0.8.26"
+version = "0.8.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7113,9 +7113,9 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tonic"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
  "axum",
@@ -7143,9 +7143,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1882ac3bf5ef12877d7ed57aad87e75154c11931c2ba7e6cde5e22d63522c734"
+checksum = "c68f61875ac5293cf72e6c8cf0158086428c82c37229e98c840878f1706b0322"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -7155,9 +7155,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
 dependencies = [
  "bytes",
  "prost",
@@ -7201,9 +7201,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.9"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28f0d049ccfaa566e14e9663d304d8577427b368cb4710a20528690287a738b"
+checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
 dependencies = [
  "async-compression",
  "bitflags 2.11.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.8.26"
+version = "0.8.27"
 edition = "2024"
 license = "MIT"
 authors = ["Everruns Contributors"]

--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "everruns-ui",
-  "version": "0.8.26",
+  "version": "0.8.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "everruns-ui",
-      "version": "0.8.26",
+      "version": "0.8.27",
       "dependencies": {
         "@base-ui/react": "^1.2.0",
         "@openuidev/react-lang": "^0.1.3",

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "everruns-ui",
-  "version": "0.8.26",
+  "version": "0.8.27",
   "private": true,
   "exports": {
     "./route-manifest": "./src/lib/ui-route-manifest.ts",


### PR DESCRIPTION
## What
Patch release v0.8.27.

- Bumps `workspace.package.version` and `apps/ui/package.json` from 0.8.26 to 0.8.27.
- Regenerates `Cargo.lock` and `apps/ui/package-lock.json`.
- Adds `## [0.8.27] - 2026-05-07` section to `CHANGELOG.md` with highlights and the full commit list since v0.8.26.

## Why
Release the work that has accumulated on `main` since v0.8.26 (A2A channel, Knowledge Bases foundation, org memory stores + Memory page UX, MCP Apps entity-card standard, session context usage report, AG-UI public image uploads, ship-workflow follow-ups) so it can be picked up downstream (saas, dev.everruns.com).

## How
Followed `/prepare-release`:

1. Bumped versions in `Cargo.toml` and `apps/ui/package.json`.
2. Drafted CHANGELOG entry from `git log v0.8.26..origin/main`.
3. Regenerated lockfiles via `cargo generate-lockfile` and `npm install --package-lock-only`.
4. Verified migration ordering is untouched and remains strictly sequential (`001_..034_`).

## Risk
- Low. Release-prep only — no code changes, only version + lockfile + changelog.

## Security
- Threat categories reviewed: No security-relevant code changes — release-prep only (version, lockfile, changelog).
- Findings and resolutions: None.

## Checklist
- [ ] Tests added or updated — N/A (release prep)
- [x] Backward compatibility considered — patch release
- [x] Security review performed against relevant threat model categories
- [ ] All review comments addressed (code change or written reasoning)

### Post-merge
The release workflow will:
- Create git tag `v0.8.27`
- Create a GitHub Release using the new CHANGELOG entry
- Trigger Docker image build with version tag


---
_Generated by [Claude Code](https://claude.ai/code/session_014y8LCp4oW27WYngeHcLjKm)_