### PR TITLE
chore(deps): bump governor to 0.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3117,9 +3117,9 @@ dependencies = [
 
 [[package]]
 name = "governor"
-version = "0.8.1"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be93b4ec2e4710b04d9264c0c7350cdd62a8c20e5e4ac732552ebb8f0debe8eb"
+checksum = "9efcab3c1958580ff1f25a2a41be1668f7603d849bb63af523b208a3cc1223b8"
 dependencies = [
  "cfg-if",
  "dashmap",
@@ -3127,7 +3127,7 @@ dependencies = [
  "futures-timer",
  "futures-util",
  "getrandom 0.3.4",
- "no-std-compat",
+ "hashbrown 0.16.1",
  "nonzero_ext",
  "parking_lot",
  "portable-atomic",
@@ -4647,12 +4647,6 @@ dependencies = [
  "rand 0.8.6",
  "signatory",
 ]
-
-[[package]]
-name = "no-std-compat"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
 
 [[package]]
 name = "nom"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,7 @@ rand = "0.9"
 base64 = "0.22"
 
 # Rate limiting
-governor = "0.8"
+governor = "0.10"
 
 # Valkey/Redis (distributed rate limiting)
 fred = { version = "10", features = ["enable-rustls-ring", "i-scripts"] }


### PR DESCRIPTION
## What
Bump workspace `governor` from `0.8` to `0.10` (two minors of accumulated rate-limiter drift).

## Why
`governor` is the in-process token-bucket library used for:
- HTTP request rate limiting (`crates/server/src/auth/rate_limit.rs`)
- per-app/per-channel rate limiting (`crates/server/src/api/channel_rate_limit.rs`)
- Valkey-backed distributed rate-limiter shims (`crates/server/src/valkey.rs`)

Rate-limiting touches public ingress, so I had been holding it back; verified the API surface we depend on is unchanged across 0.8 → 0.10 by compiling and running the 24 existing rate-limit unit tests.

## How
- Bumped the version in `Cargo.toml`.
- `cargo update -p governor` refreshed `Cargo.lock` (0.8.1 → 0.10.4).
- No source changes required. The `RateLimiter::keyed` constructor, `Quota::with_period(...).allow_burst(...)`, the `.check_key()` / `.check()` methods, and `NotUntil::wait_time_from(...)` all stayed compatible.

## Risk
- Low/Medium for the surface (public ingress rate limiting), but Low for the change itself — no behavioral or API delta exercised.

## Security
- Threat categories reviewed: TM-API (rate-limit bypass), dependency-supply-chain. Behavior unchanged; CI rate-limit tests cover bucket isolation across IPs, apps, and namespaces.
- Findings and resolutions: none.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated — relied on existing rate-limit unit tests
- [x] Backward compatibility considered (API surface unchanged)
- [x] Security review performed against relevant threat model categories
- [ ] All review comments addressed (code change or written reasoning)

## Validation
- `cargo check -p everruns-server --all-targets` ✓
- `cargo test -p everruns-server --lib rate_limit` — 24/24 passing

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ksub5mbzQ6EFk5fB16ggNr)_