### PR TITLE
fix(memory): honor capability store config in memory tools

### DIFF
--- a/crates/core/src/capabilities/persistent_memory.rs
+++ b/crates/core/src/capabilities/persistent_memory.rs
@@ -55,10 +55,19 @@ impl Capability for MemoryCapability {
     }
 
     fn tools(&self) -> Vec<Box<dyn Tool>> {
+        self.tools_with_config(&Value::Null)
+    }
+
+    fn tools_with_config(&self, config: &Value) -> Vec<Box<dyn Tool>> {
+        let config = MemoryConfig::from_json(config);
         vec![
-            Box::new(RememberTool),
-            Box::new(RecallTool),
-            Box::new(ForgetTool),
+            Box::new(RememberTool {
+                config: config.clone(),
+            }),
+            Box::new(RecallTool {
+                config: config.clone(),
+            }),
+            Box::new(ForgetTool { config }),
         ]
     }
 
@@ -177,7 +186,18 @@ async fn resolve_store_id(
 // Remember Tool
 // ============================================================================
 
-pub struct RememberTool;
+pub struct RememberTool {
+    config: MemoryConfig,
+}
+
+#[cfg(test)]
+impl RememberTool {
+    fn with_default_config() -> Self {
+        Self {
+            config: MemoryConfig::default(),
+        }
+    }
+}
 
 #[derive(Debug, Deserialize)]
 struct RememberParams {
@@ -309,11 +329,7 @@ impl Tool for RememberTool {
             None => MemoryKind::Fact,
         };
 
-        // TODO(V1): Resolve MemoryConfig from agent/harness capability config
-        // instead of using defaults. Tools don't currently have access to the
-        // per-agent AgentCapabilityConfig; requires ToolContext extension.
-        let config = MemoryConfig::default();
-        let store_id = match resolve_store_id(&config, context).await {
+        let store_id = match resolve_store_id(&self.config, context).await {
             Ok(id) => id,
             Err(e) => return e,
         };
@@ -359,7 +375,18 @@ impl Tool for RememberTool {
 // Recall Tool
 // ============================================================================
 
-pub struct RecallTool;
+pub struct RecallTool {
+    config: MemoryConfig,
+}
+
+#[cfg(test)]
+impl RecallTool {
+    fn with_default_config() -> Self {
+        Self {
+            config: MemoryConfig::default(),
+        }
+    }
+}
 
 #[derive(Debug, Deserialize)]
 struct RecallParams {
@@ -445,9 +472,7 @@ impl Tool for RecallTool {
             Err(e) => return ToolExecutionResult::tool_error(format!("Invalid parameters: {e}")),
         };
 
-        // TODO(V1): Resolve MemoryConfig from agent/harness capability config
-        let config = MemoryConfig::default();
-        let store_id = match resolve_store_id(&config, context).await {
+        let store_id = match resolve_store_id(&self.config, context).await {
             Ok(id) => id,
             Err(e) => return e,
         };
@@ -519,7 +544,18 @@ impl Tool for RecallTool {
 // Forget Tool
 // ============================================================================
 
-pub struct ForgetTool;
+pub struct ForgetTool {
+    config: MemoryConfig,
+}
+
+#[cfg(test)]
+impl ForgetTool {
+    fn with_default_config() -> Self {
+        Self {
+            config: MemoryConfig::default(),
+        }
+    }
+}
 
 #[derive(Debug, Deserialize)]
 struct ForgetParams {
@@ -586,9 +622,7 @@ impl Tool for ForgetTool {
             }
         };
 
-        // TODO(V1): Resolve MemoryConfig from agent/harness capability config
-        let config = MemoryConfig::default();
-        let store_id = match resolve_store_id(&config, context).await {
+        let store_id = match resolve_store_id(&self.config, context).await {
             Ok(id) => id,
             Err(e) => return e,
         };
@@ -650,7 +684,7 @@ mod tests {
         let (ctx, _, _) = test_context();
 
         // Remember
-        let result = RememberTool
+        let result = RememberTool::with_default_config()
             .execute_with_context(
                 json!({
                     "content": "The project uses Rust edition 2024",
@@ -671,7 +705,7 @@ mod tests {
         }
 
         // Recall by query
-        let result = RecallTool
+        let result = RecallTool::with_default_config()
             .execute_with_context(json!({"query": "rust"}), &ctx)
             .await;
 
@@ -688,7 +722,7 @@ mod tests {
         }
 
         // Recall by tag
-        let result = RecallTool
+        let result = RecallTool::with_default_config()
             .execute_with_context(json!({"tags": ["project"]}), &ctx)
             .await;
 
@@ -704,7 +738,7 @@ mod tests {
     async fn test_remember_with_images() {
         let (ctx, _, _) = test_context();
 
-        let result = RememberTool
+        let result = RememberTool::with_default_config()
             .execute_with_context(
                 json!({
                     "content": "Architecture diagram",
@@ -722,7 +756,7 @@ mod tests {
         }
 
         // Recall should include image parts
-        let result = RecallTool
+        let result = RecallTool::with_default_config()
             .execute_with_context(json!({"query": "architecture"}), &ctx)
             .await;
 
@@ -743,7 +777,7 @@ mod tests {
         let (ctx, _, _) = test_context();
 
         // Create a memory
-        let result = RememberTool
+        let result = RememberTool::with_default_config()
             .execute_with_context(json!({"content": "temporary fact", "tags": ["temp"]}), &ctx)
             .await;
 
@@ -753,7 +787,7 @@ mod tests {
         };
 
         // Forget it
-        let result = ForgetTool
+        let result = ForgetTool::with_default_config()
             .execute_with_context(json!({"memory_id": memory_id}), &ctx)
             .await;
 
@@ -763,7 +797,7 @@ mod tests {
         }
 
         // Recall should return nothing
-        let result = RecallTool
+        let result = RecallTool::with_default_config()
             .execute_with_context(json!({"query": "temporary"}), &ctx)
             .await;
 
@@ -778,7 +812,7 @@ mod tests {
         let (ctx, _, _) = test_context();
 
         let long_content = "x".repeat(2001);
-        let result = RememberTool
+        let result = RememberTool::with_default_config()
             .execute_with_context(json!({"content": long_content}), &ctx)
             .await;
 
@@ -795,7 +829,7 @@ mod tests {
         let (ctx, _, _) = test_context();
 
         let tags: Vec<String> = (0..11).map(|i| format!("tag{i}")).collect();
-        let result = RememberTool
+        let result = RememberTool::with_default_config()
             .execute_with_context(json!({"content": "test", "tags": tags}), &ctx)
             .await;
 
@@ -811,7 +845,7 @@ mod tests {
     async fn test_recall_empty_store() {
         let (ctx, _, _) = test_context();
 
-        let result = RecallTool.execute_with_context(json!({}), &ctx).await;
+        let result = RecallTool::with_default_config().execute_with_context(json!({}), &ctx).await;
 
         match &result {
             ToolExecutionResult::Success(v) => {
@@ -827,7 +861,7 @@ mod tests {
         let (ctx, _, _) = test_context();
 
         let fake_id = MemoryId::new().to_string();
-        let result = ForgetTool
+        let result = ForgetTool::with_default_config()
             .execute_with_context(json!({"memory_id": fake_id}), &ctx)
             .await;
 
@@ -841,7 +875,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_remember_without_context_errors() {
-        let result = RememberTool.execute(json!({"content": "test"})).await;
+        let result = RememberTool::with_default_config().execute(json!({"content": "test"})).await;
         match result {
             ToolExecutionResult::ToolError(msg) => {
                 assert!(msg.contains("requires session context"));
@@ -854,18 +888,18 @@ mod tests {
     async fn test_recall_by_kind() {
         let (ctx, _, _) = test_context();
 
-        RememberTool
+        RememberTool::with_default_config()
             .execute_with_context(
                 json!({"content": "User prefers dark mode", "kind": "preference"}),
                 &ctx,
             )
             .await;
 
-        RememberTool
+        RememberTool::with_default_config()
             .execute_with_context(json!({"content": "The sky is blue", "kind": "fact"}), &ctx)
             .await;
 
-        let result = RecallTool
+        let result = RecallTool::with_default_config()
             .execute_with_context(json!({"kind": "preference"}), &ctx)
             .await;
 
@@ -909,8 +943,8 @@ mod tests {
 
     #[test]
     fn test_tools_require_context() {
-        assert!(RememberTool.requires_context());
-        assert!(RecallTool.requires_context());
-        assert!(ForgetTool.requires_context());
+        assert!(RememberTool::with_default_config().requires_context());
+        assert!(RecallTool::with_default_config().requires_context());
+        assert!(ForgetTool::with_default_config().requires_context());
     }
 }

--- a/crates/core/src/capabilities/persistent_memory.rs
+++ b/crates/core/src/capabilities/persistent_memory.rs
@@ -59,16 +59,28 @@ impl Capability for MemoryCapability {
     }
 
     fn tools_with_config(&self, config: &Value) -> Vec<Box<dyn Tool>> {
-        let config = MemoryConfig::from_json(config);
+        // `validate_config` runs ahead of capability assignment, so by the
+        // time we reach `tools_with_config` an unparseable JSON is already
+        // rejected upstream. Falling back to defaults here (vs panicking)
+        // keeps the deserialization tolerant to forward-compatible additions.
+        let config = MemoryConfig::from_json(config).unwrap_or_default();
         vec![
-            Box::new(RememberTool {
-                config: config.clone(),
-            }),
-            Box::new(RecallTool {
-                config: config.clone(),
-            }),
-            Box::new(ForgetTool { config }),
+            Box::new(RememberTool::new(config.clone())),
+            Box::new(RecallTool::new(config.clone())),
+            Box::new(ForgetTool::new(config)),
         ]
+    }
+
+    fn validate_config(&self, config: &Value) -> std::result::Result<(), String> {
+        if config.is_null() {
+            return Ok(());
+        }
+        // Reject malformed configs at validation time so capability assignment
+        // surfaces a clear error instead of silently routing memory ops to the
+        // org default store. This preserves store-level isolation.
+        MemoryConfig::from_json(config).map(|_| ()).map_err(|e| {
+            format!("Invalid memory capability config: {e}. Expected: {{ \"store\"?: \"mem_store_…\", \"passive_recall_count\"?: u32 }}.")
+        })
     }
 
     fn config_schema(&self) -> Option<Value> {
@@ -129,8 +141,15 @@ impl Default for MemoryConfig {
 }
 
 impl MemoryConfig {
-    pub fn from_json(value: &Value) -> Self {
-        serde_json::from_value(value.clone()).unwrap_or_default()
+    /// Parse a `MemoryConfig` from JSON.
+    ///
+    /// Returns an error when the JSON is structurally wrong (e.g. wrong field
+    /// types). `null` and missing optional fields fall back to defaults.
+    pub fn from_json(value: &Value) -> std::result::Result<Self, serde_json::Error> {
+        if value.is_null() {
+            return Ok(Self::default());
+        }
+        serde_json::from_value(value.clone())
     }
 }
 
@@ -190,12 +209,22 @@ pub struct RememberTool {
     config: MemoryConfig,
 }
 
+impl RememberTool {
+    pub fn new(config: MemoryConfig) -> Self {
+        Self { config }
+    }
+}
+
+impl Default for RememberTool {
+    fn default() -> Self {
+        Self::new(MemoryConfig::default())
+    }
+}
+
 #[cfg(test)]
 impl RememberTool {
     fn with_default_config() -> Self {
-        Self {
-            config: MemoryConfig::default(),
-        }
+        Self::default()
     }
 }
 
@@ -379,12 +408,22 @@ pub struct RecallTool {
     config: MemoryConfig,
 }
 
+impl RecallTool {
+    pub fn new(config: MemoryConfig) -> Self {
+        Self { config }
+    }
+}
+
+impl Default for RecallTool {
+    fn default() -> Self {
+        Self::new(MemoryConfig::default())
+    }
+}
+
 #[cfg(test)]
 impl RecallTool {
     fn with_default_config() -> Self {
-        Self {
-            config: MemoryConfig::default(),
-        }
+        Self::default()
     }
 }
 
@@ -548,12 +587,22 @@ pub struct ForgetTool {
     config: MemoryConfig,
 }
 
+impl ForgetTool {
+    pub fn new(config: MemoryConfig) -> Self {
+        Self { config }
+    }
+}
+
+impl Default for ForgetTool {
+    fn default() -> Self {
+        Self::new(MemoryConfig::default())
+    }
+}
+
 #[cfg(test)]
 impl ForgetTool {
     fn with_default_config() -> Self {
-        Self {
-            config: MemoryConfig::default(),
-        }
+        Self::default()
     }
 }
 
@@ -941,8 +990,19 @@ mod tests {
 
     #[test]
     fn test_memory_config_from_json() {
-        let config = MemoryConfig::from_json(&json!({"passive_recall_count": 10}));
+        let config = MemoryConfig::from_json(&json!({"passive_recall_count": 10})).unwrap();
         assert_eq!(config.passive_recall_count, 10);
+
+        // Null falls back to defaults.
+        let null_config = MemoryConfig::from_json(&Value::Null).unwrap();
+        assert_eq!(
+            null_config.passive_recall_count,
+            default_passive_recall_count()
+        );
+        assert!(null_config.store.is_none());
+
+        // Wrong type surfaces a serde error instead of silently defaulting.
+        assert!(MemoryConfig::from_json(&json!({"passive_recall_count": "ten"})).is_err());
     }
 
     #[test]

--- a/crates/core/src/capabilities/persistent_memory.rs
+++ b/crates/core/src/capabilities/persistent_memory.rs
@@ -845,7 +845,9 @@ mod tests {
     async fn test_recall_empty_store() {
         let (ctx, _, _) = test_context();
 
-        let result = RecallTool::with_default_config().execute_with_context(json!({}), &ctx).await;
+        let result = RecallTool::with_default_config()
+            .execute_with_context(json!({}), &ctx)
+            .await;
 
         match &result {
             ToolExecutionResult::Success(v) => {
@@ -875,7 +877,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_remember_without_context_errors() {
-        let result = RememberTool::with_default_config().execute(json!({"content": "test"})).await;
+        let result = RememberTool::with_default_config()
+            .execute(json!({"content": "test"}))
+            .await;
         match result {
             ToolExecutionResult::ToolError(msg) => {
                 assert!(msg.contains("requires session context"));


### PR DESCRIPTION
### Motivation
- The memory capability advertised a per-agent `store` config but tools always used `MemoryConfig::default()`, causing all ops to target the org default store and breaking store-level isolation.

### Description
- Wire `MemoryCapability::tools_with_config` so the capability parses the per-capability JSON and constructs `remember`/`recall`/`forget` tools with that `MemoryConfig`, while `tools()` delegates to `tools_with_config` with `Value::Null` to preserve default behavior.
- Update `RememberTool`, `RecallTool`, and `ForgetTool` to hold a `MemoryConfig` and resolve the store via `resolve_store_id(&self.config, ...)` instead of using `MemoryConfig::default()`.
- Add test-only `with_default_config()` helpers and update the persistent memory unit tests in `crates/core/src/capabilities/persistent_memory.rs` to instantiate tools explicitly so tests keep exercising the same behavior after the struct shape change.

### Testing
- Ran `cargo test -p everruns-core persistent_memory` in this environment; the build progressed (dependency downloads and compilation started) but the run timed out before tests completed, so no full test pass/fail result is available.
- Updated unit tests in `crates/core/src/capabilities/persistent_memory.rs` to use the new test helpers; these are compiled as part of the attempted test run (compile progress observed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fca1761914832ba8001999b7fa303a)