### PR TITLE
docs(a2a): cross-link inbound channel and outbound capability specs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,7 +152,8 @@ Always make sure you are working on top of latest main from remote.
 - `specs/agent-identities.md` - Agent identities (virtual principals for unattended execution)
 - `specs/agent-blueprints.md` - Pre-built agent definitions (private tools, fixed models, typed config)
 - `specs/messaging-integrations.md` - Messaging integrations (channel abstractions, parity requirements, platform adapters)
-- `specs/a2a-channel.md` - A2A (Agent2Agent) channel for App invocation via JSON-RPC + API key auth
+- `specs/a2a-channel.md` - A2A (Agent2Agent) inbound channel for App invocation via JSON-RPC + API key auth
+- `specs/a2a-capability.md` - A2A outbound delegation capability (Everruns agent calling external A2A agents)
 
 ### Test Cases
 

--- a/specs/a2a-channel.md
+++ b/specs/a2a-channel.md
@@ -35,10 +35,17 @@ References:
    `message/stream`, `tasks/get`, `tasks/cancel`, push notifications, etc. are
    out of scope.
 2. Authentication schemes beyond API key (HTTP, OAuth2, OIDC, mTLS).
-3. Outbound A2A delivery (one app calling another app's A2A endpoint as a
-   client) — only inbound ingress.
-4. Multi-turn task state machine — every `message/send` returns a terminal
+3. Multi-turn task state machine — every `message/send` returns a terminal
    `completed` task with no follow-up handle.
+
+This spec covers **inbound** A2A only — exposing an Everruns App as an A2A
+server for other agents to call. The complementary **outbound** direction —
+letting an Everruns agent call an external A2A agent — lives as a separate
+capability spec, [`specs/a2a-capability.md`](a2a-capability.md), and a
+separate threat-model surface (TM-AGENT-005 covers the high-risk capability
+gate; SSRF protection comes from `validate_safe_url`, response size is
+bounded by `MAX_RESULT_CHARS`, and external agent IDs are configured rather
+than model-supplied).
 
 ## Model
 


### PR DESCRIPTION
## What
Cross-link the inbound A2A channel spec (`specs/a2a-channel.md`) with the outbound A2A delegation capability spec (`specs/a2a-capability.md`), and add the capability spec to the `AGENTS.md` spec index.

## Why
Outbound A2A — letting an Everruns agent call external A2A agents — was shipped in commit cf1c9a5 as the `a2a_agent_delegation` capability with its own spec at `specs/a2a-capability.md`. But `specs/a2a-channel.md` still listed outbound as a non-goal, and the `AGENTS.md` spec index only referenced the inbound channel spec. The two surfaces are intentionally split (inbound is an App channel exposing Everruns; outbound is a built-in capability calling external agents) and the docs should make that split visible from either entry point.

EVE-435's acceptance criteria asked for "Spec section in `specs/a2a-channel.md` for outbound mode." A full duplicated section would conflate two different concerns; instead this PR lifts the stale non-goal and adds a short pointer to the capability spec.

## How
- `specs/a2a-channel.md`: drop the "Outbound A2A delivery" entry from Non-Goals (now stale). Add a short paragraph after Non-Goals that names the split, points to `specs/a2a-capability.md`, and summarizes the threat-model surface already covered for outbound (TM-AGENT-005 high-risk gate, `validate_safe_url` SSRF protection, `MAX_RESULT_CHARS` response size bound, configured external agent IDs).
- `AGENTS.md`: rename the existing inbound entry to clarify it is inbound, and add a sibling entry for `specs/a2a-capability.md`.

## Risk
- Low. Documentation-only change. No Rust, UI, OpenAPI, migration, or runtime changes.

## Security
- Threat categories reviewed: No security-relevant code changes — diff is limited to two markdown files. The PR makes the existing outbound threat-model coverage easier to find, not weaker.
- Findings and resolutions: None.

## Follow-ups
The remaining EVE-435 acceptance criterion — encrypted, secret-bearing per-call auth supplied via secrets/connections instead of static `headers` — is intentionally deferred. `specs/a2a-capability.md` already names this as future work tied to the planned org-managed external-agents registry. Filing/keeping a separate issue for that work is appropriate so this PR can land the spec correction without a multi-week feature.

## Checklist
- [x] Tests added or updated (N/A — docs-only)
- [x] Backward compatibility considered (N/A — docs-only)
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)


---
_Generated by [Claude Code](https://claude.ai/code/session_01U2JUfL8QiFMw5WPkQ43HmQ)_