### PR TITLE
fix(core): classify OpenAI insufficient_quota as provider_misconfigured

### DIFF
--- a/crates/core/src/user_facing_error.rs
+++ b/crates/core/src/user_facing_error.rs
@@ -200,6 +200,20 @@ pub fn classify_runtime_error_message(
             .with_optional_field("model_id", context.model_id.clone());
     }
 
+    // OpenAI surfaces an exhausted-billing state as HTTP 429 + body
+    // `{"error":{"type":"insufficient_quota",...}}`. The "(429)" prefix would
+    // otherwise route it to PROVIDER_RATE_LIMITED ("wait a moment"), but the
+    // condition is non-transient and needs operator action (top up the
+    // account or rotate the key), so classify it as PROVIDER_MISCONFIGURED.
+    if lower.contains("insufficient_quota")
+        || lower.contains("insufficient quota")
+        || lower.contains("exceeded your current quota")
+    {
+        return UserFacingError::new(codes::PROVIDER_MISCONFIGURED)
+            .with_optional_field("provider", context.provider.clone())
+            .with_optional_field("model_id", context.model_id.clone());
+    }
+
     if lower.contains("(429)")
         || lower.contains("rate limit")
         || lower.contains("too many requests")
@@ -411,6 +425,38 @@ mod tests {
         assert_eq!(string_field(&error.fields, "provider"), Some("openai"));
         assert_eq!(string_field(&error.fields, "model_id"), Some("gpt-5"));
         assert_eq!(number_field(&error.fields, "retry_after"), Some(7.0));
+    }
+
+    #[test]
+    fn classify_openai_insufficient_quota_as_provider_misconfigured() {
+        // OpenAI's exhausted-billing 429 needs operator action (top up or
+        // rotate key), not the transient "rate limited, wait a moment" copy.
+        let error = classify_runtime_error_message(
+            "ReasonAtom execution failed: OpenAI API error (429): {\"error\":{\"message\":\"You exceeded your current quota, please check your plan and billing details.\",\"type\":\"insufficient_quota\",\"code\":\"insufficient_quota\"}}",
+            &UserFacingErrorContext::default()
+                .with_provider("openai")
+                .with_model_id("gpt-4.1-mini"),
+        );
+
+        assert_eq!(error.code, codes::PROVIDER_MISCONFIGURED);
+        assert_eq!(string_field(&error.fields, "provider"), Some("openai"));
+        assert_eq!(
+            string_field(&error.fields, "model_id"),
+            Some("gpt-4.1-mini")
+        );
+    }
+
+    #[test]
+    fn classify_insufficient_quota_without_status_prefix() {
+        // Even if upstream wrapping drops the "(429)" prefix, the explicit
+        // quota substring must still route to PROVIDER_MISCONFIGURED rather
+        // than the canned PROCESSING_ERROR fallback (EVE-472).
+        let error = classify_runtime_error_message(
+            "LLM error: insufficient_quota: You exceeded your current quota.",
+            &UserFacingErrorContext::default(),
+        );
+
+        assert_eq!(error.code, codes::PROVIDER_MISCONFIGURED);
     }
 
     #[test]

--- a/crates/server/src/api/ag_ui.rs
+++ b/crates/server/src/api/ag_ui.rs
@@ -2230,8 +2230,9 @@ mod tests {
     #[tokio::test]
     async fn turn_failed_zero_credits_does_not_leak_quota_details() {
         // OpenAI surfaces "no credits" as 429 + insufficient_quota; classifier
-        // currently maps it to PROVIDER_RATE_LIMITED. Either way, the public
-        // channel must not echo the raw provider body.
+        // maps it to PROVIDER_MISCONFIGURED (operator must top up or rotate
+        // the key). Either way, the public channel must not echo the raw
+        // provider body.
         let mut state = test_stream_state().await;
         let raw_error = "OpenAI API error (429): {\"error\":{\"message\":\"You exceeded your current quota, please check your plan and billing details.\",\"type\":\"insufficient_quota\",\"code\":\"insufficient_quota\"}}";
         let event = turn_failed_event(
@@ -2239,7 +2240,7 @@ mod tests {
             TurnFailedData {
                 turn_id: TurnId::new(),
                 error: raw_error.to_string(),
-                error_code: Some(user_facing_error_codes::PROVIDER_RATE_LIMITED.to_string()),
+                error_code: Some(user_facing_error_codes::PROVIDER_MISCONFIGURED.to_string()),
                 error_fields: None,
             },
         );


### PR DESCRIPTION
## What

Add explicit detection for OpenAI's `insufficient_quota` / "exceeded your current quota" substrings in `classify_runtime_error_message`, routed to `PROVIDER_MISCONFIGURED` ahead of the generic `(429)` rate-limit gate. Update the AG-UI `turn_failed_zero_credits_does_not_leak_quota_details` test to expect the new code (the public translation copy is unchanged: "The service is temporarily unavailable. Please try again shortly.").

## Why

EVE-472: every chat on `dev.everruns.com` returns the canned `"I encountered an error while processing your request. Please try again later."` fallback. Operator-side root cause is the dev OpenAI key sitting at `insufficient_quota` (HTTP 429), but the OSS classifier mishandles this state two ways:

1. When the `(429)` token survives upstream wrapping, the message lands in `PROVIDER_RATE_LIMITED` → "Rate limited by the AI provider. Please wait a moment." That copy implies a transient retry; the condition is actually non-transient and needs an operator (top up the OpenAI account or rotate the key).
2. When the `(429)` token is dropped along the chain (wrappers, truncation, streaming paths), nothing else in the classifier matches and the message falls through to `PROCESSING_ERROR` — the canned generic string seen on dev.

Matching on the `insufficient_quota` literal in the body covers both shapes and gives operators a clearer signal (`provider_misconfigured`) without changing the public-safe user copy.

## How

- `crates/core/src/user_facing_error.rs`: new branch in `classify_runtime_error_message` matching `insufficient_quota`, `insufficient quota`, or `exceeded your current quota` (case-insensitive on the lowered chain) → `PROVIDER_MISCONFIGURED`, placed before the existing `(429)` / rate-limit match so the more specific billing-exhausted signal wins.
- Two regression tests: one with the real OpenAI 429 body shape, one with the `(429)` prefix dropped to prove the substring match works on its own.
- `crates/server/src/api/ag_ui.rs`: update `turn_failed_zero_credits_does_not_leak_quota_details` to seed the event with `PROVIDER_MISCONFIGURED` (matching the new classifier output) and refresh the stale comment. The leak-prevention assertions are unchanged and still pass.

## Validation

- `cargo test -p everruns-core --lib user_facing_error` — 8 passed (2 new + 6 existing)
- `cargo test -p everruns-worker --lib task_error` — 20 passed (unchanged classification on existing chains)
- `cargo test -p everruns-server --lib api::ag_ui::tests::turn_failed` — 5 passed, including the leak-prevention assertions for the zero-credits case under the new code
- `cargo fmt --check` — clean
- `cargo clippy -p everruns-core --lib --all-features -- -D warnings` — clean
- `cargo clippy -p everruns-server --lib --all-features -- -D warnings` — clean
- `bash scripts/lib/check-migration-ordering.sh` — sequential 001..042

End-to-end smoke skipped intentionally: this is a pure routing change in the error classifier. The full path (worker DLQ wraps the error → `user_facing_failure` → `classify_runtime_error_message` → `Message::assistant(fallback_message())` → AG-UI translation via `PublicError::from_internal_code`) is already covered by unit tests in `crates/worker/src/task_error.rs` and `crates/server/src/api/ag_ui.rs`, and no runtime, schema, or transport behavior changed.

## Risk

- **Low**. Additive classifier branch placed before an existing match. Worst plausible impact: a previously-correct rate-limit message changes to a misconfiguration message for an error chain that happens to contain `insufficient_quota` — by construction that string only appears in OpenAI's billing-exhausted body, so the new copy is more accurate.
- No public-facing copy change: `PublicError::from_internal_code(PROVIDER_MISCONFIGURED)` already returns "The service is temporarily unavailable. Please try again shortly." (same string used for 401/403 paths).
- Internal `output.message.completed` for authenticated `/chat` shifts from "Rate limited..." to "There is a misconfiguration with the AI provider. Please contact support." — desired behavior change.

## Security

- **Threat categories reviewed**: TM-LLM (error classification of LLM provider responses), TM-API (no API surface changes), TM-AUTHZ (no permission changes), TM-WEB (no rendering changes).
- **Findings**: None. The classifier operates on backend `anyhow::chain()` output, not user input, so no new injection vector. The `turn_failed_zero_credits_does_not_leak_quota_details` test still asserts that the public AG-UI message contains no "OpenAI", "quota", or "429" substring — passes unchanged. The internal `fallback_message()` for `PROVIDER_MISCONFIGURED` is a constant string with no user data.

## Follow-ups

- **OpenAI driver fail-fast on `insufficient_quota`**: `crates/core/src/openai_protocol.rs` currently treats every 429 as transient and burns `max_retries` cycles before surfacing the error. An `insufficient_quota` body is permanent and should short-circuit retries. Safe to defer because the user-facing outcome is identical after this PR (operator-action signal), only retry latency suffers; worth a small follow-up issue.
- **Smoke-test assertion on assistant content**: EVE-472 comment notes that `scripts/smoke-test.sh` case `[9/9]` asserts the AG-UI stream reaches `RUN_FINISHED` but not that the assistant content is real — it stayed green while every chat was returning the canned fallback. Tightening that assertion to fail when `TEXT_MESSAGE_CONTENT` matches `UserFacingError::fallback_message` for `PROCESSING_ERROR` is in EVE-473's territory (`scripts/smoke-test.sh [9/9]`, PR #210); defer to that issue rather than duplicating here.
- **Operational fix for dev.everruns.com**: the actual chat outage requires topping up the OpenAI account behind `OPENAI_API_KEY` in Doppler `everruns-dev / dev` (or rotating to a funded key) — pure ops, no code change. Tracked separately in EVE-472 asks #1-3.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered (additive routing change; public copy unchanged)
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)


---
_Generated by [Claude Code](https://claude.ai/code/session_01VvKX82Dk1KLSXfKp1jk4KJ)_