### PR TITLE
fix(ui): hide raw chat failure diagnostics

### DIFF
--- a/apps/ui/src/__tests__/chat-panel.test.tsx
+++ b/apps/ui/src/__tests__/chat-panel.test.tsx
@@ -429,6 +429,31 @@ describe("ChatPanel placeholder", () => {
     expect(
       screen.getByText("Execution stopped because a required dependency is unavailable."),
     ).toBeInTheDocument();
+    expect(screen.queryByText("backend temporarily unavailable")).not.toBeInTheDocument();
+  });
+
+  it("hides raw failed turn diagnostics when no structured error code is available", () => {
+    mockSessionContext.chatEvents = [
+      {
+        id: "evt-failed-raw-1",
+        type: "turn.failed",
+        session_id: "session-1",
+        ts: new Date().toISOString(),
+        context: { turn_id: "turn-1" },
+        data: {
+          turn_id: "turn-1",
+          error: "provider token leaked in diagnostic payload",
+        },
+      },
+    ];
+
+    render(<ChatPanel />);
+
+    expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+    expect(screen.getByText("Message failed.")).toBeInTheDocument();
+    expect(
+      screen.queryByText("provider token leaked in diagnostic payload"),
+    ).not.toBeInTheDocument();
   });
 
   it("renders a chat error alert when sending a message fails", async () => {

--- a/apps/ui/src/__tests__/chat-panel.test.tsx
+++ b/apps/ui/src/__tests__/chat-panel.test.tsx
@@ -429,7 +429,6 @@ describe("ChatPanel placeholder", () => {
     expect(
       screen.getByText("Execution stopped because a required dependency is unavailable."),
     ).toBeInTheDocument();
-    expect(screen.getByText(/backend temporarily unavailable/)).toBeInTheDocument();
   });
 
   it("renders a chat error alert when sending a message fails", async () => {

--- a/apps/ui/src/components/chat/chat-message-list.tsx
+++ b/apps/ui/src/components/chat/chat-message-list.tsx
@@ -19,7 +19,7 @@ import type {
   ToolProgressData,
 } from "@/lib/api/types";
 import type { ToolOutputStreams } from "@/app/(main)/sessions/[sessionId]/session-context";
-import { getEventData, getTextFromContent, isImageFilePart } from "@/lib/api/types";
+import { getEventData, isImageFilePart } from "@/lib/api/types";
 import { MessageInfoIcon } from "@/components/chat/message-info-icon";
 import { MessageImage } from "@/components/chat/image-attachments";
 import { MessageContent } from "@/components/chat/message-content";
@@ -71,32 +71,6 @@ function getMessageImages(content: ContentPart[]): Array<{ image_id: string; fil
     image_id: part.image_id,
     filename: part.filename,
   }));
-}
-
-function formatFailureDetails({
-  event,
-  error,
-  errorCode,
-  errorFields,
-  rawMessage,
-}: {
-  event: Event;
-  error?: string;
-  errorCode?: string;
-  errorFields?: Record<string, unknown>;
-  rawMessage?: string;
-}): string | null {
-  const lines = [
-    `event_id: ${event.id}`,
-    `event_type: ${event.type}`,
-    event.context?.turn_id ? `turn_id: ${event.context.turn_id}` : null,
-    errorCode ? `error_code: ${errorCode}` : null,
-    error && error !== rawMessage ? `error: ${error}` : null,
-    rawMessage ? `message: ${rawMessage}` : null,
-    errorFields ? `error_fields: ${JSON.stringify(errorFields, null, 2)}` : null,
-  ].filter(Boolean);
-
-  return lines.length > 0 ? lines.join("\n") : null;
 }
 
 function getTurnFailedMessage(locale: SupportedLocale, data: TurnFailedData): string {
@@ -291,12 +265,6 @@ export const ChatMessageList = memo(function ChatMessageList({
             <ChatErrorAlert
               key={event.id}
               message={getTurnFailedMessage(locale, turnFailedData)}
-              details={formatFailureDetails({
-                event,
-                error: turnFailedData.error,
-                errorCode: turnFailedData.error_code,
-                errorFields: turnFailedData.error_fields,
-              })}
             />
           );
         }
@@ -405,17 +373,10 @@ export const ChatMessageList = memo(function ChatMessageList({
         const textContent = getMessageText(data);
         const outputError = outputData ? getRuntimeErrorFromOutputMessage(outputData) : undefined;
         if (outputData && outputError) {
-          const rawMessage = getTextFromContent(outputData.message?.content ?? []);
           return (
             <ChatErrorAlert
               key={event.id}
               message={textContent}
-              details={formatFailureDetails({
-                event,
-                errorCode: outputError.code,
-                errorFields: outputError.fields,
-                rawMessage,
-              })}
             />
           );
         }

--- a/apps/ui/src/components/chat/chat-message-list.tsx
+++ b/apps/ui/src/components/chat/chat-message-list.tsx
@@ -74,7 +74,7 @@ function getMessageImages(content: ContentPart[]): Array<{ image_id: string; fil
 }
 
 function getTurnFailedMessage(locale: SupportedLocale, data: TurnFailedData): string {
-  return localizeRuntimeError(locale, getRuntimeErrorFromTurnFailed(data), data.error);
+  return localizeRuntimeError(locale, getRuntimeErrorFromTurnFailed(data), "");
 }
 
 function buildActGroups(chatEvents: Event[], workingLabel: string) {
@@ -262,10 +262,7 @@ export const ChatMessageList = memo(function ChatMessageList({
         const turnFailedData = getEventData(event, "turn.failed");
         if (turnFailedData) {
           return (
-            <ChatErrorAlert
-              key={event.id}
-              message={getTurnFailedMessage(locale, turnFailedData)}
-            />
+            <ChatErrorAlert key={event.id} message={getTurnFailedMessage(locale, turnFailedData)} />
           );
         }
 
@@ -373,12 +370,7 @@ export const ChatMessageList = memo(function ChatMessageList({
         const textContent = getMessageText(data);
         const outputError = outputData ? getRuntimeErrorFromOutputMessage(outputData) : undefined;
         if (outputData && outputError) {
-          return (
-            <ChatErrorAlert
-              key={event.id}
-              message={textContent}
-            />
-          );
+          return <ChatErrorAlert key={event.id} message={textContent} />;
         }
         const toolCalls = isUser
           ? []


### PR DESCRIPTION
### Motivation

- Prevent exposing backend/provider diagnostic payloads (raw `error`, `error_fields`, raw message text, event ids) to authenticated chat viewers via the chat transcript details UI.
- Preserve user-facing localized error messaging while removing the accidental information-disclosure surface introduced by rendering raw event diagnostics.

### Description

- Remove the diagnostic `details` plumbing from chat error rendering so `ChatErrorAlert` is only shown with the localized/sanitized `message` for `turn.failed` and runtime output errors in `ChatMessageList`.
- Drop the `formatFailureDetails` usage and any passing of `error`, `error_fields`, `rawMessage`, and `error_code` into the UI details block in `apps/ui/src/components/chat/chat-message-list.tsx`.
- Remove the now-unused import `getTextFromContent` and clean up related dead code to avoid accidental re-exposure of raw payloads.
- Update the existing unit test at `apps/ui/src/__tests__/chat-panel.test.tsx` to stop asserting that raw backend error text is visible and instead assert only the localized/sanitized copy.

### Testing

- Ran the chat-panel UI unit test target with `npm --prefix apps/ui test -- --runTestsByPath src/__tests__/chat-panel.test.tsx --runInBand`, which could not execute in this environment because `jest` is not installed (`sh: 1: jest: not found`).
- No other automated test runs were possible in the current container; changes are limited and focused to the UI surface to minimize risk and preserve existing localized error flows.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcffc742b8832bb1a1fcdf192f6600)