### PR TITLE
fix(volumes): block internal git source URLs

### DIFF
--- a/crates/server/src/domains/volumes/commands.rs
+++ b/crates/server/src/domains/volumes/commands.rs
@@ -6,6 +6,7 @@ use super::types::{
 use super::{VOLUME_MANAGE, VOLUME_VIEW};
 use crate::domains::common::*;
 use everruns_core::Policy;
+use everruns_core::url_validation::validate_safe_url;
 use everruns_core::typed_id::VolumeId;
 use everruns_durable::UpdateField;
 use serde::Deserialize;
@@ -107,33 +108,24 @@ fn validate_git_url(url: &str) -> Result<String, CommandError> {
         ));
     }
     if let Ok(parsed) = url::Url::parse(trimmed) {
-        match parsed.scheme() {
-            "https" | "ssh" | "git" => {}
-            _ => {
-                return Err(CommandError::bad_request(
-                    "Git URL must use https, ssh, or git scheme",
-                ));
-            }
+        if parsed.scheme() != "https" {
+            return Err(CommandError::bad_request(
+                "Git URL must use https scheme",
+            ));
         }
-        if parsed.password().is_some()
-            || !(parsed.username().is_empty()
-                || parsed.scheme() == "ssh" && parsed.username() == "git")
-        {
+        if parsed.password().is_some() || !parsed.username().is_empty() {
             return Err(CommandError::bad_request(
                 "Git URL must not include inline credentials",
             ));
         }
-        if parsed.host_str().is_none() {
-            return Err(CommandError::bad_request("Git URL must include a host"));
+        if validate_safe_url(trimmed).is_err() {
+            return Err(CommandError::bad_request(
+                "Git URL must target a public non-local host",
+            ));
         }
         return Ok(trimmed.to_string());
     }
-    if trimmed.starts_with("git@") && trimmed.contains(':') {
-        return Ok(trimmed.to_string());
-    }
-    Err(CommandError::bad_request(
-        "Git URL must be an absolute URL or git@host:owner/repo.git",
-    ))
+    Err(CommandError::bad_request("Git URL must be an absolute https URL"))
 }
 
 fn github_source_config(request: GitHubVolumeSourceRequest) -> Result<Value, CommandError> {
@@ -692,6 +684,36 @@ mod tests {
             .run(&ctx)
             .await
             .expect_err("secret-bearing URL should fail");
+
+            assert!(matches!(err, CommandError::BadRequest(_)));
+        }
+    }
+
+    #[tokio::test]
+    async fn git_volume_rejects_non_public_hosts_and_non_https_schemes() {
+        let ctx = ctx_for_org(DEFAULT_ORG_ID);
+
+        for url in [
+            "https://127.0.0.1/repo.git",
+            "https://10.0.0.5/repo.git",
+            "https://169.254.169.254/repo.git",
+            "https://localhost/repo.git",
+            "ssh://git@example.com/org/repo.git",
+            "git://example.com/org/repo.git",
+            "git@example.com:org/repo.git",
+        ] {
+            let err = CreateVolume {
+                name: format!("Unsafe Host Repo {url}"),
+                description: None,
+                source: Some(CreateVolumeSourceRequest::Git(GitVolumeSourceRequest {
+                    url: url.into(),
+                    branch: None,
+                    root_folder: None,
+                })),
+            }
+            .run(&ctx)
+            .await
+            .expect_err("unsafe git URL should fail");
 
             assert!(matches!(err, CommandError::BadRequest(_)));
         }


### PR DESCRIPTION
### Motivation
- Prevent SSRF/internal-network exposure: generic Git volume sources previously accepted `https`, `ssh`, `git`, and scp-like `git@` targets and persisted them as pending sync jobs, which allows an authenticated org user to cause server/worker outbound connections to internal hosts.
- Align Git source validation with existing SSRF-safe URL policies used elsewhere so persisted `source_config` cannot point at localhost, RFC1918, link-local, or cloud metadata endpoints.

### Description
- Restrict generic Git sources to absolute `https://` URLs only by updating `validate_git_url` to require the `https` scheme and to reject other schemes and scp-style `git@` forms. (file: `crates/server/src/domains/volumes/commands.rs`)
- Enforce no inline credentials by rejecting any username/password in the parsed URL. (file: `crates/server/src/domains/volumes/commands.rs`)
- Reuse the shared SSRF-aware validator `validate_safe_url` to block localhost, loopback, RFC1918, link-local, metadata, and other non-public hosts at write-time. (file: `crates/server/src/domains/volumes/commands.rs`)
- Add a regression test `git_volume_rejects_non_public_hosts_and_non_https_schemes` that asserts unsafe hosts and non-HTTPS schemes are rejected. (file: `crates/server/src/domains/volumes/commands.rs` tests)

### Testing
- Added unit test `git_volume_rejects_non_public_hosts_and_non_https_schemes` and kept existing secret-bearing-URL tests; these are under `crates/server/src/domains/volumes/commands.rs`.
- Attempted to run the targeted test with `cargo test -p everruns-server git_volume_rejects_non_public_hosts_and_non_https_schemes -- --exact`; compilation and test startup progressed in this environment but the full test completion was not observed due to a long build in the runtime window, so please run the full server test suite or `just pre-push` locally/CI to confirm green CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe7fa81c2c832b99948da8c78de654)