### PR TITLE
feat(reporting): add capability usage analytics

### DIFF
--- a/crates/core/src/atoms/act.rs
+++ b/crates/core/src/atoms/act.rs
@@ -825,6 +825,10 @@ where
             tool_def.and_then(|d| d.display_name()),
             locale,
         );
+        let capability_attribution = tool_def.and_then(|def| {
+            def.capability_attribution()
+                .map(|(id, name)| (id.to_string(), name.map(str::to_string)))
+        });
 
         // Emit tool.started event (child of act.started)
         if let Err(e) = self
@@ -1020,6 +1024,12 @@ where
                         Some(tool_duration_ms),
                     )
                     .with_display_name(display_name.clone())
+                    .with_capability_attribution(
+                        capability_attribution.as_ref().map(|(id, _)| id.clone()),
+                        capability_attribution
+                            .as_ref()
+                            .and_then(|(_, name)| name.clone()),
+                    )
                     .with_narration(Some(self.render_tool_narration(
                         Some(tool_def),
                         &tool_call,
@@ -1035,6 +1045,12 @@ where
                         Some(tool_duration_ms),
                     )
                     .with_display_name(display_name.clone())
+                    .with_capability_attribution(
+                        capability_attribution.as_ref().map(|(id, _)| id.clone()),
+                        capability_attribution
+                            .as_ref()
+                            .and_then(|(_, name)| name.clone()),
+                    )
                     .with_narration(Some(self.render_tool_narration(
                         Some(tool_def),
                         &tool_call,
@@ -1095,6 +1111,12 @@ where
                             Some(tool_duration_ms),
                         )
                         .with_display_name(display_name.clone())
+                        .with_capability_attribution(
+                            capability_attribution.as_ref().map(|(id, _)| id.clone()),
+                            capability_attribution
+                                .as_ref()
+                                .and_then(|(_, name)| name.clone()),
+                        )
                         .with_narration(Some(self.render_tool_narration(
                             Some(tool_def),
                             &tool_call,

--- a/crates/core/src/atoms/reason.rs
+++ b/crates/core/src/atoms/reason.rs
@@ -20,7 +20,7 @@ use async_trait::async_trait;
 use futures::StreamExt;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::sync::Arc;
 use std::time::Instant;
 use uuid::Uuid;
@@ -29,11 +29,12 @@ use super::{Atom, AtomContext};
 use crate::capabilities::CapabilityRegistry;
 use crate::error::{AgentLoopError, Result};
 use crate::events::{
-    EventContext, EventRequest, LlmCompactionInfo, LlmGenerationData, LlmPromptCacheInfo,
-    LlmRequestOptions, LlmRetryInfo, LlmToolSearchInfo, OutputMessageCompletedData,
-    OutputMessageDeltaData, OutputMessageReplacedData, OutputMessageStartedData,
-    ReasonCompletedData, ReasonStartedData, ReasonThinkingCompletedData, ReasonThinkingDeltaData,
-    ReasonThinkingStartedData, TokenUsage, ToolDefinitionSummary,
+    CapabilityUsageData, CapabilityUsageKind, CapabilityUsageRecord, EventContext, EventRequest,
+    LlmCompactionInfo, LlmGenerationData, LlmPromptCacheInfo, LlmRequestOptions, LlmRetryInfo,
+    LlmToolSearchInfo, OutputMessageCompletedData, OutputMessageDeltaData,
+    OutputMessageReplacedData, OutputMessageStartedData, ReasonCompletedData, ReasonStartedData,
+    ReasonThinkingCompletedData, ReasonThinkingDeltaData, ReasonThinkingStartedData, TokenUsage,
+    ToolDefinitionSummary,
 };
 use crate::llm_driver_registry::{
     DriverRegistry, LlmCallConfigBuilder, LlmCompletionMetadata, LlmMessage, LlmMessageContent,
@@ -283,6 +284,65 @@ fn build_request_options(
     (!request_options.is_empty()).then_some(request_options)
 }
 
+fn capability_name_snapshot(registry: &CapabilityRegistry, capability_id: &str) -> Option<String> {
+    registry
+        .get(capability_id)
+        .map(|capability| capability.name().to_string())
+}
+
+fn capability_usage_snapshot_records(
+    registry: &CapabilityRegistry,
+    resolved_capability_configs: &[crate::AgentCapabilityConfig],
+    tool_definitions: &[ToolDefinition],
+) -> Vec<CapabilityUsageRecord> {
+    let mut records = Vec::new();
+    let mut seen = BTreeSet::new();
+
+    for config in resolved_capability_configs {
+        let capability_id = config.capability_id().to_string();
+        if seen.insert((
+            "resolved".to_string(),
+            capability_id.clone(),
+            None::<String>,
+        )) {
+            records.push(CapabilityUsageRecord {
+                capability_name: capability_name_snapshot(registry, &capability_id),
+                capability_id,
+                usage_kind: CapabilityUsageKind::Resolved,
+                tool_name: None,
+                usage_count: Some(1),
+                duration_ms: None,
+            });
+        }
+    }
+
+    for tool in tool_definitions {
+        let Some((capability_id, capability_name)) = tool.capability_attribution() else {
+            continue;
+        };
+        let capability_id = capability_id.to_string();
+        let tool_name = tool.name().to_string();
+        if seen.insert((
+            "exposed".to_string(),
+            capability_id.clone(),
+            Some(tool_name.clone()),
+        )) {
+            records.push(CapabilityUsageRecord {
+                capability_name: capability_name
+                    .map(str::to_string)
+                    .or_else(|| capability_name_snapshot(registry, &capability_id)),
+                capability_id,
+                usage_kind: CapabilityUsageKind::Exposed,
+                tool_name: Some(tool_name),
+                usage_count: Some(1),
+                duration_ms: None,
+            });
+        }
+    }
+
+    records
+}
+
 // ============================================================================
 // ReasonAtom
 // ============================================================================
@@ -398,6 +458,39 @@ impl ReasonAtom {
         assembled: AssembledTurnContext,
     ) -> Result<ReasonResult> {
         self.execute_inner(input, Some(assembled)).await
+    }
+
+    async fn emit_capability_usage_snapshot(
+        &self,
+        session_id: SessionId,
+        context: &AtomContext,
+        resolved_capability_configs: &[crate::AgentCapabilityConfig],
+        tool_definitions: &[ToolDefinition],
+    ) {
+        let records = capability_usage_snapshot_records(
+            &self.capability_registry,
+            resolved_capability_configs,
+            tool_definitions,
+        );
+        if records.is_empty() {
+            return;
+        }
+
+        if let Err(error) = self
+            .event_emitter
+            .emit(EventRequest::new(
+                session_id,
+                EventContext::from_atom_context(context),
+                CapabilityUsageData { records },
+            ))
+            .await
+        {
+            tracing::warn!(
+                session_id = %session_id,
+                error = %error,
+                "ReasonAtom: failed to emit capability.usage event"
+            );
+        }
     }
 
     async fn execute_inner(
@@ -663,6 +756,14 @@ impl ReasonAtom {
         let compaction_config = assembled.compaction_config;
         let resolved_capability_configs = assembled.resolved_capability_configs;
         let runtime_agent = assembled.runtime_agent;
+
+        self.emit_capability_usage_snapshot(
+            session_id,
+            context,
+            &resolved_capability_configs,
+            &runtime_agent.tools,
+        )
+        .await;
 
         // Collect streaming output guardrail providers contributed by enabled
         // capabilities. Each tuple carries the contributing capability id, a
@@ -2018,6 +2119,39 @@ mod tests {
         let json = r#"{"success":true,"text":"","has_tool_calls":false}"#;
         let result: ReasonResult = serde_json::from_str(json).unwrap();
         assert_eq!(result.max_iterations, 500);
+    }
+
+    #[test]
+    fn test_capability_usage_snapshot_keeps_resolved_and_exposed_separate() {
+        let registry = CapabilityRegistry::with_builtins();
+        let tool = ToolDefinition::Builtin(crate::tool_types::BuiltinTool {
+            name: "demo_tool".to_string(),
+            display_name: None,
+            description: "demo".to_string(),
+            parameters: json!({"type": "object"}),
+            policy: crate::tool_types::ToolPolicy::Auto,
+            category: None,
+            deferrable: crate::tool_types::DeferrablePolicy::default(),
+            hints: crate::tool_types::ToolHints::default(),
+        })
+        .with_capability_attribution("cap:demo", "Demo Capability");
+
+        let records = capability_usage_snapshot_records(
+            &registry,
+            &[crate::AgentCapabilityConfig::new("current_time")],
+            &[tool],
+        );
+
+        assert!(records.iter().any(|record| {
+            matches!(record.usage_kind, CapabilityUsageKind::Resolved)
+                && record.capability_id == "current_time"
+                && record.tool_name.is_none()
+        }));
+        assert!(records.iter().any(|record| {
+            matches!(record.usage_kind, CapabilityUsageKind::Exposed)
+                && record.capability_id == "cap:demo"
+                && record.tool_name.as_deref() == Some("demo_tool")
+        }));
     }
 
     #[test]

--- a/crates/core/src/atoms/reason.rs
+++ b/crates/core/src/atoms/reason.rs
@@ -2134,7 +2134,7 @@ mod tests {
             deferrable: crate::tool_types::DeferrablePolicy::default(),
             hints: crate::tool_types::ToolHints::default(),
         })
-        .with_capability_attribution("cap:demo", "Demo Capability");
+        .with_capability_attribution("cap:demo", Some("Demo Capability"));
 
         let records = capability_usage_snapshot_records(
             &registry,

--- a/crates/core/src/capabilities/mcp.rs
+++ b/crates/core/src/capabilities/mcp.rs
@@ -114,6 +114,7 @@ impl McpCapability {
             deferrable: DeferrablePolicy::default(),
             hints,
         })
+        .with_capability_attribution(self.capability_id(), self.server_name.clone())
     }
 }
 
@@ -246,6 +247,13 @@ mod tests {
         };
         assert_eq!(builtin.name, "mcp_microsoft_learn__search");
         assert_eq!(builtin.description, "Search documentation");
+        assert_eq!(
+            defs[0].capability_attribution(),
+            Some((
+                "mcp:550e8400-e29b-41d4-a716-446655440000",
+                Some("microsoft-learn")
+            ))
+        );
     }
 
     #[test]

--- a/crates/core/src/capabilities/mcp.rs
+++ b/crates/core/src/capabilities/mcp.rs
@@ -114,7 +114,7 @@ impl McpCapability {
             deferrable: DeferrablePolicy::default(),
             hints,
         })
-        .with_capability_attribution(self.capability_id(), self.server_name.clone())
+        .with_capability_attribution(self.capability_id(), Some(self.server_name.clone()))
     }
 }
 

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -1597,7 +1597,8 @@ pub async fn collect_capabilities_with_configs(
                 let def = match (def.category(), cap_category) {
                     (None, Some(cat)) => def.with_category(cat),
                     _ => def,
-                };
+                }
+                .with_capability_attribution(cap_id, capability.name());
                 tool_definitions.push(def);
             }
 

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -1598,7 +1598,7 @@ pub async fn collect_capabilities_with_configs(
                     (None, Some(cat)) => def.with_category(cat),
                     _ => def,
                 }
-                .with_capability_attribution(cap_id, capability.name());
+                .with_capability_attribution(cap_id, Some(capability.name()));
                 tool_definitions.push(def);
             }
 

--- a/crates/core/src/events.rs
+++ b/crates/core/src/events.rs
@@ -57,6 +57,7 @@ pub const TURN_CANCELLED: &str = "turn.cancelled";
 // Atom lifecycle events
 pub const REASON_STARTED: &str = "reason.started";
 pub const REASON_COMPLETED: &str = "reason.completed";
+pub const CAPABILITY_USAGE: &str = "capability.usage";
 pub const ACT_STARTED: &str = "act.started";
 pub const ACT_COMPLETED: &str = "act.completed";
 pub const TOOL_STARTED: &str = "tool.started";
@@ -757,6 +758,43 @@ impl ReasonCompletedData {
     }
 }
 
+/// Reporting-only capability usage kinds.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub enum CapabilityUsageKind {
+    Configured,
+    Resolved,
+    Exposed,
+    Invoked,
+    EffectRan,
+}
+
+/// Single capability usage record. This intentionally carries only stable IDs
+/// and small snapshots; prompts, messages, tool arguments, and results are not
+/// allowed in reporting facts.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct CapabilityUsageRecord {
+    pub capability_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub capability_name: Option<String>,
+    pub usage_kind: CapabilityUsageKind,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub usage_count: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub duration_ms: Option<u64>,
+}
+
+/// Data for capability.usage events.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct CapabilityUsageData {
+    pub records: Vec<CapabilityUsageRecord>,
+}
+
 /// Summary of a tool call (compact form without arguments)
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
@@ -947,6 +985,15 @@ pub struct ToolCompletedData {
     /// Duration of the tool call in milliseconds
     #[serde(skip_serializing_if = "Option::is_none")]
     pub duration_ms: Option<u64>,
+
+    /// Capability that contributed the tool definition, when known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub capability_id: Option<String>,
+
+    /// Human-readable capability name snapshot, when known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub capability_name: Option<String>,
+
     /// Human-readable narration for timeline rendering
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub narration: Option<String>,
@@ -968,6 +1015,8 @@ impl ToolCompletedData {
             result: Some(result),
             error: None,
             duration_ms,
+            capability_id: None,
+            capability_name: None,
             narration: None,
         }
     }
@@ -988,6 +1037,8 @@ impl ToolCompletedData {
             result: None,
             error: Some(error),
             duration_ms,
+            capability_id: None,
+            capability_name: None,
             narration: None,
         }
     }
@@ -1001,6 +1052,17 @@ impl ToolCompletedData {
     /// Set narration on this event data
     pub fn with_narration(mut self, narration: Option<String>) -> Self {
         self.narration = narration;
+        self
+    }
+
+    /// Set reporting attribution on this event data.
+    pub fn with_capability_attribution(
+        mut self,
+        capability_id: Option<String>,
+        capability_name: Option<String>,
+    ) -> Self {
+        self.capability_id = capability_id;
+        self.capability_name = capability_name;
         self
     }
 }
@@ -1897,6 +1959,7 @@ pub struct VoiceSessionFailedData {
 /// - `turn.cancelled` → TurnCancelledData
 /// - `reason.started` → ReasonStartedData
 /// - `reason.completed` → ReasonCompletedData
+/// - `capability.usage` → CapabilityUsageData
 /// - `act.started` → ActStartedData
 /// - `act.completed` → ActCompletedData
 /// - `tool.started` → ToolStartedData
@@ -1948,6 +2011,7 @@ pub enum EventData {
     // Atom lifecycle events
     ReasonStarted(ReasonStartedData),
     ReasonCompleted(ReasonCompletedData),
+    CapabilityUsage(CapabilityUsageData),
     ActStarted(ActStartedData),
     ActCompleted(ActCompletedData),
     ToolStarted(ToolStartedData),
@@ -2034,6 +2098,7 @@ impl EventData {
             EventData::TurnCancelled(_) => TURN_CANCELLED,
             EventData::ReasonStarted(_) => REASON_STARTED,
             EventData::ReasonCompleted(_) => REASON_COMPLETED,
+            EventData::CapabilityUsage(_) => CAPABILITY_USAGE,
             EventData::ActStarted(_) => ACT_STARTED,
             EventData::ActCompleted(_) => ACT_COMPLETED,
             EventData::ToolStarted(_) => TOOL_STARTED,
@@ -2133,6 +2198,8 @@ pub fn deserialize_event_data(event_type: &str, data: serde_json::Value) -> Even
                 .map(EventData::ReasonStarted),
             REASON_COMPLETED => serde_json::from_value::<ReasonCompletedData>(data.clone())
                 .map(EventData::ReasonCompleted),
+            CAPABILITY_USAGE => serde_json::from_value::<CapabilityUsageData>(data.clone())
+                .map(EventData::CapabilityUsage),
             ACT_STARTED => {
                 serde_json::from_value::<ActStartedData>(data.clone()).map(EventData::ActStarted)
             }
@@ -2257,6 +2324,7 @@ impl_from_event_data! {
     TurnCancelledData => TurnCancelled,
     ReasonStartedData => ReasonStarted,
     ReasonCompletedData => ReasonCompleted,
+    CapabilityUsageData => CapabilityUsage,
     ActStartedData => ActStarted,
     ActCompletedData => ActCompleted,
     ToolStartedData => ToolStarted,

--- a/crates/core/src/observation/braintrust.rs
+++ b/crates/core/src/observation/braintrust.rs
@@ -2705,6 +2705,8 @@ mod tests {
             result: None,
             error: None,
             duration_ms: Some(200),
+            capability_id: None,
+            capability_name: None,
             narration: None,
         };
         let event = Event::new(
@@ -2925,6 +2927,8 @@ mod tests {
             result: None,
             error: None,
             duration_ms: Some(75),
+            capability_id: None,
+            capability_name: None,
             narration: None,
         };
         let tool_event = Event::new(
@@ -3180,6 +3184,8 @@ mod tests {
             result: None,
             error: None,
             duration_ms: Some(100),
+            capability_id: None,
+            capability_name: None,
             narration: None,
         };
         let completed_event = Event::new(
@@ -3550,6 +3556,8 @@ mod tests {
             result: Some(vec![crate::ContentPart::text("sensitive tool output")]),
             error: None,
             duration_ms: Some(50),
+            capability_id: None,
+            capability_name: None,
             narration: None,
         };
         let event = Event::new(

--- a/crates/core/src/observation/otel.rs
+++ b/crates/core/src/observation/otel.rs
@@ -1279,6 +1279,8 @@ mod tests {
             result: None,
             error: None,
             duration_ms: Some(100),
+            capability_id: None,
+            capability_name: None,
             narration: None,
         };
         listener
@@ -1304,6 +1306,8 @@ mod tests {
             result: None,
             error: Some("Connection timeout".to_string()),
             duration_ms: None,
+            capability_id: None,
+            capability_name: None,
             narration: None,
         };
         // Should not panic
@@ -1353,6 +1357,8 @@ mod tests {
                 result: None,
                 error: None,
                 duration_ms: Some(50),
+                capability_id: None,
+                capability_name: None,
                 narration: None,
             };
             listener
@@ -1675,6 +1681,8 @@ mod tests {
             result: None,
             error: None,
             duration_ms: Some(200),
+            capability_id: None,
+            capability_name: None,
             narration: None,
         };
         listener
@@ -2081,6 +2089,8 @@ mod tests {
                     result: None,
                     error: None,
                     duration_ms: Some(200),
+                    capability_id: None,
+                    capability_name: None,
                     narration: None,
                 }),
             ))

--- a/crates/core/src/tool_types.rs
+++ b/crates/core/src/tool_types.rs
@@ -217,18 +217,18 @@ impl ToolDefinition {
     pub fn with_capability_attribution(
         mut self,
         capability_id: impl Into<String>,
-        capability_name: impl Into<String>,
+        capability_name: Option<impl Into<String>>,
     ) -> Self {
         let capability_id = capability_id.into();
-        let capability_name = capability_name.into();
+        let capability_name = capability_name.map(Into::into);
         match &mut self {
             ToolDefinition::Builtin(b) => {
                 b.hints.capability_id = Some(capability_id);
-                b.hints.capability_name = Some(capability_name);
+                b.hints.capability_name = capability_name;
             }
             ToolDefinition::ClientSide(c) => {
                 c.hints.capability_id = Some(capability_id);
-                c.hints.capability_name = Some(capability_name);
+                c.hints.capability_name = capability_name;
             }
         }
         self
@@ -410,10 +410,10 @@ impl ToolHints {
     pub fn with_capability_attribution(
         mut self,
         capability_id: impl Into<String>,
-        capability_name: impl Into<String>,
+        capability_name: Option<impl Into<String>>,
     ) -> Self {
         self.capability_id = Some(capability_id.into());
-        self.capability_name = Some(capability_name.into());
+        self.capability_name = capability_name.map(Into::into);
         self
     }
 

--- a/crates/core/src/tool_types.rs
+++ b/crates/core/src/tool_types.rs
@@ -187,6 +187,14 @@ impl ToolDefinition {
         }
     }
 
+    /// Get reporting attribution for the capability that contributed this tool.
+    pub fn capability_attribution(&self) -> Option<(&str, Option<&str>)> {
+        self.hints()
+            .capability_id
+            .as_deref()
+            .map(|id| (id, self.hints().capability_name.as_deref()))
+    }
+
     /// Set the category on this tool definition (builder pattern)
     pub fn with_category(mut self, category: impl Into<String>) -> Self {
         match &mut self {
@@ -201,6 +209,27 @@ impl ToolDefinition {
         match &mut self {
             ToolDefinition::Builtin(b) => b.hints = hints,
             ToolDefinition::ClientSide(c) => c.hints = hints,
+        }
+        self
+    }
+
+    /// Set reporting attribution on this tool definition (builder pattern).
+    pub fn with_capability_attribution(
+        mut self,
+        capability_id: impl Into<String>,
+        capability_name: impl Into<String>,
+    ) -> Self {
+        let capability_id = capability_id.into();
+        let capability_name = capability_name.into();
+        match &mut self {
+            ToolDefinition::Builtin(b) => {
+                b.hints.capability_id = Some(capability_id);
+                b.hints.capability_name = Some(capability_name);
+            }
+            ToolDefinition::ClientSide(c) => {
+                c.hints.capability_id = Some(capability_id);
+                c.hints.capability_name = Some(capability_name);
+            }
         }
         self
     }
@@ -328,6 +357,17 @@ pub struct ToolHints {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub persist_output: Option<bool>,
 
+    /// Capability that contributed this tool definition.
+    ///
+    /// Reporting uses this attribution only as metadata. It must never contain
+    /// tool arguments, results, prompts, or any other sensitive payload.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub capability_id: Option<String>,
+
+    /// Human-readable capability name snapshot for reporting.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub capability_name: Option<String>,
+
     /// Entity noun for operation-based narration (e.g. "agent", "harness").
     /// When set, the narration system reads the `operation` argument and
     /// produces verb-based narration like "Created agent: Neon Cartographer"
@@ -363,6 +403,17 @@ impl ToolHints {
     /// Builder: set open_world hint.
     pub fn with_open_world(mut self, value: bool) -> Self {
         self.open_world = Some(value);
+        self
+    }
+
+    /// Builder: set reporting attribution.
+    pub fn with_capability_attribution(
+        mut self,
+        capability_id: impl Into<String>,
+        capability_name: impl Into<String>,
+    ) -> Self {
+        self.capability_id = Some(capability_id.into());
+        self.capability_name = Some(capability_name.into());
         self
     }
 

--- a/crates/internal-protocol/proto/worker.proto
+++ b/crates/internal-protocol/proto/worker.proto
@@ -316,6 +316,8 @@ message McpToolDef {
     string name = 1;  // Prefixed: mcp_{server_name}_{tool_name}
     string description = 2;
     google.protobuf.Struct parameters = 3;  // JSON Schema
+    string capability_id = 4;  // Virtual capability that contributed this tool
+    string capability_name = 5;
 }
 
 // ============================================================================

--- a/crates/internal-protocol/src/lib.rs
+++ b/crates/internal-protocol/src/lib.rs
@@ -222,6 +222,7 @@ fn serialize_event_data(data: &everruns_core::EventData) -> serde_json::Value {
         EventData::TurnCancelled(d) => serde_json::to_value(d).unwrap_or_default(),
         EventData::ReasonStarted(d) => serde_json::to_value(d).unwrap_or_default(),
         EventData::ReasonCompleted(d) => serde_json::to_value(d).unwrap_or_default(),
+        EventData::CapabilityUsage(d) => serde_json::to_value(d).unwrap_or_default(),
         EventData::ActStarted(d) => serde_json::to_value(d).unwrap_or_default(),
         EventData::ActCompleted(d) => serde_json::to_value(d).unwrap_or_default(),
         EventData::ToolStarted(d) => serde_json::to_value(d).unwrap_or_default(),

--- a/crates/server/migrations/041_capability_usage_reporting.sql
+++ b/crates/server/migrations/041_capability_usage_reporting.sql
@@ -1,0 +1,36 @@
+-- Reporting phase 2: capability usage facts.
+-- Facts carry only capability/tool attribution and counts. They must not
+-- contain prompts, messages, tool arguments, or tool results.
+
+CREATE TABLE fact_capability_usage (
+    org_id BIGINT NOT NULL REFERENCES organizations(org_id),
+    source_key TEXT NOT NULL,
+    session_id UUID,
+    turn_id TEXT,
+    user_id UUID,
+    principal_id UUID,
+    agent_id UUID,
+    agent_name_snapshot TEXT,
+    harness_id UUID,
+    harness_name_snapshot TEXT,
+    app_id UUID,
+    blueprint_id TEXT,
+    created_at TIMESTAMPTZ NOT NULL,
+    time_bucket_day DATE NOT NULL,
+    capability_id TEXT NOT NULL,
+    capability_name_snapshot TEXT,
+    capability_usage_kind TEXT NOT NULL
+        CHECK (capability_usage_kind IN ('configured', 'resolved', 'exposed', 'invoked', 'effect_ran')),
+    tool_name TEXT,
+    usage_count BIGINT NOT NULL DEFAULT 1,
+    duration_ms BIGINT NOT NULL DEFAULT 0,
+    projected_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (org_id, source_key)
+);
+
+CREATE INDEX idx_fact_capability_usage_org_created
+    ON fact_capability_usage(org_id, created_at);
+CREATE INDEX idx_fact_capability_usage_org_day
+    ON fact_capability_usage(org_id, time_bucket_day);
+CREATE INDEX idx_fact_capability_usage_capability
+    ON fact_capability_usage(org_id, capability_id, capability_usage_kind, created_at);

--- a/crates/server/src/api/ag_ui.rs
+++ b/crates/server/src/api/ag_ui.rs
@@ -1753,6 +1753,8 @@ mod tests {
                 result: Some(vec![ContentPart::text("skill_123")]),
                 error: None,
                 duration_ms: Some(10),
+                capability_id: None,
+                capability_name: None,
                 narration: None,
             },
         );
@@ -1842,6 +1844,8 @@ mod tests {
                 result: Some(vec![ContentPart::text("result")]),
                 error: None,
                 duration_ms: Some(10),
+                capability_id: None,
+                capability_name: None,
                 narration: None,
             },
         );
@@ -1939,6 +1943,8 @@ mod tests {
                 result: Some(vec![ContentPart::text("private result")]),
                 error: None,
                 duration_ms: Some(10),
+                capability_id: None,
+                capability_name: None,
                 narration: None,
             },
         );
@@ -2028,6 +2034,8 @@ mod tests {
                 result: Some(vec![ContentPart::text("result")]),
                 error: None,
                 duration_ms: Some(10),
+                capability_id: None,
+                capability_name: None,
                 narration: None,
             },
         );

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -1777,16 +1777,20 @@ impl DirectWorkerAdapters {
                     .description
                     .unwrap_or_else(|| format!("Tool from MCP server: {}", server_name));
 
-                mcp_tools.push(ToolDefinition::Builtin(BuiltinTool {
-                    name: prefixed_name,
-                    display_name: None,
-                    description,
-                    parameters: tool.input_schema,
-                    policy: ToolPolicy::Auto,
-                    category: None,
-                    deferrable: DeferrablePolicy::default(),
-                    hints: everruns_core::tool_types::ToolHints::default().with_open_world(true),
-                }));
+                mcp_tools.push(
+                    ToolDefinition::Builtin(BuiltinTool {
+                        name: prefixed_name,
+                        display_name: None,
+                        description,
+                        parameters: tool.input_schema,
+                        policy: ToolPolicy::Auto,
+                        category: None,
+                        deferrable: DeferrablePolicy::default(),
+                        hints: everruns_core::tool_types::ToolHints::default()
+                            .with_open_world(true),
+                    })
+                    .with_capability_attribution(cap_id.clone(), server_name.clone()),
+                );
             }
         }
 

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -1789,7 +1789,7 @@ impl DirectWorkerAdapters {
                         hints: everruns_core::tool_types::ToolHints::default()
                             .with_open_world(true),
                     })
-                    .with_capability_attribution(cap_id.clone(), server_name.clone()),
+                    .with_capability_attribution(cap_id.clone(), Some(server_name.clone())),
                 );
             }
         }

--- a/crates/server/src/domains/mcp_servers/scoped_mcp.rs
+++ b/crates/server/src/domains/mcp_servers/scoped_mcp.rs
@@ -201,7 +201,10 @@ pub async fn build_scoped_mcp_tool_definitions(
                     continue;
                 }
             };
-        let capability = McpCapability::new(Uuid::nil(), name.clone(), None, tools);
+        let capability_id = session_id
+            .map(|id| scoped_mcp_server_uuid(id.uuid(), name))
+            .unwrap_or_else(Uuid::nil);
+        let capability = McpCapability::new(capability_id, name.clone(), None, tools);
         definitions.extend(capability.tool_definitions());
     }
 

--- a/crates/server/src/domains/reporting/catalog.rs
+++ b/crates/server/src/domains/reporting/catalog.rs
@@ -324,6 +324,69 @@ const BUDGET_DIMS: &[FieldSpec] = &[
     },
 ];
 
+const CAPABILITY_USAGE_DIMS: &[FieldSpec] = &[
+    FieldSpec {
+        name: "session",
+        sql: "session_id",
+    },
+    FieldSpec {
+        name: "turn",
+        sql: "turn_id",
+    },
+    FieldSpec {
+        name: "user",
+        sql: "user_id",
+    },
+    FieldSpec {
+        name: "principal",
+        sql: "principal_id",
+    },
+    FieldSpec {
+        name: "agent",
+        sql: "agent_id",
+    },
+    FieldSpec {
+        name: "agent_name",
+        sql: "agent_name_snapshot",
+    },
+    FieldSpec {
+        name: "harness",
+        sql: "harness_id",
+    },
+    FieldSpec {
+        name: "harness_name",
+        sql: "harness_name_snapshot",
+    },
+    FieldSpec {
+        name: "app",
+        sql: "app_id",
+    },
+    FieldSpec {
+        name: "blueprint",
+        sql: "blueprint_id",
+    },
+    FieldSpec {
+        name: "day",
+        sql: "time_bucket_day",
+    },
+    FieldSpec {
+        name: "capability",
+        sql: "capability_id",
+    },
+    FieldSpec {
+        name: "capability_name",
+        sql: "capability_name_snapshot",
+    },
+    FieldSpec {
+        name: "capability_usage_kind",
+        sql: "capability_usage_kind",
+    },
+    FieldSpec {
+        name: "tool",
+        sql: "tool_name",
+    },
+];
+
 const LLM_MEASURES: &[MeasureSpec] = &[
     MeasureSpec {
         name: "input_tokens",
@@ -495,6 +558,21 @@ const BUDGET_MEASURES: &[MeasureSpec] = &[
     },
 ];
 
+const CAPABILITY_USAGE_MEASURES: &[MeasureSpec] = &[
+    MeasureSpec {
+        name: "usage_count",
+        sql: "COALESCE(SUM(usage_count), 0)",
+    },
+    MeasureSpec {
+        name: "duration_ms",
+        sql: "COALESCE(SUM(duration_ms), 0)",
+    },
+    MeasureSpec {
+        name: "avg_duration_ms",
+        sql: "COALESCE(AVG(NULLIF(duration_ms, 0)), 0)",
+    },
+];
+
 const DATASETS: &[DatasetSpec] = &[
     DatasetSpec {
         name: "llm_generations",
@@ -530,6 +608,13 @@ const DATASETS: &[DatasetSpec] = &[
         dimensions: BUDGET_DIMS,
         measures: BUDGET_MEASURES,
         filters: BUDGET_DIMS,
+    },
+    DatasetSpec {
+        name: "capability_usage",
+        table: "fact_capability_usage",
+        dimensions: CAPABILITY_USAGE_DIMS,
+        measures: CAPABILITY_USAGE_MEASURES,
+        filters: CAPABILITY_USAGE_DIMS,
     },
 ];
 
@@ -723,6 +808,26 @@ mod tests {
         assert!(names.contains(&"turns"));
         assert!(names.contains(&"sessions"));
         assert!(names.contains(&"budget_postings"));
+        assert!(names.contains(&"capability_usage"));
+    }
+
+    #[test]
+    fn capability_usage_keeps_kinds_and_tools_separate() {
+        let catalog = catalog();
+        let dataset = catalog
+            .datasets
+            .iter()
+            .find(|dataset| dataset.name == "capability_usage")
+            .expect("capability usage dataset");
+
+        assert!(dataset.dimensions.contains(&"capability".to_string()));
+        assert!(
+            dataset
+                .dimensions
+                .contains(&"capability_usage_kind".to_string())
+        );
+        assert!(dataset.dimensions.contains(&"tool".to_string()));
+        assert!(dataset.measures.contains(&"usage_count".to_string()));
     }
 
     #[test]

--- a/crates/server/src/grpc_service/mod.rs
+++ b/crates/server/src/grpc_service/mod.rs
@@ -789,6 +789,8 @@ impl WorkerServiceImpl {
                     name: prefixed_name,
                     description,
                     parameters: Some(parameters),
+                    capability_id: cap.capability_id().to_string(),
+                    capability_name: server.name.clone(),
                 });
             }
         }

--- a/crates/server/src/grpc_service/worker_service_impl.rs
+++ b/crates/server/src/grpc_service/worker_service_impl.rs
@@ -265,6 +265,15 @@ impl WorkerService for WorkerServiceImpl {
                             parameters: Some(everruns_internal_protocol::json_to_proto_struct(
                                 tool.parameters(),
                             )),
+                            capability_id: tool
+                                .capability_attribution()
+                                .map(|(id, _)| id.to_string())
+                                .unwrap_or_default(),
+                            capability_name: tool
+                                .capability_attribution()
+                                .and_then(|(_, name)| name)
+                                .unwrap_or_default()
+                                .to_string(),
                         })
                         .collect()
                 })

--- a/crates/server/src/storage/reporting/outbox.rs
+++ b/crates/server/src/storage/reporting/outbox.rs
@@ -215,6 +215,10 @@ impl PostgresReportingProjector {
         .await?;
         match event_type.as_ref().map(|row| row.0.as_str()) {
             Some("tool.completed") => self.project_tool_event(org_id, id).await,
+            Some("capability.usage") => self.project_capability_usage_event(org_id, id).await,
+            Some("output.message.replaced") => {
+                self.project_guardrail_effect_event(org_id, id).await
+            }
             Some("turn.completed" | "turn.failed" | "turn.cancelled") => {
                 self.project_turn_event(org_id, id).await
             }
@@ -291,6 +295,210 @@ impl PostgresReportingProjector {
                 error_count = EXCLUDED.error_count,
                 timeout_count = EXCLUDED.timeout_count,
                 cancelled_count = EXCLUDED.cancelled_count,
+                duration_ms = EXCLUDED.duration_ms,
+                projected_at = NOW()
+            "#,
+        )
+        .bind(id)
+        .bind(org_id)
+        .execute(&self.pool)
+        .await?;
+        self.project_tool_invoked_usage(org_id, id).await?;
+        Ok(())
+    }
+
+    async fn project_tool_invoked_usage(&self, org_id: i64, id: Uuid) -> Result<()> {
+        sqlx::query(
+            r#"
+            INSERT INTO fact_capability_usage (
+                org_id, source_key, session_id, turn_id, user_id, principal_id, agent_id,
+                agent_name_snapshot, harness_id, harness_name_snapshot, app_id, blueprint_id,
+                created_at, time_bucket_day, capability_id, capability_name_snapshot,
+                capability_usage_kind, tool_name, usage_count, duration_ms, projected_at
+            )
+            SELECT
+                s.org_id,
+                'event:' || e.id::TEXT || ':invoked',
+                e.session_id,
+                COALESCE(e.context->>'turn_id', e.data->>'turn_id'),
+                s.resolved_owner_user_id,
+                s.owner_principal_id,
+                s.agent_id,
+                a.name,
+                s.harness_id,
+                h.name,
+                s.app_id,
+                s.blueprint_id,
+                e.ts,
+                (e.ts AT TIME ZONE 'UTC')::DATE,
+                e.data->>'capability_id',
+                e.data->>'capability_name',
+                'invoked',
+                e.data->>'tool_name',
+                1,
+                CASE WHEN COALESCE(e.data->>'duration_ms', '') ~ '^[0-9]+$'
+                     THEN (e.data->>'duration_ms')::BIGINT
+                     ELSE 0
+                END,
+                NOW()
+            FROM events e
+            JOIN sessions s ON s.id = e.session_id
+            LEFT JOIN agents a ON a.id = s.agent_id AND a.org_id = s.org_id
+            LEFT JOIN harnesses h ON h.id = s.harness_id AND h.org_id = s.org_id
+            WHERE e.id = $1 AND s.org_id = $2 AND e.data ? 'capability_id'
+            ON CONFLICT (org_id, source_key) DO UPDATE SET
+                turn_id = EXCLUDED.turn_id,
+                user_id = EXCLUDED.user_id,
+                principal_id = EXCLUDED.principal_id,
+                agent_id = EXCLUDED.agent_id,
+                agent_name_snapshot = EXCLUDED.agent_name_snapshot,
+                harness_id = EXCLUDED.harness_id,
+                harness_name_snapshot = EXCLUDED.harness_name_snapshot,
+                app_id = EXCLUDED.app_id,
+                blueprint_id = EXCLUDED.blueprint_id,
+                created_at = EXCLUDED.created_at,
+                time_bucket_day = EXCLUDED.time_bucket_day,
+                capability_id = EXCLUDED.capability_id,
+                capability_name_snapshot = EXCLUDED.capability_name_snapshot,
+                tool_name = EXCLUDED.tool_name,
+                usage_count = EXCLUDED.usage_count,
+                duration_ms = EXCLUDED.duration_ms,
+                projected_at = NOW()
+            "#,
+        )
+        .bind(id)
+        .bind(org_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    async fn project_capability_usage_event(&self, org_id: i64, id: Uuid) -> Result<()> {
+        sqlx::query(
+            r#"
+            INSERT INTO fact_capability_usage (
+                org_id, source_key, session_id, turn_id, user_id, principal_id, agent_id,
+                agent_name_snapshot, harness_id, harness_name_snapshot, app_id, blueprint_id,
+                created_at, time_bucket_day, capability_id, capability_name_snapshot,
+                capability_usage_kind, tool_name, usage_count, duration_ms, projected_at
+            )
+            SELECT
+                s.org_id,
+                'event:' || e.id::TEXT || ':capability_usage:' || usage.ordinality::TEXT,
+                e.session_id,
+                COALESCE(e.context->>'turn_id', e.data->>'turn_id'),
+                s.resolved_owner_user_id,
+                s.owner_principal_id,
+                s.agent_id,
+                a.name,
+                s.harness_id,
+                h.name,
+                s.app_id,
+                s.blueprint_id,
+                e.ts,
+                (e.ts AT TIME ZONE 'UTC')::DATE,
+                usage.record->>'capability_id',
+                usage.record->>'capability_name',
+                usage.record->>'usage_kind',
+                usage.record->>'tool_name',
+                CASE WHEN COALESCE(usage.record->>'usage_count', '') ~ '^[0-9]+$'
+                     THEN (usage.record->>'usage_count')::BIGINT
+                     ELSE 1
+                END,
+                CASE WHEN COALESCE(usage.record->>'duration_ms', '') ~ '^[0-9]+$'
+                     THEN (usage.record->>'duration_ms')::BIGINT
+                     ELSE 0
+                END,
+                NOW()
+            FROM events e
+            JOIN sessions s ON s.id = e.session_id
+            LEFT JOIN agents a ON a.id = s.agent_id AND a.org_id = s.org_id
+            LEFT JOIN harnesses h ON h.id = s.harness_id AND h.org_id = s.org_id
+            CROSS JOIN LATERAL jsonb_array_elements(COALESCE(e.data->'records', '[]'::jsonb))
+                WITH ORDINALITY AS usage(record, ordinality)
+            WHERE e.id = $1
+              AND s.org_id = $2
+              AND usage.record ? 'capability_id'
+              AND usage.record ? 'usage_kind'
+            ON CONFLICT (org_id, source_key) DO UPDATE SET
+                turn_id = EXCLUDED.turn_id,
+                user_id = EXCLUDED.user_id,
+                principal_id = EXCLUDED.principal_id,
+                agent_id = EXCLUDED.agent_id,
+                agent_name_snapshot = EXCLUDED.agent_name_snapshot,
+                harness_id = EXCLUDED.harness_id,
+                harness_name_snapshot = EXCLUDED.harness_name_snapshot,
+                app_id = EXCLUDED.app_id,
+                blueprint_id = EXCLUDED.blueprint_id,
+                created_at = EXCLUDED.created_at,
+                time_bucket_day = EXCLUDED.time_bucket_day,
+                capability_id = EXCLUDED.capability_id,
+                capability_name_snapshot = EXCLUDED.capability_name_snapshot,
+                capability_usage_kind = EXCLUDED.capability_usage_kind,
+                tool_name = EXCLUDED.tool_name,
+                usage_count = EXCLUDED.usage_count,
+                duration_ms = EXCLUDED.duration_ms,
+                projected_at = NOW()
+            "#,
+        )
+        .bind(id)
+        .bind(org_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    async fn project_guardrail_effect_event(&self, org_id: i64, id: Uuid) -> Result<()> {
+        sqlx::query(
+            r#"
+            INSERT INTO fact_capability_usage (
+                org_id, source_key, session_id, turn_id, user_id, principal_id, agent_id,
+                agent_name_snapshot, harness_id, harness_name_snapshot, app_id, blueprint_id,
+                created_at, time_bucket_day, capability_id, capability_name_snapshot,
+                capability_usage_kind, tool_name, usage_count, duration_ms, projected_at
+            )
+            SELECT
+                s.org_id,
+                'event:' || e.id::TEXT || ':effect_ran',
+                e.session_id,
+                COALESCE(e.context->>'turn_id', e.data->>'turn_id'),
+                s.resolved_owner_user_id,
+                s.owner_principal_id,
+                s.agent_id,
+                a.name,
+                s.harness_id,
+                h.name,
+                s.app_id,
+                s.blueprint_id,
+                e.ts,
+                (e.ts AT TIME ZONE 'UTC')::DATE,
+                e.data->>'guardrail_capability_id',
+                e.data->>'guardrail_capability_id',
+                'effect_ran',
+                NULL,
+                1,
+                0,
+                NOW()
+            FROM events e
+            JOIN sessions s ON s.id = e.session_id
+            LEFT JOIN agents a ON a.id = s.agent_id AND a.org_id = s.org_id
+            LEFT JOIN harnesses h ON h.id = s.harness_id AND h.org_id = s.org_id
+            WHERE e.id = $1 AND s.org_id = $2 AND e.data ? 'guardrail_capability_id'
+            ON CONFLICT (org_id, source_key) DO UPDATE SET
+                turn_id = EXCLUDED.turn_id,
+                user_id = EXCLUDED.user_id,
+                principal_id = EXCLUDED.principal_id,
+                agent_id = EXCLUDED.agent_id,
+                agent_name_snapshot = EXCLUDED.agent_name_snapshot,
+                harness_id = EXCLUDED.harness_id,
+                harness_name_snapshot = EXCLUDED.harness_name_snapshot,
+                app_id = EXCLUDED.app_id,
+                blueprint_id = EXCLUDED.blueprint_id,
+                created_at = EXCLUDED.created_at,
+                time_bucket_day = EXCLUDED.time_bucket_day,
+                capability_id = EXCLUDED.capability_id,
+                capability_name_snapshot = EXCLUDED.capability_name_snapshot,
+                usage_count = EXCLUDED.usage_count,
                 duration_ms = EXCLUDED.duration_ms,
                 projected_at = NOW()
             "#,
@@ -496,6 +704,112 @@ impl PostgresReportingProjector {
                 cache_creation_tokens = EXCLUDED.cache_creation_tokens,
                 total_tokens = EXCLUDED.total_tokens,
                 tool_call_count = EXCLUDED.tool_call_count,
+                projected_at = NOW()
+            "#,
+        )
+        .bind(id)
+        .bind(org_id)
+        .execute(&self.pool)
+        .await?;
+        self.project_configured_capabilities(org_id, id).await?;
+        Ok(())
+    }
+
+    async fn project_configured_capabilities(&self, org_id: i64, id: Uuid) -> Result<()> {
+        sqlx::query(
+            r#"
+            DELETE FROM fact_capability_usage
+             WHERE org_id = $1
+               AND session_id = $2
+               AND capability_usage_kind = 'configured'
+               AND source_key LIKE ('session:' || $2::TEXT || ':configured:%')
+            "#,
+        )
+        .bind(org_id)
+        .bind(id)
+        .execute(&self.pool)
+        .await?;
+
+        sqlx::query(
+            r#"
+            WITH session_row AS (
+                SELECT s.*
+                  FROM sessions s
+                 WHERE s.id = $1 AND s.org_id = $2
+            ),
+            configured AS (
+                SELECT ac.capability_id, 'agent' AS source_scope
+                  FROM session_row s
+                  JOIN agent_capabilities ac ON ac.agent_id = s.agent_id
+                UNION ALL
+                SELECT hc.capability_id, 'harness' AS source_scope
+                  FROM session_row s
+                  JOIN harness_capabilities hc ON hc.harness_id = s.harness_id
+                UNION ALL
+                SELECT COALESCE(cap.value->>'ref', cap.value #>> '{}') AS capability_id,
+                       'session' AS source_scope
+                  FROM session_row s
+                  CROSS JOIN LATERAL jsonb_array_elements(
+                      CASE WHEN jsonb_typeof(s.capabilities) = 'array'
+                           THEN s.capabilities
+                           ELSE '[]'::jsonb
+                      END
+                  ) AS cap(value)
+            )
+            INSERT INTO fact_capability_usage (
+                org_id, source_key, session_id, turn_id, user_id, principal_id, agent_id,
+                agent_name_snapshot, harness_id, harness_name_snapshot, app_id, blueprint_id,
+                created_at, time_bucket_day, capability_id, capability_name_snapshot,
+                capability_usage_kind, tool_name, usage_count, duration_ms, projected_at
+            )
+            SELECT
+                s.org_id,
+                'session:' || s.id::TEXT || ':configured:' || configured.source_scope || ':' || configured.capability_id,
+                s.id,
+                NULL,
+                s.resolved_owner_user_id,
+                s.owner_principal_id,
+                s.agent_id,
+                a.name,
+                s.harness_id,
+                h.name,
+                s.app_id,
+                s.blueprint_id,
+                s.created_at,
+                (s.created_at AT TIME ZONE 'UTC')::DATE,
+                configured.capability_id,
+                COALESCE(mcp.name, skill.name, declarative.display_name, declarative.name, configured.capability_id),
+                'configured',
+                NULL,
+                1,
+                0,
+                NOW()
+            FROM session_row s
+            JOIN configured ON configured.capability_id IS NOT NULL AND configured.capability_id <> ''
+            LEFT JOIN agents a ON a.id = s.agent_id AND a.org_id = s.org_id
+            LEFT JOIN harnesses h ON h.id = s.harness_id AND h.org_id = s.org_id
+            LEFT JOIN mcp_servers mcp
+                ON configured.capability_id = ('mcp:' || mcp.id::TEXT)
+               AND mcp.org_id = s.org_id
+            LEFT JOIN skills skill
+                ON configured.capability_id = ('skill:' || skill.id::TEXT)
+               AND skill.org_id = s.org_id
+            LEFT JOIN declarative_capabilities declarative
+                ON configured.capability_id = ('declarative:' || declarative.name)
+               AND declarative.org_id = s.org_id
+            ON CONFLICT (org_id, source_key) DO UPDATE SET
+                user_id = EXCLUDED.user_id,
+                principal_id = EXCLUDED.principal_id,
+                agent_id = EXCLUDED.agent_id,
+                agent_name_snapshot = EXCLUDED.agent_name_snapshot,
+                harness_id = EXCLUDED.harness_id,
+                harness_name_snapshot = EXCLUDED.harness_name_snapshot,
+                app_id = EXCLUDED.app_id,
+                blueprint_id = EXCLUDED.blueprint_id,
+                created_at = EXCLUDED.created_at,
+                time_bucket_day = EXCLUDED.time_bucket_day,
+                capability_name_snapshot = EXCLUDED.capability_name_snapshot,
+                usage_count = EXCLUDED.usage_count,
                 projected_at = NOW()
             "#,
         )

--- a/crates/worker/src/grpc_adapters.rs
+++ b/crates/worker/src/grpc_adapters.rs
@@ -1859,11 +1859,7 @@ fn proto_mcp_tool_def_to_tool_definition(
     if !proto_tool.capability_id.is_empty() {
         hints = hints.with_capability_attribution(
             proto_tool.capability_id.clone(),
-            if proto_tool.capability_name.is_empty() {
-                proto_tool.capability_id.clone()
-            } else {
-                proto_tool.capability_name.clone()
-            },
+            (!proto_tool.capability_name.is_empty()).then_some(proto_tool.capability_name.clone()),
         );
     }
 

--- a/crates/worker/src/grpc_adapters.rs
+++ b/crates/worker/src/grpc_adapters.rs
@@ -1855,6 +1855,18 @@ fn proto_mcp_tool_def_to_tool_definition(
         .map(|s| proto_struct_to_json(&s))
         .unwrap_or_else(|| serde_json::json!({"type": "object"}));
 
+    let mut hints = everruns_core::tool_types::ToolHints::default().with_open_world(true);
+    if !proto_tool.capability_id.is_empty() {
+        hints = hints.with_capability_attribution(
+            proto_tool.capability_id.clone(),
+            if proto_tool.capability_name.is_empty() {
+                proto_tool.capability_id.clone()
+            } else {
+                proto_tool.capability_name.clone()
+            },
+        );
+    }
+
     ToolDefinition::Builtin(BuiltinTool {
         name: proto_tool.name,
         display_name: None,
@@ -1863,9 +1875,7 @@ fn proto_mcp_tool_def_to_tool_definition(
         policy: ToolPolicy::Auto, // MCP tools are auto-executed
         category: None,
         deferrable: DeferrablePolicy::default(),
-        // MCP tools are remote/networked; default open_world to true.
-        // Full annotation propagation requires extending the internal proto.
-        hints: everruns_core::tool_types::ToolHints::default().with_open_world(true),
+        hints,
     })
 }
 

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -9520,6 +9520,76 @@
           }
         }
       },
+      "CapabilityUsageData": {
+        "type": "object",
+        "description": "Data for capability.usage events.",
+        "required": [
+          "records"
+        ],
+        "properties": {
+          "records": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CapabilityUsageRecord"
+            }
+          }
+        }
+      },
+      "CapabilityUsageKind": {
+        "type": "string",
+        "description": "Reporting-only capability usage kinds.",
+        "enum": [
+          "configured",
+          "resolved",
+          "exposed",
+          "invoked",
+          "effect_ran"
+        ]
+      },
+      "CapabilityUsageRecord": {
+        "type": "object",
+        "description": "Single capability usage record. This intentionally carries only stable IDs\nand small snapshots; prompts, messages, tool arguments, and results are not\nallowed in reporting facts.",
+        "required": [
+          "capability_id",
+          "usage_kind"
+        ],
+        "properties": {
+          "capability_id": {
+            "type": "string"
+          },
+          "capability_name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "duration_ms": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "minimum": 0
+          },
+          "tool_name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "usage_count": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "minimum": 0
+          },
+          "usage_kind": {
+            "$ref": "#/components/schemas/CapabilityUsageKind"
+          }
+        }
+      },
       "ChannelType": {
         "type": "string",
         "description": "Supported channel types for app distribution.",
@@ -11342,6 +11412,9 @@
           },
           {
             "$ref": "#/components/schemas/ReasonCompletedData"
+          },
+          {
+            "$ref": "#/components/schemas/CapabilityUsageData"
           },
           {
             "$ref": "#/components/schemas/ActStartedData"
@@ -20318,6 +20391,20 @@
           "status"
         ],
         "properties": {
+          "capability_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Capability that contributed the tool definition, when known."
+          },
+          "capability_name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Human-readable capability name snapshot, when known."
+          },
           "display_name": {
             "type": [
               "string",
@@ -20456,6 +20543,20 @@
         "type": "object",
         "description": "Semantic hints describing a tool's behavioral properties.\n\nFollows the MCP tool annotations convention (readOnlyHint, destructiveHint,\nidempotentHint, openWorldHint) plus everruns-specific hints. All fields are\noptional booleans — `None` means \"unknown/unspecified\". Consumers should\ntreat `None` as the conservative default (e.g., assume not readonly, assume\nnot idempotent).\n\nThese hints are informational — they do not enforce policy. Use `ToolPolicy`\nfor execution gating (auto vs requires_approval).",
         "properties": {
+          "capability_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Capability that contributed this tool definition.\n\nReporting uses this attribution only as metadata. It must never contain\ntool arguments, results, prompts, or any other sensitive payload."
+          },
+          "capability_name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Human-readable capability name snapshot for reporting."
+          },
           "destructive": {
             "type": [
               "boolean",


### PR DESCRIPTION
## What
Add reporting analytics for capability usage across the session lifecycle: configured, resolved, exposed, invoked, and effect-run usage.

## Why
EVE-430 needs capability analytics so reporting consumers can understand which capabilities are attached, made available, actually used, and run as effects.

## How
- Add capability attribution to tool definitions and transport it through gRPC/direct worker adapters.
- Emit reporting-only `capability.usage` events from reasoning and attach capability attribution to `tool.completed` events.
- Add `fact_capability_usage`, projector logic, and the `capability_usage` semantic dataset.
- Regenerate OpenAPI for the new event/reporting schema.

## Risk
- Medium
- Reporting projections can break if event payloads drift or if org scoping is wrong. Mitigated by org-scoped joins, idempotent source keys, bounded runtime-emitted records, and focused catalog/runtime tests.

## Security
- Threat categories reviewed: TM-TENANT, TM-API, TM-SQL, TM-OBS, TM-DOS, TM-MCP, TM-TOOL
- Findings and resolutions: facts store only capability/tool identifiers, names, counts, durations, and session dimensions. They intentionally do not store prompts, messages, tool args, or tool results. Projector queries join through session org scope and use `(org_id, source_key)` conflict keys to avoid cross-org overwrite. MCP/scoped-MCP attribution is ID-based and exposes no server secrets.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

Validation:
- `CARGO_INCREMENTAL=0 just pre-push`
- `CARGO_INCREMENTAL=0 cargo test -p everruns-core test_capability_usage_snapshot_keeps_resolved_and_exposed_separate --quiet`
- `CARGO_INCREMENTAL=0 cargo test -p everruns-server domains::reporting::catalog::tests::capability_usage_keeps_kinds_and_tools_separate --quiet`
- `./scripts/export-openapi.sh`
- Smoke: `PORT_PREFIX=430 CARGO_INCREMENTAL=0 just start-dev --no-watch`; verified `GET /health` and `GET /api/v1/reports/catalog` includes `capability_usage`.