### PR TITLE
fix(durable): reduce turn startup latency

### DIFF
--- a/crates/durable/benches/db_cold_start_latency.rs
+++ b/crates/durable/benches/db_cold_start_latency.rs
@@ -23,15 +23,44 @@ use sqlx::postgres::PgListener;
 use tokio::runtime::Runtime;
 use tokio::sync::mpsc;
 
+use chrono::Utc;
 use everruns_durable::bench::{
     BenchmarkCheckpoint, BenchmarkMetrics, BenchmarkReport, CheckpointStore, EnvironmentInfo,
     ReportConfig,
 };
 use everruns_durable::persistence::{
-    PostgresWorkflowEventStore, TaskDefinition, WorkflowEventStore,
+    PostgresWorkflowEventStore, TaskDefinition, WorkerInfo, WorkflowEventStore,
 };
 use everruns_durable::workflow::ActivityOptions;
 use uuid::Uuid;
+
+async fn register_benchmark_worker(
+    store: &PostgresWorkflowEventStore,
+    worker_id: String,
+    activity_type: &str,
+) {
+    store
+        .register_worker(WorkerInfo {
+            id: worker_id,
+            worker_group: Some("bench".to_string()),
+            activity_types: vec![activity_type.to_string()],
+            max_concurrency: 1,
+            current_load: 0,
+            status: "active".to_string(),
+            accepting_tasks: true,
+            backpressure_reason: None,
+            started_at: Utc::now(),
+            last_heartbeat_at: Utc::now(),
+            hostname: None,
+            version: None,
+            metadata: None,
+            tasks_completed: 0,
+            tasks_failed: 0,
+            avg_task_duration_ms: None,
+        })
+        .await
+        .unwrap();
+}
 
 /// Get test database URL from environment or use default
 fn get_database_url() -> String {
@@ -136,10 +165,16 @@ async fn run_cold_start_scenario(pool: PgPool, config: ColdStartConfig) -> Arc<B
         let claim_time = claim_time.clone();
         let shutdown = shutdown.clone();
         let tasks_completed = tasks_completed.clone();
+        let worker_name = format!("db-cold-start-worker-{}-{}", worker_id, workflow_id);
+
+        register_benchmark_worker(
+            store.as_ref(),
+            worker_name.clone(),
+            "db_cold_start_activity",
+        )
+        .await;
 
         worker_handles.push(tokio::spawn(async move {
-            let worker_name = format!("db-cold-start-worker-{}", worker_id);
-
             loop {
                 if shutdown.load(Ordering::SeqCst) {
                     break;
@@ -258,6 +293,13 @@ async fn run_push_notification_scenario(
     // Set up LISTEN for task notifications
     let mut listener = PgListener::connect_with(&pool).await.unwrap();
     listener.listen("task_available").await.unwrap();
+    let worker_name = format!("push-notification-worker-{}", workflow_id);
+    register_benchmark_worker(
+        store.as_ref(),
+        worker_name.clone(),
+        "db_push_notification_activity",
+    )
+    .await;
 
     // Channel for notification receipt timing
     let (notify_tx, mut notify_rx) = mpsc::channel::<Instant>(1);
@@ -319,7 +361,7 @@ async fn run_push_notification_scenario(
         let claim_start = Instant::now();
         let claimed = store
             .claim_task(
-                "push-notification-worker",
+                &worker_name,
                 &["db_push_notification_activity".to_string()],
                 1,
             )
@@ -331,11 +373,7 @@ async fn run_push_notification_scenario(
         // Complete the task
         for task in claimed {
             store
-                .complete_task(
-                    task.id,
-                    "push-notification-worker",
-                    serde_json::json!({"ok": true}),
-                )
+                .complete_task(task.id, &worker_name, serde_json::json!({"ok": true}))
                 .await
                 .unwrap();
         }
@@ -477,14 +515,14 @@ fn main() {
     println!("\nCompares polling vs push-based notification approaches.");
     println!("This is what users experience when sending a message to an idle agent.\n");
 
-    // Scenario 1: Polling approach (100ms interval)
+    // Scenario 1: Polling fallback using the current worker default.
     let polling = rt.block_on(run_cold_start_scenario(
         pool.clone(),
         ColdStartConfig {
             iterations: 20,
             worker_count: 1,
-            check_interval: Duration::from_millis(100),
-            name: "polling_100ms".to_string(),
+            check_interval: Duration::from_millis(10),
+            name: "polling_10ms".to_string(),
         },
     ));
 

--- a/crates/durable/src/persistence/postgres.rs
+++ b/crates/durable/src/persistence/postgres.rs
@@ -5,6 +5,7 @@
 //! - Efficient task claiming with SKIP LOCKED
 //! - Event sourcing for workflow replay
 
+use std::collections::BTreeMap;
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -88,6 +89,124 @@ impl PostgresWorkflowEventStore {
     /// Get a reference to the connection pool
     pub fn pool(&self) -> &PgPool {
         &self.pool
+    }
+
+    /// Create a workflow, write its initial events, and enqueue the first task in
+    /// one transaction. This is the hot path for a new session turn.
+    pub async fn start_workflow_with_task(
+        &self,
+        workflow_id: Uuid,
+        workflow_type: &str,
+        input: serde_json::Value,
+        task: TaskDefinition,
+    ) -> Result<Uuid, StoreError> {
+        let task_id = Uuid::now_v7();
+        let workflow_input = sanitize_json_null_bytes(input.clone());
+        let task_input = sanitize_json_null_bytes(task.input.clone());
+        let options_json = serde_json::to_value(&task.options)
+            .map(sanitize_json_null_bytes)
+            .map_err(|e| StoreError::Serialization(e.to_string()))?;
+
+        let workflow_started = WorkflowEvent::WorkflowStarted {
+            input: workflow_input.clone(),
+        };
+        let activity_scheduled = WorkflowEvent::ActivityScheduled {
+            activity_id: task.activity_id.clone(),
+            activity_type: task.activity_type.clone(),
+            input: task_input.clone(),
+            options: task.options.clone(),
+        };
+        let workflow_started_data = serde_json::to_value(&workflow_started)
+            .map(sanitize_json_null_bytes)
+            .map_err(|e| StoreError::Serialization(e.to_string()))?;
+        let activity_scheduled_data = serde_json::to_value(&activity_scheduled)
+            .map(sanitize_json_null_bytes)
+            .map_err(|e| StoreError::Serialization(e.to_string()))?;
+
+        let mut tx = self
+            .pool
+            .begin()
+            .await
+            .map_err(|e| StoreError::Database(e.to_string()))?;
+
+        sqlx::query(
+            r#"
+            INSERT INTO durable_workflow_instances (
+                id, workflow_type, status, input, started_at
+            )
+            VALUES ($1, $2, 'running', $3, NOW())
+            "#,
+        )
+        .bind(workflow_id)
+        .bind(workflow_type)
+        .bind(&workflow_input)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| {
+            error!("Failed to create started workflow: {}", e);
+            StoreError::Database(e.to_string())
+        })?;
+
+        sqlx::query(
+            r#"
+            INSERT INTO durable_workflow_events (
+                workflow_id, sequence_num, event_type, event_data
+            )
+            VALUES
+                ($1, 0, 'workflow_started', $2),
+                ($1, 1, 'activity_scheduled', $3)
+            "#,
+        )
+        .bind(workflow_id)
+        .bind(&workflow_started_data)
+        .bind(&activity_scheduled_data)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| {
+            error!("Failed to write initial workflow events: {}", e);
+            StoreError::Database(e.to_string())
+        })?;
+
+        sqlx::query(
+            r#"
+            INSERT INTO durable_task_queue (
+                id, workflow_id, activity_id, activity_type, input, options,
+                max_attempts, priority,
+                schedule_to_start_timeout_ms, start_to_close_timeout_ms, heartbeat_timeout_ms
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+            "#,
+        )
+        .bind(task_id)
+        .bind(workflow_id)
+        .bind(&task.activity_id)
+        .bind(&task.activity_type)
+        .bind(&task_input)
+        .bind(&options_json)
+        .bind(task.options.retry_policy.max_attempts as i32)
+        .bind(task.options.priority)
+        .bind(task.options.schedule_to_start_timeout.as_millis() as i64)
+        .bind(task.options.start_to_close_timeout.as_millis() as i64)
+        .bind(task.options.heartbeat_timeout.map(|d| d.as_millis() as i64))
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| {
+            error!("Failed to enqueue initial workflow task: {}", e);
+            StoreError::Database(e.to_string())
+        })?;
+
+        tx.commit().await.map_err(|e| {
+            error!("Failed to commit initial workflow start: {}", e);
+            StoreError::Database(e.to_string())
+        })?;
+
+        debug!(
+            %workflow_id,
+            %task_id,
+            activity_type = %task.activity_type,
+            "started workflow and enqueued initial task"
+        );
+        Ok(task_id)
     }
 }
 
@@ -674,17 +793,30 @@ impl WorkflowEventStore for PostgresWorkflowEventStore {
             return Ok(vec![]);
         }
 
-        // Use SKIP LOCKED for efficient concurrent claiming
-        // This query:
+        // Use SKIP LOCKED for efficient concurrent claiming.
+        // This transaction:
         // 1. Verifies worker is not draining (early exit if draining)
         // 2. Finds pending tasks matching activity types
         // 3. Orders by priority (desc) then visibility time
         // 4. Limits to max_tasks
         // 5. Uses SKIP LOCKED to avoid contention
-        // 6. Updates status and claiming info in one atomic operation
+        // 6. Updates status and claiming info
+        // 7. Appends ActivityStarted events for workflow tasks before returning
+        //    the claim, avoiding a separate pre-execution write in the worker.
+        //
+        // The ActivityStarted sequence read is deliberately a separate statement
+        // after locking each workflow row. Under READ COMMITTED, a single-statement
+        // CTE keeps its original snapshot even after waiting on row locks, which
+        // can duplicate sequence numbers during concurrent claims for one workflow.
         // NOTE: The `attempt < max_attempts` check is critical for preventing infinite
         // retries when workers panic. Without fail_task being called, the task becomes
         // stale, gets reclaimed, but must not be claimed if attempts are exhausted.
+        let mut tx = self
+            .pool
+            .begin()
+            .await
+            .map_err(|e| StoreError::Database(e.to_string()))?;
+
         let rows = sqlx::query(
             r#"
             WITH worker_check AS (
@@ -701,26 +833,131 @@ impl WorkflowEventStore for PostgresWorkflowEventStore {
                 ORDER BY tq.priority DESC, tq.visible_at
                 LIMIT $2
                 FOR UPDATE SKIP LOCKED
+            ),
+            updated AS (
+                UPDATE durable_task_queue t
+                SET status = 'claimed',
+                    claimed_by = $3,
+                    claimed_at = NOW(),
+                    heartbeat_at = NOW(),
+                    attempt = attempt + 1
+                FROM claimable c
+                WHERE t.id = c.id
+                RETURNING t.id, t.workflow_id, t.activity_id, t.activity_type,
+                          t.input, t.options, t.attempt, t.max_attempts
             )
-            UPDATE durable_task_queue t
-            SET status = 'claimed',
-                claimed_by = $3,
-                claimed_at = NOW(),
-                heartbeat_at = NOW(),
-                attempt = attempt + 1
-            FROM claimable c
-            WHERE t.id = c.id
-            RETURNING t.id, t.workflow_id, t.activity_id, t.activity_type,
-                      t.input, t.options, t.attempt, t.max_attempts
+            SELECT id, workflow_id, activity_id, activity_type,
+                   input, options, attempt, max_attempts
+            FROM updated
             "#,
         )
         .bind(activity_types)
         .bind(max_tasks as i32)
         .bind(worker_id)
-        .fetch_all(&self.pool)
+        .fetch_all(&mut *tx)
         .await
         .map_err(|e| {
             error!("Failed to claim tasks: {}", e);
+            StoreError::Database(e.to_string())
+        })?;
+
+        let mut claimed = Vec::with_capacity(rows.len());
+        let mut started_by_workflow: BTreeMap<Uuid, Vec<(Uuid, String, i32)>> = BTreeMap::new();
+        for row in rows {
+            let options_json: serde_json::Value = row.get("options");
+            let options: ActivityOptions = serde_json::from_value(options_json)
+                .map_err(|e| StoreError::Serialization(e.to_string()))?;
+            let task_id: Uuid = row.get("id");
+            let workflow_id = row.get::<Option<Uuid>, _>("workflow_id");
+            let activity_id: String = row.get("activity_id");
+            let attempt = row.get::<i32, _>("attempt");
+
+            claimed.push(ClaimedTask {
+                id: task_id,
+                workflow_id,
+                activity_id: activity_id.clone(),
+                activity_type: row.get("activity_type"),
+                input: row.get("input"),
+                options,
+                attempt: attempt as u32,
+                max_attempts: row.get::<i32, _>("max_attempts") as u32,
+            });
+
+            if let Some(workflow_id) = workflow_id {
+                started_by_workflow.entry(workflow_id).or_default().push((
+                    task_id,
+                    activity_id,
+                    attempt,
+                ));
+            }
+        }
+
+        for (workflow_id, mut events) in started_by_workflow {
+            events.sort_by_key(|(task_id, _, _)| *task_id);
+
+            sqlx::query(
+                r#"
+                SELECT id FROM durable_workflow_instances
+                WHERE id = $1
+                FOR UPDATE
+                "#,
+            )
+            .bind(workflow_id)
+            .fetch_one(&mut *tx)
+            .await
+            .map_err(|e| {
+                error!("Failed to lock workflow for activity start event: {}", e);
+                StoreError::Database(e.to_string())
+            })?;
+
+            let mut next_sequence = sqlx::query_scalar::<_, i32>(
+                r#"
+                SELECT COALESCE(MAX(sequence_num) + 1, 0)::INTEGER
+                FROM durable_workflow_events
+                WHERE workflow_id = $1
+                "#,
+            )
+            .bind(workflow_id)
+            .fetch_one(&mut *tx)
+            .await
+            .map_err(|e| {
+                error!("Failed to get workflow event sequence: {}", e);
+                StoreError::Database(e.to_string())
+            })?;
+
+            for (_, activity_id, attempt) in events {
+                let event_data = serde_json::to_value(WorkflowEvent::ActivityStarted {
+                    activity_id: activity_id.clone(),
+                    attempt: attempt as u32,
+                    worker_id: worker_id.to_string(),
+                })
+                .map(sanitize_json_null_bytes)
+                .map_err(|e| StoreError::Serialization(e.to_string()))?;
+
+                sqlx::query(
+                    r#"
+                    INSERT INTO durable_workflow_events (
+                        workflow_id, sequence_num, event_type, event_data
+                    )
+                    VALUES ($1, $2, 'activity_started', $3)
+                    "#,
+                )
+                .bind(workflow_id)
+                .bind(next_sequence)
+                .bind(&event_data)
+                .execute(&mut *tx)
+                .await
+                .map_err(|e| {
+                    error!("Failed to write activity start event: {}", e);
+                    StoreError::Database(e.to_string())
+                })?;
+
+                next_sequence += 1;
+            }
+        }
+
+        tx.commit().await.map_err(|e| {
+            error!("Failed to commit task claim: {}", e);
             StoreError::Database(e.to_string())
         })?;
 
@@ -728,24 +965,6 @@ impl WorkflowEventStore for PostgresWorkflowEventStore {
         fail_point!("postgres_claim_task_after_query", |_| {
             Err(StoreError::Database("injected: after claim query".into()))
         });
-
-        let mut claimed = Vec::with_capacity(rows.len());
-        for row in rows {
-            let options_json: serde_json::Value = row.get("options");
-            let options: ActivityOptions = serde_json::from_value(options_json)
-                .map_err(|e| StoreError::Serialization(e.to_string()))?;
-
-            claimed.push(ClaimedTask {
-                id: row.get("id"),
-                workflow_id: row.get::<Option<Uuid>, _>("workflow_id"),
-                activity_id: row.get("activity_id"),
-                activity_type: row.get("activity_type"),
-                input: row.get("input"),
-                options,
-                attempt: row.get::<i32, _>("attempt") as u32,
-                max_attempts: row.get::<i32, _>("max_attempts") as u32,
-            });
-        }
 
         if !claimed.is_empty() {
             debug!(worker_id, count = claimed.len(), "claimed tasks");

--- a/crates/durable/src/task_events.rs
+++ b/crates/durable/src/task_events.rs
@@ -28,26 +28,25 @@ pub async fn append_event<S: WorkflowEventStore + ?Sized>(
     event: WorkflowEvent,
 ) -> Result<(), StoreError> {
     for attempt in 0..MAX_RETRY_ATTEMPTS {
-        // Get current sequence by loading events
-        let events = match store.load_events(workflow_id).await {
-            Ok(events) => events,
+        // Get current sequence without materializing the workflow replay payload.
+        let current_seq = match store.count_events(workflow_id).await {
+            Ok(count) => count as i32,
             Err(StoreError::WorkflowNotFound(_)) if attempt < MAX_RETRY_ATTEMPTS - 1 => {
                 // Workflow might not be visible yet due to race condition, retry
                 debug!(
                     %workflow_id,
                     attempt = attempt + 1,
-                    "Workflow not found when loading events, retrying"
+                    "Workflow not found when counting events, retrying"
                 );
                 tokio::time::sleep(std::time::Duration::from_millis(10 * (attempt as u64 + 1)))
                     .await;
                 continue;
             }
             Err(e) => {
-                warn!(%workflow_id, error = %e, "Failed to load events for workflow");
+                warn!(%workflow_id, error = %e, "Failed to count events for workflow");
                 return Err(e);
             }
         };
-        let current_seq = events.len() as i32;
 
         match store
             .append_events(workflow_id, current_seq, vec![event.clone()])

--- a/crates/durable/src/worker/poller.rs
+++ b/crates/durable/src/worker/poller.rs
@@ -39,7 +39,7 @@ pub struct PollerConfig {
 impl Default for PollerConfig {
     fn default() -> Self {
         Self {
-            min_interval: Duration::from_millis(100),
+            min_interval: Duration::from_millis(10),
             max_interval: Duration::from_secs(5),
             backoff_multiplier: 1.5,
             batch_size: 10,
@@ -307,7 +307,7 @@ mod tests {
     #[test]
     fn test_default_config() {
         let config = PollerConfig::default();
-        assert_eq!(config.min_interval, Duration::from_millis(100));
+        assert_eq!(config.min_interval, Duration::from_millis(10));
         assert_eq!(config.max_interval, Duration::from_secs(5));
         assert_eq!(config.backoff_multiplier, 1.5);
         assert_eq!(config.batch_size, 10);

--- a/crates/durable/tests/postgres_integration_test.rs
+++ b/crates/durable/tests/postgres_integration_test.rs
@@ -388,6 +388,17 @@ async fn test_task_enqueue_and_claim() {
     assert_eq!(claimed[0].activity_type, "send_email");
     assert_eq!(claimed[0].attempt, 1);
 
+    let events = store.load_events(workflow_id).await.unwrap();
+    assert_eq!(events.len(), 1);
+    assert!(matches!(
+        &events[0].1,
+        WorkflowEvent::ActivityStarted {
+            activity_id,
+            attempt: 1,
+            worker_id,
+        } if activity_id == "step-1" && worker_id == "worker-1"
+    ));
+
     // Second claim should get nothing (task already claimed)
     let claimed2 = store
         .claim_task("worker-2", &["send_email".to_string()], 10)
@@ -398,6 +409,52 @@ async fn test_task_enqueue_and_claim() {
     cleanup_workflow(&store, workflow_id).await;
     cleanup_worker(&store, "worker-1").await;
     cleanup_worker(&store, "worker-2").await;
+}
+
+#[tokio::test]
+async fn test_start_workflow_with_task_writes_initial_state_in_one_step() {
+    let store = create_test_store().await;
+    let workflow_id = Uuid::now_v7();
+
+    let task_id = store
+        .start_workflow_with_task(
+            workflow_id,
+            "turn_workflow",
+            json!({"session_id": "session_123"}),
+            TaskDefinition {
+                workflow_id: Some(workflow_id),
+                activity_id: "input-1".to_string(),
+                activity_type: "process_input".to_string(),
+                input: json!({"session_id": "session_123"}),
+                options: ActivityOptions::default(),
+            },
+        )
+        .await
+        .unwrap();
+
+    let workflow = store.get_workflow_info(workflow_id).await.unwrap();
+    assert_eq!(workflow.status, WorkflowStatus::Running);
+
+    let events = store.load_events(workflow_id).await.unwrap();
+    assert_eq!(events.len(), 2);
+    assert!(matches!(
+        &events[0].1,
+        WorkflowEvent::WorkflowStarted { .. }
+    ));
+    assert!(matches!(
+        &events[1].1,
+        WorkflowEvent::ActivityScheduled {
+            activity_id,
+            activity_type,
+            ..
+        } if activity_id == "input-1" && activity_type == "process_input"
+    ));
+
+    let task = store.get_task(task_id).await.unwrap();
+    assert_eq!(task.status, TaskStatus::Pending);
+    assert_eq!(task.activity_type, "process_input");
+
+    cleanup_workflow(&store, workflow_id).await;
 }
 
 #[tokio::test]

--- a/crates/runtime/tests/runtime_host_test.rs
+++ b/crates/runtime/tests/runtime_host_test.rs
@@ -508,8 +508,15 @@ async fn input_activity_emits_lifecycle_events_and_marks_session_active() {
         .into_iter()
         .map(|event| event.data.event_type().to_string())
         .collect();
-    assert!(event_types.contains(&"session.activated".to_string()));
-    assert!(event_types.contains(&"turn.started".to_string()));
+    let turn_started_pos = event_types
+        .iter()
+        .position(|event_type| event_type == "turn.started")
+        .expect("turn.started event");
+    let session_activated_pos = event_types
+        .iter()
+        .position(|event_type| event_type == "session.activated")
+        .expect("session.activated event");
+    assert!(session_activated_pos < turn_started_pos);
 }
 
 #[tokio::test]

--- a/crates/server/src/grpc_service/mod.rs
+++ b/crates/server/src/grpc_service/mod.rs
@@ -26,8 +26,8 @@ use everruns_durable::{
     ActivityOptions, CircuitBreakerConfig, CircuitState, DistributedCircuitBreaker,
     PostgresWorkflowEventStore, StoreError, TaskDefinition, TaskFailureOutcome, WorkerInfo,
     WorkflowError, WorkflowEvent, WorkflowEventStore, WorkflowStatus, append_event,
-    record_activity_completed, record_activity_failed, record_activity_started,
-    record_workflow_cancelled, record_workflow_completed, record_workflow_failed,
+    record_activity_completed, record_activity_failed, record_workflow_cancelled,
+    record_workflow_completed, record_workflow_failed,
 };
 use everruns_internal_protocol::proto::{
     self,

--- a/crates/server/src/grpc_service/worker_service_impl.rs
+++ b/crates/server/src/grpc_service/worker_service_impl.rs
@@ -1331,18 +1331,6 @@ impl WorkerService for WorkerServiceImpl {
                 Status::internal("Failed to claim tasks")
             })?;
 
-        // Record ActivityStarted events for each claimed task
-        for task in &tasks {
-            record_activity_started(
-                store.as_ref(),
-                task.workflow_id,
-                task.activity_id.clone(),
-                task.attempt,
-                req.worker_id.clone(),
-            )
-            .await;
-        }
-
         let proto_tasks: Vec<proto::DurableClaimedTask> = tasks
             .into_iter()
             .map(|t| proto::DurableClaimedTask {

--- a/crates/worker/src/durable_runner.rs
+++ b/crates/worker/src/durable_runner.rs
@@ -61,6 +61,15 @@ pub trait DurableStoreBackend: Send + Sync {
         input: serde_json::Value,
     ) -> Result<Uuid>;
 
+    async fn start_workflow_with_task(
+        &mut self,
+        workflow_id: Uuid,
+        workflow_type: &str,
+        input: serde_json::Value,
+        activity_id: String,
+        activity_type: String,
+    ) -> Result<Uuid>;
+
     async fn count_active_workflows(&mut self) -> Result<usize>;
 
     async fn cancel_pending_tasks(&mut self, workflow_id: Uuid) -> Result<u64>;
@@ -166,6 +175,55 @@ impl DurableStoreBackend for GrpcDurableStore {
         GrpcDurableStore::enqueue_task(self, workflow_id, activity_id, activity_type, input).await
     }
 
+    async fn start_workflow_with_task(
+        &mut self,
+        workflow_id: Uuid,
+        workflow_type: &str,
+        input: serde_json::Value,
+        activity_id: String,
+        activity_type: String,
+    ) -> Result<Uuid> {
+        GrpcDurableStore::create_workflow(self, workflow_id, workflow_type, input.clone()).await?;
+        let _ = self
+            .append_events(
+                workflow_id,
+                0,
+                vec![WorkflowEvent::WorkflowStarted {
+                    input: input.clone(),
+                }],
+            )
+            .await?;
+        let task_id = GrpcDurableStore::enqueue_task(
+            self,
+            workflow_id,
+            activity_id.clone(),
+            activity_type.clone(),
+            input.clone(),
+        )
+        .await?;
+        GrpcDurableStore::update_workflow_status(
+            self,
+            workflow_id,
+            runtime_to_grpc_status(WorkflowStatus::Running),
+            None,
+            None,
+        )
+        .await?;
+        let _ = self
+            .append_events(
+                workflow_id,
+                1,
+                vec![WorkflowEvent::ActivityScheduled {
+                    activity_id,
+                    activity_type,
+                    input,
+                    options: everruns_durable::ActivityOptions::default(),
+                }],
+            )
+            .await?;
+        Ok(task_id)
+    }
+
     async fn count_active_workflows(&mut self) -> Result<usize> {
         GrpcDurableStore::count_active_workflows(self).await
     }
@@ -255,6 +313,31 @@ impl DurableStoreBackend for DirectDurableStore {
                 input,
                 options: Default::default(),
             })
+            .await
+            .map_err(Into::into)
+    }
+
+    async fn start_workflow_with_task(
+        &mut self,
+        workflow_id: Uuid,
+        workflow_type: &str,
+        input: serde_json::Value,
+        activity_id: String,
+        activity_type: String,
+    ) -> Result<Uuid> {
+        self.store
+            .start_workflow_with_task(
+                workflow_id,
+                workflow_type,
+                input.clone(),
+                everruns_durable::TaskDefinition {
+                    workflow_id: Some(workflow_id),
+                    activity_id,
+                    activity_type,
+                    input,
+                    options: Default::default(),
+                },
+            )
             .await
             .map_err(Into::into)
     }
@@ -369,6 +452,56 @@ impl DurableStoreBackend for InMemoryDurableStore {
             })
             .await
             .map_err(Into::into)
+    }
+
+    async fn start_workflow_with_task(
+        &mut self,
+        workflow_id: Uuid,
+        workflow_type: &str,
+        input: serde_json::Value,
+        activity_id: String,
+        activity_type: String,
+    ) -> Result<Uuid> {
+        self.store
+            .create_workflow(workflow_id, workflow_type, input.clone(), None)
+            .await?;
+        let _ = self
+            .store
+            .append_events(
+                workflow_id,
+                0,
+                vec![WorkflowEvent::WorkflowStarted {
+                    input: input.clone(),
+                }],
+            )
+            .await?;
+        let task_id = self
+            .store
+            .enqueue_task(everruns_durable::TaskDefinition {
+                workflow_id: Some(workflow_id),
+                activity_id: activity_id.clone(),
+                activity_type: activity_type.clone(),
+                input: input.clone(),
+                options: Default::default(),
+            })
+            .await?;
+        self.store
+            .update_workflow_status(workflow_id, WorkflowStatus::Running, None, None)
+            .await?;
+        let _ = self
+            .store
+            .append_events(
+                workflow_id,
+                1,
+                vec![WorkflowEvent::ActivityScheduled {
+                    activity_id,
+                    activity_type,
+                    input,
+                    options: everruns_durable::ActivityOptions::default(),
+                }],
+            )
+            .await?;
+        Ok(task_id)
     }
 
     async fn count_active_workflows(&mut self) -> Result<usize> {
@@ -579,57 +712,17 @@ impl AgentRunner for DurableRunner {
                         return Err(anyhow::anyhow!("Failed to check workflow status: {error}"));
                     }
 
-                    store
-                        .create_workflow(workflow_id, "turn_workflow", input_json.clone())
-                        .await
-                        .map_err(|e| anyhow::anyhow!("Failed to create workflow: {e}"))?;
-
                     let activity_id = format!("input_{}", Uuid::now_v7());
-                    let sequence = store
-                        .append_events(
-                            workflow_id,
-                            0,
-                            vec![WorkflowEvent::WorkflowStarted {
-                                input: input_json.clone(),
-                            }],
-                        )
-                        .await
-                        .map_err(|e| {
-                            anyhow::anyhow!("Failed to append WorkflowStarted event: {e}")
-                        })?;
-
                     store
-                        .enqueue_task(
+                        .start_workflow_with_task(
                             workflow_id,
+                            "turn_workflow",
+                            input_json,
                             activity_id.clone(),
                             "process_input".to_string(),
-                            input_json.clone(),
                         )
                         .await
-                        .map_err(|e| anyhow::anyhow!("Failed to enqueue task: {e}"))?;
-
-                    store
-                        .update_workflow_status(workflow_id, WorkflowStatus::Running, None, None)
-                        .await
-                        .map_err(|e| {
-                            anyhow::anyhow!("Failed to set new workflow to Running: {e}")
-                        })?;
-
-                    let _ = store
-                        .append_events(
-                            workflow_id,
-                            sequence,
-                            vec![WorkflowEvent::ActivityScheduled {
-                                activity_id,
-                                activity_type: "process_input".to_string(),
-                                input: input_json,
-                                options: everruns_durable::ActivityOptions::default(),
-                            }],
-                        )
-                        .await
-                        .map_err(|e| {
-                            anyhow::anyhow!("Failed to append ActivityScheduled event: {e}")
-                        })?;
+                        .map_err(|e| anyhow::anyhow!("Failed to start workflow: {e}"))?;
 
                     Some("process_input")
                 }

--- a/crates/worker/src/durable_worker.rs
+++ b/crates/worker/src/durable_worker.rs
@@ -225,7 +225,7 @@ impl Default for DurableWorkerConfig {
                 "invoke_scheduled_app_channel".to_string(),
             ],
             max_concurrent_tasks: 1000, // High default for massive workflow parallelism
-            poll_interval: Duration::from_millis(100), // Fallback when push notifications unavailable
+            poll_interval: Duration::from_millis(10), // Fallback when push notifications unavailable
             heartbeat_interval: Duration::from_secs(10),
             grpc_address: "127.0.0.1:9001".to_string(),
             connect_timeout: Duration::from_secs(30),

--- a/crates/worker/src/unified_worker.rs
+++ b/crates/worker/src/unified_worker.rs
@@ -70,7 +70,7 @@ impl Default for TaskWorkerConfig {
                 activity_types::INVOKE_SCHEDULED_APP_CHANNEL.to_string(),
             ],
             max_concurrent_tasks: 1000,
-            poll_interval: Duration::from_millis(100),
+            poll_interval: Duration::from_millis(10),
             heartbeat_interval: Duration::from_secs(10),
             worker_group: None,
         }
@@ -84,7 +84,7 @@ impl TaskWorkerConfig {
             worker_id: format!("dev-worker-{}", Uuid::now_v7()),
             worker_group: Some("dev".to_string()),
             max_concurrent_tasks: 10,
-            poll_interval: Duration::from_millis(100),
+            poll_interval: Duration::from_millis(10),
             ..Default::default()
         }
     }
@@ -93,7 +93,7 @@ impl TaskWorkerConfig {
     pub fn production() -> Self {
         Self {
             max_concurrent_tasks: 1000,
-            poll_interval: Duration::from_millis(100),
+            poll_interval: Duration::from_millis(10),
             ..Default::default()
         }
     }

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -5555,7 +5555,7 @@
                   "type": "null"
                 },
                 {
-                  "$ref": "#/components/schemas/TypedId"
+                  "$ref": "#/components/schemas/eventId"
                 }
               ]
             }


### PR DESCRIPTION
## What
Reduce durable turn startup latency by collapsing the Postgres new-workflow hot path, moving ActivityStarted persistence into task claim, and lowering fallback worker polling from 100ms to 10ms.

## Why
The trace showed avoidable startup gaps across workflow creation/enqueue, worker pickup, and pre-activity persistence. The largest clean wins were fewer DB round trips before the first activity and faster fallback pickup when push notification timing is not enough.

## How
- Added a Postgres `start_workflow_with_task` transaction that creates the running workflow, writes `workflow_started` + `activity_scheduled`, and enqueues the first task together.
- Updated direct durable runner startup to use that transaction while preserving existing in-memory/gRPC behavior.
- Appended `ActivityStarted` inside `claim_task`, before returning claimed work, so the gRPC worker path no longer does a second pre-execution write.
- Locked workflow rows before assigning event sequence numbers to avoid duplicate sequences under concurrent claims.
- Changed fallback poll intervals/defaults to 10ms and updated the cold-start benchmark to reflect that default.
- Kept lifecycle order as requested: `session.activated` before `turn.started`, with a test assertion.

## Risk
- Medium
- What can break: durable task claiming and workflow event sequencing are in the execution hot path; a sequencing bug could affect replay or retries. Fallback polling now creates more DB wakeups when push notifications are unavailable.

## Security
- Threat categories reviewed: TM-SQL, TM-DOS, TM-AUTH.
- Findings and resolutions: SQL remains parameterized; worker registration/draining checks and max-attempt guard remain in claim path; workflow row locking prevents event sequence races; no new endpoints, permissions, secrets, or auth changes. The 10ms fallback interval has higher DB polling load, but push notifications remain the preferred path and the benchmark keeps the behavior measurable.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

## Local proof
- `cargo fmt --check && git diff --check`
- `cargo check -p everruns-server`
- `cargo test -p everruns-runtime input_activity_emits_lifecycle_events_and_marks_session_active`
- `cargo test -p everruns-durable --test postgres_integration_test --features postgres-tests -- --test-threads=1` (26/26)
- `cargo test -p everruns-durable --test failure_injection_test --features 'failpoints,postgres-tests' -- --test-threads=1` (7/7)
- `cargo test -p everruns-durable --test postgres_repository_test --features postgres-tests -- --test-threads=1` (21/21)
- `cargo bench -p everruns-durable --bench db_cold_start_latency`: polling fallback 10ms avg 9.32ms / P99 20.62ms; push avg 1.58ms / P99 6.50ms
- `PORT_PREFIX=264 just start-all --no-watch --no-ui`, then `GET /health` returned `{"status":"ok","version":"0.8.27","auth_mode":"None"}`
- `just pre-push`