### PR TITLE
fix(capabilities): gate declarative high-risk dependencies

### DIFF
--- a/crates/server/src/domains/agents/commands.rs
+++ b/crates/server/src/domains/agents/commands.rs
@@ -80,12 +80,16 @@ fn initial_files_total_bytes(files: &[InitialFile]) -> usize {
     files.iter().map(|f| f.content.len()).sum()
 }
 
-fn check_high_risk_caps(ctx: &Ctx, caps: &[AgentCapabilityConfig]) -> Result<(), CommandError> {
+async fn check_high_risk_caps(ctx: &Ctx, caps: &[AgentCapabilityConfig]) -> Result<(), CommandError> {
     if caps.is_empty() || ctx.caller.role.has_permission(OrgRole::Admin) {
         return Ok(());
     }
     let refs: Vec<&str> = caps.iter().map(|c| c.capability_ref.as_str()).collect();
-    let high = ctx.capability_service.high_risk_ids(&refs);
+    let high = ctx
+        .capability_service
+        .high_risk_ids_for_org(ctx.org_id(), &refs)
+        .await
+        .map_err(classify_anyhow)?;
     if !high.is_empty() {
         return Err(CommandError::Forbidden(format!(
             "Admin role required to assign high-risk capabilities: {}",
@@ -155,7 +159,7 @@ impl Command for CreateAgent {
         // Validate
         validate_name("Agent", &req.name)?;
         validate_create_limits(&req)?;
-        check_high_risk_caps(ctx, &req.capabilities)?;
+        check_high_risk_caps(ctx, &req.capabilities).await?;
 
         // Business rules
         q::ensure_name_available(&ctx.db, ctx.org_id(), &req.name, None).await?;
@@ -404,7 +408,7 @@ impl Command for UpdateAgentCmd {
             ));
         }
         if let Some(ref caps) = req.capabilities {
-            check_high_risk_caps(ctx, caps)?;
+            check_high_risk_caps(ctx, caps).await?;
         }
 
         // Resolve existing
@@ -626,7 +630,7 @@ impl Command for UpsertAgent {
         // Validate (same checks as CreateAgent)
         validate_name("Agent", &req.name)?;
         validate_create_limits(&req)?;
-        check_high_risk_caps(ctx, &req.capabilities)?;
+        check_high_risk_caps(ctx, &req.capabilities).await?;
 
         let caps = normalize_capability_refs(
             ctx,

--- a/crates/server/src/domains/agents/commands.rs
+++ b/crates/server/src/domains/agents/commands.rs
@@ -80,7 +80,10 @@ fn initial_files_total_bytes(files: &[InitialFile]) -> usize {
     files.iter().map(|f| f.content.len()).sum()
 }
 
-async fn check_high_risk_caps(ctx: &Ctx, caps: &[AgentCapabilityConfig]) -> Result<(), CommandError> {
+async fn check_high_risk_caps(
+    ctx: &Ctx,
+    caps: &[AgentCapabilityConfig],
+) -> Result<(), CommandError> {
     if caps.is_empty() || ctx.caller.role.has_permission(OrgRole::Admin) {
         return Ok(());
     }

--- a/crates/server/src/domains/sessions/service.rs
+++ b/crates/server/src/domains/sessions/service.rs
@@ -1190,8 +1190,15 @@ impl SessionService {
             else {
                 continue;
             };
+            // Fail closed: a broken declarative definition must NOT silently skip
+            // dependency expansion, since this gates admin-only high-risk session
+            // capability assignment.
             let definition: DeclarativeCapabilityDefinition =
-                serde_json::from_value(row.definition).unwrap_or_default();
+                serde_json::from_value(row.definition).map_err(|error| {
+                    anyhow::anyhow!(
+                        "declarative capability {cap_ref} has malformed definition: {error}"
+                    )
+                })?;
             for dep in definition.dependencies {
                 if !capability_ids.contains(&dep) {
                     capability_ids.push(dep);

--- a/crates/server/src/domains/sessions/service.rs
+++ b/crates/server/src/domains/sessions/service.rs
@@ -1170,14 +1170,11 @@ impl SessionService {
         let capability_ids = self
             .collect_session_capability_ids(org_id, harness_id, agent_id, session_capabilities)
             .await?;
-        let high_risk: Vec<String> = capability_ids
-            .into_iter()
-            .filter(|capability_id| {
-                self.capability_registry
-                    .get(capability_id)
-                    .is_some_and(|capability| capability.risk_level() == RiskLevel::High)
-            })
-            .collect();
+        let cap_refs: Vec<&str> = capability_ids.iter().map(String::as_str).collect();
+        let high_risk = self
+            .capability_service
+            .high_risk_ids_for_org(org_id, &cap_refs)
+            .await?;
         if high_risk.is_empty() {
             return Ok(());
         }

--- a/crates/server/src/domains/sessions/service.rs
+++ b/crates/server/src/domains/sessions/service.rs
@@ -21,11 +21,12 @@ use crate::storage::{
 use anyhow::Result;
 use everruns_core::session_sandbox::SESSION_SANDBOX_CAPABILITY_ID;
 use everruns_core::{
-    AgentCapabilityConfig, AgentId, Caller, CapabilityRegistry, HarnessId, InitialFile, ModelId,
-    MountPoint, OrgRole, Permission, Policy, PrincipalId, Rule, Session, SessionId, SessionStatus,
-    SubagentStatus, TokenUsage,
+    AgentCapabilityConfig, AgentId, Caller, CapabilityRegistry, DeclarativeCapabilityDefinition,
+    HarnessId, InitialFile, ModelId, MountPoint, OrgRole, Permission, Policy, PrincipalId, Rule,
+    Session, SessionId, SessionStatus, SubagentStatus, TokenUsage,
     capabilities::{RiskLevel, SystemPromptContext, collect_capabilities, compute_features},
-    merge_capabilities, merge_initial_files, normalize_initial_file_path,
+    is_declarative_capability, merge_capabilities, merge_initial_files,
+    normalize_initial_file_path, parse_declarative_capability_id,
 };
 use everruns_durable::UpdateField;
 use std::collections::HashSet;
@@ -1167,14 +1168,44 @@ impl SessionService {
             return Ok(());
         }
 
-        let capability_ids = self
+        let mut capability_ids = self
             .collect_session_capability_ids(org_id, harness_id, agent_id, session_capabilities)
             .await?;
-        let cap_refs: Vec<&str> = capability_ids.iter().map(String::as_str).collect();
-        let high_risk = self
-            .capability_service
-            .high_risk_ids_for_org(org_id, &cap_refs)
-            .await?;
+        // Expand declarative capability dependencies so hidden high-risk built-ins
+        // (e.g. `web_fetch`, `virtual_bash`) cannot bypass the admin gate. Validation
+        // forbids nested declarative deps, so a single expansion pass is sufficient.
+        let declarative_refs: Vec<String> = capability_ids
+            .iter()
+            .filter(|id| is_declarative_capability(id))
+            .cloned()
+            .collect();
+        for cap_ref in &declarative_refs {
+            let Some(name) = parse_declarative_capability_id(cap_ref) else {
+                continue;
+            };
+            let Some(row) = self
+                .db
+                .get_declarative_capability_by_name(org_id, name)
+                .await?
+            else {
+                continue;
+            };
+            let definition: DeclarativeCapabilityDefinition =
+                serde_json::from_value(row.definition).unwrap_or_default();
+            for dep in definition.dependencies {
+                if !capability_ids.contains(&dep) {
+                    capability_ids.push(dep);
+                }
+            }
+        }
+        let high_risk: Vec<String> = capability_ids
+            .into_iter()
+            .filter(|capability_id| {
+                self.capability_registry
+                    .get(capability_id)
+                    .is_some_and(|capability| capability.risk_level() == RiskLevel::High)
+            })
+            .collect();
         if high_risk.is_empty() {
             return Ok(());
         }
@@ -2126,6 +2157,91 @@ mod tests {
         db.set_harness_capabilities(
             harness.id.uuid(),
             vec![("test_high_risk".to_string(), 0, serde_json::json!({}))],
+        )
+        .await
+        .unwrap();
+
+        let member = Caller {
+            org_id: owner.org_id,
+            org_public_id: owner.org_public_id.clone(),
+            user_id: None,
+            role: OrgRole::Member,
+            is_platform_user: false,
+            is_internal: false,
+        };
+
+        let err = session_service
+            .create(
+                &member,
+                harness.id.uuid(),
+                None,
+                None,
+                build_create_request(harness.id, None, None),
+            )
+            .await
+            .unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("Admin role required to create sessions with high-risk capabilities"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn create_rejects_declarative_capability_with_high_risk_dependency_for_members() {
+        use crate::storage::models::CreateDeclarativeCapabilityRow;
+
+        let db = Arc::new(StorageBackend::in_memory());
+        let mut registry = CapabilityRegistry::new();
+        registry.register(TestHighRiskCapability);
+        let session_service = SessionService::with_registry(db.clone(), registry);
+        let owner = Caller::internal(DEFAULT_ORG_ID);
+
+        // Declarative capability that hides a high-risk built-in dependency.
+        db.create_declarative_capability(
+            owner.org_id,
+            CreateDeclarativeCapabilityRow {
+                public_id: everruns_core::DeclarativeCapabilityId::new().to_string(),
+                name: "hidden_admin_tool".to_string(),
+                display_name: Some("Hidden Admin Tool".to_string()),
+                description: "wraps a high-risk built-in".to_string(),
+                definition: serde_json::json!({
+                    "name": "hidden_admin_tool",
+                    "description": "wraps a high-risk built-in",
+                    "dependencies": ["test_high_risk"],
+                }),
+            },
+        )
+        .await
+        .unwrap();
+
+        let harness = db
+            .create_harness(
+                owner.org_id,
+                CreateHarnessRow {
+                    name: "declarative-harness".to_string(),
+                    display_name: Some("Declarative Harness".to_string()),
+                    description: None,
+                    system_prompt: "declarative".to_string(),
+                    parent_harness_id: None,
+                    default_model_id: None,
+                    tags: vec![],
+                    initial_files: serde_json::json!([]),
+                    mcp_servers: serde_json::json!({}),
+                    network_access: None,
+                    is_built_in: false,
+                },
+            )
+            .await
+            .unwrap();
+        db.set_harness_capabilities(
+            harness.id.uuid(),
+            vec![(
+                "declarative:hidden_admin_tool".to_string(),
+                0,
+                serde_json::json!({}),
+            )],
         )
         .await
         .unwrap();

--- a/crates/server/src/services/capability.rs
+++ b/crates/server/src/services/capability.rs
@@ -370,7 +370,11 @@ impl CapabilityService {
             let Some(name) = parse_declarative_capability_id(cap_ref) else {
                 continue;
             };
-            let Some(row) = self.db.get_declarative_capability_by_name(org_id, name).await? else {
+            let Some(row) = self
+                .db
+                .get_declarative_capability_by_name(org_id, name)
+                .await?
+            else {
                 continue;
             };
             let definition: DeclarativeCapabilityDefinition =
@@ -682,20 +686,25 @@ mod tests {
 
         #[tokio::test]
         async fn flags_declarative_dependencies_as_high_risk() {
+            use crate::storage::models::CreateDeclarativeCapabilityRow;
             let svc = make_service();
-            svc.db.create_declarative_capability(
-                1,
-                "hidden_fetch",
-                "hidden_fetch",
-                Some("Hidden Fetch".to_string()),
-                None,
-                &serde_json::json!({
-                    "name": "hidden_fetch",
-                    "dependencies": ["web_fetch"]
-                }),
-            )
-            .await
-            .unwrap();
+            svc.db
+                .create_declarative_capability(
+                    1,
+                    CreateDeclarativeCapabilityRow {
+                        public_id: everruns_core::DeclarativeCapabilityId::new().to_string(),
+                        name: "hidden_fetch".to_string(),
+                        display_name: Some("Hidden Fetch".to_string()),
+                        description: "test".to_string(),
+                        definition: serde_json::json!({
+                            "name": "hidden_fetch",
+                            "description": "test",
+                            "dependencies": ["web_fetch"],
+                        }),
+                    },
+                )
+                .await
+                .unwrap();
 
             let high = svc
                 .high_risk_ids_for_org(1, &["declarative:hidden_fetch"])

--- a/crates/server/src/services/capability.rs
+++ b/crates/server/src/services/capability.rs
@@ -377,8 +377,15 @@ impl CapabilityService {
             else {
                 continue;
             };
+            // Fail closed: a broken declarative definition must NOT silently skip
+            // dependency expansion, since this function gates admin-only high-risk
+            // capability assignment. Propagate the parse error to the caller.
             let definition: DeclarativeCapabilityDefinition =
-                serde_json::from_value(row.definition).unwrap_or_default();
+                serde_json::from_value(row.definition).map_err(|error| {
+                    anyhow::anyhow!(
+                        "declarative capability {cap_ref} has malformed definition: {error}"
+                    )
+                })?;
             refs.extend(definition.dependencies);
         }
 

--- a/crates/server/src/services/capability.rs
+++ b/crates/server/src/services/capability.rs
@@ -354,6 +354,35 @@ impl CapabilityService {
             .collect()
     }
 
+    /// Return high-risk built-in capability IDs reachable from the given refs.
+    ///
+    /// Declarative refs are expanded using their persisted `dependencies`.
+    pub async fn high_risk_ids_for_org(
+        &self,
+        org_id: i64,
+        cap_refs: &[&str],
+    ) -> Result<Vec<String>> {
+        let mut refs: Vec<String> = cap_refs.iter().map(|id| (*id).to_string()).collect();
+        for cap_ref in cap_refs {
+            if !is_declarative_capability(cap_ref) {
+                continue;
+            }
+            let Some(name) = parse_declarative_capability_id(cap_ref) else {
+                continue;
+            };
+            let Some(row) = self.db.get_declarative_capability_by_name(org_id, name).await? else {
+                continue;
+            };
+            let definition: DeclarativeCapabilityDefinition =
+                serde_json::from_value(row.definition).unwrap_or_default();
+            refs.extend(definition.dependencies);
+        }
+
+        refs.sort();
+        refs.dedup();
+        Ok(self.high_risk_ids(&refs.iter().map(String::as_str).collect::<Vec<_>>()))
+    }
+
     /// List system commands from all registered capabilities.
     ///
     /// System commands execute directly without the LLM (e.g., /clear, /status).
@@ -649,6 +678,30 @@ mod tests {
         fn empty_input_returns_empty() {
             let svc = make_service();
             assert!(svc.high_risk_ids(&[]).is_empty());
+        }
+
+        #[tokio::test]
+        async fn flags_declarative_dependencies_as_high_risk() {
+            let svc = make_service();
+            svc.db.create_declarative_capability(
+                1,
+                "hidden_fetch",
+                "hidden_fetch",
+                Some("Hidden Fetch".to_string()),
+                None,
+                &serde_json::json!({
+                    "name": "hidden_fetch",
+                    "dependencies": ["web_fetch"]
+                }),
+            )
+            .await
+            .unwrap();
+
+            let high = svc
+                .high_risk_ids_for_org(1, &["declarative:hidden_fetch"])
+                .await
+                .unwrap();
+            assert_eq!(high, vec!["web_fetch".to_string()]);
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Declarative capabilities could hide high-risk built-in dependencies (e.g., `web_fetch`, `virtual_bash`) so that non-admin members could assign or create agents/sessions with those hidden high-risk tools without triggering the Admin-only gate.

### Description
- Add `CapabilityService::high_risk_ids_for_org` which expands `declarative:*` refs by loading their persisted `dependencies`, deduplicates refs, and then reuses the existing built-in high-risk filter.
- Update agent capability authorization to call the new org-aware resolver by making `check_high_risk_caps` async and using `high_risk_ids_for_org` so `declarative:<name>` cannot bypass the admin gate.
- Update session creation guard to use `high_risk_ids_for_org` so session flows are protected the same way.
- Add a regression test `flags_declarative_dependencies_as_high_risk` that creates a declarative capability depending on `web_fetch` and verifies the resolver flags it as high-risk.

### Testing
- Ran `cargo check -p everruns-server` which completed successfully in this environment.
- Attempted `cargo test -p everruns-server high_risk_ids_tests` to exercise the new regression test; the build/test run was started but the compilation step was still in progress in the environment during the execution window so a final pass/fail result is not available here.
- The new unit test `flags_declarative_dependencies_as_high_risk` is included under the existing `high_risk_ids_tests` suite for CI to run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc1b111f38832b9b9c0d5c5b1bf8ec)