### PR TITLE
chore(deps): bump @openuidev/react-{lang,ui} to 0.2 / 0.11

### DIFF
--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.8.31",
       "dependencies": {
         "@base-ui/react": "^1.2.0",
-        "@openuidev/react-lang": "^0.1.3",
-        "@openuidev/react-ui": "^0.9.18",
+        "@openuidev/react-lang": "^0.2.4",
+        "@openuidev/react-ui": "^0.11.6",
         "@rjsf/core": "^6.5.1",
         "@rjsf/utils": "^6.5.1",
         "@rjsf/validator-ajv8": "^6.5.1",
@@ -2033,15 +2033,13 @@
       }
     },
     "node_modules/@openuidev/lang-core": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@openuidev/lang-core/-/lang-core-0.1.2.tgz",
-      "integrity": "sha512-ZNkNBrNPGL2VYvT1RpHueKWZozRUIDWMjRFiPcVAc5q6Ul0zcxF1meIWd3K0qbgqlGQbciB2K7oczyjB5ZkZvw==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@openuidev/lang-core/-/lang-core-0.2.4.tgz",
+      "integrity": "sha512-HfY5nb6kAEWjdHL+3pBjw2TLc7TWwVMllaKtTY9itncJJjiPA0dj7mEJmcDpoMJ+NWPv+UbhWhOkmUtqpGOwDQ==",
       "license": "MIT",
-      "dependencies": {
-        "zod": "^4.0.0"
-      },
       "peerDependencies": {
-        "@modelcontextprotocol/sdk": ">=1.0.0"
+        "@modelcontextprotocol/sdk": ">=1.0.0",
+        "zod": "^3.25.0 || ^4.0.0"
       },
       "peerDependenciesMeta": {
         "@modelcontextprotocol/sdk": {
@@ -2050,31 +2048,31 @@
       }
     },
     "node_modules/@openuidev/react-headless": {
-      "version": "0.7.11",
-      "resolved": "https://registry.npmjs.org/@openuidev/react-headless/-/react-headless-0.7.11.tgz",
-      "integrity": "sha512-CxVH8v4lhx+SGUB3jPo8XSq//j6YQ+llehilICL3tFM83ShGxOrIX/G1GLId7SzeGeIXlLR5ElRwu3OOm7cq/Q==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@openuidev/react-headless/-/react-headless-0.8.1.tgz",
+      "integrity": "sha512-D7ROgNQ6a4ZjvtGTXtth+6+QTfa36VJIOsneA1eGeQYiT6yH6s7VDChLVq9JTX1pkQ6ytl0hY8QLZFLcJgbXkg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@ag-ui/core": "^0.0.45"
       },
       "peerDependencies": {
-        "react": ">=19.0.0",
+        "react": "^18.3.1 || ^19.0.0",
         "zustand": "^4.5.5"
       }
     },
     "node_modules/@openuidev/react-lang": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@openuidev/react-lang/-/react-lang-0.1.5.tgz",
-      "integrity": "sha512-5ulTIZzCM+sRaS0arLLVMINf7nZcUIlOqEFUgzWhd1diRCzGKVZ39u7e5QFmmpu08yz2uKX358ql6bW5vD2gcg==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@openuidev/react-lang/-/react-lang-0.2.4.tgz",
+      "integrity": "sha512-DP0NbqI9nhMqK80Ra6kMMtbEdDSh9ZASKsnA/N0FIsO48QZaz4xbHOKXwwAgoFR8kWJcIZ238Hjoqplq9IX/Dw==",
       "license": "MIT",
       "dependencies": {
-        "@openuidev/lang-core": "^0.1.1",
-        "zod": "^4.0.0"
+        "@openuidev/lang-core": "^0.2.4"
       },
       "peerDependencies": {
         "@modelcontextprotocol/sdk": ">=1.0.0",
-        "react": ">=19.0.0"
+        "react": "^18.3.1 || ^19.0.0",
+        "zod": "^3.25.0 || ^4.0.0"
       },
       "peerDependenciesMeta": {
         "@modelcontextprotocol/sdk": {
@@ -2083,15 +2081,16 @@
       }
     },
     "node_modules/@openuidev/react-ui": {
-      "version": "0.9.20",
-      "resolved": "https://registry.npmjs.org/@openuidev/react-ui/-/react-ui-0.9.20.tgz",
-      "integrity": "sha512-SBhBUCg953mbhV1cu5pLiqu95+1lrWvP1AAJ7gG/mZIwpol4ypc+tZOiV5AzYB1yF2SnoqJ/Fk5wmikerWurAA==",
+      "version": "0.11.6",
+      "resolved": "https://registry.npmjs.org/@openuidev/react-ui/-/react-ui-0.11.6.tgz",
+      "integrity": "sha512-CTqisiVn19vw+hmVU+bZnGDounFSXsLsqw0E0u+7pdW3WJDBvfEf2kBVZAmDZ3K54pSKbX9JJc8Kkj7bs+orVg==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/react-dom": "^2.1.2",
         "@radix-ui/react-accordion": "^1.2.2",
         "@radix-ui/react-aspect-ratio": "^1.1.1",
         "@radix-ui/react-checkbox": "^1.1.3",
+        "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.7",
         "@radix-ui/react-label": "^2.1.1",
         "@radix-ui/react-radio-group": "^1.2.2",
@@ -2115,14 +2114,14 @@
         "remark-emoji": "^5.0.1",
         "remark-gfm": "^4.0.1",
         "remark-math": "^6.0.0",
-        "tiny-invariant": "^1.3.3",
-        "zod": "^4.3.6"
+        "tiny-invariant": "^1.3.3"
       },
       "peerDependencies": {
-        "@openuidev/react-headless": "^0.7.10",
-        "@openuidev/react-lang": "^0.1.4",
-        "react": ">=19.0.0",
-        "react-dom": ">=19.0.0",
+        "@openuidev/react-headless": "^0.8.1",
+        "@openuidev/react-lang": "^0.2.4",
+        "react": "^18.3.1 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0",
+        "zod": "^3.25.0 || ^4.0.0",
         "zustand": "^4.5.5"
       }
     },

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -26,8 +26,8 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.2.0",
-    "@openuidev/react-lang": "^0.1.3",
-    "@openuidev/react-ui": "^0.9.18",
+    "@openuidev/react-lang": "^0.2.4",
+    "@openuidev/react-ui": "^0.11.6",
     "@rjsf/core": "^6.5.1",
     "@rjsf/utils": "^6.5.1",
     "@rjsf/validator-ajv8": "^6.5.1",

--- a/apps/ui/src/app/dev/openui-blocks/page.tsx
+++ b/apps/ui/src/app/dev/openui-blocks/page.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+/**
+ * Dev page: OpenUI Blocks
+ *
+ * Smoke surface for the OpenUI renderer integration (specs/openui.md).
+ * Renders representative OpenUI Lang snippets through the production
+ * <OpenUIBlock> + @openuidev/react-lang + @openuidev/react-ui pipeline so
+ * upstream package bumps fail visibly during dev review.
+ */
+
+import { OpenUIBlock } from "@/components/chat/openui-renderer";
+import { DevPageShell } from "@/app/dev/_components/dev-page-shell";
+
+const SAMPLES: { label: string; code: string }[] = [
+  {
+    label: "Card with text",
+    code: `root = Card([Text("Hello from OpenUI")])`,
+  },
+  {
+    label: "Card with header and bar chart",
+    code: `root = Card([header, chart])
+header = CardHeader("Monthly Revenue", "Q1 2024")
+chart = BarChart(labels, [series1])
+labels = ["Jan", "Feb", "Mar"]
+series1 = Series("Revenue", [45000, 52000, 61000])`,
+  },
+  {
+    label: "Malformed input (should hit error boundary fallback)",
+    code: `this is not valid openui lang $$$`,
+  },
+];
+
+export default function OpenUIBlocksDevPage() {
+  return (
+    <DevPageShell
+      eyebrow="OpenUI Blocks"
+      title="OpenUI Lang renderer"
+      description="Renders sample OpenUI Lang snippets through the production OpenUIBlock. Use as a visual smoke check after bumping @openuidev/react-lang or @openuidev/react-ui."
+      widthClassName="max-w-3xl"
+    >
+      <div className="space-y-10">
+        {SAMPLES.map((sample) => (
+          <section key={sample.label} className="space-y-3">
+            <h2 className="text-sm font-medium text-foreground">{sample.label}</h2>
+            <pre className="overflow-x-auto border border-dashed border-border bg-muted/30 p-3 text-xs text-muted-foreground">
+              <code>{sample.code}</code>
+            </pre>
+            <OpenUIBlock code={sample.code} />
+          </section>
+        ))}
+      </div>
+    </DevPageShell>
+  );
+}

--- a/apps/ui/src/app/dev/page.tsx
+++ b/apps/ui/src/app/dev/page.tsx
@@ -74,6 +74,13 @@ const devPages = [
     href: "/dev/mcp-cards",
     icon: IdCard,
   },
+  {
+    title: "OpenUI Blocks",
+    description:
+      "OpenUI Lang renderer smoke surface (specs/openui.md) — Cards, charts, error boundary",
+    href: "/dev/openui-blocks",
+    icon: Sparkles,
+  },
 ];
 
 export default function DevPage() {

--- a/apps/ui/src/components/chat/openui-renderer.tsx
+++ b/apps/ui/src/components/chat/openui-renderer.tsx
@@ -7,6 +7,13 @@
  * to parse and render OpenUI Lang DSL code into React components (charts, tables,
  * forms, cards, etc.).
  *
+ * Decision: dynamic-import @openuidev/react-lang and @openuidev/react-ui with
+ * { ssr: false }. Starting at @openuidev/react-ui 0.11 the genui-lib bundle
+ * references `document` at module load time, which crashes Next.js's
+ * server-side render path for client components. Loading them lazily on the
+ * client only avoids the SSR error without affecting end-user behavior — chat
+ * messages never render until the client mounts anyway.
+ *
  * Wraps the Renderer in an error boundary to catch "Objects are not valid as a
  * React child" errors that occur when the LLM generates malformed OpenUI code
  * (e.g. passing an element where a string prop is expected). The parser doesn't
@@ -17,10 +24,27 @@
  * @see https://github.com/thesysdev/openui
  */
 
-import { Renderer } from "@openuidev/react-lang";
-import { openuiLibrary } from "@openuidev/react-ui/genui-lib";
-import "@openuidev/react-ui/components.css";
+import dynamic from "next/dynamic";
 import { Component, type ErrorInfo, type ReactNode } from "react";
+// CSS is a static side-effect import; safe under SSR (Next emits the link tag
+// rather than executing module code). Only the JS bundle touches `document`.
+import "@openuidev/react-ui/components.css";
+
+const OpenUIRendererInner = dynamic(
+  () =>
+    Promise.all([import("@openuidev/react-lang"), import("@openuidev/react-ui/genui-lib")]).then(
+      ([lang, lib]) => {
+        const { Renderer } = lang;
+        const { openuiLibrary } = lib;
+        function ClientRenderer({ code, isStreaming }: { code: string; isStreaming: boolean }) {
+          return <Renderer response={code} library={openuiLibrary} isStreaming={isStreaming} />;
+        }
+        ClientRenderer.displayName = "OpenUIClientRenderer";
+        return ClientRenderer;
+      },
+    ),
+  { ssr: false },
+);
 
 interface OpenUIBlockProps {
   /** Raw OpenUI Lang code (without the ```openui fences) */
@@ -73,12 +97,6 @@ class OpenUIErrorBoundary extends Component<EBProps, EBState> {
 
 /**
  * Renders a single OpenUI Lang code block into interactive UI components.
- *
- * The Renderer component from @openuidev/react-lang handles:
- * - Parsing the OpenUI Lang DSL
- * - Resolving forward references (hoisting)
- * - Progressive rendering during streaming
- * - Error boundaries for malformed output
  */
 export function OpenUIBlock({ code, isStreaming = false }: OpenUIBlockProps) {
   if (!code.trim()) return null;
@@ -92,7 +110,7 @@ export function OpenUIBlock({ code, isStreaming = false }: OpenUIBlockProps) {
   return (
     <div className="openui-block my-2 overflow-hidden border border-border bg-card">
       <OpenUIErrorBoundary fallback={fallback}>
-        <Renderer response={code} library={openuiLibrary} isStreaming={isStreaming} />
+        <OpenUIRendererInner code={code} isStreaming={isStreaming} />
       </OpenUIErrorBoundary>
     </div>
   );


### PR DESCRIPTION
## What
Bump `@openuidev/react-lang` from `^0.1.3` (resolved 0.1.5) to `^0.2.4`, and `@openuidev/react-ui` from `^0.9.18` (resolved 0.9.20) to `^0.11.6`.

Adds a permanent `/dev/openui-blocks` dev surface that renders representative OpenUI Lang snippets through the production `OpenUIBlock`. Linked from the dev index so future bumps can be visually smoke-tested without spinning up an agent + chat.

## Why
Both upstream packages crossed a packaging boundary (0.1 → 0.2 and 0.10 → 0.11): switched to dual ESM/CJS builds, `zod` moved from a direct dep to a peer, and the React peer range broadened. The public Renderer surface (`response`, `library`, `isStreaming`) and the `genui-lib` / `components.css` subpath exports stayed compatible — verified by smoke-testing the dev page against a running `next dev` (HTTP 200, OpenUI containers rendered).

This was deferred from earlier maintenance because the OpenUI renderer is the canonical generative-UI surface and the changelog flagged restructured exports. Holding off on a blind bump was correct: smoke-testing revealed a real SSR regression (see below).

## How
- `apps/ui/package.json`: bumped the two minimum versions; `npm install` refreshed the lockfile (installed 0.2.4 and 0.11.6).
- `apps/ui/src/components/chat/openui-renderer.tsx`: switched the JS imports to `next/dynamic` with `ssr: false`. The CSS stays as a top-level side-effect import so the stylesheet link is still emitted during SSR.
- `apps/ui/src/app/dev/openui-blocks/page.tsx` (new): three sample snippets — text card, bar chart, malformed (error-boundary fallback). Linked from `src/app/dev/page.tsx`.

### Why the SSR change is required
Starting at `@openuidev/react-ui` 0.11, the `genui-lib` bundle references `document` at module load. Importing it from a `"use client"` component still executes during Next.js's server-side render of the client component, which fails with:
```
ReferenceError: document is not defined
   at .../@openuidev/react-ui/dist/genui-lib/index.mjs:2497:25
```
Dynamic-importing with `{ ssr: false }` defers the bundle execution to the browser. Chat messages already render only on the client, so end-user behavior is unchanged.

## Risk
- Low/Medium. The bumped packages drive the generative-UI rendering for chat messages — broken rendering is user-visible.
- Mitigated by: the new dev page (visual smoke), the existing 16 `openui-utils` unit tests, and an end-to-end SSR verification against the bumped versions (HTTP 200, output contains the expected `openui-block` containers and the `BAILOUT_TO_CLIENT_SIDE_RENDERING` markers that confirm the `ssr: false` is taking effect).
- One behavioral change worth noting: the OpenUI tree no longer renders during SSR; previously it did (in 0.9). For chat this is invisible, but anyone server-rendering OpenUI elsewhere should be aware.

## Security
- Threat categories reviewed: dependency-supply-chain. No new auth, network, or sandbox surface. OpenUI is sandboxed via its own component library; no `dangerouslySetInnerHTML` paths added.
- Findings and resolutions: none.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated — new `/dev/openui-blocks` smoke page; existing `openui-utils` tests pass
- [x] Backward compatibility considered (SSR change documented; chat behavior unchanged)
- [x] Security review performed against relevant threat model categories
- [ ] All review comments addressed (code change or written reasoning)

## Validation
- `npm run build` ✓ (Compiled successfully in 31.2s)
- `npm run lint` ✓ (0 errors, 6 pre-existing warnings)
- `npm test -- --testPathPatterns="openui"` — 16/16 passing
- `curl http://localhost:9100/dev/openui-blocks` returns HTTP 200 with the three sample sections and `openui-block` containers present in the SSR output

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ksub5mbzQ6EFk5fB16ggNr)_