### PR TITLE
feat(ui): add provider model counts and edit page

### DIFF
--- a/apps/ui/src/__tests__/models-page.test.tsx
+++ b/apps/ui/src/__tests__/models-page.test.tsx
@@ -3,6 +3,19 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactNode } from "react";
 import ModelsPage from "@/app/(main)/models/page";
 
+const mockUseSearchParams = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useSearchParams: () => mockUseSearchParams(),
+}));
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
 const mockProviders = [
   {
     id: "provider-1",
@@ -11,6 +24,16 @@ const mockProviders = [
     status: "active",
     api_key_set: true,
     base_url: "https://api.openai.com/v1",
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+  },
+  {
+    id: "provider-2",
+    name: "Anthropic Dev",
+    provider_type: "anthropic",
+    status: "active",
+    api_key_set: true,
+    base_url: null,
     created_at: "2024-01-01T00:00:00Z",
     updated_at: "2024-01-01T00:00:00Z",
   },
@@ -112,6 +135,7 @@ describe("ModelsPage", () => {
       mutateAsync: jest.fn(),
       isPending: false,
     });
+    mockUseSearchParams.mockReturnValue(new URLSearchParams());
   });
 
   it("renders Models section header", () => {
@@ -156,6 +180,37 @@ describe("ModelsPage", () => {
 
     expect(screen.getByRole("heading", { name: "Enabled models" })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Available models" })).toBeInTheDocument();
+  });
+
+  it("filters models by provider query parameter", () => {
+    mockUseSearchParams.mockReturnValue(new URLSearchParams("provider=provider-2"));
+    mockUseLlmModels.mockReturnValue({
+      data: [
+        ...mockModels,
+        {
+          id: "model-2",
+          model_id: "claude-sonnet-4-5",
+          display_name: "Claude Sonnet 4.5",
+          provider_id: "provider-2",
+          provider_name: "Anthropic Dev",
+          provider_type: "anthropic",
+          healthy: true,
+          enabled: true,
+          capabilities: ["chat"],
+          created_at: "2024-01-01T00:00:00Z",
+          updated_at: "2024-01-01T00:00:00Z",
+        },
+      ],
+      isLoading: false,
+      error: null,
+    });
+
+    render(<ModelsPage />, { wrapper });
+
+    expect(screen.getByText("Manage the models available from Anthropic Dev.")).toBeInTheDocument();
+    expect(screen.getByText("Claude Sonnet 4.5")).toBeInTheDocument();
+    expect(screen.queryByText(/gpt-5\.2 - OpenAI Production/)).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Clear filter/i })).toHaveAttribute("href", "/models");
   });
 
   it("sorts models within a section by release date descending", () => {

--- a/apps/ui/src/__tests__/provider-detail-page.test.tsx
+++ b/apps/ui/src/__tests__/provider-detail-page.test.tsx
@@ -1,0 +1,129 @@
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactNode } from "react";
+import ProviderDetailPage from "@/app/(main)/settings/providers/[providerId]/page";
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({
+    children,
+    href,
+    className,
+  }: {
+    children: React.ReactNode;
+    href: string;
+    className?: string;
+  }) => (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  ),
+}));
+
+const mockProvider = {
+  id: "provider-1",
+  name: "OpenAI Production",
+  provider_type: "openai",
+  status: "active",
+  api_key_set: true,
+  base_url: "https://api.openai.com/v1",
+  created_at: "2024-01-01T00:00:00Z",
+  updated_at: "2024-01-01T00:00:00Z",
+};
+
+const mockModels = [
+  {
+    id: "model-1",
+    model_id: "gpt-5.2",
+    display_name: "GPT-5.2",
+    provider_id: "provider-1",
+    provider_name: "OpenAI Production",
+    provider_type: "openai",
+    healthy: true,
+    enabled: true,
+    capabilities: ["chat"],
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+  },
+  {
+    id: "model-2",
+    model_id: "gpt-4.1",
+    display_name: "GPT-4.1",
+    provider_id: "provider-1",
+    provider_name: "OpenAI Production",
+    provider_type: "openai",
+    healthy: true,
+    enabled: false,
+    capabilities: ["chat"],
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+  },
+];
+
+const mockUseLlmProvider = jest.fn();
+const mockUseLlmModels = jest.fn();
+const mockUseUpdateLlmProvider = jest.fn();
+
+jest.mock("@/hooks/use-llm-providers", () => ({
+  useLlmProvider: () => mockUseLlmProvider(),
+  useLlmModels: () => mockUseLlmModels(),
+  useUpdateLlmProvider: () => mockUseUpdateLlmProvider(),
+}));
+
+describe("ProviderDetailPage", () => {
+  let queryClient: QueryClient;
+  let updateProvider: jest.Mock;
+
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+    updateProvider = jest.fn().mockResolvedValue(mockProvider);
+    mockUseLlmProvider.mockReturnValue({ data: mockProvider, isLoading: false, error: null });
+    mockUseLlmModels.mockReturnValue({ data: mockModels, isLoading: false, error: null });
+    mockUseUpdateLlmProvider.mockReturnValue({ mutateAsync: updateProvider, isPending: false });
+  });
+
+  it("renders provider details with model counts", async () => {
+    await act(async () => {
+      render(<ProviderDetailPage params={Promise.resolve({ providerId: "provider-1" })} />, {
+        wrapper,
+      });
+    });
+
+    expect(
+      await screen.findByRole("heading", { name: /OpenAI Production active/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByDisplayValue("OpenAI Production")).toBeInTheDocument();
+    expect(screen.getByText("2 models available")).toBeInTheDocument();
+    expect(screen.getByText("1 enabled")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /View Models/i })).toHaveAttribute(
+      "href",
+      "/models?provider=provider-1",
+    );
+  });
+
+  it("saves provider name changes", async () => {
+    await act(async () => {
+      render(<ProviderDetailPage params={Promise.resolve({ providerId: "provider-1" })} />, {
+        wrapper,
+      });
+    });
+
+    fireEvent.change(await screen.findByLabelText("Name"), {
+      target: { value: "OpenAI Renamed" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Save Changes/i }));
+
+    await waitFor(() => {
+      expect(updateProvider).toHaveBeenCalledWith({ name: "OpenAI Renamed" });
+    });
+  });
+});

--- a/apps/ui/src/__tests__/provider-detail-page.test.tsx
+++ b/apps/ui/src/__tests__/provider-detail-page.test.tsx
@@ -126,4 +126,32 @@ describe("ProviderDetailPage", () => {
       expect(updateProvider).toHaveBeenCalledWith({ name: "OpenAI Renamed" });
     });
   });
+
+  it("does not reset an in-progress name edit after provider refetch", async () => {
+    let provider = mockProvider;
+    mockUseLlmProvider.mockImplementation(() => ({
+      data: provider,
+      isLoading: false,
+      error: null,
+    }));
+
+    let rerender: ReturnType<typeof render>["rerender"];
+    await act(async () => {
+      ({ rerender } = render(
+        <ProviderDetailPage params={Promise.resolve({ providerId: "provider-1" })} />,
+        { wrapper },
+      ));
+    });
+
+    fireEvent.change(await screen.findByLabelText("Name"), {
+      target: { value: "Draft Name" },
+    });
+
+    provider = { ...mockProvider };
+    await act(async () => {
+      rerender(<ProviderDetailPage params={Promise.resolve({ providerId: "provider-1" })} />);
+    });
+
+    expect(screen.getByDisplayValue("Draft Name")).toBeInTheDocument();
+  });
 });

--- a/apps/ui/src/__tests__/settings-providers.test.tsx
+++ b/apps/ui/src/__tests__/settings-providers.test.tsx
@@ -3,6 +3,23 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactNode } from "react";
 import ProvidersPage from "@/app/(main)/settings/providers/page";
 
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({
+    children,
+    href,
+    className,
+  }: {
+    children: React.ReactNode;
+    href: string;
+    className?: string;
+  }) => (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  ),
+}));
+
 // Mock the LLM providers hooks
 const mockProviders = [
   {
@@ -34,6 +51,8 @@ const mockModels = [
     display_name: "GPT-4",
     provider_id: "provider-1",
     provider_name: "OpenAI Production",
+    provider_type: "openai",
+    healthy: true,
     status: "active",
     enabled: true,
     capabilities: ["chat", "function_calling"],
@@ -53,6 +72,7 @@ const mockUseSyncProviderModels = jest.fn();
 
 jest.mock("@/hooks/use-llm-providers", () => ({
   useLlmProviders: () => mockUseLlmProviders(),
+  useLlmProvider: () => ({ data: null, isLoading: false, error: null }),
   useLlmModels: () => mockUseLlmModels(),
   useCreateLlmProvider: () => mockUseCreateLlmProvider(),
   useUpdateLlmProvider: () => mockUseUpdateLlmProvider(),
@@ -177,6 +197,21 @@ describe("ProvidersPage", () => {
 
     expect(screen.getByText("OpenAI Production")).toBeInTheDocument();
     expect(screen.getByText("Anthropic Dev")).toBeInTheDocument();
+  });
+
+  it("shows provider model counts and links to filtered models", () => {
+    render(<ProvidersPage />, { wrapper });
+
+    expect(screen.getByText("1 model available, 1 enabled")).toBeInTheDocument();
+    expect(screen.getByText("0 models available, 0 enabled")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /OpenAI Production/i })).toHaveAttribute(
+      "href",
+      "/settings/providers/provider-1",
+    );
+    expect(screen.getAllByRole("link", { name: /View models/i })[0]).toHaveAttribute(
+      "href",
+      "/models?provider=provider-1",
+    );
   });
 
   it("shows loading skeleton when providers are loading", () => {

--- a/apps/ui/src/app/(main)/models/page.tsx
+++ b/apps/ui/src/app/(main)/models/page.tsx
@@ -50,12 +50,20 @@ export default function ModelsPage() {
   const [addModelOpen, setAddModelOpen] = useState(false);
   const [togglingModelId, setTogglingModelId] = useState<string | null>(null);
   const selectedProviderId = searchParams.get("provider");
-  const selectedProvider = selectedProviderId
-    ? providers.find((provider) => provider.id === selectedProviderId)
-    : undefined;
-  const filteredModels = selectedProviderId
-    ? models.filter((model) => model.provider_id === selectedProviderId)
-    : models;
+  const selectedProvider = useMemo(
+    () =>
+      selectedProviderId
+        ? providers.find((provider) => provider.id === selectedProviderId)
+        : undefined,
+    [providers, selectedProviderId],
+  );
+  const filteredModels = useMemo(
+    () =>
+      selectedProviderId
+        ? models.filter((model) => model.provider_id === selectedProviderId)
+        : models,
+    [models, selectedProviderId],
+  );
 
   const { enabledModels, availableModels } = useMemo(() => {
     const enabled = filteredModels.filter((m) => m.enabled).sort(compareByRecency);

--- a/apps/ui/src/app/(main)/models/page.tsx
+++ b/apps/ui/src/app/(main)/models/page.tsx
@@ -2,6 +2,8 @@
 
 import { useMemo, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
 import { Cpu, Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
@@ -39,6 +41,7 @@ function compareByRecency(a: LlmModelWithProvider, b: LlmModelWithProvider): num
 export default function ModelsPage() {
   usePageTitle("Models");
   const queryClient = useQueryClient();
+  const searchParams = useSearchParams();
   const { data: providers = [] } = useLlmProviders();
   const { data: models = [], isLoading: modelsLoading, error: modelsError } = useLlmModels();
   const { data: org } = useOrganization();
@@ -46,14 +49,25 @@ export default function ModelsPage() {
   const deleteModel = useDeleteLlmModel();
   const [addModelOpen, setAddModelOpen] = useState(false);
   const [togglingModelId, setTogglingModelId] = useState<string | null>(null);
+  const selectedProviderId = searchParams.get("provider");
+  const selectedProvider = selectedProviderId
+    ? providers.find((provider) => provider.id === selectedProviderId)
+    : undefined;
+  const filteredModels = selectedProviderId
+    ? models.filter((model) => model.provider_id === selectedProviderId)
+    : models;
 
   const { enabledModels, availableModels } = useMemo(() => {
-    const enabled = models.filter((m) => m.enabled).sort(compareByRecency);
-    const available = models.filter((m) => !m.enabled).sort(compareByRecency);
+    const enabled = filteredModels.filter((m) => m.enabled).sort(compareByRecency);
+    const available = filteredModels.filter((m) => !m.enabled).sort(compareByRecency);
     return { enabledModels: enabled, availableModels: available };
-  }, [models]);
+  }, [filteredModels]);
+  const allEnabledModels = useMemo(
+    () => models.filter((model) => model.enabled).sort(compareByRecency),
+    [models],
+  );
   const selectedDefaultModelName = org?.default_model_id
-    ? (enabledModels.find((model) => model.id === org.default_model_id)?.display_name ??
+    ? (allEnabledModels.find((model) => model.id === org.default_model_id)?.display_name ??
       "Unknown model")
     : undefined;
 
@@ -90,12 +104,23 @@ export default function ModelsPage() {
     <PageShell>
       <PageHeader
         title="Models"
-        description="Manage the models available from your configured providers."
+        description={
+          selectedProvider
+            ? `Manage the models available from ${selectedProvider.name}.`
+            : "Manage the models available from your configured providers."
+        }
         actions={
-          <Button onClick={() => setAddModelOpen(true)} disabled={providers.length === 0}>
-            <Plus className="h-4 w-4 mr-2" />
-            Add Model
-          </Button>
+          <>
+            {selectedProviderId && (
+              <Link href="/models">
+                <Button variant="outline">Clear filter</Button>
+              </Link>
+            )}
+            <Button onClick={() => setAddModelOpen(true)} disabled={providers.length === 0}>
+              <Plus className="h-4 w-4 mr-2" />
+              Add Model
+            </Button>
+          </>
         }
       />
 
@@ -113,14 +138,18 @@ export default function ModelsPage() {
                 <Skeleton key={index} className="h-16 w-full" />
               ))}
             </div>
-          ) : models.length === 0 ? (
+          ) : filteredModels.length === 0 ? (
             <Card className="p-8 text-center">
               <Cpu className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
-              <h3 className="text-lg font-medium mb-2">No models configured</h3>
+              <h3 className="text-lg font-medium mb-2">
+                {selectedProvider ? "No models for this provider" : "No models configured"}
+              </h3>
               <p className="text-muted-foreground mb-4">
-                {providers.length === 0
-                  ? "Add a provider first, then add models to it."
-                  : "Add models to your providers to use them with agents."}
+                {selectedProvider
+                  ? "Sync or add models for this provider to use them with agents."
+                  : providers.length === 0
+                    ? "Add a provider first, then add models to it."
+                    : "Add models to your providers to use them with agents."}
               </p>
               {providers.length > 0 && (
                 <Button onClick={() => setAddModelOpen(true)}>
@@ -186,7 +215,7 @@ export default function ModelsPage() {
           )}
         </section>
 
-        {enabledModels.length > 0 && (
+        {allEnabledModels.length > 0 && (
           <section>
             <div className="mb-4">
               <h2 className="text-xl font-semibold">Organization Settings</h2>
@@ -213,7 +242,7 @@ export default function ModelsPage() {
                     </SelectTrigger>
                     <SelectContent>
                       <SelectItem value="none">No default model</SelectItem>
-                      {enabledModels.map((model) => (
+                      {allEnabledModels.map((model) => (
                         <SelectItem key={model.id} value={model.id}>
                           <div className="flex items-center gap-2">
                             <ProviderIcon

--- a/apps/ui/src/app/(main)/settings/providers/[providerId]/page.tsx
+++ b/apps/ui/src/app/(main)/settings/providers/[providerId]/page.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import { use, useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { ArrowLeft, Boxes, Key, Save } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Skeleton } from "@/components/ui/skeleton";
+import { PageBody, PageHeader, PageShell } from "@/components/layout";
+import { ProviderIcon, getProviderLabel } from "@/components/providers/provider-icon";
+import { ResourceNotFound } from "@/components/resource-not-found";
+import { useLlmModels, useLlmProvider, useUpdateLlmProvider } from "@/hooks/use-llm-providers";
+import { usePageTitle } from "@/hooks";
+import { formatCountLabel } from "@/lib/formatting";
+
+export default function ProviderDetailPage({
+  params,
+}: {
+  params: Promise<{ providerId: string }>;
+}) {
+  const { providerId } = use(params);
+  const { data: provider, isLoading } = useLlmProvider(providerId);
+  const { data: models = [] } = useLlmModels();
+  const updateProvider = useUpdateLlmProvider(providerId);
+  const [name, setName] = useState("");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  usePageTitle(provider ? provider.name : null, "Provider");
+
+  useEffect(() => {
+    if (provider) setName(provider.name);
+  }, [provider]);
+
+  const modelCounts = useMemo(() => {
+    return models.reduce(
+      (counts, model) => {
+        if (model.provider_id !== providerId) return counts;
+        counts.total += 1;
+        if (model.enabled) counts.enabled += 1;
+        return counts;
+      },
+      { total: 0, enabled: 0 },
+    );
+  }, [models, providerId]);
+
+  const trimmedName = name.trim();
+  const nameChanged = !!provider && trimmedName !== provider.name;
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!provider || !trimmedName || !nameChanged) return;
+    setErrorMessage(null);
+    try {
+      await updateProvider.mutateAsync({ name: trimmedName });
+    } catch {
+      setErrorMessage("Failed to save provider.");
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <PageShell>
+        <Skeleton className="h-5 w-40 mb-6" />
+        <Skeleton className="h-8 w-1/3 mb-4" />
+        <Skeleton className="h-52 w-full" />
+      </PageShell>
+    );
+  }
+
+  if (!provider) {
+    return (
+      <ResourceNotFound
+        title="Provider not found"
+        description="This provider may have been deleted, moved to another organization, or the URL may be wrong."
+        backHref="/settings/providers"
+        backLabel="Back to providers"
+        resourceId={providerId}
+      />
+    );
+  }
+
+  return (
+    <PageShell>
+      <Link
+        href="/settings/providers"
+        className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground mb-6"
+      >
+        <ArrowLeft className="w-4 h-4 mr-2" />
+        Back to Providers
+      </Link>
+
+      <PageHeader
+        title={
+          <>
+            <ProviderIcon providerType={provider.provider_type} size="md" />
+            {provider.name}
+            <Badge
+              variant="outline"
+              className={
+                provider.status === "active"
+                  ? "bg-green-100 text-green-800"
+                  : "bg-gray-100 text-gray-800"
+              }
+            >
+              {provider.status}
+            </Badge>
+          </>
+        }
+        description={getProviderLabel(provider.provider_type)}
+        actions={
+          <Link href={`/models?provider=${encodeURIComponent(provider.id)}`}>
+            <Button variant="outline">
+              <Boxes className="h-4 w-4 mr-2" />
+              View Models
+            </Button>
+          </Link>
+        }
+      />
+
+      <PageBody>
+        <Card>
+          <CardHeader>
+            <CardTitle>Provider Settings</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <form onSubmit={handleSubmit} className="space-y-4 max-w-xl">
+              <div className="space-y-2">
+                <Label htmlFor="provider-name">Name</Label>
+                <Input
+                  id="provider-name"
+                  value={name}
+                  onChange={(event) => setName(event.target.value)}
+                  required
+                />
+              </div>
+              {provider.base_url && (
+                <div className="space-y-2">
+                  <Label>Base URL</Label>
+                  <p className="break-all text-sm text-muted-foreground">{provider.base_url}</p>
+                </div>
+              )}
+              <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                <Key className="h-4 w-4" />
+                API Key: {provider.api_key_set ? "Configured" : "Not set"}
+              </div>
+              {errorMessage && <p className="text-sm text-destructive">{errorMessage}</p>}
+              <Button
+                type="submit"
+                disabled={updateProvider.isPending || !trimmedName || !nameChanged}
+              >
+                <Save className="h-4 w-4 mr-2" />
+                {updateProvider.isPending ? "Saving..." : "Save Changes"}
+              </Button>
+            </form>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Models</CardTitle>
+          </CardHeader>
+          <CardContent className="flex flex-wrap items-center gap-3 text-sm">
+            <span className="text-muted-foreground">
+              {formatCountLabel(modelCounts.total, "model")} available
+            </span>
+            <Badge variant="outline">{modelCounts.enabled} enabled</Badge>
+            <Link href={`/models?provider=${encodeURIComponent(provider.id)}`}>
+              <Button variant="outline" size="sm">
+                View provider models
+              </Button>
+            </Link>
+          </CardContent>
+        </Card>
+      </PageBody>
+    </PageShell>
+  );
+}

--- a/apps/ui/src/app/(main)/settings/providers/[providerId]/page.tsx
+++ b/apps/ui/src/app/(main)/settings/providers/[providerId]/page.tsx
@@ -26,13 +26,17 @@ export default function ProviderDetailPage({
   const { data: models = [] } = useLlmModels();
   const updateProvider = useUpdateLlmProvider(providerId);
   const [name, setName] = useState("");
+  const [nameProviderId, setNameProviderId] = useState<string | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   usePageTitle(provider ? provider.name : null, "Provider");
 
   useEffect(() => {
-    if (provider) setName(provider.name);
-  }, [provider]);
+    if (provider && nameProviderId !== provider.id) {
+      setName(provider.name);
+      setNameProviderId(provider.id);
+    }
+  }, [provider, nameProviderId]);
 
   const modelCounts = useMemo(() => {
     return models.reduce(

--- a/apps/ui/src/app/(main)/settings/providers/[providerId]/page.tsx
+++ b/apps/ui/src/app/(main)/settings/providers/[providerId]/page.tsx
@@ -23,7 +23,7 @@ export default function ProviderDetailPage({
 }) {
   const { providerId } = use(params);
   const { data: provider, isLoading } = useLlmProvider(providerId);
-  const { data: models = [] } = useLlmModels();
+  const { data: models = [], isLoading: modelsLoading } = useLlmModels();
   const updateProvider = useUpdateLlmProvider(providerId);
   const [name, setName] = useState("");
   const [nameProviderId, setNameProviderId] = useState<string | null>(null);
@@ -167,15 +167,24 @@ export default function ProviderDetailPage({
             <CardTitle>Models</CardTitle>
           </CardHeader>
           <CardContent className="flex flex-wrap items-center gap-3 text-sm">
-            <span className="text-muted-foreground">
-              {formatCountLabel(modelCounts.total, "model")} available
-            </span>
-            <Badge variant="outline">{modelCounts.enabled} enabled</Badge>
-            <Link href={`/models?provider=${encodeURIComponent(provider.id)}`}>
-              <Button variant="outline" size="sm">
-                View provider models
-              </Button>
-            </Link>
+            {modelsLoading ? (
+              <>
+                <Skeleton className="h-4 w-32" />
+                <Skeleton className="h-5 w-20" />
+              </>
+            ) : (
+              <>
+                <span className="text-muted-foreground">
+                  {formatCountLabel(modelCounts.total, "model")} available
+                </span>
+                <Badge variant="outline">{modelCounts.enabled} enabled</Badge>
+                <Link href={`/models?provider=${encodeURIComponent(provider.id)}`}>
+                  <Button variant="outline" size="sm">
+                    View provider models
+                  </Button>
+                </Link>
+              </>
+            )}
           </CardContent>
         </Card>
       </PageBody>

--- a/apps/ui/src/app/(main)/settings/providers/page.tsx
+++ b/apps/ui/src/app/(main)/settings/providers/page.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import {
+  useLlmModels,
   useLlmProviders,
   useDeleteLlmProvider,
   useSyncProviderModels,
@@ -22,6 +23,7 @@ export default function ProvidersPage() {
     isLoading: providersLoading,
     error: providersError,
   } = useLlmProviders();
+  const { data: models = [], isLoading: modelsLoading } = useLlmModels();
   const deleteProvider = useDeleteLlmProvider();
   const syncModels = useSyncProviderModels();
 
@@ -32,6 +34,17 @@ export default function ProvidersPage() {
     type: "success" | "error";
     text: string;
   } | null>(null);
+
+  const modelCountsByProvider = useMemo(() => {
+    const counts = new Map<string, { total: number; enabled: number }>();
+    for (const model of models) {
+      const current = counts.get(model.provider_id) ?? { total: 0, enabled: 0 };
+      current.total += 1;
+      if (model.enabled) current.enabled += 1;
+      counts.set(model.provider_id, current);
+    }
+    return counts;
+  }, [models]);
 
   const handleDeleteProvider = async (id: string) => {
     if (
@@ -132,6 +145,8 @@ export default function ProvidersPage() {
                 onSetApiKey={setApiKeyProvider}
                 onSyncModels={handleSyncModels}
                 isSyncing={syncingProviderId === provider.id}
+                modelCounts={modelCountsByProvider.get(provider.id) ?? { total: 0, enabled: 0 }}
+                modelsLoading={modelsLoading}
               />
             ))}
           </div>

--- a/apps/ui/src/app/(main)/settings/providers/provider-card.tsx
+++ b/apps/ui/src/app/(main)/settings/providers/provider-card.tsx
@@ -1,12 +1,19 @@
 "use client";
 
+import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Key, Trash2, RefreshCw } from "lucide-react";
+import { Key, Trash2, RefreshCw, Boxes, ExternalLink } from "lucide-react";
 import { ProviderIcon, getProviderLabel } from "@/components/providers/provider-icon";
+import { formatCountLabel } from "@/lib/formatting";
 import type { LlmProvider } from "@/lib/api/types";
+
+type ProviderModelCounts = {
+  total: number;
+  enabled: number;
+};
 
 export function ProviderCard({
   provider,
@@ -14,15 +21,20 @@ export function ProviderCard({
   onSetApiKey,
   onSyncModels,
   isSyncing,
+  modelCounts,
+  modelsLoading,
 }: {
   provider: LlmProvider;
   onDelete: (id: string) => void;
   onSetApiKey: (provider: LlmProvider) => void;
   onSyncModels: (id: string) => void;
   isSyncing: boolean;
+  modelCounts: ProviderModelCounts;
+  modelsLoading: boolean;
 }) {
   // Only show sync button for providers without custom base URL (standard providers)
   const canSync = !provider.base_url && provider.api_key_set;
+  const modelsHref = `/models?provider=${encodeURIComponent(provider.id)}`;
 
   return (
     <Card>
@@ -30,7 +42,11 @@ export function ProviderCard({
         <div className="flex items-center gap-3">
           <ProviderIcon providerType={provider.provider_type} size="md" />
           <div>
-            <CardTitle className="text-lg">{provider.name}</CardTitle>
+            <CardTitle className="text-lg">
+              <Link href={`/settings/providers/${provider.id}`} className="hover:underline">
+                {provider.name}
+              </Link>
+            </CardTitle>
             <CardDescription className="text-sm">
               {getProviderLabel(provider.provider_type)}
             </CardDescription>
@@ -57,6 +73,26 @@ export function ProviderCard({
             <span className="text-muted-foreground">
               API Key: {provider.api_key_set ? "Configured" : "Not set"}
             </span>
+          </div>
+          <div className="flex items-start gap-2">
+            <Boxes className="h-4 w-4 text-muted-foreground mt-0.5" />
+            {modelsLoading ? (
+              <Skeleton className="h-4 w-40" />
+            ) : (
+              <div className="text-muted-foreground">
+                <span>
+                  {formatCountLabel(modelCounts.total, "model")} available, {modelCounts.enabled}{" "}
+                  enabled
+                </span>
+                <Link
+                  href={modelsHref}
+                  className="ml-2 inline-flex items-center gap-1 text-foreground hover:underline"
+                >
+                  View models
+                  <ExternalLink className="h-3 w-3" />
+                </Link>
+              </div>
+            )}
           </div>
         </div>
         <div className="flex items-center justify-end gap-2 mt-4">
@@ -105,6 +141,7 @@ export function ProviderCardSkeleton() {
       </CardHeader>
       <CardContent>
         <Skeleton className="h-4 w-full mb-4" />
+        <Skeleton className="h-4 w-2/3 mb-4" />
         <Skeleton className="h-8 w-24 ml-auto" />
       </CardContent>
     </Card>


### PR DESCRIPTION
## What
- Show total and enabled model counts on each LLM provider card.
- Link each provider card to a filtered Models view and a provider detail page.
- Add a provider detail page that allows editing the provider name.

## Why
Provider settings should make model coverage visible per provider and provide a place to edit provider metadata.

## How
- Reuse the existing LLM models query to compute per-provider counts.
- Add `/models?provider=<provider-id>` client-side filtering.
- Add `/settings/providers/[providerId]` with the existing provider read/update hooks.
- Cover provider counts, model filtering, and provider name updates with focused UI tests.

## Risk
- Low
- Provider/model management UI only. Main risk is stale or incorrect client-side counts if model queries are stale; existing query invalidation after model sync/delete remains in place.

## Security
- Threat categories reviewed: TM-WEB.
- Findings and resolutions: No new API endpoints, auth rules, secret handling, or tenant-scoped data access paths. The new query parameter is used only for client-side filtering of models already returned to the authenticated UI. API key display remains limited to the existing configured/not-set boolean.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (none at creation)
