### PR TITLE
feat(apps): redesign app channel management

### DIFF
--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -20,6 +20,8 @@
         "@xyflow/react": "^12.10.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "cron-parser": "^5.5.0",
+        "cronstrue": "^3.14.0",
         "date-fns": "^4.1.0",
         "lucide-react": "^0.577.0",
         "next": "^16.2.6",
@@ -6856,6 +6858,27 @@
         "layout-base": "^1.0.0"
       }
     },
+    "node_modules/cron-parser": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-5.5.0.tgz",
+      "integrity": "sha512-oML4lKUXxizYswqmxuOCpgFS8BNUJpIu6k/2HVHyaL8Ynnf3wdf9tkns0yRdJLSIjkJ+b0DXHMZEHGpMwjnPww==",
+      "license": "MIT",
+      "dependencies": {
+        "luxon": "^3.7.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cronstrue": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/cronstrue/-/cronstrue-3.14.0.tgz",
+      "integrity": "sha512-XnW4vuK/jPJjmTyDWiej1Zq36Od7ITwxaV2O1pzHZuyMVvdy7NAvyvIBzybt+idqSpfqYuoDG7uf/ocGtJVWxA==",
+      "license": "MIT",
+      "bin": {
+        "cronstrue": "bin/cli.js"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -10260,6 +10283,15 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/luxon": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+      "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/lz-string": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
@@ -11937,7 +11969,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -37,6 +37,8 @@
     "@xyflow/react": "^12.10.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "cron-parser": "^5.5.0",
+    "cronstrue": "^3.14.0",
     "date-fns": "^4.1.0",
     "lucide-react": "^0.577.0",
     "next": "^16.2.6",

--- a/apps/ui/src/__tests__/app-channel-redesign.test.tsx
+++ b/apps/ui/src/__tests__/app-channel-redesign.test.tsx
@@ -1,0 +1,129 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { CronLabel, describeCronExpression } from "@/components/apps/cron-label";
+import {
+  buildChannelConfig,
+  ChannelForm,
+  getDefaultChannelFormState,
+  isChannelFormValid,
+} from "@/components/apps/channel-form";
+import { ChannelRow } from "@/components/apps/channel-row";
+import type { App, AppChannel } from "@/lib/api/types";
+
+const app: App = {
+  id: "app_123",
+  name: "Dad Joke Hourly",
+  description: "Runs hourly.",
+  harness_id: "harness_123",
+  agent_id: null,
+  agent_version_policy: "default",
+  agent_version_id: null,
+  owner_principal_id: "principal_123",
+  channels: [],
+  status: "published",
+  published_at: "2026-05-10T00:00:00Z",
+  created_at: "2026-05-10T00:00:00Z",
+  updated_at: "2026-05-10T00:00:00Z",
+  archived_at: null,
+  deleted_at: null,
+};
+
+const scheduleChannel: AppChannel = {
+  id: "appchan_123",
+  channel_type: "schedule",
+  channel_config: {
+    cron_expression: "0 30 * * * * *",
+    timezone: "America/Chicago",
+    session_mode: "shared_session",
+    message: "Tell a dad joke for {{app.name}}.",
+  },
+  enabled: true,
+  created_at: "2026-05-10T00:00:00Z",
+  updated_at: "2026-05-10T00:00:00Z",
+};
+
+describe("app channel redesign", () => {
+  it("renders cron labels as human-readable text with timezone", () => {
+    render(<CronLabel expr="0 30 * * * * *" tz="America/Chicago" />);
+
+    expect(screen.getByText("At 30 minutes past the hour · America/Chicago")).toBeInTheDocument();
+    expect(screen.queryByText("0 30 * * * * *")).not.toBeInTheDocument();
+  });
+
+  it("builds backend-compatible schedule channel config", () => {
+    const state = {
+      ...getDefaultChannelFormState("schedule"),
+      scheduleCronExpression: "0 30 * * * * *",
+      scheduleTimezone: "America/Chicago",
+      channelMessage: "Run {{app.name}} now.",
+    };
+
+    expect(isChannelFormValid(state)).toBe(true);
+    expect(buildChannelConfig(state)).toEqual({
+      cron_expression: "0 30 * * * * *",
+      timezone: "America/Chicago",
+      session_mode: "shared_session",
+      message: "Run {{app.name}} now.",
+    });
+    expect(describeCronExpression(state.scheduleCronExpression)).toBe(
+      "At 30 minutes past the hour",
+    );
+  });
+
+  it("rejects unsupported cron shapes before submit", () => {
+    const base = {
+      ...getDefaultChannelFormState("schedule"),
+      channelMessage: "Run {{app.name}} now.",
+    };
+
+    expect(isChannelFormValid({ ...base, scheduleCronExpression: "0 */5 * * * *" })).toBe(false);
+    expect(isChannelFormValid({ ...base, scheduleCronExpression: "0 0 9 * * * 2027" })).toBe(false);
+    expect(isChannelFormValid({ ...base, scheduleCronExpression: "0 0 9 * * * *" })).toBe(true);
+  });
+
+  it("shows raw cron only inside the editable cron input", () => {
+    const state = {
+      ...getDefaultChannelFormState("schedule"),
+      scheduleCronExpression: "0 30 * * * * *",
+      scheduleTimezone: "America/Chicago",
+      channelMessage: "Run {{app.name}} now.",
+    };
+
+    render(<ChannelForm state={state} onChange={() => {}} mode="new" section="schedule" />);
+
+    expect(screen.getByLabelText("Cron expression")).toHaveValue("0 30 * * * * *");
+    expect(screen.getByText("At 30 minutes past the hour")).toBeInTheDocument();
+  });
+
+  it("updates channel form state when cron preset is selected", () => {
+    const onChange = jest.fn();
+    const state = {
+      ...getDefaultChannelFormState("schedule"),
+      channelMessage: "Run {{app.name}} now.",
+    };
+
+    render(<ChannelForm state={state} onChange={onChange} mode="new" section="schedule" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Hourly :30" }));
+
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ scheduleCronExpression: "0 30 * * * * *" }),
+    );
+  });
+
+  it("renders schedule channel rows without exposing raw cron", () => {
+    render(
+      <ChannelRow
+        app={{ ...app, channels: [scheduleChannel] }}
+        channel={scheduleChannel}
+        expanded={false}
+        onToggle={() => {}}
+        configureHref="/apps/app_123/channels/appchan_123"
+      />,
+    );
+
+    expect(screen.getByText("At 30 minutes past the hour · America/Chicago")).toBeInTheDocument();
+    expect(screen.queryByText("0 30 * * * * *")).not.toBeInTheDocument();
+    expect(screen.getByText(/Active$/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Tell a dad joke/ })).toBeInTheDocument();
+  });
+});

--- a/apps/ui/src/app/(main)/apps/[appId]/channels/[channelId]/page.tsx
+++ b/apps/ui/src/app/(main)/apps/[appId]/channels/[channelId]/page.tsx
@@ -1,0 +1,317 @@
+"use client";
+
+import { use, useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { ArrowLeft, Play, Trash2 } from "lucide-react";
+import { useApp } from "@/hooks/use-apps";
+import { usePolicies } from "@/hooks/use-policies";
+import { deleteChannel, triggerChannel, updateChannel } from "@/lib/api/apps";
+import { queryKeys } from "@/lib/query-keys";
+import { useFeatureFlag } from "@/providers/feature-flags-provider";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { ResourceNotFound } from "@/components/resource-not-found";
+import { CronLabel } from "@/components/apps/cron-label";
+import { MiniTimeline } from "@/components/apps/mini-timeline";
+import {
+  buildChannelConfig,
+  ChannelForm,
+  getDefaultChannelFormState,
+  isChannelFormValid,
+  type ChannelFormState,
+} from "@/components/apps/channel-form";
+import type { ScheduleChannelConfig } from "@/lib/api/types";
+import { getChannelTypeDisplayName } from "@/lib/app-channels";
+import { isReadOnlyStatus } from "@/lib/entity-lifecycle";
+
+function channelTitle(state: ChannelFormState): string {
+  if (state.kind === "schedule") return "Schedule channel";
+  return `${getChannelTypeDisplayName(state.kind)} channel`;
+}
+
+export default function EditChannelPage({
+  params,
+}: {
+  params: Promise<{ appId: string; channelId: string }>;
+}) {
+  const { appId, channelId } = use(params);
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const detailV2Enabled = useFeatureFlag("apps.detailV2");
+  const { data: app, isLoading } = useApp(appId);
+  const { can, isLoading: policiesLoading } = usePolicies("apps");
+  const channel = app?.channels.find((candidate) => candidate.id === channelId);
+  const [formState, setFormState] = useState<ChannelFormState | null>(null);
+  const [activeTab, setActiveTab] = useState("schedule");
+  const formStateKind = formState?.kind;
+  const isReadOnly = isReadOnlyStatus(app?.status);
+  const canManage = !policiesLoading && can("app.manage") && !isReadOnly;
+  const canRunNow =
+    canManage && formState?.kind === "schedule" && formState.enabled && app?.status === "published";
+
+  useEffect(() => {
+    if (!detailV2Enabled) router.replace(`/apps/${appId}`);
+  }, [appId, detailV2Enabled, router]);
+
+  useEffect(() => {
+    if (app && !policiesLoading && !canManage) router.replace(`/apps/${appId}`);
+  }, [app, appId, canManage, policiesLoading, router]);
+
+  useEffect(() => {
+    if (channel) setFormState(getDefaultChannelFormState(channel.channel_type, channel));
+  }, [channel]);
+
+  useEffect(() => {
+    if (formStateKind && formStateKind !== "schedule" && activeTab === "schedule") {
+      setActiveTab("invocation");
+    }
+  }, [activeTab, formStateKind]);
+
+  const saveChannel = useMutation({
+    mutationFn: () => {
+      if (!canManage) throw new Error("Channel management is not available for this app");
+      if (!formState) throw new Error("Missing channel form state");
+      return updateChannel(appId, channelId, {
+        channel_config: buildChannelConfig(formState),
+        enabled: formState.enabled,
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.apps.detail(appId) });
+      router.push(`/apps/${appId}`);
+    },
+  });
+
+  const toggleChannel = useMutation({
+    mutationFn: (enabled: boolean) => {
+      if (!canManage) throw new Error("Channel management is not available for this app");
+      return updateChannel(appId, channelId, { enabled });
+    },
+    onMutate: (enabled) => {
+      setFormState((current) => (current ? { ...current, enabled } : current));
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: queryKeys.apps.detail(appId) }),
+  });
+
+  const removeChannel = useMutation({
+    mutationFn: () => {
+      if (!canManage) throw new Error("Channel management is not available for this app");
+      return deleteChannel(appId, channelId);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.apps.detail(appId) });
+      router.push(`/apps/${appId}`);
+    },
+  });
+
+  const runNow = useMutation({
+    mutationFn: () => {
+      if (!canRunNow) throw new Error("Channel cannot be triggered right now");
+      return triggerChannel(appId, channelId);
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: queryKeys.apps.detail(appId) }),
+  });
+
+  const subline = useMemo(() => {
+    if (!formState || !channel) return "";
+    if (formState.kind === "schedule") {
+      const config = channel.channel_config as ScheduleChannelConfig;
+      return (
+        <>
+          Schedule · <CronLabel expr={config.cron_expression} tz={config.timezone} /> ·{" "}
+          {!formState.enabled
+            ? "Paused"
+            : app?.status === "published"
+              ? "Active"
+              : "Active when published"}
+        </>
+      );
+    }
+    return `${getChannelTypeDisplayName(formState.kind)} · ${formState.enabled ? "Enabled" : "Disabled"}`;
+  }, [app?.status, channel, formState]);
+
+  if (!detailV2Enabled) {
+    return null;
+  }
+
+  if (isLoading || policiesLoading || !formState)
+    return <div className="container mx-auto p-6">Loading channel...</div>;
+  if (!app || !channel) {
+    return (
+      <ResourceNotFound
+        title="Channel not found"
+        description="This channel may have been deleted, moved to another app, or the URL may be wrong."
+        backHref={`/apps/${appId}`}
+        backLabel="Back to app"
+        resourceId={channelId}
+      />
+    );
+  }
+
+  return (
+    <div className="min-h-[calc(100vh-3rem)]">
+      <div className="border-b bg-background">
+        <div className="container mx-auto px-6 py-4">
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Link href="/apps" className="hover:text-foreground">
+              Apps
+            </Link>
+            <span>/</span>
+            <Link href={`/apps/${app.id}`} className="hover:text-foreground">
+              {app.name}
+            </Link>
+            <span>/</span>
+            <span>{channelTitle(formState)}</span>
+          </div>
+          <div className="mt-4 flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+            <div className="flex items-start gap-4">
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                onClick={() => router.push(`/apps/${app.id}`)}
+              >
+                <ArrowLeft className="size-4" />
+              </Button>
+              <div>
+                <div className="flex items-center gap-2">
+                  <h1 className="text-2xl font-semibold">{channelTitle(formState)}</h1>
+                  <Badge variant={formState.enabled ? "default" : "secondary"}>
+                    {formState.enabled ? "active" : "paused"}
+                  </Badge>
+                </div>
+                <p className="mt-1 text-muted-foreground">{subline}</p>
+              </div>
+            </div>
+            <div className="flex gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => toggleChannel.mutate(!formState.enabled)}
+                disabled={!canManage || toggleChannel.isPending}
+              >
+                {formState.enabled ? "Pause" : "Enable"}
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => runNow.mutate()}
+                disabled={!canRunNow || runNow.isPending}
+              >
+                <Play className="size-4" />
+                Run now
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="container mx-auto grid gap-6 px-6 py-6 lg:grid-cols-[minmax(0,1fr)_320px]">
+        <Card>
+          <CardContent className="py-4">
+            <Tabs value={activeTab} onValueChange={setActiveTab}>
+              <TabsList>
+                {formState.kind === "schedule" && (
+                  <TabsTrigger value="schedule">Schedule</TabsTrigger>
+                )}
+                <TabsTrigger value="invocation">Invocation</TabsTrigger>
+                <TabsTrigger value="session">Session</TabsTrigger>
+                <TabsTrigger value="runs">Runs</TabsTrigger>
+              </TabsList>
+              {formState.kind === "schedule" && (
+                <TabsContent value="schedule" className="mt-6">
+                  <ChannelForm
+                    state={formState}
+                    onChange={setFormState}
+                    mode="edit"
+                    section="schedule"
+                  />
+                </TabsContent>
+              )}
+              <TabsContent value="invocation" className="mt-6">
+                <ChannelForm
+                  state={formState}
+                  onChange={setFormState}
+                  mode="edit"
+                  section="invocation"
+                />
+              </TabsContent>
+              <TabsContent value="session" className="mt-6">
+                <ChannelForm
+                  state={formState}
+                  onChange={setFormState}
+                  mode="edit"
+                  section="session"
+                />
+              </TabsContent>
+              <TabsContent value="runs" className="mt-6">
+                <ChannelForm state={formState} onChange={setFormState} mode="edit" section="runs" />
+              </TabsContent>
+            </Tabs>
+          </CardContent>
+        </Card>
+
+        <Card className="h-fit">
+          <CardHeader>
+            <CardTitle>24h stats</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="grid grid-cols-2 gap-3 text-sm">
+              <div className="border p-3">
+                <p className="text-xs uppercase text-muted-foreground">Runs</p>
+                <p className="mt-1 text-xl font-semibold">0</p>
+              </div>
+              <div className="border p-3">
+                <p className="text-xs uppercase text-muted-foreground">Errors</p>
+                <p className="mt-1 text-xl font-semibold">0</p>
+              </div>
+              <div className="border p-3">
+                <p className="text-xs uppercase text-muted-foreground">p95</p>
+                <p className="mt-1 text-xl font-semibold">--</p>
+              </div>
+              <div className="border p-3">
+                <p className="text-xs uppercase text-muted-foreground">Success</p>
+                <p className="mt-1 text-xl font-semibold">--</p>
+              </div>
+            </div>
+            <MiniTimeline />
+            <div className="text-sm text-muted-foreground">
+              <p>Created {new Date(channel.created_at).toLocaleString()}</p>
+              <p>Updated {new Date(channel.updated_at).toLocaleString()}</p>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="sticky bottom-0 border-t bg-background/95 px-6 py-3 backdrop-blur">
+        <div className="container mx-auto flex items-center justify-between gap-2">
+          <Button
+            type="button"
+            variant="destructive"
+            onClick={() => removeChannel.mutate()}
+            disabled={!canManage || removeChannel.isPending}
+          >
+            <Trash2 className="size-4" />
+            Delete
+          </Button>
+          <div className="flex gap-2">
+            <Button type="button" variant="outline" onClick={() => router.push(`/apps/${app.id}`)}>
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              disabled={!canManage || !isChannelFormValid(formState) || saveChannel.isPending}
+              onClick={() => saveChannel.mutate()}
+            >
+              {saveChannel.isPending ? "Saving..." : "Save"}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/ui/src/app/(main)/apps/[appId]/channels/new/page.tsx
+++ b/apps/ui/src/app/(main)/apps/[appId]/channels/new/page.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import { use, useEffect, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { ArrowLeft } from "lucide-react";
+import { useApp } from "@/hooks/use-apps";
+import { usePolicies } from "@/hooks/use-policies";
+import { addChannel } from "@/lib/api/apps";
+import { queryKeys } from "@/lib/query-keys";
+import { useFeatureFlag } from "@/providers/feature-flags-provider";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ResourceNotFound } from "@/components/resource-not-found";
+import {
+  buildChannelConfig,
+  ChannelForm,
+  ChannelFormSummary,
+  ChannelTypePicker,
+  getDefaultChannelFormState,
+  isChannelFormValid,
+} from "@/components/apps/channel-form";
+import { isReadOnlyStatus } from "@/lib/entity-lifecycle";
+
+export default function NewChannelPage({ params }: { params: Promise<{ appId: string }> }) {
+  const { appId } = use(params);
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const detailV2Enabled = useFeatureFlag("apps.detailV2");
+  const { data: app, isLoading } = useApp(appId);
+  const { can, isLoading: policiesLoading } = usePolicies("apps");
+  const [formState, setFormState] = useState(() => getDefaultChannelFormState("schedule"));
+  const isReadOnly = isReadOnlyStatus(app?.status);
+  const canManage = !policiesLoading && can("app.manage") && !isReadOnly;
+
+  useEffect(() => {
+    if (!detailV2Enabled) router.replace(`/apps/${appId}`);
+  }, [appId, detailV2Enabled, router]);
+
+  useEffect(() => {
+    if (app && !policiesLoading && !canManage) router.replace(`/apps/${appId}`);
+  }, [app, appId, canManage, policiesLoading, router]);
+
+  const createChannel = useMutation({
+    mutationFn: () => {
+      if (!canManage) throw new Error("Channel management is not available for this app");
+      return addChannel(appId, {
+        channel_type: formState.kind,
+        channel_config: buildChannelConfig(formState),
+        enabled: formState.enabled,
+      });
+    },
+    onSuccess: (channel) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.apps.detail(appId) });
+      router.push(`/apps/${appId}/channels/${channel.id}`);
+    },
+  });
+
+  if (!detailV2Enabled) {
+    return null;
+  }
+
+  if (isLoading || policiesLoading)
+    return <div className="container mx-auto p-6">Loading channel form...</div>;
+  if (!app) {
+    return (
+      <ResourceNotFound
+        title="App not found"
+        description="This app may have been deleted, moved to another organization, or the URL may be wrong."
+        backHref="/apps"
+        backLabel="Back to apps"
+        resourceId={appId}
+      />
+    );
+  }
+
+  return (
+    <div className="min-h-[calc(100vh-3rem)]">
+      <div className="border-b bg-background">
+        <div className="container mx-auto px-6 py-4">
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Link href="/apps" className="hover:text-foreground">
+              Apps
+            </Link>
+            <span>/</span>
+            <Link href={`/apps/${app.id}`} className="hover:text-foreground">
+              {app.name}
+            </Link>
+            <span>/</span>
+            <span>Add channel</span>
+          </div>
+          <div className="mt-4 flex items-start gap-4">
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              onClick={() => router.push(`/apps/${app.id}`)}
+            >
+              <ArrowLeft className="size-4" />
+            </Button>
+            <div>
+              <div className="flex items-center gap-2">
+                <h1 className="text-2xl font-semibold">Add channel</h1>
+                <Badge variant="outline">{app.status}</Badge>
+              </div>
+              <p className="mt-1 text-muted-foreground">
+                Invoke this app on a schedule, via webhook, through AG-UI, or from Slack.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="container mx-auto grid gap-6 px-6 py-6 lg:grid-cols-[minmax(0,1fr)_320px]">
+        <div className="space-y-4">
+          <Card>
+            <CardHeader>
+              <CardTitle>1. Channel type</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <ChannelTypePicker
+                value={formState.kind}
+                onChange={(kind) => setFormState(getDefaultChannelFormState(kind))}
+              />
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>
+                2. Configure {formState.kind === "ag_ui" ? "AG-UI" : formState.kind}
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <ChannelForm state={formState} onChange={setFormState} mode="new" />
+            </CardContent>
+          </Card>
+        </div>
+
+        <ChannelFormSummary app={app} state={formState} />
+      </div>
+
+      <div className="sticky bottom-0 border-t bg-background/95 px-6 py-3 backdrop-blur">
+        <div className="container mx-auto flex justify-end gap-2">
+          <Button type="button" variant="outline" onClick={() => router.push(`/apps/${app.id}`)}>
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            disabled={!canManage || !isChannelFormValid(formState) || createChannel.isPending}
+            onClick={() => createChannel.mutate()}
+          >
+            {createChannel.isPending ? "Saving..." : "Save channel"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/ui/src/app/(main)/apps/[appId]/page.tsx
+++ b/apps/ui/src/app/(main)/apps/[appId]/page.tsx
@@ -71,6 +71,7 @@ import { A2aAgentCardPreview } from "@/components/apps/a2a-agent-card-preview";
 import { A2aSetupGuidance } from "@/components/apps/a2a-setup-guidance";
 import { AgUiSetupGuidance } from "@/components/apps/ag-ui-setup-guidance";
 import { AppBudgetsCard } from "@/components/apps/app-budgets-card";
+import { AppDetailV2 } from "@/components/apps/app-detail-v2";
 import { ScheduleSetupGuidance } from "@/components/apps/schedule-setup-guidance";
 import { SlackSetupGuidance } from "@/components/apps/slack-setup-guidance";
 import { WebhookSetupGuidance } from "@/components/apps/webhook-setup-guidance";
@@ -245,7 +246,7 @@ function ChannelMessagePreview({ message }: { message: string }) {
   );
 }
 
-export default function AppDetailPage({ params }: { params: Promise<{ appId: string }> }) {
+function AppDetailPageLegacy({ params }: { params: Promise<{ appId: string }> }) {
   const { appId } = use(params);
   const router = useRouter();
   const queryClient = useQueryClient();
@@ -1748,8 +1749,8 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
                       }}
                       aria-pressed={selected}
                       className={cn(
-                        "w-full rounded-md border p-3 text-left transition-colors hover:bg-muted/50",
-                        selected ? "border-primary bg-muted" : "border-border",
+                        "w-full rounded-md border border-border p-3 text-left transition-colors outline-none hover:bg-muted/50 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50",
+                        selected && "bg-muted",
                       )}
                     >
                       <div className="flex items-start justify-between gap-3">
@@ -2050,4 +2051,15 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
       </Dialog>
     </div>
   );
+}
+
+export default function AppDetailPage({ params }: { params: Promise<{ appId: string }> }) {
+  const detailV2Enabled = useFeatureFlag("apps.detailV2");
+  const { appId } = use(params);
+
+  if (detailV2Enabled) {
+    return <AppDetailV2 appId={appId} />;
+  }
+
+  return <AppDetailPageLegacy params={Promise.resolve({ appId })} />;
 }

--- a/apps/ui/src/components/apps/app-detail-v2.tsx
+++ b/apps/ui/src/components/apps/app-detail-v2.tsx
@@ -1,0 +1,262 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { Archive, ArrowLeft, GlobeLock, Play, Plus, Rocket } from "lucide-react";
+import { useAgents, usePageTitle } from "@/hooks";
+import { useHarnesses } from "@/hooks/use-harnesses";
+import { usePolicies } from "@/hooks/use-policies";
+import { useApp, useDeleteApp, usePublishApp, useUnpublishApp } from "@/hooks/use-apps";
+import { triggerChannel } from "@/lib/api/apps";
+import { queryKeys } from "@/lib/query-keys";
+import { Button, buttonVariants } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { ResourceNotFound } from "@/components/resource-not-found";
+import { ChannelRow } from "@/components/apps/channel-row";
+import { LiveActivityRail } from "@/components/apps/live-activity-rail";
+import { StatStrip, type StatStripStats } from "@/components/apps/stat-strip";
+import type { App, AppChannel } from "@/lib/api/types";
+import {
+  getDisplayName,
+  getEntityStatusBadgeVariant,
+  isReadOnlyStatus,
+} from "@/lib/entity-lifecycle";
+
+function buildStats(app: App): StatStripStats {
+  const enabled = app.channels.filter((channel) => channel.enabled).length;
+  const activeTriggers = app.channels.filter(
+    (channel) =>
+      channel.enabled && (channel.channel_type === "schedule" || channel.channel_type === "slack"),
+  ).length;
+  const endpoints = app.channels.filter(
+    (channel) => channel.channel_type === "webhook" || channel.channel_type === "ag_ui",
+  ).length;
+
+  return {
+    health: enabled === app.channels.length ? "Healthy" : "Needs attention",
+    healthSub:
+      app.channels.length === 0
+        ? "No channels configured"
+        : `${enabled} of ${app.channels.length} channels enabled`,
+    invocations24h: 0,
+    invocationSub: `${activeTriggers} active triggers · ${endpoints} endpoints`,
+    successRate: null,
+    successSub: "Run metrics pending backend aggregation",
+    timeline: [],
+  };
+}
+
+function findFirstRunnableChannel(app?: App): AppChannel | undefined {
+  return app?.channels.find(
+    (channel) =>
+      channel.channel_type === "schedule" && channel.enabled && app.status === "published",
+  );
+}
+
+export function AppDetailV2({ appId }: { appId: string }) {
+  const queryClient = useQueryClient();
+  const { data: app, isLoading } = useApp(appId);
+  const { data: agents } = useAgents({ includeArchived: true });
+  const { data: harnesses } = useHarnesses({ includeArchived: true });
+  const { can } = usePolicies("apps");
+  const deleteAppMutation = useDeleteApp();
+  const publishApp = usePublishApp();
+  const unpublishApp = useUnpublishApp();
+  const [expandedChannelId, setExpandedChannelId] = useState<string | null>(null);
+
+  usePageTitle(app ? getDisplayName(app) : null, "App");
+
+  const triggerMutation = useMutation({
+    mutationFn: (channelId: string) => triggerChannel(appId, channelId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.apps.detail(appId) });
+    },
+  });
+
+  const agent = agents?.find((candidate) => candidate.id === app?.agent_id);
+  const harness = harnesses?.find((candidate) => candidate.id === app?.harness_id);
+  const stats = useMemo(() => (app ? buildStats(app) : null), [app]);
+  const isReadOnly = isReadOnlyStatus(app?.status);
+  const canManage = can("app.manage") && !isReadOnly;
+  const runnableChannel = findFirstRunnableChannel(app);
+
+  if (isLoading) {
+    return (
+      <div className="container mx-auto space-y-4 p-6">
+        <Skeleton className="h-10 w-64" />
+        <Skeleton className="h-28 w-full" />
+        <Skeleton className="h-80 w-full" />
+      </div>
+    );
+  }
+
+  if (!app) {
+    return (
+      <ResourceNotFound
+        title="App not found"
+        description="This app may have been deleted, moved to another organization, or the URL may be wrong."
+        backHref="/apps"
+        backLabel="Back to apps"
+        resourceId={appId}
+      />
+    );
+  }
+
+  return (
+    <div className="container mx-auto space-y-6 p-6">
+      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        <Link href="/apps" className="hover:text-foreground">
+          Apps
+        </Link>
+        <span>/</span>
+        <span>{app.name}</span>
+      </div>
+
+      <div className="flex flex-col gap-4 border-b pb-5 lg:flex-row lg:items-start lg:justify-between">
+        <div className="flex min-w-0 gap-4">
+          <span className="flex size-11 shrink-0 items-center justify-center border bg-accent/20">
+            <Rocket className="size-5" />
+          </span>
+          <div className="min-w-0">
+            <div className="flex flex-wrap items-center gap-2">
+              <h1 className="text-2xl font-semibold">{app.name}</h1>
+              <Badge variant={getEntityStatusBadgeVariant(app.status)}>{app.status}</Badge>
+            </div>
+            {app.description && <p className="mt-1 text-muted-foreground">{app.description}</p>}
+            <div className="mt-2 flex flex-wrap gap-x-5 gap-y-1 text-sm text-muted-foreground">
+              <span>
+                Agent{" "}
+                {app.agent_id ? (
+                  <Link
+                    href={`/agents/${app.agent_id}`}
+                    className="text-foreground hover:underline"
+                  >
+                    {agent?.name ?? app.agent_id}
+                  </Link>
+                ) : (
+                  "unassigned"
+                )}
+              </span>
+              <span>
+                Harness{" "}
+                <Link
+                  href={`/harnesses/${app.harness_id}`}
+                  className="text-foreground hover:underline"
+                >
+                  {harness?.name ?? app.harness_id}
+                </Link>
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          <Button
+            variant="outline"
+            onClick={() => runnableChannel && triggerMutation.mutate(runnableChannel.id)}
+            disabled={!runnableChannel || triggerMutation.isPending}
+          >
+            <Play className="size-4" />
+            Test run
+          </Button>
+          {app.status === "published" ? (
+            <Button
+              variant="outline"
+              onClick={() => unpublishApp.mutate(app.id)}
+              disabled={unpublishApp.isPending || !canManage}
+            >
+              <GlobeLock className="size-4" />
+              Unpublish
+            </Button>
+          ) : (
+            <Button
+              onClick={() => publishApp.mutate(app.id)}
+              disabled={publishApp.isPending || !canManage}
+            >
+              Publish
+            </Button>
+          )}
+          <Button
+            variant="outline"
+            onClick={() => deleteAppMutation.mutate(app.id)}
+            disabled={deleteAppMutation.isPending || !canManage}
+          >
+            <Archive className="size-4" />
+            Archive
+          </Button>
+        </div>
+      </div>
+
+      {stats && <StatStrip stats={stats} />}
+
+      <div className="grid gap-6 2xl:grid-cols-[minmax(0,1fr)_360px]">
+        <section className="space-y-3">
+          <div className="flex items-end justify-between gap-4">
+            <div>
+              <h2 className="text-lg font-semibold">Channels</h2>
+              <p className="text-sm text-muted-foreground">
+                {app.channels.length} channels ·{" "}
+                {app.channels.filter((channel) => channel.enabled).length} enabled
+              </p>
+            </div>
+            {canManage && (
+              <Link
+                href={`/apps/${app.id}/channels/new`}
+                className={buttonVariants({ variant: "outline", size: "sm" })}
+              >
+                <Plus className="size-4" />
+                Add channel
+              </Link>
+            )}
+          </div>
+
+          {app.channels.length === 0 ? (
+            <Card>
+              <CardContent className="flex min-h-48 flex-col items-center justify-center gap-3 text-center">
+                <p className="text-sm text-muted-foreground">Add a channel to expose this app.</p>
+                {canManage && (
+                  <Link
+                    href={`/apps/${app.id}/channels/new`}
+                    className={buttonVariants({ size: "sm" })}
+                  >
+                    <Plus className="size-4" />
+                    Add channel
+                  </Link>
+                )}
+              </CardContent>
+            </Card>
+          ) : (
+            <div className="space-y-2">
+              {app.channels.map((channel) => (
+                <ChannelRow
+                  key={channel.id}
+                  channel={channel}
+                  app={app}
+                  expanded={expandedChannelId === channel.id}
+                  onToggle={() =>
+                    setExpandedChannelId((current) => (current === channel.id ? null : channel.id))
+                  }
+                  onRunNow={() => triggerMutation.mutate(channel.id)}
+                  configureHref={`/apps/${app.id}/channels/${channel.id}`}
+                />
+              ))}
+            </div>
+          )}
+        </section>
+
+        <LiveActivityRail appId={app.id} />
+      </div>
+
+      <Link
+        href="/apps"
+        className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground"
+      >
+        <ArrowLeft className="mr-2 size-4" />
+        Back to Apps
+      </Link>
+    </div>
+  );
+}

--- a/apps/ui/src/components/apps/channel-form.tsx
+++ b/apps/ui/src/components/apps/channel-form.tsx
@@ -1,0 +1,602 @@
+"use client";
+
+import { Monitor, RefreshCw, Slack, Webhook, Hash, CalendarClock } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import { Textarea } from "@/components/ui/textarea";
+import { CronInput, CronLabel, isSupportedCronExpression } from "@/components/apps/cron-label";
+import {
+  DEFAULT_AG_UI_GENERIC_TOOL_TEXT,
+  DEFAULT_AG_UI_SESSION_EXPIRATION_SECONDS,
+} from "@/lib/api/types/app-types";
+import type {
+  AgUiChannelConfig,
+  AgUiToolVisibility,
+  App,
+  AppChannel,
+  ChannelType,
+  InvocationSessionMode,
+  ScheduleChannelConfig,
+  SessionStrategy,
+  SlackChannelConfig,
+  SlackReplyMode,
+  WebhookChannelConfig,
+} from "@/lib/api/types";
+import {
+  getAgUiToolVisibilityDisplayName,
+  getChannelTypeDisplayName,
+  getInvocationSessionModeDisplayName,
+  getSessionStrategyDisplayName,
+  getSlackReplyModeDisplayName,
+} from "@/lib/app-channels";
+import { generateChannelToken } from "@/lib/channel-tokens";
+import { cn } from "@/lib/utils";
+
+export const CHANNEL_FORM_KINDS: ChannelType[] = ["schedule", "webhook", "ag_ui", "slack"];
+
+export type ChannelFormSection = "all" | "schedule" | "invocation" | "session" | "runs";
+
+export type ChannelFormState = {
+  kind: ChannelType;
+  enabled: boolean;
+  slackSigningSecret: string;
+  slackBotToken: string;
+  slackTeamId: string;
+  slackChannelId: string;
+  slackSessionStrategy: SessionStrategy;
+  slackReplyMode: SlackReplyMode;
+  scheduleCronExpression: string;
+  scheduleTimezone: string;
+  invocationSessionMode: InvocationSessionMode;
+  channelMessage: string;
+  webhookToken: string;
+  agUiToken: string;
+  agUiExpirationHours: number;
+  agUiRateLimitPerMinute: string;
+  agUiToolVisibility: AgUiToolVisibility;
+  agUiGenericToolText: string;
+};
+
+function secretValue(value?: string, configured?: boolean): string {
+  if (value) return value;
+  return configured ? "" : "";
+}
+
+export function getDefaultChannelFormState(
+  kind: ChannelType,
+  channel?: AppChannel,
+): ChannelFormState {
+  const base: ChannelFormState = {
+    kind,
+    enabled: channel?.enabled ?? true,
+    slackSigningSecret: "",
+    slackBotToken: "",
+    slackTeamId: "",
+    slackChannelId: "",
+    slackSessionStrategy: "per_thread",
+    slackReplyMode: "all_messages",
+    scheduleCronExpression: "0 0 * * * * *",
+    scheduleTimezone: "UTC",
+    invocationSessionMode: "shared_session",
+    channelMessage: "",
+    webhookToken: "",
+    agUiToken: "",
+    agUiExpirationHours: DEFAULT_AG_UI_SESSION_EXPIRATION_SECONDS / 3600,
+    agUiRateLimitPerMinute: "",
+    agUiToolVisibility: "generic",
+    agUiGenericToolText: DEFAULT_AG_UI_GENERIC_TOOL_TEXT,
+  };
+
+  if (!channel) return base;
+
+  if (channel.channel_type === "schedule") {
+    const config = channel.channel_config as ScheduleChannelConfig;
+    return {
+      ...base,
+      kind: "schedule",
+      scheduleCronExpression: config.cron_expression || base.scheduleCronExpression,
+      scheduleTimezone: config.timezone || "UTC",
+      invocationSessionMode: config.session_mode || "shared_session",
+      channelMessage: config.message || "",
+    };
+  }
+  if (channel.channel_type === "webhook") {
+    const config = channel.channel_config as WebhookChannelConfig;
+    return {
+      ...base,
+      kind: "webhook",
+      webhookToken: secretValue(config.token, config.token_configured),
+      invocationSessionMode: config.session_mode || "shared_session",
+      channelMessage: config.message || "",
+    };
+  }
+  if (channel.channel_type === "ag_ui") {
+    const config = channel.channel_config as AgUiChannelConfig;
+    return {
+      ...base,
+      kind: "ag_ui",
+      agUiToken: secretValue(config.token, config.token_configured),
+      agUiExpirationHours:
+        typeof config.session_expiration_seconds === "number"
+          ? config.session_expiration_seconds / 3600
+          : base.agUiExpirationHours,
+      agUiRateLimitPerMinute:
+        typeof config.rate_limit_per_minute === "number"
+          ? String(config.rate_limit_per_minute)
+          : "",
+      agUiToolVisibility: config.tool_visibility || "generic",
+      agUiGenericToolText: config.generic_tool_text || DEFAULT_AG_UI_GENERIC_TOOL_TEXT,
+    };
+  }
+  if (channel.channel_type === "slack") {
+    const config = channel.channel_config as SlackChannelConfig;
+    return {
+      ...base,
+      kind: "slack",
+      slackSigningSecret: secretValue(config.signing_secret, config.signing_secret_configured),
+      slackBotToken: secretValue(config.bot_token, config.bot_token_configured),
+      slackTeamId: config.team_id || "",
+      slackChannelId: config.channel_id || "",
+      slackSessionStrategy: config.session_strategy || "per_thread",
+      slackReplyMode: config.reply_mode || "all_messages",
+    };
+  }
+  return { ...base, kind: channel.channel_type };
+}
+
+export function buildChannelConfig(state: ChannelFormState) {
+  switch (state.kind) {
+    case "schedule":
+      return {
+        cron_expression: state.scheduleCronExpression,
+        timezone: state.scheduleTimezone || "UTC",
+        session_mode: state.invocationSessionMode,
+        message: state.channelMessage,
+      };
+    case "webhook":
+      return {
+        ...(state.webhookToken.trim() ? { token: state.webhookToken.trim() } : {}),
+        session_mode: state.invocationSessionMode,
+        message: state.channelMessage,
+      };
+    case "ag_ui": {
+      const rateLimit = Number.parseInt(state.agUiRateLimitPerMinute, 10);
+      return {
+        anonymous: true,
+        ...(state.agUiToken.trim() ? { token: state.agUiToken.trim() } : {}),
+        session_expiration_seconds: Math.max(0, Math.round(state.agUiExpirationHours * 3600)),
+        ...(Number.isFinite(rateLimit) && rateLimit > 0
+          ? { rate_limit_per_minute: rateLimit }
+          : {}),
+        tool_visibility: state.agUiToolVisibility,
+        generic_tool_text: state.agUiGenericToolText.trim() || DEFAULT_AG_UI_GENERIC_TOOL_TEXT,
+      };
+    }
+    case "slack":
+      return {
+        ...(state.slackSigningSecret.trim()
+          ? { signing_secret: state.slackSigningSecret.trim() }
+          : {}),
+        ...(state.slackBotToken.trim() ? { bot_token: state.slackBotToken.trim() } : {}),
+        ...(state.slackTeamId.trim() ? { team_id: state.slackTeamId.trim() } : {}),
+        ...(state.slackChannelId.trim() ? { channel_id: state.slackChannelId.trim() } : {}),
+        session_strategy: state.slackSessionStrategy,
+        reply_mode: state.slackReplyMode,
+      };
+    default:
+      return {};
+  }
+}
+
+export function isChannelFormValid(state: ChannelFormState): boolean {
+  if (!CHANNEL_FORM_KINDS.includes(state.kind)) return false;
+  if (state.kind === "schedule") {
+    return isSupportedCronExpression(state.scheduleCronExpression) && !!state.channelMessage.trim();
+  }
+  if (state.kind === "webhook") return !!state.channelMessage.trim();
+  if (state.kind === "ag_ui") {
+    return state.agUiToolVisibility !== "generic" || state.agUiGenericToolText.trim().length <= 120;
+  }
+  if (state.kind === "slack") return true;
+  return false;
+}
+
+function channelIcon(kind: ChannelType) {
+  switch (kind) {
+    case "schedule":
+      return CalendarClock;
+    case "webhook":
+      return Webhook;
+    case "ag_ui":
+      return Monitor;
+    case "slack":
+      return Slack;
+    default:
+      return Hash;
+  }
+}
+
+function channelDescription(kind: ChannelType): string {
+  switch (kind) {
+    case "schedule":
+      return "Run on a cron-driven cadence in any timezone. App-level automation, not in-session.";
+    case "webhook":
+      return "Authenticated HTTP endpoint. Bearer token or Everruns webhook token header.";
+    case "ag_ui":
+      return "Public client surface. Tool names, args, and results are never sent to AG-UI clients.";
+    case "slack":
+      return "React to messages in Slack. Per-thread, channel, or user session strategies.";
+    default:
+      return "Channel";
+  }
+}
+
+export function ChannelTypePicker({
+  value,
+  onChange,
+}: {
+  value: ChannelType;
+  onChange: (value: ChannelType) => void;
+}) {
+  return (
+    <div className="grid gap-3 md:grid-cols-2">
+      {CHANNEL_FORM_KINDS.map((kind) => {
+        const Icon = channelIcon(kind);
+        const selected = value === kind;
+        return (
+          <button
+            key={kind}
+            type="button"
+            onClick={() => onChange(kind)}
+            className={cn(
+              "border p-4 text-left transition-colors hover:bg-muted/40",
+              selected ? "border-primary bg-muted" : "border-border",
+            )}
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div className="flex gap-3">
+                <span className="flex size-8 items-center justify-center border bg-background">
+                  <Icon className="size-4" />
+                </span>
+                <div>
+                  <p className="font-medium">{getChannelTypeDisplayName(kind)}</p>
+                  <p className="mt-1 text-sm text-muted-foreground">{channelDescription(kind)}</p>
+                </div>
+              </div>
+              {selected && <span className="text-sm font-medium">Selected</span>}
+            </div>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function FieldGrid({ children }: { children: React.ReactNode }) {
+  return <div className="grid gap-4 md:grid-cols-2">{children}</div>;
+}
+
+export function ChannelForm({
+  state,
+  onChange,
+  mode,
+  section = "all",
+}: {
+  state: ChannelFormState;
+  onChange: (state: ChannelFormState) => void;
+  mode: "new" | "edit";
+  section?: ChannelFormSection;
+}) {
+  const update = <K extends keyof ChannelFormState>(key: K, value: ChannelFormState[K]) =>
+    onChange({ ...state, [key]: value });
+
+  if (section === "runs") {
+    return (
+      <div className="border border-dashed p-4 text-sm text-muted-foreground">
+        Run history will appear here when the app run aggregation endpoint is available.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {mode === "edit" && section === "all" && (
+        <div className="flex items-center justify-between border p-3">
+          <div>
+            <p className="text-sm font-medium">Enabled</p>
+            <p className="text-xs text-muted-foreground">
+              Disabled channels stay configured but do not invoke the app.
+            </p>
+          </div>
+          <Switch
+            checked={state.enabled}
+            onCheckedChange={(checked) => update("enabled", checked)}
+          />
+        </div>
+      )}
+
+      {state.kind === "schedule" && (section === "all" || section === "schedule") && (
+        <CronInput
+          value={state.scheduleCronExpression}
+          timezone={state.scheduleTimezone}
+          onChange={(value) => update("scheduleCronExpression", value)}
+          onTimezoneChange={(value) => update("scheduleTimezone", value)}
+        />
+      )}
+
+      {(state.kind === "schedule" || state.kind === "webhook") &&
+        (section === "all" || section === "invocation") && (
+          <div className="space-y-2">
+            <Label htmlFor="channel_message">Invocation message</Label>
+            <Textarea
+              id="channel_message"
+              value={state.channelMessage}
+              onChange={(event) => update("channelMessage", event.target.value)}
+              placeholder={
+                state.kind === "schedule"
+                  ? "Run {{app.name}} now."
+                  : "Process webhook payload for {{payload.repo.name}}."
+              }
+            />
+          </div>
+        )}
+
+      {(state.kind === "schedule" || state.kind === "webhook") &&
+        (section === "all" || section === "session") && (
+          <div className="space-y-2">
+            <Label htmlFor="session_mode">Session mode</Label>
+            <Select
+              value={state.invocationSessionMode}
+              onValueChange={(value) =>
+                update("invocationSessionMode", value as InvocationSessionMode)
+              }
+            >
+              <SelectTrigger id="session_mode">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="shared_session">
+                  {getInvocationSessionModeDisplayName("shared_session")}
+                </SelectItem>
+                <SelectItem value="session_per_invocation">
+                  {getInvocationSessionModeDisplayName("session_per_invocation")}
+                </SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        )}
+
+      {state.kind === "webhook" && (section === "all" || section === "invocation") && (
+        <div className="space-y-2">
+          <Label htmlFor="webhook_token">Webhook token</Label>
+          <Input
+            id="webhook_token"
+            type="password"
+            value={state.webhookToken}
+            onChange={(event) => update("webhookToken", event.target.value)}
+            placeholder={mode === "edit" ? "Leave blank to keep existing token" : "shared-secret"}
+          />
+          <p className="text-xs text-muted-foreground">
+            Send as Authorization: Bearer &lt;token&gt; or X-Everruns-Webhook-Token.
+          </p>
+        </div>
+      )}
+
+      {state.kind === "ag_ui" && (section === "all" || section === "invocation") && (
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="ag_ui_token">Bearer token</Label>
+            <div className="flex gap-2">
+              <Input
+                id="ag_ui_token"
+                value={state.agUiToken}
+                onChange={(event) => update("agUiToken", event.target.value)}
+                className="font-mono"
+                placeholder={
+                  mode === "edit" ? "Leave blank to keep existing token" : "Generated bearer token"
+                }
+              />
+              <Button
+                type="button"
+                variant="outline"
+                size="icon"
+                onClick={() => update("agUiToken", generateChannelToken())}
+                aria-label="Regenerate AG-UI token"
+              >
+                <RefreshCw className="size-4" />
+              </Button>
+            </div>
+          </div>
+          <FieldGrid>
+            <div className="space-y-2">
+              <Label htmlFor="ag_ui_tool_visibility">Tool visibility</Label>
+              <Select
+                value={state.agUiToolVisibility}
+                onValueChange={(value) => update("agUiToolVisibility", value as AgUiToolVisibility)}
+              >
+                <SelectTrigger id="ag_ui_tool_visibility">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="none">{getAgUiToolVisibilityDisplayName("none")}</SelectItem>
+                  <SelectItem value="generic">
+                    {getAgUiToolVisibilityDisplayName("generic")}
+                  </SelectItem>
+                  <SelectItem value="narrated">
+                    {getAgUiToolVisibilityDisplayName("narrated")}
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="ag_ui_rate_limit">Rate limit / minute</Label>
+              <Input
+                id="ag_ui_rate_limit"
+                value={state.agUiRateLimitPerMinute}
+                onChange={(event) => update("agUiRateLimitPerMinute", event.target.value)}
+                inputMode="numeric"
+                placeholder="No per-channel cap"
+              />
+            </div>
+          </FieldGrid>
+          {state.agUiToolVisibility === "generic" && (
+            <div className="space-y-2">
+              <Label htmlFor="ag_ui_generic_tool_text">Generic activity text</Label>
+              <Input
+                id="ag_ui_generic_tool_text"
+                value={state.agUiGenericToolText}
+                onChange={(event) => update("agUiGenericToolText", event.target.value)}
+                maxLength={120}
+              />
+              <p className="text-xs text-muted-foreground">
+                Tool names, arguments, and results are never sent to public clients.
+              </p>
+            </div>
+          )}
+        </div>
+      )}
+
+      {state.kind === "slack" && (section === "all" || section === "invocation") && (
+        <div className="space-y-4">
+          <FieldGrid>
+            <div className="space-y-2">
+              <Label htmlFor="slack_signing_secret">Signing secret</Label>
+              <Input
+                id="slack_signing_secret"
+                type="password"
+                value={state.slackSigningSecret}
+                onChange={(event) => update("slackSigningSecret", event.target.value)}
+                placeholder={
+                  mode === "edit" ? "Leave blank to keep existing secret" : "Slack signing secret"
+                }
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="slack_bot_token">Bot token</Label>
+              <Input
+                id="slack_bot_token"
+                type="password"
+                value={state.slackBotToken}
+                onChange={(event) => update("slackBotToken", event.target.value)}
+                placeholder={mode === "edit" ? "Leave blank to keep existing token" : "xoxb-..."}
+              />
+            </div>
+          </FieldGrid>
+          <FieldGrid>
+            <div className="space-y-2">
+              <Label htmlFor="slack_team_id">Workspace ID</Label>
+              <Input
+                id="slack_team_id"
+                value={state.slackTeamId}
+                onChange={(event) => update("slackTeamId", event.target.value)}
+                placeholder="T0123456789"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="slack_channel_id">Channel ID</Label>
+              <Input
+                id="slack_channel_id"
+                value={state.slackChannelId}
+                onChange={(event) => update("slackChannelId", event.target.value)}
+                placeholder="C0123456789"
+              />
+            </div>
+          </FieldGrid>
+        </div>
+      )}
+
+      {state.kind === "slack" && (section === "all" || section === "session") && (
+        <FieldGrid>
+          <div className="space-y-2">
+            <Label htmlFor="slack_session_strategy">Session strategy</Label>
+            <Select
+              value={state.slackSessionStrategy}
+              onValueChange={(value) => update("slackSessionStrategy", value as SessionStrategy)}
+            >
+              <SelectTrigger id="slack_session_strategy">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="per_thread">
+                  {getSessionStrategyDisplayName("per_thread")}
+                </SelectItem>
+                <SelectItem value="per_channel">
+                  {getSessionStrategyDisplayName("per_channel")}
+                </SelectItem>
+                <SelectItem value="per_user">
+                  {getSessionStrategyDisplayName("per_user")}
+                </SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="slack_reply_mode">Reply mode</Label>
+            <Select
+              value={state.slackReplyMode}
+              onValueChange={(value) => update("slackReplyMode", value as SlackReplyMode)}
+            >
+              <SelectTrigger id="slack_reply_mode">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all_messages">
+                  {getSlackReplyModeDisplayName("all_messages")}
+                </SelectItem>
+                <SelectItem value="report_progress_only">
+                  {getSlackReplyModeDisplayName("report_progress_only")}
+                </SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </FieldGrid>
+      )}
+    </div>
+  );
+}
+
+export function ChannelFormSummary({ app, state }: { app?: App; state: ChannelFormState }) {
+  return (
+    <Card className="h-fit">
+      <CardContent className="space-y-4 py-4">
+        <div>
+          <p className="text-xs font-medium uppercase text-muted-foreground">Channel</p>
+          <p className="mt-1 font-medium">{getChannelTypeDisplayName(state.kind)}</p>
+        </div>
+        {state.kind === "schedule" && (
+          <div>
+            <p className="text-xs font-medium uppercase text-muted-foreground">Schedule preview</p>
+            <p className="mt-1 text-sm">
+              <CronLabel expr={state.scheduleCronExpression} tz={state.scheduleTimezone} />
+            </p>
+          </div>
+        )}
+        {(state.kind === "webhook" || state.kind === "ag_ui") && (
+          <div>
+            <p className="text-xs font-medium uppercase text-muted-foreground">Activation</p>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Publish {app?.name ?? "the app"} before external clients can invoke this endpoint.
+            </p>
+          </div>
+        )}
+        {state.kind === "slack" && (
+          <div>
+            <p className="text-xs font-medium uppercase text-muted-foreground">Slack</p>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Reuse the existing manifest flow after saving credentials.
+            </p>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/ui/src/components/apps/channel-row.tsx
+++ b/apps/ui/src/components/apps/channel-row.tsx
@@ -1,0 +1,219 @@
+"use client";
+
+import Link from "next/link";
+import {
+  CalendarClock,
+  ChevronDown,
+  Hash,
+  Monitor,
+  MoreHorizontal,
+  Play,
+  Slack,
+  Webhook,
+} from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button, buttonVariants } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuPositioner,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { CronLabel } from "@/components/apps/cron-label";
+import { MiniTimeline, type TimelineBin } from "@/components/apps/mini-timeline";
+import type {
+  AgUiChannelConfig,
+  App,
+  AppChannel,
+  ChannelType,
+  ScheduleChannelConfig,
+  SlackChannelConfig,
+  WebhookChannelConfig,
+} from "@/lib/api/types";
+import { getChannelTypeDisplayName } from "@/lib/app-channels";
+
+function iconFor(kind: ChannelType) {
+  switch (kind) {
+    case "schedule":
+      return CalendarClock;
+    case "webhook":
+      return Webhook;
+    case "ag_ui":
+      return Monitor;
+    case "slack":
+      return Slack;
+    default:
+      return Hash;
+  }
+}
+
+function relativeTime(value?: string | null): string {
+  if (!value) return "never";
+  const seconds = Math.round((new Date(value).getTime() - Date.now()) / 1000);
+  const formatter = new Intl.RelativeTimeFormat(undefined, { numeric: "auto" });
+  const abs = Math.abs(seconds);
+  if (abs < 60) return formatter.format(seconds, "second");
+  if (abs < 3600) return formatter.format(Math.round(seconds / 60), "minute");
+  if (abs < 86400) return formatter.format(Math.round(seconds / 3600), "hour");
+  return formatter.format(Math.round(seconds / 86400), "day");
+}
+
+function channelName(channel: AppChannel): string {
+  if (channel.channel_type === "schedule") {
+    const config = channel.channel_config as ScheduleChannelConfig;
+    return config.message?.trim() || "Scheduled invocation";
+  }
+  if (channel.channel_type === "slack") {
+    const config = channel.channel_config as SlackChannelConfig;
+    return config.channel_id || config.team_id || "Slack channel";
+  }
+  if (channel.channel_type === "webhook") return "Webhook endpoint";
+  if (channel.channel_type === "ag_ui") return "AG-UI endpoint";
+  return getChannelTypeDisplayName(channel.channel_type);
+}
+
+function channelSubline(channel: AppChannel, app: App): React.ReactNode {
+  const statusText = !channel.enabled
+    ? "Paused"
+    : app.status === "published"
+      ? "Active"
+      : "Active when published";
+
+  if (channel.channel_type === "schedule") {
+    const config = channel.channel_config as ScheduleChannelConfig;
+    return (
+      <>
+        Schedule · <CronLabel expr={config.cron_expression} tz={config.timezone} /> · {statusText}
+      </>
+    );
+  }
+  const lastInvokedAt = channel.last_invoked_at ?? null;
+  return (
+    <>
+      {getChannelTypeDisplayName(channel.channel_type)} · {relativeTime(lastInvokedAt)} ·{" "}
+      {channel.enabled ? "Enabled" : "Disabled"}
+    </>
+  );
+}
+
+function detailText(channel: AppChannel): string {
+  if (channel.channel_type === "schedule") {
+    const config = channel.channel_config as ScheduleChannelConfig;
+    return `Session mode: ${config.session_mode ?? "shared_session"}`;
+  }
+  if (channel.channel_type === "webhook") {
+    const config = channel.channel_config as WebhookChannelConfig;
+    return `Token: ${config.token_configured || config.token ? "configured" : "not configured"}`;
+  }
+  if (channel.channel_type === "ag_ui") {
+    const config = channel.channel_config as AgUiChannelConfig;
+    return `Tool visibility: ${config.tool_visibility ?? "generic"}`;
+  }
+  if (channel.channel_type === "slack") {
+    const config = channel.channel_config as SlackChannelConfig;
+    return `Session strategy: ${config.session_strategy ?? "per_thread"}`;
+  }
+  return "Configured channel";
+}
+
+export function ChannelRow({
+  channel,
+  app,
+  expanded,
+  onToggle,
+  onRunNow,
+  configureHref,
+  timeline = [],
+}: {
+  channel: AppChannel;
+  app: App;
+  expanded: boolean;
+  onToggle: () => void;
+  onRunNow?: () => void;
+  configureHref: string;
+  timeline?: TimelineBin[];
+}) {
+  const Icon = iconFor(channel.channel_type);
+  const canRunNow =
+    channel.channel_type === "schedule" && channel.enabled && app.status === "published";
+
+  return (
+    <div className="border bg-card">
+      <div className="grid gap-3 p-4 md:grid-cols-[minmax(0,1fr)_140px_120px_120px_48px] md:items-center">
+        <button type="button" onClick={onToggle} className="min-w-0 text-left">
+          <div className="flex min-w-0 items-start gap-3">
+            <span className="flex size-9 shrink-0 items-center justify-center border bg-background">
+              <Icon className="size-4" />
+            </span>
+            <div className="min-w-0">
+              <div className="flex flex-wrap items-center gap-2">
+                <p className="truncate font-medium">{channelName(channel)}</p>
+                <Badge variant="outline">{getChannelTypeDisplayName(channel.channel_type)}</Badge>
+                <Badge variant={channel.enabled ? "default" : "secondary"}>
+                  {channel.enabled ? "active" : "disabled"}
+                </Badge>
+              </div>
+              <p className="mt-1 text-sm text-muted-foreground">{channelSubline(channel, app)}</p>
+            </div>
+          </div>
+        </button>
+        <div>
+          <p className="text-xs font-medium uppercase text-muted-foreground">
+            {channel.channel_type === "schedule" ? "Next run" : "Last invoke"}
+          </p>
+          <p className="mt-1 text-sm">
+            {channel.channel_type === "schedule"
+              ? relativeTime(channel.next_run_at ?? null)
+              : relativeTime(channel.last_invoked_at ?? null)}
+          </p>
+        </div>
+        <div>
+          <p className="text-xs font-medium uppercase text-muted-foreground">Runs · 24h</p>
+          <p className="mt-1 text-sm">0</p>
+        </div>
+        <MiniTimeline runs={timeline} length={12} className="hidden md:flex" />
+        <DropdownMenu>
+          <DropdownMenuTrigger
+            className={buttonVariants({ variant: "ghost", size: "icon" })}
+            aria-label="Channel actions"
+          >
+            <MoreHorizontal className="size-4" />
+          </DropdownMenuTrigger>
+          <DropdownMenuPositioner>
+            <DropdownMenuContent>
+              <DropdownMenuItem render={<Link href={configureHref} />}>Configure</DropdownMenuItem>
+              <DropdownMenuItem onClick={onRunNow} disabled={!canRunNow}>
+                <Play className="size-4" />
+                Run now
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenuPositioner>
+        </DropdownMenu>
+      </div>
+      {expanded && (
+        <div className="border-t bg-muted/20 px-4 py-3">
+          <div className="grid gap-3 text-sm md:grid-cols-3">
+            <div>
+              <p className="text-xs font-medium uppercase text-muted-foreground">Configuration</p>
+              <p className="mt-1">{detailText(channel)}</p>
+            </div>
+            <div>
+              <p className="text-xs font-medium uppercase text-muted-foreground">Created</p>
+              <p className="mt-1">{new Date(channel.created_at).toLocaleString()}</p>
+            </div>
+            <div className="flex items-center justify-between gap-3 md:justify-end">
+              <Button type="button" variant="outline" size="sm" onClick={onToggle}>
+                <ChevronDown className="size-4 rotate-180 transition-transform" />
+                Collapse
+              </Button>
+              <Link href={configureHref} className={buttonVariants({ size: "sm" })}>
+                Configure
+              </Link>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/ui/src/components/apps/cron-label.tsx
+++ b/apps/ui/src/components/apps/cron-label.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import cronstrue from "cronstrue";
+import { CronExpressionParser } from "cron-parser";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
+
+const CRON_PRESETS = [
+  { label: "Every minute", value: "0 * * * * * *" },
+  { label: "5 min", value: "0 */5 * * * * *" },
+  { label: "Hourly :00", value: "0 0 * * * * *" },
+  { label: "Hourly :30", value: "0 30 * * * * *" },
+  { label: "Daily 09:00", value: "0 0 9 * * * *" },
+];
+
+function previewExpression(expression: string): string | null {
+  const fields = expression.trim().split(/\s+/).filter(Boolean);
+  if (fields.length === 5) return fields.join(" ");
+  if (fields.length === 7 && fields[6] === "*") return fields.slice(0, 6).join(" ");
+  return null;
+}
+
+export function describeCronExpression(expression: string): string {
+  try {
+    if (!previewExpression(expression)) return "Invalid schedule";
+    return cronstrue.toString(expression, {
+      throwExceptionOnParseError: true,
+      verbose: false,
+    });
+  } catch {
+    return "Invalid schedule";
+  }
+}
+
+export function isSupportedCronExpression(expression: string): boolean {
+  if (describeCronExpression(expression) === "Invalid schedule") return false;
+  return getNextRuns(expression, "UTC").length > 0;
+}
+
+export function CronLabel({
+  expr,
+  tz,
+  className,
+}: {
+  expr: string;
+  tz?: string;
+  className?: string;
+}) {
+  const timezone = tz?.trim() || "UTC";
+  return (
+    <span className={className}>
+      {describeCronExpression(expr)} · {timezone}
+    </span>
+  );
+}
+
+function getNextRuns(expression: string, timezone: string): Date[] {
+  try {
+    const parserExpression = previewExpression(expression);
+    if (!parserExpression) return [];
+    const interval = CronExpressionParser.parse(parserExpression, { tz: timezone });
+    return Array.from({ length: 8 }, () => interval.next().toDate());
+  } catch {
+    return [];
+  }
+}
+
+function formatRunTime(date: Date, timezone: string): string {
+  return new Intl.DateTimeFormat(undefined, {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+    timeZone: timezone,
+  }).format(date);
+}
+
+function formatRunOffset(date: Date): string {
+  const minutes = Math.max(0, Math.round((date.getTime() - Date.now()) / 60000));
+  if (minutes < 60) return `in ${minutes} min`;
+  const hours = Math.round(minutes / 60);
+  return `+${hours}h`;
+}
+
+export function CronInput({
+  value,
+  timezone,
+  onChange,
+  onTimezoneChange,
+  className,
+}: {
+  value: string;
+  timezone: string;
+  onChange: (value: string) => void;
+  onTimezoneChange: (value: string) => void;
+  className?: string;
+}) {
+  const resolvedTimezone = timezone || "UTC";
+  const description = describeCronExpression(value);
+  const nextRuns = getNextRuns(value, resolvedTimezone);
+  const invalid = description === "Invalid schedule";
+
+  return (
+    <div className={cn("space-y-4", className)}>
+      <div className="flex flex-wrap gap-2">
+        {CRON_PRESETS.map((preset) => (
+          <Button
+            key={preset.value}
+            type="button"
+            variant={preset.value === value ? "default" : "outline"}
+            size="sm"
+            onClick={() => onChange(preset.value)}
+          >
+            {preset.label}
+          </Button>
+        ))}
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-[minmax(0,1fr),220px]">
+        <div className="space-y-2">
+          <Label htmlFor="cron_expression">Cron expression</Label>
+          <Input
+            id="cron_expression"
+            value={value}
+            onChange={(event) => onChange(event.target.value)}
+            aria-invalid={invalid}
+            className="font-mono"
+            placeholder="0 30 * * * * *"
+          />
+          <p className={cn("text-xs", invalid ? "text-destructive" : "text-muted-foreground")}>
+            {invalid
+              ? "Enter a valid 5-field cron, or a 7-field cron with * as the year."
+              : description}
+          </p>
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="cron_timezone">Timezone</Label>
+          <Input
+            id="cron_timezone"
+            value={timezone}
+            onChange={(event) => onTimezoneChange(event.target.value)}
+            placeholder="UTC"
+          />
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <p className="text-xs font-medium uppercase text-muted-foreground">Next 8 runs</p>
+        <div className="grid grid-cols-2 gap-2 sm:grid-cols-4 lg:grid-cols-8">
+          {nextRuns.length > 0 ? (
+            nextRuns.map((run) => (
+              <div key={run.toISOString()} className="border bg-background p-2 text-center">
+                <p className="text-sm font-semibold">{formatRunTime(run, resolvedTimezone)}</p>
+                <p className="text-xs text-muted-foreground">{formatRunOffset(run)}</p>
+              </div>
+            ))
+          ) : (
+            <div className="col-span-full border border-dashed p-3 text-sm text-muted-foreground">
+              Next runs appear after the schedule is valid.
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/ui/src/components/apps/live-activity-rail.tsx
+++ b/apps/ui/src/components/apps/live-activity-rail.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { listAppRuns } from "@/lib/api/apps";
+import type { AppRunEvent } from "@/lib/api/types";
+import { createEventStream } from "@/lib/event-stream";
+import { cn } from "@/lib/utils";
+
+function relativeTime(value?: string | null): string {
+  if (!value) return "Unknown";
+  const seconds = Math.round((new Date(value).getTime() - Date.now()) / 1000);
+  const formatter = new Intl.RelativeTimeFormat(undefined, { numeric: "auto" });
+  const abs = Math.abs(seconds);
+  if (abs < 60) return formatter.format(seconds, "second");
+  if (abs < 3600) return formatter.format(Math.round(seconds / 60), "minute");
+  if (abs < 86400) return formatter.format(Math.round(seconds / 3600), "hour");
+  return formatter.format(Math.round(seconds / 86400), "day");
+}
+
+export function LiveActivityRail({ appId, className }: { appId: string; className?: string }) {
+  const [events, setEvents] = useState<AppRunEvent[]>([]);
+  const [streamUnavailable, setStreamUnavailable] = useState(false);
+
+  const polling = useQuery({
+    queryKey: ["apps", appId, "runs", streamUnavailable ? "polling" : "idle"],
+    queryFn: () => listAppRuns(appId),
+    enabled: streamUnavailable,
+    refetchInterval: 5000,
+  });
+
+  useEffect(() => {
+    setEvents([]);
+    setStreamUnavailable(false);
+
+    let source: ReturnType<typeof createEventStream>;
+    try {
+      source = createEventStream(`/api/v1/apps/${appId}/runs/stream`, { withCredentials: true });
+    } catch {
+      setStreamUnavailable(true);
+      return;
+    }
+    source.addEventListener("run", (event) => {
+      try {
+        const next = JSON.parse((event as MessageEvent).data) as AppRunEvent;
+        setEvents((existing) =>
+          [next, ...existing.filter((item) => item.id !== next.id)].slice(0, 20),
+        );
+      } catch {
+        setStreamUnavailable(true);
+      }
+    });
+    source.onerror = () => {
+      setStreamUnavailable(true);
+      source.close();
+    };
+
+    return () => source.close();
+  }, [appId]);
+
+  const visibleEvents = useMemo(() => {
+    const polled = polling.data?.data ?? [];
+    return [...events, ...polled].filter(
+      (event, index, all) => all.findIndex((candidate) => candidate.id === event.id) === index,
+    );
+  }, [events, polling.data]);
+
+  return (
+    <Card className={cn("h-fit", className)}>
+      <CardHeader>
+        <CardTitle>Live activity</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {visibleEvents.length === 0 ? (
+          <div className="border border-dashed p-4 text-sm text-muted-foreground">
+            Runs will appear here as channels invoke this app.
+          </div>
+        ) : (
+          visibleEvents.slice(0, 12).map((event) => (
+            <div key={event.id} className="border p-3">
+              <div className="flex items-center justify-between gap-3">
+                <p className="truncate text-sm font-medium">
+                  {event.channel_name ?? event.channel_id}
+                </p>
+                <Badge variant={event.status === "failed" ? "destructive" : "secondary"}>
+                  {event.status}
+                </Badge>
+              </div>
+              <p className="mt-1 text-xs text-muted-foreground">
+                {event.channel_type} · {relativeTime(event.completed_at ?? event.created_at)}
+              </p>
+            </div>
+          ))
+        )}
+        {streamUnavailable && (
+          <p className="text-xs text-muted-foreground">
+            Streaming unavailable; polling every 5 seconds.
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/ui/src/components/apps/mini-timeline.tsx
+++ b/apps/ui/src/components/apps/mini-timeline.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+
+export type TimelineBin = {
+  hour: string;
+  ok?: number;
+  err?: number;
+  running?: number;
+};
+
+export function MiniTimeline({
+  runs = [],
+  length = 24,
+  className,
+}: {
+  runs?: TimelineBin[];
+  length?: number;
+  className?: string;
+}) {
+  const bins = Array.from({ length }, (_, index) => runs[index] ?? { hour: String(index) });
+
+  return (
+    <div className={cn("flex items-end gap-1", className)} aria-label={`${length} hour timeline`}>
+      {bins.map((bin, index) => {
+        const ok = bin.ok ?? 0;
+        const err = bin.err ?? 0;
+        const running = bin.running ?? 0;
+        const total = ok + err + running;
+        return (
+          <span
+            key={`${bin.hour}-${index}`}
+            title={`${bin.hour}: ${ok} ok, ${err} errors${running ? `, ${running} running` : ""}`}
+            className={cn(
+              "h-6 w-1.5 border",
+              total === 0 && "border-muted bg-muted/40",
+              ok > 0 && err === 0 && "border-emerald-200 bg-emerald-500",
+              err > 0 && "border-red-200 bg-red-500",
+              running > 0 && "border-amber-200 bg-amber-500",
+            )}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/ui/src/components/apps/stat-strip.tsx
+++ b/apps/ui/src/components/apps/stat-strip.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { Card, CardContent } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { MiniTimeline, type TimelineBin } from "./mini-timeline";
+
+export type StatStripStats = {
+  health: string;
+  healthSub: string;
+  invocations24h: number;
+  invocationSub: string;
+  successRate: number | null;
+  successSub: string;
+  timeline: TimelineBin[];
+};
+
+export function StatStrip({
+  stats,
+  loading = false,
+}: {
+  stats: StatStripStats;
+  loading?: boolean;
+}) {
+  const items = [
+    { label: "Health", value: stats.health, sub: stats.healthSub },
+    { label: "Invocations · 24h", value: String(stats.invocations24h), sub: stats.invocationSub },
+    {
+      label: "Success rate",
+      value: stats.successRate === null ? "No runs" : `${stats.successRate.toFixed(1)}%`,
+      sub: stats.successSub,
+    },
+  ];
+
+  return (
+    <div className="grid gap-3 lg:grid-cols-4">
+      {items.map((item) => (
+        <Card key={item.label}>
+          <CardContent className="space-y-2 py-4">
+            <p className="text-xs font-medium uppercase text-muted-foreground">{item.label}</p>
+            {loading ? (
+              <Skeleton className="h-7 w-24" />
+            ) : (
+              <p className="text-2xl font-semibold">{item.value}</p>
+            )}
+            {loading ? (
+              <Skeleton className="h-4 w-32" />
+            ) : (
+              <p className="text-sm text-muted-foreground">{item.sub}</p>
+            )}
+          </CardContent>
+        </Card>
+      ))}
+      <Card>
+        <CardContent className="space-y-3 py-4">
+          <p className="text-xs font-medium uppercase text-muted-foreground">Activity</p>
+          {loading ? <Skeleton className="h-7 w-full" /> : <MiniTimeline runs={stats.timeline} />}
+          <p className="text-sm text-muted-foreground">Last 24 hours</p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/ui/src/lib/api/apps.ts
+++ b/apps/ui/src/lib/api/apps.ts
@@ -7,6 +7,8 @@ import type {
   AddChannelRequest,
   App,
   AppChannel,
+  AppRunBucket,
+  AppRunEvent,
   CreateAppRequest,
   InvocationSessionMode,
   UpdateAppRequest,
@@ -67,6 +69,30 @@ export async function updateChannel(
 
 export async function deleteChannel(appId: string, channelId: string): Promise<void> {
   await api.delete(`/v1/apps/${appId}/channels/${channelId}`);
+}
+
+export async function triggerChannel(
+  appId: string,
+  channelId: string,
+): Promise<{ session_id: string; created_session: boolean }> {
+  const response = await api.post<{ session_id: string; created_session: boolean }>(
+    `/v1/apps/${appId}/channels/${channelId}/trigger`,
+    {},
+  );
+  return response.data;
+}
+
+export async function listAppRuns(
+  appId: string,
+): Promise<{ data: AppRunEvent[]; buckets?: AppRunBucket[] }> {
+  try {
+    const response = await api.get<{ data: AppRunEvent[]; buckets?: AppRunBucket[] }>(
+      `/v1/apps/${appId}/runs?window=24h&groupBy=hour`,
+    );
+    return response.data;
+  } catch {
+    return { data: [] };
+  }
 }
 
 /**

--- a/apps/ui/src/lib/api/types/app-types.ts
+++ b/apps/ui/src/lib/api/types/app-types.ts
@@ -105,8 +105,28 @@ export interface AppChannel {
     | A2aChannelConfig
     | Record<string, unknown>;
   enabled: boolean;
+  next_run_at?: string | null;
+  last_invoked_at?: string | null;
   created_at: string;
   updated_at: string;
+}
+
+export interface AppRunEvent {
+  id: string;
+  app_id: string;
+  channel_id: string;
+  channel_type: ChannelType;
+  channel_name?: string | null;
+  status: "pending" | "running" | "completed" | "failed" | "skipped";
+  created_at: string;
+  completed_at?: string | null;
+}
+
+export interface AppRunBucket {
+  hour: string;
+  ok: number;
+  err: number;
+  running?: number;
 }
 
 export interface App {

--- a/apps/ui/src/lib/api/types/auth-types.ts
+++ b/apps/ui/src/lib/api/types/auth-types.ts
@@ -14,6 +14,7 @@ export interface FeatureFlags {
   app_budgets: boolean;
   agent_versions: boolean;
   voice: boolean;
+  "apps.detailV2": boolean;
 }
 
 export interface AuthConfigResponse {

--- a/apps/ui/src/providers/feature-flags-provider.tsx
+++ b/apps/ui/src/providers/feature-flags-provider.tsx
@@ -19,6 +19,7 @@ const DEFAULT_FLAGS: FeatureFlags = {
   app_budgets: false,
   agent_versions: false,
   voice: false,
+  "apps.detailV2": false,
 };
 
 export interface FeatureFlagsContextValue {

--- a/crates/core/src/feature_flags.rs
+++ b/crates/core/src/feature_flags.rs
@@ -34,6 +34,9 @@ pub struct FeatureFlags {
     pub agent_versions: bool,
     /// Realtime voice endpoints and microphone controls. Experimental.
     pub voice: bool,
+    /// Channels-first app detail page and full-page channel forms. Experimental.
+    #[serde(rename = "apps.detailV2")]
+    pub apps_detail_v2: bool,
 }
 
 impl FeatureFlags {
@@ -47,6 +50,7 @@ impl FeatureFlags {
             app_budgets: experimental_flag("FEATURE_APP_BUDGETS", grade),
             agent_versions: experimental_flag("FEATURE_AGENT_VERSIONS", grade),
             voice: experimental_flag("FEATURE_VOICE", grade),
+            apps_detail_v2: experimental_flag("FEATURE_APPS_DETAIL_V2", grade),
         }
     }
 
@@ -66,6 +70,7 @@ impl FeatureFlags {
             "app_budgets" => self.app_budgets,
             "agent_versions" => self.agent_versions,
             "voice" => self.voice,
+            "apps.detailV2" => self.apps_detail_v2,
             _ => false,
         }
     }
@@ -81,6 +86,7 @@ impl FeatureFlags {
             app_budgets: true,
             agent_versions: true,
             voice: true,
+            apps_detail_v2: true,
         }
     }
 }
@@ -215,6 +221,7 @@ mod tests {
             app_budgets: true,
             agent_versions: true,
             voice: true,
+            apps_detail_v2: true,
         };
         assert!(flags.is_enabled("global_chat"));
         assert!(flags.is_enabled("notifications"));
@@ -223,6 +230,7 @@ mod tests {
         assert!(flags.is_enabled("app_budgets"));
         assert!(flags.is_enabled("agent_versions"));
         assert!(flags.is_enabled("voice"));
+        assert!(flags.is_enabled("apps.detailV2"));
         assert!(!flags.is_enabled("nonexistent"));
     }
 
@@ -236,6 +244,7 @@ mod tests {
             app_budgets: true,
             agent_versions: true,
             voice: true,
+            apps_detail_v2: true,
         };
         let json = serde_json::to_string(&flags).unwrap();
         assert!(json.contains("\"global_chat\":true"));
@@ -243,6 +252,7 @@ mod tests {
         assert!(json.contains("\"app_budgets\":true"));
         assert!(json.contains("\"agent_versions\":true"));
         assert!(json.contains("\"voice\":true"));
+        assert!(json.contains("\"apps.detailV2\":true"));
 
         let parsed: FeatureFlags = serde_json::from_str(&json).unwrap();
         assert_eq!(flags, parsed);

--- a/specs/apps.md
+++ b/specs/apps.md
@@ -121,6 +121,20 @@ draft → published → draft → archived → deleted
 - `archived`: Read-only, hidden from lists by default, not assignable, not executable
 - `deleted`: Tombstone state for historical references only; normal detail API returns `404`
 
+## UI
+
+The App detail page has two implementations during the redesign rollout:
+
+- `apps.detailV2=false`: legacy configuration/detail page.
+- `apps.detailV2=true`: channels-first operations page.
+
+The channels-first page folds App configuration into the header, renders a Health / Invocations 24h / Success rate / Activity stat strip, lists channels as expandable rows, and shows a live activity rail. Channel creation and editing are full-page routes, not dialogs:
+
+- `/apps/{app_id}/channels/new`
+- `/apps/{app_id}/channels/{channel_id}`
+
+Schedule labels in rows, headers, breadcrumbs, summaries, and other read-only UI must render a human-readable cron description plus timezone. Raw cron expressions are only shown inside the editable Cron input.
+
 ## Data Model
 
 See `crates/core/src/app.rs` for the complete `App` and `AppChannel` definitions.
@@ -147,6 +161,7 @@ All endpoints under `/v1/apps`. See `crates/server/src/api/apps.rs`.
 | POST | `/v1/apps/{app_id}/channels` | Add a channel |
 | PATCH | `/v1/apps/{app_id}/channels/{channel_id}` | Update a channel |
 | DELETE | `/v1/apps/{app_id}/channels/{channel_id}` | Remove a channel |
+| POST | `/v1/apps/{app_id}/channels/{channel_id}/trigger` | Manually trigger a schedule channel |
 | POST | `/v1/apps/{app_id}/webhooks/{channel_id}` | Trigger a webhook channel |
 
 ## ID Schema

--- a/specs/feature-flags.md
+++ b/specs/feature-flags.md
@@ -44,6 +44,7 @@ Planned flag:
 Current API-visible experimental flags include:
 
 - `agent_versions`: gates immutable Agent snapshots, forks, rollback, version diffs, and App version binding. See `specs/agent-versions.md`.
+- `apps.detailV2`: gates the channels-first App detail page and full-page channel New/Edit routes. Env var: `FEATURE_APPS_DETAIL_V2`.
 
 ## Architecture
 

--- a/test_cases/ui/apps/TC001_app_detail_channels_first.md
+++ b/test_cases/ui/apps/TC001_app_detail_channels_first.md
@@ -1,0 +1,40 @@
+# TC001 App detail channels-first view
+
+## Description
+
+Verifies the `apps.detailV2` App detail page renders a channels-first operations view with no raw cron expressions outside editable cron inputs.
+
+## Preconditions
+
+- `AUTH_MODE=none`
+- `FEATURE_APPS_DETAIL_V2=true`
+- `just start-dev --no-watch` is running
+- A published App exists with a schedule channel using cron `0 30 * * * * *` and timezone `America/Chicago`
+
+## Test Data
+
+| Field | Value |
+| --- | --- |
+| App name | Dad Joke Hourly |
+| Channel type | schedule |
+| Cron | `0 30 * * * * *` |
+| Timezone | `America/Chicago` |
+
+## Steps
+
+1. Navigate to `/apps`.
+2. Open the App detail page.
+3. Verify the header shows the App name, lifecycle pill, agent/harness references, and actions.
+4. Verify the stat strip shows Health, Invocations 24h, Success rate, and Activity.
+5. Verify the Channels section renders the schedule channel row.
+6. Verify the row subline uses a human-readable schedule label with timezone.
+7. Verify the raw cron expression is not visible anywhere on the detail page.
+8. Click the channel row to expand it.
+9. Open the channel kebab and verify Configure links to `/apps/{appId}/channels/{channelId}`.
+
+## Expected Result
+
+- The App detail page uses the channels-first V2 layout.
+- The schedule row displays a human-readable cadence such as `At 30 minutes past the hour · America/Chicago`.
+- The raw cron expression is not visible outside the edit form.
+- Configure deep-links to the full-page Edit Channel route.

--- a/test_cases/ui/apps/TC002_new_channel_route.md
+++ b/test_cases/ui/apps/TC002_new_channel_route.md
@@ -1,0 +1,42 @@
+# TC002 New channel full-page route
+
+## Description
+
+Verifies Add channel opens a reload-safe full-page route with channel type cards, kind-specific configuration, and sticky footer actions.
+
+## Preconditions
+
+- `AUTH_MODE=none`
+- `FEATURE_APPS_DETAIL_V2=true`
+- `just start-dev --no-watch` is running
+- A draft or published App exists
+
+## Test Data
+
+| Field | Value |
+| --- | --- |
+| Route | `/apps/{appId}/channels/new` |
+| Channel type | schedule |
+| Cron preset | Hourly :30 |
+| Timezone | `America/Chicago` |
+| Message | `Run {{app.name}} now.` |
+
+## Steps
+
+1. Navigate to the App detail page.
+2. Click Add channel.
+3. Verify the browser URL is `/apps/{appId}/channels/new`.
+4. Verify the four channel type cards are visible: Schedule, Webhook, AG-UI, Slack.
+5. Select Schedule.
+6. Choose the Hourly :30 preset.
+7. Enter `America/Chicago` as the timezone.
+8. Enter the invocation message.
+9. Verify the summary sidebar displays a human-readable schedule preview and timezone.
+10. Click Save channel.
+
+## Expected Result
+
+- The Add channel flow is not a dialog.
+- Reloading the route preserves a valid page state.
+- The schedule preview never shows the raw cron expression.
+- Saving creates a channel and navigates to the full-page Edit Channel route for the new channel.

--- a/test_cases/ui/apps/TC003_edit_channel_route.md
+++ b/test_cases/ui/apps/TC003_edit_channel_route.md
@@ -1,0 +1,42 @@
+# TC003 Edit channel full-page route
+
+## Description
+
+Verifies the Edit Channel page supports schedule editing, pause/enable, run now, delete, and sticky footer actions on a deep-linkable route.
+
+## Preconditions
+
+- `AUTH_MODE=none`
+- `FEATURE_APPS_DETAIL_V2=true`
+- `just start-dev --no-watch` is running
+- A published App exists with an enabled schedule channel
+
+## Test Data
+
+| Field | Value |
+| --- | --- |
+| Route | `/apps/{appId}/channels/{channelId}` |
+| Updated cron preset | Daily 09:00 |
+| Updated timezone | `UTC` |
+
+## Steps
+
+1. Navigate directly to `/apps/{appId}/channels/{channelId}`.
+2. Verify the header shows channel kind, active status, and a human-readable schedule subline.
+3. Verify the Schedule tab is selected for a schedule channel.
+4. Change the schedule preset and timezone.
+5. Click Save.
+6. Re-open the Edit Channel route.
+7. Click Pause and verify the status changes to paused.
+8. Click Enable and verify the status changes to active.
+9. Click Run now.
+10. Click Delete and confirm the channel no longer appears on the App detail page.
+
+## Expected Result
+
+- The edit flow is not a dialog and is reload-safe.
+- The schedule tab uses `<CronInput>` and is the only place raw cron appears.
+- Header and breadcrumbs use human-readable schedule labels.
+- Pause/Enable updates channel `enabled` state.
+- Run now invokes the schedule trigger route for published enabled schedule channels.
+- Delete returns to the App detail page with the channel removed.


### PR DESCRIPTION
## What
Redesigns the app detail page behind `apps.detailV2` with a channels-first layout, full-page new/edit channel routes, richer channel cards, cron summaries, stats, and a live activity rail shell.

Adds focused Jest coverage, manual UI test cases under `test_cases/ui/apps`, and spec updates for the feature flag and app-channel UX contract.

Refs EVE-461.

## Why
The legacy app page put channel management in a bordered inline panel and the add-channel workflow disappeared into transient page state. EVE-461 calls for channels to be the primary app detail surface, with reload-safe full-page create/edit flows.

## How
- Adds API-visible `apps.detailV2` / `FEATURE_APPS_DETAIL_V2` flag while preserving the legacy page when disabled.
- Introduces reusable app-channel components for the V2 detail, channel rows, channel forms, cron labels, stats, timelines, and activity rail.
- Adds `/apps/[appId]/channels/new` and `/apps/[appId]/channels/[channelId]` routes using the same form surface.
- Uses `cronstrue` and `cron-parser` for human cron labels and bounded preview generation.
- Adds trigger and app-runs client helpers; app-runs currently fall back to empty data if the backend route is unavailable.

## Risk
- Medium
- What can break: app detail/channel management when `apps.detailV2` is enabled, cron display/preview behavior, and new channel route navigation.
- Flag-off legacy behavior remains available.

## Security
- Threat categories reviewed: TM-WEB, TM-AUTHZ, TM-API, TM-DOS, TM-DATA.
- Findings and resolutions: no `dangerouslySetInnerHTML`; cron/user content is rendered as React text; new UI calls existing authorized app/channel endpoints; schedule preview is bounded to eight runs; live activity display is bounded; secrets are not re-sent on edit unless the user enters replacements. No threat-model update needed because this PR does not add a backend trust boundary or authorization path.

## Follow-ups
- Backend run aggregation/SSE support for the activity rail if the `/runs` and `/stream` endpoints are not yet implemented; the UI degrades to empty activity data today.
- Storybook coverage once this repo has Storybook infrastructure; there are currently no `.stories` files or Storybook config in `apps/ui`.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
