### PR TITLE
feat(skills): add search, view dialog, and usage counts

### DIFF
--- a/apps/ui/src/app/(main)/skills/skills-page-client.tsx
+++ b/apps/ui/src/app/(main)/skills/skills-page-client.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { QueryStateWrapper } from "@/components/query-state-wrapper";
+import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import {
@@ -20,23 +21,62 @@ import {
   useSkills,
   useCreateSkill,
   useDestroySkill,
+  useSkillContent,
+  useSkillsUsage,
   useUpdateSkill,
   useUploadSkill,
 } from "@/hooks/use-skills";
 import { usePolicies } from "@/hooks/use-policies";
-import { Plus, BookOpen, Trash2, Upload, FileText, Archive, Box } from "lucide-react";
-import type { Skill } from "@/lib/api/types";
+import {
+  Plus,
+  BookOpen,
+  Trash2,
+  Upload,
+  FileText,
+  Archive,
+  Box,
+  Bot,
+  Eye,
+  Layers,
+  Search,
+} from "lucide-react";
+import type { Skill, SkillUsage } from "@/lib/api/types";
 import { getEntityNameClassName, getEntityStatusBadgeVariant } from "@/lib/entity-lifecycle";
 import { ArchiveFilter } from "@/components/archive-filter";
+import { InlineStreamdownMessage } from "@/components/chat/streamdown-message";
+
+function SkillUsageRow({ usage }: { usage: SkillUsage | undefined }) {
+  const agents = usage?.agents ?? 0;
+  const harnesses = usage?.harnesses ?? 0;
+  if (agents === 0 && harnesses === 0) {
+    return <div className="text-xs text-muted-foreground">Not in use</div>;
+  }
+  return (
+    <div className="flex items-center gap-3 text-xs text-muted-foreground">
+      <span className="inline-flex items-center gap-1" aria-label={`${agents} agents`}>
+        <Bot className="h-3.5 w-3.5" />
+        {agents} {agents === 1 ? "agent" : "agents"}
+      </span>
+      <span className="inline-flex items-center gap-1" aria-label={`${harnesses} harnesses`}>
+        <Layers className="h-3.5 w-3.5" />
+        {harnesses} {harnesses === 1 ? "harness" : "harnesses"}
+      </span>
+    </div>
+  );
+}
 
 function SkillCard({
   skill,
+  usage,
   canDestroy,
   onDelete,
+  onView,
 }: {
   skill: Skill;
+  usage: SkillUsage | undefined;
   canDestroy: boolean;
   onDelete: (skill: Skill) => void;
+  onView: (skill: Skill) => void;
 }) {
   const updateSkill = useUpdateSkill(skill.id);
   const isArchived = skill.status === "archived";
@@ -74,8 +114,13 @@ function SkillCard({
           {skill.allowed_tools && (
             <div className="text-muted-foreground">Tools: {skill.allowed_tools}</div>
           )}
+          <SkillUsageRow usage={usage} />
         </div>
         <div className="flex items-center justify-end gap-2 mt-4">
+          <Button variant="outline" size="sm" onClick={() => onView(skill)}>
+            <Eye className="h-4 w-4 mr-1" />
+            View
+          </Button>
           {!isArchived && !isDeleted && (
             <Button
               variant="outline"
@@ -96,6 +141,140 @@ function SkillCard({
         </div>
       </CardContent>
     </Card>
+  );
+}
+
+/**
+ * Parses YAML frontmatter and markdown body from a reconstructed SKILL.md.
+ * Falls back to treating the whole text as the body if no fenced frontmatter
+ * block is present.
+ */
+function splitFrontmatter(skillMd: string): { frontmatter: string; body: string } {
+  const match = skillMd.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/);
+  if (!match) return { frontmatter: "", body: skillMd };
+  return { frontmatter: match[1] ?? "", body: (match[2] ?? "").trimStart() };
+}
+
+function SkillDetailDialog({
+  skill,
+  usage,
+  onOpenChange,
+}: {
+  skill: Skill | null;
+  usage: SkillUsage | undefined;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const open = skill !== null;
+  const { data: content, isLoading, error } = useSkillContent(skill?.id ?? "");
+  const split = useMemo(
+    () => (content ? splitFrontmatter(content.skill_md) : { frontmatter: "", body: "" }),
+    [content],
+  );
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-4xl max-h-[85vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            {skill?.source_type === "archive" ? (
+              <Archive className="h-5 w-5 text-primary" />
+            ) : (
+              <FileText className="h-5 w-5 text-primary" />
+            )}
+            {skill?.name}
+          </DialogTitle>
+          <DialogDescription>{skill?.description}</DialogDescription>
+        </DialogHeader>
+        {skill && (
+          <div className="space-y-6">
+            <section className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
+              <div>
+                <Label className="text-muted-foreground">Status</Label>
+                <div>
+                  <Badge variant={getEntityStatusBadgeVariant(skill.status)}>{skill.status}</Badge>
+                </div>
+              </div>
+              <div>
+                <Label className="text-muted-foreground">Source</Label>
+                <div>{skill.source_type}</div>
+              </div>
+              <div>
+                <Label className="text-muted-foreground">Version</Label>
+                <div>{skill.version}</div>
+              </div>
+              <div>
+                <Label className="text-muted-foreground">License</Label>
+                <div>{skill.license ?? "—"}</div>
+              </div>
+              <div>
+                <Label className="text-muted-foreground">Compatibility</Label>
+                <div>{skill.compatibility ?? "—"}</div>
+              </div>
+              <div>
+                <Label className="text-muted-foreground">Allowed tools</Label>
+                <div>{skill.allowed_tools ?? "—"}</div>
+              </div>
+              <div className="col-span-2">
+                <Label className="text-muted-foreground">Used by</Label>
+                <SkillUsageRow usage={usage} />
+              </div>
+            </section>
+
+            <section>
+              <Label className="text-muted-foreground">Frontmatter</Label>
+              {isLoading && <Skeleton className="h-24 w-full mt-1" />}
+              {error && (
+                <p className="text-sm text-destructive mt-1">Failed to load skill content.</p>
+              )}
+              {content && (
+                <pre className="mt-1 p-3 bg-muted text-xs font-mono whitespace-pre-wrap break-all overflow-x-auto">
+                  {split.frontmatter || "(no frontmatter)"}
+                </pre>
+              )}
+            </section>
+
+            <section>
+              <Label className="text-muted-foreground">SKILL.md</Label>
+              {isLoading && <Skeleton className="h-32 w-full mt-1" />}
+              {content && (
+                <div className="mt-1 p-3 bg-muted text-sm overflow-x-auto">
+                  {split.body.trim() ? (
+                    <InlineStreamdownMessage>{split.body}</InlineStreamdownMessage>
+                  ) : (
+                    <span className="text-muted-foreground">(empty)</span>
+                  )}
+                </div>
+              )}
+            </section>
+
+            {content && content.files.length > 0 && (
+              <section>
+                <Label className="text-muted-foreground">
+                  Bundled files ({content.files.length})
+                </Label>
+                <div className="mt-1 space-y-2">
+                  {content.files.map((file) => (
+                    <details key={file.path} className="border bg-muted/40">
+                      <summary className="cursor-pointer px-3 py-2 text-sm font-mono">
+                        {file.path}
+                      </summary>
+                      <pre className="px-3 py-2 text-xs font-mono whitespace-pre-wrap break-all border-t bg-background overflow-x-auto">
+                        {file.content}
+                      </pre>
+                    </details>
+                  ))}
+                </div>
+              </section>
+            )}
+          </div>
+        )}
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Close
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }
 
@@ -235,7 +414,9 @@ function SkillCardSkeleton() {
 
 export default function SkillsPageClient() {
   const [showArchived, setShowArchived] = useState(false);
+  const [search, setSearch] = useState("");
   const { data: skills, isLoading, error } = useSkills({ includeArchived: showArchived });
+  const { data: usage } = useSkillsUsage();
   const destroySkillMutation = useDestroySkill();
   const { can: canPolicies } = usePolicies("skills");
   const canDestroy = canPolicies("skill.dangerous");
@@ -243,6 +424,19 @@ export default function SkillsPageClient() {
   const [addSkillOpen, setAddSkillOpen] = useState(false);
   const [uploadSkillOpen, setUploadSkillOpen] = useState(false);
   const [pendingDeleteSkill, setPendingDeleteSkill] = useState<Skill | null>(null);
+  const [viewingSkill, setViewingSkill] = useState<Skill | null>(null);
+
+  const filteredSkills = useMemo(() => {
+    if (!skills) return skills;
+    const query = search.trim().toLowerCase();
+    if (!query) return skills;
+    return skills.filter(
+      (s) =>
+        s.name.toLowerCase().includes(query) ||
+        s.description.toLowerCase().includes(query) ||
+        (s.allowed_tools?.toLowerCase().includes(query) ?? false),
+    );
+  }, [skills, search]);
 
   const handleDeleteSkill = async () => {
     if (!pendingDeleteSkill) return;
@@ -252,9 +446,19 @@ export default function SkillsPageClient() {
 
   return (
     <div className="container mx-auto p-6">
-      <div className="flex items-center justify-between mb-6">
+      <div className="flex items-center justify-between mb-6 gap-2 flex-wrap">
         <h1 className="text-2xl font-bold">Skills</h1>
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 flex-wrap">
+          <div className="relative">
+            <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+            <Input
+              placeholder="Search skills..."
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="pl-8 w-64"
+              aria-label="Search skills"
+            />
+          </div>
           <ArchiveFilter showArchived={showArchived} onShowArchivedChange={setShowArchived} />
           <Button variant="outline" onClick={() => setUploadSkillOpen(true)}>
             <Upload className="h-4 w-4 mr-2" />
@@ -270,7 +474,7 @@ export default function SkillsPageClient() {
       <QueryStateWrapper
         isLoading={isLoading}
         error={error}
-        data={skills}
+        data={filteredSkills}
         errorMessagePrefix="Failed to load skills"
         loadingSkeleton={
           <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
@@ -282,17 +486,21 @@ export default function SkillsPageClient() {
         emptyState={
           <div className="text-center py-12">
             <BookOpen className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
-            <p className="text-muted-foreground mb-4">No skills yet</p>
-            <div className="flex justify-center gap-2">
-              <Button variant="outline" onClick={() => setUploadSkillOpen(true)}>
-                <Upload className="h-4 w-4 mr-2" />
-                Upload ZIP
-              </Button>
-              <Button onClick={() => setAddSkillOpen(true)}>
-                <Plus className="h-4 w-4 mr-2" />
-                Add Skill
-              </Button>
-            </div>
+            <p className="text-muted-foreground mb-4">
+              {search.trim() ? "No skills match your search" : "No skills yet"}
+            </p>
+            {!search.trim() && (
+              <div className="flex justify-center gap-2">
+                <Button variant="outline" onClick={() => setUploadSkillOpen(true)}>
+                  <Upload className="h-4 w-4 mr-2" />
+                  Upload ZIP
+                </Button>
+                <Button onClick={() => setAddSkillOpen(true)}>
+                  <Plus className="h-4 w-4 mr-2" />
+                  Add Skill
+                </Button>
+              </div>
+            )}
           </div>
         }
       >
@@ -302,14 +510,21 @@ export default function SkillsPageClient() {
               <SkillCard
                 key={skill.id}
                 skill={skill}
+                usage={usage?.[skill.id]}
                 canDestroy={canDestroy}
                 onDelete={setPendingDeleteSkill}
+                onView={setViewingSkill}
               />
             ))}
           </div>
         )}
       </QueryStateWrapper>
 
+      <SkillDetailDialog
+        skill={viewingSkill}
+        usage={viewingSkill ? usage?.[viewingSkill.id] : undefined}
+        onOpenChange={(open) => !open && setViewingSkill(null)}
+      />
       <AddSkillDialog open={addSkillOpen} onOpenChange={setAddSkillOpen} />
       <UploadSkillDialog open={uploadSkillOpen} onOpenChange={setUploadSkillOpen} />
       <Dialog

--- a/apps/ui/src/hooks/use-skills.ts
+++ b/apps/ui/src/hooks/use-skills.ts
@@ -1,7 +1,12 @@
 "use client";
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { getSkillContent, skillsCrudApi, uploadSkillArchive } from "@/lib/api/skills";
+import {
+  getSkillContent,
+  getSkillsUsage,
+  skillsCrudApi,
+  uploadSkillArchive,
+} from "@/lib/api/skills";
 import type { CreateSkillRequest, UpdateSkillRequest } from "@/lib/api/types";
 import { queryKeys } from "@/lib/query-keys";
 import { createCrudHooks, useOrgScopedQuery } from "./create-crud-hooks";
@@ -43,6 +48,14 @@ export function useSkillContent(skillId: string) {
     queryKey: queryKeys.skills.content(skillId),
     queryFn: () => getSkillContent(skillId),
     enabled: !!skillId,
+  });
+}
+
+export function useSkillsUsage() {
+  return useOrgScopedQuery({
+    queryKey: queryKeys.skills.usage(),
+    queryFn: getSkillsUsage,
+    staleTime: 30000,
   });
 }
 

--- a/apps/ui/src/lib/api/skills.ts
+++ b/apps/ui/src/lib/api/skills.ts
@@ -7,6 +7,7 @@ import type {
   CreateSkillRequest,
   Skill,
   SkillContent,
+  SkillUsageMap,
   SkillValidationResult,
   UpdateSkillRequest,
   ValidateSkillRequest,
@@ -25,6 +26,11 @@ export const destroySkill = skillsCrudApi.destroy;
 
 export async function getSkillContent(skillId: string): Promise<SkillContent> {
   const response = await api.get<SkillContent>(`/v1/skills/${skillId}/content`);
+  return response.data;
+}
+
+export async function getSkillsUsage(): Promise<SkillUsageMap> {
+  const response = await api.get<SkillUsageMap>("/v1/skills/usage");
   return response.data;
 }
 

--- a/apps/ui/src/lib/api/types/skill-types.ts
+++ b/apps/ui/src/lib/api/types/skill-types.ts
@@ -36,6 +36,15 @@ export interface SkillFileEntry {
   content: string;
 }
 
+/** Per-skill usage counts (active agents/harnesses referencing the skill capability). */
+export interface SkillUsage {
+  agents: number;
+  harnesses: number;
+}
+
+/** Map keyed by SkillId (e.g. `skill_<32hex>`); skills with zero usage are absent. */
+export type SkillUsageMap = Record<string, SkillUsage>;
+
 /** Validation result for SKILL.md */
 export interface SkillValidationResult {
   valid: boolean;

--- a/apps/ui/src/lib/query-keys.ts
+++ b/apps/ui/src/lib/query-keys.ts
@@ -230,5 +230,6 @@ export const queryKeys = {
     list: (includeArchived = false) => ["skills", { includeArchived }] as const,
     detail: (skillId: string) => ["skill", skillId] as const,
     content: (skillId: string) => ["skill", skillId, "content"] as const,
+    usage: () => ["skills", "usage"] as const,
   },
 };

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -370,7 +370,7 @@ pub use session_sqldb::{
     SqlQueryResult, TableSchema,
 };
 pub use skill::{
-    ParsedSkillMd, Skill, SkillContent, SkillFileEntry, SkillSourceType, SkillStatus,
+    ParsedSkillMd, Skill, SkillContent, SkillFileEntry, SkillSourceType, SkillStatus, SkillUsage,
     SkillValidationResult, parse_skill_md, validate_skill_md, validate_skill_name,
 };
 pub use typed_id::{

--- a/crates/core/src/skill.rs
+++ b/crates/core/src/skill.rs
@@ -229,9 +229,9 @@ pub struct SkillFileEntry {
 }
 
 /// Number of agents and harnesses that reference a skill via its
-/// `skill:{uuid}` capability id. Skills with zero usage are returned as
-/// `agents = 0, harnesses = 0` rather than being omitted, so the UI can
-/// distinguish "loaded but unused" from "not yet loaded".
+/// `skill:{uuid}` capability id. The `/v1/skills/usage` endpoint returns this
+/// keyed by public `SkillId`; skills with no references are omitted from the
+/// map and the UI defaults missing entries to zero.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct SkillUsage {

--- a/crates/core/src/skill.rs
+++ b/crates/core/src/skill.rs
@@ -228,6 +228,17 @@ pub struct SkillFileEntry {
     pub content: String,
 }
 
+/// Number of agents and harnesses that reference a skill via its
+/// `skill:{uuid}` capability id. Skills with zero usage are returned as
+/// `agents = 0, harnesses = 0` rather than being omitted, so the UI can
+/// distinguish "loaded but unused" from "not yet loaded".
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct SkillUsage {
+    pub agents: u64,
+    pub harnesses: u64,
+}
+
 /// Validation result for SKILL.md
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]

--- a/crates/server/src/api/skills.rs
+++ b/crates/server/src/api/skills.rs
@@ -21,10 +21,11 @@ use axum::{
 };
 use axum_extra::extract::Multipart;
 use everruns_core::{
-    Caller, ResourceConfigResponse, Skill, SkillContent, SkillValidationResult,
+    Caller, ResourceConfigResponse, Skill, SkillContent, SkillUsage, SkillValidationResult,
     evaluate_policies_with, validate_skill_md,
 };
 use serde::Deserialize;
+use std::collections::HashMap;
 use std::sync::Arc;
 use utoipa::{IntoParams, ToSchema};
 
@@ -128,6 +129,7 @@ pub fn routes(state: AppState) -> Router {
     Router::new()
         .route("/v1/skills", post(create_skill).get(list_skills))
         .route("/v1/skills/config", get(skill_config))
+        .route("/v1/skills/usage", get(list_skills_usage))
         .route(
             "/v1/skills/upload",
             post(upload_skill).layer(DefaultBodyLimit::max(MAX_ARCHIVE_UPLOAD)),
@@ -262,6 +264,25 @@ pub async fn list_skills(
             search: query.search,
             include_archived: query.include_archived.unwrap_or(false),
         })
+        .await
+}
+
+/// GET /v1/skills/usage - Count agents/harnesses referencing each skill
+#[utoipa::path(
+    get,
+    path = "/v1/skills/usage",
+    responses(
+        (status = 200, description = "Usage map keyed by skill id", body = HashMap<String, SkillUsage>),
+    ),
+    tag = "skills"
+)]
+pub async fn list_skills_usage(
+    org: ResolvedOrg,
+    State(state): State<AppState>,
+) -> ApiResult<HashMap<String, SkillUsage>> {
+    state
+        .dispatcher(&org)
+        .run(crate::domains::skills::ListSkillsUsage {})
         .await
 }
 

--- a/crates/server/src/domains/skills/commands.rs
+++ b/crates/server/src/domains/skills/commands.rs
@@ -593,16 +593,11 @@ impl Command for ListSkillsUsage {
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<HashMap<String, SkillUsage>, CommandError> {
-        let agent_counts = ctx
-            .db
-            .count_agent_capability_references(ctx.org_id())
-            .await
-            .map_err(classify_anyhow)?;
-        let harness_counts = ctx
-            .db
-            .count_harness_capability_references(ctx.org_id())
-            .await
-            .map_err(classify_anyhow)?;
+        let (agent_counts, harness_counts) = tokio::try_join!(
+            ctx.db.count_agent_capability_references(ctx.org_id()),
+            ctx.db.count_harness_capability_references(ctx.org_id()),
+        )
+        .map_err(classify_anyhow)?;
 
         let mut usage: HashMap<String, SkillUsage> = HashMap::new();
         for (cap_id, count) in agent_counts {

--- a/crates/server/src/domains/skills/commands.rs
+++ b/crates/server/src/domains/skills/commands.rs
@@ -11,7 +11,8 @@ use super::types::{CreateSkillRequest, CreateSkillRow, UpdateSkill, UpdateSkillR
 use super::{SKILL_DANGEROUS, SKILL_MANAGE, SKILL_VIEW};
 use crate::domains::common::*;
 use everruns_core::{
-    Policy, Skill, SkillContent, SkillFileEntry, SkillId, SkillStatus, parse_skill_md,
+    Policy, SKILL_CAPABILITY_PREFIX, Skill, SkillContent, SkillFileEntry, SkillId, SkillStatus,
+    SkillUsage, parse_skill_md,
 };
 use serde::Deserialize;
 use std::collections::HashMap;
@@ -562,3 +563,66 @@ impl Command for DestroySkill {
 }
 
 inventory::submit! { CommandDescriptor::of::<DestroySkill>() }
+
+// ============================================================================
+// ListSkillsUsage
+// ============================================================================
+
+/// List skill usage counts: how many active agents and harnesses reference each
+/// skill via its `skill:{uuid}` capability id. Returned map is keyed by the
+/// public SkillId string (e.g. `skill_<32hex>`). Skills with zero references
+/// are omitted; the UI defaults missing entries to zero.
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct ListSkillsUsage {}
+
+impl Command for ListSkillsUsage {
+    type Output = HashMap<String, SkillUsage>;
+
+    fn meta() -> CommandMeta {
+        CommandMeta {
+            name: "list_skills_usage",
+            category: "skills",
+            description: "Count agents and harnesses referencing each skill capability.",
+            method: "GET",
+            path: "/v1/skills/usage",
+        }
+    }
+
+    fn policy() -> Option<&'static Policy> {
+        Some(&SKILL_VIEW)
+    }
+
+    async fn execute(self, ctx: &Ctx) -> Result<HashMap<String, SkillUsage>, CommandError> {
+        let agent_counts = ctx
+            .db
+            .count_agent_capability_references(ctx.org_id())
+            .await
+            .map_err(classify_anyhow)?;
+        let harness_counts = ctx
+            .db
+            .count_harness_capability_references(ctx.org_id())
+            .await
+            .map_err(classify_anyhow)?;
+
+        let mut usage: HashMap<String, SkillUsage> = HashMap::new();
+        for (cap_id, count) in agent_counts {
+            if let Some(uuid_str) = cap_id.strip_prefix(SKILL_CAPABILITY_PREFIX)
+                && let Ok(uuid) = uuid::Uuid::parse_str(uuid_str)
+            {
+                let key = SkillId::from_uuid(uuid).to_string();
+                usage.entry(key).or_default().agents = count;
+            }
+        }
+        for (cap_id, count) in harness_counts {
+            if let Some(uuid_str) = cap_id.strip_prefix(SKILL_CAPABILITY_PREFIX)
+                && let Ok(uuid) = uuid::Uuid::parse_str(uuid_str)
+            {
+                let key = SkillId::from_uuid(uuid).to_string();
+                usage.entry(key).or_default().harnesses = count;
+            }
+        }
+        Ok(usage)
+    }
+}
+
+inventory::submit! { CommandDescriptor::of::<ListSkillsUsage>() }


### PR DESCRIPTION
## What
Three improvements to the Skills page:

- **Search**: text input filters skills client-side by name, description, and allowed-tools — same pattern already used on `agents/examples` and `capabilities`.
- **View dialog**: per-skill modal that renders the YAML frontmatter, the SKILL.md body (markdown via `InlineStreamdownMessage`), and each bundled file in a collapsible block.
- **Usage counts**: each skill card shows "N agents · M harnesses" (or "Not in use") via a new `GET /v1/skills/usage` endpoint that derives counts from existing capability-reference repo helpers, keyed by `skill:{uuid}` capability ids and re-keyed back to public `SkillId`s.

## Why
The skills list was a flat grid with no way to find a skill in a long list, no way to inspect what was inside a skill without exporting it, and no signal about whether a skill is actually wired into any agent/harness.

## How
- Backend: new `SkillUsage { agents, harnesses }` core type, `ListSkillsUsage` domain command behind `SKILL_VIEW`, and `GET /v1/skills/usage` route. The command calls existing org-scoped `count_agent_capability_references` / `count_harness_capability_references`, filters keys by `skill:` prefix, parses the uuid, and re-formats as the public `SkillId` string the UI already uses.
- UI: new `useSkillsUsage` hook, `SkillUsageRow` cell, `SkillDetailDialog` with frontmatter / SKILL.md / files sections. Search is `useState` + `useMemo` filter — no extra fetches, matching the existing client-side filter convention.

## Risk
- Low. Read-only endpoint protected by the same policy as `/v1/skills`. UI is additive — no changes to create/upload/archive/delete flows. Skill content is rendered through the existing Streamdown markdown component (sanitized) and React text nodes (auto-escaped) — no new XSS surface.

## Security
- Threat categories reviewed: **TM-API**, **TM-AUTHZ**, **TM-TENANT**, **TM-WEB**, **TM-DOS**, **TM-SQL**.
- Findings:
  - **TM-AUTHZ**: `ListSkillsUsage::policy()` returns `SKILL_VIEW`, evaluated by the dispatcher — same gate as the existing list/get skill endpoints.
  - **TM-TENANT**: both underlying repo helpers join through `agents`/`harnesses` and filter on `org_id`. The result is keyed by capability_id, then we map to `SkillId` for the response. The UI looks up `usage[skill.id]` against the org-local skills list, so cross-org skill uuids (if any) cannot leak via card display.
  - **TM-API / TM-SQL**: the new route uses the standard dispatcher pattern; queries are parameterized sqlx and bounded by the org's capability table size (group-by, no scan).
  - **TM-WEB**: SKILL.md body rendered via `InlineStreamdownMessage` (existing renderer); frontmatter and bundled file contents rendered as text children of `<pre>` blocks (React-escaped). No new innerHTML or untrusted-URL paths.
- No threat-model entries needed — no new mitigations or trust boundaries.

## Validation
- `cargo check -p everruns-server`
- `cargo test -p everruns-server --lib domains::skills` (4 tests pass)
- `./scripts/lib/pre-push.sh` (rust fmt, clippy, lockfile, migrations, author all green; UI fmt/lint skipped — no node_modules in this cloud env)
- Rebased onto latest `origin/main`; `bash scripts/lib/check-migration-ordering.sh` passes (no migrations changed).
- **UI smoke test not run locally**: this cloud env doesn't have `caddy` or `just`, so `start-dev` cannot run end-to-end. The change is additive UI plus a thin read-only endpoint exercised by an existing dispatcher pattern; CI build + lint will cover the UI surface.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated (existing skills domain tests still pass; new endpoint is a thin orchestration over already-tested repo helpers)
- [x] Backward compatibility considered (additive endpoint; no schema changes)
- [x] Security review performed against relevant threat model categories
- [ ] All review comments addressed (will sweep after CI / reviewer bots)


---
_Generated by [Claude Code](https://claude.ai/code/session_01KsBqR1P4vrz2EUY5xnfLBB)_