### PR TITLE
feat(ui): add full-page skill view

### DIFF
--- a/apps/ui/src/__tests__/skill-detail-view.test.tsx
+++ b/apps/ui/src/__tests__/skill-detail-view.test.tsx
@@ -1,0 +1,64 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { SkillDetailView } from "@/components/skills/skill-detail-view";
+import type { Skill, SkillContent } from "@/lib/api/types";
+
+jest.mock("streamdown", () => ({
+  Streamdown: ({ children }: { children: string }) => (
+    <pre data-testid="streamdown-mock">{children}</pre>
+  ),
+}));
+
+jest.mock("@streamdown/code", () => ({
+  code: {},
+}));
+
+jest.mock("@/components/chat/streamdown-message", () => ({
+  InlineStreamdownMessage: ({ children }: { children: string }) => (
+    <pre data-testid="inline-streamdown-mock">{children}</pre>
+  ),
+}));
+
+const skill: Skill = {
+  id: "skill_123",
+  name: "data-analysis",
+  description: "Analyze data files.",
+  metadata: {},
+  source_type: "archive",
+  status: "active",
+  version: "1",
+  created_at: "2026-01-01T00:00:00.000Z",
+  updated_at: "2026-01-02T00:00:00.000Z",
+  archived_at: null,
+  deleted_at: null,
+};
+
+const content: SkillContent = {
+  skill_md:
+    "---\nname: data-analysis\ndescription: Analyze data files.\n---\n\n# Data Analysis\n\nUse the scripts.",
+  files: [{ path: "scripts/run.py", content: "print('ready')\n" }],
+};
+
+describe("SkillDetailView", () => {
+  it("renders a read-only file browser tab with SKILL.md and extracted files", () => {
+    render(
+      <SkillDetailView
+        skill={skill}
+        usage={{ agents: 1, harnesses: 0 }}
+        content={content}
+        contentLoading={false}
+        contentError={null}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("tab", { name: /files/i }));
+
+    expect(screen.getByText("Skill Files")).toBeTruthy();
+    expect(screen.getByRole("button", { name: /SKILL\.md/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /scripts\/run\.py/i })).toBeTruthy();
+    expect(screen.getAllByText("read-only")).toHaveLength(2);
+
+    fireEvent.click(screen.getByRole("button", { name: /scripts\/run\.py/i }));
+
+    expect(screen.getByText(/print\('ready'\)/)).toBeTruthy();
+  });
+});

--- a/apps/ui/src/app/(main)/skills/[skillId]/page.tsx
+++ b/apps/ui/src/app/(main)/skills/[skillId]/page.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { use } from "react";
+import Link from "next/link";
+import { ArrowLeft, Archive, FileText } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { ResourceNotFound } from "@/components/resource-not-found";
+import { SkillDetailView } from "@/components/skills/skill-detail-view";
+import { usePageTitle } from "@/hooks";
+import { useSkill, useSkillContent, useSkillsUsage } from "@/hooks/use-skills";
+import {
+  getDisplayName,
+  getEntityNameClassName,
+  getEntityStatusBadgeVariant,
+} from "@/lib/entity-lifecycle";
+
+export default function SkillDetailPage({ params }: { params: Promise<{ skillId: string }> }) {
+  const { skillId } = use(params);
+  const { data: skill, isLoading: skillLoading } = useSkill(skillId);
+  const {
+    data: content,
+    isLoading: contentLoading,
+    error: contentError,
+  } = useSkillContent(skillId);
+  const { data: usage } = useSkillsUsage();
+  usePageTitle(skill ? getDisplayName(skill) : null, "Skill");
+
+  if (skillLoading) {
+    return (
+      <div className="container mx-auto p-6">
+        <Skeleton className="mb-6 h-5 w-36" />
+        <Skeleton className="mb-4 h-8 w-1/3" />
+        <Skeleton className="mb-8 h-4 w-2/3" />
+        <Skeleton className="h-72 w-full" />
+      </div>
+    );
+  }
+
+  if (!skill) {
+    return (
+      <ResourceNotFound
+        title="Skill not found"
+        description="This skill may have been deleted, moved to another organization, or the URL may be wrong."
+        backHref="/skills"
+        backLabel="Back to skills"
+        resourceId={skillId}
+      />
+    );
+  }
+
+  return (
+    <div className="container mx-auto p-6">
+      <Link
+        href="/skills"
+        className="mb-6 inline-flex items-center text-sm text-muted-foreground hover:text-foreground"
+      >
+        <ArrowLeft className="mr-2 h-4 w-4" />
+        Back to Skills
+      </Link>
+
+      <header className="mb-6 flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div className="min-w-0">
+          <h1 className="flex min-w-0 flex-wrap items-center gap-2 text-2xl font-bold">
+            {skill.source_type === "archive" ? (
+              <Archive className="h-6 w-6 shrink-0 text-primary" />
+            ) : (
+              <FileText className="h-6 w-6 shrink-0 text-primary" />
+            )}
+            <span className={getEntityNameClassName(skill.status)}>{getDisplayName(skill)}</span>
+            <Badge variant={getEntityStatusBadgeVariant(skill.status)}>{skill.status}</Badge>
+          </h1>
+          <p className="mt-2 max-w-3xl text-sm leading-6 text-muted-foreground">
+            {skill.description}
+          </p>
+        </div>
+      </header>
+
+      <SkillDetailView
+        skill={skill}
+        usage={usage?.[skill.id]}
+        content={content}
+        contentLoading={contentLoading}
+        contentError={contentError}
+      />
+    </div>
+  );
+}

--- a/apps/ui/src/app/(main)/skills/skills-page-client.tsx
+++ b/apps/ui/src/app/(main)/skills/skills-page-client.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { Button } from "@/components/ui/button";
+import Link from "next/link";
+import { Button, buttonVariants } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -21,62 +22,27 @@ import {
   useSkills,
   useCreateSkill,
   useDestroySkill,
-  useSkillContent,
   useSkillsUsage,
   useUpdateSkill,
   useUploadSkill,
 } from "@/hooks/use-skills";
 import { usePolicies } from "@/hooks/use-policies";
-import {
-  Plus,
-  BookOpen,
-  Trash2,
-  Upload,
-  FileText,
-  Archive,
-  Box,
-  Bot,
-  Eye,
-  Layers,
-  Search,
-} from "lucide-react";
+import { Plus, BookOpen, Trash2, Upload, FileText, Archive, Box, Eye, Search } from "lucide-react";
 import type { Skill, SkillUsage } from "@/lib/api/types";
 import { getEntityNameClassName, getEntityStatusBadgeVariant } from "@/lib/entity-lifecycle";
 import { ArchiveFilter } from "@/components/archive-filter";
-import { InlineStreamdownMessage } from "@/components/chat/streamdown-message";
-
-function SkillUsageRow({ usage }: { usage: SkillUsage | undefined }) {
-  const agents = usage?.agents ?? 0;
-  const harnesses = usage?.harnesses ?? 0;
-  if (agents === 0 && harnesses === 0) {
-    return <div className="text-xs text-muted-foreground">Not in use</div>;
-  }
-  return (
-    <div className="flex items-center gap-3 text-xs text-muted-foreground">
-      <span className="inline-flex items-center gap-1" aria-label={`${agents} agents`}>
-        <Bot className="h-3.5 w-3.5" />
-        {agents} {agents === 1 ? "agent" : "agents"}
-      </span>
-      <span className="inline-flex items-center gap-1" aria-label={`${harnesses} harnesses`}>
-        <Layers className="h-3.5 w-3.5" />
-        {harnesses} {harnesses === 1 ? "harness" : "harnesses"}
-      </span>
-    </div>
-  );
-}
+import { SkillUsageRow } from "@/components/skills/skill-usage-row";
 
 function SkillCard({
   skill,
   usage,
   canDestroy,
   onDelete,
-  onView,
 }: {
   skill: Skill;
   usage: SkillUsage | undefined;
   canDestroy: boolean;
   onDelete: (skill: Skill) => void;
-  onView: (skill: Skill) => void;
 }) {
   const updateSkill = useUpdateSkill(skill.id);
   const isArchived = skill.status === "archived";
@@ -117,10 +83,13 @@ function SkillCard({
           <SkillUsageRow usage={usage} />
         </div>
         <div className="flex items-center justify-end gap-2 mt-4">
-          <Button variant="outline" size="sm" onClick={() => onView(skill)}>
+          <Link
+            href={`/skills/${skill.id}`}
+            className={buttonVariants({ variant: "outline", size: "sm" })}
+          >
             <Eye className="h-4 w-4 mr-1" />
             View
-          </Button>
+          </Link>
           {!isArchived && !isDeleted && (
             <Button
               variant="outline"
@@ -141,140 +110,6 @@ function SkillCard({
         </div>
       </CardContent>
     </Card>
-  );
-}
-
-/**
- * Parses YAML frontmatter and markdown body from a reconstructed SKILL.md.
- * Falls back to treating the whole text as the body if no fenced frontmatter
- * block is present.
- */
-function splitFrontmatter(skillMd: string): { frontmatter: string; body: string } {
-  const match = skillMd.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/);
-  if (!match) return { frontmatter: "", body: skillMd };
-  return { frontmatter: match[1] ?? "", body: (match[2] ?? "").trimStart() };
-}
-
-function SkillDetailDialog({
-  skill,
-  usage,
-  onOpenChange,
-}: {
-  skill: Skill | null;
-  usage: SkillUsage | undefined;
-  onOpenChange: (open: boolean) => void;
-}) {
-  const open = skill !== null;
-  const { data: content, isLoading, error } = useSkillContent(skill?.id ?? "");
-  const split = useMemo(
-    () => (content ? splitFrontmatter(content.skill_md) : { frontmatter: "", body: "" }),
-    [content],
-  );
-
-  return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-4xl max-h-[85vh] overflow-y-auto">
-        <DialogHeader>
-          <DialogTitle className="flex items-center gap-2">
-            {skill?.source_type === "archive" ? (
-              <Archive className="h-5 w-5 text-primary" />
-            ) : (
-              <FileText className="h-5 w-5 text-primary" />
-            )}
-            {skill?.name}
-          </DialogTitle>
-          <DialogDescription>{skill?.description}</DialogDescription>
-        </DialogHeader>
-        {skill && (
-          <div className="space-y-6">
-            <section className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
-              <div>
-                <Label className="text-muted-foreground">Status</Label>
-                <div>
-                  <Badge variant={getEntityStatusBadgeVariant(skill.status)}>{skill.status}</Badge>
-                </div>
-              </div>
-              <div>
-                <Label className="text-muted-foreground">Source</Label>
-                <div>{skill.source_type}</div>
-              </div>
-              <div>
-                <Label className="text-muted-foreground">Version</Label>
-                <div>{skill.version}</div>
-              </div>
-              <div>
-                <Label className="text-muted-foreground">License</Label>
-                <div>{skill.license ?? "—"}</div>
-              </div>
-              <div>
-                <Label className="text-muted-foreground">Compatibility</Label>
-                <div>{skill.compatibility ?? "—"}</div>
-              </div>
-              <div>
-                <Label className="text-muted-foreground">Allowed tools</Label>
-                <div>{skill.allowed_tools ?? "—"}</div>
-              </div>
-              <div className="col-span-2">
-                <Label className="text-muted-foreground">Used by</Label>
-                <SkillUsageRow usage={usage} />
-              </div>
-            </section>
-
-            <section>
-              <Label className="text-muted-foreground">Frontmatter</Label>
-              {isLoading && <Skeleton className="h-24 w-full mt-1" />}
-              {error && (
-                <p className="text-sm text-destructive mt-1">Failed to load skill content.</p>
-              )}
-              {content && (
-                <pre className="mt-1 p-3 bg-muted text-xs font-mono whitespace-pre-wrap break-all overflow-x-auto">
-                  {split.frontmatter || "(no frontmatter)"}
-                </pre>
-              )}
-            </section>
-
-            <section>
-              <Label className="text-muted-foreground">SKILL.md</Label>
-              {isLoading && <Skeleton className="h-32 w-full mt-1" />}
-              {content && (
-                <div className="mt-1 p-3 bg-muted text-sm overflow-x-auto">
-                  {split.body.trim() ? (
-                    <InlineStreamdownMessage>{split.body}</InlineStreamdownMessage>
-                  ) : (
-                    <span className="text-muted-foreground">(empty)</span>
-                  )}
-                </div>
-              )}
-            </section>
-
-            {content && content.files.length > 0 && (
-              <section>
-                <Label className="text-muted-foreground">
-                  Bundled files ({content.files.length})
-                </Label>
-                <div className="mt-1 space-y-2">
-                  {content.files.map((file) => (
-                    <details key={file.path} className="border bg-muted/40">
-                      <summary className="cursor-pointer px-3 py-2 text-sm font-mono">
-                        {file.path}
-                      </summary>
-                      <pre className="px-3 py-2 text-xs font-mono whitespace-pre-wrap break-all border-t bg-background overflow-x-auto">
-                        {file.content}
-                      </pre>
-                    </details>
-                  ))}
-                </div>
-              </section>
-            )}
-          </div>
-        )}
-        <DialogFooter>
-          <Button variant="outline" onClick={() => onOpenChange(false)}>
-            Close
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
   );
 }
 
@@ -424,7 +259,6 @@ export default function SkillsPageClient() {
   const [addSkillOpen, setAddSkillOpen] = useState(false);
   const [uploadSkillOpen, setUploadSkillOpen] = useState(false);
   const [pendingDeleteSkill, setPendingDeleteSkill] = useState<Skill | null>(null);
-  const [viewingSkill, setViewingSkill] = useState<Skill | null>(null);
 
   const filteredSkills = useMemo(() => {
     if (!skills) return skills;
@@ -513,18 +347,12 @@ export default function SkillsPageClient() {
                 usage={usage?.[skill.id]}
                 canDestroy={canDestroy}
                 onDelete={setPendingDeleteSkill}
-                onView={setViewingSkill}
               />
             ))}
           </div>
         )}
       </QueryStateWrapper>
 
-      <SkillDetailDialog
-        skill={viewingSkill}
-        usage={viewingSkill ? usage?.[viewingSkill.id] : undefined}
-        onOpenChange={(open) => !open && setViewingSkill(null)}
-      />
       <AddSkillDialog open={addSkillOpen} onOpenChange={setAddSkillOpen} />
       <UploadSkillDialog open={uploadSkillOpen} onOpenChange={setUploadSkillOpen} />
       <Dialog

--- a/apps/ui/src/components/skills/skill-detail-view.tsx
+++ b/apps/ui/src/components/skills/skill-detail-view.tsx
@@ -1,0 +1,196 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import type { ReactNode } from "react";
+import { Archive, FileText, FolderTree, Info, ScrollText } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { InlineStreamdownMessage } from "@/components/chat/streamdown-message";
+import { InitialFilesPreview } from "@/components/files/initial-files-preview";
+import { SkillUsageRow } from "@/components/skills/skill-usage-row";
+import { getEntityStatusBadgeVariant } from "@/lib/entity-lifecycle";
+import type { InitialFile, Skill, SkillContent, SkillUsage } from "@/lib/api/types";
+
+type SkillDetailTab = "overview" | "instructions" | "files";
+
+interface SkillDetailViewProps {
+  skill: Skill;
+  usage: SkillUsage | undefined;
+  content: SkillContent | undefined;
+  contentLoading: boolean;
+  contentError: unknown;
+}
+
+export function SkillDetailView({
+  skill,
+  usage,
+  content,
+  contentLoading,
+  contentError,
+}: SkillDetailViewProps) {
+  const [activeTab, setActiveTab] = useState<SkillDetailTab>("overview");
+  const split = useMemo(
+    () => (content ? splitFrontmatter(content.skill_md) : { frontmatter: "", body: "" }),
+    [content],
+  );
+  const skillFiles = useMemo(() => toReadonlySkillFiles(content), [content]);
+
+  return (
+    <Tabs
+      value={activeTab}
+      onValueChange={(value) => setActiveTab(value as SkillDetailTab)}
+      className="space-y-6"
+    >
+      <TabsList>
+        <TabsTrigger value="overview">
+          <Info className="mr-2 h-4 w-4" />
+          Overview
+        </TabsTrigger>
+        <TabsTrigger value="instructions">
+          <ScrollText className="mr-2 h-4 w-4" />
+          Instructions
+        </TabsTrigger>
+        <TabsTrigger value="files">
+          <FolderTree className="mr-2 h-4 w-4" />
+          Files
+        </TabsTrigger>
+      </TabsList>
+
+      <TabsContent value="overview">
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-lg">
+              {skill.source_type === "archive" ? (
+                <Archive className="h-5 w-5 text-primary" />
+              ) : (
+                <FileText className="h-5 w-5 text-primary" />
+              )}
+              Details
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <section className="grid grid-cols-1 gap-x-6 gap-y-4 text-sm md:grid-cols-2">
+              <DetailField label="Status">
+                <Badge variant={getEntityStatusBadgeVariant(skill.status)}>{skill.status}</Badge>
+              </DetailField>
+              <DetailField label="Source">{skill.source_type}</DetailField>
+              <DetailField label="Version">{skill.version}</DetailField>
+              <DetailField label="License">{skill.license ?? "-"}</DetailField>
+              <DetailField label="Compatibility">{skill.compatibility ?? "-"}</DetailField>
+              <DetailField label="Allowed tools">{skill.allowed_tools ?? "-"}</DetailField>
+              <DetailField label="Created">{formatDateTime(skill.created_at)}</DetailField>
+              <DetailField label="Updated">{formatDateTime(skill.updated_at)}</DetailField>
+              <div className="md:col-span-2">
+                <Label className="text-muted-foreground">Used by</Label>
+                <div className="mt-1">
+                  <SkillUsageRow usage={usage} />
+                </div>
+              </div>
+            </section>
+          </CardContent>
+        </Card>
+      </TabsContent>
+
+      <TabsContent value="instructions" className="space-y-6">
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-lg">Frontmatter</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {contentLoading && <Skeleton className="h-28 w-full" />}
+            {contentError != null && (
+              <p className="text-sm text-destructive">Failed to load skill content.</p>
+            )}
+            {content && (
+              <pre className="max-h-[360px] overflow-auto bg-muted p-3 font-mono text-xs whitespace-pre-wrap break-all">
+                {split.frontmatter || "(no frontmatter)"}
+              </pre>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-lg">SKILL.md</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {contentLoading && <Skeleton className="h-64 w-full" />}
+            {content && (
+              <div className="min-h-[240px] overflow-x-auto bg-muted p-4 text-sm">
+                {split.body.trim() ? (
+                  <InlineStreamdownMessage>{split.body}</InlineStreamdownMessage>
+                ) : (
+                  <span className="text-muted-foreground">(empty)</span>
+                )}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </TabsContent>
+
+      <TabsContent value="files">
+        {contentLoading ? (
+          <Card>
+            <CardContent className="p-6">
+              <Skeleton className="h-[480px] w-full" />
+            </CardContent>
+          </Card>
+        ) : contentError != null ? (
+          <Card>
+            <CardContent className="p-6">
+              <p className="text-sm text-destructive">Failed to load skill files.</p>
+            </CardContent>
+          </Card>
+        ) : (
+          <InitialFilesPreview
+            files={skillFiles}
+            title="Skill Files"
+            description="Read-only reconstructed skill files. Archive skills include extracted text files alongside SKILL.md."
+          />
+        )}
+      </TabsContent>
+    </Tabs>
+  );
+}
+
+function DetailField({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div>
+      <Label className="text-muted-foreground">{label}</Label>
+      <div className="mt-1 break-words">{children}</div>
+    </div>
+  );
+}
+
+function splitFrontmatter(skillMd: string): { frontmatter: string; body: string } {
+  const match = skillMd.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/);
+  if (!match) return { frontmatter: "", body: skillMd };
+  return { frontmatter: match[1] ?? "", body: (match[2] ?? "").trimStart() };
+}
+
+function toReadonlySkillFiles(content: SkillContent | undefined): InitialFile[] {
+  if (!content) return [];
+  return [
+    {
+      path: "SKILL.md",
+      content: content.skill_md,
+      encoding: "text",
+      is_readonly: true,
+    },
+    ...content.files.map((file) => ({
+      path: file.path,
+      content: file.content,
+      encoding: "text" as const,
+      is_readonly: true,
+    })),
+  ];
+}
+
+function formatDateTime(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString();
+}

--- a/apps/ui/src/components/skills/skill-usage-row.tsx
+++ b/apps/ui/src/components/skills/skill-usage-row.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { Bot, Layers } from "lucide-react";
+import type { SkillUsage } from "@/lib/api/types";
+
+export function SkillUsageRow({ usage }: { usage: SkillUsage | undefined }) {
+  const agents = usage?.agents ?? 0;
+  const harnesses = usage?.harnesses ?? 0;
+  const agentsLabel = `${agents} ${agents === 1 ? "agent" : "agents"}`;
+  const harnessesLabel = `${harnesses} ${harnesses === 1 ? "harness" : "harnesses"}`;
+  if (agents === 0 && harnesses === 0) {
+    return <div className="text-xs text-muted-foreground">Not in use</div>;
+  }
+  return (
+    <div className="flex items-center gap-3 text-xs text-muted-foreground">
+      <span className="inline-flex items-center gap-1" aria-label={agentsLabel}>
+        <Bot className="h-3.5 w-3.5" />
+        {agentsLabel}
+      </span>
+      <span className="inline-flex items-center gap-1" aria-label={harnessesLabel}>
+        <Layers className="h-3.5 w-3.5" />
+        {harnessesLabel}
+      </span>
+    </div>
+  );
+}


### PR DESCRIPTION
## What
Add a full-page skill detail view at `/skills/[skillId]` and route skill cards there instead of opening the inline dialog.

The new page includes:
- Overview tab for skill metadata and usage.
- Instructions tab for reconstructed frontmatter and `SKILL.md` content.
- Files tab with a read-only browser for reconstructed `SKILL.md` plus extracted archive text files.

## Why
Skill details need room for richer inspection. A full page makes the skill view linkable and gives archive skills a dedicated read-only file browser surface.

## How
- Added `SkillDetailPage` under `apps/ui/src/app/(main)/skills/[skillId]/page.tsx`.
- Extracted shared skill usage UI into `SkillUsageRow`.
- Added `SkillDetailView` with Overview, Instructions, and Files tabs.
- Reused `InitialFilesPreview` for the read-only skill file browser.
- Updated the skill list View action to link to `/skills/{id}`.
- Added a focused test for the Files tab and read-only file rendering.

## Risk
- Low
- Main risk is UI regression in skill detail rendering or navigation. The change is frontend-only and reuses existing skill/content APIs and file preview components.

## Security
- Threat categories reviewed: TM-WEB.
- Findings and resolutions: No new API, auth, tenant, database, command execution, or server-side filesystem trust boundary. The Files tab reuses the existing file preview path, including the documented SVG sandbox/CSP mitigation for TM-WEB-009. React rendering and existing markdown/file preview components preserve the current XSS boundary.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

Validation:
- `bash scripts/lib/check-migration-ordering.sh`
- `npm test -- --runTestsByPath src/__tests__/skill-detail-view.test.tsx` (passes; existing Base UI ScrollArea act warnings are emitted)
- `npm run build`
- `just pre-push`
- Browser smoke: `/skills/skill_123` redirects unauthenticated users to login with `return_to=/skills/skill_123`.
