### PR TITLE
docs(getting-started): add Claude Code section to Use in AI Tools

### DIFF
--- a/docs/getting-started/use-in-ai-tools.md
+++ b/docs/getting-started/use-in-ai-tools.md
@@ -34,8 +34,8 @@ guidance.
    On first run the plugin opens an OAuth flow in your browser to authenticate
    against the Everruns(Dev) platform over MCP.
 
-If `/plugin` is not recognized, update Claude Code (plugin marketplaces are a
-recent feature) and try again.
+If `/plugin` is not recognized, update Claude Code to a version that supports
+the plugin marketplace and try again.
 
 ### Use Everruns
 

--- a/docs/getting-started/use-in-ai-tools.md
+++ b/docs/getting-started/use-in-ai-tools.md
@@ -1,10 +1,60 @@
 ---
 title: Use in AI Tools
-description: Set up Everruns in AI tools, starting with Codex.
+description: Set up Everruns in AI tools through the Everruns(Dev) plugin.
 ---
 
-Use Everruns from the AI tools where you already work. This page starts with
-Codex support through the Everruns(Dev) plugin.
+Use Everruns from the AI tools where you already work. The Everruns(Dev) plugin
+ships in this repository with both Claude Code and Codex support.
+
+## Claude Code
+
+The Claude Code plugin connects Claude Code to `https://dev.everruns.com/mcp`
+and adds Everruns(Dev) tools, slash commands, and a skill with platform
+guidance.
+
+### Install the Plugin
+
+1. Add the Everruns marketplace and install the plugin from inside Claude Code:
+
+   ```text
+   /plugin marketplace add everruns/everruns
+   /plugin install everruns-dev@everruns-dev
+   ```
+
+   Claude Code reads `.claude-plugin/marketplace.json` from the repository to
+   discover available plugins. The install syntax is
+   `<plugin-name>@<marketplace-name>`.
+
+2. Verify the install by running:
+
+   ```text
+   /everruns-dev:whoami
+   ```
+
+   On first run the plugin opens an OAuth flow in your browser to authenticate
+   against the Everruns(Dev) platform over MCP.
+
+If `/plugin` is not recognized, update Claude Code (plugin marketplaces are a
+recent feature) and try again.
+
+### Use Everruns
+
+Ask Claude Code for an Everruns task in natural language, for example:
+
+```text
+Create an Everruns(Dev) agent that summarizes https://news.ycombinator.com/ and run it once.
+```
+
+The plugin also exposes slash commands such as `/everruns-dev:agent-run`,
+`/everruns-dev:session-send`, and `/everruns-dev:discover` for common
+workflows.
+
+### Alternative Install
+
+To install from a local clone or point at a self-hosted Everruns deployment,
+see [`plugins/everruns-dev/README.md`](https://github.com/everruns/everruns/blob/main/plugins/everruns-dev/README.md).
+To target another Everruns deployment, update the `url` in
+`plugins/everruns-dev/.mcp.json` to that deployment's `/mcp` endpoint.
 
 ## Codex
 


### PR DESCRIPTION
## What
Adds a Claude Code section to `docs/getting-started/use-in-ai-tools.md`, mirroring the existing Codex section. Covers marketplace add + plugin install, OAuth verification via `/everruns-dev:whoami`, example natural-language prompts, key slash commands, and a pointer to `plugins/everruns-dev/README.md` for local-clone or self-hosted installs. Also updates the page intro and frontmatter description (page is no longer Codex-only).

## Why
The repo already ships the `everruns-dev` plugin for both Claude Code and Codex (`.claude-plugin/marketplace.json` + `plugins/everruns-dev/.claude-plugin/plugin.json`), but the public "Use in AI Tools" page only documented Codex. Users coming from Claude Code had no on-site instructions.

## How
- Edit `docs/getting-started/use-in-ai-tools.md`: add a `## Claude Code` section above the existing `## Codex` section, update the intro paragraph and frontmatter `description` to reflect plugin support across both tools.
- Reuse the install commands from `plugins/everruns-dev/README.md` so the docs stay consistent with the plugin's own README.
- No sidebar changes needed — the page slug (`getting-started/use-in-ai-tools`) is unchanged.

## Risk
- Low
- Docs-only change. Worst case is wording drift relative to the plugin README. Verified the marketplace name, plugin name, install syntax, slash commands (`/everruns-dev:whoami`, `agent-run`, `session-send`, `discover` exist under `plugins/everruns-dev/commands/`), and MCP endpoint (`https://dev.everruns.com/mcp`) against the actual repo state.

## Security
- Threat categories reviewed: No security-relevant code changes. Markdown-only edit to a public docs page; no code, configuration, infrastructure, or trust boundary touched. No secrets, URLs, or commands beyond what is already documented in `plugins/everruns-dev/README.md`.
- Findings and resolutions: None.

## Validation
- `npm run check` (astro check) → 0 errors, 0 warnings, 2 pre-existing hints in `scripts/generate-og-image.mjs`
- `npm run build` → 231 pages built, postbuild notebook verification passed
- Visually inspected the rendered page in the build output for the new section
- Smoke testing the runtime is skipped (justification: docs-only edit; no runtime, API, or migration surface affected)

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated (n/a — docs-only)
- [x] Backward compatibility considered (n/a — docs-only)
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PGi8EqBnqCG68RnAdSP98P)_