### PR TITLE
fix(skills): hide deleted skills from usage and content

### DIFF
--- a/crates/server/src/domains/skills/commands.rs
+++ b/crates/server/src/domains/skills/commands.rs
@@ -594,20 +594,15 @@ impl Command for ListSkillsUsage {
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<HashMap<String, SkillUsage>, CommandError> {
-        let visible_skill_ids = ctx
-            .db
-            .list_skills(ctx.org_id(), None, true)
-            .await
-            .map_err(classify_anyhow)?
-            .into_iter()
-            .map(|row| row.id.uuid())
-            .collect::<std::collections::HashSet<_>>();
-
-        let (agent_counts, harness_counts) = tokio::try_join!(
+        let (visible_skill_ids, agent_counts, harness_counts) = tokio::try_join!(
+            ctx.db.list_non_deleted_skill_ids(ctx.org_id()),
             ctx.db.count_agent_capability_references(ctx.org_id()),
             ctx.db.count_harness_capability_references(ctx.org_id()),
         )
         .map_err(classify_anyhow)?;
+        let visible_skill_ids = visible_skill_ids
+            .into_iter()
+            .collect::<std::collections::HashSet<_>>();
 
         let mut usage: HashMap<String, SkillUsage> = HashMap::new();
         for (cap_id, count) in agent_counts {

--- a/crates/server/src/domains/skills/commands.rs
+++ b/crates/server/src/domains/skills/commands.rs
@@ -246,6 +246,7 @@ impl Command for GetSkillContent {
             .get_skill(ctx.org_id(), skill_id.uuid())
             .await
             .map_err(classify_anyhow)?
+            .filter(|r| r.status != "deleted")
             .ok_or_else(|| CommandError::not_found("Skill"))?;
 
         // Reconstruct SKILL.md with frontmatter
@@ -593,6 +594,15 @@ impl Command for ListSkillsUsage {
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<HashMap<String, SkillUsage>, CommandError> {
+        let visible_skill_ids = ctx
+            .db
+            .list_skills(ctx.org_id(), None, true)
+            .await
+            .map_err(classify_anyhow)?
+            .into_iter()
+            .map(|row| row.id.uuid())
+            .collect::<std::collections::HashSet<_>>();
+
         let (agent_counts, harness_counts) = tokio::try_join!(
             ctx.db.count_agent_capability_references(ctx.org_id()),
             ctx.db.count_harness_capability_references(ctx.org_id()),
@@ -603,6 +613,7 @@ impl Command for ListSkillsUsage {
         for (cap_id, count) in agent_counts {
             if let Some(uuid_str) = cap_id.strip_prefix(SKILL_CAPABILITY_PREFIX)
                 && let Ok(uuid) = uuid::Uuid::parse_str(uuid_str)
+                && visible_skill_ids.contains(&uuid)
             {
                 let key = SkillId::from_uuid(uuid).to_string();
                 usage.entry(key).or_default().agents = count;
@@ -611,6 +622,7 @@ impl Command for ListSkillsUsage {
         for (cap_id, count) in harness_counts {
             if let Some(uuid_str) = cap_id.strip_prefix(SKILL_CAPABILITY_PREFIX)
                 && let Ok(uuid) = uuid::Uuid::parse_str(uuid_str)
+                && visible_skill_ids.contains(&uuid)
             {
                 let key = SkillId::from_uuid(uuid).to_string();
                 usage.entry(key).or_default().harnesses = count;

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -1802,6 +1802,10 @@ impl StorageBackend {
         dispatch!(self, list_skills, org_id, search, include_archived)
     }
 
+    pub async fn list_non_deleted_skill_ids(&self, org_id: i64) -> Result<Vec<Uuid>> {
+        dispatch!(self, list_non_deleted_skill_ids, org_id)
+    }
+
     pub async fn update_skill(
         &self,
         org_id: i64,

--- a/crates/server/src/storage/memory/skills.rs
+++ b/crates/server/src/storage/memory/skills.rs
@@ -198,6 +198,16 @@ impl InMemoryDatabase {
         Ok(skills)
     }
 
+    pub async fn list_non_deleted_skill_ids(&self, org_id: i64) -> Result<Vec<Uuid>> {
+        Ok(self
+            .skills
+            .read()
+            .values()
+            .filter(|s| s.org_id == org_id && s.status != "deleted")
+            .map(|s| s.id.uuid())
+            .collect())
+    }
+
     pub async fn update_skill(
         &self,
         org_id: i64,

--- a/crates/server/src/storage/repositories/skills.rs
+++ b/crates/server/src/storage/repositories/skills.rs
@@ -106,6 +106,21 @@ impl Database {
         Ok(query.fetch_all(&self.pool).await?)
     }
 
+    pub async fn list_non_deleted_skill_ids(&self, org_id: i64) -> Result<Vec<Uuid>> {
+        let rows = sqlx::query_scalar::<_, Uuid>(
+            r#"
+            SELECT id
+            FROM skills
+            WHERE org_id = $1 AND status != 'deleted'
+            "#,
+        )
+        .bind(org_id)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows)
+    }
+
     pub async fn update_skill(
         &self,
         org_id: i64,

--- a/crates/server/tests/skills_integration_test.rs
+++ b/crates/server/tests/skills_integration_test.rs
@@ -101,6 +101,36 @@ async fn test_get_skill_content() {
 }
 
 #[tokio::test]
+async fn test_deleted_skill_content_returns_not_found() {
+    let server = TestServer::new().await;
+
+    let skill_name = format!(
+        "deleted-content-skill-{}",
+        &uuid::Uuid::now_v7().simple().to_string()[..8]
+    );
+    let skill_md = format!(
+        "---\nname: {skill_name}\ndescription: Deleted content visibility test.\n---\n\n# Deleted Content Skill\n"
+    );
+    let create_resp = server
+        .post("/v1/skills", json!({ "skill_md": skill_md }))
+        .await
+        .assert_status(StatusCode::CREATED);
+    let skill_id = create_resp.json_value()["id"].as_str().unwrap().to_string();
+
+    server
+        .delete(&format!("/v1/skills/{skill_id}"))
+        .await
+        .assert_status(StatusCode::NO_CONTENT);
+    server
+        .post(&format!("/v1/skills/{skill_id}/delete"), json!({}))
+        .await
+        .assert_success();
+
+    let content_resp = server.get(&format!("/v1/skills/{skill_id}/content")).await;
+    assert_eq!(content_resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
 async fn test_update_skill() {
     let server = TestServer::new().await;
 
@@ -442,4 +472,63 @@ async fn test_agent_with_skill_capability() {
         agent_caps.iter().any(|c| c["ref"].as_str() == Some(cap_id)),
         "Agent should have skill capability assigned"
     );
+}
+
+#[tokio::test]
+async fn test_deleted_skill_hidden_from_usage() {
+    let server = TestServer::new().await;
+
+    let skill_name = format!(
+        "deleted-usage-skill-{}",
+        &uuid::Uuid::now_v7().simple().to_string()[..8]
+    );
+    let skill_md = format!(
+        "---\nname: {skill_name}\ndescription: Deleted usage visibility test.\n---\n\n# Deleted Usage Skill\n"
+    );
+    let create_resp = server
+        .post("/v1/skills", json!({ "skill_md": skill_md }))
+        .await
+        .assert_status(StatusCode::CREATED);
+    let skill_id = create_resp.json_value()["id"].as_str().unwrap().to_string();
+
+    let caps_resp = server.get("/v1/capabilities").await.assert_success();
+    let capabilities = caps_resp.json_value()["data"].as_array().unwrap().clone();
+    let skill_cap = capabilities
+        .iter()
+        .find(|c| c["name"].as_str() == Some(skill_name.as_str()))
+        .expect("Skill capability should exist");
+    let cap_id = skill_cap["id"].as_str().unwrap().to_string();
+    let agent_name = format!("deleted-skill-usage-agent-{}", &skill_id[6..14]);
+
+    server
+        .post(
+            "/v1/agents",
+            json!({
+                "name": agent_name,
+                "display_name": "Deleted Skill Usage Agent",
+                "system_prompt": "You are a helpful assistant.",
+                "capabilities": [
+                    { "ref": cap_id, "config": {} }
+                ]
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED);
+
+    let usage_before = server.get("/v1/skills/usage").await.assert_success();
+    let usage_before_body = usage_before.json_value();
+    assert_eq!(usage_before_body[&skill_id]["agents"], 1);
+
+    server
+        .delete(&format!("/v1/skills/{skill_id}"))
+        .await
+        .assert_status(StatusCode::NO_CONTENT);
+    server
+        .post(&format!("/v1/skills/{skill_id}/delete"), json!({}))
+        .await
+        .assert_success();
+
+    let usage_after = server.get("/v1/skills/usage").await.assert_success();
+    let usage_after_body = usage_after.json_value();
+    assert!(usage_after_body.get(&skill_id).is_none());
 }


### PR DESCRIPTION
## What
Hide deleted skills from content retrieval and usage reporting.

## Why
Deleted skill identifiers and content should follow the same visibility model as `GET /v1/skills/{id}`. A deleted skill could still be returned by `/v1/skills/{id}/content` and could still appear in `/v1/skills/usage` when an existing agent or harness referenced `skill:{uuid}`.

## How
Filter deleted rows out of skill content lookup, add a lightweight UUID-only storage query for non-deleted skills, and use it alongside the agent/harness capability counts so usage only reports visible skill ids. Added Postgres API regressions for deleted skill content and deleted skill usage.

## Risk
- Medium
- Changes visibility semantics for deleted skills and usage reporting; archived skills remain included in usage while deleted skills are hidden.

## Security
- Threat categories reviewed: TM-AUTHZ, TM-TENANT, TM-API, TM-DOS.
- Findings and resolutions: closed deleted-skill content/id exposure while preserving org scoping and existing permissions. Replaced full-row loading with UUID-only lookup to avoid unnecessary transfer of instructions/archive data.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)