### PR TITLE
fix(ui): standardize organization label

### DIFF
--- a/apps/ui/src/__tests__/command-palette.test.tsx
+++ b/apps/ui/src/__tests__/command-palette.test.tsx
@@ -42,7 +42,7 @@ jest.mock("@/hooks/use-global-search", () => ({
       category: "organization",
       icon: Boxes,
       title: "Second Org",
-      subtitle: "Switch organisation > org_second",
+      subtitle: "Switch organization > org_second",
       href: "/settings/organization",
       onSelect: mockOnSelect,
     },

--- a/apps/ui/src/__tests__/settings-layout.test.tsx
+++ b/apps/ui/src/__tests__/settings-layout.test.tsx
@@ -30,7 +30,7 @@ describe("SettingsLayout", () => {
     );
 
     expect(screen.queryByText("General")).not.toBeInTheDocument();
-    expect(screen.getAllByText("Organisation")).toHaveLength(2);
+    expect(screen.getAllByText("Organization")).toHaveLength(2);
     expect(screen.getByText("LLM Providers")).toBeInTheDocument();
     expect(screen.getByText("Members")).toBeInTheDocument();
     expect(screen.getByText("Payments")).toBeInTheDocument();
@@ -39,7 +39,7 @@ describe("SettingsLayout", () => {
     expect(screen.getByText("API Keys")).toBeInTheDocument();
   });
 
-  it("renders section labels for Organisation and Personal", () => {
+  it("renders section labels for Organization and Personal", () => {
     render(
       <SettingsLayout>
         <div>Test Content</div>
@@ -47,7 +47,7 @@ describe("SettingsLayout", () => {
     );
 
     expect(
-      screen.getAllByText("Organisation").some((node) => node.classList.contains("uppercase")),
+      screen.getAllByText("Organization").some((node) => node.classList.contains("uppercase")),
     ).toBe(true);
     expect(screen.getByText("Personal")).toBeInTheDocument();
   });
@@ -59,7 +59,7 @@ describe("SettingsLayout", () => {
       </SettingsLayout>,
     );
 
-    const organisationLink = screen.getByRole("link", { name: /Organisation/i });
+    const organizationLink = screen.getByRole("link", { name: /Organization/i });
     const providersLink = screen.getByRole("link", { name: /LLM Providers/i });
     const membersLink = screen.getByRole("link", { name: /Members/i });
     const paymentsLink = screen.getByRole("link", { name: /Payments/i });
@@ -67,7 +67,7 @@ describe("SettingsLayout", () => {
     const connectionsLink = screen.getByRole("link", { name: /Connections/i });
     const apiKeysLink = screen.getByRole("link", { name: /API Keys/i });
 
-    expect(organisationLink).toHaveAttribute("href", "/settings/organization");
+    expect(organizationLink).toHaveAttribute("href", "/settings/organization");
     expect(providersLink).toHaveAttribute("href", "/settings/providers");
     expect(membersLink).toHaveAttribute("href", "/settings/members");
     expect(paymentsLink).toHaveAttribute("href", "/settings/payments");
@@ -142,14 +142,14 @@ describe("SettingsLayout", () => {
     );
 
     const orgLabel = screen
-      .getAllByText("Organisation")
+      .getAllByText("Organization")
       .find((node) => node.classList.contains("uppercase"))!;
     const personalLabel = screen.getByText("Personal");
 
-    // Organisation section contains its items
+    // Organization section contains its items
     const orgSection = orgLabel.closest("div[class]")!.parentElement!;
     expect(orgSection).not.toHaveTextContent("General");
-    expect(orgSection).toHaveTextContent("Organisation");
+    expect(orgSection).toHaveTextContent("Organization");
     expect(orgSection).toHaveTextContent("LLM Providers");
     expect(orgSection).toHaveTextContent("Members");
     expect(orgSection).toHaveTextContent("Payments");
@@ -161,7 +161,7 @@ describe("SettingsLayout", () => {
     expect(personalSection).toHaveTextContent("Profile");
     expect(personalSection).toHaveTextContent("Connections");
     expect(personalSection).toHaveTextContent("API Keys");
-    expect(personalSection).not.toHaveTextContent("Organisation");
+    expect(personalSection).not.toHaveTextContent("Organization");
     expect(personalSection).not.toHaveTextContent("Members");
   });
 
@@ -173,7 +173,7 @@ describe("SettingsLayout", () => {
     );
 
     const orgLabel = screen
-      .getAllByText("Organisation")
+      .getAllByText("Organization")
       .find((node) => node.classList.contains("uppercase"))!;
     const personalLabel = screen.getByText("Personal");
 
@@ -194,16 +194,16 @@ describe("SettingsLayout", () => {
       </SettingsLayout>,
     );
 
-    const organisationLink = screen.getByRole("link", { name: /Organisation/i });
+    const organizationLink = screen.getByRole("link", { name: /Organization/i });
     const membersLink = screen.getByRole("link", { name: /Members/i });
     const apiKeysLink = screen.getByRole("link", { name: /API Keys/i });
 
-    expect(organisationLink).toHaveClass("border-transparent");
+    expect(organizationLink).toHaveClass("border-transparent");
     expect(membersLink).toHaveClass("border-transparent");
     expect(apiKeysLink).toHaveClass("border-transparent");
   });
 
-  it("highlights active item for Organisation page", () => {
+  it("highlights active item for Organization page", () => {
     mockPathname.mockReturnValue("/settings/organization");
     render(
       <SettingsLayout>
@@ -211,8 +211,8 @@ describe("SettingsLayout", () => {
       </SettingsLayout>,
     );
 
-    const organisationLink = screen.getByRole("link", { name: /Organisation/i });
-    expect(organisationLink).toHaveClass("border-accent");
+    const organizationLink = screen.getByRole("link", { name: /Organization/i });
+    expect(organizationLink).toHaveClass("border-accent");
   });
 
   it("highlights active item for Profile page", () => {

--- a/apps/ui/src/__tests__/settings-organization.test.tsx
+++ b/apps/ui/src/__tests__/settings-organization.test.tsx
@@ -103,18 +103,18 @@ describe("OrganizationPage", () => {
     };
   });
 
-  it("renders accessible organisations separately from general settings", () => {
+  it("renders accessible organizations separately from general settings", () => {
     render(<OrganizationPage />);
 
-    expect(screen.getByRole("heading", { name: "Organisation" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Organization" })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Models" })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Harnesses" })).toBeInTheDocument();
     expect(screen.getByLabelText("Default Model")).toBeInTheDocument();
     expect(screen.getByLabelText("Select default harness")).toBeInTheDocument();
     expect(screen.getByLabelText("Select base harness")).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "Organisations" })).toBeInTheDocument();
-    expect(screen.getByRole("table", { name: "Organisations" })).toBeInTheDocument();
-    expect(screen.getByRole("columnheader", { name: "Organisation" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Organizations" })).toBeInTheDocument();
+    expect(screen.getByRole("table", { name: "Organizations" })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "Organization" })).toBeInTheDocument();
     expect(screen.getByRole("columnheader", { name: "ID" })).toBeInTheDocument();
     expect(screen.getByRole("columnheader", { name: "Role" })).toBeInTheDocument();
     expect(screen.getByRole("columnheader", { name: "Status" })).toBeInTheDocument();
@@ -126,7 +126,7 @@ describe("OrganizationPage", () => {
     expect(screen.getByText("Current")).toBeInTheDocument();
   });
 
-  it("switches to another organisation", () => {
+  it("switches to another organization", () => {
     render(<OrganizationPage />);
 
     fireEvent.click(screen.getByRole("button", { name: "Switch to Second Org" }));
@@ -138,12 +138,12 @@ describe("OrganizationPage", () => {
     });
   });
 
-  it("creates a new organisation and routes to setup", async () => {
+  it("creates a new organization and routes to setup", async () => {
     mockMutateAsync.mockResolvedValue({ id: "org-3", name: "New Org" });
 
     render(<OrganizationPage />);
 
-    fireEvent.click(screen.getByRole("button", { name: "Create Organisation" }));
+    fireEvent.click(screen.getByRole("button", { name: "Create Organization" }));
     fireEvent.change(screen.getByLabelText("Name"), { target: { value: "New Org" } });
     fireEvent.click(screen.getByRole("button", { name: "Create" }));
 
@@ -158,12 +158,12 @@ describe("OrganizationPage", () => {
     });
   });
 
-  it("autosaves organisation identity changes", async () => {
+  it("autosaves organization identity changes", async () => {
     jest.useFakeTimers();
 
     render(<OrganizationPage />);
 
-    fireEvent.change(screen.getByLabelText("Organisation Name"), {
+    fireEvent.change(screen.getByLabelText("Organization Name"), {
       target: { value: "Renamed Org" },
     });
 
@@ -195,7 +195,7 @@ describe("OrganizationPage", () => {
 
     render(<OrganizationPage />);
 
-    fireEvent.change(screen.getByLabelText("Organisation Name"), {
+    fireEvent.change(screen.getByLabelText("Organization Name"), {
       target: { value: "Renamed Org" },
     });
 
@@ -215,7 +215,7 @@ describe("OrganizationPage", () => {
     jest.useRealTimers();
   });
 
-  it("ignores stale autosaves after the loaded organisation changes", async () => {
+  it("ignores stale autosaves after the loaded organization changes", async () => {
     jest.useFakeTimers();
     let resolveSave: () => void = () => {};
     mockUpdateOrganization.mockReturnValueOnce(
@@ -226,7 +226,7 @@ describe("OrganizationPage", () => {
 
     const { rerender } = render(<OrganizationPage />);
 
-    fireEvent.change(screen.getByLabelText("Organisation Name"), {
+    fireEvent.change(screen.getByLabelText("Organization Name"), {
       target: { value: "Renamed Org" },
     });
 
@@ -250,7 +250,7 @@ describe("OrganizationPage", () => {
       await Promise.resolve();
     });
 
-    expect(screen.getByLabelText("Organisation Name")).toHaveValue("Second Org");
+    expect(screen.getByLabelText("Organization Name")).toHaveValue("Second Org");
 
     jest.useRealTimers();
   });

--- a/apps/ui/src/__tests__/sidebar.test.tsx
+++ b/apps/ui/src/__tests__/sidebar.test.tsx
@@ -404,7 +404,7 @@ describe("Sidebar with config", () => {
     render(<Sidebar config={config} />);
 
     // Dialog title should not be in the DOM when custom handler overrides default
-    expect(screen.queryByText("Create a new organisation")).not.toBeInTheDocument();
+    expect(screen.queryByText("Create a new organization")).not.toBeInTheDocument();
     // The org selector trigger should still render
     expect(screen.getByText("Test Org")).toBeInTheDocument();
   });
@@ -496,7 +496,7 @@ describe("Sidebar with config", () => {
   });
 });
 
-describe("Create Organisation dialog", () => {
+describe("Create Organization dialog", () => {
   beforeEach(() => {
     mockPathname.mockReturnValue("/dashboard");
     mockPush.mockClear();
@@ -516,12 +516,12 @@ describe("Create Organisation dialog", () => {
     const orgTrigger = screen.getByText("Test Org");
     fireEvent.click(orgTrigger);
 
-    // Click "Create Organisation"
-    const createBtn = screen.getByText("Create Organisation");
+    // Click "Create Organization"
+    const createBtn = screen.getByText("Create Organization");
     fireEvent.click(createBtn);
 
     // Fill in the org name
-    const input = screen.getByPlaceholderText("Organisation name");
+    const input = screen.getByPlaceholderText("Organization name");
     fireEvent.change(input, { target: { value: "New Org" } });
 
     // Submit the form
@@ -546,8 +546,8 @@ describe("Create Organisation dialog", () => {
     const orgTrigger = screen.getByText("Test Org");
     fireEvent.click(orgTrigger);
 
-    // Click "Create Organisation"
-    const createBtn = screen.getByText("Create Organisation");
+    // Click "Create Organization"
+    const createBtn = screen.getByText("Create Organization");
     fireEvent.click(createBtn);
 
     // Click Cancel

--- a/apps/ui/src/__tests__/use-global-search.test.tsx
+++ b/apps/ui/src/__tests__/use-global-search.test.tsx
@@ -76,6 +76,13 @@ describe("useGlobalSearch", () => {
     expect(mockSetCurrentOrg).toHaveBeenCalledWith(mockSecondOrg);
   });
 
+  it("keeps the previous British spelling as a search alias", () => {
+    const { result } = renderHook(() => useGlobalSearch("organisation"));
+
+    expect(result.current.some((item) => item.href === "/settings/organization")).toBe(true);
+    expect(result.current.some((item) => item.id === "organization:org_second")).toBe(true);
+  });
+
   it("marks the current organization without attaching a switch action", () => {
     const { result } = renderHook(() => useGlobalSearch("current"));
 

--- a/apps/ui/src/__tests__/use-global-search.test.tsx
+++ b/apps/ui/src/__tests__/use-global-search.test.tsx
@@ -66,7 +66,7 @@ describe("useGlobalSearch", () => {
     expect(orgResult).toMatchObject({
       id: "organization:org_second",
       title: "Second Org",
-      subtitle: "Switch organisation > org_second",
+      subtitle: "Switch organization > org_second",
     });
 
     act(() => {
@@ -84,7 +84,7 @@ describe("useGlobalSearch", () => {
     expect(orgResult).toMatchObject({
       id: "organization:org_current",
       title: "Current Org",
-      subtitle: "Current organisation > org_current",
+      subtitle: "Current organization > org_current",
     });
     expect(orgResult?.onSelect).toBeUndefined();
   });

--- a/apps/ui/src/app/(main)/orgs/[orgId]/setup/page.tsx
+++ b/apps/ui/src/app/(main)/orgs/[orgId]/setup/page.tsx
@@ -38,8 +38,8 @@ interface StepContext {
 
 const SETUP_STEPS: SetupStep[] = [
   {
-    label: "Organisation created",
-    description: "Your new organisation has been provisioned",
+    label: "Organization created",
+    description: "Your new organization has been provisioned",
     check: (ctx) => ctx.orgLoaded,
   },
   {
@@ -222,7 +222,7 @@ export default function OrgSetupPage() {
               <Building2 className="h-6 w-6 text-primary" />
             </div>
             <h1 className="text-xl font-semibold">
-              {is404 ? "Organisation not found" : "Failed to load organisation"}
+              {is404 ? "Organization not found" : "Failed to load organization"}
             </h1>
             {!is404 && orgErrorDetail?.message && (
               <p className="text-sm text-muted-foreground">{orgErrorDetail.message}</p>
@@ -246,7 +246,7 @@ export default function OrgSetupPage() {
           </div>
           <h1 className="text-xl font-semibold">Setting up {org?.name}</h1>
           <p className="text-sm text-muted-foreground">
-            Your organisation is being configured with everything you need to get started.
+            Your organization is being configured with everything you need to get started.
           </p>
         </div>
 

--- a/apps/ui/src/app/(main)/settings/layout.tsx
+++ b/apps/ui/src/app/(main)/settings/layout.tsx
@@ -19,13 +19,13 @@ interface NavSection {
 
 const settingsSections: NavSection[] = [
   {
-    label: "Organisation",
+    label: "Organization",
     items: [
       {
-        name: "Organisation",
+        name: "Organization",
         href: "/settings/organization",
         icon: Building2,
-        description: "Manage organisation defaults and memberships",
+        description: "Manage organization defaults and memberships",
       },
       {
         name: "LLM Providers",

--- a/apps/ui/src/app/(main)/settings/organization/page.tsx
+++ b/apps/ui/src/app/(main)/settings/organization/page.tsx
@@ -58,7 +58,7 @@ const CONTROL_CLASS_NAME = "w-full";
 const AUTOSAVE_DELAY_MS = 700;
 
 export default function OrganizationPage() {
-  usePageTitle("Organisation", "Settings");
+  usePageTitle("Organization", "Settings");
   const router = useRouter();
   const { currentOrg, organizations, setCurrentOrg } = useOrg();
   const { data: organization, isLoading, error } = useOrganization();
@@ -201,7 +201,7 @@ export default function OrganizationPage() {
 
         setSavingGroups([]);
         setAutoSaveState("error");
-        setAutoSaveError(err instanceof Error ? err.message : "Failed to save organisation");
+        setAutoSaveError(err instanceof Error ? err.message : "Failed to save organization");
       }
     }, AUTOSAVE_DELAY_MS);
   };
@@ -238,16 +238,16 @@ export default function OrganizationPage() {
     <div className="space-y-8">
       <section>
         <div className="mb-6">
-          <h2 className="text-xl font-semibold">Organisation</h2>
+          <h2 className="text-xl font-semibold">Organization</h2>
           <p className="text-sm text-muted-foreground">
-            Manage organisation-level defaults and identity.
+            Manage organization-level defaults and identity.
           </p>
         </div>
 
         {error ? (
           <Card className="p-8 text-center">
             <AlertCircle className="h-12 w-12 mx-auto text-destructive mb-4" />
-            <h3 className="text-lg font-medium mb-2">Failed to load organisation</h3>
+            <h3 className="text-lg font-medium mb-2">Failed to load organization</h3>
             <p className="text-muted-foreground">{error.message}</p>
           </Card>
         ) : isLoading ? (
@@ -271,7 +271,7 @@ export default function OrganizationPage() {
           <div className="space-y-6">
             <SettingsGroup
               title="Identity"
-              description="Name and stable identifier for this organisation."
+              description="Name and stable identifier for this organization."
               status={
                 <AutoSaveBadge
                   group="identity"
@@ -283,7 +283,7 @@ export default function OrganizationPage() {
               }
             >
               <SettingsRow
-                label="Organisation Name"
+                label="Organization Name"
                 description="Shown in navigation, resource ownership, and member-facing views."
                 htmlFor="org-name"
               >
@@ -292,14 +292,14 @@ export default function OrganizationPage() {
                   value={name}
                   onChange={handleNameChange}
                   onKeyDown={handleKeyDown}
-                  placeholder="Organisation name"
+                  placeholder="Organization name"
                   className={CONTROL_CLASS_NAME}
                 />
               </SettingsRow>
 
               <SettingsRow
-                label="Organisation ID"
-                description="Use this ID when making API calls scoped to this organisation."
+                label="Organization ID"
+                description="Use this ID when making API calls scoped to this organization."
                 htmlFor="org-id"
               >
                 <div className="flex items-center gap-2">
@@ -412,30 +412,30 @@ export default function OrganizationPage() {
       <section>
         <div className="mb-6 flex flex-col items-stretch gap-3 xl:flex-row xl:items-center xl:justify-between">
           <div>
-            <h2 className="text-xl font-semibold">Organisations</h2>
-            <p className="text-sm text-muted-foreground">All organisations you are a member of.</p>
+            <h2 className="text-xl font-semibold">Organizations</h2>
+            <p className="text-sm text-muted-foreground">All organizations you are a member of.</p>
           </div>
           <Button className="w-full xl:w-auto" onClick={() => setCreateDialogOpen(true)}>
             <Plus className="h-4 w-4 mr-2" />
-            Create Organisation
+            Create Organization
           </Button>
         </div>
 
         {organizations.length === 0 ? (
           <Card className="p-8 text-center">
             <Building2 className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
-            <h3 className="text-lg font-medium mb-2">No organisations</h3>
+            <h3 className="text-lg font-medium mb-2">No organizations</h3>
             <p className="text-muted-foreground">
-              Create an organisation to start managing shared resources.
+              Create an organization to start managing shared resources.
             </p>
           </Card>
         ) : (
           <Card className="overflow-hidden">
             <div className="overflow-x-auto">
-              <Table aria-label="Organisations" className="min-w-[42rem]">
+              <Table aria-label="Organizations" className="min-w-[42rem]">
                 <TableHeader>
                   <TableRow>
-                    <TableHead>Organisation</TableHead>
+                    <TableHead>Organization</TableHead>
                     <TableHead>ID</TableHead>
                     <TableHead>Role</TableHead>
                     <TableHead>Status</TableHead>
@@ -486,9 +486,9 @@ export default function OrganizationPage() {
       <Dialog open={createDialogOpen} onOpenChange={setCreateDialogOpen}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Create Organisation</DialogTitle>
+            <DialogTitle>Create Organization</DialogTitle>
             <DialogDescription>
-              Create a new organisation. You will be added as a member automatically.
+              Create a new organization. You will be added as a member automatically.
             </DialogDescription>
           </DialogHeader>
           <form onSubmit={handleCreateOrg} className="space-y-4">
@@ -498,7 +498,7 @@ export default function OrganizationPage() {
                 id="new-org-name"
                 value={newOrgName}
                 onChange={(e) => setNewOrgName(e.target.value)}
-                placeholder="Organisation name"
+                placeholder="Organization name"
                 required
               />
             </div>

--- a/apps/ui/src/app/(main)/volumes/[volumeId]/page.tsx
+++ b/apps/ui/src/app/(main)/volumes/[volumeId]/page.tsx
@@ -47,7 +47,7 @@ export default function VolumeDetailPage({ params }: { params: Promise<{ volumeI
     return (
       <ResourceNotFound
         title="Volume not found"
-        description="The requested volume is not available in the current organisation."
+        description="The requested volume is not available in the current organization."
         backHref="/volumes"
         backLabel="Back to Volumes"
         resourceId={volumeId}

--- a/apps/ui/src/components/command-palette.tsx
+++ b/apps/ui/src/components/command-palette.tsx
@@ -30,7 +30,7 @@ const CATEGORY_LABELS: Record<SearchResultCategory, string> = {
   mcp_server: "MCP Servers",
   app: "Apps",
   eval: "Evals",
-  organization: "Organisations",
+  organization: "Organizations",
   id: "Go to",
 };
 
@@ -169,7 +169,7 @@ export function CommandPalette() {
                 ref={inputRef}
                 value={query}
                 onChange={(e) => setQuery(e.target.value)}
-                placeholder="Search pages, organisations, agents..."
+                placeholder="Search pages, organizations, agents..."
                 className="flex-1 bg-transparent py-3.5 text-sm outline-none placeholder:text-muted-foreground"
               />
               <kbd className="hidden sm:inline-flex h-5 items-center gap-1 border bg-muted px-1.5 font-mono text-[10px] font-medium text-muted-foreground">

--- a/apps/ui/src/components/layout/sidebar-organization-menu.tsx
+++ b/apps/ui/src/components/layout/sidebar-organization-menu.tsx
@@ -59,9 +59,9 @@ function CreateOrganizationDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Create Organisation</DialogTitle>
+          <DialogTitle>Create Organization</DialogTitle>
           <DialogDescription>
-            Create a new organisation. You will be added as a member automatically.
+            Create a new organization. You will be added as a member automatically.
           </DialogDescription>
         </DialogHeader>
         <form onSubmit={handleSubmit} className="space-y-4">
@@ -71,13 +71,13 @@ function CreateOrganizationDialog({
               id="org-name"
               value={name}
               onChange={(event) => setName(event.target.value)}
-              placeholder="Organisation name"
+              placeholder="Organization name"
               required
             />
           </div>
           {createOrg.isError && (
             <p className="text-sm text-destructive">
-              Failed to create organisation: {createOrg.error.message}
+              Failed to create organization: {createOrg.error.message}
             </p>
           )}
           <DialogFooter>
@@ -145,7 +145,7 @@ export function SidebarOrganizationMenu({
               <DropdownMenuSeparator />
               <DropdownMenuItem onClick={handleCreate}>
                 <Plus className="icon-sharp mr-2 h-4 w-4" />
-                Create Organisation
+                Create Organization
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenuPositioner>

--- a/apps/ui/src/components/layout/sidebar.tsx
+++ b/apps/ui/src/components/layout/sidebar.tsx
@@ -8,7 +8,7 @@
  *
  * Extension points:
  * - navigation: replace the default navigation sections entirely
- * - orgActions.createOrg: override "Create Organisation" click handler
+ * - orgActions.createOrg: override "Create Organization" click handler
  * - extraSections: append additional sections (billing, usage, etc.)
  * - profileMenu.items: append items inside the authenticated profile menu
  */

--- a/apps/ui/src/hooks/use-global-search.ts
+++ b/apps/ui/src/hooks/use-global-search.ts
@@ -192,7 +192,7 @@ const NAVIGATION_PAGES: NavigationPage[] = [
     keywords: ["openai", "anthropic", "credentials"],
   },
   {
-    title: "Settings > Organisation",
+    title: "Settings > Organization",
     href: "/settings/organization",
     icon: Settings,
     keywords: ["org", "organization", "organizations", "team", "switch"],
@@ -365,7 +365,7 @@ export function useGlobalSearch(query: string) {
           org.name,
           org.public_id,
           org.role,
-          "organization organisation org team tenant switch",
+          "organization org team tenant switch",
         )
       ) {
         results.push({
@@ -374,8 +374,8 @@ export function useGlobalSearch(query: string) {
           icon: Building2,
           title: org.name,
           subtitle: isCurrent
-            ? `Current organisation > ${org.public_id}`
-            : `Switch organisation > ${org.public_id}`,
+            ? `Current organization > ${org.public_id}`
+            : `Switch organization > ${org.public_id}`,
           href: "/settings/organization",
           onSelect: isCurrent ? undefined : () => setCurrentOrg(org),
         });

--- a/apps/ui/src/hooks/use-global-search.ts
+++ b/apps/ui/src/hooks/use-global-search.ts
@@ -195,7 +195,15 @@ const NAVIGATION_PAGES: NavigationPage[] = [
     title: "Settings > Organization",
     href: "/settings/organization",
     icon: Settings,
-    keywords: ["org", "organization", "organizations", "team", "switch"],
+    keywords: [
+      "org",
+      "organization",
+      "organizations",
+      "organisation",
+      "organisations",
+      "team",
+      "switch",
+    ],
   },
   {
     title: "Settings > Members",
@@ -365,7 +373,7 @@ export function useGlobalSearch(query: string) {
           org.name,
           org.public_id,
           org.role,
-          "organization org team tenant switch",
+          "organization organisation org team tenant switch",
         )
       ) {
         results.push({

--- a/specs/multitenancy.md
+++ b/specs/multitenancy.md
@@ -564,12 +564,12 @@ Some resources remain system-wide (not org-scoped):
 - `/v1/auth/*` - Authentication endpoints
 
 ### UI Organization Selector
-Located in sidebar (`apps/ui/src/components/layout/sidebar.tsx`). Shows current org with dropdown to switch between user's organizations. Uses Base UI's `DropdownMenu` component. Includes a "Create Organisation" button at the bottom of the dropdown.
+Located in sidebar (`apps/ui/src/components/layout/sidebar.tsx`). Shows current org with dropdown to switch between user's organizations. Uses Base UI's `DropdownMenu` component. Includes a "Create Organization" button at the bottom of the dropdown.
 
 ### UI Organization Creation
-Two entry points for creating organisations:
-1. **Sidebar dropdown:** "Create Organisation" menu item opens a dialog
-2. **Settings > Organisation page:** "Create Organisation" button in the "Your Organisations" section
+Two entry points for creating organizations:
+1. **Sidebar dropdown:** "Create Organization" menu item opens a dialog
+2. **Settings > Organization page:** "Create Organization" button in the "Your Organizations" section
 
 Both use the `useCreateOrganization` hook (`hooks/use-organizations.ts`) which calls `POST /v1/orgs`. On success, the new org is auto-selected as the current org via `setCurrentOrg()`.
 
@@ -577,8 +577,8 @@ Both use the `useCreateOrganization` hook (`hooks/use-organizations.ts`) which c
 
 The settings sidebar (`/settings/*`) is organized into two labeled sections:
 
-**Organisation** (org-scoped settings):
-- **General** (`/settings/organisation`) — Org name, ID, "Your Organisations" list
+**Organization** (org-scoped settings):
+- **General** (`/settings/organization`) — Org name, ID, "Your Organizations" list
 - **LLM Providers** (`/settings/providers`) — Provider configs and API keys
 - **Members** (`/settings/members`) — Team member list
 
@@ -588,14 +588,14 @@ The settings sidebar (`/settings/*`) is organized into two labeled sections:
 
 Section labels are rendered as uppercase headers (`text-xs font-semibold uppercase tracking-wider`). Active nav item highlighted with accent left border.
 
-### UI Organisation Management
-The settings page (`/settings/organisation`) has two sections:
-1. **Current Organisation:** Edit name, view org ID (existing)
-2. **Your Organisations:** Lists all orgs the user belongs to with switch buttons. Current org highlighted with a "Current" badge.
+### UI Organization Management
+The settings page (`/settings/organization`) has two sections:
+1. **Current Organization:** Edit name, view org ID (existing)
+2. **Your Organizations:** Lists all orgs the user belongs to with switch buttons. Current org highlighted with a "Current" badge.
 
 ## Cross-Org Resource Resolution
 
-Users who belong to multiple organisations routinely follow direct links
+Users who belong to multiple organizations routinely follow direct links
 (shared URLs, bookmarks, external notifications) that point at a resource
 owned by one of their orgs but not the one currently selected. With strict
 org scoping (see the Query Rules above) the entity API returns 404 for that


### PR DESCRIPTION
## What
Standardize organization-related UI copy on American English across the settings navigation, organization settings page, sidebar organization menu, command palette/search text, related setup/error states, and matching UI tests. Update the multitenancy spec to match the existing `/settings/organization` route.

## Why
The route slug is `/settings/organization`, but several user-facing labels used British English, so users clicked “Organisation” and landed on an American-English URL.

## How
Replaced `Organisation`/`organisation` copy with `Organization`/`organization` in affected UI surfaces and tests. Kept existing route and API names unchanged.

## Risk
- Low
- Text-only UI/spec change; the main risk is missed copy or tests asserting old labels.

## Security
- Threat categories reviewed: TM-WEB
- Findings and resolutions: No security-relevant behavior changed. The diff only updates static UI strings, test expectations, and spec copy. No rendering paths, auth/authz checks, API inputs, tenant queries, secrets, or dependencies changed.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)