### PR TITLE
fix(plugin): shorten everruns dev default prompt

### DIFF
--- a/plugins/everruns-dev/.codex-plugin/plugin.json
+++ b/plugins/everruns-dev/.codex-plugin/plugin.json
@@ -30,7 +30,7 @@
     ],
     "websiteURL": "https://everruns.com",
     "defaultPrompt": [
-      "Create an Everruns(Dev) agent to summarize news from https://news.ycombinator.com/, pick the right harness and capabilities, and run it against this task"
+      "Create an Everruns(Dev) Hacker News summarizer, pick the right harness and capabilities, and run it."
     ],
     "brandColor": "#D4A43A",
     "composerIcon": "./assets/everruns-small.svg",

--- a/scripts/test-everruns-dev-plugin.sh
+++ b/scripts/test-everruns-dev-plugin.sh
@@ -39,6 +39,22 @@ claude_marketplace = json.loads((root / ".claude-plugin" / "marketplace.json").r
 codex_marketplace = json.loads((root / ".agents" / "plugins" / "marketplace.json").read_text())
 cursor_marketplace = json.loads((root / ".cursor-plugin" / "marketplace.json").read_text())
 
+codex_interface = codex.get("interface")
+if not isinstance(codex_interface, dict):
+    raise SystemExit("Codex plugin.json must declare an 'interface' object")
+
+codex_default_prompts = codex_interface.get("defaultPrompt", [])
+if not isinstance(codex_default_prompts, list):
+    raise SystemExit("Codex interface.defaultPrompt must be a list")
+
+for index, prompt in enumerate(codex_default_prompts):
+    if not isinstance(prompt, str):
+        raise SystemExit(f"Codex defaultPrompt[{index}] must be a string")
+    if len(prompt) > 128:
+        raise SystemExit(
+            f"Codex defaultPrompt[{index}] is too long: {len(prompt)} > 128"
+        )
+
 
 def marketplace_plugin(label, marketplace, name):
     for plugin in marketplace["plugins"]:


### PR DESCRIPTION
## What
Shorten the Codex `everruns-dev` plugin `interface.defaultPrompt[0]` so it stays under Codex's 128-character manifest limit.

Add a plugin metadata check that fails when any Codex default prompt exceeds 128 characters.

## Why
Codex was ignoring the prompt and logging:

`ignoring interface.defaultPrompt[0]: prompt must be at most 128 characters`

## How
Replace the long sample prompt with a shorter 100-character prompt that preserves the intended Hacker News summarizer example.

Extend `scripts/test-everruns-dev-plugin.sh` to enforce the Codex prompt length contract.

## Risk
- Low
- Plugin metadata only; possible breakage is limited to the displayed default prompt text or the plugin metadata smoke test.

## Security
- Threat categories reviewed: No security-relevant code changes.
- Findings and resolutions: The change only edits static plugin manifest text and a local metadata validation script. No auth, authorization, API, tool execution, filesystem, network, dependency, or runtime behavior changed.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

## Validation
- `./scripts/test-everruns-dev-plugin.sh`
- `python3 -m json.tool plugins/everruns-dev/.codex-plugin/plugin.json >/dev/null`
- `just pre-push` (UI format/lint skipped because `apps/ui/node_modules` is absent)
- `bash scripts/lib/check-migration-ordering.sh`
