### PR TITLE
feat(chat): render MCP app resources

### DIFF
--- a/apps/ui/src/__tests__/mcp-card-iframe.test.tsx
+++ b/apps/ui/src/__tests__/mcp-card-iframe.test.tsx
@@ -16,6 +16,13 @@ describe("McpCardIframe", () => {
     expect(iframe.title).toContain(URI);
   });
 
+  it("allows hosts to override the default entity-card max width", () => {
+    const { container } = render(<McpCardIframe uri={URI} html={SAMPLE_HTML} maxWidth="100%" />);
+    const iframe = container.querySelector("iframe")!;
+
+    expect(iframe.style.maxWidth).toBe("100%");
+  });
+
   it("ignores postMessage events whose source is not the iframe contentWindow", () => {
     const onAction = jest.fn();
     render(<McpCardIframe uri={URI} html={SAMPLE_HTML} onAction={onAction} />);

--- a/apps/ui/src/__tests__/tool-activity-group.test.tsx
+++ b/apps/ui/src/__tests__/tool-activity-group.test.tsx
@@ -96,6 +96,57 @@ describe("ToolActivityGroup", () => {
     expect(screen.queryByText(/"stdout":/)).not.toBeInTheDocument();
   });
 
+  it("renders MCP App resources in generic tool activity rows", () => {
+    const html = "<!doctype html><html><body>Agent card</body></html>";
+    const toolCalls: ToolCallContent[] = [
+      {
+        id: "tool-mcp-card",
+        name: "mcp_everruns__agent_get_card",
+        arguments: { agent_id: "agent_01" },
+      },
+    ];
+
+    const toolResultsMap = new Map<string, ToolCompletedData>([
+      [
+        "tool-mcp-card",
+        {
+          tool_call_id: "tool-mcp-card",
+          tool_name: "mcp_everruns__agent_get_card",
+          success: true,
+          status: "success",
+          result: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                content: [
+                  {
+                    type: "resource",
+                    uri: "ui://everruns/agent/agent_01/card",
+                    mime_type: "text/html",
+                    text: html,
+                  },
+                  { type: "text", text: "Agent: customer-support" },
+                ],
+              }),
+            },
+          ],
+        },
+      ],
+    ]);
+
+    const { container } = render(
+      <ToolActivityGroup toolCalls={toolCalls} toolResultsMap={toolResultsMap} />,
+    );
+    const iframe = container.querySelector("iframe")!;
+
+    expect(iframe).toBeInTheDocument();
+    expect(iframe.getAttribute("sandbox")).toBe("allow-scripts");
+    expect(iframe.getAttribute("srcdoc")).toBe(html);
+    expect(iframe.getAttribute("data-mcp-card-uri")).toBe("ui://everruns/agent/agent_01/card");
+    expect(iframe.style.maxWidth).toBe("100%");
+    expect(screen.getByText("Agent: customer-support")).toBeInTheDocument();
+  });
+
   it("renders bash calls as standalone rows without grouped chrome", () => {
     const toolCalls: ToolCallContent[] = [
       {

--- a/apps/ui/src/__tests__/tool-call-utils.test.ts
+++ b/apps/ui/src/__tests__/tool-call-utils.test.ts
@@ -1,0 +1,114 @@
+import {
+  extractMcpAppResources,
+  getFullText,
+  type McpAppResource,
+} from "@/components/chat/tool-call-utils";
+import type { ContentPart } from "@/lib/api/types";
+
+const html = "<!doctype html><html><body>Agent card</body></html>";
+
+describe("tool-call-utils MCP App resources", () => {
+  it("extracts embedded ui:// HTML resources from MCP content wrappers", () => {
+    const result: ContentPart[] = [
+      {
+        type: "text",
+        text: JSON.stringify({
+          content: [
+            {
+              type: "resource",
+              uri: "ui://everruns/agent/agent_01/card",
+              mime_type: "text/html",
+              text: html,
+            },
+            { type: "text", text: "Agent: customer-support" },
+          ],
+        }),
+      },
+    ];
+
+    expect(extractMcpAppResources(result)).toEqual<McpAppResource[]>([
+      {
+        uri: "ui://everruns/agent/agent_01/card",
+        mimeType: "text/html",
+        html,
+      },
+    ]);
+    expect(getFullText(result)).toBe("Agent: customer-support");
+  });
+
+  it("extracts nested MCP resource content shape", () => {
+    const result: ContentPart[] = [
+      {
+        type: "resource",
+        uri: "ui://everruns/agent/agent_01/card",
+        resource: {
+          uri: "ui://everruns/agent/agent_01/card",
+          mimeType: "text/html",
+          text: html,
+        },
+      },
+    ];
+
+    expect(extractMcpAppResources(result)).toEqual([
+      {
+        uri: "ui://everruns/agent/agent_01/card",
+        mimeType: "text/html",
+        html,
+      },
+    ]);
+  });
+
+  it("falls back to outer resource fields when nested fields are partial", () => {
+    const result: ContentPart[] = [
+      {
+        type: "resource",
+        uri: "ui://everruns/agent/agent_01/card",
+        mimeType: "text/html",
+        text: html,
+        resource: {},
+      },
+    ];
+
+    expect(extractMcpAppResources(result)).toEqual([
+      {
+        uri: "ui://everruns/agent/agent_01/card",
+        mimeType: "text/html",
+        html,
+      },
+    ]);
+  });
+
+  it("ignores non-ui and non-html resources", () => {
+    const result: ContentPart[] = [
+      {
+        type: "text",
+        text: JSON.stringify({
+          content: [
+            {
+              type: "resource",
+              uri: "https://example.com/card.html",
+              mime_type: "text/html",
+              text: html,
+            },
+            {
+              type: "resource",
+              uri: "ui://everruns/agent/agent_01/json",
+              mime_type: "application/json",
+              text: "{}",
+            },
+          ],
+        }),
+      },
+    ];
+
+    expect(extractMcpAppResources(result)).toEqual([]);
+    expect(getFullText(result)).toBe("");
+  });
+
+  it("does not parse large non-wrapper text output", () => {
+    const text = `${"x".repeat(512 * 1024 + 1)}{"content":[]}`;
+
+    expect(getFullText([{ type: "text", text }])).toBe(text);
+    expect(extractMcpAppResources([{ type: "text", text }])).toEqual([]);
+  });
+});

--- a/apps/ui/src/components/chat/mcp-app-resource-list.tsx
+++ b/apps/ui/src/components/chat/mcp-app-resource-list.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { McpCardIframe } from "@/components/mcp/mcp-card-iframe";
+import type { McpAppResource } from "./tool-call-utils";
+
+interface McpAppResourceListProps {
+  resources: McpAppResource[];
+  className?: string;
+}
+
+export function McpAppResourceList({ resources, className }: McpAppResourceListProps) {
+  if (resources.length === 0) return null;
+
+  return (
+    <div className={className ?? "mt-2 space-y-2"}>
+      {resources.map((resource) => (
+        <McpCardIframe
+          key={resource.uri}
+          uri={resource.uri}
+          html={resource.html}
+          height={360}
+          maxWidth="100%"
+          title={`MCP App (${resource.uri})`}
+          className="rounded-md border border-border/70 bg-background"
+        />
+      ))}
+    </div>
+  );
+}

--- a/apps/ui/src/components/chat/tool-activity-row.tsx
+++ b/apps/ui/src/components/chat/tool-activity-row.tsx
@@ -9,13 +9,14 @@ import { useState } from "react";
 import { AlertCircle, CalendarClock, Check, Loader2, MonitorSmartphone } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { ToolCompletedData } from "@/lib/api/types";
+import { McpAppResourceList } from "./mcp-app-resource-list";
 import type { ToolCallContent } from "./tool-call-utils";
 import {
   formatResultDetails,
   getToolActivitySummaryChip,
   getToolLabel,
 } from "./tool-activity-utils";
-import { getFullText } from "./tool-call-utils";
+import { extractMcpAppResources, getFullText } from "./tool-call-utils";
 import { useLocale } from "@/providers/locale-provider";
 
 export function ToolActivityRow({
@@ -35,6 +36,7 @@ export function ToolActivityRow({
   const { t } = useLocale();
   const [isExpanded, setIsExpanded] = useState(false);
   const fullText = getFullText(toolResult?.result);
+  const mcpAppResources = extractMcpAppResources(toolResult?.result);
   const detailsId = `tool-activity-details-${toolCall.id}`;
   const hasOutput = fullText.length > 0;
   const hasToolError = Boolean(toolResult?.error);
@@ -103,6 +105,8 @@ export function ToolActivityRow({
           {hasToolError && (
             <div className="mt-1 text-xs text-red-600 dark:text-red-400">{toolResult?.error}</div>
           )}
+
+          <McpAppResourceList resources={mcpAppResources} />
 
           <div
             id={detailsId}

--- a/apps/ui/src/components/chat/tool-activity-timeline-group.tsx
+++ b/apps/ui/src/components/chat/tool-activity-timeline-group.tsx
@@ -4,8 +4,9 @@ import { useMemo, useState } from "react";
 import { AlertCircle, Check, ChevronDown, ChevronRight, Loader2 } from "lucide-react";
 import type { ToolCompletedData } from "@/lib/api/types";
 import { cn } from "@/lib/utils";
+import { McpAppResourceList } from "./mcp-app-resource-list";
 import { formatResultDetails, getResultPreview } from "./tool-activity-utils";
-import { getFullText } from "./tool-call-utils";
+import { extractMcpAppResources, getFullText } from "./tool-call-utils";
 import { useLocale } from "@/providers/locale-provider";
 
 export interface TimelineToolRow {
@@ -39,6 +40,7 @@ function TimelineRow({ row }: { row: TimelineToolRow }) {
         getFullText(row.result.result),
       )
     : "";
+  const mcpAppResources = extractMcpAppResources(row.result?.result);
   const preview = resultPreview(row.result);
   const hasDetails = fullText.length > 0;
 
@@ -65,6 +67,8 @@ function TimelineRow({ row }: { row: TimelineToolRow }) {
           {row.result?.error && (
             <div className="mt-0.5 text-xs text-red-600 dark:text-red-400">{row.result.error}</div>
           )}
+
+          <McpAppResourceList resources={mcpAppResources} />
 
           {hasDetails && (
             <button

--- a/apps/ui/src/components/chat/tool-call-card-from-event.tsx
+++ b/apps/ui/src/components/chat/tool-call-card-from-event.tsx
@@ -4,10 +4,16 @@ import { useState } from "react";
 import { Check, Loader2, ChevronDown, ChevronRight } from "lucide-react";
 import type { ToolCompletedData } from "@/lib/api/types";
 import { useLocale } from "@/providers/locale-provider";
+import { McpAppResourceList } from "./mcp-app-resource-list";
 import { TodoListRenderer, isWriteTodosTool } from "./todo-list-renderer";
 import { BashToolCallCard, isBashTool } from "./bash-tool-call-card";
 import { ReadFileToolCallCard, isReadFileTool } from "./read-file-tool-call-card";
-import { formatArguments, getFullText, type ToolCallContent } from "./tool-call-utils";
+import {
+  extractMcpAppResources,
+  formatArguments,
+  getFullText,
+  type ToolCallContent,
+} from "./tool-call-utils";
 import { ClientToolCallCard } from "./client-tool-call-card";
 import { WriteFileToolCallCard, isWriteLikeTool } from "./write-file-tool-call-card";
 
@@ -80,6 +86,7 @@ export function ToolCallCardFromEvent({
 
   const fullText = toolResult?.result ? getFullText(toolResult.result) : "";
   const hasOutput = fullText.length > 0;
+  const mcpAppResources = extractMcpAppResources(toolResult?.result);
 
   return (
     <div className="text-xs text-muted-foreground/70">
@@ -98,6 +105,8 @@ export function ToolCallCardFromEvent({
           {t("error_prefix", { value: toolResult?.error ?? "" })}
         </div>
       )}
+
+      <McpAppResourceList resources={mcpAppResources} className="ml-4 mt-2 space-y-2" />
 
       {/* Expanded output */}
       {isExpanded && hasOutput && (

--- a/apps/ui/src/components/chat/tool-call-utils.ts
+++ b/apps/ui/src/components/chat/tool-call-utils.ts
@@ -25,6 +25,14 @@ export interface ToolResultContent {
   error?: string;
 }
 
+export interface McpAppResource {
+  uri: string;
+  mimeType: string;
+  html: string;
+}
+
+const MCP_CONTENT_WRAPPER_PARSE_LIMIT = 512 * 1024;
+
 /**
  * Extract tool call content from ContentPart array
  */
@@ -101,10 +109,13 @@ export function getResultPreview(
  */
 export function getFullText(result: ContentPart[] | undefined): string {
   if (!result || result.length === 0) return "";
-  return result
-    .filter((part): part is { type: "text"; text: string } => part.type === "text")
-    .map((part) => part.text)
-    .join("\n");
+  const text = result.flatMap((part) => {
+    if (part.type !== "text") return [];
+    const embedded = parseMcpContentWrapper(part.text);
+    if (!embedded) return [part.text];
+    return embedded.flatMap((embeddedPart) => textFromMcpContentPart(embeddedPart) ?? []);
+  });
+  return text.join("\n");
 }
 
 /**
@@ -112,4 +123,79 @@ export function getFullText(result: ContentPart[] | undefined): string {
  */
 export function formatResult(result: unknown): string {
   return typeof result === "string" ? result : JSON.stringify(result, null, 2);
+}
+
+export function extractMcpAppResources(result: ContentPart[] | undefined): McpAppResource[] {
+  if (!result || result.length === 0) return [];
+
+  return result.flatMap((part) => {
+    if (part.type === "text") {
+      return parseMcpContentWrapper(part.text)?.flatMap(normalizeMcpAppResource) ?? [];
+    }
+    return normalizeMcpAppResource(part);
+  });
+}
+
+function parseMcpContentWrapper(text: string): unknown[] | null {
+  if (text.length > MCP_CONTENT_WRAPPER_PARSE_LIMIT) return null;
+  const trimmed = text.trimStart();
+  if (!trimmed.startsWith("{") || !trimmed.includes('"content"')) return null;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+
+  if (!isPlainObject(parsed) || !Array.isArray(parsed.content)) return null;
+  if (!parsed.content.some(isMcpContentPartLike)) return null;
+  return parsed.content;
+}
+
+function isMcpContentPartLike(value: unknown): boolean {
+  return isPlainObject(value) && (value.type === "text" || value.type === "resource");
+}
+
+function textFromMcpContentPart(value: unknown): string | null {
+  if (!isPlainObject(value) || value.type !== "text") return null;
+  return typeof value.text === "string" ? value.text : null;
+}
+
+function normalizeMcpAppResource(value: unknown): McpAppResource[] {
+  if (!isPlainObject(value) || value.type !== "resource") return [];
+
+  const nested = isPlainObject(value.resource) ? value.resource : value;
+  const uri =
+    typeof nested.uri === "string"
+      ? nested.uri
+      : typeof value.uri === "string"
+        ? value.uri
+        : undefined;
+  const mimeType =
+    typeof nested.mimeType === "string"
+      ? nested.mimeType
+      : typeof nested.mime_type === "string"
+        ? nested.mime_type
+        : typeof value.mimeType === "string"
+          ? value.mimeType
+          : typeof value.mime_type === "string"
+            ? value.mime_type
+            : undefined;
+  const html =
+    typeof nested.text === "string"
+      ? nested.text
+      : typeof value.text === "string"
+        ? value.text
+        : undefined;
+
+  if (!uri?.startsWith("ui://")) return [];
+  if (mimeType?.toLowerCase() !== "text/html") return [];
+  if (!html) return [];
+
+  return [{ uri, mimeType, html }];
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/apps/ui/src/components/mcp/mcp-card-iframe.tsx
+++ b/apps/ui/src/components/mcp/mcp-card-iframe.tsx
@@ -42,6 +42,8 @@ export interface McpCardIframeProps {
   onAction?: (msg: CardMessage) => void;
   /** Initial iframe height in px. Cards are designed for ~360px wide. */
   height?: number;
+  /** Maximum rendered width. Entity-card previews default to 400px. */
+  maxWidth?: number | string;
   className?: string;
   /** Optional title for the iframe (a11y). */
   title?: string;
@@ -97,6 +99,7 @@ export function McpCardIframe({
   html,
   onAction,
   height = 280,
+  maxWidth = 400,
   className,
   title,
 }: McpCardIframeProps) {
@@ -106,6 +109,7 @@ export function McpCardIframe({
   // Hash the URI for stable iframe identity (helps React reconcile when
   // many cards live on one page).
   const iframeName = useMemo(() => `mcp-card-${hashCode(uri)}`, [uri]);
+  const iframeTitle = title ?? `MCP card (${uri})`;
 
   useEffect(() => {
     if (!onAction) return;
@@ -136,7 +140,7 @@ export function McpCardIframe({
     <iframe
       ref={iframeRef}
       name={iframeName}
-      title={title ?? `MCP card (${uri})`}
+      title={iframeTitle}
       data-mcp-card-uri={uri}
       // sandbox lacks allow-same-origin on purpose — keeps the iframe in
       // an opaque origin so it cannot read parent state, cookies, or
@@ -146,7 +150,7 @@ export function McpCardIframe({
       srcDoc={html}
       style={{
         width: "100%",
-        maxWidth: 400,
+        maxWidth,
         height,
         border: "none",
         background: "transparent",

--- a/apps/ui/src/lib/api/types/message-types.ts
+++ b/apps/ui/src/lib/api/types/message-types.ts
@@ -27,6 +27,19 @@ export type ContentPart =
   | { type: "image"; url?: string; base64?: string; media_type?: string }
   | { type: "image_file"; image_id: string; filename?: string }
   | {
+      type: "resource";
+      uri?: string;
+      mimeType?: string;
+      mime_type?: string;
+      text?: string;
+      resource?: {
+        uri?: string;
+        mimeType?: string;
+        mime_type?: string;
+        text?: string;
+      };
+    }
+  | {
       type: "tool_call";
       id: string;
       name: string;
@@ -66,6 +79,12 @@ export function isImageFilePart(
   part: ContentPart,
 ): part is { type: "image_file"; image_id: string; filename?: string } {
   return part.type === "image_file";
+}
+
+export function isResourcePart(
+  part: ContentPart,
+): part is Extract<ContentPart, { type: "resource" }> {
+  return part.type === "resource";
 }
 
 // Reasoning configuration for model controls

--- a/specs/mcp-cards.md
+++ b/specs/mcp-cards.md
@@ -202,8 +202,12 @@ Hosts that render `ui://everruns/...` resources MUST:
    second; drop on exceed).
 
 The Everruns chat UI implements these requirements in
-`apps/ui/src/components/mcp/mcp-card-iframe.tsx`. A standalone showcase lives
-under `apps/ui/src/app/dev/mcp-cards/`.
+`apps/ui/src/components/mcp/mcp-card-iframe.tsx`. Chat transcript tool
+activity surfaces render any successful `ui://` + `text/html` MCP resource
+inside this iframe, including resources wrapped in the remote-MCP executor's
+`{"content":[...]}` JSON text envelope. The text content from that envelope is
+used as the normal details/fallback output. A standalone showcase lives under
+`apps/ui/src/app/dev/mcp-cards/`.
 
 ## Server Module
 


### PR DESCRIPTION
## What
- Render MCP App `ui://` + `text/html` resources inside chat tool activity rows and narrated timelines.
- Parse remote MCP tool-result `{"content":[...]}` envelopes so the HTML resource renders while text content remains the fallback/details output.
- Let MCP app iframes opt into full chat width while keeping the existing 400px default for entity-card previews.
- Document the chat-host behavior in `specs/mcp-cards.md`.

## Why
MCP Apps-aware tool results, including our own `agent_get_card` resource shape, were only visible as raw JSON text in chat. The chat experience should render the embedded app inline while preserving a text fallback for hosts and details views.

## How
- Added `extractMcpAppResources` and normalized both flat MCP resource content and nested embedded-resource shapes.
- Added `McpAppResourceList` to render normalized resources through the existing sandboxed `McpCardIframe`.
- Wired MCP app rendering into generic tool cards, grouped activity rows, and narrated timelines.
- Extended tests for parser behavior, iframe width configuration, and tool-activity rendering.

## Risk
- Medium
- Rendering third-party HTML in chat can affect transcript layout or browser performance if a remote MCP server returns large or script-heavy app HTML. The iframe remains sandboxed without same-origin access, forms, popups, or top navigation, and only `ui://` `text/html` resources are rendered.

## Security
- Threat categories reviewed: TM-WEB, TM-TOOL, TM-DOS
- Findings and resolutions: MCP App HTML is rendered only through the existing sandboxed iframe (`sandbox="allow-scripts"`, `srcDoc`, `referrerPolicy="no-referrer"`) and no tool/action callback is granted from chat. Resource parsing rejects non-`ui://` and non-`text/html` resources. Text fallback extraction avoids exposing raw HTML outside the iframe.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)