### PR TITLE
fix(mcp): align discover output schema with response

### DIFF
--- a/crates/server/src/api/mcp_endpoint/tool_registry.rs
+++ b/crates/server/src/api/mcp_endpoint/tool_registry.rs
@@ -618,8 +618,6 @@ fn discover_output_schema() -> Value {
             "name": { "type": "string" },
             "category": { "type": "string" },
             "description": { "type": "string" },
-            "method": { "type": "string" },
-            "path": { "type": "string" },
             "read_only": { "type": "boolean" },
             "positional_arg": { "type": "string" },
             "input_schema": { "type": "object", "additionalProperties": true },
@@ -629,7 +627,7 @@ fn discover_output_schema() -> Value {
                 "enum": ["array", "paginated", "unknown"]
             }
         },
-        "required": ["name", "category", "description", "method", "path", "read_only", "output_shape"]
+        "required": ["name", "category", "description", "read_only", "output_shape"]
     });
 
     json!({

--- a/crates/server/tests/mcp_endpoint_test.rs
+++ b/crates/server/tests/mcp_endpoint_test.rs
@@ -397,6 +397,22 @@ async fn test_mcp_tools_list() {
             .contains("pass this on each org-scoped call")
     );
     assert_eq!(discover["outputSchema"]["type"], "object");
+    let operation_properties =
+        &discover["outputSchema"]["properties"]["operations"]["items"]["properties"];
+    assert!(operation_properties["method"].is_null());
+    assert!(operation_properties["path"].is_null());
+    let operation_required =
+        discover["outputSchema"]["properties"]["operations"]["items"]["required"]
+            .as_array()
+            .expect("discover operations required must be array");
+    assert!(
+        !operation_required.iter().any(|field| field == "method"),
+        "discover output schema should not require method"
+    );
+    assert!(
+        !operation_required.iter().any(|field| field == "path"),
+        "discover output schema should not require path"
+    );
     assert!(discover.as_object().unwrap().get("_meta").is_none());
 
     let query = tools.iter().find(|tool| tool["name"] == "query").unwrap();


### PR DESCRIPTION
### Motivation
- The MCP `discover` runtime response stopped emitting HTTP metadata fields `method` and `path`, but the advertised `discover` `outputSchema` still declared and required them, causing a schema mismatch that can break strict clients that validate `structuredContent` against `outputSchema`.

### Description
- Remove the `method` and `path` properties and their required entries from `discover_output_schema()` in `crates/server/src/api/mcp_endpoint/tool_registry.rs` so the advertised schema matches runtime output.
- Add regression assertions in `crates/server/tests/mcp_endpoint_test.rs` (inside `test_mcp_tools_list`) that assert the `discover` `outputSchema` does not expose or require `method`/`path`.
- This is a schema-only change and does not alter internal `CommandMeta` usage or command execution behavior.

### Testing
- Started `cargo test -p everruns-server --test mcp_endpoint_test test_mcp_tools_list_uses_latest_annotations_and_exposes_card_tool -- --nocapture`, which progressed through dependency download and compilation but did not finish within the session timeout; no test failures were observed before the timeout.
- Added unit assertions to `test_mcp_tools_list` to ensure CI will catch any regression where `method`/`path` reappear in the advertised `discover` schema.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0152529be4832b9d85deb29a558895)