### PR TITLE
test(worker): scaffold turmoil-based transport reliability tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2571,6 +2571,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.22.1",
+ "bytes",
  "chrono",
  "everruns-anthropic",
  "everruns-config",
@@ -2605,6 +2606,7 @@ dependencies = [
  "tonic",
  "tracing",
  "tracing-subscriber",
+ "turmoil",
  "url",
  "uuid 1.23.1",
 ]
@@ -6565,6 +6567,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8174,6 +8182,21 @@ dependencies = [
  "rand 0.9.4",
  "sha1 0.10.6",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "turmoil"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0061c28f1469e94771bb8aa626ce6b29265c2fb5034115046a170b0cba2e33d2"
+dependencies = [
+ "bytes",
+ "indexmap",
+ "rand 0.9.4",
+ "rand_distr",
+ "scoped-tls",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2571,7 +2571,6 @@ dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.22.1",
- "bytes",
  "chrono",
  "everruns-anthropic",
  "everruns-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,6 +141,11 @@ tonic-prost-build = "0.14"
 
 # Protocol Buffers (used by tonic/gRPC)
 prost = "0.14"
+
+# Deterministic network simulation (dev-only). Used to test worker↔control-plane
+# transport reliability (drops, partitions, latency, reorder) with a simulated
+# clock. See specs/agent-reliability-tests.md scenario 3.
+turmoil = "0.7"
 prost-build = "0.14"
 prost-types = "0.14"
 

--- a/crates/worker/Cargo.toml
+++ b/crates/worker/Cargo.toml
@@ -50,3 +50,11 @@ url = "2.5"
 # gRPC dependencies
 tonic.workspace = true
 prost-types.workspace = true
+
+[dev-dependencies]
+# Deterministic network simulator. Used by tests/network_reliability_test.rs to
+# exercise worker↔control-plane transport faults (partitions, latency, reorder)
+# with a simulated clock. See specs/agent-reliability-tests.md scenario 3.
+turmoil.workspace = true
+tokio = { workspace = true }
+bytes = "1"

--- a/crates/worker/Cargo.toml
+++ b/crates/worker/Cargo.toml
@@ -57,4 +57,3 @@ prost-types.workspace = true
 # with a simulated clock. See specs/agent-reliability-tests.md scenario 3.
 turmoil.workspace = true
 tokio = { workspace = true }
-bytes = "1"

--- a/crates/worker/tests/network_reliability_test.rs
+++ b/crates/worker/tests/network_reliability_test.rs
@@ -5,13 +5,14 @@
 // model because it injects at the store layer rather than the transport.
 //
 // What this file currently exercises:
-//   * Two simulated hosts ("cp", "worker") communicating over turmoil's TCP
-//     shim, modelling a heartbeat-like request/response loop.
-//   * `partition` / `repair` to verify the worker observes I/O errors during
+//   * One simulated host ("cp") and one simulated client ("driver")
+//     communicating over turmoil's TCP shim, modelling a heartbeat-like
+//     request/response loop.
+//   * `partition` / `repair` to verify the client observes I/O errors during
 //     an outage and reconnects after recovery.
 //
 // Next step (not yet wired): drive the real tonic `WorkerService` client from
-// `everruns-worker::grpc_durable_store` through turmoil. That requires a
+// `everruns_worker::grpc_durable_store` through turmoil. That requires a
 // custom tonic connector that calls `turmoil::net::TcpStream::connect` instead
 // of `tokio::net::TcpStream::connect`. See turmoil's `examples/grpc.rs`.
 

--- a/crates/worker/tests/network_reliability_test.rs
+++ b/crates/worker/tests/network_reliability_test.rs
@@ -1,0 +1,108 @@
+// Scaffold for worker↔control-plane transport-fault tests using `turmoil`
+// (https://github.com/tokio-rs/turmoil). Covers scenario 3 of
+// specs/agent-reliability-tests.md: deterministic network partitions, latency,
+// and reorder between the worker and the control plane, which `fail-rs` cannot
+// model because it injects at the store layer rather than the transport.
+//
+// What this file currently exercises:
+//   * Two simulated hosts ("cp", "worker") communicating over turmoil's TCP
+//     shim, modelling a heartbeat-like request/response loop.
+//   * `partition` / `repair` to verify the worker observes I/O errors during
+//     an outage and reconnects after recovery.
+//
+// Next step (not yet wired): drive the real tonic `WorkerService` client from
+// `everruns-worker::grpc_durable_store` through turmoil. That requires a
+// custom tonic connector that calls `turmoil::net::TcpStream::connect` instead
+// of `tokio::net::TcpStream::connect`. See turmoil's `examples/grpc.rs`.
+
+use std::io;
+use std::net::{IpAddr, Ipv4Addr};
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use turmoil::Builder;
+use turmoil::net::{TcpListener, TcpStream};
+
+const CP_PORT: u16 = 9001;
+
+/// Minimal "control plane": accepts a connection and echoes a single byte per
+/// request. Stands in for a heartbeat RPC handler until the real tonic server
+/// is wired through turmoil's connector.
+async fn run_control_plane() -> turmoil::Result {
+    let listener = TcpListener::bind((IpAddr::V4(Ipv4Addr::UNSPECIFIED), CP_PORT)).await?;
+    loop {
+        let (mut sock, _peer) = listener.accept().await?;
+        tokio::spawn(async move {
+            let mut buf = [0u8; 1];
+            while sock.read_exact(&mut buf).await.is_ok() {
+                if sock.write_all(&buf).await.is_err() {
+                    break;
+                }
+            }
+        });
+    }
+}
+
+async fn heartbeat_once() -> io::Result<()> {
+    let mut sock = TcpStream::connect(("cp", CP_PORT)).await?;
+    sock.write_all(&[1u8]).await?;
+    let mut buf = [0u8; 1];
+    sock.read_exact(&mut buf).await?;
+    Ok(())
+}
+
+/// Partition mid-flight, then repair: the worker's heartbeat must fail during
+/// the partition and succeed after `repair`. Mirrors scenario 3's "extended
+/// outage" variant from specs/agent-reliability-tests.md.
+///
+/// `turmoil::partition` and `turmoil::repair` resolve the world via a
+/// thread-local that is only set while a host/client task is running, so the
+/// driver itself runs as a client.
+#[test]
+fn heartbeat_survives_partition_and_repair() {
+    let mut sim = Builder::new().build();
+    sim.host("cp", run_control_plane);
+
+    sim.client("driver", async move {
+        heartbeat_once().await.expect("healthy heartbeat");
+
+        turmoil::partition("driver", "cp");
+        let during = heartbeat_once().await;
+        assert!(
+            during.is_err(),
+            "heartbeat must fail while partitioned, got {during:?}"
+        );
+
+        turmoil::repair("driver", "cp");
+        heartbeat_once()
+            .await
+            .expect("heartbeat recovers after repair");
+        Ok(())
+    });
+
+    sim.run().unwrap();
+}
+
+/// Smoke test: a clean run with no faults must succeed. Guards against
+/// turmoil-version regressions in the simulator setup itself.
+#[test]
+fn heartbeat_clean_run() {
+    let mut sim = Builder::new().build();
+    sim.host("cp", run_control_plane);
+    sim.client("worker", async {
+        for _ in 0..5 {
+            heartbeat_once().await?;
+        }
+        Ok(())
+    });
+    sim.run().unwrap();
+}
+
+// TODO(turmoil-grpc): replace the byte-echo control plane with the real tonic
+// WorkerService and drive `GrpcDurableStore` from the client side. Plan:
+//   1. Build a `tonic::transport::Channel` via `Endpoint::connect_with_connector`,
+//      passing a `tower::service_fn` that returns
+//      `turmoil::net::TcpStream::connect((host, port))`.
+//   2. Serve `WorkerServiceServer` on a `turmoil::net::TcpListener` inside the
+//      "cp" host.
+//   3. Port scenario 3 variants from specs/agent-reliability-tests.md:
+//      transient failure, extended outage, late completion → TaskNotOwned.

--- a/specs/agent-reliability-tests.md
+++ b/specs/agent-reliability-tests.md
@@ -51,7 +51,10 @@ stabilized.
 
 **What happens in production:** gRPC connection drops. Worker detects stream disconnect, falls back to polling, attempts reconnection with exponential backoff (1s→60s). Tasks in flight continue executing locally but can't report completion. If heartbeat times out, tasks are reclaimed. When network recovers, worker reconnects and late completions get `TaskNotOwned` (idempotent).
 
-**Test approach:** Use failpoints in the persistence layer to simulate gRPC failures (since gRPC ultimately calls store operations). Test sequences: claim succeeds → complete fails → retry complete → verify idempotent; claim fails → retry → succeeds.
+**Test approach:** Two complementary layers.
+
+1. **Store-layer failpoints** (existing): use `fail-rs` failpoints in the persistence layer to simulate gRPC-induced store failures. Test sequences: claim succeeds → complete fails → retry complete → verify idempotent; claim fails → retry → succeeds.
+2. **Transport-layer simulation** (in progress): use [`turmoil`](https://github.com/tokio-rs/turmoil) to drop, partition, and reorder packets between worker and control plane with a simulated clock. Scaffold lives at `crates/worker/tests/network_reliability_test.rs`. Currently exercises a TCP heartbeat loop; the next step is wiring the real tonic `WorkerService` through a turmoil connector so the actual `GrpcDurableStore` client retry/backoff paths are covered. This adds determinism that fail-rs cannot provide for transport faults (RST mid-stream, latency spikes, message reorder).
 
 **Variants:**
 - Transient failure (1 failure then success)


### PR DESCRIPTION
## What
Adds [`turmoil`](https://github.com/tokio-rs/turmoil) as a workspace dev-dependency (worker crate only) and an initial test module at `crates/worker/tests/network_reliability_test.rs` that exercises a TCP heartbeat loop between two simulated hosts (`cp`, `worker`) with deterministic `partition` / `repair`.

## Why
Scenario 3 of `specs/agent-reliability-tests.md` ("Network Between Control Plane and Worker") is currently covered only at the store layer via `fail-rs` failpoints. That cannot model real transport faults — TCP RST mid-stream, latency spikes, message reorder, reconnect/backoff under sustained partition. `turmoil` provides a deterministic discrete-event simulator on top of tokio's net types, which fills that gap.

This PR is the foundation; it lands the dependency, proves the simulator works against our test infra, and documents the next step (wiring the real tonic `WorkerService` through a turmoil connector).

## How
- Add `turmoil = "0.7"` to `[workspace.dependencies]` and to `[dev-dependencies]` in `crates/worker/Cargo.toml`.
- New test file with two tests:
  - `heartbeat_clean_run` — smoke test, guards against simulator setup regressions.
  - `heartbeat_survives_partition_and_repair` — partitions the driver from the control plane, asserts the heartbeat fails, repairs, asserts it recovers. Driver runs as a `client` so `turmoil::partition` / `repair` resolve the world thread-local correctly.
- Spec note in `specs/agent-reliability-tests.md` describing the two-layer (store + transport) approach for scenario 3.
- TODO in the test file with the concrete plan for wiring tonic via `Endpoint::connect_with_connector` + `tower::service_fn` returning `turmoil::net::TcpStream::connect`.

## Risk
- Low.
- Dev-dependency-only; no production code paths touched.
- Two new tests, both passing locally.

## Validation
- `cargo test -p everruns-worker --test network_reliability_test` — both tests pass.
- `./scripts/lib/pre-push.sh` — clean (fmt, clippy, lockfile, migration ordering, author).
- Branch rebased onto latest `origin/main`.

## Security
- Threat categories reviewed: none — no production code, configuration, or trust-boundary changes. Only a dev-dependency and test-only code.
- Supply chain: `turmoil` is maintained by tokio-rs; pulled into `[dev-dependencies]` only, so it never ships with production binaries.
- Findings: none.

## Follow-ups
- Wire the real tonic `WorkerService` server through `turmoil::net::TcpListener` and a custom `tonic::transport::Endpoint` connector, then port scenario 3 variants from the spec (transient failure, extended outage, late completion → `TaskNotOwned`). Tracked as `TODO(turmoil-grpc)` in the test file. Deferred because it requires non-trivial connector plumbing and is best landed once the simulator scaffold is on `main`.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (test-only)
- [x] Security review performed against relevant threat model categories
- [ ] All review comments addressed (code change or written reasoning)


---
_Generated by [Claude Code](https://claude.ai/code/session_017A7FtAo1348omyNdirMx3d)_