### PR TITLE
fix(ui): handle legacy capability configs

### DIFF
--- a/apps/ui/src/__tests__/selected-capability-list.test.tsx
+++ b/apps/ui/src/__tests__/selected-capability-list.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from "@testing-library/react";
+import { SelectedCapabilityList } from "@/components/agents/selected-capability-list";
+import type { AgentCapabilityConfig, Capability } from "@/lib/api/types";
+
+function capability(overrides: Partial<Capability> = {}): Capability {
+  return {
+    id: "legacy_capability",
+    name: "Legacy Capability",
+    description: "Capability with legacy config data",
+    status: "available",
+    config_schema: {
+      type: "object",
+      properties: {
+        endpoint: { type: "string", title: "Endpoint" },
+      },
+    },
+    ...overrides,
+  };
+}
+
+describe("SelectedCapabilityList", () => {
+  it("renders capabilities whose legacy config is missing", () => {
+    const selected = [
+      { ref: "legacy_capability", config: undefined },
+    ] as unknown as AgentCapabilityConfig[];
+    const cap = capability();
+
+    render(
+      <SelectedCapabilityList
+        selected={selected}
+        getCapability={(id) => (id === cap.id ? cap : undefined)}
+        getDependents={() => []}
+        onRemove={jest.fn()}
+        onConfigChange={jest.fn()}
+        onMoveUp={jest.fn()}
+        onMoveDown={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Legacy Capability")).toBeInTheDocument();
+  });
+});

--- a/apps/ui/src/app/(main)/agents/[agentId]/edit/page.tsx
+++ b/apps/ui/src/app/(main)/agents/[agentId]/edit/page.tsx
@@ -31,6 +31,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { CapabilitySelector } from "@/components/agents/capability-selector";
+import { normalizeCapabilityConfigs } from "@/components/agents/capability-config";
 import { AgentPreview } from "@/components/agents/agent-preview";
 import { EntityDeleteErrorNotice } from "@/components/entity-delete-error-notice";
 import { InitialFilesEditor } from "@/components/initial-files-editor";
@@ -118,7 +119,7 @@ export default function EditAgentPage({ params }: { params: Promise<{ agentId: s
   // Capabilities state - now included directly in agent response
   // Use full AgentCapabilityConfig objects to preserve per-agent config
   const initialCapabilities = useMemo(() => {
-    return agent?.capabilities ?? [];
+    return normalizeCapabilityConfigs(agent?.capabilities);
   }, [agent?.capabilities]);
 
   const [localCapabilities, setLocalCapabilities] = useState<AgentCapabilityConfig[] | null>(null);

--- a/apps/ui/src/app/(main)/harnesses/[harnessId]/edit/page.tsx
+++ b/apps/ui/src/app/(main)/harnesses/[harnessId]/edit/page.tsx
@@ -32,6 +32,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { CapabilitySelector } from "@/components/agents/capability-selector";
+import { normalizeCapabilityConfigs } from "@/components/agents/capability-config";
 import { EntityDeleteErrorNotice } from "@/components/entity-delete-error-notice";
 import { HarnessSelect } from "@/components/harness/harness-select";
 import { HarnessPreview } from "@/components/harnesses/harness-preview";
@@ -122,7 +123,7 @@ export default function EditHarnessPage({ params }: { params: Promise<{ harnessI
   }, []);
 
   const initialCapabilities = useMemo(() => {
-    return harness?.capabilities ?? [];
+    return normalizeCapabilityConfigs(harness?.capabilities);
   }, [harness?.capabilities]);
 
   const [localCapabilities, setLocalCapabilities] = useState<AgentCapabilityConfig[] | null>(null);

--- a/apps/ui/src/components/agents/capability-config.ts
+++ b/apps/ui/src/components/agents/capability-config.ts
@@ -1,0 +1,17 @@
+import type { AgentCapabilityConfig } from "@/lib/api/types";
+
+export function capabilityConfigRecord(config: unknown): Record<string, unknown> {
+  if (!config || typeof config !== "object" || Array.isArray(config)) {
+    return {};
+  }
+  return config as Record<string, unknown>;
+}
+
+export function normalizeCapabilityConfigs(
+  capabilities: AgentCapabilityConfig[] | null | undefined,
+): AgentCapabilityConfig[] {
+  return (capabilities ?? []).map((capability) => ({
+    ...capability,
+    config: capabilityConfigRecord(capability.config),
+  }));
+}

--- a/apps/ui/src/components/agents/selected-capability-list.tsx
+++ b/apps/ui/src/components/agents/selected-capability-list.tsx
@@ -8,6 +8,7 @@ import { ChevronUp, ChevronDown, X, Plug, Lock, Settings } from "lucide-react";
 import type { Capability, CapabilityId, AgentCapabilityConfig } from "@/lib/api/types";
 import { getCapabilityIcon } from "@/lib/capability-icons";
 import { cn } from "@/lib/utils";
+import { capabilityConfigRecord } from "./capability-config";
 import { CapabilitySettingsEditor, hasCapabilitySettings } from "./capability-settings-editor";
 
 interface SelectedCapabilityListProps {
@@ -62,7 +63,8 @@ export function SelectedCapabilityList({
         const IconComponent = getCapabilityIcon(cap.icon);
         const hasSettings = hasCapabilitySettings(cap);
         const isSettingsExpanded = expandedSettings.has(capConfig.ref);
-        const hasConfigValues = Object.keys(capConfig.config).length > 0;
+        const config = capabilityConfigRecord(capConfig.config);
+        const hasConfigValues = Object.keys(config).length > 0;
         const dependents = getDependents(capConfig.ref);
         const isRequired = dependents.length > 0;
 
@@ -182,7 +184,7 @@ export function SelectedCapabilityList({
                   <div className="px-2 pb-2 border-t border-border/50 mx-2 pt-2">
                     <CapabilitySettingsEditor
                       capability={cap}
-                      config={capConfig.config}
+                      config={config}
                       onChange={(newConfig) => onConfigChange(capConfig.ref, newConfig)}
                       disabled={disabled}
                     />


### PR DESCRIPTION
## What
Normalize legacy/malformed capability config values before rendering agent and harness edit pages.

## Why
The agent edit page could crash with `TypeError: Cannot convert undefined or null to object` when an existing agent capability had `config: null` or missing config in the API payload.

## How
- Added shared capability config normalization for UI capability lists.
- Applied normalization when loading agent and harness edit capabilities.
- Guarded `SelectedCapabilityList` before calling `Object.keys` or rendering settings editors.
- Added a regression test for a selected capability with missing legacy config.

## Risk
- Low
- Affected surface is frontend rendering of capability configs on edit pages. Incorrect normalization could hide non-object config payloads, but the UI/API contract already treats capability config as an object and falls back to `{}` for empty config.

## Security
- Threat categories reviewed: TM-WEB
- Findings and resolutions: Frontend-only data-shape hardening. No new rendering of untrusted HTML, no auth/authz changes, no API changes, and no new dependencies. No threat-model update needed.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

Validation:
- `npm test -- --runTestsByPath src/__tests__/selected-capability-list.test.tsx`
- `npm run format:check`
- `npm run lint` (existing warnings only, no errors)
- `npm run build`
- Playwright smoke: agent edit page renders with mocked `capabilities: [{ ref: "current_time", config: null }]`
- `bash scripts/lib/check-migration-ordering.sh`
- `CARGO_INCREMENTAL=0 cargo clippy --all-targets --all-features -- -D warnings`
- `just pre-push`