### PR TITLE
refactor(runtime): add session filesystem factory

### DIFF
--- a/crates/core/src/atoms/act.rs
+++ b/crates/core/src/atoms/act.rs
@@ -41,7 +41,7 @@ use crate::tool_narration::{
 };
 use crate::tool_types::{ToolCall, ToolDefinition, ToolResult};
 use crate::traits::{
-    AgentStore, EventEmitter, SessionFileStore, SessionMutator, SessionStore, ToolContext,
+    AgentStore, EventEmitter, SessionFileSystem, SessionMutator, SessionStore, ToolContext,
     ToolExecutor,
 };
 use crate::typed_id::{AgentId, HarnessId};
@@ -153,7 +153,7 @@ where
     tool_executor: T,
     event_emitter: Arc<E>,
     /// Optional file store for context-aware tools
-    file_store: Option<Arc<dyn SessionFileStore>>,
+    file_store: Option<Arc<dyn SessionFileSystem>>,
     /// Optional SQL database store for sql_execute/sql_query/sql_schema tools
     sqldb_store: Option<crate::traits::SessionSqlDbStoreRef>,
     /// Optional session storage store for kv_store/secret_store tools
@@ -247,7 +247,7 @@ where
     pub fn with_file_store(
         tool_executor: T,
         event_emitter: E,
-        file_store: Arc<dyn SessionFileStore>,
+        file_store: Arc<dyn SessionFileSystem>,
     ) -> Self {
         Self {
             tool_executor,

--- a/crates/core/src/atoms/reason.rs
+++ b/crates/core/src/atoms/reason.rs
@@ -374,7 +374,7 @@ pub struct ReasonAtom {
     image_resolver: Option<Arc<dyn ImageResolver>>,
     /// Optional file store for capabilities that need filesystem access
     /// (e.g., agent_instructions reads AGENTS.md, skills_discovery scans for skills)
-    file_store: Option<Arc<dyn crate::traits::SessionFileStore>>,
+    file_store: Option<Arc<dyn crate::traits::SessionFileSystem>>,
 }
 
 impl ReasonAtom {
@@ -410,7 +410,10 @@ impl ReasonAtom {
     /// Capabilities like `agent_instructions` (reads AGENTS.md) and
     /// `skills_discovery` (scans for skills) use this to generate dynamic
     /// system prompt content.
-    pub fn with_file_store(mut self, file_store: Arc<dyn crate::traits::SessionFileStore>) -> Self {
+    pub fn with_file_store(
+        mut self,
+        file_store: Arc<dyn crate::traits::SessionFileSystem>,
+    ) -> Self {
         self.file_store = Some(file_store);
         self
     }

--- a/crates/core/src/capabilities/a2a_delegation.rs
+++ b/crates/core/src/capabilities/a2a_delegation.rs
@@ -1404,7 +1404,7 @@ impl Tool for CancelAgentTool {
 mod tests {
     use super::*;
     use crate::session_file::{FileInfo, FileStat, GrepMatch, SessionFile};
-    use crate::traits::SessionFileStore;
+    use crate::traits::SessionFileSystem;
     use crate::typed_id::SessionId;
     use a2a::StreamResponse;
     use a2a::{AgentCapabilities, AgentInterface, Artifact, TaskStatus, TaskStatusUpdateEvent};
@@ -1497,7 +1497,7 @@ mod tests {
     }
 
     #[async_trait]
-    impl SessionFileStore for TestFileStore {
+    impl SessionFileSystem for TestFileStore {
         async fn read_file(
             &self,
             session_id: SessionId,

--- a/crates/core/src/capabilities/agent_instructions.rs
+++ b/crates/core/src/capabilities/agent_instructions.rs
@@ -336,7 +336,7 @@ mod tests {
     use crate::capabilities::CapabilityRegistry;
     use crate::error::Result;
     use crate::session_file::{FileInfo, FileStat, GrepMatch, SessionFile};
-    use crate::traits::SessionFileStore;
+    use crate::traits::SessionFileSystem;
     use crate::typed_id::SessionId;
     use std::collections::HashMap;
     use std::sync::{Arc, Mutex};
@@ -379,7 +379,7 @@ mod tests {
     }
 
     #[async_trait::async_trait]
-    impl SessionFileStore for MockFileStore {
+    impl SessionFileSystem for MockFileStore {
         async fn read_file(
             &self,
             _session_id: SessionId,

--- a/crates/core/src/capabilities/fake_aws.rs
+++ b/crates/core/src/capabilities/fake_aws.rs
@@ -22,7 +22,7 @@ use super::{Capability, CapabilityStatus};
 use crate::SessionId;
 use crate::tool_types::ToolHints;
 use crate::tools::{Tool, ToolExecutionResult};
-use crate::traits::{SessionFileStore, ToolContext};
+use crate::traits::{SessionFileSystem, ToolContext};
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
@@ -92,7 +92,7 @@ async fn simulate_latency(op: OpKind) {
 /// Read a JSON collection from the session file store, returning seed data on
 /// first access and persisting it.
 async fn read_or_seed<T: Serialize + for<'de> Deserialize<'de>>(
-    store: &dyn SessionFileStore,
+    store: &dyn SessionFileSystem,
     session_id: SessionId,
     path: &str,
     seed: impl FnOnce() -> Vec<T>,
@@ -112,7 +112,7 @@ async fn read_or_seed<T: Serialize + for<'de> Deserialize<'de>>(
 
 /// Persist a collection back to the session file store.
 async fn persist<T: Serialize>(
-    store: &dyn SessionFileStore,
+    store: &dyn SessionFileSystem,
     session_id: SessionId,
     path: &str,
     items: &[T],

--- a/crates/core/src/capabilities/file_system.rs
+++ b/crates/core/src/capabilities/file_system.rs
@@ -1619,7 +1619,7 @@ mod tests {
     use super::*;
     use crate::error::Result;
     use crate::session_file::{FileInfo, FileStat, GrepMatch, SessionFile};
-    use crate::traits::SessionFileStore;
+    use crate::traits::SessionFileSystem;
     use crate::typed_id::SessionId;
     use chrono::Utc;
     use std::collections::HashMap;
@@ -1750,7 +1750,7 @@ mod tests {
     }
 
     #[async_trait]
-    impl SessionFileStore for MockFileStore {
+    impl SessionFileSystem for MockFileStore {
         async fn read_file(
             &self,
             _session_id: SessionId,

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -25,7 +25,7 @@ use crate::message_filter::MessageFilterProvider;
 use crate::runtime_agent::RuntimeAgent;
 use crate::tool_types::{ToolCall, ToolDefinition};
 use crate::tools::{Tool, ToolRegistry};
-use crate::traits::SessionFileStore;
+use crate::traits::SessionFileSystem;
 use crate::typed_id::SessionId;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
@@ -264,7 +264,7 @@ pub struct SystemPromptContext {
     /// Optional locale for localized prompts and tool behavior.
     pub locale: Option<String>,
     /// Optional file store for reading session files (e.g., AGENTS.md)
-    pub file_store: Option<Arc<dyn SessionFileStore>>,
+    pub file_store: Option<Arc<dyn SessionFileSystem>>,
 }
 
 impl SystemPromptContext {

--- a/crates/core/src/capabilities/skills.rs
+++ b/crates/core/src/capabilities/skills.rs
@@ -32,7 +32,7 @@
 // (`ProcessCommandExecutor`, `preprocess_command_injections`, unit tests) so a
 // follow-up can flip the gate once a non-user-spoofable provenance signal
 // (e.g. a `mount_capability_id` column populated only by mount application
-// code) is added to `SessionFile` / `SessionFileStore`. See EVE-388.
+// code) is added to `SessionFile` / `SessionFileSystem`. See EVE-388.
 //
 // Re-enable must ALSO replace `ProcessCommandExecutor` (which spawns worker-host
 // `bash -c`) with a session-sandbox-backed executor: execution MUST run against
@@ -676,7 +676,7 @@ mod tests {
     use crate::session_resource::{
         RegisterSessionResource, SessionResourceEntry, SessionResourceFilter, SessionResourceStatus,
     };
-    use crate::traits::{SessionFileStore, SessionResourceRegistry};
+    use crate::traits::{SessionFileSystem, SessionResourceRegistry};
     use crate::typed_id::SessionId;
     use std::collections::HashMap;
     use std::sync::atomic::{AtomicUsize, Ordering};
@@ -743,7 +743,7 @@ mod tests {
     }
 
     #[async_trait]
-    impl SessionFileStore for MockFileStore {
+    impl SessionFileSystem for MockFileStore {
         async fn read_file(
             &self,
             session_id: SessionId,

--- a/crates/core/src/capabilities/tool_output_persistence.rs
+++ b/crates/core/src/capabilities/tool_output_persistence.rs
@@ -26,7 +26,7 @@ use super::{Capability, CapabilityStatus};
 use crate::atoms::PostToolExecHook;
 use crate::tool_output_sanitizer::EXEC_OUTPUT_BUDGET;
 use crate::tool_types::{ToolCall, ToolDefinition, ToolResult};
-use crate::traits::{SessionFileStore, ToolContext};
+use crate::traits::{SessionFileSystem, ToolContext};
 use crate::typed_id::SessionId;
 
 /// Max bytes persisted per output stream file to avoid storage exhaustion.
@@ -51,7 +51,7 @@ pub struct PersistResult {
 ///
 /// This is the shared helper that any sandbox tool or hook can call.
 pub async fn persist_large_output(
-    file_store: &Arc<dyn SessionFileStore>,
+    file_store: &Arc<dyn SessionFileSystem>,
     session_id: SessionId,
     tool_call_id: &str,
     stdout: &str,
@@ -417,7 +417,7 @@ mod tests {
 
     use crate::error::Result;
     use crate::session_file::{FileInfo, FileStat, GrepMatch, SessionFile};
-    use crate::traits::SessionFileStore;
+    use crate::traits::SessionFileSystem;
     use chrono::Utc;
     use std::collections::HashMap;
     use std::sync::Mutex;
@@ -435,7 +435,7 @@ mod tests {
     }
 
     #[async_trait]
-    impl SessionFileStore for MockFileStore {
+    impl SessionFileSystem for MockFileStore {
         async fn read_file(
             &self,
             _session_id: SessionId,
@@ -511,7 +511,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_persist_large_output_returns_none_below_budget() {
-        let store: Arc<dyn SessionFileStore> = Arc::new(MockFileStore::default());
+        let store: Arc<dyn SessionFileSystem> = Arc::new(MockFileStore::default());
         let small = "a".repeat(EXEC_OUTPUT_BUDGET);
         let result = persist_large_output(&store, test_session_id(), "call-1", &small, "").await;
         assert!(result.is_none());
@@ -520,7 +520,7 @@ mod tests {
     #[tokio::test]
     async fn test_persist_large_output_persists_stdout_above_budget() {
         let mock = Arc::new(MockFileStore::default());
-        let store: Arc<dyn SessionFileStore> = mock.clone();
+        let store: Arc<dyn SessionFileSystem> = mock.clone();
         let large = "x".repeat(EXEC_OUTPUT_BUDGET + 1);
         let result = persist_large_output(&store, test_session_id(), "call-2", &large, "").await;
         let r = result.expect("should persist");
@@ -538,7 +538,7 @@ mod tests {
     #[tokio::test]
     async fn test_persist_large_output_caps_persisted_stdout_size() {
         let mock = Arc::new(MockFileStore::default());
-        let store: Arc<dyn SessionFileStore> = mock.clone();
+        let store: Arc<dyn SessionFileSystem> = mock.clone();
         let huge = "x".repeat(MAX_PERSISTED_STREAM_BYTES + 2048);
         let result = persist_large_output(&store, test_session_id(), "call-cap", &huge, "").await;
         assert!(result.is_some());
@@ -550,7 +550,7 @@ mod tests {
     #[tokio::test]
     async fn test_persist_large_output_persists_stderr_above_threshold() {
         let mock = Arc::new(MockFileStore::default());
-        let store: Arc<dyn SessionFileStore> = mock.clone();
+        let store: Arc<dyn SessionFileSystem> = mock.clone();
         let large_stderr = "e".repeat(4097);
         let result =
             persist_large_output(&store, test_session_id(), "call-3", "small", &large_stderr).await;
@@ -563,7 +563,7 @@ mod tests {
     #[tokio::test]
     async fn test_persist_large_output_both_stdout_and_stderr() {
         let mock = Arc::new(MockFileStore::default());
-        let store: Arc<dyn SessionFileStore> = mock.clone();
+        let store: Arc<dyn SessionFileSystem> = mock.clone();
         let large_stdout = "o".repeat(EXEC_OUTPUT_BUDGET + 100);
         let large_stderr = "e".repeat(5000);
         let result = persist_large_output(
@@ -582,7 +582,7 @@ mod tests {
     #[tokio::test]
     async fn test_persist_large_output_sanitizes_id() {
         let mock = Arc::new(MockFileStore::default());
-        let store: Arc<dyn SessionFileStore> = mock.clone();
+        let store: Arc<dyn SessionFileSystem> = mock.clone();
         let large = "x".repeat(EXEC_OUTPUT_BUDGET + 1);
         let result =
             persist_large_output(&store, test_session_id(), "call/../../../etc", &large, "").await;
@@ -593,7 +593,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_persist_large_output_empty_id_returns_none() {
-        let store: Arc<dyn SessionFileStore> = Arc::new(MockFileStore::default());
+        let store: Arc<dyn SessionFileSystem> = Arc::new(MockFileStore::default());
         let large = "x".repeat(EXEC_OUTPUT_BUDGET + 1);
         let result = persist_large_output(&store, test_session_id(), "///...", &large, "").await;
         assert!(result.is_none());
@@ -602,7 +602,7 @@ mod tests {
     #[tokio::test]
     async fn test_persist_large_output_line_count() {
         let mock = Arc::new(MockFileStore::default());
-        let store: Arc<dyn SessionFileStore> = mock.clone();
+        let store: Arc<dyn SessionFileSystem> = mock.clone();
         // Create multi-line output that exceeds budget
         let line = "x".repeat(200);
         let lines: Vec<&str> = std::iter::repeat_n(line.as_str(), 100).collect();

--- a/crates/core/src/capabilities/virtual_bash.rs
+++ b/crates/core/src/capabilities/virtual_bash.rs
@@ -6,11 +6,11 @@
 //!
 //! Design decisions:
 //! - SessionFileSystemAdapter implements bashkit's FileSystem trait
-//! - Direct delegation to SessionFileStore - no sync overhead
+//! - Direct delegation to SessionFileSystem - no sync overhead
 //! - Live visibility: files written by other tools are immediately visible
 //! - Resource limits prevent runaway scripts (max commands, loop iterations)
 //! - Context-aware tool that requires session filesystem access
-//! - SearchCapable impl delegates grep to SessionFileStore::grep_files for
+//! - SearchCapable impl delegates grep to SessionFileSystem::grep_files for
 //!   single-query indexed search instead of per-file linear scan
 //!
 //! Trust boundary (TM-AGENT-005, TM-BASH-001..016):
@@ -40,7 +40,7 @@ use crate::exec_tool_result::ExecToolResultPayload;
 use crate::session_file::SessionFile;
 use crate::tool_types::ToolHints;
 use crate::tools::{Tool, ToolExecutionResult};
-use crate::traits::{SessionFileStore, ToolContext};
+use crate::traits::{SessionFileSystem, ToolContext};
 use crate::typed_id::SessionId;
 use async_trait::async_trait;
 use bashkit::{
@@ -722,17 +722,17 @@ fn collect_partial_output(mut rx: tokio::sync::mpsc::Receiver<(String, String)>)
 // SessionFileSystemAdapter
 // ============================================================================
 
-/// Adapter that implements bashkit's FileSystem trait by delegating to SessionFileStore.
+/// Adapter that implements bashkit's FileSystem trait by delegating to SessionFileSystem.
 ///
 /// This provides live visibility of session files during bash execution - any files
 /// written by other tools are immediately visible, and vice versa.
 pub struct SessionFileSystemAdapter {
     session_id: SessionId,
-    store: Arc<dyn SessionFileStore>,
+    store: Arc<dyn SessionFileSystem>,
 }
 
 impl SessionFileSystemAdapter {
-    pub fn new(session_id: SessionId, store: Arc<dyn SessionFileStore>) -> Self {
+    pub fn new(session_id: SessionId, store: Arc<dyn SessionFileSystem>) -> Self {
         Self { session_id, store }
     }
 
@@ -1071,7 +1071,7 @@ impl FileSystem for SessionFileSystemAdapter {
 }
 
 // ============================================================================
-// SearchCapable / SearchProvider — indexed search via SessionFileStore
+// SearchCapable / SearchProvider — indexed search via SessionFileSystem
 // ============================================================================
 
 impl SearchCapable for SessionFileSystemAdapter {
@@ -1085,13 +1085,13 @@ impl SearchCapable for SessionFileSystemAdapter {
     }
 }
 
-/// Bridges bashkit's synchronous `SearchProvider` to `SessionFileStore::grep_files`.
+/// Bridges bashkit's synchronous `SearchProvider` to `SessionFileSystem::grep_files`.
 ///
 /// Uses a scoped thread with a dedicated tokio runtime to call the async
 /// store method from the sync trait, avoiding nested `block_on` calls.
 struct SessionSearchProvider {
     session_id: SessionId,
-    store: Arc<dyn SessionFileStore>,
+    store: Arc<dyn SessionFileSystem>,
 }
 
 impl SearchProvider for SessionSearchProvider {
@@ -1180,7 +1180,7 @@ impl SearchProvider for SessionSearchProvider {
 mod tests {
     use super::*;
     use crate::session_file::FileInfo;
-    use crate::traits::SessionFileStore;
+    use crate::traits::SessionFileSystem;
     use crate::typed_id::SessionId;
     use crate::{FileStat, GrepMatch, Result};
     use std::collections::HashMap;
@@ -1217,7 +1217,7 @@ mod tests {
     }
 
     #[async_trait]
-    impl SessionFileStore for MockFileStore {
+    impl SessionFileSystem for MockFileStore {
         async fn read_file(
             &self,
             session_id: SessionId,
@@ -1577,7 +1577,7 @@ mod tests {
 
     fn create_context_with_mock_store() -> (ToolContext, SessionId) {
         let session_id = SessionId::new();
-        let store: Arc<dyn SessionFileStore> = Arc::new(MockFileStore::new());
+        let store: Arc<dyn SessionFileSystem> = Arc::new(MockFileStore::new());
         let mut context = ToolContext::new(session_id);
         context.file_store = Some(store);
         (context, session_id)
@@ -1954,7 +1954,7 @@ mod tests {
     #[tokio::test]
     async fn test_adapter_read_write_workspace_file() {
         let session_id = SessionId::new();
-        let store: Arc<dyn SessionFileStore> = Arc::new(MockFileStore::new());
+        let store: Arc<dyn SessionFileSystem> = Arc::new(MockFileStore::new());
         let adapter = SessionFileSystemAdapter::new(session_id, store);
 
         // Write a file
@@ -1974,7 +1974,7 @@ mod tests {
     #[tokio::test]
     async fn test_adapter_read_outside_workspace_fails() {
         let session_id = SessionId::new();
-        let store: Arc<dyn SessionFileStore> = Arc::new(MockFileStore::new());
+        let store: Arc<dyn SessionFileSystem> = Arc::new(MockFileStore::new());
         let adapter = SessionFileSystemAdapter::new(session_id, store);
 
         let result = adapter.read_file(Path::new("/tmp/file.txt")).await;
@@ -1987,7 +1987,7 @@ mod tests {
     #[tokio::test]
     async fn test_adapter_write_outside_workspace_fails() {
         let session_id = SessionId::new();
-        let store: Arc<dyn SessionFileStore> = Arc::new(MockFileStore::new());
+        let store: Arc<dyn SessionFileSystem> = Arc::new(MockFileStore::new());
         let adapter = SessionFileSystemAdapter::new(session_id, store);
 
         let result = adapter
@@ -2002,7 +2002,7 @@ mod tests {
     #[tokio::test]
     async fn test_adapter_stat_workspace_root() {
         let session_id = SessionId::new();
-        let store: Arc<dyn SessionFileStore> = Arc::new(MockFileStore::new());
+        let store: Arc<dyn SessionFileSystem> = Arc::new(MockFileStore::new());
         let adapter = SessionFileSystemAdapter::new(session_id, store);
 
         let stat = adapter.stat(Path::new("/workspace")).await.unwrap();
@@ -2012,7 +2012,7 @@ mod tests {
     #[tokio::test]
     async fn test_adapter_stat_directory_returns_dir_type() {
         let session_id = SessionId::new();
-        let store: Arc<dyn SessionFileStore> = Arc::new(MockFileStore::new());
+        let store: Arc<dyn SessionFileSystem> = Arc::new(MockFileStore::new());
         let adapter = SessionFileSystemAdapter::new(session_id, store);
 
         // Create a directory
@@ -2032,7 +2032,7 @@ mod tests {
     #[tokio::test]
     async fn test_adapter_stat_file_returns_file_type() {
         let session_id = SessionId::new();
-        let store: Arc<dyn SessionFileStore> = Arc::new(MockFileStore::new());
+        let store: Arc<dyn SessionFileSystem> = Arc::new(MockFileStore::new());
         let adapter = SessionFileSystemAdapter::new(session_id, store);
 
         // Write a file
@@ -2056,7 +2056,7 @@ mod tests {
     #[tokio::test]
     async fn test_adapter_exists_workspace() {
         let session_id = SessionId::new();
-        let store: Arc<dyn SessionFileStore> = Arc::new(MockFileStore::new());
+        let store: Arc<dyn SessionFileSystem> = Arc::new(MockFileStore::new());
         let adapter = SessionFileSystemAdapter::new(session_id, store);
 
         // /workspace always exists
@@ -2069,7 +2069,7 @@ mod tests {
     #[tokio::test]
     async fn test_adapter_mkdir_and_list() {
         let session_id = SessionId::new();
-        let store: Arc<dyn SessionFileStore> = Arc::new(MockFileStore::new());
+        let store: Arc<dyn SessionFileSystem> = Arc::new(MockFileStore::new());
         let adapter = SessionFileSystemAdapter::new(session_id, store.clone());
 
         // Create a directory
@@ -2096,7 +2096,7 @@ mod tests {
     #[tokio::test]
     async fn test_adapter_rename_file() {
         let session_id = SessionId::new();
-        let store: Arc<dyn SessionFileStore> = Arc::new(MockFileStore::new());
+        let store: Arc<dyn SessionFileSystem> = Arc::new(MockFileStore::new());
         let adapter = SessionFileSystemAdapter::new(session_id, store);
 
         // Write original file
@@ -2129,7 +2129,7 @@ mod tests {
     #[tokio::test]
     async fn test_adapter_copy_file() {
         let session_id = SessionId::new();
-        let store: Arc<dyn SessionFileStore> = Arc::new(MockFileStore::new());
+        let store: Arc<dyn SessionFileSystem> = Arc::new(MockFileStore::new());
         let adapter = SessionFileSystemAdapter::new(session_id, store);
 
         // Write original file
@@ -2163,7 +2163,7 @@ mod tests {
     #[tokio::test]
     async fn test_adapter_append_file() {
         let session_id = SessionId::new();
-        let store: Arc<dyn SessionFileStore> = Arc::new(MockFileStore::new());
+        let store: Arc<dyn SessionFileSystem> = Arc::new(MockFileStore::new());
         let adapter = SessionFileSystemAdapter::new(session_id, store);
 
         // Write initial content
@@ -2189,7 +2189,7 @@ mod tests {
     #[tokio::test]
     async fn test_adapter_symlink_not_supported() {
         let session_id = SessionId::new();
-        let store: Arc<dyn SessionFileStore> = Arc::new(MockFileStore::new());
+        let store: Arc<dyn SessionFileSystem> = Arc::new(MockFileStore::new());
         let adapter = SessionFileSystemAdapter::new(session_id, store);
 
         let result = adapter
@@ -2202,7 +2202,7 @@ mod tests {
     #[tokio::test]
     async fn test_adapter_chmod_is_noop() {
         let session_id = SessionId::new();
-        let store: Arc<dyn SessionFileStore> = Arc::new(MockFileStore::new());
+        let store: Arc<dyn SessionFileSystem> = Arc::new(MockFileStore::new());
         let adapter = SessionFileSystemAdapter::new(session_id, store);
 
         // chmod should succeed as a no-op
@@ -2636,7 +2636,7 @@ mod tests {
     #[tokio::test]
     async fn test_adapter_overwrite_existing_file() {
         let session_id = SessionId::new();
-        let store: Arc<dyn SessionFileStore> = Arc::new(MockFileStore::new());
+        let store: Arc<dyn SessionFileSystem> = Arc::new(MockFileStore::new());
         let adapter = SessionFileSystemAdapter::new(session_id, store);
 
         // Write initial
@@ -2662,7 +2662,7 @@ mod tests {
     #[tokio::test]
     async fn test_adapter_append_to_existing_file() {
         let session_id = SessionId::new();
-        let store: Arc<dyn SessionFileStore> = Arc::new(MockFileStore::new());
+        let store: Arc<dyn SessionFileSystem> = Arc::new(MockFileStore::new());
         let adapter = SessionFileSystemAdapter::new(session_id, store);
 
         // Write initial
@@ -2818,7 +2818,7 @@ mod tests {
     #[test]
     fn test_adapter_is_search_capable() {
         let session_id = SessionId::new();
-        let store: Arc<dyn SessionFileStore> = Arc::new(MockFileStore::new());
+        let store: Arc<dyn SessionFileSystem> = Arc::new(MockFileStore::new());
         let adapter = SessionFileSystemAdapter::new(session_id, store);
 
         let sc = adapter.as_search_capable();
@@ -2838,7 +2838,7 @@ mod tests {
     #[tokio::test]
     async fn test_search_provider_returns_grep_results() {
         let session_id = SessionId::new();
-        let store: Arc<dyn SessionFileStore> = Arc::new(MockFileStore::new());
+        let store: Arc<dyn SessionFileSystem> = Arc::new(MockFileStore::new());
         let adapter = SessionFileSystemAdapter::new(session_id, store.clone());
 
         // Write files via the adapter
@@ -2880,7 +2880,7 @@ mod tests {
     #[tokio::test]
     async fn test_search_provider_truncates_at_max_results() {
         let session_id = SessionId::new();
-        let store: Arc<dyn SessionFileStore> = Arc::new(MockFileStore::new());
+        let store: Arc<dyn SessionFileSystem> = Arc::new(MockFileStore::new());
         let adapter = SessionFileSystemAdapter::new(session_id, store.clone());
 
         adapter

--- a/crates/core/src/capabilities/web_fetch.rs
+++ b/crates/core/src/capabilities/web_fetch.rs
@@ -29,7 +29,7 @@
 use super::{Capability, CapabilityStatus, RiskLevel};
 use crate::tool_types::ToolHints;
 use crate::tools::{Tool, ToolExecutionResult};
-use crate::traits::{SessionFileStore, ToolContext};
+use crate::traits::{SessionFileSystem, ToolContext};
 use crate::typed_id::SessionId;
 use async_trait::async_trait;
 use base64::Engine as _;
@@ -232,14 +232,14 @@ impl Capability for WebFetchCapability {
 }
 
 // ============================================================================
-// SessionFileSaver — bridges fetchkit::FileSaver to SessionFileStore
+// SessionFileSaver — bridges fetchkit::FileSaver to SessionFileSystem
 // ============================================================================
 
 /// Adapter that routes fetchkit file saves through the session virtual filesystem.
 ///
 /// Binary content is encoded as base64; text content is stored as-is.
 struct SessionFileSaver {
-    file_store: Arc<dyn SessionFileStore>,
+    file_store: Arc<dyn SessionFileSystem>,
     session_id: SessionId,
 }
 
@@ -279,7 +279,7 @@ impl FileSaver for SessionFileSaver {
 /// reserved IP ranges via resolve-then-check with DNS pinning.
 ///
 /// File download: when `save_to_file` is provided, content is saved through
-/// the session filesystem (SessionFileStore) via the SessionFileSaver adapter.
+/// the session filesystem (SessionFileSystem) via the SessionFileSaver adapter.
 pub struct WebFetchTool {
     fetchkit_tool: fetchkit::Tool,
     enable_save_to_file: bool,
@@ -410,7 +410,7 @@ impl Tool for WebFetchTool {
     }
 
     fn requires_context(&self) -> bool {
-        // Needed for save_to_file (SessionFileStore access)
+        // Needed for save_to_file (SessionFileSystem access)
         true
     }
 
@@ -479,7 +479,7 @@ impl Tool for WebFetchTool {
             };
         }
 
-        // save_to_file requested — need SessionFileStore
+        // save_to_file requested — need SessionFileSystem
         let file_store = match &context.file_store {
             Some(store) => store.clone(),
             None => {
@@ -1528,7 +1528,7 @@ mod tests {
     // File download tests (save_to_file via SessionFileSaver)
     // ========================================================================
 
-    /// In-memory SessionFileStore for testing file downloads
+    /// In-memory SessionFileSystem for testing file downloads
     struct MockFileStore {
         files: tokio::sync::Mutex<std::collections::HashMap<(SessionId, String), (String, String)>>,
     }
@@ -1550,7 +1550,7 @@ mod tests {
     }
 
     #[async_trait]
-    impl SessionFileStore for MockFileStore {
+    impl SessionFileSystem for MockFileStore {
         async fn read_file(
             &self,
             session_id: SessionId,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -160,10 +160,11 @@ pub use runtime_context::{
     resolve_runtime_capabilities,
 };
 pub use traits::{
-    EventEmitter, HarnessStore, ImageResolver, KeyInfo, LeasedResourceStore, LlmProviderStore,
-    ModelWithProvider, NoopEventEmitter, ResolvedImage, SecretInfo, SessionFileStore,
-    SessionMutator, SessionResourceRegistry, SessionSqlDbStoreRef, SessionStorageStore,
-    SessionStore, ToolContext, ToolExecutor, UserConnectionResolver,
+    DisabledSessionFileSystemFactory, EventEmitter, HarnessStore, ImageResolver, KeyInfo,
+    LeasedResourceStore, LlmProviderStore, ModelWithProvider, NoopEventEmitter, ResolvedImage,
+    SecretInfo, SessionFileStore, SessionFileSystem, SessionFileSystemFactory,
+    SessionFileSystemFactoryContext, SessionMutator, SessionResourceRegistry, SessionSqlDbStoreRef,
+    SessionStorageStore, SessionStore, ToolContext, ToolExecutor, UserConnectionResolver,
 };
 pub use user_facing_error::{
     UserFacingError, UserFacingErrorContext, UserFacingErrorFields, classify_runtime_error_message,

--- a/crates/core/src/platform_definition.rs
+++ b/crates/core/src/platform_definition.rs
@@ -7,11 +7,13 @@
 //!
 //! Server-only concerns such as route wiring, auth backends, and background
 //! task scheduling stay outside this module so the type can be reused from any
-//! binary crate.
+//! binary crate. Platform-wide host services belong here as factories, not as
+//! server-owned concrete dependencies.
 
 use crate::{
     Capability, CapabilityRegistry, ConnectionProvider, ConnectionProviderRegistry, DriverRegistry,
     EmailSender,
+    traits::{DisabledSessionFileSystemFactory, SessionFileSystemFactory},
 };
 use serde_json::Value;
 use std::sync::Arc;
@@ -147,9 +149,9 @@ impl BuiltInHarnessDefinition {
 /// Shared definition of the Everruns platform surface.
 ///
 /// `PlatformDefinition` lets an embedder decide which capabilities, LLM
-/// drivers, connection providers, and built-in harness templates exist at
-/// runtime. Server and worker code should consume the same definition so the
-/// control plane and execution plane stay aligned.
+/// drivers, connection providers, built-in harness templates, and platform
+/// service factories exist at runtime. Server and worker code should consume
+/// the same definition so the control plane and execution plane stay aligned.
 ///
 /// # Example
 ///
@@ -184,6 +186,7 @@ pub struct PlatformDefinition {
     connection_providers: ConnectionProviderRegistry,
     built_in_harnesses: Vec<BuiltInHarnessDefinition>,
     email_sender: Arc<dyn EmailSender>,
+    session_file_system_factory: Arc<dyn SessionFileSystemFactory>,
 }
 
 impl PlatformDefinition {
@@ -195,6 +198,7 @@ impl PlatformDefinition {
             connection_providers: ConnectionProviderRegistry::new(),
             built_in_harnesses: Vec::new(),
             email_sender: Arc::new(crate::DisabledEmailSender),
+            session_file_system_factory: Arc::new(DisabledSessionFileSystemFactory),
         }
     }
 
@@ -248,6 +252,11 @@ impl PlatformDefinition {
         self.email_sender.clone()
     }
 
+    /// Factory for the platform-selected session filesystem implementation.
+    pub fn session_file_system_factory(&self) -> Arc<dyn SessionFileSystemFactory> {
+        self.session_file_system_factory.clone()
+    }
+
     /// Append a built-in harness template.
     pub fn add_built_in_harness(&mut self, harness: BuiltInHarnessDefinition) {
         self.built_in_harnesses.push(harness);
@@ -274,6 +283,10 @@ impl std::fmt::Debug for PlatformDefinition {
             .field("connection_providers", &self.connection_providers)
             .field("built_in_harnesses", &harness_keys)
             .field("email_sender", &self.email_sender.name())
+            .field(
+                "session_file_system_factory",
+                &self.session_file_system_factory.name(),
+            )
             .finish()
     }
 }
@@ -339,6 +352,15 @@ impl PlatformDefinitionBuilder {
     /// Set the system-wide email sender.
     pub fn email_sender(mut self, sender: Arc<dyn EmailSender>) -> Self {
         self.platform.email_sender = sender;
+        self
+    }
+
+    /// Set the platform-wide session filesystem factory.
+    pub fn session_file_system_factory(
+        mut self,
+        factory: Arc<dyn SessionFileSystemFactory>,
+    ) -> Self {
+        self.platform.session_file_system_factory = factory;
         self
     }
 

--- a/crates/core/src/runtime_context.rs
+++ b/crates/core/src/runtime_context.rs
@@ -21,7 +21,7 @@ use crate::runtime_agent::RuntimeAgentBuilder;
 use crate::session::Session;
 use crate::tool_types::ToolDefinition;
 use crate::traits::{
-    AgentStore, HarnessStore, LlmProviderStore, ModelWithProvider, SessionFileStore, SessionStore,
+    AgentStore, HarnessStore, LlmProviderStore, ModelWithProvider, SessionFileSystem, SessionStore,
 };
 use crate::typed_id::{AgentId, HarnessId, ModelId, SessionId};
 use std::sync::Arc;
@@ -75,7 +75,7 @@ pub async fn assemble_turn_context(
     harness_id: HarnessId,
     agent_id: Option<AgentId>,
     mcp_tool_definitions: &[ToolDefinition],
-    file_store: Option<Arc<dyn SessionFileStore>>,
+    file_store: Option<Arc<dyn SessionFileSystem>>,
 ) -> Result<AssembledTurnContext> {
     assemble_turn_context_with_mode(
         harness_store,
@@ -110,7 +110,7 @@ pub async fn inspect_turn_context(
     harness_id: HarnessId,
     agent_id: Option<AgentId>,
     mcp_tool_definitions: &[ToolDefinition],
-    file_store: Option<Arc<dyn SessionFileStore>>,
+    file_store: Option<Arc<dyn SessionFileSystem>>,
 ) -> Result<AssembledTurnContext> {
     assemble_turn_context_with_mode(
         harness_store,
@@ -147,7 +147,7 @@ async fn assemble_turn_context_with_mode(
     harness_id: HarnessId,
     agent_id: Option<AgentId>,
     mcp_tool_definitions: &[ToolDefinition],
-    file_store: Option<Arc<dyn SessionFileStore>>,
+    file_store: Option<Arc<dyn SessionFileSystem>>,
     mode: ContextAssemblyMode,
 ) -> Result<AssembledTurnContext> {
     let harness_chain = harness_store.get_harness_chain(harness_id).await?;

--- a/crates/core/src/tools.rs
+++ b/crates/core/src/tools.rs
@@ -1412,7 +1412,7 @@ impl SessionBackgroundSink {
 }
 
 async fn ensure_directory(
-    file_store: &dyn crate::traits::SessionFileStore,
+    file_store: &dyn crate::traits::SessionFileSystem,
     session_id: crate::SessionId,
     path: &str,
 ) -> Result<()> {
@@ -1504,7 +1504,7 @@ mod tests {
     use crate::platform_store::PlatformStore;
     use crate::session_file::{FileInfo, FileStat, SessionFile};
     use crate::session_resource::{SessionResourceEntry, SessionResourceFilter};
-    use crate::traits::{SessionFileStore, SessionResourceRegistry, SessionScheduleStore};
+    use crate::traits::{SessionFileSystem, SessionResourceRegistry, SessionScheduleStore};
     use crate::typed_id::{HarnessId, SessionId};
     use crate::{AgentId, KeyInfo, PlatformMessage, SecretInfo};
     use async_trait::async_trait;
@@ -1766,7 +1766,7 @@ mod tests {
     }
 
     #[async_trait]
-    impl crate::traits::SessionFileStore for TestFileStore {
+    impl crate::traits::SessionFileSystem for TestFileStore {
         async fn read_file(
             &self,
             _session_id: SessionId,

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -8,11 +8,12 @@
 use crate::agent::Agent;
 use crate::harness::Harness;
 use crate::llm_models::LlmProviderType;
-use crate::session_file::{FileInfo, FileStat, GrepMatch, SessionFile};
+use crate::session_file::{FileInfo, FileStat, GrepMatch, InitialFile, SessionFile};
 use crate::tool_types::{ToolCall, ToolDefinition, ToolResult};
 use crate::typed_id::{AgentId, HarnessId, ImageId, ModelId, SessionId};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
+use std::any::{Any, TypeId};
 use std::collections::HashMap;
 use std::sync::Arc;
 use uuid::Uuid;
@@ -283,17 +284,18 @@ pub trait ToolExecutor: Send + Sync {
 }
 
 // ============================================================================
-// SessionFileStore - For session filesystem operations
+// SessionFileSystem - For session filesystem operations
 // ============================================================================
 
 /// Trait for session filesystem operations
 ///
-/// This trait abstracts file operations for tools that need to interact with
-/// the session's virtual filesystem. Implementations can:
+/// This trait abstracts the session filesystem contract for tools and hosts.
+/// Implementations can:
 /// - Store files in a database (production)
 /// - Use an in-memory filesystem for testing
+/// - Project files onto real disk or object storage
 #[async_trait]
-pub trait SessionFileStore: Send + Sync {
+pub trait SessionFileSystem: Send + Sync {
     /// Read a file by path
     async fn read_file(&self, session_id: SessionId, path: &str) -> Result<Option<SessionFile>>;
 
@@ -357,6 +359,94 @@ pub trait SessionFileStore: Send + Sync {
 
     /// Create a directory
     async fn create_directory(&self, session_id: SessionId, path: &str) -> Result<FileInfo>;
+
+    /// Seed a starter file into a session workspace.
+    async fn seed_initial_file(&self, session_id: SessionId, file: &InitialFile) -> Result<()> {
+        if file.is_readonly {
+            return Err(crate::error::AgentLoopError::store(
+                "read-only initial files require a SessionFileSystem-specific seed implementation",
+            ));
+        }
+        self.write_file(session_id, &file.path, &file.content, &file.encoding)
+            .await?;
+        Ok(())
+    }
+}
+
+/// Backward-compatible alias for the old session filesystem trait name.
+pub use SessionFileSystem as SessionFileStore;
+
+/// Host-supplied values used by platform file-system factories.
+///
+/// The context is intentionally type-erased so `everruns-core` can own the
+/// platform contract without depending on server-only types such as
+/// `StorageBackend` or future object-storage clients.
+#[derive(Clone, Default)]
+pub struct SessionFileSystemFactoryContext {
+    values: Arc<HashMap<TypeId, Arc<dyn Any + Send + Sync>>>,
+}
+
+impl SessionFileSystemFactoryContext {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with<T: Any + Send + Sync>(mut self, value: Arc<T>) -> Self {
+        let values = Arc::make_mut(&mut self.values);
+        values.insert(TypeId::of::<T>(), value);
+        self
+    }
+
+    pub fn get<T: Any + Send + Sync>(&self) -> Option<Arc<T>> {
+        self.values
+            .get(&TypeId::of::<T>())
+            .and_then(|value| value.clone().downcast::<T>().ok())
+    }
+}
+
+/// Factory for deployment-selected session filesystem implementations.
+#[async_trait]
+pub trait SessionFileSystemFactory: Send + Sync {
+    /// Human-readable factory name for diagnostics.
+    fn name(&self) -> &'static str {
+        "SessionFileSystemFactory"
+    }
+
+    /// Whether this factory intentionally leaves filesystem selection to the
+    /// runtime default.
+    fn is_disabled(&self) -> bool {
+        false
+    }
+
+    /// Resolve a live filesystem from host-provided dependencies.
+    async fn create_session_file_system(
+        &self,
+        context: SessionFileSystemFactoryContext,
+    ) -> Result<Arc<dyn SessionFileSystem>>;
+}
+
+/// Default factory used when a platform does not configure session files.
+#[derive(Debug, Clone, Default)]
+pub struct DisabledSessionFileSystemFactory;
+
+#[async_trait]
+impl SessionFileSystemFactory for DisabledSessionFileSystemFactory {
+    fn name(&self) -> &'static str {
+        "DisabledSessionFileSystemFactory"
+    }
+
+    fn is_disabled(&self) -> bool {
+        true
+    }
+
+    async fn create_session_file_system(
+        &self,
+        _context: SessionFileSystemFactoryContext,
+    ) -> Result<Arc<dyn SessionFileSystem>> {
+        Err(crate::error::AgentLoopError::config(
+            "session filesystem is disabled",
+        ))
+    }
 }
 
 // ============================================================================
@@ -638,7 +728,7 @@ pub struct ToolContext {
     pub session_id: SessionId,
 
     /// Optional file store for filesystem operations
-    pub file_store: Option<Arc<dyn SessionFileStore>>,
+    pub file_store: Option<Arc<dyn SessionFileSystem>>,
 
     /// Optional storage store for key/value and secret storage
     pub storage_store: Option<Arc<dyn SessionStorageStore>>,
@@ -752,7 +842,7 @@ impl ToolContext {
     }
 
     /// Create a context with a file store
-    pub fn with_file_store(session_id: SessionId, file_store: Arc<dyn SessionFileStore>) -> Self {
+    pub fn with_file_store(session_id: SessionId, file_store: Arc<dyn SessionFileSystem>) -> Self {
         Self {
             session_id,
             file_store: Some(file_store),
@@ -821,7 +911,7 @@ impl ToolContext {
     /// Create a context with both file store and storage store
     pub fn with_stores(
         session_id: SessionId,
-        file_store: Arc<dyn SessionFileStore>,
+        file_store: Arc<dyn SessionFileSystem>,
         storage_store: Arc<dyn SessionStorageStore>,
     ) -> Self {
         Self {

--- a/crates/runtime/examples/real_disk_agent_instructions.rs
+++ b/crates/runtime/examples/real_disk_agent_instructions.rs
@@ -1,5 +1,5 @@
 // Demonstrates that `AgentInstructionsCapability` reads `AGENTS.md` from
-// whichever `SessionFileStore` the embedder plugs in — here, a
+// whichever `SessionFileSystem` the embedder plugs in — here, a
 // `RealDiskFileStore` rooted at a temp directory.
 //
 // What this proves:

--- a/crates/runtime/examples/real_disk_file_system_tools.rs
+++ b/crates/runtime/examples/real_disk_file_system_tools.rs
@@ -1,6 +1,6 @@
 // Demonstrates that the built-in `file_system` capability's tools
 // (`write_file`, `read_file`, `list_directory`) operate against whichever
-// `SessionFileStore` the embedder plugs in — here, a `RealDiskFileStore`
+// `SessionFileSystem` the embedder plugs in — here, a `RealDiskFileStore`
 // rooted at a temp directory. The agent's tool calls land on real disk.
 //
 // What this proves:

--- a/crates/runtime/src/backends.rs
+++ b/crates/runtime/src/backends.rs
@@ -2,7 +2,7 @@
 // Decision: runtime extends core's read-only traits with the minimal write
 // operations needed for seeding and message persistence.
 
-use crate::in_memory::{InMemorySessionFileStore, InMemorySessionStore};
+use crate::in_memory::InMemorySessionStore;
 use async_trait::async_trait;
 use everruns_core::agent::Agent;
 use everruns_core::error::Result;
@@ -16,9 +16,9 @@ use everruns_core::memory_store::MemoryStoreBackend;
 use everruns_core::message::Message;
 use everruns_core::message_retriever::{InputMessage, MessageRetriever};
 use everruns_core::session::Session;
-use everruns_core::session_file::{InitialFile, SessionFile};
+use everruns_core::session_file::SessionFile;
 use everruns_core::traits::{
-    AgentStore, EventEmitter, HarnessStore, LlmProviderStore, ModelWithProvider, SessionFileStore,
+    AgentStore, EventEmitter, HarnessStore, LlmProviderStore, ModelWithProvider, SessionFileSystem,
     SessionMutator, SessionStorageStore, SessionStore,
 };
 use everruns_core::typed_id::{AgentId, HarnessId, MessageId, ModelId, SessionId};
@@ -59,12 +59,8 @@ pub trait RuntimeMessageStore: MessageRetriever + Send + Sync {
     async fn store_message(&self, session_id: SessionId, message: Message) -> Result<()>;
 }
 
-/// Filesystem contract for runtime seeding and lookup.
-#[async_trait]
-pub trait RuntimeFileStore: SessionFileStore + Send + Sync {
-    /// Seed a starter file into a session workspace.
-    async fn seed_initial_file(&self, session_id: SessionId, file: &InitialFile) -> Result<()>;
-}
+/// Backward-compatible alias for the old runtime filesystem extension.
+pub use everruns_core::traits::SessionFileSystem as RuntimeFileStore;
 
 /// Provider store contract for runtime lookup and default-model configuration.
 #[async_trait]
@@ -101,7 +97,7 @@ pub struct RuntimeBackends {
     /// Optional collector for `InProcessRuntime::events()`.
     pub event_collector: Option<Arc<dyn RuntimeEventCollector>>,
     /// Session filesystem backend.
-    pub file_store: Arc<dyn RuntimeFileStore>,
+    pub file_store: Arc<dyn SessionFileSystem>,
     /// Session key/value + secret storage backend.
     pub storage_store: Arc<dyn SessionStorageStore>,
     /// Persistent cross-session memory backend.
@@ -180,10 +176,10 @@ impl MessageRetriever for DynMessageStore {
 }
 
 #[derive(Clone)]
-pub(crate) struct DynFileStore(pub Arc<dyn RuntimeFileStore>);
+pub(crate) struct DynFileStore(pub Arc<dyn SessionFileSystem>);
 
 #[async_trait]
-impl SessionFileStore for DynFileStore {
+impl SessionFileSystem for DynFileStore {
     async fn read_file(&self, session_id: SessionId, path: &str) -> Result<Option<SessionFile>> {
         self.0.read_file(session_id, path).await
     }
@@ -329,12 +325,6 @@ impl RuntimeMessageStore for InMemoryMessageRetriever {
 }
 
 #[async_trait]
-impl RuntimeFileStore for InMemorySessionFileStore {
-    async fn seed_initial_file(&self, session_id: SessionId, file: &InitialFile) -> Result<()> {
-        InMemorySessionFileStore::seed_initial_file(self, session_id, file).await
-    }
-}
-
 #[async_trait]
 impl RuntimeProviderStore for InMemoryLlmProviderStore {
     async fn set_default_model(&self, model: ModelWithProvider) -> Result<()> {

--- a/crates/runtime/src/host.rs
+++ b/crates/runtime/src/host.rs
@@ -19,7 +19,7 @@ use everruns_core::session::SessionStatus;
 use everruns_core::traits::{
     AgentStore, BudgetChecker, EventEmitter, HarnessStore, ImageArtifactStore, ImageResolver,
     LeasedResourceStore, LlmProviderStore, ModelWithProvider, PaymentAuthority,
-    ProviderCredentialStore, SessionFileStore, SessionMutator, SessionResourceRegistry,
+    ProviderCredentialStore, SessionFileSystem, SessionMutator, SessionResourceRegistry,
     SessionScheduleStore, SessionSqlDbStoreRef, SessionStorageStore, SessionStore,
     UserConnectionResolver,
 };
@@ -201,7 +201,7 @@ pub trait RuntimeHostAdapter: Send + Sync + Clone + 'static {
 
     fn event_emitter(&self) -> Arc<dyn EventEmitter>;
 
-    fn file_store(&self) -> Arc<dyn SessionFileStore>;
+    fn file_store(&self) -> Arc<dyn SessionFileSystem>;
 
     fn image_resolver(&self, _org_id: i64) -> Option<Arc<dyn ImageResolver>> {
         None

--- a/crates/runtime/src/in_memory.rs
+++ b/crates/runtime/src/in_memory.rs
@@ -8,7 +8,8 @@ use everruns_core::error::{AgentLoopError, Result};
 use everruns_core::session::Session;
 use everruns_core::session_file::{FileInfo, FileStat, GrepMatch, InitialFile, SessionFile};
 use everruns_core::traits::{
-    KeyInfo, SecretInfo, SessionFileStore, SessionMutator, SessionStorageStore, SessionStore,
+    KeyInfo, SecretInfo, SessionFileSystem, SessionFileSystemFactory,
+    SessionFileSystemFactoryContext, SessionMutator, SessionStorageStore, SessionStore,
 };
 use everruns_core::typed_id::SessionId;
 use std::collections::{BTreeSet, HashMap};
@@ -70,6 +71,24 @@ struct FileEntry {
 #[derive(Debug, Default, Clone)]
 pub struct InMemorySessionFileStore {
     files: Arc<RwLock<HashMap<(SessionId, String), FileEntry>>>,
+}
+
+/// Factory for the runtime's in-memory session filesystem.
+#[derive(Debug, Clone, Default)]
+pub struct InMemorySessionFileSystemFactory;
+
+#[async_trait]
+impl SessionFileSystemFactory for InMemorySessionFileSystemFactory {
+    fn name(&self) -> &'static str {
+        "InMemorySessionFileSystemFactory"
+    }
+
+    async fn create_session_file_system(
+        &self,
+        _context: SessionFileSystemFactoryContext,
+    ) -> Result<Arc<dyn SessionFileSystem>> {
+        Ok(Arc::new(InMemorySessionFileStore::new()))
+    }
 }
 
 impl InMemorySessionFileStore {
@@ -195,7 +214,11 @@ impl InMemorySessionFileStore {
 }
 
 #[async_trait]
-impl SessionFileStore for InMemorySessionFileStore {
+impl SessionFileSystem for InMemorySessionFileStore {
+    async fn seed_initial_file(&self, session_id: SessionId, file: &InitialFile) -> Result<()> {
+        InMemorySessionFileStore::seed_initial_file(self, session_id, file).await
+    }
+
     async fn read_file(&self, session_id: SessionId, path: &str) -> Result<Option<SessionFile>> {
         let normalized = normalize_path(path);
         if normalized == "/" {

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -72,9 +72,10 @@
 //!
 //! Embedders who want built-in capabilities (`file_system`,
 //! `agent_instructions`, `skills`, ...) to read and write a real directory
-//! on disk plug a [`RealDiskFileStore`] into [`RuntimeBackends::file_store`].
-//! Every capability that goes through `ToolContext.file_store` or
-//! `SystemPromptContext.file_store` picks it up automatically.
+//! on disk can configure [`RealDiskSessionFileSystemFactory`] on their
+//! [`PlatformDefinition`]. Every capability that goes through
+//! `ToolContext.file_store` or `SystemPromptContext.file_store` picks it up
+//! automatically.
 //!
 //! See the runnable examples for the full wiring:
 //!
@@ -103,7 +104,10 @@ pub use host::{
     RuntimeHostAdapter, RuntimeHostTurnContext, RuntimeSessionLifecycle, detect_dependency_blocker,
     execute_act_activity, execute_input_activity, execute_reason_activity,
 };
-pub use in_memory::{InMemorySessionFileStore, InMemorySessionStorageStore, InMemorySessionStore};
-pub use real_disk::RealDiskFileStore;
+pub use in_memory::{
+    InMemorySessionFileStore, InMemorySessionFileSystemFactory, InMemorySessionStorageStore,
+    InMemorySessionStore,
+};
+pub use real_disk::{RealDiskFileStore, RealDiskSessionFileSystemFactory};
 pub use runtime::{InProcessRuntime, InProcessRuntimeBuilder, TurnResult};
 pub use turn_strategy::{RuntimeActPlan, RuntimeTurnPlan, RuntimeTurnState, plan_next_host_turn};

--- a/crates/runtime/src/real_disk.rs
+++ b/crates/runtime/src/real_disk.rs
@@ -1,11 +1,10 @@
-// Real-disk SessionFileStore implementation.
+// Real-disk SessionFileSystem implementation.
 //
 // Rationale: built-in capabilities (`file_system`, `agent_instructions`,
-// `skills`, ...) read and write through `SessionFileStore`. For non-server
+// `skills`, ...) read and write through `SessionFileSystem`. For non-server
 // embedders like the coding-CLI, the workspace is a real directory on disk,
-// not the in-memory VFS. `RealDiskFileStore` is the bridge: an embedder
-// constructs one rooted at a workspace path and plugs it into
-// `RuntimeBackends.file_store`. The trait shape is unchanged.
+// not the in-memory VFS. `RealDiskSessionFileSystemFactory` lets the platform
+// resolve a `RealDiskFileStore` rooted at a workspace path.
 //
 // See `specs/file-store.md` for the contract, path-namespace rules, and the
 // forward-compatibility plan with the mount-overlay resolver (Option B).
@@ -14,7 +13,9 @@ use async_trait::async_trait;
 use chrono::{DateTime, TimeZone, Utc};
 use everruns_core::error::{AgentLoopError, Result};
 use everruns_core::session_file::{FileInfo, FileStat, GrepMatch, InitialFile, SessionFile};
-use everruns_core::traits::SessionFileStore;
+use everruns_core::traits::{
+    SessionFileSystem, SessionFileSystemFactory, SessionFileSystemFactoryContext,
+};
 use everruns_core::typed_id::SessionId;
 use ignore::WalkBuilder;
 use std::collections::HashSet;
@@ -24,11 +25,9 @@ use std::time::SystemTime;
 use tokio::sync::RwLock;
 use uuid::Uuid;
 
-use crate::backends::RuntimeFileStore;
-
-/// A `SessionFileStore` rooted at a real host directory.
+/// A `SessionFileSystem` rooted at a real host directory.
 ///
-/// Paths are interpreted per the FileStore namespace rules (leading `/`,
+/// Paths are interpreted per the session filesystem namespace rules (leading `/`,
 /// optional `/workspace` prefix, `..` rejected anywhere). `session_id` is
 /// accepted on every method but ignored — the store is single-workspace per
 /// process. See `specs/file-store.md` for the multi-tenant upgrade path.
@@ -42,6 +41,32 @@ use crate::backends::RuntimeFileStore;
 pub struct RealDiskFileStore {
     root: PathBuf,
     readonly: Arc<RwLock<HashSet<String>>>,
+}
+
+/// Factory for real-disk session files rooted at a fixed host directory.
+#[derive(Debug, Clone)]
+pub struct RealDiskSessionFileSystemFactory {
+    root: PathBuf,
+}
+
+impl RealDiskSessionFileSystemFactory {
+    pub fn new(root: impl Into<PathBuf>) -> Self {
+        Self { root: root.into() }
+    }
+}
+
+#[async_trait]
+impl SessionFileSystemFactory for RealDiskSessionFileSystemFactory {
+    fn name(&self) -> &'static str {
+        "RealDiskSessionFileSystemFactory"
+    }
+
+    async fn create_session_file_system(
+        &self,
+        _context: SessionFileSystemFactoryContext,
+    ) -> Result<Arc<dyn SessionFileSystem>> {
+        Ok(Arc::new(RealDiskFileStore::new(self.root.clone())?))
+    }
 }
 
 impl RealDiskFileStore {
@@ -175,7 +200,22 @@ impl RealDiskFileStore {
 }
 
 #[async_trait]
-impl SessionFileStore for RealDiskFileStore {
+impl SessionFileSystem for RealDiskFileStore {
+    async fn seed_initial_file(&self, session_id: SessionId, file: &InitialFile) -> Result<()> {
+        // Clear any prior readonly mark so seeding always wins over a
+        // previous starter-file declaration with the same path.
+        let absolute = self.resolve(&file.path)?;
+        let canonical = self.relative_capability_path(&absolute)?;
+        self.mark_readonly(canonical.clone(), false).await;
+
+        self.write_file(session_id, &file.path, &file.content, &file.encoding)
+            .await?;
+        if file.is_readonly {
+            self.mark_readonly(canonical, true).await;
+        }
+        Ok(())
+    }
+
     async fn read_file(&self, session_id: SessionId, path: &str) -> Result<Option<SessionFile>> {
         let absolute = self.resolve(path)?;
         let metadata = match tokio::fs::metadata(&absolute).await {
@@ -563,24 +603,6 @@ impl SessionFileStore for RealDiskFileStore {
             created_at,
             updated_at,
         })
-    }
-}
-
-#[async_trait]
-impl RuntimeFileStore for RealDiskFileStore {
-    async fn seed_initial_file(&self, session_id: SessionId, file: &InitialFile) -> Result<()> {
-        // Clear any prior readonly mark so seeding always wins over a
-        // previous starter-file declaration with the same path.
-        let absolute = self.resolve(&file.path)?;
-        let canonical = self.relative_capability_path(&absolute)?;
-        self.mark_readonly(canonical.clone(), false).await;
-
-        self.write_file(session_id, &file.path, &file.content, &file.encoding)
-            .await?;
-        if file.is_readonly {
-            self.mark_readonly(canonical, true).await;
-        }
-        Ok(())
     }
 }
 

--- a/crates/runtime/src/runtime.rs
+++ b/crates/runtime/src/runtime.rs
@@ -5,12 +5,12 @@
 use crate::backends::{
     DynAgentStore, DynEventEmitter, DynFileStore, DynHarnessStore, DynMessageStore,
     DynProviderStore, DynSessionStore, RuntimeAgentStore, RuntimeBackends, RuntimeEventCollector,
-    RuntimeFileStore, RuntimeHarnessStore, RuntimeMessageStore, RuntimeProviderStore,
-    RuntimeSessionStore,
+    RuntimeHarnessStore, RuntimeMessageStore, RuntimeProviderStore, RuntimeSessionStore,
 };
 use crate::builders::SingleSessionBuilder;
 use crate::in_memory::{
-    InMemorySessionFileStore, InMemorySessionStorageStore, InMemorySessionStore,
+    InMemorySessionFileStore, InMemorySessionFileSystemFactory, InMemorySessionStorageStore,
+    InMemorySessionStore,
 };
 use async_trait::async_trait;
 use everruns_core::agent::Agent;
@@ -45,7 +45,9 @@ use everruns_core::tools::{ToolRegistry, ToolResultImage};
 use everruns_core::traits::{EventEmitter, ModelWithProvider, SessionStorageStore};
 use everruns_core::turn::{TurnAction, TurnContext, TurnOutcome, TurnStateMachine};
 use everruns_core::typed_id::{AgentId, OrgId, SessionId};
-use everruns_core::{InputMessage, MemoryStoreBackend};
+use everruns_core::{
+    InputMessage, MemoryStoreBackend, SessionFileSystem, SessionFileSystemFactoryContext,
+};
 use std::sync::Arc;
 
 #[derive(Debug, Clone)]
@@ -117,6 +119,7 @@ pub struct InProcessRuntimeBuilder {
     llm_sim_config: Option<LlmSimConfig>,
     default_model: Option<ModelWithProvider>,
     backends: Option<RuntimeBackends>,
+    session_file_system_factory_context: SessionFileSystemFactoryContext,
     harnesses: Vec<Harness>,
     agents: Vec<Agent>,
     sessions: Vec<Session>,
@@ -139,13 +142,15 @@ impl InProcessRuntimeBuilder {
     ///   default model via [`Self::default_model`].
     pub fn new() -> Self {
         Self {
-            platform_definition: PlatformDefinition::new(
-                CapabilityRegistry::with_builtins(),
-                DriverRegistry::new(),
-            ),
+            platform_definition: PlatformDefinition::builder()
+                .capability_registry(CapabilityRegistry::with_builtins())
+                .driver_registry(DriverRegistry::new())
+                .session_file_system_factory(Arc::new(InMemorySessionFileSystemFactory))
+                .build(),
             llm_sim_config: None,
             default_model: None,
             backends: None,
+            session_file_system_factory_context: SessionFileSystemFactoryContext::new(),
             harnesses: Vec::new(),
             agents: Vec::new(),
             sessions: Vec::new(),
@@ -189,6 +194,15 @@ impl InProcessRuntimeBuilder {
     /// Supply a custom backend bundle instead of the built-in in-memory stores.
     pub fn backends(mut self, backends: RuntimeBackends) -> Self {
         self.backends = Some(backends);
+        self
+    }
+
+    /// Supply host dependencies needed by the platform session filesystem factory.
+    pub fn session_file_system_factory_context(
+        mut self,
+        context: SessionFileSystemFactoryContext,
+    ) -> Self {
+        self.session_file_system_factory_context = context;
         self
     }
 
@@ -253,10 +267,16 @@ impl InProcessRuntimeBuilder {
     /// Returns a configuration error when no default model is available after
     /// applying explicit configuration and any requested `llmsim` setup.
     pub async fn build(mut self) -> Result<InProcessRuntime> {
-        let backends = self
-            .backends
-            .take()
-            .unwrap_or_else(default_in_memory_backends);
+        let backends = match self.backends.take() {
+            Some(backends) => backends,
+            None => {
+                default_in_memory_backends(
+                    &self.platform_definition,
+                    self.session_file_system_factory_context.clone(),
+                )
+                .await?
+            }
+        };
 
         if let Some(config) = self.llm_sim_config.take() {
             let driver = LlmSimDriver::new(config);
@@ -339,12 +359,22 @@ impl InProcessRuntimeBuilder {
     }
 }
 
-fn default_in_memory_backends() -> RuntimeBackends {
+async fn default_in_memory_backends(
+    platform_definition: &PlatformDefinition,
+    file_system_factory_context: SessionFileSystemFactoryContext,
+) -> Result<RuntimeBackends> {
     let harness_store: Arc<dyn RuntimeHarnessStore> = Arc::new(InMemoryHarnessStore::new());
     let agent_store: Arc<dyn RuntimeAgentStore> = Arc::new(InMemoryAgentStore::new());
     let session_store: Arc<dyn RuntimeSessionStore> = Arc::new(InMemorySessionStore::new());
     let message_store: Arc<dyn RuntimeMessageStore> = Arc::new(InMemoryMessageRetriever::new());
-    let file_store: Arc<dyn RuntimeFileStore> = Arc::new(InMemorySessionFileStore::new());
+    let file_system_factory = platform_definition.session_file_system_factory();
+    let file_store: Arc<dyn SessionFileSystem> = if file_system_factory.is_disabled() {
+        Arc::new(InMemorySessionFileStore::new())
+    } else {
+        file_system_factory
+            .create_session_file_system(file_system_factory_context)
+            .await?
+    };
     let storage_store: Arc<dyn SessionStorageStore> = Arc::new(InMemorySessionStorageStore::new());
     let memory_store: Arc<dyn MemoryStoreBackend> = Arc::new(InMemoryMemoryStore::new());
     let provider_store: Arc<dyn RuntimeProviderStore> = Arc::new(InMemoryLlmProviderStore::new());
@@ -352,7 +382,7 @@ fn default_in_memory_backends() -> RuntimeBackends {
     let event_emitter: Arc<dyn EventEmitter> = Arc::new(event_emitter_impl.clone());
     let event_collector: Arc<dyn RuntimeEventCollector> = Arc::new(event_emitter_impl);
 
-    RuntimeBackends {
+    Ok(RuntimeBackends {
         harness_store,
         agent_store,
         session_store,
@@ -363,7 +393,7 @@ fn default_in_memory_backends() -> RuntimeBackends {
         file_store,
         storage_store,
         memory_store,
-    }
+    })
 }
 
 #[derive(Clone)]
@@ -383,7 +413,7 @@ pub struct InProcessRuntime {
     event_emitter: PersistingEventEmitter,
     raw_event_emitter: Arc<dyn EventEmitter>,
     event_collector: Option<Arc<dyn RuntimeEventCollector>>,
-    file_store: Arc<dyn RuntimeFileStore>,
+    file_store: Arc<dyn SessionFileSystem>,
     storage_store: Arc<dyn SessionStorageStore>,
     memory_store: Arc<dyn MemoryStoreBackend>,
 }
@@ -733,7 +763,7 @@ fn effective_overlay(
 async fn seed_runtime_initial_files(
     harness_store: &dyn RuntimeHarnessStore,
     agent_store: &dyn RuntimeAgentStore,
-    file_store: &dyn RuntimeFileStore,
+    file_store: &dyn SessionFileSystem,
     session: &Session,
 ) -> Result<()> {
     let harness_chain = harness_store.get_harness_chain(session.harness_id).await?;

--- a/crates/runtime/tests/in_process_runtime_test.rs
+++ b/crates/runtime/tests/in_process_runtime_test.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use chrono::{TimeZone, Utc};
 use everruns_core::capabilities::TestMathCapability;
 use everruns_core::llm_driver_registry::DriverRegistry;
@@ -7,13 +8,16 @@ use everruns_core::memory::{
     InMemoryMemoryStore, InMemoryMessageRetriever,
 };
 use everruns_core::{
-    Agent, CapabilityRegistry, Harness, LlmProviderType, MessageRole, ModelWithProvider,
-    PlatformDefinition, Session, ToolCall,
+    Agent, CapabilityRegistry, Harness, InitialFile, LlmProviderType, MessageRole,
+    ModelWithProvider, PlatformDefinition, Session, SessionFileSystem, SessionFileSystemFactory,
+    SessionFileSystemFactoryContext, ToolCall,
 };
 use everruns_runtime::{
     AgentBuilder, HarnessBuilder, InMemorySessionFileStore, InMemorySessionStorageStore,
-    InMemorySessionStore, InProcessRuntimeBuilder, RuntimeBackends, SessionBuilder,
+    InMemorySessionStore, InProcessRuntimeBuilder, RealDiskFileStore, RuntimeBackends,
+    SessionBuilder,
 };
+use std::path::PathBuf;
 use std::sync::Arc;
 
 fn minimal_platform() -> PlatformDefinition {
@@ -49,6 +53,26 @@ fn session(
     match agent_id {
         Some(agent_id) => builder.agent(agent_id).build(),
         None => builder.build(),
+    }
+}
+
+#[derive(Debug)]
+struct ContextRealDiskFactory;
+
+#[async_trait]
+impl SessionFileSystemFactory for ContextRealDiskFactory {
+    fn name(&self) -> &'static str {
+        "ContextRealDiskFactory"
+    }
+
+    async fn create_session_file_system(
+        &self,
+        context: SessionFileSystemFactoryContext,
+    ) -> everruns_core::Result<Arc<dyn SessionFileSystem>> {
+        let root = context
+            .get::<PathBuf>()
+            .ok_or_else(|| everruns_core::AgentLoopError::config("missing real-disk root"))?;
+        Ok(Arc::new(RealDiskFileStore::new(root.as_path())?))
     }
 }
 
@@ -307,6 +331,49 @@ async fn runtime_accepts_explicit_backend_bundle() {
 
     assert!(result.success);
     assert_eq!(result.response, "Custom backend bundle works");
+}
+
+#[tokio::test]
+async fn runtime_uses_platform_session_file_system_factory() {
+    let harness_id = "harness_00000000000000000000000000000053".parse().unwrap();
+    let session_id = "session_00000000000000000000000000000053".parse().unwrap();
+    let tempdir = tempfile::tempdir().unwrap();
+
+    let mut capabilities = CapabilityRegistry::new();
+    capabilities.register(TestMathCapability);
+    let platform = PlatformDefinition::builder()
+        .capability_registry(capabilities)
+        .driver_registry(DriverRegistry::new())
+        .session_file_system_factory(Arc::new(ContextRealDiskFactory))
+        .build();
+
+    let mut harness = harness(harness_id);
+    harness.initial_files = vec![InitialFile {
+        path: "/seed.txt".into(),
+        content: "from platform factory".into(),
+        encoding: "text".into(),
+        is_readonly: false,
+    }];
+
+    let runtime = InProcessRuntimeBuilder::new()
+        .platform_definition(platform)
+        .session_file_system_factory_context(
+            SessionFileSystemFactoryContext::new().with(Arc::new(tempdir.path().to_path_buf())),
+        )
+        .llm_sim(LlmSimConfig::fixed("ok"))
+        .harness(harness)
+        .session(session(session_id, harness_id, None))
+        .build()
+        .await
+        .unwrap();
+
+    let file = runtime
+        .read_file(session_id, "/seed.txt")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(file.content.as_deref(), Some("from platform factory"));
+    assert!(tempdir.path().join("seed.txt").exists());
 }
 
 #[tokio::test]

--- a/crates/runtime/tests/runtime_host_test.rs
+++ b/crates/runtime/tests/runtime_host_test.rs
@@ -15,7 +15,7 @@ use everruns_core::memory::{
 };
 use everruns_core::memory_store::MemoryStoreBackend;
 use everruns_core::traits::{
-    AgentStore, EventEmitter, HarnessStore, LlmProviderStore, SessionFileStore, SessionMutator,
+    AgentStore, EventEmitter, HarnessStore, LlmProviderStore, SessionFileSystem, SessionMutator,
     SessionStore,
 };
 use everruns_core::typed_id::{AgentId, HarnessId, MessageId, SessionId, TurnId};
@@ -179,7 +179,7 @@ impl RuntimeHostAdapter for MockHostAdapter {
         self.event_emitter.clone()
     }
 
-    fn file_store(&self) -> Arc<dyn SessionFileStore> {
+    fn file_store(&self) -> Arc<dyn SessionFileSystem> {
         self.file_store.clone()
     }
 

--- a/crates/server/src/domains/session_files/service.rs
+++ b/crates/server/src/domains/session_files/service.rs
@@ -10,9 +10,11 @@ use crate::storage::{
     models::{CreateSessionFileRow, SessionFileInfoRow, SessionFileRow, UpdateSessionFile},
 };
 use anyhow::{Result, anyhow};
+use async_trait::async_trait;
 use everruns_core::{
-    FileInfo, FileStat, GrepMatch, GrepResult, MountAccess, MountEntry, MountPoint, MountSource,
-    SessionFile, SessionId,
+    AgentLoopError, FileInfo, FileStat, GrepMatch, GrepResult, MountAccess, MountEntry, MountPoint,
+    MountSource, SessionFile, SessionFileSystem, SessionFileSystemFactory,
+    SessionFileSystemFactoryContext, SessionId,
 };
 use regex::Regex;
 use std::sync::Arc;
@@ -54,6 +56,38 @@ pub struct CopyFileInput {
 pub struct GrepInput {
     pub pattern: String,
     pub path_pattern: Option<String>,
+}
+
+/// Factory for the server-backed session filesystem.
+///
+/// The resolved filesystem uses `StorageBackend`, so it works with PostgreSQL
+/// in production and the in-memory backend in dev/test. Optional virtual mounts
+/// are supplied through the factory context when the host has one.
+#[derive(Debug, Clone, Default)]
+pub struct StorageSessionFileSystemFactory;
+
+#[async_trait]
+impl SessionFileSystemFactory for StorageSessionFileSystemFactory {
+    fn name(&self) -> &'static str {
+        "StorageSessionFileSystemFactory"
+    }
+
+    async fn create_session_file_system(
+        &self,
+        context: SessionFileSystemFactoryContext,
+    ) -> everruns_core::Result<Arc<dyn SessionFileSystem>> {
+        let db = context.get::<StorageBackend>().ok_or_else(|| {
+            AgentLoopError::config("StorageSessionFileSystemFactory requires StorageBackend")
+        })?;
+        let service =
+            match context
+                .get::<crate::domains::session_files::virtual_mount_registry::VirtualMountRegistry>(
+                ) {
+                Some(registry) => SessionFileService::new(db).with_virtual_registry(registry),
+                None => SessionFileService::new(db),
+            };
+        Ok(Arc::new(service))
+    }
 }
 
 pub struct SessionFileService {
@@ -501,6 +535,8 @@ impl SessionFileService {
         encoding: &str,
     ) -> Result<Option<SessionFile>> {
         let path = Self::normalize_path(path);
+        Self::validate_path(&path)?;
+        self.ensure_path_not_virtual(session_id, &path)?;
 
         let expected_bytes = SessionFile::decode_content(expected_content, expected_encoding)?;
         let content = SessionFile::decode_content(content, encoding)?;
@@ -987,6 +1023,240 @@ impl SessionFileService {
     }
 }
 
+fn file_system_error(error: anyhow::Error) -> AgentLoopError {
+    AgentLoopError::store(error.to_string())
+}
+
+fn is_already_exists_error(error: &anyhow::Error) -> bool {
+    let msg = error.to_string();
+    msg.contains("already exists")
+        || msg.contains("duplicate key")
+        || msg.contains("unique constraint")
+        || msg.contains("UNIQUE constraint")
+}
+
+fn file_system_display_error(error: impl std::fmt::Display) -> AgentLoopError {
+    AgentLoopError::store(error.to_string())
+}
+
+#[async_trait]
+impl SessionFileSystem for SessionFileService {
+    async fn seed_initial_file(
+        &self,
+        session_id: SessionId,
+        file: &everruns_core::InitialFile,
+    ) -> everruns_core::Result<()> {
+        let session_id_uuid = session_id.uuid();
+        let path = Self::normalize_path(&file.path);
+        Self::validate_path(&path).map_err(file_system_error)?;
+        self.ensure_path_not_virtual(session_id_uuid, &path)
+            .map_err(file_system_error)?;
+        self.ensure_parent_path_writable(session_id_uuid, &path)
+            .await
+            .map_err(file_system_error)?;
+
+        if let Some(parent) = FileInfo::parent_path(&path) {
+            self.ensure_directory_exists(session_id_uuid, &parent)
+                .await
+                .map_err(file_system_error)?;
+        }
+
+        let content = SessionFile::decode_content(&file.content, &file.encoding)
+            .map_err(file_system_display_error)?;
+
+        if self
+            .db
+            .session_file_exists(session_id_uuid, &path)
+            .await
+            .map_err(file_system_error)?
+        {
+            self.db
+                .update_session_file(
+                    session_id_uuid,
+                    &path,
+                    UpdateSessionFile {
+                        content: Some(content),
+                        is_readonly: Some(file.is_readonly),
+                    },
+                )
+                .await
+                .map_err(file_system_error)?
+                .ok_or_else(|| AgentLoopError::store("File not found after update"))?;
+        } else {
+            self.db
+                .create_session_file(CreateSessionFileRow {
+                    session_id,
+                    path,
+                    content: Some(content),
+                    is_directory: false,
+                    is_readonly: file.is_readonly,
+                })
+                .await
+                .map_err(file_system_error)?;
+        }
+
+        Ok(())
+    }
+
+    async fn read_file(
+        &self,
+        session_id: SessionId,
+        path: &str,
+    ) -> everruns_core::Result<Option<SessionFile>> {
+        SessionFileService::read_file(self, session_id.uuid(), path)
+            .await
+            .map_err(file_system_error)
+    }
+
+    async fn write_file(
+        &self,
+        session_id: SessionId,
+        path: &str,
+        content: &str,
+        encoding: &str,
+    ) -> everruns_core::Result<SessionFile> {
+        let session_id_uuid = session_id.uuid();
+        if SessionFileService::read_file(self, session_id_uuid, path)
+            .await
+            .map_err(file_system_error)?
+            .is_some()
+        {
+            return self
+                .update_file(
+                    session_id_uuid,
+                    path,
+                    UpdateFileInput {
+                        content: Some(content.to_string()),
+                        encoding: Some(encoding.to_string()),
+                        is_readonly: None,
+                    },
+                )
+                .await
+                .map_err(file_system_error)?
+                .ok_or_else(|| AgentLoopError::store("File not found after update"));
+        }
+
+        match self
+            .create_file(
+                session_id_uuid,
+                CreateFileInput {
+                    path: path.to_string(),
+                    content: Some(content.to_string()),
+                    encoding: Some(encoding.to_string()),
+                    is_readonly: Some(false),
+                },
+            )
+            .await
+        {
+            Ok(file) => Ok(file),
+            Err(error) if is_already_exists_error(&error) => self
+                .update_file(
+                    session_id_uuid,
+                    path,
+                    UpdateFileInput {
+                        content: Some(content.to_string()),
+                        encoding: Some(encoding.to_string()),
+                        is_readonly: None,
+                    },
+                )
+                .await
+                .map_err(file_system_error)?
+                .ok_or_else(|| AgentLoopError::store("File not found after race recovery")),
+            Err(error) => Err(file_system_error(error)),
+        }
+    }
+
+    async fn write_file_if_content_matches(
+        &self,
+        session_id: SessionId,
+        path: &str,
+        expected_content: &str,
+        expected_encoding: &str,
+        content: &str,
+        encoding: &str,
+    ) -> everruns_core::Result<Option<SessionFile>> {
+        self.update_file_if_content_matches(
+            session_id.uuid(),
+            path,
+            expected_content,
+            expected_encoding,
+            content,
+            encoding,
+        )
+        .await
+        .map_err(file_system_error)
+    }
+
+    async fn delete_file(
+        &self,
+        session_id: SessionId,
+        path: &str,
+        recursive: bool,
+    ) -> everruns_core::Result<bool> {
+        self.delete(session_id.uuid(), path, recursive)
+            .await
+            .map_err(file_system_error)
+    }
+
+    async fn list_directory(
+        &self,
+        session_id: SessionId,
+        path: &str,
+    ) -> everruns_core::Result<Vec<FileInfo>> {
+        SessionFileService::list_directory(self, session_id.uuid(), path)
+            .await
+            .map_err(file_system_error)
+    }
+
+    async fn stat_file(
+        &self,
+        session_id: SessionId,
+        path: &str,
+    ) -> everruns_core::Result<Option<FileStat>> {
+        self.stat(session_id.uuid(), path)
+            .await
+            .map_err(file_system_error)
+    }
+
+    async fn grep_files(
+        &self,
+        session_id: SessionId,
+        pattern: &str,
+        path_pattern: Option<&str>,
+    ) -> everruns_core::Result<Vec<GrepMatch>> {
+        let results = self
+            .grep(
+                session_id.uuid(),
+                GrepInput {
+                    pattern: pattern.to_string(),
+                    path_pattern: path_pattern.map(ToString::to_string),
+                },
+            )
+            .await
+            .map_err(file_system_error)?;
+        Ok(results
+            .into_iter()
+            .flat_map(|result| result.matches)
+            .collect())
+    }
+
+    async fn create_directory(
+        &self,
+        session_id: SessionId,
+        path: &str,
+    ) -> everruns_core::Result<FileInfo> {
+        SessionFileService::create_directory(
+            self,
+            session_id.uuid(),
+            CreateDirectoryInput {
+                path: path.to_string(),
+            },
+        )
+        .await
+        .map_err(file_system_error)
+    }
+}
+
 /// Max regex pattern length to prevent resource-intensive compilation (TM-DOS-008).
 const MAX_GREP_PATTERN_LEN: usize = 1000;
 
@@ -1402,6 +1672,57 @@ mod tests {
             err.to_string().contains("readonly"),
             "Expected readonly error, got: {err}"
         );
+    }
+
+    #[tokio::test]
+    async fn virtual_cas_update_rejected() {
+        let (svc, registry, sid) = make_virtual_svc();
+
+        svc.create_directory(
+            sid,
+            CreateDirectoryInput {
+                path: "/docs".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+        svc.create_file(
+            sid,
+            CreateFileInput {
+                path: "/docs/readme.md".to_string(),
+                content: Some("DB content".to_string()),
+                encoding: None,
+                is_readonly: Some(false),
+            },
+        )
+        .await
+        .unwrap();
+
+        registry.register(sid, "/docs".into(), sample_tree(), "test_cap".into());
+
+        let err = svc
+            .update_file_if_content_matches(
+                sid,
+                "/docs/readme.md",
+                "DB content",
+                "text",
+                "modified",
+                "text",
+            )
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("readonly"),
+            "Expected readonly error, got: {err}"
+        );
+
+        let stored = svc
+            .db
+            .get_session_file(sid, "/docs/readme.md")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(stored.content.as_deref(), Some("DB content".as_bytes()));
     }
 
     #[tokio::test]

--- a/crates/server/src/platform.rs
+++ b/crates/server/src/platform.rs
@@ -11,6 +11,7 @@ use everruns_core::deployment::DeploymentGrade;
 use everruns_core::{
     BuiltInHarnessDefinition, CapabilityRegistry, PlatformDefinition, SystemEmailConfig,
 };
+use std::sync::Arc;
 
 /// Build the default OSS `PlatformDefinition` for the current deployment grade.
 pub fn oss_platform_definition() -> PlatformDefinition {
@@ -32,6 +33,9 @@ pub fn oss_platform_definition_for_grade(grade: DeploymentGrade) -> PlatformDefi
         .connection_providers(connection_providers)
         .built_in_harnesses(oss_built_in_harnesses())
         .email_sender(email_sender)
+        .session_file_system_factory(Arc::new(
+            crate::domains::session_files::StorageSessionFileSystemFactory,
+        ))
         .build()
 }
 

--- a/crates/server/src/storage/mod.rs
+++ b/crates/server/src/storage/mod.rs
@@ -5,7 +5,7 @@
 // - DbAgentStore: implements AgentStore for agent retrieval
 // - DbSessionStore: implements SessionStore for session retrieval
 // - DbMessageRetriever: implements MessageRetriever for message loading
-// - DbSessionFileStore: implements SessionFileStore for session filesystem
+// - DbSessionFileStore: implements SessionFileSystem for session filesystem
 // - DbSessionStorageStore: implements SessionStorageStore for key/value and secret storage
 // - DbLlmProviderStore: implements LlmProviderStore for LLM provider retrieval
 

--- a/crates/server/src/storage/session_file_store.rs
+++ b/crates/server/src/storage/session_file_store.rs
@@ -1,12 +1,12 @@
-// Database-backed SessionFileStore implementation
+// Database-backed SessionFileSystem implementation
 //
-// This module implements the core SessionFileStore trait for persisting
+// This module implements the core SessionFileSystem trait for persisting
 // session files to the database.
 
 use async_trait::async_trait;
 use everruns_core::{
     AgentLoopError, FileInfo, FileStat, GrepMatch, Result, SessionFile, SessionId, StoreResultExt,
-    traits::SessionFileStore,
+    traits::SessionFileSystem,
 };
 use regex::Regex;
 
@@ -113,7 +113,7 @@ impl DbSessionFileStore {
 }
 
 #[async_trait]
-impl SessionFileStore for DbSessionFileStore {
+impl SessionFileSystem for DbSessionFileStore {
     async fn read_file(&self, session_id: SessionId, path: &str) -> Result<Option<SessionFile>> {
         let path = Self::normalize_path(path);
         let row = self

--- a/crates/worker/src/grpc_adapters.rs
+++ b/crates/worker/src/grpc_adapters.rs
@@ -21,7 +21,7 @@ use everruns_core::session_file::{FileInfo, FileStat, GrepMatch, SessionFile};
 use everruns_core::traits::{
     AgentStore, CreateStoredImage, EventEmitter, HarnessStore, ImageArtifactStore,
     LeasedResourceStore, LlmProviderStore, ModelWithProvider, ProviderCredentialStore,
-    ProviderCredentials, ResolvedImage, SessionFileStore, SessionStore, StoredImage,
+    ProviderCredentials, ResolvedImage, SessionFileSystem, SessionStore, StoredImage,
     StoredImageInfo,
 };
 use everruns_core::typed_id::{
@@ -626,7 +626,7 @@ impl GrpcClient {
 
 /// Session-scoped gRPC adapter (no org_id needed).
 ///
-/// Implements: MessageRetriever, SessionFileStore, EventEmitter,
+/// Implements: MessageRetriever, SessionFileSystem, EventEmitter,
 /// SessionStorageStore, UserConnectionResolver, LeasedResourceStore,
 /// SessionSqlDbStore.
 #[derive(Clone)]
@@ -1649,11 +1649,11 @@ fn proto_model_with_provider_to_model(
 }
 
 // ============================================================================
-// SessionFileStore implementation
+// SessionFileSystem implementation
 // ============================================================================
 
 #[async_trait]
-impl SessionFileStore for GrpcAdapter {
+impl SessionFileSystem for GrpcAdapter {
     async fn read_file(&self, session_id: SessionId, path: &str) -> Result<Option<SessionFile>> {
         let mut client = self.client.inner.lock().await;
 

--- a/crates/worker/src/grpc_worker_adapters.rs
+++ b/crates/worker/src/grpc_worker_adapters.rs
@@ -218,7 +218,7 @@ impl WorkerAdapters for GrpcWorkerAdapters {
 
     async fn read_file(&self, session_id: Uuid, path: &str) -> Result<Option<SessionFile>> {
         let store = GrpcSessionFileStore::new(self.client.clone());
-        everruns_core::traits::SessionFileStore::read_file(
+        everruns_core::traits::SessionFileSystem::read_file(
             &store,
             SessionId::from_uuid(session_id),
             path,
@@ -234,7 +234,7 @@ impl WorkerAdapters for GrpcWorkerAdapters {
         encoding: &str,
     ) -> Result<SessionFile> {
         let store = GrpcSessionFileStore::new(self.client.clone());
-        everruns_core::traits::SessionFileStore::write_file(
+        everruns_core::traits::SessionFileSystem::write_file(
             &store,
             SessionId::from_uuid(session_id),
             path,
@@ -254,7 +254,7 @@ impl WorkerAdapters for GrpcWorkerAdapters {
         encoding: &str,
     ) -> Result<Option<SessionFile>> {
         let store = GrpcSessionFileStore::new(self.client.clone());
-        everruns_core::traits::SessionFileStore::write_file_if_content_matches(
+        everruns_core::traits::SessionFileSystem::write_file_if_content_matches(
             &store,
             SessionId::from_uuid(session_id),
             path,
@@ -268,7 +268,7 @@ impl WorkerAdapters for GrpcWorkerAdapters {
 
     async fn delete_file(&self, session_id: Uuid, path: &str, recursive: bool) -> Result<bool> {
         let store = GrpcSessionFileStore::new(self.client.clone());
-        everruns_core::traits::SessionFileStore::delete_file(
+        everruns_core::traits::SessionFileSystem::delete_file(
             &store,
             SessionId::from_uuid(session_id),
             path,
@@ -279,7 +279,7 @@ impl WorkerAdapters for GrpcWorkerAdapters {
 
     async fn list_directory(&self, session_id: Uuid, path: &str) -> Result<Vec<FileInfo>> {
         let store = GrpcSessionFileStore::new(self.client.clone());
-        everruns_core::traits::SessionFileStore::list_directory(
+        everruns_core::traits::SessionFileSystem::list_directory(
             &store,
             SessionId::from_uuid(session_id),
             path,
@@ -289,7 +289,7 @@ impl WorkerAdapters for GrpcWorkerAdapters {
 
     async fn stat_file(&self, session_id: Uuid, path: &str) -> Result<Option<FileStat>> {
         let store = GrpcSessionFileStore::new(self.client.clone());
-        everruns_core::traits::SessionFileStore::stat_file(
+        everruns_core::traits::SessionFileSystem::stat_file(
             &store,
             SessionId::from_uuid(session_id),
             path,
@@ -304,7 +304,7 @@ impl WorkerAdapters for GrpcWorkerAdapters {
         path_pattern: Option<&str>,
     ) -> Result<Vec<GrepMatch>> {
         let store = GrpcSessionFileStore::new(self.client.clone());
-        everruns_core::traits::SessionFileStore::grep_files(
+        everruns_core::traits::SessionFileSystem::grep_files(
             &store,
             SessionId::from_uuid(session_id),
             pattern,
@@ -315,7 +315,7 @@ impl WorkerAdapters for GrpcWorkerAdapters {
 
     async fn create_directory(&self, session_id: Uuid, path: &str) -> Result<FileInfo> {
         let store = GrpcSessionFileStore::new(self.client.clone());
-        everruns_core::traits::SessionFileStore::create_directory(
+        everruns_core::traits::SessionFileSystem::create_directory(
             &store,
             SessionId::from_uuid(session_id),
             path,

--- a/crates/worker/src/runtime_host.rs
+++ b/crates/worker/src/runtime_host.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 use everruns_core::error::Result;
 use everruns_core::traits::{
     AgentStore, EventEmitter, HarnessStore, ImageArtifactStore, ImageResolver, LlmProviderStore,
-    PaymentAuthority, ProviderCredentialStore, SessionFileStore, SessionMutator, SessionStore,
+    PaymentAuthority, ProviderCredentialStore, SessionFileSystem, SessionMutator, SessionStore,
 };
 use everruns_core::typed_id::{AgentId, HarnessId, SessionId};
 use everruns_core::{Agent, CapabilityRegistry, DriverRegistry, Harness, Session, SessionStatus};
@@ -119,7 +119,7 @@ impl<A: WorkerAdapters> RuntimeHostAdapter for WorkerRuntimeHost<A> {
         Arc::new(AdapterEventEmitter::new(self.adapters.clone()))
     }
 
-    fn file_store(&self) -> Arc<dyn SessionFileStore> {
+    fn file_store(&self) -> Arc<dyn SessionFileSystem> {
         Arc::new(AdapterSessionFileStore::new(self.adapters.clone()))
     }
 

--- a/crates/worker/src/worker_adapters.rs
+++ b/crates/worker/src/worker_adapters.rs
@@ -361,7 +361,7 @@ pub struct TurnContext {
 
 /// Session-scoped adapter: bridges WorkerAdapters → core traits that don't need org_id.
 ///
-/// Implements: MessageRetriever, EventEmitter, SessionFileStore.
+/// Implements: MessageRetriever, EventEmitter, SessionFileSystem.
 pub struct SessionAdapter<A: WorkerAdapters> {
     adapters: A,
 }
@@ -484,7 +484,7 @@ impl<A: WorkerAdapters> everruns_core::traits::EventEmitter for SessionAdapter<A
 }
 
 #[async_trait]
-impl<A: WorkerAdapters> everruns_core::traits::SessionFileStore for SessionAdapter<A> {
+impl<A: WorkerAdapters> everruns_core::traits::SessionFileSystem for SessionAdapter<A> {
     async fn read_file(&self, session_id: SessionId, path: &str) -> Result<Option<SessionFile>> {
         self.adapters.read_file(session_id.uuid(), path).await
     }

--- a/specs/agent-instructions.md
+++ b/specs/agent-instructions.md
@@ -69,7 +69,7 @@ XML tags provide clear boundaries between sections. See `specs/xml-prompt-format
 
 ## ReasonAtom Changes
 
-ReasonAtom holds an optional `SessionFileStore` that is passed to capabilities via `SystemPromptContext`. See `crates/core/src/atoms/reason.rs` for the `with_file_store` builder method.
+ReasonAtom holds an optional `SessionFileSystem` that is passed to capabilities via `SystemPromptContext`. See `crates/core/src/atoms/reason.rs` for the `with_file_store` builder method.
 
 ## Constants
 

--- a/specs/architecture.md
+++ b/specs/architecture.md
@@ -270,7 +270,7 @@ Workers communicate with the control-plane via gRPC instead of direct database a
    - `GrpcSessionStore` - Implements `SessionStore` trait via gRPC
    - `WorkerRuntimeHost` - Bridges worker adapters into `everruns-runtime` host execution
    - `GrpcLlmProviderStore` - Implements `LlmProviderStore` trait via gRPC
-   - `GrpcSessionFileStore` - Implements `SessionFileStore` trait via gRPC
+   - `GrpcSessionFileStore` - Implements `SessionFileSystem` trait via gRPC
    - `GrpcEventEmitter` - Implements `EventEmitter` trait via gRPC
    - `GrpcDurableStore` - Implements durable workflow operations via gRPC
    - `GrpcPlatformStore` - Implements `PlatformStore` trait via gRPC (platform management capability)

--- a/specs/bashkit-requirements.md
+++ b/specs/bashkit-requirements.md
@@ -8,7 +8,7 @@
 > seamless file sharing between bash commands and file system tools.
 >
 > **Indexed Search**: `SessionFileSystemAdapter` implements bashkit's `SearchCapable` trait,
-> delegating `grep -r` to `SessionFileStore::grep_files` for single-query database search
+> delegating `grep -r` to `SessionFileSystem::grep_files` for single-query database search
 > instead of per-file linear scanning.
 
 ## Context
@@ -21,7 +21,7 @@ The implementation is in `crates/core/src/capabilities/virtual_bash.rs` with `Se
 
 Bashkit v0.1.12 restored `SearchCapable`/`SearchProvider` traits. When a `FileSystem` implements `SearchCapable`, builtins like `grep -r` use indexed search instead of reading every file individually.
 
-`SessionFileSystemAdapter` implements `SearchCapable` by delegating to `SessionFileStore::grep_files()`, which executes a single SQL query with server-side regex matching. This eliminates N+1 database calls for recursive grep.
+`SessionFileSystemAdapter` implements `SearchCapable` by delegating to `SessionFileSystem::grep_files()`, which executes a single SQL query with server-side regex matching. This eliminates N+1 database calls for recursive grep.
 
 The sync-to-async bridge uses `std::thread::scope` with a dedicated thread and its own tokio runtime to avoid nesting `block_on` calls.
 

--- a/specs/capabilities.md
+++ b/specs/capabilities.md
@@ -358,14 +358,18 @@ For the full list of built-in capabilities with their tools, parameters, and sys
 
 FileSystem tools require session context to access the isolated virtual filesystem. Each tool implements `requires_context() -> true` and uses `execute_with_context()` instead of the standard `execute()`. The `ToolContext` provides:
 - `session_id`: The session whose filesystem to access
-- `file_store`: A `SessionFileStore` trait implementation for file operations
+- `file_store`: A `SessionFileSystem` trait implementation for file operations
 
-See `specs/file-store.md` for the pluggable `SessionFileStore` contract and
+See `specs/file-store.md` for the pluggable `SessionFileSystem` contract and
 the in-memory and real-disk implementations. New capabilities that need
 filesystem access should go through `ToolContext.file_store` or
 `SystemPromptContext.file_store` rather than calling `std::fs` directly,
 except for host-process tools (e.g. the bash tool) where the shell
-inherits the host filesystem regardless of which `FileStore` is plugged in.
+inherits the host filesystem regardless of which `SessionFileSystem` is plugged
+in.
+The active session filesystem is selected by the platform's
+`SessionFileSystemFactory` unless an embedder supplies an explicit runtime
+backend override.
 
 ##### Design Decision: Session Isolation
 
@@ -397,7 +401,7 @@ This capability uses the [bashkit](https://github.com/everruns/bashkit) library 
 
 ##### Design Decision: SessionFileSystemAdapter
 
-The `SessionFileSystemAdapter` implements bashkit's `FileSystem` trait, bridging bash file operations to the session file store. This enables:
+The `SessionFileSystemAdapter` implements bashkit's `FileSystem` trait, bridging bash file operations to the session filesystem. This enables:
 - **Live file visibility**: Files written by other tools during bash execution are immediately visible
 - **No sync overhead**: Eliminates pre/post execution sync of entire filesystem
 - **Memory efficiency**: Files read on-demand instead of loading all into memory

--- a/specs/embedding.md
+++ b/specs/embedding.md
@@ -22,8 +22,16 @@ This spec defines the contract for embedding. See `crates/core/src/platform_defi
 - LLM driver registry
 - Connection-provider registry
 - Built-in harness templates
+- System email sender
+- Session filesystem factory
 
 The type lives in `everruns-core` so any binary can construct or mutate it without depending on `everruns-server`.
+
+Platform-wide host services are represented as provider-neutral traits or
+factories. For example, `SessionFileSystemFactory` lets a platform select
+in-memory, storage-backed, real-disk, or future S3-backed session files while
+allowing each host to provide the concrete dependencies needed to resolve the
+live filesystem.
 
 ## In-process Runtime
 
@@ -94,6 +102,7 @@ The server must derive the following from the platform definition:
 - LLM driver registry for provider resolution and model sync
 - Connection providers for user connection APIs
 - Built-in harness templates for org initialization
+- Session filesystem factory for session file operations
 - Seed behavior for providers, models, harnesses, and agents
 - gRPC worker service capability/session registries
 - DEV_MODE in-process worker registries

--- a/specs/fetchkit.md
+++ b/specs/fetchkit.md
@@ -14,7 +14,7 @@ External library ([github.com/everruns/fetchkit](https://github.com/everruns/fet
 
 fetchkit owns the `FileSaver` abstraction; consumers inject implementations:
 - **CLI**: `LocalFileSaver` (real filesystem, ships with fetchkit)
-- **Everruns**: `SessionFileSaver` adapter → `SessionFileStore` (per-session virtual filesystem)
+- **Everruns**: `SessionFileSaver` adapter → `SessionFileSystem` (per-session virtual filesystem)
 
 Key decisions:
 - **Config-gated**: file download enabled via per-capability config `{"enable_file_download": true}` — harnesses/agents opt in

--- a/specs/file-store.md
+++ b/specs/file-store.md
@@ -1,23 +1,23 @@
-# FileStore Specification
+# Session Filesystem Specification
 
 ## Abstract
 
-`SessionFileStore` (and its runtime extension `RuntimeFileStore`) is the
-canonical seam through which built-in capabilities read and write files.
-Implementations of this trait decide what "the workspace" physically is: an
-in-memory map, a PostgreSQL table, a remote gRPC adapter, or a real
-host-filesystem directory.
+`SessionFileSystem` is the canonical seam through which built-in capabilities
+read and write files. Implementations of this trait decide what "the
+workspace" physically is: an in-memory map, a PostgreSQL table, a remote gRPC
+adapter, a real host-filesystem directory, or a future object-store-backed
+filesystem.
 
 This spec defines the contract every implementation must honor and the
 discipline new capabilities should follow when they need filesystem access.
 
 ## Status
 
-This is the **Option A** pluggable-store seam (single trait, embedder picks
-the impl). It is a stepping stone toward the mount-overlay resolver
-(Option B) which will compose mounts on top of a base `FileStore`. The work
-here is preserved when B lands; see the forward-compatibility note at the
-bottom of this document.
+This is the platform-level session filesystem seam. `PlatformDefinition`
+carries a `SessionFileSystemFactory`, and runtime/server hosts resolve a live
+`SessionFileSystem` from host dependencies such as in-memory state, a storage
+backend, or a root directory. It is still compatible with the mount-overlay
+resolver direction, which can compose mounts on top of a base filesystem.
 
 ## Background
 
@@ -29,8 +29,9 @@ TUI in PR #1839) revealed a real seam: `AgentInstructionsCapability` and
 VFS *is* the workspace) but breaks in an embedded coding-CLI where the
 workspace is a real directory on disk.
 
-The pluggable seam already existed (`RuntimeBackends.file_store`); what was
-missing was a real-disk implementation and a documented contract.
+The original pluggable seam lived on `RuntimeBackends.file_store`; the platform
+profile now owns the higher-level factory so embedders can choose the session
+filesystem as part of the deployment surface.
 
 ## Decision Process
 
@@ -38,35 +39,36 @@ We evaluated four options before landing on the pluggable-store approach:
 
 | Option | Description | Outcome |
 |--------|-------------|---------|
-| A. Pluggable `SessionFileStore` at runtime builder | Single trait, embedder picks the impl. Already supported by `RuntimeBackends.file_store`. | **Chosen.** Unblocks `coding-cli` with no core API changes. |
-| B. Mount-point overlay (`MountSource::HostPath`) | Compose mounts on top of a base `FileStore` via a resolver. | Eventual destination. Strict superset of A; A is preserved when B lands. |
+| A. Pluggable `SessionFileSystem` at runtime builder | Single trait, embedder picks the impl. Already supported by `RuntimeBackends.file_store`. | Superseded by platform factories. |
+| B. Mount-point overlay (`MountSource::HostPath`) | Compose mounts on top of a base filesystem via a resolver. | Eventual destination. Strict superset of the factory seam. |
 | C. Split `SystemPromptContext` into `file_store` + `WorkspaceSource` | Separate sandbox writes from project-context reads. | Rejected. Parallel abstraction that B subsumes naturally via `MountAccess::ReadOnly`. |
 | D. Per-capability factory (`AgentInstructionsCapability::with_loader(...)`) | Each capability re-solves the loader problem itself. | Rejected. Does not compose; doesn't scale to N capabilities. |
 
 A unblocks every existing built-in capability (`file_system`,
 `agent_instructions`, `skills`, `web_fetch`, `tool_output_persistence`) the
-day the embedder plugs a real-disk `FileStore`.
+day the embedder plugs a real-disk filesystem.
 
 ## Contract
 
 ### Traits
 
-The public surface is two traits:
+The public surface is two core traits:
 
-- `everruns_core::traits::SessionFileStore` — the read/write contract every
+- `everruns_core::traits::SessionFileSystem` — the read/write contract every
   filesystem-aware capability calls.
-- `everruns_runtime::RuntimeFileStore` — extends `SessionFileStore` with
-  `seed_initial_file`, used during session bootstrap.
+- `everruns_core::traits::SessionFileSystemFactory` — resolves the platform's
+  chosen filesystem from host-provided dependencies.
 
-See `crates/core/src/traits.rs` and `crates/runtime/src/backends.rs` for the
-full method signatures and doc comments. The trait shape is intentionally
-small: an implementation supports `read_file`, `write_file`,
-`write_file_if_content_matches` (CAS), `delete_file`, `list_directory`,
-`stat_file`, `grep_files`, and `create_directory`.
+See `crates/core/src/traits.rs` for the full method signatures and doc
+comments. The filesystem trait shape is intentionally small: an implementation
+supports `read_file`, `write_file`, `write_file_if_content_matches` (CAS),
+`delete_file`, `list_directory`, `stat_file`, `grep_files`,
+`create_directory`, and `seed_initial_file`.
 
 ### Path Namespace
 
-`FileStore` paths are **absolute, forward-slash, leading-slash** strings.
+Session filesystem paths are **absolute, forward-slash, leading-slash**
+strings.
 
 | Input | Canonical form |
 |-------|----------------|
@@ -204,11 +206,23 @@ Implementation notes:
 
 Source: `crates/runtime/src/real_disk.rs`.
 
+### Factories
+
+- `InMemorySessionFileSystemFactory` resolves the runtime in-memory filesystem.
+- `RealDiskSessionFileSystemFactory` resolves a filesystem rooted at a host
+  directory.
+- `StorageSessionFileSystemFactory` resolves the server storage-backed
+  filesystem from `StorageBackend`.
+
+Future factories can resolve S3/object-store-backed filesystems without
+changing capability code.
+
 ### Future implementations
 
-Worker-side gRPC adapters and the server's `DbSessionFileStore` continue to
-implement the same trait. Adding a new backend (e.g. S3, in-memory zip)
-means implementing the trait; no API changes are required upstream.
+Worker-side gRPC adapters and the server's storage filesystem continue to
+implement the same trait. Adding a new backend (e.g. S3, in-memory zip) means
+implementing the trait and a factory; no capability API changes are required
+upstream.
 
 ## Capability Rule
 
@@ -217,7 +231,7 @@ means implementing the trait; no API changes are required upstream.
 > NOT call `std::fs`, `tokio::fs`, or other host-filesystem APIs
 > directly — *except* when the capability's execution model is inherently
 > a host process (e.g. the bash tool spawns a shell, which inherits the
-> host filesystem regardless of which `FileStore` is plugged in).
+> host filesystem regardless of which `SessionFileSystem` is plugged in).
 
 This rule keeps all existing and future capabilities aligned with the
 pluggable seam. A capability that follows the rule works against the
@@ -226,25 +240,38 @@ without code changes.
 
 Exceptions are limited to host-process tools (bash and equivalents) and
 require a comment in the capability's source naming the constraint that
-forced the bypass. Anything else goes through the `FileStore`.
+forced the bypass. Anything else goes through the `SessionFileSystem`.
 
 ## Wiring
 
-Embedders construct `RuntimeBackends` with their chosen `file_store`:
+Embedders normally configure the platform factory:
 
 ```rust
 let workspace_root = std::env::current_dir()?;
-let file_store = Arc::new(RealDiskFileStore::new(workspace_root)?);
 
-let backends = RuntimeBackends {
-    file_store,
-    // ...
-};
+let platform = PlatformDefinition::builder()
+    .session_file_system_factory(Arc::new(
+        RealDiskSessionFileSystemFactory::new(workspace_root),
+    ))
+    .build();
 ```
 
-The runtime forwards this `file_store` into every `ToolContext` and
-`SystemPromptContext` it constructs, so every capability picks up the new
-backend automatically.
+`RuntimeBackends.file_store` remains as an explicit override path for embedders
+that need to supply an already-resolved filesystem bundle.
+
+Factories may require host dependencies such as a database handle, virtual
+mount registry, or workspace root. `InProcessRuntimeBuilder` accepts a
+`SessionFileSystemFactoryContext` for these host-supplied values and passes it
+to the platform factory before seeding initial files.
+
+The runtime forwards the resolved filesystem into every `ToolContext` and
+`SystemPromptContext` it constructs, so every capability picks up the backend
+automatically.
+
+Server HTTP/API session-file management is a control-plane surface and remains
+wired through `SessionFileService`. The platform factory selects the filesystem
+used by runtime/tool execution, not a replacement for those management
+endpoints.
 
 See the runnable examples for the full wiring against a real
 `InProcessRuntime`:
@@ -285,19 +312,19 @@ When the mount-overlay resolver lands, the migration path is:
    backend.
 2. A new `MountSource::HostPath { root: PathBuf, access: MountAccess }`
    variant is added.
-3. The resolver composes mounts on top of a base `FileStore`. Embedders
-   that already pass `RealDiskFileStore` as `file_store` continue to work;
-   the resolver wraps it.
+3. The resolver composes mounts on top of a base `SessionFileSystem`.
+   Embedders that already use `RealDiskSessionFileSystemFactory` continue to
+   work; the resolver wraps the resolved filesystem.
 4. Capabilities can declare host-path mounts (e.g. `~/.local/share/data`
    as `/data` read-only) through `mounts()` instead of needing a custom
-   `FileStore` impl.
+   `SessionFileSystem` impl.
 
 ## Source Index
 
-- `crates/core/src/traits.rs` — `SessionFileStore` trait
+- `crates/core/src/traits.rs` — `SessionFileSystem` trait
 - `crates/core/src/session_file.rs` — `SessionFile`, `FileInfo`,
   `FileStat`, `GrepMatch`, `InitialFile`
-- `crates/runtime/src/backends.rs` — `RuntimeFileStore`, `RuntimeBackends`
+- `crates/runtime/src/backends.rs` — `RuntimeBackends`
 - `crates/runtime/src/in_memory.rs` — `InMemorySessionFileStore`
 - `crates/runtime/src/real_disk.rs` — `RealDiskFileStore`
 - `crates/runtime/examples/real_disk_agent_instructions.rs` — wiring

--- a/specs/runtime.md
+++ b/specs/runtime.md
@@ -158,7 +158,7 @@ and worker-backed hosts stay aligned.
 `everruns-runtime` ships reference in-memory stores for public embedding:
 
 - Session store
-- Session virtual filesystem store
+- Session virtual filesystem
 - Session key/value + secret store
 - Message retriever
 - Harness store
@@ -174,13 +174,13 @@ These stores are intended to make embedded execution usable out of the box.
 Embedders that need persistence across process restarts may supply their own
 backend bundle through `RuntimeBackends`.
 
-`everruns-runtime` owns a small set of extension traits for this:
+`everruns-runtime` owns a small set of extension traits for mutable runtime
+domain stores:
 
 - `RuntimeHarnessStore`
 - `RuntimeAgentStore`
 - `RuntimeSessionStore`
 - `RuntimeMessageStore`
-- `RuntimeFileStore`
 - `RuntimeProviderStore`
 - optional `RuntimeEventCollector`
 
@@ -192,13 +192,18 @@ embedded runtime needs for:
 - persisting assistant and tool-result messages from emitted events
 - configuring the runtime default model
 
-For `RuntimeFileStore` specifically, embedders can choose between
-`InMemorySessionFileStore` (default, per-session isolation, suitable for
-tests and embedded use without disk state) and `RealDiskFileStore` (rooted
-at a host directory; honours `.gitignore` for grep). See
-`specs/file-store.md` for the trait contract, path namespace, and the rule
-that capabilities should consume the seam rather than touching `std::fs`
-directly.
+Session files are a platform service: `PlatformDefinition` carries a
+`SessionFileSystemFactory`, and the runtime resolves it when no explicit
+`RuntimeBackends.file_store` is supplied. Embedders can choose
+`InMemorySessionFileSystemFactory` (default), `RealDiskSessionFileSystemFactory`
+(rooted at a host directory; honours `.gitignore` for grep), or a custom future
+factory such as S3. See `specs/file-store.md` for the trait contract, path
+namespace, and the rule that capabilities should consume the seam rather than
+touching `std::fs` directly.
+
+Factories that depend on host values receive them through
+`SessionFileSystemFactoryContext`; the in-process builder accepts this context
+and passes it to the selected platform factory before runtime seeding.
 
 This keeps `everruns-core` storage traits read-oriented where they already were,
 while making custom embedded backends a supported public path.

--- a/specs/toolkit-library-contract.md
+++ b/specs/toolkit-library-contract.md
@@ -588,7 +588,7 @@ toolkit crate (standalone)       everruns-core             other consumers
 │   └── build_output_schema()    │   ├── wires cancel/stream└── build_output_schema()
 ├── Tool (metadata+version)      │   └── maps to everruns
 ├── ToolExecutor (Value→Value)   └── AdapterImpl
-├── ToolExecution (stateful)         └── bridges to SessionFileStore
+├── ToolExecution (stateful)         └── bridges to SessionFileSystem
 │   ├── execute()
 │   ├── cancel() [optional]
 │   └── output_stream() [opt]


### PR DESCRIPTION
## What
- Add `SessionFileSystem` and `SessionFileSystemFactory` as the platform-level filesystem abstraction.
- Move default runtime filesystem selection behind `PlatformDefinition` while keeping explicit `RuntimeBackends.file_store` override compatibility.
- Wire server OSS platform setup through a storage-backed session filesystem factory.
- Update specs and add runtime coverage for platform factory resolution.

## Why
Session filesystem backend selection is a platform concern, not only an in-process runtime backend detail. This makes in-memory, database-backed, real-disk, and future S3-style backends fit behind one factory concept.

## How
- Introduce factory context and disabled/default factory primitives in core.
- Add in-memory and real-disk runtime factories, plus a server storage-backed factory.
- Resolve the runtime filesystem from explicit backends first, then platform definition, with an in-memory fallback for embedded defaults.
- Preserve existing store aliases so current embedders are not forced through a flag-day rename.

## Risk
- Medium
- Can break file capability wiring, embedded runtime defaults, or server-backed session file access if the factory resolution path is wrong.
- Mitigated by focused runtime test coverage, real-disk capability smoke, and `just pre-push`.

## Security
- Threat categories reviewed: TM-FS, TM-BASH, TM-TENANT, TM-DOS
- Findings and resolutions: No new external input surface, network dependency, endpoint, or auth path. Existing path normalization, real-disk root canonicalization, `/workspace` confinement, and session-scoped storage calls are preserved. The new factory context is internal host wiring and does not expose user-controlled backend selection.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

