### PR TITLE
chore(release): prepare v0.8.30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,54 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- New changes go here. Use `/prepare-release X.Y.Z` to generate draft from commits. -->
 
+## [0.8.30] - 2026-05-11
+
+### Highlights
+
+- **Shared App endpoint auth framework** - App-published endpoints (AG-UI, A2A, webhook) now share a unified inbound auth framework with OIDC/JWT, OAuth2 introspection, HTTP Basic, and mTLS ([#1810](https://github.com/everruns/everruns/pull/1810)).
+- **App channel management redesign** - Apps now ship redesigned channel management with publish guards and aligned schedule channel tools.
+- **Async reporting foundation** - New async reporting subsystem with capability usage analytics, saved reports, and exports.
+- **Source-backed volume sync** - Source-backed volumes can now sync their files and expose source sync controls so agents can reason about and refresh provenance.
+- **A2A capability** - Outbound A2A agent card preview in the UI plus per-channel rate limiting at parity with AG-UI ([#1800](https://github.com/everruns/everruns/pull/1800)).
+- **Session feature flags in CLI** - CLI now supports per-session feature flag overrides ([#1802](https://github.com/everruns/everruns/pull/1802)).
+
+### What's Changed
+
+- feat(deploy): add Railway template ingress scaffold by [@chaliy](https://github.com/chaliy)
+- feat(apps): add endpoint auth for app channels by [@chaliy](https://github.com/chaliy)
+- fix(migrations): restore sequential numbering by [@chaliy](https://github.com/chaliy)
+- feat(apps): redesign app channel management by [@chaliy](https://github.com/chaliy)
+- feat(reporting): add saved reports and exports by [@chaliy](https://github.com/chaliy)
+- feat(reporting): add capability usage analytics by [@chaliy](https://github.com/chaliy)
+- docs(specs): add shared App endpoint auth framework ([#1810](https://github.com/everruns/everruns/pull/1810)) by [@chaliy](https://github.com/chaliy)
+- feat(cli): support session feature flags ([#1802](https://github.com/everruns/everruns/pull/1802)) by [@chaliy](https://github.com/chaliy)
+- fix(ui): fetch A2A agent card preview by [@chaliy](https://github.com/chaliy)
+- feat(ui): preview A2A agent cards by [@chaliy](https://github.com/chaliy)
+- feat(settings): add organization settings groups by [@chaliy](https://github.com/chaliy)
+- chore(deps): bump everruns-sdk to 0.1.9 by [@chaliy](https://github.com/chaliy)
+- feat(a2a): per-channel rate limit (parity with AG-UI) ([#1800](https://github.com/everruns/everruns/pull/1800)) by [@chaliy](https://github.com/chaliy)
+- fix(memory): enforce default-store invariant in storage update ([#1775](https://github.com/everruns/everruns/pull/1775)) by [@chaliy](https://github.com/chaliy)
+- chore(apps): drop unused bare app_id from invocation message metadata ([#1797](https://github.com/everruns/everruns/pull/1797)) by [@chaliy](https://github.com/chaliy)
+- fix(apps): align schedule channel tools by [@chaliy](https://github.com/chaliy)
+- fix(core): harden email recipient validation ([#1780](https://github.com/everruns/everruns/pull/1780)) by [@chaliy](https://github.com/chaliy)
+- fix(volumes): block internal git source URLs ([#1781](https://github.com/everruns/everruns/pull/1781)) by [@chaliy](https://github.com/chaliy)
+- feat(api): add utoipa annotations to A2A admin endpoints ([#1795](https://github.com/everruns/everruns/pull/1795)) by [@chaliy](https://github.com/chaliy)
+- fix(mcp): harden oauth refresh rotation ([#1788](https://github.com/everruns/everruns/pull/1788)) by [@chaliy](https://github.com/chaliy)
+- fix(cursor): verify Valkey tarball integrity ([#1778](https://github.com/everruns/everruns/pull/1778)) by [@chaliy](https://github.com/chaliy)
+- docs(specs): document app-channel session ownership invariant ([#1794](https://github.com/everruns/everruns/pull/1794)) by [@chaliy](https://github.com/chaliy)
+- fix(apps): require channel before publish by [@chaliy](https://github.com/chaliy)
+- feat(volumes): add source sync controls by [@chaliy](https://github.com/chaliy)
+- feat(models): allow editing model provider by [@chaliy](https://github.com/chaliy)
+- fix(apps): remove experimental gate by [@chaliy](https://github.com/chaliy)
+- feat(reporting): build async reporting foundation by [@chaliy](https://github.com/chaliy)
+- fix(ui): handle legacy capability configs by [@chaliy](https://github.com/chaliy)
+- feat(ui): add full-page skill view by [@chaliy](https://github.com/chaliy)
+- fix(memory): resolve configured/default persistent memory store (EVE-459) ([#1783](https://github.com/everruns/everruns/pull/1783)) by [@chaliy](https://github.com/chaliy)
+- fix(mcp): hide HTTP metadata from discovery by [@chaliy](https://github.com/chaliy)
+- fix(apps): accept five-field schedule cron by [@chaliy](https://github.com/chaliy)
+- feat(volumes): sync source-backed volume files by [@chaliy](https://github.com/chaliy)
+- chore(skills): refresh agent-browser skill (observability dashboard) ([#1777](https://github.com/everruns/everruns/pull/1777)) by [@chaliy](https://github.com/chaliy)
+
 ## [0.8.29] - 2026-05-08
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1991,11 +1991,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-a2ui"
-version = "0.8.29"
+version = "0.8.30"
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2014,7 +2014,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-cli"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2041,14 +2041,14 @@ dependencies = [
 
 [[package]]
 name = "everruns-config"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "everruns-container-sandbox"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2069,7 +2069,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -2126,7 +2126,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-durable"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2161,7 +2161,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-gemini"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2179,7 +2179,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-brave-search"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2195,7 +2195,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-browserless"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2216,7 +2216,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-cursor"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2231,7 +2231,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2247,7 +2247,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-deno"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2271,7 +2271,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-docker"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2286,7 +2286,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2301,7 +2301,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-e2b"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2330,7 +2330,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-parallel"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2342,7 +2342,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-pi"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2357,7 +2357,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-sprites"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2373,7 +2373,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-internal-protocol"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "chrono",
  "everruns-core",
@@ -2390,7 +2390,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-macros"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2400,7 +2400,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2422,11 +2422,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-openui"
-version = "0.8.29"
+version = "0.8.30"
 
 [[package]]
 name = "everruns-runtime"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2460,7 +2460,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-server"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "aes-gcm",
  "ag-ui-core",
@@ -2550,7 +2550,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-session-sqldb"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2569,7 +2569,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-worker"
-version = "0.8.29"
+version = "0.8.30"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3202,9 +3202,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
@@ -3412,9 +3412,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
  "typenum",
 ]
@@ -3758,7 +3758,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -4055,9 +4055,9 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "10.3.0"
+version = "10.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
+checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
 dependencies = [
  "aws-lc-rs",
  "base64 0.22.1",
@@ -4068,6 +4068,7 @@ dependencies = [
  "serde_json",
  "signature",
  "simple_asn1",
+ "zeroize",
 ]
 
 [[package]]
@@ -4131,9 +4132,9 @@ dependencies = [
 
 [[package]]
 name = "kqueue-sys"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7b65860415f949f23fa882e669f2dbd4a0f0eeb1acdd56790b30494afd7da2f"
+checksum = "285efcf12ef41bec907b3000d5ffaeb54191d4d9d83c0d6157e6cbc2db255e64"
 dependencies = [
  "bitflags 2.11.1",
  "libc",
@@ -5445,9 +5446,9 @@ dependencies = [
 
 [[package]]
 name = "prefix-trie"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f561214012d3fc240a1f9c817cc4d57f5310910d066069c1b093f766bb5966"
+checksum = "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7"
 dependencies = [
  "either",
  "ipnet",
@@ -9436,6 +9437,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.8.29"
+version = "0.8.30"
 edition = "2024"
 license = "MIT"
 authors = ["Everruns Contributors"]

--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "everruns-ui",
-  "version": "0.8.29",
+  "version": "0.8.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "everruns-ui",
-      "version": "0.8.29",
+      "version": "0.8.30",
       "dependencies": {
         "@base-ui/react": "^1.2.0",
         "@openuidev/react-lang": "^0.1.3",
@@ -11969,6 +11969,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "everruns-ui",
-  "version": "0.8.29",
+  "version": "0.8.30",
   "private": true,
   "exports": {
     "./route-manifest": "./src/lib/ui-route-manifest.ts",


### PR DESCRIPTION
## Release v0.8.30

This PR prepares the v0.8.30 release.

### Checklist
- [x] Bump `workspace.package.version` to 0.8.30 in `Cargo.toml`
- [x] Bump `version` to 0.8.30 in `apps/ui/package.json`
- [x] Regenerate `Cargo.lock` and `apps/ui/package-lock.json`
- [x] Add `[0.8.30]` section to `CHANGELOG.md`
- [ ] CI passes

### Post-merge
After merging, the release workflow will automatically:
- Create git tag `v0.8.30`
- Create GitHub Release with notes from CHANGELOG.md
- Trigger Docker image build with `v0.8.30` and `latest` tags
- Build and publish CLI binaries (macOS x86_64/aarch64, Linux x86_64) and update the Homebrew tap


---
_Generated by [Claude Code](https://claude.ai/code/session_01DxmsMR4RTFFNQfahZetgH4)_