### PR TITLE
fix(core): strip human_intent from client-side tool calls

### DIFF
--- a/crates/core/src/atoms/act.rs
+++ b/crates/core/src/atoms/act.rs
@@ -1362,7 +1362,10 @@ mod tests {
         let result = atom.execute(input).await.unwrap();
 
         assert_eq!(result.client_tool_calls.len(), 1);
-        assert_eq!(result.client_tool_calls[0].arguments, json!({ "selector": "#btn" }));
+        assert_eq!(
+            result.client_tool_calls[0].arguments,
+            json!({ "selector": "#btn" })
+        );
     }
 
     fn manage_harnesses_tool_def() -> crate::ToolDefinition {

--- a/crates/core/src/atoms/act.rs
+++ b/crates/core/src/atoms/act.rs
@@ -500,6 +500,11 @@ where
                     .unwrap_or(true) // unknown tools go to server (will error there)
             });
 
+        let client_tool_calls: Vec<_> = client_tool_calls
+            .into_iter()
+            .map(|tool_call| self.transform_tool_call_for_execution(tool_call))
+            .collect();
+
         let client_tool_definitions: Vec<_> = if client_tool_calls.is_empty() {
             vec![]
         } else {
@@ -1309,6 +1314,55 @@ mod tests {
             panic!("expected tool.completed data");
         };
         assert_eq!(data.narration.as_deref(), Some("Echoing test arguments"));
+    }
+
+    #[tokio::test]
+    async fn test_act_atom_strips_human_intent_from_client_tool_calls() {
+        use crate::capabilities::{Capability, HumanIntentCapability};
+
+        let executor = ToolRegistry::new();
+        let emitter = crate::memory::InMemoryEventEmitter::new();
+        let atom = ActAtom::new(executor, emitter)
+            .with_tool_call_hooks(HumanIntentCapability.tool_call_hooks());
+
+        let context = AtomContext::new(SessionId::new(), TurnId::new(), MessageId::new());
+        let input = ActInput {
+            org_id: Some(1),
+            context,
+            harness_id: HarnessId::from_seed(1),
+            agent_id: Some(AgentId::new()),
+            tool_calls: vec![ToolCall {
+                id: "call_client".to_string(),
+                name: "browser_click".to_string(),
+                arguments: json!({
+                    "selector": "#btn",
+                    "human_intent": "Clicking approve"
+                }),
+            }],
+            tool_definitions: vec![crate::ToolDefinition::ClientSide(crate::ClientSideTool {
+                name: "browser_click".to_string(),
+                display_name: None,
+                description: "Click button".to_string(),
+                parameters: json!({
+                    "type": "object",
+                    "properties": {
+                        "selector": {"type": "string"}
+                    },
+                    "required": ["selector"]
+                }),
+                category: None,
+                deferrable: Default::default(),
+                hints: crate::tool_types::ToolHints::default(),
+            })],
+            locale: None,
+            blueprint_id: None,
+            network_access: None,
+        };
+
+        let result = atom.execute(input).await.unwrap();
+
+        assert_eq!(result.client_tool_calls.len(), 1);
+        assert_eq!(result.client_tool_calls[0].arguments, json!({ "selector": "#btn" }));
     }
 
     fn manage_harnesses_tool_def() -> crate::ToolDefinition {


### PR DESCRIPTION
### Motivation
- A model-authored `human_intent` argument was added to all tool schemas including `ClientSide` tools, but the stripping transform was only applied on server execution, allowing untrusted `human_intent` to be emitted to clients.
- The change restores the intended contract that `human_intent` is UI-only and must not cross the server→client execution boundary.

### Description
- Apply existing execution transforms by calling `self.transform_tool_call_for_execution(...)` on each client-side `ToolCall` immediately after partitioning in `ActAtom::execute` so client calls are sanitized the same as server calls (file: `crates/core/src/atoms/act.rs`).
- Add a regression test `test_act_atom_strips_human_intent_from_client_tool_calls` that constructs a client-side tool call containing `human_intent` and asserts the stored `client_tool_calls` only contain execution arguments (file: `crates/core/src/atoms/act.rs`).
- Reuse the existing `transform_tool_call_for_execution` hook pipeline so narration behavior and server-side stripping remain unchanged.

### Testing
- Ran the new unit test via `cargo test -p everruns-core test_act_atom_strips_human_intent_from_client_tool_calls -- --nocapture`, and it passed.
- The targeted core test suite finished with the new test passing alongside existing filtered tests in the `everruns-core` crate.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd24fcaf84832b9fcee2b4bf7690f3)