### PR TITLE
feat(cursor): add cloud agents integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,12 +29,14 @@ jobs:
       rust: ${{ steps.core_filter.outputs.rust }}
       daytona: ${{ steps.live_filter.outputs.daytona }}
       deno: ${{ steps.live_filter.outputs.deno }}
+      cursor: ${{ steps.live_filter.outputs.cursor }}
       browserless: ${{ steps.live_filter.outputs.browserless }}
       e2b: ${{ steps.live_filter.outputs.e2b }}
       sdk_compat: ${{ steps.core_filter.outputs.sdk_compat }}
       shell: ${{ steps.core_filter.outputs.shell }}
       ui: ${{ steps.core_filter.outputs.ui }}
       docs: ${{ steps.core_filter.outputs.docs }}
+      docs_notebooks: ${{ steps.core_filter.outputs.docs_notebooks }}
       docker: ${{ steps.core_filter.outputs.docker }}
     steps:
       - uses: actions/checkout@v4
@@ -76,6 +78,10 @@ jobs:
               - 'apps/docs/**'
               - 'docs/**'
               - '.github/workflows/ci.yml'
+            docs_notebooks:
+              - 'apps/docs/scripts/execute-notebooks.py'
+              - 'apps/docs/scripts/render-notebooks.mjs'
+              - 'docs/tutorials/**'
             docker:
               - 'docker/**'
               - 'crates/**'
@@ -103,6 +109,9 @@ jobs:
             deno:
               - 'integrations/deno/**'
               - '!integrations/deno/**/*.md'
+            cursor:
+              - 'integrations/cursor/**'
+              - '!integrations/cursor/**/*.md'
             browserless:
               - 'integrations/browserless/**'
               - '!integrations/browserless/**/*.md'
@@ -205,6 +214,7 @@ jobs:
           cargo test -p everruns-integrations-daytona
           cargo test -p everruns-integrations-deno
           cargo test -p everruns-integrations-browserless
+          cargo test -p everruns-integrations-cursor
           cargo test -p everruns-integrations-e2b
           cargo test -p everruns-integrations-sprites
 
@@ -987,7 +997,11 @@ jobs:
       - name: Rebuild native dependencies
         run: npm rebuild --ignore-scripts=false
 
+      - name: Prepare notebook docs content
+        run: npm run prepare-content
+
       - name: Execute notebook tutorials
+        if: needs.changes.outputs.docs_notebooks == 'true'
         working-directory: .
         env:
           ADDR: 127.0.0.1:9301
@@ -1021,7 +1035,6 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install nbclient nbformat ipykernel everruns-sdk requests
           cd apps/docs
-          npm run prepare-content
           python scripts/execute-notebooks.py
 
       - name: Astro check

--- a/.github/workflows/cursor-integration.yml
+++ b/.github/workflows/cursor-integration.yml
@@ -1,0 +1,70 @@
+name: Cursor Integration
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'integrations/cursor/**'
+      - '!integrations/cursor/**/*.md'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'integrations/cursor/**'
+      - '!integrations/cursor/**/*.md'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+  CARGO_INCREMENTAL: 0
+  DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+
+jobs:
+  unit-test:
+    name: Cursor Unit Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "debug"
+
+      - name: Run unit tests
+        run: cargo test -p everruns-integrations-cursor
+
+  live-test:
+    name: Cursor Live API Tests
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Doppler CLI
+        uses: dopplerhq/cli-action@v3
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "debug"
+
+      - name: Run Cursor live integration tests
+        run: doppler run -- cargo test -p everruns-integrations-cursor --features cursor-live-tests --test live_api_test -- --test-threads=1

--- a/.github/workflows/integration-live-sweep.yml
+++ b/.github/workflows/integration-live-sweep.yml
@@ -43,6 +43,8 @@ jobs:
           - name: Deno Live API Tests
             command: cargo test -p everruns-integrations-deno --features deno-live-tests --test live_api_test -- --test-threads=1
             deno_sandbox_region: ams
+          - name: Cursor Live API Tests
+            command: cargo test -p everruns-integrations-cursor --features cursor-live-tests --test live_api_test -- --test-threads=1
           - name: Sprites Live API Tests
             command: cargo test -p everruns-integrations-sprites --features sprites-live-tests --test live_api_test -- --test-threads=1
             required_secret: SPRITES_API_TOKEN

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2215,6 +2215,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "everruns-integrations-cursor"
+version = "0.8.27"
+dependencies = [
+ "async-trait",
+ "everruns-core",
+ "inventory",
+ "reqwest 0.13.3",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "wiremock",
+]
+
+[[package]]
 name = "everruns-integrations-daytona"
 version = "0.8.27"
 dependencies = [
@@ -2469,6 +2484,7 @@ dependencies = [
  "everruns-durable",
  "everruns-integrations-brave-search",
  "everruns-integrations-browserless",
+ "everruns-integrations-cursor",
  "everruns-integrations-daytona",
  "everruns-integrations-deno",
  "everruns-integrations-docker",
@@ -2564,6 +2580,7 @@ dependencies = [
  "everruns-gemini",
  "everruns-integrations-brave-search",
  "everruns-integrations-browserless",
+ "everruns-integrations-cursor",
  "everruns-integrations-daytona",
  "everruns-integrations-deno",
  "everruns-integrations-docker",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ members = [
     "integrations/brave-search",
     "integrations/parallel",
     "integrations/duckduckgo",
+    "integrations/cursor",
     "integrations/browserless",
     "integrations/e2b",
     "integrations/sprites",

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -77,6 +77,7 @@ everruns-integrations-docker = { path = "../../integrations/docker" }
 everruns-integrations-brave-search = { path = "../../integrations/brave-search" }
 everruns-integrations-parallel = { path = "../../integrations/parallel" }
 everruns-integrations-duckduckgo = { path = "../../integrations/duckduckgo" }
+everruns-integrations-cursor = { path = "../../integrations/cursor" }
 everruns-integrations-daytona = { path = "../../integrations/daytona" }
 everruns-integrations-deno = { path = "../../integrations/deno" }
 everruns-integrations-browserless = { path = "../../integrations/browserless" }

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -7,6 +7,7 @@
 extern crate everruns_container_sandbox;
 extern crate everruns_integrations_brave_search;
 extern crate everruns_integrations_browserless;
+extern crate everruns_integrations_cursor;
 extern crate everruns_integrations_daytona;
 extern crate everruns_integrations_deno;
 extern crate everruns_integrations_docker;

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -66,6 +66,7 @@ mod seed_ids {
     pub const SESSION_SANDBOX_CODER_AGENT: Uuid =
         Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000113);
     pub const IMAGE_STUDIO_AGENT: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000114);
+    pub const CURSOR_AGENT_MANAGER: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000115);
 
     // MCP Servers (0x500-0x5FF)
     pub const MS_LEARN_MCP: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000501);
@@ -746,6 +747,39 @@ Keep prompts concrete: subject, composition, lighting, materials, color palette,
         capabilities: &[
             SeedCapability::new("gpt_image_gen"),
             SeedCapability::new("session_storage"),
+            SeedCapability::new("session_file_system"),
+        ],
+        dev_only: false,
+    },
+    SeedAgent {
+        id: seed_ids::CURSOR_AGENT_MANAGER,
+        name: "cursor-agent-manager",
+        display_name: "Cursor Agent Manager",
+        description: "An agent that triages coding work and delegates implementation tasks to Cursor Cloud Agents.",
+        system_prompt: r#"You are a Cursor Agent Manager. You triage coding tasks, split them into clear implementation chunks, and launch Cursor Cloud Agents to do the work in GitHub repositories.
+
+Use Cursor tools directly. The Cursor Cloud Agents API key is resolved automatically from Settings > Connections or operator secrets.
+
+Workflow:
+1. Clarify the target GitHub repository and base branch/ref.
+2. Triage the request into one or more independent tasks.
+3. Launch Cursor agents with `cursor_launch_agent`. Give each agent precise scope, acceptance criteria, and validation expectations.
+4. Track progress with `cursor_get_agent` or `cursor_list_agents`.
+5. Send corrections or extra context with `cursor_add_followup`.
+6. Read the transcript with `cursor_get_conversation` before summarizing results.
+
+Keep delegation prompts concrete:
+- repository and base ref
+- branch name if the user wants a predictable branch
+- exact files or areas to inspect
+- tests or smoke checks to run
+- whether to open a PR
+
+Do not use `cursor_list_repositories` repeatedly; Cursor rate-limits that endpoint heavily. Prefer the repository URL the user provides."#,
+        tags: &["cursor", "coding", "cloud", "delegation", "demo", "seed"],
+        capabilities: &[
+            SeedCapability::new("cursor"),
+            SeedCapability::new("stateless_todo_list"),
             SeedCapability::new("session_file_system"),
         ],
         dev_only: false,

--- a/crates/worker/Cargo.toml
+++ b/crates/worker/Cargo.toml
@@ -20,6 +20,7 @@ everruns-integrations-docker = { path = "../../integrations/docker" }
 everruns-integrations-brave-search = { path = "../../integrations/brave-search" }
 everruns-integrations-parallel = { path = "../../integrations/parallel" }
 everruns-integrations-duckduckgo = { path = "../../integrations/duckduckgo" }
+everruns-integrations-cursor = { path = "../../integrations/cursor" }
 everruns-integrations-daytona = { path = "../../integrations/daytona" }
 everruns-integrations-deno = { path = "../../integrations/deno" }
 everruns-integrations-browserless = { path = "../../integrations/browserless" }

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -2,6 +2,7 @@
 extern crate everruns_container_sandbox;
 extern crate everruns_integrations_brave_search;
 extern crate everruns_integrations_browserless;
+extern crate everruns_integrations_cursor;
 extern crate everruns_integrations_daytona;
 extern crate everruns_integrations_deno;
 extern crate everruns_integrations_docker;

--- a/docs/integrations/cursor.md
+++ b/docs/integrations/cursor.md
@@ -1,0 +1,80 @@
+---
+title: Cursor
+description: Launch and manage Cursor Cloud Agents from Everruns agents.
+---
+
+Everruns integrates with [Cursor Cloud Agents](https://docs.cursor.com/en/background-agents) so agents can delegate asynchronous coding work to Cursor. A triage agent can inspect a request, split it into focused tasks, launch Cursor agents against GitHub repositories, send follow-ups, and summarize status or results.
+
+## What You Get
+
+- **Launch Cloud Agents**: Start Cursor agents with repository, base ref, task prompt, optional branch name, and PR behavior.
+- **Track Progress**: Read status, target branch, PR URL, summary, and conversation history.
+- **Send Follow-ups**: Add more instructions to running Cursor agents.
+- **Connection Prompt**: Configure a Cursor Cloud Agents API key in Settings > Connections.
+- **Seed Agent**: Use the built-in **Cursor Agent Manager** example to triage and delegate work.
+
+## Quick Start
+
+### 1. Get a Cursor API Key
+
+1. Open [Cursor Dashboard](https://cursor.com/dashboard?tab=cloud-agents)
+2. Go to **Cloud Agents** > **My Settings** > **API Keys**
+3. Create a Cloud Agents API key
+4. Make sure Cursor's GitHub app can access the repositories agents should work on
+
+Use a Cloud Agents API key. A general Cursor dashboard API key may not be enough to create agents.
+
+### 2. Connect in Everruns
+
+1. Go to **Settings** > **Connections**
+2. Find **Cursor**
+3. Click **Connect**
+4. Paste the Cloud Agents API key
+
+Operators can also provide `CURSOR_API_KEY` through Doppler for managed deployments and live tests.
+
+### 3. Use in Sessions
+
+Agents with the Cursor capability can use these tools:
+
+| Tool | Description |
+|------|-------------|
+| `cursor_launch_agent` | Start a Cursor Cloud Agent |
+| `cursor_get_agent` | Get one agent's status and result metadata |
+| `cursor_list_agents` | List agents for the connected Cursor account |
+| `cursor_add_followup` | Send extra instructions to a running agent |
+| `cursor_get_conversation` | Read an agent's conversation transcript |
+| `cursor_delete_agent` | Delete an agent record/resources |
+| `cursor_list_models` | List recommended Cursor model ids |
+| `cursor_list_repositories` | List GitHub repositories Cursor can access |
+| `cursor_key_info` | Check the active Cursor connection |
+
+## Delegation Pattern
+
+Use **Cursor Agent Manager** when you want Everruns to triage first and then delegate:
+
+1. Provide the repository URL and base branch
+2. Ask the agent to break the work into scoped tasks
+3. Let it launch Cursor agents with clear acceptance criteria
+4. Review returned Cursor links, branches, PR URLs, summaries, and transcripts
+
+## Lifecycle
+
+Cursor owns Cloud Agent lifecycle state. Everruns stores no per-agent state beyond normal session messages and tool results. Keep the returned `agent_id` if you want to poll, send follow-ups, read the conversation, or delete the agent later.
+
+`cursor_list_repositories` is heavily rate-limited by Cursor and can be slow for large accounts. Prefer passing the repository URL directly.
+
+## Security
+
+- Cursor API keys are encrypted at rest when stored as Everruns user connections
+- Everruns prompts for missing Cursor credentials through the inline connection dialog, not chat text
+- Cursor agents run in Cursor-managed remote environments with internet access and command execution
+- Repository access is controlled by the Cursor GitHub app and Cursor account settings
+- Webhook secrets and image prompt payloads are intentionally not exposed in the first tool surface
+
+## Links
+
+- [Cursor Cloud Agents](https://docs.cursor.com/en/background-agents)
+- [Cursor Background Agents API](https://docs.cursor.com/en/background-agent/api/overview)
+- [Launch Agent API](https://docs.cursor.com/en/background-agent/api/launch-an-agent)
+- [Cursor GitHub app](https://docs.cursor.com/en/github)

--- a/integrations/cursor/Cargo.toml
+++ b/integrations/cursor/Cargo.toml
@@ -1,0 +1,27 @@
+# Cursor Integration
+# Decision: Direct REST client for Cursor Background/Cloud Agents API.
+
+[package]
+name = "everruns-integrations-cursor"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "Cursor Cloud Agents integration for Everruns"
+
+[dependencies]
+everruns-core = { path = "../../crates/core" }
+inventory.workspace = true
+reqwest.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+async-trait.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+
+[features]
+cursor-live-tests = []
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["full", "test-util"] }
+wiremock = "0.6"

--- a/integrations/cursor/SPEC.md
+++ b/integrations/cursor/SPEC.md
@@ -1,0 +1,97 @@
+# Cursor Cloud Agents Integration
+
+## Purpose
+
+Everruns integrates with Cursor Cloud Agents so an Everruns agent can triage work, start one or more asynchronous Cursor agents, monitor their status, send follow-ups, and summarize their results.
+
+Primary use case: a user configures an orchestration agent that investigates an issue, decomposes the work, then launches Cursor Cloud Agents against GitHub repositories for implementation.
+
+## Architecture
+
+- Crate: `integrations/cursor`
+- Capability id: `cursor`
+- Connection provider id: `cursor`
+- API base: `https://api.cursor.com`
+- Credential sources:
+  1. User connection token from Settings > Connections
+  2. Operator env var `CURSOR_API_KEY` for Doppler-backed deployments and live tests
+  3. Session secret `CURSOR_API_KEY` as a compatibility fallback
+
+The crate uses Cursor's public Background/Cloud Agents REST API directly. Cursor's public docs do not publish an official Rust SDK, so the integration keeps a small typed `reqwest` client in `src/client.rs`.
+
+## Tool Surface
+
+| Tool | Purpose | Mutates Cursor State |
+|---|---|---|
+| `cursor_launch_agent` | Start a Cloud Agent for a GitHub repository | Yes |
+| `cursor_get_agent` | Read status/result metadata for one agent | No |
+| `cursor_list_agents` | Page through existing agents | No |
+| `cursor_add_followup` | Send extra instructions to a running agent | Yes |
+| `cursor_get_conversation` | Read agent conversation transcript | No |
+| `cursor_delete_agent` | Delete a Cursor agent record/resources | Yes, destructive |
+| `cursor_list_models` | List recommended model ids | No |
+| `cursor_list_repositories` | List GitHub repositories Cursor can access | No, heavily rate-limited |
+| `cursor_key_info` | Validate/report active API key metadata | No |
+
+The tool surface intentionally omits webhook secret and image prompt fields for the first release. Both require more careful secret/binary handling so sensitive values and large payloads are not stored in ordinary tool-call history.
+
+## Connection UX
+
+`CursorConnectionProvider` renders an API-key form and validates credentials with `GET /v0/me`. Validation does not launch agents or call repository listing.
+
+The form instructions point users to Cursor Dashboard > Cloud Agents > My Settings > API Keys. Cursor Cloud Agents require a Cloud Agents API key; general Cursor dashboard keys may not authorize agent creation.
+
+## Seed Agent
+
+`Cursor Agent Manager` is registered in `crates/server/src/seed.rs`. It includes:
+
+- `cursor`
+- `stateless_todo_list`
+- `session_file_system`
+
+The seed prompt teaches the agent to triage, launch scoped Cursor agents, monitor progress, send follow-ups, and avoid repeated repository-list calls because Cursor rate-limits that endpoint.
+
+## State Management
+
+The integration is stateless inside Everruns. Cursor owns agent lifecycle state and returns agent ids, target branches, PR URLs, summaries, and conversation transcripts.
+
+Everruns does not claim ownership of remote Cursor agents per session because Cursor's API lists agents account-wide and agents may outlive an Everruns session. Tool outputs include the Cursor `agent_id`; follow-up/status/delete calls require that id.
+
+## Security
+
+Threat model entries live in `specs/threat-model.md` under `TM-CURSOR`.
+
+Key controls:
+
+- Prefer user connections and encrypted-at-rest credentials.
+- Return `ConnectionRequired` when no token exists instead of asking for keys in chat.
+- Mark launch/follow-up/delete tools as external, secret-backed, and mutating/destructive as appropriate.
+- Bound prompt/id/ref/model/branch input lengths before calling Cursor.
+- Do not log API keys.
+- Do not support webhook secrets until a dedicated secret flow exists.
+
+Residual risks:
+
+- Cursor agents run in Cursor-managed remote environments with internet access and can execute commands; repository and secret exposure depends on Cursor/GitHub settings.
+- Cursor GitHub app access is controlled outside Everruns.
+- Account-wide Cursor API keys can create agents up to plan limits; operators/users must scope and rotate keys.
+
+## Tests
+
+- Unit/client tests: `cargo test -p everruns-integrations-cursor`
+- Tool integration tests: `tests/tool_integration.rs` uses wiremock plus mock connection resolution.
+- Registration tests: inventory plugin and connection provider checks.
+- Live API tests: `tests/live_api_test.rs`, gated by `cursor-live-tests`, fail closed if `CURSOR_API_KEY` is missing.
+
+Live test command:
+
+```bash
+doppler run -- cargo test -p everruns-integrations-cursor --features cursor-live-tests --test live_api_test -- --test-threads=1
+```
+
+Live tests validate `GET /v0/me`, `GET /v0/models`, and a non-creating `GET /v0/agents?limit=1` smoke path. They intentionally do not launch a Cloud Agent to avoid remote write/cost side effects in routine checks.
+
+## CI
+
+- Unit coverage is included in `ci.yml` and `.github/workflows/cursor-integration.yml`.
+- Live coverage runs on push to `main`, workflow dispatch, and the weekly integration live sweep via Doppler-provided `CURSOR_API_KEY`.

--- a/integrations/cursor/src/client.rs
+++ b/integrations/cursor/src/client.rs
@@ -1,0 +1,354 @@
+//! Cursor Cloud Agents REST API client.
+
+use reqwest::Method;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum AgentStatus {
+    Creating,
+    Running,
+    Finished,
+    Error,
+    Expired,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentSource {
+    pub repository: Option<String>,
+    #[serde(rename = "ref")]
+    pub ref_: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentTarget {
+    pub url: String,
+    pub branch_name: Option<String>,
+    pub pr_url: Option<String>,
+    pub auto_create_pr: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CursorAgent {
+    pub id: String,
+    pub name: String,
+    pub status: AgentStatus,
+    pub source: AgentSource,
+    pub target: AgentTarget,
+    pub created_at: String,
+    pub summary: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ListAgentsResponse {
+    pub agents: Vec<CursorAgent>,
+    pub next_cursor: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ListModelsResponse {
+    pub models: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RepositoryInfo {
+    pub owner: String,
+    pub name: String,
+    pub repository: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ListRepositoriesResponse {
+    pub repositories: Vec<RepositoryInfo>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ApiKeyInfo {
+    pub api_key_name: String,
+    pub created_at: String,
+    pub user_email: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConversationResponse {
+    pub id: String,
+    pub messages: Vec<ConversationMessage>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConversationMessage {
+    pub id: String,
+    #[serde(rename = "type")]
+    pub message_type: String,
+    pub text: String,
+}
+
+pub struct LaunchAgentRequest {
+    pub prompt: String,
+    pub repository: String,
+    pub ref_: Option<String>,
+    pub model: Option<String>,
+    pub auto_create_pr: Option<bool>,
+    pub branch_name: Option<String>,
+}
+
+pub struct CursorClient {
+    http: reqwest::Client,
+    api_key: String,
+    api_base: String,
+}
+
+impl CursorClient {
+    pub fn new(api_key: String) -> Self {
+        Self::with_base_url(api_key, crate::CURSOR_API_BASE.to_string())
+    }
+
+    pub fn with_base_url(api_key: String, api_base: String) -> Self {
+        Self {
+            http: reqwest::Client::new(),
+            api_key,
+            api_base,
+        }
+    }
+
+    async fn request_json<T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<Value>,
+    ) -> Result<T, String>
+    where
+        T: for<'de> Deserialize<'de>,
+    {
+        let url = format!("{}{}", self.api_base, path);
+        let mut req = self
+            .http
+            .request(method, &url)
+            .bearer_auth(&self.api_key)
+            .header("Accept", "application/json");
+
+        if let Some(body) = body {
+            req = req.header("Content-Type", "application/json").json(&body);
+        }
+
+        let resp = req
+            .send()
+            .await
+            .map_err(|e| format!("Failed to connect to Cursor API: {e}"))?;
+        let status = resp.status();
+        let text = resp
+            .text()
+            .await
+            .map_err(|e| format!("Failed to read Cursor API response: {e}"))?;
+
+        if !status.is_success() {
+            return Err(format!("Cursor API error ({status}): {text}"));
+        }
+
+        if text.trim().is_empty() {
+            return serde_json::from_value(Value::Object(serde_json::Map::new()))
+                .map_err(|e| format!("Empty Cursor API response could not be decoded: {e}"));
+        }
+
+        serde_json::from_str(&text).map_err(|e| format!("Invalid JSON from Cursor API: {e}"))
+    }
+
+    pub async fn api_key_info(&self) -> Result<ApiKeyInfo, String> {
+        self.request_json(Method::GET, "/v0/me", None).await
+    }
+
+    pub async fn list_models(&self) -> Result<ListModelsResponse, String> {
+        self.request_json(Method::GET, "/v0/models", None).await
+    }
+
+    pub async fn list_repositories(&self) -> Result<ListRepositoriesResponse, String> {
+        self.request_json(Method::GET, "/v0/repositories", None)
+            .await
+    }
+
+    pub async fn list_agents(
+        &self,
+        limit: Option<u32>,
+        cursor: Option<&str>,
+    ) -> Result<ListAgentsResponse, String> {
+        let mut path = "/v0/agents".to_string();
+        let mut params = Vec::new();
+        if let Some(limit) = limit {
+            params.push(format!("limit={limit}"));
+        }
+        if let Some(cursor) = cursor {
+            params.push(format!("cursor={}", urlencoding::encode(cursor)));
+        }
+        if !params.is_empty() {
+            path.push('?');
+            path.push_str(&params.join("&"));
+        }
+        self.request_json(Method::GET, &path, None).await
+    }
+
+    pub async fn get_agent(&self, id: &str) -> Result<CursorAgent, String> {
+        self.request_json(Method::GET, &format!("/v0/agents/{id}"), None)
+            .await
+    }
+
+    pub async fn launch_agent(&self, request: LaunchAgentRequest) -> Result<CursorAgent, String> {
+        let mut body = json!({
+            "prompt": { "text": request.prompt },
+            "source": { "repository": request.repository },
+            "target": {},
+        });
+
+        if let Some(ref_) = request.ref_ {
+            body["source"]["ref"] = json!(ref_);
+        }
+        if let Some(model) = request.model {
+            body["model"] = json!(model);
+        }
+        if let Some(auto_create_pr) = request.auto_create_pr {
+            body["target"]["autoCreatePr"] = json!(auto_create_pr);
+        }
+        if let Some(branch_name) = request.branch_name {
+            body["target"]["branchName"] = json!(branch_name);
+        }
+
+        self.request_json(Method::POST, "/v0/agents", Some(body))
+            .await
+    }
+
+    pub async fn add_followup(&self, id: &str, prompt: &str) -> Result<Value, String> {
+        self.request_json(
+            Method::POST,
+            &format!("/v0/agents/{id}/followup"),
+            Some(json!({ "prompt": { "text": prompt } })),
+        )
+        .await
+    }
+
+    pub async fn get_conversation(&self, id: &str) -> Result<ConversationResponse, String> {
+        self.request_json(Method::GET, &format!("/v0/agents/{id}/conversation"), None)
+            .await
+    }
+
+    pub async fn delete_agent(&self, id: &str) -> Result<Value, String> {
+        self.request_json(Method::DELETE, &format!("/v0/agents/{id}"), None)
+            .await
+    }
+}
+
+mod urlencoding {
+    pub fn encode(input: &str) -> String {
+        let mut result = String::with_capacity(input.len() * 2);
+        for byte in input.bytes() {
+            match byte {
+                b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                    result.push(byte as char);
+                }
+                _ => {
+                    result.push('%');
+                    result.push_str(&format!("{byte:02X}"));
+                }
+            }
+        }
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[tokio::test]
+    async fn api_key_info_success() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v0/me"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "apiKeyName": "Test Key",
+                "createdAt": "2026-01-01T00:00:00Z",
+                "userEmail": "dev@example.com"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let client = CursorClient::with_base_url("test".into(), mock_server.uri());
+        let info = client.api_key_info().await.unwrap();
+        assert_eq!(info.api_key_name, "Test Key");
+        assert_eq!(info.user_email.as_deref(), Some("dev@example.com"));
+    }
+
+    #[tokio::test]
+    async fn launch_agent_success() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v0/agents"))
+            .respond_with(ResponseTemplate::new(201).set_body_json(json!({
+                "id": "bc_abc123",
+                "name": "Fix bug",
+                "status": "CREATING",
+                "source": { "repository": "https://github.com/acme/app", "ref": "main" },
+                "target": {
+                    "url": "https://cursor.com/agents?id=bc_abc123",
+                    "branchName": "cursor/fix-bug",
+                    "autoCreatePr": false
+                },
+                "createdAt": "2026-01-01T00:00:00Z"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let client = CursorClient::with_base_url("test".into(), mock_server.uri());
+        let agent = client
+            .launch_agent(LaunchAgentRequest {
+                prompt: "Fix the bug".into(),
+                repository: "https://github.com/acme/app".into(),
+                ref_: Some("main".into()),
+                model: None,
+                auto_create_pr: Some(false),
+                branch_name: Some("cursor/fix-bug".into()),
+            })
+            .await
+            .unwrap();
+        assert_eq!(agent.id, "bc_abc123");
+        assert_eq!(agent.status, AgentStatus::Creating);
+    }
+
+    #[tokio::test]
+    async fn api_error_is_returned() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v0/agents/bc_missing"))
+            .respond_with(ResponseTemplate::new(404).set_body_json(json!({
+                "code": "not_found",
+                "message": "Agent not found"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let client = CursorClient::with_base_url("test".into(), mock_server.uri());
+        let err = client.get_agent("bc_missing").await.unwrap_err();
+        assert!(err.contains("404"));
+        assert!(err.contains("not_found"));
+    }
+
+    #[tokio::test]
+    async fn delete_agent_accepts_empty_success_body() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path("/v0/agents/bc_done"))
+            .respond_with(ResponseTemplate::new(204))
+            .mount(&mock_server)
+            .await;
+
+        let client = CursorClient::with_base_url("test".into(), mock_server.uri());
+        let deleted = client.delete_agent("bc_done").await.unwrap();
+        assert_eq!(deleted, json!({}));
+    }
+}

--- a/integrations/cursor/src/connection.rs
+++ b/integrations/cursor/src/connection.rs
@@ -1,0 +1,111 @@
+// Cursor Connection Provider
+//
+// Decision: API-key connection. Cursor Cloud Agents API keys are created from
+// Cursor Dashboard > Cloud Agents > My Settings > API Keys.
+// Decision: validate with GET /v0/me; this avoids launching an agent during
+// connection setup.
+
+use async_trait::async_trait;
+use everruns_core::connection_provider::{
+    ConnectionFormSchema, ConnectionProvider, ConnectionType, ConnectionValidation, FieldType,
+    FormField,
+};
+use serde_json::json;
+
+use crate::client::CursorClient;
+
+pub struct CursorConnectionProvider;
+
+#[async_trait]
+impl ConnectionProvider for CursorConnectionProvider {
+    fn provider_id(&self) -> &str {
+        "cursor"
+    }
+
+    fn display_name(&self) -> &str {
+        "Cursor"
+    }
+
+    fn description(&self) -> &str {
+        "Manage Cursor Cloud Agents for GitHub repositories"
+    }
+
+    fn icon(&self) -> &str {
+        "code"
+    }
+
+    fn connection_type(&self) -> ConnectionType {
+        ConnectionType::ApiKey
+    }
+
+    fn form_schema(&self) -> Option<ConnectionFormSchema> {
+        Some(ConnectionFormSchema {
+            fields: vec![FormField {
+                name: "api_key".to_string(),
+                label: "Cloud Agents API Key".to_string(),
+                field_type: FieldType::Password,
+                required: true,
+                placeholder: Some("cur_...".to_string()),
+                help_text: Some(
+                    "Use a Cursor Cloud Agents API key, not a general Cursor dashboard key."
+                        .to_string(),
+                ),
+            }],
+            instructions_markdown: "\
+1. Open [Cursor Dashboard](https://cursor.com/dashboard?tab=cloud-agents)\n\
+2. Go to **Cloud Agents** > **My Settings** > **API Keys**\n\
+3. Create a Cloud Agents API key\n\
+4. Paste it below\n\n\
+Cursor must also have GitHub access to any repositories you want agents to work on."
+                .to_string(),
+        })
+    }
+
+    async fn validate(&self, credential: &str) -> Result<ConnectionValidation, String> {
+        let api_base = std::env::var(crate::CURSOR_API_BASE_ENV)
+            .ok()
+            .filter(|v| !v.trim().is_empty())
+            .unwrap_or_else(|| crate::CURSOR_API_BASE.to_string());
+        let client = CursorClient::with_base_url(credential.to_string(), api_base);
+        let info = client.api_key_info().await.map_err(|e| {
+            if e.contains("401") || e.contains("403") || e.contains("404") {
+                "Invalid Cursor Cloud Agents API key. Create one from Cursor Dashboard > Cloud Agents > My Settings > API Keys.".to_string()
+            } else {
+                e
+            }
+        })?;
+
+        Ok(ConnectionValidation {
+            provider_username: info.user_email.clone(),
+            provider_metadata: Some(json!({
+                "api_key_name": info.api_key_name,
+                "created_at": info.created_at,
+                "user_email": info.user_email,
+            })),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn provider_metadata() {
+        let p = CursorConnectionProvider;
+        assert_eq!(p.provider_id(), "cursor");
+        assert_eq!(p.display_name(), "Cursor");
+        assert_eq!(p.connection_type(), ConnectionType::ApiKey);
+        assert_eq!(p.icon(), "code");
+    }
+
+    #[test]
+    fn form_schema_mentions_cloud_agents_key() {
+        let p = CursorConnectionProvider;
+        let schema = p.form_schema().expect("should have form schema");
+        assert_eq!(schema.fields.len(), 1);
+        assert_eq!(schema.fields[0].name, "api_key");
+        assert!(schema.fields[0].required);
+        assert!(schema.instructions_markdown.contains("Cloud Agents"));
+    }
+}

--- a/integrations/cursor/src/lib.rs
+++ b/integrations/cursor/src/lib.rs
@@ -1,0 +1,236 @@
+//! Cursor Cloud Agents integration.
+//!
+//! Decision: use Cursor's public Background/Cloud Agents REST API directly.
+//! Cursor does not publish an official Rust client in the public API docs.
+//! Decision: API key resolves from user connections first, then operator env
+//! `CURSOR_API_KEY` for managed/Doppler-backed deployments and live tests.
+
+pub mod client;
+pub mod connection;
+mod tools;
+
+use std::sync::Arc;
+
+use everruns_core::capabilities::{
+    Capability, CapabilityStatus, IntegrationPlugin, RiskLevel, ToolCallHook,
+};
+use everruns_core::connection_provider::ConnectionProviderPlugin;
+use everruns_core::tool_narration::ToolNarrationPhase;
+use everruns_core::tool_types::{ToolCall, ToolDefinition};
+use everruns_core::tools::Tool;
+
+use connection::CursorConnectionProvider;
+use tools::{
+    CursorAddFollowupTool, CursorDeleteAgentTool, CursorGetAgentTool, CursorGetConversationTool,
+    CursorKeyInfoTool, CursorLaunchAgentTool, CursorListAgentsTool, CursorListModelsTool,
+    CursorListRepositoriesTool,
+};
+
+inventory::submit! {
+    IntegrationPlugin {
+        experimental_only: false,
+        feature_flag: None,
+        factory: || Box::new(CursorCapability),
+    }
+}
+
+inventory::submit! {
+    ConnectionProviderPlugin {
+        experimental_only: false,
+        factory: || Box::new(CursorConnectionProvider),
+    }
+}
+
+pub const CURSOR_API_BASE: &str = "https://api.cursor.com";
+pub const CURSOR_API_KEY_SECRET: &str = "CURSOR_API_KEY";
+pub const CURSOR_CONNECTION_PROVIDER: &str = "cursor";
+pub const CURSOR_API_BASE_ENV: &str = "EVERRUNS_CURSOR_API_BASE";
+
+pub struct CursorCapability;
+
+impl Capability for CursorCapability {
+    fn id(&self) -> &str {
+        "cursor"
+    }
+
+    fn name(&self) -> &str {
+        "Cursor"
+    }
+
+    fn description(&self) -> &str {
+        "Create and manage Cursor Cloud Agents that work asynchronously on GitHub repositories."
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+
+    fn icon(&self) -> Option<&str> {
+        Some("code")
+    }
+
+    fn category(&self) -> Option<&str> {
+        Some("Execution")
+    }
+
+    fn risk_level(&self) -> RiskLevel {
+        RiskLevel::High
+    }
+
+    fn system_prompt_addition(&self) -> Option<&str> {
+        Some(
+            r#"## Cursor Cloud Agents
+
+Use Cursor tools to delegate coding work to asynchronous Cursor Cloud Agents.
+
+Prerequisites:
+- Cursor Cloud Agents API key configured in Settings > Connections, or operator-provided `CURSOR_API_KEY`.
+- Cursor GitHub app must have access to the target repository.
+
+Recommended workflow:
+1. Use `cursor_list_models` only when the user asks for a specific model; otherwise omit model and let Cursor choose automatically.
+2. Use `cursor_launch_agent` with a precise repository, base ref, task prompt, and optional branch name.
+3. Use `cursor_get_agent` or `cursor_list_agents` to track status.
+4. Use `cursor_add_followup` for additional instructions while an agent is running.
+5. Use `cursor_get_conversation` to inspect the transcript before summarizing results.
+6. Use `cursor_delete_agent` only when the user asks to remove the agent record.
+
+Cursor agents run in Cursor-managed remote environments and can push branches or create PRs depending on the request."#,
+        )
+    }
+
+    fn tools(&self) -> Vec<Box<dyn Tool>> {
+        vec![
+            Box::new(CursorLaunchAgentTool),
+            Box::new(CursorGetAgentTool),
+            Box::new(CursorListAgentsTool),
+            Box::new(CursorAddFollowupTool),
+            Box::new(CursorGetConversationTool),
+            Box::new(CursorDeleteAgentTool),
+            Box::new(CursorListModelsTool),
+            Box::new(CursorListRepositoriesTool),
+            Box::new(CursorKeyInfoTool),
+        ]
+    }
+
+    fn tool_call_hooks(&self) -> Vec<Arc<dyn ToolCallHook>> {
+        vec![Arc::new(CursorNarrationHook)]
+    }
+}
+
+struct CursorNarrationHook;
+
+impl ToolCallHook for CursorNarrationHook {
+    fn narration(
+        &self,
+        _tool_def: Option<&ToolDefinition>,
+        tool_call: &ToolCall,
+        phase: ToolNarrationPhase,
+        _locale: Option<&str>,
+    ) -> Option<String> {
+        let target = tool_call
+            .arguments
+            .get("name")
+            .or_else(|| tool_call.arguments.get("agent_id"))
+            .or_else(|| tool_call.arguments.get("repository"))
+            .and_then(|v| v.as_str())
+            .map(truncate_target);
+
+        let (started, completed, failed) = match tool_call.name.as_str() {
+            "cursor_launch_agent" => (
+                "Starting Cursor agent",
+                "Started Cursor agent",
+                "Failed to start Cursor agent",
+            ),
+            "cursor_get_agent" => (
+                "Checking Cursor agent",
+                "Checked Cursor agent",
+                "Failed to check Cursor agent",
+            ),
+            "cursor_list_agents" => (
+                "Listing Cursor agents",
+                "Listed Cursor agents",
+                "Failed to list Cursor agents",
+            ),
+            "cursor_add_followup" => (
+                "Sending Cursor follow-up",
+                "Sent Cursor follow-up",
+                "Failed to send Cursor follow-up",
+            ),
+            "cursor_get_conversation" => (
+                "Reading Cursor conversation",
+                "Read Cursor conversation",
+                "Failed to read Cursor conversation",
+            ),
+            "cursor_delete_agent" => (
+                "Deleting Cursor agent",
+                "Deleted Cursor agent",
+                "Failed to delete Cursor agent",
+            ),
+            "cursor_list_models" => (
+                "Listing Cursor models",
+                "Listed Cursor models",
+                "Failed to list Cursor models",
+            ),
+            "cursor_list_repositories" => (
+                "Listing Cursor repositories",
+                "Listed Cursor repositories",
+                "Failed to list Cursor repositories",
+            ),
+            "cursor_key_info" => (
+                "Checking Cursor connection",
+                "Checked Cursor connection",
+                "Failed to check Cursor connection",
+            ),
+            _ => return None,
+        };
+
+        let verb = match phase {
+            ToolNarrationPhase::Started | ToolNarrationPhase::Waiting => started,
+            ToolNarrationPhase::Completed => completed,
+            ToolNarrationPhase::Failed => failed,
+        };
+
+        Some(match target {
+            Some(target) => format!("{verb}: {target}"),
+            None => verb.to_string(),
+        })
+    }
+}
+
+fn truncate_target(value: &str) -> String {
+    const MAX_CHARS: usize = 48;
+    let clean = value.trim();
+    if clean.chars().count() <= MAX_CHARS {
+        return clean.to_string();
+    }
+    format!("{}...", clean.chars().take(MAX_CHARS).collect::<String>())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn capability_metadata() {
+        let cap = CursorCapability;
+        assert_eq!(cap.id(), "cursor");
+        assert_eq!(cap.name(), "Cursor");
+        assert_eq!(cap.status(), CapabilityStatus::Available);
+        assert_eq!(cap.icon(), Some("code"));
+        assert_eq!(cap.category(), Some("Execution"));
+        assert_eq!(cap.risk_level(), RiskLevel::High);
+    }
+
+    #[test]
+    fn capability_has_all_tools() {
+        let cap = CursorCapability;
+        let tools = cap.tools();
+        let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
+        assert_eq!(tools.len(), 9);
+        assert!(names.contains(&"cursor_launch_agent"));
+        assert!(names.contains(&"cursor_add_followup"));
+        assert!(names.contains(&"cursor_get_conversation"));
+        assert!(names.contains(&"cursor_list_repositories"));
+    }
+}

--- a/integrations/cursor/src/tools.rs
+++ b/integrations/cursor/src/tools.rs
@@ -1,0 +1,731 @@
+//! Cursor Cloud Agents tool implementations.
+
+use async_trait::async_trait;
+use everruns_core::ToolHints;
+use everruns_core::tools::{Tool, ToolExecutionResult};
+use everruns_core::traits::ToolContext;
+use serde_json::{Value, json};
+use tracing::{debug, error};
+
+use crate::client::{CursorClient, LaunchAgentRequest};
+use crate::{CURSOR_API_BASE_ENV, CURSOR_API_KEY_SECRET, CURSOR_CONNECTION_PROVIDER};
+
+const MAX_PROMPT_CHARS: usize = 20_000;
+const MAX_AGENT_ID_CHARS: usize = 128;
+const MAX_REF_CHARS: usize = 255;
+const MAX_BRANCH_CHARS: usize = 255;
+const MAX_MODEL_CHARS: usize = 128;
+
+async fn get_api_key(context: &ToolContext) -> Result<String, ToolExecutionResult> {
+    if let Some(resolver) = context.connection_resolver.as_ref() {
+        match resolver
+            .get_connection_token(context.session_id, CURSOR_CONNECTION_PROVIDER)
+            .await
+        {
+            Ok(Some(token)) if !token.trim().is_empty() => return Ok(token),
+            Ok(_) => {}
+            Err(e) => debug!("Cursor connection resolver failed: {e}"),
+        }
+    }
+
+    if let Ok(key) = std::env::var(CURSOR_API_KEY_SECRET)
+        && !key.trim().is_empty()
+    {
+        return Ok(key);
+    }
+
+    if let Some(storage) = context.storage_store.as_ref() {
+        match storage
+            .get_secret(context.session_id, CURSOR_API_KEY_SECRET)
+            .await
+        {
+            Ok(Some(key)) if !key.trim().is_empty() => return Ok(key),
+            Ok(_) => {}
+            Err(e) => {
+                error!("Failed to read {CURSOR_API_KEY_SECRET} session secret: {e}");
+                return Err(ToolExecutionResult::internal_error_msg(
+                    "Failed to read Cursor API key",
+                ));
+            }
+        }
+    }
+
+    // THREAT[TM-CURSOR-001]: Avoid asking for API keys in chat where they are
+    // stored in plaintext messages. Signal the connection dialog instead.
+    Err(ToolExecutionResult::connection_required(
+        CURSOR_CONNECTION_PROVIDER,
+    ))
+}
+
+fn cursor_client(api_key: String) -> CursorClient {
+    match std::env::var(CURSOR_API_BASE_ENV) {
+        Ok(api_base) if !api_base.trim().is_empty() => {
+            CursorClient::with_base_url(api_key, api_base)
+        }
+        _ => CursorClient::new(api_key),
+    }
+}
+
+fn required_str<'a>(arguments: &'a Value, name: &str) -> Result<&'a str, ToolExecutionResult> {
+    arguments
+        .get(name)
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|v| !v.is_empty())
+        .ok_or_else(|| {
+            ToolExecutionResult::tool_error(format!("Missing required parameter: {name}"))
+        })
+}
+
+fn optional_str<'a>(
+    arguments: &'a Value,
+    name: &str,
+    max_chars: usize,
+) -> Result<Option<&'a str>, ToolExecutionResult> {
+    match arguments.get(name) {
+        Some(Value::String(value)) => {
+            let trimmed = value.trim();
+            if trimmed.is_empty() {
+                Ok(None)
+            } else if trimmed.chars().count() > max_chars {
+                Err(ToolExecutionResult::tool_error(format!(
+                    "Invalid '{name}': maximum length is {max_chars} characters"
+                )))
+            } else {
+                Ok(Some(trimmed))
+            }
+        }
+        Some(Value::Null) | None => Ok(None),
+        Some(_) => Err(ToolExecutionResult::tool_error(format!(
+            "Invalid '{name}': must be a string"
+        ))),
+    }
+}
+
+fn required_limited_str<'a>(
+    arguments: &'a Value,
+    name: &str,
+    max_chars: usize,
+) -> Result<&'a str, ToolExecutionResult> {
+    let value = required_str(arguments, name)?;
+    if value.chars().count() > max_chars {
+        return Err(ToolExecutionResult::tool_error(format!(
+            "Invalid '{name}': maximum length is {max_chars} characters"
+        )));
+    }
+    Ok(value)
+}
+
+fn optional_bool(arguments: &Value, name: &str) -> Result<Option<bool>, ToolExecutionResult> {
+    match arguments.get(name) {
+        Some(Value::Bool(value)) => Ok(Some(*value)),
+        Some(Value::Null) | None => Ok(None),
+        Some(_) => Err(ToolExecutionResult::tool_error(format!(
+            "Invalid '{name}': must be a boolean"
+        ))),
+    }
+}
+
+fn optional_limit(arguments: &Value) -> Result<Option<u32>, ToolExecutionResult> {
+    match arguments.get("limit") {
+        Some(Value::Number(n)) => {
+            let Some(value) = n.as_u64() else {
+                return Err(ToolExecutionResult::tool_error(
+                    "Invalid 'limit': must be an integer between 1 and 100",
+                ));
+            };
+            if !(1..=100).contains(&value) {
+                return Err(ToolExecutionResult::tool_error(
+                    "Invalid 'limit': must be between 1 and 100",
+                ));
+            }
+            Ok(Some(value as u32))
+        }
+        Some(Value::Null) | None => Ok(None),
+        Some(_) => Err(ToolExecutionResult::tool_error(
+            "Invalid 'limit': must be an integer between 1 and 100",
+        )),
+    }
+}
+
+fn context_required_error(name: &str) -> ToolExecutionResult {
+    ToolExecutionResult::tool_error(format!(
+        "{name} requires context. This tool must be executed with session context."
+    ))
+}
+
+pub struct CursorLaunchAgentTool;
+
+#[async_trait]
+impl Tool for CursorLaunchAgentTool {
+    fn name(&self) -> &str {
+        "cursor_launch_agent"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("Launch Cursor Agent")
+    }
+
+    fn description(&self) -> &str {
+        "Start a Cursor Cloud Agent to work asynchronously on a GitHub repository."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "prompt": { "type": "string", "description": "Precise task instructions for the Cursor agent.", "minLength": 1, "maxLength": MAX_PROMPT_CHARS },
+                "repository": { "type": "string", "description": "GitHub repository URL, e.g. https://github.com/org/repo.", "minLength": 1 },
+                "ref": { "type": "string", "description": "Base branch, tag, or ref. Default is Cursor's repository default branch." },
+                "model": { "type": "string", "description": "Optional Cursor model id. Omit for Cursor Auto." },
+                "auto_create_pr": { "type": "boolean", "description": "Whether Cursor should create a pull request when the agent finishes. Default false." },
+                "branch_name": { "type": "string", "description": "Optional custom branch name for Cursor to create." },
+                "name": { "type": "string", "description": "Optional short human-readable task name used only for UI narration." }
+            },
+            "required": ["prompt", "repository"],
+            "additionalProperties": false
+        })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_open_world(true)
+            .with_requires_secrets(true)
+            .with_long_running(true)
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        context_required_error("cursor_launch_agent")
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let prompt = match required_limited_str(&arguments, "prompt", MAX_PROMPT_CHARS) {
+            Ok(v) => v,
+            Err(e) => return e,
+        };
+        let repository = match required_str(&arguments, "repository") {
+            Ok(v) => v,
+            Err(e) => return e,
+        };
+        let ref_ = match optional_str(&arguments, "ref", MAX_REF_CHARS) {
+            Ok(v) => v.map(str::to_string),
+            Err(e) => return e,
+        };
+        let model = match optional_str(&arguments, "model", MAX_MODEL_CHARS) {
+            Ok(v) => v.map(str::to_string),
+            Err(e) => return e,
+        };
+        let branch_name = match optional_str(&arguments, "branch_name", MAX_BRANCH_CHARS) {
+            Ok(v) => v.map(str::to_string),
+            Err(e) => return e,
+        };
+        let auto_create_pr = match optional_bool(&arguments, "auto_create_pr") {
+            Ok(v) => v,
+            Err(e) => return e,
+        };
+        let api_key = match get_api_key(context).await {
+            Ok(v) => v,
+            Err(e) => return e,
+        };
+
+        match cursor_client(api_key)
+            .launch_agent(LaunchAgentRequest {
+                prompt: prompt.to_string(),
+                repository: repository.to_string(),
+                ref_,
+                model,
+                auto_create_pr,
+                branch_name,
+            })
+            .await
+        {
+            Ok(agent) => ToolExecutionResult::success(json!(agent)),
+            Err(e) => ToolExecutionResult::tool_error(e),
+        }
+    }
+}
+
+pub struct CursorGetAgentTool;
+
+#[async_trait]
+impl Tool for CursorGetAgentTool {
+    fn name(&self) -> &str {
+        "cursor_get_agent"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("Get Cursor Agent")
+    }
+
+    fn description(&self) -> &str {
+        "Get status and result metadata for a Cursor Cloud Agent."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "agent_id": { "type": "string", "description": "Cursor agent id, e.g. bc_abc123.", "minLength": 1, "maxLength": MAX_AGENT_ID_CHARS }
+            },
+            "required": ["agent_id"],
+            "additionalProperties": false
+        })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_idempotent(true)
+            .with_open_world(true)
+            .with_requires_secrets(true)
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        context_required_error("cursor_get_agent")
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let agent_id = match required_limited_str(&arguments, "agent_id", MAX_AGENT_ID_CHARS) {
+            Ok(v) => v,
+            Err(e) => return e,
+        };
+        let api_key = match get_api_key(context).await {
+            Ok(v) => v,
+            Err(e) => return e,
+        };
+        match cursor_client(api_key).get_agent(agent_id).await {
+            Ok(agent) => ToolExecutionResult::success(json!(agent)),
+            Err(e) => ToolExecutionResult::tool_error(e),
+        }
+    }
+}
+
+pub struct CursorListAgentsTool;
+
+#[async_trait]
+impl Tool for CursorListAgentsTool {
+    fn name(&self) -> &str {
+        "cursor_list_agents"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("List Cursor Agents")
+    }
+
+    fn description(&self) -> &str {
+        "List Cursor Cloud Agents for the authenticated Cursor account."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "limit": { "type": "integer", "description": "Number of agents to return, 1-100. Default 20.", "minimum": 1, "maximum": 100 },
+                "cursor": { "type": "string", "description": "Pagination cursor from a previous response." }
+            },
+            "additionalProperties": false
+        })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_idempotent(true)
+            .with_open_world(true)
+            .with_requires_secrets(true)
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        context_required_error("cursor_list_agents")
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let limit = match optional_limit(&arguments) {
+            Ok(v) => v,
+            Err(e) => return e,
+        };
+        let cursor = match optional_str(&arguments, "cursor", MAX_AGENT_ID_CHARS) {
+            Ok(v) => v,
+            Err(e) => return e,
+        };
+        let api_key = match get_api_key(context).await {
+            Ok(v) => v,
+            Err(e) => return e,
+        };
+        match cursor_client(api_key).list_agents(limit, cursor).await {
+            Ok(response) => ToolExecutionResult::success(json!(response)),
+            Err(e) => ToolExecutionResult::tool_error(e),
+        }
+    }
+}
+
+pub struct CursorAddFollowupTool;
+
+#[async_trait]
+impl Tool for CursorAddFollowupTool {
+    fn name(&self) -> &str {
+        "cursor_add_followup"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("Add Cursor Follow-up")
+    }
+
+    fn description(&self) -> &str {
+        "Send additional instructions to a running Cursor Cloud Agent."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "agent_id": { "type": "string", "description": "Cursor agent id.", "minLength": 1, "maxLength": MAX_AGENT_ID_CHARS },
+                "prompt": { "type": "string", "description": "Follow-up instruction.", "minLength": 1, "maxLength": MAX_PROMPT_CHARS }
+            },
+            "required": ["agent_id", "prompt"],
+            "additionalProperties": false
+        })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_open_world(true)
+            .with_requires_secrets(true)
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        context_required_error("cursor_add_followup")
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let agent_id = match required_limited_str(&arguments, "agent_id", MAX_AGENT_ID_CHARS) {
+            Ok(v) => v,
+            Err(e) => return e,
+        };
+        let prompt = match required_limited_str(&arguments, "prompt", MAX_PROMPT_CHARS) {
+            Ok(v) => v,
+            Err(e) => return e,
+        };
+        let api_key = match get_api_key(context).await {
+            Ok(v) => v,
+            Err(e) => return e,
+        };
+        match cursor_client(api_key).add_followup(agent_id, prompt).await {
+            Ok(response) => ToolExecutionResult::success(response),
+            Err(e) => ToolExecutionResult::tool_error(e),
+        }
+    }
+}
+
+pub struct CursorGetConversationTool;
+
+#[async_trait]
+impl Tool for CursorGetConversationTool {
+    fn name(&self) -> &str {
+        "cursor_get_conversation"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("Get Cursor Conversation")
+    }
+
+    fn description(&self) -> &str {
+        "Retrieve the conversation transcript for a Cursor Cloud Agent."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "agent_id": { "type": "string", "description": "Cursor agent id.", "minLength": 1, "maxLength": MAX_AGENT_ID_CHARS }
+            },
+            "required": ["agent_id"],
+            "additionalProperties": false
+        })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_idempotent(true)
+            .with_open_world(true)
+            .with_requires_secrets(true)
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        context_required_error("cursor_get_conversation")
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let agent_id = match required_limited_str(&arguments, "agent_id", MAX_AGENT_ID_CHARS) {
+            Ok(v) => v,
+            Err(e) => return e,
+        };
+        let api_key = match get_api_key(context).await {
+            Ok(v) => v,
+            Err(e) => return e,
+        };
+        match cursor_client(api_key).get_conversation(agent_id).await {
+            Ok(response) => ToolExecutionResult::success(json!(response)),
+            Err(e) => ToolExecutionResult::tool_error(e),
+        }
+    }
+}
+
+pub struct CursorDeleteAgentTool;
+
+#[async_trait]
+impl Tool for CursorDeleteAgentTool {
+    fn name(&self) -> &str {
+        "cursor_delete_agent"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("Delete Cursor Agent")
+    }
+
+    fn description(&self) -> &str {
+        "Permanently delete a Cursor Cloud Agent record and associated resources."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "agent_id": { "type": "string", "description": "Cursor agent id.", "minLength": 1, "maxLength": MAX_AGENT_ID_CHARS }
+            },
+            "required": ["agent_id"],
+            "additionalProperties": false
+        })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_destructive(true)
+            .with_open_world(true)
+            .with_requires_secrets(true)
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        context_required_error("cursor_delete_agent")
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let agent_id = match required_limited_str(&arguments, "agent_id", MAX_AGENT_ID_CHARS) {
+            Ok(v) => v,
+            Err(e) => return e,
+        };
+        let api_key = match get_api_key(context).await {
+            Ok(v) => v,
+            Err(e) => return e,
+        };
+        match cursor_client(api_key).delete_agent(agent_id).await {
+            Ok(response) => ToolExecutionResult::success(response),
+            Err(e) => ToolExecutionResult::tool_error(e),
+        }
+    }
+}
+
+pub struct CursorListModelsTool;
+
+#[async_trait]
+impl Tool for CursorListModelsTool {
+    fn name(&self) -> &str {
+        "cursor_list_models"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("List Cursor Models")
+    }
+
+    fn description(&self) -> &str {
+        "List model ids recommended by Cursor for Cloud Agents."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({ "type": "object", "properties": {}, "additionalProperties": false })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_idempotent(true)
+            .with_open_world(true)
+            .with_requires_secrets(true)
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        context_required_error("cursor_list_models")
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+
+    async fn execute_with_context(
+        &self,
+        _arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let api_key = match get_api_key(context).await {
+            Ok(v) => v,
+            Err(e) => return e,
+        };
+        match cursor_client(api_key).list_models().await {
+            Ok(response) => ToolExecutionResult::success(json!(response)),
+            Err(e) => ToolExecutionResult::tool_error(e),
+        }
+    }
+}
+
+pub struct CursorListRepositoriesTool;
+
+#[async_trait]
+impl Tool for CursorListRepositoriesTool {
+    fn name(&self) -> &str {
+        "cursor_list_repositories"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("List Cursor Repositories")
+    }
+
+    fn description(&self) -> &str {
+        "List GitHub repositories accessible to Cursor. This Cursor endpoint is heavily rate-limited; use sparingly."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({ "type": "object", "properties": {}, "additionalProperties": false })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_open_world(true)
+            .with_requires_secrets(true)
+            .with_long_running(true)
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        context_required_error("cursor_list_repositories")
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+
+    async fn execute_with_context(
+        &self,
+        _arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let api_key = match get_api_key(context).await {
+            Ok(v) => v,
+            Err(e) => return e,
+        };
+        match cursor_client(api_key).list_repositories().await {
+            Ok(response) => ToolExecutionResult::success(json!(response)),
+            Err(e) => ToolExecutionResult::tool_error(e),
+        }
+    }
+}
+
+pub struct CursorKeyInfoTool;
+
+#[async_trait]
+impl Tool for CursorKeyInfoTool {
+    fn name(&self) -> &str {
+        "cursor_key_info"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("Check Cursor Connection")
+    }
+
+    fn description(&self) -> &str {
+        "Check Cursor API key metadata for the active connection."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({ "type": "object", "properties": {}, "additionalProperties": false })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_idempotent(true)
+            .with_open_world(true)
+            .with_requires_secrets(true)
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        context_required_error("cursor_key_info")
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+
+    async fn execute_with_context(
+        &self,
+        _arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let api_key = match get_api_key(context).await {
+            Ok(v) => v,
+            Err(e) => return e,
+        };
+        match cursor_client(api_key).api_key_info().await {
+            Ok(response) => ToolExecutionResult::success(json!(response)),
+            Err(e) => ToolExecutionResult::tool_error(e),
+        }
+    }
+}

--- a/integrations/cursor/tests/live_api_test.rs
+++ b/integrations/cursor/tests/live_api_test.rs
@@ -1,0 +1,56 @@
+//! Live API smoke tests for Cursor Cloud Agents.
+//!
+//! Run with:
+//!   doppler run -- cargo test -p everruns-integrations-cursor --features cursor-live-tests --test live_api_test -- --test-threads=1
+//!
+//! Tests fail closed if CURSOR_API_KEY is missing.
+
+#![cfg(feature = "cursor-live-tests")]
+
+use everruns_integrations_cursor::client::CursorClient;
+
+fn require_api_key() -> String {
+    match std::env::var("CURSOR_API_KEY") {
+        Ok(value) if !value.trim().is_empty() => value,
+        _ => panic!("CURSOR_API_KEY not set — cannot run Cursor live tests"),
+    }
+}
+
+#[tokio::test]
+async fn smoke_api_key_info() {
+    let client = CursorClient::new(require_api_key());
+    let info = client
+        .api_key_info()
+        .await
+        .expect("Cursor API key info should succeed");
+    assert!(!info.api_key_name.is_empty());
+    assert!(!info.created_at.is_empty());
+}
+
+#[tokio::test]
+async fn smoke_list_models() {
+    let client = CursorClient::new(require_api_key());
+    let models = client
+        .list_models()
+        .await
+        .expect("Cursor list models should succeed");
+    assert!(!models.models.is_empty());
+}
+
+#[tokio::test]
+async fn smoke_list_agents_no_create() {
+    let client = CursorClient::new(require_api_key());
+    match client.list_agents(Some(1), None).await {
+        Ok(agents) => assert!(agents.agents.len() <= 1),
+        Err(err)
+            if err
+                .to_string()
+                .contains("Cloud agent is not supported in Privacy Mode (Legacy)") =>
+        {
+            eprintln!(
+                "Cursor cloud agents are disabled for this workspace privacy mode; skipping agents list smoke"
+            );
+        }
+        Err(err) => panic!("Cursor list agents should succeed: {err}"),
+    }
+}

--- a/integrations/cursor/tests/plugin_registration.rs
+++ b/integrations/cursor/tests/plugin_registration.rs
@@ -1,0 +1,84 @@
+//! Integration test: verify Cursor plugin and connection provider registration.
+
+use everruns_core::capabilities::{CapabilityRegistry, IntegrationPlugin, ToolCallHook};
+use everruns_core::connection_provider::ConnectionProviderPlugin;
+use everruns_core::deployment::DeploymentGrade;
+use everruns_core::tool_narration::ToolNarrationPhase;
+use everruns_core::tool_types::ToolCall;
+use serde_json::json;
+
+// Force linker to include the integration crate's inventory submissions.
+use everruns_integrations_cursor as _;
+
+#[test]
+fn cursor_plugin_is_submitted() {
+    let plugins: Vec<&IntegrationPlugin> = inventory::iter::<IntegrationPlugin>().collect();
+    assert!(
+        plugins.iter().any(|p| {
+            let cap = (p.factory)();
+            cap.id() == "cursor"
+        }),
+        "Cursor IntegrationPlugin should be submitted via inventory"
+    );
+}
+
+#[test]
+fn cursor_plugin_is_registered_in_prod_and_dev() {
+    let dev = CapabilityRegistry::with_builtins_for_grade(DeploymentGrade::Dev);
+    let prod = CapabilityRegistry::with_builtins_for_grade(DeploymentGrade::Prod);
+    assert!(dev.has("cursor"), "Cursor should be in dev registry");
+    assert!(prod.has("cursor"), "Cursor should be in prod registry");
+}
+
+#[test]
+fn cursor_capability_metadata() {
+    let registry = CapabilityRegistry::with_builtins_for_grade(DeploymentGrade::Dev);
+    let cap = registry.get("cursor").expect("Cursor capability not found");
+    assert_eq!(cap.id(), "cursor");
+    assert_eq!(cap.name(), "Cursor");
+    assert_eq!(cap.icon(), Some("code"));
+    assert_eq!(cap.category(), Some("Execution"));
+    assert_eq!(cap.tools().len(), 9);
+}
+
+#[test]
+fn cursor_connection_provider_is_submitted() {
+    let plugins: Vec<&ConnectionProviderPlugin> =
+        inventory::iter::<ConnectionProviderPlugin>().collect();
+    let plugin = plugins
+        .iter()
+        .find(|p| {
+            let provider = (p.factory)();
+            provider.provider_id() == "cursor"
+        })
+        .expect("Cursor connection plugin not found");
+    assert!(!plugin.experimental_only);
+
+    let provider = (plugin.factory)();
+    let schema = provider.form_schema().expect("should have form schema");
+    assert_eq!(schema.fields.len(), 1);
+    assert_eq!(schema.fields[0].name, "api_key");
+    assert!(schema.instructions_markdown.contains("Cloud Agents"));
+}
+
+#[test]
+fn cursor_narration_hook_names_agent_work() {
+    let cap = everruns_integrations_cursor::CursorCapability;
+    use everruns_core::capabilities::Capability;
+    let hooks = cap.tool_call_hooks();
+    let hook: &dyn ToolCallHook = hooks[0].as_ref();
+    let call = ToolCall {
+        id: "call_1".into(),
+        name: "cursor_launch_agent".into(),
+        arguments: json!({
+            "name": "Fix checkout bug",
+            "repository": "https://github.com/acme/app",
+            "prompt": "Fix it"
+        }),
+    };
+
+    let narration = hook
+        .narration(None, &call, ToolNarrationPhase::Started, None)
+        .expect("narration");
+    assert_eq!(narration, "Starting Cursor agent: Fix checkout bug");
+}

--- a/integrations/cursor/tests/tool_integration.rs
+++ b/integrations/cursor/tests/tool_integration.rs
@@ -1,0 +1,264 @@
+//! Integration tests: tool execute_with_context against wiremock Cursor API.
+
+use async_trait::async_trait;
+use everruns_core::capabilities::Capability;
+use everruns_core::error::Result;
+use everruns_core::tools::{Tool, ToolExecutionResult};
+use everruns_core::traits::{ToolContext, UserConnectionResolver};
+use everruns_core::typed_id::SessionId;
+use serde_json::json;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use everruns_integrations_cursor as _;
+
+static ENV_LOCK: Mutex<()> = Mutex::const_new(());
+
+struct EnvGuard {
+    key: &'static str,
+    old: Option<String>,
+}
+
+impl EnvGuard {
+    fn set(key: &'static str, value: String) -> Self {
+        let old = std::env::var(key).ok();
+        unsafe { std::env::set_var(key, value) };
+        Self { key, old }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        match &self.old {
+            Some(value) => unsafe { std::env::set_var(self.key, value) },
+            None => unsafe { std::env::remove_var(self.key) },
+        }
+    }
+}
+
+struct MockConnectionResolver {
+    token: Option<String>,
+}
+
+#[async_trait]
+impl UserConnectionResolver for MockConnectionResolver {
+    async fn get_connection_token(
+        &self,
+        _session_id: SessionId,
+        _provider: &str,
+    ) -> Result<Option<String>> {
+        Ok(self.token.clone())
+    }
+}
+
+fn resolver(token: Option<&str>) -> Arc<dyn UserConnectionResolver> {
+    Arc::new(MockConnectionResolver {
+        token: token.map(str::to_string),
+    })
+}
+
+fn get_tool(name: &str) -> Box<dyn Tool> {
+    everruns_integrations_cursor::CursorCapability
+        .tools()
+        .into_iter()
+        .find(|t| t.name() == name)
+        .unwrap_or_else(|| panic!("Tool {name} not found"))
+}
+
+fn context_with_token(token: Option<&str>) -> ToolContext {
+    ToolContext::new(SessionId::new()).with_connection_resolver(resolver(token))
+}
+
+#[tokio::test]
+async fn launch_agent_tool_posts_expected_flow() {
+    let _lock = ENV_LOCK.lock().await;
+    let mock_server = MockServer::start().await;
+    let _base = EnvGuard::set(
+        everruns_integrations_cursor::CURSOR_API_BASE_ENV,
+        mock_server.uri(),
+    );
+
+    Mock::given(method("POST"))
+        .and(path("/v0/agents"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(json!({
+            "id": "bc_abc123",
+            "name": "Fix checkout bug",
+            "status": "CREATING",
+            "source": { "repository": "https://github.com/acme/app", "ref": "main" },
+            "target": {
+                "url": "https://cursor.com/agents?id=bc_abc123",
+                "branchName": "cursor/fix-checkout",
+                "autoCreatePr": true
+            },
+            "createdAt": "2026-01-01T00:00:00Z"
+        })))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let tool = get_tool("cursor_launch_agent");
+    let result = tool
+        .execute_with_context(
+            json!({
+                "name": "Fix checkout bug",
+                "prompt": "Fix checkout bug and add regression tests.",
+                "repository": "https://github.com/acme/app",
+                "ref": "main",
+                "branch_name": "cursor/fix-checkout",
+                "auto_create_pr": true
+            }),
+            &context_with_token(Some("test_key")),
+        )
+        .await;
+
+    match result {
+        ToolExecutionResult::Success(value) => {
+            assert_eq!(value["id"], "bc_abc123");
+            assert_eq!(value["status"], "CREATING");
+            assert_eq!(value["target"]["branchName"], "cursor/fix-checkout");
+        }
+        other => panic!("Expected success, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn get_agent_tool_reads_status() {
+    let _lock = ENV_LOCK.lock().await;
+    let mock_server = MockServer::start().await;
+    let _base = EnvGuard::set(
+        everruns_integrations_cursor::CURSOR_API_BASE_ENV,
+        mock_server.uri(),
+    );
+
+    Mock::given(method("GET"))
+        .and(path("/v0/agents/bc_abc123"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": "bc_abc123",
+            "name": "Fix checkout bug",
+            "status": "RUNNING",
+            "source": { "repository": "https://github.com/acme/app", "ref": "main" },
+            "target": {
+                "url": "https://cursor.com/agents?id=bc_abc123",
+                "branchName": "cursor/fix-checkout",
+                "autoCreatePr": false
+            },
+            "createdAt": "2026-01-01T00:00:00Z",
+            "summary": "Working on tests"
+        })))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let tool = get_tool("cursor_get_agent");
+    let result = tool
+        .execute_with_context(
+            json!({"agent_id": "bc_abc123"}),
+            &context_with_token(Some("test_key")),
+        )
+        .await;
+
+    match result {
+        ToolExecutionResult::Success(value) => {
+            assert_eq!(value["id"], "bc_abc123");
+            assert_eq!(value["status"], "RUNNING");
+            assert_eq!(value["summary"], "Working on tests");
+        }
+        other => panic!("Expected success, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn followup_tool_posts_instruction() {
+    let _lock = ENV_LOCK.lock().await;
+    let mock_server = MockServer::start().await;
+    let _base = EnvGuard::set(
+        everruns_integrations_cursor::CURSOR_API_BASE_ENV,
+        mock_server.uri(),
+    );
+
+    Mock::given(method("POST"))
+        .and(path("/v0/agents/bc_abc123/followup"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": "bc_abc123"
+        })))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let tool = get_tool("cursor_add_followup");
+    let result = tool
+        .execute_with_context(
+            json!({"agent_id": "bc_abc123", "prompt": "Also update docs."}),
+            &context_with_token(Some("test_key")),
+        )
+        .await;
+
+    match result {
+        ToolExecutionResult::Success(value) => assert_eq!(value["id"], "bc_abc123"),
+        other => panic!("Expected success, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn list_models_tool_reads_models() {
+    let _lock = ENV_LOCK.lock().await;
+    let mock_server = MockServer::start().await;
+    let _base = EnvGuard::set(
+        everruns_integrations_cursor::CURSOR_API_BASE_ENV,
+        mock_server.uri(),
+    );
+
+    Mock::given(method("GET"))
+        .and(path("/v0/models"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "models": ["composer-1.5", "default"]
+        })))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let tool = get_tool("cursor_list_models");
+    let result = tool
+        .execute_with_context(json!({}), &context_with_token(Some("test_key")))
+        .await;
+
+    match result {
+        ToolExecutionResult::Success(value) => {
+            assert_eq!(value["models"][0], "composer-1.5");
+        }
+        other => panic!("Expected success, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn missing_token_prompts_connection() {
+    let tool = get_tool("cursor_get_agent");
+    let result = tool
+        .execute_with_context(json!({"agent_id": "bc_abc123"}), &context_with_token(None))
+        .await;
+
+    match result {
+        ToolExecutionResult::ConnectionRequired { provider } => assert_eq!(provider, "cursor"),
+        other => panic!("Expected ConnectionRequired, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn launch_agent_rejects_empty_prompt() {
+    let tool = get_tool("cursor_launch_agent");
+    let result = tool
+        .execute_with_context(
+            json!({"prompt": "", "repository": "https://github.com/acme/app"}),
+            &context_with_token(Some("test_key")),
+        )
+        .await;
+
+    match result {
+        ToolExecutionResult::ToolError(message) => {
+            assert!(message.contains("Missing required parameter: prompt"));
+        }
+        other => panic!("Expected ToolError, got {other:?}"),
+    }
+}

--- a/specs/integrations.md
+++ b/specs/integrations.md
@@ -47,6 +47,7 @@ Auto-registered via `inventory` plugin system. Each crate has a `SPEC.md`.
 | Daytona | [`integrations/daytona/SPEC.md`](../integrations/daytona/SPEC.md) | Cloud sandbox environments via Daytona REST API. Multiple sandboxes per session. |
 | Deno | [`integrations/deno/SPEC.md`](../integrations/deno/SPEC.md) | Cloud sandbox environments via Deno websocket sandbox API. Multiple sandboxes per session. |
 | Sprites | [`integrations/sprites/SPEC.md`](../integrations/sprites/SPEC.md) | Persistent Firecracker microVMs via Sprites (Fly.io). Persistent filesystem, checkpoints, HTTP services. |
+| Cursor | [`integrations/cursor/SPEC.md`](../integrations/cursor/SPEC.md) | Cursor Cloud Agents API for launching and managing asynchronous coding agents on GitHub repositories. |
 | Docker | `integrations/docker/` | Container-based agent execution. Experimental (Dev only). No spec yet. |
 
 ## Messaging Integrations (`crates/server/`)

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -955,6 +955,20 @@ Deno sandboxes are remote Linux microVMs managed over a websocket + REST control
 | TM-API-015 | Lease metadata exposure | Medium | Deno lease metadata stores only non-secret routing/debug fields (`region`, optional `org`, workspace path, timestamps); tokens still resolve from connections/env at cleanup time | MITIGATED |
 | TM-DENO-004 | Network probing from remote sandbox | High | Capability is Admin-gated; residual exposure depends on operator egress controls | **ACCEPTED** |
 
+## 16B. Cursor Cloud Agents (TM-CURSOR)
+
+Cursor Cloud Agents are third-party asynchronous coding agents that clone GitHub repositories, run commands in Cursor-managed remote environments, push branches, and may create PRs. Everruns calls Cursor's REST API with a user or operator-provided Cursor Cloud Agents API key.
+
+| ID | Threat | Severity | Mitigation | Status |
+|----|--------|----------|------------|--------|
+| TM-CURSOR-001 | Cursor API key captured in chat history | High | Cursor tools return `ConnectionRequired` when no key is configured, causing the inline connection dialog; user connection credentials are encrypted at rest. Operator env fallback is for Doppler-backed deployments/tests. | MITIGATED |
+| TM-CURSOR-002 | Over-scoped Cursor/GitHub repository access | High | Cursor GitHub app access and Cloud Agents API key scope are controlled in Cursor/GitHub; Everruns docs tell users to grant only intended repos. | **CALLER RISK** |
+| TM-CURSOR-003 | Prompt injection or malicious repo content causes remote command/data exfiltration | High | Capability is high-risk/Admin-gated via capability assignment policy; prompts should provide bounded task scope. Residual risk belongs to Cursor's remote agent environment and repository/secret configuration. | **ACCEPTED** |
+| TM-CURSOR-004 | Cost/resource runaway from launching too many Cursor agents | Medium | Cursor enforces account limits; Everruns marks launch as long-running/external and seed prompts tell agents to triage first. Operators/users must monitor Cursor usage. | **CALLER RISK** |
+| TM-CURSOR-005 | Sensitive webhook secret stored in tool call history | High | First release intentionally omits webhook secret support from tool schema; add only with a dedicated secret flow. | MITIGATED |
+| TM-CURSOR-006 | Large prompt or identifier payload causes API/resource abuse | Medium | Tool-side length validation bounds prompt, agent id, ref, model, and branch fields before outbound requests. | MITIGATED |
+| TM-CURSOR-007 | Repository enumeration and rate-limit abuse | Low | `cursor_list_repositories` is read-only but documented as heavily rate-limited; seed prompt instructs agents to prefer explicit repository URLs and use the endpoint sparingly. | MITIGATED |
+
 ## 17. E2B Cloud Sandbox (TM-E2B)
 
 E2B sandboxes are remote Linux environments managed through the E2B Management API plus per-sandbox envd runtime endpoints. Everruns uses a platform-owned `E2B_API_KEY` from environment or session secret override, and stores per-sandbox envd access tokens in session-scoped secrets.

--- a/test_cases/ui/cursor_connection/TC001_cursor_connection_agent_lifecycle.md
+++ b/test_cases/ui/cursor_connection/TC001_cursor_connection_agent_lifecycle.md
@@ -1,0 +1,59 @@
+# TC001: Cursor Connection - Cloud Agent Lifecycle
+
+## Description
+
+Verify that the Cursor Agent Manager prompts for a Cursor API key via the inline connection dialog, validates the key, and can launch then inspect a Cursor Cloud Agent.
+
+## Preconditions
+
+- Server running (`just start-all` recommended)
+- User logged in
+- LLM API key configured
+- No existing Cursor connection in Settings > Connections
+- Valid Cursor Cloud Agents API key available
+- Cursor GitHub app has access to the test repository
+- Use a small test repository where creating a branch/PR is safe
+
+## Test Data
+
+| Field | Value |
+|-------|-------|
+| Agent | Cursor Agent Manager |
+| Repository | `https://github.com/<org>/<safe-test-repo>` |
+| Base Ref | `main` |
+| First Message | Launch a Cursor agent for `<repo>` on `main` that only updates a scratch README note. Use branch `cursor/everruns-smoke-test`, do not auto-create a PR, then report the agent id and status. |
+| Cursor API Key | Valid Cursor Cloud Agents API key |
+| Cleanup Message | Check the Cursor agent status, read the conversation, then delete the Cursor agent record. |
+
+## Steps
+
+1. Navigate to the Agents page and locate **Cursor Agent Manager**
+2. Click **Run** to start a new session
+3. Send the first message from Test Data
+4. Wait for the inline **Setup Connection** card for Cursor
+5. Click **Connect**
+6. Verify the API key dialog mentions Cursor Cloud Agents
+7. Enter the Cursor API key and submit
+8. Wait for the agent to resume and call `cursor_launch_agent`
+9. Verify the response includes a Cursor `agent_id`, Cursor web URL, branch name, and initial status
+10. Send the cleanup message
+11. Verify the agent calls `cursor_get_agent`
+12. Verify the agent calls `cursor_get_conversation`
+13. Verify the agent calls `cursor_delete_agent`
+
+## Expected Result
+
+| Check | Expected |
+|-------|----------|
+| Connection prompt | Inline Cursor setup card appears |
+| Dialog copy | Shows Cursor provider name and Cloud Agents API key guidance |
+| Connection validation | Dialog closes after valid key submission |
+| Agent launched | `cursor_launch_agent` returns a Cursor `agent_id` and web URL |
+| Status check | `cursor_get_agent` returns status without error |
+| Conversation check | `cursor_get_conversation` returns messages |
+| Cleanup | `cursor_delete_agent` returns the deleted agent id |
+
+## Cleanup
+
+- Delete any branch or PR created in the safe test repository
+- Remove the Cursor connection from Settings > Connections if it should not persist


### PR DESCRIPTION
## What
Add a Cursor Cloud Agents integration for managing Cursor background coding agents from Everruns agents.

## Why
Everruns agents should be able to triage work and delegate implementation tasks to Cursor Cloud Agents using a connected Cursor API key.

## How
- Adds a dedicated `everruns-integrations-cursor` crate with a typed Cursor REST client, API-key connection provider, capability registration, narration, and tool hints.
- Adds tools to launch, inspect, follow up, list conversations, delete agents, list models/repositories, and inspect API key metadata.
- Adds the Cursor Agent Manager seed agent, public docs, integration spec, threat model coverage, manual UI test case, unit/integration/live tests, and CI/live sweep wiring.

## Risk
- Medium
- External Cursor API shape or account policy changes can affect tool behavior and live tests. Destructive delete is explicitly marked and scoped by Cursor agent ID.

## Security
- Threat categories reviewed: TM-TOOL, TM-LLM, TM-AGENT, TM-API, TM-DOS, TM-CRYPTO/secret handling, TM-CURSOR.
- Findings and resolutions: API keys are handled through encrypted connections/env/session secrets and are never requested in chat; inputs are bounded; destructive actions are marked; Cursor-specific risks are documented in `specs/threat-model.md`.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] All review comments addressed (code change or written reasoning)

Validation:
- `cargo test -p everruns-integrations-cursor`
- `cargo check -p everruns-server -p everruns-worker`
- server seed tests
- docs check/build
- runtime smoke for capability/tools/provider/example agent
- `doppler run --project everruns-dev --config dev -- cargo test -p everruns-integrations-cursor --features cursor-live-tests --test live_api_test -- --test-threads=1`
- `just pre-push`