### PR TITLE
chore(skills): refresh agent-browser skill (observability dashboard)

### DIFF
--- a/.agents/skills/agent-browser/SKILL.md
+++ b/.agents/skills/agent-browser/SKILL.md
@@ -49,3 +49,7 @@ installed version.
 - Accessibility-tree snapshots with element refs for reliable interaction
 - Sessions, authentication vault, state persistence, video recording
 - Specialized skills for Electron apps, Slack, exploratory testing, cloud providers
+
+## Observability Dashboard
+
+The dashboard runs independently of browser sessions on port 4848 and can also be opened through a proxied or forwarded URL such as `https://dashboard.agent-browser.localhost`. Agents should stay on the dashboard origin: session tabs, status, and stream traffic are proxied internally, so session ports do not need to be exposed.

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -5,7 +5,7 @@
       "source": "vercel-labs/agent-browser",
       "sourceType": "github",
       "skillPath": "skills/agent-browser/SKILL.md",
-      "computedHash": "c19a532a3777698b80b35270939a1dc559da451381971b3e1e78174d1ab54863"
+      "computedHash": "228f87d57035100d9dc6efcfc05aafd4b6e3962adacaa04b8217ab2fadb15dc8"
     }
   }
 }


### PR DESCRIPTION
## What
Refreshes the project-tracked `agent-browser` skill from upstream `vercel-labs/agent-browser`, picking up a new "Observability Dashboard" section in the SKILL.md and rotating the `skills-lock.json` `computedHash`.

Diff in the SKILL.md is purely additive — appends a section explaining that the dashboard runs on port 4848 (also reachable via `https://dashboard.agent-browser.localhost`) and that agents should stay on the dashboard origin since session tabs/status/streams are proxied internally.

## Why
Keep the in-tree agent-browser skill in lockstep with upstream so agents see current guidance (the new dashboard origin/proxy guidance affects how they should drive the browser).

Side benefit: this is the first PR exercising the in-place update flow now that the lock entry includes `skillPath` (added in #1757) — `npx skills update agent-browser -p -y` worked directly without needing `skills add`.

## How
1. `git fetch origin && git rebase origin/main` — branch was 34 behind, rebase dropped the already-squashed commit from #1757 cleanly.
2. `npx skills update agent-browser -p -y` — refreshed SKILL.md and rotated `computedHash` to `228f87d5…`.
3. `bash scripts/lib/check-migration-ordering.sh` — passed (`migrations sequential (001..039)`).
4. `npx skills list -p` — agent-browser still discovered and wired to all 5 agents.

Lock-file delta:
```diff
       "skillPath": "skills/agent-browser/SKILL.md",
-      "computedHash": "c19a532a3777698b80b35270939a1dc559da451381971b3e1e78174d1ab54863"
+      "computedHash": "228f87d57035100d9dc6efcfc05aafd4b6e3962adacaa04b8217ab2fadb15dc8"
```

## Risk
- Low. Touches only `.agents/skills/agent-browser/SKILL.md` (additive section) and `skills-lock.json`. No runtime, infra, migrations, UI, or specs. The `agent-browser` CLI binary is unchanged by this PR; downstream consumers (`ui-screenshots`, `manual-ui-testing`) are unaffected.

## Security
- Threat categories reviewed: none — skill-content refresh, no runtime/code/infra/dependency surface touched. The new section is documentation pointing agents at an existing dashboard surface (port 4848 / `dashboard.agent-browser.localhost`); no new tool capability is granted (`allowed-tools` unchanged).
- Source authenticity: fetched by `npx skills` (CLI v1.5.5) over HTTPS from `vercel-labs/agent-browser`; lock-file hash rotation records the new content.
- Findings and resolutions: none.

## Validation
- `bash scripts/lib/check-migration-ordering.sh` — passed.
- `npx skills list -p` — skill discovered, wired to Claude Code, Codex, Cursor, GitHub Copilot, OpenCode.
- Smoke test of platform runtime intentionally skipped — zero Rust/UI/infra/migration changes; falls under the docs/config-only carve-out in `specs/shipping.md`.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated — N/A, content-only refresh of a third-party skill bundle
- [x] Backward compatibility considered — additive change, CLI surface unchanged
- [x] Security review performed against relevant threat model categories — see Security
- [x] All review comments addressed (code change or written reasoning)