### PR TITLE
fix(events): bound q filter for list_events

### DIFF
--- a/crates/server/src/domains/events/commands.rs
+++ b/crates/server/src/domains/events/commands.rs
@@ -11,6 +11,8 @@ const MAX_EVENT_TYPE_FILTER_SIZE: usize = 40;
 const MAX_EVENT_LIMIT: i32 = 1000;
 const MAX_TAGS_FILTER_SIZE: usize = 20;
 const MAX_AROUND_WINDOW: i32 = 500;
+const MAX_Q_BYTES: usize = 4096;
+const MAX_Q_TOKENS: usize = 64;
 
 #[derive(Debug, Serialize)]
 pub struct ListEventsResult {
@@ -32,6 +34,25 @@ fn validate_event_type_list(types: &[String], param_name: &str) -> Result<(), Co
                 "{param_name}: unknown event type '{event_type}'"
             )));
         }
+    }
+    Ok(())
+}
+
+fn validate_q_filter(q: Option<&str>) -> Result<(), CommandError> {
+    let Some(q) = q else {
+        return Ok(());
+    };
+    if q.len() > MAX_Q_BYTES {
+        return Err(CommandError::bad_request(format!(
+            "q: too long ({} bytes, max {MAX_Q_BYTES})",
+            q.len()
+        )));
+    }
+    let token_count = q.split_whitespace().count();
+    if token_count > MAX_Q_TOKENS {
+        return Err(CommandError::bad_request(format!(
+            "q: too many tokens ({token_count}, max {MAX_Q_TOKENS})"
+        )));
     }
     Ok(())
 }
@@ -117,6 +138,7 @@ impl Command for ListEvents {
     async fn execute(self, ctx: &Ctx) -> Result<ListEventsResult, CommandError> {
         validate_event_type_list(&self.types, "types")?;
         validate_event_type_list(&self.exclude, "exclude")?;
+        validate_q_filter(self.q.as_deref())?;
 
         if self.tags.len() > MAX_TAGS_FILTER_SIZE {
             return Err(CommandError::bad_request(format!(
@@ -406,3 +428,31 @@ impl Command for StreamSse {
 }
 
 inventory::submit! { CommandDescriptor::of::<StreamSse>() }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn q_filter_rejects_long_input() {
+        let q = "a".repeat(MAX_Q_BYTES + 1);
+        let err = validate_q_filter(Some(&q)).expect_err("long q should fail");
+        assert!(err.to_string().contains("q: too long"));
+    }
+
+    #[test]
+    fn q_filter_rejects_too_many_tokens() {
+        let q = (0..=MAX_Q_TOKENS)
+            .map(|_| "token")
+            .collect::<Vec<_>>()
+            .join(" ");
+        let err = validate_q_filter(Some(&q)).expect_err("too many tokens should fail");
+        assert!(err.to_string().contains("q: too many tokens"));
+    }
+
+    #[test]
+    fn q_filter_accepts_bounded_input() {
+        let q = "tool failed retry";
+        validate_q_filter(Some(q)).expect("bounded q should pass");
+    }
+}


### PR DESCRIPTION
### Motivation
- Prevent unbounded attacker-controlled `q` strings from forcing expensive PostgreSQL `plainto_tsquery` planning or in-memory per-event substring scans that can exhaust CPU/memory.
- Apply validation at the command boundary so backends never receive oversized or high-token queries.
- Keep existing event search semantics for normal queries while limiting resource-exhaustion risk.

### Description
- Add `MAX_Q_BYTES = 4096` and `MAX_Q_TOKENS = 64` and a new `validate_q_filter` helper to `crates/server/src/domains/events/commands.rs`.
- Invoke `validate_q_filter(self.q.as_deref())?` during `ListEvents::execute` to reject oversized inputs with `CommandError::bad_request` before backend execution.
- Add unit tests (in the same file under `#[cfg(test)]`) that assert rejection of too-long input, rejection of too-many tokens, and acceptance of a bounded query.

### Testing
- Ran `cargo fmt --package everruns-server`, which completed successfully.
- Added focused unit tests for the `q` validator; test execution was attempted with `cargo test -p everruns-server domains::events::commands::tests -q` but the build/test run did not finish within the session environment (dependency/toolchain compilation in progress), so tests were not observed to complete here.
- Committed the change as `fix(events): bound q filter for list_events` and kept the change validation-only to minimize risk.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcffc85bd0832ba0cbab3466832452)