### PR TITLE
fix(apps): align schedule channel tools

### DIFF
--- a/apps/ui/src/app/(main)/apps/[appId]/page.tsx
+++ b/apps/ui/src/app/(main)/apps/[appId]/page.tsx
@@ -124,13 +124,30 @@ type ChannelSummary = {
   healthVariant: "default" | "secondary" | "destructive" | "outline";
 };
 
+function hasSlackCredentials(config?: SlackChannelConfig): boolean {
+  return (
+    !!(
+      (config?.signing_secret && config.signing_secret.trim()) ||
+      config?.signing_secret_configured
+    ) && !!((config?.bot_token && config.bot_token.trim()) || config?.bot_token_configured)
+  );
+}
+
+function hasToken(config?: AgUiChannelConfig | WebhookChannelConfig): boolean {
+  return !!((config?.token && config.token.trim()) || config?.token_configured);
+}
+
+function hasA2aKey(config?: A2aChannelConfig): boolean {
+  return !!(config?.api_key_hash || config?.api_key_prefix);
+}
+
 function getChannelSummary(channel: AppChannel, isPublished: boolean): ChannelSummary {
   const publishedPrefix = isPublished ? "" : "Draft: ";
 
   switch (channel.channel_type) {
     case "slack": {
       const config = channel.channel_config as SlackChannelConfig;
-      const hasCredentials = !!config?.signing_secret && !!config?.bot_token;
+      const hasCredentials = hasSlackCredentials(config);
       const target = config?.channel_id ?? config?.team_id ?? "Workspace events";
       if (!hasCredentials) {
         return {
@@ -166,7 +183,7 @@ function getChannelSummary(channel: AppChannel, isPublished: boolean): ChannelSu
     case "ag_ui": {
       const config = channel.channel_config as AgUiChannelConfig;
       return {
-        target: config?.token ? "Token-protected endpoint" : "Public client endpoint",
+        target: hasToken(config) ? "Token-protected endpoint" : "Public client endpoint",
         group: "Client surfaces",
         health: isPublished ? "Ready" : "Draft",
         healthVariant: isPublished ? "default" : "secondary",
@@ -186,7 +203,7 @@ function getChannelSummary(channel: AppChannel, isPublished: boolean): ChannelSu
     }
     case "webhook": {
       const config = channel.channel_config as WebhookChannelConfig;
-      const configured = !!config?.token && !!config?.message;
+      const configured = hasToken(config) && !!config?.message;
       return {
         target: "Authenticated HTTP endpoint",
         group: "Programmatic ingress",
@@ -196,7 +213,7 @@ function getChannelSummary(channel: AppChannel, isPublished: boolean): ChannelSu
     }
     case "a2a": {
       const config = channel.channel_config as A2aChannelConfig;
-      const configured = !!config?.api_key_hash && !!config?.message;
+      const configured = hasA2aKey(config) && !!config?.message;
       return {
         target: config?.agent_card_name || "Agent endpoint",
         group: "Programmatic ingress",
@@ -415,7 +432,7 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
       switch (channel.channel_type) {
         case "slack": {
           const config = channel.channel_config as SlackChannelConfig;
-          return !!config?.signing_secret && !!config?.bot_token;
+          return hasSlackCredentials(config);
         }
         case "ag_ui":
           return true;
@@ -425,11 +442,11 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
         }
         case "webhook": {
           const config = channel.channel_config as WebhookChannelConfig;
-          return !!config?.token && !!config?.message;
+          return hasToken(config) && !!config?.message;
         }
         case "a2a": {
           const config = channel.channel_config as A2aChannelConfig;
-          return !!config?.api_key_hash && !!config?.message;
+          return hasA2aKey(config) && !!config?.message;
         }
       }
     }) ?? false;
@@ -1178,6 +1195,7 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
             }
             rateLimitPerMinute={config?.rate_limit_per_minute}
             token={config?.token}
+            tokenConfigured={hasToken(config)}
             toolVisibility={config?.tool_visibility ?? "generic"}
             genericToolText={config?.generic_tool_text ?? DEFAULT_AG_UI_GENERIC_TOOL_TEXT}
             onConfigure={() => startEditChannel(channel)}
@@ -1215,7 +1233,7 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
             endpointUrl={endpointUrl}
             sessionMode={config?.session_mode ?? "shared_session"}
             message={config?.message ?? ""}
-            tokenConfigured={!!config?.token}
+            tokenConfigured={hasToken(config)}
             isPublished={isPublished}
             onConfigure={() => startEditChannel(channel)}
           />
@@ -1249,7 +1267,7 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
     }
 
     const config = channel.channel_config as SlackChannelConfig;
-    const chHasConfig = config?.signing_secret && config?.bot_token;
+    const chHasConfig = hasSlackCredentials(config);
     const chWebhookVerified = !!config?.webhook_verified_at;
     const chFirstMsg = !!config?.first_message_received_at;
 
@@ -1343,7 +1361,7 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
       const config = channel.channel_config as AgUiChannelConfig;
       return (
         <div className="grid gap-4 md:grid-cols-2">
-          <ChannelFact label="Access" value={config?.token ? "Token protected" : "No token"} />
+          <ChannelFact label="Access" value={hasToken(config) ? "Token protected" : "No token"} />
           <ChannelFact
             label="Thread expiration"
             value={`${(config?.session_expiration_seconds ?? DEFAULT_AG_UI_SESSION_EXPIRATION_SECONDS) / 3600}h`}
@@ -1366,7 +1384,7 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
 
     if (channel.channel_type === "slack") {
       const config = channel.channel_config as SlackChannelConfig;
-      const hasCredentials = !!config?.signing_secret && !!config?.bot_token;
+      const hasCredentials = hasSlackCredentials(config);
       return (
         <div className="grid gap-4 md:grid-cols-2">
           <ChannelFact label="Credentials" value={hasCredentials ? "Configured" : "Missing"} />
@@ -1411,7 +1429,10 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
       return (
         <div className="space-y-4">
           <div className="grid gap-4 md:grid-cols-2">
-            <ChannelFact label="Authentication" value={config?.token ? "Token set" : "Missing"} />
+            <ChannelFact
+              label="Authentication"
+              value={hasToken(config) ? "Token set" : "Missing"}
+            />
             <ChannelFact
               label="Session mode"
               value={getInvocationSessionModeDisplayName(config?.session_mode ?? "shared_session")}

--- a/apps/ui/src/components/apps/ag-ui-setup-guidance.tsx
+++ b/apps/ui/src/components/apps/ag-ui-setup-guidance.tsx
@@ -13,6 +13,7 @@ interface AgUiSetupGuidanceProps {
   sessionExpirationSeconds: number;
   rateLimitPerMinute?: number;
   token?: string;
+  tokenConfigured?: boolean;
   toolVisibility?: AgUiToolVisibility;
   genericToolText?: string;
   onConfigure?: () => void;
@@ -44,12 +45,13 @@ export function AgUiSetupGuidance({
   sessionExpirationSeconds,
   rateLimitPerMinute,
   token,
+  tokenConfigured,
   toolVisibility = "generic",
   genericToolText,
   onConfigure,
 }: AgUiSetupGuidanceProps) {
   const hasRateLimit = !!rateLimitPerMinute && rateLimitPerMinute > 0;
-  const hasToken = !!token;
+  const hasToken = !!token || !!tokenConfigured;
   const accessBadge = hasToken ? "Token Protected" : anonymousEnabled ? "Anonymous" : "Restricted";
   return (
     <div className="space-y-4">
@@ -82,11 +84,13 @@ export function AgUiSetupGuidance({
 
       <div>
         <p className="text-sm font-medium">Token</p>
-        {hasToken ? (
+        {token ? (
           <div className="mt-2 flex items-center gap-2 bg-muted p-3">
             <code className="flex-1 truncate text-sm">{token}</code>
             <CopyButton value={token} />
           </div>
+        ) : hasToken ? (
+          <p className="text-sm text-muted-foreground">Channel token configured</p>
         ) : (
           <p className="text-sm text-muted-foreground">No channel token required</p>
         )}

--- a/apps/ui/src/lib/api/types/app-types.ts
+++ b/apps/ui/src/lib/api/types/app-types.ts
@@ -11,8 +11,10 @@ export type AgUiToolVisibility = "none" | "generic" | "narrated";
 export type AgentVersionPolicy = "default" | "latest" | "pinned";
 
 export interface SlackChannelConfig {
-  signing_secret: string;
-  bot_token: string;
+  signing_secret?: string;
+  signing_secret_configured?: boolean;
+  bot_token?: string;
+  bot_token_configured?: boolean;
   channel_id?: string;
   team_id?: string;
   session_strategy: SessionStrategy;
@@ -32,6 +34,7 @@ export interface AgUiChannelConfig {
    * must send it as `Authorization: Bearer <token>` or `X-Everruns-AG-UI-Token`.
    */
   token?: string;
+  token_configured?: boolean;
   /**
    * How long an AG-UI thread can be resumed (in seconds) after the underlying
    * session was created. After this elapses the same `thread_id` cannot reuse
@@ -62,7 +65,8 @@ export interface ScheduleChannelConfig {
 }
 
 export interface WebhookChannelConfig {
-  token: string;
+  token?: string;
+  token_configured?: boolean;
   session_mode?: InvocationSessionMode;
   message: string;
 }
@@ -71,12 +75,12 @@ export interface WebhookChannelConfig {
  * A2A (Agent2Agent) channel configuration.
  *
  * The plaintext API key is **never** returned by the API after creation /
- * regeneration — only the SHA-256 hash and a non-secret display prefix are
- * persisted and surfaced. Use `addA2aChannel` / `regenerateA2aChannelKey` to
- * obtain the plaintext (which is shown exactly once).
+ * regeneration. Reads only surface the non-secret display prefix; use
+ * `addA2aChannel` / `regenerateA2aChannelKey` to obtain the plaintext (which is
+ * shown exactly once).
  */
 export interface A2aChannelConfig {
-  api_key_hash: string;
+  api_key_hash?: string;
   api_key_prefix: string;
   session_mode?: InvocationSessionMode;
   message: string;

--- a/crates/server/src/api/apps.rs
+++ b/crates/server/src/api/apps.rs
@@ -10,6 +10,8 @@ use crate::domains::apps::{
     APP_DANGEROUS, APP_MANAGE, APP_VIEW, AddA2aChannelCmd, AddA2aChannelOutput,
     RegenerateA2aApiKeyCmd, RegenerateA2aApiKeyOutput,
 };
+use crate::domains::messages::MessageService;
+use crate::domains::sessions::SessionService;
 use crate::services::CapabilityService;
 use crate::storage::{EncryptionService, StorageBackend};
 use axum::{
@@ -36,6 +38,8 @@ pub struct AppState {
     pub workflow_store: Option<Arc<dyn WorkflowEventStore + Send + Sync>>,
     pub capability_service: Arc<CapabilityService>,
     pub auth: AuthState,
+    pub session_service: Option<Arc<SessionService>>,
+    pub message_service: Option<Arc<MessageService>>,
 }
 
 impl AppState {
@@ -52,19 +56,38 @@ impl AppState {
             workflow_store,
             capability_service,
             auth,
+            session_service: None,
+            message_service: None,
         }
+    }
+
+    pub fn with_invocation_services(
+        mut self,
+        session_service: Arc<SessionService>,
+        message_service: Arc<MessageService>,
+    ) -> Self {
+        self.session_service = Some(session_service);
+        self.message_service = Some(message_service);
+        self
     }
 
     /// Build a domain Ctx from this AppState for the given org.
     pub fn ctx(&self, org: &ResolvedOrg) -> crate::domains::common::Ctx {
-        crate::domains::common::Ctx::new(
+        let mut ctx = crate::domains::common::Ctx::new(
             Caller::from(org),
             self.db.clone(),
             self.capability_service.clone(),
             self.encryption.clone(),
             self.auth.permission_resolver.clone(),
         )
-        .with_workflow_store(self.workflow_store.clone())
+        .with_workflow_store(self.workflow_store.clone());
+        if let Some(session_service) = &self.session_service {
+            ctx = ctx.with_session_service(session_service.clone());
+        }
+        if let Some(message_service) = &self.message_service {
+            ctx = ctx.with_message_service(message_service.clone());
+        }
+        ctx
     }
 }
 
@@ -84,7 +107,14 @@ pub fn routes(state: AppState) -> Router {
         .route("/v1/apps/{app_id}/publish", post(publish_app))
         .route("/v1/apps/{app_id}/unpublish", post(unpublish_app))
         // Channel sub-routes
-        .route("/v1/apps/{app_id}/channels", post(add_channel))
+        .route(
+            "/v1/apps/{app_id}/channels",
+            get(list_channels).post(add_channel),
+        )
+        .route(
+            "/v1/apps/{app_id}/channels/{channel_id}/trigger",
+            post(trigger_channel),
+        )
         .route(
             "/v1/apps/{app_id}/channels/{channel_id}",
             axum::routing::patch(update_channel).delete(delete_channel),
@@ -309,6 +339,21 @@ pub async fn unpublish_app(
 // Channel sub-routes
 // ============================================
 
+/// GET /v1/apps/{app_id}/channels - List channels on an app
+pub async fn list_channels(
+    org: ResolvedOrg,
+    State(state): State<AppState>,
+    Path(app_id): Path<String>,
+) -> ApiResult<ListResponse<AppChannel>> {
+    let channels = crate::domains::apps::ListAppChannels {
+        app_id,
+        channel_type: None,
+    }
+    .run(&state.ctx(&org))
+    .await?;
+    Ok(Json(ListResponse::new(channels)))
+}
+
 /// POST /v1/apps/{app_id}/channels - Add a channel to an app
 pub async fn add_channel(
     org: ResolvedOrg,
@@ -320,6 +365,18 @@ pub async fn add_channel(
         .run(&state.ctx(&org))
         .await?;
     Ok((StatusCode::CREATED, Json(channel)))
+}
+
+/// POST /v1/apps/{app_id}/channels/{channel_id}/trigger - Trigger an app schedule channel
+pub async fn trigger_channel(
+    org: ResolvedOrg,
+    State(state): State<AppState>,
+    Path((app_id, channel_id)): Path<(String, String)>,
+) -> ApiResult<crate::domains::apps::TriggerAppScheduleChannelOutput> {
+    let output = crate::domains::apps::TriggerAppScheduleChannelCmd { app_id, channel_id }
+        .run(&state.ctx(&org))
+        .await?;
+    Ok(Json(output))
 }
 
 /// PATCH /v1/apps/{app_id}/channels/{channel_id} - Update a channel

--- a/crates/server/src/api/mcp_endpoint/catalog.rs
+++ b/crates/server/src/api/mcp_endpoint/catalog.rs
@@ -28,11 +28,21 @@ fn excluded_from_read_only_query(name: &str) -> bool {
     matches!(name, "preview_agent" | "preview_harness")
 }
 
+fn exposed_to_scripting(meta: &crate::domains::common::CommandMeta) -> bool {
+    // Durable control-plane APIs are infrastructure internals. App schedule
+    // channels expose their own user-facing commands instead.
+    !meta.path.starts_with("/v1/durable/")
+}
+
 static INVENTORY_TOOL_DEFS: LazyLock<HashMap<&'static str, ToolDef>> = LazyLock::new(|| {
     inventory::iter::<crate::domains::common::CommandDescriptor>
         .into_iter()
-        .map(|desc| {
+        .filter_map(|desc| {
             let meta = (desc.meta)();
+            exposed_to_scripting(&meta).then_some((desc, meta))
+        })
+        .map(|desc| {
+            let (desc, meta) = desc;
             let schema = bashkit_inventory_schema((desc.param_schema)());
             let def = ToolDef::new(meta.name, meta.description)
                 .with_schema(schema)
@@ -91,6 +101,9 @@ pub fn build_toolset(ctx: CatalogContext, mode: ToolsetMode) -> ScriptingToolSet
         // THREAT[TM-MCP-002]: MCP `query` must not expose mutating server
         // tools. Read-only classification is backed by inventory tests.
         let meta = (desc.meta)();
+        if !exposed_to_scripting(&meta) {
+            continue;
+        }
         if mode == ToolsetMode::ReadOnly
             && (!(desc.read_only)() || excluded_from_read_only_query(meta.name))
         {

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -951,6 +951,10 @@ impl ServerAppBuilder {
             scheduler_store.clone(),
             capability_service.clone(),
             auth_state.clone(),
+        )
+        .with_invocation_services(
+            messages_state.session_service.clone(),
+            messages_state.message_service.clone(),
         );
         let schedules_state = api::schedules::routes(api::schedules::ScheduleAppState::new(
             db.clone(),

--- a/crates/server/src/domains/apps/commands.rs
+++ b/crates/server/src/domains/apps/commands.rs
@@ -148,18 +148,28 @@ fn durable_store(ctx: &Ctx) -> Result<&Arc<dyn WorkflowEventStore + Send + Sync>
     })
 }
 
-fn normalize_cron_expression(cron_expression: &str) -> String {
-    let fields: Vec<&str> = cron_expression.split_whitespace().collect();
-    if fields.len() == 5 {
-        format!("0 {} *", fields.join(" "))
-    } else {
-        cron_expression.trim().to_string()
-    }
+fn normalize_cron_expression(cron_expression: &str) -> Result<String, CommandError> {
+    let fields = cron_expression.split_whitespace().collect::<Vec<_>>();
+    let normalized = match fields.len() {
+        5 => format!("0 {} *", fields.join(" ")),
+        7 => fields.join(" "),
+        _ => {
+            return Err(CommandError::bad_request(
+                "Cron expression must be either 5 fields (min hour day month weekday) or 7 fields (sec min hour day month weekday year)",
+            ));
+        }
+    };
+    cron::Schedule::from_str(&normalized).map_err(|e| {
+        CommandError::bad_request(format!(
+            "Invalid schedule cron expression '{cron_expression}': {e}"
+        ))
+    })?;
+    Ok(normalized)
 }
 
 fn normalize_and_validate_channel_config(
     channel_type: ChannelType,
-    channel_config: Value,
+    mut channel_config: Value,
 ) -> Result<Value, CommandError> {
     match channel_type {
         ChannelType::Slack => {
@@ -223,21 +233,10 @@ fn normalize_and_validate_channel_config(
                     "Schedule channel config requires a non-empty message",
                 ));
             }
-            let cron_expression = normalize_cron_expression(&config.cron_expression);
-            cron::Schedule::from_str(&cron_expression).map_err(|e| {
-                CommandError::bad_request(format!(
-                    "Invalid schedule cron expression '{}': {e}",
-                    cron_expression
-                ))
-            })?;
-            let mut channel_config = channel_config;
-            if let Some(object) = channel_config.as_object_mut() {
-                object.insert(
-                    "cron_expression".to_string(),
-                    Value::String(cron_expression),
-                );
+            let normalized = normalize_cron_expression(&config.cron_expression)?;
+            if let Some(map) = channel_config.as_object_mut() {
+                map.insert("cron_expression".to_string(), Value::String(normalized));
             }
-            return Ok(channel_config);
         }
         ChannelType::Webhook => {
             let config: WebhookChannelConfig = serde_json::from_value(channel_config.clone())
@@ -284,10 +283,108 @@ fn normalize_and_validate_channel_config(
 fn calculate_schedule_next_trigger(
     cron_expression: &str,
 ) -> Result<Option<DateTime<Utc>>, CommandError> {
-    let schedule = cron::Schedule::from_str(cron_expression).map_err(|e| {
+    let normalized = normalize_cron_expression(cron_expression)?;
+    let schedule = cron::Schedule::from_str(&normalized).map_err(|e| {
         CommandError::bad_request(format!("Invalid cron expression '{cron_expression}': {e}"))
     })?;
     Ok(schedule.upcoming(Utc).next())
+}
+
+fn redact_channel_config(channel_type: &ChannelType, config: &mut Value) {
+    let Some(map) = config.as_object_mut() else {
+        return;
+    };
+    match channel_type {
+        ChannelType::Slack => {
+            if map.remove("signing_secret").is_some() {
+                map.insert("signing_secret_configured".to_string(), Value::Bool(true));
+            }
+            if map.remove("bot_token").is_some() {
+                map.insert("bot_token_configured".to_string(), Value::Bool(true));
+            }
+        }
+        ChannelType::AgUi => {
+            if map.remove("token").is_some() {
+                map.insert("token_configured".to_string(), Value::Bool(true));
+            }
+        }
+        ChannelType::Webhook => {
+            if map.remove("token").is_some() {
+                map.insert("token_configured".to_string(), Value::Bool(true));
+            }
+        }
+        ChannelType::A2a => {
+            map.remove("api_key_hash");
+        }
+        ChannelType::Schedule => {}
+    }
+}
+
+fn redact_channel_for_response(mut channel: AppChannel) -> AppChannel {
+    redact_channel_config(&channel.channel_type, &mut channel.channel_config);
+    channel
+}
+
+fn redact_app_for_response(mut app: App) -> App {
+    app.channels = app
+        .channels
+        .into_iter()
+        .map(redact_channel_for_response)
+        .collect();
+    app
+}
+
+fn merge_preserved_secret_fields(
+    channel_type: ChannelType,
+    final_channel_config: &mut Value,
+    existing_decrypted: &Value,
+) {
+    let (Some(out), Some(existing)) = (
+        final_channel_config.as_object_mut(),
+        existing_decrypted.as_object(),
+    ) else {
+        return;
+    };
+
+    match channel_type {
+        ChannelType::Slack => {
+            for key in ["signing_secret", "bot_token"] {
+                let should_preserve = out
+                    .get(key)
+                    .and_then(Value::as_str)
+                    .map(str::trim)
+                    .is_none_or(str::is_empty);
+                if should_preserve && let Some(existing_value) = existing.get(key) {
+                    out.insert(key.to_string(), existing_value.clone());
+                }
+            }
+        }
+        ChannelType::AgUi => {
+            if !out.contains_key("token")
+                && let Some(existing_value) = existing.get("token")
+            {
+                out.insert("token".to_string(), existing_value.clone());
+            }
+        }
+        ChannelType::Webhook => {
+            let should_preserve = out
+                .get("token")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .is_none_or(str::is_empty);
+            if should_preserve && let Some(existing_value) = existing.get("token") {
+                out.insert("token".to_string(), existing_value.clone());
+            }
+        }
+        ChannelType::A2a => {
+            for key in ["api_key_hash", "api_key_prefix"] {
+                if let Some(existing_value) = existing.get(key) {
+                    out.insert(key.to_string(), existing_value.clone());
+                }
+            }
+        }
+        ChannelType::Schedule => {}
+    }
 }
 
 fn schedule_binding_name(channel_id: AppChannelId) -> String {
@@ -423,9 +520,10 @@ async fn sync_schedule_binding_for_channel(
     let config = channel
         .schedule_config()
         .ok_or_else(|| CommandError::bad_request("Invalid schedule channel configuration"))?;
+    let cron_expression = normalize_cron_expression(&config.cron_expression)?;
     let enabled = app.status == AppStatus::Published && channel.enabled;
     let next_trigger_at = if enabled {
-        UpdateField::from_option(calculate_schedule_next_trigger(&config.cron_expression)?)
+        UpdateField::from_option(calculate_schedule_next_trigger(&cron_expression)?)
     } else {
         UpdateField::Clear
     };
@@ -439,7 +537,7 @@ async fn sync_schedule_binding_for_channel(
                     "App schedule channel {} for {}",
                     channel.public_id, app.name
                 )),
-                cron_expression: Some(config.cron_expression.clone()),
+                cron_expression: Some(cron_expression.clone()),
                 timezone: Some(config.timezone.clone()),
                 target_type: Some(ScheduleTargetType::Activity),
                 target_name: Some(SCHEDULE_CHANNEL_ACTIVITY.to_string()),
@@ -462,7 +560,7 @@ async fn sync_schedule_binding_for_channel(
                                 "App schedule channel {} for {}",
                                 channel.public_id, app.name
                             )),
-                            cron_expression: config.cron_expression.clone(),
+                            cron_expression: cron_expression.clone(),
                             timezone: config.timezone.clone(),
                             target_type: ScheduleTargetType::Activity,
                             target_name: SCHEDULE_CHANNEL_ACTIVITY.to_string(),
@@ -473,7 +571,7 @@ async fn sync_schedule_binding_for_channel(
                             max_catch_up: Some(1),
                             retry_policy: None,
                             next_trigger_at: if enabled {
-                                calculate_schedule_next_trigger(&config.cron_expression)?
+                                calculate_schedule_next_trigger(&cron_expression)?
                             } else {
                                 None
                             },
@@ -494,7 +592,7 @@ async fn sync_schedule_binding_for_channel(
                         "App schedule channel {} for {}",
                         channel.public_id, app.name
                     )),
-                    cron_expression: config.cron_expression.clone(),
+                    cron_expression: cron_expression.clone(),
                     timezone: config.timezone.clone(),
                     target_type: ScheduleTargetType::Activity,
                     target_name: SCHEDULE_CHANNEL_ACTIVITY.to_string(),
@@ -505,7 +603,7 @@ async fn sync_schedule_binding_for_channel(
                     max_catch_up: Some(1),
                     retry_policy: None,
                     next_trigger_at: if enabled {
-                        calculate_schedule_next_trigger(&config.cron_expression)?
+                        calculate_schedule_next_trigger(&cron_expression)?
                     } else {
                         None
                     },
@@ -1213,7 +1311,7 @@ impl Command for CreateApp {
             sync_schedule_binding_for_channel(ctx, &app, channel_row).await?;
         }
 
-        Ok(app)
+        Ok(redact_app_for_response(app))
     }
 }
 
@@ -1255,9 +1353,12 @@ impl Command for ListApps {
             .list_apps(ctx.org_id(), self.search.as_deref(), self.include_archived)
             .await
             .map_err(classify_anyhow)?;
-        q::load_apps_list(&ctx.db, encryption, rows, ctx.org_id())
+        Ok(q::load_apps_list(&ctx.db, encryption, rows, ctx.org_id())
             .await
-            .map_err(classify_anyhow)
+            .map_err(classify_anyhow)?
+            .into_iter()
+            .map(redact_app_for_response)
+            .collect())
     }
 }
 
@@ -1304,11 +1405,71 @@ impl Command for GetApp {
         q::get_by_public_id(&ctx.db, encryption, ctx.org_id(), &app_id.to_string())
             .await
             .map_err(classify_anyhow)?
+            .map(redact_app_for_response)
             .ok_or_else(|| CommandError::not_found("App"))
     }
 }
 
 inventory::submit! { CommandDescriptor::of::<GetApp>() }
+
+// ============================================================================
+// ListAppChannels
+// ============================================================================
+
+/// List channels attached to an app.
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct ListAppChannels {
+    pub app_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub channel_type: Option<ChannelType>,
+}
+
+impl Command for ListAppChannels {
+    type Output = Vec<AppChannel>;
+
+    fn meta() -> CommandMeta {
+        CommandMeta {
+            name: "list_app_channels",
+            category: "apps",
+            description: "List channels attached to an app. Secret fields are redacted.",
+            method: "GET",
+            path: "/v1/apps/{id}/channels",
+        }
+    }
+
+    fn policy() -> Option<&'static Policy> {
+        Some(&APP_VIEW)
+    }
+
+    fn positional_arg() -> Option<&'static str> {
+        Some("app_id")
+    }
+
+    async fn execute(self, ctx: &Ctx) -> Result<Vec<AppChannel>, CommandError> {
+        let app_id: AppId = self
+            .app_id
+            .parse()
+            .map_err(|e| CommandError::bad_request(format!("Invalid app ID: {e}")))?;
+
+        let encryption = ctx.encryption.as_ref();
+        let app = q::get_by_public_id(&ctx.db, encryption, ctx.org_id(), &app_id.to_string())
+            .await
+            .map_err(classify_anyhow)?
+            .ok_or_else(|| CommandError::not_found("App"))?;
+        Ok(app
+            .channels
+            .into_iter()
+            .filter(|channel| {
+                self.channel_type
+                    .as_ref()
+                    .is_none_or(|channel_type| &channel.channel_type == channel_type)
+            })
+            .map(redact_channel_for_response)
+            .collect())
+    }
+}
+
+inventory::submit! { CommandDescriptor::of::<ListAppChannels>() }
 
 // ============================================================================
 // UpdateApp
@@ -1514,7 +1675,7 @@ impl Command for UpdateAppCmd {
         if req.status.is_some() {
             sync_all_schedule_bindings(ctx, &app).await?;
         }
-        Ok(app)
+        Ok(redact_app_for_response(app))
     }
 }
 
@@ -1720,7 +1881,7 @@ impl Command for PublishApp {
             .ok_or_else(|| CommandError::not_found("App"))?;
         let app = q::row_to_app(&ctx.db, encryption, row, ctx.org_id()).await;
         sync_all_schedule_bindings(ctx, &app).await?;
-        Ok(app)
+        Ok(redact_app_for_response(app))
     }
 }
 
@@ -1784,7 +1945,7 @@ impl Command for UnpublishApp {
             .ok_or_else(|| CommandError::not_found("App"))?;
         let app = q::row_to_app(&ctx.db, encryption, row, ctx.org_id()).await;
         sync_all_schedule_bindings(ctx, &app).await?;
-        Ok(app)
+        Ok(redact_app_for_response(app))
     }
 }
 
@@ -1870,7 +2031,9 @@ impl Command for AddChannel {
         let app = q::row_to_app(&ctx.db, encryption, app, ctx.org_id()).await;
         sync_schedule_binding_for_channel(ctx, &app, &row).await?;
 
-        Ok(q::channel_row_to_channel(encryption, row))
+        Ok(redact_channel_for_response(q::channel_row_to_channel(
+            encryption, row,
+        )))
     }
 }
 
@@ -1884,6 +2047,8 @@ inventory::submit! { CommandDescriptor::of::<AddChannel>() }
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct AddScheduleChannelCmd {
     pub app_id: String,
+    /// Cron expression. Accepts 5 fields (`*/10 * * * *`) or 7 fields
+    /// (`0 */10 * * * * *`); 5-field input is stored as 7-field cron.
     pub cron_expression: String,
     pub timezone: Option<String>,
     #[serde(default)]
@@ -1902,7 +2067,7 @@ impl Command for AddScheduleChannelCmd {
         CommandMeta {
             name: "add_schedule_app_channel",
             category: "apps",
-            description: "Add a schedule invocation channel to an app using flat args.",
+            description: "Add a schedule invocation channel to an app using flat args. cron_expression accepts 5-field or 7-field cron; 5-field input is normalized to 7-field cron.",
             method: "POST",
             path: "/v1/apps/{id}/channels",
         }
@@ -1932,6 +2097,70 @@ impl Command for AddScheduleChannelCmd {
 }
 
 inventory::submit! { CommandDescriptor::of::<AddScheduleChannelCmd>() }
+
+// ============================================================================
+// TriggerAppScheduleChannel
+// ============================================================================
+
+#[derive(Debug, serde::Serialize, ToSchema)]
+pub struct TriggerAppScheduleChannelOutput {
+    pub session_id: SessionId,
+    pub created_session: bool,
+}
+
+/// Manually trigger an app schedule channel, primarily for testing.
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct TriggerAppScheduleChannelCmd {
+    pub app_id: String,
+    pub channel_id: String,
+}
+
+impl Command for TriggerAppScheduleChannelCmd {
+    type Output = TriggerAppScheduleChannelOutput;
+
+    fn meta() -> CommandMeta {
+        CommandMeta {
+            name: "trigger_app_schedule_channel",
+            category: "apps",
+            description: "Manually trigger an app schedule channel. Use app_id and channel_id from list_app_channels.",
+            method: "POST",
+            path: "/v1/apps/{id}/channels/{channel_id}/trigger",
+        }
+    }
+
+    fn policy() -> Option<&'static Policy> {
+        Some(&APP_MANAGE)
+    }
+
+    async fn execute(self, ctx: &Ctx) -> Result<TriggerAppScheduleChannelOutput, CommandError> {
+        let session_service = ctx.session_service.as_ref().ok_or_else(|| {
+            CommandError::Internal(anyhow::anyhow!("Session service not available"))
+        })?;
+        let message_service = ctx.message_service.as_ref().ok_or_else(|| {
+            CommandError::Internal(anyhow::anyhow!("Message service not available"))
+        })?;
+        let app_id: AppId = self
+            .app_id
+            .parse()
+            .map_err(|e| CommandError::bad_request(format!("Invalid app ID: {e}")))?;
+        let result = invoke_scheduled_app_channel(
+            &ctx.db,
+            ctx.encryption.as_ref(),
+            session_service,
+            message_service,
+            ctx.org_id(),
+            &app_id.to_string(),
+            &self.channel_id,
+        )
+        .await?;
+        Ok(TriggerAppScheduleChannelOutput {
+            session_id: result.session_id,
+            created_session: result.created_session,
+        })
+    }
+}
+
+inventory::submit! { CommandDescriptor::of::<TriggerAppScheduleChannelCmd>() }
 
 // ============================================================================
 // AddWebhookChannel
@@ -2199,7 +2428,7 @@ impl Command for RegenerateA2aApiKeyCmd {
 
         Ok(RegenerateA2aApiKeyOutput {
             api_key: plaintext,
-            channel: q::channel_row_to_channel(encryption, row),
+            channel: redact_channel_for_response(q::channel_row_to_channel(encryption, row)),
         })
     }
 }
@@ -2286,23 +2515,13 @@ impl Command for UpdateChannelCmd {
             .channel_config
             .clone()
             .unwrap_or_else(|| existing_decrypted.clone());
-        // A2A: server preserves the secret key material across PATCH. Clients
-        // updating non-secret fields (message, session_mode, agent card)
-        // should not need to round-trip the api_key_hash and api_key_prefix —
-        // and must not be able to overwrite them with bogus values. Use the
-        // dedicated regenerate-key endpoint to rotate the key.
-        if final_channel_type == ChannelType::A2a
-            && let (Some(out), Some(existing)) = (
-                final_channel_config.as_object_mut(),
-                existing_decrypted.as_object(),
-            )
-        {
-            for key in ["api_key_hash", "api_key_prefix"] {
-                if let Some(existing_value) = existing.get(key) {
-                    out.insert(key.to_string(), existing_value.clone());
-                }
-            }
-        }
+        // Secret-bearing channel fields are write-only. Preserve existing
+        // secret material when a PATCH only sends user-editable fields.
+        merge_preserved_secret_fields(
+            final_channel_type.clone(),
+            &mut final_channel_config,
+            &existing_decrypted,
+        );
         if final_channel_type == ChannelType::Schedule {
             let _ = durable_store(ctx)?;
         }
@@ -2339,7 +2558,9 @@ impl Command for UpdateChannelCmd {
         let app = q::row_to_app(&ctx.db, encryption, app, ctx.org_id()).await;
         sync_schedule_binding_for_channel(ctx, &app, &row).await?;
 
-        Ok(q::channel_row_to_channel(encryption, row))
+        Ok(redact_channel_for_response(q::channel_row_to_channel(
+            encryption, row,
+        )))
     }
 }
 

--- a/crates/server/src/domains/schedules/commands.rs
+++ b/crates/server/src/domains/schedules/commands.rs
@@ -42,8 +42,9 @@ impl Command for CreateSchedule {
     async fn execute(self, ctx: &Ctx) -> Result<ScheduleResponse, CommandError> {
         q::ensure_platform_user(ctx)?;
         let store = q::store(ctx)?;
-        let req = self.0;
+        let mut req = self.0;
         let target_type = q::parse_target_type(&req.target.target_type)?;
+        req.cron_expression = q::normalize_cron_expression(&req.cron_expression)?;
         let next_trigger_at = if req.enabled {
             q::calculate_next_trigger(&req.cron_expression)?
         } else {
@@ -209,7 +210,11 @@ impl Command for UpdateScheduleCmd {
     async fn execute(self, ctx: &Ctx) -> Result<ScheduleResponse, CommandError> {
         q::ensure_platform_user(ctx)?;
         let store = q::store(ctx)?;
-        let req = self.req;
+        let mut req = self.req;
+        req.cron_expression = req
+            .cron_expression
+            .map(|cron| q::normalize_cron_expression(&cron))
+            .transpose()?;
         let target_type = q::optional_target_type(
             req.target
                 .as_ref()

--- a/crates/server/src/domains/schedules/queries.rs
+++ b/crates/server/src/domains/schedules/queries.rs
@@ -55,9 +55,26 @@ pub fn parse_execution_status(value: &str) -> Result<ScheduleExecutionStatus, Co
 pub fn calculate_next_trigger(
     cron_expression: &str,
 ) -> Result<Option<DateTime<Utc>>, CommandError> {
-    let schedule = cron::Schedule::from_str(cron_expression)
+    let normalized = normalize_cron_expression(cron_expression)?;
+    let schedule = cron::Schedule::from_str(&normalized)
         .map_err(|e| CommandError::bad_request(format!("Invalid cron expression: {e}")))?;
     Ok(schedule.upcoming(Utc).next())
+}
+
+pub fn normalize_cron_expression(cron_expression: &str) -> Result<String, CommandError> {
+    let fields = cron_expression.split_whitespace().collect::<Vec<_>>();
+    let normalized = match fields.len() {
+        5 => format!("0 {} *", fields.join(" ")),
+        7 => fields.join(" "),
+        _ => {
+            return Err(CommandError::bad_request(
+                "Cron expression must be either 5 fields (min hour day month weekday) or 7 fields (sec min hour day month weekday year)",
+            ));
+        }
+    };
+    cron::Schedule::from_str(&normalized)
+        .map_err(|e| CommandError::bad_request(format!("Invalid cron expression: {e}")))?;
+    Ok(normalized)
 }
 
 pub fn map_store_error(error: StoreError) -> CommandError {

--- a/crates/server/tests/api_integration_test.rs
+++ b/crates/server/tests/api_integration_test.rs
@@ -4026,6 +4026,14 @@ async fn test_create_app_schedule_and_webhook_channels_persist_in_postgres() {
 
     assert_eq!(stored_webhook_app["channels"].as_array().unwrap().len(), 1);
     assert_eq!(stored_webhook_app["channels"][0]["channel_type"], "webhook");
+    assert!(
+        stored_webhook_app["channels"][0]["channel_config"]["token"].is_null(),
+        "webhook token must not be returned"
+    );
+    assert_eq!(
+        stored_webhook_app["channels"][0]["channel_config"]["token_configured"],
+        true
+    );
     assert_eq!(
         stored_webhook_app["channels"][0]["channel_config"]["session_mode"],
         "session_per_invocation"

--- a/crates/server/tests/mcp_endpoint_test.rs
+++ b/crates/server/tests/mcp_endpoint_test.rs
@@ -1631,7 +1631,7 @@ async fn test_mcp_execute_app_commands_support_schedule_and_webhook_channels() {
         "execute",
         json!({
             "commands": format!(
-                "add_schedule_app_channel --app_id {app_id} --cron_expression '0 * * * *' --timezone UTC --session_mode shared_session --message 'run checks'"
+                "add_schedule_app_channel --app_id {app_id} --cron_expression '*/10 * * * *' --timezone UTC --session_mode shared_session --message 'run checks'"
             )
         }),
     )
@@ -1641,11 +1641,15 @@ async fn test_mcp_execute_app_commands_support_schedule_and_webhook_channels() {
         "add_app_channel schedule failed: {}",
         tool_text(&add_schedule_resp)
     );
-    assert_eq!(tool_json(&add_schedule_resp)["channel_type"], "schedule");
+    let schedule_channel = tool_json(&add_schedule_resp);
+    assert_eq!(schedule_channel["channel_type"], "schedule");
     assert_eq!(
-        tool_json(&add_schedule_resp)["channel_config"]["cron_expression"],
-        "0 0 * * * * *"
+        schedule_channel["channel_config"]["cron_expression"],
+        "0 */10 * * * * *"
     );
+    let schedule_channel_id = schedule_channel["id"]
+        .as_str()
+        .expect("schedule channel id");
 
     let add_webhook_resp = mcp_tool_call(
         &server,
@@ -1663,6 +1667,31 @@ async fn test_mcp_execute_app_commands_support_schedule_and_webhook_channels() {
         tool_text(&add_webhook_resp)
     );
     assert_eq!(tool_json(&add_webhook_resp)["channel_type"], "webhook");
+
+    let list_channels_resp = mcp_tool_call(
+        &server,
+        "execute",
+        json!({ "commands": format!("list_app_channels {app_id}") }),
+    )
+    .await;
+    assert!(
+        !tool_is_error(&list_channels_resp),
+        "list_app_channels failed: {}",
+        tool_text(&list_channels_resp)
+    );
+    let channels = tool_json(&list_channels_resp);
+    let serialized_channels = serde_json::to_string(&channels).unwrap();
+    assert!(
+        !serialized_channels.contains("secret-1"),
+        "channel listing leaked webhook token: {serialized_channels}"
+    );
+    assert!(
+        channels
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|channel| channel["channel_config"]["token_configured"] == true)
+    );
 
     let get_resp = mcp_tool_call(
         &server,
@@ -1684,6 +1713,45 @@ async fn test_mcp_execute_app_commands_support_schedule_and_webhook_channels() {
         .collect::<Vec<_>>();
     assert!(channel_types.contains(&"schedule"));
     assert!(channel_types.contains(&"webhook"));
+    let serialized_app = serde_json::to_string(&fetched_app).unwrap();
+    assert!(
+        !serialized_app.contains("secret-1"),
+        "get_app leaked webhook token: {serialized_app}"
+    );
+
+    let publish_resp = mcp_tool_call(
+        &server,
+        "execute",
+        json!({ "commands": format!("publish_app {app_id}") }),
+    )
+    .await;
+    assert!(
+        !tool_is_error(&publish_resp),
+        "publish_app failed: {}",
+        tool_text(&publish_resp)
+    );
+
+    let trigger_resp = mcp_tool_call(
+        &server,
+        "execute",
+        json!({
+            "commands": format!(
+                "trigger_app_schedule_channel --app_id {app_id} --channel_id {schedule_channel_id}"
+            )
+        }),
+    )
+    .await;
+    assert!(
+        !tool_is_error(&trigger_resp),
+        "trigger_app_schedule_channel failed: {}",
+        tool_text(&trigger_resp)
+    );
+    assert!(
+        tool_json(&trigger_resp)["session_id"]
+            .as_str()
+            .unwrap()
+            .starts_with("session_")
+    );
 }
 
 // Contract matrix for recent MCP execute regressions:
@@ -2262,6 +2330,14 @@ async fn test_mcp_execute_discover_all() {
     let stdout = result["stdout"].as_str().unwrap();
     assert!(stdout.contains("agents"), "Should list agents category");
     assert!(stdout.contains("sessions"), "Should list sessions category");
+    assert!(
+        !stdout.contains("list_schedules"),
+        "durable schedule tools should not be exposed through MCP execute"
+    );
+    assert!(
+        !stdout.contains("/v1/durable/"),
+        "durable control-plane tools should not be exposed through MCP execute"
+    );
 }
 
 // ============================================================================

--- a/crates/server/tests/schedule_integration_test.rs
+++ b/crates/server/tests/schedule_integration_test.rs
@@ -46,6 +46,43 @@ async fn test_create_schedule() {
 }
 
 #[tokio::test]
+async fn test_schedule_accepts_five_field_cron_on_create_and_update() {
+    let server = TestServer::new().await;
+
+    let created: Value = server
+        .post(
+            "/v1/durable/schedules",
+            json!({
+                "name": "five-field-cron",
+                "cron_expression": "*/15 * * * *",
+                "target": {
+                    "type": "workflow",
+                    "name": "test-workflow"
+                }
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    assert_eq!(created["cron_expression"], "0 */15 * * * * *");
+
+    let id = created["id"].as_str().unwrap();
+    let updated: Value = server
+        .patch(
+            &format!("/v1/durable/schedules/{}", id),
+            json!({
+                "cron_expression": "5 6 * * *"
+            }),
+        )
+        .await
+        .assert_status(StatusCode::OK)
+        .json();
+
+    assert_eq!(updated["cron_expression"], "0 5 6 * * * *");
+}
+
+#[tokio::test]
 async fn test_create_schedule_invalid_cron() {
     let server = TestServer::new().await;
 

--- a/crates/server/tests/test_harness.rs
+++ b/crates/server/tests/test_harness.rs
@@ -432,6 +432,10 @@ impl TestServer {
             Some(durable_store.clone()),
             capability_service.clone(),
             auth_state.clone(),
+        )
+        .with_invocation_services(
+            messages_state.session_service.clone(),
+            messages_state.message_service.clone(),
         );
         let slack_state = api::slack_events::SlackState::new(
             db.clone(),

--- a/plugins/everruns-dev/skills/everruns-dev/SKILL.md
+++ b/plugins/everruns-dev/skills/everruns-dev/SKILL.md
@@ -256,6 +256,26 @@ query { "commands": "list_agents | jq -r '.data[].id' | while read id; do\n  get
 execute { "commands": "create_mcp_server --name \"jira\" --url \"https://mcp.example.com/jira\" --auth_mode oauth" }
 ```
 
+**Work with app invocation channels.**
+
+Use app-channel commands for app schedules. Do not use durable schedule
+commands for app schedules; those infrastructure builtins are intentionally not
+exposed through MCP scripting.
+
+```bash
+query { "commands": "list_app_channels app_01933b5a00007000800000000000001 | jq '.[] | {id, channel_type, enabled, channel_config}'" }
+```
+
+Schedule channels accept either 5-field cron (`*/10 * * * *`) or 7-field cron
+(`0 */10 * * * * *`). The server stores 7-field cron.
+
+```bash
+execute { "commands": "CID=$(add_schedule_app_channel --app_id \"$APP_ID\" --cron_expression '*/10 * * * *' --timezone UTC --session_mode shared_session --message 'Run the scheduled check' | jq -r .id)\npublish_app \"$APP_ID\"\ntrigger_app_schedule_channel --app_id \"$APP_ID\" --channel_id \"$CID\"" }
+```
+
+Channel secret fields are write-only. Reads return non-secret fields and
+`*_configured` booleans instead of plaintext tokens or signing secrets.
+
 **Look up an org by id.**
 
 `get_org` accepts the `org_...` entity id as a positional arg.

--- a/specs/app-invocation-channels.md
+++ b/specs/app-invocation-channels.md
@@ -127,11 +127,16 @@ config or syncing the backing durable schedule.
 
 Behavior:
 
+- accepted cron input is either 5-field (`*/10 * * * *`) or 7-field
+  (`0 */10 * * * * *`); 5-field input is normalized to the durable
+  scheduler's 7-field representation when stored
 - create/update/delete stays in the app domain
 - the app domain creates or updates the backing durable schedule
 - publish state and channel `enabled` control whether the durable binding is enabled
 - deleting the app channel deletes the durable binding
 - unpublishing disables the binding without deleting it
+- `POST /v1/apps/{app_id}/channels/{channel_id}/trigger` manually invokes a
+  schedule channel for testing without exposing the backing durable schedule ID
 
 The durable scheduler only knows how to fire `invoke_scheduled_app_channel`. All app-specific resolution happens in the app domain at execution time.
 
@@ -159,9 +164,16 @@ Behavior:
 Invocation channels must be reachable through all app-management surfaces:
 
 - HTTP app APIs
-- MCP/bash command catalog (`create_app`, `add_app_channel`, `update_app_channel`, etc.)
+- MCP/bash command catalog (`create_app`, `list_app_channels`,
+  `add_app_channel`, `trigger_app_schedule_channel`, etc.). Generic durable
+  schedule commands are intentionally not exposed through MCP scripting; app
+  schedule channels own their lifecycle.
 - `platform_management` capability (`read_apps`, `manage_apps`, `manage_app_channels`)
 - Apps UI
+
+Secrets in channel configs are write-only in user-facing responses. App and
+channel reads return only non-secret fields plus `*_configured` booleans where
+callers need to know whether a secret exists.
 
 ## Testing
 

--- a/specs/scheduled-tasks.md
+++ b/specs/scheduled-tasks.md
@@ -64,7 +64,11 @@ See `crates/server/migrations/002_durable_execution.sql` for the full schema. Tr
 
 ### Cron Expression Format
 
-Cron expressions follow the durable scheduler's current parser format. In practice this codebase uses 7-field expressions in APIs and tests. Examples: `0 * * * * * *` (every minute), `0 */30 * * * * *` (every 30 minutes).
+Cron expressions accepted by platform APIs may be either 5-field
+(`*/10 * * * *`) or 7-field (`0 */10 * * * * *`). The durable scheduler stores
+and evaluates the 7-field form (`sec min hour day month weekday year`), so
+5-field input is normalized by prefixing seconds (`0`) and suffixing year (`*`).
+Examples: `0 * * * * * *` (every minute), `0 */30 * * * * *` (every 30 minutes).
 
 ## Timezone Semantics
 


### PR DESCRIPTION
## What
- Hide durable control-plane tools from MCP scripting and expose app-channel-specific schedule operations instead.
- Add `list_app_channels` and `trigger_app_schedule_channel` plus matching HTTP routes.
- Accept 5-field and 7-field cron for app and durable schedules, storing normalized 7-field cron.
- Redact channel secrets from app/channel reads and surface `*_configured` flags for UI/API consumers.
- Update specs and the everruns-dev plugin guidance.

## Why
App schedule channels and durable schedules were exposed with overlapping names, which made `list_schedules` / `trigger_schedule` look like they applied to app schedules even though they target durable schedules. Channel reads also returned secret-bearing config fields.

## How
- Filter `/v1/durable/*` inventory commands out of MCP scripting discovery/execution.
- Keep app schedule lifecycle in the app domain and add explicit list/trigger app-channel commands.
- Normalize cron during validation and schedule binding sync.
- Redact Slack, AG-UI, webhook, and A2A secret fields on response serialization; preserve existing write-only secrets on PATCH.
- Update UI typing/status logic to use configured flags instead of plaintext secrets.

## Risk
- Medium
- Changes API/MCP command exposure, app-channel response shapes for secret fields, and schedule cron validation/storage. Existing consumers relying on plaintext secret reads must switch to write-only update semantics plus configured flags.

## Security
- Threat categories reviewed: TM-API, TM-TOOL, TM-AUTHZ, TM-TENANT, TM-DOS, TM-WEB.
- Findings and resolutions: app/channel read responses now redact secret-bearing fields; app commands retain APP_VIEW/APP_MANAGE policies; org-scoped app lookup remains unchanged; cron expressions are bounded by field count and parser validation; durable internal commands are removed from MCP scripting exposure; UI no longer assumes secret plaintext is returned.
- Threat-model update: not needed; this narrows an existing data exposure risk and preserves the existing MCP read/mutation mitigation comment.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] All review comments addressed (code change or written reasoning)

Validation:
- `CARGO_INCREMENTAL=0 cargo test -p everruns-server --test mcp_endpoint_test test_mcp_execute_app_commands_support_schedule_and_webhook_channels -- --nocapture`
- `CARGO_INCREMENTAL=0 just pre-push`
- `npm run build` in `apps/ui`
- `PORT_PREFIX=274 CARGO_INCREMENTAL=0 just start-dev --no-watch`; `GET /health`; MCP `discover --all | grep -E "list_app_channels|trigger_app_schedule_channel|list_schedules"`; `PORT_PREFIX=274 just stop-all`
