### PR TITLE
feat(ui): search organisations in command palette

### DIFF
--- a/apps/ui/src/__tests__/command-palette.test.tsx
+++ b/apps/ui/src/__tests__/command-palette.test.tsx
@@ -1,0 +1,69 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import type React from "react";
+import { Boxes } from "lucide-react";
+import { CommandPalette } from "@/components/command-palette";
+
+const mockSetOpen = jest.fn();
+const mockPush = jest.fn();
+const mockOnSelect = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+  usePathname: () => "/dashboard",
+}));
+
+jest.mock("@base-ui/react/dialog", () => {
+  const ReactRuntime = jest.requireActual<typeof import("react")>("react");
+  return {
+    Dialog: {
+      Root: ({ open, children }: { open: boolean; children: React.ReactNode }) =>
+        open ? ReactRuntime.createElement(ReactRuntime.Fragment, null, children) : null,
+      Portal: ({ children }: { children: React.ReactNode }) =>
+        ReactRuntime.createElement(ReactRuntime.Fragment, null, children),
+      Backdrop: (props: React.HTMLAttributes<HTMLDivElement>) =>
+        ReactRuntime.createElement("div", props),
+      Popup: (props: React.HTMLAttributes<HTMLDivElement>) =>
+        ReactRuntime.createElement("div", props),
+    },
+  };
+});
+
+jest.mock("@/hooks/use-command-palette", () => ({
+  useCommandPalette: () => ({
+    open: true,
+    setOpen: mockSetOpen,
+  }),
+}));
+
+jest.mock("@/hooks/use-global-search", () => ({
+  useGlobalSearch: () => [
+    {
+      id: "organization:org_second",
+      category: "organization",
+      icon: Boxes,
+      title: "Second Org",
+      subtitle: "Switch organisation > org_second",
+      href: "/settings/organisations",
+      onSelect: mockOnSelect,
+    },
+  ],
+}));
+
+describe("CommandPalette", () => {
+  beforeEach(() => {
+    window.HTMLElement.prototype.scrollIntoView = jest.fn();
+    mockSetOpen.mockClear();
+    mockPush.mockClear();
+    mockOnSelect.mockClear();
+  });
+
+  it("runs a search result action directly instead of routing", () => {
+    render(<CommandPalette />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Second Org/i }));
+
+    expect(mockSetOpen).toHaveBeenCalledWith(false);
+    expect(mockOnSelect).toHaveBeenCalled();
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ui/src/__tests__/use-global-search.test.tsx
+++ b/apps/ui/src/__tests__/use-global-search.test.tsx
@@ -1,0 +1,91 @@
+import { act, renderHook } from "@testing-library/react";
+import { useGlobalSearch } from "@/hooks/use-global-search";
+import type { OrganizationMembership } from "@/lib/api/types";
+
+jest.mock("@/hooks/use-agents", () => ({
+  useAgents: () => ({ data: [] }),
+}));
+jest.mock("@/hooks/use-sessions", () => ({
+  useSessions: () => ({ data: { data: [] } }),
+}));
+jest.mock("@/hooks/use-harnesses", () => ({
+  useHarnesses: () => ({ data: [] }),
+}));
+jest.mock("@/hooks/use-skills", () => ({
+  useSkills: () => ({ data: [] }),
+}));
+jest.mock("@/hooks/use-mcp-servers", () => ({
+  useMcpServers: () => ({ data: [] }),
+}));
+jest.mock("@/hooks/use-capabilities", () => ({
+  useCapabilities: () => ({ data: [] }),
+  useDeclarativeCapabilities: () => ({ data: [] }),
+}));
+jest.mock("@/hooks/use-evals", () => ({
+  useEvals: () => ({ data: [] }),
+}));
+jest.mock("@/hooks/use-apps", () => ({
+  useApps: () => ({ data: [] }),
+}));
+jest.mock("@/hooks/use-agent-identities", () => ({
+  useAgentIdentities: () => ({ data: [] }),
+}));
+
+const mockSetCurrentOrg = jest.fn();
+
+const mockCurrentOrg: OrganizationMembership = {
+  public_id: "org_current",
+  name: "Current Org",
+  role: "owner",
+};
+
+const mockSecondOrg: OrganizationMembership = {
+  public_id: "org_second",
+  name: "Second Org",
+  role: "member",
+};
+
+jest.mock("@/providers/org-provider", () => ({
+  useOrg: () => ({
+    currentOrg: mockCurrentOrg,
+    organizations: [mockCurrentOrg, mockSecondOrg],
+    setCurrentOrg: mockSetCurrentOrg,
+  }),
+}));
+
+describe("useGlobalSearch", () => {
+  beforeEach(() => {
+    mockSetCurrentOrg.mockClear();
+  });
+
+  it("finds organizations and switches to the selected organization", () => {
+    const { result } = renderHook(() => useGlobalSearch("second"));
+
+    const orgResult = result.current.find((item) => item.category === "organization");
+
+    expect(orgResult).toMatchObject({
+      id: "organization:org_second",
+      title: "Second Org",
+      subtitle: "Switch organisation > org_second",
+    });
+
+    act(() => {
+      orgResult?.onSelect?.();
+    });
+
+    expect(mockSetCurrentOrg).toHaveBeenCalledWith(mockSecondOrg);
+  });
+
+  it("marks the current organization without attaching a switch action", () => {
+    const { result } = renderHook(() => useGlobalSearch("current"));
+
+    const orgResult = result.current.find((item) => item.category === "organization");
+
+    expect(orgResult).toMatchObject({
+      id: "organization:org_current",
+      title: "Current Org",
+      subtitle: "Current organisation > org_current",
+    });
+    expect(orgResult?.onSelect).toBeUndefined();
+  });
+});

--- a/apps/ui/src/components/command-palette.tsx
+++ b/apps/ui/src/components/command-palette.tsx
@@ -30,12 +30,14 @@ const CATEGORY_LABELS: Record<SearchResultCategory, string> = {
   mcp_server: "MCP Servers",
   app: "Apps",
   eval: "Evals",
+  organization: "Organisations",
   id: "Go to",
 };
 
 const CATEGORY_ORDER: SearchResultCategory[] = [
   "id",
   "navigation",
+  "organization",
   "agent",
   "agent_identity",
   "session",
@@ -103,6 +105,10 @@ export function CommandPalette() {
   const navigate = useCallback(
     (result: SearchResult) => {
       setOpen(false);
+      if (result.onSelect) {
+        result.onSelect();
+        return;
+      }
       router.push(result.href);
     },
     [router, setOpen],
@@ -163,7 +169,7 @@ export function CommandPalette() {
                 ref={inputRef}
                 value={query}
                 onChange={(e) => setQuery(e.target.value)}
-                placeholder="Search pages, agents, sessions..."
+                placeholder="Search pages, organisations, agents..."
                 className="flex-1 bg-transparent py-3.5 text-sm outline-none placeholder:text-muted-foreground"
               />
               <kbd className="hidden sm:inline-flex h-5 items-center gap-1 border bg-muted px-1.5 font-mono text-[10px] font-medium text-muted-foreground">

--- a/apps/ui/src/hooks/use-global-search.ts
+++ b/apps/ui/src/hooks/use-global-search.ts
@@ -3,16 +3,17 @@
  *
  * Sources:
  * 1. Static navigation pages (always available, no fetch)
- * 2. Agents (client-side filter over cached list)
- * 3. Sessions (client-side filter over first page)
- * 4. Harnesses (client-side filter over cached list)
- * 5. Skills (client-side filter over cached list)
- * 6. MCP Servers (client-side filter over cached list)
- * 7. Capabilities (client-side filter over cached list)
- * 8. ID-based lookup (detects prefixed IDs and provides direct navigation)
- * 9. Evals (client-side filter over cached list)
- * 10. Apps (client-side filter over cached list)
- * 11. Agent Identities (client-side filter over cached list)
+ * 2. Organizations (client-side filter over authenticated user's memberships)
+ * 3. Agents (client-side filter over cached list)
+ * 4. Sessions (client-side filter over first page)
+ * 5. Harnesses (client-side filter over cached list)
+ * 6. Skills (client-side filter over cached list)
+ * 7. MCP Servers (client-side filter over cached list)
+ * 8. Capabilities (client-side filter over cached list)
+ * 9. ID-based lookup (detects prefixed IDs and provides direct navigation)
+ * 10. Evals (client-side filter over cached list)
+ * 11. Apps (client-side filter over cached list)
+ * 12. Agent Identities (client-side filter over cached list)
  *
  * All entity searches are client-side over already-fetched React Query data.
  * Backend search endpoints are available for server-side filtering when needed.

--- a/apps/ui/src/hooks/use-global-search.ts
+++ b/apps/ui/src/hooks/use-global-search.ts
@@ -39,6 +39,7 @@ import {
   FlaskConical,
   Cpu,
   HardDrive,
+  Building2,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { useAgents } from "@/hooks/use-agents";
@@ -51,6 +52,7 @@ import { useEvals } from "@/hooks/use-evals";
 import { useApps } from "@/hooks/use-apps";
 import { useAgentIdentities } from "@/hooks/use-agent-identities";
 import { getDisplayName } from "@/lib/entity-lifecycle";
+import { useOrg } from "@/providers/org-provider";
 
 export type SearchResultCategory =
   | "navigation"
@@ -63,6 +65,7 @@ export type SearchResultCategory =
   | "capability"
   | "app"
   | "eval"
+  | "organization"
   | "id";
 
 export interface SearchResult {
@@ -73,6 +76,7 @@ export interface SearchResult {
   /** Breadcrumb-style subtitle, e.g. "Agents > Daytona Coder" */
   subtitle?: string;
   href: string;
+  onSelect?: () => void;
 }
 
 interface NavigationPage {
@@ -249,6 +253,7 @@ function matchesTokens(tokens: string[], ...texts: (string | undefined | null)[]
 const EMPTY_ARRAY: never[] = [];
 
 export function useGlobalSearch(query: string) {
+  const { currentOrg, organizations, setCurrentOrg } = useOrg();
   const { data: agentsData } = useAgents();
   const { data: sessionsData } = useSessions(undefined, { limit: 100 });
   const { data: harnessesData } = useHarnesses();
@@ -348,7 +353,36 @@ export function useGlobalSearch(query: string) {
       }
     }
 
-    // 3. Agents
+    // 3. Organizations
+    let orgCount = 0;
+    for (const org of organizations) {
+      if (orgCount >= MAX_PER_CATEGORY) break;
+      const isCurrent = currentOrg?.public_id === org.public_id;
+      if (
+        matchesTokens(
+          tokens,
+          org.name,
+          org.public_id,
+          org.role,
+          "organization organisation org team tenant switch",
+        )
+      ) {
+        results.push({
+          id: `organization:${org.public_id}`,
+          category: "organization",
+          icon: Building2,
+          title: org.name,
+          subtitle: isCurrent
+            ? `Current organisation > ${org.public_id}`
+            : `Switch organisation > ${org.public_id}`,
+          href: "/settings/organisations",
+          onSelect: isCurrent ? undefined : () => setCurrentOrg(org),
+        });
+        orgCount++;
+      }
+    }
+
+    // 4. Agents
     let agentCount = 0;
     for (const agent of agents) {
       if (agentCount >= MAX_PER_CATEGORY) break;
@@ -368,7 +402,7 @@ export function useGlobalSearch(query: string) {
       }
     }
 
-    // 4. Sessions
+    // 5. Sessions
     let sessionCount = 0;
     for (const session of sessions) {
       if (sessionCount >= MAX_PER_CATEGORY) break;
@@ -386,7 +420,7 @@ export function useGlobalSearch(query: string) {
       }
     }
 
-    // 5. Harnesses
+    // 6. Harnesses
     let harnessCount = 0;
     for (const harness of harnesses) {
       if (harnessCount >= MAX_PER_CATEGORY) break;
@@ -413,7 +447,7 @@ export function useGlobalSearch(query: string) {
       }
     }
 
-    // 6. Skills
+    // 7. Skills
     let skillCount = 0;
     for (const skill of skills) {
       if (skillCount >= MAX_PER_CATEGORY) break;
@@ -430,7 +464,7 @@ export function useGlobalSearch(query: string) {
       }
     }
 
-    // 7. MCP Servers
+    // 8. MCP Servers
     let mcpCount = 0;
     for (const server of mcpServers) {
       if (mcpCount >= MAX_PER_CATEGORY) break;
@@ -447,7 +481,7 @@ export function useGlobalSearch(query: string) {
       }
     }
 
-    // 8. Capabilities
+    // 9. Capabilities
     let capabilityCount = 0;
     for (const capability of capabilities) {
       if (capabilityCount >= MAX_PER_CATEGORY) break;
@@ -473,7 +507,7 @@ export function useGlobalSearch(query: string) {
       }
     }
 
-    // 8b. Declarative capability resources by public ID/display name
+    // 9b. Declarative capability resources by public ID/display name
     for (const capability of declarativeCapabilities) {
       if (capabilityCount >= MAX_PER_CATEGORY) break;
       if (
@@ -500,7 +534,7 @@ export function useGlobalSearch(query: string) {
       }
     }
 
-    // 9. Evals
+    // 10. Evals
     let evalCount = 0;
     for (const ev of evals) {
       if (evalCount >= MAX_PER_CATEGORY) break;
@@ -517,7 +551,7 @@ export function useGlobalSearch(query: string) {
       }
     }
 
-    // 10. Apps
+    // 11. Apps
     let appCount = 0;
     for (const app of apps) {
       if (appCount >= MAX_PER_CATEGORY) break;
@@ -534,7 +568,7 @@ export function useGlobalSearch(query: string) {
       }
     }
 
-    // 11. Agent Identities
+    // 12. Agent Identities
     let identityCount = 0;
     for (const identity of agentIdentities) {
       if (identityCount >= MAX_PER_CATEGORY) break;
@@ -556,6 +590,9 @@ export function useGlobalSearch(query: string) {
     return results;
   }, [
     query,
+    currentOrg?.public_id,
+    organizations,
+    setCurrentOrg,
     agents,
     sessions,
     harnesses,

--- a/test_cases/ui/global_search/TC001_command_palette_ui.md
+++ b/test_cases/ui/global_search/TC001_command_palette_ui.md
@@ -8,6 +8,7 @@ Verify the Cmd+K / Ctrl+K command palette opens, shows navigation pages by defau
 
 - UI running (dev or full mode)
 - At least 1 agent and 1 session exist
+- User belongs to at least 2 organisations
 
 ## Steps
 
@@ -19,6 +20,8 @@ Verify the Cmd+K / Ctrl+K command palette opens, shows navigation pages by defau
 6. Open palette again, press Escape — verify palette closes
 7. Type a long poem — verify no hang, shows "No results" message
 8. Type an entity ID prefix (e.g. `agent_`) — verify "Go to" section appears
+9. Search for another organisation by name — verify it appears under "Organisations"
+10. Select that organisation — verify the current organisation switches without going to settings
 
 ## Expected Result
 
@@ -29,3 +32,4 @@ Verify the Cmd+K / Ctrl+K command palette opens, shows navigation pages by defau
 - Step 6: Palette closes on Escape
 - Step 7: "No results" displayed promptly (no lag)
 - Step 8: ID-based lookup result with "Go to Agent" label
+- Steps 9-10: Palette closes and the selected organisation becomes current


### PR DESCRIPTION
## What
Add organisation results to the global command palette and let users switch directly from those search results.

## Why
Users who belong to multiple organisations should be able to jump between them through Cmd+K instead of navigating to settings first.

## How
- Search the existing org-provider membership list alongside other command palette sources.
- Add a command palette result action path so selecting an organisation invokes the existing `setCurrentOrg` switch flow instead of routing.
- Cover organisation search/switch behavior with focused tests and update the manual command palette test case.

## Risk
- Low
- Command palette result selection could route incorrectly or fail to switch orgs; covered by unit tests and browser smoke.

## Security
- Threat categories reviewed: TM-TENANT, TM-WEB.
- Findings and resolutions: No new backend endpoint or broader data access. Results are limited to organisations already present in the authenticated user's membership list, and switching uses the existing org switch API/context path.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
