### PR TITLE
feat(models): allow editing model provider

### DIFF
--- a/apps/ui/src/__tests__/edit-model-dialog.test.tsx
+++ b/apps/ui/src/__tests__/edit-model-dialog.test.tsx
@@ -1,0 +1,99 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type React from "react";
+import { EditModelDialog } from "@/components/models/edit-model-dialog";
+import type { LlmModelWithProvider, LlmProvider } from "@/lib/api/types";
+
+jest.mock("@/components/ui/select", () => {
+  const React = jest.requireActual("react");
+  const SelectContext = React.createContext({ onValueChange: (_value: string) => {} });
+
+  return {
+    Select: ({
+      children,
+      onValueChange,
+    }: {
+      children: React.ReactNode;
+      onValueChange: (value: string) => void;
+    }) => <SelectContext.Provider value={{ onValueChange }}>{children}</SelectContext.Provider>,
+    SelectTrigger: ({ children, id }: { children: React.ReactNode; id?: string }) => (
+      <div id={id}>{children}</div>
+    ),
+    SelectValue: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+    SelectContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    SelectItem: ({ value, children }: { value: string; children: React.ReactNode }) => {
+      const { onValueChange } = React.useContext(SelectContext);
+      return (
+        <button type="button" onClick={() => onValueChange(value)}>
+          {children}
+        </button>
+      );
+    },
+  };
+});
+
+const providers: LlmProvider[] = [
+  {
+    id: "provider-1",
+    name: "OpenAI Production",
+    provider_type: "openai",
+    status: "active",
+    api_key_set: true,
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+  },
+  {
+    id: "provider-2",
+    name: "OpenRouter",
+    provider_type: "openai",
+    status: "active",
+    api_key_set: true,
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+  },
+];
+
+const model: LlmModelWithProvider = {
+  id: "model-1",
+  provider_id: "provider-1",
+  model_id: "gpt-4.5",
+  display_name: "GPT-4.5",
+  provider_name: "OpenAI Production",
+  provider_type: "openai",
+  healthy: true,
+  capabilities: [],
+  enabled: true,
+  is_favorite: false,
+  created_at: "2024-01-01T00:00:00Z",
+  updated_at: "2024-01-01T00:00:00Z",
+};
+
+describe("EditModelDialog", () => {
+  it("submits provider changes with the model update", async () => {
+    const onSubmit = jest.fn().mockResolvedValue(undefined);
+
+    render(
+      <EditModelDialog
+        model={model}
+        providers={providers}
+        open
+        onOpenChange={jest.fn()}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "OpenRouter" }));
+    fireEvent.change(screen.getByLabelText("Display Name"), {
+      target: { value: "GPT-4.5 via OpenRouter" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith("model-1", {
+        provider_id: "provider-2",
+        model_id: "gpt-4.5",
+        display_name: "GPT-4.5 via OpenRouter",
+        enabled: true,
+      });
+    });
+  });
+});

--- a/apps/ui/src/app/(main)/models/page.tsx
+++ b/apps/ui/src/app/(main)/models/page.tsx
@@ -76,6 +76,12 @@ export default function ModelsPage() {
     }
   };
 
+  const handleUpdateModel = async (modelId: string, data: Parameters<typeof updateLlmModel>[1]) => {
+    await updateLlmModel(modelId, data);
+    await queryClient.invalidateQueries({ queryKey: queryKeys.llmModels.all });
+    await queryClient.invalidateQueries({ queryKey: queryKeys.llmProviders.all });
+  };
+
   const handleSetDefaultModel = async (modelId: string) => {
     await updateOrg.mutateAsync({ default_model_id: modelId || undefined });
   };
@@ -138,7 +144,9 @@ export default function ModelsPage() {
                       <ModelRow
                         key={model.id}
                         model={model}
+                        providers={providers}
                         onDelete={handleDeleteModel}
+                        onUpdate={handleUpdateModel}
                         onToggleEnabled={handleToggleEnabled}
                         isTogglingEnabled={togglingModelId === model.id}
                       />
@@ -164,7 +172,9 @@ export default function ModelsPage() {
                       <ModelRow
                         key={model.id}
                         model={model}
+                        providers={providers}
                         onDelete={handleDeleteModel}
+                        onUpdate={handleUpdateModel}
                         onToggleEnabled={handleToggleEnabled}
                         isTogglingEnabled={togglingModelId === model.id}
                       />

--- a/apps/ui/src/components/models/edit-model-dialog.tsx
+++ b/apps/ui/src/components/models/edit-model-dialog.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { ProviderIcon } from "@/components/providers/provider-icon";
+import type { LlmModelWithProvider, LlmProvider, UpdateLlmModelRequest } from "@/lib/api/types";
+
+export function EditModelDialog({
+  model,
+  providers,
+  open,
+  onOpenChange,
+  onSubmit,
+}: {
+  model: LlmModelWithProvider;
+  providers: LlmProvider[];
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: (modelId: string, data: UpdateLlmModelRequest) => Promise<void>;
+}) {
+  const [providerId, setProviderId] = useState(model.provider_id);
+  const [modelId, setModelId] = useState(model.model_id);
+  const [displayName, setDisplayName] = useState(model.display_name);
+  const [enabled, setEnabled] = useState(model.enabled);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    setProviderId(model.provider_id);
+    setModelId(model.model_id);
+    setDisplayName(model.display_name);
+    setEnabled(model.enabled);
+  }, [model, open]);
+
+  const selectedProvider = useMemo(
+    () => providers.find((provider) => provider.id === providerId),
+    [providerId, providers],
+  );
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSaving(true);
+    try {
+      await onSubmit(model.id, {
+        provider_id: providerId,
+        model_id: modelId.trim(),
+        display_name: displayName.trim(),
+        enabled,
+      });
+      onOpenChange(false);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Edit Model</DialogTitle>
+          <DialogDescription>
+            Update the model ID, display name, provider, or visibility.
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor={`edit-model-provider-${model.id}`}>Provider</Label>
+            <Select value={providerId} onValueChange={setProviderId}>
+              <SelectTrigger id={`edit-model-provider-${model.id}`} className="w-full">
+                <SelectValue placeholder="Select provider">
+                  {selectedProvider?.name ?? model.provider_name}
+                </SelectValue>
+              </SelectTrigger>
+              <SelectContent>
+                {providers.map((provider) => (
+                  <SelectItem key={provider.id} value={provider.id}>
+                    <div className="flex items-center gap-2">
+                      <ProviderIcon
+                        providerType={provider.provider_type}
+                        size="sm"
+                        showBackground={false}
+                      />
+                      <span>{provider.name}</span>
+                    </div>
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor={`edit-model-id-${model.id}`}>Model ID</Label>
+            <Input
+              id={`edit-model-id-${model.id}`}
+              value={modelId}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setModelId(e.target.value)}
+              required
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor={`edit-model-display-name-${model.id}`}>Display Name</Label>
+            <Input
+              id={`edit-model-display-name-${model.id}`}
+              value={displayName}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setDisplayName(e.target.value)}
+              required
+            />
+          </div>
+          <div className="flex items-center gap-2">
+            <Checkbox
+              id={`edit-model-enabled-${model.id}`}
+              checked={enabled}
+              onCheckedChange={(checked) => setEnabled(checked === true)}
+            />
+            <Label htmlFor={`edit-model-enabled-${model.id}`}>
+              Enable model (visible in UI model pickers)
+            </Label>
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              disabled={saving || !providerId || !modelId.trim() || !displayName.trim()}
+            >
+              {saving ? "Saving..." : "Save Changes"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/ui/src/components/models/model-row.tsx
+++ b/apps/ui/src/components/models/model-row.tsx
@@ -13,13 +13,15 @@ import {
   Info,
   ChevronDown,
   ChevronUp,
+  Pencil,
   ToggleLeft,
   ToggleRight,
   Trash2,
 } from "lucide-react";
 import { ProviderIcon } from "@/components/providers/provider-icon";
+import { EditModelDialog } from "@/components/models/edit-model-dialog";
 import { formatTokens } from "@/lib/formatting";
-import type { LlmModelWithProvider } from "@/lib/api/types";
+import type { LlmModelWithProvider, LlmProvider, UpdateLlmModelRequest } from "@/lib/api/types";
 
 function formatCost(cost: number): string {
   if (cost >= 100) {
@@ -58,16 +60,21 @@ function formatReleaseDate(value: string): string {
 
 export function ModelRow({
   model,
+  providers,
   onDelete,
+  onUpdate,
   onToggleEnabled,
   isTogglingEnabled,
 }: {
   model: LlmModelWithProvider;
+  providers: LlmProvider[];
   onDelete: (id: string) => void;
+  onUpdate: (id: string, data: UpdateLlmModelRequest) => Promise<void>;
   onToggleEnabled: (id: string, enabled: boolean) => void;
   isTogglingEnabled: boolean;
 }) {
   const [expanded, setExpanded] = useState(false);
+  const [editOpen, setEditOpen] = useState(false);
   const profile = model.profile;
 
   return (
@@ -109,6 +116,21 @@ export function ModelRow({
                     Released {formatReleaseDate(profile.release_date)}
                   </span>
                 </>
+              )}
+              {profile && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setExpanded(!expanded)}
+                  className="ml-2 h-6 px-1.5 align-baseline text-muted-foreground"
+                  title={expanded ? "Collapse profile details" : "Expand profile details"}
+                >
+                  {expanded ? (
+                    <ChevronUp className="h-3.5 w-3.5" />
+                  ) : (
+                    <ChevronDown className="h-3.5 w-3.5" />
+                  )}
+                </Button>
               )}
             </div>
           </div>
@@ -155,10 +177,9 @@ export function ModelRow({
               <TooltipTrigger asChild>
                 <span
                   role="img"
-                  tabIndex={0}
                   aria-label={model.healthy ? "Model healthy" : "Model not ready"}
                   className={
-                    "inline-block h-2.5 w-2.5 rounded-full outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 " +
+                    "inline-block h-2.5 w-2.5 rounded-full " +
                     (model.healthy ? "bg-green-500" : "bg-gray-300")
                   }
                 />
@@ -195,16 +216,15 @@ export function ModelRow({
               </>
             )}
           </Button>
-          {profile && (
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={() => setExpanded(!expanded)}
-              title={expanded ? "Collapse" : "Expand profile details"}
-            >
-              {expanded ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
-            </Button>
-          )}
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setEditOpen(true)}
+            aria-label={`Edit ${model.display_name}`}
+            title="Edit model"
+          >
+            <Pencil className="h-4 w-4" />
+          </Button>
           <Button
             variant="ghost"
             size="sm"
@@ -289,6 +309,13 @@ export function ModelRow({
           </div>
         </div>
       )}
+      <EditModelDialog
+        model={model}
+        providers={providers}
+        open={editOpen}
+        onOpenChange={setEditOpen}
+        onSubmit={onUpdate}
+      />
     </div>
   );
 }

--- a/apps/ui/src/lib/api/types/llm-types.ts
+++ b/apps/ui/src/lib/api/types/llm-types.ts
@@ -182,6 +182,7 @@ export interface CreateLlmModelRequest {
 }
 
 export interface UpdateLlmModelRequest {
+  provider_id?: string;
   model_id?: string;
   display_name?: string;
   capabilities?: string[];

--- a/crates/server/src/api/llm_models.rs
+++ b/crates/server/src/api/llm_models.rs
@@ -110,6 +110,10 @@ fn default_true() -> bool {
 /// Request to update an LLM model. Only provided fields will be updated.
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct UpdateLlmModelRequest {
+    /// Provider that owns this model.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(example = "provider_019df670b5af7db7a5685a4ad18a544a")]
+    pub provider_id: Option<String>,
     /// The model identifier used by the provider's API.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schema(example = "gpt-4o-mini")]
@@ -269,6 +273,7 @@ pub async fn update_model(
         .dispatcher(&org)
         .run_with_urls(UpdateModel {
             id,
+            provider_id: req.provider_id,
             model_id: req.model_id,
             display_name: req.display_name,
             capabilities: req.capabilities,

--- a/crates/server/src/domains/llm_models/commands.rs
+++ b/crates/server/src/domains/llm_models/commands.rs
@@ -1,7 +1,7 @@
 use super::queries as q;
 use super::{LLM_MODEL_MANAGE, LLM_MODEL_VIEW};
 use crate::domains::common::*;
-use everruns_core::{LlmModel, LlmModelSource, LlmModelWithProvider, Policy};
+use everruns_core::{LlmModel, LlmModelSource, LlmModelWithProvider, Policy, ProviderId};
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
@@ -185,6 +185,7 @@ inventory::submit! { CommandDescriptor::of::<GetModel>() }
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct UpdateModel {
     pub id: String,
+    pub provider_id: Option<String>,
     pub model_id: Option<String>,
     pub display_name: Option<String>,
     pub capabilities: Option<Vec<String>>,
@@ -215,11 +216,17 @@ impl Command for UpdateModel {
 
     async fn execute(self, ctx: &Ctx) -> Result<LlmModel, CommandError> {
         let model_id = q::parse_model_id(&self.id)?;
+        let provider_id = self
+            .provider_id
+            .as_deref()
+            .map(q::parse_provider_id)
+            .transpose()?;
         q::service(ctx)
             .update(
                 &ctx.caller,
                 model_id,
                 crate::api::llm_models::UpdateLlmModelRequest {
+                    provider_id: provider_id.map(|id| ProviderId::from_uuid(id).to_string()),
                     model_id: self.model_id,
                     display_name: self.display_name,
                     capabilities: self.capabilities,

--- a/crates/server/src/domains/llm_models/service.rs
+++ b/crates/server/src/domains/llm_models/service.rs
@@ -12,7 +12,7 @@ use crate::storage::{
 use anyhow::Result;
 use everruns_core::{
     Caller, LlmModel, LlmModelProfile, LlmModelSource, LlmModelWithProvider, LlmProviderType,
-    Permission, Policy, Rule, get_model_profile,
+    Permission, Policy, ProviderId, Rule, get_model_profile,
 };
 use std::sync::Arc;
 use tracing::error;
@@ -230,7 +230,26 @@ impl LlmModelService {
         id: Uuid,
         req: UpdateLlmModelRequest,
     ) -> Result<Option<LlmModel>> {
+        let provider_id = match req.provider_id.as_deref() {
+            Some(provider_id) => Some(
+                provider_id
+                    .parse::<ProviderId>()
+                    .map(|id| id.uuid())
+                    .map_err(|err| anyhow::anyhow!("Invalid provider ID: {err}"))?,
+            ),
+            None => None,
+        };
+        let provider_id = if let Some(provider_id) = provider_id {
+            Some(
+                self.validate_provider_id(caller.org_id, provider_id)
+                    .await?,
+            )
+        } else {
+            None
+        };
+
         let input = UpdateLlmModel {
+            provider_id: provider_id.map(Into::into),
             model_id: req.model_id,
             display_name: req.display_name,
             capabilities: req.capabilities,
@@ -478,6 +497,70 @@ mod tests {
 
         let err = service
             .create(&caller, other_provider_id.uuid(), build_create_request())
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.to_string(), "Provider not found");
+    }
+
+    #[tokio::test]
+    async fn update_can_move_model_to_another_provider_in_same_org() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let service = LlmModelService::new(db.clone());
+        let caller = Caller::internal(DEFAULT_ORG_ID);
+        let first_provider_id = create_provider(&db, DEFAULT_ORG_ID).await;
+        let second_provider_id = create_provider(&db, DEFAULT_ORG_ID).await;
+        let model = service
+            .create(&caller, first_provider_id.uuid(), build_create_request())
+            .await
+            .unwrap();
+
+        let updated = service
+            .update(
+                &caller,
+                model.id.uuid(),
+                UpdateLlmModelRequest {
+                    provider_id: Some(second_provider_id.to_string()),
+                    model_id: None,
+                    display_name: None,
+                    capabilities: None,
+                    enabled: None,
+                    is_favorite: None,
+                },
+            )
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(updated.provider_id, second_provider_id);
+    }
+
+    #[tokio::test]
+    async fn update_rejects_provider_from_another_org() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let service = LlmModelService::new(db.clone());
+        let caller = Caller::internal(DEFAULT_ORG_ID);
+        let provider_id = create_provider(&db, DEFAULT_ORG_ID).await;
+        let other_org_id = create_second_org(&db).await;
+        let other_provider_id = create_provider(&db, other_org_id).await;
+        let model = service
+            .create(&caller, provider_id.uuid(), build_create_request())
+            .await
+            .unwrap();
+
+        let err = service
+            .update(
+                &caller,
+                model.id.uuid(),
+                UpdateLlmModelRequest {
+                    provider_id: Some(other_provider_id.to_string()),
+                    model_id: None,
+                    display_name: None,
+                    capabilities: None,
+                    enabled: None,
+                    is_favorite: None,
+                },
+            )
             .await
             .unwrap_err();
 

--- a/crates/server/src/storage/memory/llm.rs
+++ b/crates/server/src/storage/memory/llm.rs
@@ -459,12 +459,27 @@ impl InMemoryDatabase {
         input: UpdateLlmModel,
     ) -> Result<Option<LlmModelRow>> {
         let id = ModelId::from_uuid(id);
+        if let Some(provider_id) = input.provider_id {
+            let providers = self.llm_providers.read();
+            if providers
+                .get(&provider_id)
+                .is_none_or(|provider| provider.org_id != org_id)
+            {
+                return Ok(None);
+            }
+        }
         let mut models = self.llm_models.write();
         // Check existence and org ownership
         if models.get(&id).is_none_or(|m| m.org_id != org_id) {
             return Ok(None);
         }
         let model = models.get_mut(&id).unwrap();
+        if let Some(provider_id) = input.provider_id {
+            model.provider_id = provider_id;
+        }
+        if let Some(model_id) = input.model_id {
+            model.model_id = model_id;
+        }
         if let Some(display_name) = input.display_name {
             model.display_name = display_name;
         }
@@ -476,6 +491,12 @@ impl InMemoryDatabase {
         }
         if let Some(enabled) = input.enabled {
             model.enabled = enabled;
+        }
+        if let Some(last_seen_at) = input.last_seen_at {
+            model.last_seen_at = Some(last_seen_at);
+        }
+        if let Some(provider_metadata) = input.provider_metadata {
+            model.provider_metadata = Some(provider_metadata);
         }
         model.updated_at = Self::now();
         Ok(Some(model.clone()))

--- a/crates/server/src/storage/models.rs
+++ b/crates/server/src/storage/models.rs
@@ -904,6 +904,7 @@ pub struct CreateLlmModelRow {
 
 #[derive(Debug, Clone, Default)]
 pub struct UpdateLlmModel {
+    pub provider_id: Option<ProviderId>,
     pub model_id: Option<String>,
     pub display_name: Option<String>,
     pub capabilities: Option<Vec<String>>,

--- a/crates/server/src/storage/repositories/llm.rs
+++ b/crates/server/src/storage/repositories/llm.rs
@@ -392,20 +392,29 @@ impl Database {
             r#"
             UPDATE llm_models
             SET
-                model_id = COALESCE($3, model_id),
-                display_name = COALESCE($4, display_name),
-                capabilities = COALESCE($5, capabilities),
-                is_favorite = COALESCE($6, is_favorite),
-                enabled = COALESCE($7, enabled),
-                last_seen_at = COALESCE($8, last_seen_at),
-                provider_metadata = COALESCE($9, provider_metadata),
+                provider_id = COALESCE($3, provider_id),
+                model_id = COALESCE($4, model_id),
+                display_name = COALESCE($5, display_name),
+                capabilities = COALESCE($6, capabilities),
+                is_favorite = COALESCE($7, is_favorite),
+                enabled = COALESCE($8, enabled),
+                last_seen_at = COALESCE($9, last_seen_at),
+                provider_metadata = COALESCE($10, provider_metadata),
                 updated_at = NOW()
             WHERE org_id = $1 AND id = $2
+              AND (
+                  $3::uuid IS NULL
+                  OR EXISTS (
+                      SELECT 1 FROM llm_providers p
+                      WHERE p.org_id = $1 AND p.id = $3
+                  )
+              )
             RETURNING id, org_id, provider_id, model_id, display_name, capabilities, is_favorite, enabled, source, last_seen_at, provider_metadata, created_at, updated_at
             "#,
         )
         .bind(org_id)
         .bind(id)
+        .bind(input.provider_id)
         .bind(&input.model_id)
         .bind(&input.display_name)
         .bind(&capabilities_json)

--- a/crates/server/tests/org_isolation_test.rs
+++ b/crates/server/tests/org_isolation_test.rs
@@ -181,7 +181,6 @@ async fn test_llm_provider_positive_own_org() {
         )
         .await
         .unwrap();
-
     // Positive: own org can get, list, update, delete
     assert!(
         db.get_llm_provider(ORG1, provider.id.uuid())
@@ -296,7 +295,6 @@ async fn test_llm_model_positive_own_org() {
         )
         .await
         .unwrap();
-
     let model = db
         .create_llm_model(
             ORG1,
@@ -373,6 +371,19 @@ async fn test_llm_model_negative_cross_org() {
         )
         .await
         .unwrap();
+    let foreign_provider = db
+        .create_llm_provider(
+            org2,
+            CreateLlmProviderRow {
+                name: "Foreign Provider".to_string(),
+                provider_type: "openai".to_string(),
+                base_url: None,
+                api_key_encrypted: None,
+                settings: None,
+            },
+        )
+        .await
+        .unwrap();
 
     let model = db
         .create_llm_model(
@@ -426,6 +437,19 @@ async fn test_llm_model_negative_cross_org() {
         .unwrap()
         .is_none()
     );
+    assert!(
+        db.update_llm_model(
+            ORG1,
+            model.id.uuid(),
+            UpdateLlmModel {
+                provider_id: Some(foreign_provider.id),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap()
+        .is_none()
+    );
     assert!(!db.delete_llm_model(org2, model.id.uuid()).await.unwrap());
 
     // Verify original is untouched
@@ -435,6 +459,7 @@ async fn test_llm_model_negative_cross_org() {
         .unwrap()
         .unwrap();
     assert_eq!(original.display_name, "GPT-4");
+    assert_eq!(original.provider_id, provider.id);
 }
 
 #[tokio::test]

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -20427,6 +20427,14 @@
             ],
             "description": "The model identifier used by the provider's API.",
             "example": "gpt-4o-mini"
+          },
+          "provider_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Provider that owns this model.",
+            "example": "provider_019df670b5af7db7a5685a4ad18a544a"
           }
         }
       },

--- a/specs/apis.md
+++ b/specs/apis.md
@@ -340,7 +340,7 @@ When `limit` is provided:
 | POST | `/v1/llm-providers/{id}/models` | Create model for provider |
 | GET | `/v1/llm-models` | List all models |
 | GET | `/v1/llm-models/{id}` | Get model |
-| PATCH | `/v1/llm-models/{id}` | Update model |
+| PATCH | `/v1/llm-models/{id}` | Update model, including provider assignment |
 | DELETE | `/v1/llm-models/{id}` | Delete model |
 
 #### Model Sync

--- a/specs/models.md
+++ b/specs/models.md
@@ -241,6 +241,7 @@ Configuration for a specific model within a provider. See `crates/core/src/llm_m
 Key design points:
 - `source` enum: `manual` (user-added), `discovered` (from provider API), `predefined` (seeded)
 - `enabled` flag: only enabled models appear in UI model pickers (Chat UI). All models remain available via API regardless of enabled status. See `crates/server/src/seed.rs` for default enabled models.
+- Model/provider assignment is editable so an existing model config can be moved to a different configured provider without deleting and recreating it.
 - Organization default model: stored in `organization_settings.default_model_id` (not on the model itself). Auto-elects a new default from enabled models if the current default is disabled or deleted.
 - Stale model detection: `last_seen_at < provider.last_synced_at` means model no longer returned by provider API. Stale models kept (not deleted) to preserve customizations.
 


### PR DESCRIPTION
## What
Allow editing a model's provider from the Models page.

Adds a row edit action that opens an Edit Model dialog with Provider, Model ID, Display Name, and enabled-state fields. Moves the profile details expand control into the model metadata area so it is no longer between edit and delete actions.

## Why
Models could be renamed, enabled, disabled, or deleted, but their provider assignment was fixed after creation. That blocked moving an existing model such as `gpt-4.5` or `gpt-5.5` to another configured provider.

## How
- Adds `provider_id` to the model update API request and OpenAPI schema.
- Validates provider reassignment through the LLM model service using the caller org scope.
- Updates SQL and memory storage to persist provider reassignment with org-scoped provider checks.
- Adds the Edit Model dialog and row edit action in the UI.
- Covers provider edits with UI and service tests.

## Risk
- Medium
- Model update behavior now includes provider assignment, so bugs here could point a model at the wrong provider. Mitigated by typed provider IDs, service-level org validation, storage-level org checks, and focused tests for same-org and cross-org provider changes.

## Security
- Threat categories reviewed: TM-API, TM-AUTHZ, TM-TENANT, TM-WEB.
- Findings and resolutions: Provider changes are parsed as typed `ProviderId`s, validated against the caller organization in the service layer, and guarded again in storage with org-scoped provider existence checks. No new secrets, auth flows, external calls, or dependencies.

## Follow-ups
No follow-ups.

## Validation
- `CARGO_INCREMENTAL=0 just pre-push`
- `cargo test -p everruns-server --lib llm_models::service::tests::update_`
- `npm --prefix apps/ui test -- --runTestsByPath src/__tests__/edit-model-dialog.test.tsx src/__tests__/models-page.test.tsx --runInBand`
- Browser smoke on `http://localhost:27400/models`: opened Edit GPT-5.5, opened Provider selector, changed provider to LlmSim, saved, and verified the list updated.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
