### PR TITLE
chore(specs): add maintenance completeness checks

### DIFF
--- a/.agents/skills/maintenance/SKILL.md
+++ b/.agents/skills/maintenance/SKILL.md
@@ -45,7 +45,8 @@ Use this skill when the task is about repo maintenance rather than a single feat
 - Prefer the highest-signal path first: recent diffs, flaky areas, failing checks, stale specs, outdated dependencies, or known security/performance hotspots.
 - Always run `cargo outdated` (or `cargo search` per-crate) and `npm outdated` during release-readiness or dependency-scoped maintenance — even when no security advisory exists. Patch/minor bumps are cheap to miss and cheap to apply; skipping them silently accumulates drift.
 - Check Linear issues in the OSS project (EVE team) already in `In Progress` when maintenance covers release readiness or workflow hygiene. Treat issues whose `updatedAt` is older than 1 day as stale by default, then triage or report them.
-- When maintenance covers release readiness or repo workflow hygiene, review recent upstream plugin-platform changes before declaring local plugins current. Check the Codex and Claude Code Everruns Dev plugin surfaces together: compare `.agents/plugins/marketplace.json`, `.claude-plugin/marketplace.json`, `plugins/everruns-dev/.codex-plugin/plugin.json`, `plugins/everruns-dev/.claude-plugin/plugin.json`, and shipped plugin behavior; run `scripts/test-everruns-dev-plugin.sh` or equivalent metadata validation so registration and version parity are proven.
+- When maintenance covers release readiness or repo workflow hygiene, review recent upstream plugin-platform changes before declaring local plugins current. Check the Codex and Claude Code Everruns Dev plugin surfaces together: compare `.agents/plugins/marketplace.json`, `.claude-plugin/marketplace.json`, `plugins/everruns-dev/.codex-plugin/plugin.json`, `plugins/everruns-dev/.claude-plugin/plugin.json`, shipped plugin behavior, skills, docs, and marketplace entries; run `scripts/test-everruns-dev-plugin.sh` or equivalent metadata validation so registration, version parity, compatibility, and non-contradiction are proven.
+- When maintenance covers recently shipped features or release readiness, check for half-built cross-surface features: UI disconnected from backend behavior, backend capabilities missing intended MCP/CLI/docs exposure, MCP or CLI behavior lagging API semantics, or tests/manual cases claiming more than the product provides.
 - Skip untouched areas when there is a clear reason. Say why they were skipped.
 - Prefer fixing over reporting.
 - For bugs uncovered during maintenance, prefer a failing test before the fix when practical.
@@ -80,6 +81,17 @@ Goal: docs describe the current system intent and constraints, without drifting 
 Good evidence:
 - changed behavior reflected in `specs/`, `apps/docs/`, OpenAPI, or examples when relevant
 - stale or duplicate spec detail removed in favor of links to source files
+
+### Feature Completeness Across Surfaces
+
+Goal: features that appear shipped in one surface are connected, reachable, and consistent across the intended UI, backend, MCP, CLI, docs, and tests.
+
+Good evidence:
+- UI affordances call real backend APIs and handle loading, errors, auth, and state refresh
+- backend features intended for agent or automation use are exposed through MCP/app surfaces where applicable
+- CLI commands and flags match current API semantics and do not duplicate stale assumptions
+- docs, specs, examples, tests, and manual test cases do not claim unavailable behavior
+- gaps are fixed locally or captured as specific findings with the missing surface, user impact, and next action
 
 ### Security And Threat Posture
 

--- a/specs/maintenance.md
+++ b/specs/maintenance.md
@@ -14,6 +14,8 @@ Maintenance work should optimize for these outcomes:
 2. Improve the repo in concrete ways or produce crisp findings with evidence.
 3. Match validation depth to the actual risk surface.
 4. Keep release claims honest: do not call the repo ready unless the relevant surfaces were checked.
+5. Detect half-built features whose visible surfaces do not match their implementation status, especially gaps between UI, backend APIs, MCP, CLI, docs, and tests.
+6. Keep shipped plugin surfaces current, mutually consistent, and aligned with upstream platform behavior.
 
 ## Ownership Boundary
 
@@ -40,9 +42,23 @@ Relevant references:
 - Maintenance is risk-proportional, not sweep-proportional. A larger checklist is not inherently better.
 - The selected maintenance scope must be explained, including what was skipped and why.
 - If maintenance changes code or behavior, affected artifacts must stay in sync: specs, docs, OpenAPI, threat model, test cases, agent instructions, and release materials as applicable.
-- When maintenance covers repo workflow hygiene, treat Codex and Claude Code plugin surfaces as maintained workflow artifacts. Review recent upstream plugin-platform changes before claiming either plugin is current, and verify the shared Everruns Dev plugin metadata stays in parity across Codex and Claude manifests.
+- When maintenance covers repo workflow hygiene, treat Codex and Claude Code plugin surfaces as maintained workflow artifacts. Review recent upstream plugin-platform changes before claiming either plugin is current, verify the shared Everruns Dev plugin metadata stays in parity across Codex and Claude manifests, and resolve contradictions between plugin manifests, skills, MCP/app behavior, docs, and marketplace entries.
 - Specs should not duplicate operational workflow text that belongs in skills or commands.
 - Maintenance should prefer concrete fixes over ceremonial audits when a safe local fix exists.
+
+## Feature Completeness Drift
+
+Maintenance should look for features that appear shipped in one surface but are missing, stubbed, or disconnected in another. A feature is not release-ready merely because one layer exists.
+
+Examples of drift to catch:
+
+- UI controls or pages that are not connected to backend state, mutations, streaming updates, auth, or error handling
+- backend APIs with no reachable UI, CLI, MCP, SDK, or docs path when those surfaces are part of the intended product contract
+- MCP tools, resources, or app cards that lag backend capabilities or expose behavior the UI/CLI cannot support consistently
+- CLI commands that duplicate stale assumptions, omit important flags, or contradict current API semantics
+- specs, docs, examples, tests, and manual test cases that describe a more complete feature than the product actually provides
+
+The expected outcome is either a small fix that reconnects the surfaces or a crisp finding that names the missing surface, the user-visible impact, and the next action. Maintenance should not bury these gaps as generic technical debt because half-built features distort release readiness.
 
 ## Spec Hygiene
 
@@ -70,7 +86,8 @@ Before a release, maintenance should cover:
   - `cargo outdated --root-deps-only --workspace` currently fails with a `libsqlite3-sys` `links` conflict because its temporary solve combines the workspace `sqlx 0.8` pin with the latest `rusqlite`. The real lockfile builds, so treat that failure as a tooling artifact and inspect `Cargo.toml` plus `cargo tree -i sqlx` / `cargo tree -i rusqlite` instead until `sqlx` and `rusqlite` are upgraded together
   - major npm upgrades (TypeScript, lucide-react, marked, openui packages) ship as separate PRs per framework family so each can be validated by the matching UI or docs build
   - bump npm packages that have transitive runtime dependencies (e.g. `@ag-ui/core`) together with the packages that pin them (e.g. `@openuidev/*`), otherwise npm installs duplicate copies in the lockfile
-- the Codex and Claude Code plugin surfaces reviewed against recent upstream plugin-platform changes: inspect the latest relevant platform references, then compare them to `.agents/plugins/marketplace.json`, `.claude-plugin/marketplace.json`, `plugins/everruns-dev/.codex-plugin/plugin.json`, `plugins/everruns-dev/.claude-plugin/plugin.json`, and shipped plugin behavior; run `scripts/test-everruns-dev-plugin.sh` or equivalent metadata validation to prove registration and version parity before claiming release readiness
+- feature completeness across product surfaces: changed or recently shipped features should have their intended UI, backend, MCP, CLI, docs, tests, and manual-test coverage checked for disconnected, stubbed, or contradictory behavior
+- the Codex and Claude Code plugin surfaces reviewed against recent upstream plugin-platform changes: inspect the latest relevant platform references, then compare them to `.agents/plugins/marketplace.json`, `.claude-plugin/marketplace.json`, `plugins/everruns-dev/.codex-plugin/plugin.json`, `plugins/everruns-dev/.claude-plugin/plugin.json`, shipped plugin behavior, skills, docs, and marketplace entries; run `scripts/test-everruns-dev-plugin.sh` or equivalent metadata validation to prove registration, version parity, compatibility, and non-contradiction before claiming release readiness
 
 A full-repo sweep is not mandatory if the evidence is already strong. The bar is confidence, not checklist completion theater.
 


### PR DESCRIPTION
## What
Adds maintenance guidance for detecting half-built cross-surface features and plugin drift. Updates both `specs/maintenance.md` and the `/maintenance` skill so the durable intent and operating workflow match.

## Why
Maintenance should catch features that are only partially connected, such as UI without backend behavior, backend capabilities missing MCP or CLI exposure, and plugin surfaces that drift or contradict one another.

## How
- Adds design goals for feature-completeness drift and plugin consistency.
- Defines examples of UI/backend/MCP/CLI/docs/test drift to catch.
- Extends release-readiness and skill guidance to verify plugin manifests, skills, docs, marketplace entries, and shipped behavior for parity and non-contradiction.

## Risk
- Low
- Docs and skill guidance only; no runtime behavior changes.

## Security
- Threat categories reviewed: No security-relevant code changes. This PR only changes maintenance documentation and agent workflow text.
- Findings and resolutions: None.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

Validation: `git diff --check`, `bash scripts/lib/check-migration-ordering.sh`, `just pre-push`. Smoke testing skipped because this is docs/skill text only and does not affect runtime behavior.