### PR TITLE
fix(auth): enforce password minimum on registration API

### DIFF
--- a/crates/server/src/auth/routes.rs
+++ b/crates/server/src/auth/routes.rs
@@ -420,6 +420,12 @@ pub async fn login(
     generate_token_response(&state, jar, &auth_user).await
 }
 
+/// Minimum password length enforced on `/v1/auth/register`. Matches the
+/// commitment in `specs/authentication.md` and the UI's `minLength={8}` on
+/// the register form (TM-AUTH-004 / EVE-453). UI validation is convenience;
+/// this server-side check is the trust boundary.
+const PASSWORD_MIN_LENGTH: usize = 8;
+
 /// POST /v1/auth/register - Register a new user
 pub async fn register(
     State(state): State<BuiltinAuthBackend>,
@@ -435,6 +441,21 @@ pub async fn register(
     // Check if password auth is enabled
     if !state.config.password_auth_enabled() {
         return Err(AuthError::forbidden("Password registration is disabled"));
+    }
+
+    // EVE-453 / TM-AUTH-004: enforce the documented 8-character minimum here
+    // so direct API callers cannot bypass the UI's `minLength={8}` and create
+    // weak-password accounts. Validate using `chars().count()` so a password
+    // padded with multi-byte characters that happens to be < 8 codepoints
+    // long still fails. Run before the email lookup and password hash so
+    // timing reflects "request rejected" rather than "registration failed",
+    // and use `unprocessable` (422) instead of the generic 401, since this
+    // is an input validation error and does not touch any account record —
+    // no new account-enumeration signal.
+    if req.password.chars().count() < PASSWORD_MIN_LENGTH {
+        return Err(AuthError::unprocessable(
+            "Password must be at least 8 characters",
+        ));
     }
 
     // Hash password first to make timing consistent whether or not the email exists.

--- a/crates/server/tests/auth_integration_test.rs
+++ b/crates/server/tests/auth_integration_test.rs
@@ -134,6 +134,93 @@ async fn register_user(
 }
 
 // ============================================
+// Registration validation tests (EVE-453)
+// ============================================
+
+// EVE-453 / TM-AUTH-004: direct API calls must not be able to bypass the UI's
+// `minLength={8}` and create weak-password accounts.
+#[tokio::test]
+async fn test_register_rejects_short_password_via_api() {
+    let (router, _db) = auth_router().await;
+
+    let (status, body, _cookies) = send(
+        &router,
+        "POST",
+        "/v1/auth/register",
+        Some(json!({
+            "email": "weak@example.com",
+            "password": "short",
+            "name": "Weak Pw User"
+        })),
+        None,
+    )
+    .await;
+
+    assert_eq!(
+        status,
+        StatusCode::UNPROCESSABLE_ENTITY,
+        "short password must be rejected: {body}"
+    );
+
+    // Acceptable password works.
+    let (status_ok, _body_ok, _) = send(
+        &router,
+        "POST",
+        "/v1/auth/register",
+        Some(json!({
+            "email": "weak@example.com",
+            "password": "longenough",
+            "name": "Weak Pw User"
+        })),
+        None,
+    )
+    .await;
+    assert_eq!(status_ok, StatusCode::CREATED);
+}
+
+// EVE-453: rejection happens before any account-existence check, so the
+// short-password error is identical whether or not the email already exists.
+// Prevents using the new validation as an enumeration oracle.
+#[tokio::test]
+async fn test_register_short_password_does_not_leak_account_existence() {
+    let (router, _db) = auth_router().await;
+
+    // Pre-register the email with a valid password.
+    register_user(&router, "exists@example.com", "validpassword").await;
+
+    let (status_a, body_a, _) = send(
+        &router,
+        "POST",
+        "/v1/auth/register",
+        Some(json!({
+            "email": "exists@example.com",
+            "password": "short",
+            "name": "X"
+        })),
+        None,
+    )
+    .await;
+    let (status_b, body_b, _) = send(
+        &router,
+        "POST",
+        "/v1/auth/register",
+        Some(json!({
+            "email": "fresh@example.com",
+            "password": "short",
+            "name": "Y"
+        })),
+        None,
+    )
+    .await;
+    assert_eq!(status_a, StatusCode::UNPROCESSABLE_ENTITY);
+    assert_eq!(status_b, StatusCode::UNPROCESSABLE_ENTITY);
+    assert_eq!(
+        body_a, body_b,
+        "short-password rejection must not depend on account existence"
+    );
+}
+
+// ============================================
 // Positive path tests
 // ============================================
 

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -95,7 +95,7 @@ Format: `TM-<CATEGORY>-<NNN>`
 | TM-AUTH-001 | Brute force login | High | Per-IP rate limiting on auth endpoints (login 10/min, register 5/min, refresh 30/min); dual backend: in-memory governor or Valkey distributed sliding-window | MITIGATED |
 | TM-AUTH-002 | JWT secret compromise | Critical | Stored in env var `AUTH_JWT_SECRET`; min 32 bytes recommended; never logged | MITIGATED |
 | TM-AUTH-003 | Token replay after logout | Medium | Refresh tokens stored in DB, revocable via DELETE; access tokens short-lived (15 min) | MITIGATED |
-| TM-AUTH-004 | Weak password | Medium | Minimum 8 characters enforced; Argon2id hashing | MITIGATED |
+| TM-AUTH-004 | Weak password | Medium | Minimum 8 characters enforced **server-side** in `register` (`crates/server/src/auth/routes.rs`, before account lookup or creation), independent of the UI's `minLength={8}`. Argon2id hashing on storage. Covered by `test_register_rejects_short_password_via_api`. | MITIGATED |
 | TM-AUTH-005 | API key exposure in transit | High | HTTPS required in production; keys prefixed `evr_` for scanning | MITIGATED |
 | TM-AUTH-006 | API key brute force | Medium | Keys stored as SHA-256 hashes; 128-bit entropy makes brute force infeasible | MITIGATED |
 | TM-AUTH-007 | OAuth state fixation | High | State generated in `oauth_redirect`, stored in HttpOnly/Secure/SameSite=Lax cookie (`oauth_state`), validated and consumed (single-use) in `oauth_callback`; mismatch or missing cookie returns 401 | MITIGATED |


### PR DESCRIPTION
## What
Enforce the documented 8-character password minimum on the `/v1/auth/register` API before any account lookup or password hash. Returns `422 Unprocessable Entity` with `Password must be at least 8 characters`.

## Why
DeepSec finding (revalidated). The UI enforced an 8-character minimum on `/v1/auth/register` via React state + `minLength={8}`, but the server hashed `req.password` and created the account without server-side length validation. Direct API callers could bypass the UI and create accounts with arbitrarily short passwords, contradicting `specs/authentication.md` and TM-AUTH-004.

Resolves EVE-453.

## How
- Add `PASSWORD_MIN_LENGTH = 8` constant in `crates/server/src/auth/routes.rs`.
- In `register`, reject `req.password.chars().count() < PASSWORD_MIN_LENGTH` with `AuthError::unprocessable("Password must be at least 8 characters")`. Uses `chars().count()` (codepoints), not `len()` (bytes), so multi-byte padding cannot smuggle a sub-8-codepoint password through.
- Runs **before** the email lookup and password hash so timing reflects "request rejected" rather than "registration failed", and **after** the `disable_signup` / `password_auth_enabled` gates so existing config errors take precedence.
- Use `unprocessable` (422) instead of the generic 401 — this is input validation, not a credential failure, and 422 does not touch any account record so no enumeration oracle is added.

## Risk
- Low. Single conditional in a single hot path. No DB schema change. UI is unchanged (still has its `minLength={8}` as a UX convenience).

## Security
- Threat categories reviewed: TM-AUTH (TM-AUTH-004 weak password), TM-AUTH-014 (account enumeration via registration), TM-API (input validation).
- Findings:
  - **TM-AUTH-004 (Weak password):** mitigation entry updated to call out the **server-side** enforcement explicitly; the previous wording could be read as relying on the UI.
  - **TM-AUTH-014 (Account enumeration via registration):** preserved. The validation runs before the email lookup, so the rejection body and timing are identical for an existing email vs. a fresh email. Verified by `test_register_short_password_does_not_leak_account_existence` which asserts the JSON bodies for both cases are byte-identical.

## Validation
- `cargo test -p everruns-server --test auth_integration_test` — **16 passed** (14 existing + 2 new).
- `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- `just pre-push` — all 8 checks pass.
- `bash scripts/lib/check-migration-ordering.sh` — sequential.
- Smoke test: not run end-to-end. The change is a server-only validation gate covered by two integration tests (positive: short rejected + valid accepted; enumeration-oracle guard).

## Follow-ups
- No follow-ups. UI keeps `minLength={8}` as a convenience hint per the issue acceptance criteria.

## Checklist
- [x] Tests added or updated (short-password rejection + enumeration-oracle guard)
- [x] Backward compatibility considered (additive validation; same error shape as existing `unprocessable` paths)
- [x] Security review performed against relevant threat model categories (TM-AUTH-004 mitigation entry tightened)
- [x] All review comments addressed (will sweep after CI / reviewer bots)

Fixes EVE-453
