### PR TITLE
fix(mcp): block scoped preview commands from read-only query

### DIFF
--- a/crates/server/src/api/mcp_endpoint/catalog.rs
+++ b/crates/server/src/api/mcp_endpoint/catalog.rs
@@ -21,6 +21,13 @@ pub enum ToolsetMode {
     ReadOnly,
 }
 
+fn excluded_from_read_only_query(name: &str) -> bool {
+    // THREAT[TM-MCP-002]: read-only MCP `query` must not allow commands that
+    // can perform open-world side effects (for example, scoped MCP tool
+    // discovery performs outbound HTTP requests).
+    matches!(name, "preview_agent" | "preview_harness")
+}
+
 static INVENTORY_TOOL_DEFS: LazyLock<HashMap<&'static str, ToolDef>> = LazyLock::new(|| {
     inventory::iter::<crate::domains::common::CommandDescriptor>
         .into_iter()
@@ -83,7 +90,10 @@ pub fn build_toolset(ctx: CatalogContext, mode: ToolsetMode) -> ScriptingToolSet
     for desc in inventory::iter::<crate::domains::common::CommandDescriptor> {
         // THREAT[TM-MCP-002]: MCP `query` must not expose mutating server
         // tools. Read-only classification is backed by inventory tests.
-        if mode == ToolsetMode::ReadOnly && !(desc.read_only)() {
+        let meta = (desc.meta)();
+        if mode == ToolsetMode::ReadOnly
+            && (!(desc.read_only)() || excluded_from_read_only_query(meta.name))
+        {
             continue;
         }
         let def = command_descriptor_to_def(desc);
@@ -753,5 +763,12 @@ mod tests {
         assert!(internal.starts_with("internal:"));
         assert!(forbidden.starts_with("forbidden:"));
         assert_ne!(internal, forbidden);
+    }
+
+    #[test]
+    fn read_only_query_excludes_preview_commands_with_network_side_effects() {
+        assert!(excluded_from_read_only_query("preview_agent"));
+        assert!(excluded_from_read_only_query("preview_harness"));
+        assert!(!excluded_from_read_only_query("list_agents"));
     }
 }

--- a/crates/server/tests/mcp_endpoint_test.rs
+++ b/crates/server/tests/mcp_endpoint_test.rs
@@ -1262,7 +1262,11 @@ async fn test_mcp_query_list_harnesses_wrong_jq_shape_is_concise() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_mcp_query_allows_read_only_post_helpers() {
+async fn test_mcp_query_rejects_preview_commands_with_network_side_effects() {
+    // EVE / TM-MCP-002: even though `preview_agent` and `preview_harness`
+    // are flagged `read_only()`, they perform scoped MCP discovery which
+    // makes outbound HTTP requests. They must not be exposed under the
+    // read-only `query` tool, which is the no-side-effects entry point.
     let server = TestServer::in_memory().await;
     let resp = mcp_tool_call(
         &server,
@@ -1271,14 +1275,22 @@ async fn test_mcp_query_allows_read_only_post_helpers() {
     )
     .await;
     assert!(
-        !tool_is_error(&resp),
-        "query preview_agent failed: {}",
+        tool_is_error(&resp),
+        "query preview_agent unexpectedly succeeded: {}",
         tool_text(&resp)
     );
 
-    let result = tool_json(&resp);
-    assert_eq!(result["system_prompt"], "Preview via query");
-    assert!(result["tools"].is_array());
+    let resp_harness = mcp_tool_call(
+        &server,
+        "query",
+        json!({ "commands": "preview_harness --system_prompt 'Preview via query'" }),
+    )
+    .await;
+    assert!(
+        tool_is_error(&resp_harness),
+        "query preview_harness unexpectedly succeeded: {}",
+        tool_text(&resp_harness)
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]


### PR DESCRIPTION
### Motivation
- The change closes a regression where generic bash JSON flag coercion allowed read-only MCP `query` scripts to pass `mcp_servers` through to preview commands that perform live scoped MCP discovery (causing outbound HTTP requests despite `open_world_hint: false`).
- The goal is to preserve the full toolset behavior while restoring the intended read-only/no-network trust boundary for `query`.

### Description
- Added an `excluded_from_read_only_query` helper and used it when building the read-only `ScriptingToolSet` to explicitly exclude `preview_agent` and `preview_harness` from the `query` toolset (`crates/server/src/api/mcp_endpoint/catalog.rs`).
- The `build_toolset` loop now skips commands that are either not `read_only()` or are on the explicit exclusion list, leaving full-mode availability unchanged. (`crates/server/src/api/mcp_endpoint/catalog.rs`).
- Added a regression unit test `read_only_query_excludes_preview_commands_with_network_side_effects` asserting the exclusion behavior is enforced (`crates/server/src/api/mcp_endpoint/catalog.rs::tests`).

### Testing
- Added a targeted unit test that asserts `excluded_from_read_only_query` returns true for `preview_agent` and `preview_harness` and false for a normal read-only command. 
- Attempted to run `cargo test -p everruns-server read_only_query_excludes_preview_commands_with_network_side_effects -- --nocapture`, which started dependency fetch and compilation in this environment but did not complete within the session. 
- Recommend running the full test suite and CI (`just pre-push` / GitHub Actions) to verify the change across platforms and confirm no regressions in the broader test matrix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcffc7c1a8832b9b3842b2ce175655)