### PR TITLE
fix(apps): accept five-field schedule cron

### DIFF
--- a/crates/server/src/domains/apps/commands.rs
+++ b/crates/server/src/domains/apps/commands.rs
@@ -148,10 +148,19 @@ fn durable_store(ctx: &Ctx) -> Result<&Arc<dyn WorkflowEventStore + Send + Sync>
     })
 }
 
-fn validate_channel_config(
+fn normalize_cron_expression(cron_expression: &str) -> String {
+    let fields: Vec<&str> = cron_expression.split_whitespace().collect();
+    if fields.len() == 5 {
+        format!("0 {} *", fields.join(" "))
+    } else {
+        cron_expression.trim().to_string()
+    }
+}
+
+fn normalize_and_validate_channel_config(
     channel_type: ChannelType,
-    channel_config: &Value,
-) -> Result<(), CommandError> {
+    channel_config: Value,
+) -> Result<Value, CommandError> {
     match channel_type {
         ChannelType::Slack => {
             let config: SlackChannelConfig = serde_json::from_value(channel_config.clone())
@@ -214,12 +223,21 @@ fn validate_channel_config(
                     "Schedule channel config requires a non-empty message",
                 ));
             }
-            cron::Schedule::from_str(&config.cron_expression).map_err(|e| {
+            let cron_expression = normalize_cron_expression(&config.cron_expression);
+            cron::Schedule::from_str(&cron_expression).map_err(|e| {
                 CommandError::bad_request(format!(
                     "Invalid schedule cron expression '{}': {e}",
-                    config.cron_expression
+                    cron_expression
                 ))
             })?;
+            let mut channel_config = channel_config;
+            if let Some(object) = channel_config.as_object_mut() {
+                object.insert(
+                    "cron_expression".to_string(),
+                    Value::String(cron_expression),
+                );
+            }
+            return Ok(channel_config);
         }
         ChannelType::Webhook => {
             let config: WebhookChannelConfig = serde_json::from_value(channel_config.clone())
@@ -260,7 +278,7 @@ fn validate_channel_config(
         }
     }
 
-    Ok(())
+    Ok(channel_config)
 }
 
 fn calculate_schedule_next_trigger(
@@ -1084,13 +1102,13 @@ impl Command for CreateApp {
             ));
         }
 
-        let channel_config = channel_config.unwrap_or_default();
+        let mut channel_config = channel_config.unwrap_or_default();
 
         if let Some(channel_type) = channel_type.clone() {
             if channel_type == ChannelType::Schedule {
                 let _ = durable_store(ctx)?;
             }
-            validate_channel_config(channel_type, &channel_config)?;
+            channel_config = normalize_and_validate_channel_config(channel_type, channel_config)?;
         }
 
         // Validate references
@@ -1797,8 +1815,10 @@ impl Command for AddChannel {
             let _ = durable_store(ctx)?;
         }
 
-        let channel_config = self.req.channel_config.unwrap_or_default();
-        validate_channel_config(self.req.channel_type.clone(), &channel_config)?;
+        let channel_config = normalize_and_validate_channel_config(
+            self.req.channel_type.clone(),
+            self.req.channel_config.unwrap_or_default(),
+        )?;
         let (stored_plaintext, encrypted) =
             q::prepare_channel_config(encryption, &channel_config).map_err(classify_anyhow)?;
 
@@ -2124,7 +2144,8 @@ impl Command for RegenerateA2aApiKeyCmd {
                 "Existing A2A channel configuration is not a JSON object",
             ));
         }
-        validate_channel_config(ChannelType::A2a, &existing_config)?;
+        let existing_config =
+            normalize_and_validate_channel_config(ChannelType::A2a, existing_config)?;
 
         let (stored, encrypted) =
             q::prepare_channel_config(encryption, &existing_config).map_err(classify_anyhow)?;
@@ -2251,13 +2272,16 @@ impl Command for UpdateChannelCmd {
         if final_channel_type == ChannelType::Schedule {
             let _ = durable_store(ctx)?;
         }
-        validate_channel_config(final_channel_type, &final_channel_config)?;
+        let normalized_channel_config =
+            normalize_and_validate_channel_config(final_channel_type, final_channel_config)?;
 
-        let (channel_config, channel_config_encrypted) = if self.req.channel_config.is_some() {
+        let config_changed = self.req.channel_config.is_some();
+        let (channel_config, channel_config_encrypted) = if config_changed {
             // Persist the merged config (so A2A preserves the existing
             // api_key_hash / prefix when the client omits them).
-            let (stored, encrypted) = q::prepare_channel_config(encryption, &final_channel_config)
-                .map_err(classify_anyhow)?;
+            let (stored, encrypted) =
+                q::prepare_channel_config(encryption, &normalized_channel_config)
+                    .map_err(classify_anyhow)?;
             (Some(stored), encrypted)
         } else {
             (None, None)

--- a/crates/server/tests/app_invocation_channels_integration_test.rs
+++ b/crates/server/tests/app_invocation_channels_integration_test.rs
@@ -123,16 +123,22 @@ async fn schedule_channel_binds_to_durable_schedule_and_invokes_shared_session()
         "schedule-checker",
         "schedule",
         json!({
-            "cron_expression": "0 * * * * * *",
+            "cron_expression": "0 * * * *",
             "timezone": "UTC",
             "session_mode": "shared_session",
             "message": "scheduled {{app.name}} {{invocation.source}}",
+            "extra": "preserved",
         }),
     )
     .await;
 
     let app_id = app["id"].as_str().unwrap();
     let channel_id = app["channels"][0]["id"].as_str().unwrap();
+    assert_eq!(
+        app["channels"][0]["channel_config"]["cron_expression"],
+        "0 0 * * * * *"
+    );
+    assert_eq!(app["channels"][0]["channel_config"]["extra"], "preserved");
 
     let draft_schedule = find_schedule(&server, app_id, channel_id)
         .await
@@ -143,7 +149,7 @@ async fn schedule_channel_binds_to_durable_schedule_and_invokes_shared_session()
         "invoke_scheduled_app_channel"
     );
     assert_eq!(draft_schedule["enabled"], false);
-    assert_eq!(draft_schedule["cron_expression"], "0 * * * * * *");
+    assert_eq!(draft_schedule["cron_expression"], "0 0 * * * * *");
 
     publish_app(&server, app_id).await;
 
@@ -200,10 +206,11 @@ async fn schedule_channel_binds_to_durable_schedule_and_invokes_shared_session()
             &format!("/v1/apps/{app_id}/channels/{channel_id}"),
             json!({
                 "channel_config": {
-                    "cron_expression": "0 15 * * * * *",
+                    "cron_expression": "15 * * * *",
                     "timezone": "America/Chicago",
                     "session_mode": "shared_session",
                     "message": "updated {{app.id}}",
+                    "extra": "still-preserved",
                 }
             }),
         )
@@ -215,6 +222,20 @@ async fn schedule_channel_binds_to_durable_schedule_and_invokes_shared_session()
         .expect("updated schedule binding");
     assert_eq!(updated_schedule["cron_expression"], "0 15 * * * * *");
     assert_eq!(updated_schedule["timezone"], "America/Chicago");
+
+    let updated_app: Value = server
+        .get(&format!("/v1/apps/{app_id}"))
+        .await
+        .assert_status(StatusCode::OK)
+        .json();
+    assert_eq!(
+        updated_app["channels"][0]["channel_config"]["cron_expression"],
+        "0 15 * * * * *"
+    );
+    assert_eq!(
+        updated_app["channels"][0]["channel_config"]["extra"],
+        "still-preserved"
+    );
 
     server
         .delete(&format!("/v1/apps/{app_id}/channels/{channel_id}"))

--- a/crates/server/tests/mcp_endpoint_test.rs
+++ b/crates/server/tests/mcp_endpoint_test.rs
@@ -1559,7 +1559,7 @@ async fn test_mcp_execute_app_commands_support_schedule_and_webhook_channels() {
         "execute",
         json!({
             "commands": format!(
-                "add_schedule_app_channel --app_id {app_id} --cron_expression '0 * * * * * *' --timezone UTC --session_mode shared_session --message 'run checks'"
+                "add_schedule_app_channel --app_id {app_id} --cron_expression '0 * * * *' --timezone UTC --session_mode shared_session --message 'run checks'"
             )
         }),
     )
@@ -1570,6 +1570,10 @@ async fn test_mcp_execute_app_commands_support_schedule_and_webhook_channels() {
         tool_text(&add_schedule_resp)
     );
     assert_eq!(tool_json(&add_schedule_resp)["channel_type"], "schedule");
+    assert_eq!(
+        tool_json(&add_schedule_resp)["channel_config"]["cron_expression"],
+        "0 0 * * * * *"
+    );
 
     let add_webhook_resp = mcp_tool_call(
         &server,

--- a/specs/app-invocation-channels.md
+++ b/specs/app-invocation-channels.md
@@ -100,6 +100,11 @@ Config fields:
 - `session_mode`
 - `message`
 
+`cron_expression` accepts standard 5-field cron input and the durable
+scheduler's 7-field format. App channel creation/update normalizes 5-field
+input to the canonical 7-field durable expression before storing the channel
+config or syncing the backing durable schedule.
+
 Behavior:
 
 - create/update/delete stays in the app domain


### PR DESCRIPTION
## What
Allow app schedule channel commands and channel config writes to accept standard 5-field cron expressions, normalizing them to the durable scheduler's canonical 7-field expression before storage and schedule binding.

## Why
`add_schedule_app_channel --cron_expression "0 * * * *"` failed through MCP bash mode with a generic `callback failed`, while the equivalent 7-field expression worked. The command should accept common cron input and keep durable scheduler storage consistent.

## How
- Added cron normalization during schedule channel config validation while preserving unknown schedule config fields.
- Applied normalized config in create, add, and update channel flows when config is provided.
- Added MCP regression coverage for the 5-field `add_schedule_app_channel` command.
- Added HTTP app invocation channel coverage for schedule create/update normalization and durable schedule sync.
- Documented the app schedule channel cron contract in `specs/app-invocation-channels.md`.

## Risk
- Low
- App schedule channel cron parsing/storage could regress if callers depended on preserving the original 5-field string. Existing durable scheduler execution remains on validated 7-field cron expressions.

## Security
- Threat categories reviewed: TM-SCHED, TM-API.
- Findings and resolutions: Invalid cron expressions are still rejected by the existing cron parser after normalization. No auth, authorization, tenant scoping, secrets, or execution-permission behavior changed.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

## Validation
- Reproduced failure with focused MCP regression before fix: `add_schedule_app_channel: callback failed` for `0 * * * *`.
- `cargo fmt --check`
- `cargo test -p everruns-server --test mcp_endpoint_test test_mcp_execute_app_commands_support_schedule_and_webhook_channels -- --nocapture`
- `cargo test -p everruns-server --test app_invocation_channels_integration_test schedule_channel_binds_to_durable_schedule_and_invokes_shared_session -- --nocapture`
- Smoke: `PORT_PREFIX=271 CARGO_INCREMENTAL=0 just start-dev --no-watch`, then MCP `execute` created an app and ran `add_schedule_app_channel --cron_expression '0 * * * *' --timezone America/Chicago --session_mode shared_session --message ... --enabled`; response returned `channel_type: schedule`, `enabled: true`, `cron_expression: 0 0 * * * * *`.
- `bash scripts/lib/check-migration-ordering.sh`
- `CARGO_INCREMENTAL=0 just pre-push`