### PR TITLE
chore(deps): bump lucide-react to 1.16

### DIFF
--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -23,7 +23,7 @@
         "cron-parser": "^5.5.0",
         "cronstrue": "^3.14.0",
         "date-fns": "^4.1.0",
-        "lucide-react": "^0.577.0",
+        "lucide-react": "^1.16.0",
         "next": "^16.2.6",
         "radix-ui": "^1.4.3",
         "react": "^19.2.4",
@@ -10197,9 +10197,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "0.577.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.577.0.tgz",
-      "integrity": "sha512-4LjoFv2eEPwYDPg/CUdBJQSDfPyzXCRrVW1X7jrx/trgxnxkHFjnVZINbzvzxjN70dxychOfg+FTYwBiS3pQ5A==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.16.0.tgz",
+      "integrity": "sha512-dYwyPzb4MEKpGUmNYk3WKWPnMrHs3FKM+q94kAnJrcDIqqn1hq2xY8scaS2ovsOCM5D51ey2gaRG3PBb1vgoYQ==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -40,7 +40,7 @@
     "cron-parser": "^5.5.0",
     "cronstrue": "^3.14.0",
     "date-fns": "^4.1.0",
-    "lucide-react": "^0.577.0",
+    "lucide-react": "^1.16.0",
     "next": "^16.2.6",
     "radix-ui": "^1.4.3",
     "react": "^19.2.4",

--- a/apps/ui/src/app/(main)/volumes/[volumeId]/page.tsx
+++ b/apps/ui/src/app/(main)/volumes/[volumeId]/page.tsx
@@ -7,11 +7,11 @@ import {
   Archive,
   ArrowLeft,
   GitBranch,
-  Github,
   HardDrive,
   Pencil,
   RefreshCw,
 } from "lucide-react";
+import { GithubIcon as Github } from "@/components/icons/github-icon";
 import { ResourceNotFound } from "@/components/resource-not-found";
 import { ArchiveVolumeDialog } from "@/components/volumes/archive-volume-dialog";
 import { VolumeFormDialog } from "@/components/volumes/volume-form-dialog";

--- a/apps/ui/src/app/(main)/volumes/page.tsx
+++ b/apps/ui/src/app/(main)/volumes/page.tsx
@@ -7,13 +7,13 @@ import {
   Archive,
   FolderOpen,
   GitBranch,
-  Github,
   HardDrive,
   Pencil,
   Plus,
   RefreshCw,
   Search,
 } from "lucide-react";
+import { GithubIcon as Github } from "@/components/icons/github-icon";
 import { ArchiveFilter } from "@/components/archive-filter";
 import { QueryStateWrapper } from "@/components/query-state-wrapper";
 import { ArchiveVolumeDialog } from "@/components/volumes/archive-volume-dialog";

--- a/apps/ui/src/components/apps/channel-form.tsx
+++ b/apps/ui/src/components/apps/channel-form.tsx
@@ -1,14 +1,7 @@
 "use client";
 
-import {
-  CalendarClock,
-  Hash,
-  MessageSquareText,
-  Monitor,
-  RefreshCw,
-  Slack,
-  Webhook,
-} from "lucide-react";
+import { CalendarClock, Hash, MessageSquareText, Monitor, RefreshCw, Webhook } from "lucide-react";
+import { SlackIcon as Slack } from "@/components/icons/slack-icon";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";

--- a/apps/ui/src/components/apps/channel-row.tsx
+++ b/apps/ui/src/components/apps/channel-row.tsx
@@ -8,9 +8,9 @@ import {
   Monitor,
   MoreHorizontal,
   Play,
-  Slack,
   Webhook,
 } from "lucide-react";
+import { SlackIcon as Slack } from "@/components/icons/slack-icon";
 import { Badge } from "@/components/ui/badge";
 import { Button, buttonVariants } from "@/components/ui/button";
 import {

--- a/apps/ui/src/components/connections/provider-icon.tsx
+++ b/apps/ui/src/components/connections/provider-icon.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import type { ComponentType } from "react";
-import { Github, Cloud, Search, LinkIcon } from "lucide-react";
+import { Cloud, Search, LinkIcon } from "lucide-react";
+import { GithubIcon as Github } from "@/components/icons/github-icon";
 import { getCapabilityIcon } from "@/lib/capability-icons";
 
 const iconMap: Record<string, ComponentType<{ className?: string }>> = {

--- a/apps/ui/src/components/icons/github-icon.tsx
+++ b/apps/ui/src/components/icons/github-icon.tsx
@@ -1,0 +1,37 @@
+import { forwardRef, type SVGProps } from "react";
+import { cn } from "@/lib/utils";
+
+/**
+ * Custom GitHub icon, drop-in replacement for the `Github` icon that
+ * lucide-react removed in 1.0 (along with the rest of the brand-icon set).
+ *
+ * The SVG path matches the lucide v0 octocat-style mark so visual parity is
+ * preserved across the call sites that previously imported `Github` from
+ * `lucide-react`. Same props contract as a lucide icon (SVG props pass through,
+ * `className` mergeable, `aria-hidden` default).
+ */
+export const GithubIcon = forwardRef<SVGSVGElement, SVGProps<SVGSVGElement>>(function GithubIcon(
+  { className, ...props },
+  ref,
+) {
+  return (
+    <svg
+      ref={ref}
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      className={cn(className)}
+      {...props}
+    >
+      <path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4" />
+      <path d="M9 18c-4.51 2-5-2-7-2" />
+    </svg>
+  );
+});

--- a/apps/ui/src/components/icons/slack-icon.tsx
+++ b/apps/ui/src/components/icons/slack-icon.tsx
@@ -1,0 +1,39 @@
+import { forwardRef, type SVGProps } from "react";
+import { cn } from "@/lib/utils";
+
+/**
+ * Custom Slack icon, drop-in replacement for the `Slack` icon that lucide-react
+ * removed in 1.0 (brand-icon cleanup). Path matches the lucide v0 Slack mark
+ * (four-rect-and-bars composition) for visual parity at existing call sites.
+ */
+export const SlackIcon = forwardRef<SVGSVGElement, SVGProps<SVGSVGElement>>(function SlackIcon(
+  { className, ...props },
+  ref,
+) {
+  return (
+    <svg
+      ref={ref}
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      className={cn(className)}
+      {...props}
+    >
+      <rect width="3" height="8" x="13" y="2" rx="1.5" />
+      <path d="M19 8.5V10h1.5A1.5 1.5 0 1 0 19 8.5" />
+      <rect width="3" height="8" x="8" y="14" rx="1.5" />
+      <path d="M5 15.5V14H3.5A1.5 1.5 0 1 0 5 15.5" />
+      <rect width="8" height="3" x="14" y="13" rx="1.5" />
+      <path d="M15.5 19H14v1.5a1.5 1.5 0 1 0 1.5-1.5" />
+      <rect width="8" height="3" x="2" y="8" rx="1.5" />
+      <path d="M8.5 5H10V3.5A1.5 1.5 0 1 0 8.5 5" />
+    </svg>
+  );
+});

--- a/apps/ui/src/components/icons/twitter-icon.tsx
+++ b/apps/ui/src/components/icons/twitter-icon.tsx
@@ -1,0 +1,32 @@
+import { forwardRef, type SVGProps } from "react";
+import { cn } from "@/lib/utils";
+
+/**
+ * Custom Twitter icon, drop-in replacement for the `Twitter` icon that
+ * lucide-react removed in 1.0 (brand-icon cleanup). Path matches the lucide
+ * v0 Twitter mark for visual parity at existing call sites.
+ */
+export const TwitterIcon = forwardRef<SVGSVGElement, SVGProps<SVGSVGElement>>(function TwitterIcon(
+  { className, ...props },
+  ref,
+) {
+  return (
+    <svg
+      ref={ref}
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      className={cn(className)}
+      {...props}
+    >
+      <path d="M22 4s-.7 2.1-2 3.4c1.6 10-9.4 17.3-18 11.6 2.2.1 4.4-.6 6-2C3 15.5.5 9.6 3 5c2.2 2.6 5.6 4.1 9 4-.9-4.2 4-6.6 7-3.8 1.1 0 3-1.2 3-1.2z" />
+    </svg>
+  );
+});

--- a/apps/ui/src/components/markdown/markdown-link.tsx
+++ b/apps/ui/src/components/markdown/markdown-link.tsx
@@ -1,6 +1,8 @@
 "use client";
 
-import { Github, Globe2, Twitter, type LucideIcon } from "lucide-react";
+import { Globe2, type LucideIcon } from "lucide-react";
+import { GithubIcon as Github } from "@/components/icons/github-icon";
+import { TwitterIcon as Twitter } from "@/components/icons/twitter-icon";
 import { type AnchorHTMLAttributes, type ComponentType } from "react";
 import { cn } from "@/lib/utils";
 


### PR DESCRIPTION
## What
Bump `lucide-react` from `^0.577.0` to `^1.16.0`.

`lucide-react` 1.0 removed the brand-icon set (Github, Gitlab, Slack, Twitter, Figma, Facebook, Instagram, LinkedIn, etc.). Standard utility icons (Plus, X, Edit, ArrowLeft, …) were not affected — 167 of our 170 lucide imports keep working unchanged.

Three of the removed brand icons are used in this codebase. Added drop-in custom replacements:

- `src/components/icons/github-icon.tsx`
- `src/components/icons/twitter-icon.tsx`
- `src/components/icons/slack-icon.tsx`

Each uses the lucide v0 SVG path data so visual rendering is unchanged at every call site. Same props contract (`SVGProps<SVGSVGElement>`, `forwardRef`, `aria-hidden` default) so they behave as drop-in replacements.

Call sites updated to import via aliases (`GithubIcon as Github`, etc.) so usage code didn't have to change beyond the import line:

- `src/components/connections/provider-icon.tsx` (provider icon map)
- `src/components/markdown/markdown-link.tsx` (link kind icons)
- `src/app/(main)/volumes/page.tsx`
- `src/app/(main)/volumes/[volumeId]/page.tsx`
- `src/components/apps/channel-form.tsx`
- `src/components/apps/channel-row.tsx`

## Why
Two-version drift on a foundational icon library wasn't catching up; the 1.0 rename event made it a chore PR rather than a one-line bump, so it was held back earlier. Now done.

## How
1. `lucide-react` bumped in `apps/ui/package.json`.
2. `npm install` refreshed the lockfile (resolved 1.16.0).
3. Added three custom SVG icon components matching the lucide v0 mark.
4. Updated import lines at the six call sites to source the brand icons from `@/components/icons/*`.

## Risk
- Low/Medium. Icon SVGs are visually identical to v0. The renamed-via-alias imports preserve the existing JSX usage exactly (still `<Github className="..." />` etc.).
- Verified by `npm run build` (compiles clean), `npm run lint` (no new warnings), `npm test` (`provider-icon` + `volumes-page` — 36/36 passing), and `tsc --noEmit` (no new type errors in touched files).

## Security
- Threat categories reviewed: dependency-supply-chain, TM-WEB. No new attack surface — SVG paths are static literals; no new DOM/HTML injection paths. The icon components don't accept arbitrary children or `dangerouslySetInnerHTML`. npm audit clean.
- Findings and resolutions: none.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated — relied on existing component tests
- [x] Backward compatibility considered — drop-in aliasing preserves JSX usage
- [x] Security review performed against relevant threat model categories
- [ ] All review comments addressed (code change or written reasoning)

## Validation
- `npm run build` ✓ Compiled successfully in 30.1s
- `npm run lint` ✓ (0 errors, 6 pre-existing warnings)
- `npm test -- --testPathPatterns="provider-icon|volumes-page"` — 36/36 ✓
- `tsc --noEmit` — no new type errors in touched files

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ksub5mbzQ6EFk5fB16ggNr)_