### PR TITLE
chore(plugin): sync everruns-dev claude manifest with codex

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "everruns-dev",
       "source": "./plugins/everruns-dev",
       "description": "Interact with the Everruns(Dev) managed harnesses platform. Manage harnesses, agents, and capabilities. Run agentic sessions. Create and deploy agentic applications.",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "author": {
         "name": "Everruns",
         "url": "https://everruns.com"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,6 +125,7 @@ Always make sure you are working on top of latest main from remote.
 - `specs/xml-prompt-formatting.md` - XML tags for system prompt structure
 - `specs/skills-registry.md` - Agent Skills registry (agentskills.io format)
 - `specs/commands.md` - Slash commands system (system + skill commands)
+- `specs/everruns-dev-plugin.md` - Everruns(Dev) plugin sync contract for Claude Code and Codex
 - `specs/domains.md` - Domain modules: Command trait, feature-oriented structure, MCP catalog generation
 - `specs/issue-tracking.md` - Issue tracking (Linear, OSS project)
 - `specs/harness-types.md` - Built-in harness types (Base, Generic, Data Analyst)

--- a/plugins/everruns-dev/.claude-plugin/plugin.json
+++ b/plugins/everruns-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "everruns-dev",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Interact with the Everruns(Dev) managed harnesses platform. Manage harnesses, agents, and capabilities. Run agentic sessions. Create and deploy agentic applications.",
   "author": {
     "name": "Everruns",
@@ -15,5 +15,7 @@
     "mcp",
     "harness",
     "llm"
-  ]
+  ],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json"
 }

--- a/plugins/everruns-dev/.codex-plugin/plugin.json
+++ b/plugins/everruns-dev/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "everruns-dev",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Interact with the Everruns(Dev) managed harnesses platform from Codex. Manage harnesses, agents, and capabilities. Run agentic sessions. Create and deploy agentic applications.",
   "author": {
     "name": "Everruns",

--- a/scripts/test-everruns-dev-plugin.sh
+++ b/scripts/test-everruns-dev-plugin.sh
@@ -118,12 +118,28 @@ for key in shared_keys:
         )
 
 # Descriptions must match aside from the optional Codex host marker.
-codex_desc_normalized = codex["description"].replace(" from Codex", "")
-if codex_desc_normalized != claude["description"]:
+# The marker is allowed to appear at most once, anywhere in the Codex
+# description; any other deviation (multiple insertions, different wording)
+# is treated as drift.
+codex_desc = codex.get("description")
+claude_desc = claude.get("description")
+if not codex_desc or not claude_desc:
+    raise SystemExit(
+        "Both Everruns Dev plugin.json files must declare a non-empty "
+        "'description'. See specs/everruns-dev-plugin.md."
+    )
+
+marker = " from Codex"
+matches_exact = codex_desc == claude_desc
+matches_with_marker = (
+    codex_desc.count(marker) == 1
+    and codex_desc.replace(marker, "", 1) == claude_desc
+)
+if not (matches_exact or matches_with_marker):
     raise SystemExit(
         "Everruns Dev description drifted between Claude and Codex manifests. "
-        "Codex may insert ' from Codex' once; otherwise the wording must "
-        "match. See specs/everruns-dev-plugin.md."
+        "Codex may insert ' from Codex' exactly once; otherwise the wording "
+        "must match. See specs/everruns-dev-plugin.md."
     )
 
 skill = (plugin_dir / "skills" / "everruns-dev" / "SKILL.md").read_text()

--- a/scripts/test-everruns-dev-plugin.sh
+++ b/scripts/test-everruns-dev-plugin.sh
@@ -82,10 +82,48 @@ if "category" in claude:
         "plugin entry instead."
     )
 
+if "interface" in claude:
+    raise SystemExit(
+        "Claude plugin.json must not declare 'interface' — it is a Codex-only "
+        "field. Adding it to the Claude manifest breaks plugin loading."
+    )
+
 if not claude_marketplace.get("description"):
     raise SystemExit(
         "marketplace.json must declare a top-level 'description' so the "
         "marketplace renders correctly in Claude Code's plugin browser."
+    )
+
+# Both manifests must declare the shared payload explicitly so each host
+# loads the same skills and MCP server. See specs/everruns-dev-plugin.md.
+expected_pointers = {"skills": "./skills/", "mcpServers": "./.mcp.json"}
+for label, plugin in {"codex": codex, "claude": claude}.items():
+    for key, value in expected_pointers.items():
+        if plugin.get(key) != value:
+            raise SystemExit(
+                f"Everruns Dev {label} plugin must declare {key!r}: {value!r} "
+                f"to keep Claude Code and Codex pointing at the same shared "
+                f"payload (got {plugin.get(key)!r}). "
+                f"See specs/everruns-dev-plugin.md."
+            )
+
+# Shared metadata that must match verbatim between both host manifests.
+shared_keys = ("author", "homepage", "repository", "license", "keywords")
+for key in shared_keys:
+    if codex.get(key) != claude.get(key):
+        raise SystemExit(
+            f"Everruns Dev plugin {key!r} drifted between Claude and Codex "
+            f"manifests. Keep them identical. "
+            f"See specs/everruns-dev-plugin.md."
+        )
+
+# Descriptions must match aside from the optional Codex host marker.
+codex_desc_normalized = codex["description"].replace(" from Codex", "")
+if codex_desc_normalized != claude["description"]:
+    raise SystemExit(
+        "Everruns Dev description drifted between Claude and Codex manifests. "
+        "Codex may insert ' from Codex' once; otherwise the wording must "
+        "match. See specs/everruns-dev-plugin.md."
     )
 
 skill = (plugin_dir / "skills" / "everruns-dev" / "SKILL.md").read_text()

--- a/specs/everruns-dev-plugin.md
+++ b/specs/everruns-dev-plugin.md
@@ -159,12 +159,15 @@ hosts behave the same.
 - Claude marketplace `source` is `./plugins/everruns-dev`; Codex marketplace
   `source` is local at the same path.
 - Claude `plugin.json` does NOT contain `category`.
+- Claude `plugin.json` does NOT contain `interface` (Codex-only field;
+  including it breaks Claude Code plugin loading).
 - Both manifests declare `skills: "./skills/"` and
   `mcpServers: "./.mcp.json"`.
 - Shared metadata (`author`, `homepage`, `repository`, `license`, `keywords`)
   matches between the two manifests.
-- Codex description equals the Claude description, optionally with the
-  `from Codex` host marker inserted.
+- Both manifests declare a non-empty `description`. The Codex description
+  equals the Claude description, optionally with the `from Codex` host
+  marker inserted exactly once; any other deviation fails the check.
 - `marketplace.json` declares a top-level `description`.
 - `SKILL.md` has no `switch_organization` references and contains the
   required multi-org phrases.

--- a/specs/everruns-dev-plugin.md
+++ b/specs/everruns-dev-plugin.md
@@ -1,0 +1,172 @@
+# Everruns(Dev) Plugin
+
+## Abstract
+
+Single-source plugin under `plugins/everruns-dev/` packages the Everruns(Dev)
+MCP server, the `everruns-dev` skill, and shared slash commands for both
+Claude Code and Codex. The two host manifests
+(`.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`) MUST stay in sync
+on shared metadata and on the shared payload they expose. Drift between the
+two hosts is a release-blocking bug.
+
+`scripts/test-everruns-dev-plugin.sh` is the authoritative gate. CI invokes it
+through `just pre-push`. Any change to the plugin layout, manifests, or
+marketplace registrations MUST keep that script green.
+
+## Layout
+
+```
+plugins/everruns-dev/
+├── .claude-plugin/plugin.json   # Claude Code manifest
+├── .codex-plugin/plugin.json    # Codex manifest
+├── .mcp.json                    # Shared MCP server config
+├── README.md
+├── assets/                      # Codex UI metadata (icon, logo)
+├── commands/                    # Shared slash commands
+└── skills/everruns-dev/SKILL.md # Shared skill
+```
+
+Marketplace registrations live outside the plugin directory:
+
+- `.claude-plugin/marketplace.json` — Claude Code marketplace
+- `.agents/plugins/marketplace.json` — Codex marketplace
+
+## Sync Contract
+
+The two manifests describe the same plugin to two different hosts. Some fields
+are shared verbatim; some are host-specific.
+
+### Fields That MUST Match Verbatim
+
+| Field        | Source of truth                                                  |
+| ------------ | ---------------------------------------------------------------- |
+| `name`       | Always `everruns-dev`                                            |
+| `version`    | Bumped together; `claude-marketplace` entry must match           |
+| `author`     | Identical object in both manifests                               |
+| `homepage`   | `https://everruns.com`                                           |
+| `repository` | `https://github.com/everruns/everruns`                           |
+| `license`    | `MIT`                                                            |
+| `keywords`   | Identical, identical order                                       |
+
+### Description
+
+Both descriptions describe the same product, but the Codex variant is allowed
+to add `from Codex` to disambiguate the host. Aside from the optional
+`from Codex` insertion, the wording MUST match.
+
+- Claude:
+  `Interact with the Everruns(Dev) managed harnesses platform. Manage
+  harnesses, agents, and capabilities. Run agentic sessions. Create and deploy
+  agentic applications.`
+- Codex:
+  `Interact with the Everruns(Dev) managed harnesses platform from Codex.
+  Manage harnesses, agents, and capabilities. Run agentic sessions. Create and
+  deploy agentic applications.`
+
+### Component Pointers
+
+Both manifests MUST declare the shared payload explicitly so each host loads
+the same skill set and MCP config:
+
+- `skills`: `"./skills/"`
+- `mcpServers`: `"./.mcp.json"`
+
+These paths point at files at the plugin root, not inside `.claude-plugin/`.
+Claude Code rejects components living inside `.claude-plugin/`.
+
+### Host-Specific Fields
+
+| Field       | Host   | Notes                                                                                                                |
+| ----------- | ------ | -------------------------------------------------------------------------------------------------------------------- |
+| `interface` | Codex  | UI metadata: `displayName`, `shortDescription`, `longDescription`, `category`, `capabilities`, icons, screenshots    |
+| `category`  | Marketplace entry only | Claude Code's `plugin.json` schema does NOT accept `category`. Put it on the marketplace plugin entry instead. |
+
+Adding `interface` to the Claude manifest breaks loading (`Invalid manifest
+file`). Codex tolerates the extra fields it does not understand, but
+new host-specific keys SHOULD live on the matching host's manifest only.
+
+### Marketplace Registrations
+
+- Claude Code: `.claude-plugin/marketplace.json` — top-level `description` is
+  required for the plugin browser to render. The plugin entry's `version` MUST
+  match `plugin.json`.
+- Codex: `.agents/plugins/marketplace.json` — uses `source: { source: local,
+  path: ./plugins/everruns-dev }` and a `policy` block
+  (`installation: AVAILABLE`, `authentication: ON_INSTALL`).
+
+Both marketplaces MUST point at `./plugins/everruns-dev`.
+
+### MCP Server Endpoint
+
+`.mcp.json` MUST declare a single server named `everruns-dev` pointing at
+`https://dev.everruns.com/mcp`, with `oauth_resource` set to the same URL
+(RFC 8707) and no `scopes` (PropelAuth rejects scopes on this resource). See
+`specs/mcp.md` for the MCP server's auth contract.
+
+### Skill Content
+
+`skills/everruns-dev/SKILL.md` is the shared skill body. It MUST NOT mention
+`switch_organization` (removed) and MUST contain the multi-org guidance
+phrases enforced by the validator. MCP is stateless: callers route to a
+specific organization by passing `organization_id` per call, not by switching
+context. See `specs/mcp.md`.
+
+## Sync Workflow
+
+When changing the plugin:
+
+1. Update the shared payload (`.mcp.json`, `commands/`, `skills/`, README) once
+   — both hosts pick it up.
+2. Update both `plugin.json` files together for any shared metadata change.
+3. Bump `version` in both `plugin.json` files and in
+   `.claude-plugin/marketplace.json` together. Codex marketplace does not
+   pin a version; Claude marketplace does.
+4. Run `bash scripts/test-everruns-dev-plugin.sh` and `just pre-push` before
+   pushing.
+5. Smoke test:
+   - Claude Code: `/plugin install everruns-dev@everruns-dev`, then
+     `/everruns-dev:whoami`.
+   - Codex: workspace marketplace install, then the same skill command.
+
+## Connector Install UX (Claude vs Codex)
+
+Codex installs the plugin's MCP server during plugin install, gated on the
+marketplace `authentication: ON_INSTALL` policy. The OAuth flow runs
+inline at install time and the connector is wired up automatically.
+
+Claude Code surfaces every plugin-declared MCP server as a **connector**
+that the user MUST explicitly enable from the plugin's Connectors tab. The
+plugin manifest cannot opt out of this prompt: Claude Code treats remote MCP
+servers as user-granted capabilities, so OAuth and tool exposure require an
+explicit click. This is a host-side product decision, not a plugin
+configuration. The plugin's role is limited to declaring `mcpServers` in
+`plugin.json` and shipping a valid `.mcp.json` with `oauth_resource`; the
+rest is up to the host.
+
+If Claude Code adds an auto-install policy in the future, this spec and the
+validator should be updated to require the equivalent declaration so both
+hosts behave the same.
+
+## Validation
+
+`scripts/test-everruns-dev-plugin.sh` enforces:
+
+- `.mcp.json` `url` and `oauth_resource` equal `https://dev.everruns.com/mcp`,
+  no `scopes`.
+- Both manifests declare `name: everruns-dev`.
+- `version` is identical across both manifests and the Claude marketplace
+  entry.
+- Claude marketplace `source` is `./plugins/everruns-dev`; Codex marketplace
+  `source` is local at the same path.
+- Claude `plugin.json` does NOT contain `category`.
+- Both manifests declare `skills: "./skills/"` and
+  `mcpServers: "./.mcp.json"`.
+- Shared metadata (`author`, `homepage`, `repository`, `license`, `keywords`)
+  matches between the two manifests.
+- Codex description equals the Claude description, optionally with the
+  `from Codex` host marker inserted.
+- `marketplace.json` declares a top-level `description`.
+- `SKILL.md` has no `switch_organization` references and contains the
+  required multi-org phrases.
+
+Adding new sync requirements means extending this script in the same PR.


### PR DESCRIPTION
## What
Sync the Claude Code plugin manifest for `everruns-dev` with the Codex
manifest, document the sync contract, and extend the validator to enforce it.

- `plugins/everruns-dev/.claude-plugin/plugin.json`: declare `skills: "./skills/"` and `mcpServers: "./.mcp.json"` so Claude Code points at the same shared payload Codex declares. Did NOT add Codex-only fields (`interface`, `category`) — Claude Code's manifest schema rejects them.
- `specs/everruns-dev-plugin.md` (new): sync contract — fields that must match verbatim, allowed description divergence (Codex may insert `from Codex`), host-specific fields, marketplace registration, MCP endpoint contract, and the Claude-vs-Codex connector install UX.
- `scripts/test-everruns-dev-plugin.sh`: enforce no `interface` in Claude, both manifests declare the shared component pointers, shared metadata (`author`/`homepage`/`repository`/`license`/`keywords`) matches, descriptions match modulo the `from Codex` marker.
- Version bump 0.1.3 → 0.1.4 in both `plugin.json`s and the Claude marketplace entry per `plugins/AGENTS.md`.
- Indexed the new spec in `AGENTS.md`.

## Why
The Claude manifest had drifted to a minimum-fields metadata stub while the
Codex manifest carried explicit `skills` and `mcpServers` pointers and richer
host metadata. With nothing enforcing parity beyond `version` and `name`,
description/author/keyword drift between hosts was easy to miss and hard to
spot in review. A shared payload lives in one repo directory and should be
described identically to both hosts — this PR makes that an enforced
invariant rather than a convention.

The new spec also captures one frequently-asked question: why Claude Code
surfaces the plugin's MCP server as a Connector requiring a manual Install
click, while Codex installs it automatically. That is a host-side product
decision, not a plugin-manifest field — Codex uses
`policy: { authentication: ON_INSTALL }` on its marketplace entry; Claude
Code has no equivalent today. Documenting it stops future debugging cycles
that look for a plugin-side fix that does not exist.

## How
- Added `skills` and `mcpServers` paths to the Claude manifest (verified via Claude Code's schema docs and `claude plugin validate`, both accept them).
- Wrote `specs/everruns-dev-plugin.md` with the complete sync contract.
- Extended the existing validator (`scripts/test-everruns-dev-plugin.sh`) to assert: shared component pointers in both manifests; verbatim match on `author`/`homepage`/`repository`/`license`/`keywords`; description match modulo the `from Codex` host marker; no `interface` in the Claude manifest.
- Bumped version 0.1.3 → 0.1.4 across the two `plugin.json` files and the Claude marketplace entry.

Validation:

- `bash scripts/test-everruns-dev-plugin.sh` — green
- `claude plugin validate plugins/everruns-dev` — `Validation passed`
- Negative tests against the validator: dropped `skills` from the Claude manifest → fails with the expected `must declare 'skills': './skills/'` error; drifted `author.name` → fails with the expected drift error; both reverted.
- `bash scripts/lib/check-migration-ordering.sh` — sequential 001..037

Smoke test: docs/config/spec-only change with no runtime code path. The
validator runs against committed JSON only (no untrusted input, no
subprocess of external data). Plugin schema validation by Claude Code's own
CLI is the relevant runtime gate and passes.

## Risk
- Low.
- The Claude manifest gains two redundant explicit pointers (`skills`, `mcpServers`) that match Claude Code's default discovery paths, so Claude Code loads exactly what it loaded before. The Codex manifest already declared them.
- A patch version bump may make hosts re-fetch metadata; no behavior change for end users.

## Security
- Threat categories reviewed: TM-MCP (plugin-declared MCP server), TM-TOOL.
- Findings and resolutions: no new threat surface. The plugin's MCP server URL, `oauth_resource`, and the absence of OAuth scopes are unchanged and still asserted by the validator (`https://dev.everruns.com/mcp`, no scopes per PropelAuth). No new endpoint, auth flow, tool registration, or input parsing. The validator runs `json.load` over repo-tracked files only — no untrusted input, no `eval`, no subprocess of external data. No secrets exposed in manifests, spec, or validator.

## Follow-ups
- If/when Claude Code adds an auto-install policy for plugin MCP servers (the equivalent of Codex's `authentication: ON_INSTALL`), update `specs/everruns-dev-plugin.md` and the validator to require parity. Documented inline in the spec.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)


---
_Generated by [Claude Code](https://claude.ai/code/session_01GFdsMHGGc6Hyg5QR9SqNb3)_