### PR TITLE
feat(plugin): add cursor host to everruns-dev plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "everruns-dev",
       "source": "./plugins/everruns-dev",
       "description": "Interact with the Everruns(Dev) managed harnesses platform. Manage harnesses, agents, and capabilities. Run agentic sessions. Create and deploy agentic applications.",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "author": {
         "name": "Everruns",
         "url": "https://everruns.com"

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -1,0 +1,40 @@
+{
+  "name": "everruns-dev",
+  "owner": {
+    "name": "Everruns",
+    "email": "support@everruns.com"
+  },
+  "metadata": {
+    "description": "Everruns plugins for Cursor — connect Cursor to the Everruns(Dev) managed harnesses platform to manage agents, harnesses, capabilities, sessions, and apps.",
+    "version": "0.1.5"
+  },
+  "plugins": [
+    {
+      "name": "everruns-dev",
+      "source": "./plugins/everruns-dev",
+      "description": "Interact with the Everruns(Dev) managed harnesses platform from Cursor. Manage harnesses, agents, and capabilities. Run agentic sessions. Create and deploy agentic applications.",
+      "version": "0.1.5",
+      "author": {
+        "name": "Everruns",
+        "email": "support@everruns.com"
+      },
+      "homepage": "https://everruns.com",
+      "repository": "https://github.com/everruns/everruns",
+      "license": "MIT",
+      "logo": "plugins/everruns-dev/assets/everruns.png",
+      "category": "agents",
+      "tags": [
+        "agents",
+        "automation",
+        "developer-tools"
+      ],
+      "keywords": [
+        "agents",
+        "everruns-dev",
+        "mcp",
+        "harness",
+        "llm"
+      ]
+    }
+  ]
+}

--- a/plugins/AGENTS.md
+++ b/plugins/AGENTS.md
@@ -8,7 +8,10 @@ For `plugins/everruns-dev`, update:
 
 - `plugins/everruns-dev/.codex-plugin/plugin.json`
 - `plugins/everruns-dev/.claude-plugin/plugin.json`
+- `plugins/everruns-dev/.cursor-plugin/plugin.json`
 - `.claude-plugin/marketplace.json`
+- `.cursor-plugin/marketplace.json` (both the top-level `metadata.version`
+  and the per-plugin `version`)
 
 Validate with:
 

--- a/plugins/everruns-dev/.claude-plugin/plugin.json
+++ b/plugins/everruns-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "everruns-dev",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Interact with the Everruns(Dev) managed harnesses platform. Manage harnesses, agents, and capabilities. Run agentic sessions. Create and deploy agentic applications.",
   "author": {
     "name": "Everruns",

--- a/plugins/everruns-dev/.codex-plugin/plugin.json
+++ b/plugins/everruns-dev/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "everruns-dev",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Interact with the Everruns(Dev) managed harnesses platform from Codex. Manage harnesses, agents, and capabilities. Run agentic sessions. Create and deploy agentic applications.",
   "author": {
     "name": "Everruns",

--- a/plugins/everruns-dev/.cursor-plugin/plugin.json
+++ b/plugins/everruns-dev/.cursor-plugin/plugin.json
@@ -1,0 +1,31 @@
+{
+  "name": "everruns-dev",
+  "displayName": "Everruns(Dev)",
+  "version": "0.1.5",
+  "description": "Interact with the Everruns(Dev) managed harnesses platform from Cursor. Manage harnesses, agents, and capabilities. Run agentic sessions. Create and deploy agentic applications.",
+  "author": {
+    "name": "Everruns",
+    "email": "support@everruns.com"
+  },
+  "publisher": "Everruns",
+  "homepage": "https://everruns.com",
+  "repository": "https://github.com/everruns/everruns",
+  "license": "MIT",
+  "logo": "assets/everruns.png",
+  "category": "agents",
+  "tags": [
+    "agents",
+    "automation",
+    "developer-tools"
+  ],
+  "keywords": [
+    "agents",
+    "everruns-dev",
+    "mcp",
+    "harness",
+    "llm"
+  ],
+  "skills": "./skills/",
+  "commands": "./commands/",
+  "mcpServers": "./.mcp.json"
+}

--- a/plugins/everruns-dev/README.md
+++ b/plugins/everruns-dev/README.md
@@ -1,7 +1,7 @@
 # Everruns(Dev) Plugin
 
-This directory is the shared source of truth for the Everruns(Dev) plugin in both
-Claude Code and Codex.
+This directory is the shared source of truth for the Everruns(Dev) plugin in
+Claude Code, Codex, and Cursor.
 
 It wires the [Everruns](https://everruns.com) dev managed harnesses platform into
 local agent tools. The shared payload is the Everruns(Dev) MCP server config, the
@@ -15,10 +15,11 @@ local agent tools. The shared payload is the Everruns(Dev) MCP server config, th
 
 - `.claude-plugin/plugin.json` for Claude Code metadata
 - `.codex-plugin/plugin.json` for Codex metadata
-- `.mcp.json` for the Everruns(Dev) MCP server
+- `.cursor-plugin/plugin.json` for Cursor metadata
+- `.mcp.json` for the Everruns(Dev) MCP server (referenced by all three hosts)
 - `skills/everruns-dev/SKILL.md` for Everruns(Dev) concepts and workflows
 - `commands/` for the main Everruns(Dev) slash commands
-- `assets/` for Codex UI metadata
+- `assets/` for Codex and Cursor marketplace metadata
 
 ## Install
 
@@ -48,14 +49,24 @@ claude --plugin-dir ./plugins/everruns-dev
 Codex discovers the plugin through the workspace marketplace at
 `.agents/plugins/marketplace.json`, which points at `./plugins/everruns-dev`.
 
+### Cursor
+
+Cursor discovers the plugin through the marketplace manifest at
+`.cursor-plugin/marketplace.json` in the repository root, which points at
+`./plugins/everruns-dev`. Submit the repository to the
+[Cursor Marketplace](https://cursor.com/marketplace/publish) for public listing,
+or load it locally during development by opening the repo in Cursor and
+enabling the plugin from the marketplace UI.
+
 ## First Run
 
-1. Install the plugin in Claude Code or expose it through the Codex marketplace.
-2. Run `/everruns-dev:whoami`.
+1. Install the plugin in Claude Code, Codex, or Cursor.
+2. Run `/everruns-dev:whoami` (Claude/Codex) or invoke the `whoami` command (Cursor).
 3. Complete the OAuth flow in the browser if prompted.
 4. Ask for an Everruns(Dev) task in natural language.
 
 ## Pointing At Another Everruns(Dev) Deployment
 
 Edit `plugins/everruns-dev/.mcp.json` and replace the `url` value with your
-deployment's `/mcp` endpoint.
+deployment's `/mcp` endpoint. All three hosts (Claude Code, Codex, Cursor) read
+this file, so a single change keeps them aligned.

--- a/plugins/everruns-dev/commands/agent-card.md
+++ b/plugins/everruns-dev/commands/agent-card.md
@@ -1,4 +1,5 @@
 ---
+name: agent-card
 description: Render an Everruns(Dev) MCP-Apps card for an agent (sandboxed HTML stats card)
 argument-hint: "<agent_id_or_name>"
 ---

--- a/plugins/everruns-dev/commands/agent-run.md
+++ b/plugins/everruns-dev/commands/agent-run.md
@@ -1,4 +1,5 @@
 ---
+name: agent-run
 description: Start a new Everruns(Dev) agentic session and send the first message
 argument-hint: "<agent_id_or_name> <message>"
 ---

--- a/plugins/everruns-dev/commands/discover.md
+++ b/plugins/everruns-dev/commands/discover.md
@@ -1,4 +1,5 @@
 ---
+name: discover
 description: Search the Everruns(Dev) API catalog for available operations
 argument-hint: "<query> | --all"
 ---

--- a/plugins/everruns-dev/commands/execute.md
+++ b/plugins/everruns-dev/commands/execute.md
@@ -1,4 +1,5 @@
 ---
+name: execute
 description: Run an Everruns(Dev) workflow that can modify platform state
 argument-hint: "<bash script>"
 ---

--- a/plugins/everruns-dev/commands/query.md
+++ b/plugins/everruns-dev/commands/query.md
@@ -1,4 +1,5 @@
 ---
+name: query
 description: Inspect Everruns(Dev) platform data with a bash script
 argument-hint: "<bash script>"
 ---

--- a/plugins/everruns-dev/commands/session-send.md
+++ b/plugins/everruns-dev/commands/session-send.md
@@ -1,4 +1,5 @@
 ---
+name: session-send
 description: Send a follow-up message to an existing Everruns(Dev) session
 argument-hint: "<session_id> <message>"
 ---

--- a/plugins/everruns-dev/commands/session-status.md
+++ b/plugins/everruns-dev/commands/session-status.md
@@ -1,4 +1,5 @@
 ---
+name: session-status
 description: Poll status and recent events for an Everruns(Dev) session
 argument-hint: "<session_id>"
 ---

--- a/plugins/everruns-dev/commands/whoami.md
+++ b/plugins/everruns-dev/commands/whoami.md
@@ -1,4 +1,5 @@
 ---
+name: whoami
 description: Show the current Everruns(Dev) user and default organization
 ---
 

--- a/scripts/test-everruns-dev-plugin.sh
+++ b/scripts/test-everruns-dev-plugin.sh
@@ -6,6 +6,7 @@ PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 
 python3 - <<'PY' "$PROJECT_ROOT"
 import json
+import re
 import sys
 from pathlib import Path
 
@@ -33,8 +34,10 @@ if server.get("scopes"):
 
 codex = json.loads((plugin_dir / ".codex-plugin" / "plugin.json").read_text())
 claude = json.loads((plugin_dir / ".claude-plugin" / "plugin.json").read_text())
+cursor = json.loads((plugin_dir / ".cursor-plugin" / "plugin.json").read_text())
 claude_marketplace = json.loads((root / ".claude-plugin" / "marketplace.json").read_text())
 codex_marketplace = json.loads((root / ".agents" / "plugins" / "marketplace.json").read_text())
+cursor_marketplace = json.loads((root / ".cursor-plugin" / "marketplace.json").read_text())
 
 
 def marketplace_plugin(label, marketplace, name):
@@ -50,15 +53,21 @@ claude_marketplace_plugin = marketplace_plugin(
 codex_marketplace_plugin = marketplace_plugin(
     "Codex", codex_marketplace, "everruns-dev"
 )
+cursor_marketplace_plugin = marketplace_plugin(
+    "Cursor", cursor_marketplace, "everruns-dev"
+)
 
-for label, plugin in {"codex": codex, "claude": claude}.items():
+for label, plugin in {"codex": codex, "claude": claude, "cursor": cursor}.items():
     if plugin["name"] != "everruns-dev":
         raise SystemExit(f"Everruns Dev {label} plugin name drifted: {plugin['name']}")
 
 versions = {
     "codex": codex["version"],
     "claude": claude["version"],
+    "cursor": cursor["version"],
     "claude_marketplace": claude_marketplace_plugin["version"],
+    "cursor_marketplace_plugin": cursor_marketplace_plugin["version"],
+    "cursor_marketplace_metadata": cursor_marketplace["metadata"]["version"],
 }
 
 if len(set(versions.values())) != 1:
@@ -74,6 +83,58 @@ if codex_source.get("source") != "local" or codex_source.get("path") != "./plugi
     raise SystemExit(
         "Codex marketplace must point at local ./plugins/everruns-dev"
     )
+
+if cursor_marketplace_plugin["source"] != "./plugins/everruns-dev":
+    raise SystemExit(
+        "Cursor marketplace must point at ./plugins/everruns-dev"
+    )
+
+if cursor.get("mcpServers") != "./.mcp.json":
+    raise SystemExit(
+        "Cursor plugin manifest must reference the shared ./.mcp.json so all "
+        "three hosts read the same MCP server config."
+    )
+
+cursor_name_pattern = r"^[a-z0-9]([a-z0-9.-]*[a-z0-9])?$"
+
+if not re.match(cursor_name_pattern, cursor["name"]):
+    raise SystemExit(
+        "Cursor plugin name must match Cursor marketplace pattern "
+        f"{cursor_name_pattern}: got {cursor['name']!r}"
+    )
+
+if not cursor.get("displayName"):
+    raise SystemExit("Cursor plugin manifest must declare displayName.")
+
+cursor_logo = cursor.get("logo", "")
+if not cursor_logo or (cursor_logo.startswith(("http://", "https://")) is False
+                       and not (plugin_dir / cursor_logo).exists()):
+    raise SystemExit(
+        f"Cursor plugin logo path is invalid or missing on disk: {cursor_logo!r}"
+    )
+
+commands_dir = plugin_dir / "commands"
+for command_file in sorted(commands_dir.glob("*.md")):
+    text = command_file.read_text()
+    if not text.startswith("---\n"):
+        raise SystemExit(f"Command file missing frontmatter: {command_file}")
+    end = text.find("\n---\n", 4)
+    if end == -1:
+        raise SystemExit(f"Command file frontmatter unterminated: {command_file}")
+    block = text[4:end]
+    fields = {}
+    for line in block.split("\n"):
+        if ":" in line and not line.lstrip().startswith("#"):
+            key, _, value = line.partition(":")
+            fields[key.strip()] = value.strip()
+    expected_name = command_file.stem
+    if fields.get("name") != expected_name:
+        raise SystemExit(
+            f"Command {command_file.name} must declare 'name: {expected_name}' "
+            f"in frontmatter for Cursor compatibility (got {fields.get('name')!r})."
+        )
+    if not fields.get("description"):
+        raise SystemExit(f"Command {command_file.name} missing 'description' frontmatter.")
 
 if "category" in claude:
     raise SystemExit(
@@ -94,20 +155,22 @@ if not claude_marketplace.get("description"):
         "marketplace renders correctly in Claude Code's plugin browser."
     )
 
-# Both manifests must declare the shared payload explicitly so each host
+# All host manifests must declare the shared payload explicitly so every host
 # loads the same skills and MCP server. See specs/everruns-dev-plugin.md.
 expected_pointers = {"skills": "./skills/", "mcpServers": "./.mcp.json"}
-for label, plugin in {"codex": codex, "claude": claude}.items():
+for label, plugin in {"codex": codex, "claude": claude, "cursor": cursor}.items():
     for key, value in expected_pointers.items():
         if plugin.get(key) != value:
             raise SystemExit(
                 f"Everruns Dev {label} plugin must declare {key!r}: {value!r} "
-                f"to keep Claude Code and Codex pointing at the same shared "
-                f"payload (got {plugin.get(key)!r}). "
+                f"to keep all hosts pointing at the same shared payload "
+                f"(got {plugin.get(key)!r}). "
                 f"See specs/everruns-dev-plugin.md."
             )
 
-# Shared metadata that must match verbatim between both host manifests.
+# Shared metadata that must match verbatim between Claude and Codex manifests.
+# Cursor uses a stricter schema (author.email instead of author.url, no homepage
+# URL fields under author) so author parity is enforced separately below.
 shared_keys = ("author", "homepage", "repository", "license", "keywords")
 for key in shared_keys:
     if codex.get(key) != claude.get(key):
@@ -117,28 +180,59 @@ for key in shared_keys:
             f"See specs/everruns-dev-plugin.md."
         )
 
-# Descriptions must match aside from the optional Codex host marker.
-# The marker is allowed to appear at most once, anywhere in the Codex
-# description; any other deviation (multiple insertions, different wording)
-# is treated as drift.
+# Cursor manifest schema rejects `url` under `author` (only `name`, `email` are
+# allowed) so we cannot share the full author object with Claude/Codex. Enforce
+# `author.name` parity and the rest of the shared metadata.
+cursor_shared_keys = ("homepage", "repository", "license", "keywords")
+for key in cursor_shared_keys:
+    if cursor.get(key) != claude.get(key):
+        raise SystemExit(
+            f"Everruns Dev cursor plugin {key!r} drifted from the Claude "
+            f"manifest. Keep them identical. "
+            f"See specs/everruns-dev-plugin.md."
+        )
+
+if cursor.get("author", {}).get("name") != claude.get("author", {}).get("name"):
+    raise SystemExit(
+        "Everruns Dev cursor plugin author.name drifted from the Claude "
+        "manifest. Cursor manifests cannot share the full author object "
+        "(schema rejects `author.url`); keep `author.name` aligned. "
+        "See specs/everruns-dev-plugin.md."
+    )
+
+# Descriptions must match aside from the optional host marker. Codex may
+# insert " from Codex" exactly once; Cursor may insert " from Cursor" exactly
+# once. Any other deviation (multiple insertions, different wording) is drift.
 codex_desc = codex.get("description")
 claude_desc = claude.get("description")
-if not codex_desc or not claude_desc:
+cursor_desc = cursor.get("description")
+if not codex_desc or not claude_desc or not cursor_desc:
     raise SystemExit(
-        "Both Everruns Dev plugin.json files must declare a non-empty "
+        "Every Everruns Dev plugin.json must declare a non-empty "
         "'description'. See specs/everruns-dev-plugin.md."
     )
 
-marker = " from Codex"
-matches_exact = codex_desc == claude_desc
-matches_with_marker = (
-    codex_desc.count(marker) == 1
-    and codex_desc.replace(marker, "", 1) == claude_desc
-)
-if not (matches_exact or matches_with_marker):
+
+def description_matches(host_desc: str, base_desc: str, marker: str) -> bool:
+    if host_desc == base_desc:
+        return True
+    return (
+        host_desc.count(marker) == 1
+        and host_desc.replace(marker, "", 1) == base_desc
+    )
+
+
+if not description_matches(codex_desc, claude_desc, " from Codex"):
     raise SystemExit(
         "Everruns Dev description drifted between Claude and Codex manifests. "
         "Codex may insert ' from Codex' exactly once; otherwise the wording "
+        "must match. See specs/everruns-dev-plugin.md."
+    )
+
+if not description_matches(cursor_desc, claude_desc, " from Cursor"):
+    raise SystemExit(
+        "Everruns Dev description drifted between Claude and Cursor manifests. "
+        "Cursor may insert ' from Cursor' exactly once; otherwise the wording "
         "must match. See specs/everruns-dev-plugin.md."
     )
 
@@ -158,5 +252,5 @@ missing = [phrase for phrase in required_multi_org_phrases if phrase not in skil
 if missing:
     raise SystemExit(f"Everruns Dev skill is missing multi-org guidance: {missing}")
 
-print("everruns-dev plugin metadata checks passed")
+print("everruns-dev plugin metadata checks passed (claude, codex, cursor)")
 PY

--- a/specs/everruns-dev-plugin.md
+++ b/specs/everruns-dev-plugin.md
@@ -3,11 +3,12 @@
 ## Abstract
 
 Single-source plugin under `plugins/everruns-dev/` packages the Everruns(Dev)
-MCP server, the `everruns-dev` skill, and shared slash commands for both
-Claude Code and Codex. The two host manifests
-(`.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`) MUST stay in sync
-on shared metadata and on the shared payload they expose. Drift between the
-two hosts is a release-blocking bug.
+MCP server, the `everruns-dev` skill, and shared slash commands for Claude
+Code, Codex, and Cursor. The three host manifests
+(`.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`,
+`.cursor-plugin/plugin.json`) MUST stay in sync on shared metadata and on the
+shared payload they expose. Drift between any two hosts is a release-blocking
+bug.
 
 `scripts/test-everruns-dev-plugin.sh` is the authoritative gate. CI invokes it
 through `just pre-push`. Any change to the plugin layout, manifests, or
@@ -17,42 +18,55 @@ marketplace registrations MUST keep that script green.
 
 ```
 plugins/everruns-dev/
-├── .claude-plugin/plugin.json   # Claude Code manifest
-├── .codex-plugin/plugin.json    # Codex manifest
-├── .mcp.json                    # Shared MCP server config
+├── .claude-plugin/plugin.json    # Claude Code manifest
+├── .codex-plugin/plugin.json     # Codex manifest
+├── .cursor-plugin/plugin.json    # Cursor manifest
+├── .mcp.json                     # Shared MCP server config
 ├── README.md
-├── assets/                      # Codex UI metadata (icon, logo)
-├── commands/                    # Shared slash commands
-└── skills/everruns-dev/SKILL.md # Shared skill
+├── assets/                       # Codex/Cursor UI metadata (icon, logo)
+├── commands/                     # Shared slash commands
+└── skills/everruns-dev/SKILL.md  # Shared skill
 ```
 
 Marketplace registrations live outside the plugin directory:
 
 - `.claude-plugin/marketplace.json` — Claude Code marketplace
 - `.agents/plugins/marketplace.json` — Codex marketplace
+- `.cursor-plugin/marketplace.json` — Cursor marketplace
 
 ## Sync Contract
 
-The two manifests describe the same plugin to two different hosts. Some fields
-are shared verbatim; some are host-specific.
+The three manifests describe the same plugin to three different hosts. Some
+fields are shared verbatim; some are host-specific. The Claude manifest is the
+canonical source for shared metadata; Codex and Cursor mirror it.
 
-### Fields That MUST Match Verbatim
+### Fields That MUST Match Verbatim Across All Hosts
 
 | Field        | Source of truth                                                  |
 | ------------ | ---------------------------------------------------------------- |
 | `name`       | Always `everruns-dev`                                            |
-| `version`    | Bumped together; `claude-marketplace` entry must match           |
-| `author`     | Identical object in both manifests                               |
+| `version`    | Bumped together across all manifests + Claude/Cursor marketplaces |
 | `homepage`   | `https://everruns.com`                                           |
 | `repository` | `https://github.com/everruns/everruns`                           |
 | `license`    | `MIT`                                                            |
 | `keywords`   | Identical, identical order                                       |
 
+### Author
+
+Claude and Codex share an identical `author` object including
+`{ "name": "Everruns", "url": "https://everruns.com" }`. Cursor's plugin
+manifest schema rejects `author.url` (only `name` and `email` are accepted),
+so Cursor's `author` is `{ "name": "Everruns", "email": "support@everruns.com" }`.
+The validator enforces:
+
+- Claude `author` == Codex `author` (verbatim object equality)
+- Cursor `author.name` == Claude `author.name`
+
 ### Description
 
-Both descriptions describe the same product, but the Codex variant is allowed
-to add `from Codex` to disambiguate the host. Aside from the optional
-`from Codex` insertion, the wording MUST match.
+All three descriptions describe the same product. The Codex variant may add
+`from Codex` and the Cursor variant may add `from Cursor` to disambiguate the
+host. Aside from at-most-one such marker insertion, the wording MUST match.
 
 - Claude:
   `Interact with the Everruns(Dev) managed harnesses platform. Manage
@@ -62,28 +76,52 @@ to add `from Codex` to disambiguate the host. Aside from the optional
   `Interact with the Everruns(Dev) managed harnesses platform from Codex.
   Manage harnesses, agents, and capabilities. Run agentic sessions. Create and
   deploy agentic applications.`
+- Cursor:
+  `Interact with the Everruns(Dev) managed harnesses platform from Cursor.
+  Manage harnesses, agents, and capabilities. Run agentic sessions. Create and
+  deploy agentic applications.`
 
 ### Component Pointers
 
-Both manifests MUST declare the shared payload explicitly so each host loads
-the same skill set and MCP config:
+All three manifests MUST declare the shared payload explicitly so each host
+loads the same skill set and MCP config:
 
 - `skills`: `"./skills/"`
 - `mcpServers`: `"./.mcp.json"`
 
-These paths point at files at the plugin root, not inside `.claude-plugin/`.
-Claude Code rejects components living inside `.claude-plugin/`.
+The Cursor manifest additionally declares `commands: "./commands/"` to make
+the slash commands explicit (Cursor would otherwise discover them via the
+default folder, but the explicit path keeps the manifest self-describing).
+
+These paths point at files at the plugin root, not inside `.claude-plugin/`,
+`.codex-plugin/`, or `.cursor-plugin/`. Each host rejects components living
+inside the manifest folder.
+
+The shared `.mcp.json` file (with leading dot) lives at the plugin root.
+Cursor's default convention is `mcp.json` (no dot); we override discovery via
+the explicit `mcpServers: "./.mcp.json"` path so all three hosts read the
+same file. Cursor's official plugin validator emits a "no mcp.json file"
+warning, which is informational — the manifest path resolves correctly.
 
 ### Host-Specific Fields
 
-| Field       | Host   | Notes                                                                                                                |
-| ----------- | ------ | -------------------------------------------------------------------------------------------------------------------- |
-| `interface` | Codex  | UI metadata: `displayName`, `shortDescription`, `longDescription`, `category`, `capabilities`, icons, screenshots    |
-| `category`  | Marketplace entry only | Claude Code's `plugin.json` schema does NOT accept `category`. Put it on the marketplace plugin entry instead. |
+| Field         | Host   | Notes                                                                                                                |
+| ------------- | ------ | -------------------------------------------------------------------------------------------------------------------- |
+| `interface`   | Codex  | UI metadata: `displayName`, `shortDescription`, `longDescription`, `category`, `capabilities`, icons, screenshots    |
+| `displayName` | Cursor | Human-readable name; rendered in the Cursor marketplace and plugin chrome.                                           |
+| `publisher`   | Cursor | Publishing org. Set to `Everruns`.                                                                                   |
+| `logo`        | Cursor | Relative path to a logo image (`assets/everruns.png`) committed to the repo.                                         |
+| `tags`        | Cursor | Free-form filter tags surfaced in the marketplace UI.                                                                |
+| `category`    | Marketplace entry only | Claude Code's `plugin.json` schema does NOT accept `category`. Put it on the marketplace plugin entry instead (Cursor accepts it on either). |
 
 Adding `interface` to the Claude manifest breaks loading (`Invalid manifest
 file`). Codex tolerates the extra fields it does not understand, but
 new host-specific keys SHOULD live on the matching host's manifest only.
+
+Cursor's manifest schema is `additionalProperties: false`, so unknown fields
+are rejected. Slash command files MUST declare both `name` and `description`
+in YAML frontmatter for Cursor compatibility — this is a no-op for Claude
+Code and Codex, which ignore the extra `name` field.
 
 ### Marketplace Registrations
 
@@ -93,8 +131,14 @@ new host-specific keys SHOULD live on the matching host's manifest only.
 - Codex: `.agents/plugins/marketplace.json` — uses `source: { source: local,
   path: ./plugins/everruns-dev }` and a `policy` block
   (`installation: AVAILABLE`, `authentication: ON_INSTALL`).
+- Cursor: `.cursor-plugin/marketplace.json` at the repo root — uses
+  `source: "./plugins/everruns-dev"`. Both `metadata.version` and the per-plugin
+  `version` MUST match `plugin.json`. The marketplace entry's `logo` is
+  resolved from the repo root (`plugins/everruns-dev/assets/everruns.png`),
+  while the plugin manifest's `logo` is resolved relative to the plugin
+  directory (`assets/everruns.png`).
 
-Both marketplaces MUST point at `./plugins/everruns-dev`.
+All marketplaces MUST point at `./plugins/everruns-dev`.
 
 ### MCP Server Endpoint
 
@@ -116,19 +160,23 @@ context. See `specs/mcp.md`.
 When changing the plugin:
 
 1. Update the shared payload (`.mcp.json`, `commands/`, `skills/`, README) once
-   — both hosts pick it up.
-2. Update both `plugin.json` files together for any shared metadata change.
-3. Bump `version` in both `plugin.json` files and in
-   `.claude-plugin/marketplace.json` together. Codex marketplace does not
-   pin a version; Claude marketplace does.
+   — all three hosts pick it up.
+2. Update all three `plugin.json` files together for any shared metadata change.
+3. Bump `version` in all three `plugin.json` files, in
+   `.claude-plugin/marketplace.json`, and in `.cursor-plugin/marketplace.json`
+   (both `metadata.version` and the per-plugin `version`) together. Codex
+   marketplace does not pin a version.
 4. Run `bash scripts/test-everruns-dev-plugin.sh` and `just pre-push` before
    pushing.
 5. Smoke test:
    - Claude Code: `/plugin install everruns-dev@everruns-dev`, then
      `/everruns-dev:whoami`.
    - Codex: workspace marketplace install, then the same skill command.
+   - Cursor: load the local marketplace via the plugins UI (or push and
+     submit at <https://cursor.com/marketplace/publish>), install the plugin,
+     and run the `whoami` slash command.
 
-## Connector Install UX (Claude vs Codex)
+## Connector Install UX (Claude vs Codex vs Cursor)
 
 Codex installs the plugin's MCP server during plugin install, gated on the
 marketplace `authentication: ON_INSTALL` policy. The OAuth flow runs
@@ -143,9 +191,15 @@ configuration. The plugin's role is limited to declaring `mcpServers` in
 `plugin.json` and shipping a valid `.mcp.json` with `oauth_resource`; the
 rest is up to the host.
 
-If Claude Code adds an auto-install policy in the future, this spec and the
-validator should be updated to require the equivalent declaration so both
-hosts behave the same.
+Cursor reads the `mcpServers` path from `plugin.json` and registers the
+remote MCP server during plugin install. OAuth runs in the user's browser on
+first use; there is no plugin-side switch to skip the consent flow. The
+manifest shape is the same as Claude/Codex — the differences are purely in
+how each host renders consent and lifetime of the granted credential.
+
+If any host adds or changes its auto-install policy, this spec and the
+validator should be updated to require the equivalent declaration so all
+three hosts behave the same.
 
 ## Validation
 
@@ -153,21 +207,32 @@ hosts behave the same.
 
 - `.mcp.json` `url` and `oauth_resource` equal `https://dev.everruns.com/mcp`,
   no `scopes`.
-- Both manifests declare `name: everruns-dev`.
-- `version` is identical across both manifests and the Claude marketplace
-  entry.
+- All three manifests declare `name: everruns-dev`.
+- `version` is identical across all three manifests, the Claude marketplace
+  entry, and both `metadata.version` and the per-plugin `version` of the
+  Cursor marketplace.
 - Claude marketplace `source` is `./plugins/everruns-dev`; Codex marketplace
-  `source` is local at the same path.
-- Claude `plugin.json` does NOT contain `category`.
-- Claude `plugin.json` does NOT contain `interface` (Codex-only field;
-  including it breaks Claude Code plugin loading).
-- Both manifests declare `skills: "./skills/"` and
+  `source` is local at the same path; Cursor marketplace `source` is
+  `./plugins/everruns-dev`.
+- Claude `plugin.json` does NOT contain `category` or `interface`.
+- All three manifests declare `skills: "./skills/"` and
   `mcpServers: "./.mcp.json"`.
 - Shared metadata (`author`, `homepage`, `repository`, `license`, `keywords`)
-  matches between the two manifests.
-- Both manifests declare a non-empty `description`. The Codex description
-  equals the Claude description, optionally with the `from Codex` host
-  marker inserted exactly once; any other deviation fails the check.
+  matches between Claude and Codex manifests verbatim.
+- Cursor manifest's `homepage`, `repository`, `license`, and `keywords` match
+  Claude verbatim. `author.name` matches Claude (the rest of `author` may
+  differ because Cursor's schema rejects `author.url`).
+- All three manifests declare a non-empty `description`. The Codex
+  description equals the Claude description with at most one ` from Codex`
+  insertion; the Cursor description equals the Claude description with at
+  most one ` from Cursor` insertion.
+- Cursor manifest declares a non-empty `displayName` and a `logo` whose path
+  resolves to a file on disk (or an absolute URL).
+- Cursor manifest's `name` matches the Cursor marketplace name pattern
+  `^[a-z0-9]([a-z0-9.-]*[a-z0-9])?$`.
+- Every command file under `commands/*.md` declares `name: <filename-stem>`
+  and a non-empty `description` in YAML frontmatter (required by Cursor;
+  ignored by Claude/Codex).
 - `marketplace.json` declares a top-level `description`.
 - `SKILL.md` has no `switch_organization` references and contains the
   required multi-org phrases.


### PR DESCRIPTION
## What

Ship the `everruns-dev` plugin to a third host alongside Claude Code and
Codex by adding a Cursor manifest, a Cursor marketplace registration, and
extending the existing Claude+Codex sync contract introduced in #1752 to
keep all three hosts aligned.

- `plugins/everruns-dev/.cursor-plugin/plugin.json` (new): Cursor manifest
  with `displayName`, `publisher`, `logo`, `category`, `tags`, plus
  `skills`/`commands`/`mcpServers` pointers to the shared payload.
  `mcpServers` points at `./.mcp.json` so all three hosts read one MCP
  config.
- `.cursor-plugin/marketplace.json` (new): repo-root Cursor marketplace
  listing for the plugin, mirroring `.claude-plugin/marketplace.json` and
  `.agents/plugins/marketplace.json`.
- `plugins/everruns-dev/commands/*.md`: add `name:` to YAML frontmatter so
  each command satisfies Cursor's frontmatter requirement (no-op for
  Claude/Codex which ignore the extra field).
- `specs/everruns-dev-plugin.md`: extend sync contract from two hosts to
  three; document Cursor-specific fields (`displayName`, `publisher`,
  `logo`, `tags`), the divergent author shape (Cursor schema rejects
  `author.url`), the description-marker convention (` from Cursor` mirrors
  ` from Codex`), Cursor connector install UX, and the validator checklist.
- `scripts/test-everruns-dev-plugin.sh`: extend validator with Cursor
  invariants — manifest pointers, name pattern, `displayName`, on-disk
  `logo`, command frontmatter (`name` + `description`),
  Claude↔Cursor description sync with the ` from Cursor` marker, and
  `homepage`/`repository`/`license`/`keywords` parity.
- `plugins/everruns-dev/README.md`, `plugins/AGENTS.md`: document Cursor
  install flow and the new manifest in the version-bump checklist.
- Version bump 0.1.4 → 0.1.5 across all three `plugin.json` files,
  `.claude-plugin/marketplace.json`, and both
  `.cursor-plugin/marketplace.json` versions per `plugins/AGENTS.md`
  policy.

## Why

We already ship `everruns-dev` to Claude Code and Codex from a single
shared payload under `plugins/everruns-dev/`. Cursor recently published its
plugin marketplace ([reference](https://cursor.com/docs/reference/plugins),
[template](https://github.com/cursor/plugin-template)) using a
near-identical manifest shape — `.cursor-plugin/plugin.json` per plugin,
`.cursor-plugin/marketplace.json` for multi-plugin repos, with the same
`skills`/`commands`/`mcpServers` pointers. Adding a Cursor manifest gives
Cursor users the same Everruns(Dev) MCP integration without duplicating
any shared payload, and keeps the three hosts described identically by
the sync contract from #1752.

The contract was previously two-host-only. Without extending it to cover
Cursor, drift between Cursor and the other two manifests would go
undetected the same way Claude/Codex drift used to — and that drift was
the original motivation for the contract.

## How

- Read the Cursor plugin reference and the
  [`cursor/plugin-template`](https://github.com/cursor/plugin-template)
  layout. Mirrored their `.cursor-plugin/{plugin.json,marketplace.json}`
  shape, validated the result with the upstream `validate-template.mjs`
  script and our own validator.
- Reused the existing `.mcp.json` (Claude convention with leading dot) by
  setting `mcpServers: "./.mcp.json"` in the Cursor manifest. Cursor's
  schema accepts a path string for `mcpServers`, so we do not duplicate
  the MCP config. The upstream validator emits an informational warning
  ("no `mcp.json` file"); the manifest path is independently validated
  and resolves correctly. Documented this in the spec.
- Added `name:` to every command's YAML frontmatter — required by Cursor,
  ignored by Claude/Codex.
- Extended `scripts/test-everruns-dev-plugin.sh` so the same gate enforces
  Cursor's sync invariants. Refactored the description-match check into a
  `description_matches(host, base, marker)` helper used for both
  ` from Codex` and ` from Cursor` markers.
- Cursor `author` cannot share Claude/Codex's `author.url` because
  Cursor's schema is `additionalProperties: false` with only
  `name`/`email`. Validator enforces `author.name` parity and lets the
  rest diverge; documented in the spec.

## Validation

- `bash scripts/test-everruns-dev-plugin.sh` — green
  (`everruns-dev plugin metadata checks passed (claude, codex, cursor)`)
- `node cursor-plugin-template/scripts/validate-template.mjs` — green
  (informational warnings only: no hooks, no top-level `mcp.json` since
  we override discovery via the manifest path)
- `bash scripts/lib/check-migration-ordering.sh` — sequential 001..037
- Negative tests against the validator:
  - dropped `mcpServers` from `.cursor-plugin/plugin.json` → fails with
    expected pointer error
  - changed `author.name` in `.cursor-plugin/plugin.json` → fails with
    expected `author.name drifted` error
  - dropped `name:` from a command → fails with expected frontmatter
    error
  - both reverted

Smoke test: docs/config/spec-only change with no runtime code path. The
validator runs `json.load` over repo-tracked files only — no untrusted
input, no subprocess of external data. Cursor-side runtime gate is
Cursor's own plugin loader, which the upstream template validator
emulates and is green.

## Risk

- Low.
- The shared payload (`.mcp.json`, `commands/`, `skills/`, README, assets)
  is unchanged in content, so Claude Code and Codex load exactly what they
  loaded before. The new Cursor manifest references the same files.
- Adding `name:` to command frontmatter is a no-op for Claude/Codex —
  their parsers ignore unknown keys, and the slash-command name is still
  derived from the filename.
- A patch version bump may make hosts re-fetch metadata; no behavior
  change for end users.
- The spec/validator extensions tighten the gate. They cannot block
  unrelated PRs because they only fire when the everruns-dev manifests
  drift, which already required validator-aware changes.

## Security

- Threat categories reviewed: **TM-MCP** (plugin-declared MCP server),
  **TM-TOOL** (tool registration paths).
- Findings and resolutions: no new threat surface. The plugin's MCP
  server URL (`https://dev.everruns.com/mcp`), `oauth_resource`, and the
  absence of OAuth scopes are unchanged and still asserted by the
  validator. No new endpoint, auth flow, tool registration, or input
  parsing. The validator reads only repo-tracked JSON files; no `eval`,
  no subprocess of external data, no network. No secrets exposed in the
  new manifests, spec, or validator.

## Follow-ups

No follow-ups. Cursor parity for the plugin is complete — manifest,
marketplace, sync contract, and validator are all in place. If Cursor
adds an auto-install policy for plugin MCP servers (the equivalent of
Codex's `authentication: ON_INSTALL`), update
`specs/everruns-dev-plugin.md` and the validator to require parity;
already noted inline in the spec's Connector Install UX section.

## Checklist

- [x] Tests added or updated (validator extended with Cursor invariants)
- [x] Backward compatibility considered (shared payload unchanged;
  existing hosts unaffected)
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (will follow up after first review
  pass)
