### PR TITLE
chore(release): prepare v0.8.28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Highlights
 
-- **Flagged agent versioning** - Agent definitions can now be versioned behind a feature flag, letting operators iterate on agent configurations safely while keeping a stable production version.
+- **Agent versioning** - Agent definitions can now be versioned, letting operators iterate on agent configurations safely while keeping a stable production version.
 - **A2A inbound and outbound parity** - Inbound A2A channels now support `message/stream` SSE ([#1716](https://github.com/everruns/everruns/pull/1716)) and `tasks/get`/`tasks/cancel` with derived state ([#1720](https://github.com/everruns/everruns/pull/1720)); outbound A2A delegation is now governed by the network access policy ([#1711](https://github.com/everruns/everruns/pull/1711)).
 - **Declarative capabilities** - Capabilities can now be defined declaratively, with a runtime gate that blocks high-risk declarative dependencies ([#1710](https://github.com/everruns/everruns/pull/1710)).
 - **Cursor cloud agents integration** - New first-class integration for running Everruns agents from Cursor's cloud agents surface.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- New changes go here. Use `/prepare-release X.Y.Z` to generate draft from commits. -->
 
+## [0.8.28] - 2026-05-07
+
+### Highlights
+
+- **Flagged agent versioning** - Agent definitions can now be versioned behind a feature flag, letting operators iterate on agent configurations safely while keeping a stable production version.
+- **A2A inbound and outbound parity** - Inbound A2A channels now support `message/stream` SSE ([#1716](https://github.com/everruns/everruns/pull/1716)) and `tasks/get`/`tasks/cancel` with derived state ([#1720](https://github.com/everruns/everruns/pull/1720)); outbound A2A delegation is now governed by the network access policy ([#1711](https://github.com/everruns/everruns/pull/1711)).
+- **Declarative capabilities** - Capabilities can now be defined declaratively, with a runtime gate that blocks high-risk declarative dependencies ([#1710](https://github.com/everruns/everruns/pull/1710)).
+- **Cursor cloud agents integration** - New first-class integration for running Everruns agents from Cursor's cloud agents surface.
+- **MCP app resource rendering in chat** - Chat now renders `ui://everruns/...` MCP app resources inline so agents can return rich UI cards.
+- **Machine payment authority** - New payment authority surface lets agents and machine clients act on behalf of an authenticated principal for paid actions ([#1703](https://github.com/everruns/everruns/pull/1703)).
+- **Apps channels UI redesign** - The app channels management UI has been redesigned for clarity and faster channel configuration.
+
+### What's Changed
+
+- feat(capabilities): add declarative capabilities by [@chaliy](https://github.com/chaliy)
+- feat(payments): add machine payment authority ([#1703](https://github.com/everruns/everruns/pull/1703)) by [@chaliy](https://github.com/chaliy)
+- docs(reporting): evaluate StarRocks and DuckDB backends ([#1707](https://github.com/everruns/everruns/pull/1707)) by [@chaliy](https://github.com/chaliy)
+- feat(events): list_events debug filters + events_summary tool ([#1706](https://github.com/everruns/everruns/pull/1706)) by [@chaliy](https://github.com/chaliy)
+- docs(getting-started): add Claude Code section to Use in AI Tools ([#1702](https://github.com/everruns/everruns/pull/1702)) by [@chaliy](https://github.com/chaliy)
+- fix(apps): preserve app owner across channel ingress + wire tests into CI ([#1701](https://github.com/everruns/everruns/pull/1701)) by [@chaliy](https://github.com/chaliy)
+- docs(a2a): cross-link inbound channel and outbound capability specs ([#1708](https://github.com/everruns/everruns/pull/1708)) by [@chaliy](https://github.com/chaliy)
+- fix(mcp): remove stateless org switch tool by [@chaliy](https://github.com/chaliy)
+- fix(durable): reduce turn startup latency by [@chaliy](https://github.com/chaliy)
+- fix(payments): disable redirects in payment authority HTTP client ([#1709](https://github.com/everruns/everruns/pull/1709)) by [@chaliy](https://github.com/chaliy)
+- feat(a2a): implement message/stream SSE on inbound channel ([#1716](https://github.com/everruns/everruns/pull/1716)) by [@chaliy](https://github.com/chaliy)
+- feat(chat): render MCP app resources by [@chaliy](https://github.com/chaliy)
+- fix(capabilities): gate declarative high-risk dependencies ([#1710](https://github.com/everruns/everruns/pull/1710)) by [@chaliy](https://github.com/chaliy)
+- feat(ui): search organisations in command palette by [@chaliy](https://github.com/chaliy)
+- feat(cursor): add cloud agents integration by [@chaliy](https://github.com/chaliy)
+- feat(a2a): add tasks/get and tasks/cancel with derived state ([#1720](https://github.com/everruns/everruns/pull/1720)) by [@chaliy](https://github.com/chaliy)
+- chore(specs): design realtime voice sessions by [@chaliy](https://github.com/chaliy)
+- feat(apps): redesign app channels UI by [@chaliy](https://github.com/chaliy)
+- fix(core): enforce network policy for A2A delegation ([#1711](https://github.com/everruns/everruns/pull/1711)) by [@chaliy](https://github.com/chaliy)
+- fix(ui): bump next to 16.2.6 for security patches ([#1732](https://github.com/everruns/everruns/pull/1732)) by [@chaliy](https://github.com/chaliy)
+- test(worker): scaffold turmoil-based transport reliability tests ([#1724](https://github.com/everruns/everruns/pull/1724)) by [@chaliy](https://github.com/chaliy)
+- fix(server): keep AG-UI open through tool commentary by [@chaliy](https://github.com/chaliy)
+- feat(agent-versions): add flagged agent versioning by [@chaliy](https://github.com/chaliy)
+- fix(ui): skip auth proxy redirects when AUTH_MODE is none by [@chaliy](https://github.com/chaliy)
+- fix(server): harden public AG-UI image uploads ([#1712](https://github.com/everruns/everruns/pull/1712)) by [@chaliy](https://github.com/chaliy)
+
 ## [0.8.27] - 2026-05-07
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1991,11 +1991,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-a2ui"
-version = "0.8.27"
+version = "0.8.28"
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2014,7 +2014,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-cli"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2041,14 +2041,14 @@ dependencies = [
 
 [[package]]
 name = "everruns-config"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "everruns-container-sandbox"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2069,7 +2069,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -2126,7 +2126,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-durable"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2161,7 +2161,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-gemini"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2179,7 +2179,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-brave-search"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2195,7 +2195,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-browserless"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2216,7 +2216,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-cursor"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2231,7 +2231,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2247,7 +2247,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-deno"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2271,7 +2271,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-docker"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2286,7 +2286,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2301,7 +2301,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-e2b"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2330,7 +2330,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-parallel"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2342,7 +2342,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-pi"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2357,7 +2357,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-sprites"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2373,7 +2373,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-internal-protocol"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "chrono",
  "everruns-core",
@@ -2390,7 +2390,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-macros"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2400,7 +2400,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2422,11 +2422,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-openui"
-version = "0.8.27"
+version = "0.8.28"
 
 [[package]]
 name = "everruns-runtime"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2460,7 +2460,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-server"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "aes-gcm",
  "ag-ui-core",
@@ -2547,7 +2547,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-session-sqldb"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2566,7 +2566,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-worker"
-version = "0.8.27"
+version = "0.8.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4041,9 +4041,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.97"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -7923,9 +7923,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost-build"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3144df636917574672e93d0f56d7edec49f90305749c668df5101751bb8f95a"
+checksum = "654e5643eff75d7f8c99197ce1440ed19a3474eada74c12bbac488b2cafdae27"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -8499,9 +8499,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -8512,9 +8512,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.70"
+version = "0.4.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -8522,9 +8522,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -8532,9 +8532,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -8545,9 +8545,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
@@ -8614,9 +8614,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.97"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.8.27"
+version = "0.8.28"
 edition = "2024"
 license = "MIT"
 authors = ["Everruns Contributors"]

--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "everruns-ui",
-  "version": "0.8.27",
+  "version": "0.8.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "everruns-ui",
-      "version": "0.8.27",
+      "version": "0.8.28",
       "dependencies": {
         "@base-ui/react": "^1.2.0",
         "@openuidev/react-lang": "^0.1.3",

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "everruns-ui",
-  "version": "0.8.27",
+  "version": "0.8.28",
   "private": true,
   "exports": {
     "./route-manifest": "./src/lib/ui-route-manifest.ts",


### PR DESCRIPTION
## Release v0.8.28

This PR prepares the v0.8.28 patch release.

### Highlights

- **Agent versioning** — versioned agent definitions for safe iteration on agent configurations.
- **A2A inbound and outbound parity** — `message/stream` SSE (#1716), `tasks/get`/`tasks/cancel` with derived state (#1720), and outbound A2A delegation now governed by the network access policy (#1711).
- **Declarative capabilities** — declarative capability definitions plus a high-risk dependency gate (#1710).
- **Cursor cloud agents integration** — first-class Cursor cloud agents integration.
- **MCP app resource rendering in chat** — chat now renders `ui://everruns/...` MCP app resources inline.
- **Machine payment authority** — new payment authority for agents/machine clients (#1703).
- **Apps channels UI redesign** — clearer, faster channel configuration UI.

### Checklist
- [x] Review CHANGELOG.md entries
- [x] Verify version numbers updated
- [ ] CI passes

### Post-merge
After merging, the release workflow will automatically:
- Create git tag `v0.8.28`
- Create GitHub Release with notes from CHANGELOG.md
- Trigger Docker image build with version tag
- Publish CLI binaries and update the Homebrew formula
