### PR TITLE
fix(apps): require channel before publish

### DIFF
--- a/crates/server/src/domains/apps/commands.rs
+++ b/crates/server/src/domains/apps/commands.rs
@@ -543,6 +543,23 @@ async fn sync_all_schedule_bindings(ctx: &Ctx, app: &App) -> Result<(), CommandE
     Ok(())
 }
 
+async fn require_app_channel_before_publish(
+    ctx: &Ctx,
+    app_internal_id: Uuid,
+) -> Result<(), CommandError> {
+    let has_channels = ctx
+        .db
+        .app_has_channels(app_internal_id)
+        .await
+        .map_err(classify_anyhow)?;
+    if !has_channels {
+        return Err(CommandError::bad_request(
+            "App must have at least one channel before publishing",
+        ));
+    }
+    Ok(())
+}
+
 async fn remove_schedule_binding_for_channel(
     ctx: &Ctx,
     channel_row: &crate::storage::models::AppChannelRow,
@@ -1351,6 +1368,11 @@ impl Command for UpdateAppCmd {
                 "Archived or deleted apps cannot be edited",
             ));
         }
+        if matches!(req.status, Some(AppStatus::Published | AppStatus::Draft)) {
+            return Err(CommandError::bad_request(
+                "Use publish/unpublish endpoints to change app publish status",
+            ));
+        }
 
         // Validate optional references
         let harness_id = if let Some(hid) = req.harness_id {
@@ -1676,6 +1698,12 @@ impl Command for PublishApp {
             .await
             .map_err(classify_anyhow)?
             .ok_or_else(|| CommandError::not_found("App"))?;
+        if existing.status != "draft" {
+            return Err(CommandError::bad_request(
+                "App must be draft before publishing",
+            ));
+        }
+        require_app_channel_before_publish(ctx, existing.id).await?;
 
         let input = UpdateApp {
             status: Some("published".to_string()),

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -2673,6 +2673,10 @@ impl StorageBackend {
         dispatch!(self, list_app_channels, app_id)
     }
 
+    pub async fn app_has_channels(&self, app_id: Uuid) -> Result<bool> {
+        dispatch!(self, app_has_channels, app_id)
+    }
+
     pub async fn get_app_channel_by_public_id(
         &self,
         public_id: &str,

--- a/crates/server/src/storage/memory/app_channels.rs
+++ b/crates/server/src/storage/memory/app_channels.rs
@@ -44,6 +44,11 @@ impl InMemoryDatabase {
         Ok(result)
     }
 
+    pub async fn app_has_channels(&self, app_id: Uuid) -> Result<bool> {
+        let channels = self.app_channels.read();
+        Ok(channels.values().any(|ch| ch.app_id == app_id))
+    }
+
     pub async fn get_app_channel_by_public_id(
         &self,
         public_id: &str,

--- a/crates/server/src/storage/repositories/app_channels.rs
+++ b/crates/server/src/storage/repositories/app_channels.rs
@@ -51,6 +51,23 @@ impl Database {
         Ok(rows)
     }
 
+    pub async fn app_has_channels(&self, app_id: Uuid) -> Result<bool> {
+        let exists = sqlx::query_scalar::<_, bool>(
+            r#"
+            SELECT EXISTS (
+                SELECT 1
+                FROM app_channels
+                WHERE app_id = $1
+            )
+            "#,
+        )
+        .bind(app_id)
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(exists)
+    }
+
     pub async fn get_app_channel_by_public_id(
         &self,
         public_id: &str,

--- a/crates/server/tests/api_integration_test.rs
+++ b/crates/server/tests/api_integration_test.rs
@@ -4037,6 +4037,122 @@ async fn test_create_app_schedule_and_webhook_channels_persist_in_postgres() {
 }
 
 #[tokio::test]
+async fn test_publish_app_without_channels_returns_bad_request() {
+    let server = TestServer::new().await;
+
+    let app: Value = server
+        .post(
+            "/v1/apps",
+            json!({
+                "name": "Channel-less App",
+                "harness_id": server.seed_generic_harness_id
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    let response: Value = server
+        .post(
+            &format!("/v1/apps/{}/publish", app["id"].as_str().unwrap()),
+            json!({}),
+        )
+        .await
+        .assert_status(StatusCode::BAD_REQUEST)
+        .json();
+
+    assert!(
+        response["error"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("at least one channel"),
+        "unexpected response: {response:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_update_app_to_published_returns_bad_request() {
+    let server = TestServer::new().await;
+
+    let app: Value = server
+        .post(
+            "/v1/apps",
+            json!({
+                "name": "Patch Published App",
+                "harness_id": server.seed_generic_harness_id
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    let response: Value = server
+        .patch(
+            &format!("/v1/apps/{}", app["id"].as_str().unwrap()),
+            json!({ "status": "published" }),
+        )
+        .await
+        .assert_status(StatusCode::BAD_REQUEST)
+        .json();
+
+    assert!(
+        response["error"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("publish/unpublish endpoints"),
+        "unexpected response: {response:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_publish_archived_app_returns_bad_request() {
+    let server = TestServer::new().await;
+
+    let app: Value = server
+        .post(
+            "/v1/apps",
+            json!({
+                "name": "Archived Publish App",
+                "harness_id": server.seed_generic_harness_id,
+                "channel_type": "webhook",
+                "channel_config": {
+                    "token": "secret-token",
+                    "session_mode": "session_per_invocation",
+                    "message": "check webhook"
+                }
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    server
+        .patch(
+            &format!("/v1/apps/{}", app["id"].as_str().unwrap()),
+            json!({ "status": "archived" }),
+        )
+        .await
+        .assert_status(StatusCode::OK);
+
+    let response: Value = server
+        .post(
+            &format!("/v1/apps/{}/publish", app["id"].as_str().unwrap()),
+            json!({}),
+        )
+        .await
+        .assert_status(StatusCode::BAD_REQUEST)
+        .json();
+
+    assert!(
+        response["error"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("draft before publishing"),
+        "unexpected response: {response:?}"
+    );
+}
+
+#[tokio::test]
 async fn test_update_app_missing_harness_returns_not_found() {
     let server = TestServer::new().await;
 


### PR DESCRIPTION
## What
Require apps to have at least one channel before they can be published.

## Why
A published app with no channels is an invalid state: schedule and webhook invocation are modeled as app channels, so a scheduled app should surface a schedule channel and own a durable schedule binding.

## How
- Added a shared publish guard backed by a lightweight `app_channels` existence query.
- Required `POST /v1/apps/{id}/publish` to publish only draft apps with at least one channel.
- Rejected publish/unpublish lifecycle changes through the generic `PATCH /v1/apps/{id}` path.
- Added API regression tests for channel-less publish rejection, PATCH publish rejection, and archived-app publish rejection.

## Risk
- Low
- Apps intentionally created without channels must add a channel before publishing. Existing draft creation remains unchanged.

## Security
- Threat categories reviewed: TM-API, TM-AUTHZ, TM-TENANT.
- Findings and resolutions: no new public input, auth, tenant, or secret handling surface. The change tightens existing mutating app lifecycle paths, preserves the stronger publish endpoint policy, and uses existing org-scoped app lookup before checking channel existence.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

## Validation
- `bash scripts/lib/check-migration-ordering.sh`
- `cargo fmt --check`
- `CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/tmp/everruns-target-pr1784 cargo check -p everruns-server`
- `CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/tmp/everruns-target-pr1784 cargo test -p everruns-server --test api_integration_test test_update_app_to_published_returns_bad_request --no-run`
- `PORT_PREFIX=286 just start-dev --no-watch` API smoke: channel-less app publish returned 400; schedule-channel app publish succeeded
- `CARGO_TARGET_DIR=/tmp/everruns-target-pr1784 CARGO_INCREMENTAL=0 just pre-push`

Note: PostgreSQL-backed integration tests were compiled locally and are covered by CI. The earlier local attempt to run one targeted PostgreSQL-backed test before starting the dev smoke could not connect to PostgreSQL (`PoolTimedOut`).
