### PR TITLE
chore(release): prepare v0.8.29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,66 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- New changes go here. Use `/prepare-release X.Y.Z` to generate draft from commits. -->
 
+## [0.8.29] - 2026-05-08
+
+### Highlights
+
+- **Realtime voice sessions** - New voice capability allows sessions to interact via realtime voice with hardened authorization on tool execution ([#1767](https://github.com/everruns/everruns/pull/1767)).
+- **Skills discovery** - Skills page now ships search, view dialog, and usage counts so operators can find and adopt skills faster ([#1751](https://github.com/everruns/everruns/pull/1751)).
+- **Memory store management** - Memory stores can now be renamed and toggled as default through a new PATCH endpoint ([#1696](https://github.com/everruns/everruns/pull/1696)), with a redesigned memory stores page UX ([#1750](https://github.com/everruns/everruns/pull/1750)).
+- **Source-backed volumes** - Workspace volumes now carry source-backed metadata so agents can reason about volume provenance.
+- **Cursor host in everruns-dev plugin** - The everruns-dev plugin now supports Cursor as a host alongside Claude Code and Codex ([#1754](https://github.com/everruns/everruns/pull/1754)).
+- **Auth hardening** - Generic login errors hide credential validity ([#1763](https://github.com/everruns/everruns/pull/1763)), registration enforces password minimums ([#1762](https://github.com/everruns/everruns/pull/1762)), refresh token rotation is now atomic ([#1761](https://github.com/everruns/everruns/pull/1761)), and Google OAuth requires `email_verified` plus an allowed domain ([#1759](https://github.com/everruns/everruns/pull/1759)).
+
+### What's Changed
+
+- feat(volumes): add source-backed volume metadata by [@chaliy](https://github.com/chaliy)
+- fix(cursor): make cloud Dockerfile build with Valkey on amd64 ([#1773](https://github.com/everruns/everruns/pull/1773)) by [@chaliy](https://github.com/chaliy)
+- fix(skills): hide deleted skills from usage and content ([#1770](https://github.com/everruns/everruns/pull/1770)) by [@chaliy](https://github.com/chaliy)
+- feat(core): add system email sender by [@chaliy](https://github.com/chaliy)
+- test(apps): pin shared session reuse by [@chaliy](https://github.com/chaliy)
+- fix(voice): disable unauthorized realtime tool execution ([#1767](https://github.com/everruns/everruns/pull/1767)) by [@chaliy](https://github.com/chaliy)
+- feat(memory): add PATCH endpoint to rename memory store and toggle default ([#1696](https://github.com/everruns/everruns/pull/1696)) by [@chaliy](https://github.com/chaliy)
+- fix(apps): audit app-channel invocations by [@chaliy](https://github.com/chaliy)
+- fix(server): resolve org for volume IDs ([#1734](https://github.com/everruns/everruns/pull/1734)) by [@chaliy](https://github.com/chaliy)
+- fix(cloud-agent): verify doppler tarball checksum in Dockerfile ([#1765](https://github.com/everruns/everruns/pull/1765)) by [@chaliy](https://github.com/chaliy)
+- fix(llm-models): enforce enabled flag in model resolution paths ([#1730](https://github.com/everruns/everruns/pull/1730)) by [@chaliy](https://github.com/chaliy)
+- fix(agents): enforce high-risk checks on version activation ([#1749](https://github.com/everruns/everruns/pull/1749)) by [@chaliy](https://github.com/chaliy)
+- fix(server): avoid double-applying message query window ([#1746](https://github.com/everruns/everruns/pull/1746)) by [@chaliy](https://github.com/chaliy)
+- fix(server): bound harness usage count fan-out ([#1740](https://github.com/everruns/everruns/pull/1740)) by [@chaliy](https://github.com/chaliy)
+- fix(ui): hide raw chat failure diagnostics ([#1743](https://github.com/everruns/everruns/pull/1743)) by [@chaliy](https://github.com/chaliy)
+- fix(a2a): align stream taskId with session task identity ([#1745](https://github.com/everruns/everruns/pull/1745)) by [@chaliy](https://github.com/chaliy)
+- fix(server): bound in-memory AG-UI limiter cache per app ([#1742](https://github.com/everruns/everruns/pull/1742)) by [@chaliy](https://github.com/chaliy)
+- fix(mcp): block scoped preview commands from read-only query ([#1741](https://github.com/everruns/everruns/pull/1741)) by [@chaliy](https://github.com/chaliy)
+- fix(plugin): shorten everruns dev default prompt ([#1766](https://github.com/everruns/everruns/pull/1766)) by [@chaliy](https://github.com/chaliy)
+- fix(server): map domain anyhow::bail! cases to typed 4xx errors ([#1764](https://github.com/everruns/everruns/pull/1764)) by [@chaliy](https://github.com/chaliy)
+- fix(auth): use generic login errors for credential failures ([#1763](https://github.com/everruns/everruns/pull/1763)) by [@chaliy](https://github.com/chaliy)
+- fix(auth): enforce password minimum on registration API ([#1762](https://github.com/everruns/everruns/pull/1762)) by [@chaliy](https://github.com/chaliy)
+- fix(server): authorize AG-UI before parsing JSON body ([#1755](https://github.com/everruns/everruns/pull/1755)) by [@chaliy](https://github.com/chaliy)
+- fix(core): strip human_intent from client-side tool calls ([#1756](https://github.com/everruns/everruns/pull/1756)) by [@chaliy](https://github.com/chaliy)
+- feat(organizations): add resolve_org command for entity-id lookup ([#1758](https://github.com/everruns/everruns/pull/1758)) by [@chaliy](https://github.com/chaliy)
+- fix(events): bound q filter for list_events ([#1737](https://github.com/everruns/everruns/pull/1737)) by [@chaliy](https://github.com/chaliy)
+- fix(core): avoid utf8 panic in prompt canary truncation ([#1744](https://github.com/everruns/everruns/pull/1744)) by [@chaliy](https://github.com/chaliy)
+- fix(auth): make refresh token rotation atomic ([#1761](https://github.com/everruns/everruns/pull/1761)) by [@chaliy](https://github.com/chaliy)
+- fix(ui): restrict MCP card resources to ui://everruns ([#1736](https://github.com/everruns/everruns/pull/1736)) by [@chaliy](https://github.com/chaliy)
+- fix(durable): direct workflow lookup for detail and SSE ([#1760](https://github.com/everruns/everruns/pull/1760)) by [@chaliy](https://github.com/chaliy)
+- feat(skills): add search, view dialog, and usage counts ([#1751](https://github.com/everruns/everruns/pull/1751)) by [@chaliy](https://github.com/chaliy)
+- fix(auth): enforce Google OAuth email_verified and allowed-domain ([#1759](https://github.com/everruns/everruns/pull/1759)) by [@chaliy](https://github.com/chaliy)
+- chore(skills): upgrade agent-browser skill to discovery stub ([#1757](https://github.com/everruns/everruns/pull/1757)) by [@chaliy](https://github.com/chaliy)
+- feat(plugin): add cursor host to everruns-dev plugin ([#1754](https://github.com/everruns/everruns/pull/1754)) by [@chaliy](https://github.com/chaliy)
+- chore(cloud-agent): add repo environment setup ([#1753](https://github.com/everruns/everruns/pull/1753)) by [@chaliy](https://github.com/chaliy)
+- fix(mcp): count card sessions by internal agent id ([#1733](https://github.com/everruns/everruns/pull/1733)) by [@chaliy](https://github.com/chaliy)
+- fix(ui): handle null workspace volume configs ([#1731](https://github.com/everruns/everruns/pull/1731)) by [@chaliy](https://github.com/chaliy)
+- fix(memory): redesign memory stores page UX ([#1750](https://github.com/everruns/everruns/pull/1750)) by [@chaliy](https://github.com/chaliy)
+- chore(plugin): sync everruns-dev claude manifest with codex ([#1752](https://github.com/everruns/everruns/pull/1752)) by [@chaliy](https://github.com/chaliy)
+- fix(memory): honor capability store config in memory tools ([#1729](https://github.com/everruns/everruns/pull/1729)) by [@chaliy](https://github.com/chaliy)
+- fix(ui): block unsafe memory image media types ([#1728](https://github.com/everruns/everruns/pull/1728)) by [@chaliy](https://github.com/chaliy)
+- fix(a2a): block stream on shared-session channels ([#1727](https://github.com/everruns/everruns/pull/1727)) by [@chaliy](https://github.com/chaliy)
+- fix(cursor): remove global api key fallback ([#1726](https://github.com/everruns/everruns/pull/1726)) by [@chaliy](https://github.com/chaliy)
+- fix(mcp): block oauth token use in explicit scoped servers ([#1714](https://github.com/everruns/everruns/pull/1714)) by [@chaliy](https://github.com/chaliy)
+- feat(voice): add realtime voice sessions by [@chaliy](https://github.com/chaliy)
+- chore(maintenance): add deepsec scan workflow by [@chaliy](https://github.com/chaliy)
+
 ## [0.8.28] - 2026-05-07
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -826,9 +826,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1991,11 +1991,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-a2ui"
-version = "0.8.28"
+version = "0.8.29"
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.8.28"
+version = "0.8.29"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2014,7 +2014,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-cli"
-version = "0.8.28"
+version = "0.8.29"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2041,14 +2041,14 @@ dependencies = [
 
 [[package]]
 name = "everruns-config"
-version = "0.8.28"
+version = "0.8.29"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "everruns-container-sandbox"
-version = "0.8.28"
+version = "0.8.29"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2069,7 +2069,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.8.28"
+version = "0.8.29"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -2126,7 +2126,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-durable"
-version = "0.8.28"
+version = "0.8.29"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2161,7 +2161,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-gemini"
-version = "0.8.28"
+version = "0.8.29"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2179,7 +2179,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-brave-search"
-version = "0.8.28"
+version = "0.8.29"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2195,7 +2195,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-browserless"
-version = "0.8.28"
+version = "0.8.29"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2216,7 +2216,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-cursor"
-version = "0.8.28"
+version = "0.8.29"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2231,7 +2231,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.8.28"
+version = "0.8.29"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2247,7 +2247,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-deno"
-version = "0.8.28"
+version = "0.8.29"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2271,7 +2271,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-docker"
-version = "0.8.28"
+version = "0.8.29"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2286,7 +2286,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.8.28"
+version = "0.8.29"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2301,7 +2301,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-e2b"
-version = "0.8.28"
+version = "0.8.29"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2330,7 +2330,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-parallel"
-version = "0.8.28"
+version = "0.8.29"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2342,7 +2342,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-pi"
-version = "0.8.28"
+version = "0.8.29"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2357,7 +2357,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-sprites"
-version = "0.8.28"
+version = "0.8.29"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2373,7 +2373,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-internal-protocol"
-version = "0.8.28"
+version = "0.8.29"
 dependencies = [
  "chrono",
  "everruns-core",
@@ -2390,7 +2390,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-macros"
-version = "0.8.28"
+version = "0.8.29"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2400,7 +2400,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.8.28"
+version = "0.8.29"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2422,11 +2422,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-openui"
-version = "0.8.28"
+version = "0.8.29"
 
 [[package]]
 name = "everruns-runtime"
-version = "0.8.28"
+version = "0.8.29"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2460,7 +2460,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-server"
-version = "0.8.28"
+version = "0.8.29"
 dependencies = [
  "aes-gcm",
  "ag-ui-core",
@@ -2549,7 +2549,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-session-sqldb"
-version = "0.8.28"
+version = "0.8.29"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2568,7 +2568,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-worker"
-version = "0.8.28"
+version = "0.8.29"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2735,13 +2735,12 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.27"
+version = "0.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+checksum = "2d5b2eef6fafbf69f877e55509ce5b11a760690ac9700a2921be067aa6afaef6"
 dependencies = [
  "cfg-if",
  "libc",
- "libredox",
 ]
 
 [[package]]
@@ -4168,9 +4167,9 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.18.3+1.9.2"
+version = "0.18.4+1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9b3acc4b91781bb0b3386669d325163746af5f6e4f73e6d2d630e09a35f3487"
+checksum = "9b26f66f35e1871b22efcf7191564123d2a446ca0538cde63c23adfefa9b15b7"
 dependencies = [
  "cc",
  "libc",
@@ -7668,9 +7667,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.2"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.8.28"
+version = "0.8.29"
 edition = "2024"
 license = "MIT"
 authors = ["Everruns Contributors"]

--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "everruns-ui",
-  "version": "0.8.28",
+  "version": "0.8.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "everruns-ui",
-      "version": "0.8.28",
+      "version": "0.8.29",
       "dependencies": {
         "@base-ui/react": "^1.2.0",
         "@openuidev/react-lang": "^0.1.3",

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "everruns-ui",
-  "version": "0.8.28",
+  "version": "0.8.29",
   "private": true,
   "exports": {
     "./route-manifest": "./src/lib/ui-route-manifest.ts",


### PR DESCRIPTION
## What
Prepares the v0.8.29 patch release: bumps workspace version (Cargo.toml, apps/ui/package.json, lock files) and adds the v0.8.29 section to CHANGELOG.md with highlights and the full commit list since v0.8.28.

## Why
Patch release covering 46 commits since v0.8.28. Notable user-facing additions: realtime voice sessions, skills discovery (search + view dialog + usage counts), memory store rename/default PATCH endpoint, source-backed workspace volume metadata, and Cursor host support in the everruns-dev plugin. Also a wave of auth hardening (generic login errors, registration password minimums, atomic refresh token rotation, Google OAuth `email_verified` + allowed-domain enforcement) and many targeted server/UI/MCP/A2A robustness fixes.

## How
Followed `specs/release-process.md` and `/prepare-release`:
- Bumped `[workspace.package].version` in Cargo.toml to 0.8.29.
- Bumped `version` in apps/ui/package.json to 0.8.29.
- Regenerated Cargo.lock via `cargo generate-lockfile`.
- Regenerated apps/ui/package-lock.json via `npm install --package-lock-only`.
- Added `## [0.8.29] - 2026-05-08` section to CHANGELOG.md with Highlights + What's Changed sourced from `git log v0.8.28..HEAD`.
- Verified migration sequence (`crates/server/migrations/001..039`) — strictly sequential, no gaps, no rewritten migrations.

## Risk
- Low. Release-prep PR — no source code changes, only version metadata, lock files, and CHANGELOG.

## Security
- Threat categories reviewed: No security-relevant code changes — release prep is metadata + changelog only. The underlying release does include several security-tagged fixes (TM-AUTH: generic login errors, password minimum, atomic refresh rotation, Google OAuth gating; TM-API: AG-UI authorize-before-parse; TM-MCP: scoped server oauth/preview blocks) which were reviewed in their respective PRs.
- Findings and resolutions: None for this PR.

## Follow-ups
No follow-ups.

## Post-merge
After merging, the release workflow will automatically:
- Create git tag `v0.8.29`
- Create GitHub Release with notes from CHANGELOG.md
- Trigger Docker image build with version tag
- Trigger CLI binaries build and Homebrew tap update

## Checklist
- [x] Tests added or updated (n/a — release prep)
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_018TfqgZKgdjHPYGyDPs8m9S)_