### PR TITLE
docs(railway): update release template guidance

### DIFF
--- a/infra/railway/README.md
+++ b/infra/railway/README.md
@@ -1,9 +1,19 @@
-# Railway Template
+# Railway Deployment And Template
 
 This directory documents the Everruns Railway template shape and keeps a
-maintainable Caddy ingress config for future repo-backed deployments. Railway
-does not run Docker Compose directly, so the live template maps
+maintainable Caddy ingress config for repo-backed deployments. Railway does not
+run Docker Compose directly, so the live template maps
 `examples/docker-compose-full.yaml` into individual Railway services.
+
+Current validated Everruns image tag:
+
+```text
+v0.8.31
+```
+
+Pin the live validation deployment to `v0.8.31`. The public template can use
+`latest` after the validation deployment is healthy, because the release
+workflow only moves `latest` on versioned releases.
 
 ## Service Shape
 
@@ -12,20 +22,32 @@ does not run Docker Compose directly, so the live template maps
 | `postgres` | Railway PostgreSQL | No | Use Railway-managed Postgres. |
 | `redis` | Railway Redis | No | Used as `VALKEY_URL` for distributed rate limiting. |
 | `nats` | Docker image `nats:2-alpine` | No | Start with JetStream and a `/data` volume. |
-| `server` | Docker image `ghcr.io/everruns/everruns-server:latest` | No | HTTP API on `9000`, worker gRPC on `9001`. |
-| `worker` | Docker image `ghcr.io/everruns/everruns-worker:latest` | No | Scale replicas as needed. |
-| `ui` | Docker image `ghcr.io/everruns/everruns-ui:latest` | No | Next.js server on `9100`. |
-| `caddy` | Docker image `caddy:2-alpine` | Yes | Single public ingress. |
+| `server` | Docker image `ghcr.io/everruns/everruns-server:v0.8.31` | No | HTTP API on `9000`, worker gRPC on `9001`. |
+| `worker` | Docker image `ghcr.io/everruns/everruns-worker:v0.8.31` | No | Scale replicas as needed. |
+| `ui` | Docker image `ghcr.io/everruns/everruns-ui:v0.8.31` | No | Next.js server on `9100`. |
+| `caddy` | GitHub repo path `infra/railway/caddy` | Yes | Single public ingress. |
+
+## Template Inputs
+
+Required user inputs:
+
+```env
+AUTH_ADMIN_EMAIL=<template input>
+AUTH_ADMIN_PASSWORD=<template input>
+```
+
+Optional user inputs:
+
+```env
+DEFAULT_OPENAI_API_KEY=<template input>
+DEFAULT_ANTHROPIC_API_KEY=<template input>
+DEFAULT_GEMINI_API_KEY=<template input>
+```
 
 ## Caddy Service
 
-The published template uses Docker image `caddy:2-alpine` and writes the
-Caddyfile from its Railway start command. Keep public HTTP networking enabled
-only on this service.
-
-The files in `infra/railway/caddy/` are the source-of-truth version of that
-ingress config. They can replace the inline start command after this directory
-is available on the default branch.
+Use the repo-backed service at `infra/railway/caddy`. Keep public HTTP
+networking enabled only on this service.
 
 Variables:
 
@@ -94,9 +116,35 @@ WORKER_GRPC_AUTH_TOKEN=${{ server.WORKER_GRPC_AUTH_TOKEN }}
 
 ## UI Variables
 
+Set these in the template. They are fixed service configuration, not user
+inputs.
+
 ```env
 PORT=9100
 HOSTNAME=0.0.0.0
+```
+
+## Cleanup Checklist
+
+Remove these legacy or now-defaulted variables from the live Railway project
+unless the deployment intentionally overrides them:
+
+Server:
+
+```env
+ADDR
+WORKER_GRPC_ADDR
+API_PREFIX
+RUST_LOG
+FRONTEND_URL
+AUTH_BASE_URL
+```
+
+Worker:
+
+```env
+WORKER_GRPC_ADDRESS
+RUST_LOG
 ```
 
 ## Template Notes

--- a/infra/railway/README.md
+++ b/infra/railway/README.md
@@ -1,4 +1,4 @@
-# Railway Deployment And Template
+# Railway Deployment and Template
 
 This directory documents the Everruns Railway template shape and keeps a
 maintainable Caddy ingress config for repo-backed deployments. Railway does not
@@ -88,7 +88,7 @@ DATABASE_UNPOOLED_URL=${{ postgres.DATABASE_URL }}
 VALKEY_URL=${{ redis.REDIS_URL }}
 NATS_URL=nats://${{ nats.RAILWAY_PRIVATE_DOMAIN }}:4222
 
-DEPLOYMENT_GRADE=dev
+DEPLOYMENT_GRADE=preview
 
 AUTH_MODE=admin
 AUTH_ADMIN_EMAIL=<template input>

--- a/infra/railway/README.md
+++ b/infra/railway/README.md
@@ -15,6 +15,12 @@ Pin the live validation deployment to `v0.8.31`. The public template can use
 `latest` after the validation deployment is healthy, because the release
 workflow only moves `latest` on versioned releases.
 
+Template image URL:
+
+```text
+https://raw.githubusercontent.com/everruns/everruns/main/infra/railway/template-icon.svg
+```
+
 ## Service Shape
 
 | Service | Source | Public | Notes |

--- a/infra/railway/README.md
+++ b/infra/railway/README.md
@@ -36,13 +36,9 @@ AUTH_ADMIN_EMAIL=<template input>
 AUTH_ADMIN_PASSWORD=<template input>
 ```
 
-Optional user inputs:
-
-```env
-DEFAULT_OPENAI_API_KEY=<template input>
-DEFAULT_ANTHROPIC_API_KEY=<template input>
-DEFAULT_GEMINI_API_KEY=<template input>
-```
+Provider API keys are intentionally not template inputs. Configure provider
+keys in the Everruns UI after deployment, or add `DEFAULT_*` variables to the
+server service manually when a deployment should start with seeded defaults.
 
 ## Caddy Service
 
@@ -99,12 +95,14 @@ SECRETS_ENCRYPTION_KEY=kek-v1:${{ secret(43, "abcdefghijklmnopqrstuvwxyzABCDEFGH
 PUBLIC_APP_URL=https://${{ caddy.RAILWAY_PUBLIC_DOMAIN }}
 ```
 
-Optional LLM defaults:
+Optional LLM defaults. Do not include these in the public template form; add
+them manually to the server service only when a deployment should start with
+seeded provider defaults:
 
 ```env
-DEFAULT_OPENAI_API_KEY=<template input>
-DEFAULT_ANTHROPIC_API_KEY=<template input>
-DEFAULT_GEMINI_API_KEY=<template input>
+DEFAULT_OPENAI_API_KEY=<manual server variable>
+DEFAULT_ANTHROPIC_API_KEY=<manual server variable>
+DEFAULT_GEMINI_API_KEY=<manual server variable>
 ```
 
 ## Worker Variables

--- a/infra/railway/caddy/Caddyfile
+++ b/infra/railway/caddy/Caddyfile
@@ -27,6 +27,10 @@
 		reverse_proxy {$SERVER_HOST}:9000
 	}
 
+	handle /cli/login-success {
+		reverse_proxy {$SERVER_HOST}:9000
+	}
+
 	handle /health {
 		reverse_proxy {$SERVER_HOST}:9000
 	}

--- a/infra/railway/template-icon.svg
+++ b/infra/railway/template-icon.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512" role="img" aria-label="Everruns">
+  <rect width="512" height="512" rx="112" fill="#0A1636"/>
+  <g fill="none" stroke-width="28" stroke-linecap="round" stroke-linejoin="round">
+    <circle cx="256" cy="206" r="116" stroke="#F8FAFC"/>
+    <circle cx="188" cy="302" r="116" stroke="#D4A43A"/>
+    <circle cx="324" cy="302" r="116" stroke="#F8FAFC"/>
+  </g>
+</svg>


### PR DESCRIPTION
## What
Update the Railway deployment/template guide for the v0.8.31 release, add the repo-backed Caddy ingress asset, and add a stable Railway template icon.

## Why
The released images include the simplified environment-variable shape, so the Railway template guidance should stop exposing old/defaulted variables and should document the released deployment topology accurately.

## How
- Document v0.8.31 as the validated image tag for the live validation deployment.
- Document the Railway service shape with repo-backed Caddy from `infra/railway/caddy`.
- Add the Railway template icon asset and image URL.
- Keep only admin email/password as template user inputs; provider keys are documented as post-deploy/manual server defaults.
- Route server-owned paths, including `/cli/login-success`, through Caddy to the server.
- Use `DEPLOYMENT_GRADE=preview` for the Railway template to avoid dev-only experimental flags.
- Add cleanup guidance for legacy/defaulted server and worker env vars.

## Risk
- Low
- Docs/config only. The main risk is stale Railway operator guidance or Caddy route drift; mitigated by aligning with the production route contract and review feedback.

## Security
- Threat categories reviewed: deployment/configuration surface, `TM-AUTH`, `TM-WEB`.
- Findings and resolutions: no application code or secret handling changes. The guide keeps only Caddy public, documents generated JWT/worker/encryption secrets, avoids dev-only experimental flags in the public Railway template, and preserves the CLI auth success route through ingress.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

Validation:
- `docker manifest inspect ghcr.io/everruns/everruns-server:v0.8.31`
- `docker manifest inspect ghcr.io/everruns/everruns-worker:v0.8.31`
- `docker manifest inspect ghcr.io/everruns/everruns-ui:v0.8.31`
- `git diff --check`
- `bash scripts/lib/check-migration-ordering.sh`
- `just pre-push`
