### PR TITLE
fix(budgets): recognize AG-UI app tags for budget scope

### DIFF
--- a/crates/server/src/domains/budgets/service.rs
+++ b/crates/server/src/domains/budgets/service.rs
@@ -709,8 +709,8 @@ impl EventListener for BudgetService {
 // ============================================================================
 
 /// Pull `(app_id, app_channel_id)` from session tags. Both legacy
-/// `slack:app:<id>` and the canonical `app:<id>` / `app_channel:<id>` forms
-/// are recognised.
+/// `slack:app:<id>`, `ag_ui:app:<id>`, and the canonical
+/// `app:<id>` / `app_channel:<id>` forms are recognised.
 fn extract_app_subjects(tags: &[String]) -> (Option<String>, Option<String>) {
     let mut app_id: Option<String> = None;
     let mut channel_id: Option<String> = None;
@@ -720,6 +720,8 @@ fn extract_app_subjects(tags: &[String]) -> (Option<String>, Option<String>) {
         } else if let Some(rest) = tag.strip_prefix("app_channel:") {
             channel_id.get_or_insert_with(|| rest.to_string());
         } else if let Some(rest) = tag.strip_prefix("slack:app:") {
+            app_id.get_or_insert_with(|| rest.to_string());
+        } else if let Some(rest) = tag.strip_prefix("ag_ui:app:") {
             app_id.get_or_insert_with(|| rest.to_string());
         }
     }
@@ -800,7 +802,7 @@ mod period_tests {
     }
 
     #[test]
-    fn extract_subjects_handles_both_tag_styles() {
+    fn extract_subjects_handles_supported_tag_styles() {
         let tags = vec![
             "app:app_abc".to_string(),
             "app_channel:appchan_xyz".to_string(),
@@ -809,8 +811,12 @@ mod period_tests {
         assert_eq!(app.as_deref(), Some("app_abc"));
         assert_eq!(ch.as_deref(), Some("appchan_xyz"));
 
-        let legacy = vec!["slack:app:app_legacy".to_string()];
-        let (app, _) = extract_app_subjects(&legacy);
+        let slack_legacy = vec!["slack:app:app_legacy".to_string()];
+        let (app, _) = extract_app_subjects(&slack_legacy);
         assert_eq!(app.as_deref(), Some("app_legacy"));
+
+        let ag_ui_legacy = vec!["ag_ui:app:app_ag_ui".to_string()];
+        let (app, _) = extract_app_subjects(&ag_ui_legacy);
+        assert_eq!(app.as_deref(), Some("app_ag_ui"));
     }
 }

--- a/crates/server/src/domains/sessions/service.rs
+++ b/crates/server/src/domains/sessions/service.rs
@@ -323,10 +323,11 @@ impl SessionService {
                 tag.starts_with("app:")
                     || tag.starts_with("app_channel:")
                     || tag.starts_with("slack:app:")
+                    || tag.starts_with("ag_ui:app:")
             })
         {
             return Err(BadRequestError::new(
-                "Tags with 'app:', 'app_channel:', or 'slack:app:' prefix are reserved for internal subsystems",
+                "Tags with 'app:', 'app_channel:', 'slack:app:', or 'ag_ui:app:' prefix are reserved for internal subsystems",
             )
             .into());
         }
@@ -862,11 +863,12 @@ impl SessionService {
                     tag.starts_with("app:")
                         || tag.starts_with("app_channel:")
                         || tag.starts_with("slack:app:")
+                        || tag.starts_with("ag_ui:app:")
                 })
             })
         {
             return Err(BadRequestError::new(
-                "Tags with 'app:', 'app_channel:', or 'slack:app:' prefix are reserved for internal subsystems",
+                "Tags with 'app:', 'app_channel:', 'slack:app:', or 'ag_ui:app:' prefix are reserved for internal subsystems",
             )
             .into());
         }
@@ -2526,6 +2528,7 @@ mod tests {
             vec!["app:app_other".to_string()],
             vec!["app_channel:appchan_other".to_string()],
             vec!["slack:app:app_legacy_other".to_string()],
+            vec!["ag_ui:app:app_ag_ui_other".to_string()],
         ] {
             let err = session_service
                 .update(
@@ -2575,6 +2578,7 @@ mod tests {
             "app:app_someone_else",
             "app_channel:appchan_someone_else",
             "slack:app:app_legacy_someone_else",
+            "ag_ui:app:app_ag_ui_someone_else",
         ] {
             let mut req = build_create_request(harness.id, None, None);
             req.tags = vec![forbidden.to_string()];


### PR DESCRIPTION
### Motivation
- The budget subject extractor only recognized `app:`, `app_channel:`, and legacy `slack:app:` tags, so sessions created by AG-UI (which use `ag_ui:app:<id>`) could miss app/app_channel budget attribution and bypass spend caps.

### Description
- Extend `extract_app_subjects` in `crates/server/src/domains/budgets/service.rs` to recognize `ag_ui:app:<id>` as an app subject and update the existing unit test to assert extraction for `ag_ui:app:` alongside `app:` and `slack:app:`.

### Testing
- Attempted to run the unit test `extract_subjects_handles_supported_tag_styles` via `cargo test -p everruns-server`, but the run did not complete in this environment due to extensive toolchain/dependency installation and artifact-lock contention, so the assertion was added to the test module while automated execution here was inconclusive.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8b6017c04832bb81495469e19f774)