### PR TITLE
fix(ui): fetch A2A agent card preview

### DIFF
--- a/apps/ui/src/__tests__/a2a-agent-card-preview.test.tsx
+++ b/apps/ui/src/__tests__/a2a-agent-card-preview.test.tsx
@@ -48,6 +48,35 @@ describe("A2aAgentCardPreview", () => {
     expect(JSON.stringify(card)).not.toContain("secret");
   });
 
+  it("redacts secret-shaped fields before rendering", () => {
+    render(
+      <A2aAgentCardPreview
+        appName="Inbox Triage"
+        sessionMode="shared_session"
+        card={{
+          name: "Inbox Triage",
+          description: "Reviews inbox items",
+          url: "https://example.com/a2a",
+          protocolVersion: A2A_AGENT_CARD_PROTOCOL_VERSION,
+          version: A2A_AGENT_CARD_VERSION,
+          preferredTransport: "JSONRPC",
+          capabilities: { streaming: false },
+          skills: [{ id: "default", name: "Inbox Triage" }],
+          securitySchemes: { apiKey: { type: "http", scheme: "bearer" } },
+          api_key: "evra2a_0123456789abcdef0123456789abcdef",
+          api_key_hash: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        }}
+      />,
+    );
+
+    const rendered = screen.getByLabelText("Agent Card JSON preview").textContent ?? "";
+    expect(rendered).toContain("apiKey");
+    expect(rendered).not.toContain("api_key");
+    expect(rendered).not.toContain("api_key_hash");
+    expect(rendered).not.toContain("0123456789abcdef0123456789abcdef");
+    expect(rendered).not.toContain("evra2a_0123456789abcdef");
+  });
+
   it("renders the inline JSON preview", () => {
     render(
       <A2aAgentCardPreview

--- a/apps/ui/src/__tests__/a2a-setup-guidance.test.tsx
+++ b/apps/ui/src/__tests__/a2a-setup-guidance.test.tsx
@@ -1,0 +1,98 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { A2aSetupGuidance } from "@/components/apps/a2a-setup-guidance";
+
+const agentCard = {
+  name: "Published A2A Agent",
+  description: "Visible to external agents",
+  url: "https://example.com/api/v1/apps/app-123/a2a/appchan-123",
+  protocolVersion: "0.3.0",
+  version: "0.1",
+  preferredTransport: "JSONRPC",
+  capabilities: {
+    streaming: true,
+    pushNotifications: false,
+    stateTransitionHistory: false,
+  },
+  defaultInputModes: ["text/plain"],
+  defaultOutputModes: ["text/plain"],
+  skills: [{ id: "default", name: "Published A2A Agent", tags: ["everruns", "a2a"] }],
+  securitySchemes: { apiKey: { type: "http", scheme: "bearer" } },
+  security: [{ apiKey: [] }],
+};
+
+function renderGuidance(overrides: Partial<React.ComponentProps<typeof A2aSetupGuidance>> = {}) {
+  return render(
+    <A2aSetupGuidance
+      endpointUrl="https://example.com/api/v1/apps/app-123/a2a/appchan-123"
+      agentCardUrl="https://example.com/api/v1/apps/app-123/a2a/appchan-123/.well-known/agent-card.json"
+      apiKeyPrefix="evra2a_12345678..."
+      sessionMode="session_per_invocation"
+      message="A2A request: {{a2a.text}}"
+      appName="A2A App"
+      isPublished={true}
+      channelEnabled={true}
+      {...overrides}
+    />,
+  );
+}
+
+describe("A2aSetupGuidance", () => {
+  let originalFetch: typeof global.fetch;
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => agentCard,
+    }) as jest.Mock;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+
+  it("fetches and renders the published Agent Card", async () => {
+    renderGuidance();
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://example.com/api/v1/apps/app-123/a2a/appchan-123/.well-known/agent-card.json",
+      expect.objectContaining({
+        cache: "no-store",
+        headers: { Accept: "application/json" },
+      }),
+    );
+    expect((await screen.findAllByText("Published A2A Agent")).length).toBeGreaterThan(0);
+    expect(screen.getByText("0.3.0")).toBeInTheDocument();
+    expect(screen.getByText("JSONRPC")).toBeInTheDocument();
+    expect(screen.getByText("streaming: true")).toBeInTheDocument();
+    expect(screen.getByText("apiKey")).toBeInTheDocument();
+  });
+
+  it("refreshes the Agent Card on demand", async () => {
+    renderGuidance();
+    await screen.findAllByText("Published A2A Agent");
+
+    fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
+
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(2));
+  });
+
+  it("does not fetch while unpublished or disabled", () => {
+    renderGuidance({ isPublished: false });
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(screen.getByText(/Publish the app and enable this channel/)).toBeInTheDocument();
+  });
+
+  it("keeps the raw URL copy fallback when fetch fails", async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({ ok: false, status: 404 });
+    renderGuidance();
+
+    expect(await screen.findByText(/Could not load Agent Card/)).toBeInTheDocument();
+    expect(
+      screen.getAllByText(
+        "https://example.com/api/v1/apps/app-123/a2a/appchan-123/.well-known/agent-card.json",
+      ).length,
+    ).toBeGreaterThan(0);
+  });
+});

--- a/apps/ui/src/app/(main)/apps/[appId]/page.tsx
+++ b/apps/ui/src/app/(main)/apps/[appId]/page.tsx
@@ -1311,10 +1311,10 @@ export default function AppDetailPage({ params }: { params: Promise<{ appId: str
             sessionMode={config?.session_mode ?? "shared_session"}
             message={config?.message ?? ""}
             appName={app.name}
-            appDescription={app.description}
             agentCardName={config?.agent_card_name}
             agentCardDescription={config?.agent_card_description}
             isPublished={isPublished}
+            channelEnabled={channel.enabled}
             onConfigure={() => startEditChannel(channel)}
             onRotateKey={isReadOnly ? undefined : () => rotateA2aMutation.mutate(channel.id)}
             isRotating={rotateA2aMutation.isPending && rotatingA2aChannelId === channel.id}

--- a/apps/ui/src/components/apps/a2a-agent-card-preview.tsx
+++ b/apps/ui/src/components/apps/a2a-agent-card-preview.tsx
@@ -3,7 +3,31 @@ import { getInvocationSessionModeDisplayName } from "@/lib/app-channels";
 import type { InvocationSessionMode } from "@/lib/api/types";
 import { Bot, FileJson } from "lucide-react";
 
+type JsonObject = Record<string, unknown>;
+
+export interface A2aAgentCard {
+  [key: string]: unknown;
+  name: string;
+  description?: string;
+  url: string;
+  protocolVersion: string;
+  version?: string;
+  preferredTransport: string;
+  capabilities: Record<string, unknown>;
+  defaultInputModes?: string[];
+  defaultOutputModes?: string[];
+  skills?: Array<{
+    id?: string;
+    name?: string;
+    description?: string;
+    tags?: string[];
+  }>;
+  securitySchemes?: JsonObject;
+  security?: unknown;
+}
+
 interface A2aAgentCardPreviewProps {
+  card?: A2aAgentCard;
   appName: string;
   appDescription?: string | null;
   endpointUrl?: string;
@@ -15,6 +39,29 @@ interface A2aAgentCardPreviewProps {
 export const A2A_AGENT_CARD_PROTOCOL_VERSION = "0.3.0";
 export const A2A_AGENT_CARD_VERSION = "0.1";
 
+function redactSecretLikeValues(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(redactSecretLikeValues);
+  }
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as JsonObject)
+        .filter(([key]) => key !== "api_key" && key !== "api_key_hash" && key !== "apiKeyHash")
+        .map(([key, nested]) => [key, redactSecretLikeValues(nested)]),
+    );
+  }
+  if (typeof value === "string") {
+    if (/^evra2a_[a-f0-9]{16,}$/i.test(value) || /^[a-f0-9]{64}$/i.test(value)) {
+      return "[redacted]";
+    }
+  }
+  return value;
+}
+
+export function sanitizeA2aAgentCardForDisplay(card: A2aAgentCard): A2aAgentCard {
+  return redactSecretLikeValues(card) as A2aAgentCard;
+}
+
 export function buildA2aAgentCardPreview({
   appName,
   appDescription,
@@ -22,7 +69,7 @@ export function buildA2aAgentCardPreview({
   agentCardName,
   agentCardDescription,
   sessionMode,
-}: A2aAgentCardPreviewProps) {
+}: Omit<A2aAgentCardPreviewProps, "card">): A2aAgentCard {
   const description = agentCardDescription?.trim() || appDescription?.trim() || "";
 
   return {
@@ -55,8 +102,10 @@ export function buildA2aAgentCardPreview({
 }
 
 export function A2aAgentCardPreview(props: A2aAgentCardPreviewProps) {
-  const card = buildA2aAgentCardPreview(props);
+  const card = sanitizeA2aAgentCardForDisplay(props.card ?? buildA2aAgentCardPreview(props));
   const previewJson = JSON.stringify(card, null, 2);
+  const capabilityEntries = Object.entries(card.capabilities ?? {});
+  const securitySchemeNames = Object.keys(card.securitySchemes ?? {});
 
   return (
     <div className="rounded-md border bg-muted/20 p-3">
@@ -77,14 +126,77 @@ export function A2aAgentCardPreview(props: A2aAgentCardPreviewProps) {
 
       <div className="mt-3 grid gap-3 text-sm md:grid-cols-2">
         <div>
+          <p className="font-medium">Name</p>
+          <p className="text-muted-foreground">{card.name}</p>
+        </div>
+        <div>
+          <p className="font-medium">Description</p>
+          <p className="text-muted-foreground">{card.description || "Not set"}</p>
+        </div>
+        <div>
+          <p className="font-medium">Protocol</p>
+          <p className="text-muted-foreground">{card.protocolVersion}</p>
+        </div>
+        <div>
+          <p className="font-medium">Transport</p>
+          <p className="text-muted-foreground">{card.preferredTransport}</p>
+        </div>
+        <div>
+          <p className="font-medium">Authentication</p>
+          <p className="text-muted-foreground">
+            {securitySchemeNames.length ? securitySchemeNames.join(", ") : "Not advertised"}
+          </p>
+        </div>
+        <div>
           <p className="font-medium">Session mode</p>
           <p className="text-muted-foreground">
             {getInvocationSessionModeDisplayName(props.sessionMode)}
           </p>
         </div>
-        <div>
-          <p className="font-medium">Authentication</p>
-          <p className="text-muted-foreground">Bearer API key</p>
+      </div>
+
+      <div className="mt-3">
+        <p className="text-sm font-medium">Capabilities</p>
+        <div className="mt-2 flex flex-wrap gap-1.5">
+          {capabilityEntries.length ? (
+            capabilityEntries.map(([key, value]) => (
+              <Badge key={key} variant={value ? "default" : "secondary"}>
+                {key}: {String(value)}
+              </Badge>
+            ))
+          ) : (
+            <p className="text-sm text-muted-foreground">None advertised</p>
+          )}
+        </div>
+      </div>
+
+      <div className="mt-3">
+        <p className="text-sm font-medium">Skills</p>
+        <div className="mt-2 space-y-2">
+          {card.skills?.length ? (
+            card.skills.map((skill, index) => (
+              <div key={`${skill.id ?? "skill"}-${index}`} className="rounded-md border p-2">
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="text-sm font-medium">{skill.name || skill.id || "Skill"}</span>
+                  {skill.id && <Badge variant="outline">{skill.id}</Badge>}
+                </div>
+                {skill.description && (
+                  <p className="mt-1 text-sm text-muted-foreground">{skill.description}</p>
+                )}
+                {!!skill.tags?.length && (
+                  <div className="mt-2 flex flex-wrap gap-1">
+                    {skill.tags.map((tag) => (
+                      <Badge key={tag} variant="secondary">
+                        {tag}
+                      </Badge>
+                    ))}
+                  </div>
+                )}
+              </div>
+            ))
+          ) : (
+            <p className="text-sm text-muted-foreground">None advertised</p>
+          )}
         </div>
       </div>
 

--- a/apps/ui/src/components/apps/a2a-setup-guidance.tsx
+++ b/apps/ui/src/components/apps/a2a-setup-guidance.tsx
@@ -1,7 +1,10 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { CopyButton } from "@/components/ui/copy-button";
-import { A2aAgentCardPreview } from "@/components/apps/a2a-agent-card-preview";
+import { A2aAgentCard, A2aAgentCardPreview } from "@/components/apps/a2a-agent-card-preview";
 import { getInvocationSessionModeDisplayName } from "@/lib/app-channels";
 import type { InvocationSessionMode } from "@/lib/api/types";
 import { Bot, Globe, KeyRound, RefreshCw } from "lucide-react";
@@ -13,10 +16,10 @@ interface A2aSetupGuidanceProps {
   sessionMode: InvocationSessionMode;
   message: string;
   appName: string;
-  appDescription?: string | null;
   agentCardName?: string;
   agentCardDescription?: string;
   isPublished: boolean;
+  channelEnabled: boolean;
   onConfigure?: () => void;
   onRotateKey?: () => void;
   isRotating?: boolean;
@@ -29,14 +32,50 @@ export function A2aSetupGuidance({
   sessionMode,
   message,
   appName,
-  appDescription,
   agentCardName,
   agentCardDescription,
   isPublished,
+  channelEnabled,
   onConfigure,
   onRotateKey,
   isRotating,
 }: A2aSetupGuidanceProps) {
+  const [agentCard, setAgentCard] = useState<A2aAgentCard | null>(null);
+  const [agentCardError, setAgentCardError] = useState<string | null>(null);
+  const [agentCardLoading, setAgentCardLoading] = useState(false);
+  const canFetchAgentCard = isPublished && channelEnabled;
+
+  const fetchAgentCard = useCallback(async () => {
+    if (!canFetchAgentCard) return;
+    setAgentCardLoading(true);
+    setAgentCardError(null);
+    try {
+      const response = await fetch(agentCardUrl, {
+        headers: { Accept: "application/json" },
+        cache: "no-store",
+      });
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+      setAgentCard((await response.json()) as A2aAgentCard);
+    } catch (error) {
+      setAgentCard(null);
+      setAgentCardError(error instanceof Error ? error.message : "Unable to fetch Agent Card");
+    } finally {
+      setAgentCardLoading(false);
+    }
+  }, [agentCardUrl, canFetchAgentCard]);
+
+  useEffect(() => {
+    if (!canFetchAgentCard) {
+      setAgentCard(null);
+      setAgentCardError(null);
+      setAgentCardLoading(false);
+      return;
+    }
+    fetchAgentCard();
+  }, [canFetchAgentCard, fetchAgentCard]);
+
   return (
     <div className="space-y-4">
       <div className="flex items-center gap-2">
@@ -118,14 +157,40 @@ export function A2aSetupGuidance({
         </div>
       )}
 
-      <A2aAgentCardPreview
-        appName={appName}
-        appDescription={appDescription}
-        endpointUrl={endpointUrl}
-        agentCardName={agentCardName}
-        agentCardDescription={agentCardDescription}
-        sessionMode={sessionMode}
-      />
+      <div>
+        <div className="mb-2 flex items-center justify-between gap-3">
+          <p className="text-sm font-medium">Discovered Agent Card</p>
+          {canFetchAgentCard && (
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              onClick={fetchAgentCard}
+              disabled={agentCardLoading}
+            >
+              <RefreshCw className="mr-1 h-3 w-3" />
+              {agentCardLoading ? "Refreshing" : "Refresh"}
+            </Button>
+          )}
+        </div>
+        {!canFetchAgentCard ? (
+          <div className="rounded-md border p-3 text-sm text-muted-foreground">
+            Publish the app and enable this channel to fetch the public Agent Card. Until then,
+            discovery returns 404.
+          </div>
+        ) : agentCard ? (
+          <A2aAgentCardPreview card={agentCard} appName={appName} sessionMode={sessionMode} />
+        ) : (
+          <div className="rounded-md border p-3 text-sm text-muted-foreground">
+            {agentCardLoading ? "Loading Agent Card..." : "Could not load Agent Card."}
+            {agentCardError && <span className="ml-1">({agentCardError})</span>}
+            <div className="mt-2 flex items-center gap-2 bg-muted p-2">
+              <code className="flex-1 truncate text-xs">{agentCardUrl}</code>
+              <CopyButton value={agentCardUrl} />
+            </div>
+          </div>
+        )}
+      </div>
 
       <div>
         <p className="text-sm font-medium">Invocation Message</p>


### PR DESCRIPTION
## What
Fetch and render the published A2A Agent Card inline in the app channel setup panel.

## Why
EVE-445 requires operators to verify the actual public discovery document, including protocol, transport, capabilities, security schemes, and skills, without manually copying the URL into curl.

## How
- Fetch `agentCardUrl` only when the app is published and the A2A channel is enabled.
- Add Refresh and loading/error states, with the raw URL copy fallback preserved on failure.
- Render structured Agent Card fields and sanitized JSON.
- Keep the add/edit draft preview local because no published endpoint exists before save/publish.
- Add tests for fetch, refresh, unpublished/disabled no-fetch behavior, fetch failure fallback, and secret-shaped redaction.

## Risk
- Low / Medium
- Low runtime risk, scoped to A2A setup UI. Medium drift risk because this mirrors protocol data from the server; mitigated by fetching the actual endpoint when published and keeping full-shape tests for the local draft preview.

## Security
- Threat categories reviewed: TM-WEB, TM-A2A
- Findings and resolutions: fetched JSON is rendered through React escaping; display sanitization removes snake_case API key/hash fields and secret-shaped values before rendering the JSON preview; tests assert `api_key` and hash-shaped values are not rendered.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)