### PR TITLE
feat(runtime): add embedder builders

### DIFF
--- a/crates/runtime/examples/in_process_runtime.rs
+++ b/crates/runtime/examples/in_process_runtime.rs
@@ -1,13 +1,8 @@
-use chrono::Utc;
 use everruns_core::capabilities::TestMathCapability;
 use everruns_core::llm_driver_registry::DriverRegistry;
 use everruns_core::llmsim_driver::LlmSimConfig;
-use everruns_core::{
-    Agent, AgentCapabilityConfig, AgentStatus, CapabilityRegistry, Harness, HarnessStatus,
-    LlmProviderType, ModelWithProvider, PlatformDefinition, Session, SessionStatus,
-};
-use everruns_runtime::InProcessRuntimeBuilder;
-use uuid::Uuid;
+use everruns_core::{CapabilityRegistry, LlmProviderType, ModelWithProvider, PlatformDefinition};
+use everruns_runtime::{AgentBuilder, HarnessBuilder, InProcessRuntimeBuilder, SessionBuilder};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -16,10 +11,27 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let platform = PlatformDefinition::new(capabilities, DriverRegistry::new());
 
-    let harness_id = "harness_00000000000000000000000000000010".parse()?;
-    let agent_id = "agent_00000000000000000000000000000010".parse()?;
-    let session_id = "session_00000000000000000000000000000010".parse()?;
+    // Per-type builders are useful when an embedder needs stable ids or
+    // separate construction. IDs are generated unless `.id(...)` is called.
+    let harness_builder = HarnessBuilder::new("math", "You are a math assistant.")
+        .display_name("Math")
+        .description("Minimal embedded harness")
+        .capability("test_math");
+    let harness_id = harness_builder.harness_id();
+    let agent_builder = AgentBuilder::new("math-agent", "Use tools when they help.")
+        .display_name("Math Agent")
+        .max_iterations(8);
+    let agent_id = agent_builder.agent_id();
+    let session_builder = SessionBuilder::new(harness_id)
+        .agent(agent_id)
+        .title("Embedded Math Session");
+    let _per_type_builders = (
+        harness_builder.build(),
+        agent_builder.build(),
+        session_builder.build(),
+    );
 
+    // The runtime below uses the compact convenience.
     let runtime = InProcessRuntimeBuilder::new()
         .platform_definition(platform)
         .llm_sim(
@@ -38,96 +50,20 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             api_key: Some("fake-key".into()),
             base_url: None,
         })
-        .harness(Harness {
-            id: harness_id,
-            name: "math".into(),
-            display_name: Some("Math".into()),
-            description: Some("Minimal embedded harness".into()),
-            system_prompt: "You are a math assistant.".into(),
-            parent_harness_id: None,
-            default_model_id: None,
-            tags: vec![],
-            capabilities: vec![AgentCapabilityConfig::new("test_math")],
-            initial_files: vec![],
-            network_access: None,
-            mcp_servers: Default::default(),
-            is_built_in: false,
-            status: HarnessStatus::Active,
-            created_at: Utc::now(),
-            updated_at: Utc::now(),
-            archived_at: None,
-            deleted_at: None,
-        })
-        .agent(Agent {
-            public_id: agent_id,
-            internal_id: Uuid::nil(),
-            name: "math-agent".into(),
-            display_name: Some("Math Agent".into()),
-            description: None,
-            system_prompt: "Use tools when they help.".into(),
-            default_model_id: None,
-            default_version_id: None,
-            forked_from_agent_id: None,
-            forked_from_version_id: None,
-            root_agent_id: None,
-            tags: vec![],
-            capabilities: vec![],
-            initial_files: vec![],
-            network_access: None,
-            max_iterations: Some(8),
-            tools: vec![],
-            mcp_servers: Default::default(),
-            status: AgentStatus::Active,
-            created_at: Utc::now(),
-            updated_at: Utc::now(),
-            archived_at: None,
-            deleted_at: None,
-            usage: None,
-        })
-        .session(Session {
-            id: session_id,
-            organization_id: everruns_core::DEFAULT_ORG_PUBLIC_ID.to_string(),
-            harness_id,
-            agent_id: Some(agent_id),
-            agent_version_id: None,
-            agent_identity_id: None,
-            owner_principal_id: everruns_core::PrincipalId::from_seed(1),
-            resolved_owner_user_id: None,
-            owner: None,
-            effective_owner: None,
-            title: Some("Embedded Math Session".into()),
-            locale: None,
-            preview: None,
-            output_preview: None,
-            tags: vec![],
-            model_id: None,
-            capabilities: vec![],
-            tools: vec![],
-            mcp_servers: Default::default(),
-            system_prompt: None,
-            initial_files: vec![],
-            hints: None,
-            network_access: None,
-            max_iterations: None,
-            status: SessionStatus::Started,
-            created_at: Utc::now(),
-            updated_at: Utc::now(),
-            started_at: None,
-            finished_at: None,
-            usage: None,
-            is_pinned: None,
-            active_schedule_count: None,
-            features: vec![],
-            parent_session_id: None,
-            subagent_name: None,
-            subagent_task: None,
-            subagent_status: None,
-            blueprint_id: None,
-            blueprint_config: None,
+        .single_session(|s| {
+            s.harness("math", "You are a math assistant.")
+                .harness_display_name("Math")
+                .harness_description("Minimal embedded harness")
+                .with_capability("test_math")
+                .agent("math-agent", "Use tools when they help.")
+                .agent_display_name("Math Agent")
+                .agent_max_iterations(8)
+                .session_title("Embedded Math Session")
         })
         .build()
         .await?;
 
+    let session_id = runtime.default_session_id().expect("single_session id");
     let result = runtime.run_text_turn(session_id, "What is 6 * 7?").await?;
 
     println!("success: {}", result.success);

--- a/crates/runtime/src/builders.rs
+++ b/crates/runtime/src/builders.rs
@@ -1,0 +1,803 @@
+// Embedder-facing builders for core seed models.
+// Decision: keep these in everruns-runtime so core domain structs stay literal
+// data models while runtime owns the public embedding ergonomics.
+
+use chrono::{DateTime, Utc};
+use everruns_core::network_access::NetworkAccessList;
+use everruns_core::{
+    Agent, AgentCapabilityConfig, AgentId, AgentStatus, DEFAULT_ORG_PUBLIC_ID, Harness, HarnessId,
+    HarnessStatus, ModelId, PrincipalId, ScopedMcpServers, Session, SessionId, SessionStatus,
+    ToolDefinition,
+};
+use uuid::Uuid;
+
+/// Builds a [`Harness`] with runtime-friendly defaults.
+///
+/// Use this when embedding Everruns directly and seeding a harness in code.
+/// IDs and timestamps are generated at [`build`](Self::build) time unless
+/// explicitly set.
+#[derive(Debug, Clone)]
+pub struct HarnessBuilder {
+    id: HarnessId,
+    name: String,
+    display_name: Option<String>,
+    description: Option<String>,
+    system_prompt: String,
+    parent_harness_id: Option<HarnessId>,
+    default_model_id: Option<ModelId>,
+    tags: Vec<String>,
+    capabilities: Vec<AgentCapabilityConfig>,
+    initial_files: Vec<everruns_core::InitialFile>,
+    network_access: Option<NetworkAccessList>,
+    mcp_servers: ScopedMcpServers,
+    is_built_in: bool,
+    status: HarnessStatus,
+    created_at: Option<DateTime<Utc>>,
+    updated_at: Option<DateTime<Utc>>,
+}
+
+impl HarnessBuilder {
+    /// Create a harness builder from the required embedder-facing fields.
+    pub fn new(name: impl Into<String>, system_prompt: impl Into<String>) -> Self {
+        Self {
+            id: HarnessId::new(),
+            name: name.into(),
+            display_name: None,
+            description: None,
+            system_prompt: system_prompt.into(),
+            parent_harness_id: None,
+            default_model_id: None,
+            tags: Vec::new(),
+            capabilities: Vec::new(),
+            initial_files: Vec::new(),
+            network_access: None,
+            mcp_servers: ScopedMcpServers::default(),
+            is_built_in: false,
+            status: HarnessStatus::Active,
+            created_at: None,
+            updated_at: None,
+        }
+    }
+
+    /// Set a stable harness id instead of generating one.
+    pub fn id(mut self, id: HarnessId) -> Self {
+        self.id = id;
+        self
+    }
+
+    /// Return the id currently assigned to this builder.
+    pub fn harness_id(&self) -> HarnessId {
+        self.id
+    }
+
+    pub fn display_name(mut self, display_name: impl Into<String>) -> Self {
+        self.display_name = Some(display_name.into());
+        self
+    }
+
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        self.description = Some(description.into());
+        self
+    }
+
+    pub fn system_prompt(mut self, system_prompt: impl Into<String>) -> Self {
+        self.system_prompt = system_prompt.into();
+        self
+    }
+
+    pub fn parent_harness_id(mut self, parent_harness_id: HarnessId) -> Self {
+        self.parent_harness_id = Some(parent_harness_id);
+        self
+    }
+
+    pub fn default_model_id(mut self, default_model_id: ModelId) -> Self {
+        self.default_model_id = Some(default_model_id);
+        self
+    }
+
+    pub fn tag(mut self, tag: impl Into<String>) -> Self {
+        self.tags.push(tag.into());
+        self
+    }
+
+    pub fn tags<I, S>(mut self, tags: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.tags.extend(tags.into_iter().map(Into::into));
+        self
+    }
+
+    pub fn capability(mut self, capability: impl Into<AgentCapabilityConfig>) -> Self {
+        self.capabilities.push(capability.into());
+        self
+    }
+
+    pub fn with_capability(self, capability: impl Into<AgentCapabilityConfig>) -> Self {
+        self.capability(capability)
+    }
+
+    pub fn capabilities<I, C>(mut self, capabilities: I) -> Self
+    where
+        I: IntoIterator<Item = C>,
+        C: Into<AgentCapabilityConfig>,
+    {
+        self.capabilities
+            .extend(capabilities.into_iter().map(Into::into));
+        self
+    }
+
+    pub fn initial_file(mut self, file: everruns_core::InitialFile) -> Self {
+        self.initial_files.push(file);
+        self
+    }
+
+    pub fn network_access(mut self, network_access: NetworkAccessList) -> Self {
+        self.network_access = Some(network_access);
+        self
+    }
+
+    pub fn mcp_servers(mut self, mcp_servers: ScopedMcpServers) -> Self {
+        self.mcp_servers = mcp_servers;
+        self
+    }
+
+    pub fn is_built_in(mut self, is_built_in: bool) -> Self {
+        self.is_built_in = is_built_in;
+        self
+    }
+
+    pub fn status(mut self, status: HarnessStatus) -> Self {
+        self.status = status;
+        self
+    }
+
+    pub fn created_at(mut self, created_at: DateTime<Utc>) -> Self {
+        self.created_at = Some(created_at);
+        self
+    }
+
+    pub fn updated_at(mut self, updated_at: DateTime<Utc>) -> Self {
+        self.updated_at = Some(updated_at);
+        self
+    }
+
+    /// Build the harness. Builders do not validate domain invariants.
+    pub fn build(self) -> Harness {
+        let created_at = self.created_at.unwrap_or_else(Utc::now);
+        let updated_at = self.updated_at.unwrap_or(created_at);
+
+        Harness {
+            id: self.id,
+            name: self.name,
+            display_name: self.display_name,
+            description: self.description,
+            system_prompt: self.system_prompt,
+            parent_harness_id: self.parent_harness_id,
+            default_model_id: self.default_model_id,
+            tags: self.tags,
+            capabilities: self.capabilities,
+            initial_files: self.initial_files,
+            network_access: self.network_access,
+            mcp_servers: self.mcp_servers,
+            is_built_in: self.is_built_in,
+            status: self.status,
+            created_at,
+            updated_at,
+            archived_at: None,
+            deleted_at: None,
+        }
+    }
+}
+
+/// Builds an [`Agent`] with runtime-friendly defaults.
+#[derive(Debug, Clone)]
+pub struct AgentBuilder {
+    id: AgentId,
+    name: String,
+    display_name: Option<String>,
+    description: Option<String>,
+    system_prompt: String,
+    default_model_id: Option<ModelId>,
+    tags: Vec<String>,
+    capabilities: Vec<AgentCapabilityConfig>,
+    initial_files: Vec<everruns_core::InitialFile>,
+    network_access: Option<NetworkAccessList>,
+    max_iterations: Option<usize>,
+    tools: Vec<ToolDefinition>,
+    mcp_servers: ScopedMcpServers,
+    status: AgentStatus,
+    created_at: Option<DateTime<Utc>>,
+    updated_at: Option<DateTime<Utc>>,
+}
+
+impl AgentBuilder {
+    /// Create an agent builder from the required embedder-facing fields.
+    pub fn new(name: impl Into<String>, system_prompt: impl Into<String>) -> Self {
+        Self {
+            id: AgentId::new(),
+            name: name.into(),
+            display_name: None,
+            description: None,
+            system_prompt: system_prompt.into(),
+            default_model_id: None,
+            tags: Vec::new(),
+            capabilities: Vec::new(),
+            initial_files: Vec::new(),
+            network_access: None,
+            max_iterations: None,
+            tools: Vec::new(),
+            mcp_servers: ScopedMcpServers::default(),
+            status: AgentStatus::Active,
+            created_at: None,
+            updated_at: None,
+        }
+    }
+
+    /// Set a stable agent id instead of generating one.
+    pub fn id(mut self, id: AgentId) -> Self {
+        self.id = id;
+        self
+    }
+
+    /// Return the id currently assigned to this builder.
+    pub fn agent_id(&self) -> AgentId {
+        self.id
+    }
+
+    pub fn display_name(mut self, display_name: impl Into<String>) -> Self {
+        self.display_name = Some(display_name.into());
+        self
+    }
+
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        self.description = Some(description.into());
+        self
+    }
+
+    pub fn system_prompt(mut self, system_prompt: impl Into<String>) -> Self {
+        self.system_prompt = system_prompt.into();
+        self
+    }
+
+    pub fn default_model_id(mut self, default_model_id: ModelId) -> Self {
+        self.default_model_id = Some(default_model_id);
+        self
+    }
+
+    pub fn tag(mut self, tag: impl Into<String>) -> Self {
+        self.tags.push(tag.into());
+        self
+    }
+
+    pub fn tags<I, S>(mut self, tags: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.tags.extend(tags.into_iter().map(Into::into));
+        self
+    }
+
+    pub fn capability(mut self, capability: impl Into<AgentCapabilityConfig>) -> Self {
+        self.capabilities.push(capability.into());
+        self
+    }
+
+    pub fn with_capability(self, capability: impl Into<AgentCapabilityConfig>) -> Self {
+        self.capability(capability)
+    }
+
+    pub fn capabilities<I, C>(mut self, capabilities: I) -> Self
+    where
+        I: IntoIterator<Item = C>,
+        C: Into<AgentCapabilityConfig>,
+    {
+        self.capabilities
+            .extend(capabilities.into_iter().map(Into::into));
+        self
+    }
+
+    pub fn initial_file(mut self, file: everruns_core::InitialFile) -> Self {
+        self.initial_files.push(file);
+        self
+    }
+
+    pub fn network_access(mut self, network_access: NetworkAccessList) -> Self {
+        self.network_access = Some(network_access);
+        self
+    }
+
+    pub fn max_iterations(mut self, max_iterations: usize) -> Self {
+        self.max_iterations = Some(max_iterations);
+        self
+    }
+
+    pub fn tool(mut self, tool: ToolDefinition) -> Self {
+        self.tools.push(tool);
+        self
+    }
+
+    pub fn tools<I>(mut self, tools: I) -> Self
+    where
+        I: IntoIterator<Item = ToolDefinition>,
+    {
+        self.tools.extend(tools);
+        self
+    }
+
+    pub fn mcp_servers(mut self, mcp_servers: ScopedMcpServers) -> Self {
+        self.mcp_servers = mcp_servers;
+        self
+    }
+
+    pub fn status(mut self, status: AgentStatus) -> Self {
+        self.status = status;
+        self
+    }
+
+    pub fn created_at(mut self, created_at: DateTime<Utc>) -> Self {
+        self.created_at = Some(created_at);
+        self
+    }
+
+    pub fn updated_at(mut self, updated_at: DateTime<Utc>) -> Self {
+        self.updated_at = Some(updated_at);
+        self
+    }
+
+    /// Build the agent. Builders do not validate domain invariants.
+    pub fn build(self) -> Agent {
+        let created_at = self.created_at.unwrap_or_else(Utc::now);
+        let updated_at = self.updated_at.unwrap_or(created_at);
+
+        Agent {
+            public_id: self.id,
+            internal_id: Uuid::nil(),
+            name: self.name,
+            display_name: self.display_name,
+            description: self.description,
+            system_prompt: self.system_prompt,
+            default_model_id: self.default_model_id,
+            default_version_id: None,
+            forked_from_agent_id: None,
+            forked_from_version_id: None,
+            root_agent_id: None,
+            tags: self.tags,
+            capabilities: self.capabilities,
+            initial_files: self.initial_files,
+            network_access: self.network_access,
+            max_iterations: self.max_iterations,
+            tools: self.tools,
+            mcp_servers: self.mcp_servers,
+            status: self.status,
+            created_at,
+            updated_at,
+            archived_at: None,
+            deleted_at: None,
+            usage: None,
+        }
+    }
+}
+
+/// Builds a [`Session`] with runtime-friendly defaults.
+#[derive(Debug, Clone)]
+pub struct SessionBuilder {
+    id: SessionId,
+    organization_id: String,
+    harness_id: HarnessId,
+    agent_id: Option<AgentId>,
+    owner_principal_id: PrincipalId,
+    title: Option<String>,
+    locale: Option<String>,
+    tags: Vec<String>,
+    model_id: Option<ModelId>,
+    capabilities: Vec<AgentCapabilityConfig>,
+    tools: Vec<ToolDefinition>,
+    mcp_servers: ScopedMcpServers,
+    system_prompt: Option<String>,
+    initial_files: Vec<everruns_core::InitialFile>,
+    network_access: Option<NetworkAccessList>,
+    max_iterations: Option<usize>,
+    status: SessionStatus,
+    created_at: Option<DateTime<Utc>>,
+    updated_at: Option<DateTime<Utc>>,
+}
+
+impl SessionBuilder {
+    /// Create a session builder for the required harness id.
+    pub fn new(harness_id: HarnessId) -> Self {
+        Self {
+            id: SessionId::new(),
+            organization_id: DEFAULT_ORG_PUBLIC_ID.to_string(),
+            harness_id,
+            agent_id: None,
+            owner_principal_id: PrincipalId::from_seed(1),
+            title: None,
+            locale: None,
+            tags: Vec::new(),
+            model_id: None,
+            capabilities: Vec::new(),
+            tools: Vec::new(),
+            mcp_servers: ScopedMcpServers::default(),
+            system_prompt: None,
+            initial_files: Vec::new(),
+            network_access: None,
+            max_iterations: None,
+            status: SessionStatus::Started,
+            created_at: None,
+            updated_at: None,
+        }
+    }
+
+    /// Set a stable session id instead of generating one.
+    pub fn id(mut self, id: SessionId) -> Self {
+        self.id = id;
+        self
+    }
+
+    /// Return the id currently assigned to this builder.
+    pub fn session_id(&self) -> SessionId {
+        self.id
+    }
+
+    pub fn organization_id(mut self, organization_id: impl Into<String>) -> Self {
+        self.organization_id = organization_id.into();
+        self
+    }
+
+    pub fn harness(mut self, harness_id: HarnessId) -> Self {
+        self.harness_id = harness_id;
+        self
+    }
+
+    pub fn agent(mut self, agent_id: AgentId) -> Self {
+        self.agent_id = Some(agent_id);
+        self
+    }
+
+    pub fn owner_principal_id(mut self, owner_principal_id: PrincipalId) -> Self {
+        self.owner_principal_id = owner_principal_id;
+        self
+    }
+
+    pub fn title(mut self, title: impl Into<String>) -> Self {
+        self.title = Some(title.into());
+        self
+    }
+
+    pub fn locale(mut self, locale: impl Into<String>) -> Self {
+        self.locale = Some(locale.into());
+        self
+    }
+
+    pub fn tag(mut self, tag: impl Into<String>) -> Self {
+        self.tags.push(tag.into());
+        self
+    }
+
+    pub fn tags<I, S>(mut self, tags: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.tags.extend(tags.into_iter().map(Into::into));
+        self
+    }
+
+    pub fn model_id(mut self, model_id: ModelId) -> Self {
+        self.model_id = Some(model_id);
+        self
+    }
+
+    pub fn capability(mut self, capability: impl Into<AgentCapabilityConfig>) -> Self {
+        self.capabilities.push(capability.into());
+        self
+    }
+
+    pub fn with_capability(self, capability: impl Into<AgentCapabilityConfig>) -> Self {
+        self.capability(capability)
+    }
+
+    pub fn capabilities<I, C>(mut self, capabilities: I) -> Self
+    where
+        I: IntoIterator<Item = C>,
+        C: Into<AgentCapabilityConfig>,
+    {
+        self.capabilities
+            .extend(capabilities.into_iter().map(Into::into));
+        self
+    }
+
+    pub fn tool(mut self, tool: ToolDefinition) -> Self {
+        self.tools.push(tool);
+        self
+    }
+
+    pub fn tools<I>(mut self, tools: I) -> Self
+    where
+        I: IntoIterator<Item = ToolDefinition>,
+    {
+        self.tools.extend(tools);
+        self
+    }
+
+    pub fn mcp_servers(mut self, mcp_servers: ScopedMcpServers) -> Self {
+        self.mcp_servers = mcp_servers;
+        self
+    }
+
+    pub fn system_prompt(mut self, system_prompt: impl Into<String>) -> Self {
+        self.system_prompt = Some(system_prompt.into());
+        self
+    }
+
+    pub fn initial_file(mut self, file: everruns_core::InitialFile) -> Self {
+        self.initial_files.push(file);
+        self
+    }
+
+    pub fn network_access(mut self, network_access: NetworkAccessList) -> Self {
+        self.network_access = Some(network_access);
+        self
+    }
+
+    pub fn max_iterations(mut self, max_iterations: usize) -> Self {
+        self.max_iterations = Some(max_iterations);
+        self
+    }
+
+    pub fn status(mut self, status: SessionStatus) -> Self {
+        self.status = status;
+        self
+    }
+
+    pub fn created_at(mut self, created_at: DateTime<Utc>) -> Self {
+        self.created_at = Some(created_at);
+        self
+    }
+
+    pub fn updated_at(mut self, updated_at: DateTime<Utc>) -> Self {
+        self.updated_at = Some(updated_at);
+        self
+    }
+
+    /// Build the session. Builders do not validate domain invariants.
+    pub fn build(self) -> Session {
+        let created_at = self.created_at.unwrap_or_else(Utc::now);
+        let updated_at = self.updated_at.unwrap_or(created_at);
+
+        Session {
+            id: self.id,
+            organization_id: self.organization_id,
+            harness_id: self.harness_id,
+            agent_id: self.agent_id,
+            agent_version_id: None,
+            agent_identity_id: None,
+            owner_principal_id: self.owner_principal_id,
+            resolved_owner_user_id: None,
+            owner: None,
+            effective_owner: None,
+            title: self.title,
+            locale: self.locale,
+            preview: None,
+            output_preview: None,
+            tags: self.tags,
+            model_id: self.model_id,
+            capabilities: self.capabilities,
+            tools: self.tools,
+            mcp_servers: self.mcp_servers,
+            system_prompt: self.system_prompt,
+            initial_files: self.initial_files,
+            hints: None,
+            network_access: self.network_access,
+            max_iterations: self.max_iterations,
+            status: self.status,
+            created_at,
+            updated_at,
+            started_at: None,
+            finished_at: None,
+            usage: None,
+            is_pinned: None,
+            active_schedule_count: None,
+            features: Vec::new(),
+            parent_session_id: None,
+            subagent_name: None,
+            subagent_task: None,
+            subagent_status: None,
+            blueprint_id: None,
+            blueprint_config: None,
+        }
+    }
+}
+
+/// High-level builder for seeding one harness, one agent, and one session.
+///
+/// This is the compact path used by embedders that want a runnable runtime
+/// without constructing each core model separately.
+#[derive(Debug, Clone)]
+pub struct SingleSessionBuilder {
+    harness: HarnessBuilder,
+    agent: AgentBuilder,
+    session: SessionBuilder,
+}
+
+impl Default for SingleSessionBuilder {
+    fn default() -> Self {
+        let harness = HarnessBuilder::new("embedded-harness", "");
+        let agent = AgentBuilder::new("embedded-agent", "");
+        let session = SessionBuilder::new(harness.harness_id()).agent(agent.agent_id());
+        Self {
+            harness,
+            agent,
+            session,
+        }
+    }
+}
+
+impl SingleSessionBuilder {
+    /// Configure the seeded harness.
+    pub fn harness(mut self, name: impl Into<String>, system_prompt: impl Into<String>) -> Self {
+        let harness_id = self.harness.harness_id();
+        self.harness = HarnessBuilder::new(name, system_prompt).id(harness_id);
+        self.session = self.session.harness(harness_id);
+        self
+    }
+
+    /// Configure the seeded agent.
+    pub fn agent(mut self, name: impl Into<String>, system_prompt: impl Into<String>) -> Self {
+        let agent_id = self.agent.agent_id();
+        self.agent = AgentBuilder::new(name, system_prompt).id(agent_id);
+        self.session = self.session.agent(agent_id);
+        self
+    }
+
+    /// Add a harness-level capability.
+    pub fn with_capability(self, capability: impl Into<AgentCapabilityConfig>) -> Self {
+        self.harness_capability(capability)
+    }
+
+    /// Add a harness-level capability.
+    pub fn harness_capability(mut self, capability: impl Into<AgentCapabilityConfig>) -> Self {
+        self.harness = self.harness.capability(capability);
+        self
+    }
+
+    /// Add an agent-level capability.
+    pub fn agent_capability(mut self, capability: impl Into<AgentCapabilityConfig>) -> Self {
+        self.agent = self.agent.capability(capability);
+        self
+    }
+
+    /// Add a session-level capability.
+    pub fn session_capability(mut self, capability: impl Into<AgentCapabilityConfig>) -> Self {
+        self.session = self.session.capability(capability);
+        self
+    }
+
+    pub fn harness_display_name(mut self, display_name: impl Into<String>) -> Self {
+        self.harness = self.harness.display_name(display_name);
+        self
+    }
+
+    pub fn agent_display_name(mut self, display_name: impl Into<String>) -> Self {
+        self.agent = self.agent.display_name(display_name);
+        self
+    }
+
+    pub fn harness_description(mut self, description: impl Into<String>) -> Self {
+        self.harness = self.harness.description(description);
+        self
+    }
+
+    pub fn agent_description(mut self, description: impl Into<String>) -> Self {
+        self.agent = self.agent.description(description);
+        self
+    }
+
+    pub fn session_title(mut self, title: impl Into<String>) -> Self {
+        self.session = self.session.title(title);
+        self
+    }
+
+    pub fn locale(mut self, locale: impl Into<String>) -> Self {
+        self.session = self.session.locale(locale);
+        self
+    }
+
+    pub fn tag(mut self, tag: impl Into<String>) -> Self {
+        let tag = tag.into();
+        self.harness = self.harness.tag(tag.clone());
+        self.agent = self.agent.tag(tag.clone());
+        self.session = self.session.tag(tag);
+        self
+    }
+
+    pub fn session_model_id(mut self, model_id: ModelId) -> Self {
+        self.session = self.session.model_id(model_id);
+        self
+    }
+
+    pub fn harness_default_model_id(mut self, model_id: ModelId) -> Self {
+        self.harness = self.harness.default_model_id(model_id);
+        self
+    }
+
+    pub fn agent_default_model_id(mut self, model_id: ModelId) -> Self {
+        self.agent = self.agent.default_model_id(model_id);
+        self
+    }
+
+    pub fn agent_max_iterations(mut self, max_iterations: usize) -> Self {
+        self.agent = self.agent.max_iterations(max_iterations);
+        self
+    }
+
+    pub fn session_max_iterations(mut self, max_iterations: usize) -> Self {
+        self.session = self.session.max_iterations(max_iterations);
+        self
+    }
+
+    pub fn agent_tool(mut self, tool: ToolDefinition) -> Self {
+        self.agent = self.agent.tool(tool);
+        self
+    }
+
+    pub fn session_tool(mut self, tool: ToolDefinition) -> Self {
+        self.session = self.session.tool(tool);
+        self
+    }
+
+    pub fn harness_initial_file(mut self, file: everruns_core::InitialFile) -> Self {
+        self.harness = self.harness.initial_file(file);
+        self
+    }
+
+    pub fn agent_initial_file(mut self, file: everruns_core::InitialFile) -> Self {
+        self.agent = self.agent.initial_file(file);
+        self
+    }
+
+    pub fn session_initial_file(mut self, file: everruns_core::InitialFile) -> Self {
+        self.session = self.session.initial_file(file);
+        self
+    }
+
+    pub fn harness_network_access(mut self, network_access: NetworkAccessList) -> Self {
+        self.harness = self.harness.network_access(network_access);
+        self
+    }
+
+    pub fn agent_network_access(mut self, network_access: NetworkAccessList) -> Self {
+        self.agent = self.agent.network_access(network_access);
+        self
+    }
+
+    pub fn session_network_access(mut self, network_access: NetworkAccessList) -> Self {
+        self.session = self.session.network_access(network_access);
+        self
+    }
+
+    pub fn harness_id(&self) -> HarnessId {
+        self.harness.harness_id()
+    }
+
+    pub fn agent_id(&self) -> AgentId {
+        self.agent.agent_id()
+    }
+
+    pub fn session_id(&self) -> SessionId {
+        self.session.session_id()
+    }
+
+    pub(crate) fn build(self) -> (Harness, Agent, Session, SessionId) {
+        let session_id = self.session.session_id();
+        (
+            self.harness.build(),
+            self.agent.build(),
+            self.session.build(),
+            session_id,
+        )
+    }
+}

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -25,9 +25,8 @@
 //!
 //! ```ignore
 //! use everruns_core::{
-//!     Agent, AgentCapabilityConfig, AgentStatus, CapabilityRegistry, DriverRegistry, Harness,
-//!     HarnessStatus, InputMessage, LlmProviderType, ModelWithProvider, PlatformDefinition,
-//!     Session, SessionStatus,
+//!     CapabilityRegistry, DriverRegistry, InputMessage, LlmProviderType, ModelWithProvider,
+//!     PlatformDefinition,
 //! };
 //! use everruns_core::capabilities::TestMathCapability;
 //! use everruns_runtime::InProcessRuntimeBuilder;
@@ -39,80 +38,14 @@
 //!
 //! let runtime = InProcessRuntimeBuilder::new()
 //!     .platform_definition(platform)
-//!     .harness(Harness {
-//!         id: "harness_00000000000000000000000000000010".parse().unwrap(),
-//!         name: "math".into(),
-//!         display_name: Some("Math".into()),
-//!         description: Some("Minimal in-process harness".into()),
-//!         system_prompt: "You are a calculator.".into(),
-//!         parent_harness_id: None,
-//!         default_model_id: None,
-//!         tags: vec![],
-//!         capabilities: vec![AgentCapabilityConfig::new("test_math")],
-//!         initial_files: vec![],
-//!         network_access: None,
-//!         is_built_in: false,
-//!         status: HarnessStatus::Active,
-//!         created_at: chrono::Utc::now(),
-//!         updated_at: chrono::Utc::now(),
-//!         archived_at: None,
-//!         deleted_at: None,
-//!     })
-//!     .agent(Agent {
-//!         public_id: "agent_00000000000000000000000000000010".parse().unwrap(),
-//!         internal_id: uuid::Uuid::nil(),
-//!         name: "math-agent".into(),
-//!         display_name: Some("Math Agent".into()),
-//!         description: None,
-//!         system_prompt: "Use tools when needed.".into(),
-//!         default_model_id: None,
-//!         tags: vec![],
-//!         capabilities: vec![],
-//!         initial_files: vec![],
-//!         network_access: None,
-//!         max_iterations: Some(8),
-//!         tools: vec![],
-//!         status: AgentStatus::Active,
-//!         created_at: chrono::Utc::now(),
-//!         updated_at: chrono::Utc::now(),
-//!         archived_at: None,
-//!         deleted_at: None,
-//!         usage: None,
-//!     })
-//!     .session(Session {
-//!         id: "session_00000000000000000000000000000010".parse().unwrap(),
-//!         organization_id: everruns_core::DEFAULT_ORG_PUBLIC_ID.to_string(),
-//!         harness_id: "harness_00000000000000000000000000000010".parse().unwrap(),
-//!         agent_id: Some("agent_00000000000000000000000000000010".parse().unwrap()),
-//!         agent_identity_id: None,
-//!         title: Some("Math Session".into()),
-//!         locale: None,
-//!         preview: None,
-//!         output_preview: None,
-//!         tags: vec![],
-//!         model_id: None,
-//!         capabilities: vec![],
-//!         tools: vec![],
-//!         system_prompt: None,
-//!         initial_files: vec![],
-//!         hints: None,
-//!         network_access: None,
-//!         max_iterations: None,
-//!         status: SessionStatus::Started,
-//!         created_at: chrono::Utc::now(),
-//!         updated_at: chrono::Utc::now(),
-//!         started_at: None,
-//!         finished_at: None,
-//!         usage: None,
-//!         is_pinned: None,
-//!         active_schedule_count: None,
-//!         features: vec![],
-//!         parent_session_id: None,
-//!         subagent_name: None,
-//!         subagent_task: None,
-//!         subagent_status: None,
-//!         blueprint_id: None,
-//!         blueprint_config: None,
+//!     .single_session(|s| {
+//!         s.harness("math", "You are a calculator.")
+//!             .harness_display_name("Math")
+//!             .with_capability("test_math")
+//!             .agent("math-agent", "Use tools when needed.")
+//!             .agent_display_name("Math Agent")
+//!             .agent_max_iterations(8)
+//!             .session_title("Math Session")
 //!     })
 //!     .llm_sim(everruns_core::llmsim_driver::LlmSimConfig::fixed("4"))
 //!     .default_model(ModelWithProvider {
@@ -124,9 +57,10 @@
 //!     .build()
 //!     .await?;
 //!
+//! let session_id = runtime.default_session_id().expect("single_session id");
 //! let result = runtime
 //!     .run_turn(
-//!         "session_00000000000000000000000000000010".parse().unwrap(),
+//!         session_id,
 //!         InputMessage::user("What is 2 + 2?"),
 //!     )
 //!     .await?;
@@ -152,6 +86,7 @@
 //! And `specs/file-store.md` for the trait contract.
 
 mod backends;
+mod builders;
 mod host;
 mod in_memory;
 mod real_disk;
@@ -162,6 +97,7 @@ pub use backends::{
     RuntimeAgentStore, RuntimeBackends, RuntimeEventCollector, RuntimeFileStore,
     RuntimeHarnessStore, RuntimeMessageStore, RuntimeProviderStore, RuntimeSessionStore,
 };
+pub use builders::{AgentBuilder, HarnessBuilder, SessionBuilder, SingleSessionBuilder};
 pub use everruns_core::AssembledTurnContext;
 pub use host::{
     RuntimeHostAdapter, RuntimeHostTurnContext, RuntimeSessionLifecycle, detect_dependency_blocker,

--- a/crates/runtime/src/runtime.rs
+++ b/crates/runtime/src/runtime.rs
@@ -8,6 +8,7 @@ use crate::backends::{
     RuntimeFileStore, RuntimeHarnessStore, RuntimeMessageStore, RuntimeProviderStore,
     RuntimeSessionStore,
 };
+use crate::builders::SingleSessionBuilder;
 use crate::in_memory::{
     InMemorySessionFileStore, InMemorySessionStorageStore, InMemorySessionStore,
 };
@@ -119,6 +120,7 @@ pub struct InProcessRuntimeBuilder {
     harnesses: Vec<Harness>,
     agents: Vec<Agent>,
     sessions: Vec<Session>,
+    default_session_id: Option<SessionId>,
     seeded_files: Vec<(SessionId, InitialFile)>,
 }
 
@@ -147,6 +149,7 @@ impl InProcessRuntimeBuilder {
             harnesses: Vec::new(),
             agents: Vec::new(),
             sessions: Vec::new(),
+            default_session_id: None,
             seeded_files: Vec::new(),
         }
     }
@@ -204,6 +207,23 @@ impl InProcessRuntimeBuilder {
     /// Seed a session into the runtime store.
     pub fn session(mut self, session: Session) -> Self {
         self.sessions.push(session);
+        self
+    }
+
+    /// Seed one harness, one agent, and one session with a compact sub-builder.
+    ///
+    /// The generated session id is exposed from the built runtime via
+    /// [`InProcessRuntime::default_session_id`].
+    pub fn single_session<F>(mut self, configure: F) -> Self
+    where
+        F: FnOnce(SingleSessionBuilder) -> SingleSessionBuilder,
+    {
+        let (harness, agent, session, session_id) =
+            configure(SingleSessionBuilder::default()).build();
+        self.harnesses.push(harness);
+        self.agents.push(agent);
+        self.sessions.push(session);
+        self.default_session_id = Some(session_id);
         self
     }
 
@@ -306,6 +326,7 @@ impl InProcessRuntimeBuilder {
             harness_store: backends.harness_store,
             agent_store: backends.agent_store,
             session_store: backends.session_store,
+            default_session_id: self.default_session_id,
             message_store: backends.message_store,
             provider_store: backends.provider_store,
             event_emitter,
@@ -356,6 +377,7 @@ pub struct InProcessRuntime {
     harness_store: Arc<dyn RuntimeHarnessStore>,
     agent_store: Arc<dyn RuntimeAgentStore>,
     session_store: Arc<dyn RuntimeSessionStore>,
+    default_session_id: Option<SessionId>,
     message_store: Arc<dyn RuntimeMessageStore>,
     provider_store: Arc<dyn RuntimeProviderStore>,
     event_emitter: PersistingEventEmitter,
@@ -370,6 +392,12 @@ impl InProcessRuntime {
     /// Create a builder for the in-process runtime.
     pub fn builder() -> InProcessRuntimeBuilder {
         InProcessRuntimeBuilder::new()
+    }
+
+    /// Return the default session id seeded by
+    /// [`InProcessRuntimeBuilder::single_session`], if one was configured.
+    pub fn default_session_id(&self) -> Option<SessionId> {
+        self.default_session_id
     }
 
     /// Execute one turn for an existing session.

--- a/crates/runtime/tests/in_process_runtime_test.rs
+++ b/crates/runtime/tests/in_process_runtime_test.rs
@@ -1,4 +1,4 @@
-use chrono::Utc;
+use chrono::{TimeZone, Utc};
 use everruns_core::capabilities::TestMathCapability;
 use everruns_core::llm_driver_registry::DriverRegistry;
 use everruns_core::llmsim_driver::LlmSimConfig;
@@ -7,16 +7,14 @@ use everruns_core::memory::{
     InMemoryMemoryStore, InMemoryMessageRetriever,
 };
 use everruns_core::{
-    Agent, AgentCapabilityConfig, AgentStatus, CapabilityRegistry, Harness, HarnessStatus,
-    LlmProviderType, MessageRole, ModelWithProvider, PlatformDefinition, Session, SessionStatus,
-    ToolCall,
+    Agent, CapabilityRegistry, Harness, LlmProviderType, MessageRole, ModelWithProvider,
+    PlatformDefinition, Session, ToolCall,
 };
 use everruns_runtime::{
-    InMemorySessionFileStore, InMemorySessionStorageStore, InMemorySessionStore,
-    InProcessRuntimeBuilder, RuntimeBackends,
+    AgentBuilder, HarnessBuilder, InMemorySessionFileStore, InMemorySessionStorageStore,
+    InMemorySessionStore, InProcessRuntimeBuilder, RuntimeBackends, SessionBuilder,
 };
 use std::sync::Arc;
-use uuid::Uuid;
 
 fn minimal_platform() -> PlatformDefinition {
     let mut capabilities = CapabilityRegistry::new();
@@ -25,55 +23,19 @@ fn minimal_platform() -> PlatformDefinition {
 }
 
 fn harness(harness_id: everruns_core::HarnessId) -> Harness {
-    Harness {
-        id: harness_id,
-        name: "math".into(),
-        display_name: Some("Math".into()),
-        description: None,
-        system_prompt: "You are a math assistant.".into(),
-        parent_harness_id: None,
-        default_model_id: None,
-        tags: vec![],
-        capabilities: vec![AgentCapabilityConfig::new("test_math")],
-        initial_files: vec![],
-        network_access: None,
-        mcp_servers: Default::default(),
-        is_built_in: false,
-        status: HarnessStatus::Active,
-        created_at: Utc::now(),
-        updated_at: Utc::now(),
-        archived_at: None,
-        deleted_at: None,
-    }
+    HarnessBuilder::new("math", "You are a math assistant.")
+        .id(harness_id)
+        .display_name("Math")
+        .capability("test_math")
+        .build()
 }
 
 fn agent(agent_id: everruns_core::AgentId) -> Agent {
-    Agent {
-        public_id: agent_id,
-        internal_id: Uuid::nil(),
-        name: "math-agent".into(),
-        display_name: Some("Math Agent".into()),
-        description: None,
-        system_prompt: "Use tools when needed.".into(),
-        default_model_id: None,
-        default_version_id: None,
-        forked_from_agent_id: None,
-        forked_from_version_id: None,
-        root_agent_id: None,
-        tags: vec![],
-        capabilities: vec![],
-        initial_files: vec![],
-        network_access: None,
-        max_iterations: Some(8),
-        tools: vec![],
-        mcp_servers: Default::default(),
-        status: AgentStatus::Active,
-        created_at: Utc::now(),
-        updated_at: Utc::now(),
-        archived_at: None,
-        deleted_at: None,
-        usage: None,
-    }
+    AgentBuilder::new("math-agent", "Use tools when needed.")
+        .id(agent_id)
+        .display_name("Math Agent")
+        .max_iterations(8)
+        .build()
 }
 
 fn session(
@@ -81,47 +43,45 @@ fn session(
     harness_id: everruns_core::HarnessId,
     agent_id: Option<everruns_core::AgentId>,
 ) -> Session {
-    Session {
-        id: session_id,
-        organization_id: everruns_core::DEFAULT_ORG_PUBLIC_ID.to_string(),
-        harness_id,
-        agent_id,
-        agent_version_id: None,
-        agent_identity_id: None,
-        owner_principal_id: everruns_core::PrincipalId::from_seed(1),
-        resolved_owner_user_id: None,
-        owner: None,
-        effective_owner: None,
-        title: Some("Embedded Session".into()),
-        locale: None,
-        preview: None,
-        output_preview: None,
-        tags: vec![],
-        model_id: None,
-        capabilities: vec![],
-        tools: vec![],
-        mcp_servers: Default::default(),
-        system_prompt: None,
-        initial_files: vec![],
-        hints: None,
-        network_access: None,
-        max_iterations: None,
-        status: SessionStatus::Started,
-        created_at: Utc::now(),
-        updated_at: Utc::now(),
-        started_at: None,
-        finished_at: None,
-        usage: None,
-        is_pinned: None,
-        active_schedule_count: None,
-        features: vec![],
-        parent_session_id: None,
-        subagent_name: None,
-        subagent_task: None,
-        subagent_status: None,
-        blueprint_id: None,
-        blueprint_config: None,
+    let builder = SessionBuilder::new(harness_id)
+        .id(session_id)
+        .title("Embedded Session");
+    match agent_id {
+        Some(agent_id) => builder.agent(agent_id).build(),
+        None => builder.build(),
     }
+}
+
+#[test]
+fn per_type_builders_accept_explicit_timestamps() {
+    let timestamp = Utc.with_ymd_and_hms(2026, 1, 2, 3, 4, 5).unwrap();
+    let harness_id = everruns_core::HarnessId::from_seed(51);
+    let agent_id = everruns_core::AgentId::from_seed(51);
+    let session_id = everruns_core::SessionId::from_seed(51);
+
+    let harness = HarnessBuilder::new("math", "prompt")
+        .id(harness_id)
+        .created_at(timestamp)
+        .updated_at(timestamp)
+        .build();
+    let agent = AgentBuilder::new("math-agent", "prompt")
+        .id(agent_id)
+        .created_at(timestamp)
+        .updated_at(timestamp)
+        .build();
+    let session = SessionBuilder::new(harness_id)
+        .id(session_id)
+        .agent(agent_id)
+        .created_at(timestamp)
+        .updated_at(timestamp)
+        .build();
+
+    assert_eq!(harness.created_at, timestamp);
+    assert_eq!(harness.updated_at, timestamp);
+    assert_eq!(agent.created_at, timestamp);
+    assert_eq!(agent.updated_at, timestamp);
+    assert_eq!(session.created_at, timestamp);
+    assert_eq!(session.updated_at, timestamp);
 }
 
 #[tokio::test]
@@ -195,6 +155,38 @@ async fn runtime_executes_tool_loop_and_persists_messages() {
             .any(|event_type| event_type == "tool.completed"),
         "tool execution events must be captured for embedders",
     );
+}
+
+#[tokio::test]
+async fn single_session_builder_seeds_runnable_runtime() {
+    let runtime = InProcessRuntimeBuilder::new()
+        .platform_definition(minimal_platform())
+        .llm_sim(LlmSimConfig::fixed("single session works"))
+        .single_session(|s| {
+            s.harness("math", "You are a math assistant.")
+                .with_capability("test_math")
+                .agent("math-agent", "Use tools when needed.")
+                .agent_max_iterations(8)
+                .session_title("Embedded Session")
+        })
+        .build()
+        .await
+        .unwrap();
+
+    let session_id = runtime.default_session_id().expect("default session id");
+    let context = runtime.load_context(session_id).await.unwrap();
+
+    assert_eq!(context.harness_chain.last().expect("harness").name, "math");
+    assert_eq!(
+        context.agent.expect("agent").system_prompt,
+        "Use tools when needed."
+    );
+
+    let result = runtime
+        .run_text_turn(session_id, "Say this is working.")
+        .await
+        .unwrap();
+    assert!(result.success);
 }
 
 #[tokio::test]

--- a/specs/runtime.md
+++ b/specs/runtime.md
@@ -57,12 +57,23 @@ The builder must allow an embedder to:
 - Optionally register `llmsim` for deterministic local examples and tests
 - Swap the default in-memory stores for custom backends via `RuntimeBackends`
 
+`everruns-runtime` also exposes `HarnessBuilder`, `AgentBuilder`, and
+`SessionBuilder` as the supported embedder construction path for those seed
+models. The core structs remain public data models and may still be constructed
+directly, but embedders should prefer the builders so new optional core fields
+can be defaulted inside the runtime crate instead of forcing every embedder to
+update struct literals. `InProcessRuntimeBuilder::single_session(...)` is the
+recommended compact path for the common one-harness, one-agent, one-session
+runtime shape and records the generated session id for
+`InProcessRuntime::default_session_id()`.
+
 ### Runtime responsibilities
 
 `InProcessRuntime` must expose:
 
 - `run_turn(session_id, input)` for one turn of execution
 - `run_text_turn(session_id, text)` convenience helper
+- `default_session_id()` for runtimes seeded with `single_session(...)`
 - `load_context(session_id)` to inspect the assembled turn context without
   executing a new turn, including empty sessions before the first message
 - `messages(session_id)` to inspect conversation history
@@ -251,6 +262,7 @@ test binaries in `crates/runtime/tests/`.
 ## Source Index
 
 - `crates/runtime/src/lib.rs`
+- `crates/runtime/src/builders.rs`
 - `crates/runtime/src/runtime.rs`
 - `crates/runtime/src/host.rs`
 - `crates/runtime/src/in_memory.rs`


### PR DESCRIPTION
## What
Add embedder-facing builders in `everruns-runtime` for `Harness`, `Agent`, and `Session`, plus `InProcessRuntimeBuilder::single_session(...)` and `InProcessRuntime::default_session_id()` for the common one-harness/one-agent/one-session setup.

## Why
EVE-479: embedders should not need large core struct literals just to seed a runnable in-process runtime, and new optional core fields should be defaultable inside runtime builders.

## How
- Added `HarnessBuilder`, `AgentBuilder`, `SessionBuilder`, and `SingleSessionBuilder` in `crates/runtime/src/builders.rs`.
- Re-exported builders from `everruns_runtime`.
- Wired `single_session(...)` into `InProcessRuntimeBuilder` and tracked its generated default session id.
- Migrated runtime docs/examples/tests to the new builder path and updated `specs/runtime.md`.

## Risk
- Low
- Main risk is public API shape for embedders; existing struct literal construction and explicit `harness(...)`/`agent(...)`/`session(...)` seeding remain supported.

## Security
- Threat categories reviewed: No security-relevant code changes.
- Findings and resolutions: This adds in-process construction helpers plus docs/tests. It does not add network access, auth/authz checks, persistence queries, external input parsing, or new dependencies. The session builder keeps the existing embedded default org/principal seed behavior already used by runtime examples/tests.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

Validation:
- `cargo test -p everruns-runtime`
- `cargo clippy -p everruns-runtime -- -D warnings`
- `cargo run -p everruns-runtime --example in_process_runtime`
- `bash scripts/lib/check-migration-ordering.sh`
- `just pre-push`

Fixes EVE-479