### PR TITLE
chore(release): prepare v0.8.31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- New changes go here. Use `/prepare-release X.Y.Z` to generate draft from commits. -->
 
+## [0.8.31] - 2026-05-17
+
+### Highlights
+
+- **Free Communication Protocol (FCP) app channel** - New text-first HTTP inbound channel for App invocation alongside AG-UI and A2A ([#1827](https://github.com/everruns/everruns/pull/1827)).
+- **A2A HMAC request signing** - Opt-in HMAC request signing on outbound A2A delegation guards against replay attacks ([#1826](https://github.com/everruns/everruns/pull/1826)).
+
+### What's Changed
+
+- fix(reporting): escape LF-prefixed CSV formulas by [@chaliy](https://github.com/chaliy)
+- feat(fcp): Free Communication Protocol app channel ([#1827](https://github.com/everruns/everruns/pull/1827)) by [@chaliy](https://github.com/chaliy)
+- fix(ui): default AG-UI channels to generated token ([#1828](https://github.com/everruns/everruns/pull/1828)) by [@chaliy](https://github.com/chaliy)
+- feat(a2a): opt-in HMAC request signing for replay protection ([#1826](https://github.com/everruns/everruns/pull/1826)) by [@chaliy](https://github.com/chaliy)
+- refactor(config): simplify deployment env vars by [@chaliy](https://github.com/chaliy)
+- docs: restructure documentation along Diataxis quadrants ([#1824](https://github.com/everruns/everruns/pull/1824)) by [@chaliy](https://github.com/chaliy)
+- fix(core): classify OpenAI insufficient_quota as provider_misconfigured ([#1819](https://github.com/everruns/everruns/pull/1819)) by [@chaliy](https://github.com/chaliy)
+- fix(server): block DNS-rebinding SSRF in endpoint auth ([#1820](https://github.com/everruns/everruns/pull/1820)) by [@chaliy](https://github.com/chaliy)
+- fix(session-files): enforce readonly ancestor writes ([#1821](https://github.com/everruns/everruns/pull/1821)) by [@chaliy](https://github.com/chaliy)
+- fix(reporting): scope projector runs to caller org ([#1822](https://github.com/everruns/everruns/pull/1822)) by [@chaliy](https://github.com/chaliy)
+- fix(mcp): align discover output schema with response ([#1823](https://github.com/everruns/everruns/pull/1823)) by [@chaliy](https://github.com/chaliy)
+- chore(deps): bump node from 25-alpine to 26-alpine in /apps/ui ([#1817](https://github.com/everruns/everruns/pull/1817)) by [@dependabot](https://github.com/dependabot)
+- chore(deps): bump the npm_and_yarn group across 2 directories with 2 updates ([#1818](https://github.com/everruns/everruns/pull/1818)) by [@dependabot](https://github.com/dependabot)
+- fix(reporting): make outbox enqueue best-effort on event/session/llm writes ([#1816](https://github.com/everruns/everruns/pull/1816)) by [@chaliy](https://github.com/chaliy)
+- docs(readme): rewrite to reflect current platform scope ([#1808](https://github.com/everruns/everruns/pull/1808)) by [@chaliy](https://github.com/chaliy)
+
 ## [0.8.30] - 2026-05-11
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,11 +4,11 @@ version = 4
 
 [[package]]
 name = "a2a-client-lf"
-version = "0.1.16"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b4ed8c8e815c4ca1947f9dcab76dd0d0878ab429d8f37875ce398fb0165982"
+checksum = "b0558dfc905fc3ffdf99655cc5b11a404b2c1258889ebff828b5a54471ddba35"
 dependencies = [
- "a2a-lf 0.3.0",
+ "a2a-lf",
  "a2a-pb",
  "async-trait",
  "auto_impl",
@@ -41,26 +41,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "a2a-lf"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fb24275cca126dc3301d272eef07bd4cefd87f9a7dd5d6f27200fe87e8a83d0"
-dependencies = [
- "base64 0.22.1",
- "chrono",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "uuid 1.23.1",
-]
-
-[[package]]
 name = "a2a-pb"
-version = "0.1.8"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e44fccf50ee3f44badfb7861e9b9d1e7af7f276b970762b25eb5911b9f03c0b"
+checksum = "b899eaa7a0d1c21797a94f9350ca8ccdf4cc87b1fa52118a6e7adf41c4544df3"
 dependencies = [
- "a2a-lf 0.3.0",
+ "a2a-lf",
  "chrono",
  "pbjson",
  "pbjson-build",
@@ -81,7 +67,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3690b4f128f66c16efd61aa16f9d9360fdc6551bffdacff85e154773b89eff9f"
 dependencies = [
- "a2a-lf 0.2.4",
+ "a2a-lf",
  "a2a-pb",
  "async-trait",
  "axum",
@@ -441,9 +427,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.0"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -452,9 +438,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.41.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
 dependencies = [
  "cc",
  "cmake",
@@ -2086,7 +2072,7 @@ name = "everruns-core"
 version = "0.8.31"
 dependencies = [
  "a2a-client-lf",
- "a2a-lf 0.2.4",
+ "a2a-lf",
  "a2a-server-lf",
  "anyhow",
  "async-trait",
@@ -2750,9 +2736,9 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.29"
+version = "0.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+checksum = "2d5b2eef6fafbf69f877e55509ce5b11a760690ac9700a2921be067aa6afaef6"
 dependencies = [
  "cfg-if",
  "libc",
@@ -4146,9 +4132,9 @@ dependencies = [
 
 [[package]]
 name = "kqueue-sys"
-version = "1.1.2"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+checksum = "285efcf12ef41bec907b3000d5ffaeb54191d4d9d83c0d6157e6cbc2db255e64"
 dependencies = [
  "bitflags 2.11.1",
  "libc",
@@ -4444,9 +4430,9 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.24.6"
+version = "0.24.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89550ee9f79e88fef3119de263694973a8adb26c21d75322164fb8c493039fe2"
+checksum = "ff56c2e7dce6bd462e3b8919986a617027481b1dcc703175b58cf9dd98a2f071"
 dependencies = [
  "portable-atomic",
  "rapidhash",
@@ -4944,9 +4930,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.80"
+version = "0.10.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
+checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
@@ -4981,9 +4967,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.116"
+version = "0.9.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
+checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
 dependencies = [
  "cc",
  "libc",
@@ -5337,18 +5323,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.13"
+version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+checksum = "cbf0d9e68100b3a7989b4901972f265cd542e560a3a8a724e1e20322f4d06ce9"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.13"
+version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+checksum = "a990e22f43e84855daf260dded30524ef4a9021cc7541c26540500a50b624389"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7867,7 +7853,7 @@ dependencies = [
  "indexmap",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.3",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -7876,7 +7862,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.3",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -9233,9 +9219,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.3"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 dependencies = [
  "memchr",
 ]
@@ -9427,9 +9413,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.8"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,11 +4,11 @@ version = 4
 
 [[package]]
 name = "a2a-client-lf"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0558dfc905fc3ffdf99655cc5b11a404b2c1258889ebff828b5a54471ddba35"
+checksum = "60b4ed8c8e815c4ca1947f9dcab76dd0d0878ab429d8f37875ce398fb0165982"
 dependencies = [
- "a2a-lf",
+ "a2a-lf 0.3.0",
  "a2a-pb",
  "async-trait",
  "auto_impl",
@@ -41,12 +41,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "a2a-pb"
-version = "0.1.7"
+name = "a2a-lf"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b899eaa7a0d1c21797a94f9350ca8ccdf4cc87b1fa52118a6e7adf41c4544df3"
+checksum = "7fb24275cca126dc3301d272eef07bd4cefd87f9a7dd5d6f27200fe87e8a83d0"
 dependencies = [
- "a2a-lf",
+ "base64 0.22.1",
+ "chrono",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "uuid 1.23.1",
+]
+
+[[package]]
+name = "a2a-pb"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e44fccf50ee3f44badfb7861e9b9d1e7af7f276b970762b25eb5911b9f03c0b"
+dependencies = [
+ "a2a-lf 0.3.0",
  "chrono",
  "pbjson",
  "pbjson-build",
@@ -67,7 +81,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3690b4f128f66c16efd61aa16f9d9360fdc6551bffdacff85e154773b89eff9f"
 dependencies = [
- "a2a-lf",
+ "a2a-lf 0.2.4",
  "a2a-pb",
  "async-trait",
  "axum",
@@ -427,9 +441,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.3"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -438,9 +452,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",
@@ -1991,11 +2005,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-a2ui"
-version = "0.8.30"
+version = "0.8.31"
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2014,7 +2028,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-cli"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2041,14 +2055,14 @@ dependencies = [
 
 [[package]]
 name = "everruns-config"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "everruns-container-sandbox"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2069,10 +2083,10 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "a2a-client-lf",
- "a2a-lf",
+ "a2a-lf 0.2.4",
  "a2a-server-lf",
  "anyhow",
  "async-trait",
@@ -2126,7 +2140,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-durable"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2161,7 +2175,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-gemini"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2179,7 +2193,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-brave-search"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2195,7 +2209,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-browserless"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2216,7 +2230,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-cursor"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2231,7 +2245,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2247,7 +2261,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-deno"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2271,7 +2285,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-docker"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2286,7 +2300,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2301,7 +2315,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-e2b"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2330,7 +2344,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-parallel"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2342,7 +2356,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-pi"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2357,7 +2371,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-sprites"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2373,7 +2387,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-internal-protocol"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "chrono",
  "everruns-core",
@@ -2390,7 +2404,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-macros"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2400,7 +2414,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2422,11 +2436,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-openui"
-version = "0.8.30"
+version = "0.8.31"
 
 [[package]]
 name = "everruns-runtime"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2460,7 +2474,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-server"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "aes-gcm",
  "ag-ui-core",
@@ -2550,7 +2564,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-session-sqldb"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2569,7 +2583,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-worker"
-version = "0.8.30"
+version = "0.8.31"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2736,9 +2750,9 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.28"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d5b2eef6fafbf69f877e55509ce5b11a760690ac9700a2921be067aa6afaef6"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
 dependencies = [
  "cfg-if",
  "libc",
@@ -4132,9 +4146,9 @@ dependencies = [
 
 [[package]]
 name = "kqueue-sys"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "285efcf12ef41bec907b3000d5ffaeb54191d4d9d83c0d6157e6cbc2db255e64"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
 dependencies = [
  "bitflags 2.11.1",
  "libc",
@@ -4430,9 +4444,9 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.24.5"
+version = "0.24.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff56c2e7dce6bd462e3b8919986a617027481b1dcc703175b58cf9dd98a2f071"
+checksum = "89550ee9f79e88fef3119de263694973a8adb26c21d75322164fb8c493039fe2"
 dependencies = [
  "portable-atomic",
  "rapidhash",
@@ -4930,9 +4944,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.79"
+version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
@@ -4967,9 +4981,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.115"
+version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",
@@ -5323,18 +5337,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.12"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf0d9e68100b3a7989b4901972f265cd542e560a3a8a724e1e20322f4d06ce9"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.12"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a990e22f43e84855daf260dded30524ef4a9021cc7541c26540500a50b624389"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7853,7 +7867,7 @@ dependencies = [
  "indexmap",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -7862,7 +7876,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -9219,9 +9233,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
@@ -9413,9 +9427,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.8.30"
+version = "0.8.31"
 edition = "2024"
 license = "MIT"
 authors = ["Everruns Contributors"]

--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "everruns-ui",
-  "version": "0.8.30",
+  "version": "0.8.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "everruns-ui",
-      "version": "0.8.30",
+      "version": "0.8.31",
       "dependencies": {
         "@base-ui/react": "^1.2.0",
         "@openuidev/react-lang": "^0.1.3",
@@ -11892,6 +11892,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "everruns-ui",
-  "version": "0.8.30",
+  "version": "0.8.31",
   "private": true,
   "exports": {
     "./route-manifest": "./src/lib/ui-route-manifest.ts",


### PR DESCRIPTION
## Release v0.8.31

This PR prepares the v0.8.31 maintenance release.

### Highlights

- **Free Communication Protocol (FCP) app channel** - New text-first HTTP inbound channel for App invocation alongside AG-UI and A2A ([#1827](https://github.com/everruns/everruns/pull/1827)).
- **A2A HMAC request signing** - Opt-in HMAC request signing on outbound A2A delegation guards against replay attacks ([#1826](https://github.com/everruns/everruns/pull/1826)).

Also includes several security and reliability fixes: DNS-rebinding SSRF protection in endpoint auth, readonly ancestor enforcement for session files, org-scoped reporting projector runs, and best-effort outbox enqueue on event/session/LLM writes.

### Checklist
- [x] Review CHANGELOG.md entries
- [x] Verify version numbers updated
- [ ] CI passes

### Post-merge
After merging, the release workflow will automatically:
- Create git tag `v0.8.31`
- Create GitHub Release with notes from CHANGELOG.md
- Trigger Docker image build with version tag
- Publish CLI binaries and update Homebrew formula


---
_Generated by [Claude Code](https://claude.ai/code/session_014F5KUJbN5zk6dgRdWimpGm)_