### PR TITLE
fix(ui): restrict MCP card resources to ui://everruns

### DIFF
--- a/apps/ui/src/__tests__/tool-call-utils.test.ts
+++ b/apps/ui/src/__tests__/tool-call-utils.test.ts
@@ -78,6 +78,44 @@ describe("tool-call-utils MCP App resources", () => {
     ]);
   });
 
+  it("rejects untrusted ui:// authorities", () => {
+    const result: ContentPart[] = [
+      {
+        type: "text",
+        text: JSON.stringify({
+          content: [
+            {
+              type: "resource",
+              uri: "ui://evil/agent/agent_01/card",
+              mime_type: "text/html",
+              text: html,
+            },
+            {
+              type: "resource",
+              uri: "ui://everruns.evil.com/agent/agent_01/card",
+              mime_type: "text/html",
+              text: html,
+            },
+            {
+              type: "resource",
+              uri: "ui://everrunsx/agent/agent_01/card",
+              mime_type: "text/html",
+              text: html,
+            },
+            {
+              type: "resource",
+              uri: "ui://everruns",
+              mime_type: "text/html",
+              text: html,
+            },
+          ],
+        }),
+      },
+    ];
+
+    expect(extractMcpAppResources(result)).toEqual([]);
+  });
+
   it("ignores non-ui and non-html resources", () => {
     const result: ContentPart[] = [
       {

--- a/apps/ui/src/components/chat/tool-call-utils.ts
+++ b/apps/ui/src/components/chat/tool-call-utils.ts
@@ -189,7 +189,7 @@ function normalizeMcpAppResource(value: unknown): McpAppResource[] {
         ? value.text
         : undefined;
 
-  if (!uri?.startsWith("ui://")) return [];
+  if (!uri?.startsWith("ui://everruns/")) return [];
   if (mimeType?.toLowerCase() !== "text/html") return [];
   if (!html) return [];
 


### PR DESCRIPTION
### Motivation
- Prevent rendering attacker-controlled MCP HTML by ensuring only first-party MCP card resources under `ui://everruns/...` are accepted for inline iframe rendering.

### Description
- Tighten resource extraction in `normalizeMcpAppResource` to accept URIs that start with `ui://everruns/` instead of any `ui://` (file: `apps/ui/src/components/chat/tool-call-utils.ts`).
- Add a regression test `rejects untrusted ui:// authorities` to `apps/ui/src/__tests__/tool-call-utils.test.ts` to assert that `ui://evil/...` HTML resources are ignored.
- Files changed: `apps/ui/src/components/chat/tool-call-utils.ts`, `apps/ui/src/__tests__/tool-call-utils.test.ts`.

### Testing
- Added unit test verifying untrusted `ui://` authorities are rejected; existing tests for trusted `ui://everruns/...` extraction remain in place.
- Attempted to run `npm run test -- tool-call-utils.test.ts` but test execution failed in this environment because `jest` is not available (`sh: 1: jest: not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcfefa2824832ba0d0a77be0a6d51d)