### PR TITLE
chore(apps): drop unused bare app_id from invocation message metadata

### DIFF
--- a/crates/server/src/domains/apps/commands.rs
+++ b/crates/server/src/domains/apps/commands.rs
@@ -312,17 +312,19 @@ fn build_schedule_target_input(app: &App, channel: &AppChannel) -> Value {
 }
 
 /// Metadata stamped onto the user message that an app channel injects into a
-/// session. The `_app_id` / `app_channel_id` / `app_channel_type` keys mirror
-/// the convention used by the AG-UI (`crates/server/src/api/ag_ui.rs`) and
-/// Slack (`crates/server/src/api/slack_events.rs`) ingress paths so all three
-/// channel kinds expose the same shape to message-metadata consumers.
+/// session. `_app_id` is the canonical "system metadata" key shared with the
+/// AG-UI (`crates/server/src/api/ag_ui.rs`) and Slack
+/// (`crates/server/src/api/slack_events.rs`) ingress paths; the rest of the
+/// keys (`app_channel_id`, `app_channel_type`, `source`) are specific to the
+/// schedule / webhook / A2A invocation channels documented in
+/// `specs/app-invocation-channels.md` and are not emitted by AG-UI or Slack.
 ///
-/// `_app_id` (leading underscore) is the canonical "system metadata" key —
-/// app-channel image authorization in `is_ag_ui_app_image` and the matching
-/// system-id assertions in the channel ingress unit tests both read it. The
-/// audit-log payload emitted by `emit_app_invocation_audit_event` uses a bare
-/// `app_id` field for human-readable filtering; that is intentional and lives
-/// on a separate audit struct, not on this metadata bag.
+/// `_app_id` is the system-id consumed by `is_ag_ui_app_image` for AG-UI
+/// image authorization and by the matching system-id assertions in the
+/// channel ingress unit tests. The audit-log payload emitted by
+/// `emit_app_invocation_audit_event` uses a bare `app_id` field on its own
+/// `AuditEvent` struct for human-readable filtering; that is intentional and
+/// lives separately from this metadata bag.
 fn app_invocation_message_metadata(
     app: &App,
     channel: &AppChannel,

--- a/crates/server/src/domains/apps/commands.rs
+++ b/crates/server/src/domains/apps/commands.rs
@@ -311,6 +311,18 @@ fn build_schedule_target_input(app: &App, channel: &AppChannel) -> Value {
     })
 }
 
+/// Metadata stamped onto the user message that an app channel injects into a
+/// session. The `_app_id` / `app_channel_id` / `app_channel_type` keys mirror
+/// the convention used by the AG-UI (`crates/server/src/api/ag_ui.rs`) and
+/// Slack (`crates/server/src/api/slack_events.rs`) ingress paths so all three
+/// channel kinds expose the same shape to message-metadata consumers.
+///
+/// `_app_id` (leading underscore) is the canonical "system metadata" key —
+/// app-channel image authorization in `is_ag_ui_app_image` and the matching
+/// system-id assertions in the channel ingress unit tests both read it. The
+/// audit-log payload emitted by `emit_app_invocation_audit_event` uses a bare
+/// `app_id` field for human-readable filtering; that is intentional and lives
+/// on a separate audit struct, not on this metadata bag.
 fn app_invocation_message_metadata(
     app: &App,
     channel: &AppChannel,
@@ -320,10 +332,6 @@ fn app_invocation_message_metadata(
         (
             "source".to_string(),
             Value::String(format!("app_{}", source.as_str())),
-        ),
-        (
-            "app_id".to_string(),
-            Value::String(app.public_id.to_string()),
         ),
         (
             "_app_id".to_string(),
@@ -2476,5 +2484,9 @@ mod tests {
             metadata.get("app_channel_id"),
             Some(&Value::String(channel.public_id.to_string()))
         );
+        // The bare `app_id` key was previously emitted alongside `_app_id`
+        // but had no consumer; the metadata bag uses the same `_app_id`
+        // convention as the AG-UI and Slack ingress paths.
+        assert!(!metadata.contains_key("app_id"));
     }
 }


### PR DESCRIPTION
## What
Removes the duplicate `app_id` key from `app_invocation_message_metadata` and documents the `_app_id` "system metadata" convention.

Resolves EVE-438.

## Why
`app_invocation_message_metadata` was emitting both `app_id` and `_app_id` with the same value. No caller anywhere in the workspace reads the bare `app_id` from a session's message metadata bag — `is_ag_ui_app_image` reads `_app_id`, the channel-ingress unit tests read `_app_id`, and the audit-log payload uses a separate bare-`app_id` field on its own `AuditEvent` struct (not on this metadata bag). The duplicate was dead weight and risked future code cargo-culting the pattern.

## How
- Drop the duplicate bare `app_id` entry in `app_invocation_message_metadata`.
- Add a doc comment describing the `_app_id` convention shared with `api/ag_ui.rs` and `api/slack_events.rs`, and call out that the audit-log payload's bare `app_id` is intentionally separate.
- Tighten `app_invocation_message_metadata_includes_system_app_id` to assert the bare `app_id` is no longer present.

## Risk
- Low. The bare key had no readers, so removing it does not affect downstream behavior. `_app_id`, `app_channel_id`, `app_channel_type`, and `source` are unchanged. Audit-log payloads are emitted by a separate function and are not touched.

## Security
- Threat categories reviewed: TM-AUTHZ (no change to authorization-relevant tags), TM-A2A (channel-ingress contract unchanged), TM-AUDIT (audit-log surface untouched).
- Findings and resolutions: None — the change is a metadata-shape cleanup with no policy impact.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (no consumers; safe to drop)
- [x] Security review performed against relevant threat model categories
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D31EyHMKtKtVa4x5GW4mL9)_