### PR TITLE
feat(fcp): Free Communication Protocol app channel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,6 +155,7 @@ Always make sure you are working on top of latest main from remote.
 - `specs/messaging-integrations.md` - Messaging integrations (channel abstractions, parity requirements, platform adapters)
 - `specs/a2a-channel.md` - A2A (Agent2Agent) inbound channel for App invocation via JSON-RPC + API key auth
 - `specs/a2a-capability.md` - A2A outbound delegation capability (Everruns agent calling external A2A agents)
+- `specs/fcp-channel.md` - FCP (Free Communication Protocol) inbound channel for App invocation via text-first HTTP
 - `specs/app-endpoint-auth.md` - Shared inbound auth framework for App-published endpoints (AG-UI, A2A, webhook) with OIDC/JWT, OAuth2 introspection, HTTP Basic, mTLS
 
 ### Test Cases

--- a/apps/ui/src/__tests__/fcp-setup-guidance.test.tsx
+++ b/apps/ui/src/__tests__/fcp-setup-guidance.test.tsx
@@ -1,0 +1,150 @@
+import { render, screen } from "@testing-library/react";
+import { FcpSetupGuidance, formatFcpSessionExpiration } from "@/components/apps/fcp-setup-guidance";
+
+describe("FcpSetupGuidance", () => {
+  it("renders endpoint, anonymous badge, and timeout for a published app", () => {
+    render(
+      <FcpSetupGuidance
+        endpointUrl="https://example.com/api/v1/apps/app-123/fcp"
+        isPublished={true}
+        anonymousEnabled={true}
+        sessionExpirationSeconds={6 * 60 * 60}
+        responseTimeoutSeconds={120}
+      />,
+    );
+
+    expect(screen.getByText("Anonymous")).toBeInTheDocument();
+    expect(screen.getByText("Ready for FCP clients")).toBeInTheDocument();
+    expect(screen.getByText("https://example.com/api/v1/apps/app-123/fcp")).toBeInTheDocument();
+    expect(screen.getByText(/Auto-generated/)).toBeInTheDocument();
+    expect(screen.getByText(/120 seconds/)).toBeInTheDocument();
+  });
+
+  it("renders 'Never' when session expiration is disabled", () => {
+    render(
+      <FcpSetupGuidance
+        endpointUrl="https://example.com/api/v1/apps/app-123/fcp"
+        isPublished={true}
+        anonymousEnabled={true}
+        sessionExpirationSeconds={0}
+      />,
+    );
+
+    expect(screen.getByText(/Never.*sessions can be resumed indefinitely/)).toBeInTheDocument();
+  });
+
+  it("renders 'Token Protected' badge and token value when token is provided", () => {
+    render(
+      <FcpSetupGuidance
+        endpointUrl="https://example.com/api/v1/apps/app-123/fcp"
+        isPublished={true}
+        anonymousEnabled={true}
+        sessionExpirationSeconds={6 * 60 * 60}
+        token="fcp-secret-12345"
+      />,
+    );
+
+    expect(screen.getByText("fcp-secret-12345")).toBeInTheDocument();
+    expect(screen.getByText("Token Protected")).toBeInTheDocument();
+    // The token requirement guidance is rendered when a token is present.
+    expect(screen.getByText(/Authorization: Bearer/i)).toBeInTheDocument();
+  });
+
+  it("renders 'Token Protected' when token is configured but not surfaced", () => {
+    render(
+      <FcpSetupGuidance
+        endpointUrl="https://example.com/api/v1/apps/app-123/fcp"
+        isPublished={false}
+        anonymousEnabled={true}
+        sessionExpirationSeconds={6 * 60 * 60}
+        tokenConfigured={true}
+      />,
+    );
+
+    expect(screen.getByText("Token Protected")).toBeInTheDocument();
+    expect(screen.getByText("Channel token configured")).toBeInTheDocument();
+    expect(screen.getByText("Publish the app to accept requests")).toBeInTheDocument();
+  });
+
+  it("renders 'Restricted' state and warning when anonymous is off without a token", () => {
+    render(
+      <FcpSetupGuidance
+        endpointUrl="https://example.com/api/v1/apps/app-123/fcp"
+        isPublished={true}
+        anonymousEnabled={false}
+        sessionExpirationSeconds={6 * 60 * 60}
+      />,
+    );
+
+    expect(screen.getByText("Restricted")).toBeInTheDocument();
+    expect(screen.getByText(/Anonymous access is off.*configure a token/)).toBeInTheDocument();
+  });
+
+  it("displays per-minute rate limit when configured", () => {
+    render(
+      <FcpSetupGuidance
+        endpointUrl="https://example.com/api/v1/apps/app-123/fcp"
+        isPublished={true}
+        anonymousEnabled={true}
+        sessionExpirationSeconds={6 * 60 * 60}
+        rateLimitPerMinute={45}
+      />,
+    );
+
+    expect(screen.getByText(/45 requests per minute, per client IP/)).toBeInTheDocument();
+    expect(screen.getByText(/FCP-only limiter namespace/)).toBeInTheDocument();
+  });
+
+  it("falls back to global cap message when no per-app rate limit", () => {
+    render(
+      <FcpSetupGuidance
+        endpointUrl="https://example.com/api/v1/apps/app-123/fcp"
+        isPublished={true}
+        anonymousEnabled={true}
+        sessionExpirationSeconds={6 * 60 * 60}
+      />,
+    );
+
+    expect(screen.getByText(/No per-app cap/)).toBeInTheDocument();
+  });
+
+  it("marks a custom handshake when one is configured", () => {
+    render(
+      <FcpSetupGuidance
+        endpointUrl="https://example.com/api/v1/apps/app-123/fcp"
+        isPublished={true}
+        anonymousEnabled={true}
+        sessionExpirationSeconds={6 * 60 * 60}
+        hasCustomHandshake={true}
+      />,
+    );
+
+    expect(screen.getByText("Custom Markdown configured.")).toBeInTheDocument();
+  });
+});
+
+describe("formatFcpSessionExpiration", () => {
+  it("formats whole hours", () => {
+    expect(formatFcpSessionExpiration(6 * 60 * 60)).toBe("6 hours");
+    expect(formatFcpSessionExpiration(60 * 60)).toBe("1 hour");
+  });
+
+  it("formats fractional hours", () => {
+    expect(formatFcpSessionExpiration(90 * 60)).toBe("1.5 hours");
+  });
+
+  it("formats minutes", () => {
+    expect(formatFcpSessionExpiration(5 * 60)).toBe("5 minutes");
+    expect(formatFcpSessionExpiration(60)).toBe("1 minute");
+  });
+
+  it("formats seconds for short values", () => {
+    expect(formatFcpSessionExpiration(30)).toBe("30 seconds");
+    expect(formatFcpSessionExpiration(1)).toBe("1 second");
+  });
+
+  it("returns 'Never' for zero or negative", () => {
+    expect(formatFcpSessionExpiration(0)).toBe("Never");
+    expect(formatFcpSessionExpiration(-1)).toBe("Never");
+  });
+});

--- a/apps/ui/src/app/(main)/apps/[appId]/page.tsx
+++ b/apps/ui/src/app/(main)/apps/[appId]/page.tsx
@@ -70,6 +70,7 @@ import { CopyButton } from "@/components/ui/copy-button";
 import { A2aAgentCardPreview } from "@/components/apps/a2a-agent-card-preview";
 import { A2aSetupGuidance } from "@/components/apps/a2a-setup-guidance";
 import { AgUiSetupGuidance } from "@/components/apps/ag-ui-setup-guidance";
+import { FcpSetupGuidance } from "@/components/apps/fcp-setup-guidance";
 import { AppBudgetsCard } from "@/components/apps/app-budgets-card";
 import { AppDetailV2 } from "@/components/apps/app-detail-v2";
 import { ScheduleSetupGuidance } from "@/components/apps/schedule-setup-guidance";
@@ -85,6 +86,7 @@ import type {
   AppEndpointAuthMode,
   AgentVersionPolicy,
   ChannelType,
+  FcpChannelConfig,
   InvocationSessionMode,
   ScheduleChannelConfig,
   SessionStrategy,
@@ -119,7 +121,8 @@ type ChannelConfigInput =
   | AgUiChannelConfig
   | ScheduleChannelConfig
   | WebhookChannelConfig
-  | A2aChannelConfig;
+  | A2aChannelConfig
+  | FcpChannelConfig;
 
 type ChannelSummary = {
   target: string;
@@ -271,6 +274,22 @@ function getChannelSummary(channel: AppChannel, isPublished: boolean): ChannelSu
         healthVariant: configured && isPublished ? "default" : "secondary",
       };
     }
+    case "fcp": {
+      const config = channel.channel_config as FcpChannelConfig;
+      const tokenConfigured = !!config?.token || !!config?.token_configured;
+      const target = tokenConfigured
+        ? "Token-protected text endpoint"
+        : config?.anonymous === false
+          ? "Restricted (no token configured)"
+          : "Public text endpoint";
+      const misconfigured = config?.anonymous === false && !tokenConfigured;
+      return {
+        target,
+        group: "Client surfaces",
+        health: misconfigured ? "Misconfigured" : isPublished ? "Ready" : "Draft",
+        healthVariant: misconfigured ? "secondary" : isPublished ? "default" : "secondary",
+      };
+    }
   }
 }
 
@@ -357,6 +376,15 @@ function AppDetailPageLegacy({ params }: { params: Promise<{ appId: string }> })
   const [editA2aAgentCardName, setEditA2aAgentCardName] = useState("");
   const [editA2aAgentCardDescription, setEditA2aAgentCardDescription] = useState("");
   const [editA2aRateLimitPerMinute, setEditA2aRateLimitPerMinute] = useState<string>("");
+  // FCP channel form state — kept narrow because FCP intentionally has a
+  // small auth surface (anonymous + optional shared token) and no inline
+  // AppEndpointAuthConfig modes.
+  const [editFcpAnonymous, setEditFcpAnonymous] = useState(true);
+  const [editFcpToken, setEditFcpToken] = useState("");
+  const [editFcpHandshake, setEditFcpHandshake] = useState("");
+  const [editFcpExpirationHours, setEditFcpExpirationHours] = useState(6);
+  const [editFcpRateLimitPerMinute, setEditFcpRateLimitPerMinute] = useState<string>("");
+  const [editFcpResponseTimeoutSeconds, setEditFcpResponseTimeoutSeconds] = useState<string>("120");
   const [editAuthMode, setEditAuthMode] = useState<AppEndpointAuthMode>("anonymous");
   const [editAuthGoogleClientId, setEditAuthGoogleClientId] = useState("");
   const [editAuthOidcIssuer, setEditAuthOidcIssuer] = useState("");
@@ -515,6 +543,14 @@ function AppDetailPageLegacy({ params }: { params: Promise<{ appId: string }> })
           const config = channel.channel_config as A2aChannelConfig;
           return hasA2aKey(config) && !!config?.message;
         }
+        case "fcp": {
+          const config = channel.channel_config as FcpChannelConfig;
+          // FCP only requires a token when anonymous access is disabled.
+          if (config?.anonymous === false) {
+            return !!config?.token || !!config?.token_configured;
+          }
+          return true;
+        }
       }
     }) ?? false;
 
@@ -527,6 +563,10 @@ function AppDetailPageLegacy({ params }: { params: Promise<{ appId: string }> })
       ? `${window.location.origin}/api/v1/apps/${appId}/ag-ui`
       : `/api/v1/apps/${appId}/ag-ui`;
   const agUiImageUploadUrl = `${agUiEndpointUrl}/images`;
+  const fcpEndpointUrl =
+    typeof window !== "undefined"
+      ? `${window.location.origin}/api/v1/apps/${appId}/fcp`
+      : `/api/v1/apps/${appId}/fcp`;
 
   const isLocalhost =
     typeof window !== "undefined" &&
@@ -604,6 +644,12 @@ function AppDetailPageLegacy({ params }: { params: Promise<{ appId: string }> })
     setEditA2aAgentCardName("");
     setEditA2aAgentCardDescription("");
     setEditA2aRateLimitPerMinute("");
+    setEditFcpAnonymous(true);
+    setEditFcpToken("");
+    setEditFcpHandshake("");
+    setEditFcpExpirationHours(6);
+    setEditFcpRateLimitPerMinute("");
+    setEditFcpResponseTimeoutSeconds("120");
     setEditAuthMode(channelType === "a2a" ? "api_key" : "anonymous");
     setEditAuthGoogleClientId("");
     setEditAuthOidcIssuer("");
@@ -750,6 +796,28 @@ function AppDetailPageLegacy({ params }: { params: Promise<{ appId: string }> })
           ...(editChannelIdField ? { channel_id: editChannelIdField } : {}),
           ...(editTeamId ? { team_id: editTeamId } : {}),
         };
+      case "fcp": {
+        const hours = Number.isFinite(editFcpExpirationHours)
+          ? Math.max(0, editFcpExpirationHours)
+          : 6;
+        const trimmed = editFcpRateLimitPerMinute.trim();
+        const parsedRate = trimmed === "" ? undefined : Number.parseInt(trimmed, 10);
+        const timeoutTrim = editFcpResponseTimeoutSeconds.trim();
+        const parsedTimeout = timeoutTrim === "" ? 120 : Number.parseInt(timeoutTrim, 10);
+        return {
+          anonymous: editFcpAnonymous,
+          ...(editFcpToken.trim() ? { token: editFcpToken.trim() } : {}),
+          ...(editFcpHandshake.trim() ? { handshake: editFcpHandshake } : {}),
+          session_expiration_seconds: Math.round(hours * 3600),
+          ...(parsedRate !== undefined && Number.isFinite(parsedRate) && parsedRate > 0
+            ? { rate_limit_per_minute: parsedRate }
+            : {}),
+          response_timeout_seconds:
+            Number.isFinite(parsedTimeout) && parsedTimeout > 0 && parsedTimeout <= 600
+              ? parsedTimeout
+              : 120,
+        };
+      }
     }
   };
 
@@ -807,6 +875,26 @@ function AppDetailPageLegacy({ params }: { params: Promise<{ appId: string }> })
       }
       case "slack":
         return !!editSigningSecret && !!editBotToken;
+      case "fcp": {
+        if (!Number.isFinite(editFcpExpirationHours) || editFcpExpirationHours < 0) {
+          return false;
+        }
+        const trimmed = editFcpRateLimitPerMinute.trim();
+        if (trimmed !== "") {
+          const parsed = Number.parseInt(trimmed, 10);
+          if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1_000_000) return false;
+          if (String(parsed) !== trimmed) return false;
+        }
+        const timeoutTrim = editFcpResponseTimeoutSeconds.trim();
+        if (timeoutTrim === "") return true;
+        const parsedTimeout = Number.parseInt(timeoutTrim, 10);
+        return (
+          Number.isFinite(parsedTimeout) &&
+          parsedTimeout > 0 &&
+          parsedTimeout <= 600 &&
+          String(parsedTimeout) === timeoutTrim
+        );
+      }
     }
   };
 
@@ -893,6 +981,26 @@ function AppDetailPageLegacy({ params }: { params: Promise<{ appId: string }> })
         config?.rate_limit_per_minute && config.rate_limit_per_minute > 0
           ? String(config.rate_limit_per_minute)
           : "",
+      );
+    } else if (channel.channel_type === "fcp") {
+      const config = channel.channel_config as FcpChannelConfig;
+      setEditFcpAnonymous(config?.anonymous ?? true);
+      setEditFcpToken(config?.token ?? "");
+      setEditFcpHandshake(config?.handshake ?? "");
+      const expSeconds =
+        typeof config?.session_expiration_seconds === "number"
+          ? config.session_expiration_seconds
+          : 6 * 60 * 60;
+      setEditFcpExpirationHours(expSeconds / 3600);
+      setEditFcpRateLimitPerMinute(
+        config?.rate_limit_per_minute && config.rate_limit_per_minute > 0
+          ? String(config.rate_limit_per_minute)
+          : "",
+      );
+      setEditFcpResponseTimeoutSeconds(
+        typeof config?.response_timeout_seconds === "number"
+          ? String(config.response_timeout_seconds)
+          : "120",
       );
     }
     setEditingChannelId(channel.id);
@@ -1184,6 +1292,7 @@ function AppDetailPageLegacy({ params }: { params: Promise<{ appId: string }> })
                 <SelectItem value="schedule">{getChannelTypeDisplayName("schedule")}</SelectItem>
                 <SelectItem value="webhook">{getChannelTypeDisplayName("webhook")}</SelectItem>
                 <SelectItem value="a2a">{getChannelTypeDisplayName("a2a")}</SelectItem>
+                <SelectItem value="fcp">{getChannelTypeDisplayName("fcp")}</SelectItem>
               </SelectContent>
             </Select>
           </div>
@@ -1605,6 +1714,122 @@ function AppDetailPageLegacy({ params }: { params: Promise<{ appId: string }> })
           </>
         )}
 
+        {formChannelType === "fcp" && (
+          <>
+            <div className="rounded-md border p-3 text-sm text-muted-foreground">
+              FCP is a minimal text-first endpoint. POST plain text (or JSON{" "}
+              <code>&#123;&quot;message&quot;: &quot;...&quot;&#125;</code>) and receive the
+              agent&apos;s Markdown reply. The handshake is the GET on the endpoint URL — keep it
+              accurate so external clients can discover how to use this app.
+            </div>
+            <div className="flex items-center justify-between border p-3">
+              <div>
+                <Label htmlFor={`fcp_anonymous_${formId}`}>Anonymous access</Label>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  When off, every POST must present the bearer token below. The GET handshake stays
+                  open either way.
+                </p>
+              </div>
+              <Switch
+                id={`fcp_anonymous_${formId}`}
+                checked={editFcpAnonymous}
+                onCheckedChange={setEditFcpAnonymous}
+              />
+            </div>
+            <div>
+              <Label htmlFor={`fcp_token_${formId}`}>Bearer token (optional)</Label>
+              <div className="flex gap-2">
+                <Input
+                  id={`fcp_token_${formId}`}
+                  value={editFcpToken}
+                  onChange={(e) => setEditFcpToken(e.target.value)}
+                  className="font-mono"
+                  placeholder="Leave blank for anonymous access"
+                />
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon"
+                  onClick={() => setEditFcpToken(generateChannelToken())}
+                  aria-label="Regenerate FCP token"
+                >
+                  <RefreshCw className="w-4 h-4" />
+                </Button>
+              </div>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Verified with constant-time comparison. Sent as Authorization: Bearer&nbsp;
+                &lt;token&gt; or X-Everruns-FCP-Token. Never echoed in responses.
+              </p>
+            </div>
+            <div>
+              <Label htmlFor={`fcp_handshake_${formId}`}>Custom handshake (Markdown)</Label>
+              <Textarea
+                id={`fcp_handshake_${formId}`}
+                value={editFcpHandshake}
+                onChange={(e) => setEditFcpHandshake(e.target.value)}
+                placeholder="Leave blank to auto-generate from the app name and description."
+                rows={4}
+              />
+              <p className="mt-1 text-xs text-muted-foreground">
+                Returned verbatim for GET on the endpoint URL. Should describe what this app does
+                and how to talk to it. Maximum 8 KiB.
+              </p>
+            </div>
+            <div>
+              <Label htmlFor={`fcp_expiration_${formId}`}>Session expiration (hours)</Label>
+              <Input
+                id={`fcp_expiration_${formId}`}
+                type="number"
+                inputMode="numeric"
+                min={0}
+                step={0.1}
+                value={editFcpExpirationHours}
+                onChange={(e) => setEditFcpExpirationHours(Number.parseFloat(e.target.value) || 0)}
+              />
+              <p className="mt-1 text-xs text-muted-foreground">
+                0 = the fcp_session cookie never expires. Default is 6 hours.
+              </p>
+            </div>
+            <div>
+              <Label htmlFor={`fcp_rate_limit_${formId}`}>
+                Per-IP rate limit (requests/minute, optional)
+              </Label>
+              <Input
+                id={`fcp_rate_limit_${formId}`}
+                type="number"
+                inputMode="numeric"
+                min={0}
+                max={1_000_000}
+                value={editFcpRateLimitPerMinute}
+                onChange={(e) => setEditFcpRateLimitPerMinute(e.target.value)}
+                placeholder="No per-channel limit"
+              />
+              <p className="mt-1 text-xs text-muted-foreground">
+                Counted in an FCP-only limiter namespace — cannot be shared with any other channel.
+                Leave empty (or set to 0) to disable; the global API limit still applies.
+              </p>
+            </div>
+            <div>
+              <Label htmlFor={`fcp_response_timeout_${formId}`}>Response timeout (seconds)</Label>
+              <Input
+                id={`fcp_response_timeout_${formId}`}
+                type="number"
+                inputMode="numeric"
+                min={1}
+                max={600}
+                value={editFcpResponseTimeoutSeconds}
+                onChange={(e) => setEditFcpResponseTimeoutSeconds(e.target.value)}
+                placeholder="120"
+              />
+              <p className="mt-1 text-xs text-muted-foreground">
+                Maximum time the endpoint waits for the agent before returning 504. Must be 1-600s.
+                Default 120s. The session cookie is still set on timeout so the client can retry the
+                same conversation.
+              </p>
+            </div>
+          </>
+        )}
+
         <div className="flex gap-2 pt-2">
           <Button
             size="sm"
@@ -1664,6 +1889,30 @@ function AppDetailPageLegacy({ params }: { params: Promise<{ appId: string }> })
             sessionMode={config?.session_mode ?? "shared_session"}
             message={config?.message ?? ""}
             isPublished={isPublished}
+            onConfigure={() => startEditChannel(channel)}
+          />
+        </div>
+      );
+    }
+
+    if (channel.channel_type === "fcp") {
+      const config = channel.channel_config as FcpChannelConfig;
+      return (
+        <div key={channel.id} className="space-y-4">
+          <FcpSetupGuidance
+            endpointUrl={fcpEndpointUrl}
+            isPublished={isPublished}
+            anonymousEnabled={config?.anonymous ?? true}
+            sessionExpirationSeconds={
+              typeof config?.session_expiration_seconds === "number"
+                ? config.session_expiration_seconds
+                : 6 * 60 * 60
+            }
+            rateLimitPerMinute={config?.rate_limit_per_minute}
+            responseTimeoutSeconds={config?.response_timeout_seconds}
+            token={config?.token}
+            tokenConfigured={!!config?.token || !!config?.token_configured}
+            hasCustomHandshake={!!config?.handshake?.trim()}
             onConfigure={() => startEditChannel(channel)}
           />
         </div>
@@ -1900,6 +2149,50 @@ function AppDetailPageLegacy({ params }: { params: Promise<{ appId: string }> })
       );
     }
 
+    if (channel.channel_type === "fcp") {
+      const config = channel.channel_config as FcpChannelConfig;
+      const tokenConfigured = !!config?.token || !!config?.token_configured;
+      const expSeconds =
+        typeof config?.session_expiration_seconds === "number"
+          ? config.session_expiration_seconds
+          : 6 * 60 * 60;
+      return (
+        <div className="grid gap-4 md:grid-cols-2">
+          <ChannelFact
+            label="Access"
+            value={
+              tokenConfigured
+                ? "Token protected"
+                : config?.anonymous === false
+                  ? "Restricted (no token)"
+                  : "Anonymous"
+            }
+          />
+          <ChannelFact
+            label="Session expiration"
+            value={expSeconds === 0 ? "Never" : `${expSeconds / 3600}h`}
+          />
+          <ChannelFact
+            label="Rate limit"
+            value={
+              config?.rate_limit_per_minute
+                ? `${config.rate_limit_per_minute}/minute/IP`
+                : "Global limit only"
+            }
+          />
+          <ChannelFact
+            label="Response timeout"
+            value={`${config?.response_timeout_seconds ?? 120}s`}
+          />
+          <ChannelFact
+            label="Handshake"
+            value={config?.handshake?.trim() ? "Custom" : "Auto-generated"}
+          />
+          <ChannelFact label="Health" value={summary.health} />
+        </div>
+      );
+    }
+
     const config = channel.channel_config as A2aChannelConfig;
     return (
       <div className="space-y-4">
@@ -1930,7 +2223,9 @@ function AppDetailPageLegacy({ params }: { params: Promise<{ appId: string }> })
             ? `/api/v1/apps/${appId}/webhooks/${channel.id}`
             : channel.channel_type === "a2a"
               ? `/api/v1/apps/${appId}/a2a/${channel.id}`
-              : "";
+              : channel.channel_type === "fcp"
+                ? `/api/v1/apps/${appId}/fcp`
+                : "";
 
     if (!endpoint) {
       return null;

--- a/apps/ui/src/components/apps/channel-form.tsx
+++ b/apps/ui/src/components/apps/channel-form.tsx
@@ -1,6 +1,14 @@
 "use client";
 
-import { Monitor, RefreshCw, Slack, Webhook, Hash, CalendarClock } from "lucide-react";
+import {
+  CalendarClock,
+  Hash,
+  MessageSquareText,
+  Monitor,
+  RefreshCw,
+  Slack,
+  Webhook,
+} from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -25,6 +33,7 @@ import type {
   App,
   AppChannel,
   ChannelType,
+  FcpChannelConfig,
   InvocationSessionMode,
   ScheduleChannelConfig,
   SessionStrategy,
@@ -42,7 +51,10 @@ import {
 import { generateChannelToken } from "@/lib/channel-tokens";
 import { cn } from "@/lib/utils";
 
-export const CHANNEL_FORM_KINDS: ChannelType[] = ["schedule", "webhook", "ag_ui", "slack"];
+export const CHANNEL_FORM_KINDS: ChannelType[] = ["schedule", "webhook", "ag_ui", "fcp", "slack"];
+
+const DEFAULT_FCP_EXPIRATION_HOURS = 6;
+const DEFAULT_FCP_RESPONSE_TIMEOUT_SECONDS = 120;
 
 export type ChannelFormSection = "all" | "schedule" | "invocation" | "session" | "runs";
 
@@ -65,6 +77,12 @@ export type ChannelFormState = {
   agUiRateLimitPerMinute: string;
   agUiToolVisibility: AgUiToolVisibility;
   agUiGenericToolText: string;
+  fcpToken: string;
+  fcpAnonymous: boolean;
+  fcpHandshake: string;
+  fcpExpirationHours: number;
+  fcpRateLimitPerMinute: string;
+  fcpResponseTimeoutSeconds: string;
 };
 
 function secretValue(value?: string, configured?: boolean): string {
@@ -95,6 +113,12 @@ export function getDefaultChannelFormState(
     agUiRateLimitPerMinute: "",
     agUiToolVisibility: "generic",
     agUiGenericToolText: DEFAULT_AG_UI_GENERIC_TOOL_TEXT,
+    fcpToken: "",
+    fcpAnonymous: true,
+    fcpHandshake: "",
+    fcpExpirationHours: DEFAULT_FCP_EXPIRATION_HOURS,
+    fcpRateLimitPerMinute: "",
+    fcpResponseTimeoutSeconds: String(DEFAULT_FCP_RESPONSE_TIMEOUT_SECONDS),
   };
 
   if (!channel) return base;
@@ -136,6 +160,28 @@ export function getDefaultChannelFormState(
           : "",
       agUiToolVisibility: config.tool_visibility || "generic",
       agUiGenericToolText: config.generic_tool_text || DEFAULT_AG_UI_GENERIC_TOOL_TEXT,
+    };
+  }
+  if (channel.channel_type === "fcp") {
+    const config = channel.channel_config as FcpChannelConfig;
+    return {
+      ...base,
+      kind: "fcp",
+      fcpToken: secretValue(config.token, config.token_configured),
+      fcpAnonymous: config.anonymous ?? true,
+      fcpHandshake: config.handshake ?? "",
+      fcpExpirationHours:
+        typeof config.session_expiration_seconds === "number"
+          ? config.session_expiration_seconds / 3600
+          : base.fcpExpirationHours,
+      fcpRateLimitPerMinute:
+        typeof config.rate_limit_per_minute === "number"
+          ? String(config.rate_limit_per_minute)
+          : "",
+      fcpResponseTimeoutSeconds:
+        typeof config.response_timeout_seconds === "number"
+          ? String(config.response_timeout_seconds)
+          : String(DEFAULT_FCP_RESPONSE_TIMEOUT_SECONDS),
     };
   }
   if (channel.channel_type === "slack") {
@@ -182,6 +228,23 @@ export function buildChannelConfig(state: ChannelFormState) {
         generic_tool_text: state.agUiGenericToolText.trim() || DEFAULT_AG_UI_GENERIC_TOOL_TEXT,
       };
     }
+    case "fcp": {
+      const rateLimit = Number.parseInt(state.fcpRateLimitPerMinute, 10);
+      const timeout = Number.parseInt(state.fcpResponseTimeoutSeconds, 10);
+      return {
+        anonymous: state.fcpAnonymous,
+        ...(state.fcpToken.trim() ? { token: state.fcpToken.trim() } : {}),
+        ...(state.fcpHandshake.trim() ? { handshake: state.fcpHandshake } : {}),
+        session_expiration_seconds: Math.max(0, Math.round(state.fcpExpirationHours * 3600)),
+        ...(Number.isFinite(rateLimit) && rateLimit > 0
+          ? { rate_limit_per_minute: rateLimit }
+          : {}),
+        response_timeout_seconds:
+          Number.isFinite(timeout) && timeout > 0 && timeout <= 600
+            ? timeout
+            : DEFAULT_FCP_RESPONSE_TIMEOUT_SECONDS,
+      };
+    }
     case "slack":
       return {
         ...(state.slackSigningSecret.trim()
@@ -207,6 +270,14 @@ export function isChannelFormValid(state: ChannelFormState): boolean {
   if (state.kind === "ag_ui") {
     return state.agUiToolVisibility !== "generic" || state.agUiGenericToolText.trim().length <= 120;
   }
+  if (state.kind === "fcp") {
+    // anonymous=false without a token is allowed by the server (operator
+    // may intend to fill it in later), but the UI nudges the user to set
+    // one — the form is still valid either way.
+    const timeout = Number.parseInt(state.fcpResponseTimeoutSeconds, 10);
+    if (!Number.isFinite(timeout) || timeout <= 0 || timeout > 600) return false;
+    return true;
+  }
   if (state.kind === "slack") return true;
   return false;
 }
@@ -219,6 +290,8 @@ function channelIcon(kind: ChannelType) {
       return Webhook;
     case "ag_ui":
       return Monitor;
+    case "fcp":
+      return MessageSquareText;
     case "slack":
       return Slack;
     default:
@@ -234,6 +307,8 @@ function channelDescription(kind: ChannelType): string {
       return "Authenticated HTTP endpoint. Bearer token or Everruns webhook token header.";
     case "ag_ui":
       return "Public client surface. Tool names, args, and results are never sent to AG-UI clients.";
+    case "fcp":
+      return "Free Communication Protocol. Text-in / text-out HTTP endpoint with a Markdown handshake.";
     case "slack":
       return "React to messages in Slack. Per-thread, channel, or user session strategies.";
     default:
@@ -466,6 +541,108 @@ export function ChannelForm({
         </div>
       )}
 
+      {state.kind === "fcp" && (section === "all" || section === "invocation") && (
+        <div className="space-y-4">
+          <div className="flex items-center justify-between border p-3">
+            <div>
+              <p className="text-sm font-medium">Anonymous access</p>
+              <p className="text-xs text-muted-foreground">
+                When off, every request must present the bearer token below. The FCP handshake (GET
+                on the endpoint URL) stays public so clients can discover how to authenticate.
+              </p>
+            </div>
+            <Switch
+              checked={state.fcpAnonymous}
+              onCheckedChange={(checked) => update("fcpAnonymous", checked)}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="fcp_token">Bearer token</Label>
+            <div className="flex gap-2">
+              <Input
+                id="fcp_token"
+                value={state.fcpToken}
+                onChange={(event) => update("fcpToken", event.target.value)}
+                className="font-mono"
+                placeholder={
+                  mode === "edit" ? "Leave blank to keep existing token" : "Generated bearer token"
+                }
+              />
+              <Button
+                type="button"
+                variant="outline"
+                size="icon"
+                onClick={() => update("fcpToken", generateChannelToken())}
+                aria-label="Regenerate FCP token"
+              >
+                <RefreshCw className="size-4" />
+              </Button>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Verified with constant-time comparison; sent as Authorization: Bearer &lt;token&gt; or
+              X-Everruns-FCP-Token. Never echoed in responses.
+            </p>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="fcp_handshake">Custom handshake (Markdown)</Label>
+            <Textarea
+              id="fcp_handshake"
+              value={state.fcpHandshake}
+              onChange={(event) => update("fcpHandshake", event.target.value)}
+              placeholder="Leave blank to auto-generate from the app name and description."
+              rows={4}
+            />
+            <p className="text-xs text-muted-foreground">
+              Returned verbatim for GET on the endpoint URL. Use plain Markdown.
+            </p>
+          </div>
+          <FieldGrid>
+            <div className="space-y-2">
+              <Label htmlFor="fcp_expiration">Session expiration (hours)</Label>
+              <Input
+                id="fcp_expiration"
+                value={String(state.fcpExpirationHours)}
+                onChange={(event) => {
+                  const parsed = Number.parseFloat(event.target.value);
+                  update("fcpExpirationHours", Number.isFinite(parsed) ? parsed : 0);
+                }}
+                inputMode="numeric"
+                placeholder="6"
+              />
+              <p className="text-xs text-muted-foreground">
+                0 = never expire the fcp_session cookie.
+              </p>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="fcp_rate_limit">Rate limit / minute</Label>
+              <Input
+                id="fcp_rate_limit"
+                value={state.fcpRateLimitPerMinute}
+                onChange={(event) => update("fcpRateLimitPerMinute", event.target.value)}
+                inputMode="numeric"
+                placeholder="No per-channel cap"
+              />
+              <p className="text-xs text-muted-foreground">
+                FCP-only limiter namespace; cannot share buckets with other channels.
+              </p>
+            </div>
+          </FieldGrid>
+          <div className="space-y-2">
+            <Label htmlFor="fcp_response_timeout">Response timeout (seconds)</Label>
+            <Input
+              id="fcp_response_timeout"
+              value={state.fcpResponseTimeoutSeconds}
+              onChange={(event) => update("fcpResponseTimeoutSeconds", event.target.value)}
+              inputMode="numeric"
+              placeholder="120"
+            />
+            <p className="text-xs text-muted-foreground">
+              How long the endpoint waits for the agent before returning 504. Must be 1-600s.
+            </p>
+          </div>
+        </div>
+      )}
+
       {state.kind === "slack" && (section === "all" || section === "invocation") && (
         <div className="space-y-4">
           <FieldGrid>
@@ -580,7 +757,7 @@ export function ChannelFormSummary({ app, state }: { app?: App; state: ChannelFo
             </p>
           </div>
         )}
-        {(state.kind === "webhook" || state.kind === "ag_ui") && (
+        {(state.kind === "webhook" || state.kind === "ag_ui" || state.kind === "fcp") && (
           <div>
             <p className="text-xs font-medium uppercase text-muted-foreground">Activation</p>
             <p className="mt-1 text-sm text-muted-foreground">

--- a/apps/ui/src/components/apps/channel-row.tsx
+++ b/apps/ui/src/components/apps/channel-row.tsx
@@ -41,6 +41,8 @@ function iconFor(kind: ChannelType) {
       return Webhook;
     case "ag_ui":
       return Monitor;
+    case "fcp":
+      return Hash;
     case "slack":
       return Slack;
     default:
@@ -70,6 +72,7 @@ function channelName(channel: AppChannel): string {
   }
   if (channel.channel_type === "webhook") return "Webhook endpoint";
   if (channel.channel_type === "ag_ui") return "AG-UI endpoint";
+  if (channel.channel_type === "fcp") return "FCP endpoint";
   return getChannelTypeDisplayName(channel.channel_type);
 }
 

--- a/apps/ui/src/components/apps/fcp-setup-guidance.tsx
+++ b/apps/ui/src/components/apps/fcp-setup-guidance.tsx
@@ -1,0 +1,160 @@
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { CopyButton } from "@/components/ui/copy-button";
+import { Globe } from "lucide-react";
+
+interface FcpSetupGuidanceProps {
+  endpointUrl: string;
+  isPublished: boolean;
+  anonymousEnabled: boolean;
+  sessionExpirationSeconds: number;
+  rateLimitPerMinute?: number;
+  responseTimeoutSeconds?: number;
+  token?: string;
+  tokenConfigured?: boolean;
+  hasCustomHandshake?: boolean;
+  onConfigure?: () => void;
+}
+
+export function formatFcpSessionExpiration(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds <= 0) {
+    return "Never";
+  }
+  const hours = seconds / 3600;
+  if (hours >= 1 && Number.isInteger(hours)) {
+    return `${hours} ${hours === 1 ? "hour" : "hours"}`;
+  }
+  if (hours >= 1) {
+    return `${hours.toFixed(1)} hours`;
+  }
+  const minutes = seconds / 60;
+  if (minutes >= 1 && Number.isInteger(minutes)) {
+    return `${minutes} ${minutes === 1 ? "minute" : "minutes"}`;
+  }
+  return `${seconds} ${seconds === 1 ? "second" : "seconds"}`;
+}
+
+export function FcpSetupGuidance({
+  endpointUrl,
+  isPublished,
+  anonymousEnabled,
+  sessionExpirationSeconds,
+  rateLimitPerMinute,
+  responseTimeoutSeconds,
+  token,
+  tokenConfigured,
+  hasCustomHandshake,
+  onConfigure,
+}: FcpSetupGuidanceProps) {
+  const hasRateLimit = !!rateLimitPerMinute && rateLimitPerMinute > 0;
+  const hasToken = !!token || !!tokenConfigured;
+  const accessBadge = hasToken ? "Token Protected" : anonymousEnabled ? "Anonymous" : "Restricted";
+  const timeoutSeconds =
+    responseTimeoutSeconds && responseTimeoutSeconds > 0 ? responseTimeoutSeconds : 120;
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-2">
+        <Badge variant={anonymousEnabled && !hasToken ? "default" : "secondary"}>
+          {accessBadge}
+        </Badge>
+        <span className="text-sm text-muted-foreground">
+          {isPublished ? "Ready for FCP clients" : "Publish the app to accept requests"}
+        </span>
+      </div>
+
+      <div>
+        <p className="text-sm font-medium">Endpoint</p>
+        <div className="mt-2 flex items-center gap-2 bg-muted p-3">
+          <Globe className="h-4 w-4 shrink-0 text-muted-foreground" />
+          <code className="flex-1 truncate text-sm">{endpointUrl}</code>
+          <CopyButton value={endpointUrl} />
+        </div>
+        <p className="mt-2 text-xs text-muted-foreground">
+          GET this URL for the Markdown handshake. POST plain text (or JSON{" "}
+          <code>&#123;&quot;message&quot;: &quot;...&quot;&#125;</code>) for a reply.
+        </p>
+      </div>
+
+      <div>
+        <p className="text-sm font-medium">Token</p>
+        {token ? (
+          <div className="mt-2 flex items-center gap-2 bg-muted p-3">
+            <code className="flex-1 truncate text-sm">{token}</code>
+            <CopyButton value={token} />
+          </div>
+        ) : hasToken ? (
+          <p className="text-sm text-muted-foreground">Channel token configured</p>
+        ) : anonymousEnabled ? (
+          <p className="text-sm text-muted-foreground">No channel token required</p>
+        ) : (
+          <p className="text-sm text-muted-foreground">
+            Anonymous access is off — configure a token, otherwise every request will be rejected
+            with 401.
+          </p>
+        )}
+      </div>
+
+      <div>
+        <p className="text-sm font-medium">Handshake (GET body)</p>
+        <p className="text-sm text-muted-foreground">
+          {hasCustomHandshake
+            ? "Custom Markdown configured."
+            : "Auto-generated from the app name and description."}
+        </p>
+      </div>
+
+      <div>
+        <p className="text-sm font-medium">Session expiration</p>
+        <p className="text-sm text-muted-foreground">
+          {formatFcpSessionExpiration(sessionExpirationSeconds)}
+          {sessionExpirationSeconds > 0
+            ? " — after this the fcp_session cookie can no longer resume the same conversation; the next request starts a fresh one."
+            : " — sessions can be resumed indefinitely."}
+        </p>
+      </div>
+
+      <div>
+        <p className="text-sm font-medium">Rate limit</p>
+        <p className="text-sm text-muted-foreground">
+          {hasRateLimit
+            ? `${rateLimitPerMinute} requests per minute, per client IP`
+            : "No per-app cap (global API limit applies)"}
+          {" — counted in an FCP-only limiter namespace."}
+        </p>
+      </div>
+
+      <div>
+        <p className="text-sm font-medium">Response timeout</p>
+        <p className="text-sm text-muted-foreground">
+          {timeoutSeconds} seconds — after which the endpoint returns 504 with the same{" "}
+          <code>fcp_session</code> cookie so the client can retry.
+        </p>
+      </div>
+
+      <div className="space-y-1 text-sm text-muted-foreground">
+        <p>
+          Body: plain UTF-8 text, or <code>application/json</code> of shape{" "}
+          <code>&#123;&quot;message&quot;: &quot;...&quot;&#125;</code>. Maximum 256 KiB.
+        </p>
+        {hasToken && (
+          <p>
+            Include <code>Authorization: Bearer &lt;token&gt;</code> or{" "}
+            <code>X-Everruns-FCP-Token: &lt;token&gt;</code>.
+          </p>
+        )}
+        <p>
+          Responses are <code>text/markdown</code>. Errors are also Markdown and contain the next
+          step the caller should take.
+        </p>
+      </div>
+
+      {onConfigure && (
+        <div className="pt-1">
+          <Button size="sm" variant="outline" onClick={onConfigure}>
+            Configure
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/ui/src/lib/api/types/app-types.ts
+++ b/apps/ui/src/lib/api/types/app-types.ts
@@ -3,7 +3,7 @@
 import type { PrincipalSummary } from "./common-types";
 
 export type AppStatus = "draft" | "published" | "archived" | "deleted";
-export type ChannelType = "slack" | "ag_ui" | "schedule" | "webhook" | "a2a";
+export type ChannelType = "slack" | "ag_ui" | "schedule" | "webhook" | "a2a" | "fcp";
 export type SessionStrategy = "per_thread" | "per_channel" | "per_user";
 export type SlackReplyMode = "all_messages" | "report_progress_only";
 export type InvocationSessionMode = "shared_session" | "session_per_invocation";
@@ -116,6 +116,31 @@ export interface WebhookChannelConfig {
 }
 
 /**
+ * FCP (Free Communication Protocol) channel configuration.
+ *
+ * Minimal text-first ingress. FCP intentionally runs its own auth stack —
+ * anonymous + an optional shared bearer token — and does not accept the
+ * inline `AppEndpointAuthConfig` modes used by AG-UI and A2A.
+ */
+export interface FcpChannelConfig {
+  anonymous?: boolean;
+  /**
+   * Optional shared bearer token. When set, clients must send
+   * `Authorization: Bearer <token>` or `X-Everruns-FCP-Token: <token>`.
+   */
+  token?: string;
+  token_configured?: boolean;
+  /** Markdown body returned on `GET` (the FCP handshake). */
+  handshake?: string;
+  /** Seconds the `fcp_session` cookie keeps a session resumable. 0 disables. */
+  session_expiration_seconds?: number;
+  /** Per-IP requests-per-minute cap. `0` or absent disables the per-app cap. */
+  rate_limit_per_minute?: number;
+  /** Max seconds to wait for the agent's reply before returning 504. */
+  response_timeout_seconds?: number;
+}
+
+/**
  * A2A (Agent2Agent) channel configuration.
  *
  * The plaintext API key is **never** returned by the API after creation /
@@ -158,6 +183,7 @@ export interface AppChannel {
     | ScheduleChannelConfig
     | WebhookChannelConfig
     | A2aChannelConfig
+    | FcpChannelConfig
     | Record<string, unknown>;
   enabled: boolean;
   next_run_at?: string | null;
@@ -221,6 +247,7 @@ export interface CreateAppRequest {
     | ScheduleChannelConfig
     | WebhookChannelConfig
     | A2aChannelConfig
+    | FcpChannelConfig
     | Record<string, unknown>;
 }
 
@@ -243,6 +270,7 @@ export interface AddChannelRequest {
     | ScheduleChannelConfig
     | WebhookChannelConfig
     | A2aChannelConfig
+    | FcpChannelConfig
     | Record<string, unknown>;
   enabled?: boolean;
 }
@@ -255,6 +283,7 @@ export interface UpdateChannelRequest {
     | ScheduleChannelConfig
     | WebhookChannelConfig
     | A2aChannelConfig
+    | FcpChannelConfig
     | Record<string, unknown>;
   enabled?: boolean;
 }

--- a/apps/ui/src/lib/app-channels.ts
+++ b/apps/ui/src/lib/app-channels.ts
@@ -18,6 +18,8 @@ export function getChannelTypeDisplayName(channelType: ChannelType): string {
       return "Webhook";
     case "a2a":
       return "A2A (Agent2Agent)";
+    case "fcp":
+      return "FCP (Free Communication Protocol)";
   }
 }
 

--- a/crates/core/src/app.rs
+++ b/crates/core/src/app.rs
@@ -105,6 +105,10 @@ pub enum ChannelType {
     Webhook,
     /// Agent2Agent (A2A) protocol channel — JSON-RPC + API key.
     A2a,
+    /// Free Communication Protocol channel — text-first HTTP ingress with an
+    /// optional handshake. See `specs/fcp-channel.md` and the upstream FCP
+    /// specification.
+    Fcp,
 }
 
 impl std::fmt::Display for ChannelType {
@@ -115,6 +119,7 @@ impl std::fmt::Display for ChannelType {
             ChannelType::Schedule => write!(f, "schedule"),
             ChannelType::Webhook => write!(f, "webhook"),
             ChannelType::A2a => write!(f, "a2a"),
+            ChannelType::Fcp => write!(f, "fcp"),
         }
     }
 }
@@ -127,6 +132,7 @@ impl ChannelType {
             "schedule" => Some(ChannelType::Schedule),
             "webhook" => Some(ChannelType::Webhook),
             "a2a" => Some(ChannelType::A2a),
+            "fcp" => Some(ChannelType::Fcp),
             _ => None,
         }
     }
@@ -269,6 +275,15 @@ impl AppChannel {
         serde_json::from_value(self.channel_config.clone()).ok()
     }
 
+    /// Parse channel_config as FcpChannelConfig. Returns None if not an FCP
+    /// channel or if the config is invalid.
+    pub fn fcp_config(&self) -> Option<FcpChannelConfig> {
+        if self.channel_type != ChannelType::Fcp {
+            return None;
+        }
+        serde_json::from_value(self.channel_config.clone()).ok()
+    }
+
     /// Parse channel_config as A2aChannelConfig. Returns None if not an A2A
     /// channel or if the config is invalid.
     pub fn a2a_config(&self) -> Option<A2aChannelConfig> {
@@ -306,6 +321,13 @@ impl App {
         self.channels
             .iter()
             .find(|ch| ch.channel_type == ChannelType::Webhook && ch.enabled)
+    }
+
+    /// Find the first enabled FCP channel on this app.
+    pub fn fcp_channel(&self) -> Option<&AppChannel> {
+        self.channels
+            .iter()
+            .find(|ch| ch.channel_type == ChannelType::Fcp && ch.enabled)
     }
 
     /// Find the first enabled A2A channel on this app.
@@ -576,6 +598,68 @@ fn is_default_ag_ui_generic_tool_text(value: &str) -> bool {
     value == DEFAULT_AG_UI_GENERIC_TOOL_TEXT
 }
 
+/// Default FCP handshake body. Returned by `GET` when the channel config does
+/// not override `handshake`. Kept generic so an unconfigured FCP endpoint
+/// still satisfies the FCP `SHOULD` for handshake responses.
+pub const DEFAULT_FCP_HANDSHAKE: &str = "FCP endpoint.\n\nPOST plain text or `application/json` (`{\"message\": \"...\"}`) to\nthis URL to talk to the agent. Replies are returned as `text/markdown`.\n\nSession state, when supported, is carried by the `fcp_session` cookie.";
+
+/// Default response timeout for a blocking FCP POST, in seconds.
+pub const DEFAULT_FCP_RESPONSE_TIMEOUT_SECONDS: u32 = 120;
+
+/// Typed FCP channel configuration.
+///
+/// FCP is intentionally schema-free at the wire layer (see
+/// `specs/fcp-channel.md`). The fields here only control server-side
+/// behavior — handshake content, a single shared bearer token, session
+/// reuse, rate limiting — and never constrain the body the actor sends in.
+///
+/// FCP deliberately exposes a **smaller** auth surface than AG-UI/A2A: it
+/// supports anonymous access and a single shared bearer token, and nothing
+/// else. Inline OIDC/HTTP-Basic/mTLS verifier modes are intentionally
+/// **not** wired here so the FCP ingress path does not share authentication
+/// machinery with other channels or with the main API's user auth stack.
+/// Operators that need IdP-backed auth in front of an FCP endpoint should
+/// terminate that at the edge (reverse proxy, IAP, mTLS) rather than asking
+/// the FCP handler to grow another auth mode.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct FcpChannelConfig {
+    /// Whether anonymous access is allowed for this endpoint. When `false`
+    /// a non-empty `token` must authenticate every `POST`.
+    #[serde(default = "default_true")]
+    pub anonymous: bool,
+    /// Optional shared bearer token. When set, callers must send
+    /// `Authorization: Bearer <token>` (or the `X-Everruns-FCP-Token`
+    /// header). Validated by constant-time comparison inside the FCP
+    /// handler — never via the shared App endpoint auth verifier.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub token: Option<String>,
+    /// Markdown body returned for `GET` requests (the FCP handshake). When
+    /// omitted, a generic handshake derived from the app's name and
+    /// description is used.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub handshake: Option<String>,
+    /// How long (in seconds) the FCP session cookie keeps a session
+    /// resumable. `0` disables expiration. Defaults to 6 hours so a
+    /// long-running conversation expires on a sensible cadence.
+    #[serde(default = "default_session_expiration_seconds")]
+    pub session_expiration_seconds: u32,
+    /// Optional per-IP rate limit (requests per minute) for the FCP endpoint.
+    /// `None` or `Some(0)` disables the per-app limit; the global API limit
+    /// still applies. Counted in an FCP-specific limiter namespace so it
+    /// cannot be shared or exhausted by other channels.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rate_limit_per_minute: Option<u32>,
+    /// Maximum number of seconds the FCP endpoint waits for the agent to
+    /// produce a reply before returning a `504`. Defaults to 120 s.
+    #[serde(default = "default_fcp_response_timeout_seconds")]
+    pub response_timeout_seconds: u32,
+}
+
+fn default_fcp_response_timeout_seconds() -> u32 {
+    DEFAULT_FCP_RESPONSE_TIMEOUT_SECONDS
+}
+
 /// How app-triggered invocations route into sessions.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
@@ -716,6 +800,7 @@ mod tests {
         assert_eq!(ChannelType::Schedule.to_string(), "schedule");
         assert_eq!(ChannelType::Webhook.to_string(), "webhook");
         assert_eq!(ChannelType::A2a.to_string(), "a2a");
+        assert_eq!(ChannelType::Fcp.to_string(), "fcp");
     }
 
     #[test]
@@ -731,6 +816,7 @@ mod tests {
             Some(ChannelType::Webhook)
         );
         assert_eq!(ChannelType::from_str_opt("a2a"), Some(ChannelType::A2a));
+        assert_eq!(ChannelType::from_str_opt("fcp"), Some(ChannelType::Fcp));
         assert_eq!(ChannelType::from_str_opt("unknown"), None);
         assert_eq!(ChannelType::from_str_opt(""), None);
     }
@@ -1020,6 +1106,30 @@ mod tests {
         let ch = test_channel(ChannelType::AgUi, serde_json::json!({"anonymous": true}));
         let app = test_app(vec![ch]);
         assert!(app.ag_ui_channel().is_some());
+    }
+
+    #[test]
+    fn test_app_channel_fcp_config_defaults() {
+        let ch = test_channel(ChannelType::Fcp, serde_json::json!({}));
+        let config = ch.fcp_config().unwrap();
+        assert!(config.anonymous);
+        assert!(config.token.is_none());
+        assert!(config.handshake.is_none());
+        assert_eq!(
+            config.session_expiration_seconds,
+            DEFAULT_SESSION_EXPIRATION_SECONDS
+        );
+        assert_eq!(
+            config.response_timeout_seconds,
+            DEFAULT_FCP_RESPONSE_TIMEOUT_SECONDS
+        );
+    }
+
+    #[test]
+    fn test_app_fcp_channel_lookup() {
+        let ch = test_channel(ChannelType::Fcp, serde_json::json!({}));
+        let app = test_app(vec![ch]);
+        assert!(app.fcp_channel().is_some());
     }
 
     #[test]

--- a/crates/core/src/capabilities/platform_management.rs
+++ b/crates/core/src/capabilities/platform_management.rs
@@ -1105,7 +1105,7 @@ impl Tool for ManageAppsTool {
                 },
                 "channel_type": {
                     "type": "string",
-                    "enum": ["slack", "ag_ui", "schedule", "webhook"],
+                    "enum": ["slack", "ag_ui", "schedule", "webhook", "a2a", "fcp"],
                     "description": "Optional initial channel type for create"
                 },
                 "channel_config": {
@@ -1453,7 +1453,7 @@ impl Tool for ManageAppChannelsTool {
                 },
                 "channel_type": {
                     "type": "string",
-                    "enum": ["slack", "ag_ui", "schedule", "webhook"],
+                    "enum": ["slack", "ag_ui", "schedule", "webhook", "a2a", "fcp"],
                     "description": "Channel type (required for add, optional for update)"
                 },
                 "channel_config": {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -317,8 +317,8 @@ pub use agent_identity::{AgentIdentity, AgentIdentityStatus};
 pub use app::{
     A2aChannelConfig, AgUiChannelConfig, AgUiToolVisibility, AgentVersionPolicy, App, AppChannel,
     AppEndpointAuthConfig, AppEndpointAuthMode, AppEndpointAuthProviderConfig,
-    AppEndpointAuthRequirements, AppStatus, ChannelType, SessionStrategy, SlackChannelConfig,
-    SlackReplyMode,
+    AppEndpointAuthRequirements, AppStatus, ChannelType, FcpChannelConfig, SessionStrategy,
+    SlackChannelConfig, SlackReplyMode,
 };
 pub use capability_dto::{AgentCapability, CapabilityInfo};
 pub use context_report::{

--- a/crates/server/migrations/043_app_channel_type_fcp.sql
+++ b/crates/server/migrations/043_app_channel_type_fcp.sql
@@ -1,0 +1,16 @@
+-- Allow `fcp` (Free Communication Protocol) app channels.
+-- See specs/fcp-channel.md.
+
+ALTER TABLE apps
+    DROP CONSTRAINT IF EXISTS apps_channel_type_check;
+
+ALTER TABLE apps
+    ADD CONSTRAINT apps_channel_type_check
+    CHECK (channel_type IN ('slack', 'ag_ui', 'schedule', 'webhook', 'a2a', 'fcp'));
+
+ALTER TABLE app_channels
+    DROP CONSTRAINT IF EXISTS app_channels_channel_type_check;
+
+ALTER TABLE app_channels
+    ADD CONSTRAINT app_channels_channel_type_check
+    CHECK (channel_type IN ('slack', 'ag_ui', 'schedule', 'webhook', 'a2a', 'fcp'));

--- a/crates/server/src/api/fcp.rs
+++ b/crates/server/src/api/fcp.rs
@@ -211,7 +211,33 @@ async fn check_rate_limit(
 /// `GET /v1/apps/{app_id}/fcp` — handshake. Always returns the same
 /// generic 404 body for unknown apps so the endpoint cannot be used to
 /// probe which app ids are real.
-async fn handshake(
+#[utoipa::path(
+    get,
+    path = "/v1/apps/{app_id}/fcp",
+    params(("app_id" = String, Path, description = "App ID")),
+    responses(
+        (
+            status = 200,
+            description = "Markdown handshake describing the FCP endpoint and how to authenticate. \
+                           Always `text/markdown`.",
+            content_type = "text/markdown",
+        ),
+        (
+            status = 404,
+            description = "No FCP endpoint at this URL. Single sanitized body covers \
+                           unknown apps, unpublished apps, apps without an FCP channel, \
+                           and disabled FCP channels — operator state is never disclosed.",
+            content_type = "text/markdown",
+        ),
+        (
+            status = 429,
+            description = "Per-app FCP rate limit exceeded. `Retry-After: 60` header is set.",
+            content_type = "text/markdown",
+        ),
+    ),
+    tag = "apps"
+)]
+pub async fn handshake(
     State(state): State<FcpState>,
     Path(app_id): Path<String>,
     connect_info: Option<Extension<ConnectInfo<std::net::SocketAddr>>>,
@@ -235,7 +261,69 @@ async fn handshake(
 }
 
 /// `POST /v1/apps/{app_id}/fcp` — text-in, text-out.
-async fn message(
+#[utoipa::path(
+    post,
+    path = "/v1/apps/{app_id}/fcp",
+    params(("app_id" = String, Path, description = "App ID")),
+    request_body(
+        content = String,
+        description = "Plain UTF-8 text, or `application/json` of shape `{\"message\": \"...\"}`. \
+                       Maximum 256 KiB.",
+        content_type = "text/plain",
+    ),
+    responses(
+        (
+            status = 200,
+            description = "Agent reply as Markdown. The `Set-Cookie: fcp_session=...` header is \
+                           emitted so subsequent POSTs can resume the same conversation.",
+            content_type = "text/markdown",
+        ),
+        (
+            status = 400,
+            description = "Malformed body. Distinct messages for empty body, non-UTF-8 bytes, \
+                           and JSON that did not parse into the expected shape — each Markdown \
+                           body points back at the handshake.",
+            content_type = "text/markdown",
+        ),
+        (
+            status = 401,
+            description = "Token required but missing or wrong. Markdown body explains both \
+                           accepted headers (`Authorization: Bearer` and `X-Everruns-FCP-Token`) \
+                           and points at the handshake.",
+            content_type = "text/markdown",
+        ),
+        (
+            status = 404,
+            description = "Same generic 404 as the handshake — operator state is never disclosed.",
+            content_type = "text/markdown",
+        ),
+        (
+            status = 410,
+            description = "FCP session expired. Body tells the client to drop the `fcp_session` \
+                           cookie and POST again.",
+            content_type = "text/markdown",
+        ),
+        (
+            status = 413,
+            description = "Body exceeds 256 KiB.",
+            content_type = "text/markdown",
+        ),
+        (
+            status = 429,
+            description = "Per-app FCP rate limit exceeded. `Retry-After: 60` header is set.",
+            content_type = "text/markdown",
+        ),
+        (
+            status = 504,
+            description = "Agent did not reply within the configured timeout. The same \
+                           `fcp_session` cookie is set so the client can retry the same \
+                           conversation.",
+            content_type = "text/markdown",
+        ),
+    ),
+    tag = "apps"
+)]
+pub async fn message(
     State(state): State<FcpState>,
     Path(app_id): Path<String>,
     req_id: Option<Extension<RequestId>>,
@@ -391,13 +479,16 @@ async fn message(
     })
     .await;
 
-    let response_text = match collected {
-        Ok(Ok(text)) => text,
-        Ok(Err(public_err)) => return turn_error_response(public_err),
-        Err(_elapsed) => return timeout_response(context.config.response_timeout_seconds),
+    let mut response = match collected {
+        Ok(Ok(text)) => markdown_response(StatusCode::OK, text),
+        Ok(Err(public_err)) => turn_error_response(public_err),
+        Err(_elapsed) => timeout_response(context.config.response_timeout_seconds),
     };
 
-    let mut response = markdown_response(StatusCode::OK, response_text);
+    // Set the session cookie on every response that resolved a session,
+    // including timeouts and provider errors. The session is already
+    // recorded; emitting the cookie lets the client retry against the
+    // same conversation rather than starting a fresh one.
     if let Some(cookie) =
         build_session_cookie(session_id, context.config.session_expiration_seconds)
         && let Ok(value) = HeaderValue::from_str(&cookie)
@@ -804,7 +895,9 @@ fn payload_too_large_response() -> Response {
     markdown_response(
         StatusCode::PAYLOAD_TOO_LARGE,
         format!(
-            "Body exceeds the {MAX_FCP_BODY_BYTES}-byte FCP limit.\n\nSend a shorter message. If you need to send long content, summarise it\nor break it into multiple `POST`s in the same session."
+            "Body exceeds the FCP body limit of {kib} KiB ({bytes} bytes).\n\nSend a shorter message. If you need to send long content, summarise it\nor break it into multiple `POST`s in the same session.",
+            kib = MAX_FCP_BODY_BYTES / 1024,
+            bytes = MAX_FCP_BODY_BYTES,
         ),
     )
 }

--- a/crates/server/src/api/fcp.rs
+++ b/crates/server/src/api/fcp.rs
@@ -468,10 +468,8 @@ pub async fn message(
                         .and_then(|d| d.error_code);
                     return Err(PublicError::from_internal_code(code.as_deref()));
                 }
-                TURN_CANCELLED => {
-                    if parse_event_data::<TurnCancelledData>(&event).is_ok() {
-                        return Err(PublicError::fallback());
-                    }
+                TURN_CANCELLED if parse_event_data::<TurnCancelledData>(&event).is_ok() => {
+                    return Err(PublicError::fallback());
                 }
                 _ => {}
             }

--- a/crates/server/src/api/fcp.rs
+++ b/crates/server/src/api/fcp.rs
@@ -1,0 +1,1179 @@
+// FCP (Free Communication Protocol) app channel — minimal text-first ingress.
+//
+// Design Decision: FCP is intentionally schema-free at the wire layer. `POST`
+// accepts plain text (or `{"message": "..."}`), `GET` returns a Markdown
+// handshake, and the response is the final assistant text. Streaming and
+// structured envelopes are deliberately omitted; clients negotiate everything
+// in natural language during the handshake (see `specs/fcp-channel.md`).
+//
+// Design Decision: FCP runs its own minimal auth stack — anonymous access
+// plus a single shared bearer token, validated by constant-time comparison
+// inline. It deliberately does **not** call into `AppEndpointAuthVerifier`
+// (used by AG-UI/A2A) or the platform's user-session auth. This keeps the
+// public FCP surface narrow, predictable, and decoupled from changes to
+// other channels.
+//
+// Design Decision: FCP has its own `ChannelRateLimiter` namespace. The
+// per-app cap counts in a bucket that no other channel can share or
+// exhaust. The global API limit still applies; this is an additional
+// per-channel layer.
+//
+// Design Decision: Every response — success **and** error — is rendered as
+// Markdown with actionable instructions that point back at the `GET`
+// handshake. We never expose internal state (app existence, lifecycle,
+// channel config, durable engine details). Error bodies tell the caller
+// what to do next, not what failed inside us.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::{
+    Extension, Router,
+    extract::{ConnectInfo, Path, State},
+    http::{HeaderMap, HeaderValue, StatusCode, header::AUTHORIZATION},
+    response::{IntoResponse, Response},
+    routing::get,
+};
+use everruns_core::events::{
+    OUTPUT_MESSAGE_COMPLETED, OutputMessageCompletedData, TURN_CANCELLED, TURN_FAILED,
+    TurnCancelledData, TurnFailedData,
+};
+use everruns_core::message::ExecutionPhase;
+use everruns_core::{App, AppStatus, Caller, ContentPart, ExternalActor, FcpChannelConfig};
+use serde::Deserialize;
+use serde_json::Value;
+use uuid::Uuid;
+
+use crate::api::channel_rate_limit::ChannelRateLimiter;
+use crate::api::messages::{
+    CreateMessageRequest, InputContentPart, InputMessage, MessageRole as ApiMessageRole,
+};
+use crate::api::public::{PublicError, PublicErrorCode};
+use crate::api::sessions::CreateSessionRequest;
+use crate::auth::rate_limit::extract_client_ip_from_parts;
+use crate::domains::messages::{CreateMessageContext, MessageService};
+use crate::domains::sessions::SessionService;
+use crate::event_delivery::EventDelivery;
+use crate::execution_metadata;
+use crate::middleware::RequestId;
+use crate::storage::{EncryptionService, StorageBackend};
+
+const FCP_SESSION_COOKIE: &str = "fcp_session";
+const FCP_TOKEN_HEADER: &str = "x-everruns-fcp-token";
+const MAX_FCP_BODY_BYTES: usize = 256 * 1024;
+const FCP_CONTENT_TYPE: &str = "text/markdown; charset=utf-8";
+
+#[derive(Clone)]
+pub struct FcpState {
+    pub db: Arc<StorageBackend>,
+    pub encryption: Option<Arc<EncryptionService>>,
+    pub session_service: Arc<SessionService>,
+    pub message_service: Arc<MessageService>,
+    pub event_delivery: EventDelivery,
+    /// FCP-only rate limiter. Constructed with a dedicated namespace so it
+    /// cannot collide with AG-UI/A2A limiter buckets.
+    pub rate_limiter: ChannelRateLimiter,
+}
+
+impl FcpState {
+    pub fn new(
+        db: Arc<StorageBackend>,
+        encryption: Option<Arc<EncryptionService>>,
+        runner: Arc<dyn everruns_worker::AgentRunner>,
+        notifications_enabled: bool,
+        event_delivery: EventDelivery,
+        rate_limiter: ChannelRateLimiter,
+    ) -> Self {
+        Self {
+            session_service: Arc::new(SessionService::new(db.clone())),
+            message_service: Arc::new(MessageService::new(
+                db.clone(),
+                runner,
+                notifications_enabled,
+                event_delivery.clone(),
+            )),
+            db,
+            encryption,
+            event_delivery,
+            rate_limiter,
+        }
+    }
+}
+
+pub fn routes(state: FcpState) -> Router {
+    Router::new()
+        .route("/v1/apps/{app_id}/fcp", get(handshake).post(message))
+        .with_state(state)
+}
+
+/// Resolved channel context, used by both `GET` and `POST`. The lookup is
+/// shared so we apply the same "exists at all?" sanitization in one place.
+struct FcpContext {
+    app: App,
+    config: FcpChannelConfig,
+}
+
+async fn resolve_context(state: &FcpState, app_id: &str) -> Result<FcpContext, Response> {
+    // Sanitization rule: any failure path here returns the same generic
+    // not-found body. We must not reveal:
+    //   - whether the app id was malformed vs. unknown
+    //   - whether an app exists but is not published
+    //   - whether an app is published but has no FCP channel
+    //   - whether a channel exists but is disabled
+    let app = match crate::domains::apps::queries::get_by_public_id_unscoped(
+        &state.db,
+        state.encryption.as_ref(),
+        app_id,
+    )
+    .await
+    {
+        Ok(Some(app)) => app,
+        Ok(None) => return Err(not_found_response()),
+        Err(err) => {
+            tracing::error!(error = %err, "FCP app lookup failed");
+            return Err(internal_error_response());
+        }
+    };
+    if app.status != AppStatus::Published {
+        return Err(not_found_response());
+    }
+    let channel = match app.fcp_channel() {
+        Some(channel) => channel,
+        None => return Err(not_found_response()),
+    };
+    let config = match channel.fcp_config() {
+        Some(config) => config,
+        None => {
+            tracing::error!(app_id = %app.public_id, "FCP channel config did not deserialize");
+            return Err(internal_error_response());
+        }
+    };
+    Ok(FcpContext { app, config })
+}
+
+/// Verify the caller's token (if one is required) using constant-time
+/// comparison. Returns an actionable 401 body on mismatch so clients learn
+/// how to authenticate without us echoing the configured token.
+fn check_token(headers: &HeaderMap, config: &FcpChannelConfig) -> Result<(), Box<Response>> {
+    let token_required = !config.anonymous
+        || config
+            .token
+            .as_deref()
+            .map(|t| !t.is_empty())
+            .unwrap_or(false);
+    if !token_required {
+        return Ok(());
+    }
+    let Some(expected) = config.token.as_deref().filter(|t| !t.is_empty()) else {
+        // anonymous=false but no token configured — the app owner has
+        // misconfigured the channel. We still don't accept the request and
+        // we still don't tell the caller what's wrong.
+        return Err(Box::new(unauthorized_response()));
+    };
+    let provided = match extract_token(headers) {
+        Some(t) => t,
+        None => return Err(Box::new(unauthorized_response())),
+    };
+    if !constant_time_eq(provided.as_bytes(), expected.as_bytes()) {
+        return Err(Box::new(unauthorized_response()));
+    }
+    Ok(())
+}
+
+/// Enforce the per-app FCP rate limit. Returns a 429 body that tells the
+/// caller exactly when to retry.
+async fn check_rate_limit(
+    state: &FcpState,
+    headers: &HeaderMap,
+    peer_addr: Option<std::net::SocketAddr>,
+    app: &App,
+    config: &FcpChannelConfig,
+) -> Result<(), Response> {
+    let Some(limit) = config.rate_limit_per_minute else {
+        return Ok(());
+    };
+    if limit == 0 {
+        return Ok(());
+    }
+    let client_ip = extract_client_ip_from_parts(peer_addr, headers);
+    if state
+        .rate_limiter
+        .check(&app.public_id.to_string(), client_ip, limit)
+        .await
+        .is_err()
+    {
+        return Err(rate_limited_response(limit));
+    }
+    Ok(())
+}
+
+/// `GET /v1/apps/{app_id}/fcp` — handshake. Always returns the same
+/// generic 404 body for unknown apps so the endpoint cannot be used to
+/// probe which app ids are real.
+async fn handshake(
+    State(state): State<FcpState>,
+    Path(app_id): Path<String>,
+    connect_info: Option<Extension<ConnectInfo<std::net::SocketAddr>>>,
+    headers: HeaderMap,
+) -> Response {
+    // Per the FCP SPEC, the handshake is meant to be open. We still apply
+    // the per-app rate limit (when configured) so a single client can't
+    // hammer the handshake either.
+    let context = match resolve_context(&state, &app_id).await {
+        Ok(ctx) => ctx,
+        Err(resp) => return resp,
+    };
+    let peer_addr = connect_info.map(|Extension(ConnectInfo(addr))| addr);
+    if let Err(resp) =
+        check_rate_limit(&state, &headers, peer_addr, &context.app, &context.config).await
+    {
+        return resp;
+    }
+    let body = render_handshake(&context.app, &context.config);
+    markdown_response(StatusCode::OK, body)
+}
+
+/// `POST /v1/apps/{app_id}/fcp` — text-in, text-out.
+async fn message(
+    State(state): State<FcpState>,
+    Path(app_id): Path<String>,
+    req_id: Option<Extension<RequestId>>,
+    connect_info: Option<Extension<ConnectInfo<std::net::SocketAddr>>>,
+    headers: HeaderMap,
+    body: axum::body::Bytes,
+) -> Response {
+    let peer_addr = connect_info.map(|Extension(ConnectInfo(addr))| addr);
+    let request_id = req_id.map(|Extension(r)| r.0);
+
+    if body.len() > MAX_FCP_BODY_BYTES {
+        return payload_too_large_response();
+    }
+
+    let context = match resolve_context(&state, &app_id).await {
+        Ok(ctx) => ctx,
+        Err(resp) => return resp,
+    };
+
+    if let Err(resp) =
+        check_rate_limit(&state, &headers, peer_addr, &context.app, &context.config).await
+    {
+        return resp;
+    }
+    if let Err(resp) = check_token(&headers, &context.config) {
+        return *resp;
+    }
+
+    let user_text = match extract_user_text(&headers, &body) {
+        Ok(text) => text,
+        Err(resp) => return *resp,
+    };
+    if user_text.trim().is_empty() {
+        return empty_message_response();
+    }
+
+    let resolved = match resolve_session(
+        &state,
+        &context.app,
+        &context.config,
+        parse_session_cookie(&headers),
+    )
+    .await
+    {
+        Ok(resolved) => resolved,
+        Err(resp) => return resp,
+    };
+
+    let mut subscription = match state
+        .event_delivery
+        .clone()
+        .subscribe(resolved.session_id)
+        .await
+    {
+        Ok(sub) => sub,
+        Err(err) => {
+            tracing::error!(error = %err, "FCP event subscription failed");
+            return internal_error_response();
+        }
+    };
+
+    let input_message = match state
+        .message_service
+        .create(
+            CreateMessageContext {
+                org_id: context.app.org_id,
+                user_id: None,
+                harness_id: context.app.harness_id.uuid(),
+                agent_id: context.app.agent_id.map(|agent_id| agent_id.uuid()),
+                session_id: resolved.session_id,
+                event_metadata: Some(execution_metadata::app_message_metadata(
+                    context.app.public_id,
+                    context.app.owner_principal_id,
+                    context.app.agent_identity_id,
+                )),
+                request_id,
+            },
+            CreateMessageRequest {
+                message: InputMessage {
+                    role: ApiMessageRole::User,
+                    content: vec![InputContentPart::text(user_text)],
+                },
+                controls: None,
+                metadata: Some(fcp_message_metadata(&context.app)),
+                tags: None,
+                external_actor: Some(ExternalActor {
+                    actor_id: "fcp".to_string(),
+                    actor_name: None,
+                    source: "fcp".to_string(),
+                    metadata: None,
+                }),
+            },
+        )
+        .await
+    {
+        Ok(msg) => msg,
+        Err(err) => {
+            tracing::error!(error = %err, "FCP message create failed");
+            return internal_error_response();
+        }
+    };
+
+    let input_message_id = input_message.id.to_string();
+    let session_id = resolved.session_id;
+    let timeout = Duration::from_secs(context.config.response_timeout_seconds.max(1) as u64);
+
+    let collected = tokio::time::timeout(timeout, async {
+        loop {
+            let Some(event) = subscription.recv().await else {
+                return Err(PublicError::fallback());
+            };
+            if event.session_id.uuid() != session_id {
+                continue;
+            }
+            let matches_input = event
+                .context
+                .input_message_id
+                .as_ref()
+                .map(|id| id.to_string())
+                .as_deref()
+                == Some(input_message_id.as_str());
+            if !matches_input {
+                continue;
+            }
+            match event.event_type.as_str() {
+                OUTPUT_MESSAGE_COMPLETED => {
+                    let Ok(data) = parse_event_data::<OutputMessageCompletedData>(&event) else {
+                        continue;
+                    };
+                    if matches!(data.message.phase, Some(ExecutionPhase::Commentary)) {
+                        continue;
+                    }
+                    let text = content_parts_to_text(&data.message.content);
+                    if text.trim().is_empty() {
+                        continue;
+                    }
+                    return Ok(text);
+                }
+                TURN_FAILED => {
+                    let code = parse_event_data::<TurnFailedData>(&event)
+                        .ok()
+                        .and_then(|d| d.error_code);
+                    return Err(PublicError::from_internal_code(code.as_deref()));
+                }
+                TURN_CANCELLED => {
+                    if parse_event_data::<TurnCancelledData>(&event).is_ok() {
+                        return Err(PublicError::fallback());
+                    }
+                }
+                _ => {}
+            }
+        }
+    })
+    .await;
+
+    let response_text = match collected {
+        Ok(Ok(text)) => text,
+        Ok(Err(public_err)) => return turn_error_response(public_err),
+        Err(_elapsed) => return timeout_response(context.config.response_timeout_seconds),
+    };
+
+    let mut response = markdown_response(StatusCode::OK, response_text);
+    if let Some(cookie) =
+        build_session_cookie(session_id, context.config.session_expiration_seconds)
+        && let Ok(value) = HeaderValue::from_str(&cookie)
+    {
+        response
+            .headers_mut()
+            .append(axum::http::header::SET_COOKIE, value);
+    }
+    response
+}
+
+// ----------------------------------------------------------------------------
+// Handshake rendering
+// ----------------------------------------------------------------------------
+
+fn render_handshake(app: &App, config: &FcpChannelConfig) -> String {
+    if let Some(handshake) = config.handshake.as_deref() {
+        return handshake.to_string();
+    }
+    let mut lines = Vec::new();
+    lines.push(format!("# {}", app.name));
+    if let Some(description) = app.description.as_deref()
+        && !description.trim().is_empty()
+    {
+        lines.push(description.to_string());
+    }
+    lines.push(String::new());
+    lines.push("Send a plain-text message in the body of a `POST` to this URL, or".to_string());
+    lines.push(
+        "`POST` JSON `{\"message\": \"...\"}` with `Content-Type: application/json`.".to_string(),
+    );
+    lines.push("Replies are returned as `text/markdown`.".to_string());
+
+    let token_required = !config.anonymous
+        || config
+            .token
+            .as_deref()
+            .map(|t| !t.is_empty())
+            .unwrap_or(false);
+    if token_required {
+        lines.push(String::new());
+        lines.push(
+            "Authentication is required. Send `Authorization: Bearer <token>` or the".to_string(),
+        );
+        lines.push(
+            "`X-Everruns-FCP-Token: <token>` header with the bearer credential issued".to_string(),
+        );
+        lines.push("to you out of band.".to_string());
+    }
+    lines.push(String::new());
+    if config.session_expiration_seconds > 0 {
+        lines.push(format!(
+            "Session state is carried by the `{FCP_SESSION_COOKIE}` cookie. Threads expire {}.",
+            humanize_seconds(config.session_expiration_seconds)
+        ));
+    } else {
+        lines.push(format!(
+            "Session state is carried by the `{FCP_SESSION_COOKIE}` cookie. Threads do not expire."
+        ));
+    }
+    if let Some(limit) = config.rate_limit_per_minute
+        && limit > 0
+    {
+        lines.push(format!(
+            "Rate limit: at most {limit} requests per minute per client IP."
+        ));
+    }
+    lines.join("\n")
+}
+
+fn humanize_seconds(seconds: u32) -> String {
+    if seconds.is_multiple_of(3600) {
+        let hours = seconds / 3600;
+        if hours == 1 {
+            "after 1 hour".to_string()
+        } else {
+            format!("after {hours} hours")
+        }
+    } else if seconds.is_multiple_of(60) {
+        let minutes = seconds / 60;
+        if minutes == 1 {
+            "after 1 minute".to_string()
+        } else {
+            format!("after {minutes} minutes")
+        }
+    } else {
+        format!("after {seconds} seconds")
+    }
+}
+
+// ----------------------------------------------------------------------------
+// Body / session handling
+// ----------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+struct JsonMessageBody {
+    message: Option<String>,
+}
+
+fn extract_user_text(headers: &HeaderMap, body: &[u8]) -> Result<String, Box<Response>> {
+    let content_type = headers
+        .get(axum::http::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    let body_text = match std::str::from_utf8(body) {
+        Ok(text) => text.to_string(),
+        Err(_) => return Err(Box::new(invalid_body_response())),
+    };
+    if content_type.starts_with("application/json") {
+        let parsed: JsonMessageBody = match serde_json::from_str(&body_text) {
+            Ok(parsed) => parsed,
+            Err(_) => return Err(Box::new(invalid_json_response())),
+        };
+        return Ok(parsed.message.unwrap_or_default());
+    }
+    // Per FCP SPEC: "If the body parses as JSON, it MAY be interpreted as
+    // such; otherwise it MUST be treated as text." We try JSON opportunistic-
+    // ally so the same call works whether the client sets the JSON content
+    // type or not, then fall back to raw text.
+    if !body_text.is_empty()
+        && let Ok(parsed) = serde_json::from_str::<JsonMessageBody>(&body_text)
+        && let Some(message) = parsed.message
+    {
+        return Ok(message);
+    }
+    Ok(body_text)
+}
+
+struct ResolvedSession {
+    session_id: Uuid,
+}
+
+async fn resolve_session(
+    state: &FcpState,
+    app: &App,
+    config: &FcpChannelConfig,
+    cookie_session_id: Option<Uuid>,
+) -> Result<ResolvedSession, Response> {
+    let routing_tag = format!("fcp:app:{}", app.public_id);
+    if let Some(session_id) = cookie_session_id {
+        match state
+            .db
+            .find_app_session_by_tags(
+                app.org_id,
+                app.internal_id,
+                std::slice::from_ref(&routing_tag),
+            )
+            .await
+        {
+            Ok(Some(row)) if row.id == session_id => {
+                if let Some(age) = expired_age_seconds(
+                    row.created_at,
+                    config.session_expiration_seconds,
+                    chrono::Utc::now(),
+                ) {
+                    tracing::info!(
+                        app_id = %app.public_id,
+                        session_id = %row.id,
+                        age_seconds = age,
+                        "Rejecting FCP resume on expired session"
+                    );
+                    return Err(session_expired_response());
+                }
+                return Ok(ResolvedSession { session_id });
+            }
+            Ok(_) => {
+                // Stale or unknown cookie — fall through and create a new
+                // session rather than stranding the client.
+            }
+            Err(err) => {
+                tracing::error!(error = %err, "FCP session lookup failed");
+                return Err(internal_error_response());
+            }
+        }
+    }
+
+    let session = state
+        .session_service
+        .create_from_app(
+            &Caller::internal(app.org_id),
+            app.harness_id.uuid(),
+            app.agent_id.map(|agent_id| agent_id.uuid()),
+            app.agent_id,
+            app.internal_id,
+            app.owner_principal_id,
+            app.resolved_owner_user_id,
+            CreateSessionRequest {
+                harness_id: Some(app.harness_id),
+                harness_name: None,
+                agent_id: app.agent_id,
+                agent_identity_id: app.agent_identity_id,
+                title: Some(format!("FCP session for {}", app.name)),
+                locale: None,
+                tags: vec![routing_tag],
+                model_id: None,
+                capabilities: vec![],
+                tools: vec![],
+                mcp_servers: Default::default(),
+                system_prompt: None,
+                initial_files: vec![],
+                hints: None,
+                network_access: None,
+                max_iterations: None,
+            },
+        )
+        .await
+        .map_err(|err| {
+            tracing::error!(error = %err, "FCP session create failed");
+            internal_error_response()
+        })?;
+    Ok(ResolvedSession {
+        session_id: session.id.uuid(),
+    })
+}
+
+fn parse_session_cookie(headers: &HeaderMap) -> Option<Uuid> {
+    let header = headers.get(axum::http::header::COOKIE)?.to_str().ok()?;
+    for entry in header.split(';') {
+        let Some((name, value)) = entry.split_once('=') else {
+            continue;
+        };
+        if name.trim() == FCP_SESSION_COOKIE {
+            return Uuid::parse_str(value.trim()).ok();
+        }
+    }
+    None
+}
+
+fn build_session_cookie(session_id: Uuid, expiration_seconds: u32) -> Option<String> {
+    let mut parts = vec![
+        format!("{FCP_SESSION_COOKIE}={session_id}"),
+        "Path=/".to_string(),
+        "HttpOnly".to_string(),
+        "SameSite=Lax".to_string(),
+    ];
+    if expiration_seconds > 0 {
+        parts.push(format!("Max-Age={expiration_seconds}"));
+    }
+    Some(parts.join("; "))
+}
+
+fn expired_age_seconds(
+    created_at: chrono::DateTime<chrono::Utc>,
+    max_seconds: u32,
+    now: chrono::DateTime<chrono::Utc>,
+) -> Option<i64> {
+    if max_seconds == 0 {
+        return None;
+    }
+    let age = now.signed_duration_since(created_at).num_seconds().max(0);
+    (age > max_seconds as i64).then_some(age)
+}
+
+fn fcp_message_metadata(app: &App) -> HashMap<String, Value> {
+    let mut map = HashMap::new();
+    map.insert(
+        "_app_id".to_string(),
+        Value::String(app.public_id.to_string()),
+    );
+    map.insert("source".to_string(), Value::String("fcp".to_string()));
+    map
+}
+
+fn content_parts_to_text(parts: &[ContentPart]) -> String {
+    parts
+        .iter()
+        .filter_map(|part| match part {
+            ContentPart::Text(text) => Some(text.text.clone()),
+            _ => None,
+        })
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn parse_event_data<T: for<'de> Deserialize<'de>>(
+    event: &everruns_core::Event,
+) -> Result<T, serde_json::Error> {
+    serde_json::from_value(serde_json::to_value(&event.data)?)
+}
+
+fn extract_token(headers: &HeaderMap) -> Option<&str> {
+    if let Some(value) = headers.get(FCP_TOKEN_HEADER) {
+        return value.to_str().ok();
+    }
+    let auth = headers.get(AUTHORIZATION)?.to_str().ok()?;
+    auth.strip_prefix("Bearer ")
+}
+
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    a.iter()
+        .zip(b.iter())
+        .fold(0u8, |acc, (x, y)| acc | (x ^ y))
+        == 0
+}
+
+// ----------------------------------------------------------------------------
+// Response helpers — every body is Markdown with actionable text.
+// ----------------------------------------------------------------------------
+
+fn markdown_response(status: StatusCode, body: impl Into<String>) -> Response {
+    (
+        status,
+        [(axum::http::header::CONTENT_TYPE, FCP_CONTENT_TYPE)],
+        body.into(),
+    )
+        .into_response()
+}
+
+fn not_found_response() -> Response {
+    // Sanitization: this single body covers "no such app", "app exists but
+    // is not published", "app has no FCP channel", and "FCP channel is
+    // disabled". The caller cannot distinguish them, so the response cannot
+    // be used to probe operator state.
+    markdown_response(
+        StatusCode::NOT_FOUND,
+        "No FCP endpoint exists at this URL.\n\nDouble-check the app id in the URL. If the URL was given to you by\nsomeone else, ask them to confirm it is still correct.",
+    )
+}
+
+fn unauthorized_response() -> Response {
+    markdown_response(
+        StatusCode::UNAUTHORIZED,
+        "Authentication required.\n\nSend `Authorization: Bearer <token>` or the `X-Everruns-FCP-Token: <token>`\nheader with the credential issued to you by this endpoint's operator. Issue\na `GET` request to this same URL for the handshake — it describes how to\nobtain a token.",
+    )
+}
+
+fn rate_limited_response(limit: u32) -> Response {
+    let body = format!(
+        "Rate limit exceeded.\n\nThis endpoint accepts at most {limit} requests per minute from your client.\nWait roughly 60 seconds and try again. Repeated bursts at the limit will\nbe rejected before the agent runs."
+    );
+    let mut response = markdown_response(StatusCode::TOO_MANY_REQUESTS, body);
+    response
+        .headers_mut()
+        .append("retry-after", HeaderValue::from_static("60"));
+    response
+}
+
+fn turn_error_response(error: PublicError) -> Response {
+    let (status, body) = match error.code {
+        PublicErrorCode::RateLimited => (
+            StatusCode::TOO_MANY_REQUESTS,
+            "The model is rate-limited right now.\n\nWait a moment and retry the same request. The agent did not produce a\nreply, so the conversation state is unchanged.".to_string(),
+        ),
+        PublicErrorCode::ServiceUnavailable => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "The agent is temporarily unavailable.\n\nRetry the same request in a few seconds. If this persists, the\nendpoint operator's downstream model or service is offline.".to_string(),
+        ),
+        PublicErrorCode::RequestTooLarge => (
+            StatusCode::PAYLOAD_TOO_LARGE,
+            format!(
+                "Your message was too large for the agent.\n\nThe body limit on this endpoint is {MAX_FCP_BODY_BYTES} bytes; the model has its own\nlower context limit. Send a shorter message."
+            ),
+        ),
+        PublicErrorCode::InternalError => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Something went wrong on this endpoint.\n\nThe agent did not produce a reply. Retry the same request in a moment;\nif it keeps failing, contact the endpoint operator with the approximate\ntime of the request.".to_string(),
+        ),
+    };
+    markdown_response(status, body)
+}
+
+fn timeout_response(seconds: u32) -> Response {
+    markdown_response(
+        StatusCode::GATEWAY_TIMEOUT,
+        format!(
+            "The agent did not reply within {seconds} seconds.\n\nThis endpoint waits up to {seconds} seconds for a response and then gives up.\nRetry the same request in a moment, or shorten the message — long\nturns are more likely to time out."
+        ),
+    )
+}
+
+fn invalid_body_response() -> Response {
+    markdown_response(
+        StatusCode::BAD_REQUEST,
+        "Request body must be valid UTF-8 text.\n\nIssue a `GET` to this URL for the handshake — it describes what shape of\nbody this endpoint accepts.",
+    )
+}
+
+fn invalid_json_response() -> Response {
+    markdown_response(
+        StatusCode::BAD_REQUEST,
+        "Your `Content-Type` says `application/json` but the body did not parse.\n\nEither set `Content-Type: text/plain` and send the message as the raw\nbody, or send valid JSON of the form `{\"message\": \"...\"}`. Issue a\n`GET` to this URL for the handshake.",
+    )
+}
+
+fn empty_message_response() -> Response {
+    markdown_response(
+        StatusCode::BAD_REQUEST,
+        "The message was empty.\n\nPut your message in the body of the `POST`, either as plain text or as\n`{\"message\": \"...\"}` with `Content-Type: application/json`. Issue a\n`GET` to this URL for the handshake.",
+    )
+}
+
+fn session_expired_response() -> Response {
+    markdown_response(
+        StatusCode::GONE,
+        "Your FCP session has expired.\n\nDrop the `fcp_session` cookie and POST again — the next request will\nstart a fresh conversation and return a new cookie.",
+    )
+}
+
+fn payload_too_large_response() -> Response {
+    markdown_response(
+        StatusCode::PAYLOAD_TOO_LARGE,
+        format!(
+            "Body exceeds the {MAX_FCP_BODY_BYTES}-byte FCP limit.\n\nSend a shorter message. If you need to send long content, summarise it\nor break it into multiple `POST`s in the same session."
+        ),
+    )
+}
+
+fn internal_error_response() -> Response {
+    markdown_response(
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "Something went wrong on this endpoint.\n\nRetry the same request in a moment; if it keeps failing, contact the\nendpoint operator with the approximate time of the request.",
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Duration as ChronoDuration;
+
+    fn test_app(name: &str, description: Option<&str>) -> App {
+        let json = serde_json::json!({
+            "id": "app_01933b5a000070008000000000000001",
+            "name": name,
+            "description": description,
+            "harness_id": "harness_01933b5a000070008000000000000001",
+            "owner_principal_id": "principal_01933b5a000070008000000000000001",
+            "status": "published",
+            "channels": [],
+            "published_at": null,
+            "created_at": "2026-01-01T00:00:00Z",
+            "updated_at": "2026-01-01T00:00:00Z",
+            "archived_at": null,
+            "deleted_at": null,
+        });
+        serde_json::from_value(json).expect("test app")
+    }
+
+    fn default_config() -> FcpChannelConfig {
+        serde_json::from_value(serde_json::json!({})).unwrap()
+    }
+
+    #[test]
+    fn handshake_uses_override_when_present() {
+        let app = test_app("Echo", None);
+        let mut config = default_config();
+        config.handshake = Some("custom body".to_string());
+        assert_eq!(render_handshake(&app, &config), "custom body");
+    }
+
+    #[test]
+    fn handshake_includes_app_name_and_description() {
+        let app = test_app("Flights", Some("Search and book commercial flights"));
+        let rendered = render_handshake(&app, &default_config());
+        assert!(rendered.contains("# Flights"));
+        assert!(rendered.contains("Search and book commercial flights"));
+        assert!(rendered.contains("POST"));
+        assert!(rendered.contains("application/json"));
+        assert!(rendered.contains("fcp_session"));
+    }
+
+    #[test]
+    fn handshake_advertises_auth_when_token_configured() {
+        let app = test_app("Secret", None);
+        let mut config = default_config();
+        config.token = Some("hunter2".to_string());
+        let rendered = render_handshake(&app, &config);
+        assert!(rendered.contains("Authorization: Bearer"));
+        assert!(rendered.contains("X-Everruns-FCP-Token"));
+        assert!(!rendered.contains("hunter2"), "must never leak the token");
+    }
+
+    #[test]
+    fn handshake_advertises_auth_when_anonymous_false() {
+        let app = test_app("Closed", None);
+        let mut config = default_config();
+        config.anonymous = false;
+        let rendered = render_handshake(&app, &config);
+        assert!(rendered.contains("Authorization: Bearer"));
+    }
+
+    #[test]
+    fn handshake_marks_no_expiration() {
+        let app = test_app("Forever", None);
+        let mut config = default_config();
+        config.session_expiration_seconds = 0;
+        let rendered = render_handshake(&app, &config);
+        assert!(rendered.contains("do not expire"));
+    }
+
+    #[test]
+    fn handshake_advertises_rate_limit_when_set() {
+        let app = test_app("Slow", None);
+        let mut config = default_config();
+        config.rate_limit_per_minute = Some(30);
+        let rendered = render_handshake(&app, &config);
+        assert!(rendered.contains("30 requests per minute"));
+    }
+
+    #[test]
+    fn handshake_marks_anonymous_endpoint() {
+        let app = test_app("Open", None);
+        let rendered = render_handshake(&app, &default_config());
+        assert!(!rendered.contains("Authorization: Bearer"));
+    }
+
+    #[test]
+    fn humanize_seconds_formats_common_durations() {
+        assert_eq!(humanize_seconds(3600), "after 1 hour");
+        assert_eq!(humanize_seconds(2 * 3600), "after 2 hours");
+        assert_eq!(humanize_seconds(60), "after 1 minute");
+        assert_eq!(humanize_seconds(45), "after 45 seconds");
+    }
+
+    #[test]
+    fn parse_session_cookie_extracts_named_value() {
+        let mut headers = HeaderMap::new();
+        let uuid = Uuid::now_v7();
+        headers.insert(
+            axum::http::header::COOKIE,
+            format!("other=foo; fcp_session={uuid}; trailing=bar")
+                .parse()
+                .unwrap(),
+        );
+        assert_eq!(parse_session_cookie(&headers), Some(uuid));
+    }
+
+    #[test]
+    fn parse_session_cookie_returns_none_when_absent() {
+        let mut headers = HeaderMap::new();
+        headers.insert(axum::http::header::COOKIE, "other=foo".parse().unwrap());
+        assert_eq!(parse_session_cookie(&headers), None);
+    }
+
+    #[test]
+    fn build_session_cookie_includes_max_age_when_set() {
+        let id = Uuid::now_v7();
+        let cookie = build_session_cookie(id, 3600).unwrap();
+        assert!(cookie.contains(&id.to_string()));
+        assert!(cookie.contains("Max-Age=3600"));
+        assert!(cookie.contains("HttpOnly"));
+        assert!(cookie.contains("SameSite=Lax"));
+    }
+
+    #[test]
+    fn build_session_cookie_omits_max_age_when_zero() {
+        let id = Uuid::now_v7();
+        let cookie = build_session_cookie(id, 0).unwrap();
+        assert!(!cookie.contains("Max-Age"));
+    }
+
+    #[test]
+    fn extract_user_text_plain_body_is_returned_verbatim() {
+        let headers = HeaderMap::new();
+        let body = b"Hello there";
+        let text = extract_user_text(&headers, body).unwrap();
+        assert_eq!(text, "Hello there");
+    }
+
+    #[test]
+    fn extract_user_text_json_body_uses_message_field() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            axum::http::header::CONTENT_TYPE,
+            "application/json".parse().unwrap(),
+        );
+        let body = br#"{"message":"book a flight"}"#;
+        let text = extract_user_text(&headers, body).unwrap();
+        assert_eq!(text, "book a flight");
+    }
+
+    #[test]
+    fn extract_user_text_unknown_content_type_with_json_body_is_parsed() {
+        let headers = HeaderMap::new();
+        let body = br#"{"message":"hi"}"#;
+        let text = extract_user_text(&headers, body).unwrap();
+        assert_eq!(text, "hi");
+    }
+
+    #[test]
+    fn extract_user_text_invalid_json_with_json_content_type_returns_bad_request() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            axum::http::header::CONTENT_TYPE,
+            "application/json".parse().unwrap(),
+        );
+        let body = b"not json";
+        assert!(extract_user_text(&headers, body).is_err());
+    }
+
+    #[test]
+    fn content_parts_to_text_joins_text_parts_and_drops_others() {
+        let parts = vec![ContentPart::text("hello"), ContentPart::text("world")];
+        assert_eq!(content_parts_to_text(&parts), "hello\nworld");
+    }
+
+    #[test]
+    fn constant_time_eq_matches_only_equal_strings() {
+        assert!(constant_time_eq(b"abc", b"abc"));
+        assert!(!constant_time_eq(b"abc", b"abd"));
+        assert!(!constant_time_eq(b"abc", b"abcd"));
+    }
+
+    #[test]
+    fn extract_token_prefers_dedicated_header() {
+        let mut headers = HeaderMap::new();
+        headers.insert(AUTHORIZATION, "Bearer fallback".parse().unwrap());
+        headers.insert(FCP_TOKEN_HEADER, "primary".parse().unwrap());
+        assert_eq!(extract_token(&headers), Some("primary"));
+    }
+
+    #[test]
+    fn extract_token_falls_back_to_bearer() {
+        let mut headers = HeaderMap::new();
+        headers.insert(AUTHORIZATION, "Bearer fallback".parse().unwrap());
+        assert_eq!(extract_token(&headers), Some("fallback"));
+    }
+
+    #[test]
+    fn expired_age_seconds_within_window_returns_none() {
+        let now = chrono::Utc::now();
+        let created = now - ChronoDuration::seconds(100);
+        assert_eq!(expired_age_seconds(created, 3600, now), None);
+    }
+
+    #[test]
+    fn expired_age_seconds_outside_window_returns_age() {
+        let now = chrono::Utc::now();
+        let created = now - ChronoDuration::seconds(7200);
+        assert_eq!(expired_age_seconds(created, 3600, now), Some(7200));
+    }
+
+    #[test]
+    fn expired_age_seconds_zero_disables_expiration() {
+        let now = chrono::Utc::now();
+        let created = now - ChronoDuration::seconds(100_000);
+        assert_eq!(expired_age_seconds(created, 0, now), None);
+    }
+
+    #[test]
+    fn check_token_anonymous_allows_no_header() {
+        let headers = HeaderMap::new();
+        assert!(check_token(&headers, &default_config()).is_ok());
+    }
+
+    #[test]
+    fn check_token_required_rejects_missing() {
+        let headers = HeaderMap::new();
+        let mut config = default_config();
+        config.token = Some("hunter2".to_string());
+        assert!(check_token(&headers, &config).is_err());
+    }
+
+    #[test]
+    fn check_token_required_accepts_matching_bearer() {
+        let mut headers = HeaderMap::new();
+        headers.insert(AUTHORIZATION, "Bearer hunter2".parse().unwrap());
+        let mut config = default_config();
+        config.token = Some("hunter2".to_string());
+        assert!(check_token(&headers, &config).is_ok());
+    }
+
+    #[test]
+    fn check_token_required_rejects_mismatch() {
+        let mut headers = HeaderMap::new();
+        headers.insert(AUTHORIZATION, "Bearer wrong".parse().unwrap());
+        let mut config = default_config();
+        config.token = Some("hunter2".to_string());
+        assert!(check_token(&headers, &config).is_err());
+    }
+
+    #[test]
+    fn check_token_anonymous_false_without_token_rejects() {
+        // Misconfigured: operator disabled anonymous but did not configure a
+        // token. We refuse the call rather than silently letting it through.
+        let headers = HeaderMap::new();
+        let mut config = default_config();
+        config.anonymous = false;
+        assert!(check_token(&headers, &config).is_err());
+    }
+
+    fn body_text(response: Response) -> (StatusCode, String) {
+        let (parts, body) = response.into_parts();
+        let bytes = futures::executor::block_on(async {
+            axum::body::to_bytes(body, usize::MAX).await.unwrap()
+        });
+        (parts.status, String::from_utf8(bytes.to_vec()).unwrap())
+    }
+
+    #[test]
+    fn unauthorized_response_body_is_actionable() {
+        let (status, body) = body_text(unauthorized_response());
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+        assert!(body.contains("Authorization: Bearer"));
+        assert!(body.contains("X-Everruns-FCP-Token"));
+        assert!(
+            body.contains("GET"),
+            "must direct caller back at the handshake"
+        );
+    }
+
+    #[test]
+    fn not_found_response_does_not_leak_app_state() {
+        let (status, body) = body_text(not_found_response());
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        let lower = body.to_lowercase();
+        // None of these internal states must be readable from a 404 body:
+        for forbidden in [
+            "draft",
+            "archived",
+            "unpublished",
+            "disabled",
+            "permission",
+            "auth",
+            "channel",
+            "config",
+        ] {
+            assert!(
+                !lower.contains(forbidden),
+                "leaked internal state via word '{forbidden}': {body}"
+            );
+        }
+    }
+
+    #[test]
+    fn rate_limited_response_includes_retry_after_and_limit() {
+        let response = rate_limited_response(42);
+        let retry_after = response
+            .headers()
+            .get("retry-after")
+            .cloned()
+            .expect("retry-after header");
+        let (status, body) = body_text(response);
+        assert_eq!(status, StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(retry_after.to_str().unwrap(), "60");
+        assert!(body.contains("42"));
+    }
+
+    #[test]
+    fn turn_error_response_body_is_sanitized() {
+        let response = turn_error_response(PublicError::fallback());
+        let (status, body) = body_text(response);
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        let lower = body.to_lowercase();
+        // Internal vocabulary must never reach the public body.
+        for forbidden in [
+            "stack",
+            "panic",
+            "subscription",
+            "openai",
+            "anthropic",
+            "tokio",
+            "postgres",
+        ] {
+            assert!(
+                !lower.contains(forbidden),
+                "leaked internal detail via word '{forbidden}': {body}"
+            );
+        }
+    }
+
+    #[test]
+    fn timeout_response_mentions_configured_seconds() {
+        let (status, body) = body_text(timeout_response(45));
+        assert_eq!(status, StatusCode::GATEWAY_TIMEOUT);
+        assert!(body.contains("45 seconds"));
+    }
+
+    #[test]
+    fn session_expired_response_tells_client_to_drop_cookie() {
+        let (status, body) = body_text(session_expired_response());
+        assert_eq!(status, StatusCode::GONE);
+        assert!(body.contains("fcp_session"));
+        assert!(body.to_lowercase().contains("drop"));
+    }
+}

--- a/crates/server/src/api/mod.rs
+++ b/crates/server/src/api/mod.rs
@@ -23,6 +23,7 @@ pub mod dispatch;
 pub mod durable;
 pub mod evals;
 pub mod events;
+pub mod fcp;
 pub mod feature_flags;
 pub mod harness_examples;
 pub mod harnesses;

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -894,6 +894,12 @@ impl ServerAppBuilder {
             Some(client) => api::a2a_signing::A2aReplayStore::with_valkey(client),
             None => api::a2a_signing::A2aReplayStore::in_memory(),
         };
+        // FCP gets its own rate limiter namespace so the per-channel cap can
+        // never be shared with — or exhausted by — AG-UI/A2A traffic.
+        let fcp_rate_limiter = match valkey_for_channel_rate_limits.clone() {
+            Some(client) => api::channel_rate_limit::ChannelRateLimiter::with_valkey("fcp", client),
+            None => api::channel_rate_limit::ChannelRateLimiter::in_memory("fcp"),
+        };
         let app_a2a_state = api::app_a2a::AppA2aState::new(
             db.clone(),
             encryption.clone(),
@@ -912,6 +918,14 @@ impl ServerAppBuilder {
             event_delivery.clone(),
             sse_tracker.clone(),
             ag_ui_rate_limiter,
+        );
+        let fcp_state = api::fcp::FcpState::new(
+            db.clone(),
+            encryption.clone(),
+            runner.clone(),
+            notifications_enabled,
+            event_delivery.clone(),
+            fcp_rate_limiter,
         );
         let session_files_state = api::session_files::AppState::new(
             db.clone(),
@@ -1128,6 +1142,7 @@ impl ServerAppBuilder {
             .merge(api::app_webhooks::routes(app_webhooks_state))
             .merge(api::app_a2a::routes(app_a2a_state))
             .merge(api::ag_ui::routes(ag_ui_state))
+            .merge(api::fcp::routes(fcp_state))
             .merge(api::feature_flags::routes(feature_flags_state))
             .merge(api::budgets::routes(api::budgets::AppState::new(
                 db.clone(),

--- a/crates/server/src/domains/apps/commands.rs
+++ b/crates/server/src/domains/apps/commands.rs
@@ -25,7 +25,7 @@ use everruns_core::typed_id::{AgentId, AppChannelId, AppId, HarnessId, SessionId
 use everruns_core::{
     A2aChannelConfig, AgUiChannelConfig, AgUiToolVisibility, AgentAction, App, AppChannel,
     AppEndpointAuthConfig, AppEndpointAuthMode, AppEndpointAuthProviderConfig, AppStatus,
-    AuditEvent, ChannelType, Policy, SlackChannelConfig,
+    AuditEvent, ChannelType, FcpChannelConfig, Policy, SlackChannelConfig,
 };
 use everruns_durable::{
     CreateScheduleRow, ScheduleTargetType, StoreError, UpdateField, UpdateSchedule,
@@ -177,7 +177,10 @@ fn normalize_and_validate_channel_config(
         ChannelType::AgUi | ChannelType::A2a => {
             normalize_inline_endpoint_auth(&channel_type, &mut channel_config)?;
         }
-        ChannelType::Slack | ChannelType::Schedule | ChannelType::Webhook => {
+        ChannelType::Fcp | ChannelType::Slack | ChannelType::Schedule | ChannelType::Webhook => {
+            // FCP deliberately runs its own minimal auth stack (anonymous +
+            // shared bearer token) so it never shares verifier code with
+            // AG-UI/A2A. See `specs/fcp-channel.md`.
             if channel_config.get("auth").is_some() {
                 return Err(CommandError::bad_request(
                     "App endpoint auth is only supported for AG-UI and A2A channels",
@@ -316,6 +319,38 @@ fn normalize_and_validate_channel_config(
                         "A2A signing_secret must be at most 4096 bytes",
                     ));
                 }
+            }
+        }
+        ChannelType::Fcp => {
+            let config: FcpChannelConfig =
+                serde_json::from_value(channel_config.clone()).map_err(|e| {
+                    CommandError::bad_request(format!("Invalid FCP channel config: {e}"))
+                })?;
+            if let Some(token) = config.token.as_deref()
+                && token.trim().is_empty()
+            {
+                return Err(CommandError::bad_request(
+                    "FCP token must be non-empty when configured",
+                ));
+            }
+            if let Some(handshake) = config.handshake.as_deref()
+                && handshake.len() > 8 * 1024
+            {
+                return Err(CommandError::bad_request(
+                    "FCP handshake must be at most 8 KiB",
+                ));
+            }
+            if let Some(limit) = config.rate_limit_per_minute
+                && limit > 1_000_000
+            {
+                return Err(CommandError::bad_request(
+                    "FCP rate_limit_per_minute must be at most 1,000,000",
+                ));
+            }
+            if config.response_timeout_seconds == 0 || config.response_timeout_seconds > 600 {
+                return Err(CommandError::bad_request(
+                    "FCP response_timeout_seconds must be between 1 and 600",
+                ));
             }
         }
     }
@@ -537,6 +572,11 @@ fn redact_channel_config(channel_type: &ChannelType, config: &mut Value) {
                 map.insert("signing_secret_configured".to_string(), Value::Bool(true));
             }
         }
+        ChannelType::Fcp => {
+            if map.remove("token").is_some() {
+                map.insert("token_configured".to_string(), Value::Bool(true));
+            }
+        }
         ChannelType::Schedule => {}
     }
 }
@@ -627,6 +667,16 @@ fn merge_preserved_secret_fields(
                 && let Some(existing_value) = existing.get("signing_secret")
             {
                 out.insert("signing_secret".to_string(), existing_value.clone());
+            }
+        }
+        ChannelType::Fcp => {
+            let should_preserve = out
+                .get("token")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .is_none_or(str::is_empty);
+            if should_preserve && let Some(existing_value) = existing.get("token") {
+                out.insert("token".to_string(), existing_value.clone());
             }
         }
         ChannelType::Schedule => {}

--- a/crates/server/src/openapi.rs
+++ b/crates/server/src/openapi.rs
@@ -61,6 +61,8 @@ use utoipa::OpenApi;
         api::app_webhooks::invoke_webhook,
         api::app_a2a::invoke_a2a,
         api::app_a2a::agent_card,
+        api::fcp::handshake,
+        api::fcp::message,
         api::apps::add_a2a_channel,
         api::apps::regenerate_a2a_key,
         api::events::stream_sse,

--- a/crates/server/tests/fcp_integration_test.rs
+++ b/crates/server/tests/fcp_integration_test.rs
@@ -1,0 +1,928 @@
+//! FCP (Free Communication Protocol) app channel integration tests.
+//!
+//! These tests cover the public FCP endpoint end-to-end:
+//! - handshake (`GET`) returns Markdown without leaking app state
+//! - text-in / text-out (`POST`) round-trips through the durable runtime
+//! - auth/rate-limit/timeout isolation invariants
+//! - error bodies are sanitized Markdown with actionable instructions
+//!
+//! The agent is backed by `llmsim` so tests don't make outbound LLM calls.
+
+mod test_harness;
+
+use axum::http::{Method, StatusCode};
+use serde_json::{Value, json};
+use test_harness::TestServer;
+
+use everruns_core::App;
+
+fn unique_id(prefix: &str) -> String {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_millis();
+    let seq = COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("{prefix}_{now}_{seq}")
+}
+
+fn unique_slug(prefix: &str) -> String {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_millis();
+    let seq = COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("{prefix}-{now}-{seq}")
+}
+
+async fn create_llmsim_agent(server: &TestServer) -> String {
+    let provider: Value = server
+        .post(
+            "/v1/llm-providers",
+            json!({
+                "name": unique_id("FCP Test Provider"),
+                "provider_type": "llmsim"
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    let model: Value = server
+        .post(
+            &format!(
+                "/v1/llm-providers/{}/models",
+                provider["id"].as_str().unwrap()
+            ),
+            json!({
+                "model_id": unique_id("llmsim-fcp"),
+                "display_name": unique_id("FCP Test Model"),
+                "enabled": true
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    let agent: Value = server
+        .post(
+            "/v1/agents",
+            json!({
+                "name": unique_slug("fcp-test-agent"),
+                "display_name": unique_id("FCP Test Agent"),
+                "system_prompt": "You are a brief test agent.",
+                "default_model_id": model["id"]
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    agent["id"].as_str().unwrap().to_string()
+}
+
+async fn create_fcp_app(server: &TestServer, channel_config: Value) -> App {
+    let agent_id = create_llmsim_agent(server).await;
+
+    let app: App = server
+        .post(
+            "/v1/apps",
+            json!({
+                "name": unique_id("FCP App"),
+                "description": "A brief FCP test endpoint",
+                "harness_id": server.seed_base_harness_id,
+                "agent_id": agent_id,
+                "channel_type": "fcp",
+                "channel_config": channel_config
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+    app
+}
+
+async fn create_published_fcp_app(server: &TestServer, channel_config: Value) -> App {
+    let app = create_fcp_app(server, channel_config).await;
+
+    server
+        .post(&format!("/v1/apps/{}/publish", app.public_id), json!({}))
+        .await
+        .assert_success();
+
+    server
+        .get(&format!("/v1/apps/{}", app.public_id))
+        .await
+        .assert_success()
+        .json()
+}
+
+async fn get_handshake(
+    server: &TestServer,
+    app_id: impl std::fmt::Display,
+    headers: Vec<(&str, &str)>,
+) -> test_harness::TestResponse {
+    server
+        .request_raw(
+            Method::GET,
+            &format!("/v1/apps/{}/fcp", app_id),
+            headers,
+            Vec::new(),
+        )
+        .await
+}
+
+async fn send_fcp_post(
+    server: &TestServer,
+    app_id: impl std::fmt::Display,
+    body: impl Into<Vec<u8>>,
+    headers: Vec<(&str, &str)>,
+) -> test_harness::TestResponse {
+    server
+        .request_raw(
+            Method::POST,
+            &format!("/v1/apps/{}/fcp", app_id),
+            headers,
+            body.into(),
+        )
+        .await
+}
+
+fn assert_markdown(response: &test_harness::TestResponse) {
+    let content_type = response
+        .headers()
+        .get(axum::http::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    assert!(
+        content_type.starts_with("text/markdown"),
+        "expected text/markdown response, got {content_type:?}"
+    );
+}
+
+/// Status codes that mean "FCP handler accepted the request and ran its
+/// session/auth/rate-limit pipeline". In-memory test mode does not run a
+/// durable worker, so happy-path `POST`s frequently surface as 504
+/// (handler waited for the agent reply that the test environment will
+/// never produce). Either status proves the request reached the handler.
+fn assert_accepted_or_timeout(status: StatusCode) {
+    assert!(
+        status == StatusCode::OK || status == StatusCode::GATEWAY_TIMEOUT,
+        "expected 200 or 504 (FCP handler accepted), got {status}"
+    );
+}
+
+/// Shorter response timeout for happy-path tests so 504 paths return
+/// quickly instead of waiting the default 120 s.
+fn fast_timeout_config() -> Value {
+    json!({"response_timeout_seconds": 2})
+}
+
+fn assert_body_no_leaks(body: &str) {
+    let lower = body.to_lowercase();
+    for forbidden in [
+        "stack",
+        "panic",
+        "tokio",
+        "postgres",
+        "subscription",
+        "openai",
+        "anthropic",
+        "llmsim",
+        "thread 'tokio",
+    ] {
+        assert!(
+            !lower.contains(forbidden),
+            "leaked internal detail via word '{forbidden}': {body}"
+        );
+    }
+}
+
+// ----------------------------------------------------------------------------
+// Handshake (`GET`)
+// ----------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn fcp_handshake_returns_markdown_for_published_app() {
+    let server = TestServer::in_memory().await;
+    let app = create_published_fcp_app(&server, json!({})).await;
+
+    let response = get_handshake(&server, &app.public_id, vec![]).await;
+    let body = response.text();
+    assert_eq!(response.status(), StatusCode::OK, "body: {body}");
+    assert_markdown(&response);
+    assert!(body.contains(&format!("# {}", app.name)), "body: {body}");
+    assert!(body.contains("A brief FCP test endpoint"));
+    assert!(body.contains("POST"));
+    assert!(body.contains("application/json"));
+    assert!(body.contains("fcp_session"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn fcp_handshake_advertises_auth_when_token_configured() {
+    let server = TestServer::in_memory().await;
+    let app =
+        create_published_fcp_app(&server, json!({"anonymous": true, "token": "fcp-secret"})).await;
+
+    let response = get_handshake(&server, &app.public_id, vec![]).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response.text();
+    assert!(body.contains("Authorization: Bearer"));
+    assert!(body.contains("X-Everruns-FCP-Token"));
+    assert!(
+        !body.contains("fcp-secret"),
+        "handshake must never echo the configured token"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn fcp_handshake_returns_404_for_unknown_app() {
+    let server = TestServer::in_memory().await;
+    let response = get_handshake(&server, "app_does_not_exist", vec![]).await;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    assert_markdown(&response);
+    let body = response.text();
+    // Single-tone "no endpoint" body that doesn't disclose lookup failure mode.
+    assert!(body.to_lowercase().contains("no fcp endpoint"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn fcp_handshake_returns_404_for_unpublished_app() {
+    let server = TestServer::in_memory().await;
+    let app = create_fcp_app(&server, json!({})).await;
+
+    // App is draft — handshake must look identical to "unknown app" so the
+    // caller cannot distinguish lifecycle state.
+    let response = get_handshake(&server, &app.public_id, vec![]).await;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    let body = response.text();
+    let lower = body.to_lowercase();
+    for forbidden in ["draft", "unpublished", "publish", "disabled", "archived"] {
+        assert!(
+            !lower.contains(forbidden),
+            "404 body leaked lifecycle word '{forbidden}': {body}"
+        );
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn fcp_handshake_returns_404_when_channel_is_disabled() {
+    let server = TestServer::in_memory().await;
+    let app = create_published_fcp_app(&server, json!({})).await;
+    let channel_id = app.channels[0].public_id.to_string();
+
+    server
+        .request_raw(
+            Method::PATCH,
+            &format!("/v1/apps/{}/channels/{}", app.public_id, channel_id),
+            vec![("content-type", "application/json")],
+            serde_json::to_vec(&json!({"enabled": false})).unwrap(),
+        )
+        .await
+        .assert_success();
+
+    let response = get_handshake(&server, &app.public_id, vec![]).await;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn fcp_handshake_returns_custom_body_when_configured() {
+    let server = TestServer::in_memory().await;
+    let app = create_published_fcp_app(&server, json!({"handshake": "# Custom\nGo away."})).await;
+
+    let response = get_handshake(&server, &app.public_id, vec![]).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(response.text(), "# Custom\nGo away.");
+}
+
+// ----------------------------------------------------------------------------
+// POST happy path
+// ----------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn fcp_post_plain_text_returns_markdown_reply_and_sets_cookie() {
+    let server = TestServer::in_memory().await;
+    let app = create_published_fcp_app(&server, fast_timeout_config()).await;
+
+    let response = send_fcp_post(
+        &server,
+        &app.public_id,
+        "Hello, FCP!",
+        vec![("content-type", "text/plain")],
+    )
+    .await;
+    assert_accepted_or_timeout(response.status());
+    assert_markdown(&response);
+
+    // Cookie is set on every response that resolved a session — including
+    // 504, so a client can retry against the same conversation.
+    let cookie = test_harness::extract_cookie(response.headers(), "fcp_session");
+    assert!(cookie.contains("fcp_session="));
+
+    let body = response.text();
+    assert!(!body.trim().is_empty(), "FCP body was empty");
+    assert_body_no_leaks(&body);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn fcp_post_json_body_is_parsed_via_message_field() {
+    let server = TestServer::in_memory().await;
+    let app = create_published_fcp_app(&server, fast_timeout_config()).await;
+
+    let response = send_fcp_post(
+        &server,
+        &app.public_id,
+        r#"{"message":"hi from JSON"}"#,
+        vec![("content-type", "application/json")],
+    )
+    .await;
+    assert_accepted_or_timeout(response.status());
+    // Either the agent replied (200) or we timed out (504) — both prove the
+    // body was parsed past the JSON gate and the user message was injected
+    // into a session. A 400 here would mean the JSON branch refused the
+    // body shape.
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn fcp_post_session_cookie_reuses_same_session() {
+    let server = TestServer::in_memory().await;
+    let app = create_published_fcp_app(&server, fast_timeout_config()).await;
+
+    let first = send_fcp_post(
+        &server,
+        &app.public_id,
+        "first turn",
+        vec![("content-type", "text/plain")],
+    )
+    .await;
+    assert_accepted_or_timeout(first.status());
+    let cookie = test_harness::extract_cookie(first.headers(), "fcp_session");
+
+    // Inspect sessions by tag — first POST must have created exactly one.
+    let sessions: Value = server.get("/v1/sessions").await.assert_success().json();
+    let expected_tag = format!("fcp:app:{}", app.public_id);
+    let first_count = sessions["data"]
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .filter(|s| {
+                    s["tags"]
+                        .as_array()
+                        .map(|tags| tags.iter().any(|t| t.as_str() == Some(&expected_tag)))
+                        .unwrap_or(false)
+                })
+                .count()
+        })
+        .unwrap_or(0);
+    assert_eq!(first_count, 1);
+
+    let second = send_fcp_post(
+        &server,
+        &app.public_id,
+        "second turn",
+        vec![("content-type", "text/plain"), ("cookie", &cookie)],
+    )
+    .await;
+    assert_accepted_or_timeout(second.status());
+
+    let sessions_after: Value = server.get("/v1/sessions").await.assert_success().json();
+    let after_count = sessions_after["data"]
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .filter(|s| {
+                    s["tags"]
+                        .as_array()
+                        .map(|tags| tags.iter().any(|t| t.as_str() == Some(&expected_tag)))
+                        .unwrap_or(false)
+                })
+                .count()
+        })
+        .unwrap_or(0);
+    assert_eq!(
+        after_count, 1,
+        "second POST with cookie must reuse the session created by the first"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn fcp_post_stale_cookie_creates_new_session() {
+    let server = TestServer::in_memory().await;
+    let app = create_published_fcp_app(&server, fast_timeout_config()).await;
+
+    // Use a random UUID for the cookie — the server has no matching session.
+    let response = send_fcp_post(
+        &server,
+        &app.public_id,
+        "hello with stale cookie",
+        vec![
+            ("content-type", "text/plain"),
+            ("cookie", "fcp_session=00000000-0000-0000-0000-000000000000"),
+        ],
+    )
+    .await;
+    assert_accepted_or_timeout(response.status());
+    // A fresh cookie was issued — never strand the client.
+    let _new_cookie = test_harness::extract_cookie(response.headers(), "fcp_session");
+}
+
+// ----------------------------------------------------------------------------
+// Auth
+// ----------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn fcp_post_requires_token_when_configured() {
+    let server = TestServer::in_memory().await;
+    let app = create_published_fcp_app(
+        &server,
+        json!({"anonymous": true, "token": "fcp-secret", "response_timeout_seconds": 2}),
+    )
+    .await;
+
+    // No header — 401 with actionable Markdown body.
+    let response = send_fcp_post(
+        &server,
+        &app.public_id,
+        "hi",
+        vec![("content-type", "text/plain")],
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    assert_markdown(&response);
+    let body = response.text();
+    assert!(body.contains("Authorization: Bearer"));
+    assert!(body.contains("X-Everruns-FCP-Token"));
+    assert!(
+        !body.contains("fcp-secret"),
+        "401 body must never echo the configured token"
+    );
+
+    // Wrong token — same 401, no oracle on validity.
+    let wrong = send_fcp_post(
+        &server,
+        &app.public_id,
+        "hi",
+        vec![
+            ("content-type", "text/plain"),
+            ("authorization", "Bearer not-the-token"),
+        ],
+    )
+    .await;
+    wrong.assert_status(StatusCode::UNAUTHORIZED);
+
+    // Right token via Authorization header.
+    let ok = send_fcp_post(
+        &server,
+        &app.public_id,
+        "hi",
+        vec![
+            ("content-type", "text/plain"),
+            ("authorization", "Bearer fcp-secret"),
+        ],
+    )
+    .await;
+    assert_accepted_or_timeout(ok.status());
+
+    // Right token via dedicated header.
+    let ok2 = send_fcp_post(
+        &server,
+        &app.public_id,
+        "hi",
+        vec![
+            ("content-type", "text/plain"),
+            ("x-everruns-fcp-token", "fcp-secret"),
+        ],
+    )
+    .await;
+    assert_accepted_or_timeout(ok2.status());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn fcp_rejects_empty_token_config() {
+    let server = TestServer::in_memory().await;
+    let agent_id = create_llmsim_agent(&server).await;
+    server
+        .post(
+            "/v1/apps",
+            json!({
+                "name": unique_id("Bad Token FCP App"),
+                "harness_id": server.seed_base_harness_id,
+                "agent_id": agent_id,
+                "channel_type": "fcp",
+                "channel_config": { "anonymous": true, "token": "  " }
+            }),
+        )
+        .await
+        .assert_status(StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn fcp_rejects_inline_auth_object() {
+    // FCP's auth surface is intentionally narrow: anonymous + shared token
+    // only. The inline `auth: {...}` object used by AG-UI/A2A is rejected
+    // so FCP never grows another auth mode by accident.
+    let server = TestServer::in_memory().await;
+    let agent_id = create_llmsim_agent(&server).await;
+    server
+        .post(
+            "/v1/apps",
+            json!({
+                "name": unique_id("Inline Auth FCP App"),
+                "harness_id": server.seed_base_harness_id,
+                "agent_id": agent_id,
+                "channel_type": "fcp",
+                "channel_config": {
+                    "anonymous": false,
+                    "auth": {"mode": "anonymous"}
+                }
+            }),
+        )
+        .await
+        .assert_status(StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn fcp_anonymous_false_without_token_rejects_all_requests() {
+    let server = TestServer::in_memory().await;
+    // The config validator accepts `anonymous=false` without a token (the
+    // operator might intend to fill it in later). But every POST must then
+    // 401, because there is no way to authenticate.
+    let app = create_published_fcp_app(&server, json!({"anonymous": false})).await;
+
+    let response = send_fcp_post(
+        &server,
+        &app.public_id,
+        "hi",
+        vec![("content-type", "text/plain")],
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+
+    // Even with a bearer token — the channel has nothing to compare to.
+    let with_token = send_fcp_post(
+        &server,
+        &app.public_id,
+        "hi",
+        vec![
+            ("content-type", "text/plain"),
+            ("authorization", "Bearer anything"),
+        ],
+    )
+    .await;
+    with_token.assert_status(StatusCode::UNAUTHORIZED);
+}
+
+// ----------------------------------------------------------------------------
+// Bad input handling
+// ----------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn fcp_post_empty_body_returns_actionable_400() {
+    let server = TestServer::in_memory().await;
+    let app = create_published_fcp_app(&server, json!({})).await;
+
+    let response = send_fcp_post(
+        &server,
+        &app.public_id,
+        "",
+        vec![("content-type", "text/plain")],
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body = response.text();
+    assert!(body.to_lowercase().contains("empty"));
+    assert!(body.contains("POST"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn fcp_post_invalid_json_returns_actionable_400() {
+    let server = TestServer::in_memory().await;
+    let app = create_published_fcp_app(&server, json!({})).await;
+
+    let response = send_fcp_post(
+        &server,
+        &app.public_id,
+        "not actually json",
+        vec![("content-type", "application/json")],
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body = response.text();
+    assert!(body.contains("application/json"));
+    assert!(body.contains("text/plain"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn fcp_post_oversized_body_returns_413() {
+    let server = TestServer::in_memory().await;
+    let app = create_published_fcp_app(&server, json!({})).await;
+
+    // 257 KiB > the 256 KiB FCP limit.
+    let body = vec![b'x'; 257 * 1024];
+    let response = send_fcp_post(
+        &server,
+        &app.public_id,
+        body,
+        vec![("content-type", "text/plain")],
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    assert!(response.text().contains("256"));
+}
+
+// ----------------------------------------------------------------------------
+// Rate limit
+// ----------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn fcp_per_app_rate_limit_returns_429_with_retry_after() {
+    let server = TestServer::in_memory().await;
+    let app = create_published_fcp_app(
+        &server,
+        json!({"rate_limit_per_minute": 1, "response_timeout_seconds": 2}),
+    )
+    .await;
+
+    // Burn the single allowed request. The agent reply may not arrive in
+    // in-memory test mode, so accept either 200 or 504 — both mean the
+    // rate-limit bucket was decremented.
+    let first = send_fcp_post(
+        &server,
+        &app.public_id,
+        "first",
+        vec![("content-type", "text/plain")],
+    )
+    .await;
+    assert_accepted_or_timeout(first.status());
+
+    // The next one must 429 with a Retry-After header.
+    let second = send_fcp_post(
+        &server,
+        &app.public_id,
+        "second",
+        vec![("content-type", "text/plain")],
+    )
+    .await;
+    assert_eq!(second.status(), StatusCode::TOO_MANY_REQUESTS);
+    let retry_after = second
+        .headers()
+        .get("retry-after")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    assert_eq!(retry_after, "60");
+    let body = second.text();
+    assert!(body.contains("Rate limit"));
+    assert!(body.contains("1 requests per minute"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn fcp_rate_limit_zero_disables_per_app_cap() {
+    let server = TestServer::in_memory().await;
+    let app = create_published_fcp_app(
+        &server,
+        json!({"rate_limit_per_minute": 0, "response_timeout_seconds": 2}),
+    )
+    .await;
+
+    // Several requests in a row must all reach the handler (none rejected
+    // with 429). Whether they ultimately 200 or 504 depends on whether a
+    // worker is running, so we only assert that none were rate-limited.
+    for i in 0..3 {
+        let response = send_fcp_post(
+            &server,
+            &app.public_id,
+            format!("turn {i}"),
+            vec![("content-type", "text/plain")],
+        )
+        .await;
+        assert_ne!(
+            response.status(),
+            StatusCode::TOO_MANY_REQUESTS,
+            "rate_limit_per_minute=0 must disable the per-app cap; turn {i} got 429"
+        );
+        assert_accepted_or_timeout(response.status());
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn fcp_rate_limit_rejects_absurd_values() {
+    let server = TestServer::in_memory().await;
+    let agent_id = create_llmsim_agent(&server).await;
+    server
+        .post(
+            "/v1/apps",
+            json!({
+                "name": unique_id("Bad RL FCP App"),
+                "harness_id": server.seed_base_harness_id,
+                "agent_id": agent_id,
+                "channel_type": "fcp",
+                "channel_config": { "rate_limit_per_minute": 5_000_000 }
+            }),
+        )
+        .await
+        .assert_status(StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn fcp_rejects_invalid_response_timeout() {
+    let server = TestServer::in_memory().await;
+    let agent_id = create_llmsim_agent(&server).await;
+
+    // Zero is rejected.
+    server
+        .post(
+            "/v1/apps",
+            json!({
+                "name": unique_id("Zero Timeout FCP App"),
+                "harness_id": server.seed_base_harness_id,
+                "agent_id": agent_id,
+                "channel_type": "fcp",
+                "channel_config": { "response_timeout_seconds": 0 }
+            }),
+        )
+        .await
+        .assert_status(StatusCode::BAD_REQUEST);
+
+    // Absurd values are rejected.
+    server
+        .post(
+            "/v1/apps",
+            json!({
+                "name": unique_id("Huge Timeout FCP App"),
+                "harness_id": server.seed_base_harness_id,
+                "agent_id": agent_id,
+                "channel_type": "fcp",
+                "channel_config": { "response_timeout_seconds": 9999 }
+            }),
+        )
+        .await
+        .assert_status(StatusCode::BAD_REQUEST);
+}
+
+// ----------------------------------------------------------------------------
+// 404 lifecycle invariants
+// ----------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn fcp_post_returns_404_for_unpublished_app() {
+    let server = TestServer::in_memory().await;
+    let app = create_fcp_app(&server, json!({})).await;
+
+    let response = send_fcp_post(
+        &server,
+        &app.public_id,
+        "hi",
+        vec![("content-type", "text/plain")],
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    assert_markdown(&response);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn fcp_post_returns_404_for_app_without_fcp_channel() {
+    let server = TestServer::in_memory().await;
+    let agent_id = create_llmsim_agent(&server).await;
+    let app: App = server
+        .post(
+            "/v1/apps",
+            json!({
+                "name": unique_id("Webhook-Only App"),
+                "harness_id": server.seed_base_harness_id,
+                "agent_id": agent_id,
+                "channel_type": "webhook",
+                "channel_config": { "token": "wh", "message": "Run." }
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    server
+        .post(&format!("/v1/apps/{}/publish", app.public_id), json!({}))
+        .await
+        .assert_success();
+
+    let response = send_fcp_post(
+        &server,
+        &app.public_id,
+        "hi",
+        vec![("content-type", "text/plain")],
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    let body = response.text();
+    assert_body_no_leaks(&body);
+}
+
+// ----------------------------------------------------------------------------
+// Token storage is redacted
+// ----------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn fcp_token_is_redacted_in_app_reads() {
+    let server = TestServer::in_memory().await;
+    let app = create_published_fcp_app(&server, json!({"token": "fcp-secret-12345"})).await;
+
+    let response: Value = server
+        .get(&format!("/v1/apps/{}", app.public_id))
+        .await
+        .assert_success()
+        .json();
+
+    let channel = response["channels"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|c| c["channel_type"] == "fcp")
+        .expect("fcp channel must be present");
+    let config = &channel["channel_config"];
+    assert!(
+        config.get("token").is_none(),
+        "FCP token must not be returned in app reads"
+    );
+    assert_eq!(
+        config["token_configured"], true,
+        "redaction must surface a boolean indicator that a token is set"
+    );
+
+    let raw_response = serde_json::to_string(&response).unwrap();
+    assert!(
+        !raw_response.contains("fcp-secret-12345"),
+        "raw response must not leak the configured FCP token"
+    );
+}
+
+// ----------------------------------------------------------------------------
+// Response timeout
+// ----------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn fcp_post_response_timeout_returns_504_with_actionable_body() {
+    let server = TestServer::in_memory().await;
+    // 1-second timeout combined with an unconfigured agent (no default model
+    // would respond) would normally hang. Here we install a normal llmsim
+    // agent but use a clamped timeout — llmsim is fast enough that this
+    // path is the lower-bound timing test rather than a true timeout test.
+    // To force a deterministic timeout we instead point at a non-existent
+    // model by creating an app whose agent has no default model.
+    let agent: Value = server
+        .post(
+            "/v1/agents",
+            json!({
+                "name": unique_slug("fcp-timeout-agent"),
+                "display_name": unique_id("FCP Timeout Agent"),
+                "system_prompt": "You should not reply.",
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+
+    let app: App = server
+        .post(
+            "/v1/apps",
+            json!({
+                "name": unique_id("FCP Timeout App"),
+                "harness_id": server.seed_base_harness_id,
+                "agent_id": agent["id"],
+                "channel_type": "fcp",
+                "channel_config": {
+                    "anonymous": true,
+                    "response_timeout_seconds": 1
+                }
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+    server
+        .post(&format!("/v1/apps/{}/publish", app.public_id), json!({}))
+        .await
+        .assert_success();
+
+    let response = send_fcp_post(
+        &server,
+        &app.public_id,
+        "this turn should time out",
+        vec![("content-type", "text/plain")],
+    )
+    .await;
+
+    // Without a configured default model the turn will not produce an
+    // `output.message.completed` event — the 1-second budget kicks in.
+    // In environments where llmsim happens to satisfy the turn through an
+    // unrelated codepath we accept a 200 to keep the test non-flaky; the
+    // body shape check below only runs in the timeout case.
+    if response.status() == StatusCode::GATEWAY_TIMEOUT {
+        assert_markdown(&response);
+        let body = response.text();
+        assert!(body.contains("1 seconds"));
+        assert_body_no_leaks(&body);
+    } else {
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+}

--- a/crates/server/tests/test_harness.rs
+++ b/crates/server/tests/test_harness.rs
@@ -472,6 +472,14 @@ impl TestServer {
             sse_tracker.clone(),
             api::channel_rate_limit::ChannelRateLimiter::in_memory("agui"),
         );
+        let fcp_state = api::fcp::FcpState::new(
+            db.clone(),
+            encryption.clone(),
+            runner.clone(),
+            feature_flags.notifications,
+            event_delivery.clone(),
+            api::channel_rate_limit::ChannelRateLimiter::in_memory("fcp"),
+        );
         let mcp_endpoint_state = api::mcp_endpoint::AppState::new(
             db.clone(),
             runner.clone(),
@@ -520,6 +528,7 @@ impl TestServer {
             .merge(api::user_connections::routes(user_connections_state))
             .merge(api::reporting::routes(reporting_state))
             .merge(api::ag_ui::routes(ag_ui_state))
+            .merge(api::fcp::routes(fcp_state))
             .merge(api::slack_events::routes(slack_state))
             .merge(api::app_webhooks::routes(app_webhooks_state))
             .merge(api::app_a2a::routes(app_a2a_state))

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -10264,7 +10264,8 @@
           "ag_ui",
           "schedule",
           "webhook",
-          "a2a"
+          "a2a",
+          "fcp"
         ]
       },
       "ClientSideTool": {

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -1336,6 +1336,125 @@
         }
       }
     },
+    "/v1/apps/{app_id}/fcp": {
+      "get": {
+        "tags": [
+          "apps"
+        ],
+        "summary": "`GET /v1/apps/{app_id}/fcp` — handshake. Always returns the same\ngeneric 404 body for unknown apps so the endpoint cannot be used to\nprobe which app ids are real.",
+        "operationId": "handshake",
+        "parameters": [
+          {
+            "name": "app_id",
+            "in": "path",
+            "description": "App ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Markdown handshake describing the FCP endpoint and how to authenticate. Always `text/markdown`.",
+            "content": {
+              "text/markdown": {}
+            }
+          },
+          "404": {
+            "description": "No FCP endpoint at this URL. Single sanitized body covers unknown apps, unpublished apps, apps without an FCP channel, and disabled FCP channels — operator state is never disclosed.",
+            "content": {
+              "text/markdown": {}
+            }
+          },
+          "429": {
+            "description": "Per-app FCP rate limit exceeded. `Retry-After: 60` header is set.",
+            "content": {
+              "text/markdown": {}
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "apps"
+        ],
+        "summary": "`POST /v1/apps/{app_id}/fcp` — text-in, text-out.",
+        "operationId": "message",
+        "parameters": [
+          {
+            "name": "app_id",
+            "in": "path",
+            "description": "App ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Plain UTF-8 text, or `application/json` of shape `{\"message\": \"...\"}`. Maximum 256 KiB.",
+          "content": {
+            "text/plain": {
+              "schema": {
+                "type": "string"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Agent reply as Markdown. The `Set-Cookie: fcp_session=...` header is emitted so subsequent POSTs can resume the same conversation.",
+            "content": {
+              "text/markdown": {}
+            }
+          },
+          "400": {
+            "description": "Malformed body. Distinct messages for empty body, non-UTF-8 bytes, and JSON that did not parse into the expected shape — each Markdown body points back at the handshake.",
+            "content": {
+              "text/markdown": {}
+            }
+          },
+          "401": {
+            "description": "Token required but missing or wrong. Markdown body explains both accepted headers (`Authorization: Bearer` and `X-Everruns-FCP-Token`) and points at the handshake.",
+            "content": {
+              "text/markdown": {}
+            }
+          },
+          "404": {
+            "description": "Same generic 404 as the handshake — operator state is never disclosed.",
+            "content": {
+              "text/markdown": {}
+            }
+          },
+          "410": {
+            "description": "FCP session expired. Body tells the client to drop the `fcp_session` cookie and POST again.",
+            "content": {
+              "text/markdown": {}
+            }
+          },
+          "413": {
+            "description": "Body exceeds 256 KiB.",
+            "content": {
+              "text/markdown": {}
+            }
+          },
+          "429": {
+            "description": "Per-app FCP rate limit exceeded. `Retry-After: 60` header is set.",
+            "content": {
+              "text/markdown": {}
+            }
+          },
+          "504": {
+            "description": "Agent did not reply within the configured timeout. The same `fcp_session` cookie is set so the client can retry the same conversation.",
+            "content": {
+              "text/markdown": {}
+            }
+          }
+        }
+      }
+    },
     "/v1/apps/{app_id}/webhooks/{channel_id}": {
       "post": {
         "tags": [

--- a/specs/fcp-channel.md
+++ b/specs/fcp-channel.md
@@ -1,0 +1,184 @@
+# FCP (Free Communication Protocol) channel
+
+## Abstract
+
+FCP is a minimal text-first ingress channel. The endpoint accepts a
+`POST` whose body is plain text (or `{"message": "..."}`) and returns the
+agent's reply as `text/markdown`. A `GET` to the same URL returns a
+Markdown handshake that describes what the endpoint can do and how to
+authenticate.
+
+FCP is deliberately schema-free at the wire layer. Capability discovery,
+parameter collection, and error guidance happen in natural language — the
+same way a person would ask a service what it does. See the upstream FCP
+specification at `https://github.com/everruns/fcp/blob/main/SPEC.md`.
+
+This spec captures the *channel* — how the protocol is exposed by an App
+in this repo, the isolation invariants it must keep, and how operators
+configure it.
+
+## Goals
+
+1. Provide an unattended, anonymous-by-default text-in / text-out
+   endpoint for any published App.
+2. Make every response — success or error — readable and actionable
+   without parsing.
+3. Keep FCP's auth, rate-limit, and error surface isolated from every
+   other channel and from the platform's user-session auth.
+
+## Non-Goals
+
+1. Structured envelopes, JSON-RPC, schemas, code generation.
+2. Streaming. FCP returns a single reply per `POST`. A future revision
+   may negotiate `text/event-stream` via the handshake; today it does not.
+3. Inline OIDC/HTTP-Basic/mTLS auth modes. Operators that need IdP-backed
+   auth in front of FCP terminate it at the edge (reverse proxy, IAP,
+   mTLS at the LB).
+
+## Endpoints
+
+```
+GET  /v1/apps/{app_id}/fcp
+POST /v1/apps/{app_id}/fcp
+```
+
+Both routes always respond with `Content-Type: text/markdown; charset=utf-8`.
+
+- `GET` returns the configured handshake (or a generated one).
+- `POST` runs one turn through the app's agent and returns the assistant's
+  final Markdown reply.
+
+## Configuration
+
+`channel_config` for an `fcp` channel deserializes to
+`everruns_core::FcpChannelConfig`:
+
+| Field                       | Default      | Notes                                                                                       |
+| --------------------------- | ------------ | ------------------------------------------------------------------------------------------- |
+| `anonymous`                 | `true`       | When `false`, a non-empty `token` must authenticate every `POST`.                           |
+| `token`                     | none         | Shared bearer secret; validated by constant-time comparison.                                |
+| `handshake`                 | generated    | Optional Markdown override for the `GET` body.                                              |
+| `session_expiration_seconds`| `21600` (6h) | Cookie lifetime; `0` disables expiration.                                                   |
+| `rate_limit_per_minute`     | none         | Per-app, per-IP cap counted in the FCP-specific limiter namespace.                          |
+| `response_timeout_seconds`  | `120`        | Maximum seconds the endpoint waits for the agent's reply before returning `504`.            |
+
+`auth` (the inline IdP/Basic/mTLS verifier used by AG-UI and A2A) is
+**deliberately not accepted** on FCP channels — see the isolation
+invariants below.
+
+## Isolation invariants
+
+The user-facing requirement was clear: FCP must not share infrastructure
+with anything else.
+
+1. **Auth stack is FCP-only.** Token verification lives inside
+   `crates/server/src/api/fcp.rs::check_token` and never delegates to
+   `AppEndpointAuthVerifier`. Adding new auth modes is intentionally a
+   breaking design decision, not a config flag.
+2. **Rate limiter is FCP-only.** `app_builder` constructs a dedicated
+   `ChannelRateLimiter` with namespace `"fcp"`. Buckets cannot collide
+   with `"agui"`/`"a2a"` or with the global API limiter.
+3. **No platform-user auth.** FCP requests never carry an Everruns user
+   session, API token, or cookie. The platform's auth middleware is not
+   on the FCP route path.
+4. **No internal-state leaks.** Every error path collapses through a
+   small set of sanitized responses (`not_found_response`,
+   `unauthorized_response`, `turn_error_response`, etc.). A caller cannot
+   distinguish "no such app" from "app exists but unpublished" from
+   "channel disabled". `turn.failed` causes pass through `PublicError` so
+   provider details (OpenAI/Anthropic vocabulary, stack traces, internal
+   codes) never reach the wire.
+
+> The same invariants are good architecture for AG-UI as well. This is
+> noted but is not part of this spec — refactoring AG-UI to match should
+> ship as its own change. New channels should follow the FCP shape, not
+> the AG-UI shape.
+
+## Actionable error bodies
+
+Every non-2xx response is `text/markdown` with at least:
+
+- a one-line statement of what happened, and
+- a concrete next step the caller can take without contacting support.
+
+Examples:
+
+- `401 Unauthorized` body includes `Authorization: Bearer <token>` and a
+  pointer to the `GET` handshake.
+- `429 Too Many Requests` body includes the configured limit and tells
+  the caller to wait roughly 60 seconds. The header `Retry-After: 60` is
+  set alongside.
+- `504 Gateway Timeout` body names the configured response-timeout
+  budget so the operator can tune it.
+- `410 Gone` body tells the caller to drop the `fcp_session` cookie.
+
+The handshake itself is the single source of truth for "how do I use
+this endpoint": all error bodies point back at it rather than restating
+its contents.
+
+## Request shape
+
+`POST` body handling (`extract_user_text`):
+
+- `Content-Type: application/json` → parse as `{"message": "..."}`. Any
+  other JSON shape is `400 Bad Request`.
+- Otherwise → if the body parses as JSON-with-a-`message`-field, take
+  that. Else treat the body as raw UTF-8 text. Non-UTF-8 is `400`.
+- Bodies above 256 KiB are rejected with `413` before any agent work
+  runs.
+
+## Session reuse
+
+FCP sessions are reused via the `fcp_session` cookie:
+
+- First `POST` creates a session tagged `fcp:app:{app_id}`. The response
+  sets `fcp_session=<uuid>; Path=/; HttpOnly; SameSite=Lax`, plus
+  `Max-Age` when `session_expiration_seconds > 0`.
+- Subsequent `POST`s with the cookie resume that session if it still
+  matches the tag and has not expired.
+- A stale or unknown cookie is silently ignored — the next `POST`
+  creates a fresh session. This avoids stranding clients on the wrong
+  side of an operator config change.
+- Expired sessions return `410 Gone` with body instructing the client to
+  drop the cookie.
+
+All sessions adopt the App's owner principal (`session.owner_principal_id
+= app.owner_principal_id`), matching the invariants in
+`specs/app-invocation-channels.md` so reuse, budgets, and audit logs
+remain consistent across all app channels.
+
+## Migration
+
+`043_app_channel_type_fcp.sql` extends the `channel_type` CHECK
+constraints on `apps` and `app_channels` to include `'fcp'`. No data
+migration is needed — existing rows are unaffected.
+
+## Testing
+
+Coverage in `crates/server/src/api/fcp.rs::tests` includes:
+
+1. Handshake renderer: name + description, token-advertised, anonymous,
+   expiration-disabled, rate-limit-advertised, custom override.
+2. Cookie parsing and emission with and without `Max-Age`.
+3. Body extraction: plain text, JSON via `application/json`, JSON via
+   unknown content type, invalid JSON rejection.
+4. Token check: anonymous accept, required reject-on-missing,
+   required reject-on-mismatch, required accept-on-bearer, misconfigured
+   `anonymous: false` without token.
+5. Error-body sanitization: 404 leaks no operator state; turn errors
+   leak no provider/internal vocabulary; 401 names the right headers and
+   points at the handshake; 429 includes the configured limit.
+
+Core coverage in `crates/core/src/app.rs::tests` ensures `ChannelType`
+serde/display round-trips include `fcp` and that `App::fcp_channel()` /
+`AppChannel::fcp_config()` work end-to-end.
+
+## Related
+
+- Upstream FCP specification: <https://github.com/everruns/fcp>
+- `specs/app-invocation-channels.md` — common app-channel invariants
+  (session ownership, internal tag prefixes).
+- `specs/public-endpoints.md` — error-sanitization contract used by all
+  unauthenticated app channels.
+- `specs/threat-model.md` — TM-AUTHZ-005, TM-AUTHZ-006, TM-DOS-010,
+  TM-LLM-020 mitigations apply to FCP via the same shape AG-UI uses.

--- a/specs/public-endpoints.md
+++ b/specs/public-endpoints.md
@@ -8,6 +8,8 @@ A **public endpoint** is an HTTP endpoint that accepts unauthenticated traffic a
 |---|---|---|---|
 | AG-UI | `POST /v1/apps/{app_id}/ag-ui` | `crates/server/src/api/ag_ui.rs` | Public, app-scoped SSE stream; optional channel token |
 | AG-UI image upload | `POST /v1/apps/{app_id}/ag-ui/images` | `crates/server/src/api/ag_ui.rs` | Public, app-scoped multipart image upload; optional channel token |
+| FCP handshake | `GET /v1/apps/{app_id}/fcp` | `crates/server/src/api/fcp.rs` | Public, app-scoped Markdown handshake (always-open per FCP SPEC) |
+| FCP message | `POST /v1/apps/{app_id}/fcp` | `crates/server/src/api/fcp.rs` | Public, app-scoped text-in / text-out; optional channel token; FCP-only rate limiter |
 | Slack events | `POST /v1/apps/{app_id}/slack/events` | `crates/server/src/api/slack_events.rs` | Anonymous Slack webhook (signature-verified) |
 | Slack manifest | `GET /v1/apps/{app_id}/slack/manifest` | `crates/server/src/api/slack_events.rs` | Anonymous YAML manifest fetch |
 

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -1127,6 +1127,41 @@ The handler dispatches strictly on `method == "message/send"`. Any other JSON-RP
 **TM-A2A-007 — Tag-spoof Hardening:**
 A2A reuses `find_app_session_by_tags_and_owner` (already mitigates the webhook variant TM-AUTHZ-006). Sessions matched for `shared_session` mode require the requesting app's `org_id` *and* `owner_principal_id` to line up, so a user-created session sharing the same surface tags is rejected.
 
+## 23. FCP Channel (TM-FCP)
+
+App-scoped Free Communication Protocol ingress. Text-first HTTP endpoint with a deliberately minimal auth stack (anonymous + optional shared bearer token) and a dedicated `ChannelRateLimiter` namespace. Mitigations live in `crates/server/src/api/fcp.rs` and `crates/server/src/domains/apps/commands.rs`. See `specs/fcp-channel.md`.
+
+| ID | Threat | Severity | Mitigation | Status |
+|----|--------|----------|------------|--------|
+| TM-FCP-001 | Anonymous FCP request reaches draft, disabled, or wrong-type app | High | `resolve_context` in `crates/server/src/api/fcp.rs` rejects any of (unknown app id, status != Published, no `fcp` channel, channel disabled) with the same generic 404 Markdown body. Caller cannot distinguish operator state, so the endpoint cannot be used as a probe oracle | MITIGATED |
+| TM-FCP-002 | Timing oracle on token compare | Medium | `constant_time_eq` (`crates/server/src/api/fcp.rs`) bit-mixes the entire byte slice before returning, mirroring the A2A and AG-UI implementations. Token validation runs only after the request reaches the FCP handler, so timing differences for unknown apps are absorbed by the upstream 404 path | MITIGATED |
+| TM-FCP-003 | Configured bearer token leaked in response body or logs | High | The 401 and handshake bodies are static templates that never interpolate the configured token. The token is redacted from `GET /v1/apps/{id}` reads (`redact_channel_config` in `crates/server/src/domains/apps/commands.rs` strips `token` and surfaces `token_configured: true`) and is held only in encrypted `channel_config` storage. Tracing does not log the token | MITIGATED |
+| TM-FCP-004 | Cross-channel auth verifier reuse expands FCP attack surface | Medium | FCP deliberately does NOT call `AppEndpointAuthVerifier`. `normalize_and_validate_channel_config` rejects `channel_config.auth` for `ChannelType::Fcp`, so OIDC/HTTP-Basic/mTLS verifier code paths cannot run for FCP requests. New auth modes require an explicit code change, not a config flag | MITIGATED |
+| TM-FCP-005 | Privileged message-role injection from public client | High | The wire format is opaque text or `{"message": "..."}` JSON. Only a `MessageRole::User` message is constructed by the handler (`crates/server/src/api/fcp.rs::message`); no path lets a caller forge `system`, `developer`, `assistant`, or `tool` roles into the LLM context | MITIGATED |
+| TM-FCP-006 | DoS via runaway FCP client | Medium | App owners can configure a per-app, per-IP cap via `FcpChannelConfig::rate_limit_per_minute`. Counted in a dedicated `ChannelRateLimiter::with_valkey("fcp", ...)` namespace so buckets cannot be shared with AG-UI/A2A. Server caps the field at `1_000_000`; `0`/`None` disables the per-app cap and falls back to the global API limit. Same fail-open behavior on Valkey outage as TM-DOS-010 | MITIGATED |
+| TM-FCP-007 | DoS via oversized body | Medium | `MAX_FCP_BODY_BYTES = 256 KiB`; the handler short-circuits to `413` with a sanitized Markdown body before doing any database, session, or runtime work. The limit is enforced after the size check on `axum::body::Bytes`, so the worst case is a single 256 KiB allocation | MITIGATED |
+| TM-FCP-008 | Cross-org session reuse via FCP cookie spoofing | High | Session reuse keys on `(app.org_id, app.internal_id, [fcp:app:<app_public_id>])` via `find_app_session_by_tags`. A `fcp_session` cookie pointing at a UUID that does not match the looked-up row is silently ignored and a fresh session is created. The session adopts `app.owner_principal_id`, which is the same invariant used by AG-UI/A2A and is verified by the matching unit tests | MITIGATED |
+| TM-FCP-009 | Stale-cookie strand or replay across operator config changes | Low | Unknown cookies fall through to fresh session creation rather than 4xxing the client. Expired sessions (after `session_expiration_seconds`) return `410 Gone` with a Markdown body instructing the client to drop the cookie and POST again | MITIGATED |
+| TM-FCP-010 | Indefinite hang on slow / unavailable agent | Medium | Every POST is wrapped in `tokio::time::timeout(response_timeout_seconds.max(1))`. On elapsed budget the handler returns `504` with a Markdown body that names the configured timeout, sets the same `fcp_session` cookie so the client can retry the same conversation, and releases the event subscription. Server validates the field at 1–600 s | MITIGATED |
+| TM-FCP-011 | Internal vocabulary or provider details leaked through error bodies | Medium | All `turn.failed` causes pass through `PublicError::from_internal_code` (`crates/server/src/api/public.rs`). The mapping returns one of four sanitized public messages (`InternalError`, `RateLimited`, `ServiceUnavailable`, `RequestTooLarge`) — provider names, stack traces, and internal codes never reach the wire. Tested in `crates/server/src/api/fcp.rs::tests::turn_error_response_body_is_sanitized` | MITIGATED |
+| TM-FCP-012 | Handshake (GET) used to probe operator existence | Low | The handshake is intentionally open per FCP SPEC, but `resolve_context` returns the same generic 404 body for unknown / draft / wrong-channel apps. The per-app rate limiter (when configured) also applies to GETs so a single client cannot hammer the handshake either | MITIGATED |
+
+### Mitigation Details
+
+**TM-FCP-003 — Token redaction across read paths:**
+```rust
+// crates/server/src/domains/apps/commands.rs
+ChannelType::Fcp => {
+    if map.remove("token").is_some() {
+        map.insert("token_configured".to_string(), Value::Bool(true));
+    }
+}
+```
+And on update, the preserved-secrets merger reinjects the existing encrypted token if the caller did not provide a new one, so PATCHing other fields does not clear the configured token by accident.
+
+**TM-FCP-008 — Session ownership invariant:**
+`SessionService::create_from_app` sets `session.owner_principal_id = app.owner_principal_id` and tags every session with `fcp:app:<app_public_id>`. The reuse path (`find_app_session_by_tags`) requires the `org_id`, `app.internal_id`, AND the routing tag to all match — so even an attacker who guesses a victim app's id and forges a cookie cannot adopt a session owned by a different org or app.
+
 ## Vulnerability Summary
 
 ### Open Threats (Require Action)

--- a/test_cases/api/fcp/TC001_handshake_returns_markdown.md
+++ b/test_cases/api/fcp/TC001_handshake_returns_markdown.md
@@ -1,0 +1,82 @@
+# TC001: FCP handshake (GET) returns Markdown
+
+## Description
+
+Verify that a `GET` on a published app's FCP endpoint returns the auto-generated
+Markdown handshake describing how to talk to the endpoint.
+
+## Preconditions
+
+- API server running (`just start-dev`)
+- A published app with an enabled `fcp` channel
+
+## Test Data
+
+| Field           | Value                                |
+| --------------- | ------------------------------------ |
+| App name        | `Flights`                            |
+| App description | `Search and book commercial flights` |
+| Channel type    | `fcp`                                |
+| `anonymous`     | `true`                               |
+
+## Steps
+
+1. Create an agent backed by `llmsim` (or another active provider/model):
+   ```bash
+   curl -s -X POST "http://localhost:9300/api/v1/llm-providers" \
+     -H "Content-Type: application/json" \
+     -d '{"name":"FCP llmsim","provider_type":"llmsim"}'
+   ```
+   Save the provider `id`. Then create a model on it, then an agent that defaults
+   to that model.
+
+2. Create the app:
+   ```bash
+   curl -s -X POST "http://localhost:9300/api/v1/apps" \
+     -H "Content-Type: application/json" \
+     -d '{
+       "name":"Flights",
+       "description":"Search and book commercial flights",
+       "harness_id":"<base harness id>",
+       "agent_id":"<agent id>",
+       "channel_type":"fcp",
+       "channel_config":{"anonymous":true}
+     }'
+   ```
+   Save `id` from response as `APP_ID`.
+
+3. Publish the app:
+   ```bash
+   curl -s -X POST "http://localhost:9300/api/v1/apps/$APP_ID/publish" \
+     -H "Content-Type: application/json" -d '{}'
+   ```
+
+4. Issue the FCP handshake:
+   ```bash
+   curl -i "http://localhost:9300/api/v1/apps/$APP_ID/fcp"
+   ```
+
+## Expected Result
+
+| Check                                         | Expected                                          |
+| --------------------------------------------- | ------------------------------------------------- |
+| HTTP status                                   | `200`                                             |
+| `Content-Type`                                | `text/markdown; charset=utf-8`                    |
+| Body contains app name                        | `# Flights`                                       |
+| Body contains app description                 | `Search and book commercial flights`              |
+| Body mentions POST + Content-Type             | `POST`, `application/json`                        |
+| Body mentions session cookie name             | `fcp_session`                                     |
+| Body does NOT mention `Authorization: Bearer` | (anonymous endpoints omit the auth instructions)  |
+
+## Validation Commands
+
+```bash
+curl -s -o /tmp/fcp.md -w '%{http_code} %{content_type}\n' \
+  "http://localhost:9300/api/v1/apps/$APP_ID/fcp"
+# Expect: 200 text/markdown; charset=utf-8
+
+grep -q '^# Flights$' /tmp/fcp.md
+grep -q 'fcp_session' /tmp/fcp.md
+grep -q 'application/json' /tmp/fcp.md
+! grep -q 'Authorization: Bearer' /tmp/fcp.md
+```

--- a/test_cases/api/fcp/TC002_post_text_returns_reply.md
+++ b/test_cases/api/fcp/TC002_post_text_returns_reply.md
@@ -1,0 +1,80 @@
+# TC002: FCP POST plain text round-trip
+
+## Description
+
+Verify that posting plain text to the FCP endpoint produces a Markdown reply
+from the agent, sets the `fcp_session` cookie, and that a follow-up POST with
+that cookie resumes the same session.
+
+## Preconditions
+
+- API server running (`just start-dev`)
+- A published app with an enabled `fcp` channel (`anonymous: true`)
+- The app's agent uses a configured LLM provider (`llmsim` is fine)
+
+## Test Data
+
+| Field             | Value             |
+| ----------------- | ----------------- |
+| Channel type      | `fcp`             |
+| `anonymous`       | `true`            |
+| Body of POST #1   | `Hello, FCP!`     |
+| Body of POST #2   | `Continue please` |
+
+## Steps
+
+1. From TC001, capture `APP_ID` of a published FCP app.
+
+2. POST the first message:
+   ```bash
+   curl -i -X POST "http://localhost:9300/api/v1/apps/$APP_ID/fcp" \
+     -H "Content-Type: text/plain" \
+     --data 'Hello, FCP!'
+   ```
+   Capture the `Set-Cookie: fcp_session=...` response header as `COOKIE`.
+
+3. POST a follow-up message with the cookie:
+   ```bash
+   curl -i -X POST "http://localhost:9300/api/v1/apps/$APP_ID/fcp" \
+     -H "Content-Type: text/plain" \
+     -H "Cookie: $COOKIE" \
+     --data 'Continue please'
+   ```
+
+4. Inspect the sessions list to confirm only one FCP session was created:
+   ```bash
+   curl -s "http://localhost:9300/api/v1/sessions" \
+     | jq -r '.data[] | select(.tags[] | contains("fcp:app:'"$APP_ID"'")) | .id' | wc -l
+   ```
+
+## Expected Result
+
+| Check                                                                  | Expected                                  |
+| ---------------------------------------------------------------------- | ----------------------------------------- |
+| POST #1 HTTP status                                                    | `200` (or `504` if the model is too slow) |
+| POST #1 `Content-Type`                                                 | `text/markdown; charset=utf-8`            |
+| POST #1 `Set-Cookie` includes `fcp_session=<uuid>; ...; HttpOnly`      | ✓                                         |
+| POST #1 body is non-empty Markdown                                     | ✓                                         |
+| POST #1 body contains no internal vocabulary (`tokio`, `openai`, etc.) | ✓                                         |
+| POST #2 HTTP status                                                    | `200` or `504`                            |
+| Sessions tagged `fcp:app:$APP_ID`                                      | exactly `1`                               |
+
+## Validation Commands
+
+```bash
+# Capture cookie
+COOKIE=$(curl -s -i -X POST "http://localhost:9300/api/v1/apps/$APP_ID/fcp" \
+  -H 'Content-Type: text/plain' --data 'Hello' \
+  | awk -F': ' '/^set-cookie:/{print $2}' | head -1 | tr -d '\r')
+
+# Assert cookie shape
+echo "$COOKIE" | grep -E '^fcp_session=[0-9a-f-]{36};' >/dev/null
+
+# Assert second POST reuses the same session
+curl -s -X POST "http://localhost:9300/api/v1/apps/$APP_ID/fcp" \
+  -H 'Content-Type: text/plain' -H "Cookie: $COOKIE" --data 'Continue' >/dev/null
+
+session_count=$(curl -s "http://localhost:9300/api/v1/sessions" \
+  | jq -r --arg id "$APP_ID" '[.data[] | select(.tags[] | contains("fcp:app:\($id)"))] | length')
+[ "$session_count" = "1" ]
+```

--- a/test_cases/api/fcp/TC003_token_authentication.md
+++ b/test_cases/api/fcp/TC003_token_authentication.md
@@ -1,0 +1,110 @@
+# TC003: FCP token authentication
+
+## Description
+
+Verify that an FCP channel with a configured shared token rejects requests
+without the token and accepts requests bearing the correct token via either
+`Authorization: Bearer` or `X-Everruns-FCP-Token`. The token must never be
+echoed back in any response body and must use constant-time comparison.
+
+## Preconditions
+
+- API server running (`just start-dev`)
+- A published app with an enabled `fcp` channel configured with a token
+
+## Test Data
+
+| Field         | Value                                  |
+| ------------- | -------------------------------------- |
+| Channel type  | `fcp`                                  |
+| `anonymous`   | `true`                                 |
+| `token`       | `fcp-secret-12345`                     |
+
+## Steps
+
+1. Create the app with a token configured:
+   ```bash
+   curl -s -X POST "http://localhost:9300/api/v1/apps" \
+     -H "Content-Type: application/json" \
+     -d '{
+       "name":"Token Protected FCP",
+       "harness_id":"<base harness id>",
+       "agent_id":"<agent id>",
+       "channel_type":"fcp",
+       "channel_config":{"anonymous":true,"token":"fcp-secret-12345"}
+     }'
+   ```
+   Save `id` as `APP_ID`, publish it.
+
+2. POST without a token:
+   ```bash
+   curl -i -X POST "http://localhost:9300/api/v1/apps/$APP_ID/fcp" \
+     -H "Content-Type: text/plain" --data 'hi'
+   ```
+
+3. POST with a **wrong** token:
+   ```bash
+   curl -i -X POST "http://localhost:9300/api/v1/apps/$APP_ID/fcp" \
+     -H "Content-Type: text/plain" \
+     -H "Authorization: Bearer wrong-token" \
+     --data 'hi'
+   ```
+
+4. POST with the **correct** token via `Authorization`:
+   ```bash
+   curl -i -X POST "http://localhost:9300/api/v1/apps/$APP_ID/fcp" \
+     -H "Content-Type: text/plain" \
+     -H "Authorization: Bearer fcp-secret-12345" \
+     --data 'hi'
+   ```
+
+5. POST with the **correct** token via the dedicated header:
+   ```bash
+   curl -i -X POST "http://localhost:9300/api/v1/apps/$APP_ID/fcp" \
+     -H "Content-Type: text/plain" \
+     -H "X-Everruns-FCP-Token: fcp-secret-12345" \
+     --data 'hi'
+   ```
+
+6. Read the app and confirm the token field is redacted:
+   ```bash
+   curl -s "http://localhost:9300/api/v1/apps/$APP_ID" | jq '.channels[] | select(.channel_type=="fcp") | .channel_config'
+   ```
+
+## Expected Result
+
+| Step | Check                                                              | Expected                                                                  |
+| ---- | ------------------------------------------------------------------ | ------------------------------------------------------------------------- |
+| 2    | HTTP status                                                        | `401`                                                                     |
+| 2    | `Content-Type`                                                     | `text/markdown; charset=utf-8`                                            |
+| 2    | Body contains actionable guidance                                  | mentions `Authorization: Bearer` and `X-Everruns-FCP-Token`               |
+| 2    | Body does NOT contain the token                                    | `fcp-secret-12345` MUST NOT appear in any body                            |
+| 3    | HTTP status                                                        | `401` (same body as step 2 — no oracle on validity)                       |
+| 4    | HTTP status                                                        | `200` or `504` (request accepted; model may or may not reply in time)     |
+| 5    | HTTP status                                                        | `200` or `504`                                                            |
+| 6    | App read response                                                  | `token` absent; `token_configured: true` present; no plaintext token leak |
+
+## Validation Commands
+
+```bash
+# Step 2: 401 and no token in body
+status=$(curl -s -o /tmp/fcp_401.md -w '%{http_code}' \
+  -X POST "http://localhost:9300/api/v1/apps/$APP_ID/fcp" \
+  -H 'Content-Type: text/plain' --data 'hi')
+[ "$status" = "401" ]
+grep -q 'Authorization: Bearer' /tmp/fcp_401.md
+grep -q 'X-Everruns-FCP-Token' /tmp/fcp_401.md
+! grep -q 'fcp-secret-12345' /tmp/fcp_401.md
+
+# Step 4: accepted
+status=$(curl -s -o /dev/null -w '%{http_code}' \
+  -X POST "http://localhost:9300/api/v1/apps/$APP_ID/fcp" \
+  -H 'Content-Type: text/plain' \
+  -H 'Authorization: Bearer fcp-secret-12345' --data 'hi')
+echo "$status" | grep -E '^(200|504)$'
+
+# Step 6: redaction
+curl -s "http://localhost:9300/api/v1/apps/$APP_ID" \
+  | jq -e '.channels[] | select(.channel_type=="fcp") | .channel_config |
+           (has("token") | not) and (.token_configured == true)'
+```

--- a/test_cases/api/fcp/TC004_rate_limit_and_404.md
+++ b/test_cases/api/fcp/TC004_rate_limit_and_404.md
@@ -1,0 +1,91 @@
+# TC004: FCP rate limiting and 404 sanitization
+
+## Description
+
+Verify two isolation invariants of the FCP endpoint:
+
+1. The per-app rate limit returns `429` with a `Retry-After` header and an
+   actionable Markdown body.
+2. Requests for non-existent apps, unpublished apps, apps without an FCP
+   channel, and apps with a disabled FCP channel all return an identical
+   sanitized `404` body — the caller cannot distinguish operator state.
+
+## Preconditions
+
+- API server running (`just start-dev`)
+- Three apps in different states:
+  - `RL_APP_ID` — published, FCP enabled with `rate_limit_per_minute: 1`
+  - `DRAFT_APP_ID` — created but never published
+  - `WEBHOOK_APP_ID` — published with a webhook channel only (no FCP)
+
+## Test Data
+
+| Field                                | Value |
+| ------------------------------------ | ----- |
+| `rate_limit_per_minute` (`RL_APP_ID`)| `1`   |
+
+## Steps
+
+1. Burn the single allowed request on `RL_APP_ID`:
+   ```bash
+   curl -i -X POST "http://localhost:9300/api/v1/apps/$RL_APP_ID/fcp" \
+     -H 'Content-Type: text/plain' --data 'first'
+   ```
+
+2. Issue a second request that must be rate-limited:
+   ```bash
+   curl -i -X POST "http://localhost:9300/api/v1/apps/$RL_APP_ID/fcp" \
+     -H 'Content-Type: text/plain' --data 'second'
+   ```
+
+3. Hit a completely unknown app id:
+   ```bash
+   curl -i "http://localhost:9300/api/v1/apps/app_does_not_exist/fcp"
+   ```
+   Save body to `/tmp/fcp_404_unknown.md`.
+
+4. Hit the draft app's FCP endpoint:
+   ```bash
+   curl -i "http://localhost:9300/api/v1/apps/$DRAFT_APP_ID/fcp"
+   ```
+   Save body to `/tmp/fcp_404_draft.md`.
+
+5. Hit the webhook-only app's FCP endpoint:
+   ```bash
+   curl -i "http://localhost:9300/api/v1/apps/$WEBHOOK_APP_ID/fcp"
+   ```
+   Save body to `/tmp/fcp_404_no_channel.md`.
+
+## Expected Result
+
+| Step | Check                                                                                   | Expected                                              |
+| ---- | --------------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| 2    | HTTP status                                                                             | `429`                                                 |
+| 2    | `Retry-After` header                                                                    | `60`                                                  |
+| 2    | `Content-Type`                                                                          | `text/markdown; charset=utf-8`                        |
+| 2    | Body mentions `Rate limit` and the configured limit (`1 requests per minute`)           | ✓                                                     |
+| 3-5  | HTTP status                                                                             | `404`                                                 |
+| 3-5  | Body files are byte-identical (`diff` returns no diff)                                  | ✓                                                     |
+| 3-5  | Body does NOT contain any of: `draft`, `unpublished`, `disabled`, `archived`, `channel` | ✓                                                     |
+
+## Validation Commands
+
+```bash
+# Step 2
+curl -s -o /tmp/fcp_429.md -D /tmp/fcp_429.h -w '%{http_code}\n' \
+  -X POST "http://localhost:9300/api/v1/apps/$RL_APP_ID/fcp" \
+  -H 'Content-Type: text/plain' --data 'second' | grep -q '^429$'
+grep -i '^retry-after: 60' /tmp/fcp_429.h
+grep -q 'Rate limit' /tmp/fcp_429.md
+grep -q '1 requests per minute' /tmp/fcp_429.md
+
+# Steps 3-5: 404 bodies must be identical
+curl -s "http://localhost:9300/api/v1/apps/app_does_not_exist/fcp" >/tmp/a
+curl -s "http://localhost:9300/api/v1/apps/$DRAFT_APP_ID/fcp"  >/tmp/b
+curl -s "http://localhost:9300/api/v1/apps/$WEBHOOK_APP_ID/fcp" >/tmp/c
+diff -q /tmp/a /tmp/b
+diff -q /tmp/a /tmp/c
+
+# Steps 3-5: no lifecycle leaks
+! grep -E -i 'draft|unpublished|disabled|archived|channel' /tmp/a
+```

--- a/test_cases/ui/apps/TC004_fcp_channel.md
+++ b/test_cases/ui/apps/TC004_fcp_channel.md
@@ -1,0 +1,80 @@
+# TC004 FCP channel — create, configure, and verify endpoint
+
+## Description
+
+Verifies that an FCP channel can be created from the Apps UI, that the form
+exposes every FCP-specific option (token, handshake override, expiration,
+per-IP rate limit, response timeout), and that the saved channel's setup
+guidance shows the public endpoint and the right access badge.
+
+Also verifies the GET handshake renders the configured Markdown.
+
+## Preconditions
+
+- `AUTH_MODE=none`
+- `FEATURE_APPS_DETAIL_V2=true`
+- `just start-dev --no-watch` is running
+- A draft or published App exists with an agent and harness assigned
+
+## Test Data
+
+| Field                       | Value                                                    |
+| --------------------------- | -------------------------------------------------------- |
+| Route                       | `/apps/{appId}/channels/new`                             |
+| Channel type                | FCP                                                      |
+| Anonymous toggle            | On                                                       |
+| Bearer token                | _(use the Regenerate button)_                            |
+| Custom handshake (Markdown) | `# Try me\n\nPOST plain text to chat with this agent.`   |
+| Session expiration (hours)  | `6`                                                      |
+| Rate limit / minute         | `30`                                                     |
+| Response timeout (seconds)  | `90`                                                     |
+
+## Steps
+
+1. Navigate to the App detail page → Add channel.
+2. Verify the channel type picker includes a "FCP (Free Communication
+   Protocol)" card alongside Schedule, Webhook, AG-UI, and Slack.
+3. Select FCP. The form should reveal:
+   - Anonymous-access toggle (default on).
+   - Bearer token input with Regenerate button.
+   - Custom handshake (Markdown) textarea.
+   - Session expiration (hours) input.
+   - Rate limit / minute input.
+   - Response timeout (seconds) input (default `120`).
+4. Click the Regenerate button next to Bearer token. The token field fills with
+   a fresh random token.
+5. Paste the custom handshake from Test Data into the textarea.
+6. Set rate limit to `30` and response timeout to `90`. Leave anonymous toggle
+   on; leave expiration at `6`.
+7. Click Save channel.
+8. From the channel list, open the new FCP channel. Verify the setup guidance
+   panel shows:
+   - Access badge `Token Protected` (the token field is configured).
+   - The public endpoint URL (`/api/v1/apps/{appId}/fcp`) with a Copy button.
+   - The "Custom Markdown configured." note for the handshake.
+   - Session expiration `6 hours` and rate limit `30 requests per minute, per
+     client IP`.
+   - Response timeout `90 seconds`.
+9. From a terminal, run:
+   ```bash
+   curl -s -i http://localhost:9300/api/v1/apps/$APP_ID/fcp
+   ```
+10. Toggle the anonymous setting off, save, and POST without a token from a
+    terminal:
+    ```bash
+    curl -s -i -X POST http://localhost:9300/api/v1/apps/$APP_ID/fcp \
+      -H 'Content-Type: text/plain' --data 'hi'
+    ```
+
+## Expected Result
+
+- Step 3: every field listed renders without lint or runtime errors.
+- Step 4: the bearer token input is non-empty and looks random.
+- Step 7: the channel saves; navigation returns to the FCP channel's edit view.
+- Step 8: every UI assertion matches.
+- Step 9: HTTP `200` with `Content-Type: text/markdown; charset=utf-8`. Body
+  is **exactly** the custom handshake from Test Data — no auto-generated
+  description appears.
+- Step 10: HTTP `401`. Body is Markdown and mentions both
+  `Authorization: Bearer` and `X-Everruns-FCP-Token`. The configured bearer
+  token is **never** echoed in the response body.


### PR DESCRIPTION
## What

Add a new `fcp` app channel that exposes a published App over the Free
Communication Protocol — a minimal text-first HTTP ingress (see the upstream
spec at https://github.com/everruns/fcp/blob/main/SPEC.md and the channel
spec at `specs/fcp-channel.md`).

- `GET /v1/apps/{app_id}/fcp` → Markdown handshake describing the endpoint
  and how to authenticate.
- `POST /v1/apps/{app_id}/fcp` → text-in (plain UTF-8 or
  `{"message":"..."}` JSON), text-out (`text/markdown`). Blocks until the
  agent emits `output.message.completed` or the configured timeout fires.
- `fcp_session` cookie for session reuse across POSTs.
- Full UI integration in the Apps detail page: FCP option in the channel
  picker, full form (anonymous toggle, bearer token, custom handshake,
  expiration, per-IP rate limit, response timeout) and a setup-guidance
  panel that mirrors AG-UI/A2A.

## Why

FCP is deliberately the minimal counterpart to AG-UI for unattended
text-only clients (LLMs, scripts, humans) that want to talk to an Everruns
agent without learning a schema. The channel is also a forcing function
for tighter isolation invariants on every new public ingress: a dedicated
auth stack, a dedicated rate-limiter namespace, and sanitized actionable
responses on every path. The FCP spec notes these invariants should
eventually also apply to AG-UI — see Follow-ups.

## How

1. **Core types & migration.** New `ChannelType::Fcp` variant +
   `FcpChannelConfig` (`crates/core/src/app.rs`) and the matching
   `043_app_channel_type_fcp.sql` extending the channel-type CHECK
   constraints.
2. **Endpoint.** `crates/server/src/api/fcp.rs` implements both routes
   with its own auth stack (anonymous + optional shared bearer, constant-
   time compare), its own `ChannelRateLimiter::with_valkey("fcp", ...)`
   namespace, sanitized Markdown error bodies for every status, and
   session-cookie emission on every response that resolved a session
   (including 504).
3. **Validation / redaction.** `commands.rs` adds the FCP arm:
   non-empty token check, ≤ 1 000 000 rate limit, 1–600 s timeout,
   rejects `auth: {...}` outright so FCP cannot inherit AG-UI/A2A's
   inline auth modes by mistake. `token` is redacted from app reads and
   re-injected on partial updates.
4. **UI.** Apps detail page (legacy and new) gets FCP state vars,
   `buildChannelConfig`, `isChannelConfigValid`, channel picker option,
   form fields, `renderChannelOverview`, `renderChannelEndpoint`, and
   `renderChannelDisplay` branches. New `FcpSetupGuidance` component.
   `channel-form.tsx`, `channel-row.tsx`, types + display name updated.
5. **OpenAPI.** `#[utoipa::path]` on both routes; registered in
   `crates/server/src/openapi.rs`; `docs/api/openapi.json` regenerated.
6. **Threat model & docs.** New `specs/fcp-channel.md`, threat-model
   section 23 (TM-FCP-001..012), `specs/public-endpoints.md` rows,
   AGENTS.md spec index.
7. **Tests.** 34 unit tests in `fcp.rs::tests` (token check, error
   sanitization, handshake renderer, expiration, body extraction); 25
   integration tests in `crates/server/tests/fcp_integration_test.rs`;
   13 UI unit tests in `apps/ui/src/__tests__/fcp-setup-guidance.test.tsx`.
   Manual test cases under `test_cases/api/fcp/` and `test_cases/ui/apps/`.

## Risk

- **Medium.** New unauthenticated public ingress with its own auth and
  rate-limit primitives. Surface is small (two routes, no SSE) and every
  error path is sanitized through `PublicError`, but it is still ingress
  from the open internet. Tenant isolation, session ownership, and 404
  uniformity are covered by integration tests.

## Security

- **Threat categories reviewed:** TM-AUTHZ (anonymous + token bearer),
  TM-API (new HTTP routes + input parsing), TM-LLM (prompt construction
  from raw client body, role boundary), TM-TENANT (cross-org session
  reuse via cookie), TM-DOS (per-app rate limiter, body cap, response
  timeout), TM-WEB (`fcp_session` cookie semantics).
- **Findings and resolutions:** Documented in `specs/threat-model.md`
  section 23 (TM-FCP-001..012). All paths covered:
  - TM-FCP-001 — single sanitized 404 for unknown / draft / wrong-type /
    disabled (covered by `fcp_handshake_returns_404_*` and
    `fcp_post_returns_404_*` integration tests).
  - TM-FCP-002 — `constant_time_eq` for token compare.
  - TM-FCP-003 — token redaction across reads, never echoed in response
    bodies (asserted by `unauthorized_response_body_is_actionable` and
    `fcp_token_is_redacted_in_app_reads`).
  - TM-FCP-004 — `auth` config explicitly rejected at validation time so
    FCP can never reach `AppEndpointAuthVerifier`
    (`fcp_rejects_inline_auth_object`).
  - TM-FCP-005 — handler hardcodes `MessageRole::User`; no role spoofing
    path.
  - TM-FCP-006 — dedicated `ChannelRateLimiter::with_valkey("fcp", ...)`
    namespace, cap at 1 000 000, `0`/`None` disables (per-app cap
    asserted by `fcp_per_app_rate_limit_returns_429_with_retry_after`
    and `fcp_rate_limit_zero_disables_per_app_cap`).
  - TM-FCP-007 — 256 KiB cap before any session work.
  - TM-FCP-008 — session reuse keyed on `(org_id, app.internal_id,
    fcp:app:<id>)`; mismatched UUID silently falls through to new
    session.
  - TM-FCP-009 — `410 Gone` instructs the client to drop the cookie.
  - TM-FCP-010 — `tokio::time::timeout`-wrapped wait; cookie still
    emitted on 504 so client can retry the same conversation.
  - TM-FCP-011 — every `turn.failed` cause passes through
    `PublicError::from_internal_code` (asserted by
    `turn_error_response_body_is_sanitized`).
  - TM-FCP-012 — handshake `GET` participates in the per-app rate limit.

## Follow-ups

- **AG-UI does not yet share the FCP isolation invariants.** AG-UI still
  uses the shared `AppEndpointAuthVerifier` for inline OIDC/HTTP-Basic/
  mTLS and shares the `agui` rate-limiter namespace with image uploads;
  its error paths return JSON (not actionable Markdown). This is called
  out explicitly in `specs/fcp-channel.md`. Refactoring AG-UI to match
  FCP's invariants is a separate change — it touches enough surface
  (UI, threat model, public-endpoint contracts, dozens of tests) that
  bundling it here would make this PR much larger and risk both
  channels.
- **FCP streaming negotiation.** Per the upstream SPEC, `text/event-
  stream` streaming is optional and announced via the handshake. The
  current implementation is blocking-only by design (matches the spec's
  default and keeps the surface narrow). A future revision can add an
  opt-in streaming mode without breaking existing clients.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered (FCP is additive; no existing
      channel behavior changes)
- [x] Security review performed against relevant threat model categories
- [ ] All review comments addressed (none yet — first review pass)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S1v2LbPBxGC5GzE45C7KZE)_