### PR TITLE
fix(cursor): make cloud Dockerfile build with Valkey on amd64

### DIFF
--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -10,13 +10,45 @@ ENV CARGO_INCREMENTAL=0
 # If you bump versions in one place, bump all three.
 
 # System tools required by full-stack local runs.
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    postgresql \
-    postgresql-client \
-    valkey \
-    netcat-openbsd \
-    jq \
-    && rm -rf /var/lib/apt/lists/*
+#
+# Valkey: build from the GitHub release tarball so we ship real `valkey-server`
+# / `valkey-cli` (licensing) without relying on `download.valkey.io` (often
+# blocks automated downloads with HTTP 403) or mixing prebuilt glibc versions.
+#
+# The universal devcontainer image ships a Yarn APT source that can break
+# `apt-get update` (missing/rotated key). Yarn is provided via other tooling in
+# the base image; drop the apt source so package installs remain reliable.
+#
+# NOTE(sync): Bump VALKEY_VERSION with `examples/docker-compose-full.yaml` /
+# production Valkey major line when you intentionally upgrade.
+RUN set -eux; \
+    rm -f /etc/apt/sources.list.d/yarn.list /etc/apt/sources.list.d/yarn-stable.list; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+      ca-certificates \
+      curl \
+      build-essential \
+      pkg-config \
+      libssl-dev \
+      postgresql \
+      postgresql-client \
+      netcat-openbsd \
+      jq; \
+    VALKEY_VERSION="8.1.7"; \
+    curl -fsSL --retry 3 --retry-delay 2 \
+      "https://github.com/valkey-io/valkey/archive/refs/tags/${VALKEY_VERSION}.tar.gz" \
+      -o /tmp/valkey.tgz; \
+    tar -xzf /tmp/valkey.tgz -C /tmp; \
+    make -C "/tmp/valkey-${VALKEY_VERSION}" MALLOC=libc -j"$(nproc)"; \
+    make -C "/tmp/valkey-${VALKEY_VERSION}" MALLOC=libc install PREFIX=/usr/local; \
+    rm -rf "/tmp/valkey-${VALKEY_VERSION}" /tmp/valkey.tgz; \
+    valkey-server --version; \
+    valkey-cli --version; \
+    apt-get purge -y --auto-remove \
+      build-essential \
+      pkg-config \
+      libssl-dev; \
+    rm -rf /var/lib/apt/lists/*
 
 # Preinstall tools that scripts/init-cloud-env.sh expects.
 # NOTE(sync): Versions below intentionally mirror scripts/init-cloud-env.sh:


### PR DESCRIPTION
## What
Fix `.cursor/Dockerfile` so Cursor cloud / devcontainer builds succeed: remove the Yarn apt source that breaks `apt-get update`, and install **Valkey** by building release **8.1.7** from the GitHub tarball with `MALLOC=libc` (official `download.valkey.io` apt key is HTTP 403 from automated clients here; prebuilt Valkey images target newer glibc than Ubuntu 20.04 in the universal base).

## Why
Cloud environment failed during image build (apt + Valkey install). We need Valkey (not Redis) for licensing alignment.

## How
- Delete `/etc/apt/sources.list.d/yarn.list` (and `yarn-stable.list` if present) before `apt-get update`.
- Download `valkey-8.1.7` source from GitHub, `make MALLOC=libc`, `make install PREFIX=/usr/local`, purge build deps.
- Keep PostgreSQL, jq, netcat, and the existing tool install block unchanged in spirit.

## Risk
- **Low–Medium.** Cloud image build time increases (Valkey compile once per image build). Runtime behavior: same Valkey CLI/server commands as packaged Valkey.
- Local ARM hosts must build with `--platform linux/amd64` to match cloud; the universal base has no `linux/arm64` manifest.

## Security
- Threat categories reviewed: supply chain / dependency integrity (pinned Valkey tag tarball from `github.com/valkey-io/valkey`), reduced apt attack surface (removed broken third-party Yarn list).
- Findings: none. No new secrets, listeners, or trust boundaries in application code.

## Follow-ups
- Optional: add `.dockerignore` or narrow build context for `.cursor/Dockerfile` builds to avoid sending a large context to the daemon (not required for correctness).

## Checklist
- [ ] Tests added or updated
- [x] Backward compatibility considered (cloud-only image path)
- [x] Security review performed against relevant threat model categories
- [ ] All review comments addressed (code change or written reasoning)

## Evidence
- `just pre-push` passed locally.
- `docker build --platform linux/amd64 -f .cursor/Dockerfile` succeeded; `valkey-server` / `valkey-cli` smoke test (`PING` → `PONG`).