### PR TITLE
fix(mcp): count card sessions by internal agent id

### DIFF
--- a/crates/server/src/api/mcp_endpoint/mod.rs
+++ b/crates/server/src/api/mcp_endpoint/mod.rs
@@ -1179,9 +1179,10 @@ async fn tool_agent_get_card(
     // intentionally hit the storage layer directly here instead of going
     // through a list-and-count: callers asking for a card don't need the
     // list payload, and `count_sessions_for_agent` is a single COUNT query.
+    let agent_id = everruns_core::AgentId::from_uuid(agent.internal_id);
     let session_count = state
         .db
-        .count_sessions_for_agent(org.org_id, agent.public_id)
+        .count_sessions_for_agent(org.org_id, agent_id)
         .await
         .map_err(|e| format!("Failed to count sessions: {e}"))?;
 

--- a/crates/server/tests/mcp_endpoint_test.rs
+++ b/crates/server/tests/mcp_endpoint_test.rs
@@ -711,6 +711,83 @@ async fn test_mcp_agent_run_invalid_agent_id() {
     assert!(tool_is_error(&resp), "Expected error for invalid agent_id");
 }
 
+// Regression test for the `agent_get_card` session-count bug: the count must
+// be keyed by the agent's internal id, not its public id. Public and internal
+// ids are distinct UUIDs (see `crates/server/src/storage/repositories/agents.rs`
+// where `id` and `public_id` are populated independently), and
+// `sessions.agent_id` references `agents.id`. If the count keyed by public_id
+// instead, the assertion below would observe `0` sessions despite one existing.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_agent_get_card_counts_sessions_by_internal_id() {
+    let server = TestServer::new().await;
+
+    // Create an agent via REST (auto-generated public_id != internal_id).
+    let agent: Value = server
+        .post(
+            "/v1/agents",
+            json!({
+                "name": format!("card-count-agent-{}", unique_suffix()),
+                "display_name": "Card Count Agent",
+                "system_prompt": "Test"
+            }),
+        )
+        .await
+        .assert_success()
+        .json();
+    let agent_public_id = agent["id"].as_str().unwrap().to_string();
+
+    // Baseline: no sessions yet, card should report 0.
+    let resp = mcp_tool_call(
+        &server,
+        "agent_get_card",
+        json!({ "agent_id": agent_public_id }),
+    )
+    .await;
+    assert!(
+        !tool_is_error(&resp),
+        "agent_get_card failed: {}",
+        tool_text(&resp)
+    );
+    assert!(
+        tool_text(&resp).contains("0 session(s)"),
+        "expected 0 sessions in summary, got: {}",
+        tool_text(&resp)
+    );
+
+    // Create a session bound to this agent (REST resolves public_id ->
+    // internal_id and stores the internal id in `sessions.agent_id`).
+    let _session: Value = server
+        .post(
+            "/v1/sessions",
+            json!({
+                "harness_id": server.seed_base_harness_id,
+                "agent_id": agent_public_id,
+            }),
+        )
+        .await
+        .assert_success()
+        .json();
+
+    // Now the card must reflect 1 session. With the old (buggy) code that
+    // counted by public_id, this would still be 0.
+    let resp = mcp_tool_call(
+        &server,
+        "agent_get_card",
+        json!({ "agent_id": agent_public_id }),
+    )
+    .await;
+    assert!(
+        !tool_is_error(&resp),
+        "agent_get_card failed: {}",
+        tool_text(&resp)
+    );
+    assert!(
+        tool_text(&resp).contains("1 session(s)"),
+        "expected 1 session in summary, got: {}",
+        tool_text(&resp)
+    );
+}
+
 // ============================================================================
 // Tier 1: session_send_message
 // ============================================================================


### PR DESCRIPTION
### Motivation
- The MCP `agent_get_card` tool counted sessions using `agent.public_id`, but the `sessions.agent_id` FK references the agent's internal UUID, causing incorrect session totals for agents created with client-supplied public IDs.

### Description
- Replace the `public_id` argument with an `AgentId` derived from `agent.internal_id` before calling `count_sessions_for_agent` in `crates/server/src/api/mcp_endpoint/mod.rs`.
- This is a minimal, single-purpose change that aligns the card session count key with the sessions table without altering API shapes or behavior.
- Commit message: `fix(mcp): count card sessions by internal agent id`.

### Testing
- Prior validation (original feature rollout) showed the MCP card unit tests and related Jest tests passing (`5` Rust unit tests for `cards`, `5` jest tests for iframe) and `tools/list` behavior under both protocol versions; those were green before this fix.
- After applying the change I ran a targeted `cargo test -p everruns-server --test mcp_endpoint_test test_mcp_tools_list`, which began compiling and executing but did not complete to a final result in this environment; CI should run the full test matrix and confirm green status.
- Recommend `just pre-push` / CI to verify `cargo fmt`, `cargo clippy`, and the full test suite before merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fca4d4a27c832ba33147b65595cf80)