### PR TITLE
fix(reporting): scope projector runs to caller org

### DIFF
--- a/crates/server/src/domains/reporting/commands.rs
+++ b/crates/server/src/domains/reporting/commands.rs
@@ -421,7 +421,7 @@ impl Command for RunReportingProjector {
         let service = ctx.reporting_service.as_ref().ok_or_else(|| {
             CommandError::Internal(anyhow::anyhow!("Reporting service not configured"))
         })?;
-        service.run_projector_once(self.limit).await
+        service.run_projector_once(ctx.org_id(), self.limit).await
     }
 }
 

--- a/crates/server/src/domains/reporting/service.rs
+++ b/crates/server/src/domains/reporting/service.rs
@@ -365,10 +365,14 @@ impl ReportingService {
         }
     }
 
-    pub async fn run_projector_once(&self, limit: i64) -> Result<ProjectorRunResult, CommandError> {
+    pub async fn run_projector_once(
+        &self,
+        org_id: i64,
+        limit: i64,
+    ) -> Result<ProjectorRunResult, CommandError> {
         match self.db.as_ref() {
             StorageBackend::Postgres(db) => PostgresReportingProjector::new(db.pool().clone())
-                .run_once(limit)
+                .run_once(org_id, limit)
                 .await
                 .map_err(classify_anyhow),
             StorageBackend::InMemory(_) => Ok(ProjectorRunResult {

--- a/crates/server/src/storage/reporting/outbox.rs
+++ b/crates/server/src/storage/reporting/outbox.rs
@@ -15,8 +15,8 @@ impl PostgresReportingProjector {
         Self { pool }
     }
 
-    pub async fn run_once(&self, limit: i64) -> Result<ProjectorRunResult> {
-        let rows = self.claim_pending(limit).await?;
+    pub async fn run_once(&self, org_id: i64, limit: i64) -> Result<ProjectorRunResult> {
+        let rows = self.claim_pending(org_id, limit).await?;
         let claimed = rows.len();
         let mut completed = 0;
         let mut failed = 0;
@@ -42,7 +42,7 @@ impl PostgresReportingProjector {
         })
     }
 
-    async fn claim_pending(&self, limit: i64) -> Result<Vec<ReportingOutboxRow>> {
+    async fn claim_pending(&self, org_id: i64, limit: i64) -> Result<Vec<ReportingOutboxRow>> {
         let rows = sqlx::query_as::<_, ReportingOutboxRow>(
             r#"
             UPDATE reporting_outbox
@@ -53,16 +53,18 @@ impl PostgresReportingProjector {
              WHERE id IN (
                 SELECT id
                   FROM reporting_outbox
-                 WHERE status IN ('pending', 'failed')
+                 WHERE org_id = $1
+                   AND status IN ('pending', 'failed')
                    AND next_attempt_at <= NOW()
                  ORDER BY created_at ASC
-                 LIMIT $1
+                 LIMIT $2
                  FOR UPDATE SKIP LOCKED
              )
          RETURNING id, org_id, source_type, source_id, source_version, reason, status,
                    attempts, next_attempt_at, last_error, created_at, updated_at
             "#,
         )
+        .bind(org_id)
         .bind(limit.clamp(1, 1_000))
         .fetch_all(&self.pool)
         .await?;


### PR DESCRIPTION
### Motivation
- The manual reporting projector endpoint was authorized with an org-scoped owner permission but claimed outbox rows globally, allowing cross-tenant processing and leaking aggregate activity counts.

### Description
- Thread `org_id` from the `RunReportingProjector` command into `ReportingService::run_projector_once` so the caller org is propagated to service calls.
- Update `PostgresReportingProjector::run_once` and `claim_pending` to accept `org_id` and use it to scope work to the caller organization.
- Add `org_id = $1` predicate to the `reporting_outbox` claim SQL and shift `limit` to the second bind parameter so only rows for the caller org are claimed.
- Files changed: `crates/server/src/domains/reporting/commands.rs`, `crates/server/src/domains/reporting/service.rs`, and `crates/server/src/storage/reporting/outbox.rs`.

### Testing
- Ran `cargo fmt` successfully to apply formatting to touched files.
- Invoked `cargo check -p everruns-server`; dependency fetch and compilation started in this environment but a full, final `cargo check` result was not captured here due to the toolchain bootstrap time.
- No new automated unit/integration tests were added in this change; add a test asserting that `claim_pending` cannot claim rows belonging to other orgs as a recommended follow-up.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0152529208832b927f8d3fc2fe56ff)