### PR TITLE
fix(mcp): hide HTTP metadata from discovery

### DIFF
--- a/crates/server/src/api/mcp_endpoint/mod.rs
+++ b/crates/server/src/api/mcp_endpoint/mod.rs
@@ -1230,8 +1230,6 @@ async fn tool_discover(
             "name": entry.name,
             "category": entry.category,
             "description": entry.description,
-            "method": entry.method,
-            "path": entry.path,
             "read_only": entry.read_only,
             "output_shape": entry.output_shape,
         });

--- a/crates/server/tests/mcp_endpoint_test.rs
+++ b/crates/server/tests/mcp_endpoint_test.rs
@@ -1001,6 +1001,15 @@ async fn test_mcp_discover_agents() {
         .iter()
         .find(|op| op["name"] == "list_agents")
         .expect("list_agents operation");
+    let list_agents_object = list_agents.as_object().expect("operation object");
+    assert!(
+        !list_agents_object.contains_key("method"),
+        "discover should not expose HTTP methods"
+    );
+    assert!(
+        !list_agents_object.contains_key("path"),
+        "discover should not expose HTTP paths"
+    );
     assert_eq!(list_agents["output_shape"], "paginated");
     assert_eq!(
         list_agents["output_schema"]["properties"]["data"]["type"],
@@ -1130,6 +1139,47 @@ async fn test_mcp_discover_all() {
     assert!(
         !first_operation.contains_key("output_schema"),
         "discover --all should omit output schemas by default"
+    );
+    assert!(
+        !first_operation.contains_key("method"),
+        "discover --all should not expose HTTP methods"
+    );
+    assert!(
+        !first_operation.contains_key("path"),
+        "discover --all should not expose HTTP paths"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_discover_session_database_schema_omits_http_metadata() {
+    let server = TestServer::in_memory().await;
+    let resp = mcp_tool_call(
+        &server,
+        "discover",
+        json!({ "query": "session database schema" }),
+    )
+    .await;
+
+    assert!(
+        !tool_is_error(&resp),
+        "discover failed: {}",
+        tool_text(&resp)
+    );
+    let payload = tool_json(&resp);
+    let operation = payload["operations"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|op| op["name"] == "get_session_database_schema")
+        .expect("get_session_database_schema operation");
+    let operation = operation.as_object().expect("operation object");
+    assert!(
+        !operation.contains_key("method"),
+        "discover should not expose HTTP methods"
+    );
+    assert!(
+        !operation.contains_key("path"),
+        "discover should not expose HTTP paths"
     );
 }
 


### PR DESCRIPTION
## What
Remove HTTP method and path fields from MCP `discover` operation results, and add regression coverage for focused and `all: true` discovery responses.

## Why
MCP discovery should expose model-facing command metadata, not HTTP transport details like `GET /v1/sessions/{session_id}/databases/{name}/schema`.

## How
The MCP `tool_discover` JSON serializer now omits `method` and `path` while keeping internal `CommandMeta` unchanged for read-only classification, tracing, and other internal uses. Tests assert those fields are absent for `list_agents`, `discover all`, and the session database schema operation.

## Risk
- Low
- MCP clients that depended on `discover` returning HTTP transport metadata would need to use the public API docs/OpenAPI surface instead. `query` and `execute` command invocation are unchanged.

## Security
- Threat categories reviewed: TM-MCP / tool catalog data exposure.
- Findings and resolutions: the change reduces model-facing metadata exposure by removing HTTP method and route template fields from discovery output. No auth, authorization, input parsing, SQL, dependency, or resource-limit behavior changed. No threat-model update needed.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

## Validation
- `cargo test -p everruns-server --test mcp_endpoint_test test_mcp_discover -- --nocapture`
- `just pre-push`
- `PORT_PREFIX=274 CARGO_INCREMENTAL=0 just start-dev --no-watch` plus MCP smoke: `discover` for `session database schema` returned `has_method: false` and `has_path: false`
