### PR TITLE
fix(core): harden email recipient validation

### DIFF
--- a/crates/core/src/email.rs
+++ b/crates/core/src/email.rs
@@ -80,17 +80,32 @@ impl EmailAddress {
     }
 
     fn validate(&self, field: &str) -> EmailResult<()> {
-        if self.email.trim().is_empty() {
+        let email = self.email.trim();
+        if email.is_empty() {
             return Err(EmailError::invalid(format!("{field} email is empty")));
         }
-        if self.email.contains(['\r', '\n']) {
+        if self.email != email {
+            return Err(EmailError::invalid(format!(
+                "{field} email must not include leading or trailing whitespace"
+            )));
+        }
+        if email.contains(['\r', '\n']) {
             return Err(EmailError::invalid(format!(
                 "{field} email contains a newline"
             )));
         }
-        if !self.email.contains('@') {
+        if email.contains([' ', '\t', ',', ';', '<', '>', '"', '\'', '(', ')', '[', ']']) {
             return Err(EmailError::invalid(format!(
-                "{field} email must contain an @ sign"
+                "{field} email must be a single mailbox address"
+            )));
+        }
+        let mut parts = email.split('@');
+        let local = parts.next().unwrap_or_default();
+        let domain = parts.next().unwrap_or_default();
+        let has_extra_parts = parts.next().is_some();
+        if local.is_empty() || domain.is_empty() || has_extra_parts {
+            return Err(EmailError::invalid(format!(
+                "{field} email must be a single mailbox address"
             )));
         }
         if let Some(name) = &self.name
@@ -429,5 +444,56 @@ mod tests {
 
         assert!(matches!(error, EmailError::InvalidRequest(_)));
         assert!(error.to_string().contains("control characters"));
+    }
+
+    #[tokio::test]
+    async fn rejects_multi_recipient_in_single_to_field() {
+        let sender = NoopEmailSender;
+        let error = sender
+            .send_email(EmailMessage::generic(
+                "victim@example.com, attacker@example.com",
+                "Hi",
+                "hello",
+                "<p>hello</p>",
+            ))
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, EmailError::InvalidRequest(_)));
+        assert!(error.to_string().contains("single mailbox"));
+    }
+
+    #[tokio::test]
+    async fn rejects_structured_mailbox_syntax_in_raw_email_field() {
+        let sender = NoopEmailSender;
+        let error = sender
+            .send_email(EmailMessage::generic(
+                "Victim <victim@example.com>",
+                "Hi",
+                "hello",
+                "<p>hello</p>",
+            ))
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, EmailError::InvalidRequest(_)));
+        assert!(error.to_string().contains("single mailbox"));
+    }
+
+    #[tokio::test]
+    async fn rejects_email_with_surrounding_whitespace() {
+        let sender = NoopEmailSender;
+        let error = sender
+            .send_email(EmailMessage::generic(
+                " user@example.com ",
+                "Hi",
+                "hello",
+                "<p>hello</p>",
+            ))
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, EmailError::InvalidRequest(_)));
+        assert!(error.to_string().contains("leading or trailing whitespace"));
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent recipient-injection and structured-mailbox attacks where user-provided address strings could include address-list delimiters or mailbox syntax and cause emails to be delivered to unintended recipients.
- The existing check only enforced non-empty/no-newline and presence of `@`, which allowed inputs like `a@x.com, b@x.com` or `Name <a@x.com>` to pass validation.

### Description
- Tighten `EmailAddress::validate` in `crates/core/src/email.rs` to trim and reject leading/trailing whitespace, reject newline/control characters, and reject characters used for lists/structured mailbox syntax (spaces, commas, semicolons, angle brackets, quotes, parentheses, and brackets).
- Enforce exactly one `@` with non-empty local and domain parts to ensure the raw `email` field is a single mailbox-like address.
- Leave `format_for_provider` behavior unchanged but rely on the stronger validation to ensure unsafe raw values never reach provider payloads.
- Add three focused regression tests in `crates/core/src/email.rs` that assert rejection of comma-separated recipients, structured mailbox syntax, and surrounding-whitespace cases.

### Testing
- Ran the crate tests with `cargo test -p everruns-core rejects_` and the test suite completed successfully with the new tests passing (core tests: 81 passed, 0 failed).
- The new tests are `rejects_multi_recipient_in_single_to_field`, `rejects_structured_mailbox_syntax_in_raw_email_field`, and `rejects_email_with_surrounding_whitespace`, and they all pass under the test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe7fa76454832b83d843f475c6d307)