### PR TITLE
refactor(runtime): resolve filesystem from platform

### DIFF
--- a/crates/runtime/examples/real_disk_agent_instructions.rs
+++ b/crates/runtime/examples/real_disk_agent_instructions.rs
@@ -21,7 +21,7 @@ use everruns_core::{
     Agent, AgentCapabilityConfig, AgentStatus, CapabilityRegistry, Harness, HarnessStatus,
     LlmProviderType, ModelWithProvider, PlatformDefinition, Session, SessionStatus,
 };
-use everruns_runtime::{InProcessRuntimeBuilder, RealDiskFileStore, RuntimeBackends};
+use everruns_runtime::{InProcessRuntimeBuilder, RealDiskSessionFileSystemFactory};
 use tempfile::TempDir;
 use uuid::Uuid;
 
@@ -37,16 +37,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         "## Project rules\nPrefer snake_case identifiers.",
     )?;
 
-    // 3. Build a RuntimeBackends with the real-disk file_store. Everything
-    //    else stays in memory — only the workspace surface is real.
-    let backends = RuntimeBackends::in_memory()
-        .with_file_store(Arc::new(RealDiskFileStore::new(workspace.path())?));
-
-    // 4. Register AgentInstructionsCapability and a no-op math capability so
-    //    the harness has something to assemble.
+    // 3. Register AgentInstructionsCapability and configure the platform
+    //    filesystem factory so only the workspace surface is real.
     let mut capabilities = CapabilityRegistry::new();
     capabilities.register(AgentInstructionsCapability);
-    let platform = PlatformDefinition::new(capabilities, DriverRegistry::new());
+    let platform = PlatformDefinition::builder()
+        .capability_registry(capabilities)
+        .driver_registry(DriverRegistry::new())
+        .session_file_system_factory(Arc::new(RealDiskSessionFileSystemFactory::new(
+            workspace.path(),
+        )))
+        .build();
 
     let harness_id = "harness_00000000000000000000000000000091".parse().unwrap();
     let agent_id = "agent_00000000000000000000000000000091".parse().unwrap();
@@ -54,7 +55,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let runtime = InProcessRuntimeBuilder::new()
         .platform_definition(platform)
-        .backends(backends)
         .llm_sim(LlmSimConfig::fixed("ack"))
         .default_model(ModelWithProvider {
             model: "llmsim-model".into(),

--- a/crates/runtime/examples/real_disk_file_system_tools.rs
+++ b/crates/runtime/examples/real_disk_file_system_tools.rs
@@ -24,7 +24,7 @@ use everruns_core::{
     Agent, AgentCapabilityConfig, AgentStatus, CapabilityRegistry, Harness, HarnessStatus,
     LlmProviderType, ModelWithProvider, PlatformDefinition, Session, SessionStatus, ToolCall,
 };
-use everruns_runtime::{InProcessRuntimeBuilder, RealDiskFileStore, RuntimeBackends};
+use everruns_runtime::{InProcessRuntimeBuilder, RealDiskSessionFileSystemFactory};
 use tempfile::TempDir;
 use uuid::Uuid;
 
@@ -37,16 +37,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // 2. Pre-seed a source file directly on disk so the agent can read it.
     std::fs::write(workspace.path().join("input.txt"), "hello from real disk")?;
 
-    // 3. Plug RealDiskFileStore into the runtime backends.
-    let backends = RuntimeBackends::in_memory()
-        .with_file_store(Arc::new(RealDiskFileStore::new(workspace.path())?));
-
-    // 4. Register only the built-in FileSystemCapability — no custom tools.
+    // 3. Register only the built-in FileSystemCapability — no custom tools.
+    //    PlatformDefinition selects the real-disk session filesystem.
     let mut capabilities = CapabilityRegistry::new();
     capabilities.register(FileSystemCapability);
-    let platform = PlatformDefinition::new(capabilities, DriverRegistry::new());
+    let platform = PlatformDefinition::builder()
+        .capability_registry(capabilities)
+        .driver_registry(DriverRegistry::new())
+        .session_file_system_factory(Arc::new(RealDiskSessionFileSystemFactory::new(
+            workspace.path(),
+        )))
+        .build();
 
-    // 5. Drive the agent with a fixed tool-call script via llmsim: read the
+    // 4. Drive the agent with a fixed tool-call script via llmsim: read the
     //    seeded file, then write a new file. The runtime forwards every
     //    tool call through `ToolContext.file_store` to the real-disk store.
     let llmsim = LlmSimConfig::fixed("done").with_tool_call_sequence(vec![
@@ -72,7 +75,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let runtime = InProcessRuntimeBuilder::new()
         .platform_definition(platform)
-        .backends(backends)
         .llm_sim(llmsim)
         .default_model(ModelWithProvider {
             model: "llmsim-model".into(),

--- a/crates/runtime/src/backends.rs
+++ b/crates/runtime/src/backends.rs
@@ -4,9 +4,7 @@
 // blanket `Arc<T>: T` impls in core let the runtime forward to atoms without
 // shim wrappers.
 
-use crate::in_memory::{
-    InMemorySessionFileStore, InMemorySessionStorageStore, InMemorySessionStore,
-};
+use crate::in_memory::{InMemorySessionStorageStore, InMemorySessionStore};
 use async_trait::async_trait;
 use everruns_core::agent::Agent;
 use everruns_core::error::Result;
@@ -21,8 +19,8 @@ use everruns_core::message::Message;
 use everruns_core::message_retriever::{InputMessage, MessageRetriever};
 use everruns_core::session::Session;
 use everruns_core::traits::{
-    AgentStore, EventEmitter, HarnessStore, LlmProviderStore, ModelWithProvider, SessionFileSystem,
-    SessionMutator, SessionStorageStore, SessionStore,
+    AgentStore, EventEmitter, HarnessStore, LlmProviderStore, ModelWithProvider, SessionMutator,
+    SessionStorageStore, SessionStore,
 };
 use everruns_core::typed_id::SessionId;
 use std::sync::Arc;
@@ -62,9 +60,6 @@ pub trait RuntimeMessageStore: MessageRetriever + Send + Sync {
     async fn store_message(&self, session_id: SessionId, message: Message) -> Result<()>;
 }
 
-/// Backward-compatible alias for the old runtime filesystem extension.
-pub use everruns_core::traits::SessionFileSystem as RuntimeFileStore;
-
 /// Provider store contract for runtime lookup and default-model configuration.
 #[async_trait]
 pub trait RuntimeProviderStore: LlmProviderStore + Send + Sync {
@@ -93,12 +88,11 @@ impl<T: EventBus + ?Sized> EventBus for Arc<T> {
     }
 }
 
-/// Backend bundle supplied to the embedded runtime.
+/// Non-filesystem backend bundle supplied to the embedded runtime.
 ///
 /// Use this when you want the public runtime orchestration but your own store
-/// implementations instead of the built-in in-memory ones. For an
-/// all-in-memory baseline plus targeted overrides, use
-/// [`RuntimeBackends::in_memory`] followed by `with_*` setters.
+/// implementations instead of the built-in in-memory ones. Session filesystem
+/// selection is always resolved from `PlatformDefinition`.
 #[derive(Clone)]
 pub struct RuntimeBackends {
     /// Harness definitions available to the runtime.
@@ -113,8 +107,6 @@ pub struct RuntimeBackends {
     pub provider_store: Arc<dyn RuntimeProviderStore>,
     /// Event sink (emit + optional collection).
     pub event_bus: Arc<dyn EventBus>,
-    /// Session filesystem backend.
-    pub file_store: Arc<dyn SessionFileSystem>,
     /// Session key/value + secret storage backend.
     pub storage_store: Arc<dyn SessionStorageStore>,
     /// Persistent cross-session memory backend.
@@ -135,7 +127,6 @@ impl RuntimeBackends {
             message_store: Arc::new(InMemoryMessageRetriever::new()),
             provider_store: Arc::new(InMemoryLlmProviderStore::new()),
             event_bus,
-            file_store: Arc::new(InMemorySessionFileStore::new()),
             storage_store: Arc::new(InMemorySessionStorageStore::new()),
             memory_store: Arc::new(InMemoryMemoryStore::new()),
         }
@@ -168,11 +159,6 @@ impl RuntimeBackends {
 
     pub fn with_event_bus(mut self, bus: Arc<dyn EventBus>) -> Self {
         self.event_bus = bus;
-        self
-    }
-
-    pub fn with_file_store(mut self, store: Arc<dyn SessionFileSystem>) -> Self {
-        self.file_store = store;
         self
     }
 

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -95,8 +95,8 @@ mod runtime;
 mod turn_strategy;
 
 pub use backends::{
-    EventBus, RuntimeAgentStore, RuntimeBackends, RuntimeFileStore, RuntimeHarnessStore,
-    RuntimeMessageStore, RuntimeProviderStore, RuntimeSessionStore,
+    EventBus, RuntimeAgentStore, RuntimeBackends, RuntimeHarnessStore, RuntimeMessageStore,
+    RuntimeProviderStore, RuntimeSessionStore,
 };
 pub use builders::{AgentBuilder, HarnessBuilder, SessionBuilder, SingleSessionBuilder};
 pub use everruns_core::AssembledTurnContext;

--- a/crates/runtime/src/runtime.rs
+++ b/crates/runtime/src/runtime.rs
@@ -11,7 +11,7 @@ use crate::host::{
     RuntimeHostAdapter, RuntimeHostTurnContext, RuntimeSessionLifecycle, execute_act_activity,
     execute_input_activity, execute_reason_activity,
 };
-use crate::in_memory::InMemorySessionFileSystemFactory;
+use crate::in_memory::{InMemorySessionFileStore, InMemorySessionFileSystemFactory};
 use async_trait::async_trait;
 use everruns_core::agent::Agent;
 use everruns_core::atoms::{ActInput, AtomContext, InputAtomInput, ReasonInput};
@@ -270,20 +270,13 @@ impl InProcessRuntimeBuilder {
     pub async fn build(mut self) -> Result<InProcessRuntime> {
         let backends = match self.backends.take() {
             Some(backends) => backends,
-            None => {
-                let factory = self.platform_definition.session_file_system_factory();
-                let file_store: Arc<dyn SessionFileSystem> = if factory.is_disabled() {
-                    Arc::new(crate::in_memory::InMemorySessionFileStore::new())
-                } else {
-                    factory
-                        .create_session_file_system(
-                            self.session_file_system_factory_context.clone(),
-                        )
-                        .await?
-                };
-                RuntimeBackends::in_memory().with_file_store(file_store)
-            }
+            None => RuntimeBackends::in_memory(),
         };
+        let file_store = resolve_session_file_system(
+            &self.platform_definition,
+            self.session_file_system_factory_context.clone(),
+        )
+        .await?;
 
         if let Some(config) = self.llm_sim_config.take() {
             let driver = LlmSimDriver::new(config);
@@ -330,17 +323,14 @@ impl InProcessRuntimeBuilder {
             seed_runtime_initial_files(
                 backends.harness_store.as_ref(),
                 backends.agent_store.as_ref(),
-                backends.file_store.as_ref(),
+                file_store.as_ref(),
                 session,
             )
             .await?;
         }
 
         for (session_id, file) in &self.seeded_files {
-            backends
-                .file_store
-                .seed_initial_file(*session_id, file)
-                .await?;
+            file_store.seed_initial_file(*session_id, file).await?;
         }
 
         let persisting_emitter =
@@ -356,10 +346,24 @@ impl InProcessRuntimeBuilder {
             provider_store: backends.provider_store,
             event_bus: backends.event_bus,
             persisting_emitter,
-            file_store: backends.file_store,
+            file_store,
             storage_store: backends.storage_store,
             memory_store: backends.memory_store,
         })
+    }
+}
+
+async fn resolve_session_file_system(
+    platform_definition: &PlatformDefinition,
+    file_system_factory_context: SessionFileSystemFactoryContext,
+) -> Result<Arc<dyn SessionFileSystem>> {
+    let file_system_factory = platform_definition.session_file_system_factory();
+    if file_system_factory.is_disabled() {
+        Ok(Arc::new(InMemorySessionFileStore::new()))
+    } else {
+        Ok(file_system_factory
+            .create_session_file_system(file_system_factory_context)
+            .await?)
     }
 }
 

--- a/examples/coding-cli/README.md
+++ b/examples/coding-cli/README.md
@@ -116,22 +116,22 @@ ercode --provider llmsim -p "hi"
 
 ## How it's wired
 
-- `src/runtime.rs` — plugs `RealDiskFileStore` (from `everruns-runtime`)
-  rooted at the workspace, wrapped by two policy decorators
-  (`WriteBlocklistFileStore` and `ApprovalGatingFileStore`), into
-  `RuntimeBackends.file_store`. Registers the built-in
+- `src/runtime.rs` — registers a platform `SessionFileSystemFactory` that
+  creates a `RealDiskFileStore` (from `everruns-runtime`) rooted at the
+  workspace and wraps it with two policy decorators
+  (`WriteBlocklistFileStore` and `ApprovalGatingFileStore`). Registers the built-in
   `AgentInstructionsCapability` (live-reloads AGENTS.md every turn),
   `FileSystemCapability` (read/write/edit/list/grep/delete/stat tools on real
-  disk via the FileStore stack), and a tiny custom `CodingBashCapability` for
+  disk via the platform session filesystem stack), and a tiny custom `CodingBashCapability` for
   the shell tool. Picks a driver (Anthropic / OpenAI / llmsim).
 - `src/file_store_decorators.rs` — `WriteBlocklistFileStore` and
-  `ApprovalGatingFileStore`. Both implement `SessionFileStore +
-  RuntimeFileStore` and compose freely. EVE-478 plans to ship these in
-  `everruns-runtime`; until then they live here.
+  `ApprovalGatingFileStore`. Both implement `SessionFileSystem` and compose
+  freely. EVE-478 plans to ship these in `everruns-runtime`; until then they
+  live here.
 - `src/tools.rs` — `BashTool` only. Built-in `virtual_bash` runs against the
   VFS, not the real workspace, so the shell tool stays custom.
 - `src/approval.rs` — `ApprovalGate` and the request enum; the gate is shared
-  between the bash tool and the FileStore decorator.
+  between the bash tool and the session filesystem approval decorator.
 - `src/app.rs` + `src/main.rs` — ratatui TUI and one-shot CLI driver.
 
 ## Caveats

--- a/examples/coding-cli/src/approval.rs
+++ b/examples/coding-cli/src/approval.rs
@@ -1,5 +1,5 @@
 // Approval gate for destructive operations.
-// Decision: writes/deletes flow through SessionFileStore decorators; bash
+// Decision: writes/deletes flow through SessionFileSystem decorators; bash
 // goes through the BashTool directly. Both await an explicit yes from the
 // human via a oneshot channel. Read-only ops (read_file, list_directory,
 // grep) run free. The TUI installs an interactive gate, the `--print`

--- a/examples/coding-cli/src/file_store_decorators.rs
+++ b/examples/coding-cli/src/file_store_decorators.rs
@@ -1,7 +1,7 @@
-// Composable SessionFileStore decorators for policy enforcement.
+// Composable SessionFileSystem decorators for policy enforcement.
 //
 // EVE-478 plans to ship these in everruns-runtime; until then they live here
-// alongside the embedder that needs them. They wrap any `SessionFileStore`
+// alongside the embedder that needs them. They wrap any `SessionFileSystem`
 // (today: the runtime's `RealDiskFileStore`) and layer two concerns:
 //
 //   * WriteBlocklistFileStore — reject writes/deletes inside vendored or
@@ -18,9 +18,8 @@ use crate::approval::{ApprovalGate, ApprovalRequest};
 use async_trait::async_trait;
 use everruns_core::error::{AgentLoopError, Result};
 use everruns_core::session_file::{FileInfo, FileStat, GrepMatch, InitialFile, SessionFile};
-use everruns_core::traits::SessionFileStore;
+use everruns_core::traits::SessionFileSystem;
 use everruns_core::typed_id::SessionId;
-use everruns_runtime::RuntimeFileStore;
 use std::path::Component;
 use std::sync::Arc;
 
@@ -39,22 +38,18 @@ const DEFAULT_WRITE_BLOCKLIST: &[&str] = &[
 
 /// Reject writes into vendored / build directories.
 //
-// Non-generic over the wrapped store: we store an `Arc<dyn RuntimeFileStore>`
+// Non-generic over the wrapped store: we store an `Arc<dyn SessionFileSystem>`
 // rather than a generic `Arc<S>`. Two reasons:
-//   1. CI rustc (stable 1.95.0) reports E0119 on generic decorators that impl
-//      both `SessionFileStore` and `RuntimeFileStore` for the same generic
-//      `WriteBlocklistFileStore<S>`, even though the trait param of each impl
-//      differs. Couldn't reproduce locally on identical rustc, but trait
-//      objects sidestep the coherence question entirely.
+//   1. Trait objects sidestep coherence questions for decorator stacks.
 //   2. The only concrete value of `S` that ever flows through is the runtime's
 //      `RealDiskFileStore`; monomorphization wasn't earning anything.
 pub struct WriteBlocklistFileStore {
-    inner: Arc<dyn RuntimeFileStore>,
+    inner: Arc<dyn SessionFileSystem>,
     blocklist: Vec<String>,
 }
 
 impl WriteBlocklistFileStore {
-    pub fn new(inner: Arc<dyn RuntimeFileStore>) -> Self {
+    pub fn new(inner: Arc<dyn SessionFileSystem>) -> Self {
         Self {
             inner,
             blocklist: DEFAULT_WRITE_BLOCKLIST
@@ -81,7 +76,7 @@ impl WriteBlocklistFileStore {
 }
 
 #[async_trait]
-impl SessionFileStore for WriteBlocklistFileStore {
+impl SessionFileSystem for WriteBlocklistFileStore {
     async fn read_file(&self, session_id: SessionId, path: &str) -> Result<Option<SessionFile>> {
         self.inner.read_file(session_id, path).await
     }
@@ -167,18 +162,18 @@ impl SessionFileStore for WriteBlocklistFileStore {
 /// so the approval prompt can show a diff. That's one extra read per write,
 /// acceptable for a coding agent where writes are rare and small.
 pub struct ApprovalGatingFileStore {
-    inner: Arc<dyn RuntimeFileStore>,
+    inner: Arc<dyn SessionFileSystem>,
     gate: Arc<ApprovalGate>,
 }
 
 impl ApprovalGatingFileStore {
-    pub fn new(inner: Arc<dyn RuntimeFileStore>, gate: Arc<ApprovalGate>) -> Self {
+    pub fn new(inner: Arc<dyn SessionFileSystem>, gate: Arc<ApprovalGate>) -> Self {
         Self { inner, gate }
     }
 }
 
 #[async_trait]
-impl SessionFileStore for ApprovalGatingFileStore {
+impl SessionFileSystem for ApprovalGatingFileStore {
     async fn read_file(&self, session_id: SessionId, path: &str) -> Result<Option<SessionFile>> {
         self.inner.read_file(session_id, path).await
     }

--- a/examples/coding-cli/src/runtime.rs
+++ b/examples/coding-cli/src/runtime.rs
@@ -1,13 +1,14 @@
-// Runtime construction: wires `InProcessRuntime` with a real-disk
-// `SessionFileStore` so the built-in `agent_instructions`, `file_system`,
-// and `skills` capabilities operate against the embedder's actual workspace.
-// Only the `bash` tool is custom — it shells out to the host instead of
-// running against the VFS.
+// Runtime construction: wires `InProcessRuntime` through a platform
+// `SessionFileSystemFactory` so the built-in `agent_instructions`,
+// `file_system`, and `skills` capabilities operate against the embedder's
+// actual workspace. Only the `bash` tool is custom — it shells out to the host
+// instead of running against the VFS.
 
 use crate::approval::ApprovalGate;
 use crate::file_store_decorators::{ApprovalGatingFileStore, WriteBlocklistFileStore};
 use crate::tools::{BashTool, Workspace};
 use anyhow::{Context, Result, anyhow};
+use async_trait::async_trait;
 use everruns_core::capabilities::{
     AGENT_INSTRUCTIONS_CAPABILITY_ID, AgentInstructionsCapability, Capability, CapabilityStatus,
     FileSystemCapability, INFINITY_CONTEXT_CAPABILITY_ID, InfinityContextCapability,
@@ -21,11 +22,12 @@ use everruns_core::tools::Tool;
 use everruns_core::typed_id::SessionId;
 use everruns_core::{
     AgentCapabilityConfig, CapabilityRegistry, ModelWithProvider, PlatformDefinition,
+    SessionFileSystem, SessionFileSystemFactory, SessionFileSystemFactoryContext,
 };
 use everruns_integrations_duckduckgo::DuckDuckGoCapability;
 use everruns_runtime::{
     InProcessRuntime, InProcessRuntimeBuilder, RealDiskFileStore, RuntimeBackends,
-    RuntimeFileStore, RuntimeProviderStore,
+    RuntimeProviderStore,
 };
 use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
@@ -70,6 +72,30 @@ impl Capability for CodingBashCapability {
             self.workspace.clone(),
             self.gate.clone(),
         ))]
+    }
+}
+
+struct CodingCliSessionFileSystemFactory {
+    root: PathBuf,
+    gate: Arc<ApprovalGate>,
+}
+
+#[async_trait]
+impl SessionFileSystemFactory for CodingCliSessionFileSystemFactory {
+    fn name(&self) -> &'static str {
+        "CodingCliSessionFileSystemFactory"
+    }
+
+    async fn create_session_file_system(
+        &self,
+        _context: SessionFileSystemFactoryContext,
+    ) -> everruns_core::Result<Arc<dyn SessionFileSystem>> {
+        let disk: Arc<dyn SessionFileSystem> = Arc::new(RealDiskFileStore::new(&self.root)?);
+        let blocklisted: Arc<dyn SessionFileSystem> = Arc::new(WriteBlocklistFileStore::new(disk));
+        Ok(Arc::new(ApprovalGatingFileStore::new(
+            blocklisted,
+            self.gate.clone(),
+        )))
     }
 }
 
@@ -263,23 +289,17 @@ pub async fn build(
         .with_context(|| format!("canonicalize workspace: {}", workspace_root.display()))?;
     let workspace = Workspace::new(canonical_root.clone());
 
-    // Build the FileStore stack: ApprovalGating(WriteBlocklist(RealDisk)).
-    let disk: Arc<dyn RuntimeFileStore> = Arc::new(RealDiskFileStore::new(&canonical_root)?);
-    let blocklisted: Arc<dyn RuntimeFileStore> = Arc::new(WriteBlocklistFileStore::new(disk));
-    let gated: Arc<dyn RuntimeFileStore> =
-        Arc::new(ApprovalGatingFileStore::new(blocklisted, gate.clone()));
-    let file_store = gated;
-
-    // The rest of the backends stay in memory.
-    let backends = RuntimeBackends::in_memory().with_file_store(file_store);
+    // Non-filesystem backends stay in memory; the session filesystem is owned
+    // by the platform factory below.
+    let backends = RuntimeBackends::in_memory();
     let provider_store = backends.provider_store.clone();
 
     // Register a curated set of built-in capabilities (no opinionated bundle
     // — we want a tight, predictable surface for the coding-CLI) plus our
     // bash capability.
     //
-    // Filesystem-anchored (all read via the FileStore stack we built above,
-    // so they target the real workspace transparently):
+    // Filesystem-anchored (all read via the platform filesystem factory, so
+    // they target the real workspace transparently):
     //   * agent_instructions   — re-reads AGENTS.md every turn
     //   * session_file_system  — read/write/edit/list/grep/delete/stat tools
     //   * skills               — discovers SKILL.md under /.agents/skills/
@@ -302,7 +322,7 @@ pub async fn build(
     capabilities.register(WebFetchCapability::from_env());
     capabilities.register(CodingBashCapability {
         workspace: workspace.clone(),
-        gate,
+        gate: gate.clone(),
     });
 
     let mut driver_registry = DriverRegistry::new();
@@ -320,7 +340,14 @@ pub async fn build(
         },
     };
 
-    let platform = PlatformDefinition::new(capabilities, driver_registry);
+    let platform = PlatformDefinition::builder()
+        .capability_registry(capabilities)
+        .driver_registry(driver_registry)
+        .session_file_system_factory(Arc::new(CodingCliSessionFileSystemFactory {
+            root: canonical_root.clone(),
+            gate: gate.clone(),
+        }))
+        .build();
 
     // SingleSessionBuilder bundles the harness/agent/session shape with
     // defaults that runtime owns — keeps this example small and absorbs
@@ -341,7 +368,7 @@ pub async fn build(
         AgentCapabilityConfig::new(PROMPT_CACHING_CAPABILITY_ID),
         AgentCapabilityConfig::new("duckduckgo"),
         // enable_file_download=true: saved responses land on disk through the
-        // RealDiskFileStore stack, so the blocklist and approval gate apply.
+        // platform filesystem stack, so the blocklist and approval gate apply.
         AgentCapabilityConfig::with_config(
             "web_fetch",
             serde_json::json!({ "enable_file_download": true }),
@@ -351,8 +378,8 @@ pub async fn build(
 
     let mut builder = InProcessRuntimeBuilder::new()
         .platform_definition(platform)
-        .backends(backends)
         .default_model(default_model)
+        .backends(backends)
         .single_session(move |s| {
             let mut s = s
                 .harness("coding-cli", HARNESS_PROMPT)
@@ -392,7 +419,7 @@ pub async fn build(
 
     // Probe for AGENTS.md / CLAUDE.md / .agents.md on disk for the startup
     // banner only — the agent itself sees content via AgentInstructionsCapability,
-    // which re-reads /AGENTS.md every turn through the runtime FileStore.
+    // which re-reads /AGENTS.md every turn through the session filesystem.
     let instruction_files = ["AGENTS.md", "CLAUDE.md", ".agents.md"]
         .iter()
         .filter(|f| canonical_root.join(f).exists())

--- a/examples/coding-cli/src/tools.rs
+++ b/examples/coding-cli/src/tools.rs
@@ -1,8 +1,8 @@
 // Bash tool for the coding CLI.
 //
 // Read/write/edit/list/grep/stat all live in the built-in `file_system`
-// capability now that ercode plugs `RealDiskFileStore` as the runtime
-// FileStore. The bash tool stays custom because the built-in `virtual_bash`
+// capability now that ercode selects `RealDiskFileStore` through its platform
+// filesystem factory. The bash tool stays custom because the built-in `virtual_bash`
 // runs commands against the VFS, not against the real workspace, and the
 // security model for unsandboxed shell-on-host needs ercode-specific policy
 // (timeout, output cap, approval gate). See EVE-478 for the eventual
@@ -19,7 +19,7 @@ use tokio::io::AsyncReadExt;
 use tokio::process::Command;
 
 /// Workspace context for the bash tool. Just the root path — path
-/// resolution for file ops now lives inside `RealDiskFileStore`.
+/// resolution for file ops now lives inside the configured session filesystem.
 #[derive(Clone)]
 pub struct Workspace {
     root: Arc<PathBuf>,

--- a/specs/file-store.md
+++ b/specs/file-store.md
@@ -29,9 +29,8 @@ TUI in PR #1839) revealed a real seam: `AgentInstructionsCapability` and
 VFS *is* the workspace) but breaks in an embedded coding-CLI where the
 workspace is a real directory on disk.
 
-The original pluggable seam lived on `RuntimeBackends.file_store`; the platform
-profile now owns the higher-level factory so embedders can choose the session
-filesystem as part of the deployment surface.
+The pluggable seam is `PlatformDefinition.session_file_system_factory`, so
+embedders choose the session filesystem as part of the deployment surface.
 
 ## Decision Process
 
@@ -39,7 +38,7 @@ We evaluated four options before landing on the pluggable-store approach:
 
 | Option | Description | Outcome |
 |--------|-------------|---------|
-| A. Pluggable `SessionFileSystem` at runtime builder | Single trait, embedder picks the impl. Already supported by `RuntimeBackends.file_store`. | Superseded by platform factories. |
+| A. Pluggable `SessionFileSystem` at runtime builder | Single trait, embedder picks the impl. | Superseded by platform factories. |
 | B. Mount-point overlay (`MountSource::HostPath`) | Compose mounts on top of a base filesystem via a resolver. | Eventual destination. Strict superset of the factory seam. |
 | C. Split `SystemPromptContext` into `file_store` + `WorkspaceSource` | Separate sandbox writes from project-context reads. | Rejected. Parallel abstraction that B subsumes naturally via `MountAccess::ReadOnly`. |
 | D. Per-capability factory (`AgentInstructionsCapability::with_loader(...)`) | Each capability re-solves the loader problem itself. | Rejected. Does not compose; doesn't scale to N capabilities. |
@@ -255,9 +254,6 @@ let platform = PlatformDefinition::builder()
     ))
     .build();
 ```
-
-`RuntimeBackends.file_store` remains as an explicit override path for embedders
-that need to supply an already-resolved filesystem bundle.
 
 Factories may require host dependencies such as a database handle, virtual
 mount registry, or workspace root. `InProcessRuntimeBuilder` accepts a

--- a/specs/runtime.md
+++ b/specs/runtime.md
@@ -199,22 +199,17 @@ embedded runtime needs for:
 - configuring the runtime default model
 
 Use `RuntimeBackends::in_memory()` for the all-in-memory default, then chain
-`.with_file_store(...)`, `.with_message_store(...)`, etc. to override individual
-stores.
+`.with_message_store(...)`, `.with_storage_store(...)`, etc. to override
+individual non-filesystem stores.
 
 Session files are a platform service: `PlatformDefinition` carries a
-`SessionFileSystemFactory`, and the runtime consults it only when the
-builder falls back to its default backends — i.e., when the embedder does
-not call `InProcessRuntimeBuilder::backends(...)`. A custom `RuntimeBackends`
-bundle always carries its own `file_store` (including the one
-`RuntimeBackends::in_memory()` installs), and that value wins; the platform
-factory is not consulted to override it. Embedders can choose
-`InMemorySessionFileSystemFactory` (default), `RealDiskSessionFileSystemFactory`
-(rooted at a host directory; honours `.gitignore` for grep), or a custom future
-factory such as S3 — or skip the factory and supply an explicit `file_store`
-via `.with_file_store(...)`. See `specs/file-store.md` for the trait contract,
-path namespace, and the rule that capabilities should consume the seam rather
-than touching `std::fs` directly.
+`SessionFileSystemFactory`, and the runtime always resolves the concrete
+filesystem from that factory before seeding files or executing turns. Embedders
+can choose `InMemorySessionFileSystemFactory` (default),
+`RealDiskSessionFileSystemFactory` (rooted at a host directory; honours
+`.gitignore` for grep), or a custom future factory such as S3. See
+`specs/file-store.md` for the trait contract, path namespace, and the rule that
+capabilities should consume the seam rather than touching `std::fs` directly.
 
 Factories that depend on host values receive them through
 `SessionFileSystemFactoryContext`; the in-process builder accepts this context


### PR DESCRIPTION
## What
- Remove session filesystem ownership from `RuntimeBackends`.
- Make `InProcessRuntimeBuilder` always resolve the concrete `SessionFileSystem` from `PlatformDefinition.session_file_system_factory`.
- Move coding-cli real-disk/blocklist/approval wiring into a platform `SessionFileSystemFactory`.
- Update runtime real-disk examples and specs to use the platform factory path.

## Why
Filesystem backend selection is a platform concern. Keeping `file_store` in `RuntimeBackends` preserved the old lower-level concept and let embedders bypass the platform factory, as coding-cli did.

## How
- `RuntimeBackends` now contains non-filesystem stores only.
- Runtime build resolves `file_store` separately from the platform factory before initial-file seeding and turn execution.
- Removed the old `RuntimeFileStore` alias from the runtime public exports.
- Coding-cli registers `CodingCliSessionFileSystemFactory`, which constructs `ApprovalGatingFileStore(WriteBlocklistFileStore(RealDiskFileStore))`.

## Risk
- Medium
- Can break embedders that still construct `RuntimeBackends` with `file_store`; this is intentional for the new single-concept model.
- Can break runtime file seeding if platform factory resolution happens too late; covered by runtime tests and the real-disk example smoke test.

## Security
- Threat categories reviewed: TM-FS, TM-BASH, TM-DOS
- Findings and resolutions: No new external input surface. Existing real-disk path canonicalization remains in `RealDiskFileStore`; coding-cli write blocklist and approval gate still wrap writes/deletes through the new factory. Bash execution path is unchanged.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

## Validation
- `cargo fmt --check`
- `cargo check -p everruns-coding-cli`
- `cargo test -p everruns-runtime --test in_process_runtime_test -- --nocapture`
- `cargo run -p everruns-runtime --example real_disk_file_system_tools`
- `cargo run -p everruns-coding-cli -- --provider sim --print 'write /workspace/codex-factory-smoke.txt with ok'`
- `just pre-push`
