### PR TITLE
fix(core): avoid utf8 panic in prompt canary truncation

### DIFF
--- a/crates/core/src/capabilities/prompt_canary_guardrail.rs
+++ b/crates/core/src/capabilities/prompt_canary_guardrail.rs
@@ -162,9 +162,7 @@ fn extract_canary(prompt: &str) -> Option<String> {
             let end = (i + 1).min(bytes.len());
             let sentence = core[start..end].trim();
             let mut needle = normalize(sentence);
-            if needle.len() > MAX_CANARY_LEN {
-                needle.truncate(MAX_CANARY_LEN);
-            }
+            truncate_at_char_boundary(&mut needle, MAX_CANARY_LEN);
             if needle.len() >= MIN_CANARY_LEN {
                 return Some(needle);
             }
@@ -174,10 +172,21 @@ fn extract_canary(prompt: &str) -> Option<String> {
     // No sentence boundary found — fall back to the whole prompt if it's
     // long enough on its own.
     let mut needle = normalize(&core[start..]);
-    if needle.len() > MAX_CANARY_LEN {
-        needle.truncate(MAX_CANARY_LEN);
-    }
+    truncate_at_char_boundary(&mut needle, MAX_CANARY_LEN);
     (needle.len() >= MIN_CANARY_LEN).then_some(needle)
+}
+
+fn truncate_at_char_boundary(s: &mut String, max_bytes: usize) {
+    if s.len() <= max_bytes {
+        return;
+    }
+    let truncate_at = s
+        .char_indices()
+        .map(|(idx, _)| idx)
+        .take_while(|idx| *idx <= max_bytes)
+        .last()
+        .unwrap_or(0);
+    s.truncate(truncate_at);
 }
 
 /// Append the normalized form of `chunk` to `acc`, preserving the
@@ -404,5 +413,19 @@ mod tests {
             }
         }
         assert!(tripped, "expected canary to trip on multi-chunk leak");
+    }
+
+    #[test]
+    fn extract_canary_does_not_panic_when_truncation_hits_multibyte_in_sentence_path() {
+        let prompt = format!("{}é. trailing sentence.", "a".repeat(MAX_CANARY_LEN - 1));
+        let needle = extract_canary(&prompt).expect("extracted");
+        assert!(needle.len() <= MAX_CANARY_LEN);
+    }
+
+    #[test]
+    fn extract_canary_does_not_panic_when_truncation_hits_multibyte_in_fallback_path() {
+        let prompt = format!("{}é trailing text", "a".repeat(MAX_CANARY_LEN - 1));
+        let needle = extract_canary(&prompt).expect("extracted");
+        assert!(needle.len() <= MAX_CANARY_LEN);
     }
 }


### PR DESCRIPTION
### Motivation
- The prompt canary used `String::truncate(MAX_CANARY_LEN)` on a normalized UTF-8 `String`, which can panic when the byte cutoff lands inside a multi-byte character and cause a DoS in guarded executions. 
- The change aims to ensure the guardrail cannot be crashed by attacker-controlled non-ASCII system prompts while preserving the original length cap and matching behavior.

### Description
- Added a UTF-8-safe helper `truncate_at_char_boundary(&mut String, max_bytes: usize)` and replaced both raw `truncate` call sites in `extract_canary` (sentence-path and fallback-path) with the helper. 
- Preserved the existing semantics of `MIN_CANARY_LEN` / `MAX_CANARY_LEN` and the normalization logic; only truncation mechanics were changed. 
- Added two regression tests exercising the previously panic-able cases and ensuring the extracted `needle` remains ≤ `MAX_CANARY_LEN` for both the sentence-boundary and fallback paths. 
- Modified file: `crates/core/src/capabilities/prompt_canary_guardrail.rs` (helper, call-site updates, and tests).

### Testing
- Ran `cargo test -p everruns-core prompt_canary_guardrail` and the entire test run for the package completed successfully. 
- The prompt canary unit test suite passed (14 tests in the module passed) and the `reason_atom_test` that exercises the guardrail behavior also passed. 
- Added tests: `extract_canary_does_not_panic_when_truncation_hits_multibyte_in_sentence_path` and `extract_canary_does_not_panic_when_truncation_hits_multibyte_in_fallback_path`, both of which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcffc742ec832b85a1b2b664f120a4)