### PR TITLE
fix(apps): audit app-channel invocations

### DIFF
--- a/crates/core/src/audit.rs
+++ b/crates/core/src/audit.rs
@@ -148,6 +148,7 @@ pub enum AgentAction {
     RunFailed,
     ToolExecuted,
     LlmRequest,
+    AppInvocationStarted,
 }
 
 impl AgentAction {
@@ -158,6 +159,7 @@ impl AgentAction {
             Self::RunFailed => "agent.run.failed",
             Self::ToolExecuted => "agent.tool.executed",
             Self::LlmRequest => "agent.llm.request",
+            Self::AppInvocationStarted => "agent.app_invocation.started",
         }
     }
 }
@@ -274,6 +276,7 @@ impl std::str::FromStr for AgentAction {
             "agent.run.failed" => Ok(Self::RunFailed),
             "agent.tool.executed" => Ok(Self::ToolExecuted),
             "agent.llm.request" => Ok(Self::LlmRequest),
+            "agent.app_invocation.started" => Ok(Self::AppInvocationStarted),
             other => Err(format!("unknown agent action: {other}")),
         }
     }

--- a/crates/server/src/domains/apps/commands.rs
+++ b/crates/server/src/domains/apps/commands.rs
@@ -11,6 +11,7 @@ use super::types::{
 use super::{APP_DANGEROUS, APP_MANAGE, APP_VIEW};
 use crate::api::messages::{CreateMessageRequest, InputContentPart, InputMessage, MessageRole};
 use crate::api::sessions::CreateSessionRequest;
+use crate::auth::audit;
 use crate::domains::common::*;
 use crate::domains::messages::{CreateMessageContext, MessageService};
 use crate::domains::sessions::SessionService;
@@ -21,8 +22,8 @@ use chrono::{DateTime, Utc};
 use everruns_core::app::{InvocationSessionMode, ScheduleChannelConfig, WebhookChannelConfig};
 use everruns_core::typed_id::{AgentId, AppChannelId, AppId, HarnessId, SessionId};
 use everruns_core::{
-    A2aChannelConfig, AgUiChannelConfig, AgUiToolVisibility, App, AppChannel, AppStatus,
-    ChannelType, Policy, SlackChannelConfig,
+    A2aChannelConfig, AgUiChannelConfig, AgUiToolVisibility, AgentAction, App, AppChannel,
+    AppStatus, AuditEvent, ChannelType, Policy, SlackChannelConfig,
 };
 use everruns_durable::{
     CreateScheduleRow, ScheduleTargetType, StoreError, UpdateField, UpdateSchedule,
@@ -321,6 +322,29 @@ fn app_invocation_message_metadata(
     ]
     .into_iter()
     .collect()
+}
+
+fn emit_app_invocation_audit_event(
+    db: Arc<crate::storage::StorageBackend>,
+    app: &App,
+    channel: &AppChannel,
+    session_id: SessionId,
+    source: AppInvocationSource,
+    created_session: bool,
+) {
+    let mut event = AuditEvent::agent(AgentAction::AppInvocationStarted, app.org_id, None)
+        .target("app_channel", channel.public_id.to_string())
+        .detail("source", format!("app_{}", source.as_str()))
+        .detail("app_id", app.public_id.to_string())
+        .detail("app_channel_id", channel.public_id.to_string())
+        .detail("app_channel_type", channel.channel_type.to_string())
+        .detail("session_id", session_id.to_string())
+        .detail("created_session", created_session);
+    event = event.detail("app_owner_principal_id", app.owner_principal_id.to_string());
+    if let Some(agent_identity_id) = app.agent_identity_id {
+        event = event.detail("agent_identity_id", agent_identity_id.to_string());
+    }
+    audit::emit_event(db, event.build());
 }
 
 async fn set_channel_durable_schedule_id(
@@ -777,6 +801,15 @@ where
         rendered_message,
     )
     .await?;
+
+    emit_app_invocation_audit_event(
+        Arc::clone(services.db),
+        &app,
+        &channel,
+        session_id,
+        source,
+        created_session,
+    );
 
     Ok(AppInvocationResult {
         session_id,

--- a/crates/server/tests/app_a2a_integration_test.rs
+++ b/crates/server/tests/app_a2a_integration_test.rs
@@ -3,8 +3,11 @@
 mod test_harness;
 
 use axum::http::{Method, StatusCode};
+use everruns_core::DEFAULT_ORG_ID;
+use everruns_server::storage::models::{AuditLogQuery, AuditLogRow};
 use serde_json::{Value, json};
 use test_harness::TestServer;
+use tokio::time::{Duration, sleep};
 
 async fn create_app_with_a2a(server: &TestServer, name: &str, message: &str) -> (Value, String) {
     create_app_with_a2a_mode(server, name, message, "shared_session").await
@@ -80,6 +83,35 @@ async fn list_user_message_texts(server: &TestServer, session_id: &str) -> Vec<S
             })
         })
         .collect()
+}
+
+async fn wait_for_app_invocation_audit_log(
+    server: &TestServer,
+    channel_id: &str,
+    session_id: &str,
+) -> AuditLogRow {
+    for _ in 0..20 {
+        let rows = server
+            .db
+            .list_audit_logs(AuditLogQuery {
+                org_id: DEFAULT_ORG_ID,
+                limit: 50,
+                action: Some("agent.app_invocation.started"),
+                ..Default::default()
+            })
+            .await
+            .expect("list audit logs");
+        if let Some(row) = rows.into_iter().find(|row| {
+            row.target_type.as_deref() == Some("app_channel")
+                && row.target_id.as_deref() == Some(channel_id)
+                && row.metadata.get("session_id").and_then(Value::as_str) == Some(session_id)
+        }) {
+            return row;
+        }
+        sleep(Duration::from_millis(25)).await;
+    }
+
+    panic!("expected app invocation audit log for channel {channel_id} session {session_id}");
 }
 
 #[tokio::test]
@@ -169,6 +201,57 @@ async fn a2a_message_send_creates_session_and_returns_submitted_task() {
     let texts = list_user_message_texts(&server, session_id).await;
     assert!(texts.iter().any(|t| t == "from a2a: hello"));
     assert!(texts.iter().any(|t| t == "from a2a: again"));
+}
+
+#[tokio::test]
+async fn a2a_message_send_emits_app_invocation_audit_log() {
+    let server = TestServer::in_memory().await;
+    let (app, api_key) = create_app_with_a2a(&server, "a2a-audit", "{{a2a.text}}").await;
+    let app_id = app["id"].as_str().unwrap();
+    let channel_id = app["channels"][0]["id"].as_str().unwrap();
+    publish_app(&server, app_id).await;
+
+    let body = serde_json::to_vec(&json!({
+        "jsonrpc": "2.0",
+        "id": "req-audit",
+        "method": "message/send",
+        "params": {
+            "message": {
+                "role": "user",
+                "messageId": "msg-audit",
+                "parts": [{ "kind": "text", "text": "audit me" }]
+            }
+        }
+    }))
+    .unwrap();
+
+    let response: Value = server
+        .request_raw(
+            Method::POST,
+            &format!("/v1/apps/{app_id}/a2a/{channel_id}"),
+            vec![
+                ("content-type", "application/json"),
+                ("authorization", &format!("Bearer {api_key}")),
+            ],
+            body,
+        )
+        .await
+        .assert_status(StatusCode::OK)
+        .json();
+
+    let session_id = response["result"]["contextId"].as_str().unwrap();
+    let audit_log = wait_for_app_invocation_audit_log(&server, channel_id, session_id).await;
+
+    assert_eq!(audit_log.domain, "agent");
+    assert_eq!(audit_log.action, "agent.app_invocation.started");
+    assert_eq!(audit_log.event_type, "agent.app_invocation.started");
+    assert_eq!(audit_log.actor_id, None);
+    assert_eq!(audit_log.metadata["source"], "app_a2a");
+    assert_eq!(audit_log.metadata["app_id"], app_id);
+    assert_eq!(audit_log.metadata["app_channel_id"], channel_id);
+    assert_eq!(audit_log.metadata["app_channel_type"], "a2a");
+    assert_eq!(audit_log.metadata["session_id"], session_id);
+    assert_eq!(audit_log.metadata["created_session"], true);
 }
 
 #[tokio::test]

--- a/specs/a2a-channel.md
+++ b/specs/a2a-channel.md
@@ -286,6 +286,24 @@ Template context:
 If no `text` part is present the channel rejects the request with
 `-32602 Invalid params`.
 
+## Audit Logging
+
+A2A uses the shared app-channel invocation path with webhook and schedule
+channels. After a request successfully resolves a session and dispatches the
+rendered user message, the server emits one audit log entry:
+
+- domain/action: `agent` / `agent.app_invocation.started`
+- target: `app_channel:{channel_id}`
+- actor: none, because the caller is an external API-key holder rather than an
+  Everruns user
+- metadata: `source = "app_a2a"`, `app_id`, `app_channel_id`,
+  `app_channel_type = "a2a"`, `session_id`, `created_session`, and the app
+  owner principal id; `agent_identity_id` is also present when the invocation
+  runs through an agent identity
+
+This mirrors webhook/schedule coverage because the event is emitted by the
+common app-channel invocation helper, not by the A2A HTTP adapter.
+
 ## Lifecycle
 
 - Publish/unpublish controls whether the endpoint accepts traffic.

--- a/specs/audit-logging.md
+++ b/specs/audit-logging.md
@@ -13,11 +13,20 @@ Two audit domains cover complementary surfaces:
 | Domain | What it tracks | Who writes |
 |--------|---------------|------------|
 | **Management** | Org CRUD, member invite/remove, role change, API key create/revoke, settings changes | Service layer via `#[audit]` macro |
-| **Agent** | Agent runs, tool calls, LLM interactions | Execution engine (future) |
+| **Agent** | Agent runs, app-channel invocations, tool calls, LLM interactions | Execution engine and app-channel ingress |
 
 ## Core Types
 
 See `crates/core/src/audit.rs` for full type definitions (`AuditDomain`, `AuditAction`, `AuditTarget`, `AuditEvent`, `AuditLogger` trait) and domain-specific builders.
+
+## App-Channel Invocations
+
+Webhook, schedule, and A2A app-channel invocations emit
+`agent.app_invocation.started` after the session is resolved and the rendered
+user message is dispatched. The target is the app channel; metadata records the
+source (`app_webhook`, `app_schedule`, or `app_a2a`), app id, channel id/type,
+session id, whether a new session was created, the app owner principal id, and
+the agent identity id when the invocation runs through an agent identity.
 
 ## AOP: `#[audit]` Proc Macro
 


### PR DESCRIPTION
## What
Adds app-channel invocation audit logs for webhook, schedule, and A2A invocations through the shared app invocation path.

## Why
[EVE-446](https://linear.app/everruns/issue/EVE-446/a2a-confirm-wire-audit-log-coverage-for-invocations) found that A2A, webhook, and schedule ingress created sessions/messages but did not write `audit_logs` entries for the invocation itself.

## How
- Added `agent.app_invocation.started` as an agent audit action.
- Emits the audit event after a session is resolved and the rendered app-channel user message is dispatched.
- Records only non-secret identifiers and routing shape: source, app id, channel id/type, session id, created-session flag, app owner principal id, and optional agent identity id.
- Added an A2A integration test asserting an audit row is emitted.
- Documented the shared audit shape in `specs/a2a-channel.md` and `specs/audit-logging.md`.

## Risk
- Low
- Audit log volume increases by one row per successful app-channel invocation.
- Consumers filtering agent-domain audit actions may see the new `agent.app_invocation.started` action.

## Security
- Threat categories reviewed: TM-A2A, TM-AUTHZ, TM-TENANT, TM-OBS-007, TM-DOS.
- Findings and resolutions: no request payloads, headers, bearer tokens, or webhook secrets are written to audit metadata. The write is fire-and-forget through the existing audit helper, so audit persistence failures do not block invocation. The event is emitted only after existing publish/enabled/auth/session-routing checks pass.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
