### PR TITLE
fix(reporting): make outbox enqueue best-effort on event/session/llm writes

### DIFF
--- a/crates/server/src/storage/repositories/events.rs
+++ b/crates/server/src/storage/repositories/events.rs
@@ -89,7 +89,10 @@ impl Database {
         // "If an outbox write fails after canonical state commits, a periodic
         // reconciler must be able to discover and enqueue missing projection
         // work from canonical tables." Never fail the canonical event write
-        // because the reporting projector queue is unavailable.
+        // because the reporting projector queue is unavailable. No reconciler
+        // job exists yet (tracked separately); until it lands, a failed
+        // enqueue means the corresponding fact will remain stale until the
+        // canonical row is touched again and the next enqueue succeeds.
         if let Err(e) = sqlx::query(
             r#"
             INSERT INTO reporting_outbox (
@@ -107,12 +110,23 @@ impl Database {
         .execute(&self.pool)
         .await
         {
+            // Look up org_id for log correlation. Failure to resolve is
+            // expected when sessions row is gone or pool is unhealthy; we
+            // still log the underlying error and don't propagate.
+            let org_id: Option<i64> =
+                sqlx::query_scalar::<_, i64>("SELECT org_id FROM sessions WHERE id = $1")
+                    .bind(row.session_id.uuid())
+                    .fetch_optional(&self.pool)
+                    .await
+                    .ok()
+                    .flatten();
             warn!(
                 event_id = %row.id.uuid(),
                 session_id = %row.session_id.uuid(),
+                org_id = ?org_id,
                 event_type = %row.event_type,
                 error = %e,
-                "reporting outbox enqueue failed; event persisted, projection will be reconciled"
+                "reporting outbox enqueue failed; event persisted, projection may remain stale until reconciliation lands or the source row is updated again"
             );
         }
 

--- a/crates/server/src/storage/repositories/events.rs
+++ b/crates/server/src/storage/repositories/events.rs
@@ -6,6 +6,7 @@ use anyhow::Result;
 use chrono::{DateTime, Utc};
 use everruns_core::message_filter::{MessageFilter, MessageQuery};
 use everruns_core::typed_id::{EventId, SessionId};
+use tracing::warn;
 use uuid::Uuid;
 
 /// Shared filter builder for `list_events_advanced` (and its `around_id` branch).
@@ -84,7 +85,12 @@ impl Database {
         .fetch_one(&self.pool)
         .await?;
 
-        sqlx::query(
+        // Reporting outbox enqueue is best-effort per specs/reporting.md:
+        // "If an outbox write fails after canonical state commits, a periodic
+        // reconciler must be able to discover and enqueue missing projection
+        // work from canonical tables." Never fail the canonical event write
+        // because the reporting projector queue is unavailable.
+        if let Err(e) = sqlx::query(
             r#"
             INSERT INTO reporting_outbox (
                 org_id, source_type, source_id, source_version, reason, status, next_attempt_at
@@ -99,7 +105,16 @@ impl Database {
         .bind(row.id.uuid().to_string())
         .bind(row.session_id.uuid())
         .execute(&self.pool)
-        .await?;
+        .await
+        {
+            warn!(
+                event_id = %row.id.uuid(),
+                session_id = %row.session_id.uuid(),
+                event_type = %row.event_type,
+                error = %e,
+                "reporting outbox enqueue failed; event persisted, projection will be reconciled"
+            );
+        }
 
         Ok(row)
     }

--- a/crates/server/src/storage/repositories/llm.rs
+++ b/crates/server/src/storage/repositories/llm.rs
@@ -510,8 +510,9 @@ impl Database {
         .await?;
 
         // Reporting outbox enqueue is best-effort (see specs/reporting.md).
-        // The canonical llm_generations row is already durable; reporting
-        // facts will be reconciled from canonical state on failure.
+        // The canonical llm_generations row is already durable; no reconciler
+        // exists yet (tracked separately), so on failure the corresponding
+        // fact will remain stale until reconciliation lands.
         if let Err(e) = self
             .enqueue_reporting_outbox(
                 org_id,
@@ -526,7 +527,7 @@ impl Database {
                 generation_id = %id,
                 org_id,
                 error = %e,
-                "reporting outbox enqueue failed for llm_generation; projection will be reconciled"
+                "reporting outbox enqueue failed for llm_generation; projection may remain stale until reconciliation lands"
             );
         }
 
@@ -563,8 +564,10 @@ impl Database {
         .await?;
 
         // Reporting outbox enqueue is best-effort (see specs/reporting.md).
-        // The canonical session totals are already committed; reporting facts
-        // will be reconciled from canonical state on failure.
+        // The canonical session totals are already committed; no reconciler
+        // exists yet (tracked separately), so on failure the corresponding
+        // fact will remain stale until reconciliation lands or the session
+        // totals are updated again and the next enqueue succeeds.
         if let Err(e) = self
             .enqueue_reporting_outbox(
                 row.0,
@@ -579,7 +582,7 @@ impl Database {
                 session_id = %row.1,
                 org_id = row.0,
                 error = %e,
-                "reporting outbox enqueue failed for session snapshot; projection will be reconciled"
+                "reporting outbox enqueue failed for session snapshot; projection may remain stale until reconciliation lands or the source row is updated again"
             );
         }
 

--- a/crates/server/src/storage/repositories/llm.rs
+++ b/crates/server/src/storage/repositories/llm.rs
@@ -3,6 +3,7 @@
 use super::super::models::*;
 use super::Database;
 use anyhow::Result;
+use tracing::warn;
 
 use uuid::Uuid;
 
@@ -508,14 +509,26 @@ impl Database {
         .fetch_one(&self.pool)
         .await?;
 
-        self.enqueue_reporting_outbox(
-            org_id,
-            "llm_generation",
-            &id.to_string(),
-            Some(&id.to_string()),
-            "llm_generation_projection",
-        )
-        .await?;
+        // Reporting outbox enqueue is best-effort (see specs/reporting.md).
+        // The canonical llm_generations row is already durable; reporting
+        // facts will be reconciled from canonical state on failure.
+        if let Err(e) = self
+            .enqueue_reporting_outbox(
+                org_id,
+                "llm_generation",
+                &id.to_string(),
+                Some(&id.to_string()),
+                "llm_generation_projection",
+            )
+            .await
+        {
+            warn!(
+                generation_id = %id,
+                org_id,
+                error = %e,
+                "reporting outbox enqueue failed for llm_generation; projection will be reconciled"
+            );
+        }
 
         Ok(())
     }
@@ -549,14 +562,26 @@ impl Database {
         .fetch_one(&self.pool)
         .await?;
 
-        self.enqueue_reporting_outbox(
-            row.0,
-            "session",
-            &row.1.to_string(),
-            Some(&row.2.to_rfc3339()),
-            "session_snapshot",
-        )
-        .await?;
+        // Reporting outbox enqueue is best-effort (see specs/reporting.md).
+        // The canonical session totals are already committed; reporting facts
+        // will be reconciled from canonical state on failure.
+        if let Err(e) = self
+            .enqueue_reporting_outbox(
+                row.0,
+                "session",
+                &row.1.to_string(),
+                Some(&row.2.to_rfc3339()),
+                "session_snapshot",
+            )
+            .await
+        {
+            warn!(
+                session_id = %row.1,
+                org_id = row.0,
+                error = %e,
+                "reporting outbox enqueue failed for session snapshot; projection will be reconciled"
+            );
+        }
 
         Ok(())
     }

--- a/crates/server/src/storage/repositories/sessions.rs
+++ b/crates/server/src/storage/repositories/sessions.rs
@@ -8,6 +8,7 @@ use chrono::{DateTime, Utc};
 use everruns_core::AgentIdentityId;
 use everruns_core::PrincipalId;
 use everruns_core::typed_id::{AgentId, HarnessId, SessionId};
+use tracing::warn;
 use uuid::Uuid;
 
 impl Database {
@@ -49,14 +50,26 @@ impl Database {
         .fetch_one(&self.pool)
         .await?;
 
-        self.enqueue_reporting_outbox(
-            row.org_id,
-            "session",
-            &row.id.uuid().to_string(),
-            Some(&row.updated_at.to_rfc3339()),
-            "session_snapshot",
-        )
-        .await?;
+        // Reporting outbox enqueue is best-effort (see specs/reporting.md).
+        // The canonical session row is durable; reporting facts will be
+        // reconciled from canonical state if the projector queue is down.
+        if let Err(e) = self
+            .enqueue_reporting_outbox(
+                row.org_id,
+                "session",
+                &row.id.uuid().to_string(),
+                Some(&row.updated_at.to_rfc3339()),
+                "session_snapshot",
+            )
+            .await
+        {
+            warn!(
+                session_id = %row.id.uuid(),
+                org_id = row.org_id,
+                error = %e,
+                "reporting outbox enqueue failed for session create; projection will be reconciled"
+            );
+        }
 
         Ok(row)
     }

--- a/crates/server/src/storage/repositories/sessions.rs
+++ b/crates/server/src/storage/repositories/sessions.rs
@@ -51,8 +51,10 @@ impl Database {
         .await?;
 
         // Reporting outbox enqueue is best-effort (see specs/reporting.md).
-        // The canonical session row is durable; reporting facts will be
-        // reconciled from canonical state if the projector queue is down.
+        // The canonical session row is durable; no reconciler exists yet
+        // (tracked separately), so on failure the corresponding fact will
+        // remain stale until reconciliation lands or the session row is
+        // updated again and the next enqueue succeeds.
         if let Err(e) = self
             .enqueue_reporting_outbox(
                 row.org_id,
@@ -67,7 +69,7 @@ impl Database {
                 session_id = %row.id.uuid(),
                 org_id = row.org_id,
                 error = %e,
-                "reporting outbox enqueue failed for session create; projection will be reconciled"
+                "reporting outbox enqueue failed for session create; projection may remain stale until reconciliation lands"
             );
         }
 


### PR DESCRIPTION
## What
Make `reporting_outbox` enqueue best-effort on the four call sites that currently couple the outbox INSERT to a canonical write via `?`-propagated errors:
- `crates/server/src/storage/repositories/events.rs::create_event`
- `crates/server/src/storage/repositories/llm.rs::create_llm_generation`
- `crates/server/src/storage/repositories/llm.rs::increment_session_usage`
- `crates/server/src/storage/repositories/sessions.rs::create_session`

Each enqueue is now wrapped in a tolerant `if let Err(...)` that logs a structured `warn!` (`event_id` / `session_id` / `org_id` / underlying error) and returns the canonical row successfully.

## Why
This is the leading suspect for **EVE-472** (P0): all agent chat replies on `dev.everruns.com` v0.8.30 return the canned `"I encountered an error..."` fallback. The error message is the DLQ-handler fallback in `crates/worker/src/durable_worker.rs::emit_dlq_error_event`, so every reason/act task is exhausting all retries.

Commit 7a4b46a (`feat(reporting): build async reporting foundation`) introduced an unconditional `INSERT INTO reporting_outbox` immediately after the canonical `INSERT INTO events` in `create_event`, with `?`-propagated error handling. Any outbox-side failure (missing/migrated table edge case, FK violation, deadlock, projector restart, schema drift) therefore fails the canonical event write and bubbles up through reason/act activities until DLQ.

`specs/reporting.md` is explicit about the intended contract:

> "Outbox writes must be small and transactionally tied to the canonical source when practical. If an outbox write fails after canonical state commits, a periodic reconciler must be able to discover and enqueue missing projection work from canonical tables."

The current implementation violates that contract. This PR restores it.

## How
- Replaced `await?` on outbox enqueues with `if let Err(e) = ... { warn!(...) }` at each call site.
- Each log line carries the canonical row identifier (`event_id` / `session_id` / `org_id` / `generation_id`) plus the underlying error so operators can correlate to `reporting_outbox.last_error` rows or external monitoring.
- No change to `enqueue_reporting_outbox` itself — the strictness/policy decision stays at each call site. Future call sites can choose strict (`?`) or tolerant (`if let Err`) as fits the surface.
- No change to `crates/server/src/storage/repositories/budgets.rs`: the ledger ↔ outbox INSERT runs inside an explicit `tx` for atomic financial accounting and is intentionally strict.

## Risk
- **Low.**
- Reporting projections may briefly drift from canonical state if outbox enqueue fails; the existing reconciliation invariant (and the future periodic reconciler in the spec) close that gap. With no implemented reconciler yet, repeated outbox failures will leak rows from facts — but that is far less bad than the current state where the same failures kill chat entirely.
- Surface area is three files; no public API change; no schema change; no migration.
- Build: `cargo check -p everruns-server` green; `cargo clippy -p everruns-server -- -D warnings` clean; `./scripts/lib/pre-push.sh` all 8 checks pass.
- Existing tests are unaffected: `repository_integration_test.rs` exercises the happy path (outbox INSERT succeeds), which still returns `Ok(row)`.

## Security
- **Threat categories reviewed**: TM-DATA (no PII exposure — the new `warn!` log lines contain `Uuid` ids, `event_type`, and the sqlx error; sqlx errors do not include user-supplied content), TM-API (no API surface change), TM-AUTH (no change to authz path), TM-DOS (this strictly reduces blast radius — a noisy reporting projector or stuck outbox row can no longer take down chat).
- **Findings and resolutions**: None. The log fields are operational metadata, not sensitive data. The change is strictly defensive.

## Follow-ups
- Implement the periodic reconciler referenced in `specs/reporting.md` so projection drift from tolerated outbox failures self-heals without operator action. Out of scope here; should be its own PR once the failure mode in EVE-472 is confirmed and root-caused on the dev VPS.
- Confirm via dev VPS logs (`journalctl -u everruns-worker --since "2026-05-12 05:50:00" --until "2026-05-12 06:20:00" | grep "Task execution failed"`) whether the underlying error is in fact a reporting_outbox error. If not, EVE-472 has a different root cause and this PR still stands on its own as a spec-compliance fix.

## Checklist
- [x] Tests added or updated — N/A: the change is a defensive `if let Err` around an existing call site; postgres-only paths are covered by existing integration tests which still exercise the happy path. A negative-path test (outbox table missing) would require destructive schema manipulation mid-test and was not added.
- [x] Backward compatibility considered — no API, schema, or wire change.
- [x] Security review performed against relevant threat model categories.
- [ ] All review comments addressed (code change or written reasoning).


---
_Generated by [Claude Code](https://claude.ai/code/session_019xeqNE7edqME7gBNbcmuNT)_