### PR TITLE
fix(ui): default AG-UI channels to generated token

### DIFF
--- a/apps/ui/src/__tests__/app-channel-redesign.test.tsx
+++ b/apps/ui/src/__tests__/app-channel-redesign.test.tsx
@@ -42,6 +42,14 @@ const scheduleChannel: AppChannel = {
 };
 
 describe("app channel redesign", () => {
+  it("generates a token by default for new AG-UI channels", () => {
+    const state = getDefaultChannelFormState("ag_ui");
+    const config = buildChannelConfig(state);
+
+    expect(state.agUiToken).toMatch(/^[A-Za-z0-9\-_]{16,}$/);
+    expect(config).toEqual(expect.objectContaining({ anonymous: true, token: state.agUiToken }));
+  });
+
   it("renders cron labels as human-readable text with timezone", () => {
     render(<CronLabel expr="0 30 * * * * *" tz="America/Chicago" />);
 

--- a/apps/ui/src/components/apps/channel-form.tsx
+++ b/apps/ui/src/components/apps/channel-form.tsx
@@ -90,7 +90,7 @@ export function getDefaultChannelFormState(
     invocationSessionMode: "shared_session",
     channelMessage: "",
     webhookToken: "",
-    agUiToken: "",
+    agUiToken: kind === "ag_ui" && !channel ? generateChannelToken() : "",
     agUiExpirationHours: DEFAULT_AG_UI_SESSION_EXPIRATION_SECONDS / 3600,
     agUiRateLimitPerMinute: "",
     agUiToolVisibility: "generic",


### PR DESCRIPTION
## What
Default new AG-UI channels to a securely generated bearer token instead of an empty string in the V2 channel creation form.

## Why
The V2 channel creation flow initialized new `ag_ui` channels with `agUiToken: ""`, so published AG-UI endpoints accepted anonymous requests by default — a security regression. New channels should ship with a secure bearer token unless the operator explicitly clears it.

## How
- `getDefaultChannelFormState` in `apps/ui/src/components/apps/channel-form.tsx` now calls `generateChannelToken()` when initializing a new (`!channel`) `ag_ui` form, so the form state and `buildChannelConfig` output include a token by default.
- Edit flows for existing channels are unchanged — token is still loaded via `secretValue(config.token, config.token_configured)` and can be intentionally blank.
- Added a Jest unit test in `apps/ui/src/__tests__/app-channel-redesign.test.tsx` asserting the generated token shape and that `buildChannelConfig` includes it.

## Risk
- Low. UI-only form-state change scoped to new-channel initialization.
- Tokens are cryptographically random (63 chars from a 64-char alphabet via `crypto.getRandomValues`), so no weak-token risk.
- Operators who want anonymous AG-UI access can still clear the token field before saving.

## Security
- Threat categories reviewed: TM-AUTH (default token on a public endpoint), TM-API (input to public AG-UI endpoint), TM-WEB (frontend form default).
- Findings and resolutions: This change is the resolution — closes the regression that allowed unauthenticated requests by default. `generateChannelToken()` uses `crypto.getRandomValues` (see `apps/ui/src/lib/channel-tokens.ts`). No new threat surface introduced; edit flows for existing channels are untouched.

## Follow-ups
- No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (edit flow unchanged)
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (no review comments — Copilot left an overview only)

## Testing
- `cd apps/ui && ./node_modules/.bin/jest --runTestsByPath src/__tests__/app-channel-redesign.test.tsx` — 7/7 passed locally.
- `cd apps/ui && npm run lint` — 0 errors (6 pre-existing warnings unrelated to this PR).
- `cd apps/ui && npm run format:check` — clean.
- CI: UI Build/Lint/Test, UI Playwright Smoke, CodeQL, Migration Immutability all green; Rust jobs skipped (UI-only change).