### PR TITLE
feat(organizations): add resolve_org command for entity-id lookup

### DIFF
--- a/crates/server/src/api/resolver.rs
+++ b/crates/server/src/api/resolver.rs
@@ -71,56 +71,21 @@ pub async fn resolve_org(
     auth: AuthUser,
     Query(query): Query<ResolveOrgQuery>,
 ) -> Result<Json<ResolveOrgResponse>, StatusCode> {
-    let trimmed = query.id.trim();
-    if trimmed.is_empty() {
-        return Err(StatusCode::NOT_FOUND);
-    }
-
-    let owning_org_id = org_resolver::resolve_resource_org(&state.db, trimmed)
+    // SECURITY: shared with the `resolve_org` domain command. THREAT[TM-TENANT-010]
+    // — the membership gate inside `resolve_owning_org_for_user` is what
+    // prevents this endpoint from becoming a generic resource→org oracle.
+    let resolved = org_resolver::resolve_owning_org_for_user(&state.db, auth.id, &query.id)
         .await
         .map_err(|e| {
             tracing::error!("resolve-org lookup failed: {e}");
             StatusCode::INTERNAL_SERVER_ERROR
         })?;
 
-    let Some(owning_org_id) = owning_org_id else {
+    let Some((org_id, org_name)) = resolved else {
         return Err(StatusCode::NOT_FOUND);
     };
 
-    // Gate: only reveal the org if the caller is already a member. Without
-    // this filter the endpoint would be a generic resource→org oracle.
-    // THREAT[TM-TENANT-010]: membership gate — DO NOT remove.
-    let is_member = state
-        .db
-        .is_organization_member(owning_org_id, auth.id)
-        .await
-        .map_err(|e| {
-            tracing::error!("resolve-org membership lookup failed: {e}");
-            StatusCode::INTERNAL_SERVER_ERROR
-        })?;
-    if !is_member {
-        return Err(StatusCode::NOT_FOUND);
-    }
-
-    // Only load the org record once membership is established.
-    let Some(org) = state
-        .db
-        .get_organization(owning_org_id)
-        .await
-        .map_err(|e| {
-            tracing::error!("resolve-org org lookup failed: {e}");
-            StatusCode::INTERNAL_SERVER_ERROR
-        })?
-    else {
-        // Theoretically unreachable (membership implies the org exists),
-        // but treat a vanished row as 404 rather than 500.
-        return Err(StatusCode::NOT_FOUND);
-    };
-
-    Ok(Json(ResolveOrgResponse {
-        org_id: org.public_id,
-        org_name: org.name,
-    }))
+    Ok(Json(ResolveOrgResponse { org_id, org_name }))
 }
 
 pub fn routes(state: AppState) -> Router {

--- a/crates/server/src/domains/org_resolver.rs
+++ b/crates/server/src/domains/org_resolver.rs
@@ -21,6 +21,7 @@ use everruns_core::{
     CapabilityId,
     typed_id::{McpServerId, SessionId, SkillId},
 };
+use uuid::Uuid;
 
 use crate::storage::StorageBackend;
 
@@ -72,6 +73,44 @@ pub async fn resolve_resource_org(db: &StorageBackend, id: &str) -> Result<Optio
         }
     }
     Ok(None)
+}
+
+/// Resolve and authorize the owning org for a prefixed entity id.
+///
+/// SECURITY: this is the only path that may reveal an org id outside the
+/// caller's currently active org. It enforces `is_organization_member` and
+/// returns `None` for any failure mode (unknown id, unknown prefix, empty
+/// id, non-member, vanished org row) so callers cannot distinguish them —
+/// preserving the org-enumeration guarantee documented in
+/// specs/multitenancy.md (THREAT[TM-TENANT-010]).
+///
+/// Returns `(org_public_id, org_name)` on success, `None` otherwise.
+/// Used by both `GET /v1/resolve-org` and the `resolve_org` domain command.
+pub async fn resolve_owning_org_for_user(
+    db: &StorageBackend,
+    user_id: Uuid,
+    id: &str,
+) -> Result<Option<(String, String)>> {
+    let trimmed = id.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+
+    let Some(owning_org_id) = resolve_resource_org(db, trimmed).await? else {
+        return Ok(None);
+    };
+
+    if !db.is_organization_member(owning_org_id, user_id).await? {
+        return Ok(None);
+    }
+
+    // Theoretically unreachable (membership implies the org exists), but
+    // treat a vanished row as `None` rather than surfacing an error.
+    let Some(org) = db.get_organization(owning_org_id).await? else {
+        return Ok(None);
+    };
+
+    Ok(Some((org.public_id, org.name)))
 }
 
 // ============================================================================

--- a/crates/server/src/domains/organizations/commands.rs
+++ b/crates/server/src/domains/organizations/commands.rs
@@ -85,10 +85,11 @@ impl Command for GetOrg {
 inventory::submit! { CommandDescriptor::of::<GetOrg>() }
 
 // SECURITY: this is the only domain command that may reveal an `org_id` the
-// caller's active session is not currently scoped to. The membership gate
-// below mirrors the `/v1/resolve-org` endpoint (THREAT[TM-TENANT-010]) — for
-// non-member orgs we return NotFound to preserve the org-enumeration
-// guarantee. See specs/multitenancy.md (Cross-Org Resource Resolution).
+// caller's active session is not currently scoped to. The shared helper
+// `org_resolver::resolve_owning_org_for_user` enforces the membership gate
+// (THREAT[TM-TENANT-010]); we return NotFound for every failure mode to
+// preserve the org-enumeration guarantee. See specs/multitenancy.md
+// (Cross-Org Resource Resolution).
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct ResolveOrg {
     pub id: String,
@@ -101,7 +102,7 @@ impl Command for ResolveOrg {
         CommandMeta {
             name: "resolve_org",
             category: "organizations",
-            description: "Resolve the owning organization for a prefixed entity id (agent, session, harness, app, skill, mcp server, identity, eval). Returns 404 unless the caller is a member of the owning org.",
+            description: "Resolve the owning organization for a prefixed entity id (agent, session, harness, app, skill, mcp server, identity, eval). Requires an authenticated user; returns NotFound when the caller is not a member of the owning org or the id does not resolve.",
             method: "GET",
             path: "/v1/resolve-org",
         }
@@ -112,37 +113,16 @@ impl Command for ResolveOrg {
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<ResolveOrgResponse, CommandError> {
-        let trimmed = self.id.trim();
-        if trimmed.is_empty() {
-            return Err(CommandError::not_found("Resource"));
-        }
-
         let user_id = q::require_user_id(ctx)?;
 
-        let owning_org_id = org_resolver::resolve_resource_org(&ctx.db, trimmed)
-            .await
-            .map_err(classify_anyhow)?
-            .ok_or_else(|| CommandError::not_found("Resource"))?;
-
-        let is_member = ctx
-            .db
-            .is_organization_member(owning_org_id, user_id)
-            .await
-            .map_err(classify_anyhow)?;
-        if !is_member {
-            return Err(CommandError::not_found("Resource"));
-        }
-
-        let row = ctx
-            .db
-            .get_organization(owning_org_id)
+        let resolved = org_resolver::resolve_owning_org_for_user(&ctx.db, user_id, &self.id)
             .await
             .map_err(classify_anyhow)?
             .ok_or_else(|| CommandError::not_found("Resource"))?;
 
         Ok(ResolveOrgResponse {
-            org_id: row.public_id,
-            org_name: row.name,
+            org_id: resolved.0,
+            org_name: resolved.1,
         })
     }
 }

--- a/crates/server/src/domains/organizations/commands.rs
+++ b/crates/server/src/domains/organizations/commands.rs
@@ -1,6 +1,7 @@
 use super::queries as q;
-use super::types::{ListOrganizationsResponse, OrganizationResponse};
+use super::types::{ListOrganizationsResponse, OrganizationResponse, ResolveOrgResponse};
 use crate::domains::common::*;
+use crate::domains::org_resolver;
 use everruns_core::validate_org_public_id;
 use serde::Deserialize;
 use utoipa::ToSchema;
@@ -83,13 +84,188 @@ impl Command for GetOrg {
 
 inventory::submit! { CommandDescriptor::of::<GetOrg>() }
 
+// SECURITY: this is the only domain command that may reveal an `org_id` the
+// caller's active session is not currently scoped to. The membership gate
+// below mirrors the `/v1/resolve-org` endpoint (THREAT[TM-TENANT-010]) — for
+// non-member orgs we return NotFound to preserve the org-enumeration
+// guarantee. See specs/multitenancy.md (Cross-Org Resource Resolution).
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct ResolveOrg {
+    pub id: String,
+}
+
+impl Command for ResolveOrg {
+    type Output = ResolveOrgResponse;
+
+    fn meta() -> CommandMeta {
+        CommandMeta {
+            name: "resolve_org",
+            category: "organizations",
+            description: "Resolve the owning organization for a prefixed entity id (agent, session, harness, app, skill, mcp server, identity, eval). Returns 404 unless the caller is a member of the owning org.",
+            method: "GET",
+            path: "/v1/resolve-org",
+        }
+    }
+
+    fn positional_arg() -> Option<&'static str> {
+        Some("id")
+    }
+
+    async fn execute(self, ctx: &Ctx) -> Result<ResolveOrgResponse, CommandError> {
+        let trimmed = self.id.trim();
+        if trimmed.is_empty() {
+            return Err(CommandError::not_found("Resource"));
+        }
+
+        let user_id = q::require_user_id(ctx)?;
+
+        let owning_org_id = org_resolver::resolve_resource_org(&ctx.db, trimmed)
+            .await
+            .map_err(classify_anyhow)?
+            .ok_or_else(|| CommandError::not_found("Resource"))?;
+
+        let is_member = ctx
+            .db
+            .is_organization_member(owning_org_id, user_id)
+            .await
+            .map_err(classify_anyhow)?;
+        if !is_member {
+            return Err(CommandError::not_found("Resource"));
+        }
+
+        let row = ctx
+            .db
+            .get_organization(owning_org_id)
+            .await
+            .map_err(classify_anyhow)?
+            .ok_or_else(|| CommandError::not_found("Resource"))?;
+
+        Ok(ResolveOrgResponse {
+            org_id: row.public_id,
+            org_name: row.name,
+        })
+    }
+}
+
+inventory::submit! { CommandDescriptor::of::<ResolveOrg>() }
+
 #[cfg(test)]
 mod tests {
-    use crate::domains::common::Ctx;
+    use crate::domains::common::{CommandError, Ctx};
     use crate::storage::StorageBackend;
+    use crate::storage::models::CreateAgentRow;
     use everruns_core::{Caller, DEFAULT_ORG_ID, OrgRole};
     use serde_json::json;
     use std::sync::Arc;
+    use uuid::Uuid;
+
+    fn seed_caller(user_id: Uuid) -> Caller {
+        Caller {
+            org_id: DEFAULT_ORG_ID,
+            org_public_id: "org_00000000000000000000000000000001".to_string(),
+            user_id: Some(user_id),
+            role: OrgRole::Owner,
+            is_platform_user: false,
+            is_internal: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn resolve_org_returns_owning_org_when_caller_is_member() {
+        let db = Arc::new(StorageBackend::in_memory());
+        crate::seed::seed_all(
+            &db,
+            everruns_core::DeploymentGrade::Dev,
+            &crate::seed::SeedAuthContext::default(),
+        )
+        .await
+        .expect("seed test data");
+
+        let agent_public_id = "agent_00000000000000000000000000000077".to_string();
+        db.create_agent(
+            DEFAULT_ORG_ID,
+            CreateAgentRow {
+                public_id: agent_public_id.clone(),
+                name: "resolve-test".to_string(),
+                display_name: None,
+                description: None,
+                system_prompt: String::new(),
+                default_model_id: None,
+                tags: vec![],
+                initial_files: serde_json::json!([]),
+                tools: serde_json::json!([]),
+                mcp_servers: serde_json::json!([]),
+                network_access: None,
+                max_iterations: None,
+            },
+        )
+        .await
+        .expect("create agent");
+
+        let ctx = Ctx::minimal_for_test(seed_caller(everruns_core::ANONYMOUS_USER_ID), db, None);
+
+        let json =
+            crate::domains::common::dispatch("resolve_org", json!({ "id": agent_public_id }), &ctx)
+                .await
+                .expect("dispatch resolve_org");
+        let response: serde_json::Value =
+            serde_json::from_str(&json).expect("deserialize resolve_org response");
+        assert_eq!(
+            response.get("org_id").and_then(|v| v.as_str()),
+            Some("org_00000000000000000000000000000001")
+        );
+        assert!(response.get("org_name").and_then(|v| v.as_str()).is_some());
+    }
+
+    #[tokio::test]
+    async fn resolve_org_returns_not_found_for_non_member() {
+        let db = Arc::new(StorageBackend::in_memory());
+
+        // Other-org agent: created in org 42 with no membership for the caller.
+        let agent_public_id = "agent_00000000000000000000000000000088".to_string();
+        db.create_agent(
+            42,
+            CreateAgentRow {
+                public_id: agent_public_id.clone(),
+                name: "other-org-agent".to_string(),
+                display_name: None,
+                description: None,
+                system_prompt: String::new(),
+                default_model_id: None,
+                tags: vec![],
+                initial_files: serde_json::json!([]),
+                tools: serde_json::json!([]),
+                mcp_servers: serde_json::json!([]),
+                network_access: None,
+                max_iterations: None,
+            },
+        )
+        .await
+        .expect("create agent");
+
+        let ctx = Ctx::minimal_for_test(seed_caller(Uuid::new_v4()), db, None);
+
+        let err =
+            crate::domains::common::dispatch("resolve_org", json!({ "id": agent_public_id }), &ctx)
+                .await
+                .expect_err("dispatch resolve_org should fail for non-member");
+        assert!(matches!(err, CommandError::NotFound(_)), "got {err:?}");
+    }
+
+    #[tokio::test]
+    async fn resolve_org_returns_not_found_for_unknown_prefix() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let ctx = Ctx::minimal_for_test(seed_caller(everruns_core::ANONYMOUS_USER_ID), db, None);
+
+        let err = crate::domains::common::dispatch(
+            "resolve_org",
+            json!({ "id": "totallybogus_00000000000000000000000000000001" }),
+            &ctx,
+        )
+        .await
+        .expect_err("unknown prefix should not resolve");
+        assert!(matches!(err, CommandError::NotFound(_)), "got {err:?}");
+    }
 
     #[tokio::test]
     async fn list_orgs_dispatch_accepts_empty_object_params() {

--- a/crates/server/src/domains/organizations/types.rs
+++ b/crates/server/src/domains/organizations/types.rs
@@ -1,4 +1,5 @@
 // Organizations domain types — reuse the public API response DTOs.
 
 pub use crate::api::organizations::OrganizationResponse;
+pub use crate::api::resolver::ResolveOrgResponse;
 pub type ListOrganizationsResponse = crate::api::common::ListResponse<OrganizationResponse>;

--- a/plugins/everruns-dev/skills/everruns-dev/SKILL.md
+++ b/plugins/everruns-dev/skills/everruns-dev/SKILL.md
@@ -256,6 +256,28 @@ query { "commands": "list_agents | jq -r '.data[].id' | while read id; do\n  get
 execute { "commands": "create_mcp_server --name \"jira\" --url \"https://mcp.example.com/jira\" --auth_mode oauth" }
 ```
 
+**Look up an org by id.**
+
+`get_org` accepts the `org_...` entity id as a positional arg.
+
+```bash
+query { "commands": "get_org org_01933b5a00007000800000000000004 | jq '{id, name, display_name}'" }
+```
+
+**Preview an agent or harness before saving.**
+
+`preview_agent` and `preview_harness` resolve capabilities, scoped MCP servers, and
+parent harness inheritance into the final system prompt and tool list without
+persisting anything. Read-only, available in `query`.
+
+```bash
+query { "commands": "preview_agent --system_prompt \"You are a careful researcher.\" --capabilities '[{\"ref\":\"web_fetch\"}]' | jq '{system_prompt, tools: [.tools[].name]}'" }
+```
+
+```bash
+query { "commands": "preview_harness --parent_harness_id \"$HID\" --system_prompt \"Research harness.\" | jq '{system_prompt, tools: [.tools[].name]}'" }
+```
+
 ### Raw builtin examples
 
 ```bash

--- a/plugins/everruns-dev/skills/everruns-dev/SKILL.md
+++ b/plugins/everruns-dev/skills/everruns-dev/SKILL.md
@@ -264,6 +264,18 @@ execute { "commands": "create_mcp_server --name \"jira\" --url \"https://mcp.exa
 query { "commands": "get_org org_01933b5a00007000800000000000004 | jq '{id, name, display_name}'" }
 ```
 
+**Find which org owns an entity.**
+
+`resolve_org` takes any prefixed entity id (`agent_...`, `session_...`,
+`harness_...`, `app_...`, `skill_...`, `mcp:...`, `identity_...`, `eval_...`)
+and returns `{org_id, org_name}` of the owning org — but only if the caller
+is a member of that org. Use it to recover from a direct link into a
+resource owned by a different org you also belong to.
+
+```bash
+query { "commands": "resolve_org session_019db85695a8785e87e8203109109343 | jq" }
+```
+
 **Preview an agent or harness before saving.**
 
 `preview_agent` and `preview_harness` resolve capabilities, scoped MCP servers, and

--- a/plugins/everruns-dev/skills/everruns-dev/SKILL.md
+++ b/plugins/everruns-dev/skills/everruns-dev/SKILL.md
@@ -261,7 +261,7 @@ execute { "commands": "create_mcp_server --name \"jira\" --url \"https://mcp.exa
 `get_org` accepts the `org_...` entity id as a positional arg.
 
 ```bash
-query { "commands": "get_org org_01933b5a00007000800000000000004 | jq '{id, name, display_name}'" }
+query { "commands": "get_org org_01933b5a00007000800000000000004 | jq '{id, name, default_model_id, default_harness_id}'" }
 ```
 
 **Find which org owns an entity.**


### PR DESCRIPTION
## What
- New domain command `resolve_org` (`GET /v1/resolve-org`, positional `id`) that resolves the owning organization for any prefixed top-level entity id (`agent_…`, `session_…`, `harness_…`, `app_…`, `skill_…`, `mcp:…`, `identity_…`, `eval_…`).
- Re-exports `ResolveOrgResponse` from `api::resolver` through `domains::organizations::types` so the command and the existing HTTP endpoint share one DTO.
- Updates the `everruns-dev` skill with examples for `resolve_org`, `get_org`, `preview_agent`, and `preview_harness`.

## Why
The UI already has a cross-org link recovery flow backed by `GET /v1/resolve-org`. MCP `query`/`execute` (and SDK callers) had no equivalent — there was no way for an agent to ask "which org owns this entity id?". Surfacing the same logic as a domain command exposes it through the inventory-backed MCP catalog with no extra wiring.

The skill already documented `discover` and the bash-builtin model but did not call out `get_org`, `preview_agent`, or `preview_harness`, so they were essentially invisible unless you ran `discover`. Brief examples surface them.

## How
- Wraps `domains::org_resolver::resolve_resource_org` (the existing inventory-dispatched resolver) and re-applies the same membership gate the HTTP endpoint uses, returning `NotFound` for non-members to preserve the org-enumeration guarantee.
- `read_only()` defaults to `true` because the meta is `GET`, so the command is exposed via MCP `query` (and `execute`).
- Registered via `inventory::submit!` like every other domain command — no router changes needed.

## Risk
- Low.
- Behavior mirrors the already-shipped `/v1/resolve-org` endpoint; the membership gate is identical. Worst case is a spurious `NotFound` for a malformed id.

## Security
- Threat categories reviewed: TM-TENANT (multitenancy / cross-org leakage), TM-API (input handling), TM-MCP (read-only catalog classification).
- Findings and resolutions:
  - **TM-TENANT-010 (org-enumeration via cross-org resource resolver):** the command re-implements the same `is_organization_member` gate as `/v1/resolve-org`. A non-member caller, an unknown id, an unknown prefix, and an empty/whitespace id all return `NotFound`. Covered by `resolve_org_returns_not_found_for_non_member` and `resolve_org_returns_not_found_for_unknown_prefix`. A `SECURITY:` comment above the struct documents the invariant.
  - **TM-API:** input is a single `String` parsed with `serde`; trimmed before dispatch. The underlying `resolve_resource_org` uses typed-id parsing for ids that need it (e.g. `SessionId`) and returns `Ok(None)` for malformed values, surfaced as `NotFound`.
  - **TM-MCP-002 (mutating tools must not appear under `query`):** command is GET, so `read_only()` returns `true` by default — correctly classified.
  - No new policy required: the membership check inside `execute()` is sufficient and matches the existing pattern used by `ListOrgs` and `GetOrg`.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated (3 unit tests covering member success, non-member denial, unknown-prefix denial)
- [x] Backward compatibility considered (additive command + additive type re-export)
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_015Y7zRaMXog28fVcByfSozg)_