### PR TITLE
feat(reporting): build async reporting foundation

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -73,6 +73,7 @@ pub mod network_access;
 pub mod organization;
 pub mod payment;
 pub mod principal;
+pub mod reporting;
 pub mod session;
 pub mod session_file;
 pub mod session_resource;

--- a/crates/core/src/permissions.rs
+++ b/crates/core/src/permissions.rs
@@ -50,6 +50,12 @@ pub enum Permission {
     OrgApiKeysManage,
     /// View audit logs (read-only)
     OrgAuditLogsView,
+    /// View semantic reports (read-only)
+    OrgReportsView,
+    /// Manage saved reports and reporting definitions
+    OrgReportsManage,
+    /// Run reporting administrative operations
+    OrgReportsAdmin,
 }
 
 impl Permission {
@@ -73,6 +79,9 @@ impl Permission {
             Permission::OrgMembersManage => "org:members:manage",
             Permission::OrgApiKeysManage => "org:api-keys:manage",
             Permission::OrgAuditLogsView => "org:audit-logs:view",
+            Permission::OrgReportsView => "org:reports:view",
+            Permission::OrgReportsManage => "org:reports:manage",
+            Permission::OrgReportsAdmin => "org:reports:admin",
         }
     }
 
@@ -95,6 +104,9 @@ impl Permission {
         Permission::OrgMembersManage,
         Permission::OrgApiKeysManage,
         Permission::OrgAuditLogsView,
+        Permission::OrgReportsView,
+        Permission::OrgReportsManage,
+        Permission::OrgReportsAdmin,
     ];
 }
 
@@ -127,6 +139,9 @@ const OWNER_PERMISSIONS: &[Permission] = &[
     Permission::OrgMembersManage,
     Permission::OrgApiKeysManage,
     Permission::OrgAuditLogsView,
+    Permission::OrgReportsView,
+    Permission::OrgReportsManage,
+    Permission::OrgReportsAdmin,
 ];
 
 /// Permissions granted to Admin role.
@@ -143,6 +158,8 @@ const ADMIN_PERMISSIONS: &[Permission] = &[
     Permission::OrgMembersManage,
     Permission::OrgApiKeysManage,
     Permission::OrgAuditLogsView,
+    Permission::OrgReportsView,
+    Permission::OrgReportsManage,
 ];
 
 /// Permissions granted to Member role.
@@ -154,6 +171,7 @@ const MEMBER_PERMISSIONS: &[Permission] = &[
     Permission::OrgLlmProvidersView,
     Permission::OrgSettingsView,
     Permission::OrgMembersView,
+    Permission::OrgReportsView,
 ];
 
 /// Check whether a role grants a specific permission.
@@ -886,9 +904,21 @@ mod tests {
 
     #[test]
     fn role_permissions_returns_correct_sets() {
-        assert_eq!(role_permissions(OrgRole::Owner).len(), 17);
-        assert_eq!(role_permissions(OrgRole::Admin).len(), 12);
-        assert_eq!(role_permissions(OrgRole::Member).len(), 6);
+        assert_eq!(role_permissions(OrgRole::Owner).len(), 20);
+        assert_eq!(role_permissions(OrgRole::Admin).len(), 14);
+        assert_eq!(role_permissions(OrgRole::Member).len(), 7);
+        assert!(role_has_permission(
+            OrgRole::Owner,
+            &Permission::OrgReportsAdmin
+        ));
+        assert!(role_has_permission(
+            OrgRole::Admin,
+            &Permission::OrgReportsManage
+        ));
+        assert!(role_has_permission(
+            OrgRole::Member,
+            &Permission::OrgReportsView
+        ));
     }
 
     // -- Caller --

--- a/crates/core/src/reporting.rs
+++ b/crates/core/src/reporting.rs
@@ -1,0 +1,160 @@
+//! Backend-neutral reporting contract.
+//!
+//! Reporting facts are derived, org-scoped analytical data. Callers submit a
+//! constrained semantic query; backend implementations compile that shape to
+//! their own storage/query language and must inject tenant scope themselves.
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::Caller;
+
+#[derive(Debug, Clone)]
+pub struct ReportScope {
+    pub org_id: i64,
+    pub caller: Caller,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct ReportTimeRange {
+    pub from: DateTime<Utc>,
+    pub to: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct ReportQuery {
+    pub dataset: String,
+    pub time_range: ReportTimeRange,
+    #[serde(default)]
+    pub dimensions: Vec<String>,
+    #[serde(default)]
+    pub measures: Vec<String>,
+    #[serde(default)]
+    pub filters: Vec<ReportFilter>,
+    #[serde(default)]
+    pub order_by: Vec<ReportOrderBy>,
+    #[serde(default = "default_report_limit")]
+    pub limit: u32,
+}
+
+fn default_report_limit() -> u32 {
+    100
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct ReportFilter {
+    pub field: String,
+    pub op: ReportFilterOp,
+    pub value: Value,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub enum ReportFilterOp {
+    Eq,
+    Neq,
+    In,
+    Gt,
+    Gte,
+    Lt,
+    Lte,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct ReportOrderBy {
+    #[serde(default)]
+    pub dimension: Option<String>,
+    #[serde(default)]
+    pub measure: Option<String>,
+    #[serde(default = "default_order_direction")]
+    pub direction: ReportOrderDirection,
+}
+
+fn default_order_direction() -> ReportOrderDirection {
+    ReportOrderDirection::Asc
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub enum ReportOrderDirection {
+    Asc,
+    Desc,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct ReportResult {
+    pub as_of: DateTime<Utc>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub freshness_lag_ms: Option<i64>,
+    pub columns: Vec<ReportColumn>,
+    pub rows: Vec<Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct ReportColumn {
+    pub name: String,
+    pub kind: ReportColumnKind,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub enum ReportColumnKind {
+    Dimension,
+    Measure,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct DatasetCatalog {
+    pub datasets: Vec<DatasetCatalogEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct DatasetCatalogEntry {
+    pub name: String,
+    pub dimensions: Vec<String>,
+    pub measures: Vec<String>,
+    pub filter_fields: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SourceKey {
+    pub source_type: String,
+    pub source_id: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct FactBatch {
+    pub records: Vec<FactRecord>,
+}
+
+#[derive(Debug, Clone)]
+pub struct FactRecord {
+    pub dataset: String,
+    pub org_id: i64,
+    pub source_key: String,
+    pub values: Value,
+}
+
+#[async_trait]
+pub trait ReportingProjectionSink: Send + Sync {
+    async fn upsert_facts(&self, batch: FactBatch) -> anyhow::Result<()>;
+    async fn supersede_source(&self, source: SourceKey) -> anyhow::Result<()>;
+}
+
+#[async_trait]
+pub trait ReportingQueryBackend: Send + Sync {
+    async fn query(&self, scope: ReportScope, query: ReportQuery) -> anyhow::Result<ReportResult>;
+}

--- a/crates/server/migrations/040_reporting_foundation.sql
+++ b/crates/server/migrations/040_reporting_foundation.sql
@@ -1,0 +1,210 @@
+-- Reporting phase 1: durable projection outbox, PostgreSQL facts, and indexes.
+-- Facts are replayable projections of canonical operational tables; never use
+-- them as sources of truth for enforcement, conversation replay, or balances.
+
+CREATE TABLE reporting_outbox (
+    id UUID PRIMARY KEY DEFAULT uuidv7(),
+    org_id BIGINT NOT NULL REFERENCES organizations(org_id),
+    source_type TEXT NOT NULL,
+    source_id TEXT NOT NULL,
+    source_version TEXT NOT NULL DEFAULT '',
+    reason TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending'
+        CHECK (status IN ('pending', 'processing', 'completed', 'failed')),
+    attempts INTEGER NOT NULL DEFAULT 0,
+    next_attempt_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_error TEXT,
+    claimed_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT reporting_outbox_source_unique
+        UNIQUE (org_id, source_type, source_id, source_version, reason)
+);
+
+CREATE INDEX idx_reporting_outbox_poll
+    ON reporting_outbox(status, next_attempt_at, org_id, created_at);
+CREATE INDEX idx_reporting_outbox_org_status
+    ON reporting_outbox(org_id, status, next_attempt_at);
+
+CREATE TRIGGER update_reporting_outbox_updated_at BEFORE UPDATE ON reporting_outbox
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+CREATE TABLE fact_llm_generation (
+    org_id BIGINT NOT NULL REFERENCES organizations(org_id),
+    source_key TEXT NOT NULL,
+    session_id UUID,
+    turn_id TEXT,
+    user_id UUID,
+    principal_id UUID,
+    agent_id UUID,
+    agent_name_snapshot TEXT,
+    harness_id UUID,
+    harness_name_snapshot TEXT,
+    app_id UUID,
+    blueprint_id TEXT,
+    created_at TIMESTAMPTZ NOT NULL,
+    time_bucket_day DATE NOT NULL,
+    model TEXT,
+    provider TEXT,
+    finish_reason TEXT,
+    input_tokens BIGINT NOT NULL DEFAULT 0,
+    output_tokens BIGINT NOT NULL DEFAULT 0,
+    cache_read_tokens BIGINT NOT NULL DEFAULT 0,
+    cache_creation_tokens BIGINT NOT NULL DEFAULT 0,
+    total_tokens BIGINT NOT NULL DEFAULT 0,
+    duration_ms BIGINT NOT NULL DEFAULT 0,
+    time_to_first_token_ms BIGINT NOT NULL DEFAULT 0,
+    success_count BIGINT NOT NULL DEFAULT 1,
+    error_count BIGINT NOT NULL DEFAULT 0,
+    projected_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (org_id, source_key)
+);
+
+CREATE INDEX idx_fact_llm_generation_org_created
+    ON fact_llm_generation(org_id, created_at);
+CREATE INDEX idx_fact_llm_generation_org_day
+    ON fact_llm_generation(org_id, time_bucket_day);
+CREATE INDEX idx_fact_llm_generation_model
+    ON fact_llm_generation(org_id, model, provider, created_at);
+
+CREATE TABLE fact_tool_call (
+    org_id BIGINT NOT NULL REFERENCES organizations(org_id),
+    source_key TEXT NOT NULL,
+    session_id UUID,
+    turn_id TEXT,
+    user_id UUID,
+    principal_id UUID,
+    agent_id UUID,
+    agent_name_snapshot TEXT,
+    harness_id UUID,
+    harness_name_snapshot TEXT,
+    app_id UUID,
+    blueprint_id TEXT,
+    created_at TIMESTAMPTZ NOT NULL,
+    time_bucket_day DATE NOT NULL,
+    tool_call_id TEXT,
+    tool_name TEXT,
+    tool_display_name_snapshot TEXT,
+    tool_status TEXT,
+    capability_id TEXT,
+    capability_name_snapshot TEXT,
+    call_count BIGINT NOT NULL DEFAULT 1,
+    success_count BIGINT NOT NULL DEFAULT 0,
+    error_count BIGINT NOT NULL DEFAULT 0,
+    timeout_count BIGINT NOT NULL DEFAULT 0,
+    cancelled_count BIGINT NOT NULL DEFAULT 0,
+    duration_ms BIGINT NOT NULL DEFAULT 0,
+    projected_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (org_id, source_key)
+);
+
+CREATE INDEX idx_fact_tool_call_org_created
+    ON fact_tool_call(org_id, created_at);
+CREATE INDEX idx_fact_tool_call_org_day
+    ON fact_tool_call(org_id, time_bucket_day);
+CREATE INDEX idx_fact_tool_call_tool
+    ON fact_tool_call(org_id, tool_name, tool_status, created_at);
+
+CREATE TABLE fact_turn (
+    org_id BIGINT NOT NULL REFERENCES organizations(org_id),
+    source_key TEXT NOT NULL,
+    session_id UUID,
+    turn_id TEXT,
+    user_id UUID,
+    principal_id UUID,
+    agent_id UUID,
+    agent_name_snapshot TEXT,
+    harness_id UUID,
+    harness_name_snapshot TEXT,
+    app_id UUID,
+    blueprint_id TEXT,
+    created_at TIMESTAMPTZ NOT NULL,
+    time_bucket_day DATE NOT NULL,
+    turn_status TEXT,
+    turn_count BIGINT NOT NULL DEFAULT 1,
+    duration_ms BIGINT NOT NULL DEFAULT 0,
+    iterations BIGINT NOT NULL DEFAULT 0,
+    input_tokens BIGINT NOT NULL DEFAULT 0,
+    output_tokens BIGINT NOT NULL DEFAULT 0,
+    cache_read_tokens BIGINT NOT NULL DEFAULT 0,
+    cache_creation_tokens BIGINT NOT NULL DEFAULT 0,
+    total_tokens BIGINT NOT NULL DEFAULT 0,
+    tool_call_count BIGINT NOT NULL DEFAULT 0,
+    success_count BIGINT NOT NULL DEFAULT 0,
+    error_count BIGINT NOT NULL DEFAULT 0,
+    projected_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (org_id, source_key)
+);
+
+CREATE INDEX idx_fact_turn_org_created ON fact_turn(org_id, created_at);
+CREATE INDEX idx_fact_turn_org_day ON fact_turn(org_id, time_bucket_day);
+CREATE INDEX idx_fact_turn_status ON fact_turn(org_id, turn_status, created_at);
+
+CREATE TABLE fact_session (
+    org_id BIGINT NOT NULL REFERENCES organizations(org_id),
+    source_key TEXT NOT NULL,
+    session_id UUID,
+    user_id UUID,
+    principal_id UUID,
+    agent_id UUID,
+    agent_name_snapshot TEXT,
+    harness_id UUID,
+    harness_name_snapshot TEXT,
+    app_id UUID,
+    blueprint_id TEXT,
+    created_at TIMESTAMPTZ NOT NULL,
+    time_bucket_day DATE NOT NULL,
+    session_status TEXT,
+    started_at TIMESTAMPTZ,
+    finished_at TIMESTAMPTZ,
+    last_active_at TIMESTAMPTZ,
+    session_count BIGINT NOT NULL DEFAULT 1,
+    duration_ms BIGINT NOT NULL DEFAULT 0,
+    turn_count BIGINT NOT NULL DEFAULT 0,
+    input_tokens BIGINT NOT NULL DEFAULT 0,
+    output_tokens BIGINT NOT NULL DEFAULT 0,
+    cache_read_tokens BIGINT NOT NULL DEFAULT 0,
+    cache_creation_tokens BIGINT NOT NULL DEFAULT 0,
+    total_tokens BIGINT NOT NULL DEFAULT 0,
+    tool_call_count BIGINT NOT NULL DEFAULT 0,
+    projected_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (org_id, source_key)
+);
+
+CREATE INDEX idx_fact_session_org_created ON fact_session(org_id, created_at);
+CREATE INDEX idx_fact_session_org_day ON fact_session(org_id, time_bucket_day);
+CREATE INDEX idx_fact_session_status ON fact_session(org_id, session_status, created_at);
+
+CREATE TABLE fact_budget_posting (
+    org_id BIGINT NOT NULL REFERENCES organizations(org_id),
+    source_key TEXT NOT NULL,
+    session_id UUID,
+    user_id UUID,
+    principal_id UUID,
+    agent_id UUID,
+    agent_name_snapshot TEXT,
+    harness_id UUID,
+    harness_name_snapshot TEXT,
+    app_id UUID,
+    blueprint_id TEXT,
+    created_at TIMESTAMPTZ NOT NULL,
+    time_bucket_day DATE NOT NULL,
+    budget_id UUID,
+    budget_subject_type TEXT,
+    budget_subject_id TEXT,
+    currency TEXT,
+    meter_source TEXT,
+    ref_type TEXT,
+    amount DOUBLE PRECISION NOT NULL DEFAULT 0,
+    debit_count BIGINT NOT NULL DEFAULT 0,
+    credit_count BIGINT NOT NULL DEFAULT 0,
+    projected_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (org_id, source_key)
+);
+
+CREATE INDEX idx_fact_budget_posting_org_created
+    ON fact_budget_posting(org_id, created_at);
+CREATE INDEX idx_fact_budget_posting_org_day
+    ON fact_budget_posting(org_id, time_bucket_day);
+CREATE INDEX idx_fact_budget_posting_budget
+    ON fact_budget_posting(org_id, budget_id, created_at);

--- a/crates/server/src/api/mod.rs
+++ b/crates/server/src/api/mod.rs
@@ -39,6 +39,7 @@ pub mod organizations;
 pub mod payments;
 pub mod prometheus;
 pub mod public;
+pub mod reporting;
 pub mod resolver;
 pub mod schedules;
 pub mod session_databases;

--- a/crates/server/src/api/reporting.rs
+++ b/crates/server/src/api/reporting.rs
@@ -1,0 +1,130 @@
+use std::sync::Arc;
+
+use axum::{
+    Json, Router,
+    extract::{Query, State},
+    http::StatusCode,
+    routing::{get, post},
+};
+use everruns_core::Caller;
+use everruns_core::reporting::{DatasetCatalog, ReportQuery, ReportResult};
+use serde::Deserialize;
+use utoipa::{IntoParams, ToSchema};
+
+use super::common::{ErrorResponse, impl_auth_state};
+use super::dispatch::impl_dispatchable;
+use crate::auth::{AuthState, ResolvedOrg};
+use crate::domains::common::{Command, Ctx};
+use crate::domains::reporting::types::ProjectorRunResult;
+use crate::domains::reporting::{
+    GetReportCatalog, ReportingService, RunReportQuery, RunReportingProjector,
+};
+use crate::storage::StorageBackend;
+
+type ApiError = (StatusCode, Json<ErrorResponse>);
+
+#[derive(Clone)]
+pub struct AppState {
+    pub db: Arc<StorageBackend>,
+    pub reporting_service: Arc<ReportingService>,
+    pub auth: AuthState,
+}
+
+impl AppState {
+    pub fn new(db: Arc<StorageBackend>, auth: AuthState) -> Self {
+        let reporting_service = Arc::new(ReportingService::new(db.clone()));
+        Self {
+            db,
+            reporting_service,
+            auth,
+        }
+    }
+
+    fn ctx(&self, org: &ResolvedOrg) -> Ctx {
+        Ctx::minimal(
+            Caller::from(org),
+            self.db.clone(),
+            None,
+            self.auth.permission_resolver.clone(),
+        )
+        .with_reporting_service(self.reporting_service.clone())
+    }
+}
+
+impl_auth_state!(AppState);
+impl_dispatchable!(AppState);
+
+#[derive(Debug, Clone, Deserialize, IntoParams, ToSchema)]
+pub struct ProjectorRunQuery {
+    #[serde(default = "default_projector_limit")]
+    pub limit: i64,
+}
+
+fn default_projector_limit() -> i64 {
+    100
+}
+
+pub fn routes(state: AppState) -> Router {
+    Router::new()
+        .route("/v1/reports/catalog", get(get_catalog))
+        .route("/v1/reports/query", post(run_query))
+        .route("/v1/reports/projector/run", post(run_projector))
+        .with_state(state)
+}
+
+#[utoipa::path(
+    get,
+    path = "/v1/reports/catalog",
+    responses(
+        (status = 200, description = "Reporting semantic catalog", body = DatasetCatalog),
+        (status = 403, description = "Forbidden", body = ErrorResponse)
+    ),
+    tag = "reporting"
+)]
+pub async fn get_catalog(
+    org: ResolvedOrg,
+    State(state): State<AppState>,
+) -> Result<Json<DatasetCatalog>, ApiError> {
+    Ok(Json(GetReportCatalog.run(&state.ctx(&org)).await?))
+}
+
+#[utoipa::path(
+    post,
+    path = "/v1/reports/query",
+    request_body = ReportQuery,
+    responses(
+        (status = 200, description = "Reporting query result", body = ReportResult),
+        (status = 400, description = "Invalid semantic query", body = ErrorResponse),
+        (status = 403, description = "Forbidden", body = ErrorResponse)
+    ),
+    tag = "reporting"
+)]
+pub async fn run_query(
+    org: ResolvedOrg,
+    State(state): State<AppState>,
+    Json(query): Json<ReportQuery>,
+) -> Result<Json<ReportResult>, ApiError> {
+    Ok(Json(RunReportQuery(query).run(&state.ctx(&org)).await?))
+}
+
+#[utoipa::path(
+    post,
+    path = "/v1/reports/projector/run",
+    params(ProjectorRunQuery),
+    responses(
+        (status = 200, description = "Reporting projector run result", body = ProjectorRunResult),
+        (status = 403, description = "Forbidden", body = ErrorResponse)
+    ),
+    tag = "reporting"
+)]
+pub async fn run_projector(
+    org: ResolvedOrg,
+    State(state): State<AppState>,
+    Query(query): Query<ProjectorRunQuery>,
+) -> Result<Json<ProjectorRunResult>, ApiError> {
+    Ok(Json(
+        RunReportingProjector { limit: query.limit }
+            .run(&state.ctx(&org))
+            .await?,
+    ))
+}

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -971,6 +971,7 @@ impl ServerAppBuilder {
             api::knowledge_bases::AppState::new(db.clone(), auth_state.clone());
         let payments_state =
             api::payments::AppState::new(db.clone(), encryption.clone(), auth_state.clone());
+        let reporting_state = api::reporting::AppState::new(db.clone(), auth_state.clone());
         let audit_logs_state = api::audit_logs::AppState::new(
             db.clone(),
             capability_service.clone(),
@@ -1100,6 +1101,7 @@ impl ServerAppBuilder {
             .merge(api::memory_stores::routes(memory_stores_state))
             .merge(api::knowledge_bases::routes(knowledge_bases_state))
             .merge(api::payments::routes(payments_state))
+            .merge(api::reporting::routes(reporting_state))
             .merge(api::user_connections::routes(user_connections_state))
             .merge(api::session_schedules::routes(session_schedules_state))
             .merge(api::audit_logs::routes(audit_logs_state))

--- a/crates/server/src/domains/common.rs
+++ b/crates/server/src/domains/common.rs
@@ -198,6 +198,7 @@ pub struct Ctx {
     pub llm_provider_service: Option<Arc<crate::domains::llm_providers::LlmProviderService>>,
     pub model_sync_service: Option<Arc<crate::services::ModelSyncService>>,
     pub eval_service: Option<Arc<crate::domains::evals::EvalService>>,
+    pub reporting_service: Option<Arc<crate::domains::reporting::ReportingService>>,
     pub sqldb_store: Option<Arc<dyn everruns_core::session_sqldb::SessionSqlDbStore>>,
     pub workflow_store: Option<Arc<dyn WorkflowEventStore + Send + Sync>>,
     pub runner: Option<Arc<dyn everruns_worker::AgentRunner>>,
@@ -246,6 +247,7 @@ impl Ctx {
             llm_provider_service: None,
             model_sync_service: None,
             eval_service: None,
+            reporting_service: None,
             sqldb_store: None,
             workflow_store: None,
             runner: None,
@@ -371,6 +373,14 @@ impl Ctx {
 
     pub fn with_eval_service(mut self, service: Arc<crate::domains::evals::EvalService>) -> Self {
         self.eval_service = Some(service);
+        self
+    }
+
+    pub fn with_reporting_service(
+        mut self,
+        service: Arc<crate::domains::reporting::ReportingService>,
+    ) -> Self {
+        self.reporting_service = Some(service);
         self
     }
 

--- a/crates/server/src/domains/mod.rs
+++ b/crates/server/src/domains/mod.rs
@@ -25,6 +25,7 @@ pub mod notifications;
 pub mod org_resolver;
 pub mod organizations;
 pub mod payments;
+pub mod reporting;
 pub mod schedules;
 pub mod session_commands;
 pub mod session_databases;

--- a/crates/server/src/domains/reporting/catalog.rs
+++ b/crates/server/src/domains/reporting/catalog.rs
@@ -1,0 +1,775 @@
+use std::collections::BTreeMap;
+
+use everruns_core::reporting::{
+    DatasetCatalog, DatasetCatalogEntry, ReportFilterOp, ReportOrderBy, ReportQuery,
+};
+
+use crate::domains::common::CommandError;
+
+pub const MAX_REPORT_LIMIT: u32 = 1_000;
+const MAX_DIMENSIONS: usize = 8;
+const MAX_MEASURES: usize = 16;
+const MAX_FILTERS: usize = 20;
+const MAX_RANGE_DAYS: i64 = 370;
+
+#[derive(Debug, Clone, Copy)]
+pub struct FieldSpec {
+    pub name: &'static str,
+    pub sql: &'static str,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct MeasureSpec {
+    pub name: &'static str,
+    pub sql: &'static str,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct DatasetSpec {
+    pub name: &'static str,
+    pub table: &'static str,
+    pub dimensions: &'static [FieldSpec],
+    pub measures: &'static [MeasureSpec],
+    pub filters: &'static [FieldSpec],
+}
+
+const LLM_DIMS: &[FieldSpec] = &[
+    FieldSpec {
+        name: "session",
+        sql: "session_id",
+    },
+    FieldSpec {
+        name: "turn",
+        sql: "turn_id",
+    },
+    FieldSpec {
+        name: "user",
+        sql: "user_id",
+    },
+    FieldSpec {
+        name: "principal",
+        sql: "principal_id",
+    },
+    FieldSpec {
+        name: "agent",
+        sql: "agent_id",
+    },
+    FieldSpec {
+        name: "agent_name",
+        sql: "agent_name_snapshot",
+    },
+    FieldSpec {
+        name: "harness",
+        sql: "harness_id",
+    },
+    FieldSpec {
+        name: "harness_name",
+        sql: "harness_name_snapshot",
+    },
+    FieldSpec {
+        name: "app",
+        sql: "app_id",
+    },
+    FieldSpec {
+        name: "blueprint",
+        sql: "blueprint_id",
+    },
+    FieldSpec {
+        name: "day",
+        sql: "time_bucket_day",
+    },
+    FieldSpec {
+        name: "model",
+        sql: "model",
+    },
+    FieldSpec {
+        name: "provider",
+        sql: "provider",
+    },
+    FieldSpec {
+        name: "finish_reason",
+        sql: "finish_reason",
+    },
+];
+
+const TOOL_DIMS: &[FieldSpec] = &[
+    FieldSpec {
+        name: "session",
+        sql: "session_id",
+    },
+    FieldSpec {
+        name: "turn",
+        sql: "turn_id",
+    },
+    FieldSpec {
+        name: "user",
+        sql: "user_id",
+    },
+    FieldSpec {
+        name: "principal",
+        sql: "principal_id",
+    },
+    FieldSpec {
+        name: "agent",
+        sql: "agent_id",
+    },
+    FieldSpec {
+        name: "agent_name",
+        sql: "agent_name_snapshot",
+    },
+    FieldSpec {
+        name: "harness",
+        sql: "harness_id",
+    },
+    FieldSpec {
+        name: "harness_name",
+        sql: "harness_name_snapshot",
+    },
+    FieldSpec {
+        name: "app",
+        sql: "app_id",
+    },
+    FieldSpec {
+        name: "blueprint",
+        sql: "blueprint_id",
+    },
+    FieldSpec {
+        name: "day",
+        sql: "time_bucket_day",
+    },
+    FieldSpec {
+        name: "tool",
+        sql: "tool_name",
+    },
+    FieldSpec {
+        name: "tool_display_name",
+        sql: "tool_display_name_snapshot",
+    },
+    FieldSpec {
+        name: "tool_status",
+        sql: "tool_status",
+    },
+    FieldSpec {
+        name: "capability",
+        sql: "capability_id",
+    },
+    FieldSpec {
+        name: "capability_name",
+        sql: "capability_name_snapshot",
+    },
+];
+
+const TURN_DIMS: &[FieldSpec] = &[
+    FieldSpec {
+        name: "session",
+        sql: "session_id",
+    },
+    FieldSpec {
+        name: "turn",
+        sql: "turn_id",
+    },
+    FieldSpec {
+        name: "user",
+        sql: "user_id",
+    },
+    FieldSpec {
+        name: "principal",
+        sql: "principal_id",
+    },
+    FieldSpec {
+        name: "agent",
+        sql: "agent_id",
+    },
+    FieldSpec {
+        name: "agent_name",
+        sql: "agent_name_snapshot",
+    },
+    FieldSpec {
+        name: "harness",
+        sql: "harness_id",
+    },
+    FieldSpec {
+        name: "harness_name",
+        sql: "harness_name_snapshot",
+    },
+    FieldSpec {
+        name: "app",
+        sql: "app_id",
+    },
+    FieldSpec {
+        name: "blueprint",
+        sql: "blueprint_id",
+    },
+    FieldSpec {
+        name: "day",
+        sql: "time_bucket_day",
+    },
+    FieldSpec {
+        name: "turn_status",
+        sql: "turn_status",
+    },
+];
+
+const SESSION_DIMS: &[FieldSpec] = &[
+    FieldSpec {
+        name: "session",
+        sql: "session_id",
+    },
+    FieldSpec {
+        name: "user",
+        sql: "user_id",
+    },
+    FieldSpec {
+        name: "principal",
+        sql: "principal_id",
+    },
+    FieldSpec {
+        name: "agent",
+        sql: "agent_id",
+    },
+    FieldSpec {
+        name: "agent_name",
+        sql: "agent_name_snapshot",
+    },
+    FieldSpec {
+        name: "harness",
+        sql: "harness_id",
+    },
+    FieldSpec {
+        name: "harness_name",
+        sql: "harness_name_snapshot",
+    },
+    FieldSpec {
+        name: "app",
+        sql: "app_id",
+    },
+    FieldSpec {
+        name: "blueprint",
+        sql: "blueprint_id",
+    },
+    FieldSpec {
+        name: "day",
+        sql: "time_bucket_day",
+    },
+    FieldSpec {
+        name: "session_status",
+        sql: "session_status",
+    },
+];
+
+const BUDGET_DIMS: &[FieldSpec] = &[
+    FieldSpec {
+        name: "session",
+        sql: "session_id",
+    },
+    FieldSpec {
+        name: "user",
+        sql: "user_id",
+    },
+    FieldSpec {
+        name: "principal",
+        sql: "principal_id",
+    },
+    FieldSpec {
+        name: "agent",
+        sql: "agent_id",
+    },
+    FieldSpec {
+        name: "agent_name",
+        sql: "agent_name_snapshot",
+    },
+    FieldSpec {
+        name: "harness",
+        sql: "harness_id",
+    },
+    FieldSpec {
+        name: "harness_name",
+        sql: "harness_name_snapshot",
+    },
+    FieldSpec {
+        name: "app",
+        sql: "app_id",
+    },
+    FieldSpec {
+        name: "blueprint",
+        sql: "blueprint_id",
+    },
+    FieldSpec {
+        name: "day",
+        sql: "time_bucket_day",
+    },
+    FieldSpec {
+        name: "budget",
+        sql: "budget_id",
+    },
+    FieldSpec {
+        name: "budget_subject_type",
+        sql: "budget_subject_type",
+    },
+    FieldSpec {
+        name: "budget_subject",
+        sql: "budget_subject_id",
+    },
+    FieldSpec {
+        name: "currency",
+        sql: "currency",
+    },
+    FieldSpec {
+        name: "meter_source",
+        sql: "meter_source",
+    },
+    FieldSpec {
+        name: "ref_type",
+        sql: "ref_type",
+    },
+];
+
+const LLM_MEASURES: &[MeasureSpec] = &[
+    MeasureSpec {
+        name: "input_tokens",
+        sql: "COALESCE(SUM(input_tokens), 0)",
+    },
+    MeasureSpec {
+        name: "output_tokens",
+        sql: "COALESCE(SUM(output_tokens), 0)",
+    },
+    MeasureSpec {
+        name: "cache_read_tokens",
+        sql: "COALESCE(SUM(cache_read_tokens), 0)",
+    },
+    MeasureSpec {
+        name: "cache_creation_tokens",
+        sql: "COALESCE(SUM(cache_creation_tokens), 0)",
+    },
+    MeasureSpec {
+        name: "total_tokens",
+        sql: "COALESCE(SUM(total_tokens), 0)",
+    },
+    MeasureSpec {
+        name: "duration_ms",
+        sql: "COALESCE(SUM(duration_ms), 0)",
+    },
+    MeasureSpec {
+        name: "avg_duration_ms",
+        sql: "COALESCE(AVG(NULLIF(duration_ms, 0)), 0)",
+    },
+    MeasureSpec {
+        name: "time_to_first_token_ms",
+        sql: "COALESCE(SUM(time_to_first_token_ms), 0)",
+    },
+    MeasureSpec {
+        name: "avg_time_to_first_token_ms",
+        sql: "COALESCE(AVG(NULLIF(time_to_first_token_ms, 0)), 0)",
+    },
+    MeasureSpec {
+        name: "success_count",
+        sql: "COALESCE(SUM(success_count), 0)",
+    },
+    MeasureSpec {
+        name: "error_count",
+        sql: "COALESCE(SUM(error_count), 0)",
+    },
+];
+
+const TOOL_MEASURES: &[MeasureSpec] = &[
+    MeasureSpec {
+        name: "call_count",
+        sql: "COALESCE(SUM(call_count), 0)",
+    },
+    MeasureSpec {
+        name: "success_count",
+        sql: "COALESCE(SUM(success_count), 0)",
+    },
+    MeasureSpec {
+        name: "error_count",
+        sql: "COALESCE(SUM(error_count), 0)",
+    },
+    MeasureSpec {
+        name: "timeout_count",
+        sql: "COALESCE(SUM(timeout_count), 0)",
+    },
+    MeasureSpec {
+        name: "cancelled_count",
+        sql: "COALESCE(SUM(cancelled_count), 0)",
+    },
+    MeasureSpec {
+        name: "duration_ms",
+        sql: "COALESCE(SUM(duration_ms), 0)",
+    },
+    MeasureSpec {
+        name: "avg_duration_ms",
+        sql: "COALESCE(AVG(NULLIF(duration_ms, 0)), 0)",
+    },
+];
+
+const TURN_MEASURES: &[MeasureSpec] = &[
+    MeasureSpec {
+        name: "turn_count",
+        sql: "COALESCE(SUM(turn_count), 0)",
+    },
+    MeasureSpec {
+        name: "duration_ms",
+        sql: "COALESCE(SUM(duration_ms), 0)",
+    },
+    MeasureSpec {
+        name: "avg_duration_ms",
+        sql: "COALESCE(AVG(NULLIF(duration_ms, 0)), 0)",
+    },
+    MeasureSpec {
+        name: "iterations",
+        sql: "COALESCE(SUM(iterations), 0)",
+    },
+    MeasureSpec {
+        name: "tool_call_count",
+        sql: "COALESCE(SUM(tool_call_count), 0)",
+    },
+    MeasureSpec {
+        name: "success_count",
+        sql: "COALESCE(SUM(success_count), 0)",
+    },
+    MeasureSpec {
+        name: "error_count",
+        sql: "COALESCE(SUM(error_count), 0)",
+    },
+    MeasureSpec {
+        name: "input_tokens",
+        sql: "COALESCE(SUM(input_tokens), 0)",
+    },
+    MeasureSpec {
+        name: "output_tokens",
+        sql: "COALESCE(SUM(output_tokens), 0)",
+    },
+    MeasureSpec {
+        name: "total_tokens",
+        sql: "COALESCE(SUM(total_tokens), 0)",
+    },
+];
+
+const SESSION_MEASURES: &[MeasureSpec] = &[
+    MeasureSpec {
+        name: "session_count",
+        sql: "COALESCE(SUM(session_count), 0)",
+    },
+    MeasureSpec {
+        name: "duration_ms",
+        sql: "COALESCE(SUM(duration_ms), 0)",
+    },
+    MeasureSpec {
+        name: "avg_duration_ms",
+        sql: "COALESCE(AVG(NULLIF(duration_ms, 0)), 0)",
+    },
+    MeasureSpec {
+        name: "turn_count",
+        sql: "COALESCE(SUM(turn_count), 0)",
+    },
+    MeasureSpec {
+        name: "tool_call_count",
+        sql: "COALESCE(SUM(tool_call_count), 0)",
+    },
+    MeasureSpec {
+        name: "input_tokens",
+        sql: "COALESCE(SUM(input_tokens), 0)",
+    },
+    MeasureSpec {
+        name: "output_tokens",
+        sql: "COALESCE(SUM(output_tokens), 0)",
+    },
+    MeasureSpec {
+        name: "total_tokens",
+        sql: "COALESCE(SUM(total_tokens), 0)",
+    },
+];
+
+const BUDGET_MEASURES: &[MeasureSpec] = &[
+    MeasureSpec {
+        name: "amount",
+        sql: "COALESCE(SUM(amount), 0)",
+    },
+    MeasureSpec {
+        name: "debit_count",
+        sql: "COALESCE(SUM(debit_count), 0)",
+    },
+    MeasureSpec {
+        name: "credit_count",
+        sql: "COALESCE(SUM(credit_count), 0)",
+    },
+];
+
+const DATASETS: &[DatasetSpec] = &[
+    DatasetSpec {
+        name: "llm_generations",
+        table: "fact_llm_generation",
+        dimensions: LLM_DIMS,
+        measures: LLM_MEASURES,
+        filters: LLM_DIMS,
+    },
+    DatasetSpec {
+        name: "tool_calls",
+        table: "fact_tool_call",
+        dimensions: TOOL_DIMS,
+        measures: TOOL_MEASURES,
+        filters: TOOL_DIMS,
+    },
+    DatasetSpec {
+        name: "turns",
+        table: "fact_turn",
+        dimensions: TURN_DIMS,
+        measures: TURN_MEASURES,
+        filters: TURN_DIMS,
+    },
+    DatasetSpec {
+        name: "sessions",
+        table: "fact_session",
+        dimensions: SESSION_DIMS,
+        measures: SESSION_MEASURES,
+        filters: SESSION_DIMS,
+    },
+    DatasetSpec {
+        name: "budget_postings",
+        table: "fact_budget_posting",
+        dimensions: BUDGET_DIMS,
+        measures: BUDGET_MEASURES,
+        filters: BUDGET_DIMS,
+    },
+];
+
+pub fn catalog() -> DatasetCatalog {
+    DatasetCatalog {
+        datasets: DATASETS
+            .iter()
+            .map(|dataset| DatasetCatalogEntry {
+                name: dataset.name.to_string(),
+                dimensions: dataset
+                    .dimensions
+                    .iter()
+                    .map(|field| field.name.to_string())
+                    .collect(),
+                measures: dataset
+                    .measures
+                    .iter()
+                    .map(|measure| measure.name.to_string())
+                    .collect(),
+                filter_fields: dataset
+                    .filters
+                    .iter()
+                    .map(|field| field.name.to_string())
+                    .collect(),
+            })
+            .collect(),
+    }
+}
+
+pub fn dataset(name: &str) -> Option<&'static DatasetSpec> {
+    DATASETS.iter().find(|dataset| dataset.name == name)
+}
+
+pub fn dimension(dataset: &DatasetSpec, name: &str) -> Option<&'static FieldSpec> {
+    dataset.dimensions.iter().find(|field| field.name == name)
+}
+
+pub fn filter_field(dataset: &DatasetSpec, name: &str) -> Option<&'static FieldSpec> {
+    dataset.filters.iter().find(|field| field.name == name)
+}
+
+pub fn measure(dataset: &DatasetSpec, name: &str) -> Option<&'static MeasureSpec> {
+    dataset.measures.iter().find(|measure| measure.name == name)
+}
+
+pub fn validate_query(query: &ReportQuery) -> Result<(), CommandError> {
+    let dataset = dataset(&query.dataset)
+        .ok_or_else(|| CommandError::bad_request("Unknown reporting dataset"))?;
+
+    if query.time_range.from >= query.time_range.to {
+        return Err(CommandError::bad_request(
+            "time_range.from must be before time_range.to",
+        ));
+    }
+    if query.time_range.to - query.time_range.from > chrono::Duration::days(MAX_RANGE_DAYS) {
+        return Err(CommandError::bad_request(
+            "Reporting time range is too large",
+        ));
+    }
+    if query.limit == 0 || query.limit > MAX_REPORT_LIMIT {
+        return Err(CommandError::bad_request(
+            "Reporting limit must be between 1 and 1000",
+        ));
+    }
+    if query.dimensions.len() > MAX_DIMENSIONS {
+        return Err(CommandError::bad_request("Too many reporting dimensions"));
+    }
+    if query.measures.is_empty() || query.measures.len() > MAX_MEASURES {
+        return Err(CommandError::bad_request(
+            "Reporting query must include between 1 and 16 measures",
+        ));
+    }
+    if query.filters.len() > MAX_FILTERS {
+        return Err(CommandError::bad_request("Too many reporting filters"));
+    }
+
+    let mut seen_dimensions = BTreeMap::new();
+    for name in &query.dimensions {
+        if dimension(dataset, name).is_none() {
+            return Err(CommandError::bad_request(
+                "Invalid dimension for reporting dataset",
+            ));
+        }
+        if seen_dimensions.insert(name, ()).is_some() {
+            return Err(CommandError::bad_request("Duplicate reporting dimension"));
+        }
+    }
+
+    let mut seen_measures = BTreeMap::new();
+    for name in &query.measures {
+        if measure(dataset, name).is_none() {
+            return Err(CommandError::bad_request(
+                "Invalid measure for reporting dataset",
+            ));
+        }
+        if seen_measures.insert(name, ()).is_some() {
+            return Err(CommandError::bad_request("Duplicate reporting measure"));
+        }
+    }
+
+    for filter in &query.filters {
+        if filter.field == "org_id" || filter_field(dataset, &filter.field).is_none() {
+            return Err(CommandError::bad_request("Invalid reporting filter field"));
+        }
+        if matches!(filter.op, ReportFilterOp::In) && !filter.value.is_array() {
+            return Err(CommandError::bad_request(
+                "in filters require an array value",
+            ));
+        }
+        if matches!(
+            filter.op,
+            ReportFilterOp::Gt | ReportFilterOp::Gte | ReportFilterOp::Lt | ReportFilterOp::Lte
+        ) {
+            return Err(CommandError::bad_request(
+                "Reporting filters only support eq, neq, and in comparisons",
+            ));
+        }
+    }
+
+    for order in &query.order_by {
+        validate_order_by(dataset, order)?;
+    }
+    Ok(())
+}
+
+fn validate_order_by(dataset: &DatasetSpec, order: &ReportOrderBy) -> Result<(), CommandError> {
+    match (&order.dimension, &order.measure) {
+        (Some(_), Some(_)) | (None, None) => Err(CommandError::bad_request(
+            "Each order_by entry must specify exactly one dimension or measure",
+        )),
+        (Some(name), None) => {
+            if dimension(dataset, name).is_none() {
+                return Err(CommandError::bad_request("Invalid order_by dimension"));
+            }
+            Ok(())
+        }
+        (None, Some(name)) => {
+            if measure(dataset, name).is_none() {
+                return Err(CommandError::bad_request("Invalid order_by measure"));
+            }
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::{Duration, Utc};
+    use everruns_core::reporting::{
+        ReportFilter, ReportFilterOp, ReportOrderBy, ReportOrderDirection, ReportQuery,
+        ReportTimeRange,
+    };
+    use serde_json::json;
+
+    use super::{MAX_REPORT_LIMIT, catalog, validate_query};
+
+    fn query() -> ReportQuery {
+        let to = Utc::now();
+        ReportQuery {
+            dataset: "tool_calls".to_string(),
+            time_range: ReportTimeRange {
+                from: to - Duration::days(7),
+                to,
+            },
+            dimensions: vec!["tool".to_string(), "day".to_string()],
+            measures: vec!["call_count".to_string()],
+            filters: vec![ReportFilter {
+                field: "tool_status".to_string(),
+                op: ReportFilterOp::Eq,
+                value: json!("success"),
+            }],
+            order_by: vec![ReportOrderBy {
+                dimension: None,
+                measure: Some("call_count".to_string()),
+                direction: ReportOrderDirection::Desc,
+            }],
+            limit: 100,
+        }
+    }
+
+    #[test]
+    fn catalog_exposes_phase_one_datasets() {
+        let catalog = catalog();
+        let names: Vec<_> = catalog
+            .datasets
+            .iter()
+            .map(|dataset| dataset.name.as_str())
+            .collect();
+        assert!(names.contains(&"llm_generations"));
+        assert!(names.contains(&"tool_calls"));
+        assert!(names.contains(&"turns"));
+        assert!(names.contains(&"sessions"));
+        assert!(names.contains(&"budget_postings"));
+    }
+
+    #[test]
+    fn validates_representative_tool_query() {
+        validate_query(&query()).expect("valid report query");
+    }
+
+    #[test]
+    fn rejects_org_id_filters() {
+        let mut query = query();
+        query.filters = vec![ReportFilter {
+            field: "org_id".to_string(),
+            op: ReportFilterOp::Eq,
+            value: json!(1),
+        }];
+
+        assert!(validate_query(&query).is_err());
+    }
+
+    #[test]
+    fn rejects_dimension_from_another_dataset() {
+        let mut query = query();
+        query.dimensions = vec!["model".to_string()];
+
+        assert!(validate_query(&query).is_err());
+    }
+
+    #[test]
+    fn enforces_bounded_limit_and_time_range() {
+        let mut limit_query = query();
+        limit_query.limit = MAX_REPORT_LIMIT + 1;
+        assert!(validate_query(&limit_query).is_err());
+
+        let mut range_query = query();
+        range_query.time_range.from = range_query.time_range.to - Duration::days(371);
+        assert!(validate_query(&range_query).is_err());
+    }
+
+    #[test]
+    fn rejects_untyped_comparison_filters() {
+        let mut query = query();
+        query.filters = vec![ReportFilter {
+            field: "tool".to_string(),
+            op: ReportFilterOp::Gt,
+            value: json!("bash"),
+        }];
+
+        assert!(validate_query(&query).is_err());
+    }
+}

--- a/crates/server/src/domains/reporting/commands.rs
+++ b/crates/server/src/domains/reporting/commands.rs
@@ -1,0 +1,111 @@
+use everruns_core::Policy;
+use everruns_core::reporting::{DatasetCatalog, ReportQuery, ReportResult, ReportScope};
+use serde::Deserialize;
+use utoipa::ToSchema;
+
+use super::catalog;
+use super::types::ProjectorRunResult;
+use super::{REPORT_ADMIN, REPORT_VIEW};
+use crate::domains::common::{Command, CommandDescriptor, CommandError, CommandMeta, Ctx};
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct RunReportQuery(pub ReportQuery);
+
+impl Command for RunReportQuery {
+    type Output = ReportResult;
+
+    fn meta() -> CommandMeta {
+        CommandMeta {
+            name: "run_report_query",
+            category: "reporting",
+            description: "Run an org-scoped semantic reporting query.",
+            method: "POST",
+            path: "/v1/reports/query",
+        }
+    }
+
+    fn policy() -> Option<&'static Policy> {
+        Some(&REPORT_VIEW)
+    }
+
+    async fn execute(self, ctx: &Ctx) -> Result<ReportResult, CommandError> {
+        let service = ctx.reporting_service.as_ref().ok_or_else(|| {
+            CommandError::Internal(anyhow::anyhow!("Reporting service not configured"))
+        })?;
+        service
+            .query(
+                ReportScope {
+                    org_id: ctx.org_id(),
+                    caller: ctx.caller.clone(),
+                },
+                self.0,
+            )
+            .await
+    }
+}
+
+inventory::submit! { CommandDescriptor::of::<RunReportQuery>() }
+
+#[derive(Debug, Default, Deserialize, ToSchema)]
+pub struct GetReportCatalog;
+
+impl Command for GetReportCatalog {
+    type Output = DatasetCatalog;
+
+    fn meta() -> CommandMeta {
+        CommandMeta {
+            name: "get_report_catalog",
+            category: "reporting",
+            description: "Return semantic reporting datasets, dimensions, measures, and filter fields.",
+            method: "GET",
+            path: "/v1/reports/catalog",
+        }
+    }
+
+    fn policy() -> Option<&'static Policy> {
+        Some(&REPORT_VIEW)
+    }
+
+    async fn execute(self, _ctx: &Ctx) -> Result<DatasetCatalog, CommandError> {
+        Ok(catalog::catalog())
+    }
+}
+
+inventory::submit! { CommandDescriptor::of::<GetReportCatalog>() }
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct RunReportingProjector {
+    #[serde(default = "default_projector_limit")]
+    pub limit: i64,
+}
+
+fn default_projector_limit() -> i64 {
+    100
+}
+
+impl Command for RunReportingProjector {
+    type Output = ProjectorRunResult;
+
+    fn meta() -> CommandMeta {
+        CommandMeta {
+            name: "run_reporting_projector",
+            category: "reporting",
+            description: "Claim and process pending reporting outbox rows.",
+            method: "POST",
+            path: "/v1/reports/projector/run",
+        }
+    }
+
+    fn policy() -> Option<&'static Policy> {
+        Some(&REPORT_ADMIN)
+    }
+
+    async fn execute(self, ctx: &Ctx) -> Result<ProjectorRunResult, CommandError> {
+        let service = ctx.reporting_service.as_ref().ok_or_else(|| {
+            CommandError::Internal(anyhow::anyhow!("Reporting service not configured"))
+        })?;
+        service.run_projector_once(self.limit).await
+    }
+}
+
+inventory::submit! { CommandDescriptor::of::<RunReportingProjector>() }

--- a/crates/server/src/domains/reporting/mod.rs
+++ b/crates/server/src/domains/reporting/mod.rs
@@ -1,0 +1,29 @@
+//! Reporting domain.
+//!
+//! Queries are semantic and org-scoped by construction. Storage backends compile
+//! this constrained model to SQL; user input is never treated as SQL.
+
+use everruns_core::{Permission, Policy, Rule};
+
+pub mod catalog;
+pub mod commands;
+pub mod service;
+pub mod types;
+
+pub use commands::*;
+pub use service::*;
+
+pub const REPORT_VIEW: Policy = Policy {
+    id: "report.view",
+    rules: &[Rule::UserHasPermission(Permission::OrgReportsView)],
+};
+
+pub const REPORT_MANAGE: Policy = Policy {
+    id: "report.manage",
+    rules: &[Rule::UserHasPermission(Permission::OrgReportsManage)],
+};
+
+pub const REPORT_ADMIN: Policy = Policy {
+    id: "report.admin",
+    rules: &[Rule::UserHasPermission(Permission::OrgReportsAdmin)],
+};

--- a/crates/server/src/domains/reporting/service.rs
+++ b/crates/server/src/domains/reporting/service.rs
@@ -1,0 +1,67 @@
+use std::sync::Arc;
+
+use everruns_core::reporting::{ReportQuery, ReportResult, ReportScope, ReportingQueryBackend};
+
+use super::catalog;
+use super::types::ProjectorRunResult;
+use crate::domains::common::{CommandError, classify_anyhow};
+use crate::storage::StorageBackend;
+use crate::storage::reporting::{PostgresReportingProjector, PostgresReportingQueryBackend};
+
+#[derive(Clone)]
+pub struct ReportingService {
+    db: Arc<StorageBackend>,
+}
+
+impl ReportingService {
+    pub fn new(db: Arc<StorageBackend>) -> Self {
+        Self { db }
+    }
+
+    pub async fn query(
+        &self,
+        scope: ReportScope,
+        query: ReportQuery,
+    ) -> Result<ReportResult, CommandError> {
+        catalog::validate_query(&query)?;
+        match self.db.as_ref() {
+            StorageBackend::Postgres(db) => PostgresReportingQueryBackend::new(db.pool().clone())
+                .query(scope, query)
+                .await
+                .map_err(classify_anyhow),
+            StorageBackend::InMemory(_) => Ok(ReportResult {
+                as_of: chrono::Utc::now(),
+                freshness_lag_ms: None,
+                columns: query
+                    .dimensions
+                    .iter()
+                    .map(|name| everruns_core::reporting::ReportColumn {
+                        name: name.clone(),
+                        kind: everruns_core::reporting::ReportColumnKind::Dimension,
+                    })
+                    .chain(query.measures.iter().map(|name| {
+                        everruns_core::reporting::ReportColumn {
+                            name: name.clone(),
+                            kind: everruns_core::reporting::ReportColumnKind::Measure,
+                        }
+                    }))
+                    .collect(),
+                rows: Vec::new(),
+            }),
+        }
+    }
+
+    pub async fn run_projector_once(&self, limit: i64) -> Result<ProjectorRunResult, CommandError> {
+        match self.db.as_ref() {
+            StorageBackend::Postgres(db) => PostgresReportingProjector::new(db.pool().clone())
+                .run_once(limit)
+                .await
+                .map_err(classify_anyhow),
+            StorageBackend::InMemory(_) => Ok(ProjectorRunResult {
+                claimed: 0,
+                completed: 0,
+                failed: 0,
+            }),
+        }
+    }
+}

--- a/crates/server/src/domains/reporting/types.rs
+++ b/crates/server/src/domains/reporting/types.rs
@@ -1,0 +1,12 @@
+pub use everruns_core::reporting::{
+    DatasetCatalog, DatasetCatalogEntry, ReportColumn, ReportColumnKind, ReportFilter,
+    ReportFilterOp, ReportOrderBy, ReportOrderDirection, ReportQuery, ReportResult, ReportScope,
+    ReportTimeRange,
+};
+
+#[derive(Debug, Clone, serde::Serialize, utoipa::ToSchema)]
+pub struct ProjectorRunResult {
+    pub claimed: usize,
+    pub completed: usize,
+    pub failed: usize,
+}

--- a/crates/server/src/openapi.rs
+++ b/crates/server/src/openapi.rs
@@ -217,6 +217,10 @@ use utoipa::OpenApi;
         api::payments::update_payment_policy,
         api::payments::disable_payment_policy,
         api::payments::list_payment_attempts,
+        // Reporting
+        api::reporting::get_catalog,
+        api::reporting::run_query,
+        api::reporting::run_projector,
     ),
     components(
         schemas(
@@ -359,6 +363,19 @@ use utoipa::OpenApi;
             domains::payments::types::UpdatePaymentAccountRequest,
             domains::payments::types::CreatePaymentPolicyRequest,
             domains::payments::types::UpdatePaymentPolicyRequest,
+            everruns_core::reporting::DatasetCatalog,
+            everruns_core::reporting::DatasetCatalogEntry,
+            everruns_core::reporting::ReportColumn,
+            everruns_core::reporting::ReportColumnKind,
+            everruns_core::reporting::ReportFilter,
+            everruns_core::reporting::ReportFilterOp,
+            everruns_core::reporting::ReportOrderBy,
+            everruns_core::reporting::ReportOrderDirection,
+            everruns_core::reporting::ReportQuery,
+            everruns_core::reporting::ReportResult,
+            everruns_core::reporting::ReportTimeRange,
+            api::reporting::ProjectorRunQuery,
+            domains::reporting::types::ProjectorRunResult,
         )
     ),
     tags(
@@ -386,6 +403,7 @@ use utoipa::OpenApi;
         (name = "harnesses", description = "Harness management endpoints"),
         (name = "skills", description = "Skills registry endpoints"),
         (name = "payments", description = "Machine payment wallet, policy, and attempt endpoints"),
+        (name = "reporting", description = "Org-scoped semantic reporting endpoints"),
     ),
     info(
         title = "Everruns API",

--- a/crates/server/src/storage/mod.rs
+++ b/crates/server/src/storage/mod.rs
@@ -21,6 +21,7 @@ pub mod memory_store_backend;
 pub mod message_store;
 pub mod models;
 pub mod password;
+pub mod reporting;
 pub mod repositories;
 pub mod session_file_store;
 pub mod session_resource_store;

--- a/crates/server/src/storage/reporting/mod.rs
+++ b/crates/server/src/storage/reporting/mod.rs
@@ -1,0 +1,6 @@
+pub mod models;
+pub mod outbox;
+pub mod postgres_query_backend;
+
+pub use outbox::PostgresReportingProjector;
+pub use postgres_query_backend::PostgresReportingQueryBackend;

--- a/crates/server/src/storage/reporting/models.rs
+++ b/crates/server/src/storage/reporting/models.rs
@@ -1,0 +1,19 @@
+use chrono::{DateTime, Utc};
+use sqlx::FromRow;
+use uuid::Uuid;
+
+#[derive(Debug, Clone, FromRow)]
+pub struct ReportingOutboxRow {
+    pub id: Uuid,
+    pub org_id: i64,
+    pub source_type: String,
+    pub source_id: String,
+    pub source_version: String,
+    pub reason: String,
+    pub status: String,
+    pub attempts: i32,
+    pub next_attempt_at: DateTime<Utc>,
+    pub last_error: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}

--- a/crates/server/src/storage/reporting/outbox.rs
+++ b/crates/server/src/storage/reporting/outbox.rs
@@ -1,0 +1,580 @@
+use anyhow::{Context, Result};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use super::models::ReportingOutboxRow;
+use crate::domains::reporting::types::ProjectorRunResult;
+
+#[derive(Clone)]
+pub struct PostgresReportingProjector {
+    pool: PgPool,
+}
+
+impl PostgresReportingProjector {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+
+    pub async fn run_once(&self, limit: i64) -> Result<ProjectorRunResult> {
+        let rows = self.claim_pending(limit).await?;
+        let claimed = rows.len();
+        let mut completed = 0;
+        let mut failed = 0;
+
+        for row in rows {
+            match self.project_row(&row).await {
+                Ok(()) => {
+                    completed += 1;
+                    self.mark_completed(row.id).await?;
+                }
+                Err(error) => {
+                    failed += 1;
+                    self.mark_failed(row.id, row.attempts, &error.to_string())
+                        .await?;
+                }
+            }
+        }
+
+        Ok(ProjectorRunResult {
+            claimed,
+            completed,
+            failed,
+        })
+    }
+
+    async fn claim_pending(&self, limit: i64) -> Result<Vec<ReportingOutboxRow>> {
+        let rows = sqlx::query_as::<_, ReportingOutboxRow>(
+            r#"
+            UPDATE reporting_outbox
+               SET status = 'processing',
+                   attempts = attempts + 1,
+                   claimed_at = NOW(),
+                   updated_at = NOW()
+             WHERE id IN (
+                SELECT id
+                  FROM reporting_outbox
+                 WHERE status IN ('pending', 'failed')
+                   AND next_attempt_at <= NOW()
+                 ORDER BY created_at ASC
+                 LIMIT $1
+                 FOR UPDATE SKIP LOCKED
+             )
+         RETURNING id, org_id, source_type, source_id, source_version, reason, status,
+                   attempts, next_attempt_at, last_error, created_at, updated_at
+            "#,
+        )
+        .bind(limit.clamp(1, 1_000))
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows)
+    }
+
+    async fn mark_completed(&self, id: Uuid) -> Result<()> {
+        sqlx::query(
+            r#"
+            UPDATE reporting_outbox
+               SET status = 'completed',
+                   last_error = NULL,
+                   updated_at = NOW()
+             WHERE id = $1
+            "#,
+        )
+        .bind(id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    async fn mark_failed(&self, id: Uuid, attempts: i32, error: &str) -> Result<()> {
+        let delay_seconds = (2_i64.pow(attempts.clamp(1, 8) as u32) * 30).min(3_600);
+        sqlx::query(
+            r#"
+            UPDATE reporting_outbox
+               SET status = 'failed',
+                   next_attempt_at = NOW() + ($2::TEXT || ' seconds')::INTERVAL,
+                   last_error = LEFT($3, 2000),
+                   updated_at = NOW()
+             WHERE id = $1
+            "#,
+        )
+        .bind(id)
+        .bind(delay_seconds.to_string())
+        .bind(error)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    async fn project_row(&self, row: &ReportingOutboxRow) -> Result<()> {
+        match row.source_type.as_str() {
+            "llm_generation" => {
+                self.project_llm_generation(row.org_id, &row.source_id)
+                    .await
+            }
+            "event" => self.project_event(row.org_id, &row.source_id).await,
+            "session" => self.project_session(row.org_id, &row.source_id).await,
+            "usage_ledger" => {
+                self.project_budget_posting(row.org_id, &row.source_id)
+                    .await
+            }
+            source => {
+                tracing::debug!(
+                    source_type = source,
+                    "Skipping unsupported reporting source"
+                );
+                Ok(())
+            }
+        }
+    }
+
+    async fn project_llm_generation(&self, org_id: i64, source_id: &str) -> Result<()> {
+        let id = Uuid::parse_str(source_id).context("invalid llm_generation source id")?;
+        sqlx::query(
+            r#"
+            INSERT INTO fact_llm_generation (
+                org_id, source_key, session_id, turn_id, user_id, principal_id, agent_id,
+                agent_name_snapshot, harness_id, harness_name_snapshot, app_id, blueprint_id,
+                created_at, time_bucket_day, model, provider, finish_reason,
+                input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens,
+                total_tokens, duration_ms, time_to_first_token_ms, success_count, error_count,
+                projected_at
+            )
+            SELECT
+                lg.org_id,
+                'llm_generation:' || lg.id::TEXT,
+                lg.session_id,
+                lg.turn_id::TEXT,
+                s.resolved_owner_user_id,
+                s.owner_principal_id,
+                s.agent_id,
+                a.name,
+                s.harness_id,
+                h.name,
+                s.app_id,
+                s.blueprint_id,
+                lg.created_at,
+                (lg.created_at AT TIME ZONE 'UTC')::DATE,
+                lg.model,
+                lg.provider,
+                lg.finish_reason,
+                lg.input_tokens,
+                lg.output_tokens,
+                lg.cache_read_tokens,
+                lg.cache_creation_tokens,
+                lg.input_tokens + lg.output_tokens + lg.cache_read_tokens + lg.cache_creation_tokens,
+                COALESCE(lg.duration_ms, 0),
+                0,
+                1,
+                0,
+                NOW()
+            FROM llm_generations lg
+            JOIN sessions s ON s.id = lg.session_id AND s.org_id = lg.org_id
+            LEFT JOIN agents a ON a.id = s.agent_id AND a.org_id = lg.org_id
+            LEFT JOIN harnesses h ON h.id = s.harness_id AND h.org_id = lg.org_id
+            WHERE lg.id = $1 AND lg.org_id = $2
+            ON CONFLICT (org_id, source_key) DO UPDATE SET
+                session_id = EXCLUDED.session_id,
+                turn_id = EXCLUDED.turn_id,
+                user_id = EXCLUDED.user_id,
+                principal_id = EXCLUDED.principal_id,
+                agent_id = EXCLUDED.agent_id,
+                agent_name_snapshot = EXCLUDED.agent_name_snapshot,
+                harness_id = EXCLUDED.harness_id,
+                harness_name_snapshot = EXCLUDED.harness_name_snapshot,
+                app_id = EXCLUDED.app_id,
+                blueprint_id = EXCLUDED.blueprint_id,
+                created_at = EXCLUDED.created_at,
+                time_bucket_day = EXCLUDED.time_bucket_day,
+                model = EXCLUDED.model,
+                provider = EXCLUDED.provider,
+                finish_reason = EXCLUDED.finish_reason,
+                input_tokens = EXCLUDED.input_tokens,
+                output_tokens = EXCLUDED.output_tokens,
+                cache_read_tokens = EXCLUDED.cache_read_tokens,
+                cache_creation_tokens = EXCLUDED.cache_creation_tokens,
+                total_tokens = EXCLUDED.total_tokens,
+                duration_ms = EXCLUDED.duration_ms,
+                projected_at = NOW()
+            "#,
+        )
+        .bind(id)
+        .bind(org_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    async fn project_event(&self, org_id: i64, source_id: &str) -> Result<()> {
+        let id = Uuid::parse_str(source_id).context("invalid event source id")?;
+        let event_type: Option<(String,)> = sqlx::query_as(
+            "SELECT e.event_type FROM events e JOIN sessions s ON s.id = e.session_id WHERE e.id = $1 AND s.org_id = $2",
+        )
+        .bind(id)
+        .bind(org_id)
+        .fetch_optional(&self.pool)
+        .await?;
+        match event_type.as_ref().map(|row| row.0.as_str()) {
+            Some("tool.completed") => self.project_tool_event(org_id, id).await,
+            Some("turn.completed" | "turn.failed" | "turn.cancelled") => {
+                self.project_turn_event(org_id, id).await
+            }
+            _ => Ok(()),
+        }
+    }
+
+    async fn project_tool_event(&self, org_id: i64, id: Uuid) -> Result<()> {
+        sqlx::query(
+            r#"
+            INSERT INTO fact_tool_call (
+                org_id, source_key, session_id, turn_id, user_id, principal_id, agent_id,
+                agent_name_snapshot, harness_id, harness_name_snapshot, app_id, blueprint_id,
+                created_at, time_bucket_day, tool_call_id, tool_name,
+                tool_display_name_snapshot, tool_status, capability_id,
+                capability_name_snapshot, call_count, success_count, error_count,
+                timeout_count, cancelled_count, duration_ms, projected_at
+            )
+            SELECT
+                s.org_id,
+                'event:' || e.id::TEXT,
+                e.session_id,
+                COALESCE(e.context->>'turn_id', e.data->>'turn_id'),
+                s.resolved_owner_user_id,
+                s.owner_principal_id,
+                s.agent_id,
+                a.name,
+                s.harness_id,
+                h.name,
+                s.app_id,
+                s.blueprint_id,
+                e.ts,
+                (e.ts AT TIME ZONE 'UTC')::DATE,
+                e.data->>'tool_call_id',
+                e.data->>'tool_name',
+                e.data->>'display_name',
+                COALESCE(e.data->>'status', CASE WHEN e.data->>'success' = 'true' THEN 'success' ELSE 'error' END),
+                e.data->>'capability_id',
+                e.data->>'capability_name',
+                1,
+                CASE WHEN COALESCE(e.data->>'status', '') = 'success' OR e.data->>'success' = 'true' THEN 1 ELSE 0 END,
+                CASE WHEN COALESCE(e.data->>'status', '') = 'error' OR e.data->>'success' = 'false' THEN 1 ELSE 0 END,
+                CASE WHEN e.data->>'status' = 'timeout' THEN 1 ELSE 0 END,
+                CASE WHEN e.data->>'status' = 'cancelled' THEN 1 ELSE 0 END,
+                CASE WHEN COALESCE(e.data->>'duration_ms', '') ~ '^[0-9]+$'
+                     THEN (e.data->>'duration_ms')::BIGINT
+                     ELSE 0
+                END,
+                NOW()
+            FROM events e
+            JOIN sessions s ON s.id = e.session_id
+            LEFT JOIN agents a ON a.id = s.agent_id AND a.org_id = s.org_id
+            LEFT JOIN harnesses h ON h.id = s.harness_id AND h.org_id = s.org_id
+            WHERE e.id = $1 AND s.org_id = $2
+            ON CONFLICT (org_id, source_key) DO UPDATE SET
+                turn_id = EXCLUDED.turn_id,
+                user_id = EXCLUDED.user_id,
+                principal_id = EXCLUDED.principal_id,
+                agent_id = EXCLUDED.agent_id,
+                agent_name_snapshot = EXCLUDED.agent_name_snapshot,
+                harness_id = EXCLUDED.harness_id,
+                harness_name_snapshot = EXCLUDED.harness_name_snapshot,
+                app_id = EXCLUDED.app_id,
+                blueprint_id = EXCLUDED.blueprint_id,
+                created_at = EXCLUDED.created_at,
+                time_bucket_day = EXCLUDED.time_bucket_day,
+                tool_call_id = EXCLUDED.tool_call_id,
+                tool_name = EXCLUDED.tool_name,
+                tool_display_name_snapshot = EXCLUDED.tool_display_name_snapshot,
+                tool_status = EXCLUDED.tool_status,
+                capability_id = EXCLUDED.capability_id,
+                capability_name_snapshot = EXCLUDED.capability_name_snapshot,
+                success_count = EXCLUDED.success_count,
+                error_count = EXCLUDED.error_count,
+                timeout_count = EXCLUDED.timeout_count,
+                cancelled_count = EXCLUDED.cancelled_count,
+                duration_ms = EXCLUDED.duration_ms,
+                projected_at = NOW()
+            "#,
+        )
+        .bind(id)
+        .bind(org_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    async fn project_turn_event(&self, org_id: i64, id: Uuid) -> Result<()> {
+        sqlx::query(
+            r#"
+            INSERT INTO fact_turn (
+                org_id, source_key, session_id, turn_id, user_id, principal_id, agent_id,
+                agent_name_snapshot, harness_id, harness_name_snapshot, app_id, blueprint_id,
+                created_at, time_bucket_day, turn_status, turn_count, duration_ms,
+                iterations, input_tokens, output_tokens, cache_read_tokens,
+                cache_creation_tokens, total_tokens, tool_call_count, success_count,
+                error_count, projected_at
+            )
+            SELECT
+                s.org_id,
+                'event:' || e.id::TEXT,
+                e.session_id,
+                COALESCE(e.data->>'turn_id', e.context->>'turn_id'),
+                s.resolved_owner_user_id,
+                s.owner_principal_id,
+                s.agent_id,
+                a.name,
+                s.harness_id,
+                h.name,
+                s.app_id,
+                s.blueprint_id,
+                e.ts,
+                (e.ts AT TIME ZONE 'UTC')::DATE,
+                CASE e.event_type
+                    WHEN 'turn.completed' THEN 'completed'
+                    WHEN 'turn.failed' THEN 'failed'
+                    WHEN 'turn.cancelled' THEN 'cancelled'
+                    ELSE e.event_type
+                END,
+                1,
+                CASE WHEN COALESCE(e.data->>'duration_ms', '') ~ '^[0-9]+$'
+                     THEN (e.data->>'duration_ms')::BIGINT
+                     ELSE 0
+                END,
+                CASE WHEN COALESCE(e.data->>'iterations', '') ~ '^[0-9]+$'
+                     THEN (e.data->>'iterations')::BIGINT
+                     ELSE 0
+                END,
+                CASE WHEN COALESCE(e.data#>>'{usage,input_tokens}', '') ~ '^[0-9]+$'
+                     THEN (e.data#>>'{usage,input_tokens}')::BIGINT
+                     ELSE 0
+                END,
+                CASE WHEN COALESCE(e.data#>>'{usage,output_tokens}', '') ~ '^[0-9]+$'
+                     THEN (e.data#>>'{usage,output_tokens}')::BIGINT
+                     ELSE 0
+                END,
+                CASE WHEN COALESCE(e.data#>>'{usage,cache_read_tokens}', '') ~ '^[0-9]+$'
+                     THEN (e.data#>>'{usage,cache_read_tokens}')::BIGINT
+                     ELSE 0
+                END,
+                CASE WHEN COALESCE(e.data#>>'{usage,cache_creation_tokens}', '') ~ '^[0-9]+$'
+                     THEN (e.data#>>'{usage,cache_creation_tokens}')::BIGINT
+                     ELSE 0
+                END,
+                CASE WHEN COALESCE(e.data#>>'{usage,input_tokens}', '') ~ '^[0-9]+$'
+                     THEN (e.data#>>'{usage,input_tokens}')::BIGINT
+                     ELSE 0
+                END
+                + CASE WHEN COALESCE(e.data#>>'{usage,output_tokens}', '') ~ '^[0-9]+$'
+                       THEN (e.data#>>'{usage,output_tokens}')::BIGINT
+                       ELSE 0
+                  END,
+                (
+                    SELECT COUNT(*)
+                    FROM events tool_events
+                    WHERE tool_events.session_id = e.session_id
+                      AND tool_events.event_type = 'tool.completed'
+                      AND COALESCE(tool_events.context->>'turn_id', tool_events.data->>'turn_id') =
+                          COALESCE(e.data->>'turn_id', e.context->>'turn_id')
+                ),
+                CASE WHEN e.event_type = 'turn.completed' THEN 1 ELSE 0 END,
+                CASE WHEN e.event_type IN ('turn.failed', 'turn.cancelled') THEN 1 ELSE 0 END,
+                NOW()
+            FROM events e
+            JOIN sessions s ON s.id = e.session_id
+            LEFT JOIN agents a ON a.id = s.agent_id AND a.org_id = s.org_id
+            LEFT JOIN harnesses h ON h.id = s.harness_id AND h.org_id = s.org_id
+            WHERE e.id = $1 AND s.org_id = $2
+            ON CONFLICT (org_id, source_key) DO UPDATE SET
+                turn_id = EXCLUDED.turn_id,
+                user_id = EXCLUDED.user_id,
+                principal_id = EXCLUDED.principal_id,
+                agent_id = EXCLUDED.agent_id,
+                agent_name_snapshot = EXCLUDED.agent_name_snapshot,
+                harness_id = EXCLUDED.harness_id,
+                harness_name_snapshot = EXCLUDED.harness_name_snapshot,
+                app_id = EXCLUDED.app_id,
+                blueprint_id = EXCLUDED.blueprint_id,
+                created_at = EXCLUDED.created_at,
+                time_bucket_day = EXCLUDED.time_bucket_day,
+                turn_status = EXCLUDED.turn_status,
+                duration_ms = EXCLUDED.duration_ms,
+                iterations = EXCLUDED.iterations,
+                input_tokens = EXCLUDED.input_tokens,
+                output_tokens = EXCLUDED.output_tokens,
+                cache_read_tokens = EXCLUDED.cache_read_tokens,
+                cache_creation_tokens = EXCLUDED.cache_creation_tokens,
+                total_tokens = EXCLUDED.total_tokens,
+                tool_call_count = EXCLUDED.tool_call_count,
+                success_count = EXCLUDED.success_count,
+                error_count = EXCLUDED.error_count,
+                projected_at = NOW()
+            "#,
+        )
+        .bind(id)
+        .bind(org_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    async fn project_session(&self, org_id: i64, source_id: &str) -> Result<()> {
+        let id = Uuid::parse_str(source_id).context("invalid session source id")?;
+        sqlx::query(
+            r#"
+            INSERT INTO fact_session (
+                org_id, source_key, session_id, user_id, principal_id, agent_id,
+                agent_name_snapshot, harness_id, harness_name_snapshot, app_id,
+                blueprint_id, created_at, time_bucket_day, session_status, started_at,
+                finished_at, last_active_at, session_count, duration_ms, turn_count,
+                input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens,
+                total_tokens, tool_call_count, projected_at
+            )
+            SELECT
+                s.org_id,
+                'session:' || s.id::TEXT,
+                s.id,
+                s.resolved_owner_user_id,
+                s.owner_principal_id,
+                s.agent_id,
+                a.name,
+                s.harness_id,
+                h.name,
+                s.app_id,
+                s.blueprint_id,
+                s.created_at,
+                (s.created_at AT TIME ZONE 'UTC')::DATE,
+                s.status,
+                s.started_at,
+                s.finished_at,
+                s.updated_at,
+                1,
+                CASE
+                    WHEN s.started_at IS NOT NULL AND s.finished_at IS NOT NULL
+                    THEN GREATEST(EXTRACT(EPOCH FROM (s.finished_at - s.started_at)) * 1000, 0)::BIGINT
+                    ELSE 0
+                END,
+                (
+                    SELECT COUNT(*)
+                    FROM events e
+                    WHERE e.session_id = s.id
+                      AND e.event_type IN ('turn.completed', 'turn.failed', 'turn.cancelled')
+                ),
+                s.total_input_tokens,
+                s.total_output_tokens,
+                s.total_cache_read_tokens,
+                s.total_cache_creation_tokens,
+                s.total_input_tokens + s.total_output_tokens
+                    + s.total_cache_read_tokens + s.total_cache_creation_tokens,
+                (
+                    SELECT COUNT(*)
+                    FROM events e
+                    WHERE e.session_id = s.id
+                      AND e.event_type = 'tool.completed'
+                ),
+                NOW()
+            FROM sessions s
+            LEFT JOIN agents a ON a.id = s.agent_id AND a.org_id = s.org_id
+            LEFT JOIN harnesses h ON h.id = s.harness_id AND h.org_id = s.org_id
+            WHERE s.id = $1 AND s.org_id = $2
+            ON CONFLICT (org_id, source_key) DO UPDATE SET
+                user_id = EXCLUDED.user_id,
+                principal_id = EXCLUDED.principal_id,
+                agent_id = EXCLUDED.agent_id,
+                agent_name_snapshot = EXCLUDED.agent_name_snapshot,
+                harness_id = EXCLUDED.harness_id,
+                harness_name_snapshot = EXCLUDED.harness_name_snapshot,
+                app_id = EXCLUDED.app_id,
+                blueprint_id = EXCLUDED.blueprint_id,
+                session_status = EXCLUDED.session_status,
+                started_at = EXCLUDED.started_at,
+                finished_at = EXCLUDED.finished_at,
+                last_active_at = EXCLUDED.last_active_at,
+                duration_ms = EXCLUDED.duration_ms,
+                turn_count = EXCLUDED.turn_count,
+                input_tokens = EXCLUDED.input_tokens,
+                output_tokens = EXCLUDED.output_tokens,
+                cache_read_tokens = EXCLUDED.cache_read_tokens,
+                cache_creation_tokens = EXCLUDED.cache_creation_tokens,
+                total_tokens = EXCLUDED.total_tokens,
+                tool_call_count = EXCLUDED.tool_call_count,
+                projected_at = NOW()
+            "#,
+        )
+        .bind(id)
+        .bind(org_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    async fn project_budget_posting(&self, org_id: i64, source_id: &str) -> Result<()> {
+        let id = Uuid::parse_str(source_id).context("invalid usage_ledger source id")?;
+        sqlx::query(
+            r#"
+            INSERT INTO fact_budget_posting (
+                org_id, source_key, session_id, user_id, principal_id, agent_id,
+                agent_name_snapshot, harness_id, harness_name_snapshot, app_id,
+                blueprint_id, created_at, time_bucket_day, budget_id,
+                budget_subject_type, budget_subject_id, currency, meter_source,
+                ref_type, amount, debit_count, credit_count, projected_at
+            )
+            SELECT
+                ul.org_id,
+                'usage_ledger:' || ul.id::TEXT,
+                ul.session_id,
+                ul.user_id,
+                ul.principal_id,
+                ul.agent_id,
+                a.name,
+                ul.harness_id,
+                h.name,
+                s.app_id,
+                s.blueprint_id,
+                ul.created_at,
+                (ul.created_at AT TIME ZONE 'UTC')::DATE,
+                ul.budget_id,
+                b.subject_type,
+                b.subject_id,
+                ul.currency,
+                ul.meter_source,
+                ul.ref_type,
+                ul.amount,
+                CASE WHEN ul.amount >= 0 THEN 1 ELSE 0 END,
+                CASE WHEN ul.amount < 0 THEN 1 ELSE 0 END,
+                NOW()
+            FROM usage_ledger ul
+            LEFT JOIN budgets b ON b.id = ul.budget_id AND b.org_id = ul.org_id
+            LEFT JOIN sessions s ON s.id = ul.session_id AND s.org_id = ul.org_id
+            LEFT JOIN agents a ON a.id = ul.agent_id AND a.org_id = ul.org_id
+            LEFT JOIN harnesses h ON h.id = ul.harness_id AND h.org_id = ul.org_id
+            WHERE ul.id = $1 AND ul.org_id = $2
+            ON CONFLICT (org_id, source_key) DO UPDATE SET
+                session_id = EXCLUDED.session_id,
+                user_id = EXCLUDED.user_id,
+                principal_id = EXCLUDED.principal_id,
+                agent_id = EXCLUDED.agent_id,
+                agent_name_snapshot = EXCLUDED.agent_name_snapshot,
+                harness_id = EXCLUDED.harness_id,
+                harness_name_snapshot = EXCLUDED.harness_name_snapshot,
+                app_id = EXCLUDED.app_id,
+                blueprint_id = EXCLUDED.blueprint_id,
+                created_at = EXCLUDED.created_at,
+                time_bucket_day = EXCLUDED.time_bucket_day,
+                budget_id = EXCLUDED.budget_id,
+                budget_subject_type = EXCLUDED.budget_subject_type,
+                budget_subject_id = EXCLUDED.budget_subject_id,
+                currency = EXCLUDED.currency,
+                meter_source = EXCLUDED.meter_source,
+                ref_type = EXCLUDED.ref_type,
+                amount = EXCLUDED.amount,
+                debit_count = EXCLUDED.debit_count,
+                credit_count = EXCLUDED.credit_count,
+                projected_at = NOW()
+            "#,
+        )
+        .bind(id)
+        .bind(org_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+}

--- a/crates/server/src/storage/reporting/postgres_query_backend.rs
+++ b/crates/server/src/storage/reporting/postgres_query_backend.rs
@@ -1,0 +1,213 @@
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use everruns_core::reporting::{
+    ReportColumn, ReportColumnKind, ReportFilterOp, ReportOrderDirection, ReportQuery,
+    ReportResult, ReportScope, ReportingQueryBackend,
+};
+use serde_json::{Map, Value};
+use sqlx::{PgPool, QueryBuilder, Row};
+
+use crate::domains::reporting::catalog;
+
+#[derive(Clone)]
+pub struct PostgresReportingQueryBackend {
+    pool: PgPool,
+}
+
+impl PostgresReportingQueryBackend {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl ReportingQueryBackend for PostgresReportingQueryBackend {
+    async fn query(&self, scope: ReportScope, query: ReportQuery) -> Result<ReportResult> {
+        let dataset =
+            catalog::dataset(&query.dataset).context("reporting dataset already validated")?;
+        let mut columns = Vec::new();
+        let mut select_parts = Vec::new();
+        let mut group_parts = Vec::new();
+
+        for dimension_name in &query.dimensions {
+            let dimension = catalog::dimension(dataset, dimension_name)
+                .context("dimension already validated")?;
+            select_parts.push(format!(
+                "to_jsonb({}) AS \"{}\"",
+                dimension.sql, dimension.name
+            ));
+            group_parts.push(dimension.sql.to_string());
+            columns.push(ReportColumn {
+                name: dimension.name.to_string(),
+                kind: ReportColumnKind::Dimension,
+            });
+        }
+
+        for measure_name in &query.measures {
+            let measure =
+                catalog::measure(dataset, measure_name).context("measure already validated")?;
+            select_parts.push(format!("to_jsonb({}) AS \"{}\"", measure.sql, measure.name));
+            columns.push(ReportColumn {
+                name: measure.name.to_string(),
+                kind: ReportColumnKind::Measure,
+            });
+        }
+
+        let mut builder = QueryBuilder::new(format!(
+            "SELECT {} FROM {} WHERE org_id = ",
+            select_parts.join(", "),
+            dataset.table
+        ));
+        builder.push_bind(scope.org_id);
+        builder.push(" AND created_at >= ");
+        builder.push_bind(query.time_range.from);
+        builder.push(" AND created_at <= ");
+        builder.push_bind(query.time_range.to);
+
+        for filter in &query.filters {
+            let field = catalog::filter_field(dataset, &filter.field)
+                .context("filter already validated")?;
+            builder.push(" AND ");
+            builder.push(field.sql);
+            match filter.op {
+                ReportFilterOp::Eq => {
+                    builder.push("::TEXT = ");
+                    bind_scalar_as_text(&mut builder, &filter.value)?;
+                }
+                ReportFilterOp::Neq => {
+                    builder.push("::TEXT <> ");
+                    bind_scalar_as_text(&mut builder, &filter.value)?;
+                }
+                ReportFilterOp::In => {
+                    builder.push("::TEXT = ANY(");
+                    builder.push_bind(string_array(&filter.value)?);
+                    builder.push(")");
+                }
+                ReportFilterOp::Gt => {
+                    builder.push(" > ");
+                    bind_comparable(&mut builder, &filter.value)?;
+                }
+                ReportFilterOp::Gte => {
+                    builder.push(" >= ");
+                    bind_comparable(&mut builder, &filter.value)?;
+                }
+                ReportFilterOp::Lt => {
+                    builder.push(" < ");
+                    bind_comparable(&mut builder, &filter.value)?;
+                }
+                ReportFilterOp::Lte => {
+                    builder.push(" <= ");
+                    bind_comparable(&mut builder, &filter.value)?;
+                }
+            }
+        }
+
+        if !group_parts.is_empty() {
+            builder.push(" GROUP BY ");
+            builder.push(group_parts.join(", "));
+        }
+
+        if !query.order_by.is_empty() {
+            builder.push(" ORDER BY ");
+            for (index, order) in query.order_by.iter().enumerate() {
+                if index > 0 {
+                    builder.push(", ");
+                }
+                let name = order
+                    .dimension
+                    .as_deref()
+                    .or(order.measure.as_deref())
+                    .context("order_by already validated")?;
+                builder.push("\"");
+                builder.push(name);
+                builder.push("\" ");
+                builder.push(match order.direction {
+                    ReportOrderDirection::Asc => "ASC",
+                    ReportOrderDirection::Desc => "DESC",
+                });
+            }
+        }
+
+        builder.push(" LIMIT ");
+        builder.push_bind(i64::from(query.limit));
+
+        let rows = builder.build().fetch_all(&self.pool).await?;
+        let mut result_rows = Vec::with_capacity(rows.len());
+        for row in rows {
+            let mut object = Map::new();
+            for column in &columns {
+                let value: Value = row.try_get(column.name.as_str())?;
+                object.insert(column.name.clone(), value);
+            }
+            result_rows.push(Value::Object(object));
+        }
+
+        let freshness_lag_ms = latest_projection_lag_ms(&self.pool, dataset.table, scope.org_id)
+            .await
+            .ok()
+            .flatten();
+
+        Ok(ReportResult {
+            as_of: chrono::Utc::now(),
+            freshness_lag_ms,
+            columns,
+            rows: result_rows,
+        })
+    }
+}
+
+fn bind_scalar_as_text<'a>(
+    builder: &mut QueryBuilder<'a, sqlx::Postgres>,
+    value: &Value,
+) -> Result<()> {
+    let value = match value {
+        Value::String(value) => value.clone(),
+        Value::Number(value) => value.to_string(),
+        Value::Bool(value) => value.to_string(),
+        _ => anyhow::bail!("reporting filter value must be a scalar"),
+    };
+    builder.push_bind(value);
+    Ok(())
+}
+
+fn bind_comparable<'a>(
+    builder: &mut QueryBuilder<'a, sqlx::Postgres>,
+    value: &Value,
+) -> Result<()> {
+    match value {
+        Value::Number(number) => {
+            builder.push_bind(number.as_f64().context("invalid numeric filter value")?);
+        }
+        Value::String(value) => {
+            builder.push_bind(value.clone());
+        }
+        _ => anyhow::bail!("comparison reporting filter value must be string or number"),
+    }
+    Ok(())
+}
+
+fn string_array(value: &Value) -> Result<Vec<String>> {
+    let array = value
+        .as_array()
+        .context("reporting in filter value must be an array")?;
+    array
+        .iter()
+        .map(|value| match value {
+            Value::String(value) => Ok(value.clone()),
+            Value::Number(value) => Ok(value.to_string()),
+            Value::Bool(value) => Ok(value.to_string()),
+            _ => anyhow::bail!("reporting in filter array values must be scalars"),
+        })
+        .collect()
+}
+
+async fn latest_projection_lag_ms(pool: &PgPool, table: &str, org_id: i64) -> Result<Option<i64>> {
+    let sql = format!(
+        "SELECT EXTRACT(EPOCH FROM (NOW() - MAX(projected_at))) * 1000 FROM {table} WHERE org_id = $1"
+    );
+    let row: Option<(Option<f64>,)> = sqlx::query_as(&sql)
+        .bind(org_id)
+        .fetch_optional(pool)
+        .await?;
+    Ok(row.and_then(|row| row.0).map(|lag| lag.max(0.0) as i64))
+}

--- a/crates/server/src/storage/repositories/budgets.rs
+++ b/crates/server/src/storage/repositories/budgets.rs
@@ -392,6 +392,21 @@ impl Database {
         .fetch_one(&mut *tx)
         .await?;
 
+        sqlx::query(
+            r#"
+            INSERT INTO reporting_outbox (
+                org_id, source_type, source_id, source_version, reason, status, next_attempt_at
+            )
+            VALUES ($1, 'usage_ledger', $2, $2, 'budget_posting_projection', 'pending', NOW())
+            ON CONFLICT (org_id, source_type, source_id, source_version, reason)
+            DO NOTHING
+            "#,
+        )
+        .bind(entry.org_id)
+        .bind(entry.id.to_string())
+        .execute(&mut *tx)
+        .await?;
+
         tx.commit().await?;
         Ok((entry, updated_budget))
     }

--- a/crates/server/src/storage/repositories/events.rs
+++ b/crates/server/src/storage/repositories/events.rs
@@ -84,6 +84,23 @@ impl Database {
         .fetch_one(&self.pool)
         .await?;
 
+        sqlx::query(
+            r#"
+            INSERT INTO reporting_outbox (
+                org_id, source_type, source_id, source_version, reason, status, next_attempt_at
+            )
+            SELECT s.org_id, 'event', $1, $1, 'event_projection', 'pending', NOW()
+            FROM sessions s
+            WHERE s.id = $2
+            ON CONFLICT (org_id, source_type, source_id, source_version, reason)
+            DO NOTHING
+            "#,
+        )
+        .bind(row.id.uuid().to_string())
+        .bind(row.session_id.uuid())
+        .execute(&self.pool)
+        .await?;
+
         Ok(row)
     }
 

--- a/crates/server/src/storage/repositories/llm.rs
+++ b/crates/server/src/storage/repositories/llm.rs
@@ -473,13 +473,14 @@ impl Database {
         finish_reason: Option<String>,
         created_at: chrono::DateTime<chrono::Utc>,
     ) -> Result<()> {
-        sqlx::query(
+        let (id,): (uuid::Uuid,) = sqlx::query_as(
             r#"
             INSERT INTO llm_generations (
                 org_id, session_id, turn_id, event_id, model, provider,
                 input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens,
                 duration_ms, finish_reason, created_at
             ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+            RETURNING id
             "#,
         )
         .bind(org_id)
@@ -495,7 +496,16 @@ impl Database {
         .bind(duration_ms)
         .bind(&finish_reason)
         .bind(created_at)
-        .execute(&self.pool)
+        .fetch_one(&self.pool)
+        .await?;
+
+        self.enqueue_reporting_outbox(
+            org_id,
+            "llm_generation",
+            &id.to_string(),
+            Some(&id.to_string()),
+            "llm_generation_projection",
+        )
         .await?;
 
         Ok(())
@@ -509,15 +519,17 @@ impl Database {
         cache_read_tokens: i64,
         cache_creation_tokens: i64,
     ) -> Result<()> {
-        sqlx::query(
+        let row: (i64, uuid::Uuid, chrono::DateTime<chrono::Utc>) = sqlx::query_as(
             r#"
             UPDATE sessions
             SET
                 total_input_tokens = total_input_tokens + $2,
                 total_output_tokens = total_output_tokens + $3,
                 total_cache_read_tokens = total_cache_read_tokens + $4,
-                total_cache_creation_tokens = total_cache_creation_tokens + $5
+                total_cache_creation_tokens = total_cache_creation_tokens + $5,
+                updated_at = NOW()
             WHERE id = $1
+            RETURNING org_id, id, updated_at
             "#,
         )
         .bind(session_id)
@@ -525,7 +537,16 @@ impl Database {
         .bind(output_tokens)
         .bind(cache_read_tokens)
         .bind(cache_creation_tokens)
-        .execute(&self.pool)
+        .fetch_one(&self.pool)
+        .await?;
+
+        self.enqueue_reporting_outbox(
+            row.0,
+            "session",
+            &row.1.to_string(),
+            Some(&row.2.to_rfc3339()),
+            "session_snapshot",
+        )
         .await?;
 
         Ok(())

--- a/crates/server/src/storage/repositories/mod.rs
+++ b/crates/server/src/storage/repositories/mod.rs
@@ -22,6 +22,7 @@ mod notifications;
 mod organizations;
 mod payments;
 mod principals;
+mod reporting;
 mod schedules;
 mod session_files;
 mod session_git;

--- a/crates/server/src/storage/repositories/reporting.rs
+++ b/crates/server/src/storage/repositories/reporting.rs
@@ -1,0 +1,40 @@
+use anyhow::Result;
+
+use super::Database;
+
+impl Database {
+    pub async fn enqueue_reporting_outbox(
+        &self,
+        org_id: i64,
+        source_type: &str,
+        source_id: &str,
+        source_version: Option<&str>,
+        reason: &str,
+    ) -> Result<()> {
+        sqlx::query(
+            r#"
+            INSERT INTO reporting_outbox (
+                org_id, source_type, source_id, source_version, reason, status,
+                next_attempt_at
+            )
+            VALUES ($1, $2, $3, $4, $5, 'pending', NOW())
+            ON CONFLICT (org_id, source_type, source_id, source_version, reason)
+            DO UPDATE SET
+                status = CASE
+                    WHEN reporting_outbox.status = 'completed' THEN 'pending'
+                    ELSE reporting_outbox.status
+                END,
+                next_attempt_at = NOW(),
+                updated_at = NOW()
+            "#,
+        )
+        .bind(org_id)
+        .bind(source_type)
+        .bind(source_id)
+        .bind(source_version.unwrap_or(""))
+        .bind(reason)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+}

--- a/crates/server/src/storage/repositories/sessions.rs
+++ b/crates/server/src/storage/repositories/sessions.rs
@@ -49,6 +49,15 @@ impl Database {
         .fetch_one(&self.pool)
         .await?;
 
+        self.enqueue_reporting_outbox(
+            row.org_id,
+            "session",
+            &row.id.uuid().to_string(),
+            Some(&row.updated_at.to_rfc3339()),
+            "session_snapshot",
+        )
+        .await?;
+
         Ok(row)
     }
 

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -5346,6 +5346,127 @@
         }
       }
     },
+    "/v1/reports/catalog": {
+      "get": {
+        "tags": [
+          "reporting"
+        ],
+        "operationId": "get_catalog",
+        "responses": {
+          "200": {
+            "description": "Reporting semantic catalog",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DatasetCatalog"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/reports/projector/run": {
+      "post": {
+        "tags": [
+          "reporting"
+        ],
+        "operationId": "run_projector",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Reporting projector run result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectorRunResult"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/reports/query": {
+      "post": {
+        "tags": [
+          "reporting"
+        ],
+        "operationId": "run_query",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReportQuery"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Reporting query result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReportResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid semantic query",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/sessions": {
       "get": {
         "tags": [
@@ -10576,6 +10697,52 @@
             "format": "int64"
           },
           "updated_at": {
+            "type": "string"
+          }
+        }
+      },
+      "DatasetCatalog": {
+        "type": "object",
+        "required": [
+          "datasets"
+        ],
+        "properties": {
+          "datasets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DatasetCatalogEntry"
+            }
+          }
+        }
+      },
+      "DatasetCatalogEntry": {
+        "type": "object",
+        "required": [
+          "name",
+          "dimensions",
+          "measures",
+          "filter_fields"
+        ],
+        "properties": {
+          "dimensions": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "filter_fields": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "measures": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "name": {
             "type": "string"
           }
         }
@@ -17744,6 +17911,37 @@
           }
         }
       },
+      "ProjectorRunQuery": {
+        "type": "object",
+        "properties": {
+          "limit": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      },
+      "ProjectorRunResult": {
+        "type": "object",
+        "required": [
+          "claimed",
+          "completed",
+          "failed"
+        ],
+        "properties": {
+          "claimed": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "completed": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "failed": {
+            "type": "integer",
+            "minimum": 0
+          }
+        }
+      },
       "PromptCacheStrategy": {
         "type": "string",
         "description": "Strategy for prompt caching.",
@@ -17970,6 +18168,176 @@
           "value": {
             "$ref": "#/components/schemas/ReasoningEffort",
             "description": "The API value (e.g., \"low\", \"medium\")"
+          }
+        }
+      },
+      "ReportColumn": {
+        "type": "object",
+        "required": [
+          "name",
+          "kind"
+        ],
+        "properties": {
+          "kind": {
+            "$ref": "#/components/schemas/ReportColumnKind"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "ReportColumnKind": {
+        "type": "string",
+        "enum": [
+          "dimension",
+          "measure"
+        ]
+      },
+      "ReportFilter": {
+        "type": "object",
+        "required": [
+          "field",
+          "op",
+          "value"
+        ],
+        "properties": {
+          "field": {
+            "type": "string"
+          },
+          "op": {
+            "$ref": "#/components/schemas/ReportFilterOp"
+          },
+          "value": {}
+        }
+      },
+      "ReportFilterOp": {
+        "type": "string",
+        "enum": [
+          "eq",
+          "neq",
+          "in",
+          "gt",
+          "gte",
+          "lt",
+          "lte"
+        ]
+      },
+      "ReportOrderBy": {
+        "type": "object",
+        "properties": {
+          "dimension": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "direction": {
+            "$ref": "#/components/schemas/ReportOrderDirection"
+          },
+          "measure": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      },
+      "ReportOrderDirection": {
+        "type": "string",
+        "enum": [
+          "asc",
+          "desc"
+        ]
+      },
+      "ReportQuery": {
+        "type": "object",
+        "required": [
+          "dataset",
+          "time_range"
+        ],
+        "properties": {
+          "dataset": {
+            "type": "string"
+          },
+          "dimensions": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "filters": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ReportFilter"
+            }
+          },
+          "limit": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          },
+          "measures": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "order_by": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ReportOrderBy"
+            }
+          },
+          "time_range": {
+            "$ref": "#/components/schemas/ReportTimeRange"
+          }
+        }
+      },
+      "ReportResult": {
+        "type": "object",
+        "required": [
+          "as_of",
+          "columns",
+          "rows"
+        ],
+        "properties": {
+          "as_of": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "columns": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ReportColumn"
+            }
+          },
+          "freshness_lag_ms": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64"
+          },
+          "rows": {
+            "type": "array",
+            "items": {}
+          }
+        }
+      },
+      "ReportTimeRange": {
+        "type": "object",
+        "required": [
+          "from",
+          "to"
+        ],
+        "properties": {
+          "from": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "to": {
+            "type": "string",
+            "format": "date-time"
           }
         }
       },
@@ -23455,6 +23823,10 @@
     {
       "name": "payments",
       "description": "Machine payment wallet, policy, and attempt endpoints"
+    },
+    {
+      "name": "reporting",
+      "description": "Org-scoped semantic reporting endpoints"
     }
   ]
 }


### PR DESCRIPTION
## What
Add the phase 1 async reporting foundation: backend-neutral reporting contracts, reporting outbox, PostgreSQL fact projection tables, semantic catalog/query API, and manual projector trigger.

## Why
EVE-429 needs reporting data off the hot operational paths while preserving tenant isolation and avoiding arbitrary SQL.

## How
- Added `everruns_core::reporting` semantic query/result contracts and backend traits.
- Added `reporting_outbox` plus phase 1 PostgreSQL fact tables for LLM generations, tool calls, turns, sessions, and budget postings.
- Enqueued minimal outbox rows from canonical writers, then projected rows asynchronously through the PostgreSQL projector.
- Added `/v1/reports/catalog`, `/v1/reports/query`, and `/v1/reports/projector/run`, with fixed catalog validation and generated OpenAPI.
- Added reporting view/manage/admin permissions and command policies.

## Risk
- Medium
- Risk is concentrated in new reporting projection SQL and extra outbox writes on existing writers. Operational behavior remains source-of-truth driven; facts are derived only.

## Security
- Threat categories reviewed: TM-TENANT, TM-AUTHZ, TM-API, TM-SQL, TM-DOS, TM-OBS.
- Findings and resolutions: queries are org-scoped by backend construction; `org_id` user filters are rejected; authorization uses reporting policies; no arbitrary SQL is accepted; catalog dimensions/measures/filter fields are fixed constants; user values are bound parameters; query limit/time range/filter counts are bounded; facts avoid prompts, messages, tool arguments, and tool results.

## Follow-ups
Add a scheduled/background projector runner once the scheduler wiring is ready; this PR includes the outbox, projector, and admin run endpoint needed for that integration.

## Validation
- `cargo fmt`
- `bash scripts/lib/check-migration-ordering.sh`
- `cargo test -p everruns-server domains::reporting::catalog --lib`
- OpenAPI export via `cargo run --bin export-openapi` into `docs/api/openapi.json`
- Smoke-tested `PORT_PREFIX=429 just start-all --no-watch`: health, migration tables, catalog endpoint, empty semantic query
- `CARGO_BUILD_JOBS=2 just pre-push`

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

Linear: EVE-429