### PR TITLE
fix(mcp): align OAuth expires_in with actual JWT lifetime

### DIFF
--- a/crates/server/src/auth/jwt.rs
+++ b/crates/server/src/auth/jwt.rs
@@ -181,6 +181,13 @@ impl JwtService {
     pub fn refresh_token_lifetime_secs(&self) -> i64 {
         self.config.refresh_token_lifetime.as_secs() as i64
     }
+
+    /// Get access token lifetime in seconds. Matches the value used for the
+    /// JWT `exp` claim, so OAuth `expires_in` can be derived from the same
+    /// source instead of a separate hardcoded constant.
+    pub fn access_token_lifetime_secs(&self) -> i64 {
+        self.config.access_token_lifetime.as_secs() as i64
+    }
 }
 
 /// Hash a token for database storage (using SHA-256)

--- a/crates/server/src/auth/jwt.rs
+++ b/crates/server/src/auth/jwt.rs
@@ -141,7 +141,7 @@ impl JwtService {
             access_token,
             refresh_token,
             token_type: "Bearer".to_string(),
-            expires_in: self.config.access_token_lifetime.as_secs() as i64,
+            expires_in: self.access_token_lifetime_secs(),
         };
 
         Ok((token_pair, jti))

--- a/crates/server/src/auth/mcp_oauth.rs
+++ b/crates/server/src/auth/mcp_oauth.rs
@@ -39,8 +39,9 @@ use utoipa::ToSchema;
 /// Authorization code TTL (5 minutes)
 const AUTH_CODE_TTL_SECS: i64 = 300;
 
-/// MCP access token lifetime (1 hour)
-const MCP_ACCESS_TOKEN_LIFETIME_SECS: i64 = 3600;
+// MCP access token lifetime is derived from `JwtService::access_token_lifetime_secs()`
+// so the OAuth `expires_in` always matches the actual JWT `exp - iat`. A separate
+// constant here would silently drift from the JWT contract — see EVE-460.
 
 /// MCP refresh token lifetime (30 days)
 const MCP_REFRESH_TOKEN_LIFETIME_SECS: i64 = 30 * 24 * 3600;
@@ -865,7 +866,7 @@ async fn handle_authorization_code_grant(
     Ok(Json(OAuthTokenResponse {
         access_token,
         token_type: "Bearer".to_string(),
-        expires_in: MCP_ACCESS_TOKEN_LIFETIME_SECS,
+        expires_in: state.jwt_service.access_token_lifetime_secs(),
         refresh_token: Some(refresh_token_raw),
     }))
 }
@@ -994,7 +995,7 @@ async fn handle_refresh_token_grant(
     Ok(Json(OAuthTokenResponse {
         access_token,
         token_type: "Bearer".to_string(),
-        expires_in: MCP_ACCESS_TOKEN_LIFETIME_SECS,
+        expires_in: state.jwt_service.access_token_lifetime_secs(),
         refresh_token: Some(new_refresh_token),
     }))
 }
@@ -1096,5 +1097,48 @@ mod tests {
         let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
         let challenge = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM";
         assert!(verify_pkce_s256(verifier, challenge));
+    }
+
+    /// Regression for EVE-460: the `expires_in` value reported by the MCP
+    /// OAuth token endpoint must match the actual JWT `exp - iat` so a client
+    /// caching by `expires_in` cannot outlive the access token. This test
+    /// fixes the lifetime to a non-default value to catch any drift between
+    /// `JwtService::access_token_lifetime_secs()` (the new `expires_in`
+    /// source) and the encoded JWT's exp claim.
+    #[test]
+    fn mcp_expires_in_matches_jwt_exp_minus_iat() {
+        use crate::auth::config::JwtConfig;
+        use crate::auth::jwt::JwtService;
+        use std::time::Duration as StdDuration;
+
+        let lifetime_secs: i64 = 1234;
+        let cfg = JwtConfig {
+            secret: "test-secret".to_string(),
+            access_token_lifetime: StdDuration::from_secs(lifetime_secs as u64),
+            refresh_token_lifetime: StdDuration::from_secs(60),
+        };
+        let svc = JwtService::new(cfg);
+
+        assert_eq!(
+            svc.access_token_lifetime_secs(),
+            lifetime_secs,
+            "accessor must echo configured lifetime"
+        );
+
+        let token = svc
+            .generate_access_token(
+                uuid::Uuid::nil(),
+                "user@example.com",
+                "user",
+                &["user".to_string()],
+            )
+            .expect("token generation");
+        let claims = svc.validate_access_token(&token).expect("token validation");
+
+        assert_eq!(
+            claims.exp - claims.iat,
+            svc.access_token_lifetime_secs(),
+            "JWT exp-iat must equal the lifetime reported via expires_in"
+        );
     }
 }

--- a/specs/mcp.md
+++ b/specs/mcp.md
@@ -231,10 +231,12 @@ client_secret=<client_secret>
 {
   "access_token": "<jwt>",
   "token_type": "Bearer",
-  "expires_in": 3600,
+  "expires_in": 900,
   "refresh_token": "<opaque>"
 }
 ```
+
+`expires_in` is the configured JWT access-token lifetime in seconds — see `AUTH_JWT_ACCESS_TOKEN_LIFETIME` (default 900). The OAuth response always reports the same value used for the JWT `exp` claim, so MCP clients caching by `expires_in` cannot outlive the token. Override the env var to widen the window for long-running MCP sessions.
 
 ### Access Tokens
 

--- a/specs/mcp.md
+++ b/specs/mcp.md
@@ -254,7 +254,7 @@ Standard JWTs signed with `AUTH_JWT_SECRET` via `JwtService::generate_access_tok
 }
 ```
 
-MCP OAuth tokens are indistinguishable from regular access tokens at the JWT level. They are validated by the existing `BuiltinAuthBackend.validate_token()` path. The MCP-specific lifetime (1 hour) and refresh token are managed by the OAuth flow, not by JWT claims.
+MCP OAuth tokens are indistinguishable from regular access tokens at the JWT level. They are validated by the existing `BuiltinAuthBackend.validate_token()` path. The access-token lifetime is the JWT `exp - iat`, sourced from `AUTH_JWT_ACCESS_TOKEN_LIFETIME` (default 900s); the OAuth `expires_in` field reports the same value. MCP refresh tokens are managed by the OAuth flow, not by JWT claims.
 
 ### Database Schema
 


### PR DESCRIPTION
## What
The MCP OAuth token endpoint (`POST /v1/mcp/oauth/token`) reported `expires_in: 3600` from a hardcoded `MCP_ACCESS_TOKEN_LIFETIME_SECS`, but the JWT access token it issued used `JwtService::generate_access_token()` whose lifetime is configured by `AUTH_JWT_ACCESS_TOKEN_LIFETIME` (default 900s). This PR derives `expires_in` from the same source as the JWT `exp` claim so the two never drift.

Resolves EVE-460.

## Why
MCP clients (e.g. Codex) cached and reused tokens by `expires_in`, so a 3600 vs 900 mismatch made tokens look valid client-side while the server rejected them. The result was apparent auth-loss even with Postgres-backed OAuth client and refresh-token storage.

## How
- Added `JwtService::access_token_lifetime_secs()` so callers can read the configured access-token TTL without poking the private `JwtConfig`.
- Removed `MCP_ACCESS_TOKEN_LIFETIME_SECS` from `auth/mcp_oauth.rs` and used the new accessor in both grant flows (`authorization_code` and `refresh_token`).
- Updated `specs/mcp.md` to describe the contract (`expires_in` reports the configured lifetime — default 900s) and updated the example response.
- Added a regression test `mcp_expires_in_matches_jwt_exp_minus_iat` that fixes a non-default lifetime, generates an access token, decodes it, and asserts `JwtConfig.access_token_lifetime` ≡ `JwtService::access_token_lifetime_secs()` ≡ `claims.exp - claims.iat`. This is the value the OAuth handlers now feed into `expires_in`.

## Risk
- Low. The change narrows clients' cached lifetimes to the value the server actually honors, so tokens stop being treated as valid past their JWT `exp`. No public-facing field is removed; only the value reported by `expires_in` changes.
- Operators who previously relied on the implicit 3600 may want to set `AUTH_JWT_ACCESS_TOKEN_LIFETIME=3600` (called out in the spec).

## Security
- Threat categories reviewed: TM-AUTH (access-token validity), TM-MCP. The change tightens behavior — `expires_in` no longer overpromises validity. No new attack surface.
- Findings and resolutions: None.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (response shape unchanged; only the numeric value of `expires_in` changes when `AUTH_JWT_ACCESS_TOKEN_LIFETIME` ≠ 3600)
- [x] Security review performed against relevant threat model categories
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D31EyHMKtKtVa4x5GW4mL9)_