### PR TITLE
feat(reporting): complete reporting product surface

### DIFF
--- a/apps/ui/src/__tests__/reports-page.test.tsx
+++ b/apps/ui/src/__tests__/reports-page.test.tsx
@@ -1,0 +1,176 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import ReportsPage from "@/app/(main)/reports/page";
+import type { OrgRole, ReportQuery, ReportResult, SavedReport } from "@/lib/api/types";
+
+const mockUseReportCatalog = jest.fn();
+const mockUseSavedReports = jest.fn();
+const mockUseReportQuery = jest.fn();
+const mockUseReportingDiagnostics = jest.fn();
+const mockCreateSavedReport = jest.fn();
+const mockDeleteSavedReport = jest.fn();
+const mockRunSavedReport = jest.fn();
+const mockExportReportQuery = jest.fn();
+const mockExportSavedReport = jest.fn();
+const mockRunReportingProjector = jest.fn();
+const mockBackfillReporting = jest.fn();
+
+let currentRole: OrgRole = "member";
+
+jest.mock("@/providers/org-provider", () => ({
+  useOrg: () => ({
+    hasRole: (role: OrgRole) => {
+      const hierarchy: Record<OrgRole, number> = { owner: 3, admin: 2, member: 1 };
+      return hierarchy[currentRole] >= hierarchy[role];
+    },
+  }),
+}));
+
+jest.mock("@/hooks", () => ({
+  usePageTitle: () => undefined,
+  useReportCatalog: () => mockUseReportCatalog(),
+  useSavedReports: () => mockUseSavedReports(),
+  useReportQuery: (query: ReportQuery | undefined) => mockUseReportQuery(query),
+  useReportingDiagnostics: (enabled?: boolean) => mockUseReportingDiagnostics(enabled),
+  useCreateSavedReport: () => mockCreateSavedReport(),
+  useDeleteSavedReport: () => mockDeleteSavedReport(),
+  useRunSavedReport: () => mockRunSavedReport(),
+  useExportReportQuery: () => mockExportReportQuery(),
+  useExportSavedReport: () => mockExportSavedReport(),
+  useRunReportingProjector: () => mockRunReportingProjector(),
+  useBackfillReporting: () => mockBackfillReporting(),
+}));
+
+const savedQuery: ReportQuery = {
+  dataset: "tool_calls",
+  time_range: {
+    from: "2026-05-16T00:00:00.000Z",
+    to: "2026-05-17T00:00:00.000Z",
+  },
+  dimensions: ["tool", "agent"],
+  measures: ["call_count"],
+  filters: [{ field: "tool", op: "eq", value: "web_fetch" }],
+  order_by: [{ measure: "call_count", direction: "desc" }],
+  limit: 25,
+};
+
+const savedReport: SavedReport = {
+  id: "report_1",
+  name: "Filtered Tool Calls",
+  query: savedQuery,
+  dashboard: { chart_type: "table" },
+  created_at: "2026-05-17T00:00:00.000Z",
+  updated_at: "2026-05-17T00:00:00.000Z",
+};
+
+const emptyResult: ReportResult = {
+  as_of: "2026-05-17T00:00:00.000Z",
+  freshness_lag_ms: null,
+  columns: [],
+  rows: [],
+};
+
+function renderReportsPage(role: OrgRole = "member", reports: SavedReport[] = []) {
+  currentRole = role;
+  mockUseReportCatalog.mockReturnValue({
+    data: {
+      datasets: [
+        {
+          name: "tool_calls",
+          dimensions: ["day", "tool", "agent"],
+          measures: ["call_count"],
+          filter_fields: ["tool"],
+        },
+      ],
+    },
+    isLoading: false,
+  });
+  mockUseSavedReports.mockReturnValue({ data: reports });
+  mockUseReportQuery.mockReturnValue({ data: emptyResult, isFetching: false, error: null });
+  mockUseReportingDiagnostics.mockReturnValue({
+    data: {
+      projector_lag: [{ dataset: "tool_calls", latest_projected_at: null, freshness_lag_ms: null }],
+      outbox: {
+        pending: 0,
+        processing: 0,
+        failed: 0,
+        completed: 0,
+        oldest_pending_at: null,
+        failed_rows: [],
+      },
+    },
+  });
+  mockCreateSavedReport.mockReturnValue({ mutateAsync: jest.fn(), isPending: false });
+  mockDeleteSavedReport.mockReturnValue({ mutate: jest.fn(), isPending: false });
+  mockRunSavedReport.mockReturnValue({ mutateAsync: jest.fn().mockResolvedValue(emptyResult) });
+  mockExportReportQuery.mockReturnValue({
+    mutateAsync: jest.fn().mockResolvedValue({
+      format: "csv",
+      filename: "report.csv",
+      content_type: "text/csv; charset=utf-8",
+      content: "",
+      as_of: "2026-05-17T00:00:00.000Z",
+    }),
+    isPending: false,
+  });
+  mockExportSavedReport.mockReturnValue({ mutateAsync: jest.fn(), isPending: false });
+  mockRunReportingProjector.mockReturnValue({ mutate: jest.fn(), isPending: false });
+  mockBackfillReporting.mockReturnValue({ mutate: jest.fn(), isPending: false });
+
+  render(<ReportsPage />);
+}
+
+describe("ReportsPage", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    URL.createObjectURL = jest.fn(() => "blob:report");
+    URL.revokeObjectURL = jest.fn();
+    HTMLAnchorElement.prototype.click = jest.fn();
+  });
+
+  it("renders empty report states for report viewers without admin requests", () => {
+    renderReportsPage("member");
+
+    expect(screen.getByText("No saved reports.")).toBeInTheDocument();
+    expect(screen.getByText("No rows for this query.")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Save report" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Backfill" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Project" })).not.toBeInTheDocument();
+    expect(mockUseReportingDiagnostics).toHaveBeenCalledWith(false);
+  });
+
+  it("allows org admins to manage saved reports but not run admin projection actions", () => {
+    renderReportsPage("admin", [savedReport]);
+
+    expect(screen.getByRole("button", { name: "Save report" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Delete saved report" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Backfill" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Project" })).not.toBeInTheDocument();
+    expect(screen.queryByText("Projection Lag")).not.toBeInTheDocument();
+    expect(mockUseReportingDiagnostics).toHaveBeenCalledWith(false);
+  });
+
+  it("allows org owners to run reporting admin actions", () => {
+    renderReportsPage("owner", [savedReport]);
+
+    expect(screen.getByRole("button", { name: "Backfill" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Project" })).toBeInTheDocument();
+    expect(screen.getByText("Projection Lag")).toBeInTheDocument();
+    expect(mockUseReportingDiagnostics).toHaveBeenCalledWith(true);
+  });
+
+  it("exports the full saved report query after running a saved report", async () => {
+    renderReportsPage("admin", [savedReport]);
+
+    fireEvent.click(screen.getByText("Filtered Tool Calls"));
+    await waitFor(() => expect(mockRunSavedReport().mutateAsync).toHaveBeenCalledWith("report_1"));
+
+    fireEvent.click(screen.getByRole("button", { name: "CSV" }));
+
+    await waitFor(() => {
+      expect(mockExportReportQuery().mutateAsync).toHaveBeenCalledWith({
+        query: savedQuery,
+        format: "csv",
+      });
+    });
+  });
+});

--- a/apps/ui/src/app/(main)/reports/page.tsx
+++ b/apps/ui/src/app/(main)/reports/page.tsx
@@ -179,7 +179,8 @@ export default function ReportsPage() {
   const activeColumns = activeResult?.columns ?? [];
   const activeRows = activeResult?.rows ?? [];
   const measureColumn = activeColumns.find((column) => column.kind === "measure")?.name;
-  const canAdministerReports = hasRole("admin");
+  const canManageReports = hasRole("admin");
+  const canAdministerReports = canManageReports;
   const measureTotal = measureColumn
     ? activeRows.reduce(
         (sum, row) => sum + (typeof row[measureColumn] === "number" ? row[measureColumn] : 0),
@@ -410,25 +411,27 @@ export default function ReportsPage() {
                     </SelectContent>
                   </Select>
                 </div>
-                <div className="space-y-2">
-                  <Label>Save</Label>
-                  <div className="flex gap-2">
-                    <Input
-                      value={saveName}
-                      onChange={(event) => setSaveName(event.target.value)}
-                      placeholder="Report name"
-                    />
-                    <Button
-                      variant="outline"
-                      size="icon"
-                      onClick={handleSave}
-                      disabled={!saveName.trim() || createSavedReport.isPending}
-                      aria-label="Save report"
-                    >
-                      <Save className="h-4 w-4" />
-                    </Button>
+                {canManageReports && (
+                  <div className="space-y-2">
+                    <Label>Save</Label>
+                    <div className="flex gap-2">
+                      <Input
+                        value={saveName}
+                        onChange={(event) => setSaveName(event.target.value)}
+                        placeholder="Report name"
+                      />
+                      <Button
+                        variant="outline"
+                        size="icon"
+                        onClick={handleSave}
+                        disabled={!saveName.trim() || createSavedReport.isPending}
+                        aria-label="Save report"
+                      >
+                        <Save className="h-4 w-4" />
+                      </Button>
+                    </div>
                   </div>
-                </div>
+                )}
               </CardContent>
             </Card>
 
@@ -515,14 +518,16 @@ export default function ReportsPage() {
                         >
                           <Download className="h-4 w-4" />
                         </Button>
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          onClick={() => deleteSavedReport.mutate(report.id)}
-                          aria-label="Delete saved report"
-                        >
-                          <Trash2 className="h-4 w-4" />
-                        </Button>
+                        {canManageReports && (
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            onClick={() => deleteSavedReport.mutate(report.id)}
+                            aria-label="Delete saved report"
+                          >
+                            <Trash2 className="h-4 w-4" />
+                          </Button>
+                        )}
                       </div>
                     </div>
                   ))

--- a/apps/ui/src/app/(main)/reports/page.tsx
+++ b/apps/ui/src/app/(main)/reports/page.tsx
@@ -129,9 +129,11 @@ function defaultQuery(dataset: DatasetCatalogEntry | undefined, days = 7): Repor
 export default function ReportsPage() {
   usePageTitle("Reports");
   const { hasRole } = useOrg();
+  const canManageReports = hasRole("admin");
+  const canAdministerReports = hasRole("owner");
   const catalog = useReportCatalog();
   const savedReports = useSavedReports();
-  const diagnostics = useReportingDiagnostics();
+  const diagnostics = useReportingDiagnostics(canAdministerReports);
   const createSavedReport = useCreateSavedReport();
   const deleteSavedReport = useDeleteSavedReport();
   const runSavedReport = useRunSavedReport();
@@ -145,6 +147,7 @@ export default function ReportsPage() {
   const [selectedRange, setSelectedRange] = useState("7");
   const [saveName, setSaveName] = useState("");
   const [manualResult, setManualResult] = useState<ReportResult>();
+  const [savedQuery, setSavedQuery] = useState<ReportQuery>();
 
   const datasets = useMemo(() => catalog.data?.datasets ?? [], [catalog.data?.datasets]);
   const dataset = useMemo(
@@ -162,6 +165,7 @@ export default function ReportsPage() {
   }, [dataset, selectedDataset]);
 
   const query = useMemo<ReportQuery | undefined>(() => {
+    if (savedQuery) return savedQuery;
     if (!dataset || !selectedMeasure) return defaultQuery(dataset, Number(selectedRange));
     return {
       dataset: dataset.name,
@@ -172,15 +176,13 @@ export default function ReportsPage() {
       order_by: [{ measure: selectedMeasure, direction: "desc" }],
       limit: 100,
     };
-  }, [dataset, selectedDimension, selectedMeasure, selectedRange]);
+  }, [dataset, savedQuery, selectedDimension, selectedMeasure, selectedRange]);
 
   const result = useReportQuery(query);
   const activeResult = manualResult ?? result.data;
   const activeColumns = activeResult?.columns ?? [];
   const activeRows = activeResult?.rows ?? [];
   const measureColumn = activeColumns.find((column) => column.kind === "measure")?.name;
-  const canManageReports = hasRole("admin");
-  const canAdministerReports = canManageReports;
   const measureTotal = measureColumn
     ? activeRows.reduce(
         (sum, row) => sum + (typeof row[measureColumn] === "number" ? row[measureColumn] : 0),
@@ -191,6 +193,7 @@ export default function ReportsPage() {
   const handleDatasetChange = (value: string) => {
     const next = datasets.find((entry) => entry.name === value);
     setManualResult(undefined);
+    setSavedQuery(undefined);
     setSelectedDataset(value);
     setSelectedDimension(
       next?.dimensions.includes("day") ? "day" : (next?.dimensions[0] ?? "none"),
@@ -212,6 +215,7 @@ export default function ReportsPage() {
     setSelectedDataset(report.query.dataset);
     setSelectedDimension(report.query.dimensions[0] ?? "none");
     setSelectedMeasure(report.query.measures[0] ?? "");
+    setSavedQuery(report.query);
     setManualResult(await runSavedReport.mutateAsync(report.id));
   };
 
@@ -306,20 +310,22 @@ export default function ReportsPage() {
               </p>
             </CardContent>
           </Card>
-          <Card>
-            <CardHeader className="pb-2">
-              <CardTitle className="text-sm font-medium">Outbox</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="text-2xl font-semibold">
-                {(diagnostics.data?.outbox.pending ?? 0).toLocaleString()}
-              </div>
-              <p className="text-xs text-muted-foreground">
-                {diagnostics.data?.outbox.failed ?? 0} failed,{" "}
-                {diagnostics.data?.outbox.processing ?? 0} processing
-              </p>
-            </CardContent>
-          </Card>
+          {canAdministerReports && (
+            <Card>
+              <CardHeader className="pb-2">
+                <CardTitle className="text-sm font-medium">Outbox</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="text-2xl font-semibold">
+                  {(diagnostics.data?.outbox.pending ?? 0).toLocaleString()}
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  {diagnostics.data?.outbox.failed ?? 0} failed,{" "}
+                  {diagnostics.data?.outbox.processing ?? 0} processing
+                </p>
+              </CardContent>
+            </Card>
+          )}
         </div>
 
         <section className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_360px]">
@@ -353,6 +359,7 @@ export default function ReportsPage() {
                     value={selectedDimension}
                     onValueChange={(value) => {
                       setManualResult(undefined);
+                      setSavedQuery(undefined);
                       setSelectedDimension(value);
                     }}
                   >
@@ -375,6 +382,7 @@ export default function ReportsPage() {
                     value={selectedMeasure}
                     onValueChange={(value) => {
                       setManualResult(undefined);
+                      setSavedQuery(undefined);
                       setSelectedMeasure(value);
                     }}
                   >
@@ -396,6 +404,7 @@ export default function ReportsPage() {
                     value={selectedRange}
                     onValueChange={(value) => {
                       setManualResult(undefined);
+                      setSavedQuery(undefined);
                       setSelectedRange(value);
                     }}
                   >
@@ -535,45 +544,49 @@ export default function ReportsPage() {
               </CardContent>
             </Card>
 
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-base">Projection Lag</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="space-y-2">
-                  {(diagnostics.data?.projector_lag ?? []).map((lag) => (
-                    <div
-                      key={lag.dataset}
-                      className="flex items-center justify-between border-b py-1.5 last:border-b-0"
-                    >
-                      <span className="text-sm">{formatDatasetName(lag.dataset)}</span>
-                      <Badge variant={lag.freshness_lag_ms === null ? "outline" : "secondary"}>
-                        {freshnessLabel(lag.freshness_lag_ms)}
-                      </Badge>
+            {canAdministerReports && (
+              <>
+                <Card>
+                  <CardHeader>
+                    <CardTitle className="text-base">Projection Lag</CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <div className="space-y-2">
+                      {(diagnostics.data?.projector_lag ?? []).map((lag) => (
+                        <div
+                          key={lag.dataset}
+                          className="flex items-center justify-between border-b py-1.5 last:border-b-0"
+                        >
+                          <span className="text-sm">{formatDatasetName(lag.dataset)}</span>
+                          <Badge variant={lag.freshness_lag_ms === null ? "outline" : "secondary"}>
+                            {freshnessLabel(lag.freshness_lag_ms)}
+                          </Badge>
+                        </div>
+                      ))}
                     </div>
-                  ))}
-                </div>
-              </CardContent>
-            </Card>
+                  </CardContent>
+                </Card>
 
-            {diagnostics.data?.outbox.failed_rows.length ? (
-              <Card>
-                <CardHeader>
-                  <CardTitle className="text-base">Failed Rows</CardTitle>
-                </CardHeader>
-                <CardContent className="space-y-2">
-                  {diagnostics.data.outbox.failed_rows.slice(0, 5).map((row) => (
-                    <div key={row.id} className="border p-2 text-xs">
-                      <div className="font-medium">{row.source_type}</div>
-                      <div className="truncate text-muted-foreground">{row.source_id}</div>
-                      {row.last_error && (
-                        <div className="mt-1 text-destructive">{row.last_error}</div>
-                      )}
-                    </div>
-                  ))}
-                </CardContent>
-              </Card>
-            ) : null}
+                {diagnostics.data?.outbox.failed_rows.length ? (
+                  <Card>
+                    <CardHeader>
+                      <CardTitle className="text-base">Failed Rows</CardTitle>
+                    </CardHeader>
+                    <CardContent className="space-y-2">
+                      {diagnostics.data.outbox.failed_rows.slice(0, 5).map((row) => (
+                        <div key={row.id} className="border p-2 text-xs">
+                          <div className="font-medium">{row.source_type}</div>
+                          <div className="truncate text-muted-foreground">{row.source_id}</div>
+                          {row.last_error && (
+                            <div className="mt-1 text-destructive">{row.last_error}</div>
+                          )}
+                        </div>
+                      ))}
+                    </CardContent>
+                  </Card>
+                ) : null}
+              </>
+            )}
           </aside>
         </section>
       </PageBody>

--- a/apps/ui/src/app/(main)/reports/page.tsx
+++ b/apps/ui/src/app/(main)/reports/page.tsx
@@ -1,0 +1,577 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import {
+  BarChart3,
+  Database,
+  Download,
+  Play,
+  RefreshCw,
+  RotateCw,
+  Save,
+  Trash2,
+} from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { PageBody, PageHeader, PageShell } from "@/components/layout";
+import {
+  useBackfillReporting,
+  useCreateSavedReport,
+  useDeleteSavedReport,
+  useExportReportQuery,
+  useExportSavedReport,
+  usePageTitle,
+  useReportCatalog,
+  useReportQuery,
+  useReportingDiagnostics,
+  useRunReportingProjector,
+  useRunSavedReport,
+  useSavedReports,
+} from "@/hooks";
+import { useOrg } from "@/providers/org-provider";
+import type {
+  DatasetCatalogEntry,
+  ReportExport,
+  ReportQuery,
+  ReportResult,
+  SavedReport,
+} from "@/lib/api/types";
+
+const DATASET_LABELS: Record<string, string> = {
+  llm_generations: "LLM Generations",
+  tool_calls: "Tool Calls",
+  turns: "Turns",
+  sessions: "Sessions",
+  budget_postings: "Budget Postings",
+  capability_usage: "Capability Usage",
+};
+
+const RANGE_OPTIONS = [
+  { value: "1", label: "24h" },
+  { value: "7", label: "7d" },
+  { value: "30", label: "30d" },
+  { value: "90", label: "90d" },
+];
+
+function range(days: number) {
+  const to = new Date();
+  const from = new Date(to.getTime() - days * 24 * 60 * 60 * 1000);
+  return {
+    from: from.toISOString(),
+    to: to.toISOString(),
+  };
+}
+
+function formatDatasetName(name: string) {
+  return DATASET_LABELS[name] ?? name.replaceAll("_", " ");
+}
+
+function formatValue(value: unknown) {
+  if (value === null || value === undefined || value === "") return "-";
+  if (typeof value === "number") {
+    return Number.isInteger(value) ? value.toLocaleString() : value.toFixed(2);
+  }
+  if (typeof value === "string" && /^\d{4}-\d{2}-\d{2}T/.test(value)) {
+    return new Date(value).toLocaleString();
+  }
+  return String(value);
+}
+
+function freshnessLabel(ms?: number | null) {
+  if (ms === undefined || ms === null) return "No projections";
+  if (ms < 60_000) return `${Math.round(ms / 1000)}s`;
+  if (ms < 3_600_000) return `${Math.round(ms / 60_000)}m`;
+  return `${Math.round(ms / 3_600_000)}h`;
+}
+
+function saveExport(file: ReportExport) {
+  const blob = new Blob([file.content], { type: file.content_type });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = file.filename;
+  anchor.click();
+  URL.revokeObjectURL(url);
+}
+
+function defaultQuery(dataset: DatasetCatalogEntry | undefined, days = 7): ReportQuery | undefined {
+  if (!dataset) return undefined;
+  return {
+    dataset: dataset.name,
+    time_range: range(days),
+    dimensions: dataset.dimensions.includes("day") ? ["day"] : dataset.dimensions.slice(0, 1),
+    measures: dataset.measures.slice(0, 1),
+    filters: [],
+    order_by: dataset.measures[0] ? [{ measure: dataset.measures[0], direction: "desc" }] : [],
+    limit: 100,
+  };
+}
+
+export default function ReportsPage() {
+  usePageTitle("Reports");
+  const { hasRole } = useOrg();
+  const catalog = useReportCatalog();
+  const savedReports = useSavedReports();
+  const diagnostics = useReportingDiagnostics();
+  const createSavedReport = useCreateSavedReport();
+  const deleteSavedReport = useDeleteSavedReport();
+  const runSavedReport = useRunSavedReport();
+  const exportQuery = useExportReportQuery();
+  const exportSaved = useExportSavedReport();
+  const runProjector = useRunReportingProjector();
+  const backfill = useBackfillReporting();
+  const [selectedDataset, setSelectedDataset] = useState<string>("");
+  const [selectedDimension, setSelectedDimension] = useState<string>("day");
+  const [selectedMeasure, setSelectedMeasure] = useState<string>("");
+  const [selectedRange, setSelectedRange] = useState("7");
+  const [saveName, setSaveName] = useState("");
+  const [manualResult, setManualResult] = useState<ReportResult>();
+
+  const datasets = useMemo(() => catalog.data?.datasets ?? [], [catalog.data?.datasets]);
+  const dataset = useMemo(
+    () => datasets.find((entry) => entry.name === selectedDataset) ?? datasets[0],
+    [datasets, selectedDataset],
+  );
+
+  useEffect(() => {
+    if (!dataset || selectedDataset) return;
+    setSelectedDataset(dataset.name);
+    setSelectedDimension(
+      dataset.dimensions.includes("day") ? "day" : (dataset.dimensions[0] ?? "none"),
+    );
+    setSelectedMeasure(dataset.measures[0] ?? "");
+  }, [dataset, selectedDataset]);
+
+  const query = useMemo<ReportQuery | undefined>(() => {
+    if (!dataset || !selectedMeasure) return defaultQuery(dataset, Number(selectedRange));
+    return {
+      dataset: dataset.name,
+      time_range: range(Number(selectedRange)),
+      dimensions: selectedDimension === "none" ? [] : [selectedDimension],
+      measures: [selectedMeasure],
+      filters: [],
+      order_by: [{ measure: selectedMeasure, direction: "desc" }],
+      limit: 100,
+    };
+  }, [dataset, selectedDimension, selectedMeasure, selectedRange]);
+
+  const result = useReportQuery(query);
+  const activeResult = manualResult ?? result.data;
+  const activeColumns = activeResult?.columns ?? [];
+  const activeRows = activeResult?.rows ?? [];
+  const measureColumn = activeColumns.find((column) => column.kind === "measure")?.name;
+  const canAdministerReports = hasRole("admin");
+  const measureTotal = measureColumn
+    ? activeRows.reduce(
+        (sum, row) => sum + (typeof row[measureColumn] === "number" ? row[measureColumn] : 0),
+        0,
+      )
+    : activeRows.length;
+
+  const handleDatasetChange = (value: string) => {
+    const next = datasets.find((entry) => entry.name === value);
+    setManualResult(undefined);
+    setSelectedDataset(value);
+    setSelectedDimension(
+      next?.dimensions.includes("day") ? "day" : (next?.dimensions[0] ?? "none"),
+    );
+    setSelectedMeasure(next?.measures[0] ?? "");
+  };
+
+  const handleSave = async () => {
+    if (!query || !saveName.trim()) return;
+    await createSavedReport.mutateAsync({
+      name: saveName.trim(),
+      query,
+      dashboard: { chart_type: "table" },
+    });
+    setSaveName("");
+  };
+
+  const handleRunSaved = async (report: SavedReport) => {
+    setSelectedDataset(report.query.dataset);
+    setSelectedDimension(report.query.dimensions[0] ?? "none");
+    setSelectedMeasure(report.query.measures[0] ?? "");
+    setManualResult(await runSavedReport.mutateAsync(report.id));
+  };
+
+  const handleExportCurrent = async () => {
+    if (!query) return;
+    saveExport(await exportQuery.mutateAsync({ query, format: "csv" }));
+  };
+
+  if (catalog.isLoading) {
+    return (
+      <PageShell fullWidth>
+        <PageHeader title="Reports" />
+        <PageBody>
+          <div className="grid gap-4 md:grid-cols-4">
+            {[...Array(4)].map((_, index) => (
+              <Skeleton key={index} className="h-28" />
+            ))}
+          </div>
+          <Skeleton className="h-96" />
+        </PageBody>
+      </PageShell>
+    );
+  }
+
+  return (
+    <PageShell fullWidth>
+      <PageHeader
+        title="Reports"
+        description="Org-scoped analytics from reporting projections."
+        actions={
+          <>
+            {canAdministerReports && (
+              <>
+                <Button
+                  variant="outline"
+                  onClick={() => backfill.mutate()}
+                  disabled={backfill.isPending}
+                >
+                  <RefreshCw className="h-4 w-4 mr-2" />
+                  Backfill
+                </Button>
+                <Button
+                  variant="outline"
+                  onClick={() => runProjector.mutate()}
+                  disabled={runProjector.isPending}
+                >
+                  <RotateCw className="h-4 w-4 mr-2" />
+                  Project
+                </Button>
+              </>
+            )}
+            <Button onClick={handleExportCurrent} disabled={!query || exportQuery.isPending}>
+              <Download className="h-4 w-4 mr-2" />
+              CSV
+            </Button>
+          </>
+        }
+      />
+
+      <PageBody className="space-y-6">
+        <div className="grid gap-4 md:grid-cols-4">
+          <Card>
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm font-medium">Rows</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="text-2xl font-semibold">{activeRows.length.toLocaleString()}</div>
+              <p className="text-xs text-muted-foreground">Limit {query?.limit ?? 100}</p>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm font-medium">{measureColumn ?? "Measure"}</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="text-2xl font-semibold">{formatValue(measureTotal)}</div>
+              <p className="text-xs text-muted-foreground">
+                {formatDatasetName(query?.dataset ?? "")}
+              </p>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm font-medium">Freshness</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="text-2xl font-semibold">
+                {freshnessLabel(activeResult?.freshness_lag_ms)}
+              </div>
+              <p className="text-xs text-muted-foreground">
+                {activeResult?.as_of ? new Date(activeResult.as_of).toLocaleTimeString() : "-"}
+              </p>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm font-medium">Outbox</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="text-2xl font-semibold">
+                {(diagnostics.data?.outbox.pending ?? 0).toLocaleString()}
+              </div>
+              <p className="text-xs text-muted-foreground">
+                {diagnostics.data?.outbox.failed ?? 0} failed,{" "}
+                {diagnostics.data?.outbox.processing ?? 0} processing
+              </p>
+            </CardContent>
+          </Card>
+        </div>
+
+        <section className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_360px]">
+          <div className="space-y-4">
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-base">
+                  <BarChart3 className="h-5 w-5" />
+                  Query
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="grid gap-4 md:grid-cols-5">
+                <div className="space-y-2">
+                  <Label>Dataset</Label>
+                  <Select value={dataset?.name ?? ""} onValueChange={handleDatasetChange}>
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {datasets.map((entry) => (
+                        <SelectItem key={entry.name} value={entry.name}>
+                          {formatDatasetName(entry.name)}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-2">
+                  <Label>Dimension</Label>
+                  <Select
+                    value={selectedDimension}
+                    onValueChange={(value) => {
+                      setManualResult(undefined);
+                      setSelectedDimension(value);
+                    }}
+                  >
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="none">None</SelectItem>
+                      {dataset?.dimensions.map((name) => (
+                        <SelectItem key={name} value={name}>
+                          {name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-2">
+                  <Label>Measure</Label>
+                  <Select
+                    value={selectedMeasure}
+                    onValueChange={(value) => {
+                      setManualResult(undefined);
+                      setSelectedMeasure(value);
+                    }}
+                  >
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {dataset?.measures.map((name) => (
+                        <SelectItem key={name} value={name}>
+                          {name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-2">
+                  <Label>Range</Label>
+                  <Select
+                    value={selectedRange}
+                    onValueChange={(value) => {
+                      setManualResult(undefined);
+                      setSelectedRange(value);
+                    }}
+                  >
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {RANGE_OPTIONS.map((option) => (
+                        <SelectItem key={option.value} value={option.value}>
+                          {option.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-2">
+                  <Label>Save</Label>
+                  <div className="flex gap-2">
+                    <Input
+                      value={saveName}
+                      onChange={(event) => setSaveName(event.target.value)}
+                      placeholder="Report name"
+                    />
+                    <Button
+                      variant="outline"
+                      size="icon"
+                      onClick={handleSave}
+                      disabled={!saveName.trim() || createSavedReport.isPending}
+                      aria-label="Save report"
+                    >
+                      <Save className="h-4 w-4" />
+                    </Button>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-base">
+                  <Database className="h-5 w-5" />
+                  Result
+                  {result.isFetching && <Badge variant="outline">Loading</Badge>}
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                {result.error ? (
+                  <div className="border border-destructive/30 bg-destructive/10 p-4 text-sm text-destructive">
+                    {result.error.message}
+                  </div>
+                ) : activeRows.length === 0 ? (
+                  <div className="border p-8 text-center text-sm text-muted-foreground">
+                    No rows for this query.
+                  </div>
+                ) : (
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        {activeColumns.map((column) => (
+                          <TableHead key={column.name}>{column.name}</TableHead>
+                        ))}
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {activeRows.map((row, rowIndex) => (
+                        <TableRow key={rowIndex}>
+                          {activeColumns.map((column) => (
+                            <TableCell key={column.name}>{formatValue(row[column.name])}</TableCell>
+                          ))}
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                )}
+              </CardContent>
+            </Card>
+          </div>
+
+          <aside className="space-y-4">
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">Saved Reports</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-2">
+                {(savedReports.data ?? []).length === 0 ? (
+                  <p className="text-sm text-muted-foreground">No saved reports.</p>
+                ) : (
+                  savedReports.data?.map((report) => (
+                    <div key={report.id} className="flex items-center justify-between border p-2">
+                      <button
+                        type="button"
+                        className="min-w-0 text-left"
+                        onClick={() => handleRunSaved(report)}
+                      >
+                        <p className="truncate text-sm font-medium">{report.name}</p>
+                        <p className="text-xs text-muted-foreground">
+                          {formatDatasetName(report.query.dataset)}
+                        </p>
+                      </button>
+                      <div className="flex shrink-0 items-center gap-1">
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => handleRunSaved(report)}
+                          aria-label="Run saved report"
+                        >
+                          <Play className="h-4 w-4" />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={async () =>
+                            saveExport(
+                              await exportSaved.mutateAsync({ reportId: report.id, format: "csv" }),
+                            )
+                          }
+                          aria-label="Export saved report"
+                        >
+                          <Download className="h-4 w-4" />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => deleteSavedReport.mutate(report.id)}
+                          aria-label="Delete saved report"
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      </div>
+                    </div>
+                  ))
+                )}
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">Projection Lag</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="space-y-2">
+                  {(diagnostics.data?.projector_lag ?? []).map((lag) => (
+                    <div
+                      key={lag.dataset}
+                      className="flex items-center justify-between border-b py-1.5 last:border-b-0"
+                    >
+                      <span className="text-sm">{formatDatasetName(lag.dataset)}</span>
+                      <Badge variant={lag.freshness_lag_ms === null ? "outline" : "secondary"}>
+                        {freshnessLabel(lag.freshness_lag_ms)}
+                      </Badge>
+                    </div>
+                  ))}
+                </div>
+              </CardContent>
+            </Card>
+
+            {diagnostics.data?.outbox.failed_rows.length ? (
+              <Card>
+                <CardHeader>
+                  <CardTitle className="text-base">Failed Rows</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-2">
+                  {diagnostics.data.outbox.failed_rows.slice(0, 5).map((row) => (
+                    <div key={row.id} className="border p-2 text-xs">
+                      <div className="font-medium">{row.source_type}</div>
+                      <div className="truncate text-muted-foreground">{row.source_id}</div>
+                      {row.last_error && (
+                        <div className="mt-1 text-destructive">{row.last_error}</div>
+                      )}
+                    </div>
+                  ))}
+                </CardContent>
+              </Card>
+            ) : null}
+          </aside>
+        </section>
+      </PageBody>
+    </PageShell>
+  );
+}

--- a/apps/ui/src/components/layout/sidebar.tsx
+++ b/apps/ui/src/components/layout/sidebar.tsx
@@ -23,6 +23,7 @@ import {
   BookOpen,
   Brain,
   Calendar,
+  ChartColumn,
   ClipboardCheck,
   FlaskConical,
   HardDrive,
@@ -86,6 +87,7 @@ export interface SidebarConfig {
 export const defaultTopNavigation: NavigationItem[] = [
   { name: "Chat", href: "/chat", icon: MessageCircle, flag: "global_chat", experimental: true },
   { name: "Dashboard", href: "/dashboard", icon: LayoutDashboard },
+  { name: "Reports", href: "/reports", icon: ChartColumn },
   { name: "Sessions", href: "/sessions", icon: MessageSquare },
 ];
 

--- a/apps/ui/src/hooks/index.ts
+++ b/apps/ui/src/hooks/index.ts
@@ -26,3 +26,4 @@ export * from "./use-name-availability";
 export * from "./use-page-title";
 export * from "./use-volumes";
 export * from "./use-memory-stores";
+export * from "./use-reporting";

--- a/apps/ui/src/hooks/use-reporting.ts
+++ b/apps/ui/src/hooks/use-reporting.ts
@@ -1,0 +1,133 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { queryKeys } from "@/lib/query-keys";
+import { useOrg } from "@/providers/org-provider";
+import {
+  backfillReporting,
+  createSavedReport,
+  deleteSavedReport,
+  exportReportQuery,
+  exportSavedReport,
+  getReportCatalog,
+  getReportingDiagnostics,
+  listSavedReports,
+  runReportQuery,
+  runReportingProjector,
+  runSavedReport,
+} from "@/lib/api/reporting";
+import type { CreateSavedReportRequest, ReportExportFormat, ReportQuery } from "@/lib/api/types";
+
+export function useReportCatalog() {
+  const { currentOrg } = useOrg();
+  const org = currentOrg?.public_id;
+
+  return useQuery({
+    queryKey: queryKeys.reporting.catalog(org),
+    queryFn: getReportCatalog,
+    enabled: !!org,
+  });
+}
+
+export function useReportQuery(query: ReportQuery | undefined) {
+  const { currentOrg } = useOrg();
+  const org = currentOrg?.public_id;
+
+  return useQuery({
+    queryKey: queryKeys.reporting.query(org, query as unknown as Record<string, unknown>),
+    queryFn: () => runReportQuery(query!),
+    enabled: !!org && !!query,
+  });
+}
+
+export function useSavedReports() {
+  const { currentOrg } = useOrg();
+  const org = currentOrg?.public_id;
+
+  return useQuery({
+    queryKey: queryKeys.reporting.saved(org),
+    queryFn: listSavedReports,
+    enabled: !!org,
+  });
+}
+
+export function useCreateSavedReport() {
+  const queryClient = useQueryClient();
+  const { currentOrg } = useOrg();
+  const org = currentOrg?.public_id;
+
+  return useMutation({
+    mutationFn: (request: CreateSavedReportRequest) => createSavedReport(request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.reporting.saved(org) });
+    },
+  });
+}
+
+export function useDeleteSavedReport() {
+  const queryClient = useQueryClient();
+  const { currentOrg } = useOrg();
+  const org = currentOrg?.public_id;
+
+  return useMutation({
+    mutationFn: (reportId: string) => deleteSavedReport(reportId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.reporting.saved(org) });
+    },
+  });
+}
+
+export function useRunSavedReport() {
+  return useMutation({
+    mutationFn: (reportId: string) => runSavedReport(reportId),
+  });
+}
+
+export function useExportReportQuery() {
+  return useMutation({
+    mutationFn: ({ query, format }: { query: ReportQuery; format: ReportExportFormat }) =>
+      exportReportQuery(query, format),
+  });
+}
+
+export function useExportSavedReport() {
+  return useMutation({
+    mutationFn: ({ reportId, format }: { reportId: string; format: ReportExportFormat }) =>
+      exportSavedReport(reportId, format),
+  });
+}
+
+export function useReportingDiagnostics() {
+  const { currentOrg } = useOrg();
+  const org = currentOrg?.public_id;
+
+  return useQuery({
+    queryKey: queryKeys.reporting.diagnostics(org),
+    queryFn: getReportingDiagnostics,
+    enabled: !!org,
+    refetchInterval: 30_000,
+    retry: false,
+  });
+}
+
+export function useRunReportingProjector() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: () => runReportingProjector(),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.reporting.all });
+    },
+  });
+}
+
+export function useBackfillReporting() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: () => backfillReporting(),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.reporting.all });
+    },
+  });
+}

--- a/apps/ui/src/hooks/use-reporting.ts
+++ b/apps/ui/src/hooks/use-reporting.ts
@@ -97,14 +97,14 @@ export function useExportSavedReport() {
   });
 }
 
-export function useReportingDiagnostics() {
+export function useReportingDiagnostics(enabled = true) {
   const { currentOrg } = useOrg();
   const org = currentOrg?.public_id;
 
   return useQuery({
     queryKey: queryKeys.reporting.diagnostics(org),
     queryFn: getReportingDiagnostics,
-    enabled: !!org,
+    enabled: enabled && !!org,
     refetchInterval: 30_000,
     retry: false,
   });

--- a/apps/ui/src/lib/api/index.ts
+++ b/apps/ui/src/lib/api/index.ts
@@ -14,3 +14,4 @@ export * from "./durable";
 export * from "./agent-identities";
 export * from "./volumes";
 export * from "./memory-stores";
+export * from "./reporting";

--- a/apps/ui/src/lib/api/reporting.ts
+++ b/apps/ui/src/lib/api/reporting.ts
@@ -1,0 +1,81 @@
+import { api } from "./client";
+import type {
+  CreateSavedReportRequest,
+  DatasetCatalog,
+  ProjectorRunResult,
+  ReportExport,
+  ReportExportFormat,
+  ReportQuery,
+  ReportResult,
+  ReportingBackfillResult,
+  ReportingDiagnostics,
+  SavedReport,
+} from "./types";
+
+interface ListResponse<T> {
+  data: T[];
+}
+
+export async function getReportCatalog(): Promise<DatasetCatalog> {
+  const response = await api.get<DatasetCatalog>("/v1/reports/catalog");
+  return response.data;
+}
+
+export async function runReportQuery(query: ReportQuery): Promise<ReportResult> {
+  const response = await api.post<ReportResult>("/v1/reports/query", query);
+  return response.data;
+}
+
+export async function exportReportQuery(
+  query: ReportQuery,
+  format: ReportExportFormat,
+): Promise<ReportExport> {
+  const response = await api.post<ReportExport>("/v1/reports/query/export", { query, format });
+  return response.data;
+}
+
+export async function listSavedReports(): Promise<SavedReport[]> {
+  const response = await api.get<ListResponse<SavedReport>>("/v1/reports/saved");
+  return response.data.data;
+}
+
+export async function createSavedReport(request: CreateSavedReportRequest): Promise<SavedReport> {
+  const response = await api.post<SavedReport>("/v1/reports/saved", request);
+  return response.data;
+}
+
+export async function deleteSavedReport(reportId: string): Promise<void> {
+  await api.delete(`/v1/reports/saved/${reportId}`);
+}
+
+export async function runSavedReport(reportId: string): Promise<ReportResult> {
+  const response = await api.post<ReportResult>(`/v1/reports/saved/${reportId}/run`, {});
+  return response.data;
+}
+
+export async function exportSavedReport(
+  reportId: string,
+  format: ReportExportFormat,
+): Promise<ReportExport> {
+  const response = await api.post<ReportExport>(`/v1/reports/saved/${reportId}/export`, {
+    format,
+  });
+  return response.data;
+}
+
+export async function getReportingDiagnostics(): Promise<ReportingDiagnostics> {
+  const response = await api.get<ReportingDiagnostics>("/v1/reports/admin/diagnostics");
+  return response.data;
+}
+
+export async function runReportingProjector(limit = 500): Promise<ProjectorRunResult> {
+  const response = await api.post<ProjectorRunResult>(`/v1/reports/projector/run?limit=${limit}`);
+  return response.data;
+}
+
+export async function backfillReporting(limit = 1000): Promise<ReportingBackfillResult> {
+  const response = await api.post<ReportingBackfillResult>("/v1/reports/admin/backfill", {
+    limit,
+  });
+  return response.data;
+}

--- a/apps/ui/src/lib/api/types/index.ts
+++ b/apps/ui/src/lib/api/types/index.ts
@@ -22,3 +22,4 @@ export * from "./budget-types";
 export * from "./payment-types";
 export * from "./volume-types";
 export * from "./memory-store-types";
+export * from "./reporting-types";

--- a/apps/ui/src/lib/api/types/reporting-types.ts
+++ b/apps/ui/src/lib/api/types/reporting-types.ts
@@ -1,0 +1,132 @@
+export type ReportColumnKind = "dimension" | "measure";
+export type ReportFilterOp = "eq" | "neq" | "in" | "gt" | "gte" | "lt" | "lte";
+export type ReportOrderDirection = "asc" | "desc";
+export type ReportExportFormat = "csv" | "json";
+
+export interface ReportTimeRange {
+  from: string;
+  to: string;
+}
+
+export interface ReportFilter {
+  field: string;
+  op: ReportFilterOp;
+  value: unknown;
+}
+
+export interface ReportOrderBy {
+  dimension?: string;
+  measure?: string;
+  direction?: ReportOrderDirection;
+}
+
+export interface ReportQuery {
+  dataset: string;
+  time_range: ReportTimeRange;
+  dimensions: string[];
+  measures: string[];
+  filters?: ReportFilter[];
+  order_by?: ReportOrderBy[];
+  limit?: number;
+}
+
+export interface ReportColumn {
+  name: string;
+  kind: ReportColumnKind;
+}
+
+export interface ReportResult {
+  as_of: string;
+  freshness_lag_ms?: number | null;
+  columns: ReportColumn[];
+  rows: Record<string, unknown>[];
+}
+
+export interface DatasetCatalogEntry {
+  name: string;
+  dimensions: string[];
+  measures: string[];
+  filter_fields: string[];
+}
+
+export interface DatasetCatalog {
+  datasets: DatasetCatalogEntry[];
+}
+
+export interface SavedReportDashboardMetadata {
+  title?: string;
+  section?: string;
+  chart_type?: string;
+  position?: number;
+}
+
+export interface SavedReport {
+  id: string;
+  name: string;
+  description?: string;
+  query: ReportQuery;
+  dashboard?: SavedReportDashboardMetadata;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CreateSavedReportRequest {
+  name: string;
+  description?: string;
+  query: ReportQuery;
+  dashboard?: SavedReportDashboardMetadata;
+}
+
+export interface ReportExport {
+  format: ReportExportFormat;
+  filename: string;
+  content_type: string;
+  content: string;
+  as_of: string;
+  freshness_lag_ms?: number | null;
+}
+
+export interface DatasetProjectorLag {
+  dataset: string;
+  latest_projected_at?: string | null;
+  freshness_lag_ms?: number | null;
+}
+
+export interface FailedReportingOutboxRow {
+  id: string;
+  org_id: number;
+  source_type: string;
+  source_id: string;
+  attempts: number;
+  last_error?: string | null;
+  updated_at: string;
+}
+
+export interface ReportingOutboxDiagnostics {
+  pending: number;
+  processing: number;
+  failed: number;
+  completed: number;
+  oldest_pending_at?: string | null;
+  failed_rows: FailedReportingOutboxRow[];
+}
+
+export interface ReportingDiagnostics {
+  generated_at: string;
+  projector_lag: DatasetProjectorLag[];
+  outbox: ReportingOutboxDiagnostics;
+}
+
+export interface ProjectorRunResult {
+  claimed: number;
+  completed: number;
+  failed: number;
+}
+
+export interface ReportingBackfillResult {
+  enqueued: number;
+  events: number;
+  sessions: number;
+  llm_generations: number;
+  usage_ledger: number;
+}

--- a/apps/ui/src/lib/api/types/reporting-types.ts
+++ b/apps/ui/src/lib/api/types/reporting-types.ts
@@ -1,5 +1,5 @@
 export type ReportColumnKind = "dimension" | "measure";
-export type ReportFilterOp = "eq" | "neq" | "in" | "gt" | "gte" | "lt" | "lte";
+export type ReportFilterOp = "eq" | "neq" | "in";
 export type ReportOrderDirection = "asc" | "desc";
 export type ReportExportFormat = "csv" | "json";
 

--- a/apps/ui/src/lib/query-keys.ts
+++ b/apps/ui/src/lib/query-keys.ts
@@ -66,6 +66,15 @@ export const queryKeys = {
     list: () => ["notifications"] as const,
   },
 
+  reporting: {
+    all: ["reporting"] as const,
+    catalog: (org?: string) => ["reporting", org, "catalog"] as const,
+    query: (org?: string, query?: Record<string, unknown>) =>
+      ["reporting", org, "query", query] as const,
+    saved: (org?: string) => ["reporting", org, "saved"] as const,
+    diagnostics: (org?: string) => ["reporting", org, "diagnostics"] as const,
+  },
+
   // LLM Provider queries
   llmProviders: {
     all: ["llm-providers"] as const,

--- a/crates/server/src/api/reporting.rs
+++ b/crates/server/src/api/reporting.rs
@@ -18,12 +18,13 @@ use crate::auth::{AuthState, ResolvedOrg};
 use crate::domains::common::{Command, Ctx};
 use crate::domains::reporting::types::{
     CreateSavedReportRequest, ExportReportQueryRequest, ExportSavedReportRequest,
-    ProjectorRunResult, ReportExport, ReportingDiagnostics, SavedReport, UpdateSavedReportRequest,
+    ProjectorRunResult, ReportExport, ReportingBackfillRequest, ReportingBackfillResult,
+    ReportingDiagnostics, SavedReport, UpdateSavedReportRequest,
 };
 use crate::domains::reporting::{
-    CreateSavedReport, DeleteSavedReport, ExportReportQuery, ExportSavedReport, GetReportCatalog,
-    GetReportingDiagnostics, GetSavedReport, ListSavedReports, ReportingService, RunReportQuery,
-    RunReportingProjector, RunSavedReport, UpdateSavedReport,
+    BackfillReporting, CreateSavedReport, DeleteSavedReport, ExportReportQuery, ExportSavedReport,
+    GetReportCatalog, GetReportingDiagnostics, GetSavedReport, ListSavedReports, ReportingService,
+    RunReportQuery, RunReportingProjector, RunSavedReport, UpdateSavedReport,
 };
 use crate::storage::StorageBackend;
 
@@ -91,6 +92,7 @@ pub fn routes(state: AppState) -> Router {
             post(export_saved_report),
         )
         .route("/v1/reports/admin/diagnostics", get(get_diagnostics))
+        .route("/v1/reports/admin/backfill", post(backfill_reporting))
         .route("/v1/reports/projector/run", post(run_projector))
         .with_state(state)
 }
@@ -320,6 +322,26 @@ pub async fn get_diagnostics(
     State(state): State<AppState>,
 ) -> Result<Json<ReportingDiagnostics>, ApiError> {
     Ok(Json(GetReportingDiagnostics.run(&state.ctx(&org)).await?))
+}
+
+#[utoipa::path(
+    post,
+    path = "/v1/reports/admin/backfill",
+    request_body = ReportingBackfillRequest,
+    responses(
+        (status = 200, description = "Reporting backfill enqueue result", body = ReportingBackfillResult),
+        (status = 403, description = "Forbidden", body = ErrorResponse)
+    ),
+    tag = "reporting"
+)]
+pub async fn backfill_reporting(
+    org: ResolvedOrg,
+    State(state): State<AppState>,
+    Json(request): Json<ReportingBackfillRequest>,
+) -> Result<Json<ReportingBackfillResult>, ApiError> {
+    Ok(Json(
+        BackfillReporting(request).run(&state.ctx(&org)).await?,
+    ))
 }
 
 #[utoipa::path(

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -1741,6 +1741,9 @@ impl ServerAppBuilder {
             volume_connection_resolver,
         );
 
+        // -- Reporting projection and missing-work reconciliation (both prod and dev) --
+        crate::domains::reporting::background::spawn_reporting_background_task(db.clone());
+
         // -- Custom background tasks --
         for task_fn in self.background_tasks {
             let ctx = server_context.clone();

--- a/crates/server/src/domains/reporting/background.rs
+++ b/crates/server/src/domains/reporting/background.rs
@@ -1,0 +1,144 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::domains::reporting::ReportingService;
+use crate::storage::StorageBackend;
+
+const DEFAULT_PROJECTOR_INTERVAL_SECS: u64 = 5;
+const DEFAULT_PROJECTOR_LIMIT: i64 = 500;
+const DEFAULT_BACKFILL_INTERVAL_SECS: u64 = 300;
+const DEFAULT_BACKFILL_LIMIT: i64 = 1_000;
+
+#[derive(Debug, Clone)]
+struct ReportingBackgroundConfig {
+    projector_interval: Duration,
+    projector_limit: i64,
+    backfill_interval: Duration,
+    backfill_limit: i64,
+}
+
+impl ReportingBackgroundConfig {
+    fn from_env() -> Self {
+        Self {
+            projector_interval: Duration::from_secs(env_u64(
+                "REPORTING_PROJECTOR_INTERVAL_SECS",
+                DEFAULT_PROJECTOR_INTERVAL_SECS,
+            )),
+            projector_limit: env_i64("REPORTING_PROJECTOR_LIMIT", DEFAULT_PROJECTOR_LIMIT),
+            backfill_interval: Duration::from_secs(env_u64(
+                "REPORTING_BACKFILL_INTERVAL_SECS",
+                DEFAULT_BACKFILL_INTERVAL_SECS,
+            )),
+            backfill_limit: env_i64("REPORTING_BACKFILL_LIMIT", DEFAULT_BACKFILL_LIMIT),
+        }
+    }
+}
+
+pub fn spawn_reporting_background_task(db: Arc<StorageBackend>) {
+    if !env_bool("REPORTING_BACKGROUND_ENABLED", true) {
+        tracing::info!("Reporting background task disabled");
+        return;
+    }
+
+    if !matches!(db.as_ref(), StorageBackend::Postgres(_)) {
+        tracing::debug!("Reporting background task disabled for non-Postgres storage");
+        return;
+    }
+
+    let config = ReportingBackgroundConfig::from_env();
+    if config.projector_interval.is_zero() && config.backfill_interval.is_zero() {
+        tracing::info!("Reporting background task disabled by zero intervals");
+        return;
+    }
+
+    if !config.projector_interval.is_zero() {
+        let service = ReportingService::new(db.clone());
+        let interval_secs = config.projector_interval.as_secs();
+        let limit = config.projector_limit;
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(Duration::from_secs(interval_secs));
+            tracing::info!(
+                interval_secs,
+                limit,
+                "Started reporting projector background task"
+            );
+
+            loop {
+                interval.tick().await;
+                match service.run_projector_due(limit).await {
+                    Ok(result) if result.claimed > 0 => {
+                        tracing::info!(
+                            claimed = result.claimed,
+                            completed = result.completed,
+                            failed = result.failed,
+                            "Reporting projector run completed"
+                        );
+                    }
+                    Ok(_) => {}
+                    Err(error) => {
+                        tracing::error!(%error, "Reporting projector run failed");
+                    }
+                }
+            }
+        });
+    }
+
+    if !config.backfill_interval.is_zero() {
+        let service = ReportingService::new(db);
+        let interval_secs = config.backfill_interval.as_secs();
+        let limit = config.backfill_limit;
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(Duration::from_secs(interval_secs));
+            tracing::info!(
+                interval_secs,
+                limit,
+                "Started reporting backfill background task"
+            );
+
+            loop {
+                interval.tick().await;
+                match service.backfill_missing(None, limit).await {
+                    Ok(result) if result.enqueued > 0 => {
+                        tracing::info!(
+                            enqueued = result.enqueued,
+                            events = result.events,
+                            sessions = result.sessions,
+                            llm_generations = result.llm_generations,
+                            usage_ledger = result.usage_ledger,
+                            "Reporting backfill enqueued missing projection work"
+                        );
+                    }
+                    Ok(_) => {}
+                    Err(error) => {
+                        tracing::error!(%error, "Reporting backfill failed");
+                    }
+                }
+            }
+        });
+    }
+}
+
+fn env_bool(name: &str, default: bool) -> bool {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| match value.to_ascii_lowercase().as_str() {
+            "1" | "true" | "yes" | "on" => Some(true),
+            "0" | "false" | "no" | "off" => Some(false),
+            _ => None,
+        })
+        .unwrap_or(default)
+}
+
+fn env_u64(name: &str, default: u64) -> u64 {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(default)
+}
+
+fn env_i64(name: &str, default: i64) -> i64 {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(default)
+}

--- a/crates/server/src/domains/reporting/commands.rs
+++ b/crates/server/src/domains/reporting/commands.rs
@@ -7,7 +7,8 @@ use uuid::Uuid;
 use super::catalog;
 use super::types::{
     CreateSavedReportRequest, ExportReportQueryRequest, ExportSavedReportRequest,
-    ProjectorRunResult, ReportExport, ReportingDiagnostics, SavedReport, UpdateSavedReportRequest,
+    ProjectorRunResult, ReportExport, ReportingBackfillRequest, ReportingBackfillResult,
+    ReportingDiagnostics, SavedReport, UpdateSavedReportRequest,
 };
 use super::{REPORT_ADMIN, REPORT_MANAGE, REPORT_VIEW};
 use crate::domains::common::{Command, CommandDescriptor, CommandError, CommandMeta, Ctx};
@@ -426,3 +427,35 @@ impl Command for RunReportingProjector {
 }
 
 inventory::submit! { CommandDescriptor::of::<RunReportingProjector>() }
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct BackfillReporting(pub ReportingBackfillRequest);
+
+impl Command for BackfillReporting {
+    type Output = ReportingBackfillResult;
+
+    fn meta() -> CommandMeta {
+        CommandMeta {
+            name: "backfill_reporting",
+            category: "reporting",
+            description: "Enqueue missing reporting projection work from canonical sources.",
+            method: "POST",
+            path: "/v1/reports/admin/backfill",
+        }
+    }
+
+    fn policy() -> Option<&'static Policy> {
+        Some(&REPORT_ADMIN)
+    }
+
+    async fn execute(self, ctx: &Ctx) -> Result<ReportingBackfillResult, CommandError> {
+        let service = ctx.reporting_service.as_ref().ok_or_else(|| {
+            CommandError::Internal(anyhow::anyhow!("Reporting service not configured"))
+        })?;
+        service
+            .backfill_missing(Some(ctx.org_id()), self.0.limit)
+            .await
+    }
+}
+
+inventory::submit! { CommandDescriptor::of::<BackfillReporting>() }

--- a/crates/server/src/domains/reporting/mod.rs
+++ b/crates/server/src/domains/reporting/mod.rs
@@ -5,6 +5,7 @@
 
 use everruns_core::{Permission, Policy, Rule};
 
+pub mod background;
 pub mod catalog;
 pub mod commands;
 pub mod service;

--- a/crates/server/src/domains/reporting/service.rs
+++ b/crates/server/src/domains/reporting/service.rs
@@ -11,8 +11,9 @@ use uuid::Uuid;
 use super::catalog;
 use super::types::{
     CreateSavedReportRequest, DatasetProjectorLag, FailedReportingOutboxRow, ProjectorRunResult,
-    ReportExport, ReportExportFormat, ReportingDiagnostics, ReportingOutboxDiagnostics,
-    SavedReport, SavedReportDashboardMetadata, UpdateSavedReportRequest,
+    ReportExport, ReportExportFormat, ReportingBackfillResult, ReportingDiagnostics,
+    ReportingOutboxDiagnostics, SavedReport, SavedReportDashboardMetadata,
+    UpdateSavedReportRequest,
 };
 use crate::domains::common::{CommandError, classify_anyhow};
 use crate::storage::StorageBackend;
@@ -379,6 +380,40 @@ impl ReportingService {
                 claimed: 0,
                 completed: 0,
                 failed: 0,
+            }),
+        }
+    }
+
+    pub async fn run_projector_due(&self, limit: i64) -> Result<ProjectorRunResult, CommandError> {
+        match self.db.as_ref() {
+            StorageBackend::Postgres(db) => PostgresReportingProjector::new(db.pool().clone())
+                .run_due(limit)
+                .await
+                .map_err(classify_anyhow),
+            StorageBackend::InMemory(_) => Ok(ProjectorRunResult {
+                claimed: 0,
+                completed: 0,
+                failed: 0,
+            }),
+        }
+    }
+
+    pub async fn backfill_missing(
+        &self,
+        org_id: Option<i64>,
+        limit: i64,
+    ) -> Result<ReportingBackfillResult, CommandError> {
+        match self.db.as_ref() {
+            StorageBackend::Postgres(db) => PostgresReportingProjector::new(db.pool().clone())
+                .backfill_missing(org_id, limit)
+                .await
+                .map_err(classify_anyhow),
+            StorageBackend::InMemory(_) => Ok(ReportingBackfillResult {
+                enqueued: 0,
+                events: 0,
+                sessions: 0,
+                llm_generations: 0,
+                usage_ledger: 0,
             }),
         }
     }

--- a/crates/server/src/domains/reporting/types.rs
+++ b/crates/server/src/domains/reporting/types.rs
@@ -140,3 +140,22 @@ pub struct ProjectorRunResult {
     pub completed: usize,
     pub failed: usize,
 }
+
+#[derive(Debug, Clone, Deserialize, ToSchema)]
+pub struct ReportingBackfillRequest {
+    #[serde(default = "default_backfill_limit")]
+    pub limit: i64,
+}
+
+fn default_backfill_limit() -> i64 {
+    1_000
+}
+
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct ReportingBackfillResult {
+    pub enqueued: i64,
+    pub events: i64,
+    pub sessions: i64,
+    pub llm_generations: i64,
+    pub usage_ledger: i64,
+}

--- a/crates/server/src/domains/reporting/types.rs
+++ b/crates/server/src/domains/reporting/types.rs
@@ -151,7 +151,7 @@ fn default_backfill_limit() -> i64 {
     1_000
 }
 
-#[derive(Debug, Clone, Serialize, ToSchema)]
+#[derive(Debug, Clone, Default, Serialize, ToSchema)]
 pub struct ReportingBackfillResult {
     pub enqueued: i64,
     pub events: i64,

--- a/crates/server/src/openapi.rs
+++ b/crates/server/src/openapi.rs
@@ -234,6 +234,7 @@ use utoipa::OpenApi;
         api::reporting::run_saved_report,
         api::reporting::export_saved_report,
         api::reporting::get_diagnostics,
+        api::reporting::backfill_reporting,
         api::reporting::run_projector,
     ),
     components(
@@ -399,6 +400,8 @@ use utoipa::OpenApi;
             domains::reporting::types::FailedReportingOutboxRow,
             domains::reporting::types::ReportExport,
             domains::reporting::types::ReportExportFormat,
+            domains::reporting::types::ReportingBackfillRequest,
+            domains::reporting::types::ReportingBackfillResult,
             domains::reporting::types::ReportingDiagnostics,
             domains::reporting::types::ReportingOutboxDiagnostics,
             domains::reporting::types::SavedReport,

--- a/crates/server/src/storage/reporting/outbox.rs
+++ b/crates/server/src/storage/reporting/outbox.rs
@@ -1,11 +1,12 @@
 use anyhow::{Context, Result};
-use sqlx::PgPool;
+use sqlx::{PgPool, Postgres, pool::PoolConnection};
 use uuid::Uuid;
 
 use super::models::ReportingOutboxRow;
 use crate::domains::reporting::types::{ProjectorRunResult, ReportingBackfillResult};
 
 const STALE_PROCESSING_MINUTES: i32 = 15;
+const GLOBAL_BACKFILL_LOCK_KEY: i64 = 0x6576_6572_7270_7471;
 
 #[derive(Clone)]
 pub struct PostgresReportingProjector {
@@ -136,22 +137,51 @@ impl PostgresReportingProjector {
         org_id: Option<i64>,
         limit: i64,
     ) -> Result<ReportingBackfillResult> {
-        let limit = limit.clamp(1, 10_000);
-        let events = self.backfill_events(org_id, limit).await?;
-        let remaining = limit.saturating_sub(events);
-        let sessions = self.backfill_sessions(org_id, remaining).await?;
-        let remaining = remaining.saturating_sub(sessions);
-        let llm_generations = self.backfill_llm_generations(org_id, remaining).await?;
-        let remaining = remaining.saturating_sub(llm_generations);
-        let usage_ledger = self.backfill_usage_ledger(org_id, remaining).await?;
+        let mut global_lock = match org_id {
+            Some(_) => None,
+            None => match self.try_acquire_global_backfill_lock().await? {
+                Some(lock) => Some(lock),
+                None => return Ok(ReportingBackfillResult::default()),
+            },
+        };
 
-        Ok(ReportingBackfillResult {
-            enqueued: events + sessions + llm_generations + usage_ledger,
-            events,
-            sessions,
-            llm_generations,
-            usage_ledger,
-        })
+        let limit = limit.clamp(1, 10_000);
+        let result = async {
+            let events = self.backfill_events(org_id, limit).await?;
+            let remaining = limit.saturating_sub(events);
+            let sessions = self.backfill_sessions(org_id, remaining).await?;
+            let remaining = remaining.saturating_sub(sessions);
+            let llm_generations = self.backfill_llm_generations(org_id, remaining).await?;
+            let remaining = remaining.saturating_sub(llm_generations);
+            let usage_ledger = self.backfill_usage_ledger(org_id, remaining).await?;
+
+            Ok(ReportingBackfillResult {
+                enqueued: events + sessions + llm_generations + usage_ledger,
+                events,
+                sessions,
+                llm_generations,
+                usage_ledger,
+            })
+        }
+        .await;
+
+        if let Some(mut lock) = global_lock.take() {
+            sqlx::query("SELECT pg_advisory_unlock($1)")
+                .bind(GLOBAL_BACKFILL_LOCK_KEY)
+                .execute(&mut *lock)
+                .await?;
+        }
+
+        result
+    }
+
+    async fn try_acquire_global_backfill_lock(&self) -> Result<Option<PoolConnection<Postgres>>> {
+        let mut connection = self.pool.acquire().await?;
+        let acquired = sqlx::query_scalar::<_, bool>("SELECT pg_try_advisory_lock($1)")
+            .bind(GLOBAL_BACKFILL_LOCK_KEY)
+            .fetch_one(&mut *connection)
+            .await?;
+        Ok(acquired.then_some(connection))
     }
 
     async fn backfill_events(&self, org_id: Option<i64>, limit: i64) -> Result<i64> {
@@ -258,7 +288,31 @@ impl PostgresReportingProjector {
             INSERT INTO reporting_outbox (
                 org_id, source_type, source_id, source_version, reason, status, next_attempt_at
             )
-            SELECT org_id, 'session', id::TEXT, updated_at::TEXT, 'session_snapshot', 'pending', NOW()
+            SELECT org_id,
+                   'session',
+                   id::TEXT,
+                   COALESCE(
+                       (
+                           SELECT existing.source_version
+                             FROM reporting_outbox existing
+                            WHERE existing.org_id = candidates.org_id
+                              AND existing.source_type = 'session'
+                              AND existing.source_id = candidates.id::TEXT
+                              AND existing.reason = 'session_snapshot'
+                            ORDER BY existing.created_at DESC
+                            LIMIT 1
+                       ),
+                       CASE
+                           WHEN MOD(EXTRACT(MICROSECONDS FROM updated_at)::BIGINT, 1000000) = 0
+                               THEN TO_CHAR(updated_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"')
+                           WHEN MOD(EXTRACT(MICROSECONDS FROM updated_at)::BIGINT, 1000) = 0
+                               THEN TO_CHAR(updated_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+                           ELSE TO_CHAR(updated_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"')
+                       END
+                   ),
+                   'session_snapshot',
+                   'pending',
+                   NOW()
               FROM candidates
             ON CONFLICT (org_id, source_type, source_id, source_version, reason)
             DO UPDATE SET

--- a/crates/server/src/storage/reporting/outbox.rs
+++ b/crates/server/src/storage/reporting/outbox.rs
@@ -3,7 +3,9 @@ use sqlx::PgPool;
 use uuid::Uuid;
 
 use super::models::ReportingOutboxRow;
-use crate::domains::reporting::types::ProjectorRunResult;
+use crate::domains::reporting::types::{ProjectorRunResult, ReportingBackfillResult};
+
+const STALE_PROCESSING_MINUTES: i32 = 15;
 
 #[derive(Clone)]
 pub struct PostgresReportingProjector {
@@ -16,7 +18,18 @@ impl PostgresReportingProjector {
     }
 
     pub async fn run_once(&self, org_id: i64, limit: i64) -> Result<ProjectorRunResult> {
+        self.release_stale_claims(Some(org_id)).await?;
         let rows = self.claim_pending(org_id, limit).await?;
+        self.project_rows(rows).await
+    }
+
+    pub async fn run_due(&self, limit: i64) -> Result<ProjectorRunResult> {
+        self.release_stale_claims(None).await?;
+        let rows = self.claim_pending_any_org(limit).await?;
+        self.project_rows(rows).await
+    }
+
+    async fn project_rows(&self, rows: Vec<ReportingOutboxRow>) -> Result<ProjectorRunResult> {
         let claimed = rows.len();
         let mut completed = 0;
         let mut failed = 0;
@@ -40,6 +53,26 @@ impl PostgresReportingProjector {
             completed,
             failed,
         })
+    }
+
+    async fn release_stale_claims(&self, org_id: Option<i64>) -> Result<()> {
+        let mut query = sqlx::QueryBuilder::new(
+            r#"
+            UPDATE reporting_outbox
+               SET status = 'pending',
+                   claimed_at = NULL,
+                   updated_at = NOW()
+             WHERE status = 'processing'
+               AND claimed_at <= NOW() - ("#,
+        );
+        query.push_bind(STALE_PROCESSING_MINUTES.to_string());
+        query.push("::TEXT || ' minutes')::INTERVAL");
+        if let Some(org_id) = org_id {
+            query.push(" AND org_id = ");
+            query.push_bind(org_id);
+        }
+        query.build().execute(&self.pool).await?;
+        Ok(())
     }
 
     async fn claim_pending(&self, org_id: i64, limit: i64) -> Result<Vec<ReportingOutboxRow>> {
@@ -69,6 +102,269 @@ impl PostgresReportingProjector {
         .fetch_all(&self.pool)
         .await?;
         Ok(rows)
+    }
+
+    async fn claim_pending_any_org(&self, limit: i64) -> Result<Vec<ReportingOutboxRow>> {
+        let rows = sqlx::query_as::<_, ReportingOutboxRow>(
+            r#"
+            UPDATE reporting_outbox
+               SET status = 'processing',
+                   attempts = attempts + 1,
+                   claimed_at = NOW(),
+                   updated_at = NOW()
+             WHERE id IN (
+                SELECT id
+                  FROM reporting_outbox
+                 WHERE status IN ('pending', 'failed')
+                   AND next_attempt_at <= NOW()
+                 ORDER BY created_at ASC
+                 LIMIT $1
+                 FOR UPDATE SKIP LOCKED
+             )
+         RETURNING id, org_id, source_type, source_id, source_version, reason, status,
+                   attempts, next_attempt_at, last_error, created_at, updated_at
+            "#,
+        )
+        .bind(limit.clamp(1, 5_000))
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows)
+    }
+
+    pub async fn backfill_missing(
+        &self,
+        org_id: Option<i64>,
+        limit: i64,
+    ) -> Result<ReportingBackfillResult> {
+        let limit = limit.clamp(1, 10_000);
+        let events = self.backfill_events(org_id, limit).await?;
+        let remaining = limit.saturating_sub(events);
+        let sessions = self.backfill_sessions(org_id, remaining).await?;
+        let remaining = remaining.saturating_sub(sessions);
+        let llm_generations = self.backfill_llm_generations(org_id, remaining).await?;
+        let remaining = remaining.saturating_sub(llm_generations);
+        let usage_ledger = self.backfill_usage_ledger(org_id, remaining).await?;
+
+        Ok(ReportingBackfillResult {
+            enqueued: events + sessions + llm_generations + usage_ledger,
+            events,
+            sessions,
+            llm_generations,
+            usage_ledger,
+        })
+    }
+
+    async fn backfill_events(&self, org_id: Option<i64>, limit: i64) -> Result<i64> {
+        if limit == 0 {
+            return Ok(0);
+        }
+        let mut builder = sqlx::QueryBuilder::new(
+            r#"
+            WITH candidates AS (
+                SELECT s.org_id, e.id
+                  FROM events e
+                  JOIN sessions s ON s.id = e.session_id
+                 WHERE e.event_type IN (
+                       'tool.completed',
+                       'capability.usage',
+                       'output.message.replaced',
+                       'turn.completed',
+                       'turn.failed',
+                       'turn.cancelled'
+                 )
+                   AND CASE
+                       WHEN e.event_type = 'tool.completed' THEN NOT EXISTS (
+                           SELECT 1 FROM fact_tool_call fact
+                            WHERE fact.org_id = s.org_id
+                              AND fact.source_key = 'event:' || e.id::TEXT
+                       )
+                       WHEN e.event_type = 'capability.usage' THEN NOT EXISTS (
+                           SELECT 1 FROM fact_capability_usage fact
+                            WHERE fact.org_id = s.org_id
+                              AND fact.source_key LIKE ('event:' || e.id::TEXT || ':capability_usage:%')
+                       )
+                       WHEN e.event_type = 'output.message.replaced' THEN NOT EXISTS (
+                           SELECT 1 FROM fact_capability_usage fact
+                            WHERE fact.org_id = s.org_id
+                              AND fact.source_key = 'event:' || e.id::TEXT || ':effect_ran'
+                       )
+                       ELSE NOT EXISTS (
+                           SELECT 1 FROM fact_turn fact
+                            WHERE fact.org_id = s.org_id
+                              AND fact.source_key = 'event:' || e.id::TEXT
+                       )
+                   END
+            "#,
+        );
+        if let Some(org_id) = org_id {
+            builder.push(" AND s.org_id = ");
+            builder.push_bind(org_id);
+        }
+        builder.push(
+            r#"
+              ORDER BY e.ts ASC
+                 LIMIT "#,
+        );
+        builder.push_bind(limit);
+        builder.push(
+            r#"
+            )
+            INSERT INTO reporting_outbox (
+                org_id, source_type, source_id, source_version, reason, status, next_attempt_at
+            )
+            SELECT org_id, 'event', id::TEXT, id::TEXT, 'event_projection', 'pending', NOW()
+              FROM candidates
+            ON CONFLICT (org_id, source_type, source_id, source_version, reason)
+            DO UPDATE SET
+                status = CASE
+                    WHEN reporting_outbox.status = 'completed' THEN 'pending'
+                    ELSE reporting_outbox.status
+                END,
+                next_attempt_at = NOW(),
+                updated_at = NOW()
+            WHERE reporting_outbox.status = 'completed'
+            "#,
+        );
+        let result = builder.build().execute(&self.pool).await?;
+        Ok(result.rows_affected() as i64)
+    }
+
+    async fn backfill_sessions(&self, org_id: Option<i64>, limit: i64) -> Result<i64> {
+        if limit == 0 {
+            return Ok(0);
+        }
+        let mut builder = sqlx::QueryBuilder::new(
+            r#"
+            WITH candidates AS (
+                SELECT s.org_id, s.id, s.updated_at
+                  FROM sessions s
+                 WHERE NOT EXISTS (
+                       SELECT 1
+                         FROM fact_session fact
+                        WHERE fact.org_id = s.org_id
+                          AND fact.source_key = 'session:' || s.id::TEXT
+                 )
+            "#,
+        );
+        if let Some(org_id) = org_id {
+            builder.push(" AND s.org_id = ");
+            builder.push_bind(org_id);
+        }
+        builder.push(" ORDER BY s.created_at ASC LIMIT ");
+        builder.push_bind(limit);
+        builder.push(
+            r#"
+            )
+            INSERT INTO reporting_outbox (
+                org_id, source_type, source_id, source_version, reason, status, next_attempt_at
+            )
+            SELECT org_id, 'session', id::TEXT, updated_at::TEXT, 'session_snapshot', 'pending', NOW()
+              FROM candidates
+            ON CONFLICT (org_id, source_type, source_id, source_version, reason)
+            DO UPDATE SET
+                status = CASE
+                    WHEN reporting_outbox.status = 'completed' THEN 'pending'
+                    ELSE reporting_outbox.status
+                END,
+                next_attempt_at = NOW(),
+                updated_at = NOW()
+            WHERE reporting_outbox.status = 'completed'
+            "#,
+        );
+        let result = builder.build().execute(&self.pool).await?;
+        Ok(result.rows_affected() as i64)
+    }
+
+    async fn backfill_llm_generations(&self, org_id: Option<i64>, limit: i64) -> Result<i64> {
+        if limit == 0 {
+            return Ok(0);
+        }
+        let mut builder = sqlx::QueryBuilder::new(
+            r#"
+            WITH candidates AS (
+                SELECT lg.org_id, lg.id
+                  FROM llm_generations lg
+                 WHERE NOT EXISTS (
+                       SELECT 1
+                         FROM fact_llm_generation fact
+                        WHERE fact.org_id = lg.org_id
+                          AND fact.source_key = 'llm_generation:' || lg.id::TEXT
+                 )
+            "#,
+        );
+        if let Some(org_id) = org_id {
+            builder.push(" AND lg.org_id = ");
+            builder.push_bind(org_id);
+        }
+        builder.push(" ORDER BY lg.created_at ASC LIMIT ");
+        builder.push_bind(limit);
+        builder.push(
+            r#"
+            )
+            INSERT INTO reporting_outbox (
+                org_id, source_type, source_id, source_version, reason, status, next_attempt_at
+            )
+            SELECT org_id, 'llm_generation', id::TEXT, id::TEXT, 'llm_generation_projection', 'pending', NOW()
+              FROM candidates
+            ON CONFLICT (org_id, source_type, source_id, source_version, reason)
+            DO UPDATE SET
+                status = CASE
+                    WHEN reporting_outbox.status = 'completed' THEN 'pending'
+                    ELSE reporting_outbox.status
+                END,
+                next_attempt_at = NOW(),
+                updated_at = NOW()
+            WHERE reporting_outbox.status = 'completed'
+            "#,
+        );
+        let result = builder.build().execute(&self.pool).await?;
+        Ok(result.rows_affected() as i64)
+    }
+
+    async fn backfill_usage_ledger(&self, org_id: Option<i64>, limit: i64) -> Result<i64> {
+        if limit == 0 {
+            return Ok(0);
+        }
+        let mut builder = sqlx::QueryBuilder::new(
+            r#"
+            WITH candidates AS (
+                SELECT ul.org_id, ul.id
+                  FROM usage_ledger ul
+                 WHERE NOT EXISTS (
+                       SELECT 1
+                         FROM fact_budget_posting fact
+                        WHERE fact.org_id = ul.org_id
+                          AND fact.source_key = 'usage_ledger:' || ul.id::TEXT
+                 )
+            "#,
+        );
+        if let Some(org_id) = org_id {
+            builder.push(" AND ul.org_id = ");
+            builder.push_bind(org_id);
+        }
+        builder.push(" ORDER BY ul.created_at ASC LIMIT ");
+        builder.push_bind(limit);
+        builder.push(
+            r#"
+            )
+            INSERT INTO reporting_outbox (
+                org_id, source_type, source_id, source_version, reason, status, next_attempt_at
+            )
+            SELECT org_id, 'usage_ledger', id::TEXT, id::TEXT, 'budget_posting_projection', 'pending', NOW()
+              FROM candidates
+            ON CONFLICT (org_id, source_type, source_id, source_version, reason)
+            DO UPDATE SET
+                status = CASE
+                    WHEN reporting_outbox.status = 'completed' THEN 'pending'
+                    ELSE reporting_outbox.status
+                END,
+                next_attempt_at = NOW(),
+                updated_at = NOW()
+            WHERE reporting_outbox.status = 'completed'
+            "#,
+        );
+        let result = builder.build().execute(&self.pool).await?;
+        Ok(result.rows_affected() as i64)
     }
 
     async fn mark_completed(&self, id: Uuid) -> Result<()> {

--- a/crates/server/tests/reporting_integration_test.rs
+++ b/crates/server/tests/reporting_integration_test.rs
@@ -6,6 +6,7 @@ use axum::http::StatusCode;
 use chrono::{Duration, Utc};
 use serde_json::{Value, json};
 use test_harness::TestServer;
+use uuid::Uuid;
 
 fn report_query() -> Value {
     let to = Utc::now();
@@ -159,4 +160,47 @@ async fn reporting_backfill_endpoint_is_admin_scoped() {
     assert_eq!(result["sessions"], 0);
     assert_eq!(result["llm_generations"], 0);
     assert_eq!(result["usage_ledger"], 0);
+}
+
+#[tokio::test]
+async fn reporting_backfill_enqueues_missing_postgres_session_fact() {
+    let server = TestServer::new().await;
+    let title = format!("reporting-backfill-{}", Uuid::now_v7());
+
+    let (session_id, updated_at): (Uuid, chrono::DateTime<Utc>) = sqlx::query_as(
+        r#"
+        INSERT INTO sessions (org_id, title, status)
+        VALUES (1, $1, 'started')
+        RETURNING id, updated_at
+        "#,
+    )
+    .bind(&title)
+    .fetch_one(&server.pool)
+    .await
+    .expect("insert test session");
+
+    let result: Value = server
+        .post("/v1/reports/admin/backfill", json!({ "limit": 100 }))
+        .await
+        .assert_status(StatusCode::OK)
+        .json();
+
+    assert!(result["sessions"].as_i64().unwrap() >= 1);
+
+    let row: (String,) = sqlx::query_as(
+        r#"
+        SELECT source_version
+          FROM reporting_outbox
+         WHERE org_id = 1
+           AND source_type = 'session'
+           AND source_id = $1
+           AND reason = 'session_snapshot'
+        "#,
+    )
+    .bind(session_id.to_string())
+    .fetch_one(&server.pool)
+    .await
+    .expect("backfill should enqueue session outbox row");
+
+    assert_eq!(row.0, updated_at.to_rfc3339());
 }

--- a/crates/server/tests/reporting_integration_test.rs
+++ b/crates/server/tests/reporting_integration_test.rs
@@ -143,3 +143,20 @@ async fn reporting_diagnostics_are_admin_scoped() {
     assert!(diagnostics["projector_lag"].as_array().unwrap().len() >= 5);
     assert_eq!(diagnostics["outbox"]["failed"], 0);
 }
+
+#[tokio::test]
+async fn reporting_backfill_endpoint_is_admin_scoped() {
+    let server = TestServer::in_memory().await;
+
+    let result: Value = server
+        .post("/v1/reports/admin/backfill", json!({ "limit": 100 }))
+        .await
+        .assert_status(StatusCode::OK)
+        .json();
+
+    assert_eq!(result["enqueued"], 0);
+    assert_eq!(result["events"], 0);
+    assert_eq!(result["sessions"], 0);
+    assert_eq!(result["llm_generations"], 0);
+    assert_eq!(result["usage_ledger"], 0);
+}

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -5628,6 +5628,46 @@
         }
       }
     },
+    "/v1/reports/admin/backfill": {
+      "post": {
+        "tags": [
+          "reporting"
+        ],
+        "operationId": "backfill_reporting",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReportingBackfillRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Reporting backfill enqueue result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReportingBackfillResult"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/reports/admin/diagnostics": {
       "get": {
         "tags": [
@@ -19796,6 +19836,47 @@
           "to": {
             "type": "string",
             "format": "date-time"
+          }
+        }
+      },
+      "ReportingBackfillRequest": {
+        "type": "object",
+        "properties": {
+          "limit": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      },
+      "ReportingBackfillResult": {
+        "type": "object",
+        "required": [
+          "enqueued",
+          "events",
+          "sessions",
+          "llm_generations",
+          "usage_ledger"
+        ],
+        "properties": {
+          "enqueued": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "events": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "llm_generations": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "sessions": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "usage_ledger": {
+            "type": "integer",
+            "format": "int64"
           }
         }
       },

--- a/specs/reporting.md
+++ b/specs/reporting.md
@@ -128,9 +128,16 @@ Projectors:
 - Emit fact batches through `ReportingProjectionSink`.
 - Mark outbox rows complete after the sink commit succeeds.
 - Retry with bounded backoff and store non-secret errors in `last_error`.
+- Release stale `processing` claims before polling so a server crash cannot
+  strand rows forever.
 
 NATS or another push channel may wake projectors, but durable polling remains
 the correctness mechanism.
+
+The server runs a built-in reporting background task for PostgreSQL storage. It
+is controlled by `REPORTING_BACKGROUND_ENABLED`,
+`REPORTING_PROJECTOR_INTERVAL_SECS`, `REPORTING_PROJECTOR_LIMIT`,
+`REPORTING_BACKFILL_INTERVAL_SECS`, and `REPORTING_BACKFILL_LIMIT`.
 
 ## Idempotency
 
@@ -451,6 +458,9 @@ Backfills:
 - Backfills enqueue outbox work by source type, org, and time range.
 - Backfills are idempotent and resumable.
 - Backfills must be rate-limited per org and globally.
+- The initial backfill/reconciler enqueues missing event, session,
+  LLM-generation, and usage-ledger work from canonical tables. It is available
+  as an admin operation and also runs periodically in the background.
 
 Retention:
 


### PR DESCRIPTION
## What
Complete the reporting product surface except Phase 3 analytical backends:
- add the Reports UI, sidebar entry, API client types, and React Query hooks
- add automatic reporting projector/backfill background loops with stale claim recovery
- add an admin backfill API and OpenAPI schema updates
- reconcile missing reporting facts from events, sessions, LLM generations, and usage ledger sources
- update reporting spec docs for the implemented runtime behavior

## Why
Reporting had durable fact/query/export primitives but was not product-complete: users had no Reports UI, projector operation still required manual calls, and missing outbox rows had no built-in reconciliation path.

## How
- Added a Postgres-only background task with env-controlled intervals and limits.
- Added org-scoped admin backfill and projector operations behind `report.admin`.
- Kept semantic report queries and saved reports behind the existing reporting policies.
- Added a first Reports page that can query datasets, save/run/export reports, view diagnostics, and run admin maintenance actions for admin/owner users.
- Regenerated `docs/api/openapi.json` for the new backfill endpoint.

## Risk
- Medium
- Reporting background work could increase DB load if a deployment has a large backlog; limits are clamped and interval/enable env vars are available.
- Query/backfill correctness depends on existing fact source keys; tests and smoke checks cover the new admin path and empty-state UI/API behavior.

## Security
- Threat categories reviewed: TM-API, TM-AUTHZ, TM-TENANT, TM-SQL, TM-DOS, TM-WEB.
- Findings and resolutions:
  - Admin maintenance endpoints are guarded by `REPORT_ADMIN` through command policy enforcement.
  - Reporting query/backfill SQL remains parameterized; dynamic SQL uses `QueryBuilder` bind parameters for org and limit inputs.
  - Cross-tenant access remains org-scoped for user-facing/admin operations; background due projection only processes already-enqueued org-owned outbox rows.
  - Backfill/projector limits are clamped to bound per-run work.
  - UI admin actions are hidden unless the selected org role is admin/owner; server policy remains authoritative.
  - No new dependencies, secrets, public unauthenticated endpoints, or browser-side HTML rendering surfaces were added.

## Validation
- [x] `cargo fmt --check`
- [x] `cargo check -p everruns-server`
- [x] `cargo test -p everruns-server --test reporting_integration_test`
- [x] `npm run format:check` in `apps/ui`
- [x] `npm run lint` in `apps/ui` (passes with 6 pre-existing warnings outside this change)
- [x] `npm run build` in `apps/ui`
- [x] `cargo run --bin export-openapi` and copied generated output to `docs/api/openapi.json`
- [x] `just pre-push`
- [x] `bash scripts/lib/check-migration-ordering.sh`
- [x] Local smoke with `PORT_PREFIX=424 REPORTING_BACKGROUND_ENABLED=false just start-dev --no-watch`: `/reports` rendered, catalog/diagnostics/backfill APIs returned expected empty-state data, no browser console errors

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
