### PR TITLE
chore(deps): bump marked to 18

### DIFF
--- a/apps/docs/package-lock.json
+++ b/apps/docs/package-lock.json
@@ -12,7 +12,7 @@
         "@astrojs/starlight": "^0.39.2",
         "astro": "^6.1.8",
         "js-yaml": "^4.1.0",
-        "marked": "^16.4.1",
+        "marked": "^18.0.3",
         "sharp": "^0.34.5",
         "shiki": "^4.0.2",
         "starlight-openapi": "^0.24.0",
@@ -4078,9 +4078,9 @@
       }
     },
     "node_modules/marked": {
-      "version": "16.4.2",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
-      "integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
+      "version": "18.0.3",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.3.tgz",
+      "integrity": "sha512-7VT90JOkDeaRWpfjOReRGPEKn0ecdARBkDGL+tT1wZY0efPPqkUxLUSmzy/C7TIylQYJC9STISEsCHrqb/7VIA==",
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -19,7 +19,7 @@
     "@astrojs/starlight": "^0.39.2",
     "astro": "^6.1.8",
     "js-yaml": "^4.1.0",
-    "marked": "^16.4.1",
+    "marked": "^18.0.3",
     "shiki": "^4.0.2",
     "sharp": "^0.34.5",
     "starlight-openapi": "^0.24.0",


### PR DESCRIPTION
## What
Bump `marked` from `^16.4.1` to `^18.0.3` in `apps/docs`.

## Why
Two-major drift. `marked` is used in `apps/docs/scripts/render-notebooks.mjs` for tutorial-notebook HTML rendering. Held back earlier because I couldn't fetch the public changelog. Verified compatibility by running the actual notebook render via `npm run build`.

## How
- Bumped `marked` in `apps/docs/package.json`.
- `npm install` refreshed the lockfile.
- No source changes required. The renderer already uses the modern token-based API:
  - `new marked.Renderer()` (still supported)
  - `renderer.heading/code/link/image` receive token objects (`{ tokens, text, lang, href, ... }`) — that's the marked 5+ shape, unchanged across 17/18
  - `marked.parse(source, opts)` — unchanged

## Risk
- Low. Notebook rendering covered by `verify-notebooks.mjs` postbuild — passed. Docs site rebuilt clean with 308 pages.

## Security
- Threat categories reviewed: dependency-supply-chain. No new HTML/URL parsing surface; renderer already sanitizes URLs via `sanitizeMarkdownUrl` and escapes content via `escapeHtml`.
- Findings and resolutions: none.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated — relied on existing notebook verification
- [x] Backward compatibility considered (API surface preserved)
- [x] Security review performed against relevant threat model categories
- [ ] All review comments addressed (code change or written reasoning)

## Validation
- `cd apps/docs && npm run build` ✓ (308 pages built; postbuild notebook verification passing)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ksub5mbzQ6EFk5fB16ggNr)_