### PR TITLE
fix(apps): remove experimental gate

### DIFF
--- a/apps/ui/src/__tests__/sidebar.test.tsx
+++ b/apps/ui/src/__tests__/sidebar.test.tsx
@@ -69,7 +69,6 @@ jest.mock("@/components/layout/notification-bell", () => ({
 jest.mock("@/providers/feature-flags-provider", () => ({
   useFeatureFlags: () => ({
     global_chat: true,
-    apps: true,
     notifications: true,
     mcp_endpoint: true,
   }),

--- a/apps/ui/src/app/(main)/apps/page.tsx
+++ b/apps/ui/src/app/(main)/apps/page.tsx
@@ -12,7 +12,6 @@ import { ArchiveFilter } from "@/components/archive-filter";
 import { CopyButton } from "@/components/ui/copy-button";
 import Link from "next/link";
 import type { App, AppChannel, ScheduleChannelConfig } from "@/lib/api/types";
-import { ExperimentalPageBadge } from "@/components/ui/experimental-badge";
 import { getEntityNameClassName, getEntityStatusBadgeVariant } from "@/lib/entity-lifecycle";
 import { getChannelTypeDisplayName } from "@/lib/app-channels";
 
@@ -24,10 +23,7 @@ export default function AppsPage() {
   return (
     <div className="container mx-auto p-6">
       <div className="flex items-center justify-between mb-6">
-        <h1 className="text-2xl font-bold flex items-center gap-3">
-          Apps
-          <ExperimentalPageBadge />
-        </h1>
+        <h1 className="text-2xl font-bold flex items-center gap-3">Apps</h1>
         <div className="flex items-center gap-2">
           <ArchiveFilter showArchived={showArchived} onShowArchivedChange={setShowArchived} />
           <Link href="/apps/new">

--- a/apps/ui/src/components/layout/sidebar.tsx
+++ b/apps/ui/src/components/layout/sidebar.tsx
@@ -99,7 +99,7 @@ export const defaultBuildingBlocksNavigation: NavigationItem[] = [
   { name: "Models", href: "/models", icon: Cpu },
   { name: "Capabilities", href: "/capabilities", icon: Puzzle },
   { name: "MCP Servers", href: "/mcp-servers", icon: capabilityIconMap.mcp },
-  { name: "Apps", href: "/apps", icon: Rocket, flag: "apps", experimental: true },
+  { name: "Apps", href: "/apps", icon: Rocket },
   { name: "Evals", href: "/evals", icon: ClipboardCheck, flag: "evals", experimental: true },
 ];
 

--- a/apps/ui/src/lib/api/types/auth-types.ts
+++ b/apps/ui/src/lib/api/types/auth-types.ts
@@ -8,7 +8,6 @@ export type AuthMode = "none" | "admin" | "full" | "external";
 
 export interface FeatureFlags {
   global_chat: boolean;
-  apps: boolean;
   notifications: boolean;
   mcp_endpoint: boolean;
   evals: boolean;

--- a/apps/ui/src/providers/feature-flags-provider.tsx
+++ b/apps/ui/src/providers/feature-flags-provider.tsx
@@ -13,7 +13,6 @@ import type { FeatureFlags } from "@/lib/api/types";
 
 const DEFAULT_FLAGS: FeatureFlags = {
   global_chat: false,
-  apps: false,
   notifications: false,
   mcp_endpoint: false,
   evals: false,

--- a/crates/core/src/feature_flags.rs
+++ b/crates/core/src/feature_flags.rs
@@ -20,8 +20,6 @@ use crate::deployment::DeploymentGrade;
 pub struct FeatureFlags {
     /// Global chat (per-user singleton chat session). Experimental.
     pub global_chat: bool,
-    /// Apps (agent deployment to distribution channels). Experimental.
-    pub apps: bool,
     /// In-app notifications (bell, toasts, notification SSE). Experimental.
     pub notifications: bool,
     /// MCP endpoint (POST /mcp — Everruns as an MCP server). Experimental.
@@ -43,7 +41,6 @@ impl FeatureFlags {
     pub fn from_env(grade: &DeploymentGrade) -> Self {
         Self {
             global_chat: experimental_flag("FEATURE_GLOBAL_CHAT", grade),
-            apps: experimental_flag("FEATURE_APPS", grade),
             notifications: experimental_flag("FEATURE_NOTIFICATIONS", grade),
             mcp_endpoint: experimental_flag("FEATURE_MCP_ENDPOINT", grade),
             evals: experimental_flag("FEATURE_EVALS", grade),
@@ -63,7 +60,6 @@ impl FeatureFlags {
     pub fn is_enabled(&self, flag: &str) -> bool {
         match flag {
             "global_chat" => self.global_chat,
-            "apps" => self.apps,
             "notifications" => self.notifications,
             "mcp_endpoint" => self.mcp_endpoint,
             "evals" => self.evals,
@@ -79,7 +75,6 @@ impl FeatureFlags {
     pub fn all_enabled() -> Self {
         Self {
             global_chat: true,
-            apps: true,
             notifications: true,
             mcp_endpoint: true,
             evals: true,
@@ -166,7 +161,6 @@ mod tests {
     fn test_default_flags() {
         let flags = FeatureFlags::default();
         assert!(!flags.global_chat);
-        assert!(!flags.apps);
         assert!(!flags.notifications);
     }
 
@@ -177,11 +171,9 @@ mod tests {
     fn test_experimental_enabled_in_dev() {
         let _lock = lock_env();
         unsafe { std::env::remove_var("FEATURE_GLOBAL_CHAT") };
-        unsafe { std::env::remove_var("FEATURE_APPS") };
         unsafe { std::env::remove_var("FEATURE_EVALS") };
         let flags = FeatureFlags::from_env(&DeploymentGrade::Dev);
         assert!(flags.global_chat);
-        assert!(flags.apps);
         assert!(flags.evals);
     }
 
@@ -189,11 +181,9 @@ mod tests {
     fn test_experimental_disabled_in_prod() {
         let _lock = lock_env();
         unsafe { std::env::remove_var("FEATURE_GLOBAL_CHAT") };
-        unsafe { std::env::remove_var("FEATURE_APPS") };
         unsafe { std::env::remove_var("FEATURE_EVALS") };
         let flags = FeatureFlags::from_env(&DeploymentGrade::Prod);
         assert!(!flags.global_chat);
-        assert!(!flags.apps);
         assert!(!flags.evals);
     }
 
@@ -219,7 +209,6 @@ mod tests {
     fn test_is_enabled_dynamic() {
         let flags = FeatureFlags {
             global_chat: true,
-            apps: true,
             notifications: true,
             mcp_endpoint: true,
             evals: true,
@@ -228,7 +217,6 @@ mod tests {
             voice: true,
         };
         assert!(flags.is_enabled("global_chat"));
-        assert!(flags.is_enabled("apps"));
         assert!(flags.is_enabled("notifications"));
         assert!(flags.is_enabled("mcp_endpoint"));
         assert!(flags.is_enabled("evals"));
@@ -242,7 +230,6 @@ mod tests {
     fn test_serialization() {
         let flags = FeatureFlags {
             global_chat: true,
-            apps: true,
             notifications: true,
             mcp_endpoint: true,
             evals: true,


### PR DESCRIPTION
## What
Remove the Apps experimental marker and feature flag gate.

## Why
Apps should be available as a normal building-block surface instead of being hidden behind `FEATURE_APPS` or labeled experimental.

## How
- Removed the API-visible `apps` feature flag from core and UI flag types/defaults.
- Removed the Apps sidebar flag/experimental marker.
- Removed the Apps page experimental badge.
- Updated sidebar feature-flag test fixtures.

## Risk
- Low
- The `/v1/feature-flags` response no longer includes `apps`; UI consumers in this repo no longer reference it. External consumers that read the exact feature flag shape may need to tolerate the removed field.

## Security
- Threat categories reviewed: TM-WEB and TM-API.
- Findings and resolutions: No new trust boundary, input parsing, data access, auth, secret handling, or dependency surface. The API-visible flag response removes one boolean and the UI now always shows Apps navigation.

## Follow-ups
No follow-ups.

## Validation
- `cargo test -p everruns-core feature_flags`
- `npm test -- --runTestsByPath src/__tests__/sidebar.test.tsx --runInBand`
- `npm run lint -- --quiet` (0 errors, existing warnings only)
- `just pre-push` (passed after formatting fix)
- `bash scripts/lib/check-migration-ordering.sh` after latest rebase
- `npm run format:check` after latest rebase
- Smoke: `AUTH_MODE=none PORT_PREFIX=588 CARGO_INCREMENTAL=0 just start-dev --no-watch`, then Playwright verified `/apps` has title `Apps · Everruns`, sidebar Apps link, heading `Apps`, `New App` visible, and 0 experimental text matches.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] All review comments addressed (code change or written reasoning)
