### PR TITLE
chore: index 6 missing specs in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,6 +157,12 @@ Always make sure you are working on top of latest main from remote.
 - `specs/a2a-capability.md` - A2A outbound delegation capability (Everruns agent calling external A2A agents)
 - `specs/fcp-channel.md` - FCP (Free Communication Protocol) inbound channel for App invocation via text-first HTTP
 - `specs/app-endpoint-auth.md` - Shared inbound auth framework for App-published endpoints (AG-UI, A2A, webhook) with OIDC/JWT, OAuth2 introspection, HTTP Basic, mTLS
+- `specs/agent-versions.md` - Immutable Agent configuration snapshots (audit, rollback, forks, App deployment pinning)
+- `specs/model-router.md` - Model Routers: semantic LLM selection via named routes, strategies, and candidates
+- `specs/email.md` - Internal email delivery abstraction for product and operational flows
+- `specs/voice.md` - Voice Sessions (Realtime API transport over a durable Everruns session)
+- `specs/volumes.md` - Workspace Volumes (org-scoped persistent filesystem trees mounted into sessions)
+- `specs/machine-payments.md` - Capability-side payments to external paid services during agent execution
 
 ### Test Cases
 


### PR DESCRIPTION
## What
Add one-line index entries in `AGENTS.md` for six specs that already exist in `specs/` but were missing from the index:

- `specs/agent-versions.md`
- `specs/model-router.md`
- `specs/email.md`
- `specs/voice.md`
- `specs/volumes.md`
- `specs/machine-payments.md`

## Why
Caught while running maintenance: `ls specs/*.md` compared against the spec index in `AGENTS.md` showed seven uncited files. Six are durable design specs that should be discoverable from the index alongside everything else. (The seventh, `specs/dash-gap-analysis.md`, is a one-off gap-analysis investigation and is intentionally left out per the AGENTS.md guidance against using specs/ for temporary analyses; can be moved out of `specs/` in a follow-up.)

## How
- Append six entries to the spec index in `AGENTS.md` directly after the existing `specs/app-endpoint-auth.md` entry.
- One-line summaries derived from each spec's abstract/intent paragraph.

## Risk
- None. Docs-only change.

## Security
- Threat categories reviewed: none applicable — documentation-only.
- Findings and resolutions: none.

## Follow-ups
- Decide whether `specs/dash-gap-analysis.md` should stay under `specs/` or move out (per the AGENTS.md guidance against specs for temporary investigations). Not addressed here.

## Checklist
- [x] Tests added or updated — N/A
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ksub5mbzQ6EFk5fB16ggNr)_