### PR TITLE
feat(core): configure agent instruction files

### DIFF
--- a/crates/core/src/capabilities/agent_instructions.rs
+++ b/crates/core/src/capabilities/agent_instructions.rs
@@ -1,12 +1,13 @@
 //! Agent Instructions Capability (AGENTS.md)
 //!
-//! Reads AGENTS.md from the session workspace and dynamically injects its
-//! content into the system prompt on every LLM turn. This provides project-level
-//! context and conventions to agents.
+//! Reads configured instruction files from the session workspace and dynamically
+//! injects their content into the system prompt on every LLM turn. This provides
+//! project-level context and conventions to agents.
 //!
 //! Design decisions:
 //! - Capability encapsulates all AGENTS.md logic: reading, formatting, and injection
-//! - system_prompt_contribution() reads /AGENTS.md from session filesystem via context
+//! - Default behavior reads /AGENTS.md from session filesystem via context
+//! - Per-capability config can opt into additional workspace-root files
 //! - Re-read every turn so edits are picked up immediately
 //! - 32 KiB size limit (truncated with warning), matching Codex convention
 //! - Missing file is silently ignored
@@ -15,15 +16,76 @@
 
 use super::{Capability, CapabilityStatus, SystemPromptContext};
 use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use std::collections::HashSet;
 
-/// Maximum size of AGENTS.md content in bytes (32 KiB).
+/// Maximum size of each instruction file's content in bytes (32 KiB).
 pub const MAX_AGENTS_MD_SIZE: usize = 32_768;
 
 /// Path to AGENTS.md in the session filesystem.
 pub const AGENTS_MD_PATH: &str = "/AGENTS.md";
 
+/// Default instruction file name.
+pub const DEFAULT_AGENT_INSTRUCTIONS_FILE: &str = "AGENTS.md";
+
+/// Maximum configured instruction files to read per turn.
+pub const MAX_AGENT_INSTRUCTIONS_FILES: usize = 16;
+
 /// Capability ID constant.
 pub const AGENT_INSTRUCTIONS_CAPABILITY_ID: &str = "agent_instructions";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct AgentInstructionsConfig {
+    /// Workspace-root instruction files to read in order.
+    pub files: Vec<String>,
+}
+
+impl Default for AgentInstructionsConfig {
+    fn default() -> Self {
+        Self {
+            files: vec![DEFAULT_AGENT_INSTRUCTIONS_FILE.to_string()],
+        }
+    }
+}
+
+impl AgentInstructionsConfig {
+    pub fn from_value(config: &Value) -> Result<Self, String> {
+        if config.is_null() {
+            return Ok(Self::default());
+        }
+
+        let parsed: Self = serde_json::from_value(config.clone())
+            .map_err(|e| format!("invalid agent_instructions config: {e}"))?;
+        parsed.validate()?;
+        Ok(parsed)
+    }
+
+    pub fn file_paths(&self) -> Vec<String> {
+        let mut seen = HashSet::new();
+        self.files
+            .iter()
+            .filter_map(|file| normalize_instruction_file_path(file).ok())
+            .filter(|path| seen.insert(path.clone()))
+            .collect()
+    }
+
+    fn validate(&self) -> Result<(), String> {
+        if self.files.is_empty() {
+            return Err("files must include at least one instruction file".to_string());
+        }
+        if self.files.len() > MAX_AGENT_INSTRUCTIONS_FILES {
+            return Err(format!(
+                "files may include at most {MAX_AGENT_INSTRUCTIONS_FILES} instruction files"
+            ));
+        }
+        for file in &self.files {
+            normalize_instruction_file_path(file)?;
+        }
+        Ok(())
+    }
+}
 
 /// Agent Instructions capability — reads AGENTS.md from session workspace.
 pub struct AgentInstructionsCapability;
@@ -39,7 +101,7 @@ impl Capability for AgentInstructionsCapability {
     }
 
     fn description(&self) -> &str {
-        "Reads AGENTS.md from the session workspace and includes it as context in the system prompt. Content is re-read on every turn, so changes are picked up automatically.\n\n> [!TIP]\n> Write an `AGENTS.md` file to your session workspace with project conventions, coding style, or any instructions you want the agent to follow."
+        "Reads configured project instruction files from the session workspace and includes them as context in the system prompt. Defaults to AGENTS.md. Content is re-read on every turn, so changes are picked up automatically.\n\n> [!TIP]\n> Write an `AGENTS.md` file to your session workspace with project conventions, coding style, or any instructions you want the agent to follow."
     }
 
     fn status(&self) -> CapabilityStatus {
@@ -56,34 +118,109 @@ impl Capability for AgentInstructionsCapability {
 
     // No static system_prompt_addition — content is dynamic via system_prompt_contribution
 
-    /// Reads AGENTS.md from the session filesystem and returns formatted content.
+    fn config_schema(&self) -> Option<Value> {
+        Some(json!({
+            "type": "object",
+            "properties": {
+                "files": {
+                    "type": "array",
+                    "title": "Instruction files",
+                    "description": "Workspace-root Markdown files to read in order. Defaults to AGENTS.md.",
+                    "items": {
+                        "type": "string",
+                        "description": "File path relative to /workspace, for example AGENTS.md or CLAUDE.md.",
+                        "minLength": 1
+                    },
+                    "default": [DEFAULT_AGENT_INSTRUCTIONS_FILE],
+                    "minItems": 1,
+                    "maxItems": MAX_AGENT_INSTRUCTIONS_FILES,
+                    "uniqueItems": true
+                }
+            },
+            "additionalProperties": false
+        }))
+    }
+
+    fn config_ui_schema(&self) -> Option<Value> {
+        Some(json!({
+            "files": {
+                "ui:options": {
+                    "orderable": true
+                }
+            }
+        }))
+    }
+
+    fn validate_config(&self, config: &Value) -> Result<(), String> {
+        AgentInstructionsConfig::from_value(config).map(|_| ())
+    }
+
+    /// Reads configured instruction files from the session filesystem and
+    /// returns formatted content.
     ///
     /// This replaces the previous approach where ReasonAtom had hardcoded AGENTS.md
     /// reading logic. Now the capability fully encapsulates its own prompt generation.
     async fn system_prompt_contribution(&self, ctx: &SystemPromptContext) -> Option<String> {
-        let file_store = ctx.file_store.as_ref()?;
+        self.system_prompt_contribution_with_config(ctx, &Value::Null)
+            .await
+    }
 
-        match file_store.read_file(ctx.session_id, AGENTS_MD_PATH).await {
-            Ok(Some(file)) => file.content.as_deref().and_then(format_agents_md_content),
-            Ok(None) => {
-                // File doesn't exist — silently skip
-                None
-            }
-            Err(e) => {
+    async fn system_prompt_contribution_with_config(
+        &self,
+        ctx: &SystemPromptContext,
+        config: &Value,
+    ) -> Option<String> {
+        let file_store = ctx.file_store.as_ref()?;
+        let config = match AgentInstructionsConfig::from_value(config) {
+            Ok(config) => config,
+            Err(error) => {
                 tracing::warn!(
-                    error = %e,
+                    error = %error,
                     session_id = %ctx.session_id,
-                    "Failed to read AGENTS.md, skipping"
+                    "Invalid agent_instructions config, falling back to AGENTS.md"
                 );
-                None
+                AgentInstructionsConfig::default()
             }
+        };
+
+        let mut contributions = Vec::new();
+        for path in config.file_paths() {
+            let source = path.trim_start_matches('/');
+            match file_store.read_file(ctx.session_id, &path).await {
+                Ok(Some(file)) => {
+                    if let Some(content) = file
+                        .content
+                        .as_deref()
+                        .and_then(|c| format_instruction_file_content(source, c))
+                    {
+                        contributions.push(content);
+                    }
+                }
+                Ok(None) => {
+                    // File doesn't exist — silently skip
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        session_id = %ctx.session_id,
+                        path = %path,
+                        "Failed to read agent instructions file, skipping"
+                    );
+                }
+            }
+        }
+
+        if contributions.is_empty() {
+            None
+        } else {
+            Some(contributions.join("\n\n"))
         }
     }
 
     fn system_prompt_preview(&self) -> Option<String> {
         Some(
             "<agent-instructions source=\"AGENTS.md\">\n\
-             (contents of /workspace/AGENTS.md, re-read every turn)\n\
+             (contents of configured /workspace instruction files, re-read every turn)\n\
              </agent-instructions>"
                 .to_string(),
         )
@@ -99,6 +236,14 @@ impl Capability for AgentInstructionsCapability {
 /// Truncates to `MAX_AGENTS_MD_SIZE` if content exceeds the limit.
 /// Returns `None` if content is empty.
 pub fn format_agents_md_content(content: &str) -> Option<String> {
+    format_instruction_file_content(DEFAULT_AGENT_INSTRUCTIONS_FILE, content)
+}
+
+/// Format an instruction file's content for injection into the system prompt.
+///
+/// Truncates to `MAX_AGENTS_MD_SIZE` if content exceeds the limit.
+/// Returns `None` if content is empty.
+pub fn format_instruction_file_content(source: &str, content: &str) -> Option<String> {
     let content = content.trim();
     if content.is_empty() {
         return None;
@@ -106,9 +251,10 @@ pub fn format_agents_md_content(content: &str) -> Option<String> {
 
     let (body, was_truncated) = if content.len() > MAX_AGENTS_MD_SIZE {
         tracing::warn!(
+            source = %source,
             content_size = content.len(),
             max_size = MAX_AGENTS_MD_SIZE,
-            "AGENTS.md exceeds size limit, truncating"
+            "Agent instructions file exceeds size limit, truncating"
         );
         let mut truncation_idx = MAX_AGENTS_MD_SIZE;
         while truncation_idx > 0 && !content.is_char_boundary(truncation_idx) {
@@ -120,17 +266,21 @@ pub fn format_agents_md_content(content: &str) -> Option<String> {
     };
 
     let escaped_body = escape_xml_text(body);
+    let escaped_source = escape_xml_attribute(source);
 
     let mut result = format!(
-        "<agent-instructions source=\"AGENTS.md\">\n{}",
-        escaped_body
+        "<agent-instructions source=\"{}\">\n{}",
+        escaped_source, escaped_body
     );
     if was_truncated {
-        result.push_str("\n\n[AGENTS.md was truncated — content exceeds 32 KiB limit]");
+        result.push_str(&format!(
+            "\n\n[{} was truncated — content exceeds 32 KiB limit]",
+            escape_xml_text(source)
+        ));
     }
     result.push_str(concat!(
         "\n\n",
-        "AGENTS.md may reference specs, skills, and other files in the workspace. ",
+        "Instruction files may reference specs, skills, and other files in the workspace. ",
         "Read referenced files before concluding you cannot perform a task. ",
         "Follow links progressively — don't load everything upfront, ",
         "but do read a file when its topic is relevant to the current request.",
@@ -139,11 +289,45 @@ pub fn format_agents_md_content(content: &str) -> Option<String> {
     Some(result)
 }
 
+fn normalize_instruction_file_path(file: &str) -> Result<String, String> {
+    let trimmed = file.trim();
+    if trimmed.is_empty() {
+        return Err("instruction file path cannot be empty".to_string());
+    }
+    if trimmed.contains('\0') {
+        return Err("instruction file path cannot contain null bytes".to_string());
+    }
+
+    let without_workspace = trimmed
+        .strip_prefix("/workspace/")
+        .or_else(|| trimmed.strip_prefix("workspace/"))
+        .unwrap_or(trimmed);
+    let relative = without_workspace.trim_start_matches('/');
+    if relative.is_empty() {
+        return Err("instruction file path must name a file".to_string());
+    }
+    if relative.ends_with('/') {
+        return Err("instruction file path must name a file".to_string());
+    }
+
+    for segment in relative.split('/') {
+        if segment.is_empty() || segment == "." || segment == ".." {
+            return Err(format!("invalid instruction file path: {file}"));
+        }
+    }
+
+    Ok(format!("/{relative}"))
+}
+
 fn escape_xml_text(content: &str) -> String {
     content
         .replace('&', "&amp;")
         .replace('<', "&lt;")
         .replace('>', "&gt;")
+}
+
+fn escape_xml_attribute(content: &str) -> String {
+    escape_xml_text(content).replace('"', "&quot;")
 }
 
 #[cfg(test)]
@@ -154,12 +338,44 @@ mod tests {
     use crate::session_file::{FileInfo, FileStat, GrepMatch, SessionFile};
     use crate::traits::SessionFileStore;
     use crate::typed_id::SessionId;
-    use std::sync::Arc;
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
     use uuid::Uuid;
 
     /// Mock file store for testing dynamic system prompt contribution
     struct MockFileStore {
-        content: Option<String>,
+        files: HashMap<String, String>,
+        read_paths: Mutex<Vec<String>>,
+    }
+
+    impl MockFileStore {
+        fn empty() -> Self {
+            Self {
+                files: HashMap::new(),
+                read_paths: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn single(path: &str, content: &str) -> Self {
+            Self {
+                files: HashMap::from([(path.to_string(), content.to_string())]),
+                read_paths: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn with_files(files: &[(&str, &str)]) -> Self {
+            Self {
+                files: files
+                    .iter()
+                    .map(|(path, content)| (path.to_string(), content.to_string()))
+                    .collect(),
+                read_paths: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn read_paths(&self) -> Vec<String> {
+            self.read_paths.lock().unwrap().clone()
+        }
     }
 
     #[async_trait::async_trait]
@@ -167,13 +383,14 @@ mod tests {
         async fn read_file(
             &self,
             _session_id: SessionId,
-            _path: &str,
+            path: &str,
         ) -> Result<Option<SessionFile>> {
-            Ok(self.content.as_ref().map(|c| SessionFile {
+            self.read_paths.lock().unwrap().push(path.to_string());
+            Ok(self.files.get(path).map(|c| SessionFile {
                 id: Uuid::nil(),
                 session_id: Uuid::nil(),
-                path: AGENTS_MD_PATH.to_string(),
-                name: "AGENTS.md".to_string(),
+                path: path.to_string(),
+                name: path.trim_start_matches('/').to_string(),
                 content: Some(c.clone()),
                 encoding: "text".to_string(),
                 is_directory: false,
@@ -376,25 +593,27 @@ mod tests {
     #[tokio::test]
     async fn test_contribution_reads_agents_md() {
         let cap = AgentInstructionsCapability;
-        let store = Arc::new(MockFileStore {
-            content: Some("## Style\nUse snake_case.".to_string()),
-        });
+        let store = Arc::new(MockFileStore::single(
+            AGENTS_MD_PATH,
+            "## Style\nUse snake_case.",
+        ));
         let ctx = SystemPromptContext {
             session_id: test_session_id(),
             locale: None,
-            file_store: Some(store),
+            file_store: Some(store.clone()),
         };
 
         let result = cap.system_prompt_contribution(&ctx).await.unwrap();
         assert!(result.contains("Use snake_case"));
         assert!(result.starts_with("<agent-instructions"));
         assert!(result.ends_with("</agent-instructions>"));
+        assert_eq!(store.read_paths(), vec!["/AGENTS.md"]);
     }
 
     #[tokio::test]
     async fn test_contribution_none_when_file_missing() {
         let cap = AgentInstructionsCapability;
-        let store = Arc::new(MockFileStore { content: None });
+        let store = Arc::new(MockFileStore::empty());
         let ctx = SystemPromptContext {
             session_id: test_session_id(),
             locale: None,
@@ -415,9 +634,7 @@ mod tests {
     #[tokio::test]
     async fn test_contribution_none_when_empty_content() {
         let cap = AgentInstructionsCapability;
-        let store = Arc::new(MockFileStore {
-            content: Some("   \n  ".to_string()),
-        });
+        let store = Arc::new(MockFileStore::single(AGENTS_MD_PATH, "   \n  "));
         let ctx = SystemPromptContext {
             session_id: test_session_id(),
             locale: None,
@@ -425,5 +642,71 @@ mod tests {
         };
 
         assert!(cap.system_prompt_contribution(&ctx).await.is_none());
+    }
+
+    #[test]
+    fn test_agent_instructions_config_defaults_to_agents_md() {
+        let config = AgentInstructionsConfig::from_value(&serde_json::json!({})).unwrap();
+        assert_eq!(config.files, vec!["AGENTS.md"]);
+    }
+
+    #[test]
+    fn test_agent_instructions_config_rejects_invalid_shape() {
+        assert!(AgentInstructionsConfig::from_value(&serde_json::json!({"files": []})).is_err());
+        assert!(
+            AgentInstructionsConfig::from_value(&serde_json::json!({"files": ["../CLAUDE.md"]}))
+                .is_err()
+        );
+        assert!(
+            AgentInstructionsConfig::from_value(
+                &serde_json::json!({"files": ["AGENTS.md"], "extra": true})
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn test_agent_instructions_config_normalizes_configured_files() {
+        let config = AgentInstructionsConfig::from_value(&serde_json::json!({
+            "files": ["AGENTS.md", "/workspace/CLAUDE.md", ".github/copilot-instructions.md"]
+        }))
+        .unwrap();
+
+        assert_eq!(
+            config.file_paths(),
+            vec![
+                "/AGENTS.md",
+                "/CLAUDE.md",
+                "/.github/copilot-instructions.md"
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_contribution_with_config_reads_multiple_instruction_files() {
+        let cap = AgentInstructionsCapability;
+        let store = Arc::new(MockFileStore::with_files(&[
+            ("/AGENTS.md", "Prefer Rust."),
+            ("/CLAUDE.md", "Prefer concise replies."),
+        ]));
+        let ctx = SystemPromptContext {
+            session_id: test_session_id(),
+            locale: None,
+            file_store: Some(store.clone()),
+        };
+
+        let result = cap
+            .system_prompt_contribution_with_config(
+                &ctx,
+                &serde_json::json!({ "files": ["AGENTS.md", "CLAUDE.md"] }),
+            )
+            .await
+            .unwrap();
+
+        assert!(result.contains("source=\"AGENTS.md\""));
+        assert!(result.contains("Prefer Rust."));
+        assert!(result.contains("source=\"CLAUDE.md\""));
+        assert!(result.contains("Prefer concise replies."));
+        assert_eq!(store.read_paths(), vec!["/AGENTS.md", "/CLAUDE.md"]);
     }
 }

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -135,7 +135,8 @@ pub use a2a_delegation::{
 pub use a2ui::{A2UI_CAPABILITY_ID, A2UiCapability};
 pub use agent_instructions::{
     AGENT_INSTRUCTIONS_CAPABILITY_ID, AGENTS_MD_PATH, AgentInstructionsCapability,
-    MAX_AGENTS_MD_SIZE, format_agents_md_content,
+    AgentInstructionsConfig, DEFAULT_AGENT_INSTRUCTIONS_FILE, MAX_AGENT_INSTRUCTIONS_FILES,
+    MAX_AGENTS_MD_SIZE, format_agents_md_content, format_instruction_file_content,
 };
 pub use attach_skill::{
     AttachSkillCapability, SKILL_CAPABILITY_PREFIX, SKILLS_DISCOVERY_PATH, SkillContribution,

--- a/docs/capabilities/agent-instructions.md
+++ b/docs/capabilities/agent-instructions.md
@@ -1,6 +1,6 @@
 ---
 title: AGENTS.md
-description: Dynamic project instructions loaded from AGENTS.md files in the session workspace. Agents inherit coding style, tool preferences, and workflow rules automatically.
+description: Dynamic project instructions loaded from configured files in the session workspace. Agents inherit coding style, tool preferences, and workflow rules automatically.
 ---
 
 | | |
@@ -10,7 +10,7 @@ description: Dynamic project instructions loaded from AGENTS.md files in the ses
 | **Features** | None |
 | **Dependencies** | None |
 
-Reads `AGENTS.md` from the session workspace and injects its content into the system prompt. The file is re-read on every conversation turn, so changes are picked up automatically without restarting the session.
+Reads project instruction files from the session workspace and injects their content into the system prompt. By default it reads `AGENTS.md`. Configure `files` when an agent should also read another file such as `CLAUDE.md`.
 
 ## Tools
 
@@ -19,15 +19,25 @@ None — this capability only contributes to the system prompt.
 ## How It Works
 
 1. Agent sends a message
-2. Before processing, the system reads `/workspace/AGENTS.md` from the session filesystem
-3. Content is wrapped in `<agent-instructions source="AGENTS.md">` XML tags
+2. Before processing, the system reads configured files from the session filesystem
+3. Each file is wrapped in `<agent-instructions source="...">` XML tags
 4. Injected at the beginning of the system prompt (before other capability prompts)
+
+## Config
+
+```json
+{
+  "files": ["AGENTS.md", "CLAUDE.md"]
+}
+```
+
+`files` is optional. When omitted, Everruns reads only `/workspace/AGENTS.md`.
 
 ## Notes
 
-- File path: `/workspace/AGENTS.md` (plain Markdown, max 32 KiB)
+- Default file path: `/workspace/AGENTS.md` (plain Markdown, max 32 KiB per file)
 - Re-read every turn — edits take effect immediately
-- If the file doesn't exist, no instructions are added (no error)
+- Missing configured files are ignored (no error)
 - Works with [File System](/capabilities/file-system/) tools to update instructions dynamically
 
 ## See Also

--- a/docs/features/agent-instructions.md
+++ b/docs/features/agent-instructions.md
@@ -1,22 +1,23 @@
 ---
 title: AGENTS.md
-description: The AGENTS.md capability injects project-level instructions from a workspace file into the agent's system prompt on every turn.
+description: The AGENTS.md capability injects project-level instructions from workspace files into the agent's system prompt on every turn.
 ---
 
-The **AGENTS.md** capability reads an `AGENTS.md` file from the session workspace and injects it into the agent's system prompt at the start of every turn. It's Everruns' implementation of the [`AGENTS.md`](https://agents.md/) open standard — an emerging convention backed by OpenAI, Google, Cursor, Sourcegraph, and the Linux Foundation.
+The **AGENTS.md** capability reads project instruction files from the session workspace and injects them into the agent's system prompt at the start of every turn. By default it reads `AGENTS.md`, Everruns' implementation of the [`AGENTS.md`](https://agents.md/) open standard — an emerging convention backed by OpenAI, Google, Cursor, Sourcegraph, and the Linux Foundation.
 
 When the capability is enabled:
 
-- The agent reads `/workspace/AGENTS.md` on every turn.
+- The agent reads `/workspace/AGENTS.md` on every turn by default.
+- Agents can configure `files` to read additional workspace files such as `CLAUDE.md`.
 - Edits during a session apply on the next turn (no restart).
 - The content is prepended to the system prompt, before capability fragments and the agent's own prompt.
-- If the file doesn't exist, the agent operates normally.
+- If a configured file doesn't exist, the agent operates normally.
 
 ## Prompt order
 
 When `AGENTS.md` is present, the system prompt is composed top-to-bottom:
 
-1. **AGENTS.md content** — project-level instructions
+1. **Instruction file content** — project-level instructions
 2. **Capability system prompt additions** — tool guidance
 3. **Agent's base system prompt** — role and personality
 
@@ -24,12 +25,18 @@ Project context comes first, so downstream prompt fragments can build on it.
 
 ## Limits
 
-- Content cap: **32 KiB**. Excess is silently truncated.
+- Content cap: **32 KiB per file**. Excess is silently truncated.
 - Plain Markdown — no required sections.
 
 ## Compatibility
 
-Everruns reads only `AGENTS.md`. Tool-specific files like `.cursorrules`, `CLAUDE.md`, and `.github/copilot-instructions.md` are not read. If you maintain multiple, symlink or copy into `AGENTS.md`.
+Everruns keeps `AGENTS.md` as the default. Configure the capability with `files` to read additional tool-specific files:
+
+```json
+{
+  "files": ["AGENTS.md", "CLAUDE.md"]
+}
+```
 
 ## Do something
 

--- a/docs/how-to/use-agents-md.md
+++ b/docs/how-to/use-agents-md.md
@@ -3,7 +3,7 @@ title: Use AGENTS.md for project instructions
 description: Inject project-level context — coding style, build commands, architecture notes — into an agent's system prompt by enabling the AGENTS.md capability.
 ---
 
-`AGENTS.md` is an emerging open standard for providing project-level instructions to AI agents, backed by OpenAI, Google, Cursor, Sourcegraph, and others. Everruns ships it as a built-in capability that re-reads the file on every turn.
+`AGENTS.md` is an emerging open standard for providing project-level instructions to AI agents, backed by OpenAI, Google, Cursor, Sourcegraph, and others. Everruns ships it as the default file for its built-in agent instructions capability, which re-reads configured files on every turn.
 
 ## Enable the capability
 
@@ -19,6 +19,24 @@ curl -X PATCH http://localhost:9300/api/v1/agents/$AGENT_ID \
 ```
 
 `session_file_system` isn't required, but pairing it with `agent_instructions` lets the agent edit `AGENTS.md` itself.
+
+To also read another instruction file, configure `files` on the capability:
+
+```bash
+curl -X PATCH http://localhost:9300/api/v1/agents/$AGENT_ID \
+  -H "Content-Type: application/json" \
+  -d '{
+    "capabilities": [
+      {
+        "ref": "agent_instructions",
+        "config": {
+          "files": ["AGENTS.md", "CLAUDE.md"]
+        }
+      },
+      { "ref": "session_file_system" }
+    ]
+  }'
+```
 
 ## Write the file
 
@@ -58,7 +76,7 @@ There are no required sections. Write whatever a new contributor would need to k
 
 When the capability is enabled, the system prompt is composed top-to-bottom:
 
-1. **AGENTS.md content** — project-level instructions.
+1. **Instruction file content** — project-level instructions.
 2. **Capability system prompt additions** — tool guidance.
 3. **Agent's base system prompt** — the agent's role.
 
@@ -66,13 +84,13 @@ Project context comes first, so capability and agent prompts can reference it.
 
 ## Limits and dynamics
 
-- Content is capped at **32 KiB** (32,768 bytes). Excess is silently truncated.
-- The file is re-read on every turn. Edits during a session apply on the next turn — no restart needed.
-- If the file doesn't exist, the agent operates normally without it.
+- Content is capped at **32 KiB** (32,768 bytes) per file. Excess is silently truncated.
+- Configured files are re-read on every turn. Edits during a session apply on the next turn — no restart needed.
+- If a configured file doesn't exist, the agent operates normally without it.
 
 ## Other tools' instruction files
 
-Everruns reads only `AGENTS.md`. Files like `.cursorrules`, `CLAUDE.md`, or `.github/copilot-instructions.md` aren't read. If you maintain several, symlink or copy them into `AGENTS.md` for Everruns.
+Everruns reads `AGENTS.md` by default. Add other file names to `files` when an agent should also read `CLAUDE.md`, `.cursorrules`, or `.github/copilot-instructions.md`.
 
 ## See also
 

--- a/specs/agent-instructions.md
+++ b/specs/agent-instructions.md
@@ -1,25 +1,25 @@
-# AGENTS.md Specification
+# Agent Instructions Specification
 
 ## Abstract
 
-The AGENTS.md capability reads an `AGENTS.md` file from the session workspace and dynamically injects its content into the system prompt on every LLM turn. This provides project-level context and coding conventions to agents without modifying the agent's system prompt directly.
+The agent instructions capability reads configured Markdown instruction files from the session workspace and dynamically injects their content into the system prompt on every LLM turn. By default it reads `AGENTS.md`, preserving Everruns' original AGENTS.md behavior, while allowing agents to opt into files such as `CLAUDE.md`.
 
 ## Background
 
 `AGENTS.md` is an emerging open standard (backed by OpenAI, Google, Cursor, Sourcegraph, Linux Foundation) for providing project-level instructions to AI coding agents. There is no formal specification beyond "plain markdown in a file named AGENTS.md." Each tool defines its own discovery and injection semantics.
 
-Everruns implements AGENTS.md as a built-in capability that reads from the session workspace filesystem. This integrates naturally with the existing capability system—users enable/disable it per agent, and the content is picked up dynamically (no restart needed).
+Everruns implements AGENTS.md as a built-in capability that reads from the session workspace filesystem. This integrates naturally with the existing capability system—users enable/disable it per agent, configure optional additional file names per capability assignment, and the content is picked up dynamically (no restart needed).
 
 ## Design Decisions
 
 | Question | Decision |
 |----------|----------|
-| File name | `AGENTS.md` only (not CLAUDE.md, .cursorrules, etc.) |
-| Discovery | Single file at workspace root (`/AGENTS.md`) — no upward walk (session filesystem is flat) |
+| File name | Defaults to `AGENTS.md`; configurable `files` list can include names such as `CLAUDE.md` |
+| Discovery | Configured workspace-root files only — no upward walk |
 | Injection point | Prepended to system prompt, before capability additions |
 | Dynamic reading | Re-read on every LLM turn (picks up changes immediately) |
-| Size limit | 32 KiB max of AGENTS.md content; truncated with warning if exceeded, excluding wrapper/hint text (matching Codex convention) |
-| Missing file | Silently ignored (no error) |
+| Size limit | 32 KiB max per instruction file; truncated with warning if exceeded, excluding wrapper/hint text (matching Codex convention) |
+| Missing file | Silently ignored per configured file (no error) |
 | Format | Plain markdown, no special syntax, no `@` imports |
 | Link-following hint | Appended after content; nudges LLM to read referenced files progressively |
 | Architecture | Self-contained capability with `system_prompt_contribution()` override |
@@ -28,7 +28,7 @@ Everruns implements AGENTS.md as a built-in capability that reads from the sessi
 ## Capability Definition
 
 The capability encapsulates all AGENTS.md logic: reading from the session filesystem,
-formatting, size limiting, and XML wrapping. It uses the `system_prompt_contribution()`
+formatting, size limiting, and XML wrapping. It uses config-aware `system_prompt_contribution()`
 async method (via `SystemPromptContext`) to access the session filesystem.
 
 See `crates/core/src/capabilities/agent_instructions.rs` for the `AgentInstructionsCapability` implementation.
@@ -52,7 +52,7 @@ execute_llm_call()
   │   ├── with_agent_async() — resolves agent capabilities
   │   └── with_capabilities_async() — resolves session capabilities
   │       └── For each capability: call system_prompt_contribution(ctx)
-  │           └── agent_instructions: reads /AGENTS.md from file store
+  │           └── agent_instructions: reads configured instruction files from file store
   ├── Build final RuntimeAgent
   └── Execute LLM call
 ```
@@ -61,7 +61,7 @@ execute_llm_call()
 
 After injection, system prompt order (top to bottom):
 
-1. **AGENTS.md content** — wrapped in `<agent-instructions source="AGENTS.md">` tags
+1. **Instruction file content** — each file wrapped in `<agent-instructions source="...">` tags
 2. **Capability system prompt additions** — each wrapped in `<capability id="...">` tags
 3. **Agent's base system prompt** — wrapped in `<system-prompt>` tags (only when capabilities are present)
 
@@ -73,7 +73,7 @@ ReasonAtom holds an optional `SessionFileStore` that is passed to capabilities v
 
 ## Constants
 
-See `crates/core/src/capabilities/agent_instructions.rs` for `MAX_AGENTS_MD_SIZE` (32 KiB), `AGENTS_MD_PATH`, and `AGENT_INSTRUCTIONS_CAPABILITY_ID`.
+See `crates/core/src/capabilities/agent_instructions.rs` for `MAX_AGENTS_MD_SIZE` (32 KiB), `AGENTS_MD_PATH`, `DEFAULT_AGENT_INSTRUCTIONS_FILE`, `MAX_AGENT_INSTRUCTIONS_FILES`, and `AGENT_INSTRUCTIONS_CAPABILITY_ID`.
 
 ## API
 
@@ -89,7 +89,14 @@ Response includes:
   "description": "Reads AGENTS.md from the session workspace...",
   "status": "available",
   "icon": "file-text",
-  "category": "Configuration"
+  "category": "Configuration",
+  "config_schema": {
+    "properties": {
+      "files": {
+        "default": ["AGENTS.md"]
+      }
+    }
+  }
 }
 ```
 
@@ -100,9 +107,26 @@ PATCH /v1/agents/{id}
 { "capabilities": [{ "ref": "agent_instructions" }, ...] }
 ```
 
+Configure additional instruction files:
+
+```http
+PATCH /v1/agents/{id}
+{
+  "capabilities": [
+    {
+      "ref": "agent_instructions",
+      "config": {
+        "files": ["AGENTS.md", "CLAUDE.md"]
+      }
+    }
+  ]
+}
+```
+
 ## Usage
 
 1. Enable the `agent_instructions` capability on an agent
 2. Write an `AGENTS.md` file to the session workspace (via file tools, bash, or API)
-3. The agent automatically reads it on every turn
-4. Edit the file anytime — changes take effect on the next turn
+3. Optionally configure `files` when the agent should also read another instruction file
+4. The agent automatically reads configured files on every turn
+5. Edit a configured file anytime — changes take effect on the next turn

--- a/specs/capabilities.md
+++ b/specs/capabilities.md
@@ -683,7 +683,7 @@ When a session executes:
 6. **Build RuntimeAgent**:
    - System prompt = session cap additions + agent cap additions + agent's base prompt
    - Each section is wrapped in XML tags for clear boundaries (see `specs/xml-prompt-formatting.md`):
-     - AGENTS.md content: `<agent-instructions source="AGENTS.md">`
+     - Instruction file content: `<agent-instructions source="{path}">`
      - Each capability's addition: `<capability id="{cap_id}">`
      - Base prompt: `<system-prompt>` (only when capabilities contribute prompt additions)
    - Tools = merged tool list from agent capabilities + session capabilities

--- a/specs/xml-prompt-formatting.md
+++ b/specs/xml-prompt-formatting.md
@@ -2,7 +2,7 @@
 
 ## Abstract
 
-System prompts use XML tags to create clear boundaries between capability instructions, user-provided project instructions (AGENTS.md), and the agent's base system prompt. This follows Anthropic's recommendation for multi-component prompts and is the cross-provider consensus for structured prompt formatting.
+System prompts use XML tags to create clear boundaries between capability instructions, user-provided project instruction files, and the agent's base system prompt. This follows Anthropic's recommendation for multi-component prompts and is the cross-provider consensus for structured prompt formatting.
 
 ## Rationale
 
@@ -10,7 +10,7 @@ System prompts use XML tags to create clear boundaries between capability instru
 
 When multiple capabilities are enabled, the LLM receives a wall of text where:
 - Boundaries between capability sections are ambiguous (only `\n\n` separators)
-- User-provided AGENTS.md content bleeds into system capability instructions
+- User-provided instruction file content bleeds into system capability instructions
 - Tool guidance for one capability can be misattributed to another
 - The distinction between platform instructions and agent-level behavior is unclear
 
@@ -22,7 +22,7 @@ Anthropic's prompt engineering docs recommend XML tags for multi-component promp
 Key advantages over markdown-only formatting:
 - **Clear boundaries**: Unambiguous section delimiters reduce misattribution
 - **Cross-model support**: XML tags are recommended by Anthropic, Google, and OpenAI
-- **Prompt injection resistance**: XML boundaries make it harder for injected content in AGENTS.md to impersonate system instructions
+- **Prompt injection resistance**: XML boundaries make it harder for injected content in instruction files to impersonate system instructions
 - **Parseability**: Tags enable referencing sections by name (e.g., "the instructions in `<agent-instructions>`")
 
 Trade-offs accepted:
@@ -37,7 +37,7 @@ Three XML tags wrap the three logical sections of the assembled system prompt:
 
 | Tag | Purpose | Content |
 |-----|---------|---------|
-| `<agent-instructions source="AGENTS.md">` | User-provided project instructions | AGENTS.md file content (markdown) |
+| `<agent-instructions source="{path}">` | User-provided project instructions | Configured instruction file content (markdown) |
 | `<capability id="{cap_id}">` | Per-capability tool guidance | Capability's `system_prompt_addition()` (markdown) |
 | `<system-prompt>` | Agent's core behavior prompt | Agent's base `system_prompt` field |
 
@@ -66,7 +66,7 @@ You are a helpful assistant.
 
 Top to bottom (matches existing order, unchanged):
 
-1. **AGENTS.md** — user-provided project instructions (if `agent_instructions` capability enabled)
+1. **Instruction files** — user-provided project instructions (if `agent_instructions` capability enabled and configured files exist)
 2. **Capability prompts** — in capability application order (agent caps, then session caps)
 3. **Base system prompt** — agent's core behavior prompt
 
@@ -74,7 +74,7 @@ Top to bottom (matches existing order, unchanged):
 
 - `<system-prompt>` tags only appear when at least one capability contributes a `system_prompt_addition`. If no capabilities add prompts, the base prompt is used unwrapped.
 - `<capability>` tags only appear for capabilities that have a non-None `system_prompt_addition()`.
-- `<agent-instructions>` tags only appear when AGENTS.md exists and is non-empty.
+- `<agent-instructions>` tags only appear when a configured instruction file exists and is non-empty.
 - Capabilities without `system_prompt_addition` (e.g., `current_time`, `noop`) add no XML to the prompt.
 
 ### Implementation
@@ -92,12 +92,12 @@ if let Some(addition) = capability.system_prompt_addition() {
 }
 ```
 
-#### `format_agents_md_content()` (agent_instructions.rs)
+#### `format_instruction_file_content()` (agent_instructions.rs)
 
-Wraps AGENTS.md content in `<agent-instructions>` tags:
+Wraps configured instruction file content in `<agent-instructions>` tags:
 
 ```rust
-let mut result = format!("<agent-instructions source=\"AGENTS.md\">\n{}", body);
+let mut result = format!("<agent-instructions source=\"{}\">\n{}", source, body);
 // ... truncation handling ...
 result.push_str("\n</agent-instructions>");
 ```

--- a/test_cases/api/agent_instructions/TC006_configured_instruction_files.md
+++ b/test_cases/api/agent_instructions/TC006_configured_instruction_files.md
@@ -1,0 +1,37 @@
+# TC006: Configured Instruction Files
+
+## Goal
+
+Verify that `agent_instructions` keeps `AGENTS.md` as the default and reads additional configured instruction files such as `CLAUDE.md`.
+
+## Setup
+
+| Item | Value |
+|------|-------|
+| Harness | Generic |
+| Capability config | `{ "files": ["AGENTS.md", "CLAUDE.md"] }` |
+| AGENTS.md Content | `Always end with "-- agents"` |
+| CLAUDE.md Content | `Always start with "claude:"` |
+
+## Steps
+
+1. Create or update an agent with `agent_instructions` configured:
+   ```json
+   {
+     "ref": "agent_instructions",
+     "config": {
+       "files": ["AGENTS.md", "CLAUDE.md"]
+     }
+   }
+   ```
+2. Create a session for the agent.
+3. Write both files to the session filesystem.
+4. Send a message that does not mention either instruction.
+
+## Expected
+
+| Check | Expected |
+|-------|----------|
+| Both files applied | Response starts with `claude:` and ends with `-- agents` |
+| Missing file behavior | Removing `CLAUDE.md` does not fail the next turn |
+| Default behavior | An agent with `{ "ref": "agent_instructions" }` still reads only `AGENTS.md` |


### PR DESCRIPTION
## What
Add per-capability `agent_instructions.config.files` so agents can read additional workspace instruction files such as `CLAUDE.md` while keeping `AGENTS.md` as the default.

## Why
Some projects already maintain tool-specific instruction files. Everruns should support those without requiring users to copy or symlink everything into `AGENTS.md`.

## How
- Added `AgentInstructionsConfig` with validated, ordered `files` and a default of `["AGENTS.md"]`.
- Read configured files in order on every turn, wrapping each non-empty file in `<agent-instructions source="...">`.
- Kept legacy `AGENTS_MD_PATH` and `format_agents_md_content` behavior for existing callers.
- Updated specs, docs, and manual test coverage for configured instruction files.

## Risk
- Medium
- Prompt assembly and config validation changed. Regressions could cause instruction files to be skipped, duplicated, or rendered with the wrong source attribution.
- Backward compatibility covered by tests that default config still reads only `/AGENTS.md`.

## Security
- Threat categories reviewed: TM-API, TM-FS, TM-LLM, TM-DOS.
- Findings and resolutions: config rejects unknown keys, empty file lists, traversal segments, null bytes, and more than 16 files; reads remain workspace-file-store reads only; XML text and source attributes are escaped; the existing 32 KiB per-file truncation limit is preserved. No threat model update needed because the change extends existing prompt/file behavior with bounded validated config.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

## Validation
- `cargo fmt`
- `cargo test -p everruns-core capabilities::agent_instructions --lib`
- `cargo clippy -p everruns-core --all-targets -- -D warnings`
- `npm run build` in `apps/docs`
- `bash scripts/lib/check-migration-ordering.sh`
- `just pre-push`
- Runtime smoke: direct dev API returned `agent_instructions` config schema with default `["AGENTS.md"]`, `maxItems: 16`, and `additionalProperties: false`.
