### PR TITLE
fix(server): bound harness usage count fan-out

### DIFF
--- a/crates/server/src/api/harnesses.rs
+++ b/crates/server/src/api/harnesses.rs
@@ -20,7 +20,7 @@ use everruns_core::{
     AgentCapabilityConfig, Caller, DeploymentGrade, Harness, PlatformDefinition,
     ResourceConfigResponse, evaluate_policies_with,
 };
-use futures::{StreamExt, stream};
+use futures::{StreamExt, TryStreamExt, stream};
 
 use super::common::{
     ApiOptionExt, ApiResult, ApiResultExt, ErrorResponse, ListResponse, ResourceStatsResponse,
@@ -121,9 +121,8 @@ async fn add_harnesses_counts(
             .map(|harness| add_harness_counts(db, org_id, harness)),
     )
     .buffered(HARNESS_COUNT_CONCURRENCY_LIMIT)
-    .collect::<Vec<_>>()
-    .into_iter()
-    .collect()
+    .try_collect::<Vec<_>>()
+    .await
 }
 
 /// Create harness routes

--- a/crates/server/src/api/harnesses.rs
+++ b/crates/server/src/api/harnesses.rs
@@ -20,7 +20,7 @@ use everruns_core::{
     AgentCapabilityConfig, Caller, DeploymentGrade, Harness, PlatformDefinition,
     ResourceConfigResponse, evaluate_policies_with,
 };
-use futures::future::try_join_all;
+use futures::{StreamExt, stream};
 
 use super::common::{
     ApiOptionExt, ApiResult, ApiResultExt, ErrorResponse, ListResponse, ResourceStatsResponse,
@@ -108,17 +108,22 @@ async fn add_harness_counts(
     })
 }
 
+const HARNESS_COUNT_CONCURRENCY_LIMIT: usize = 8;
+
 async fn add_harnesses_counts(
     db: &StorageBackend,
     org_id: i64,
     harnesses: Vec<Harness>,
 ) -> Result<Vec<ResourceWithCounts<Harness>>, (StatusCode, Json<ErrorResponse>)> {
-    try_join_all(
+    stream::iter(
         harnesses
             .into_iter()
             .map(|harness| add_harness_counts(db, org_id, harness)),
     )
-    .await
+    .buffered(HARNESS_COUNT_CONCURRENCY_LIMIT)
+    .collect::<Vec<_>>()
+    .into_iter()
+    .collect()
 }
 
 /// Create harness routes


### PR DESCRIPTION
### Motivation
- Aardvark identified that listing harnesses could enqueue unbounded per-row `COUNT(*)` queries, allowing an authenticated caller to amplify DB work and risk exhausting the SQLx connection pool (TM-DOS). 
- The change aims to reduce this availability risk while preserving the new usage-count feature and response shape.

### Description
- Replace unbounded `try_join_all` fan-out in `add_harnesses_counts` with a buffered stream to limit in-flight per-harness count tasks. 
- Add a concurrency cap constant `HARNESS_COUNT_CONCURRENCY_LIMIT` (set to `8`) and use `futures::stream::iter(...).buffered(...)` to enforce it. 
- Update imports and keep per-harness `add_harness_counts` logic and the API response shape unchanged.

### Testing
- Ran `cargo fmt --all`, which succeeded. 
- Started `cargo check -p everruns-server`; the compile/dependency build was in progress in the execution environment and did not complete within the run window (no compile errors were reported from the changed file before the timeout).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcffc753f8832b92daf06c44d87702)