### PR TITLE
fix(fcp): resume sessions by cookie id

### DIFF
--- a/crates/server/src/api/fcp.rs
+++ b/crates/server/src/api/fcp.rs
@@ -627,12 +627,10 @@ async fn resolve_session(
 ) -> Result<ResolvedSession, Response> {
     let routing_tag = format!("fcp:app:{}", app.public_id);
     if let Some(session_id) = cookie_session_id {
-        match state
-            .db
-            .get_session(app.org_id, session_id.into())
-            .await
-        {
-            Ok(Some(row)) if row.app_id == Some(app.internal_id) && row.tags.contains(&routing_tag) => {
+        match state.db.get_session(app.org_id, session_id.into()).await {
+            Ok(Some(row))
+                if row.app_id == Some(app.internal_id) && row.tags.contains(&routing_tag) =>
+            {
                 if let Some(age) = expired_age_seconds(
                     row.created_at,
                     config.session_expiration_seconds,

--- a/crates/server/src/api/fcp.rs
+++ b/crates/server/src/api/fcp.rs
@@ -629,14 +629,10 @@ async fn resolve_session(
     if let Some(session_id) = cookie_session_id {
         match state
             .db
-            .find_app_session_by_tags(
-                app.org_id,
-                app.internal_id,
-                std::slice::from_ref(&routing_tag),
-            )
+            .get_session(app.org_id, session_id.into())
             .await
         {
-            Ok(Some(row)) if row.id == session_id => {
+            Ok(Some(row)) if row.app_id == Some(app.internal_id) && row.tags.contains(&routing_tag) => {
                 if let Some(age) = expired_age_seconds(
                     row.created_at,
                     config.session_expiration_seconds,

--- a/crates/server/tests/fcp_integration_test.rs
+++ b/crates/server/tests/fcp_integration_test.rs
@@ -409,6 +409,57 @@ async fn fcp_post_session_cookie_reuses_same_session() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn fcp_post_cookie_reuses_matching_session_when_multiple_exist() {
+    let server = TestServer::in_memory().await;
+    let app = create_published_fcp_app(&server, fast_timeout_config()).await;
+
+    let first = send_fcp_post(
+        &server,
+        &app.public_id,
+        "client one",
+        vec![("content-type", "text/plain")],
+    )
+    .await;
+    assert_accepted_or_timeout(first.status());
+    let first_cookie = test_harness::extract_cookie(first.headers(), "fcp_session");
+
+    let second = send_fcp_post(
+        &server,
+        &app.public_id,
+        "client two",
+        vec![("content-type", "text/plain")],
+    )
+    .await;
+    assert_accepted_or_timeout(second.status());
+
+    let third = send_fcp_post(
+        &server,
+        &app.public_id,
+        "client one again",
+        vec![("content-type", "text/plain"), ("cookie", &first_cookie)],
+    )
+    .await;
+    assert_accepted_or_timeout(third.status());
+
+    let sessions: Value = server.get("/v1/sessions").await.assert_success().json();
+    let expected_tag = format!("fcp:app:{}", app.public_id);
+    let tagged_count = sessions["data"]
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .filter(|s| {
+                    s["tags"]
+                        .as_array()
+                        .map(|tags| tags.iter().any(|t| t.as_str() == Some(&expected_tag)))
+                        .unwrap_or(false)
+                })
+                .count()
+        })
+        .unwrap_or(0);
+    assert_eq!(tagged_count, 2, "cookie reuse must not create a third session");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn fcp_post_stale_cookie_creates_new_session() {
     let server = TestServer::in_memory().await;
     let app = create_published_fcp_app(&server, fast_timeout_config()).await;

--- a/crates/server/tests/fcp_integration_test.rs
+++ b/crates/server/tests/fcp_integration_test.rs
@@ -175,6 +175,23 @@ fn assert_accepted_or_timeout(status: StatusCode) {
     );
 }
 
+async fn count_sessions_with_tag(server: &TestServer, tag: &str) -> usize {
+    let sessions: Value = server.get("/v1/sessions").await.assert_success().json();
+    sessions["data"]
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .filter(|s| {
+                    s["tags"]
+                        .as_array()
+                        .map(|tags| tags.iter().any(|t| t.as_str() == Some(tag)))
+                        .unwrap_or(false)
+                })
+                .count()
+        })
+        .unwrap_or(0)
+}
+
 /// Shorter response timeout for happy-path tests so 504 paths return
 /// quickly instead of waiting the default 120 s.
 fn fast_timeout_config() -> Value {
@@ -362,21 +379,8 @@ async fn fcp_post_session_cookie_reuses_same_session() {
     let cookie = test_harness::extract_cookie(first.headers(), "fcp_session");
 
     // Inspect sessions by tag — first POST must have created exactly one.
-    let sessions: Value = server.get("/v1/sessions").await.assert_success().json();
     let expected_tag = format!("fcp:app:{}", app.public_id);
-    let first_count = sessions["data"]
-        .as_array()
-        .map(|arr| {
-            arr.iter()
-                .filter(|s| {
-                    s["tags"]
-                        .as_array()
-                        .map(|tags| tags.iter().any(|t| t.as_str() == Some(&expected_tag)))
-                        .unwrap_or(false)
-                })
-                .count()
-        })
-        .unwrap_or(0);
+    let first_count = count_sessions_with_tag(&server, &expected_tag).await;
     assert_eq!(first_count, 1);
 
     let second = send_fcp_post(
@@ -388,20 +392,7 @@ async fn fcp_post_session_cookie_reuses_same_session() {
     .await;
     assert_accepted_or_timeout(second.status());
 
-    let sessions_after: Value = server.get("/v1/sessions").await.assert_success().json();
-    let after_count = sessions_after["data"]
-        .as_array()
-        .map(|arr| {
-            arr.iter()
-                .filter(|s| {
-                    s["tags"]
-                        .as_array()
-                        .map(|tags| tags.iter().any(|t| t.as_str() == Some(&expected_tag)))
-                        .unwrap_or(false)
-                })
-                .count()
-        })
-        .unwrap_or(0);
+    let after_count = count_sessions_with_tag(&server, &expected_tag).await;
     assert_eq!(
         after_count, 1,
         "second POST with cookie must reuse the session created by the first"
@@ -441,22 +432,12 @@ async fn fcp_post_cookie_reuses_matching_session_when_multiple_exist() {
     .await;
     assert_accepted_or_timeout(third.status());
 
-    let sessions: Value = server.get("/v1/sessions").await.assert_success().json();
     let expected_tag = format!("fcp:app:{}", app.public_id);
-    let tagged_count = sessions["data"]
-        .as_array()
-        .map(|arr| {
-            arr.iter()
-                .filter(|s| {
-                    s["tags"]
-                        .as_array()
-                        .map(|tags| tags.iter().any(|t| t.as_str() == Some(&expected_tag)))
-                        .unwrap_or(false)
-                })
-                .count()
-        })
-        .unwrap_or(0);
-    assert_eq!(tagged_count, 2, "cookie reuse must not create a third session");
+    let tagged_count = count_sessions_with_tag(&server, &expected_tag).await;
+    assert_eq!(
+        tagged_count, 2,
+        "cookie reuse must not create a third session"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]


### PR DESCRIPTION
### Motivation
- The FCP session resume logic fetched an oldest-matching session by routing tag and then compared it to the client cookie UUID, which only succeeds for the first-ever session and breaks resume for subsequent per-client sessions, causing unnecessary session creation.

### Description
- Update `resolve_session` in `crates/server/src/api/fcp.rs` to load the session by the `fcp_session` cookie UUID using `get_session` and then verify the row belongs to the same app and contains the expected `fcp:app:<app_id>` routing tag before reusing it.
- Preserve existing expiration handling and stale-cookie fallback so unknown or expired cookies still result in a fresh session being created.
- Add integration test `fcp_post_cookie_reuses_matching_session_when_multiple_exist` in `crates/server/tests/fcp_integration_test.rs` that reproduces the multi-client scenario and asserts a valid cookie resumes the correct session rather than creating a third one.
- No public API/schema changes; change is internal to session resolution.

### Testing
- Added integration test `crates/server/tests/fcp_integration_test.rs::fcp_post_cookie_reuses_matching_session_when_multiple_exist` covering the multi-client resume case.
- Attempted to run the new test with `cargo test -p everruns-server fcp_post_cookie_reuses_matching_session_when_multiple_exist -- --nocapture`, which started but did not complete in this environment due to long dependency compilation, so execution was not fully verified here.
- An earlier `cargo test` invocation failed due to invalid filter args; no automated test failures were observed from the code changes themselves during local edits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0904baa788832ba7815dda08675bf0)