### PR TITLE
fix(volumes): block unsafe git sync source urls

### DIFF
--- a/crates/server/src/domains/volumes/commands.rs
+++ b/crates/server/src/domains/volumes/commands.rs
@@ -5,6 +5,7 @@ use super::types::{
 };
 use super::{VOLUME_MANAGE, VOLUME_VIEW};
 use crate::domains::common::*;
+use everruns_core::url_validation::validate_safe_url;
 use everruns_core::Policy;
 use everruns_core::typed_id::VolumeId;
 use everruns_durable::UpdateField;
@@ -107,17 +108,11 @@ fn validate_git_url(url: &str) -> Result<String, CommandError> {
         ));
     }
     if let Ok(parsed) = url::Url::parse(trimmed) {
-        match parsed.scheme() {
-            "https" | "ssh" | "git" => {}
-            _ => {
-                return Err(CommandError::bad_request(
-                    "Git URL must use https, ssh, or git scheme",
-                ));
-            }
+        if parsed.scheme() != "https" {
+            return Err(CommandError::bad_request("Git URL must use https scheme"));
         }
         if parsed.password().is_some()
-            || !(parsed.username().is_empty()
-                || parsed.scheme() == "ssh" && parsed.username() == "git")
+            || !parsed.username().is_empty()
         {
             return Err(CommandError::bad_request(
                 "Git URL must not include inline credentials",
@@ -126,14 +121,14 @@ fn validate_git_url(url: &str) -> Result<String, CommandError> {
         if parsed.host_str().is_none() {
             return Err(CommandError::bad_request("Git URL must include a host"));
         }
+        if validate_safe_url(trimmed).is_err() {
+            return Err(CommandError::bad_request(
+                "Git URL host is not allowed for server-side sync",
+            ));
+        }
         return Ok(trimmed.to_string());
     }
-    if trimmed.starts_with("git@") && trimmed.contains(':') {
-        return Ok(trimmed.to_string());
-    }
-    Err(CommandError::bad_request(
-        "Git URL must be an absolute URL or git@host:owner/repo.git",
-    ))
+    Err(CommandError::bad_request("Git URL must be an absolute https URL"))
 }
 
 fn github_source_config(request: GitHubVolumeSourceRequest) -> Result<Value, CommandError> {
@@ -692,6 +687,35 @@ mod tests {
             .run(&ctx)
             .await
             .expect_err("secret-bearing URL should fail");
+
+            assert!(matches!(err, CommandError::BadRequest(_)));
+        }
+    }
+
+    #[tokio::test]
+    async fn git_volume_rejects_internal_or_non_https_urls() {
+        let ctx = ctx_for_org(DEFAULT_ORG_ID);
+
+        for url in [
+            "http://github.com/org/repo.git",
+            "ssh://git@github.com/org/repo.git",
+            "git://github.com/org/repo.git",
+            "git@github.com:org/repo.git",
+            "https://127.0.0.1/org/repo.git",
+            "https://localhost/org/repo.git",
+        ] {
+            let err = CreateVolume {
+                name: format!("Unsafe transport {url}"),
+                description: None,
+                source: Some(CreateVolumeSourceRequest::Git(GitVolumeSourceRequest {
+                    url: url.into(),
+                    branch: None,
+                    root_folder: None,
+                })),
+            }
+            .run(&ctx)
+            .await
+            .expect_err("unsafe URL should fail");
 
             assert!(matches!(err, CommandError::BadRequest(_)));
         }


### PR DESCRIPTION
### Motivation
- A background task was performing server-side `git clone` of user-provided volume sources without applying the repository's SSRF/egress protections, allowing authenticated volume managers to cause outbound connections to localhost/private/internal targets.

### Description
- Restrict generic Git volume URLs to absolute `https://` URLs by changing `validate_git_url` to require `https` and return an error for non-HTTPS and scp-like forms.
- Apply the shared SSRF-safe check by calling `validate_safe_url` from `everruns_core::url_validation` to block localhost, RFC1918, link-local, and cloud metadata hosts at write-time.
- Disallow inline credentials and simplify the validation error message to require an absolute HTTPS URL for syncable volumes in `crates/server/src/domains/volumes/commands.rs`.
- Add a regression test `git_volume_rejects_internal_or_non_https_urls` that asserts `CreateVolume` rejects `http`, `ssh`, `git` transports, scp-like `git@host:...`, and loopback/localhost `https` URLs.

### Testing
- Added unit test `git_volume_rejects_internal_or_non_https_urls` in `crates/server/src/domains/volumes/commands.rs` to cover the regression.
- Attempted to run `cargo test -p everruns-server git_volume_rejects_internal_or_non_https_urls -- --nocapture`, but the build in this environment kicked off dependency/toolchain compilation and did not complete during the run (compile and test progress observed but not finished).
- CI should run the full test suite and verify the new test and existing tests pass before merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69feaa53c780832bac93bba93c22ef88)