### PR TITLE
fix(ui): skip auth proxy redirects when AUTH_MODE is none

### DIFF
--- a/apps/ui/src/__tests__/middleware.test.ts
+++ b/apps/ui/src/__tests__/middleware.test.ts
@@ -3,7 +3,19 @@
 import { config, proxy } from "@/proxy";
 
 describe("auth proxy", () => {
+  const previousAuthMode = process.env.AUTH_MODE;
+
+  afterEach(() => {
+    if (previousAuthMode === undefined) {
+      delete process.env.AUTH_MODE;
+    } else {
+      process.env.AUTH_MODE = previousAuthMode;
+    }
+  });
+
   it("redirects protected routes to login when the access token is missing", () => {
+    process.env.AUTH_MODE = "full";
+
     const request = {
       cookies: { has: () => false },
       nextUrl: new URL("http://localhost/settings/providers?tab=models"),
@@ -17,6 +29,24 @@ describe("auth proxy", () => {
       "http://localhost/login?return_to=%2Fsettings%2Fproviders%3Ftab%3Dmodels",
     );
   });
+
+  it.each(["/chat", "/settings/providers?tab=models"])(
+    "allows %s through when AUTH_MODE=none and cookie is missing",
+    (path) => {
+      process.env.AUTH_MODE = "none";
+
+      const request = {
+        cookies: { has: () => false },
+        nextUrl: new URL(`http://localhost${path}`),
+        url: `http://localhost${path}`,
+      } as Parameters<typeof proxy>[0];
+
+      const response = proxy(request);
+
+      expect(response.headers.get("x-middleware-next")).toBe("1");
+      expect(response.headers.get("location")).toBeNull();
+    },
+  );
 
   it("allows protected routes through when the access token cookie exists", () => {
     const request = {

--- a/apps/ui/src/proxy.ts
+++ b/apps/ui/src/proxy.ts
@@ -10,6 +10,10 @@ const HOMEPAGE_DISCOVERY_LINKS = [
 // Decision: proxy only enforces cookie presence for protected app routes.
 // AuthProvider remains the source of truth for config bootstrap, user loading,
 // token refresh, and auth-unavailable fallback UI.
+function authDisabled(): boolean {
+  return process.env.AUTH_MODE === "none";
+}
+
 export function proxy(request: NextRequest) {
   if (request.nextUrl.pathname === "/") {
     const response = NextResponse.next();
@@ -17,7 +21,7 @@ export function proxy(request: NextRequest) {
     return response;
   }
 
-  if (request.cookies.has("access_token")) {
+  if (authDisabled() || request.cookies.has("access_token")) {
     return NextResponse.next();
   }
 


### PR DESCRIPTION
## What
Fix protected UI route handling when `AUTH_MODE=none`.

## Why
OSS no-auth mode intentionally has no login/session cookie requirement. Protected app routes such as `/chat` should render directly and use the anonymous/default auth context instead of redirecting to `/login`.

## How
- Bypass proxy cookie redirect checks only when `process.env.AUTH_MODE === "none"`.
- Keep existing `access_token` redirect behavior unchanged for auth-enabled modes.
- Add regression coverage for `/chat` and another protected route without cookies in no-auth mode.

## Risk
- Low
- Could break protected route redirects if the auth-mode branch were too broad; covered by existing redirect tests plus the new no-auth route tests.

## Security
- Threat categories reviewed: TM-AUTH, TM-WEB.
- Findings and resolutions: no auth-enabled route protection was weakened; the bypass is limited to explicit `AUTH_MODE=none`, which is the documented no-auth local/OSS mode. No new inputs, dependencies, cookies, redirects, or exposed data paths were introduced.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

## Validation
- `cd apps/ui && npm run format:check`
- `cd apps/ui && npm run lint`
- `cd apps/ui && npm test -- middleware.test.ts --runInBand`
- `cd apps/ui && npm run build`
- `PORT_PREFIX=272 AUTH_MODE=none CARGO_INCREMENTAL=0 just start-dev --no-watch`
- Smoke: `GET /chat` returned `200` with no redirect under `AUTH_MODE=none`
- Smoke: `GET /api/v1/auth/config` returned `mode: none`
- Smoke: `GET /api/v1/auth/me` returned anonymous admin user
- Browser smoke: opened `http://localhost:27200/chat`, stayed on `/chat`, rendered the chat UI under Default Organization
- `bash scripts/lib/check-migration-ordering.sh`
- `just pre-push`
