### PR TITLE
chore(deps): bump typescript to 6 in apps/docs

### DIFF
--- a/apps/docs/package-lock.json
+++ b/apps/docs/package-lock.json
@@ -17,7 +17,7 @@
         "shiki": "^4.0.2",
         "starlight-openapi": "^0.24.0",
         "starlight-sidebar-topics": "^0.7.1",
-        "typescript": "^5.9.3"
+        "typescript": "^6.0.3"
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {
@@ -6355,9 +6355,9 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -24,7 +24,7 @@
     "sharp": "^0.34.5",
     "starlight-openapi": "^0.24.0",
     "starlight-sidebar-topics": "^0.7.1",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   },
   "overrides": {
     "lodash": "4.17.23",


### PR DESCRIPTION
## What
Bump `typescript` from `^5.9.3` to `^6.0.3` in `apps/docs`.

Scoped to `apps/docs` only. `apps/ui` has its own `typescript` in `devDependencies` and is not touched by this PR.

## Why
Major-version drift. Held back earlier as needing a dedicated test pass. That pass is now done — `astro check` (which runs TS under the hood) reports 0 errors, 0 warnings, and the same 2 pre-existing hints (`ts(6133)` "declared but never used" in `scripts/generate-og-image.mjs`) it reported on TS 5.9.

## How
- Bumped `typescript` in `apps/docs/package.json`.
- `npm install` refreshed the lockfile.

## Risk
- Low. Docs site is a static Astro build; TS is only used for content-collection typings and the few .ts scripts under `apps/docs/`. `npm run build` succeeds with 308 pages emitted, notebook postbuild verification passes, and `npm run check` is clean.

## Security
- No security-relevant code changes — pure dev-dep bump for a static-docs build.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated — relied on `astro check` and `npm run build`
- [x] Backward compatibility considered (docs-only, no public API)
- [x] Security review performed against relevant threat model categories
- [ ] All review comments addressed (code change or written reasoning)

## Validation
- `cd apps/docs && npm run check` — 0 errors / 0 warnings / 2 pre-existing hints ✓
- `cd apps/docs && npm run build` — 308 pages built clean; notebook verification passing

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ksub5mbzQ6EFk5fB16ggNr)_