### PR TITLE
fix(voice): disable unauthorized realtime tool execution

### DIFF
--- a/crates/server/src/api/voice.rs
+++ b/crates/server/src/api/voice.rs
@@ -25,11 +25,10 @@ use everruns_core::events::{
     VOICE_OUTPUT_TRANSCRIPT_COMPLETED, VOICE_OUTPUT_TRANSCRIPT_DELTA, VoiceSessionEndedData,
     VoiceSessionFailedData, VoiceSessionStartedData, VoiceTranscriptData,
 };
-use everruns_core::traits::{LeasedResourceStore, ToolExecutor};
+use everruns_core::traits::LeasedResourceStore;
 use everruns_core::typed_id::{AgentId, SessionId};
 use everruns_core::{
-    Caller, FeatureFlags, LeasedResource, Message, ToolCall, ToolContext, ToolRegistry,
-    UpsertLeasedResource,
+    Caller, FeatureFlags, LeasedResource, Message, ToolCall, UpsertLeasedResource,
 };
 use futures_util::{SinkExt, StreamExt};
 use reqwest::multipart;
@@ -608,7 +607,7 @@ fn realtime_session_payload(options: &NormalizedVoiceOptions) -> Value {
         "reasoning": {
             "effort": options.reasoning_effort
         },
-        "tools": realtime_tools()
+        "tools": []
     });
     if let Some(instructions) = options
         .instructions
@@ -618,24 +617,6 @@ fn realtime_session_payload(options: &NormalizedVoiceOptions) -> Value {
         payload["instructions"] = json!(instructions);
     }
     payload
-}
-
-fn realtime_tools() -> Value {
-    let registry = ToolRegistry::with_defaults();
-    Value::Array(
-        registry
-            .tool_definitions()
-            .into_iter()
-            .map(|tool| {
-                json!({
-                    "type": "function",
-                    "name": tool.name(),
-                    "description": tool.description(),
-                    "parameters": tool.parameters(),
-                })
-            })
-            .collect(),
-    )
 }
 
 async fn authorize_session(
@@ -1136,36 +1117,10 @@ fn extract_function_calls(value: &Value) -> Vec<ToolCall> {
         .collect()
 }
 
-async fn execute_realtime_tool(session_id: SessionId, call: ToolCall) -> RealtimeToolOutput {
-    let registry = ToolRegistry::with_defaults();
-    let tool_def = registry
-        .tool_definitions()
-        .into_iter()
-        .find(|definition| definition.name() == call.name);
-    let Some(tool_def) = tool_def else {
-        return RealtimeToolOutput {
-            call_id: call.id,
-            output: json!({ "error": "tool_not_found" }).to_string(),
-        };
-    };
-    let context = ToolContext::new(session_id);
-    match registry
-        .execute_with_context(&call, &tool_def, &context)
-        .await
-    {
-        Ok(result) => RealtimeToolOutput {
-            call_id: result.tool_call_id,
-            output: serde_json::to_string(&json!({
-                "result": result.result,
-                "error": result.error,
-                "connection_required": result.connection_required,
-            }))
-            .unwrap_or_else(|_| "{\"error\":\"serialization_failed\"}".to_string()),
-        },
-        Err(_) => RealtimeToolOutput {
-            call_id: call.id,
-            output: json!({ "error": "tool_execution_failed" }).to_string(),
-        },
+async fn execute_realtime_tool(_session_id: SessionId, call: ToolCall) -> RealtimeToolOutput {
+    RealtimeToolOutput {
+        call_id: call.id,
+        output: json!({ "error": "tool_execution_disabled" }).to_string(),
     }
 }
 

--- a/crates/server/src/api/voice.rs
+++ b/crates/server/src/api/voice.rs
@@ -1202,4 +1202,35 @@ mod tests {
         assert_eq!(calls[0].name, "get_current_time");
         assert_eq!(calls[0].arguments["timezone"], "UTC");
     }
+
+    #[test]
+    fn realtime_session_payload_does_not_advertise_tools() {
+        let payload = realtime_session_payload(&NormalizedVoiceOptions {
+            model: DEFAULT_MODEL.to_string(),
+            voice: DEFAULT_VOICE.to_string(),
+            reasoning_effort: DEFAULT_REASONING_EFFORT.to_string(),
+            instructions: None,
+        });
+
+        assert_eq!(payload["tools"], json!([]));
+    }
+
+    #[tokio::test]
+    async fn realtime_tool_execution_is_disabled() {
+        let output = execute_realtime_tool(
+            SessionId::new(),
+            ToolCall {
+                id: "call_passthrough".to_string(),
+                name: "web_fetch".to_string(),
+                arguments: json!({ "url": "https://example.com" }),
+            },
+        )
+        .await;
+
+        assert_eq!(output.call_id, "call_passthrough");
+        assert_eq!(
+            serde_json::from_str::<Value>(&output.output).expect("json output"),
+            json!({ "error": "tool_execution_disabled" })
+        );
+    }
 }


### PR DESCRIPTION
## What
Disable realtime voice sessions from advertising or executing server-side tools through provider sideband function calls.

## Why
Realtime voice sessions were using the default tool registry without the normal session and agent capability grants, which could allow sideband tool calls to bypass authorization and network-access policy.

## How
Send an empty `tools` array in realtime session payloads, make realtime tool execution return a deterministic `tool_execution_disabled` error, and add unit coverage for both the advertised-tools payload and call-id-preserving disabled execution response.

## Risk
- Medium
- Voice sessions that previously relied on provider sideband tool execution will no longer execute those calls; this is intentional until voice tools can be wired through the normal capability and policy path.

## Security
- Threat categories reviewed: TM-AUTHZ, TM-TOOL, TM-LLM, TM-API, TM-DOS.
- Findings and resolutions: removed the unauthorized sideband path to `ToolRegistry::with_defaults()` and verified the provider receives no advertised tools plus a deterministic disabled error if it still sends a function call.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)