### PR TITLE
fix(ag-ui): prevent narrated public tool detail leaks

### DIFF
--- a/crates/server/src/api/ag_ui.rs
+++ b/crates/server/src/api/ag_ui.rs
@@ -1148,20 +1148,18 @@ fn translate_event(state: &mut AgUiStreamState, event: &everruns_core::Event) {
             state.thinking_text_started = false;
             state.public_tool_activity_opened_thinking = false;
         }
-        "tool.started" => {
-            if let Ok(data) = parse_event_data::<ToolStartedData>(event) {
-                ensure_assistant_message_id(state, event);
-                state.active_tool_activity_count += 1;
-                match state.tool_visibility {
-                    AgUiToolVisibility::None => {}
-                    AgUiToolVisibility::Generic => {
-                        push_public_tool_activity_start(state, state.generic_tool_text.clone());
-                    }
-                    AgUiToolVisibility::Narrated => {
-                        // Public streams must not emit backend/model-authored narration because
-                        // narration may derive from raw tool-call arguments.
-                        push_public_tool_activity_start(state, state.generic_tool_text.clone());
-                    }
+        "tool.started" if parse_event_data::<ToolStartedData>(event).is_ok() => {
+            ensure_assistant_message_id(state, event);
+            state.active_tool_activity_count += 1;
+            match state.tool_visibility {
+                AgUiToolVisibility::None => {}
+                AgUiToolVisibility::Generic => {
+                    push_public_tool_activity_start(state, state.generic_tool_text.clone());
+                }
+                AgUiToolVisibility::Narrated => {
+                    // Public streams must not emit backend/model-authored narration because
+                    // narration may derive from raw tool-call arguments.
+                    push_public_tool_activity_start(state, state.generic_tool_text.clone());
                 }
             }
         }

--- a/crates/server/src/api/ag_ui.rs
+++ b/crates/server/src/api/ag_ui.rs
@@ -977,6 +977,20 @@ struct AgUiStreamState {
     finished: bool,
 }
 
+impl AgUiStreamState {
+    /// Returns the channel-configured generic tool text, trimmed and with a fallback to the
+    /// platform default if the value is empty or whitespace. Used for both `Generic` and
+    /// `Narrated` visibility so the public stream always opens with non-empty safe text.
+    fn safe_public_tool_text(&self) -> String {
+        let trimmed = self.generic_tool_text.trim();
+        if trimmed.is_empty() {
+            everruns_core::app::DEFAULT_AG_UI_GENERIC_TOOL_TEXT.to_string()
+        } else {
+            trimmed.to_string()
+        }
+    }
+}
+
 fn push_public_tool_activity_start(state: &mut AgUiStreamState, text: String) {
     if !state.public_tool_activity_started {
         if !state.thinking_started {
@@ -1153,13 +1167,14 @@ fn translate_event(state: &mut AgUiStreamState, event: &everruns_core::Event) {
             state.active_tool_activity_count += 1;
             match state.tool_visibility {
                 AgUiToolVisibility::None => {}
-                AgUiToolVisibility::Generic => {
-                    push_public_tool_activity_start(state, state.generic_tool_text.clone());
-                }
-                AgUiToolVisibility::Narrated => {
-                    // Public streams must not emit backend/model-authored narration because
-                    // narration may derive from raw tool-call arguments.
-                    push_public_tool_activity_start(state, state.generic_tool_text.clone());
+                // Both Generic and Narrated emit the safe channel-configured generic text.
+                // Narrated must not forward backend/model-authored narration because narration
+                // may derive from raw tool-call arguments. `safe_public_tool_text` falls back
+                // to the platform default if the configured text is empty/whitespace so we
+                // never push an empty delta on the public stream.
+                AgUiToolVisibility::Generic | AgUiToolVisibility::Narrated => {
+                    let text = state.safe_public_tool_text();
+                    push_public_tool_activity_start(state, text);
                 }
             }
         }
@@ -2048,6 +2063,50 @@ mod tests {
                 assert!(!event.delta.contains("private query"));
             }
             _ => panic!("expected narrated thinking content"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_public_tool_text_falls_back_when_configured_value_is_empty() {
+        // Existing channels may have stored an empty/whitespace generic_tool_text from
+        // before validation tightened. The public stream must never emit an empty delta.
+        for visibility in [AgUiToolVisibility::Generic, AgUiToolVisibility::Narrated] {
+            for configured in ["", "   ", "\n\t"] {
+                let mut state = test_stream_state().await;
+                state.tool_visibility = visibility;
+                state.generic_tool_text = configured.to_string();
+                let turn_id = TurnId::new();
+                let input_message_id = MessageId::parse(&state.input_message_id).unwrap();
+                let context = EventContext::turn(turn_id, input_message_id);
+                let session_id = SessionId::from_uuid(state.session_id);
+
+                let tool_started = Event::new(
+                    session_id,
+                    context,
+                    ToolStartedData {
+                        tool_call: ToolCall {
+                            id: "call_1".to_string(),
+                            name: "web_search".to_string(),
+                            arguments: serde_json::json!({"q": "x"}),
+                        },
+                        display_name: None,
+                        narration: Some("backend narration".to_string()),
+                    },
+                );
+                translate_event(&mut state, &tool_started);
+
+                match &state.queue[2] {
+                    AgUiEvent::ThinkingTextMessageContent(event) => {
+                        assert_eq!(
+                            event.delta, "Working...",
+                            "visibility={visibility:?} configured={configured:?}"
+                        );
+                    }
+                    _ => panic!(
+                        "expected non-empty thinking content for visibility {visibility:?} configured {configured:?}"
+                    ),
+                }
+            }
         }
     }
 

--- a/crates/server/src/api/ag_ui.rs
+++ b/crates/server/src/api/ag_ui.rs
@@ -1158,12 +1158,9 @@ fn translate_event(state: &mut AgUiStreamState, event: &everruns_core::Event) {
                         push_public_tool_activity_start(state, state.generic_tool_text.clone());
                     }
                     AgUiToolVisibility::Narrated => {
-                        if let Some(narration) = data.narration {
-                            let narration = narration.trim();
-                            if !narration.is_empty() {
-                                push_public_tool_activity_start(state, narration.to_string());
-                            }
-                        }
+                        // Public streams must not emit backend/model-authored narration because
+                        // narration may derive from raw tool-call arguments.
+                        push_public_tool_activity_start(state, state.generic_tool_text.clone());
                     }
                 }
             }
@@ -2023,7 +2020,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_narrated_tool_visibility_uses_narration_only() {
+    async fn test_narrated_tool_visibility_falls_back_to_generic_text() {
         let mut state = test_stream_state().await;
         state.tool_visibility = AgUiToolVisibility::Narrated;
         let turn_id = TurnId::new();
@@ -2048,7 +2045,7 @@ mod tests {
 
         match &state.queue[2] {
             AgUiEvent::ThinkingTextMessageContent(event) => {
-                assert_eq!(event.delta, "Checking public sources");
+                assert_eq!(event.delta, "Working...");
                 assert!(!event.delta.contains("web_search"));
                 assert!(!event.delta.contains("private query"));
             }

--- a/crates/server/src/domains/apps/commands.rs
+++ b/crates/server/src/domains/apps/commands.rs
@@ -190,11 +190,16 @@ fn validate_channel_config(
                     "AG-UI generic_tool_text must be at most 120 characters",
                 ));
             }
-            if config.tool_visibility == AgUiToolVisibility::Generic
-                && config.generic_tool_text.trim().is_empty()
+            // Narrated also emits the configured generic_tool_text on public streams (the
+            // raw narration is intentionally not forwarded), so non-empty text is required
+            // for both Generic and Narrated.
+            if matches!(
+                config.tool_visibility,
+                AgUiToolVisibility::Generic | AgUiToolVisibility::Narrated
+            ) && config.generic_tool_text.trim().is_empty()
             {
                 return Err(CommandError::bad_request(
-                    "AG-UI generic_tool_text cannot be empty when tool_visibility is generic",
+                    "AG-UI generic_tool_text cannot be empty when tool_visibility is generic or narrated",
                 ));
             }
         }


### PR DESCRIPTION
## Motivation

The public `AgUiToolVisibility::Narrated` flow forwarded `ToolStartedData.narration` into public SSEs. That narration can be derived from raw tool arguments or model-authored `human_intent` text, so it may carry sensitive data. The threat model entry `TM-API-016` explicitly states public AG-UI streaming "never emits raw tool names, arguments, results, or internal tool call IDs," so narrated mode must not reintroduce any of that.

## Description

- Stop forwarding backend/model-authored narration on public AG-UI streams. Both `Generic` and `Narrated` visibility now emit a safe channel-configured generic text (`crates/server/src/api/ag_ui.rs`).
- Add `AgUiStreamState::safe_public_tool_text()` that trims `generic_tool_text` and falls back to the platform default `everruns_core::app::DEFAULT_AG_UI_GENERIC_TOOL_TEXT` (`"Working..."`) when the configured value is empty/whitespace, so the public stream can never open with an empty delta even on pre-existing channels.
- Tighten validation in `crates/server/src/domains/apps/commands.rs` to require non-empty `generic_tool_text` when `tool_visibility` is `Generic` or `Narrated` (was only enforced for `Generic`).
- Drop unused `data` binding in the `tool.started` arm to clear clippy `-D warnings`.

## Validation

- `cargo clippy -p everruns-server --lib --tests -- -D warnings` — clean locally.
- Existing test renamed to `test_narrated_tool_visibility_falls_back_to_generic_text` and asserts the public delta is the safe generic text, not the raw narration.
- New regression test `test_public_tool_text_falls_back_when_configured_value_is_empty` covers `""`, `"   "`, and `"\n\t"` for both `Generic` and `Narrated`, asserting the platform default surfaces.
- CI runs the full server test suite.

## Security

Categories reviewed against `specs/threat-model.md`:

- **TM-API** / **TM-API-016 (Public-endpoint internal error and tool-detail leakage, MITIGATED)** — this change closes a deviation from the documented mitigation: narrated public streams previously could carry model-authored narration derived from raw tool arguments. After this change, the only public-stream tool text comes from the channel-configured `generic_tool_text` (or the platform default fallback), preserving the "never emits raw tool names, arguments, results, or internal tool call IDs" guarantee. No threat-model file change required — the mitigation already described the intended behavior.
- **TM-AUTHZ** / **TM-TENANT** — unchanged; visibility is still per-channel config and validation is org-scoped.
- **TM-DOS** — no new unbounded inputs; runtime fallback uses a short constant string.

No new external dependencies. No new logging of secret material.

## Follow-ups

- No follow-ups. The runtime fallback already covers any pre-existing channels stored before the validation tightened, so no data migration is required and the `narration` field on `ToolStartedData` remains valid for non-public consumers.