### PR TITLE
fix(durable): direct workflow lookup for detail and SSE

### DIFF
--- a/crates/durable/src/persistence/memory.rs
+++ b/crates/durable/src/persistence/memory.rs
@@ -1190,6 +1190,27 @@ impl WorkflowEventStore for InMemoryWorkflowEventStore {
         })
     }
 
+    async fn get_workflow_extended(
+        &self,
+        workflow_id: Uuid,
+    ) -> Result<Option<WorkflowInfoExtended>, StoreError> {
+        // EVE-455: direct id lookup that does not depend on the
+        // `list_workflows` page size.
+        let workflows = self.workflows.read();
+        Ok(workflows.get(&workflow_id).map(|w| WorkflowInfoExtended {
+            id: workflow_id,
+            workflow_type: w.workflow_type.clone(),
+            status: w.status,
+            input: w.input.clone(),
+            result: w.result.clone(),
+            error: w.error.clone(),
+            created_at: w.created_at,
+            started_at: w.started_at,
+            completed_at: w.completed_at,
+            continued_as_new_id: w.continued_as_new_id,
+        }))
+    }
+
     async fn list_workflows(
         &self,
         filter: WorkflowFilter,
@@ -3022,5 +3043,66 @@ mod tests {
         // started_workflows counts workflows where started_at IS NOT NULL
         // wf2 (running) and wf3 (completed after running) should have started_at set
         assert_eq!(health.started_workflows, 2);
+    }
+
+    // EVE-455: previously, the API verified workflow existence by reading the
+    // first 1000 rows of `list_workflows`, ordered by `created_at DESC`. Once
+    // the store had > 1000 workflows, the oldest one fell off the page and
+    // its detail/SSE endpoint silently returned 404. The direct
+    // `get_workflow_extended` lookup must resolve any workflow regardless of
+    // how many newer workflows exist.
+    #[tokio::test]
+    async fn test_get_workflow_extended_resolves_past_first_page() {
+        let store = InMemoryWorkflowEventStore::new();
+
+        // Create the workflow we will look up first, so it has the *oldest*
+        // `created_at` and would land past the first page.
+        let target = Uuid::now_v7();
+        store
+            .create_workflow(target, "old", serde_json::json!({}), None)
+            .await
+            .unwrap();
+
+        // Pile on > 1000 newer workflows.
+        for _ in 0..1100 {
+            store
+                .create_workflow(Uuid::now_v7(), "filler", serde_json::json!({}), None)
+                .await
+                .unwrap();
+        }
+
+        // The legacy first-page scan would not find this workflow.
+        let first_page = store
+            .list_workflows(
+                WorkflowFilter::default(),
+                Pagination {
+                    offset: 0,
+                    limit: 1000,
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(first_page.len(), 1000);
+        assert!(
+            !first_page.iter().any(|w| w.id == target),
+            "regression guard: target workflow must be off the first page"
+        );
+
+        // The direct lookup must resolve it anyway.
+        let resolved = store
+            .get_workflow_extended(target)
+            .await
+            .unwrap()
+            .expect("get_workflow_extended must find old workflow");
+        assert_eq!(resolved.id, target);
+        assert_eq!(resolved.workflow_type, "old");
+    }
+
+    #[tokio::test]
+    async fn test_get_workflow_extended_returns_none_for_unknown_id() {
+        let store = InMemoryWorkflowEventStore::new();
+        let unknown = Uuid::now_v7();
+        let resolved = store.get_workflow_extended(unknown).await.unwrap();
+        assert!(resolved.is_none());
     }
 }

--- a/crates/durable/src/persistence/memory.rs
+++ b/crates/durable/src/persistence/memory.rs
@@ -3055,8 +3055,7 @@ mod tests {
     async fn test_get_workflow_extended_resolves_past_first_page() {
         let store = InMemoryWorkflowEventStore::new();
 
-        // Create the workflow we will look up first, so it has the *oldest*
-        // `created_at` and would land past the first page.
+        // Create the workflow we will look up first.
         let target = Uuid::now_v7();
         store
             .create_workflow(target, "old", serde_json::json!({}), None)
@@ -3069,6 +3068,18 @@ mod tests {
                 .create_workflow(Uuid::now_v7(), "filler", serde_json::json!({}), None)
                 .await
                 .unwrap();
+        }
+
+        // Force the target's `created_at` strictly older than every filler.
+        // Without this the regression guard would be flaky: in a tight loop
+        // two `create_workflow` calls can land on the same `Utc::now()` and
+        // `list_workflows` sorts only by `created_at` (no tie-breaker), so
+        // the target could end up inside the first 1000 by HashMap-iteration
+        // luck even with > 1000 workflows. (Copilot review on PR #1760.)
+        {
+            let mut workflows = store.workflows.write();
+            let target_state = workflows.get_mut(&target).expect("target workflow exists");
+            target_state.created_at = chrono::Utc::now() - chrono::Duration::days(1);
         }
 
         // The legacy first-page scan would not find this workflow.

--- a/crates/durable/src/persistence/postgres.rs
+++ b/crates/durable/src/persistence/postgres.rs
@@ -2092,6 +2092,46 @@ impl WorkflowEventStore for PostgresWorkflowEventStore {
     }
 
     #[instrument(skip(self))]
+    async fn get_workflow_extended(
+        &self,
+        workflow_id: Uuid,
+    ) -> Result<Option<WorkflowInfoExtended>, StoreError> {
+        // EVE-455: direct id lookup. The previous implementation scanned the
+        // first 1000 rows of `list_workflows`, which silently dropped older
+        // workflows once a deployment grew past that page.
+        let row = sqlx::query(
+            r#"
+            SELECT id, workflow_type, status, input, result, error,
+                   created_at, started_at, completed_at, continued_as_new_id
+            FROM durable_workflow_instances
+            WHERE id = $1
+            "#,
+        )
+        .bind(workflow_id)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| {
+            error!("Failed to load workflow {}: {}", workflow_id, e);
+            StoreError::Database(e.to_string())
+        })?;
+
+        let Some(row) = row else { return Ok(None) };
+        let status_str: String = row.get("status");
+        let error_json: Option<serde_json::Value> = row.get("error");
+        Ok(Some(WorkflowInfoExtended {
+            id: row.get("id"),
+            workflow_type: row.get("workflow_type"),
+            status: parse_workflow_status(&status_str)?,
+            input: row.get("input"),
+            result: row.get("result"),
+            error: error_json.and_then(|v| serde_json::from_value(v).ok()),
+            created_at: row.get("created_at"),
+            started_at: row.get("started_at"),
+            completed_at: row.get("completed_at"),
+            continued_as_new_id: row.try_get("continued_as_new_id").ok().flatten(),
+        }))
+    }
+
     async fn list_workflows(
         &self,
         filter: WorkflowFilter,

--- a/crates/durable/src/persistence/store.rs
+++ b/crates/durable/src/persistence/store.rs
@@ -807,6 +807,32 @@ pub trait WorkflowEventStore: Send + Sync + 'static {
         Ok(vec![])
     }
 
+    /// Direct lookup of a single workflow by id, returning the same
+    /// `WorkflowInfoExtended` shape as `list_workflows`. Returns `Ok(None)`
+    /// when the workflow does not exist.
+    ///
+    /// EVE-455: API handlers must use this method instead of scanning the
+    /// first page of `list_workflows`, which silently returns 404 for any
+    /// workflow older than the page once a deployment crosses the page
+    /// limit. The default implementation falls back to the old scan with
+    /// a 1000-row cap so older external impls continue to compile, but
+    /// every backend in this crate overrides it with a direct id lookup.
+    async fn get_workflow_extended(
+        &self,
+        workflow_id: Uuid,
+    ) -> Result<Option<WorkflowInfoExtended>, StoreError> {
+        let workflows = self
+            .list_workflows(
+                WorkflowFilter::default(),
+                Pagination {
+                    offset: 0,
+                    limit: 1000,
+                },
+            )
+            .await?;
+        Ok(workflows.into_iter().find(|w| w.id == workflow_id))
+    }
+
     /// List tasks with filtering and pagination
     async fn list_tasks(
         &self,

--- a/crates/server/src/api/durable.rs
+++ b/crates/server/src/api/durable.rs
@@ -1040,32 +1040,26 @@ pub async fn get_workflow(
     Path(workflow_id): Path<Uuid>,
 ) -> ApiResult<WorkflowResponse> {
     let store = state.get_store()?;
-    // Use list_workflows with a filter to get the extended info
-    let filter = WorkflowFilter::default();
-    let pagination = Pagination {
-        offset: 0,
-        limit: 1000,
-    };
-
-    let workflows = store
-        .list_workflows(filter, pagination)
+    // EVE-455: direct id lookup; do not scan the first page of
+    // `list_workflows`, which falsely 404s for older workflows.
+    let workflow = store
+        .get_workflow_extended(workflow_id)
         .await
         .map_err(|e| {
-            tracing::error!("Failed to get workflow: {}", e);
+            tracing::error!("Failed to get workflow {}: {}", workflow_id, e);
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ErrorResponse {
                     error: "Internal server error".to_string(),
                 }),
             )
-        })?;
-
-    let workflow = workflows.into_iter().find(|w| w.id == workflow_id).ok_or((
-        StatusCode::NOT_FOUND,
-        Json(ErrorResponse {
-            error: "Workflow not found".to_string(),
-        }),
-    ))?;
+        })?
+        .ok_or((
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse {
+                error: "Workflow not found".to_string(),
+            }),
+        ))?;
 
     Ok(Json(WorkflowResponse::from(workflow)))
 }
@@ -2028,22 +2022,17 @@ pub async fn stream_workflow_sse(
         .get_store()
         .map_err(|_| StatusCode::SERVICE_UNAVAILABLE)?;
 
-    // Verify workflow exists
-    let workflows = store
-        .list_workflows(
-            WorkflowFilter::default(),
-            Pagination {
-                offset: 0,
-                limit: 1000,
-            },
-        )
+    // EVE-455: direct id lookup; do not scan the first page of
+    // `list_workflows`, which silently 404s for older workflows once a
+    // deployment crosses the page limit.
+    let workflow_exists = store
+        .get_workflow_extended(workflow_id)
         .await
         .map_err(|e| {
-            tracing::error!("Failed to get workflows: {}", e);
+            tracing::error!("Failed to look up workflow {}: {}", workflow_id, e);
             StatusCode::INTERNAL_SERVER_ERROR
-        })?;
-
-    let workflow_exists = workflows.iter().any(|w| w.id == workflow_id);
+        })?
+        .is_some();
     if !workflow_exists {
         return Err(StatusCode::NOT_FOUND);
     }
@@ -2172,13 +2161,14 @@ pub async fn stream_workflow_sse(
                     }
                 };
 
-                // Fetch workflow
-                let workflows = fetch_or_disconnect!(
-                    store.list_workflows(WorkflowFilter::default(), Pagination { offset: 0, limit: 1000 }).await,
-                    "Failed to fetch workflows"
+                // EVE-455: direct id lookup so the SSE stream keeps working
+                // for workflows that fall off the first 1000-row page.
+                let workflow_lookup = fetch_or_disconnect!(
+                    store.get_workflow_extended(stream_state.workflow_id).await,
+                    "Failed to fetch workflow"
                 );
 
-                let workflow = match workflows.into_iter().find(|w| w.id == stream_state.workflow_id) {
+                let workflow = match workflow_lookup {
                     Some(w) => WorkflowResponse::from(w),
                     None => {
                         // Workflow deleted, send graceful disconnect


### PR DESCRIPTION
## What
Add `WorkflowEventStore::get_workflow_extended(id)` returning `Option<WorkflowInfoExtended>`, and switch the three API call sites that need to verify a single workflow's existence — `get_workflow`, `stream_workflow_sse` startup check, and the inline polling-loop re-fetch — to use it instead of scanning the first 1000 rows of `list_workflows`.

## Why
DeepSec finding (revalidated). `get_workflow` and `stream_workflow_sse` in `crates/server/src/api/durable.rs` verified workflow existence by reading the first 1000 rows of `list_workflows` ordered by `created_at DESC` and searching in memory. Once a deployment crossed 1000 workflows, valid older workflows fell off the page and the detail and SSE endpoints silently returned 404.

Resolves EVE-455.

## How
- New trait method `get_workflow_extended(&self, workflow_id: Uuid) -> Result<Option<WorkflowInfoExtended>, StoreError>` on `WorkflowEventStore`. Default impl preserves the legacy 1000-row scan so any external implementations keep compiling, but both shipped backends override it:
  - **PostgresWorkflowEventStore**: `SELECT … FROM durable_workflow_instances WHERE id = $1`.
  - **InMemoryWorkflowEventStore**: `HashMap::get(id)`.
- `get_workflow` (HTTP detail) and `stream_workflow_sse` (existence gate + the inline `fetch_or_disconnect` re-fetch in the polling loop) now call `get_workflow_extended` and treat `None` as 404 / disconnect.

## Risk
- Low. Direct id lookup with a `WHERE id = $1` query / `HashMap::get`. No schema or migration change. The default trait impl preserves the legacy behavior for external implementations. The error path is unchanged (500 → `Internal server error` for query failure, 404 → `Workflow not found` for missing).

## Security
- Threat categories reviewed: TM-API (no new endpoint, no new input), TM-AUTHZ (auth gate `_auth: PlatformUser` unchanged), TM-DOS (the new query is a single-row primary-key lookup; strictly less work than the previous 1000-row scan), TM-SQL (parameterized).
- No security-relevant new behavior; the change strictly tightens an existing guarantee.

## Validation
- `cargo test -p everruns-durable --lib persistence::memory::tests::test_get_workflow_extended` — **2 passed** (regression guard + unknown-id None case).
- `cargo build -p everruns-server` — clean.
- `just pre-push` — all 8 checks pass.
- `bash scripts/lib/check-migration-ordering.sh` — sequential (no migrations changed).
- Smoke test: not run end-to-end. The change is server-only and the failing path is fully covered by `test_get_workflow_extended_resolves_past_first_page`, which inserts 1100 workflows, asserts the legacy first-page scan does **not** contain the target (regression guard), then asserts `get_workflow_extended` does. Postgres path uses the same primary-key lookup pattern as `get_workflow_status` / `get_workflow_info`.

## Follow-ups
- No follow-ups.

## Checklist
- [x] Tests added or updated (regression guard + None case)
- [x] Backward compatibility considered (additive trait method with default impl)
- [x] Security review performed against relevant threat model categories (no change in trust boundary)
- [x] All review comments addressed (will sweep after CI / reviewer bots)

Fixes EVE-455
