### PR TITLE
chore(release): publish public crates

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -1,0 +1,180 @@
+name: Publish Crates
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag (e.g., v0.8.31)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-crates-${{ github.event.release.tag_name || inputs.tag || github.ref }}
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  publish:
+    name: Publish crates.io packages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve release tag
+        id: release
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ inputs.tag }}"
+          else
+            TAG="${{ github.event.release.tag_name }}"
+          fi
+          if [ -z "$TAG" ]; then
+            echo "::error::Release tag is required"
+            exit 1
+          fi
+          if [[ "$TAG" != v* ]]; then
+            echo "::error::Release tag must start with v: $TAG"
+            exit 1
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.release.outputs.tag }}
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Verify workspace version matches tag
+        run: |
+          VERSION="${{ steps.release.outputs.version }}"
+          python3 - "$VERSION" <<'PY'
+          import sys
+          import tomllib
+
+          expected = sys.argv[1]
+
+          def load(path):
+              with open(path, "rb") as handle:
+                  return tomllib.load(handle)
+
+          workspace = load("Cargo.toml")
+          workspace_version = workspace["workspace"]["package"]["version"]
+          if workspace_version != expected:
+              raise SystemExit(
+                  f"Tag version ({expected}) does not match workspace package version ({workspace_version})"
+              )
+
+          dependency_versions = {
+              "crates/core/Cargo.toml": [
+                  "everruns-config",
+                  "everruns-openui",
+                  "everruns-a2ui",
+              ],
+              "crates/runtime/Cargo.toml": [
+                  "everruns-core",
+              ],
+          }
+
+          for manifest_path, dependency_names in dependency_versions.items():
+              manifest = load(manifest_path)
+              dependencies = manifest.get("dependencies", {})
+              for dependency_name in dependency_names:
+                  dependency = dependencies[dependency_name]
+                  version = dependency.get("version") if isinstance(dependency, dict) else dependency
+                  if version != expected:
+                      raise SystemExit(
+                          f"{manifest_path} dependency {dependency_name} version ({version}) does not match tag ({expected})"
+                      )
+
+          print(f"Version verified: {expected}")
+          PY
+
+      - name: Publish crates
+        run: |
+          set -euo pipefail
+
+          VERSION="${{ steps.release.outputs.version }}"
+          CRATES=(
+            everruns-config
+            everruns-openui
+            everruns-a2ui
+            everruns-core
+            everruns-runtime
+          )
+
+          publish_status() {
+            local crate="$1"
+            local version="$2"
+            python3 - "$crate" "$version" <<'PY'
+          import sys
+          import urllib.error
+          import urllib.request
+
+          crate, version = sys.argv[1], sys.argv[2]
+          url = f"https://crates.io/api/v1/crates/{crate}/{version}"
+          request = urllib.request.Request(url, headers={"User-Agent": "everruns-ci"})
+          try:
+              with urllib.request.urlopen(request, timeout=20) as response:
+                  print("published" if response.status == 200 else "error")
+          except urllib.error.HTTPError as error:
+              print("missing" if error.code == 404 else "error")
+          except urllib.error.URLError:
+              print("error")
+          PY
+          }
+
+          initial_publish_status() {
+            local crate="$1"
+            local version="$2"
+            local status
+            for attempt in {1..6}; do
+              status="$(publish_status "$crate" "$version")"
+              if [ "$status" != "error" ]; then
+                echo "$status"
+                return 0
+              fi
+              echo "crates.io lookup for $crate $version failed ($attempt/6); retrying" >&2
+              sleep 10
+            done
+            echo "::error::Could not determine whether $crate $version is already published" >&2
+            return 1
+          }
+
+          wait_until_published() {
+            local crate="$1"
+            local version="$2"
+            local status
+            for attempt in {1..30}; do
+              status="$(publish_status "$crate" "$version")"
+              if [ "$status" = "published" ]; then
+                echo "$crate $version is visible on crates.io"
+                return 0
+              fi
+              echo "Waiting for $crate $version to appear on crates.io ($attempt/30, status=$status)"
+              sleep 10
+            done
+            echo "::error::$crate $version did not appear on crates.io in time"
+            return 1
+          }
+
+          for crate in "${CRATES[@]}"; do
+            status="$(initial_publish_status "$crate" "$VERSION")"
+            if [ "$status" = "published" ]; then
+              echo "$crate $VERSION already published; skipping"
+            elif [ "$status" = "missing" ]; then
+              echo "Publishing $crate $VERSION"
+              cargo package --locked -p "$crate"
+              CARGO_REGISTRY_TOKEN="${{ secrets.CARGO_REGISTRY_TOKEN }}" cargo publish --locked -p "$crate"
+            else
+              echo "::error::Unexpected crates.io lookup status for $crate $VERSION: $status"
+              exit 1
+            fi
+            wait_until_published "$crate" "$VERSION"
+          done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,6 +139,15 @@ jobs:
           gh workflow run cli-binaries.yml --ref "$TAG" -f "tag=$TAG"
           echo "CLI binary builds triggered for $TAG"
 
+      - name: Trigger crates.io publish for release tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="v${{ steps.version.outputs.version }}"
+          echo "Triggering crates.io publish for tag $TAG..."
+          gh workflow run publish-crates.yml --ref "$TAG" -f "tag=$TAG"
+          echo "crates.io publish triggered for $TAG"
+
       - name: Trigger server & worker binary builds for release tag
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,8 @@ version = "0.8.31"
 edition = "2024"
 license = "MIT"
 authors = ["Everruns Contributors"]
+homepage = "https://everruns.com"
+repository = "https://github.com/everruns/everruns"
 
 [workspace.dependencies]
 # Async runtime

--- a/crates/a2ui/Cargo.toml
+++ b/crates/a2ui/Cargo.toml
@@ -12,6 +12,9 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+documentation = "https://docs.rs/everruns-a2ui"
 description = "A2UI component catalog and prompt generator for Everruns"
 
 [dependencies]

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -10,6 +10,9 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+documentation = "https://docs.rs/everruns-config"
 description = "Shared configuration loading helpers for Everruns"
 
 [dependencies]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -11,11 +11,14 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+documentation = "https://docs.rs/everruns-core"
 description = "Core agent abstractions for Everruns - agent loop, events, tools, LLM providers"
 
 [dependencies]
 # Core dependencies
-everruns-config = { path = "../config" }
+everruns-config = { path = "../config", version = "0.8.31" }
 anyhow.workspace = true
 thiserror.workspace = true
 async-trait.workspace = true
@@ -98,23 +101,25 @@ inventory.workspace = true
 llmsim = "0.2.1"
 
 # OpenUI component definitions and prompt generator
-everruns-openui = { path = "../openui" }
+everruns-openui = { path = "../openui", version = "0.8.31", optional = true }
 
 # A2UI component catalog and prompt generator
-everruns-a2ui = { path = "../a2ui" }
+everruns-a2ui = { path = "../a2ui", version = "0.8.31", optional = true }
 
 # A2A outbound agent delegation
 a2a.workspace = true
 a2a-client.workspace = true
 
 # Compile-time directory embedding for virtual mounts (platform docs)
-include_dir = "0.7"
+include_dir = { version = "0.7", optional = true }
 
 [features]
 default = ["llm-tests"]
+embedded-platform-docs = ["dep:include_dir"]
 openapi = ["utoipa"]
 sqlx = ["dep:sqlx"]
 tree-sitter-outlines = ["dep:tree-sitter", "dep:tree-sitter-rust", "dep:tree-sitter-typescript", "dep:tree-sitter-python"]
+ui-capabilities = ["dep:everruns-openui", "dep:everruns-a2ui"]
 llm-tests = []  # LLM integration tests (requires API keys)
 
 [dev-dependencies]

--- a/crates/core/build.rs
+++ b/crates/core/build.rs
@@ -1,0 +1,13 @@
+use std::path::Path;
+
+fn main() {
+    println!("cargo:rustc-check-cfg=cfg(everruns_has_workspace_docs)");
+
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR is set");
+    let docs_dir = Path::new(&manifest_dir).join("../../docs");
+
+    println!("cargo:rerun-if-changed={}", docs_dir.display());
+    if docs_dir.is_dir() {
+        println!("cargo:rustc-cfg=everruns_has_workspace_docs");
+    }
+}

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -78,6 +78,7 @@ pub use crate::capability_types::{
 // ============================================================================
 
 mod a2a_delegation;
+#[cfg(feature = "ui-capabilities")]
 mod a2ui;
 mod agent_instructions;
 pub mod attach_skill;
@@ -99,6 +100,7 @@ mod loop_detection;
 pub mod mcp;
 mod noop;
 mod openai_tool_search;
+#[cfg(feature = "ui-capabilities")]
 mod openui;
 mod parallel;
 pub mod persistent_memory;
@@ -129,6 +131,7 @@ pub use a2a_delegation::{
     A2A_AGENT_DELEGATION_CAPABILITY_ID, A2aAgentDelegationCapability, CancelAgentTool,
     GetAgentRunsTool, MessageAgentTool, SpawnAgentTool, WaitAgentTool,
 };
+#[cfg(feature = "ui-capabilities")]
 pub use a2ui::{A2UI_CAPABILITY_ID, A2UiCapability};
 pub use agent_instructions::{
     AGENT_INSTRUCTIONS_CAPABILITY_ID, AGENTS_MD_PATH, AgentInstructionsCapability,
@@ -199,6 +202,7 @@ pub use noop::NoopCapability;
 pub use openai_tool_search::{
     DEFAULT_TOOL_SEARCH_THRESHOLD, OPENAI_TOOL_SEARCH_CAPABILITY_ID, OpenAiToolSearchCapability,
 };
+#[cfg(feature = "ui-capabilities")]
 pub use openui::{OPENUI_CAPABILITY_ID, OpenUiCapability};
 pub use parallel::ParallelCapability;
 pub use persistent_memory::{
@@ -826,9 +830,12 @@ impl CapabilityRegistry {
         // first sentence of the system prompt. Streaming-output guardrail.
         registry.register(PromptCanaryGuardrailCapability);
 
-        // OpenUI generative UI (all environments)
-        registry.register(OpenUiCapability);
-        registry.register(A2UiCapability);
+        // OpenUI/A2UI prompt helpers are product features, not required by embedders.
+        #[cfg(feature = "ui-capabilities")]
+        {
+            registry.register(OpenUiCapability);
+            registry.register(A2UiCapability);
+        }
 
         // Demo capability with mount points (all environments)
         registry.register(SampleDataCapability);
@@ -1797,7 +1804,7 @@ mod tests {
     }
 
     fn expected_core_builtin_ids() -> BTreeSet<&'static str> {
-        [
+        let mut ids = [
             "agent_instructions",
             "human_intent",
             "budgeting",
@@ -1828,8 +1835,6 @@ mod tests {
             "subagents",
             "a2a_agent_delegation",
             "system_commands",
-            "openui",
-            "a2ui",
             "sample_data",
             "data_knowledge",
             "knowledge_base",
@@ -1842,7 +1847,12 @@ mod tests {
             "prompt_canary_guardrail",
         ]
         .into_iter()
-        .collect()
+        .collect::<BTreeSet<_>>();
+        if cfg!(feature = "ui-capabilities") {
+            ids.insert("openui");
+            ids.insert("a2ui");
+        }
+        ids
     }
 
     fn registry_ids(registry: &CapabilityRegistry) -> BTreeSet<&str> {

--- a/crates/core/src/capabilities/platform_management.rs
+++ b/crates/core/src/capabilities/platform_management.rs
@@ -5,19 +5,23 @@
 //           write tools (manage_*) perform mutations. Session I/O split into three single-purpose tools.
 // Decision: All results include UI links via PlatformStore::base_url()
 // Decision: get_messages defaults to last 10; session_read_response defaults to 120s timeout
-// Decision: Platform docs (docs/) are embedded at compile time via include_dir! and mounted
+// Decision: Platform docs (docs/) are optionally embedded at compile time and mounted
 //           as a virtual readonly filesystem at /docs. This gives the platform chat agent
-//           access to Everruns documentation without DB writes per session.
+//           access to Everruns documentation without DB writes per session while allowing
+//           the public core crate to build without repo-root files.
 
 use super::{Capability, CapabilityStatus, MountPoint, is_declarative_capability};
 use crate::app::{App, AppChannel, ChannelType};
+#[cfg(all(feature = "embedded-platform-docs", everruns_has_workspace_docs))]
 use crate::capability_types::{MountAccess, MountSource, VirtualFileTree};
 use crate::tool_types::ToolHints;
 use crate::tools::{Tool, ToolExecutionResult};
 use crate::traits::ToolContext;
 use async_trait::async_trait;
+#[cfg(all(feature = "embedded-platform-docs", everruns_has_workspace_docs))]
 use include_dir::{Dir, include_dir};
 use serde_json::{Value, json};
+#[cfg(all(feature = "embedded-platform-docs", everruns_has_workspace_docs))]
 use std::sync::Arc;
 
 // =============================================================================
@@ -29,8 +33,10 @@ use std::sync::Arc;
 // =============================================================================
 
 /// Docs directory embedded at compile time from the repo root `docs/`.
+#[cfg(all(feature = "embedded-platform-docs", everruns_has_workspace_docs))]
 static DOCS_DIR: Dir = include_dir!("$CARGO_MANIFEST_DIR/../../docs");
 
+#[cfg(all(feature = "embedded-platform-docs", everruns_has_workspace_docs))]
 fn dir_to_tree(dir: &Dir, base: &str) -> VirtualFileTree {
     let mut tree = VirtualFileTree::new();
     tree.insert_directory(base);
@@ -38,6 +44,7 @@ fn dir_to_tree(dir: &Dir, base: &str) -> VirtualFileTree {
     tree
 }
 
+#[cfg(all(feature = "embedded-platform-docs", everruns_has_workspace_docs))]
 fn populate_tree(tree: &mut VirtualFileTree, dir: &Dir, prefix: &str) {
     for file in dir.files() {
         let name = file
@@ -71,12 +78,36 @@ fn populate_tree(tree: &mut VirtualFileTree, dir: &Dir, prefix: &str) {
 }
 
 /// Lazily-initialized shared tree (built once on first access).
+#[cfg(all(feature = "embedded-platform-docs", everruns_has_workspace_docs))]
 fn docs_tree() -> Arc<VirtualFileTree> {
     use std::sync::OnceLock;
     static TREE: OnceLock<Arc<VirtualFileTree>> = OnceLock::new();
     TREE.get_or_init(|| Arc::new(dir_to_tree(&DOCS_DIR, "/docs")))
         .clone()
 }
+
+#[cfg(all(feature = "embedded-platform-docs", everruns_has_workspace_docs))]
+const SYSTEM_PROMPT: &str = r#"Capabilities extend agent/harness functionality. Three types: built-in, MCP servers, and skills. Use `read_capabilities` to discover IDs before creating agents/harnesses. All results include UI links.
+<platform-docs>
+Platform documentation is available at /workspace/docs in the session filesystem.
+Use `read_file`, `list_directory`, or `grep` to browse and search it.
+Virtual bash commands like `cat /workspace/docs/...`, `ls /workspace/docs/`, and
+`grep -r "pattern" /workspace/docs/` also work.
+
+Key sections:
+- /workspace/docs/getting-started/ — Introduction, concepts, architecture, Docker setup
+- /workspace/docs/features/ — SDK, CLI, UI, events, harnesses, capabilities, apps, skills
+- /workspace/docs/capabilities/ — Per-capability reference (file-system, virtual-bash, web-fetch, etc.)
+- /workspace/docs/integrations/ — External integrations (Slack, Daytona, Browserless, etc.)
+- /workspace/docs/advanced/ — Budgets, compaction, embedding, network access, request signing
+- /workspace/docs/sre/ — Environment variables, admin container, runbooks
+
+When the user asks about Everruns features, configuration, or how things work,
+consult these docs before answering.
+</platform-docs>"#;
+
+#[cfg(not(all(feature = "embedded-platform-docs", everruns_has_workspace_docs)))]
+const SYSTEM_PROMPT: &str = "Capabilities extend agent/harness functionality. Three types: built-in, MCP servers, and skills. Use `read_capabilities` to discover IDs before creating agents/harnesses. All results include UI links.";
 
 pub struct PlatformManagementCapability;
 
@@ -106,27 +137,7 @@ impl Capability for PlatformManagementCapability {
     }
 
     fn system_prompt_addition(&self) -> Option<&str> {
-        Some(
-            r#"Capabilities extend agent/harness functionality. Three types: built-in, MCP servers, and skills. Use `read_capabilities` to discover IDs before creating agents/harnesses. All results include UI links.
-
-<platform-docs>
-Platform documentation is available at /workspace/docs in the session filesystem.
-Use `read_file`, `list_directory`, or `grep` to browse and search it.
-Virtual bash commands like `cat /workspace/docs/...`, `ls /workspace/docs/`, and
-`grep -r "pattern" /workspace/docs/` also work.
-
-Key sections:
-- /workspace/docs/getting-started/ — Introduction, concepts, architecture, Docker setup
-- /workspace/docs/features/ — SDK, CLI, UI, events, harnesses, capabilities, apps, skills
-- /workspace/docs/capabilities/ — Per-capability reference (file-system, virtual-bash, web-fetch, etc.)
-- /workspace/docs/integrations/ — External integrations (Slack, Daytona, Browserless, etc.)
-- /workspace/docs/advanced/ — Budgets, compaction, embedding, network access, request signing
-- /workspace/docs/sre/ — Environment variables, admin container, runbooks
-
-When the user asks about Everruns features, configuration, or how things work,
-consult these docs before answering.
-</platform-docs>"#,
-        )
+        Some(SYSTEM_PROMPT)
     }
 
     fn tools(&self) -> Vec<Box<dyn Tool>> {
@@ -149,16 +160,30 @@ consult these docs before answering.
     }
 
     fn mounts(&self) -> Vec<MountPoint> {
-        vec![MountPoint::new(
-            "/docs",
-            MountAccess::ReadOnly,
-            MountSource::Virtual { tree: docs_tree() },
-            self.id(),
-        )]
+        #[cfg(all(feature = "embedded-platform-docs", everruns_has_workspace_docs))]
+        {
+            vec![MountPoint::new(
+                "/docs",
+                MountAccess::ReadOnly,
+                MountSource::Virtual { tree: docs_tree() },
+                self.id(),
+            )]
+        }
+        #[cfg(not(all(feature = "embedded-platform-docs", everruns_has_workspace_docs)))]
+        {
+            Vec::new()
+        }
     }
 
     fn dependencies(&self) -> Vec<&'static str> {
-        vec!["session_file_system"]
+        #[cfg(all(feature = "embedded-platform-docs", everruns_has_workspace_docs))]
+        {
+            vec!["session_file_system"]
+        }
+        #[cfg(not(all(feature = "embedded-platform-docs", everruns_has_workspace_docs)))]
+        {
+            Vec::new()
+        }
     }
 }
 

--- a/crates/openui/Cargo.toml
+++ b/crates/openui/Cargo.toml
@@ -11,6 +11,9 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+documentation = "https://docs.rs/everruns-openui"
 description = "OpenUI component definitions and prompt generator for Everruns"
 
 [dependencies]

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -8,6 +8,9 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+documentation = "https://docs.rs/everruns-runtime"
 description = "Public in-process runtime for embedding Everruns harnesses"
 
 [dependencies]
@@ -19,7 +22,7 @@ tokio = { workspace = true, features = ["sync"] }
 tracing.workspace = true
 uuid.workspace = true
 
-everruns-core = { path = "../core" }
+everruns-core = { path = "../core", version = "0.8.31" }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -74,7 +74,7 @@ futures-util.workspace = true
 bashkit = { version = "0.5.0", features = ["scripted_tool", "jq"] }
 
 everruns-config = { path = "../config" }
-everruns-core = { path = "../core", features = ["openapi", "sqlx", "tree-sitter-outlines"] }
+everruns-core = { path = "../core", features = ["embedded-platform-docs", "openapi", "sqlx", "tree-sitter-outlines", "ui-capabilities"] }
 everruns-macros = { path = "../macros" }
 everruns-integrations-docker = { path = "../../integrations/docker" }
 everruns-integrations-brave-search = { path = "../../integrations/brave-search" }

--- a/crates/worker/Cargo.toml
+++ b/crates/worker/Cargo.toml
@@ -15,7 +15,7 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 
 everruns-config = { path = "../config" }
-everruns-core = { path = "../core", features = ["tree-sitter-outlines"] }
+everruns-core = { path = "../core", features = ["embedded-platform-docs", "tree-sitter-outlines", "ui-capabilities"] }
 everruns-integrations-docker = { path = "../../integrations/docker" }
 everruns-integrations-brave-search = { path = "../../integrations/brave-search" }
 everruns-integrations-parallel = { path = "../../integrations/parallel" }


### PR DESCRIPTION
## What
Prepare `everruns-core` and `everruns-runtime` for crates.io publication and add release automation to publish the public crate set.

## Why
The public runtime crates need registry-safe manifests and an automated publish path for future Everruns releases.

## How
- Adds crates.io metadata and `0.8.31` registry fallback versions for local public crate dependencies.
- Feature-gates OpenUI/A2UI prompt helpers behind `ui-capabilities` so embedders do not pull them by default.
- Feature-gates workspace docs embedding behind `embedded-platform-docs` and only enables it when repo-root docs exist.
- Keeps server and worker opted into product features.
- Adds `publish-crates.yml` and dispatches it from the release workflow.
- Publishes crates in dependency order with rerun-safe skips and crates.io visibility waits.

Validation:
- `cargo fmt --check`
- `CARGO_INCREMENTAL=0 cargo check -p everruns-core --no-default-features`
- `CARGO_INCREMENTAL=0 cargo check -p everruns-core --no-default-features --features ui-capabilities,embedded-platform-docs`
- `CARGO_INCREMENTAL=0 cargo check -p everruns-runtime --no-default-features`
- `CARGO_INCREMENTAL=0 cargo test -p everruns-core --no-default-features capability_registry_with_builtins`
- `cargo package -p everruns-config --allow-dirty`
- `cargo package -p everruns-openui --allow-dirty`
- `cargo package -p everruns-a2ui --allow-dirty`
- YAML parse check for release workflows
- Publish workflow shell step `bash -n`
- `bash scripts/lib/check-migration-ordering.sh`
- `CARGO_INCREMENTAL=0 just pre-push`

Smoke testing: skipped runtime server smoke because this changes release automation and crate packaging metadata, not runtime request handling. Product compile paths are covered by `just pre-push` and server/worker retain the gated features.

## Risk
- Medium
- Release workflow changes can fail to publish crates if crates.io propagation is slow, token permissions are wrong, or package ordering is incorrect. The workflow publishes sequentially, waits for each crate version to become visible, and skips already-published versions for safe reruns.

## Security
- Threat categories reviewed: supply chain / release automation, dependency risk, secret handling.
- Findings and resolutions: `CARGO_REGISTRY_TOKEN` is scoped to the publish step only; workflow permissions are `contents: read`; crates are published in a fixed allowlist order; no runtime auth, API, tenant, SQL, file, or command execution trust boundary changed.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
