### PR TITLE
fix(ui): block unsafe memory image media types

### DIFF
--- a/apps/ui/src/app/(main)/memory-stores/page.tsx
+++ b/apps/ui/src/app/(main)/memory-stores/page.tsx
@@ -500,6 +500,22 @@ function MemoryContentPartView({ part }: { part: MemoryContentPart }) {
     );
   }
   if (part.type === "image") {
+    const SAFE_MEMORY_IMAGE_MEDIA_TYPES = new Set([
+      "image/png",
+      "image/jpeg",
+      "image/gif",
+      "image/webp",
+      "image/bmp",
+      "image/x-icon",
+      "image/vnd.microsoft.icon",
+    ]);
+    if (!SAFE_MEMORY_IMAGE_MEDIA_TYPES.has(part.media_type.toLowerCase())) {
+      return (
+        <div className="rounded-md border bg-muted/30 p-3 text-sm text-muted-foreground">
+          Unsupported image media type: {part.media_type}
+        </div>
+      );
+    }
     const src = `data:${part.media_type};base64,${part.base64}`;
     return (
       <div className="rounded-md border bg-muted/30 p-2">

--- a/apps/ui/src/app/(main)/memory-stores/page.tsx
+++ b/apps/ui/src/app/(main)/memory-stores/page.tsx
@@ -491,6 +491,19 @@ function MemoryDetailDrawer({
   );
 }
 
+// Allowlist of safe raster MIME types for inline `<img>` rendering. SVG is
+// intentionally excluded — it can execute script in the authenticated UI
+// context. Hoisted to module scope so we don't allocate a Set per render.
+const SAFE_MEMORY_IMAGE_MEDIA_TYPES = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/gif",
+  "image/webp",
+  "image/bmp",
+  "image/x-icon",
+  "image/vnd.microsoft.icon",
+]);
+
 function MemoryContentPartView({ part }: { part: MemoryContentPart }) {
   if (part.type === "text") {
     return (
@@ -500,15 +513,6 @@ function MemoryContentPartView({ part }: { part: MemoryContentPart }) {
     );
   }
   if (part.type === "image") {
-    const SAFE_MEMORY_IMAGE_MEDIA_TYPES = new Set([
-      "image/png",
-      "image/jpeg",
-      "image/gif",
-      "image/webp",
-      "image/bmp",
-      "image/x-icon",
-      "image/vnd.microsoft.icon",
-    ]);
     if (!SAFE_MEMORY_IMAGE_MEDIA_TYPES.has(part.media_type.toLowerCase())) {
       return (
         <div className="rounded-md border bg-muted/30 p-3 text-sm text-muted-foreground">


### PR DESCRIPTION
### Motivation
- A stored XSS risk was introduced by rendering memory image parts into an unsandboxed `<img>` using `data:${part.media_type};base64,...`, which allows `image/svg+xml` payloads to execute script in the authenticated UI context.
- The project already documents that SVG previews must be sandboxed in an iframe, so the memory drawer must not reintroduce the unsafe `img`-based SVG rendering path.

### Description
- Add a strict allowlist of safe raster MIME types in `MemoryContentPartView` and refuse to render unsupported media types (including `image/svg+xml`) in the Memory detail drawer.
- Render a neutral fallback message for unsupported image media types instead of passing untrusted `media_type` and bytes to an `<img>` data URL.
- Preserve existing inline `img` rendering for known-safe raster types (`image/png`, `image/jpeg`, `image/gif`, `image/webp`, `image/bmp`, `image/x-icon`, `image/vnd.microsoft.icon`).
- Modified file: `apps/ui/src/app/(main)/memory-stores/page.tsx` where `MemoryContentPartView` is defined.

### Testing
- Attempted to run the UI linter with `npm run lint -- --file src/app/(main)/memory-stores/page.tsx`, which failed in this environment because the `oxlint` binary is not available.
- Baseline remote-sync and CI checks could not be executed because the environment does not have an accessible repository remote configured for full validation.
- No unit or integration tests were run in this environment; the change is intentionally small and UI-scoped to minimize risk and preserve existing raster image previews.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fca0791ecc832bb0a6ce15cb145ab6)