### PR TITLE
fix(session-files): enforce readonly ancestor writes

### DIFF
--- a/crates/server/src/domains/session_files/service.rs
+++ b/crates/server/src/domains/session_files/service.rs
@@ -128,6 +128,7 @@ impl SessionFileService {
         let path = Self::normalize_path(&req.path);
         Self::validate_path(&path)?;
         self.ensure_path_not_virtual(session_id, &path)?;
+        self.ensure_parent_path_writable(session_id, &path).await?;
 
         // Decode content if provided
         let content = if let Some(ref content_str) = req.content {
@@ -178,6 +179,7 @@ impl SessionFileService {
         let path = Self::normalize_path(&req.path);
         Self::validate_path(&path)?;
         self.ensure_path_not_virtual(session_id, &path)?;
+        self.ensure_parent_path_writable(session_id, &path).await?;
 
         // Check if already exists
         if let Some(existing) = self.db.get_session_file(session_id, &path).await? {
@@ -273,6 +275,26 @@ impl SessionFileService {
                 }
             }
         }
+    }
+
+    /// Ensure no parent directory in the path is marked readonly.
+    async fn ensure_parent_path_writable(&self, session_id: Uuid, path: &str) -> Result<()> {
+        let mut current = FileInfo::parent_path(path);
+
+        while let Some(parent) = current {
+            if let Some(existing) = self.db.get_session_file(session_id, &parent).await?
+                && existing.is_directory
+                && existing.is_readonly
+            {
+                return Err(anyhow!(
+                    "Cannot create file or directory under readonly path: {}",
+                    parent
+                ));
+            }
+            current = FileInfo::parent_path(&parent);
+        }
+
+        Ok(())
     }
 
     /// Read a file
@@ -1380,5 +1402,80 @@ mod tests {
             err.to_string().contains("readonly"),
             "Expected readonly error, got: {err}"
         );
+    }
+
+    #[tokio::test]
+    async fn create_file_under_readonly_directory_rejected() {
+        let (svc, sid) = make_svc();
+
+        svc.create_directory(
+            sid,
+            CreateDirectoryInput {
+                path: "/workspace".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+
+        svc.db
+            .create_session_file(CreateSessionFileRow {
+                session_id: SessionId::from_uuid(sid),
+                path: "/workspace/repo".to_string(),
+                content: None,
+                is_directory: true,
+                is_readonly: true,
+            })
+            .await
+            .unwrap();
+
+        let err = svc
+            .create_file(
+                sid,
+                CreateFileInput {
+                    path: "/workspace/repo/injected.md".to_string(),
+                    content: Some("bad".to_string()),
+                    encoding: None,
+                    is_readonly: None,
+                },
+            )
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("readonly"));
+    }
+
+    #[tokio::test]
+    async fn create_directory_under_readonly_directory_rejected() {
+        let (svc, sid) = make_svc();
+
+        svc.create_directory(
+            sid,
+            CreateDirectoryInput {
+                path: "/workspace".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+
+        svc.db
+            .create_session_file(CreateSessionFileRow {
+                session_id: SessionId::from_uuid(sid),
+                path: "/workspace/repo".to_string(),
+                content: None,
+                is_directory: true,
+                is_readonly: true,
+            })
+            .await
+            .unwrap();
+
+        let err = svc
+            .create_directory(
+                sid,
+                CreateDirectoryInput {
+                    path: "/workspace/repo/new-subdir".to_string(),
+                },
+            )
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("readonly"));
     }
 }

--- a/crates/server/src/domains/session_files/service.rs
+++ b/crates/server/src/domains/session_files/service.rs
@@ -1406,7 +1406,9 @@ mod tests {
 
     #[tokio::test]
     async fn create_file_under_readonly_directory_rejected() {
-        let (svc, sid) = make_svc();
+        let db = StorageBackend::in_memory();
+        let sid = Uuid::new_v4();
+        let svc = SessionFileService::new(Arc::new(db.clone()));
 
         svc.create_directory(
             sid,
@@ -1417,16 +1419,15 @@ mod tests {
         .await
         .unwrap();
 
-        svc.db
-            .create_session_file(CreateSessionFileRow {
-                session_id: SessionId::from_uuid(sid),
-                path: "/workspace/repo".to_string(),
-                content: None,
-                is_directory: true,
-                is_readonly: true,
-            })
-            .await
-            .unwrap();
+        db.create_session_file(CreateSessionFileRow {
+            session_id: SessionId::from_uuid(sid),
+            path: "/workspace/repo".to_string(),
+            content: None,
+            is_directory: true,
+            is_readonly: true,
+        })
+        .await
+        .unwrap();
 
         let err = svc
             .create_file(
@@ -1445,7 +1446,9 @@ mod tests {
 
     #[tokio::test]
     async fn create_directory_under_readonly_directory_rejected() {
-        let (svc, sid) = make_svc();
+        let db = StorageBackend::in_memory();
+        let sid = Uuid::new_v4();
+        let svc = SessionFileService::new(Arc::new(db.clone()));
 
         svc.create_directory(
             sid,
@@ -1456,16 +1459,15 @@ mod tests {
         .await
         .unwrap();
 
-        svc.db
-            .create_session_file(CreateSessionFileRow {
-                session_id: SessionId::from_uuid(sid),
-                path: "/workspace/repo".to_string(),
-                content: None,
-                is_directory: true,
-                is_readonly: true,
-            })
-            .await
-            .unwrap();
+        db.create_session_file(CreateSessionFileRow {
+            session_id: SessionId::from_uuid(sid),
+            path: "/workspace/repo".to_string(),
+            content: None,
+            is_directory: true,
+            is_readonly: true,
+        })
+        .await
+        .unwrap();
 
         let err = svc
             .create_directory(


### PR DESCRIPTION
### Motivation

- Source-backed workspace volumes are materialized as inline session directories marked `is_readonly`, but file/directory creation paths did not check readonly ancestors, allowing new mutable files under a readonly mount and breaking integrity guarantees.
- The change closes this integrity bypass so read-only mounts behave as intended without changing mount materialization semantics.

### Description

- Add `ensure_parent_path_writable` to `SessionFileService` to walk ancestor paths and reject writes when any directory ancestor has `is_readonly` set. 
- Call `ensure_parent_path_writable` from `create_file` and `create_directory` so both APIs enforce readonly ancestry before creating parents or inserting rows. 
- Add regression tests `create_file_under_readonly_directory_rejected` and `create_directory_under_readonly_directory_rejected` validating that creating a child file or directory under a readonly directory is rejected. 
- Commit message: `fix(session-files): enforce readonly ancestor writes`.

### Testing

- Added unit tests inside `crates/server/src/domains/session_files/service.rs` that assert creation under a readonly directory returns a readonly error. 
- Attempted to run the tests via `CARGO_INCREMENTAL=0 cargo test -p everruns-server create_file_under_readonly_directory_rejected create_directory_under_readonly_directory_rejected --lib`, which failed due to incorrect Cargo usage (Cargo accepts a single test filter). 
- Started `CARGO_INCREMENTAL=0 cargo test -p everruns-server readonly_directory_rejected --lib`, which began compiling dependencies successfully but did not complete within the run window (build in progress); tests are included and will run in CI where the full compile completes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a014f8a89c4832b9c54dbca137abf9e)