### PR TITLE
fix(server): resolve org for volume IDs

### DIFF
--- a/crates/server/migrations/038_volumes_public_id_index.sql
+++ b/crates/server/migrations/038_volumes_public_id_index.sql
@@ -1,0 +1,8 @@
+-- Add a standalone unique index on volumes(public_id) to support unscoped
+-- lookups by public_id (e.g. /v1/resolve-org for vol_* IDs). Volumes already
+-- has a composite UNIQUE index on (org_id, public_id), but the planner cannot
+-- use it efficiently for equality on the trailing column alone. This standalone
+-- unique index enables index-only lookups and enforces global uniqueness of
+-- volume public_ids, mirroring the pattern in 005_v0.8.4.sql for apps.
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_volumes_public_id ON volumes(public_id);

--- a/crates/server/src/domains/org_resolver.rs
+++ b/crates/server/src/domains/org_resolver.rs
@@ -178,6 +178,13 @@ inventory::submit! {
     }
 }
 
+inventory::submit! {
+    ResourceOrgResolver {
+        prefix: "vol",
+        resolve: |db, id| Box::pin(async move { db.get_volume_organization_id(id).await }),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -197,8 +204,8 @@ mod tests {
         // Guard against a missing `inventory::submit!` silently passing CI.
         // Must stay in sync with the registrations above.
         assert!(
-            seen.len() >= 8,
-            "expected at least 8 resolvers, found {}",
+            seen.len() >= 9,
+            "expected at least 9 resolvers, found {}",
             seen.len()
         );
     }

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -2429,6 +2429,10 @@ impl StorageBackend {
         dispatch!(self, get_eval_organization_id, public_id)
     }
 
+    pub async fn get_volume_organization_id(&self, public_id: &str) -> Result<Option<i64>> {
+        dispatch!(self, get_volume_organization_id, public_id)
+    }
+
     pub async fn upsert_leased_resource(
         &self,
         input: UpsertLeasedResourceRow,

--- a/crates/server/src/storage/memory/volumes.rs
+++ b/crates/server/src/storage/memory/volumes.rs
@@ -63,6 +63,15 @@ impl InMemoryDatabase {
             .cloned())
     }
 
+    pub async fn get_volume_organization_id(&self, public_id: &str) -> Result<Option<i64>> {
+        Ok(self
+            .volumes
+            .read()
+            .values()
+            .find(|volume| volume.public_id == public_id && volume.status != "deleted")
+            .map(|volume| volume.org_id))
+    }
+
     pub async fn list_volumes(
         &self,
         org_id: i64,

--- a/crates/server/src/storage/memory/volumes.rs
+++ b/crates/server/src/storage/memory/volumes.rs
@@ -64,11 +64,16 @@ impl InMemoryDatabase {
     }
 
     pub async fn get_volume_organization_id(&self, public_id: &str) -> Result<Option<i64>> {
+        // The new postgres unique index on volumes(public_id) makes duplicate public_ids
+        // impossible at the storage layer, but in-memory state can briefly contain
+        // overlapping rows in tests that build fixtures across orgs. Pick the newest by
+        // created_at to keep behavior deterministic across HashMap iteration orders.
         Ok(self
             .volumes
             .read()
             .values()
-            .find(|volume| volume.public_id == public_id && volume.status != "deleted")
+            .filter(|volume| volume.public_id == public_id && volume.status != "deleted")
+            .max_by_key(|volume| volume.created_at)
             .map(|volume| volume.org_id))
     }
 

--- a/crates/server/src/storage/repositories/volumes.rs
+++ b/crates/server/src/storage/repositories/volumes.rs
@@ -62,6 +62,21 @@ impl Database {
         Ok(row)
     }
 
+    pub async fn get_volume_organization_id(&self, public_id: &str) -> Result<Option<i64>> {
+        let row = sqlx::query_scalar::<_, i64>(
+            r#"
+            SELECT org_id
+            FROM volumes
+            WHERE public_id = $1 AND status != 'deleted'
+            "#,
+        )
+        .bind(public_id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row)
+    }
+
     pub async fn list_volumes(
         &self,
         org_id: i64,

--- a/crates/server/src/storage/repositories/volumes.rs
+++ b/crates/server/src/storage/repositories/volumes.rs
@@ -68,6 +68,7 @@ impl Database {
             SELECT org_id
             FROM volumes
             WHERE public_id = $1 AND status != 'deleted'
+            LIMIT 1
             "#,
         )
         .bind(public_id)


### PR DESCRIPTION
## What
Add `vol_*` support to `/v1/resolve-org` so direct workspace-volume links can recover the owning organization.

## Why
The volume detail UI opts into cross-org fallback, but the backend resolver did not register the `vol` prefix. Direct links to volumes in another org returned 404 from org resolution instead of allowing the existing membership-gated fallback flow to continue.

## How
Added a volume organization lookup to the storage backend, implemented it for Postgres and in-memory storage, registered the `vol` resolver, and added a standalone unique `volumes(public_id)` index so unscoped public-id lookup stays bounded and deterministic.

## Risk
- Medium
- Changes resolver dispatch and adds migration `038_volumes_public_id_index.sql`; incorrect lookup behavior could affect direct volume links or migration rollout.

## Security
- Threat categories reviewed: TM-AUTHZ, TM-TENANT, TM-API, TM-SQL, TM-DOS.
- Findings and resolutions: the new lookup returns only an org id and remains behind the existing `/v1/resolve-org` membership gate. The Postgres lookup filters deleted rows and uses a standalone unique index to avoid unbounded scans. No new unauthenticated endpoint was added.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)