### PR TITLE
test(apps): pin shared session reuse

### DIFF
--- a/crates/server/tests/ag_ui_integration_test.rs
+++ b/crates/server/tests/ag_ui_integration_test.rs
@@ -146,6 +146,41 @@ async fn send_ag_ui_run_with_headers(
         .await
 }
 
+async fn start_ag_ui_run(
+    server: &TestServer,
+    app_id: impl std::fmt::Display,
+    payload: &Value,
+) -> test_harness::TestResponse {
+    server
+        .request_raw_without_collecting_body(
+            Method::POST,
+            &format!("/v1/apps/{}/ag-ui", app_id),
+            vec![
+                ("content-type", "application/json"),
+                ("accept", "text/event-stream"),
+            ],
+            serde_json::to_vec(payload).unwrap(),
+        )
+        .await
+}
+
+async fn sessions_with_tag(server: &TestServer, tag: &str) -> Vec<Value> {
+    let sessions: Value = server.get("/v1/sessions").await.assert_success().json();
+    let empty = vec![];
+    sessions["data"]
+        .as_array()
+        .unwrap_or(&empty)
+        .iter()
+        .filter(|session| {
+            session["tags"]
+                .as_array()
+                .map(|tags| tags.iter().any(|candidate| candidate.as_str() == Some(tag)))
+                .unwrap_or(false)
+        })
+        .cloned()
+        .collect()
+}
+
 async fn upload_ag_ui_image(
     server: &TestServer,
     app_id: impl std::fmt::Display,
@@ -402,6 +437,66 @@ async fn test_ag_ui_run_rejects_image_uploaded_for_other_app() {
     send_ag_ui_run(&server, &second_app.public_id, &payload)
         .await
         .assert_status(StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_ag_ui_same_thread_id_reuses_session() {
+    let server = TestServer::in_memory().await;
+    let app = create_published_ag_ui_app(&server).await;
+    let thread_id = raw_uuid();
+    let expected_tag = format!("ag_ui:thread:{thread_id}");
+
+    let first_payload = json!({
+        "threadId": thread_id,
+        "runId": raw_uuid(),
+        "state": {},
+        "messages": [
+            { "id": raw_uuid(), "role": "user", "content": "Start this AG-UI thread" }
+        ],
+        "tools": [],
+        "context": [],
+        "forwardedProps": {}
+    });
+
+    start_ag_ui_run(&server, &app.public_id, &first_payload)
+        .await
+        .assert_status(StatusCode::OK);
+
+    let first_sessions = sessions_with_tag(&server, &expected_tag).await;
+    assert_eq!(
+        first_sessions.len(),
+        1,
+        "first AG-UI request should create exactly one tagged session"
+    );
+    let first_session_id = first_sessions[0]["id"].as_str().unwrap().to_string();
+
+    let second_payload = json!({
+        "threadId": thread_id,
+        "runId": raw_uuid(),
+        "state": {},
+        "messages": [
+            { "id": raw_uuid(), "role": "user", "content": "Continue this AG-UI thread" }
+        ],
+        "tools": [],
+        "context": [],
+        "forwardedProps": {}
+    });
+
+    start_ag_ui_run(&server, &app.public_id, &second_payload)
+        .await
+        .assert_status(StatusCode::OK);
+
+    let resumed_sessions = sessions_with_tag(&server, &expected_tag).await;
+    assert_eq!(
+        resumed_sessions.len(),
+        1,
+        "second AG-UI request with same threadId should not create another session"
+    );
+    assert_eq!(
+        resumed_sessions[0]["id"].as_str().unwrap(),
+        first_session_id,
+        "AG-UI thread resume should reuse the original session id"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/server/tests/slack_integration_test.rs
+++ b/crates/server/tests/slack_integration_test.rs
@@ -415,7 +415,9 @@ async fn test_slack_threaded_message_reuses_session() {
 
     // Wait for first message to create session
     let expected_tag = format!("slack:thread:{}", thread_ts);
-    wait_for_sessions_with_tag(&server, &expected_tag, 1).await;
+    let first_sessions = wait_for_sessions_with_tag(&server, &expected_tag, 1).await;
+    assert_eq!(first_sessions.len(), 1);
+    let first_session_id = first_sessions[0]["id"].as_str().unwrap().to_string();
 
     // Second message in the same thread
     let payload2 = json!({
@@ -441,6 +443,11 @@ async fn test_slack_threaded_message_reuses_session() {
         sessions.len(),
         1,
         "Should reuse the same session for threaded replies"
+    );
+    assert_eq!(
+        sessions[0]["id"].as_str().unwrap(),
+        first_session_id,
+        "Threaded replies should land in the original Slack session"
     );
 }
 

--- a/crates/server/tests/test_harness.rs
+++ b/crates/server/tests/test_harness.rs
@@ -649,6 +649,38 @@ impl TestServer {
         }
     }
 
+    /// Make a raw request and return once the response headers are available,
+    /// without collecting a streaming response body.
+    pub async fn request_raw_without_collecting_body(
+        &self,
+        method: Method,
+        uri: &str,
+        headers: Vec<(&str, &str)>,
+        body: Vec<u8>,
+    ) -> TestResponse {
+        let normalized_uri = Self::normalize_uri(uri);
+        let mut builder = Request::builder().method(method).uri(&normalized_uri);
+        for (key, value) in headers {
+            builder = builder.header(key, value);
+        }
+        let request = builder
+            .body(Body::from(body))
+            .expect("Failed to build request");
+
+        let response = self
+            .router
+            .clone()
+            .oneshot(request)
+            .await
+            .expect("Request failed");
+
+        TestResponse {
+            status: response.status(),
+            headers: response.headers().clone(),
+            body: Vec::new(),
+        }
+    }
+
     /// Make a request with custom method and optional body
     async fn request<T: Serialize>(
         &self,


### PR DESCRIPTION
## What
Adds shared-session reuse regression coverage for Slack and AG-UI app ingress.

## Why
EVE-440 tracks missing integration coverage for the Slack and AG-UI `create_from_app` call sites after owner-principal plumbing was fixed elsewhere.

## How
- Tightens the Slack threaded-message regression to capture the first session ID and assert the second same-thread event lands in that exact session.
- Adds an AG-UI same-`threadId` regression that resolves the public app session twice and asserts the tagged session ID is unchanged.
- Verified both files are wired in CI: AG-UI is in `Run domain integration tests`; Slack has its dedicated `slack_integration_test` CI step.

## Risk
- Low
- Test-only change. Main risk is test flake in async session creation; Slack retains existing wait helper and AG-UI uses deterministic in-memory storage.

## Security
- Threat categories reviewed: No security-relevant code changes; this PR only adds/strengthens integration tests.
- Findings and resolutions: None.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)