### PR TITLE
fix(mcp): remove stateless org switch tool

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "everruns-dev",
       "source": "./plugins/everruns-dev",
       "description": "Interact with the Everruns(Dev) managed harnesses platform. Manage harnesses, agents, and capabilities. Run agentic sessions. Create and deploy agentic applications.",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "author": {
         "name": "Everruns",
         "url": "https://everruns.com"

--- a/crates/server/src/api/mcp_endpoint/mod.rs
+++ b/crates/server/src/api/mcp_endpoint/mod.rs
@@ -9,12 +9,12 @@
 //   → discover: reads inventory descriptors and returns schema-bearing JSON
 //   → query: runs bash scripts with the read-only subset of API ops
 //   → execute: runs bash scripts with the full API surface, including writes
-// - Tier 0 tools: me, list_organizations, switch_organization
+// - Tier 0 tools: me, list_organizations
 //   → Identity & org context tools for multi-org OAuth flows
-//   → MCP clients can't set cookies, so org selection is via explicit tool calls
+//   → MCP clients can't set cookies, so org selection is via organization_id arguments
 // - Auth: same as rest of API (API key or session cookie via ResolvedOrg)
 // - No MCP session state — stateless request/response per JSON-RPC call
-// - Multi-org: all tools accept optional `organization_id` to override the default org
+// - Multi-org: org-scoped tools accept optional `organization_id` to override the default org
 
 mod cards;
 mod tool_registry;
@@ -127,7 +127,7 @@ const MCP_PROTOCOL_VERSION_LATEST: &str = "2025-06-18";
 const SUPPORTED_PROTOCOL_VERSIONS: &[&str] =
     &[MCP_PROTOCOL_VERSION_LATEST, MCP_PROTOCOL_VERSION_FALLBACK];
 
-const ORG_ID_DESCRIPTION: &str = "Optional organization ID (format: org_{32-hex}). Overrides the default organization for this call. Use list_organizations to see available orgs.";
+const ORG_ID_DESCRIPTION: &str = "Optional organization ID (format: org_{32-hex}). MCP has no current-organization switch; pass this on each org-scoped call to override the default organization. Use list_organizations to see available orgs.";
 
 #[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
@@ -703,9 +703,6 @@ async fn handle_tools_call(
                 // Tier 0: identity & org context
                 "me" => tool_me(auth_user, org, state).await,
                 "list_organizations" => tool_list_organizations(auth_user, state).await,
-                "switch_organization" => {
-                    tool_switch_organization(&arguments, auth_user, org, state).await
-                }
                 // Tier 1: agent conversation (org-scoped — accept organization_id override)
                 "agent_run" => {
                     match resolve_org_override(&arguments, auth_user, org, state).await {
@@ -922,39 +919,6 @@ async fn tool_list_organizations(auth_user: &AuthUser, state: &AppState) -> Resu
     Ok(serde_json::to_string_pretty(&json!({
         "organizations": orgs,
         "count": orgs.len(),
-    }))
-    .unwrap())
-}
-
-// ============================================================================
-// Tier 0: switch_organization
-// ============================================================================
-
-/// Switch the active organization for subsequent MCP tool calls.
-///
-/// Since MCP is stateless (no session/cookie), this tool validates the org
-/// and returns instructions. The MCP client should pass the org ID to
-/// subsequent calls via `organization_id`, or the platform can set the
-/// `everruns_org` cookie on the response if the transport supports it.
-async fn tool_switch_organization(
-    args: &Value,
-    auth_user: &AuthUser,
-    _current_org: &ResolvedOrg,
-    state: &AppState,
-) -> Result<String, String> {
-    let org_public_id = args
-        .get("organization_id")
-        .and_then(|v| v.as_str())
-        .ok_or("Missing required parameter: organization_id")?;
-
-    let resolved = resolve_org_by_id(org_public_id, auth_user, state).await?;
-
-    Ok(serde_json::to_string_pretty(&json!({
-        "switched": true,
-        "organization_id": resolved.public_id,
-        "name": resolved.name,
-        "role": resolved.role.to_string(),
-        "hint": "Pass this organization_id on subsequent tool calls to operate in this org's context."
     }))
     .unwrap())
 }

--- a/crates/server/src/api/mcp_endpoint/tool_registry.rs
+++ b/crates/server/src/api/mcp_endpoint/tool_registry.rs
@@ -47,7 +47,6 @@ pub fn tool_definitions(
     let mut tools = vec![
         me_tool(protocol_version),
         list_organizations_tool(protocol_version),
-        switch_organization_tool(protocol_version, org_id_description),
         agent_run_tool(protocol_version, org_id_description),
         session_send_message_tool(protocol_version, org_id_description),
         session_get_status_tool(protocol_version, org_id_description),
@@ -79,7 +78,7 @@ fn me_tool(protocol_version: &str) -> McpEndpointToolDefinition {
         protocol_version,
         "me",
         "Current User",
-        "Get the current authenticated user's profile and active organization context. Returns user ID, email, name, and the organization currently used for all operations.",
+        "Get the current authenticated user's profile and default organization context. MCP calls are stateless; to work in another organization, call list_organizations and pass that org's id as organization_id on each org-scoped tool call.",
         object_schema(vec![], vec![]),
         Some(me_output_schema()),
         Some(read_only_annotations()),
@@ -92,7 +91,7 @@ fn list_organizations_tool(protocol_version: &str) -> McpEndpointToolDefinition 
         protocol_version,
         "list_organizations",
         "List Organizations",
-        "List all organizations the authenticated user belongs to, with their role in each. Use this to discover available orgs before switching with switch_organization or passing organization_id to other tools.",
+        "List all organizations the authenticated user belongs to, with their role in each. MCP has no current-organization switch; use this to find an org id, then pass it as organization_id on each org-scoped tool call. When organization_id is omitted, tools use the default organization from me.",
         object_schema(vec![], vec![]),
         Some(json!({
             "type": "object",
@@ -114,43 +113,6 @@ fn list_organizations_tool(protocol_version: &str) -> McpEndpointToolDefinition 
                 "count": { "type": "integer" }
             },
             "required": ["organizations", "count"]
-        })),
-        Some(read_only_annotations()),
-        5_000,
-    )
-}
-
-fn switch_organization_tool(
-    protocol_version: &str,
-    org_id_description: &str,
-) -> McpEndpointToolDefinition {
-    tool(
-        protocol_version,
-        "switch_organization",
-        "Switch Organization",
-        "Validate and select an organization. Returns the validated organization details. Pass the returned organization_id to subsequent tool calls to operate in that org's context. You can also pass organization_id directly to individual tools without calling this first.",
-        object_schema(
-            vec![(
-                "organization_id",
-                json!({
-                    "type": "string",
-                    "description": org_id_description,
-                    "pattern": "^org_[0-9a-f]{32}$"
-                }),
-            )],
-            vec!["organization_id"],
-        ),
-        Some(json!({
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "switched": { "type": "boolean" },
-                "organization_id": { "type": "string" },
-                "name": { "type": "string" },
-                "role": { "type": "string" },
-                "hint": { "type": "string" }
-            },
-            "required": ["switched", "organization_id", "name", "role", "hint"]
         })),
         Some(read_only_annotations()),
         5_000,

--- a/crates/server/tests/mcp_endpoint_test.rs
+++ b/crates/server/tests/mcp_endpoint_test.rs
@@ -297,7 +297,7 @@ async fn test_mcp_tools_list() {
     let tools = resp["result"]["tools"]
         .as_array()
         .expect("Expected tools array");
-    assert_eq!(tools.len(), 10, "Expected 10 MCP tools");
+    assert_eq!(tools.len(), 9, "Expected 9 MCP tools");
 
     let names: Vec<&str> = tools.iter().map(|t| t["name"].as_str().unwrap()).collect();
     assert!(names.contains(&"me"), "Missing me");
@@ -306,8 +306,18 @@ async fn test_mcp_tools_list() {
         "Missing list_organizations"
     );
     assert!(
-        names.contains(&"switch_organization"),
-        "Missing switch_organization"
+        !names.contains(&"switch_organization"),
+        "switch_organization should not be exposed"
+    );
+    let list_organizations = tools
+        .iter()
+        .find(|tool| tool["name"] == "list_organizations")
+        .unwrap();
+    assert!(
+        list_organizations["description"]
+            .as_str()
+            .unwrap()
+            .contains("MCP has no current-organization switch")
     );
     assert!(names.contains(&"agent_run"), "Missing agent_run");
     assert!(
@@ -357,6 +367,12 @@ async fn test_mcp_tools_list() {
     assert_eq!(
         discover["inputSchema"]["properties"]["organization_id"]["pattern"],
         "^org_[0-9a-f]{32}$"
+    );
+    assert!(
+        discover["inputSchema"]["properties"]["organization_id"]["description"]
+            .as_str()
+            .unwrap()
+            .contains("pass this on each org-scoped call")
     );
     assert_eq!(discover["outputSchema"]["type"], "object");
     assert!(discover.as_object().unwrap().get("_meta").is_none());

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -5555,7 +5555,7 @@
                   "type": "null"
                 },
                 {
-                  "$ref": "#/components/schemas/TypedId"
+                  "$ref": "#/components/schemas/eventId"
                 }
               ]
             }

--- a/plugins/everruns-dev/.claude-plugin/plugin.json
+++ b/plugins/everruns-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "everruns-dev",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Interact with the Everruns(Dev) managed harnesses platform. Manage harnesses, agents, and capabilities. Run agentic sessions. Create and deploy agentic applications.",
   "author": {
     "name": "Everruns",

--- a/plugins/everruns-dev/.codex-plugin/plugin.json
+++ b/plugins/everruns-dev/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "everruns-dev",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Interact with the Everruns(Dev) managed harnesses platform from Codex. Manage harnesses, agents, and capabilities. Run agentic sessions. Create and deploy agentic applications.",
   "author": {
     "name": "Everruns",

--- a/plugins/everruns-dev/commands/agent-card.md
+++ b/plugins/everruns-dev/commands/agent-card.md
@@ -5,7 +5,8 @@ argument-hint: "<agent_id_or_name>"
 
 Call the `agent_get_card` MCP tool with the supplied positional argument as
 `agent_id`. The tool accepts either a prefixed agent ID
-(`agent_{32-hex}`) or a unique agent name within the current organization.
+(`agent_{32-hex}`) or a unique agent name within the default organization, or
+within the target organization when the user provides an `organization_id`.
 
 The result is an MCP `resource` content block at
 `ui://everruns/agent/{agent_id}/card` (`text/html`), plus a one-line text

--- a/plugins/everruns-dev/commands/whoami.md
+++ b/plugins/everruns-dev/commands/whoami.md
@@ -1,6 +1,8 @@
 ---
-description: Show the current Everruns(Dev) user and active organization
+description: Show the current Everruns(Dev) user and default organization
 ---
 
 Call the `me` MCP tool. If it fails with an auth error, tell the user to
-complete the OAuth flow their host opens in the browser.
+complete the OAuth flow their host opens in the browser. For multi-org users,
+explain that MCP has no current-org switch; use `list_organizations` and pass
+`organization_id` on each org-scoped tool call to target a non-default org.

--- a/plugins/everruns-dev/skills/everruns-dev/SKILL.md
+++ b/plugins/everruns-dev/skills/everruns-dev/SKILL.md
@@ -116,8 +116,8 @@ Examples:
 
 | Tool | When to use |
 |---|---|
-| `me` | Current user + active org. Cheap sanity check. |
-| `list_organizations`, `switch_organization` | Multi-org accounts. `switch_organization` is advisory - the MCP transport is stateless; pass `organization_id` per call to stick with a non-default org. |
+| `me` | Current user + default org. Cheap sanity check. |
+| `list_organizations` | Multi-org accounts. MCP has no current-org switch; use this to find an org id, then pass `organization_id` on every org-scoped MCP tool call that should target that org. |
 | `agent_run` | Create a session and send the first message in one go. Returns `session_id`, `message_id`. |
 | `session_send_message` | Follow-up user message in an existing session. |
 | `session_get_status` | Poll session status + latest agent message + recent events. Supports `since_event_id` for incremental polling and `event_types` to filter. |
@@ -128,6 +128,36 @@ Examples:
 
 Default to `query` for reads. Switch to `execute` only when the workflow needs
 to create, update, delete, or trigger actions.
+
+## Multi-org semantics
+
+The MCP transport is stateless. There is no org-switching tool and no server-side
+current org for MCP clients. If `organization_id` is omitted, Everruns(Dev) uses
+the default org reported by `me`.
+
+For non-default orgs:
+
+1. Call `list_organizations`.
+2. Pick the target `org_{32-hex}` id.
+3. Include `"organization_id": "org_..."` on each org-scoped MCP tool call:
+   `agent_run`, `session_send_message`, `session_get_status`, `agent_get_card`,
+   `discover`, `query`, or `execute`.
+
+For `query` and `execute`, put `organization_id` on the MCP tool call, not inside
+the bash script:
+
+```text
+query {
+  "organization_id": "org_01933b5a00007000800000000000004",
+  "commands": "list_agents | jq -r '.data[] | [.id, .name] | @tsv'"
+}
+
+agent_run {
+  "organization_id": "org_01933b5a00007000800000000000004",
+  "agent_id": "support-triage",
+  "message": "Summarize the latest failed sessions."
+}
+```
 
 ## Using `discover`, `query`, and `execute`
 
@@ -238,8 +268,9 @@ list_agents | jq '.data[] | {id, name, default_model_id}'
   workflows, split them into multiple calls.
 - `list_*` operations default to `--limit 20` (max 100) with `--offset` for
   paging.
-- Every org-scoped operation accepts `--organization_id org_{32-hex}` to target
-  a non-default org in multi-org accounts.
+- Org context for `query` and `execute` is selected by the top-level
+  `organization_id` MCP argument. Do not pass `--organization_id` to builtins
+  inside the script.
 
 ## Entity cards (MCP Apps)
 
@@ -249,6 +280,7 @@ resources hosts can render alongside text output. See
 for the standard.
 
 - Tool: `agent_get_card { "agent_id": "<agent-id-or-name>" }`.
+  Add `"organization_id": "org_..."` when targeting a non-default org.
 - Result: an MCP `resource` content item at
   `ui://everruns/agent/{agent_id}/card` (MIME `text/html`) plus a one-line
   text summary.
@@ -274,8 +306,8 @@ in `tools/list` and should use `get_agent`.
   the builtin exists under the expected name.
 - **Operation unclear** - `<cmd> --help` inside `query` or `execute` prints usage;
   `discover { "query": "<cmd>" }` shows parameter types.
-- **Wrong org** - `me` reports the active org; pass `--organization_id`
-  explicitly on each call to override.
+- **Wrong org** - `me` reports the default org. Call `list_organizations`, then
+  pass top-level `organization_id` explicitly on each org-scoped MCP call.
 
 ## Docs
 

--- a/scripts/test-everruns-dev-plugin.sh
+++ b/scripts/test-everruns-dev-plugin.sh
@@ -88,5 +88,21 @@ if not claude_marketplace.get("description"):
         "marketplace renders correctly in Claude Code's plugin browser."
     )
 
+skill = (plugin_dir / "skills" / "everruns-dev" / "SKILL.md").read_text()
+if "switch_organization" in skill:
+    raise SystemExit(
+        "Everruns Dev skill must not mention switch_organization; MCP org "
+        "selection is per-call via organization_id."
+    )
+
+required_multi_org_phrases = [
+    "MCP has no current-org switch",
+    '"organization_id": "org_01933b5a00007000800000000000004"',
+    "Do not pass `--organization_id` to builtins",
+]
+missing = [phrase for phrase in required_multi_org_phrases if phrase not in skill]
+if missing:
+    raise SystemExit(f"Everruns Dev skill is missing multi-org guidance: {missing}")
+
 print("everruns-dev plugin metadata checks passed")
 PY

--- a/specs/mcp.md
+++ b/specs/mcp.md
@@ -346,19 +346,18 @@ See `specs/threat-model.md` for the full threat model.
 
 ## Multi-Organization Support
 
-MCP clients authenticate via OAuth 2.1 Bearer tokens, which don't carry org context (unlike browser sessions that use the `everruns_org` cookie). Three mechanisms enable multi-org access:
+MCP clients authenticate via OAuth 2.1 Bearer tokens, which don't carry org context (unlike browser sessions that use the `everruns_org` cookie). Two mechanisms enable multi-org access:
 
 ### Tier 0 Tools
 
 | Tool | Description |
 |------|-------------|
-| `me` | Returns current user profile and active organization context |
+| `me` | Returns current user profile and default organization context |
 | `list_organizations` | Lists all orgs the user belongs to, with roles |
-| `switch_organization` | Validates org membership; instructs client to pass `organization_id` |
 
 ### Per-Call `organization_id` Override
 
-All org-scoped tools (`agent_run`, `session_send_message`, `session_get_status`, `query`, `execute`) accept an optional `organization_id` parameter (format: `org_{32-hex}`). When provided:
+All org-scoped tools (`agent_run`, `session_send_message`, `session_get_status`, `agent_get_card`, `discover`, `query`, `execute`) accept an optional `organization_id` parameter (format: `org_{32-hex}`). When provided:
 
 1. User membership is validated against the database (not stale JWT claims)
 2. A `ResolvedOrg` is constructed for the target org
@@ -371,7 +370,7 @@ When omitted, the default org is used (first org from the user's membership list
 1. **Stateless per-call override** — no session state needed. Each tool call independently targets an org.
 2. **DB-validated membership** — JWT org claims may be stale; always check DB for fresh membership.
 3. **`discover` accepts `organization_id` for consistency** — catalog search itself is effectively org-agnostic today, but the argument keeps org-scoped routing uniform across tools and leaves room for future org-specific catalog visibility.
-4. **`switch_organization` is advisory** — returns the validated org for the client to use in subsequent calls. The MCP transport is stateless, so there's no server-side "current org" to switch.
+4. **No `switch_organization` tool** — the MCP transport is stateless, so there is no server-side "current org" to switch. Tool descriptions tell clients to call `list_organizations` and pass `organization_id` directly on org-scoped calls.
 
 ## Implementation
 


### PR DESCRIPTION
## What
Remove the advisory `switch_organization` MCP tool and keep multi-org routing on explicit per-call `organization_id` arguments.

Update the Everruns Dev plugin guidance/examples to explain the stateless MCP org model, including the correct top-level `organization_id` usage for `query` and `execute`. Bump the plugin metadata to `0.1.3` and add plugin validation coverage for this guidance.

## Why
`switch_organization` implied server-side MCP org state that does not exist. MCP calls are stateless, so exposing a switch tool creates the wrong mental model for clients and agents.

## How
- Removed `switch_organization` from MCP tool registration and dispatch.
- Expanded `me`, `list_organizations`, and `organization_id` descriptions with direct per-call routing guidance.
- Updated MCP endpoint tests to assert the tool is absent and the org guidance is present.
- Updated `specs/mcp.md` and Everruns Dev plugin docs/commands/examples.
- Added plugin validation checks that prevent stale `switch_organization` guidance from returning.

Validation:
- `scripts/test-everruns-dev-plugin.sh`
- `cargo fmt --check`
- `git diff --check`
- `CARGO_INCREMENTAL=0 cargo test -p everruns-server --test mcp_endpoint_test test_mcp_tools_list`
- `CARGO_INCREMENTAL=0 just pre-push`
- `bash scripts/lib/check-migration-ordering.sh`

Smoke test:
- Focused MCP endpoint test exercises `tools/list` through the HTTP test server and verifies the exposed plugin/tool semantics changed as intended.
- Everruns Dev plugin validation checks shipped plugin metadata and multi-org guidance.

## Risk
- Low
- Existing clients that call `switch_organization` will now get tool-not-found; this is intended because the tool was misleading and did not actually switch server-side MCP state.
- Org-scoped calls continue to use the existing DB-validated `organization_id` override path.

## Security
- Threat categories reviewed: TM-MCP, TM-TENANT, TM-TOOL.
- Findings and resolutions: no new auth or tenant boundary was introduced. The change removes one exposed MCP tool and preserves the existing per-call org override path, including DB membership validation and API-key override restrictions. Plugin/doc updates do not expose secrets or add execution capabilities.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
