### PR TITLE
feat(core): add system email sender

### DIFF
--- a/crates/core/src/email.rs
+++ b/crates/core/src/email.rs
@@ -1,0 +1,433 @@
+// System email abstraction.
+//
+// Decision: Keep email delivery as a core, system-wide service rather than an
+// agent capability. Email sends are product/ops side effects owned by the host
+// application, not tools exposed to agents.
+// Decision: Keep provider details behind EmailSender so future SendGrid,
+// Cloudflare, SES, or SMTP implementations can reuse the same call sites.
+// Decision: Keep the sender fixed until product requirements justify
+// per-feature or per-tenant sender identity.
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use thiserror::Error;
+
+pub mod resend;
+
+pub use resend::{ResendEmailConfig, ResendEmailSender};
+
+// Intentional current product sender. Keep this as `no-replay`, not `no-reply`,
+// until the verified sender identity changes.
+pub const SYSTEM_EMAIL_FROM: &str = "no-replay@everruns.com";
+const SYSTEM_EMAIL_FROM_NAME: &str = "Everruns";
+
+pub type EmailResult<T> = std::result::Result<T, EmailError>;
+
+#[derive(Debug, Error)]
+pub enum EmailError {
+    #[error("Email configuration error: {0}")]
+    Configuration(String),
+
+    #[error("Invalid email request: {0}")]
+    InvalidRequest(String),
+
+    #[error("Email provider transport error: {0}")]
+    Transport(String),
+
+    #[error("Email provider error ({provider}, status {status}): {body}")]
+    Provider {
+        provider: &'static str,
+        status: u16,
+        body: String,
+    },
+}
+
+impl EmailError {
+    fn config(message: impl Into<String>) -> Self {
+        Self::Configuration(message.into())
+    }
+
+    fn invalid(message: impl Into<String>) -> Self {
+        Self::InvalidRequest(message.into())
+    }
+
+    fn transport(error: reqwest::Error) -> Self {
+        Self::Transport(error.to_string())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EmailAddress {
+    pub email: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+}
+
+impl EmailAddress {
+    pub fn new(email: impl Into<String>) -> Self {
+        Self {
+            email: email.into(),
+            name: None,
+        }
+    }
+
+    pub fn named(email: impl Into<String>, name: impl Into<String>) -> Self {
+        Self {
+            email: email.into(),
+            name: Some(name.into()),
+        }
+    }
+
+    fn validate(&self, field: &str) -> EmailResult<()> {
+        if self.email.trim().is_empty() {
+            return Err(EmailError::invalid(format!("{field} email is empty")));
+        }
+        if self.email.contains(['\r', '\n']) {
+            return Err(EmailError::invalid(format!(
+                "{field} email contains a newline"
+            )));
+        }
+        if !self.email.contains('@') {
+            return Err(EmailError::invalid(format!(
+                "{field} email must contain an @ sign"
+            )));
+        }
+        if let Some(name) = &self.name
+            && name.contains(['\r', '\n'])
+        {
+            return Err(EmailError::invalid(format!(
+                "{field} name contains a newline"
+            )));
+        }
+        Ok(())
+    }
+
+    fn format_for_provider(&self) -> String {
+        match self.name.as_deref().filter(|name| !name.trim().is_empty()) {
+            Some(name) => format!("{name} <{}>", self.email),
+            None => self.email.clone(),
+        }
+    }
+}
+
+impl From<&str> for EmailAddress {
+    fn from(email: &str) -> Self {
+        Self::new(email)
+    }
+}
+
+impl From<String> for EmailAddress {
+    fn from(email: String) -> Self {
+        Self::new(email)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EmailTag {
+    pub name: String,
+    pub value: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum EmailTemplate {
+    Generic(GenericEmailTemplate),
+}
+
+impl EmailTemplate {
+    fn render(&self) -> EmailResult<RenderedEmail> {
+        match self {
+            Self::Generic(template) => template.render(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GenericEmailTemplate {
+    pub text: String,
+    pub html: String,
+}
+
+impl GenericEmailTemplate {
+    pub fn new(text: impl Into<String>, html: impl Into<String>) -> Self {
+        Self {
+            text: text.into(),
+            html: html.into(),
+        }
+    }
+
+    fn render(&self) -> EmailResult<RenderedEmail> {
+        if self.text.trim().is_empty() {
+            return Err(EmailError::invalid("generic email text is required"));
+        }
+        if self.html.trim().is_empty() {
+            return Err(EmailError::invalid("generic email html is required"));
+        }
+
+        Ok(RenderedEmail {
+            text: format!("Everruns\n\n{}", self.text),
+            html: wrap_generic_html(&self.html),
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RenderedEmail {
+    pub text: String,
+    pub html: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EmailMessage {
+    pub to: Vec<EmailAddress>,
+    pub subject: String,
+    pub template: EmailTemplate,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tags: Vec<EmailTag>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub idempotency_key: Option<String>,
+}
+
+impl EmailMessage {
+    pub fn generic(
+        to: impl Into<EmailAddress>,
+        subject: impl Into<String>,
+        text: impl Into<String>,
+        html: impl Into<String>,
+    ) -> Self {
+        Self {
+            to: vec![to.into()],
+            subject: subject.into(),
+            template: EmailTemplate::Generic(GenericEmailTemplate::new(text, html)),
+            tags: Vec::new(),
+            idempotency_key: None,
+        }
+    }
+
+    pub fn with_idempotency_key(mut self, key: impl Into<String>) -> Self {
+        self.idempotency_key = Some(key.into());
+        self
+    }
+
+    pub fn with_tag(mut self, name: impl Into<String>, value: impl Into<String>) -> Self {
+        self.tags.push(EmailTag {
+            name: name.into(),
+            value: value.into(),
+        });
+        self
+    }
+
+    fn validate(&self) -> EmailResult<RenderedEmail> {
+        if self.to.is_empty() {
+            return Err(EmailError::invalid("at least one to recipient is required"));
+        }
+        if self.subject.trim().is_empty() {
+            return Err(EmailError::invalid("subject is required"));
+        }
+        for address in &self.to {
+            address.validate("to")?;
+        }
+        for tag in &self.tags {
+            if tag.name.trim().is_empty() {
+                return Err(EmailError::invalid("email tag name is required"));
+            }
+            if tag.value.trim().is_empty() {
+                return Err(EmailError::invalid("email tag value is required"));
+            }
+        }
+        if let Some(key) = &self.idempotency_key
+            && key.len() > 256
+        {
+            return Err(EmailError::invalid(
+                "idempotency_key must be 256 characters or fewer",
+            ));
+        }
+        if let Some(key) = &self.idempotency_key
+            && key.chars().any(|ch| ch.is_ascii_control())
+        {
+            return Err(EmailError::invalid(
+                "idempotency_key must not contain control characters",
+            ));
+        }
+        self.template.render()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SentEmail {
+    pub provider: &'static str,
+    pub id: String,
+}
+
+#[async_trait]
+pub trait EmailSender: Send + Sync {
+    async fn send_email(&self, message: EmailMessage) -> EmailResult<SentEmail>;
+
+    fn name(&self) -> &'static str {
+        "EmailSender"
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct NoopEmailSender;
+
+#[async_trait]
+impl EmailSender for NoopEmailSender {
+    async fn send_email(&self, message: EmailMessage) -> EmailResult<SentEmail> {
+        message.validate()?;
+        Ok(SentEmail {
+            provider: "noop",
+            id: "noop".to_string(),
+        })
+    }
+
+    fn name(&self) -> &'static str {
+        "NoopEmailSender"
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct DisabledEmailSender;
+
+#[async_trait]
+impl EmailSender for DisabledEmailSender {
+    async fn send_email(&self, _message: EmailMessage) -> EmailResult<SentEmail> {
+        Err(EmailError::config("system email delivery is disabled"))
+    }
+
+    fn name(&self) -> &'static str {
+        "DisabledEmailSender"
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SystemEmailConfig {
+    Disabled,
+    Resend(ResendEmailConfig),
+}
+
+impl SystemEmailConfig {
+    pub fn from_env() -> EmailResult<Self> {
+        let provider = env_opt("EMAIL_PROVIDER").map(|provider| provider.to_ascii_lowercase());
+        match provider.as_deref() {
+            None | Some("disabled") => Ok(Self::Disabled),
+            Some("resend") => ResendEmailConfig::from_env().map(Self::Resend),
+            Some(provider) => Err(EmailError::config(format!(
+                "unsupported EMAIL_PROVIDER '{provider}'"
+            ))),
+        }
+    }
+
+    pub fn into_sender(self) -> Arc<dyn EmailSender> {
+        match self {
+            Self::Disabled => Arc::new(DisabledEmailSender),
+            Self::Resend(config) => Arc::new(ResendEmailSender::new(config)),
+        }
+    }
+}
+
+pub fn system_email_from() -> EmailAddress {
+    EmailAddress::named(SYSTEM_EMAIL_FROM, SYSTEM_EMAIL_FROM_NAME)
+}
+
+fn env_opt(name: &str) -> Option<String> {
+    std::env::var(name).ok().filter(|value| !value.is_empty())
+}
+
+fn wrap_generic_html(inner_html: &str) -> String {
+    format!(
+        r#"<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Everruns</title>
+</head>
+<body style="margin:0;background:#f6f7f9;color:#111827;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;">
+  <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="background:#f6f7f9;padding:32px 16px;">
+    <tr>
+      <td align="center">
+        <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="max-width:640px;background:#ffffff;border:1px solid #e5e7eb;border-radius:8px;">
+          <tr>
+            <td style="padding:24px 28px 8px;font-size:18px;font-weight:700;color:#111827;">Everruns</td>
+          </tr>
+          <tr>
+            <td style="padding:12px 28px 28px;font-size:15px;line-height:1.6;color:#1f2937;">{inner_html}</td>
+          </tr>
+          <tr>
+            <td style="padding:18px 28px;border-top:1px solid #e5e7eb;font-size:12px;line-height:1.5;color:#6b7280;">
+              This email was sent by Everruns.
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>"#
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn generic_template_requires_text_content() {
+        let sender = NoopEmailSender;
+        let error = sender
+            .send_email(EmailMessage::generic(
+                "user@example.com",
+                "Empty",
+                "",
+                "<p>Hello</p>",
+            ))
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, EmailError::InvalidRequest(_)));
+        assert!(error.to_string().contains("text"));
+    }
+
+    #[tokio::test]
+    async fn generic_template_wraps_branding() {
+        let message = EmailMessage::generic("user@example.com", "Hi", "Hello", "<p>Hello</p>");
+        let rendered = message.validate().unwrap();
+
+        assert!(rendered.text.starts_with("Everruns\n\nHello"));
+        assert!(rendered.html.contains("Everruns"));
+        assert!(rendered.html.contains("<p>Hello</p>"));
+    }
+
+    #[tokio::test]
+    async fn disabled_sender_returns_configuration_error() {
+        let sender = DisabledEmailSender;
+        let error = sender
+            .send_email(EmailMessage::generic(
+                "user@example.com",
+                "Hi",
+                "hello",
+                "<p>hello</p>",
+            ))
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, EmailError::Configuration(_)));
+        assert!(error.to_string().contains("disabled"));
+    }
+
+    #[tokio::test]
+    async fn idempotency_key_rejects_control_characters() {
+        let sender = NoopEmailSender;
+        let error = sender
+            .send_email(
+                EmailMessage::generic("user@example.com", "Hi", "hello", "<p>hello</p>")
+                    .with_idempotency_key("welcome\r\nX-Other: value"),
+            )
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, EmailError::InvalidRequest(_)));
+        assert!(error.to_string().contains("control characters"));
+    }
+}

--- a/crates/core/src/email/resend.rs
+++ b/crates/core/src/email/resend.rs
@@ -1,0 +1,246 @@
+// Resend-backed system email provider.
+//
+// Decision: Keep this as a concrete EmailSender implementation, not a public
+// capability. Resend credentials are process-level deployment configuration.
+
+use async_trait::async_trait;
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+
+use super::{
+    EmailAddress, EmailError, EmailMessage, EmailResult, EmailSender, EmailTag, RenderedEmail,
+    SentEmail, system_email_from,
+};
+
+const RESEND_API_BASE_URL: &str = "https://api.resend.com";
+const RESEND_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+const RESEND_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResendEmailConfig {
+    pub api_key: String,
+    pub api_base_url: String,
+}
+
+impl ResendEmailConfig {
+    pub fn from_env() -> EmailResult<Self> {
+        let api_key = env_required("RESEND_API_KEY")?;
+        let api_base_url = env_opt("RESEND_API_BASE_URL")
+            .unwrap_or_else(|| RESEND_API_BASE_URL.trim_end_matches('/').to_string());
+
+        let config = Self {
+            api_key,
+            api_base_url: api_base_url.trim_end_matches('/').to_string(),
+        };
+        config.validate()?;
+        Ok(config)
+    }
+
+    fn validate(&self) -> EmailResult<()> {
+        if self.api_key.trim().is_empty() {
+            return Err(EmailError::config("RESEND_API_KEY is empty"));
+        }
+        let url = reqwest::Url::parse(&self.api_base_url).map_err(|error| {
+            EmailError::config(format!("RESEND_API_BASE_URL is not a valid URL: {error}"))
+        })?;
+        match url.scheme() {
+            "http" | "https" => {}
+            scheme => {
+                return Err(EmailError::config(format!(
+                    "RESEND_API_BASE_URL must use http or https, got '{scheme}'"
+                )));
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+pub struct ResendEmailSender {
+    client: Client,
+    config: ResendEmailConfig,
+}
+
+impl std::fmt::Debug for ResendEmailSender {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ResendEmailSender")
+            .field("api_base_url", &self.config.api_base_url)
+            .finish_non_exhaustive()
+    }
+}
+
+impl ResendEmailSender {
+    pub fn new(config: ResendEmailConfig) -> Self {
+        Self {
+            client: Client::builder()
+                .connect_timeout(RESEND_CONNECT_TIMEOUT)
+                .timeout(RESEND_REQUEST_TIMEOUT)
+                .build()
+                .expect("build Resend HTTP client"),
+            config,
+        }
+    }
+
+    pub fn config(&self) -> &ResendEmailConfig {
+        &self.config
+    }
+}
+
+#[async_trait]
+impl EmailSender for ResendEmailSender {
+    async fn send_email(&self, message: EmailMessage) -> EmailResult<SentEmail> {
+        let rendered = message.validate()?;
+        let request = ResendSendEmailRequest::from_message(system_email_from(), message, rendered);
+        let mut builder = self
+            .client
+            .post(format!("{}/emails", self.config.api_base_url))
+            .header("Authorization", format!("Bearer {}", self.config.api_key))
+            .header("Content-Type", "application/json");
+
+        if let Some(key) = &request.idempotency_key {
+            builder = builder.header("Idempotency-Key", key);
+        }
+
+        let response = builder
+            .json(&request)
+            .send()
+            .await
+            .map_err(EmailError::transport)?;
+        let status = response.status();
+        if !status.is_success() {
+            return Err(EmailError::Provider {
+                provider: "resend",
+                status: status.as_u16(),
+                body: response.text().await.unwrap_or_default(),
+            });
+        }
+
+        let body: ResendSendEmailResponse = response.json().await.map_err(EmailError::transport)?;
+        Ok(SentEmail {
+            provider: "resend",
+            id: body.id,
+        })
+    }
+
+    fn name(&self) -> &'static str {
+        "ResendEmailSender"
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct ResendSendEmailRequest {
+    from: String,
+    to: Vec<String>,
+    subject: String,
+    html: String,
+    text: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    tags: Vec<EmailTag>,
+    #[serde(skip)]
+    idempotency_key: Option<String>,
+}
+
+impl ResendSendEmailRequest {
+    fn from_message(from: EmailAddress, message: EmailMessage, rendered: RenderedEmail) -> Self {
+        Self {
+            from: from.format_for_provider(),
+            to: message
+                .to
+                .into_iter()
+                .map(|address| address.format_for_provider())
+                .collect(),
+            subject: message.subject,
+            html: rendered.html,
+            text: rendered.text,
+            tags: message.tags,
+            idempotency_key: message.idempotency_key,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct ResendSendEmailResponse {
+    id: String,
+}
+
+fn env_required(name: &str) -> EmailResult<String> {
+    env_opt(name).ok_or_else(|| EmailError::config(format!("{name} environment variable not set")))
+}
+
+fn env_opt(name: &str) -> Option<String> {
+    std::env::var(name).ok().filter(|value| !value.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::matchers::{header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn test_config(base_url: String) -> ResendEmailConfig {
+        ResendEmailConfig {
+            api_key: "re_test".to_string(),
+            api_base_url: base_url,
+        }
+    }
+
+    #[test]
+    fn resend_config_rejects_invalid_base_url() {
+        let error = ResendEmailConfig {
+            api_key: "re_test".to_string(),
+            api_base_url: "not a url".to_string(),
+        }
+        .validate()
+        .unwrap_err();
+
+        assert!(matches!(error, EmailError::Configuration(_)));
+        assert!(error.to_string().contains("valid URL"));
+    }
+
+    #[tokio::test]
+    async fn resend_sender_posts_branded_email() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/emails"))
+            .and(header("Authorization", "Bearer re_test"))
+            .and(header("Idempotency-Key", "welcome/user_123"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "id": "email_123"
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let sender = ResendEmailSender::new(test_config(server.uri()));
+        let sent = sender
+            .send_email(
+                EmailMessage::generic("delivered@example.com", "Welcome", "hello", "<p>hello</p>")
+                    .with_idempotency_key("welcome/user_123")
+                    .with_tag("kind", "welcome"),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(sent.provider, "resend");
+        assert_eq!(sent.id, "email_123");
+
+        let requests = server.received_requests().await.unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&requests[0].body).unwrap();
+        assert_eq!(body["from"], "Everruns <no-replay@everruns.com>");
+        assert_eq!(body["to"], json!(["delivered@example.com"]));
+        assert_eq!(body["subject"], "Welcome");
+        assert_eq!(body["text"], "Everruns\n\nhello");
+        assert!(body["html"].as_str().unwrap().contains("<p>hello</p>"));
+        assert_eq!(
+            body["tags"],
+            json!([{ "name": "kind", "value": "welcome" }])
+        );
+        assert!(body.get("cc").is_none());
+        assert!(body.get("bcc").is_none());
+        assert!(body.get("reply_to").is_none());
+        assert!(body.get("headers").is_none());
+        assert!(body.get("idempotency_key").is_none());
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -22,6 +22,7 @@ pub mod tool_types;
 
 // Deployment configuration
 pub mod deployment;
+pub mod email;
 pub mod exec_tool_result;
 
 // Feature flags
@@ -199,6 +200,14 @@ pub use event_listeners::{CompositeEventListener, EventListener, NoopEventListen
 // Error reporter re-exports
 pub use error_reporter::{
     ErrorReport, ErrorReporter, ErrorScope, ErrorSeverity, NoopErrorReporter, SharedErrorReporter,
+};
+
+// System email re-exports
+pub use email::{
+    DisabledEmailSender, EmailAddress, EmailError, EmailMessage, EmailResult, EmailSender,
+    EmailTag, EmailTemplate, GenericEmailTemplate, NoopEmailSender, RenderedEmail,
+    ResendEmailConfig, ResendEmailSender, SYSTEM_EMAIL_FROM, SentEmail, SystemEmailConfig,
+    system_email_from,
 };
 
 // LLM driver types re-exports

--- a/crates/core/src/platform_definition.rs
+++ b/crates/core/src/platform_definition.rs
@@ -11,8 +11,10 @@
 
 use crate::{
     Capability, CapabilityRegistry, ConnectionProvider, ConnectionProviderRegistry, DriverRegistry,
+    EmailSender,
 };
 use serde_json::Value;
+use std::sync::Arc;
 
 /// Stable role assigned to a built-in harness template.
 ///
@@ -181,6 +183,7 @@ pub struct PlatformDefinition {
     driver_registry: DriverRegistry,
     connection_providers: ConnectionProviderRegistry,
     built_in_harnesses: Vec<BuiltInHarnessDefinition>,
+    email_sender: Arc<dyn EmailSender>,
 }
 
 impl PlatformDefinition {
@@ -191,6 +194,7 @@ impl PlatformDefinition {
             driver_registry,
             connection_providers: ConnectionProviderRegistry::new(),
             built_in_harnesses: Vec::new(),
+            email_sender: Arc::new(crate::DisabledEmailSender),
         }
     }
 
@@ -239,6 +243,11 @@ impl PlatformDefinition {
         &mut self.built_in_harnesses
     }
 
+    /// System-wide email sender for product and operational flows.
+    pub fn email_sender(&self) -> Arc<dyn EmailSender> {
+        self.email_sender.clone()
+    }
+
     /// Append a built-in harness template.
     pub fn add_built_in_harness(&mut self, harness: BuiltInHarnessDefinition) {
         self.built_in_harnesses.push(harness);
@@ -264,6 +273,7 @@ impl std::fmt::Debug for PlatformDefinition {
             .field("drivers", &self.driver_registry.registered_providers())
             .field("connection_providers", &self.connection_providers)
             .field("built_in_harnesses", &harness_keys)
+            .field("email_sender", &self.email_sender.name())
             .finish()
     }
 }
@@ -323,6 +333,12 @@ impl PlatformDefinitionBuilder {
     /// Append a built-in harness template.
     pub fn add_built_in_harness(mut self, harness: BuiltInHarnessDefinition) -> Self {
         self.platform.built_in_harnesses.push(harness);
+        self
+    }
+
+    /// Set the system-wide email sender.
+    pub fn email_sender(mut self, sender: Arc<dyn EmailSender>) -> Self {
+        self.platform.email_sender = sender;
         self
     }
 

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -98,6 +98,8 @@ pub struct ServerContext {
     pub runner: Arc<dyn AgentRunner>,
     pub driver_registry: Arc<everruns_core::DriverRegistry>,
     pub platform_definition: Arc<PlatformDefinition>,
+    /// System-wide email sender from the platform profile.
+    pub email_sender: Arc<dyn everruns_core::EmailSender>,
     /// Vendor-neutral embedder-provided error reporter. Always present;
     /// defaults to a no-op when no embedder has installed one.
     pub error_reporter: SharedErrorReporter,
@@ -1335,6 +1337,7 @@ impl ServerAppBuilder {
             runner: runner.clone(),
             driver_registry: driver_registry.clone(),
             platform_definition: platform_definition.clone(),
+            email_sender: platform_definition.email_sender(),
             error_reporter: error_reporter.clone(),
         };
 

--- a/crates/server/src/platform.rs
+++ b/crates/server/src/platform.rs
@@ -8,7 +8,9 @@
 
 use everruns_core::connection_provider::{ConnectionProviderPlugin, ConnectionProviderRegistry};
 use everruns_core::deployment::DeploymentGrade;
-use everruns_core::{BuiltInHarnessDefinition, CapabilityRegistry, PlatformDefinition};
+use everruns_core::{
+    BuiltInHarnessDefinition, CapabilityRegistry, PlatformDefinition, SystemEmailConfig,
+};
 
 /// Build the default OSS `PlatformDefinition` for the current deployment grade.
 pub fn oss_platform_definition() -> PlatformDefinition {
@@ -20,12 +22,16 @@ pub fn oss_platform_definition_for_grade(grade: DeploymentGrade) -> PlatformDefi
     let capability_registry = CapabilityRegistry::with_builtins_for_grade(grade);
     let driver_registry = everruns_worker::create_driver_registry();
     let connection_providers = oss_connection_provider_registry_for_grade(grade);
+    let email_sender = SystemEmailConfig::from_env()
+        .expect("Invalid system email configuration")
+        .into_sender();
 
     PlatformDefinition::builder()
         .capability_registry(capability_registry)
         .driver_registry(driver_registry)
         .connection_providers(connection_providers)
         .built_in_harnesses(oss_built_in_harnesses())
+        .email_sender(email_sender)
         .build()
 }
 

--- a/docs/sre/environment-variables.md
+++ b/docs/sre/environment-variables.md
@@ -251,6 +251,29 @@ DEFAULT_GEMINI_API_KEY=AIza...
 - The `just start-all` command automatically sets these from `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, and `GEMINI_API_KEY` if present
 - If no API key is configured for a provider, LLM calls will fail and users will see an error message in the chat: "I encountered an error while processing your request. Please try again later."
 
+## System Email Delivery
+
+System email delivery is an internal service used by product and operational flows. It is not an agent capability, public API, or UI setting.
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `EMAIL_PROVIDER` | Yes, when sending email in production | unset / disabled | Email provider. Supported values: `disabled`, `resend` |
+| `RESEND_API_KEY` | Yes, when `EMAIL_PROVIDER=resend` | unset | Resend API key |
+| `RESEND_API_BASE_URL` | No | `https://api.resend.com` | Resend API base URL override for tests or controlled deployments |
+
+**Example:**
+
+```bash
+EMAIL_PROVIDER=resend
+RESEND_API_KEY=re_...
+```
+
+**Notes:**
+- Set these on the control-plane process that performs system email sends.
+- The sender is fixed in code as `Everruns <no-replay@everruns.com>`.
+- The Resend account must have `everruns.com` verified and enabled for sending.
+- See `specs/email.md` for the internal abstraction and provider contract.
+
 ## UI API Proxy Architecture
 
 The UI makes all REST API requests (including SSE) to `/api/*` paths. The backend serves those routes under `/api` directly. Root-level backend routes like `/oauth/*`, `/mcp`, and `/.well-known/*` bypass the UI and are proxied straight to the backend.

--- a/specs/architecture.md
+++ b/specs/architecture.md
@@ -91,7 +91,7 @@ Production event routing therefore prefers:
 2. **Crate Separation** (folder → package name):
    - `server/` → `everruns-server` - **Control plane**: HTTP API (axum) + gRPC server (tonic), SSE streaming, database layer
    - `worker/` → `everruns-worker` - TaskWorker, WorkerAdapters, activities, gRPC adapters, durable task execution
-   - `core/` → `everruns-core` - Core agent abstractions (traits, atoms, tools, events, capabilities, LLM drivers, shared types)
+   - `core/` → `everruns-core` - Core agent abstractions (traits, atoms, tools, events, capabilities, LLM drivers, internal system services, shared types)
    - `runtime/` → `everruns-runtime` - Public in-process runtime plus reusable host-phase execution for embedded and durable/server-backed execution
    - `internal-protocol/` → `everruns-internal-protocol` - gRPC protocol for worker ↔ server
    - `durable/` → `everruns-durable` - PostgreSQL-backed durable execution engine
@@ -167,13 +167,14 @@ Everruns runtime composition is centered on `PlatformDefinition` in `crates/core
 - LLM drivers
 - Connection providers
 - Built-in harness templates
+- System email sender
 
 The server and worker builders both accept an explicit `PlatformDefinition`. If none is supplied, they fall back to crate-local presets:
 
 - `everruns_server::oss_platform_definition()`
 - `everruns_worker::default_platform_definition()`
 
-This keeps the existing OSS runtime as the default while allowing embedders to remove integrations, add custom capabilities, replace harness templates, or register different LLM drivers without forking Everruns internals.
+This keeps the existing OSS runtime as the default while allowing embedders to remove integrations, add custom capabilities, replace harness templates, register different LLM drivers, or install a different system email provider without forking Everruns internals.
 
 ### Embedded Runtime
 

--- a/specs/email.md
+++ b/specs/email.md
@@ -1,0 +1,83 @@
+# Email Sending
+
+## Intent
+
+Provide an internal abstraction for system-owned email delivery.
+
+Email is not an agent capability, public API, or UI surface. It is a host service used by product and operational flows that need to send user-facing transactional email.
+
+## Design Goals
+
+1. Keep call sites provider-neutral.
+2. Keep provider credentials out of agent/session/user configuration.
+3. Support one system-wide sender configuration per deployment.
+4. Leave room for future concrete implementations such as SendGrid, Cloudflare, SES, SMTP, or provider-specific SDKs.
+
+## Core Contract
+
+`everruns-core` owns the email abstraction:
+
+- `EmailSender` is the async trait used by internal callers.
+- `EmailMessage` is the provider-neutral request shape.
+- `SentEmail` is the provider-neutral success result.
+- `EmailError` separates configuration, request validation, transport, and provider failures.
+- Platform/application state stores the sender as `Arc<dyn EmailSender>` when it must be shared across services.
+- `PlatformDefinition` carries the active system email sender as part of the platform profile.
+
+Messages support:
+
+- fixed system sender: `no-replay@everruns.com` (current verified sender identity)
+- `to`
+- subject
+- template-rendered HTML and plain text body
+- provider-neutral tags
+- optional idempotency key
+
+At least one `to` recipient, a subject, and a valid template are required.
+
+### Templates
+
+Email sends use explicit templates. V1 includes one template:
+
+- `EmailTemplate::Generic(GenericEmailTemplate)`
+  - accepts `text` and `html`
+  - prefixes plain text with Everruns branding
+  - wraps HTML in a small Everruns-branded shell
+
+The generic template is for internal transactional emails that do not yet need their own dedicated template.
+
+## System Configuration
+
+Email delivery is system-wide and configured from process environment:
+
+- `EMAIL_PROVIDER=disabled|resend`
+- `RESEND_API_KEY`
+- `RESEND_API_BASE_URL` for tests or controlled endpoint overrides
+
+When `EMAIL_PROVIDER` is unset, the system email configuration is disabled. Production deployments that send email must set `EMAIL_PROVIDER=resend` and provide the Resend variables.
+
+The default OSS platform profile resolves `SystemEmailConfig::from_env()` during `oss_platform_definition_for_grade()` construction. Invalid email configuration fails startup when a provider is explicitly enabled.
+
+Embedders can bypass env-based setup by constructing a custom `PlatformDefinition` and calling `PlatformDefinition::builder().email_sender(...)` before passing it to `ServerAppBuilder::platform_definition(...)`.
+
+`ServerContext.email_sender` exposes the configured sender to internal background tasks and extension code. Request handlers should access the sender through their service/application state when a feature needs transactional email.
+
+## Resend Implementation
+
+The first concrete implementation is `ResendEmailSender`.
+
+Provider behavior:
+
+- Sends mail through Resend `POST /emails`.
+- Always sends from `Everruns <no-replay@everruns.com>`.
+- Uses the `Idempotency-Key` header when `EmailMessage.idempotency_key` is set.
+
+The Resend API key is a deployment secret. It must be injected by the deployment environment, not stored in repo or database records. The Resend account must have `everruns.com` verified for sending.
+
+## Non-Goals
+
+- No user-facing email settings UI.
+- No REST API endpoints for ad hoc email sending.
+- No agent capability or tool for sending email.
+- No per-organization sender configuration yet.
+- No durable outbound email queue yet.

--- a/specs/production-deployment.md
+++ b/specs/production-deployment.md
@@ -49,6 +49,7 @@ Every production deployment must make explicit decisions for:
 - auth mode
 - worker authentication
 - secrets encryption keys
+- system email provider and verified sender domain, if email is enabled
 - observability and metrics exposure
 - whether Valkey and NATS are enabled
 
@@ -56,6 +57,7 @@ See:
 - [`docs/sre/environment-variables.md`](../docs/sre/environment-variables.md)
 - [`specs/authentication.md`](./authentication.md)
 - [`specs/encryption.md`](./encryption.md)
+- [`specs/email.md`](./email.md)
 - [`specs/prometheus-metrics.md`](./prometheus-metrics.md)
 - [`specs/observability.md`](./observability.md)
 - [`specs/threat-model.md`](./threat-model.md)
@@ -138,6 +140,7 @@ Production deployments must satisfy these minimums:
 - `AUTH_JWT_SECRET` configured
 - `WORKER_GRPC_AUTH_TOKEN` configured
 - secrets encryption key configured
+- `EMAIL_PROVIDER`, provider API key, and verified sender domain configured when deployment features send email
 - explicit CORS policy when UI and API origins differ
 - private network or equivalent isolation for PostgreSQL, worker gRPC, Valkey, and NATS
 


### PR DESCRIPTION
## What
Adds an internal system email abstraction in `everruns-core`, wires the configured sender into `PlatformDefinition` and `ServerContext`, and adds the first concrete provider implementation using Resend.

## Why
Product and operational flows need transactional email without exposing email as an agent capability, public API, or UI setting. Provider details should stay behind a stable internal contract so future SendGrid, Cloudflare, SES, or SMTP implementations can reuse the same call sites.

## How
- Adds `EmailSender`, `EmailMessage`, `EmailTemplate::Generic`, `DisabledEmailSender`, `NoopEmailSender`, and `SystemEmailConfig`.
- Adds `ResendEmailSender` with env configuration via `EMAIL_PROVIDER=resend`, `RESEND_API_KEY`, and optional `RESEND_API_BASE_URL`.
- Uses fixed sender identity `Everruns <no-replay@everruns.com>` and supports only `to`, subject, generic branded template content, tags, and optional idempotency key.
- Adds email sender setup to the OSS platform profile and exposes it through server app context.
- Documents the contract in `specs/email.md` and production env requirements in SRE/deployment specs.

## Risk
- Low
- Could break startup only when `EMAIL_PROVIDER` is explicitly set to an invalid provider or `resend` is enabled without `RESEND_API_KEY`. Default unset config remains disabled.

## Security
- Threat categories reviewed: TM-API, TM-AUTH, TM-SECRETS, TM-LLM, TM-TENANT.
- Findings and resolutions: no public endpoint, UI, or agent tool was added; Resend API key is process env only and omitted from `Debug`; fixed sender removes caller-controlled `from`; cc/bcc/reply-to/custom headers are intentionally absent; recipient/name validation rejects newlines. Generic HTML remains an internal template input, so future external/user-content call sites must sanitize or use dedicated templates.

## Follow-ups
- Add dedicated transactional templates when the first concrete product email flow is introduced.
- Add a durable email outbox if/when email sending becomes workflow-critical.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)