### PR TITLE
fix(server): map domain anyhow::bail! cases to typed 4xx errors

### DIFF
--- a/crates/server/src/domains/common.rs
+++ b/crates/server/src/domains/common.rs
@@ -92,6 +92,14 @@ pub fn classify_anyhow(e: anyhow::Error) -> CommandError {
         return CommandError::Conflict(msg);
     }
 
+    // EVE-437: this list catches `anyhow::bail!` strings emitted from
+    // `crates/server/src/domains/**` that represent client-input or
+    // already-validated resource state, not internal invariants. New entries
+    // here keep older calls that have not been migrated to typed errors from
+    // silently mapping to 500. New code SHOULD emit `BadRequestError`,
+    // `ResourceNotFoundError`, or `PolicyError` directly so this list does
+    // not have to grow indefinitely. Each substring is matched against the
+    // lowercased anyhow message — keep the patterns short and unambiguous.
     let is_bad_request = [
         "cannot be assigned",
         "cannot be edited",
@@ -106,6 +114,21 @@ pub fn classify_anyhow(e: anyhow::Error) -> CommandError {
         "invalid skill capability reference",
         "unsupported locale",
         "unsupported timezone",
+        // EVE-437: harness validation
+        "harness inheritance cycle detected",
+        "harness cannot inherit from itself",
+        "parent harness must be active",
+        "cannot archive or delete harness while child harnesses",
+        // EVE-437: unique-name allocation in agents/harnesses queries
+        "could not find a unique name",
+        // EVE-437: eval target validation
+        "eval target must specify",
+        "app targets not yet supported",
+        "harness_id and harness_name are mutually exclusive",
+        // EVE-437: MCP server config validation (auth-mode and key checks)
+        "only api key mcp servers can store an api key",
+        "api key auth mode requires",
+        "oauth mcp servers require a user connection",
     ]
     .iter()
     .any(|pattern| lowered.contains(pattern));
@@ -1031,6 +1054,62 @@ mod error_tests {
     fn classify_anyhow_maps_not_found_error() {
         let err = classify_anyhow(crate::errors::ResourceNotFoundError::new("Thing").into());
         assert!(matches!(err, CommandError::NotFound(msg) if msg == "Thing not found"));
+    }
+
+    // EVE-437: every substring added to the `is_bad_request` list must in
+    // fact map an `anyhow::bail!` to `CommandError::BadRequest` rather than
+    // silently 500ing. New entries here pin the contract.
+    #[test]
+    fn classify_anyhow_maps_eve437_validation_substrings() {
+        let cases = [
+            "Harness inheritance cycle detected",
+            "Harness cannot inherit from itself",
+            "Parent harness must be active",
+            "Cannot archive or delete harness while child harnesses still inherit from it: a, b",
+            "Could not find a unique name for 'foo'",
+            "eval target must specify harness_id or harness_name",
+            "App targets not yet supported in eval execution",
+            "harness_id and harness_name are mutually exclusive in eval target",
+            "Only API key MCP servers can store an API key",
+            "API key auth mode requires an API key",
+            "API key auth mode requires a non-empty API key",
+            "OAuth MCP servers require a user connection before tools can be refreshed",
+        ];
+        for raw in cases {
+            let err = classify_anyhow(anyhow::anyhow!("{raw}"));
+            assert!(
+                matches!(err, CommandError::BadRequest(_)),
+                "{raw} must classify as BadRequest, got {err:?}"
+            );
+        }
+    }
+
+    // EVE-437: a generic anyhow error with no recognized pattern must keep
+    // mapping to Internal so we do not accidentally widen the bad-request
+    // class for unrelated future failures.
+    #[test]
+    fn classify_anyhow_unknown_message_is_internal() {
+        let err = classify_anyhow(anyhow::anyhow!("connection timed out"));
+        assert!(
+            matches!(err, CommandError::Internal(_)),
+            "unknown messages must remain Internal: {err:?}"
+        );
+    }
+
+    // EVE-437: PolicyError stays mapped to Forbidden — this is the path used
+    // by the new sessions/service.rs high-risk capability check that used to
+    // be a bail! and 500'd.
+    #[test]
+    fn classify_anyhow_maps_policy_error() {
+        let pe = everruns_core::PolicyError::denied("test_policy", "admin role");
+        let err = classify_anyhow(anyhow::Error::new(pe));
+        let CommandError::Forbidden(msg) = &err else {
+            panic!("PolicyError must classify as Forbidden, got {err:?}");
+        };
+        assert!(
+            msg.contains("admin role"),
+            "Forbidden message must include detail, got {msg:?}"
+        );
     }
 }
 

--- a/crates/server/src/domains/harnesses/queries.rs
+++ b/crates/server/src/domains/harnesses/queries.rs
@@ -3,6 +3,7 @@
 // No policy checks, no input validation. Pure data access + mapping.
 
 use crate::domains::common::CommandError;
+use crate::errors::ResourceNotFoundError;
 use crate::storage::StorageBackend;
 use everruns_core::{
     AgentCapabilityConfig, Harness, HarnessId, HarnessStatus, InitialFile,
@@ -246,7 +247,10 @@ pub async fn resolve_effective(
             if chain.is_empty() {
                 return Ok(None);
             }
-            anyhow::bail!("Parent harness not found");
+            // EVE-437: typed 404 instead of an unclassified anyhow that
+            // would map to 500. The cycle case above stays as a generic
+            // bail because it is a true invariant violation.
+            return Err(ResourceNotFoundError::new("Parent harness").into());
         };
         cursor = harness.parent_harness_id;
         chain.push(harness);

--- a/crates/server/src/domains/harnesses/queries.rs
+++ b/crates/server/src/domains/harnesses/queries.rs
@@ -248,8 +248,12 @@ pub async fn resolve_effective(
                 return Ok(None);
             }
             // EVE-437: typed 404 instead of an unclassified anyhow that
-            // would map to 500. The cycle case above stays as a generic
-            // bail because it is a true invariant violation.
+            // would map to 500. The inheritance-cycle bail above stays as
+            // an `anyhow::bail!` but is mapped to 400 by `classify_anyhow`'s
+            // substring list — the cycle is reachable only when the
+            // operator-supplied `parent_harness_id` graph contains a loop,
+            // so it is a client-input validation failure, not an internal
+            // invariant violation.
             return Err(ResourceNotFoundError::new("Parent harness").into());
         };
         cursor = harness.parent_harness_id;

--- a/crates/server/src/domains/sessions/service.rs
+++ b/crates/server/src/domains/sessions/service.rs
@@ -1278,10 +1278,19 @@ impl SessionService {
             return Ok(());
         }
 
-        anyhow::bail!(
-            "Admin role required to create sessions with high-risk capabilities: {}",
-            high_risk.join(", ")
-        );
+        // EVE-437 / TM-AUTHZ: this is an authorization failure, not an
+        // internal error. Returning an `anyhow::bail!` here used to map to
+        // 500 because `classify_anyhow` did not recognize the message
+        // substring. A `PolicyError` maps to `Forbidden` (403) at the
+        // command boundary.
+        Err(everruns_core::PolicyError::denied(
+            "session_high_risk_capabilities",
+            &format!(
+                "Admin role required to create sessions with high-risk capabilities: {}",
+                high_risk.join(", ")
+            ),
+        )
+        .into())
     }
 
     /// Populate the `features` field on a session by aggregating features from


### PR DESCRIPTION
## What
Audit and fix the `anyhow::bail!` calls in `crates/server/src/domains/**` so client-input failures, missing resources, and authorization failures map to the correct 4xx HTTP status instead of silently 500'ing through `classify_anyhow`'s catch-all.

## Why
The TM-AUTHZ-009 incident showed an `anyhow::bail!("Tags ... reserved")` in `domains/sessions/service.rs` was 500'ing because `classify_anyhow` did not recognize the substring. That class of regression is hard to spot because the integration test asserted `assert_ne!(CREATED)` instead of the specific 4xx, and any new `bail!` whose message doesn't match the hand-coded list silently joins the 500-bucket.

Resolves EVE-437.

## How
Two highest-impact paths converted to **typed errors** directly (so `classify_anyhow`'s downcast arms catch them, regardless of message wording):

| File | Old | New |
|---|---|---|
| `domains/sessions/service.rs:1281` | `anyhow::bail!("Admin role required …")` | `Err(PolicyError::denied(…).into())` → 403 |
| `domains/harnesses/queries.rs:249` | `anyhow::bail!("Parent harness not found")` | `Err(ResourceNotFoundError::new("Parent harness").into())` → 404 |

Remaining validation strings on `bail!` calls in domain code added to the existing `is_bad_request` substring list in `classify_anyhow` (low-risk, no caller surgery needed):

- harness validation: cycle detected, cannot inherit from itself, parent must be active, child harnesses still inherit
- agents/harnesses unique-name allocation: "could not find a unique name"
- evals: target must specify, app targets not yet supported, mutually exclusive
- mcp_servers: API-key auth-mode validation, OAuth user connection requirement

The harness inheritance-cycle bail also gets a 400 mapping — it is reachable only when an operator-supplied `parent_harness_id` graph contains a loop, so it is client-input validation, not an internal invariant violation. (Previous PR-body wording on this point was wrong; fixed in `f6fb8ed`.)

Comment on the `is_bad_request` list now says explicitly: **new code SHOULD emit typed errors directly** so the substring list does not grow indefinitely.

Runtime / internal cases left as-is on purpose:
- `evals/runner.rs:520` `Case timeout exceeded` — runtime
- `evals/runner.rs:551` `Turn failed: …` — runtime

## Risk
- Low. The only behavioral change is the HTTP status code for callers that hit these specific paths. Direct API/MCP/SDK callers that previously got `500 Internal server error` for a bad request will now get the correct 4xx with a useful message — that's a strict improvement. No DB, no migration, no policy change.
- The two typed-error conversions both diverge before any side effect, same as the original `bail!`.

## Security
- Threat categories reviewed: TM-AUTHZ (the sessions high-risk capability check is the original TM-AUTHZ-009 pattern; now correctly 403'd via `PolicyError`), TM-API (status codes are the API contract; no new endpoint), TM-AUTH (no auth path touched).
- No new findings; this is a hardening / bug-fix change for an already-mitigated category.

## Validation
- `cargo test -p everruns-server --lib domains::common::error_tests` — **6 passed**:
  - `classify_anyhow_maps_eve437_validation_substrings` — pins all 12 new substring → BadRequest mappings.
  - `classify_anyhow_maps_policy_error` — covers the new sessions high-risk path that used to 500.
  - `classify_anyhow_unknown_message_is_internal` — guard against accidentally widening the bad-request class for unrelated future failures.
  - existing 3 tests still pass.
- `cargo build -p everruns-server` — clean.
- `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- `just pre-push` — all 8 checks pass.
- `bash scripts/lib/check-migration-ordering.sh` — sequential.
- Smoke test: not run end-to-end. The change is scoped to a pure-function classifier and two error-construction call sites. Postgres/SQLite paths not touched. Justified skip.

## Follow-ups
- No follow-ups in scope. Future hardening could add a clippy lint or `#[deny(anyhow::bail)]` attribute on `crates/server/src/domains/**` to force new code through typed errors, but that's a separate quality-gate change.

## Checklist
- [x] Tests added or updated (3 new unit tests covering all new mappings)
- [x] Backward compatibility considered (HTTP status improvements only; no API surface change)
- [x] Security review performed against relevant threat model categories (TM-AUTHZ, TM-API)
- [x] All review comments addressed (Copilot: cycle-bail comment vs. substring list mismatch — `f6fb8ed`)

Fixes EVE-437