### PR TITLE
fix(cursor): remove global api key fallback

### DIFF
--- a/docs/integrations/cursor.md
+++ b/docs/integrations/cursor.md
@@ -31,8 +31,6 @@ Use a Cloud Agents API key. A general Cursor dashboard API key may not be enough
 3. Click **Connect**
 4. Paste the Cloud Agents API key
 
-Operators can also provide `CURSOR_API_KEY` through Doppler for managed deployments and live tests.
-
 ### 3. Use in Sessions
 
 Agents with the Cursor capability can use these tools:

--- a/integrations/cursor/SPEC.md
+++ b/integrations/cursor/SPEC.md
@@ -14,8 +14,11 @@ Primary use case: a user configures an orchestration agent that investigates an 
 - API base: `https://api.cursor.com`
 - Credential sources:
   1. User connection token from Settings > Connections
-  2. Operator env var `CURSOR_API_KEY` for Doppler-backed deployments and live tests
-  3. Session secret `CURSOR_API_KEY` as a compatibility fallback
+  2. Session secret `CURSOR_API_KEY` (per-session opt-in)
+
+  The previous process-wide `CURSOR_API_KEY` env-var fallback was removed:
+  it let any session inherit an operator key and access account-wide Cursor
+  resources, which violates per-session credential boundaries.
 
 The crate uses Cursor's public Background/Cloud Agents REST API directly. Cursor's public docs do not publish an official Rust SDK, so the integration keeps a small typed `reqwest` client in `src/client.rs`.
 

--- a/integrations/cursor/src/lib.rs
+++ b/integrations/cursor/src/lib.rs
@@ -2,8 +2,9 @@
 //!
 //! Decision: use Cursor's public Background/Cloud Agents REST API directly.
 //! Cursor does not publish an official Rust client in the public API docs.
-//! Decision: API key resolves from user connections first, then operator env
-//! `CURSOR_API_KEY` for managed/Doppler-backed deployments and live tests.
+//! Decision: API key resolves from user connections first, then a per-session
+//! `CURSOR_API_KEY` session secret. The previous process-wide env-var
+//! fallback was removed to enforce per-session credential boundaries.
 
 pub mod client;
 pub mod connection;
@@ -84,7 +85,7 @@ impl Capability for CursorCapability {
 Use Cursor tools to delegate coding work to asynchronous Cursor Cloud Agents.
 
 Prerequisites:
-- Cursor Cloud Agents API key configured in Settings > Connections, or operator-provided `CURSOR_API_KEY`.
+- Cursor Cloud Agents API key configured in Settings > Connections (or a per-session `CURSOR_API_KEY` session secret).
 - Cursor GitHub app must have access to the target repository.
 
 Recommended workflow:

--- a/integrations/cursor/src/tools.rs
+++ b/integrations/cursor/src/tools.rs
@@ -28,7 +28,6 @@ async fn get_api_key(context: &ToolContext) -> Result<String, ToolExecutionResul
         }
     }
 
-
     if let Some(storage) = context.storage_store.as_ref() {
         match storage
             .get_secret(context.session_id, CURSOR_API_KEY_SECRET)

--- a/integrations/cursor/src/tools.rs
+++ b/integrations/cursor/src/tools.rs
@@ -28,11 +28,6 @@ async fn get_api_key(context: &ToolContext) -> Result<String, ToolExecutionResul
         }
     }
 
-    if let Ok(key) = std::env::var(CURSOR_API_KEY_SECRET)
-        && !key.trim().is_empty()
-    {
-        return Ok(key);
-    }
 
     if let Some(storage) = context.storage_store.as_ref() {
         match storage

--- a/integrations/cursor/src/tools.rs
+++ b/integrations/cursor/src/tools.rs
@@ -723,3 +723,30 @@ impl Tool for CursorKeyInfoTool {
         }
     }
 }
+
+#[cfg(test)]
+mod auth_tests {
+    use super::*;
+    use everruns_core::SessionId;
+
+    /// Regression: ensure tool auth no longer falls back to the process-wide
+    /// `CURSOR_API_KEY` env var. When no session-scoped credential is
+    /// available, `get_api_key` must surface `ConnectionRequired` even if the
+    /// env var is set, so the per-session credential boundary cannot be
+    /// reintroduced accidentally.
+    #[tokio::test]
+    async fn get_api_key_does_not_fall_back_to_global_env_var() {
+        // SAFETY: single-threaded test, no other code reads CURSOR_API_KEY here.
+        unsafe { std::env::set_var(CURSOR_API_KEY_SECRET, "should-not-be-used") };
+        let ctx = ToolContext::new(SessionId::new());
+        let err = get_api_key(&ctx).await.unwrap_err();
+        // SAFETY: same guarantee as set_var above; clean up before assert.
+        unsafe { std::env::remove_var(CURSOR_API_KEY_SECRET) };
+        match err {
+            ToolExecutionResult::ConnectionRequired { provider } => {
+                assert_eq!(provider, CURSOR_CONNECTION_PROVIDER);
+            }
+            other => panic!("expected ConnectionRequired, got {other:?}"),
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- The Cursor integration previously fell back to a process-wide `CURSOR_API_KEY` when a session had no connection, allowing sessions to inherit an operator key and access or mutate account-wide Cursor resources.
- Enforce per-session credential boundaries to prevent leakage of repository/agent metadata and destructive cross-session actions.

### Description
- Remove the environment-variable fallback from `get_api_key` in `integrations/cursor/src/tools.rs` so tools now require a session-scoped connection token or a session secret.
- Update `docs/integrations/cursor.md` to remove the guidance that recommended providing `CURSOR_API_KEY` for managed deployments.
- Preserve existing tool interfaces and behavior when a valid session credential is present, returning a connection-required error otherwise.

### Testing
- Invoked `cargo test -p everruns-integrations-cursor --no-run` to compile the crate; dependency resolution and compilation started but did not complete in this environment.
- A full CI/local `just pre-push` run is required to complete unit, integration, and live-test sweeps before merging to ensure all tests pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcf09c8f3c832ba9d94b59f199efd0)