### PR TITLE
fix(server): authorize AG-UI before parsing JSON body

### DIFF
--- a/crates/server/src/api/ag_ui.rs
+++ b/crates/server/src/api/ag_ui.rs
@@ -36,7 +36,7 @@ use ag_ui_core::types::{
 };
 use axum::{
     Extension, Json, Router,
-    extract::{ConnectInfo, DefaultBodyLimit, Path, Request, State},
+    extract::{ConnectInfo, DefaultBodyLimit, FromRequest, Path, Request, State},
     http::{HeaderMap, StatusCode, header::AUTHORIZATION},
     response::{
         IntoResponse, Response,

--- a/crates/server/src/api/ag_ui.rs
+++ b/crates/server/src/api/ag_ui.rs
@@ -36,7 +36,7 @@ use ag_ui_core::types::{
 };
 use axum::{
     Extension, Json, Router,
-    extract::{ConnectInfo, DefaultBodyLimit, Path, State},
+    extract::{ConnectInfo, DefaultBodyLimit, Path, Request, State},
     http::{HeaderMap, StatusCode, header::AUTHORIZATION},
     response::{
         IntoResponse, Response,
@@ -300,7 +300,7 @@ async fn run_agent(
     req_id: Option<Extension<RequestId>>,
     connect_info: Option<Extension<ConnectInfo<std::net::SocketAddr>>>,
     headers: HeaderMap,
-    Json(req): Json<AgUiRunAgentInput>,
+    request: Request,
 ) -> Result<Sse<impl Stream<Item = Result<SseEvent, Infallible>>>, Response> {
     // EVE-415: monotonic anchor for the AG-UI ingress phase. Used to attribute
     // the gap between accepted request and `ReasonAtom: starting LLM call`
@@ -310,6 +310,17 @@ async fn run_agent(
     // ingress portion without grepping for adjacent timestamps.
     let ingress_start = Instant::now();
 
+    let request_id = req_id.map(|Extension(r)| r.0);
+    let peer_addr = connect_info.map(|Extension(ConnectInfo(addr))| addr);
+    let AuthorizedAgUiRequest {
+        app,
+        channel_config,
+    } = authorize_ag_ui_request(&state, &app_id, &headers, peer_addr).await?;
+
+    let Json(req): Json<AgUiRunAgentInput> = Json::from_request(request, &state)
+        .await
+        .map_err(IntoResponse::into_response)?;
+
     // THREAT[TM-LLM-020]: Anonymous AG-UI clients must not be able to forge
     // privileged message roles (system/developer/tool) into the LLM context
     // that the server builds from the request body.
@@ -317,13 +328,6 @@ async fn run_agent(
     // boundary, and reject duplicate message IDs. The error is a generic
     // `invalid_request` so we don't echo the offending role back.
     validate_input_messages(&req.messages).map_err(|err| *err)?;
-
-    let request_id = req_id.map(|Extension(r)| r.0);
-    let peer_addr = connect_info.map(|Extension(ConnectInfo(addr))| addr);
-    let AuthorizedAgUiRequest {
-        app,
-        channel_config,
-    } = authorize_ag_ui_request(&state, &app_id, &headers, peer_addr).await?;
 
     let trigger_message = req
         .messages

--- a/crates/server/tests/ag_ui_integration_test.rs
+++ b/crates/server/tests/ag_ui_integration_test.rs
@@ -249,6 +249,26 @@ async fn test_ag_ui_token_requires_matching_header_when_configured() {
         .await
         .assert_status(StatusCode::UNAUTHORIZED);
 
+    let invalid_role_payload = json!({
+        "threadId": raw_uuid(),
+        "runId": raw_uuid(),
+        "state": {},
+        "messages": [
+            {
+                "id": raw_uuid(),
+                "role": "system",
+                "content": [{ "type": "text", "text": "deny" }]
+            }
+        ],
+        "tools": [],
+        "context": [],
+        "forwardedProps": {}
+    });
+
+    send_ag_ui_run(&server, &app.public_id, &invalid_role_payload)
+        .await
+        .assert_status(StatusCode::UNAUTHORIZED);
+
     send_ag_ui_run_with_headers(
         &server,
         &app.public_id,


### PR DESCRIPTION
### Motivation
- Prevent unauthenticated CPU/memory work on token-protected AG-UI endpoints by ensuring the channel token and anonymous/published checks run before any request body parsing or message validation. 
- Close a pre-auth validation gap where malicious payloads could trigger `400 invalid_request` or allocate large `HashSet`s before the token check.

### Description
- Change the `run_agent` handler to accept a raw `Request` instead of `Json(req)` and perform `authorize_ag_ui_request(...)` (which enforces published app, anonymous channel, token check, and rate limits) before extracting the JSON body via `Json::from_request(...)`.
- Move `validate_input_messages(&req.messages)` to run only after the authorization/token gate has succeeded so message validation is fully behind authentication.
- Update imports to include `Request` and adjust handler signature accordingly (`extract::{ConnectInfo, DefaultBodyLimit, Path, Request, State}`).
- Add an integration test case in `crates/server/tests/ag_ui_integration_test.rs` to assert that a token-protected endpoint returns `401 Unauthorized` even when an unauthenticated payload contains a disallowed `system` role (previously could return `400`).

### Testing
- Ran `cargo fmt --all` which completed successfully.
- Added an integration test `test_ag_ui_token_requires_matching_header_when_configured` that now includes an unauthenticated payload with an invalid role and expects `401 Unauthorized` (the test was committed and included with the PR).
- Attempted `cargo test -p everruns-server --test ag_ui_integration_test test_ag_ui_token_requires_matching_header_when_configured`, which started but dependency downloads/compilation were long-running in the environment so the full test run was not observed to completion during this session.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fca175f9d4832bb67eff9fd5b3bf01)