### PR TITLE
fix(server): block DNS-rebinding SSRF in endpoint auth

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -412,7 +412,7 @@ pub use permissions::{
 pub use dependency_blocker::{DependencyBlocker, detect_dependency_blocker};
 
 // URL validation re-exports
-pub use url_validation::{UrlValidationError, validate_safe_url};
+pub use url_validation::{UrlValidationError, is_blocked_ip, validate_safe_url};
 
 // Deployment configuration
 pub use deployment::DeploymentGrade;

--- a/crates/core/src/url_validation.rs
+++ b/crates/core/src/url_validation.rs
@@ -100,8 +100,13 @@ fn is_blocked_host(host: &str) -> bool {
     false
 }
 
-/// Check if an IP address is in a blocked range.
-fn is_blocked_ip(ip: IpAddr) -> bool {
+/// Check if an IP address is in a blocked range (loopback, private, link-local,
+/// CGNAT, documentation, IPv4-mapped IPv6 variants of any of those).
+///
+/// Use this for runtime DNS-pinned checks where the caller has already resolved
+/// a hostname to its actual address. Static URL/hostname checks should use
+/// [`validate_safe_url`] instead.
+pub fn is_blocked_ip(ip: IpAddr) -> bool {
     match ip {
         IpAddr::V4(v4) => is_blocked_ipv4(v4),
         IpAddr::V6(v6) => is_blocked_ipv6(v6),

--- a/crates/server/src/api/app_endpoint_auth.rs
+++ b/crates/server/src/api/app_endpoint_auth.rs
@@ -6,6 +6,7 @@
 // AG-UI/A2A ingress behavior.
 
 use std::collections::HashSet;
+use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -27,7 +28,10 @@ use crate::storage::password::verify_password;
 
 #[derive(Clone)]
 pub struct AppEndpointAuthVerifier {
-    http: reqwest::Client,
+    // Outbound HTTP clients are built per-request via `build_pinned_client` so
+    // each request can pin reqwest's DNS resolution to addresses we just
+    // validated, eliminating the rebinding TOCTOU window. The struct only
+    // carries the discovery/JWKS response caches across calls.
     discovery_cache: Cache<String, OidcDiscovery>,
     jwks_cache: Cache<String, Arc<JwkSet>>,
 }
@@ -41,11 +45,6 @@ impl Default for AppEndpointAuthVerifier {
 impl AppEndpointAuthVerifier {
     pub fn new() -> Self {
         Self {
-            http: reqwest::Client::builder()
-                .redirect(reqwest::redirect::Policy::none())
-                .timeout(Duration::from_secs(5))
-                .build()
-                .expect("app endpoint auth HTTP client builds"),
             discovery_cache: Cache::builder()
                 .time_to_live(Duration::from_secs(15 * 60))
                 .max_capacity(256)
@@ -196,10 +195,10 @@ impl AppEndpointAuthVerifier {
         else {
             return Err(AppEndpointAuthError::Misconfigured);
         };
-        validate_resolved_safe_url(introspection_url)
+        let client = build_pinned_client(introspection_url)
             .await
             .map_err(|_| AppEndpointAuthError::Misconfigured)?;
-        let mut req = self.http.post(introspection_url).form(&[("token", token)]);
+        let mut req = client.post(introspection_url).form(&[("token", token)]);
         if let Some(client_id) = client_id.as_deref().filter(|id| !id.is_empty()) {
             req = if let Some(secret) = client_secret.as_deref() {
                 req.basic_auth(client_id, Some(secret))
@@ -260,15 +259,17 @@ impl AppEndpointAuthVerifier {
         if let Some(discovery) = self.discovery_cache.get(&issuer).await {
             return Ok(discovery);
         }
-        validate_resolved_safe_url(&issuer)
+        // Validate the issuer URL itself even though we don't hit it directly:
+        // misconfigured private/loopback issuers should fail fast before we
+        // construct any derived URL.
+        resolve_and_validate(&issuer)
             .await
             .map_err(|_| AppEndpointAuthError::Misconfigured)?;
         let url = format!("{issuer}/.well-known/openid-configuration");
-        validate_resolved_safe_url(&url)
+        let client = build_pinned_client(&url)
             .await
             .map_err(|_| AppEndpointAuthError::Misconfigured)?;
-        let discovery = self
-            .http
+        let discovery = client
             .get(&url)
             .send()
             .await
@@ -278,7 +279,8 @@ impl AppEndpointAuthVerifier {
             .json::<OidcDiscovery>()
             .await
             .map_err(|_| AppEndpointAuthError::ProviderUnavailable)?;
-        validate_resolved_safe_url(&discovery.jwks_uri)
+        // Early-fail on a misconfigured jwks_uri before caching the discovery.
+        resolve_and_validate(&discovery.jwks_uri)
             .await
             .map_err(|_| AppEndpointAuthError::Misconfigured)?;
         self.discovery_cache.insert(issuer, discovery.clone()).await;
@@ -289,11 +291,10 @@ impl AppEndpointAuthVerifier {
         if let Some(jwks) = self.jwks_cache.get(jwks_url).await {
             return Ok(jwks);
         }
-        validate_resolved_safe_url(jwks_url)
+        let client = build_pinned_client(jwks_url)
             .await
             .map_err(|_| AppEndpointAuthError::Misconfigured)?;
-        let jwks = self
-            .http
+        let jwks = client
             .get(jwks_url)
             .send()
             .await
@@ -336,30 +337,67 @@ fn normalize_issuer(issuer: &str) -> String {
 // Cap DNS resolution to the same budget as the outbound HTTP request so a slow
 // or stuck resolver cannot stall auth verification past the overall timeout.
 const DNS_LOOKUP_TIMEOUT: Duration = Duration::from_secs(5);
+const HTTP_REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
 
-async fn validate_resolved_safe_url(raw_url: &str) -> Result<(), ()> {
+/// Result of resolving and validating an outbound auth-provider URL.
+///
+/// For hostnames we hold the pre-validated socket addresses so the actual HTTP
+/// request can pin DNS to those exact IPs (closing the TOCTOU window where a
+/// rebinding attacker could flip the DNS answer between validation and
+/// connect). For URLs that already use a literal IP, `addrs` is empty because
+/// [`validate_safe_url`] already classified the address.
+struct ResolvedTarget {
+    host: Option<String>,
+    addrs: Vec<SocketAddr>,
+}
+
+async fn resolve_and_validate(raw_url: &str) -> Result<ResolvedTarget, ()> {
     let url = validate_safe_url(raw_url).map_err(|_| ())?;
     let host = url.host().ok_or(())?;
     if matches!(host, Host::Ipv4(_) | Host::Ipv6(_)) {
-        return Ok(());
+        return Ok(ResolvedTarget {
+            host: None,
+            addrs: Vec::new(),
+        });
     }
     let port = url.port_or_known_default().ok_or(())?;
     let host = host.to_string();
-    let resolved = timeout(DNS_LOOKUP_TIMEOUT, lookup_host((host.as_str(), port)))
+    let resolved: Vec<SocketAddr> = timeout(DNS_LOOKUP_TIMEOUT, lookup_host((host.as_str(), port)))
         .await
         .map_err(|_| ())?
-        .map_err(|_| ())?;
-    let mut found = false;
-    for addr in resolved {
-        found = true;
+        .map_err(|_| ())?
+        .collect();
+    if resolved.is_empty() {
+        return Err(());
+    }
+    for addr in &resolved {
         if is_blocked_ip(addr.ip()) {
             return Err(());
         }
     }
-    if !found {
-        return Err(());
+    Ok(ResolvedTarget {
+        host: Some(host),
+        addrs: resolved,
+    })
+}
+
+/// Build a one-shot HTTP client whose DNS resolution is pinned to addresses we
+/// just validated. This eliminates the TOCTOU window where reqwest's own
+/// resolver could otherwise reach a different (and now-private) address than
+/// the one we checked.
+fn pinned_http_client(target: &ResolvedTarget) -> Result<reqwest::Client, ()> {
+    let mut builder = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .timeout(HTTP_REQUEST_TIMEOUT);
+    if let Some(host) = target.host.as_deref() {
+        builder = builder.resolve_to_addrs(host, &target.addrs);
     }
-    Ok(())
+    builder.build().map_err(|_| ())
+}
+
+async fn build_pinned_client(raw_url: &str) -> Result<reqwest::Client, ()> {
+    let target = resolve_and_validate(raw_url).await?;
+    pinned_http_client(&target)
 }
 
 fn is_public_key_algorithm(alg: Algorithm) -> bool {
@@ -601,29 +639,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn validate_resolved_safe_url_rejects_literal_loopback() {
-        assert!(
-            validate_resolved_safe_url("http://127.0.0.1/")
-                .await
-                .is_err()
-        );
-        assert!(validate_resolved_safe_url("http://[::1]/").await.is_err());
+    async fn resolve_and_validate_rejects_literal_loopback() {
+        assert!(resolve_and_validate("http://127.0.0.1/").await.is_err());
+        assert!(resolve_and_validate("http://[::1]/").await.is_err());
     }
 
     #[tokio::test]
-    async fn validate_resolved_safe_url_rejects_literal_private_ranges() {
+    async fn resolve_and_validate_rejects_literal_private_ranges() {
+        assert!(resolve_and_validate("http://10.0.0.1/").await.is_err());
+        assert!(resolve_and_validate("http://192.168.1.1/").await.is_err());
         assert!(
-            validate_resolved_safe_url("http://10.0.0.1/")
-                .await
-                .is_err()
-        );
-        assert!(
-            validate_resolved_safe_url("http://192.168.1.1/")
-                .await
-                .is_err()
-        );
-        assert!(
-            validate_resolved_safe_url("http://169.254.169.254/")
+            resolve_and_validate("http://169.254.169.254/")
                 .await
                 .is_err()
         );

--- a/crates/server/src/api/app_endpoint_auth.rs
+++ b/crates/server/src/api/app_endpoint_auth.rs
@@ -602,14 +602,26 @@ mod tests {
 
     #[tokio::test]
     async fn validate_resolved_safe_url_rejects_literal_loopback() {
-        assert!(validate_resolved_safe_url("http://127.0.0.1/").await.is_err());
+        assert!(
+            validate_resolved_safe_url("http://127.0.0.1/")
+                .await
+                .is_err()
+        );
         assert!(validate_resolved_safe_url("http://[::1]/").await.is_err());
     }
 
     #[tokio::test]
     async fn validate_resolved_safe_url_rejects_literal_private_ranges() {
-        assert!(validate_resolved_safe_url("http://10.0.0.1/").await.is_err());
-        assert!(validate_resolved_safe_url("http://192.168.1.1/").await.is_err());
+        assert!(
+            validate_resolved_safe_url("http://10.0.0.1/")
+                .await
+                .is_err()
+        );
+        assert!(
+            validate_resolved_safe_url("http://192.168.1.1/")
+                .await
+                .is_err()
+        );
         assert!(
             validate_resolved_safe_url("http://169.254.169.254/")
                 .await

--- a/crates/server/src/api/app_endpoint_auth.rs
+++ b/crates/server/src/api/app_endpoint_auth.rs
@@ -6,6 +6,7 @@
 // AG-UI/A2A ingress behavior.
 
 use std::collections::HashSet;
+use std::net::IpAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -19,6 +20,8 @@ use jsonwebtoken::{Algorithm, DecodingKey, Validation, decode, decode_header, jw
 use moka::future::Cache;
 use serde::Deserialize;
 use serde_json::Value;
+use tokio::net::lookup_host;
+use url::Host;
 
 use crate::storage::password::verify_password;
 
@@ -193,7 +196,9 @@ impl AppEndpointAuthVerifier {
         else {
             return Err(AppEndpointAuthError::Misconfigured);
         };
-        validate_safe_url(introspection_url).map_err(|_| AppEndpointAuthError::Misconfigured)?;
+        validate_resolved_safe_url(introspection_url)
+            .await
+            .map_err(|_| AppEndpointAuthError::Misconfigured)?;
         let mut req = self.http.post(introspection_url).form(&[("token", token)]);
         if let Some(client_id) = client_id.as_deref().filter(|id| !id.is_empty()) {
             req = if let Some(secret) = client_secret.as_deref() {
@@ -255,9 +260,13 @@ impl AppEndpointAuthVerifier {
         if let Some(discovery) = self.discovery_cache.get(&issuer).await {
             return Ok(discovery);
         }
-        validate_safe_url(&issuer).map_err(|_| AppEndpointAuthError::Misconfigured)?;
+        validate_resolved_safe_url(&issuer)
+            .await
+            .map_err(|_| AppEndpointAuthError::Misconfigured)?;
         let url = format!("{issuer}/.well-known/openid-configuration");
-        validate_safe_url(&url).map_err(|_| AppEndpointAuthError::Misconfigured)?;
+        validate_resolved_safe_url(&url)
+            .await
+            .map_err(|_| AppEndpointAuthError::Misconfigured)?;
         let discovery = self
             .http
             .get(&url)
@@ -269,7 +278,9 @@ impl AppEndpointAuthVerifier {
             .json::<OidcDiscovery>()
             .await
             .map_err(|_| AppEndpointAuthError::ProviderUnavailable)?;
-        validate_safe_url(&discovery.jwks_uri).map_err(|_| AppEndpointAuthError::Misconfigured)?;
+        validate_resolved_safe_url(&discovery.jwks_uri)
+            .await
+            .map_err(|_| AppEndpointAuthError::Misconfigured)?;
         self.discovery_cache.insert(issuer, discovery.clone()).await;
         Ok(discovery)
     }
@@ -278,7 +289,9 @@ impl AppEndpointAuthVerifier {
         if let Some(jwks) = self.jwks_cache.get(jwks_url).await {
             return Ok(jwks);
         }
-        validate_safe_url(jwks_url).map_err(|_| AppEndpointAuthError::Misconfigured)?;
+        validate_resolved_safe_url(jwks_url)
+            .await
+            .map_err(|_| AppEndpointAuthError::Misconfigured)?;
         let jwks = self
             .http
             .get(jwks_url)
@@ -318,6 +331,56 @@ struct OidcDiscovery {
 
 fn normalize_issuer(issuer: &str) -> String {
     issuer.trim().trim_end_matches('/').to_string()
+}
+
+async fn validate_resolved_safe_url(raw_url: &str) -> Result<(), ()> {
+    let url = validate_safe_url(raw_url).map_err(|_| ())?;
+    let host = url.host().ok_or(())?;
+    if matches!(host, Host::Ipv4(_) | Host::Ipv6(_)) {
+        return Ok(());
+    }
+    let port = url.port_or_known_default().ok_or(())?;
+    let host = host.to_string();
+    let resolved = lookup_host((host.as_str(), port)).await.map_err(|_| ())?;
+    let mut found = false;
+    for addr in resolved {
+        found = true;
+        if is_blocked_ip(addr.ip()) {
+            return Err(());
+        }
+    }
+    if !found {
+        return Err(());
+    }
+    Ok(())
+}
+
+fn is_blocked_ip(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => {
+            let octets = v4.octets();
+            octets[0] == 127
+                || v4.is_unspecified()
+                || octets[0] == 10
+                || (octets[0] == 172 && (16..=31).contains(&octets[1]))
+                || (octets[0] == 192 && octets[1] == 168)
+                || (octets[0] == 169 && octets[1] == 254)
+                || (octets[0] == 100 && (64..=127).contains(&octets[1]))
+                || (octets[0] == 192 && octets[1] == 0 && octets[2] == 2)
+                || (octets[0] == 198 && octets[1] == 51 && octets[2] == 100)
+                || (octets[0] == 203 && octets[1] == 0 && octets[2] == 113)
+        }
+        IpAddr::V6(v6) => {
+            let segments = v6.segments();
+            v6.is_loopback()
+                || v6.is_unspecified()
+                || segments[0] & 0xffc0 == 0xfe80
+                || segments[0] & 0xfe00 == 0xfc00
+                || v6
+                    .to_ipv4_mapped()
+                    .is_some_and(|v4| is_blocked_ip(IpAddr::V4(v4)))
+        }
+    }
 }
 
 fn is_public_key_algorithm(alg: Algorithm) -> bool {
@@ -556,5 +619,13 @@ mod tests {
             "tier": "prod"
         });
         assert!(validate_claim_requirements(&claims, &requirements).is_ok());
+    }
+
+    #[test]
+    fn blocks_private_ips_after_dns_resolution() {
+        assert!(is_blocked_ip(IpAddr::V4("127.0.0.1".parse().unwrap())));
+        assert!(is_blocked_ip(IpAddr::V4("10.0.0.1".parse().unwrap())));
+        assert!(is_blocked_ip(IpAddr::V6("::1".parse().unwrap())));
+        assert!(!is_blocked_ip(IpAddr::V4("8.8.8.8".parse().unwrap())));
     }
 }

--- a/crates/server/src/api/app_endpoint_auth.rs
+++ b/crates/server/src/api/app_endpoint_auth.rs
@@ -6,7 +6,6 @@
 // AG-UI/A2A ingress behavior.
 
 use std::collections::HashSet;
-use std::net::IpAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -14,13 +13,14 @@ use axum::http::{HeaderMap, header::AUTHORIZATION};
 use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64_STANDARD};
 use everruns_core::{
     AppEndpointAuthConfig, AppEndpointAuthMode, AppEndpointAuthProviderConfig,
-    AppEndpointAuthRequirements, validate_safe_url,
+    AppEndpointAuthRequirements, is_blocked_ip, validate_safe_url,
 };
 use jsonwebtoken::{Algorithm, DecodingKey, Validation, decode, decode_header, jwk::JwkSet};
 use moka::future::Cache;
 use serde::Deserialize;
 use serde_json::Value;
 use tokio::net::lookup_host;
+use tokio::time::timeout;
 use url::Host;
 
 use crate::storage::password::verify_password;
@@ -333,6 +333,10 @@ fn normalize_issuer(issuer: &str) -> String {
     issuer.trim().trim_end_matches('/').to_string()
 }
 
+// Cap DNS resolution to the same budget as the outbound HTTP request so a slow
+// or stuck resolver cannot stall auth verification past the overall timeout.
+const DNS_LOOKUP_TIMEOUT: Duration = Duration::from_secs(5);
+
 async fn validate_resolved_safe_url(raw_url: &str) -> Result<(), ()> {
     let url = validate_safe_url(raw_url).map_err(|_| ())?;
     let host = url.host().ok_or(())?;
@@ -341,7 +345,10 @@ async fn validate_resolved_safe_url(raw_url: &str) -> Result<(), ()> {
     }
     let port = url.port_or_known_default().ok_or(())?;
     let host = host.to_string();
-    let resolved = lookup_host((host.as_str(), port)).await.map_err(|_| ())?;
+    let resolved = timeout(DNS_LOOKUP_TIMEOUT, lookup_host((host.as_str(), port)))
+        .await
+        .map_err(|_| ())?
+        .map_err(|_| ())?;
     let mut found = false;
     for addr in resolved {
         found = true;
@@ -353,34 +360,6 @@ async fn validate_resolved_safe_url(raw_url: &str) -> Result<(), ()> {
         return Err(());
     }
     Ok(())
-}
-
-fn is_blocked_ip(ip: IpAddr) -> bool {
-    match ip {
-        IpAddr::V4(v4) => {
-            let octets = v4.octets();
-            octets[0] == 127
-                || v4.is_unspecified()
-                || octets[0] == 10
-                || (octets[0] == 172 && (16..=31).contains(&octets[1]))
-                || (octets[0] == 192 && octets[1] == 168)
-                || (octets[0] == 169 && octets[1] == 254)
-                || (octets[0] == 100 && (64..=127).contains(&octets[1]))
-                || (octets[0] == 192 && octets[1] == 0 && octets[2] == 2)
-                || (octets[0] == 198 && octets[1] == 51 && octets[2] == 100)
-                || (octets[0] == 203 && octets[1] == 0 && octets[2] == 113)
-        }
-        IpAddr::V6(v6) => {
-            let segments = v6.segments();
-            v6.is_loopback()
-                || v6.is_unspecified()
-                || segments[0] & 0xffc0 == 0xfe80
-                || segments[0] & 0xfe00 == 0xfc00
-                || v6
-                    .to_ipv4_mapped()
-                    .is_some_and(|v4| is_blocked_ip(IpAddr::V4(v4)))
-        }
-    }
 }
 
 fn is_public_key_algorithm(alg: Algorithm) -> bool {
@@ -621,11 +600,20 @@ mod tests {
         assert!(validate_claim_requirements(&claims, &requirements).is_ok());
     }
 
-    #[test]
-    fn blocks_private_ips_after_dns_resolution() {
-        assert!(is_blocked_ip(IpAddr::V4("127.0.0.1".parse().unwrap())));
-        assert!(is_blocked_ip(IpAddr::V4("10.0.0.1".parse().unwrap())));
-        assert!(is_blocked_ip(IpAddr::V6("::1".parse().unwrap())));
-        assert!(!is_blocked_ip(IpAddr::V4("8.8.8.8".parse().unwrap())));
+    #[tokio::test]
+    async fn validate_resolved_safe_url_rejects_literal_loopback() {
+        assert!(validate_resolved_safe_url("http://127.0.0.1/").await.is_err());
+        assert!(validate_resolved_safe_url("http://[::1]/").await.is_err());
+    }
+
+    #[tokio::test]
+    async fn validate_resolved_safe_url_rejects_literal_private_ranges() {
+        assert!(validate_resolved_safe_url("http://10.0.0.1/").await.is_err());
+        assert!(validate_resolved_safe_url("http://192.168.1.1/").await.is_err());
+        assert!(
+            validate_resolved_safe_url("http://169.254.169.254/")
+                .await
+                .is_err()
+        );
     }
 }


### PR DESCRIPTION
### Motivation
- The endpoint-auth verifier performed outbound HTTP calls to user-provided OIDC/JWKS and OAuth2 introspection URLs after only static URL checks, which allowed DNS-rebinding SSRF when a public hostname resolved to private/loopback/link-local addresses.
- Prevent the control-plane from being induced to talk to internal services or metadata endpoints by introducing a runtime DNS/address policy before making provider HTTP requests.

### Description
- Added `validate_resolved_safe_url` (runtime DNS guard) that runs `validate_safe_url` then resolves the hostname with `tokio::net::lookup_host` and rejects any resolved IP in private/link-local/loopback/metadata ranges.
- Replaced static `validate_safe_url` calls with `validate_resolved_safe_url` in the OAuth2 introspection, OIDC discovery, and JWKS fetch paths so runtime resolution is enforced before each outbound request.
- Implemented `is_blocked_ip` locally (IPv4/IPv6 checks) mirroring existing blocked-range logic and kept the original static parse/scheme/hostname checks as the first layer.
- Added a unit test `blocks_private_ips_after_dns_resolution` that exercises `is_blocked_ip` classification.

### Testing
- Ran `cargo fmt --all` which completed successfully.
- Added unit test `blocks_private_ips_after_dns_resolution` under the verifier tests; `cargo test -p everruns-server app_endpoint_auth` was executed in the environment and compilation progressed, but the full test run did not complete within the interactive session window (dependency compilation in progress).
- The change is minimal and unit-focused; CI should run the full test matrix and validate behavior (recommended: `cargo test --all-features` in CI).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0207e0a4d4832b940768ee1e0ba80f)