### PR TITLE
feat(ui): preview A2A agent cards

### DIFF
--- a/apps/ui/src/__tests__/a2a-agent-card-preview.test.tsx
+++ b/apps/ui/src/__tests__/a2a-agent-card-preview.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen } from "@testing-library/react";
+import {
+  A2A_AGENT_CARD_PROTOCOL_VERSION,
+  A2A_AGENT_CARD_VERSION,
+  A2aAgentCardPreview,
+  buildA2aAgentCardPreview,
+} from "@/components/apps/a2a-agent-card-preview";
+
+describe("A2aAgentCardPreview", () => {
+  it("builds the public Agent Card shape without secret material", () => {
+    const card = buildA2aAgentCardPreview({
+      appName: "Support Bot",
+      appDescription: "Routes support requests",
+      endpointUrl: "https://example.com/api/v1/apps/app-123/a2a/appchan-123",
+      agentCardName: "Support A2A",
+      agentCardDescription: "Answers external agents",
+      sessionMode: "session_per_invocation",
+    });
+
+    expect(card).toEqual({
+      name: "Support A2A",
+      description: "Answers external agents",
+      url: "https://example.com/api/v1/apps/app-123/a2a/appchan-123",
+      protocolVersion: A2A_AGENT_CARD_PROTOCOL_VERSION,
+      version: A2A_AGENT_CARD_VERSION,
+      preferredTransport: "JSONRPC",
+      capabilities: {
+        streaming: true,
+        pushNotifications: false,
+        stateTransitionHistory: false,
+      },
+      defaultInputModes: ["text/plain"],
+      defaultOutputModes: ["text/plain"],
+      skills: [
+        {
+          id: "default",
+          name: "Support Bot",
+          description: "Answers external agents",
+          tags: ["everruns", "a2a"],
+        },
+      ],
+      securitySchemes: {
+        apiKey: { type: "http", scheme: "bearer" },
+      },
+      security: [{ apiKey: [] }],
+    });
+    expect(JSON.stringify(card)).not.toContain("api_key");
+    expect(JSON.stringify(card)).not.toContain("secret");
+  });
+
+  it("renders the inline JSON preview", () => {
+    render(
+      <A2aAgentCardPreview
+        appName="Inbox Triage"
+        appDescription="Reviews inbox items"
+        endpointUrl="https://example.com/api/v1/apps/app-123/a2a/appchan-123"
+        sessionMode="shared_session"
+      />,
+    );
+
+    expect(screen.getByText("Agent Card preview")).toBeInTheDocument();
+    expect(screen.getByText("Send only")).toBeInTheDocument();
+    expect(screen.getByLabelText("Agent Card JSON preview")).toHaveTextContent(
+      '"streaming": false',
+    );
+    expect(screen.getByLabelText("Agent Card JSON preview")).toHaveTextContent("Inbox Triage");
+  });
+});

--- a/apps/ui/src/app/(main)/apps/[appId]/page.tsx
+++ b/apps/ui/src/app/(main)/apps/[appId]/page.tsx
@@ -67,6 +67,7 @@ import {
   RefreshCw,
 } from "lucide-react";
 import { CopyButton } from "@/components/ui/copy-button";
+import { A2aAgentCardPreview } from "@/components/apps/a2a-agent-card-preview";
 import { A2aSetupGuidance } from "@/components/apps/a2a-setup-guidance";
 import { AgUiSetupGuidance } from "@/components/apps/ag-ui-setup-guidance";
 import { AppBudgetsCard } from "@/components/apps/app-budgets-card";
@@ -764,6 +765,9 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
 
   const renderChannelForm = (isSaving: boolean, formId: string = "default") => {
     const formChannelType = editingChannelId ? editingChannelType : addChannelType;
+    const a2aEndpointPreviewUrl = editingChannelId
+      ? `${typeof window !== "undefined" ? window.location.origin : ""}/api/v1/apps/${appId}/a2a/${editingChannelId}`
+      : undefined;
 
     return (
       <div className="space-y-4">
@@ -1176,6 +1180,14 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
                 placeholder="What other agents should know about this app."
               />
             </div>
+            <A2aAgentCardPreview
+              appName={app?.name ?? "App"}
+              appDescription={app?.description}
+              endpointUrl={a2aEndpointPreviewUrl}
+              agentCardName={editA2aAgentCardName}
+              agentCardDescription={editA2aAgentCardDescription}
+              sessionMode={editInvocationSessionMode}
+            />
             <div>
               <Label htmlFor={`a2a_rate_limit_${formId}`}>
                 Per-IP rate limit (requests/minute, optional)
@@ -1298,6 +1310,8 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
             apiKeyPrefix={config?.api_key_prefix ?? ""}
             sessionMode={config?.session_mode ?? "shared_session"}
             message={config?.message ?? ""}
+            appName={app.name}
+            appDescription={app.description}
             agentCardName={config?.agent_card_name}
             agentCardDescription={config?.agent_card_description}
             isPublished={isPublished}

--- a/apps/ui/src/components/apps/a2a-agent-card-preview.tsx
+++ b/apps/ui/src/components/apps/a2a-agent-card-preview.tsx
@@ -1,0 +1,103 @@
+import { Badge } from "@/components/ui/badge";
+import { getInvocationSessionModeDisplayName } from "@/lib/app-channels";
+import type { InvocationSessionMode } from "@/lib/api/types";
+import { Bot, FileJson } from "lucide-react";
+
+interface A2aAgentCardPreviewProps {
+  appName: string;
+  appDescription?: string | null;
+  endpointUrl?: string;
+  agentCardName?: string | null;
+  agentCardDescription?: string | null;
+  sessionMode: InvocationSessionMode;
+}
+
+export const A2A_AGENT_CARD_PROTOCOL_VERSION = "0.3.0";
+export const A2A_AGENT_CARD_VERSION = "0.1";
+
+export function buildA2aAgentCardPreview({
+  appName,
+  appDescription,
+  endpointUrl,
+  agentCardName,
+  agentCardDescription,
+  sessionMode,
+}: A2aAgentCardPreviewProps) {
+  const description = agentCardDescription?.trim() || appDescription?.trim() || "";
+
+  return {
+    name: agentCardName?.trim() || appName,
+    description,
+    url: endpointUrl || "(generated after save)",
+    protocolVersion: A2A_AGENT_CARD_PROTOCOL_VERSION,
+    version: A2A_AGENT_CARD_VERSION,
+    preferredTransport: "JSONRPC",
+    capabilities: {
+      streaming: sessionMode === "session_per_invocation",
+      pushNotifications: false,
+      stateTransitionHistory: false,
+    },
+    defaultInputModes: ["text/plain"],
+    defaultOutputModes: ["text/plain"],
+    skills: [
+      {
+        id: "default",
+        name: appName,
+        description,
+        tags: ["everruns", "a2a"],
+      },
+    ],
+    securitySchemes: {
+      apiKey: { type: "http", scheme: "bearer" },
+    },
+    security: [{ apiKey: [] }],
+  };
+}
+
+export function A2aAgentCardPreview(props: A2aAgentCardPreviewProps) {
+  const card = buildA2aAgentCardPreview(props);
+  const previewJson = JSON.stringify(card, null, 2);
+
+  return (
+    <div className="rounded-md border bg-muted/20 p-3">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="flex min-w-0 items-start gap-2">
+          <Bot className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+          <div className="min-w-0">
+            <p className="text-sm font-medium">Agent Card preview</p>
+            <p className="truncate text-xs text-muted-foreground">
+              {card.name} - {card.preferredTransport}
+            </p>
+          </div>
+        </div>
+        <Badge variant={card.capabilities.streaming ? "default" : "secondary"}>
+          {card.capabilities.streaming ? "Streaming" : "Send only"}
+        </Badge>
+      </div>
+
+      <div className="mt-3 grid gap-3 text-sm md:grid-cols-2">
+        <div>
+          <p className="font-medium">Session mode</p>
+          <p className="text-muted-foreground">
+            {getInvocationSessionModeDisplayName(props.sessionMode)}
+          </p>
+        </div>
+        <div>
+          <p className="font-medium">Authentication</p>
+          <p className="text-muted-foreground">Bearer API key</p>
+        </div>
+      </div>
+
+      <div className="mt-3 flex items-center gap-2 text-xs font-medium text-muted-foreground">
+        <FileJson className="h-3.5 w-3.5" />
+        JSON
+      </div>
+      <pre
+        aria-label="Agent Card JSON preview"
+        className="mt-2 max-h-72 overflow-auto rounded-md bg-background p-3 text-xs leading-relaxed"
+      >
+        <code>{previewJson}</code>
+      </pre>
+    </div>
+  );
+}

--- a/apps/ui/src/components/apps/a2a-setup-guidance.tsx
+++ b/apps/ui/src/components/apps/a2a-setup-guidance.tsx
@@ -1,6 +1,7 @@
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { CopyButton } from "@/components/ui/copy-button";
+import { A2aAgentCardPreview } from "@/components/apps/a2a-agent-card-preview";
 import { getInvocationSessionModeDisplayName } from "@/lib/app-channels";
 import type { InvocationSessionMode } from "@/lib/api/types";
 import { Bot, Globe, KeyRound, RefreshCw } from "lucide-react";
@@ -11,6 +12,8 @@ interface A2aSetupGuidanceProps {
   apiKeyPrefix: string;
   sessionMode: InvocationSessionMode;
   message: string;
+  appName: string;
+  appDescription?: string | null;
   agentCardName?: string;
   agentCardDescription?: string;
   isPublished: boolean;
@@ -25,6 +28,8 @@ export function A2aSetupGuidance({
   apiKeyPrefix,
   sessionMode,
   message,
+  appName,
+  appDescription,
   agentCardName,
   agentCardDescription,
   isPublished,
@@ -112,6 +117,15 @@ export function A2aSetupGuidance({
           )}
         </div>
       )}
+
+      <A2aAgentCardPreview
+        appName={appName}
+        appDescription={appDescription}
+        endpointUrl={endpointUrl}
+        agentCardName={agentCardName}
+        agentCardDescription={agentCardDescription}
+        sessionMode={sessionMode}
+      />
 
       <div>
         <p className="text-sm font-medium">Invocation Message</p>


### PR DESCRIPTION
## What
Add an inline A2A Agent Card preview to the app channel setup and add/edit flows.

## Why
Operators need to see the public Agent Card shape before copying the discovery URL or saving channel metadata.

## How
- Added a reusable `A2aAgentCardPreview` component that mirrors the server Agent Card JSON shape.
- Wired the preview into the A2A setup guidance and A2A channel form.
- Added focused tests for the generated card shape and inline JSON preview.

## Risk
- Low
- Frontend-only display change on the app detail A2A channel UI. The main risk is preview drift from server output; the component follows the current server fields and test covers the public shape.

## Security
- Threat categories reviewed: TM-WEB, TM-A2A
- Findings and resolutions: no new trust boundary or endpoint. The preview renders React-escaped strings from existing app/channel metadata, and the preview intentionally excludes plaintext API keys, key hashes, and key prefixes from the Agent Card JSON.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
