### PR TITLE
fix(auth): enforce Google OAuth email_verified and allowed-domain

### DIFF
--- a/crates/server/src/auth/routes.rs
+++ b/crates/server/src/auth/routes.rs
@@ -57,15 +57,36 @@ fn email_domain_lowercase(email: &str) -> Option<String> {
         .filter(|d| !d.is_empty())
 }
 
+/// Normalize a configured `allowed_domains` entry: trim whitespace, drop an
+/// optional leading `@`, lowercase. Returns `None` for empty entries so a
+/// stray `,` in `AUTH_GOOGLE_ALLOWED_DOMAINS=,company.com` does not silently
+/// match every email.
+///
+/// Matching is intentionally **exact-domain** (not suffix).
+/// `company.com` does not authorize `attacker.company.com`. Operators who
+/// want subdomains must list each one explicitly.
+fn normalize_allowed_domain(entry: &str) -> Option<String> {
+    let trimmed = entry.trim().strip_prefix('@').unwrap_or(entry.trim());
+    let cleaned = trimmed.trim();
+    if cleaned.is_empty() {
+        None
+    } else {
+        Some(cleaned.to_ascii_lowercase())
+    }
+}
+
 /// Whether `email` belongs to one of `allowed_domains` (case-insensitive,
-/// exact match against the lowercased host portion of the address).
+/// **exact** match against the lowercased host portion of the address).
+/// Accepts configured entries written as either `company.com` or
+/// `@company.com` so a small operator typo is not silently permissive.
 fn email_domain_allowed(email: &str, allowed_domains: &[String]) -> bool {
     let Some(domain) = email_domain_lowercase(email) else {
         return false;
     };
     allowed_domains
         .iter()
-        .any(|d| d.trim().eq_ignore_ascii_case(&domain))
+        .filter_map(|d| normalize_allowed_domain(d))
+        .any(|d| d == domain)
 }
 
 /// Per-provider identity gates applied after `exchange_code` and before any
@@ -88,7 +109,9 @@ fn oauth_identity_rejection_reason(
             if let Some(google) = config.google.as_ref()
                 && let Some(allowed) = google.allowed_domains.as_ref()
             {
-                let any_real = allowed.iter().any(|d| !d.trim().is_empty());
+                let any_real = allowed
+                    .iter()
+                    .any(|d| normalize_allowed_domain(d).is_some());
                 if any_real && !email_domain_allowed(&user_info.email, allowed) {
                     return Some("domain_not_allowed");
                 }
@@ -1197,6 +1220,43 @@ mod tests {
         assert!(!email_domain_allowed("user@evil.com", &allowed));
         assert!(!email_domain_allowed("not-an-email", &allowed));
         assert!(!email_domain_allowed("user@", &allowed));
+    }
+
+    // EVE-451 (review feedback): operators sometimes write `@company.com` —
+    // accept it as an equivalent of `company.com` rather than silently
+    // failing closed.
+    #[test]
+    fn test_email_domain_allowed_accepts_at_prefixed_entries() {
+        let allowed = vec!["@company.com".to_string(), " @other.io ".to_string()];
+        assert!(email_domain_allowed("user@company.com", &allowed));
+        assert!(email_domain_allowed("user@other.io", &allowed));
+        assert!(!email_domain_allowed("user@evil.com", &allowed));
+    }
+
+    // EVE-451 (review feedback): exact-domain semantics — `company.com` must
+    // not authorize an `attacker.company.com` subdomain. Operators who want
+    // subdomains must list each one.
+    #[test]
+    fn test_email_domain_allowed_does_not_match_subdomains() {
+        let allowed = vec!["company.com".to_string()];
+        assert!(!email_domain_allowed("user@attacker.company.com", &allowed));
+        assert!(!email_domain_allowed("user@xcompany.com", &allowed));
+    }
+
+    #[test]
+    fn test_normalize_allowed_domain_drops_empty_entries() {
+        assert_eq!(normalize_allowed_domain(""), None);
+        assert_eq!(normalize_allowed_domain("   "), None);
+        assert_eq!(normalize_allowed_domain("@"), None);
+        assert_eq!(normalize_allowed_domain(" @  "), None);
+        assert_eq!(
+            normalize_allowed_domain("@Company.COM"),
+            Some("company.com".to_string())
+        );
+        assert_eq!(
+            normalize_allowed_domain("  company.com  "),
+            Some("company.com".to_string())
+        );
     }
 
     // EVE-451: Google OAuth must require email_verified=true.

--- a/crates/server/src/auth/routes.rs
+++ b/crates/server/src/auth/routes.rs
@@ -49,6 +49,56 @@ fn generate_oauth_state() -> String {
     hex::encode(bytes)
 }
 
+/// Extract the lowercased domain from an email address.
+fn email_domain_lowercase(email: &str) -> Option<String> {
+    email
+        .rsplit_once('@')
+        .map(|(_, d)| d.trim().to_ascii_lowercase())
+        .filter(|d| !d.is_empty())
+}
+
+/// Whether `email` belongs to one of `allowed_domains` (case-insensitive,
+/// exact match against the lowercased host portion of the address).
+fn email_domain_allowed(email: &str, allowed_domains: &[String]) -> bool {
+    let Some(domain) = email_domain_lowercase(email) else {
+        return false;
+    };
+    allowed_domains
+        .iter()
+        .any(|d| d.trim().eq_ignore_ascii_case(&domain))
+}
+
+/// Per-provider identity gates applied after `exchange_code` and before any
+/// user lookup or creation. Returns the audit `reason` string when the
+/// identity must be rejected.
+///
+/// Google: must report `email_verified` and, when `allowed_domains` is set,
+/// the email domain must be in that list. GitHub does not currently support
+/// per-provider gates here.
+fn oauth_identity_rejection_reason(
+    provider: super::oauth::OAuthProvider,
+    config: &super::config::AuthConfig,
+    user_info: &super::oauth::OAuthUserInfo,
+) -> Option<&'static str> {
+    match provider {
+        super::oauth::OAuthProvider::Google => {
+            if !user_info.email_verified {
+                return Some("email_unverified");
+            }
+            if let Some(google) = config.google.as_ref()
+                && let Some(allowed) = google.allowed_domains.as_ref()
+            {
+                let any_real = allowed.iter().any(|d| !d.trim().is_empty());
+                if any_real && !email_domain_allowed(&user_info.email, allowed) {
+                    return Some("domain_not_allowed");
+                }
+            }
+            None
+        }
+        super::oauth::OAuthProvider::GitHub => None,
+    }
+}
+
 /// Login request
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct LoginRequest {
@@ -745,6 +795,28 @@ pub async fn oauth_callback(
         AuthError::unauthorized("OAuth authentication failed")
     })?;
 
+    // EVE-451 / TM-AUTH: enforce provider-side identity gates before any user
+    // lookup or creation so a hostile provider account cannot mint a session
+    // even on the first use of an existing email and so deployments using
+    // `AUTH_GOOGLE_ALLOWED_DOMAINS` get the restriction they configured.
+    if let Some(reason) = oauth_identity_rejection_reason(provider_enum, &state.config, &user_info)
+    {
+        tracing::warn!(
+            "OAuth identity rejected for provider={} reason={}",
+            provider,
+            reason
+        );
+        audit::emit(
+            state.db.clone(),
+            DEFAULT_ORG_ID,
+            None,
+            "auth.oauth.failure",
+            audit::client_ip(&headers),
+            serde_json::json!({"provider": provider, "reason": reason}),
+        );
+        return Err(AuthError::forbidden("OAuth account not permitted"));
+    }
+
     // Find or create user
     let provider_str = provider_enum.as_str();
     let user = state
@@ -1090,6 +1162,147 @@ mod tests {
 
         assert!(oauth_providers(&config).is_empty());
         assert!(ensure_oauth_enabled(&config).is_err());
+    }
+
+    fn make_google_user(email: &str, verified: bool) -> super::super::oauth::OAuthUserInfo {
+        super::super::oauth::OAuthUserInfo {
+            provider_id: "google-sub-1".to_string(),
+            email: email.to_string(),
+            name: "User".to_string(),
+            avatar_url: None,
+            email_verified: verified,
+        }
+    }
+
+    fn config_with_google(allowed_domains: Option<Vec<String>>) -> AuthConfig {
+        let mut config = AuthConfig::default();
+        config.mode = AuthMode::Full;
+        config.google = Some(crate::auth::config::GoogleOAuthConfig {
+            base: crate::auth::config::OAuthProviderConfig {
+                client_id: "id".to_string(),
+                client_secret: "secret".to_string(),
+                redirect_uri: "http://localhost/callback".to_string(),
+            },
+            allowed_domains,
+        });
+        config
+    }
+
+    #[test]
+    fn test_email_domain_allowed_matches_case_insensitive() {
+        let allowed = vec!["Example.com".to_string(), "Other.io".to_string()];
+        assert!(email_domain_allowed("user@example.com", &allowed));
+        assert!(email_domain_allowed("user@EXAMPLE.COM", &allowed));
+        assert!(email_domain_allowed("user@other.io", &allowed));
+        assert!(!email_domain_allowed("user@evil.com", &allowed));
+        assert!(!email_domain_allowed("not-an-email", &allowed));
+        assert!(!email_domain_allowed("user@", &allowed));
+    }
+
+    // EVE-451: Google OAuth must require email_verified=true.
+    #[test]
+    fn test_google_rejects_unverified_email() {
+        let config = config_with_google(None);
+        let user = make_google_user("user@example.com", false);
+        assert_eq!(
+            oauth_identity_rejection_reason(
+                super::super::oauth::OAuthProvider::Google,
+                &config,
+                &user
+            ),
+            Some("email_unverified")
+        );
+    }
+
+    // EVE-451: When allowed_domains is set, mismatched email domains are rejected.
+    #[test]
+    fn test_google_rejects_disallowed_domain() {
+        let config = config_with_google(Some(vec!["company.com".to_string()]));
+        let user = make_google_user("user@evil.com", true);
+        assert_eq!(
+            oauth_identity_rejection_reason(
+                super::super::oauth::OAuthProvider::Google,
+                &config,
+                &user
+            ),
+            Some("domain_not_allowed")
+        );
+    }
+
+    // EVE-451: Allowed domain on a verified email passes.
+    #[test]
+    fn test_google_accepts_allowed_domain_verified() {
+        let config = config_with_google(Some(vec!["company.com".to_string()]));
+        let user = make_google_user("user@Company.COM", true);
+        assert!(
+            oauth_identity_rejection_reason(
+                super::super::oauth::OAuthProvider::Google,
+                &config,
+                &user
+            )
+            .is_none()
+        );
+    }
+
+    // EVE-451: No allowed_domains config means any verified domain is accepted.
+    #[test]
+    fn test_google_accepts_any_verified_domain_when_unrestricted() {
+        let config = config_with_google(None);
+        let user = make_google_user("user@anywhere.io", true);
+        assert!(
+            oauth_identity_rejection_reason(
+                super::super::oauth::OAuthProvider::Google,
+                &config,
+                &user
+            )
+            .is_none()
+        );
+    }
+
+    // EVE-451: Empty allowed_domains list (only whitespace) does not lock everyone out.
+    // Treats it as "no restriction" rather than "deny all" so an operator who
+    // sets `AUTH_GOOGLE_ALLOWED_DOMAINS=` does not accidentally brick login.
+    #[test]
+    fn test_google_empty_allowed_domains_does_not_lock_out() {
+        let config = config_with_google(Some(vec!["   ".to_string()]));
+        let user = make_google_user("user@anywhere.io", true);
+        assert!(
+            oauth_identity_rejection_reason(
+                super::super::oauth::OAuthProvider::Google,
+                &config,
+                &user
+            )
+            .is_none()
+        );
+    }
+
+    // EVE-451: GitHub flow currently has no per-provider gates here.
+    #[test]
+    fn test_github_has_no_provider_gates() {
+        let mut config = AuthConfig::default();
+        config.mode = AuthMode::Full;
+        config.github = Some(crate::auth::config::GitHubOAuthConfig {
+            base: crate::auth::config::OAuthProviderConfig {
+                client_id: "id".to_string(),
+                client_secret: "secret".to_string(),
+                redirect_uri: "http://localhost/callback".to_string(),
+            },
+        });
+        let user = super::super::oauth::OAuthUserInfo {
+            provider_id: "gh-1".to_string(),
+            email: "user@example.com".to_string(),
+            name: "User".to_string(),
+            avatar_url: None,
+            email_verified: false,
+        };
+        assert!(
+            oauth_identity_rejection_reason(
+                super::super::oauth::OAuthProvider::GitHub,
+                &config,
+                &user
+            )
+            .is_none()
+        );
     }
 
     #[test]

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -108,6 +108,7 @@ Format: `TM-<CATEGORY>-<NNN>`
 | TM-AUTH-014 | Account enumeration via registration | Medium | Returns generic "Registration failed" for existing emails; password hash computed first for timing consistency | MITIGATED |
 | TM-AUTH-015 | JWT secret insecure default | High | Falls back to hardcoded `insecure-dev-secret-change-me` if `AUTH_JWT_SECRET` unset; no startup check in production | **OPEN** |
 | TM-AUTH-016 | OSS harness reseeding via public signup | High | The signup safety net in `register` / `oauth_callback` uses `state.platform_definition.built_in_harnesses()` via `initialize_org_harnesses_with_definitions`, **not** `oss_built_in_harnesses()`. An operator's custom `PlatformDefinition` is the source of truth — public signup cannot reintroduce OSS harnesses that were removed. Original concern tracked by PR #1462; the safety-net semantics re-added in EVE-390 preserve pre-seed correctness without re-opening the override path. | MITIGATED |
+| TM-AUTH-017 | Google OAuth identity bypass | High | After `exchange_code` and before user lookup or creation, `oauth_callback` calls `oauth_identity_rejection_reason` (`crates/server/src/auth/routes.rs`). Rejects `email_verified=false` and, when `AUTH_GOOGLE_ALLOWED_DOMAINS` is set, rejects email domains not in the list (case-insensitive). Applied to both first-time and returning OAuth users. Failure path emits `auth.oauth.failure` audit with a reason and returns `403`. | MITIGATED |
 
 ### Mitigation Details
 


### PR DESCRIPTION
## What
Enforce Google OAuth identity gates in `oauth_callback` after `exchange_code` and **before** any user lookup or creation:

- Reject when Google reports `email_verified == false`.
- When `AUTH_GOOGLE_ALLOWED_DOMAINS` is set, reject email addresses whose domain is not in the list. Matching is **exact domain**, case-insensitive, after the configured entry is normalized (`trim` → strip optional leading `@` → `trim` → lowercase). `company.com` therefore does **not** authorize `attacker.company.com`; operators who want subdomains must list them explicitly.
- Apply the check uniformly to first-time and returning OAuth users.

Failure path emits `auth.oauth.failure` with the specific reason (`email_unverified` or `domain_not_allowed`) and returns `403`.

## Why
DeepSec finding (revalidated true positive). `GoogleOAuthConfig.allowed_domains` was wired through env (`AUTH_GOOGLE_ALLOWED_DOMAINS`) and the user_info struct already carried `email_verified`, but `oauth_callback` skipped both checks and proceeded straight to `get_user_by_oauth` / `get_user_by_email`. A deployment relying on `allowed_domains` to restrict sign-in to a company domain would admit any Google account.

Resolves EVE-451. Tracked in the threat model as TM-AUTH-017.

## How
- New helper `oauth_identity_rejection_reason(provider, config, user_info) -> Option<&'static str>` in `crates/server/src/auth/routes.rs`.
- For `OAuthProvider::Google`: returns `Some("email_unverified")` if not verified, then `Some("domain_not_allowed")` when a non-empty `allowed_domains` list rejects the email host. For `OAuthProvider::GitHub`: no gates currently (GitHub emails are already verified upstream).
- Domain normalization is centralized in `normalize_allowed_domain` and used both in the per-entry matcher and in the "any non-empty entry" guard. Empty / whitespace-only entries (and bare `@`) are dropped, so an operator who sets `AUTH_GOOGLE_ALLOWED_DOMAINS=` (or accidentally leaves a trailing comma) is treated as "no restriction" rather than "deny all".
- `oauth_callback` calls the helper between `exchange_code(...)?` and the first `get_user_by_oauth(...)`. On rejection it audits and returns `AuthError::forbidden("OAuth account not permitted")`.

## Risk
- Low. The change is additive validation in a single hot path. No DB schema change, no API surface change. GitHub flow is unchanged. Google logins where `email_verified` is `true` and (when configured) the domain is allowed continue to work identically.

## Security
- Threat categories reviewed: TM-AUTH (provider identity gate), TM-AUTHZ (no policy change), TM-API (no new endpoint, no new input), TM-WEB (no new headers/cookies), TM-DOS (no unbounded work).
- Findings:
  - **TM-AUTH-017 (NEW, Google OAuth identity bypass):** added in `specs/threat-model.md`. The new helper enforces `email_verified` and the optional allowed-domain list before any user lookup or creation, so the same gate covers first-time and returning OAuth users. Failure emits `auth.oauth.failure` with a reason and returns 403.
  - **TM-AUTH-007 (state CSRF):** unchanged — state validation still runs first.
  - **TM-AUTH-012 (account linking via attacker-controlled email):** still **CALLER RISK** but materially reduced for the Google + allowed_domains case, since attacker accounts on uncontrolled domains cannot reach the existing-email lookup at all.
- No new secret material is logged. Audit reasons (`email_unverified`, `domain_not_allowed`, `exchange_failed`) are stable strings, not free text.

## Validation
- `cargo test -p everruns-server --lib auth::routes::` — **17 passed, 0 failed** (10 new + 7 existing).
- `cargo clippy -p everruns-server --lib --tests -- -D warnings` — clean.
- `just pre-push` — all 8 checks pass (UI fmt/lint skipped: no `node_modules` in cloud env; CI covers).
- `bash scripts/lib/check-migration-ordering.sh` — sequential (no migrations changed).
- Smoke test: not run end-to-end. The change is server-only unit-level validation in a single OAuth code path; the failure path is fully covered by 10 unit tests against the helper, and the success path delegates unchanged to existing user-lookup code that the integration suite exercises. Justified skip — narrow, well-tested helper on a single boundary.

## Follow-ups
- No follow-ups. The Google `hd` claim is intentionally not consulted — it is only present for Google Workspace users and the email-domain check covers the same set without depending on a provider-only field.

## Checklist
- [x] Tests added or updated (10 new unit tests)
- [x] Backward compatibility considered (additive validation; default behavior unchanged when `allowed_domains` is unset and the email is verified)
- [x] Security review performed against relevant threat model categories (TM-AUTH-017 added)
- [x] All review comments addressed (Copilot suggestion on @-prefixed entries → see follow-up commit `b0aa620`)

Fixes EVE-451