### PR TITLE
chore(deps): bump tokio-tungstenite to 0.29

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -478,7 +478,7 @@ dependencies = [
  "sha1 0.10.6",
  "sync_wrapper",
  "tokio",
- "tokio-tungstenite 0.29.0",
+ "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",
@@ -2209,7 +2209,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "tokio-tungstenite 0.26.2",
+ "tokio-tungstenite",
  "tracing",
  "wiremock",
 ]
@@ -2263,7 +2263,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "tokio-tungstenite 0.26.2",
+ "tokio-tungstenite",
  "tracing",
  "urlencoding",
  "wiremock",
@@ -2534,7 +2534,7 @@ dependencies = [
  "time",
  "tokio",
  "tokio-stream",
- "tokio-tungstenite 0.26.2",
+ "tokio-tungstenite",
  "tonic",
  "tower",
  "tower-http",
@@ -7739,9 +7739,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.26.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
 dependencies = [
  "futures-util",
  "log",
@@ -7750,19 +7750,7 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
- "tungstenite 0.26.2",
-]
-
-[[package]]
-name = "tokio-tungstenite"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
-dependencies = [
- "futures-util",
- "log",
- "tokio",
- "tungstenite 0.29.0",
+ "tungstenite",
 ]
 
 [[package]]
@@ -8153,25 +8141,6 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
-version = "0.26.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
-dependencies = [
- "bytes",
- "data-encoding",
- "http",
- "httparse",
- "log",
- "rand 0.9.4",
- "rustls",
- "rustls-pki-types",
- "sha1 0.10.6",
- "thiserror 2.0.18",
- "utf-8",
-]
-
-[[package]]
-name = "tungstenite"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
@@ -8182,6 +8151,8 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.9.4",
+ "rustls",
+ "rustls-pki-types",
  "sha1 0.10.6",
  "thiserror 2.0.18",
 ]
@@ -8356,12 +8327,6 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
-
-[[package]]
-name = "utf-8"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"
@@ -8794,7 +8759,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,7 +122,7 @@ webbrowser = "1"
 dirs = "6"
 
 # WebSocket (CDP sessions)
-tokio-tungstenite = { version = "0.26", features = ["rustls-tls-native-roots"] }
+tokio-tungstenite = { version = "0.29", features = ["rustls-tls-native-roots"] }
 futures-util = "0.3"
 
 # Everruns SDK

--- a/integrations/browserless/src/cdp.rs
+++ b/integrations/browserless/src/cdp.rs
@@ -1059,7 +1059,7 @@ mod tests {
         use tokio_tungstenite::tungstenite::http;
 
         let resp = http::Response::builder().status(403).body(None).unwrap();
-        let err = tokio_tungstenite::tungstenite::Error::Http(resp);
+        let err = tokio_tungstenite::tungstenite::Error::Http(Box::new(resp));
         let msg = map_ws_connect_error(err);
         assert!(
             msg.contains("REST-mode tools"),
@@ -1073,7 +1073,7 @@ mod tests {
         use tokio_tungstenite::tungstenite::http;
 
         let resp = http::Response::builder().status(401).body(None).unwrap();
-        let err = tokio_tungstenite::tungstenite::Error::Http(resp);
+        let err = tokio_tungstenite::tungstenite::Error::Http(Box::new(resp));
         let msg = map_ws_connect_error(err);
         assert!(
             msg.contains("REST-mode tools"),


### PR DESCRIPTION
## What
Bump workspace `tokio-tungstenite` from `0.26` to `0.29` (skips two minors of accumulated drift). One small API change required: `tungstenite::Error::Http(_)` now takes `Box<Response<…>>` instead of an owned `Response<…>` to keep the enum variant compact.

## Why
`tokio-tungstenite` powers three WebSocket surfaces in the workspace:

- `crates/server/src/api/voice.rs` (Realtime API transport for Voice Sessions)
- `integrations/deno/src/client.rs`
- `integrations/browserless/src/cdp.rs` (Chrome DevTools Protocol)

Routine bump to keep on current upstream. Pre-1.0 minor drift accumulates; cheaper to do single-step now than later.

## How
- Bumped the version in `Cargo.toml`.
- `cargo update` consolidated the dep tree onto a single `tokio-tungstenite 0.29.0`.
- Pinned unrelated semver-compatible bumps back so this PR stays narrowly scoped (those are tracked separately by the cargo update PR).
- Updated two test call sites in `cdp.rs` to wrap `http::Response` in `Box::new(_)`.

## Risk
- Low. The only production code paths using tokio-tungstenite use the high-level `connect_async` / message stream APIs which did not change shape. The boxed `Error::Http` is internal — we never construct it in production code, only in tests that simulate WS-connect errors.

## Security
- Threat categories reviewed: dependency-supply-chain. WS-handshake parsing surface — fewer outstanding patches by being current.
- Findings and resolutions: none.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated — relied on existing CDP WS tests
- [x] Backward compatibility considered (wire / API surface unchanged)
- [x] Security review performed against relevant threat model categories
- [ ] All review comments addressed (code change or written reasoning)

## Validation
- `cargo check --workspace --all-targets` ✓
- `cargo test -p everruns-integrations-browserless --lib map_ws_connect_error` — 3/3 passing

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ksub5mbzQ6EFk5fB16ggNr)_