### PR TITLE
fix(server): adapt agents/commands.rs to CommandError struct refactor

### DIFF
--- a/crates/server/src/domains/agents/commands.rs
+++ b/crates/server/src/domains/agents/commands.rs
@@ -1019,7 +1019,10 @@ async fn create_auto_snapshot_from_agent(
             .await
         {
             Ok(version) => return Ok(version),
-            Err(CommandError::Conflict(message)) => {
+            Err(CommandError {
+                kind: CommandErrorKind::Conflict(message),
+                ..
+            }) => {
                 last_conflict = Some(message);
             }
             Err(error) => return Err(error),
@@ -1781,7 +1784,7 @@ mod tests {
         .expect_err("manual publish cannot use automatic change kind");
 
         assert!(
-            matches!(err, CommandError::BadRequest(_)),
+            matches!(err.kind, CommandErrorKind::BadRequest(_)),
             "expected BadRequest, got {err:?}"
         );
     }
@@ -1819,7 +1822,7 @@ mod tests {
         .expect_err("draft snapshot cannot become default");
 
         assert!(
-            matches!(err, CommandError::BadRequest(_)),
+            matches!(err.kind, CommandErrorKind::BadRequest(_)),
             "expected BadRequest, got {err:?}"
         );
     }


### PR DESCRIPTION
Superseded by #1851 (`ae19251 feat(openapi): payments + LLM + durable field descriptions`) which independently adapted the same three `CommandError` call sites in `crates/server/src/domains/agents/commands.rs`. Confirmed on `origin/main`:

```
$ git show ae19251:crates/server/src/domains/agents/commands.rs | grep -n "CommandErrorKind::Conflict\|CommandErrorKind::BadRequest"
1023:                kind: CommandErrorKind::Conflict(message),
1790:                    kind: CommandErrorKind::BadRequest(_),
1834:                    kind: CommandErrorKind::BadRequest(_),
```

Closing — no action needed.