### PR TITLE
chore(deps): bump async-nats to 0.48

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -317,9 +317,9 @@ dependencies = [
 
 [[package]]
 name = "async-nats"
-version = "0.47.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07d6f157065c3461096d51aacde0c326fa49f3f6e0199e204c566842cdaa5299"
+checksum = "31811585c7c5bc2f60f8b80d5a6b0f737115611dac47567d7f7d94562ebb180b"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -329,7 +329,7 @@ dependencies = [
  "nuid",
  "pin-project",
  "portable-atomic",
- "rand 0.8.6",
+ "rand 0.10.1",
  "regex",
  "ring",
  "rustls-native-certs",
@@ -339,7 +339,7 @@ dependencies = [
  "serde_json",
  "serde_nanos",
  "serde_repr",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "time",
  "tokio",
  "tokio-rustls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,7 @@ governor = "0.8"
 fred = { version = "10", features = ["enable-rustls-ring", "i-scripts"] }
 
 # NATS (event delivery, task queue)
-async-nats = "0.47"
+async-nats = "0.48"
 
 # Authentication
 argon2 = "0.5"


### PR DESCRIPTION
## What
Bump workspace `async-nats` from `0.47` to `0.48`.

## Why
Routine minor bump. `async-nats` is used for ephemeral event delivery and task notifications when `NATS_URL` is configured (`crates/server/src/event_delivery.rs`, `crates/server/src/nats_task_notifications.rs`). Staying current keeps us off bug-fix patches as they accumulate.

## How
- Bumped the version in `Cargo.toml`.
- `cargo update -p async-nats` to refresh `Cargo.lock`.

## Risk
- Low. No source changes required — every NATS API we use is compile-clean against 0.48. Existing `nats_task_notifications` unit tests pass.

## Security
- Threat categories reviewed: dependency-supply-chain. No new wire/parsing surface.
- Findings and resolutions: none.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated — relied on existing tests
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] All review comments addressed (code change or written reasoning)

## Validation
- `cargo check -p everruns-server --all-targets` ✓
- `cargo test -p everruns-server --lib nats` — 2/2 passing

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ksub5mbzQ6EFk5fB16ggNr)_