### PR TITLE
feat(cli): support session feature flags

### DIFF
--- a/crates/cli/src/commands/agents.rs
+++ b/crates/cli/src/commands/agents.rs
@@ -133,6 +133,7 @@ pub async fn run(
     client: &Everruns,
     api_url: &str,
     api_key: &str,
+    org_id: Option<&str>,
     output: OutputFormat,
     quiet: bool,
 ) -> Result<()> {
@@ -165,6 +166,7 @@ pub async fn run(
                 import_from_file(
                     api_url,
                     api_key,
+                    org_id,
                     &path,
                     initial_files_dir.as_deref(),
                     writable,
@@ -220,6 +222,7 @@ pub async fn run(
                 import_from_file(
                     api_url,
                     api_key,
+                    org_id,
                     &path,
                     initial_files_dir.as_deref(),
                     writable,
@@ -257,9 +260,11 @@ pub async fn run(
 /// The CLI normalizes TOML into JSON before calling the server import API.
 /// When initial_files_dir is provided, files are globbed and injected into the
 /// payload as initial_files before sending.
+#[allow(clippy::too_many_arguments)]
 async fn import_from_file(
     api_url: &str,
     api_key: &str,
+    org_id: Option<&str>,
     path: &str,
     initial_files_dir: Option<&str>,
     writable: bool,
@@ -316,7 +321,8 @@ async fn import_from_file(
         .post(format!("{}/v1/agents/import", api_url))
         .header("Authorization", format!("Bearer {}", api_key))
         .header("Content-Type", content_type);
-    if let Ok(org) = std::env::var("EVERRUNS_ORG_ID") {
+    let env_org = std::env::var("EVERRUNS_ORG_ID").ok();
+    if let Some(org) = org_id.or(env_org.as_deref()) {
         req = req.header("X-Org-Id", org);
     }
     let resp = req

--- a/crates/cli/src/commands/files/ls.rs
+++ b/crates/cli/src/commands/files/ls.rs
@@ -4,16 +4,18 @@ use crate::commands::files::remote::RemoteClient;
 use crate::output::{OutputFormat, print_table_header, print_table_row};
 use anyhow::Result;
 
+#[allow(clippy::too_many_arguments)]
 pub async fn run(
     api_url: &str,
     api_key: &str,
+    org_id: Option<&str>,
     output: OutputFormat,
     session_id: String,
     path: String,
     recursive: bool,
     long: bool,
 ) -> Result<()> {
-    let client = RemoteClient::new(api_url, api_key, &session_id);
+    let client = RemoteClient::new_with_org(api_url, api_key, &session_id, org_id);
     let entries = client.list(&path, recursive).await?;
 
     if output.is_text() {

--- a/crates/cli/src/commands/files/mod.rs
+++ b/crates/cli/src/commands/files/mod.rs
@@ -121,6 +121,7 @@ pub async fn run(
     command: FilesCommand,
     api_url: &str,
     api_key: &str,
+    org_id: Option<&str>,
     output: OutputFormat,
     quiet: bool,
 ) -> Result<()> {
@@ -139,6 +140,7 @@ pub async fn run(
             sync_cmd::run(
                 api_url,
                 api_key,
+                org_id,
                 quiet,
                 session,
                 local_dir,
@@ -159,7 +161,7 @@ pub async fn run(
             dry_run,
         } => {
             push::run(
-                api_url, api_key, output, quiet, session, local_dir, delete, dry_run,
+                api_url, api_key, org_id, output, quiet, session, local_dir, delete, dry_run,
             )
             .await
         }
@@ -170,7 +172,7 @@ pub async fn run(
             dry_run,
         } => {
             pull::run(
-                api_url, api_key, output, quiet, session, local_dir, delete, dry_run,
+                api_url, api_key, org_id, output, quiet, session, local_dir, delete, dry_run,
             )
             .await
         }
@@ -179,6 +181,11 @@ pub async fn run(
             path,
             recursive,
             long,
-        } => ls::run(api_url, api_key, output, session, path, recursive, long).await,
+        } => {
+            ls::run(
+                api_url, api_key, org_id, output, session, path, recursive, long,
+            )
+            .await
+        }
     }
 }

--- a/crates/cli/src/commands/files/pull.rs
+++ b/crates/cli/src/commands/files/pull.rs
@@ -11,6 +11,7 @@ use std::path::PathBuf;
 pub async fn run(
     api_url: &str,
     api_key: &str,
+    org_id: Option<&str>,
     output: OutputFormat,
     quiet: bool,
     session_id: String,
@@ -19,7 +20,7 @@ pub async fn run(
     dry_run: bool,
 ) -> Result<()> {
     let local_dir = PathBuf::from(&local_dir).canonicalize()?;
-    let client = RemoteClient::new(api_url, api_key, &session_id);
+    let client = RemoteClient::new_with_org(api_url, api_key, &session_id, org_id);
     let sd = state_dir(&local_dir);
     let mut state = SyncState::load(&sd, &session_id)?;
 

--- a/crates/cli/src/commands/files/push.rs
+++ b/crates/cli/src/commands/files/push.rs
@@ -11,6 +11,7 @@ use std::path::PathBuf;
 pub async fn run(
     api_url: &str,
     api_key: &str,
+    org_id: Option<&str>,
     output: OutputFormat,
     quiet: bool,
     session_id: String,
@@ -19,7 +20,7 @@ pub async fn run(
     dry_run: bool,
 ) -> Result<()> {
     let local_dir = PathBuf::from(&local_dir).canonicalize()?;
-    let client = RemoteClient::new(api_url, api_key, &session_id);
+    let client = RemoteClient::new_with_org(api_url, api_key, &session_id, org_id);
     let sd = state_dir(&local_dir);
     let mut state = SyncState::load(&sd, &session_id)?;
 

--- a/crates/cli/src/commands/files/remote.rs
+++ b/crates/cli/src/commands/files/remote.rs
@@ -51,15 +51,29 @@ pub struct RemoteClient {
     base_url: String,
     session_id: String,
     api_key: String,
+    org_id: Option<String>,
 }
 
 impl RemoteClient {
+    #[cfg(test)]
     pub fn new(api_url: &str, api_key: &str, session_id: &str) -> Self {
+        Self::new_with_org(api_url, api_key, session_id, None)
+    }
+
+    pub fn new_with_org(
+        api_url: &str,
+        api_key: &str,
+        session_id: &str,
+        org_id: Option<&str>,
+    ) -> Self {
         Self {
             http: reqwest::Client::new(),
             base_url: api_url.trim_end_matches('/').to_string(),
             session_id: session_id.to_string(),
             api_key: api_key.to_string(),
+            org_id: org_id
+                .map(ToOwned::to_owned)
+                .or_else(|| std::env::var("EVERRUNS_ORG_ID").ok()),
         }
     }
 
@@ -75,6 +89,19 @@ impl RemoteClient {
         }
     }
 
+    fn apply_auth(&self, request: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+        let request = request.header("Authorization", self.auth_header_value());
+        if let Some(org_id) = &self.org_id {
+            request.header("X-Org-Id", org_id)
+        } else {
+            request
+        }
+    }
+
+    fn auth_header_value(&self) -> String {
+        format!("Bearer {}", self.api_key)
+    }
+
     /// List files at a path. If recursive, lists the entire tree.
     pub async fn list(&self, path: &str, recursive: bool) -> Result<Vec<RemoteFileEntry>> {
         let mut url = self.fs_url(path);
@@ -84,9 +111,7 @@ impl RemoteClient {
         }
 
         let resp = self
-            .http
-            .get(&url)
-            .header("Authorization", &self.api_key)
+            .apply_auth(self.http.get(&url))
             .send()
             .await
             .context("Failed to list remote files")?;
@@ -120,9 +145,7 @@ impl RemoteClient {
     pub async fn read_file(&self, path: &str) -> Result<RemoteFileContent> {
         let url = self.fs_url(path);
         let resp = self
-            .http
-            .get(&url)
-            .header("Authorization", &self.api_key)
+            .apply_auth(self.http.get(&url))
             .send()
             .await
             .context("Failed to read remote file")?;
@@ -169,18 +192,14 @@ impl RemoteClient {
         });
 
         let resp = if create {
-            self.http
-                .post(&url)
-                .header("Authorization", &self.api_key)
+            self.apply_auth(self.http.post(&url))
                 .header("Content-Type", "application/json")
                 .json(&body)
                 .send()
                 .await
                 .context("Failed to create remote file")?
         } else {
-            self.http
-                .put(&url)
-                .header("Authorization", &self.api_key)
+            self.apply_auth(self.http.put(&url))
                 .header("Content-Type", "application/json")
                 .json(&body)
                 .send()
@@ -205,9 +224,7 @@ impl RemoteClient {
     async fn update_file(&self, path: &str, body: &serde_json::Value) -> Result<()> {
         let url = self.fs_url(path);
         let resp = self
-            .http
-            .put(&url)
-            .header("Authorization", &self.api_key)
+            .apply_auth(self.http.put(&url))
             .header("Content-Type", "application/json")
             .json(body)
             .send()
@@ -230,9 +247,7 @@ impl RemoteClient {
         }
 
         let resp = self
-            .http
-            .delete(&url)
-            .header("Authorization", &self.api_key)
+            .apply_auth(self.http.delete(&url))
             .send()
             .await
             .context("Failed to delete remote file")?;
@@ -344,6 +359,13 @@ mod tests {
     #[test]
     fn test_default_encoding() {
         assert_eq!(default_encoding(), "text");
+    }
+
+    #[test]
+    fn test_auth_header_uses_bearer_scheme() {
+        let client = RemoteClient::new("https://api.example.com", "evr_test", "session_abc");
+
+        assert_eq!(client.auth_header_value(), "Bearer evr_test");
     }
 
     #[test]

--- a/crates/cli/src/commands/files/sync_cmd.rs
+++ b/crates/cli/src/commands/files/sync_cmd.rs
@@ -17,6 +17,7 @@ use std::time::Duration;
 pub async fn run(
     api_url: &str,
     api_key: &str,
+    org_id: Option<&str>,
     quiet: bool,
     session_id: String,
     local_dir: String,
@@ -29,7 +30,7 @@ pub async fn run(
     verbose: bool,
 ) -> Result<()> {
     let local_dir = PathBuf::from(&local_dir).canonicalize()?;
-    let client = RemoteClient::new(api_url, api_key, &session_id);
+    let client = RemoteClient::new_with_org(api_url, api_key, &session_id, org_id);
     let conflict_strategy = Conflict::parse(&conflict);
     let sd = state_dir(&local_dir);
     let mut state = SyncState::load(&sd, &session_id)?;

--- a/crates/cli/src/commands/sessions.rs
+++ b/crates/cli/src/commands/sessions.rs
@@ -3,11 +3,12 @@
 use crate::output::{OutputFormat, print_field, print_table_header, print_table_row};
 use anyhow::{Context, Result};
 use clap::Subcommand;
-use everruns_sdk::{CreateBudgetRequest, CreateSessionRequest, Everruns};
+use everruns_sdk::{CreateBudgetRequest, Everruns};
 use futures::StreamExt;
 use std::collections::HashMap;
 
 #[derive(Subcommand)]
+#[allow(clippy::large_enum_variant)]
 pub enum SessionsCommand {
     /// Create a new session
     Create {
@@ -23,9 +24,49 @@ pub enum SessionsCommand {
         #[arg(long)]
         title: Option<String>,
 
+        /// Session locale (BCP 47, e.g. uk-UA)
+        #[arg(long)]
+        locale: Option<String>,
+
         /// Model ID override (e.g. mod_xxx)
         #[arg(long)]
         model: Option<String>,
+
+        /// Resident agent identity ID for unattended/background execution
+        #[arg(long = "agent-identity")]
+        agent_identity: Option<String>,
+
+        /// Session-level system prompt override
+        #[arg(long = "system-prompt")]
+        system_prompt: Option<String>,
+
+        /// Session tag (repeatable)
+        #[arg(long = "tag", short = 't')]
+        tags: Vec<String>,
+
+        /// Session capability (repeatable). Format: REF or REF=JSON_CONFIG.
+        #[arg(long = "capability", value_name = "REF[=JSON]")]
+        capabilities: Vec<String>,
+
+        /// Session client hint (repeatable). Format: KEY=JSON_VALUE.
+        #[arg(long = "hint", value_name = "KEY=JSON")]
+        hints: Vec<String>,
+
+        /// Session client hints JSON object
+        #[arg(long = "hints-json", value_name = "JSON")]
+        hints_json: Option<String>,
+
+        /// Network allow pattern (repeatable)
+        #[arg(long = "network-allow", value_name = "PATTERN")]
+        network_allow: Vec<String>,
+
+        /// Network block pattern (repeatable)
+        #[arg(long = "network-block", value_name = "PATTERN")]
+        network_block: Vec<String>,
+
+        /// Maximum LLM iterations per turn
+        #[arg(long = "max-iterations")]
+        max_iterations: Option<usize>,
 
         /// Session-scoped secret (repeatable, format: KEY=VALUE)
         #[arg(long = "secret", value_name = "KEY=VALUE")]
@@ -75,6 +116,9 @@ pub enum SessionsCommand {
 pub async fn run(
     command: SessionsCommand,
     client: &Everruns,
+    api_url: &str,
+    api_key: &str,
+    org_id: Option<&str>,
     output: OutputFormat,
     quiet: bool,
 ) -> Result<()> {
@@ -83,19 +127,42 @@ pub async fn run(
             harness,
             agent,
             title,
+            locale,
             model,
+            agent_identity,
+            system_prompt,
+            tags,
+            capabilities,
+            hints,
+            hints_json,
+            network_allow,
+            network_block,
+            max_iterations,
             secrets,
             budget_limits,
             budget_soft_limits,
         } => {
             create(
                 client,
+                api_url,
+                api_key,
+                org_id,
                 output,
                 quiet,
                 harness,
                 agent,
                 title,
+                locale,
                 model,
+                agent_identity,
+                system_prompt,
+                tags,
+                capabilities,
+                hints,
+                hints_json,
+                network_allow,
+                network_block,
+                max_iterations,
                 secrets,
                 budget_limits,
                 budget_soft_limits,
@@ -115,50 +182,66 @@ pub async fn run(
 #[allow(clippy::too_many_arguments)]
 async fn create(
     client: &Everruns,
+    api_url: &str,
+    api_key: &str,
+    org_id: Option<&str>,
     output: OutputFormat,
     quiet: bool,
     harness: Option<String>,
     agent_id: Option<String>,
     title: Option<String>,
+    locale: Option<String>,
     model_id: Option<String>,
+    agent_identity_id: Option<String>,
+    system_prompt: Option<String>,
+    tags: Vec<String>,
+    raw_capabilities: Vec<String>,
+    raw_hints: Vec<String>,
+    raw_hints_json: Option<String>,
+    network_allow: Vec<String>,
+    network_block: Vec<String>,
+    max_iterations: Option<usize>,
     raw_secrets: Vec<String>,
     raw_budget_limits: Vec<String>,
     raw_budget_soft_limits: Vec<String>,
 ) -> Result<()> {
     let secrets = parse_secrets(&raw_secrets)?;
     let budget_specs = parse_budget_limits(&raw_budget_limits, &raw_budget_soft_limits)?;
+    let body = build_create_session_body(CreateSessionArgs {
+        harness,
+        agent_id,
+        title,
+        locale,
+        model_id,
+        agent_identity_id,
+        system_prompt,
+        tags,
+        raw_capabilities,
+        raw_hints,
+        raw_hints_json,
+        network_allow,
+        network_block,
+        max_iterations,
+    })?;
 
-    let mut req = CreateSessionRequest::new();
-    if let Some(h) = harness {
-        req = if h.starts_with("harness_") && h.len() == 40 {
-            req.harness_id(h)
-        } else {
-            req.harness_name(h)
-        };
-    }
-    if let Some(a) = agent_id {
-        req = req.agent_id(a);
-    }
-    if let Some(t) = title {
-        req = req.title(t);
-    }
-    if let Some(m) = model_id {
-        req = req.model_id(m);
-    }
-
-    let session = client.sessions().create_with_options(req).await?;
+    let session = create_session_raw(api_url, api_key, org_id, &body).await?;
+    let session_id = session
+        .get("id")
+        .and_then(|id| id.as_str())
+        .context("Create session response did not include id")?
+        .to_string();
 
     // Store secrets after session creation
     if !secrets.is_empty() {
         client
             .sessions()
-            .set_secrets(&session.id, &secrets)
+            .set_secrets(&session_id, &secrets)
             .await
             .with_context(|| {
                 format!(
                     "Failed to store {} secrets for session {}",
                     secrets.len(),
-                    session.id
+                    session_id
                 )
             })?;
     }
@@ -166,26 +249,42 @@ async fn create(
     // Create budgets after session creation
     let mut created_budgets = Vec::new();
     for spec in &budget_specs {
-        let mut req = CreateBudgetRequest::new("session", &session.id, &spec.currency, spec.limit);
+        let mut req = CreateBudgetRequest::new("session", &session_id, &spec.currency, spec.limit);
         if let Some(soft) = spec.soft_limit {
             req = req.soft_limit(soft);
         }
         let budget = client.budgets().create(req).await.with_context(|| {
-            format!("Session {} created but budget creation failed", session.id)
+            format!("Session {} created but budget creation failed", session_id)
         })?;
         created_budgets.push(serde_json::to_value(&budget)?);
     }
 
     if output.is_text() {
         if quiet {
-            println!("{}", session.id);
+            println!("{}", session_id);
         } else {
-            println!("Created session: {}", session.id);
-            if let Some(agent) = &session.agent_id {
+            println!("Created session: {}", session_id);
+            if let Some(agent) = session.get("agent_id").and_then(|v| v.as_str()) {
                 print_field("Agent", agent);
             }
-            let status = format!("{:?}", session.status).to_lowercase();
-            print_field("Status", &status);
+            if let Some(identity) = session.get("agent_identity_id").and_then(|v| v.as_str()) {
+                print_field("Identity", identity);
+            }
+            if let Some(status) = session.get("status").and_then(value_as_status) {
+                print_field("Status", &status);
+            }
+            if let Some(features) = session.get("features").and_then(|v| v.as_array())
+                && !features.is_empty()
+            {
+                let features = features
+                    .iter()
+                    .filter_map(|v| v.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                if !features.is_empty() {
+                    print_field("Features", &features);
+                }
+            }
             if !secrets.is_empty() {
                 print_field("Secrets", &format!("{} injected", secrets.len()));
             }
@@ -214,7 +313,7 @@ async fn create(
             }
         }
     } else {
-        let mut json = serde_json::to_value(&session)?;
+        let mut json = session;
         if !secrets.is_empty() {
             json["secrets_count"] = serde_json::json!(secrets.len());
         }
@@ -225,6 +324,195 @@ async fn create(
     }
 
     Ok(())
+}
+
+struct CreateSessionArgs {
+    harness: Option<String>,
+    agent_id: Option<String>,
+    title: Option<String>,
+    locale: Option<String>,
+    model_id: Option<String>,
+    agent_identity_id: Option<String>,
+    system_prompt: Option<String>,
+    tags: Vec<String>,
+    raw_capabilities: Vec<String>,
+    raw_hints: Vec<String>,
+    raw_hints_json: Option<String>,
+    network_allow: Vec<String>,
+    network_block: Vec<String>,
+    max_iterations: Option<usize>,
+}
+
+fn build_create_session_body(args: CreateSessionArgs) -> Result<serde_json::Value> {
+    let mut body = serde_json::Map::new();
+
+    if let Some(h) = args.harness {
+        if is_prefixed_id(&h, "harness") {
+            body.insert("harness_id".to_string(), serde_json::json!(h));
+        } else {
+            body.insert("harness_name".to_string(), serde_json::json!(h));
+        }
+    }
+    insert_opt_string(&mut body, "agent_id", args.agent_id);
+    insert_opt_string(&mut body, "agent_identity_id", args.agent_identity_id);
+    insert_opt_string(&mut body, "title", args.title);
+    insert_opt_string(&mut body, "locale", args.locale);
+    insert_opt_string(&mut body, "model_id", args.model_id);
+    insert_opt_string(&mut body, "system_prompt", args.system_prompt);
+
+    if !args.tags.is_empty() {
+        body.insert("tags".to_string(), serde_json::json!(args.tags));
+    }
+    if !args.raw_capabilities.is_empty() {
+        body.insert(
+            "capabilities".to_string(),
+            serde_json::Value::Array(parse_capabilities(&args.raw_capabilities)?),
+        );
+    }
+
+    let hints = parse_hints(args.raw_hints_json.as_deref(), &args.raw_hints)?;
+    if !hints.is_empty() {
+        body.insert("hints".to_string(), serde_json::Value::Object(hints));
+    }
+
+    if !args.network_allow.is_empty() || !args.network_block.is_empty() {
+        let mut network_access = serde_json::Map::new();
+        if !args.network_allow.is_empty() {
+            network_access.insert("allowed".to_string(), serde_json::json!(args.network_allow));
+        }
+        if !args.network_block.is_empty() {
+            network_access.insert("blocked".to_string(), serde_json::json!(args.network_block));
+        }
+        body.insert(
+            "network_access".to_string(),
+            serde_json::Value::Object(network_access),
+        );
+    }
+
+    if let Some(max_iterations) = args.max_iterations {
+        if max_iterations == 0 {
+            anyhow::bail!("--max-iterations must be greater than zero");
+        }
+        body.insert(
+            "max_iterations".to_string(),
+            serde_json::json!(max_iterations),
+        );
+    }
+
+    Ok(serde_json::Value::Object(body))
+}
+
+fn is_prefixed_id(value: &str, prefix: &str) -> bool {
+    let expected = format!("{prefix}_");
+    let Some(rest) = value.strip_prefix(&expected) else {
+        return false;
+    };
+    rest.len() == 32 && rest.chars().all(|c| matches!(c, '0'..='9' | 'a'..='f'))
+}
+
+fn insert_opt_string(
+    body: &mut serde_json::Map<String, serde_json::Value>,
+    key: &str,
+    value: Option<String>,
+) {
+    if let Some(value) = value {
+        body.insert(key.to_string(), serde_json::json!(value));
+    }
+}
+
+fn parse_capabilities(raw: &[String]) -> Result<Vec<serde_json::Value>> {
+    raw.iter()
+        .map(|entry| {
+            let (capability_ref, config) = if let Some((left, right)) = entry.split_once('=') {
+                if left.is_empty() {
+                    anyhow::bail!("Capability ref cannot be empty: {entry}");
+                }
+                let config = serde_json::from_str(right)
+                    .with_context(|| format!("Invalid capability JSON config: {entry}"))?;
+                (left, config)
+            } else {
+                if entry.is_empty() {
+                    anyhow::bail!("Capability ref cannot be empty");
+                }
+                (entry.as_str(), serde_json::json!({}))
+            };
+            Ok(serde_json::json!({
+                "ref": capability_ref,
+                "config": config,
+            }))
+        })
+        .collect()
+}
+
+fn parse_hints(
+    hints_json: Option<&str>,
+    raw_hints: &[String],
+) -> Result<serde_json::Map<String, serde_json::Value>> {
+    let mut hints = if let Some(raw) = hints_json {
+        let value: serde_json::Value =
+            serde_json::from_str(raw).context("Invalid --hints-json value")?;
+        value
+            .as_object()
+            .cloned()
+            .context("--hints-json must be a JSON object")?
+    } else {
+        serde_json::Map::new()
+    };
+
+    for entry in raw_hints {
+        let (key, value) = entry
+            .split_once('=')
+            .with_context(|| format!("Invalid hint format (expected KEY=JSON): {entry}"))?;
+        if key.is_empty() {
+            anyhow::bail!("Hint key cannot be empty: {entry}");
+        }
+        if hints.contains_key(key) {
+            anyhow::bail!("Duplicate hint key: {key}");
+        }
+        let value = serde_json::from_str(value)
+            .with_context(|| format!("Invalid JSON value for hint '{key}'"))?;
+        hints.insert(key.to_string(), value);
+    }
+
+    Ok(hints)
+}
+
+async fn create_session_raw(
+    api_url: &str,
+    api_key: &str,
+    org_id: Option<&str>,
+    body: &serde_json::Value,
+) -> Result<serde_json::Value> {
+    let http = reqwest::Client::new();
+    let mut req = http
+        .post(format!("{}/v1/sessions", api_url.trim_end_matches('/')))
+        .header("Authorization", format!("Bearer {}", api_key))
+        .header("Content-Type", "application/json")
+        .json(body);
+    let env_org = std::env::var("EVERRUNS_ORG_ID").ok();
+    if let Some(org) = org_id.or(env_org.as_deref()) {
+        req = req.header("X-Org-Id", org);
+    }
+
+    let resp = req.send().await.context("Failed to create session")?;
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        anyhow::bail!("Create session failed ({}): {}", status, body);
+    }
+
+    resp.json()
+        .await
+        .context("Failed to parse create session response")
+}
+
+fn value_as_status(value: &serde_json::Value) -> Option<String> {
+    value.as_str().map(ToOwned::to_owned).or_else(|| {
+        value
+            .get("status")
+            .and_then(|v| v.as_str())
+            .map(ToOwned::to_owned)
+    })
 }
 
 /// Parsed budget specification from `--budget-limit` and `--budget-soft-limit`.
@@ -744,6 +1032,136 @@ mod tests {
     #[test]
     fn test_parse_budget_limits_non_numeric_fails() {
         assert!(parse_budget_limits(&["abc".into()], &[]).is_err());
+    }
+
+    #[test]
+    fn test_parse_capabilities_plain_and_configured() {
+        let parsed =
+            parse_capabilities(&["web_fetch".into(), "filesystem={\"readonly\":true}".into()])
+                .unwrap();
+        assert_eq!(parsed[0]["ref"], "web_fetch");
+        assert_eq!(parsed[0]["config"], serde_json::json!({}));
+        assert_eq!(parsed[1]["ref"], "filesystem");
+        assert_eq!(parsed[1]["config"], serde_json::json!({"readonly": true}));
+    }
+
+    #[test]
+    fn test_parse_capabilities_rejects_invalid_json() {
+        assert!(parse_capabilities(&["web_fetch={bad}".into()]).is_err());
+    }
+
+    #[test]
+    fn test_parse_hints_merges_json_and_flags() {
+        let parsed = parse_hints(
+            Some("{\"rich_media\":true}"),
+            &["setup_connection=true".into(), "max_items=3".into()],
+        )
+        .unwrap();
+        assert_eq!(parsed["rich_media"], serde_json::json!(true));
+        assert_eq!(parsed["setup_connection"], serde_json::json!(true));
+        assert_eq!(parsed["max_items"], serde_json::json!(3));
+    }
+
+    #[test]
+    fn test_parse_hints_rejects_duplicate() {
+        assert!(
+            parse_hints(
+                Some("{\"setup_connection\":false}"),
+                &["setup_connection=true".into()]
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn test_build_create_session_body_new_fields() {
+        let body = build_create_session_body(CreateSessionArgs {
+            harness: Some("generic".into()),
+            agent_id: Some("agent_abc".into()),
+            title: Some("Debug".into()),
+            locale: Some("uk-UA".into()),
+            model_id: Some("model_abc".into()),
+            agent_identity_id: Some("identity_abc".into()),
+            system_prompt: Some("Be concise".into()),
+            tags: vec!["bug".into()],
+            raw_capabilities: vec!["web_fetch={\"timeout\":10}".into()],
+            raw_hints: vec!["setup_connection=true".into()],
+            raw_hints_json: Some("{\"rich_media\":true}".into()),
+            network_allow: vec!["api.example.com".into()],
+            network_block: vec!["internal.example.com".into()],
+            max_iterations: Some(8),
+        })
+        .unwrap();
+
+        assert_eq!(body["harness_name"], "generic");
+        assert_eq!(body["agent_id"], "agent_abc");
+        assert_eq!(body["agent_identity_id"], "identity_abc");
+        assert_eq!(body["locale"], "uk-UA");
+        assert_eq!(body["system_prompt"], "Be concise");
+        assert_eq!(body["tags"], serde_json::json!(["bug"]));
+        assert_eq!(body["capabilities"][0]["ref"], "web_fetch");
+        assert_eq!(body["hints"]["setup_connection"], serde_json::json!(true));
+        assert_eq!(body["hints"]["rich_media"], serde_json::json!(true));
+        assert_eq!(
+            body["network_access"]["allowed"],
+            serde_json::json!(["api.example.com"])
+        );
+        assert_eq!(
+            body["network_access"]["blocked"],
+            serde_json::json!(["internal.example.com"])
+        );
+        assert_eq!(body["max_iterations"], 8);
+    }
+
+    #[test]
+    fn test_build_create_session_body_detects_harness_id_strictly() {
+        let body = build_create_session_body(CreateSessionArgs {
+            harness: Some("harness_00000000000000000000000000000001".into()),
+            agent_id: None,
+            title: None,
+            locale: None,
+            model_id: None,
+            agent_identity_id: None,
+            system_prompt: None,
+            tags: vec![],
+            raw_capabilities: vec![],
+            raw_hints: vec![],
+            raw_hints_json: None,
+            network_allow: vec![],
+            network_block: vec![],
+            max_iterations: None,
+        })
+        .unwrap();
+
+        assert_eq!(
+            body["harness_id"],
+            "harness_00000000000000000000000000000001"
+        );
+        assert!(body.get("harness_name").is_none());
+    }
+
+    #[test]
+    fn test_build_create_session_body_keeps_harness_prefix_names() {
+        let body = build_create_session_body(CreateSessionArgs {
+            harness: Some("harness_generic".into()),
+            agent_id: None,
+            title: None,
+            locale: None,
+            model_id: None,
+            agent_identity_id: None,
+            system_prompt: None,
+            tags: vec![],
+            raw_capabilities: vec![],
+            raw_hints: vec![],
+            raw_hints_json: None,
+            network_allow: vec![],
+            network_block: vec![],
+            max_iterations: None,
+        })
+        .unwrap();
+
+        assert_eq!(body["harness_name"], "harness_generic");
+        assert!(body.get("harness_id").is_none());
     }
 
     #[test]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -26,7 +26,7 @@ pub struct Cli {
     pub api_url: Option<String>,
 
     /// Output format
-    #[arg(long, short, global = true, default_value = "text", value_parser = ["text", "json"])]
+    #[arg(long, short, global = true, default_value = "text", value_parser = ["text", "json", "yaml"])]
     pub output: String,
 
     /// Suppress non-essential output
@@ -76,6 +76,10 @@ pub enum Commands {
 
     /// Manage capabilities
     Capabilities {
+        /// Filter by status
+        #[arg(long, default_value = "available", value_parser = ["available", "coming_soon", "all"])]
+        status: String,
+
         #[command(subcommand)]
         command: Option<CapabilitiesCommand>,
     },
@@ -164,9 +168,14 @@ async fn main() -> anyhow::Result<()> {
     )?;
     let api_key = creds.api_key;
     let api_url = creds.api_url;
+    let org_id = creds.org_id;
 
     // Build SDK client
-    let client = Everruns::with_base_url(&api_key, &api_url)?;
+    let client = if let Some(org_id) = org_id.as_deref() {
+        Everruns::with_base_url_and_org_id(&api_key, &api_url, org_id)?
+    } else {
+        Everruns::with_base_url(&api_key, &api_url)?
+    };
 
     match cli.command {
         Commands::Agents { command } => {
@@ -175,6 +184,7 @@ async fn main() -> anyhow::Result<()> {
                 &client,
                 &api_url,
                 &api_key,
+                org_id.as_deref(),
                 output_format,
                 cli.quiet,
             )
@@ -191,18 +201,35 @@ async fn main() -> anyhow::Result<()> {
             )
             .await
         }
-        Commands::Capabilities { command } => {
+        Commands::Capabilities { status, command } => {
             let status = match &command {
                 Some(CapabilitiesCommand::List { status }) => status.clone(),
-                None => "available".to_string(),
+                None => status,
             };
             commands::capabilities::run(&client, output_format, &status).await
         }
         Commands::Sessions { command } => {
-            commands::sessions::run(command, &client, output_format, cli.quiet).await
+            commands::sessions::run(
+                command,
+                &client,
+                &api_url,
+                &api_key,
+                org_id.as_deref(),
+                output_format,
+                cli.quiet,
+            )
+            .await
         }
         Commands::Files { command } => {
-            commands::files::run(command, &api_url, &api_key, output_format, cli.quiet).await
+            commands::files::run(
+                command,
+                &api_url,
+                &api_key,
+                org_id.as_deref(),
+                output_format,
+                cli.quiet,
+            )
+            .await
         }
         Commands::Chat {
             message,
@@ -223,7 +250,7 @@ async fn main() -> anyhow::Result<()> {
         }
         // Already handled above
         Commands::Login { .. } | Commands::Logout | Commands::Status | Commands::Orgs { .. } => {
-            unreachable!();
+            unreachable!()
         }
     }
 }
@@ -275,6 +302,16 @@ mod tests {
                 agent,
                 title,
                 model,
+                locale,
+                agent_identity,
+                system_prompt,
+                tags,
+                capabilities,
+                hints,
+                hints_json,
+                network_allow,
+                network_block,
+                max_iterations,
                 secrets,
                 budget_limits,
                 budget_soft_limits,
@@ -284,6 +321,16 @@ mod tests {
                 assert_eq!(agent, Some("agt_abc".to_string()));
                 assert_eq!(title, Some("Test Session".to_string()));
                 assert_eq!(model, None);
+                assert_eq!(locale, None);
+                assert_eq!(agent_identity, None);
+                assert_eq!(system_prompt, None);
+                assert!(tags.is_empty());
+                assert!(capabilities.is_empty());
+                assert!(hints.is_empty());
+                assert_eq!(hints_json, None);
+                assert!(network_allow.is_empty());
+                assert!(network_block.is_empty());
+                assert_eq!(max_iterations, None);
                 assert!(secrets.is_empty());
                 assert!(budget_limits.is_empty());
                 assert!(budget_soft_limits.is_empty());
@@ -355,6 +402,69 @@ mod tests {
     }
 
     #[test]
+    fn test_cli_parse_sessions_create_new_fields() {
+        let cli = Cli::try_parse_from([
+            "everruns",
+            "sessions",
+            "create",
+            "--agent",
+            "agent_abc",
+            "--agent-identity",
+            "identity_abc",
+            "--system-prompt",
+            "Be concise",
+            "--locale",
+            "uk-UA",
+            "--tag",
+            "debugging",
+            "--capability",
+            "web_fetch={\"timeout\":10}",
+            "--hint",
+            "setup_connection=true",
+            "--hints-json",
+            "{\"rich_media\":true}",
+            "--network-allow",
+            "api.example.com",
+            "--network-block",
+            "internal.example.com",
+            "--max-iterations",
+            "8",
+        ])
+        .unwrap();
+        if let Commands::Sessions { command } = cli.command {
+            if let commands::sessions::SessionsCommand::Create {
+                agent_identity,
+                system_prompt,
+                locale,
+                tags,
+                capabilities,
+                hints,
+                hints_json,
+                network_allow,
+                network_block,
+                max_iterations,
+                ..
+            } = command
+            {
+                assert_eq!(agent_identity, Some("identity_abc".to_string()));
+                assert_eq!(system_prompt, Some("Be concise".to_string()));
+                assert_eq!(locale, Some("uk-UA".to_string()));
+                assert_eq!(tags, vec!["debugging".to_string()]);
+                assert_eq!(capabilities, vec!["web_fetch={\"timeout\":10}".to_string()]);
+                assert_eq!(hints, vec!["setup_connection=true".to_string()]);
+                assert_eq!(hints_json, Some("{\"rich_media\":true}".to_string()));
+                assert_eq!(network_allow, vec!["api.example.com".to_string()]);
+                assert_eq!(network_block, vec!["internal.example.com".to_string()]);
+                assert_eq!(max_iterations, Some(8));
+            } else {
+                panic!("Expected Create command");
+            }
+        } else {
+            panic!("Expected Sessions command");
+        }
+    }
+
+    #[test]
     fn test_cli_parse_chat() {
         let cli = Cli::try_parse_from(["everruns", "chat", "--session", "ses_xyz", "Hello world"])
             .unwrap();
@@ -407,6 +517,9 @@ mod tests {
     fn test_cli_parse_output_format() {
         let cli = Cli::try_parse_from(["everruns", "-o", "json", "agents", "list"]).unwrap();
         assert_eq!(cli.output, "json");
+
+        let cli = Cli::try_parse_from(["everruns", "-o", "yaml", "agents", "list"]).unwrap();
+        assert_eq!(cli.output, "yaml");
     }
 
     #[test]
@@ -421,8 +534,20 @@ mod tests {
     #[test]
     fn test_cli_parse_capabilities_bare() {
         let cli = Cli::try_parse_from(["everruns", "capabilities"]).unwrap();
-        if let Commands::Capabilities { command } = cli.command {
+        if let Commands::Capabilities { command, status } = cli.command {
+            assert_eq!(status, "available");
             assert!(command.is_none()); // bare defaults to list with available
+        } else {
+            panic!("Expected Capabilities command");
+        }
+    }
+
+    #[test]
+    fn test_cli_parse_capabilities_bare_status() {
+        let cli = Cli::try_parse_from(["everruns", "capabilities", "--status", "all"]).unwrap();
+        if let Commands::Capabilities { command, status } = cli.command {
+            assert!(command.is_none());
+            assert_eq!(status, "all");
         } else {
             panic!("Expected Capabilities command");
         }
@@ -432,6 +557,7 @@ mod tests {
     fn test_cli_parse_capabilities_list() {
         let cli = Cli::try_parse_from(["everruns", "capabilities", "list"]).unwrap();
         if let Commands::Capabilities {
+            status: _,
             command: Some(CapabilitiesCommand::List { status }),
         } = cli.command
         {
@@ -446,6 +572,7 @@ mod tests {
         let cli =
             Cli::try_parse_from(["everruns", "capabilities", "list", "--status", "all"]).unwrap();
         if let Commands::Capabilities {
+            status: _,
             command: Some(CapabilitiesCommand::List { status }),
         } = cli.command
         {

--- a/crates/cli/src/output.rs
+++ b/crates/cli/src/output.rs
@@ -6,12 +6,14 @@ use serde::Serialize;
 pub enum OutputFormat {
     Text,
     Json,
+    Yaml,
 }
 
 impl OutputFormat {
     pub fn from_str(s: &str) -> Self {
         match s {
             "json" => OutputFormat::Json,
+            "yaml" => OutputFormat::Yaml,
             _ => OutputFormat::Text,
         }
     }
@@ -21,6 +23,10 @@ impl OutputFormat {
             OutputFormat::Json => match serde_json::to_string_pretty(value) {
                 Ok(json) => println!("{}", json),
                 Err(err) => eprintln!("Failed to serialize JSON output: {}", err),
+            },
+            OutputFormat::Yaml => match serde_yaml::to_string(value) {
+                Ok(yaml) => println!("{}", yaml.trim_end()),
+                Err(err) => eprintln!("Failed to serialize YAML output: {}", err),
             },
             OutputFormat::Text => {
                 // Text format is handled by each command
@@ -89,6 +95,7 @@ mod tests {
     #[test]
     fn test_output_format_from_str() {
         assert!(matches!(OutputFormat::from_str("json"), OutputFormat::Json));
+        assert!(matches!(OutputFormat::from_str("yaml"), OutputFormat::Yaml));
         assert!(matches!(OutputFormat::from_str("text"), OutputFormat::Text));
         assert!(matches!(
             OutputFormat::from_str("unknown"),
@@ -101,6 +108,7 @@ mod tests {
     fn test_output_format_is_text() {
         assert!(OutputFormat::Text.is_text());
         assert!(!OutputFormat::Json.is_text());
+        assert!(!OutputFormat::Yaml.is_text());
     }
 
     #[test]

--- a/docs/features/cli.md
+++ b/docs/features/cli.md
@@ -262,7 +262,18 @@ everruns sessions create --agent agt_xxx
 
 # With title
 everruns sessions create --agent agt_xxx --title "Debug session"
+
+# With session-level features
+everruns sessions create \
+  --agent agt_xxx \
+  --agent-identity identity_xxx \
+  --capability 'web_fetch={"timeout":10}' \
+  --hint setup_connection=true \
+  --network-allow api.example.com \
+  --max-iterations 8
 ```
+
+Session creation also supports `--locale`, repeatable `--tag`, `--system-prompt`, `--hints-json`, repeatable `--network-block`, repeatable `--secret KEY=VALUE`, and budget flags.
 
 #### List Sessions
 

--- a/specs/cli.md
+++ b/specs/cli.md
@@ -7,7 +7,7 @@
 **Crate:** `crates/cli/`
 
 **Global Flags:**
-- `-o, --output` — Output format: `text` (default), `json`
+- `-o, --output` — Output format: `text` (default), `json`, `yaml`
 - `-q, --quiet` — Suppress non-essential output
 - `--profile <name>` — Credential profile (default: `default`)
 
@@ -73,7 +73,12 @@ The hard-deny floor is checked on **every** path component, not just the root. S
 
 Session management.
 
-- `create [--harness <id>] [--agent <id>] [--title <t>] [--model <m>] [--budget-limit <[currency:]limit>] [--budget-soft-limit <[currency:]limit>]`
+- `create [--harness <id|name>] [--agent <id>] [--agent-identity <id>] [--title <t>] [--locale <tag>] [--model <m>] [--system-prompt <s>] [--tag <t>] [--capability <ref[=json]>] [--hint <key=json>] [--hints-json <json>] [--network-allow <pattern>] [--network-block <pattern>] [--max-iterations <n>] [--budget-limit <[currency:]limit>] [--budget-soft-limit <[currency:]limit>]`
+  - `--capability` is repeatable. Format: `REF` or `REF=JSON_CONFIG`. The CLI sends these as session-level capabilities additive to the agent and harness.
+  - `--hint` is repeatable. Format: `KEY=JSON_VALUE`. `--hints-json` accepts a JSON object. Duplicate hint keys are rejected.
+  - `--network-allow` and `--network-block` are repeatable network access patterns. See [`network-access.md`](network-access.md).
+  - `--agent-identity` sets the resident agent identity for unattended/background execution. See [`agent-identities.md`](agent-identities.md).
+  - `--max-iterations` must be greater than zero.
   - `--budget-limit` is repeatable. Format: `[CURRENCY:]LIMIT`. Currency defaults to `usd`. Multiple limits stack (most restrictive wins). Examples:
     - `--budget-limit 10` — $10 USD hard limit
     - `--budget-limit usd:10 --budget-soft-limit usd:8` — $10 hard, $8 soft pause
@@ -95,6 +100,7 @@ Send message and poll for response.
 
 List platform capabilities.
 
+- `capabilities [--status available|coming_soon|all]`
 - `list [--status available|coming_soon|all]`
 
 ### `everruns files`


### PR DESCRIPTION
## What
Adds CLI support for newer session creation fields and output behavior:
- YAML output via `-o yaml`
- bare `everruns capabilities --status ...`
- session create flags for locale, resident agent identity, system prompt, tags, capabilities, hints, network access, and max iterations
- selected profile org propagation for SDK, agent import, and raw session file API calls

## Why
The CLI lagged the platform session API and public CLI docs advertised behavior that was not fully supported.

## How
Session creation now builds the current `/v1/sessions` request body directly for fields not available in the pinned SDK. Existing SDK calls remain for follow-on session secrets and budgets. Raw CLI API clients now consistently include `X-Org-Id` from the selected profile or `EVERRUNS_ORG_ID`.

## Risk
- Medium
- CLI session creation request shaping could regress if API field names drift. Covered by parser/body tests and a local API smoke test.

## Security
- Threat categories reviewed: TM-AUTH, TM-TENANT, TM-API, TM-FS, TM-DOS.
- Findings and resolutions: profile org propagation preserves existing server membership validation for `X-Org-Id` (TM-TENANT-004); new JSON-bearing CLI flags are parsed as JSON values/objects and duplicate hint keys are rejected before sending (TM-API/TM-DOS); `--max-iterations` rejects zero locally and remains server-validated; file and agent import paths only add org header propagation and preserve existing path/hidden-file mitigations. No new threat-model entry needed.

## Validation
- `cargo fmt --check`
- `cargo clippy -p everruns-cli -- -D warnings`
- `cargo test -p everruns-cli`
- `just pre-push`
- `bash scripts/lib/check-migration-ordering.sh`
- Smoke: `PORT_PREFIX=287 just start-dev --no-watch`; verified `everruns -o yaml capabilities --status all`; verified `everruns sessions create` with `--locale`, `--tag`, `--capability`, `--hint`, `--hints-json`, `--network-block`, and `--max-iterations` against the local API.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)