### PR TITLE
chore(deps): bump @astrojs/starlight to 0.39.2

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -125,11 +125,11 @@ export default defineConfig({
                 },
                 {
                   label: "Features",
-                  autogenerate: { directory: "features" },
+                  items: [{ autogenerate: { directory: "features" } }],
                 },
                 {
                   label: "Advanced",
-                  autogenerate: { directory: "advanced" },
+                  items: [{ autogenerate: { directory: "advanced" } }],
                 },
               ],
             },
@@ -140,11 +140,11 @@ export default defineConfig({
               items: [
                 {
                   label: "Harnesses",
-                  autogenerate: { directory: "built-ins/harnesses" },
+                  items: [{ autogenerate: { directory: "built-ins/harnesses" } }],
                 },
                 {
                   label: "Capabilities",
-                  autogenerate: { directory: "capabilities" },
+                  items: [{ autogenerate: { directory: "capabilities" } }],
                 },
               ],
             },
@@ -155,15 +155,15 @@ export default defineConfig({
               items: [
                 {
                   label: "Integrations",
-                  autogenerate: { directory: "integrations" },
+                  items: [{ autogenerate: { directory: "integrations" } }],
                 },
                 {
                   label: "Observability",
-                  autogenerate: { directory: "observability" },
+                  items: [{ autogenerate: { directory: "observability" } }],
                 },
                 {
                   label: "Ecosystem",
-                  autogenerate: { directory: "ecosystem" },
+                  items: [{ autogenerate: { directory: "ecosystem" } }],
                 },
               ],
             },
@@ -181,7 +181,7 @@ export default defineConfig({
                 },
                 {
                   label: "How-to guides",
-                  autogenerate: { directory: "how-to" },
+                  items: [{ autogenerate: { directory: "how-to" } }],
                 },
               ],
             },
@@ -192,7 +192,7 @@ export default defineConfig({
               items: [
                 {
                   label: "Explanation",
-                  autogenerate: { directory: "explanation" },
+                  items: [{ autogenerate: { directory: "explanation" } }],
                 },
               ],
             },
@@ -218,7 +218,7 @@ export default defineConfig({
                     { label: "Admin Container", slug: "sre/admin-container" },
                     {
                       label: "Runbooks",
-                      autogenerate: { directory: "sre/runbooks" },
+                      items: [{ autogenerate: { directory: "sre/runbooks" } }],
                     },
                   ],
                 },

--- a/apps/docs/package-lock.json
+++ b/apps/docs/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@astrojs/check": "^0.9.7",
-        "@astrojs/starlight": "^0.38.0",
+        "@astrojs/starlight": "^0.39.2",
         "astro": "^6.1.8",
         "js-yaml": "^4.1.0",
         "marked": "^16.4.1",
@@ -190,9 +190,9 @@
       }
     },
     "node_modules/@astrojs/starlight": {
-      "version": "0.38.5",
-      "resolved": "https://registry.npmjs.org/@astrojs/starlight/-/starlight-0.38.5.tgz",
-      "integrity": "sha512-35xLSOtZDAMAilHG2zAEZoJ4AaPb+doYOvxuuRTAnmIBSOvujffOAHv3/rr6W/LJtkhBU38PjRDJ4i8QT1uGVw==",
+      "version": "0.39.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/starlight/-/starlight-0.39.2.tgz",
+      "integrity": "sha512-vlw+bwnjtf5buCTUtLU7JfV6D3knslxqnspr6LKs6hfRuFZiyr5hT44F7GyDqR9FKANUqFxnIzWM81F1k/kOUA==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/markdown-remark": "^7.1.1",
@@ -208,7 +208,7 @@
         "hast-util-select": "^6.0.4",
         "hast-util-to-string": "^3.0.1",
         "hastscript": "^9.0.1",
-        "i18next": "^23.11.5",
+        "i18next": "^26.0.7",
         "js-yaml": "^4.1.1",
         "klona": "^2.0.6",
         "magic-string": "^0.30.21",
@@ -3780,26 +3780,31 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/i18next": {
-      "version": "23.16.8",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-23.16.8.tgz",
-      "integrity": "sha512-06r/TitrM88Mg5FdUXAKL96dJMzgqLE5dv3ryBAra4KCwD9mJ4ndOTS95ZuymIGoE+2hzfdaMak2X11/es7ZWg==",
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.2.0.tgz",
+      "integrity": "sha512-zwBHldHdTmwN7r6UNc7lC6GWNN+YYg3DrRSeHR5PRRBf5QnJZcYHrQc0uaU26qZeYxR7iFZD+Y315dPnKP47wA==",
       "funding": [
         {
           "type": "individual",
-          "url": "https://locize.com"
-        },
-        {
-          "type": "individual",
-          "url": "https://locize.com/i18next.html"
+          "url": "https://www.locize.com/i18next"
         },
         {
           "type": "individual",
           "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.locize.com"
         }
       ],
       "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.23.2"
+      "peerDependencies": {
+        "typescript": "^5 || ^6"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/inline-style-parser": {

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@astrojs/check": "^0.9.7",
-    "@astrojs/starlight": "^0.38.0",
+    "@astrojs/starlight": "^0.39.2",
     "astro": "^6.1.8",
     "js-yaml": "^4.1.0",
     "marked": "^16.4.1",


### PR DESCRIPTION
## What
- Bumps `@astrojs/starlight` from `^0.38.0` (0.38.5) to `^0.39.2`.
- Migrates the 10 autogenerated sidebar groups in `apps/docs/astro.config.mjs` to the new 0.39 shape.

## Why
0.39 introduces a single breaking change relevant to us: autogenerated sidebar groups must wrap the `autogenerate` key in an `items` array.

Before:
```js
{ label: "Features", autogenerate: { directory: "features" } }
```

After:
```js
{ label: "Features", items: [{ autogenerate: { directory: "features" } }] }
```

This restructuring also enables mixed manual + autogenerated content in the same group going forward. Other 0.39 changes (autospacing in CJK, scrollbar-gutter, new icons, i18next 26) are non-breaking for our config.

## How
- `apps/docs/package.json`: bumped to `^0.39.2`.
- `apps/docs/astro.config.mjs`: ten `autogenerate: { directory: … }` entries migrated to `items: [{ autogenerate: { directory: … } }]`.
- `apps/docs/package-lock.json`: regenerated.

## Risk
- Low. Local `npm run build` succeeds; 307 pages built without warnings or sidebar errors. Sidebar structure unchanged from a navigation standpoint.

## Security
- Threat categories reviewed: dependency-supply-chain. Docs are static; no runtime/auth surface affected.
- Findings and resolutions: none.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated — N/A (docs build runs in CI)
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ksub5mbzQ6EFk5fB16ggNr)_