### PR TITLE
fix(mcp): block oauth token use in explicit scoped servers

### DIFF
--- a/crates/server/src/domains/mcp_servers/scoped_mcp.rs
+++ b/crates/server/src/domains/mcp_servers/scoped_mcp.rs
@@ -31,9 +31,22 @@ pub fn merge_effective_scoped_mcp_servers(
         layers.push(&agent.mcp_servers);
     }
     layers.push(&session.mcp_servers);
-    merge_scoped_mcp_server_layers(layers)
+
+    let merged = merge_scoped_mcp_server_layers(layers);
+    strip_untrusted_oauth_from_scoped_mcp_servers(&merged)
 }
 
+fn strip_untrusted_oauth_from_scoped_mcp_servers(servers: &ScopedMcpServers) -> ScopedMcpServers {
+    servers
+        .iter()
+        .map(|(name, server)| {
+            let mut server = server.clone();
+            server.auth_mode = McpServerAuthMode::None;
+            server.oauth_provider_id = None;
+            (name.clone(), server)
+        })
+        .collect()
+}
 pub fn merge_effective_scoped_mcp_servers_with_capabilities(
     harness: &Harness,
     agent: Option<&Agent>,
@@ -275,6 +288,16 @@ mod tests {
             tool_discovery: true,
         }
     }
+    fn oauth_scoped_server(url: &str, provider: &str) -> ScopedMcpServer {
+        ScopedMcpServer {
+            transport_type: everruns_core::McpServerTransportType::Http,
+            url: url.to_string(),
+            headers: Default::default(),
+            auth_mode: McpServerAuthMode::OAuth,
+            oauth_provider_id: Some(provider.to_string()),
+            tool_discovery: true,
+        }
+    }
 
     #[test]
     fn detects_authorization_header_case_insensitively() {
@@ -380,6 +403,24 @@ mod tests {
             blueprint_id: None,
             blueprint_config: None,
         }
+    }
+
+    #[test]
+    fn merge_effective_scoped_mcp_servers_strips_explicit_oauth_fields() {
+        let mut harness = test_harness();
+        harness.mcp_servers.insert(
+            "docs".to_string(),
+            oauth_scoped_server("https://harness.example.com/mcp", "github"),
+        );
+
+        let agent = test_agent();
+        let session = test_session(harness.id, agent.public_id);
+
+        let merged = merge_effective_scoped_mcp_servers(&harness, Some(&agent), &session);
+        let docs = merged.get("docs").expect("server exists");
+
+        assert_eq!(docs.auth_mode, McpServerAuthMode::None);
+        assert!(docs.oauth_provider_id.is_none());
     }
 
     #[test]

--- a/crates/server/src/domains/mcp_servers/scoped_mcp.rs
+++ b/crates/server/src/domains/mcp_servers/scoped_mcp.rs
@@ -36,13 +36,28 @@ pub fn merge_effective_scoped_mcp_servers(
     strip_untrusted_oauth_from_scoped_mcp_servers(&merged)
 }
 
+/// Sanitize explicit (user-controlled) scoped MCP servers so they cannot
+/// request OAuth connection tokens for runtime tool discovery.
+///
+/// Capability-contributed servers are trusted (built-in code) and bypass this
+/// step entirely — see `merge_effective_scoped_mcp_servers_with_capabilities`.
+///
+/// Behavior is intentionally narrow: only entries that were explicitly
+/// configured as `auth_mode = OAuth` are altered. We clear `oauth_provider_id`
+/// (so no token resolution happens) and switch `auth_mode` back to `None`. We
+/// also disable `tool_discovery` on those entries — without a token, an
+/// authenticated tools/list would 401, so attempting it would just spam logs
+/// and slow scoped-MCP wiring.
 fn strip_untrusted_oauth_from_scoped_mcp_servers(servers: &ScopedMcpServers) -> ScopedMcpServers {
     servers
         .iter()
         .map(|(name, server)| {
             let mut server = server.clone();
-            server.auth_mode = McpServerAuthMode::None;
-            server.oauth_provider_id = None;
+            if matches!(server.auth_mode, McpServerAuthMode::OAuth) {
+                server.auth_mode = McpServerAuthMode::None;
+                server.oauth_provider_id = None;
+                server.tool_discovery = false;
+            }
             (name.clone(), server)
         })
         .collect()
@@ -421,6 +436,107 @@ mod tests {
 
         assert_eq!(docs.auth_mode, McpServerAuthMode::None);
         assert!(docs.oauth_provider_id.is_none());
+        assert!(
+            !docs.tool_discovery,
+            "tool discovery must be disabled on stripped explicit OAuth servers — without a token, an authenticated tools/list would 401",
+        );
+    }
+
+    #[test]
+    fn merge_effective_scoped_mcp_servers_strips_explicit_only_when_oauth() {
+        // Non-OAuth explicit entries (e.g. `auth_mode = None`) must pass through
+        // unchanged. The sanitizer is narrow on purpose — see the doc comment on
+        // strip_untrusted_oauth_from_scoped_mcp_servers.
+        let mut harness = test_harness();
+        harness.mcp_servers.insert(
+            "docs".to_string(),
+            scoped_server("https://harness.example.com/mcp"),
+        );
+        let agent = test_agent();
+        let session = test_session(harness.id, agent.public_id);
+
+        let merged = merge_effective_scoped_mcp_servers(&harness, Some(&agent), &session);
+        let docs = merged.get("docs").expect("server exists");
+
+        assert_eq!(docs.auth_mode, McpServerAuthMode::None);
+        assert!(docs.oauth_provider_id.is_none());
+        assert!(docs.tool_discovery);
+    }
+
+    #[test]
+    fn merge_with_capabilities_preserves_capability_oauth_strips_explicit() {
+        use everruns_core::AgentCapabilityConfig;
+        use everruns_core::capabilities::{Capability, CapabilityRegistry, RiskLevel};
+
+        struct OAuthMcpCapability;
+
+        impl Capability for OAuthMcpCapability {
+            fn id(&self) -> &str {
+                "oauth_mcp_test"
+            }
+
+            fn name(&self) -> &str {
+                "OAuth MCP Test"
+            }
+
+            fn description(&self) -> &str {
+                "Capability that contributes a scoped MCP server with OAuth"
+            }
+
+            fn risk_level(&self) -> RiskLevel {
+                RiskLevel::Low
+            }
+
+            fn mcp_servers(&self) -> ScopedMcpServers {
+                let mut servers = ScopedMcpServers::default();
+                servers.insert(
+                    "trusted_docs".to_string(),
+                    oauth_scoped_server("https://capability.example.com/mcp", "github"),
+                );
+                servers
+            }
+        }
+
+        let mut registry = CapabilityRegistry::new();
+        registry.register(OAuthMcpCapability);
+
+        let mut harness = test_harness();
+        harness
+            .capabilities
+            .push(AgentCapabilityConfig::new("oauth_mcp_test"));
+        // Explicit OAuth entry on a different name — must be sanitized.
+        harness.mcp_servers.insert(
+            "user_docs".to_string(),
+            oauth_scoped_server("https://harness.example.com/mcp", "github"),
+        );
+
+        let agent = test_agent();
+        let session = test_session(harness.id, agent.public_id);
+
+        let merged = merge_effective_scoped_mcp_servers_with_capabilities(
+            &harness,
+            Some(&agent),
+            &session,
+            &registry,
+        );
+
+        let trusted = merged.get("trusted_docs").expect("contributed server");
+        assert_eq!(
+            trusted.auth_mode,
+            McpServerAuthMode::OAuth,
+            "capability-contributed OAuth must be preserved"
+        );
+        assert_eq!(trusted.oauth_provider_id.as_deref(), Some("github"));
+        assert!(trusted.tool_discovery);
+
+        let user = merged.get("user_docs").expect("explicit server");
+        assert_eq!(
+            user.auth_mode,
+            McpServerAuthMode::None,
+            "explicit OAuth must be stripped"
+        );
+        assert!(user.oauth_provider_id.is_none());
+        assert!(!user.tool_discovery);
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Prevent user-controlled harness/agent/session `mcp_servers` from requesting OAuth connection tokens and leaking them to attacker-controlled MCP endpoints.
- Preserve capability-contributed scoped MCP servers (trusted) while neutralizing untrusted explicit config that could trigger token resolution.

### Description
- Added `strip_untrusted_oauth_from_scoped_mcp_servers` which clears `auth_mode` and `oauth_provider_id` on explicit scoped servers.
- Apply the sanitizer in `merge_effective_scoped_mcp_servers` so explicit layers (harness/agent/session) cannot carry OAuth metadata into runtime discovery.  
- Keep capability-contributed MCP servers intact by merging contributed servers after the explicit layer is sanitized in `merge_effective_scoped_mcp_servers_with_capabilities`.
- Added unit test helpers and a test `merge_effective_scoped_mcp_servers_strips_explicit_oauth_fields` that asserts explicit OAuth fields are removed.

### Testing
- Added unit test `merge_effective_scoped_mcp_servers_strips_explicit_oauth_fields` (new in `crates/server/src/domains/mcp_servers/scoped_mcp.rs`).
- Ran formatting checks with `cargo fmt --all --check` which passed.  
- Ran `cargo fmt --all` (applied formatting) which completed successfully.
- Attempted `cargo test -p everruns-server scoped_mcp` but full test execution could not complete in this environment due to dependency/toolchain fetch delays; the new unit test is included and should be exercised by CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f29c3d8ac8832b8b20fc970fe60620)