### PR TITLE
fix(ui): handle null workspace volume configs

### DIFF
--- a/apps/ui/src/__tests__/workspace-volumes-config-editor.test.tsx
+++ b/apps/ui/src/__tests__/workspace-volumes-config-editor.test.tsx
@@ -97,6 +97,11 @@ describe("WorkspaceVolumesConfigEditor", () => {
     expect(screen.getAllByTestId("volume-mount-row")).toHaveLength(1);
   });
 
+  it("treats null config as empty mounts", () => {
+    render(<WorkspaceVolumesConfigEditor config={null} onChange={jest.fn()} />);
+    expect(screen.queryByTestId("volume-mount-row")).not.toBeInTheDocument();
+  });
+
   it("calls onChange when adding a mount row with empty defaults", () => {
     const onChange = jest.fn();
     render(<WorkspaceVolumesConfigEditor config={{}} onChange={onChange} />);

--- a/apps/ui/src/components/agents/workspace-volumes-config-editor.tsx
+++ b/apps/ui/src/components/agents/workspace-volumes-config-editor.tsx
@@ -28,7 +28,7 @@ interface WorkspaceVolumesConfig {
 }
 
 interface WorkspaceVolumesConfigEditorProps {
-  config: Record<string, unknown>;
+  config: unknown;
   onChange: (config: Record<string, unknown>) => void;
   disabled?: boolean;
 }
@@ -116,7 +116,8 @@ function validateMounts(mounts: VolumeMountEntry[]): MountValidation[] {
   return validations;
 }
 
-function readMounts(config: Record<string, unknown>): VolumeMountEntry[] {
+function readMounts(config: unknown): VolumeMountEntry[] {
+  if (!config || typeof config !== "object") return [];
   const typed = config as WorkspaceVolumesConfig;
   if (!Array.isArray(typed.mounts)) return [];
   return typed.mounts


### PR DESCRIPTION
### Motivation
- The new WorkspaceVolumesConfigEditor assumed `config` was an object and dereferenced `config.mounts`, but the backend accepts explicit JSON `null` as an empty `workspace_volumes` config which caused a render-time `TypeError` and a persistent UI denial-of-service for the edit view.

### Description
- Change the editor prop to accept `config` as `unknown` and add a defensive guard in `readMounts` to treat `null`/non-object configs as empty mounts so the UI no longer throws on null configs.
- Keep `writeMounts` behavior unchanged so saved configs for non-empty mounts are serialized the same way.
- Add a regression unit test `it("treats null config as empty mounts")` in `apps/ui/src/__tests__/workspace-volumes-config-editor.test.tsx` to cover the null-config case.

### Testing
- A Jest unit test was added to `apps/ui/src/__tests__/workspace-volumes-config-editor.test.tsx` covering the null-config render path.
- Attempted to run `cd apps/ui && npm test -- workspace-volumes-config-editor.test.tsx --runInBand`, but the execution environment reported `jest: not found` so the test could not be executed here.
- The change is minimal and UI-only; the full `apps/ui` Jest suite is expected to run in CI and validate the fix and guard against regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fca1769154832bba64efcc491f2017)