### PR TITLE
chore(deps): bump rstest to 0.26

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6321,21 +6321,20 @@ dependencies = [
 
 [[package]]
 name = "rstest"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fc39292f8613e913f7df8fa892b8944ceb47c247b78e1b1ae2f09e019be789d"
+checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
 dependencies = [
  "futures-timer",
  "futures-util",
  "rstest_macros",
- "rustc_version",
 ]
 
 [[package]]
 name = "rstest_macros"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f168d99749d307be9de54d23fd226628d99768225ef08f6ffb52e0182a27746"
+checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
 dependencies = [
  "cfg-if",
  "glob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,7 +161,7 @@ moka = { version = "0.12", features = ["future", "sync"] }
 
 # Fault injection testing
 fail = "0.5"
-rstest = "0.25"
+rstest = "0.26"
 tempfile = "3"
 
 # File watching and gitignore


### PR DESCRIPTION
## What
Bump workspace `rstest` from `0.25` to `0.26`.

## Why
Routine bump. `rstest` is used by `crates/core/tests/agent_run_basic.rs` and `agent_run_with_thinking.rs` for parameterized integration tests. Pre-1.0 minor bumps are cheap to apply individually.

## How
- Bumped the version in `Cargo.toml`.
- `cargo update -p rstest` to refresh `Cargo.lock` (`rstest` and `rstest_macros` 0.25.0 → 0.26.1).

## Risk
- Low. Test-only dependency. No code change needed; existing `#[rstest]` macros compile clean. All 21 parameterized cases in the two affected tests still pass.

## Security
- Threat categories reviewed: dependency-supply-chain. Test-time only.
- Findings and resolutions: none.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated — relied on existing tests
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] All review comments addressed (code change or written reasoning)

## Validation
- `cargo test -p everruns-core --test agent_run_basic` — 13/13 ✓
- `cargo test -p everruns-core --test agent_run_with_thinking` — 8/8 ✓

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ksub5mbzQ6EFk5fB16ggNr)_