### PR TITLE
refactor(runtime): drop store shim wrappers, add EventBus + in_memory()

### DIFF
--- a/crates/core/src/message_retriever.rs
+++ b/crates/core/src/message_retriever.rs
@@ -124,3 +124,31 @@ pub trait MessageRetriever: Send + Sync {
         Ok(self.load(session_id).await?.len())
     }
 }
+
+#[async_trait]
+impl<T: MessageRetriever + ?Sized> MessageRetriever for std::sync::Arc<T> {
+    async fn get(&self, session_id: SessionId, message_id: MessageId) -> Result<Option<Message>> {
+        (**self).get(session_id, message_id).await
+    }
+
+    async fn load(&self, session_id: SessionId) -> Result<Vec<Message>> {
+        (**self).load(session_id).await
+    }
+
+    async fn load_filtered(&self, query: MessageQuery) -> Result<Vec<Message>> {
+        (**self).load_filtered(query).await
+    }
+
+    async fn load_page(
+        &self,
+        session_id: SessionId,
+        offset: usize,
+        limit: usize,
+    ) -> Result<Vec<Message>> {
+        (**self).load_page(session_id, offset, limit).await
+    }
+
+    async fn count(&self, session_id: SessionId) -> Result<usize> {
+        (**self).count(session_id).await
+    }
+}

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -41,6 +41,13 @@ pub trait AgentStore: Send + Sync {
     async fn get_agent(&self, agent_id: AgentId) -> Result<Option<Agent>>;
 }
 
+#[async_trait]
+impl<T: AgentStore + ?Sized> AgentStore for std::sync::Arc<T> {
+    async fn get_agent(&self, agent_id: AgentId) -> Result<Option<Agent>> {
+        (**self).get_agent(agent_id).await
+    }
+}
+
 // ============================================================================
 // HarnessStore - For retrieving harness configurations
 // ============================================================================
@@ -64,6 +71,13 @@ pub trait HarnessStore: Send + Sync {
     async fn get_harness_chain(&self, harness_id: HarnessId) -> Result<Vec<Harness>>;
 }
 
+#[async_trait]
+impl<T: HarnessStore + ?Sized> HarnessStore for std::sync::Arc<T> {
+    async fn get_harness_chain(&self, harness_id: HarnessId) -> Result<Vec<Harness>> {
+        (**self).get_harness_chain(harness_id).await
+    }
+}
+
 // ============================================================================
 // SessionStore - For retrieving session information
 // ============================================================================
@@ -82,11 +96,25 @@ pub trait SessionStore: Send + Sync {
     async fn get_session(&self, session_id: SessionId) -> Result<Option<Session>>;
 }
 
+#[async_trait]
+impl<T: SessionStore + ?Sized> SessionStore for std::sync::Arc<T> {
+    async fn get_session(&self, session_id: SessionId) -> Result<Option<Session>> {
+        (**self).get_session(session_id).await
+    }
+}
+
 /// Trait for updating mutable session metadata.
 #[async_trait]
 pub trait SessionMutator: Send + Sync {
     /// Update a session's human-readable title.
     async fn update_session_title(&self, session_id: SessionId, title: String) -> Result<Session>;
+}
+
+#[async_trait]
+impl<T: SessionMutator + ?Sized> SessionMutator for std::sync::Arc<T> {
+    async fn update_session_title(&self, session_id: SessionId, title: String) -> Result<Session> {
+        (**self).update_session_title(session_id, title).await
+    }
 }
 
 // ============================================================================
@@ -128,6 +156,20 @@ pub trait LlmProviderStore: Send + Sync {
     ///
     /// Returns the system default model when an agent has no default_model_id set.
     async fn get_default_model(&self) -> Result<Option<ModelWithProvider>>;
+}
+
+#[async_trait]
+impl<T: LlmProviderStore + ?Sized> LlmProviderStore for std::sync::Arc<T> {
+    async fn get_model_with_provider(
+        &self,
+        model_id: ModelId,
+    ) -> Result<Option<ModelWithProvider>> {
+        (**self).get_model_with_provider(model_id).await
+    }
+
+    async fn get_default_model(&self) -> Result<Option<ModelWithProvider>> {
+        (**self).get_default_model().await
+    }
 }
 
 // ============================================================================
@@ -370,6 +412,80 @@ pub trait SessionFileSystem: Send + Sync {
         self.write_file(session_id, &file.path, &file.content, &file.encoding)
             .await?;
         Ok(())
+    }
+}
+
+#[async_trait]
+impl<T: SessionFileSystem + ?Sized> SessionFileSystem for std::sync::Arc<T> {
+    async fn read_file(&self, session_id: SessionId, path: &str) -> Result<Option<SessionFile>> {
+        (**self).read_file(session_id, path).await
+    }
+
+    async fn write_file(
+        &self,
+        session_id: SessionId,
+        path: &str,
+        content: &str,
+        encoding: &str,
+    ) -> Result<SessionFile> {
+        (**self)
+            .write_file(session_id, path, content, encoding)
+            .await
+    }
+
+    async fn write_file_if_content_matches(
+        &self,
+        session_id: SessionId,
+        path: &str,
+        expected_content: &str,
+        expected_encoding: &str,
+        content: &str,
+        encoding: &str,
+    ) -> Result<Option<SessionFile>> {
+        (**self)
+            .write_file_if_content_matches(
+                session_id,
+                path,
+                expected_content,
+                expected_encoding,
+                content,
+                encoding,
+            )
+            .await
+    }
+
+    async fn delete_file(
+        &self,
+        session_id: SessionId,
+        path: &str,
+        recursive: bool,
+    ) -> Result<bool> {
+        (**self).delete_file(session_id, path, recursive).await
+    }
+
+    async fn list_directory(&self, session_id: SessionId, path: &str) -> Result<Vec<FileInfo>> {
+        (**self).list_directory(session_id, path).await
+    }
+
+    async fn stat_file(&self, session_id: SessionId, path: &str) -> Result<Option<FileStat>> {
+        (**self).stat_file(session_id, path).await
+    }
+
+    async fn grep_files(
+        &self,
+        session_id: SessionId,
+        pattern: &str,
+        path_pattern: Option<&str>,
+    ) -> Result<Vec<GrepMatch>> {
+        (**self).grep_files(session_id, pattern, path_pattern).await
+    }
+
+    async fn create_directory(&self, session_id: SessionId, path: &str) -> Result<FileInfo> {
+        (**self).create_directory(session_id, path).await
+    }
+
+    async fn seed_initial_file(&self, session_id: SessionId, file: &InitialFile) -> Result<()> {
+        (**self).seed_initial_file(session_id, file).await
     }
 }
 

--- a/crates/runtime/examples/real_disk_agent_instructions.rs
+++ b/crates/runtime/examples/real_disk_agent_instructions.rs
@@ -17,18 +17,11 @@ use chrono::Utc;
 use everruns_core::capabilities::AgentInstructionsCapability;
 use everruns_core::llm_driver_registry::DriverRegistry;
 use everruns_core::llmsim_driver::LlmSimConfig;
-use everruns_core::memory::{
-    InMemoryAgentStore, InMemoryEventEmitter, InMemoryHarnessStore, InMemoryLlmProviderStore,
-    InMemoryMemoryStore, InMemoryMessageRetriever,
-};
 use everruns_core::{
     Agent, AgentCapabilityConfig, AgentStatus, CapabilityRegistry, Harness, HarnessStatus,
     LlmProviderType, ModelWithProvider, PlatformDefinition, Session, SessionStatus,
 };
-use everruns_runtime::{
-    InMemorySessionStorageStore, InMemorySessionStore, InProcessRuntimeBuilder, RealDiskFileStore,
-    RuntimeBackends,
-};
+use everruns_runtime::{InProcessRuntimeBuilder, RealDiskFileStore, RuntimeBackends};
 use tempfile::TempDir;
 use uuid::Uuid;
 
@@ -46,19 +39,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // 3. Build a RuntimeBackends with the real-disk file_store. Everything
     //    else stays in memory — only the workspace surface is real.
-    let event_emitter = InMemoryEventEmitter::new();
-    let backends = RuntimeBackends {
-        harness_store: Arc::new(InMemoryHarnessStore::new()),
-        agent_store: Arc::new(InMemoryAgentStore::new()),
-        session_store: Arc::new(InMemorySessionStore::new()),
-        message_store: Arc::new(InMemoryMessageRetriever::new()),
-        provider_store: Arc::new(InMemoryLlmProviderStore::new()),
-        event_emitter: Arc::new(event_emitter.clone()),
-        event_collector: Some(Arc::new(event_emitter)),
-        file_store: Arc::new(RealDiskFileStore::new(workspace.path())?),
-        storage_store: Arc::new(InMemorySessionStorageStore::new()),
-        memory_store: Arc::new(InMemoryMemoryStore::new()),
-    };
+    let backends = RuntimeBackends::in_memory()
+        .with_file_store(Arc::new(RealDiskFileStore::new(workspace.path())?));
 
     // 4. Register AgentInstructionsCapability and a no-op math capability so
     //    the harness has something to assemble.

--- a/crates/runtime/examples/real_disk_file_system_tools.rs
+++ b/crates/runtime/examples/real_disk_file_system_tools.rs
@@ -20,18 +20,11 @@ use chrono::Utc;
 use everruns_core::capabilities::FileSystemCapability;
 use everruns_core::llm_driver_registry::DriverRegistry;
 use everruns_core::llmsim_driver::LlmSimConfig;
-use everruns_core::memory::{
-    InMemoryAgentStore, InMemoryEventEmitter, InMemoryHarnessStore, InMemoryLlmProviderStore,
-    InMemoryMemoryStore, InMemoryMessageRetriever,
-};
 use everruns_core::{
     Agent, AgentCapabilityConfig, AgentStatus, CapabilityRegistry, Harness, HarnessStatus,
     LlmProviderType, ModelWithProvider, PlatformDefinition, Session, SessionStatus, ToolCall,
 };
-use everruns_runtime::{
-    InMemorySessionStorageStore, InMemorySessionStore, InProcessRuntimeBuilder, RealDiskFileStore,
-    RuntimeBackends,
-};
+use everruns_runtime::{InProcessRuntimeBuilder, RealDiskFileStore, RuntimeBackends};
 use tempfile::TempDir;
 use uuid::Uuid;
 
@@ -45,19 +38,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     std::fs::write(workspace.path().join("input.txt"), "hello from real disk")?;
 
     // 3. Plug RealDiskFileStore into the runtime backends.
-    let event_emitter = InMemoryEventEmitter::new();
-    let backends = RuntimeBackends {
-        harness_store: Arc::new(InMemoryHarnessStore::new()),
-        agent_store: Arc::new(InMemoryAgentStore::new()),
-        session_store: Arc::new(InMemorySessionStore::new()),
-        message_store: Arc::new(InMemoryMessageRetriever::new()),
-        provider_store: Arc::new(InMemoryLlmProviderStore::new()),
-        event_emitter: Arc::new(event_emitter.clone()),
-        event_collector: Some(Arc::new(event_emitter)),
-        file_store: Arc::new(RealDiskFileStore::new(workspace.path())?),
-        storage_store: Arc::new(InMemorySessionStorageStore::new()),
-        memory_store: Arc::new(InMemoryMemoryStore::new()),
-    };
+    let backends = RuntimeBackends::in_memory()
+        .with_file_store(Arc::new(RealDiskFileStore::new(workspace.path())?));
 
     // 4. Register only the built-in FileSystemCapability — no custom tools.
     let mut capabilities = CapabilityRegistry::new();

--- a/crates/runtime/src/backends.rs
+++ b/crates/runtime/src/backends.rs
@@ -1,27 +1,30 @@
 // Public backend contract for the embedded runtime.
 // Decision: runtime extends core's read-only traits with the minimal write
-// operations needed for seeding and message persistence.
+// operations needed for seeding and message persistence. Trait upcasting +
+// blanket `Arc<T>: T` impls in core let the runtime forward to atoms without
+// shim wrappers.
 
-use crate::in_memory::InMemorySessionStore;
+use crate::in_memory::{
+    InMemorySessionFileStore, InMemorySessionStorageStore, InMemorySessionStore,
+};
 use async_trait::async_trait;
 use everruns_core::agent::Agent;
 use everruns_core::error::Result;
-use everruns_core::events::{Event, EventRequest};
+use everruns_core::events::Event;
 use everruns_core::harness::Harness;
 use everruns_core::memory::{
     InMemoryAgentStore, InMemoryEventEmitter, InMemoryHarnessStore, InMemoryLlmProviderStore,
-    InMemoryMessageRetriever,
+    InMemoryMemoryStore, InMemoryMessageRetriever,
 };
 use everruns_core::memory_store::MemoryStoreBackend;
 use everruns_core::message::Message;
 use everruns_core::message_retriever::{InputMessage, MessageRetriever};
 use everruns_core::session::Session;
-use everruns_core::session_file::SessionFile;
 use everruns_core::traits::{
     AgentStore, EventEmitter, HarnessStore, LlmProviderStore, ModelWithProvider, SessionFileSystem,
     SessionMutator, SessionStorageStore, SessionStore,
 };
-use everruns_core::typed_id::{AgentId, HarnessId, MessageId, ModelId, SessionId};
+use everruns_core::typed_id::SessionId;
 use std::sync::Arc;
 
 /// Agent store contract for runtime seeding and lookup.
@@ -69,17 +72,33 @@ pub trait RuntimeProviderStore: LlmProviderStore + Send + Sync {
     async fn set_default_model(&self, model: ModelWithProvider) -> Result<()>;
 }
 
-/// Optional event collector for embedders that want to inspect emitted events.
+/// Event sink that supports emission and optional collection.
+///
+/// Every `EventBus` is an `EventEmitter`. Embedders that want to inspect
+/// emitted events override `collected_events`; production hosts inherit the
+/// no-op default.
 #[async_trait]
-pub trait RuntimeEventCollector: Send + Sync {
-    /// Return all collected events.
-    async fn events(&self) -> Vec<Event>;
+pub trait EventBus: EventEmitter {
+    /// Return all collected events. Defaults to an empty `Vec` for buses
+    /// that do not retain events.
+    async fn collected_events(&self) -> Vec<Event> {
+        Vec::new()
+    }
+}
+
+#[async_trait]
+impl<T: EventBus + ?Sized> EventBus for Arc<T> {
+    async fn collected_events(&self) -> Vec<Event> {
+        (**self).collected_events().await
+    }
 }
 
 /// Backend bundle supplied to the embedded runtime.
 ///
 /// Use this when you want the public runtime orchestration but your own store
-/// implementations instead of the built-in in-memory ones.
+/// implementations instead of the built-in in-memory ones. For an
+/// all-in-memory baseline plus targeted overrides, use
+/// [`RuntimeBackends::in_memory`] followed by `with_*` setters.
 #[derive(Clone)]
 pub struct RuntimeBackends {
     /// Harness definitions available to the runtime.
@@ -92,10 +111,8 @@ pub struct RuntimeBackends {
     pub message_store: Arc<dyn RuntimeMessageStore>,
     /// Model/provider resolution and default-model configuration.
     pub provider_store: Arc<dyn RuntimeProviderStore>,
-    /// Event sink used during turn execution.
-    pub event_emitter: Arc<dyn EventEmitter>,
-    /// Optional collector for `InProcessRuntime::events()`.
-    pub event_collector: Option<Arc<dyn RuntimeEventCollector>>,
+    /// Event sink (emit + optional collection).
+    pub event_bus: Arc<dyn EventBus>,
     /// Session filesystem backend.
     pub file_store: Arc<dyn SessionFileSystem>,
     /// Session key/value + secret storage backend.
@@ -104,184 +121,69 @@ pub struct RuntimeBackends {
     pub memory_store: Arc<dyn MemoryStoreBackend>,
 }
 
-#[derive(Clone)]
-pub(crate) struct DynAgentStore(pub Arc<dyn RuntimeAgentStore>);
-
-#[async_trait]
-impl AgentStore for DynAgentStore {
-    async fn get_agent(&self, agent_id: AgentId) -> Result<Option<Agent>> {
-        self.0.get_agent(agent_id).await
-    }
-}
-
-#[derive(Clone)]
-pub(crate) struct DynHarnessStore(pub Arc<dyn RuntimeHarnessStore>);
-
-#[async_trait]
-impl HarnessStore for DynHarnessStore {
-    async fn get_harness_chain(&self, harness_id: HarnessId) -> Result<Vec<Harness>> {
-        self.0.get_harness_chain(harness_id).await
-    }
-}
-
-#[derive(Clone)]
-pub(crate) struct DynSessionStore(pub Arc<dyn RuntimeSessionStore>);
-
-#[async_trait]
-impl SessionStore for DynSessionStore {
-    async fn get_session(&self, session_id: SessionId) -> Result<Option<Session>> {
-        self.0.get_session(session_id).await
-    }
-}
-
-#[async_trait]
-impl SessionMutator for DynSessionStore {
-    async fn update_session_title(&self, session_id: SessionId, title: String) -> Result<Session> {
-        self.0.update_session_title(session_id, title).await
-    }
-}
-
-#[derive(Clone)]
-pub(crate) struct DynMessageStore(pub Arc<dyn RuntimeMessageStore>);
-
-#[async_trait]
-impl MessageRetriever for DynMessageStore {
-    async fn get(&self, session_id: SessionId, message_id: MessageId) -> Result<Option<Message>> {
-        self.0.get(session_id, message_id).await
+impl RuntimeBackends {
+    /// Backend bundle with in-memory implementations for every store.
+    ///
+    /// Suitable for tests, examples, and the default runtime configuration.
+    /// Use the chainable `with_*` setters to override individual stores.
+    pub fn in_memory() -> Self {
+        let event_bus = Arc::new(InMemoryEventEmitter::new());
+        Self {
+            harness_store: Arc::new(InMemoryHarnessStore::new()),
+            agent_store: Arc::new(InMemoryAgentStore::new()),
+            session_store: Arc::new(InMemorySessionStore::new()),
+            message_store: Arc::new(InMemoryMessageRetriever::new()),
+            provider_store: Arc::new(InMemoryLlmProviderStore::new()),
+            event_bus,
+            file_store: Arc::new(InMemorySessionFileStore::new()),
+            storage_store: Arc::new(InMemorySessionStorageStore::new()),
+            memory_store: Arc::new(InMemoryMemoryStore::new()),
+        }
     }
 
-    async fn load(&self, session_id: SessionId) -> Result<Vec<Message>> {
-        self.0.load(session_id).await
+    pub fn with_harness_store(mut self, store: Arc<dyn RuntimeHarnessStore>) -> Self {
+        self.harness_store = store;
+        self
     }
 
-    async fn load_filtered(
-        &self,
-        query: everruns_core::message_filter::MessageQuery,
-    ) -> Result<Vec<Message>> {
-        self.0.load_filtered(query).await
+    pub fn with_agent_store(mut self, store: Arc<dyn RuntimeAgentStore>) -> Self {
+        self.agent_store = store;
+        self
     }
 
-    async fn load_page(
-        &self,
-        session_id: SessionId,
-        offset: usize,
-        limit: usize,
-    ) -> Result<Vec<Message>> {
-        self.0.load_page(session_id, offset, limit).await
+    pub fn with_session_store(mut self, store: Arc<dyn RuntimeSessionStore>) -> Self {
+        self.session_store = store;
+        self
     }
 
-    async fn count(&self, session_id: SessionId) -> Result<usize> {
-        self.0.count(session_id).await
-    }
-}
-
-#[derive(Clone)]
-pub(crate) struct DynFileStore(pub Arc<dyn SessionFileSystem>);
-
-#[async_trait]
-impl SessionFileSystem for DynFileStore {
-    async fn read_file(&self, session_id: SessionId, path: &str) -> Result<Option<SessionFile>> {
-        self.0.read_file(session_id, path).await
+    pub fn with_message_store(mut self, store: Arc<dyn RuntimeMessageStore>) -> Self {
+        self.message_store = store;
+        self
     }
 
-    async fn write_file(
-        &self,
-        session_id: SessionId,
-        path: &str,
-        content: &str,
-        encoding: &str,
-    ) -> Result<SessionFile> {
-        self.0.write_file(session_id, path, content, encoding).await
+    pub fn with_provider_store(mut self, store: Arc<dyn RuntimeProviderStore>) -> Self {
+        self.provider_store = store;
+        self
     }
 
-    async fn delete_file(
-        &self,
-        session_id: SessionId,
-        path: &str,
-        recursive: bool,
-    ) -> Result<bool> {
-        self.0.delete_file(session_id, path, recursive).await
+    pub fn with_event_bus(mut self, bus: Arc<dyn EventBus>) -> Self {
+        self.event_bus = bus;
+        self
     }
 
-    async fn list_directory(
-        &self,
-        session_id: SessionId,
-        path: &str,
-    ) -> Result<Vec<everruns_core::session_file::FileInfo>> {
-        self.0.list_directory(session_id, path).await
+    pub fn with_file_store(mut self, store: Arc<dyn SessionFileSystem>) -> Self {
+        self.file_store = store;
+        self
     }
 
-    async fn stat_file(
-        &self,
-        session_id: SessionId,
-        path: &str,
-    ) -> Result<Option<everruns_core::session_file::FileStat>> {
-        self.0.stat_file(session_id, path).await
+    pub fn with_storage_store(mut self, store: Arc<dyn SessionStorageStore>) -> Self {
+        self.storage_store = store;
+        self
     }
 
-    async fn grep_files(
-        &self,
-        session_id: SessionId,
-        pattern: &str,
-        path_pattern: Option<&str>,
-    ) -> Result<Vec<everruns_core::session_file::GrepMatch>> {
-        self.0.grep_files(session_id, pattern, path_pattern).await
-    }
-
-    async fn create_directory(
-        &self,
-        session_id: SessionId,
-        path: &str,
-    ) -> Result<everruns_core::session_file::FileInfo> {
-        self.0.create_directory(session_id, path).await
-    }
-
-    async fn write_file_if_content_matches(
-        &self,
-        session_id: SessionId,
-        path: &str,
-        expected_content: &str,
-        expected_encoding: &str,
-        content: &str,
-        encoding: &str,
-    ) -> Result<Option<SessionFile>> {
-        self.0
-            .write_file_if_content_matches(
-                session_id,
-                path,
-                expected_content,
-                expected_encoding,
-                content,
-                encoding,
-            )
-            .await
-    }
-}
-
-#[derive(Clone)]
-pub(crate) struct DynProviderStore(pub Arc<dyn RuntimeProviderStore>);
-
-#[async_trait]
-impl LlmProviderStore for DynProviderStore {
-    async fn get_model_with_provider(
-        &self,
-        model_id: ModelId,
-    ) -> Result<Option<ModelWithProvider>> {
-        self.0.get_model_with_provider(model_id).await
-    }
-
-    async fn get_default_model(&self) -> Result<Option<ModelWithProvider>> {
-        self.0.get_default_model().await
-    }
-}
-
-#[derive(Clone)]
-pub(crate) struct DynEventEmitter(pub Arc<dyn EventEmitter>);
-
-#[async_trait]
-impl EventEmitter for DynEventEmitter {
-    async fn emit(&self, request: EventRequest) -> Result<Event> {
-        self.0.emit(request).await
+    pub fn with_memory_store(mut self, store: Arc<dyn MemoryStoreBackend>) -> Self {
+        self.memory_store = store;
+        self
     }
 }
 
@@ -325,7 +227,6 @@ impl RuntimeMessageStore for InMemoryMessageRetriever {
 }
 
 #[async_trait]
-#[async_trait]
 impl RuntimeProviderStore for InMemoryLlmProviderStore {
     async fn set_default_model(&self, model: ModelWithProvider) -> Result<()> {
         InMemoryLlmProviderStore::set_default_model(self, model).await;
@@ -334,8 +235,8 @@ impl RuntimeProviderStore for InMemoryLlmProviderStore {
 }
 
 #[async_trait]
-impl RuntimeEventCollector for InMemoryEventEmitter {
-    async fn events(&self) -> Vec<Event> {
+impl EventBus for InMemoryEventEmitter {
+    async fn collected_events(&self) -> Vec<Event> {
         InMemoryEventEmitter::events(self).await
     }
 }

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -95,8 +95,8 @@ mod runtime;
 mod turn_strategy;
 
 pub use backends::{
-    RuntimeAgentStore, RuntimeBackends, RuntimeEventCollector, RuntimeFileStore,
-    RuntimeHarnessStore, RuntimeMessageStore, RuntimeProviderStore, RuntimeSessionStore,
+    EventBus, RuntimeAgentStore, RuntimeBackends, RuntimeFileStore, RuntimeHarnessStore,
+    RuntimeMessageStore, RuntimeProviderStore, RuntimeSessionStore,
 };
 pub use builders::{AgentBuilder, HarnessBuilder, SessionBuilder, SingleSessionBuilder};
 pub use everruns_core::AssembledTurnContext;

--- a/crates/runtime/src/runtime.rs
+++ b/crates/runtime/src/runtime.rs
@@ -3,15 +3,11 @@
 // and capability resolution path as the durable worker so behavior stays close.
 
 use crate::backends::{
-    DynAgentStore, DynEventEmitter, DynFileStore, DynHarnessStore, DynMessageStore,
-    DynProviderStore, DynSessionStore, RuntimeAgentStore, RuntimeBackends, RuntimeEventCollector,
-    RuntimeHarnessStore, RuntimeMessageStore, RuntimeProviderStore, RuntimeSessionStore,
+    EventBus, RuntimeAgentStore, RuntimeBackends, RuntimeHarnessStore, RuntimeMessageStore,
+    RuntimeProviderStore, RuntimeSessionStore,
 };
 use crate::builders::SingleSessionBuilder;
-use crate::in_memory::{
-    InMemorySessionFileStore, InMemorySessionFileSystemFactory, InMemorySessionStorageStore,
-    InMemorySessionStore,
-};
+use crate::in_memory::InMemorySessionFileSystemFactory;
 use async_trait::async_trait;
 use everruns_core::agent::Agent;
 use everruns_core::atoms::{
@@ -30,10 +26,6 @@ use everruns_core::harness::Harness;
 use everruns_core::llm_driver_registry::{DriverRegistry, ProviderType};
 use everruns_core::llm_models::LlmProviderType;
 use everruns_core::llmsim_driver::{LlmSimConfig, LlmSimDriver};
-use everruns_core::memory::{
-    InMemoryAgentStore, InMemoryEventEmitter, InMemoryHarnessStore, InMemoryLlmProviderStore,
-    InMemoryMemoryStore, InMemoryMessageRetriever,
-};
 use everruns_core::message::{ContentPart, Message};
 use everruns_core::platform_definition::PlatformDefinition;
 use everruns_core::runtime_context::{
@@ -42,11 +34,15 @@ use everruns_core::runtime_context::{
 use everruns_core::session::Session;
 use everruns_core::session_file::{InitialFile, SessionFile};
 use everruns_core::tools::{ToolRegistry, ToolResultImage};
-use everruns_core::traits::{EventEmitter, ModelWithProvider, SessionStorageStore};
+use everruns_core::traits::{
+    AgentStore, EventEmitter, HarnessStore, LlmProviderStore, ModelWithProvider, SessionMutator,
+    SessionStorageStore, SessionStore,
+};
 use everruns_core::turn::{TurnAction, TurnContext, TurnOutcome, TurnStateMachine};
 use everruns_core::typed_id::{AgentId, OrgId, SessionId};
 use everruns_core::{
-    InputMessage, MemoryStoreBackend, SessionFileSystem, SessionFileSystemFactoryContext,
+    InputMessage, MemoryStoreBackend, MessageRetriever, SessionFileSystem,
+    SessionFileSystemFactoryContext,
 };
 use std::sync::Arc;
 
@@ -270,11 +266,17 @@ impl InProcessRuntimeBuilder {
         let backends = match self.backends.take() {
             Some(backends) => backends,
             None => {
-                default_in_memory_backends(
-                    &self.platform_definition,
-                    self.session_file_system_factory_context.clone(),
-                )
-                .await?
+                let factory = self.platform_definition.session_file_system_factory();
+                let file_store: Arc<dyn SessionFileSystem> = if factory.is_disabled() {
+                    Arc::new(crate::in_memory::InMemorySessionFileStore::new())
+                } else {
+                    factory
+                        .create_session_file_system(
+                            self.session_file_system_factory_context.clone(),
+                        )
+                        .await?
+                };
+                RuntimeBackends::in_memory().with_file_store(file_store)
             }
         };
 
@@ -336,10 +338,8 @@ impl InProcessRuntimeBuilder {
                 .await?;
         }
 
-        let event_emitter = PersistingEventEmitter::new(
-            backends.event_emitter.clone(),
-            backends.message_store.clone(),
-        );
+        let persisting_emitter =
+            PersistingEventEmitter::new(backends.event_bus.clone(), backends.message_store.clone());
 
         Ok(InProcessRuntime {
             platform_definition: Arc::new(self.platform_definition),
@@ -349,51 +349,13 @@ impl InProcessRuntimeBuilder {
             default_session_id: self.default_session_id,
             message_store: backends.message_store,
             provider_store: backends.provider_store,
-            event_emitter,
-            raw_event_emitter: backends.event_emitter,
-            event_collector: backends.event_collector,
+            event_bus: backends.event_bus,
+            persisting_emitter,
             file_store: backends.file_store,
             storage_store: backends.storage_store,
             memory_store: backends.memory_store,
         })
     }
-}
-
-async fn default_in_memory_backends(
-    platform_definition: &PlatformDefinition,
-    file_system_factory_context: SessionFileSystemFactoryContext,
-) -> Result<RuntimeBackends> {
-    let harness_store: Arc<dyn RuntimeHarnessStore> = Arc::new(InMemoryHarnessStore::new());
-    let agent_store: Arc<dyn RuntimeAgentStore> = Arc::new(InMemoryAgentStore::new());
-    let session_store: Arc<dyn RuntimeSessionStore> = Arc::new(InMemorySessionStore::new());
-    let message_store: Arc<dyn RuntimeMessageStore> = Arc::new(InMemoryMessageRetriever::new());
-    let file_system_factory = platform_definition.session_file_system_factory();
-    let file_store: Arc<dyn SessionFileSystem> = if file_system_factory.is_disabled() {
-        Arc::new(InMemorySessionFileStore::new())
-    } else {
-        file_system_factory
-            .create_session_file_system(file_system_factory_context)
-            .await?
-    };
-    let storage_store: Arc<dyn SessionStorageStore> = Arc::new(InMemorySessionStorageStore::new());
-    let memory_store: Arc<dyn MemoryStoreBackend> = Arc::new(InMemoryMemoryStore::new());
-    let provider_store: Arc<dyn RuntimeProviderStore> = Arc::new(InMemoryLlmProviderStore::new());
-    let event_emitter_impl = InMemoryEventEmitter::new();
-    let event_emitter: Arc<dyn EventEmitter> = Arc::new(event_emitter_impl.clone());
-    let event_collector: Arc<dyn RuntimeEventCollector> = Arc::new(event_emitter_impl);
-
-    Ok(RuntimeBackends {
-        harness_store,
-        agent_store,
-        session_store,
-        message_store,
-        provider_store,
-        event_emitter,
-        event_collector: Some(event_collector),
-        file_store,
-        storage_store,
-        memory_store,
-    })
 }
 
 #[derive(Clone)]
@@ -410,9 +372,8 @@ pub struct InProcessRuntime {
     default_session_id: Option<SessionId>,
     message_store: Arc<dyn RuntimeMessageStore>,
     provider_store: Arc<dyn RuntimeProviderStore>,
-    event_emitter: PersistingEventEmitter,
-    raw_event_emitter: Arc<dyn EventEmitter>,
-    event_collector: Option<Arc<dyn RuntimeEventCollector>>,
+    event_bus: Arc<dyn EventBus>,
+    persisting_emitter: PersistingEventEmitter,
     file_store: Arc<dyn SessionFileSystem>,
     storage_store: Arc<dyn SessionStorageStore>,
     memory_store: Arc<dyn MemoryStoreBackend>,
@@ -450,7 +411,7 @@ impl InProcessRuntime {
             .message_store
             .add_input_message(session_id, input.into())
             .await?;
-        self.raw_event_emitter
+        self.event_bus
             .emit(EventRequest::new(
                 session_id,
                 EventContext::empty(),
@@ -466,7 +427,7 @@ impl InProcessRuntime {
         let system_prompt_ctx = SystemPromptContext {
             session_id,
             locale: assembled.resolved_locale.clone(),
-            file_store: Some(Arc::new(DynFileStore(self.file_store.clone()))),
+            file_store: Some(self.file_store.clone()),
         };
         let collected = collect_capabilities_with_configs(
             &assembled.resolved_capability_configs,
@@ -509,28 +470,37 @@ impl InProcessRuntime {
                     .expect("valid org id")
             });
 
-        let input_atom = InputAtom::new(DynMessageStore(self.message_store.clone()));
+        // Upcast each runtime-extended store to the core reader trait the
+        // atoms accept. Blanket `Arc<T>: T` impls in core forward the call.
+        let harness_for_atom: Arc<dyn HarnessStore> = self.harness_store.clone();
+        let agent_for_atom: Arc<dyn AgentStore> = self.agent_store.clone();
+        let session_for_atom: Arc<dyn SessionStore> = self.session_store.clone();
+        let message_for_atom: Arc<dyn MessageRetriever> = self.message_store.clone();
+        let provider_for_atom: Arc<dyn LlmProviderStore> = self.provider_store.clone();
+        let session_mutator_for_atom: Arc<dyn SessionMutator> = self.session_store.clone();
+
+        let input_atom = InputAtom::new(message_for_atom.clone());
         let reason_atom = ReasonAtom::new(
-            DynHarnessStore(self.harness_store.clone()),
-            DynAgentStore(self.agent_store.clone()),
-            DynSessionStore(self.session_store.clone()),
-            DynMessageStore(self.message_store.clone()),
-            DynProviderStore(self.provider_store.clone()),
+            harness_for_atom,
+            agent_for_atom,
+            session_for_atom.clone(),
+            message_for_atom,
+            provider_for_atom,
             capability_registry.clone(),
             driver_registry,
-            DynEventEmitter(Arc::new(self.event_emitter.clone())),
+            self.persisting_emitter.clone(),
         )
-        .with_file_store(Arc::new(DynFileStore(self.file_store.clone())));
+        .with_file_store(self.file_store.clone());
 
         let act_atom = ActAtom::with_file_store(
             tool_registry.clone(),
-            DynEventEmitter(Arc::new(self.event_emitter.clone())),
-            Arc::new(DynFileStore(self.file_store.clone())),
+            self.persisting_emitter.clone(),
+            self.file_store.clone(),
         )
         .with_tool_registry(Arc::new(tool_registry.clone()))
         .with_storage_store(self.storage_store.clone())
-        .with_session_store(Arc::new(DynSessionStore(self.session_store.clone())))
-        .with_session_mutator(Arc::new(DynSessionStore(self.session_store.clone())))
+        .with_session_store(session_for_atom)
+        .with_session_mutator(session_mutator_for_atom)
         .with_memory_store(self.memory_store.clone())
         .with_org_id(org_public_id)
         .with_capability_registry(capability_registry)
@@ -665,12 +635,12 @@ impl InProcessRuntime {
             .await
     }
 
-    /// Return all emitted events when the backend exposes an event collector.
+    /// Return all collected events from the runtime event bus.
+    ///
+    /// Event buses that do not retain events return an empty `Vec` (see
+    /// [`EventBus::collected_events`]).
     pub async fn events(&self) -> Result<Vec<Event>> {
-        let collector = self.event_collector.as_ref().ok_or_else(|| {
-            AgentLoopError::config("events are not available for this runtime backend")
-        })?;
-        Ok(collector.events().await)
+        Ok(self.event_bus.collected_events().await)
     }
 
     async fn load_execution_context_with_ids(
@@ -690,7 +660,7 @@ impl InProcessRuntime {
             harness_id,
             agent_id,
             &[],
-            Some(Arc::new(DynFileStore(self.file_store.clone()))),
+            Some(self.file_store.clone()),
         )
         .await
     }
@@ -712,7 +682,7 @@ impl InProcessRuntime {
             harness_id,
             agent_id,
             &[],
-            Some(Arc::new(DynFileStore(self.file_store.clone()))),
+            Some(self.file_store.clone()),
         )
         .await
     }
@@ -720,12 +690,12 @@ impl InProcessRuntime {
 
 #[derive(Clone)]
 struct PersistingEventEmitter {
-    inner: Arc<dyn EventEmitter>,
+    inner: Arc<dyn EventBus>,
     message_store: Arc<dyn RuntimeMessageStore>,
 }
 
 impl PersistingEventEmitter {
-    fn new(inner: Arc<dyn EventEmitter>, message_store: Arc<dyn RuntimeMessageStore>) -> Self {
+    fn new(inner: Arc<dyn EventBus>, message_store: Arc<dyn RuntimeMessageStore>) -> Self {
         Self {
             inner,
             message_store,

--- a/crates/runtime/tests/in_process_runtime_test.rs
+++ b/crates/runtime/tests/in_process_runtime_test.rs
@@ -3,18 +3,13 @@ use chrono::{TimeZone, Utc};
 use everruns_core::capabilities::TestMathCapability;
 use everruns_core::llm_driver_registry::DriverRegistry;
 use everruns_core::llmsim_driver::LlmSimConfig;
-use everruns_core::memory::{
-    InMemoryAgentStore, InMemoryEventEmitter, InMemoryHarnessStore, InMemoryLlmProviderStore,
-    InMemoryMemoryStore, InMemoryMessageRetriever,
-};
 use everruns_core::{
     Agent, CapabilityRegistry, Harness, InitialFile, LlmProviderType, MessageRole,
     ModelWithProvider, PlatformDefinition, Session, SessionFileSystem, SessionFileSystemFactory,
     SessionFileSystemFactoryContext, ToolCall,
 };
 use everruns_runtime::{
-    AgentBuilder, HarnessBuilder, InMemorySessionFileStore, InMemorySessionStorageStore,
-    InMemorySessionStore, InProcessRuntimeBuilder, RealDiskFileStore, RuntimeBackends,
+    AgentBuilder, HarnessBuilder, InProcessRuntimeBuilder, RealDiskFileStore, RuntimeBackends,
     SessionBuilder,
 };
 use std::path::PathBuf;
@@ -295,21 +290,9 @@ async fn runtime_accepts_explicit_backend_bundle() {
     let agent_id = "agent_00000000000000000000000000000051".parse().unwrap();
     let session_id = "session_00000000000000000000000000000051".parse().unwrap();
 
-    let event_emitter = InMemoryEventEmitter::new();
     let runtime = InProcessRuntimeBuilder::new()
         .platform_definition(minimal_platform())
-        .backends(RuntimeBackends {
-            harness_store: Arc::new(InMemoryHarnessStore::new()),
-            agent_store: Arc::new(InMemoryAgentStore::new()),
-            session_store: Arc::new(InMemorySessionStore::new()),
-            message_store: Arc::new(InMemoryMessageRetriever::new()),
-            provider_store: Arc::new(InMemoryLlmProviderStore::new()),
-            event_emitter: Arc::new(event_emitter.clone()),
-            event_collector: Some(Arc::new(event_emitter)),
-            file_store: Arc::new(InMemorySessionFileStore::new()),
-            storage_store: Arc::new(InMemorySessionStorageStore::new()),
-            memory_store: Arc::new(InMemoryMemoryStore::new()),
-        })
+        .backends(RuntimeBackends::in_memory())
         .llm_sim(LlmSimConfig::fixed("Custom backend bundle works"))
         .default_model(ModelWithProvider {
             model: "llmsim-model".into(),

--- a/docs/advanced/embedding-everruns.md
+++ b/docs/advanced/embedding-everruns.md
@@ -210,6 +210,9 @@ Under the hood, execute-time hosts use `everruns_core::assemble_turn_context(...
 - `RuntimeMessageStore`
 - `RuntimeFileStore`
 - `RuntimeProviderStore`
+- `EventBus` (extends `EventEmitter`; the default in-memory bus retains
+  emitted events for `InProcessRuntime::events()`, while production buses
+  inherit the default `collected_events` and return an empty `Vec`)
 
 Pass them through `RuntimeBackends` on the builder:
 
@@ -220,7 +223,8 @@ let runtime = InProcessRuntimeBuilder::new()
     .backends(
         RuntimeBackends::in_memory()
             .with_file_store(my_file_store)
-            .with_message_store(my_message_store),
+            .with_message_store(my_message_store)
+            .with_event_bus(my_event_bus),
         // Add other `.with_*` overrides as needed; defaults stay in-memory.
     )
     .build()

--- a/docs/advanced/embedding-everruns.md
+++ b/docs/advanced/embedding-everruns.md
@@ -217,18 +217,12 @@ Pass them through `RuntimeBackends` on the builder:
 use everruns_runtime::{InProcessRuntimeBuilder, RuntimeBackends};
 
 let runtime = InProcessRuntimeBuilder::new()
-    .backends(RuntimeBackends {
-        harness_store: my_harness_store,
-        agent_store: my_agent_store,
-        session_store: my_session_store,
-        message_store: my_message_store,
-        provider_store: my_provider_store,
-        event_emitter: my_event_emitter,
-        event_collector: None,
-        file_store: my_file_store,
-        storage_store: my_storage_store,
-        memory_store: my_memory_store,
-    })
+    .backends(
+        RuntimeBackends::in_memory()
+            .with_file_store(my_file_store)
+            .with_message_store(my_message_store),
+        // Add other `.with_*` overrides as needed; defaults stay in-memory.
+    )
     .build()
     .await?;
 ```

--- a/examples/coding-cli/src/runtime.rs
+++ b/examples/coding-cli/src/runtime.rs
@@ -17,10 +17,6 @@ use everruns_core::capabilities::{
 use everruns_core::llm_driver_registry::DriverRegistry;
 use everruns_core::llm_models::LlmProviderType;
 use everruns_core::llmsim_driver::LlmSimConfig;
-use everruns_core::memory::{
-    InMemoryAgentStore, InMemoryEventEmitter, InMemoryHarnessStore, InMemoryLlmProviderStore,
-    InMemoryMemoryStore, InMemoryMessageRetriever,
-};
 use everruns_core::tools::Tool;
 use everruns_core::typed_id::SessionId;
 use everruns_core::{
@@ -28,8 +24,7 @@ use everruns_core::{
 };
 use everruns_integrations_duckduckgo::DuckDuckGoCapability;
 use everruns_runtime::{
-    InMemorySessionStorageStore, InMemorySessionStore, InProcessRuntime, InProcessRuntimeBuilder,
-    RealDiskFileStore, RuntimeBackends, RuntimeFileStore,
+    InProcessRuntime, InProcessRuntimeBuilder, RealDiskFileStore, RuntimeBackends, RuntimeFileStore,
 };
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -149,19 +144,7 @@ pub async fn build(
     let file_store = gated;
 
     // The rest of the backends stay in memory.
-    let event_emitter = InMemoryEventEmitter::new();
-    let backends = RuntimeBackends {
-        harness_store: Arc::new(InMemoryHarnessStore::new()),
-        agent_store: Arc::new(InMemoryAgentStore::new()),
-        session_store: Arc::new(InMemorySessionStore::new()),
-        message_store: Arc::new(InMemoryMessageRetriever::new()),
-        provider_store: Arc::new(InMemoryLlmProviderStore::new()),
-        event_emitter: Arc::new(event_emitter.clone()),
-        event_collector: Some(Arc::new(event_emitter)),
-        file_store,
-        storage_store: Arc::new(InMemorySessionStorageStore::new()),
-        memory_store: Arc::new(InMemoryMemoryStore::new()),
-    };
+    let backends = RuntimeBackends::in_memory().with_file_store(file_store);
 
     // Register a curated set of built-in capabilities (no opinionated bundle
     // — we want a tight, predictable surface for the coding-CLI) plus our

--- a/specs/runtime.md
+++ b/specs/runtime.md
@@ -197,13 +197,18 @@ Use `RuntimeBackends::in_memory()` for the all-in-memory default, then chain
 stores.
 
 Session files are a platform service: `PlatformDefinition` carries a
-`SessionFileSystemFactory`, and the runtime resolves it when no explicit
-`RuntimeBackends.file_store` is supplied. Embedders can choose
+`SessionFileSystemFactory`, and the runtime consults it only when the
+builder falls back to its default backends — i.e., when the embedder does
+not call `InProcessRuntimeBuilder::backends(...)`. A custom `RuntimeBackends`
+bundle always carries its own `file_store` (including the one
+`RuntimeBackends::in_memory()` installs), and that value wins; the platform
+factory is not consulted to override it. Embedders can choose
 `InMemorySessionFileSystemFactory` (default), `RealDiskSessionFileSystemFactory`
 (rooted at a host directory; honours `.gitignore` for grep), or a custom future
-factory such as S3. See `specs/file-store.md` for the trait contract, path
-namespace, and the rule that capabilities should consume the seam rather than
-touching `std::fs` directly.
+factory such as S3 — or skip the factory and supply an explicit `file_store`
+via `.with_file_store(...)`. See `specs/file-store.md` for the trait contract,
+path namespace, and the rule that capabilities should consume the seam rather
+than touching `std::fs` directly.
 
 Factories that depend on host values receive them through
 `SessionFileSystemFactoryContext`; the in-process builder accepts this context

--- a/specs/runtime.md
+++ b/specs/runtime.md
@@ -182,7 +182,7 @@ domain stores:
 - `RuntimeSessionStore`
 - `RuntimeMessageStore`
 - `RuntimeProviderStore`
-- optional `RuntimeEventCollector`
+- `EventBus` (extends `EventEmitter`; default `collected_events` returns empty)
 
 These extend the corresponding core traits with the minimal write operations the
 embedded runtime needs for:
@@ -191,6 +191,10 @@ embedded runtime needs for:
 - storing input messages
 - persisting assistant and tool-result messages from emitted events
 - configuring the runtime default model
+
+Use `RuntimeBackends::in_memory()` for the all-in-memory default, then chain
+`.with_file_store(...)`, `.with_message_store(...)`, etc. to override individual
+stores.
 
 Session files are a platform service: `PlatformDefinition` carries a
 `SessionFileSystemFactory`, and the runtime resolves it when no explicit


### PR DESCRIPTION
## What
Removes the six `Dyn*` shim wrappers in `crates/runtime/src/backends.rs` and the parallel `event_emitter` / `event_collector` two-field pattern. Replaces them with:

- Blanket `Arc<T>: T` impls in `everruns-core` for `AgentStore`, `HarnessStore`, `SessionStore`, `SessionMutator`, `LlmProviderStore`, `MessageRetriever`, `SessionFileSystem` (matching the existing pattern for `EventEmitter`).
- A new `EventBus: EventEmitter` trait with a default-empty `collected_events` method; `RuntimeBackends` now carries a single `event_bus: Arc<dyn EventBus>` field.
- `RuntimeBackends::in_memory()` constructor with chainable `.with_*` setters so embedders override one field instead of literal-constructing all nine.

Updates the runtime examples, the `in_process_runtime_test` test, the coding-cli embedder, `specs/runtime.md`, and `docs/advanced/embedding-everruns.md` to the new API.

## Why
The runtime had three parallel naming schemes for the same set of store concepts (`FooStore`, `RuntimeFooStore`, `DynFooStore`) and six wrapper structs that existed solely to forward methods 1:1 from `Arc<dyn RuntimeFooStore>` to whatever `impl FooStore` the atoms accepted. The `event_emitter` / `event_collector` split also required every in-memory caller to register the *same* `InMemoryEventEmitter` instance under both fields. The end result was ~180 lines of ceremony in `backends.rs` plus a 12-line literal `RuntimeBackends { ... }` block that every embedder had to copy-paste just to swap one field (typically the file store).

## How
- Added the blanket `Arc<T>: T` impls in `crates/core/src/traits.rs` and `message_retriever.rs`. Rust 1.86+ trait upcasting handles the rest: `Arc<dyn RuntimeFooStore>` upcasts to `Arc<dyn FooStore>` via unsized coercion at the atom call sites in `crates/runtime/src/runtime.rs`.
- Deleted `DynAgentStore`, `DynHarnessStore`, `DynSessionStore`, `DynMessageStore`, `DynProviderStore`, `DynFileStore`, `DynEventEmitter`.
- Replaced `event_emitter` + `Option<event_collector>` with `event_bus: Arc<dyn EventBus>`. Production hosts that don't retain events inherit the empty-`Vec` default. `InMemoryEventEmitter` now `impl EventBus` and overrides `collected_events`.
- `PersistingEventEmitter` (the message-persisting middleware that wraps the bus for atoms) now holds `Arc<dyn EventBus>` instead of `Arc<dyn EventEmitter>`; behavior is identical.
- `default_in_memory_backends` was a private helper that hand-wired nine stores — replaced by `RuntimeBackends::in_memory()`. The platform-`SessionFileSystemFactory` lookup is inlined into `InProcessRuntimeBuilder::build()` where it's used.
- Coding-cli's backend setup goes from 12 lines to 1: `RuntimeBackends::in_memory().with_file_store(gated)`.

## Risk
- **Low.** Pure internal-API restructuring. No new public surface beyond `EventBus` + the `with_*` setters; no removed public surface except `RuntimeEventCollector` (which was never used outside the runtime crate's own examples and tests, all updated here). No behavior change: the in-memory event emitter still both emits and collects; `PersistingEventEmitter` still wraps the emitted events to persist messages identically.
- The only embedder in the repo (`examples/coding-cli`) is updated and builds. External downstreams using the old `RuntimeEventCollector` import or the literal `RuntimeBackends { event_emitter, event_collector, ... }` form would need to migrate to `in_memory()` + `with_*`.

## Security
- Threat categories reviewed: **none directly applicable**. This is a structural refactor of internal store-trait dispatch and event-bus wiring with no change to authentication, authorization, input parsing, tool execution, file path handling, sandboxing, or any trust boundary.
  - **TM-FS** considered: `SessionFileSystem` blanket impl forwards to `(**self)` only — no new path resolution, no sandbox-bypass surface. `RealDiskFileStore` semantics unchanged.
  - **TM-TOOL** considered: tool registration and execution path through `ActAtom` is untouched (same `with_file_store`, `with_session_store`, etc. wiring; just typed-Arc-direct instead of via shim wrappers).
  - **TM-API** considered: no endpoints touched.
- Findings and resolutions: none. No `THREAT[...]` comments touched. No new dependencies. No threat-model entries warrant changes.

## Follow-ups
- **Tier 2** (deferred): Extract a single `TurnExecutor<H: RuntimeHostAdapter>` to deduplicate `InProcessRuntime::run_turn` and the worker's `execute_reason_activity`. Both run the same `input -> reason -> act` loop with separately-constructed atoms; consolidating would delete ~200 LOC from `runtime.rs` and align the in-process and durable execution paths. Deferred because it touches the worker boundary and deserves its own PR.
- **Tier 3** (deferred): Provider-config ergonomics for embedders (e.g. `Provider::anthropic_from_env(...)`, `coding_capability_bundle()`) to collapse coding-cli's 190-line `build()` further. Cosmetic and out of scope for a structural cleanup PR.
- Per-turn atom construction in `InProcessRuntime::run_turn` (atoms are rebuilt on every turn even though they're stateless) and per-turn `ToolRegistry::with_defaults()` rebuild — pre-existing, not regressed here, fold naturally into Tier 2.

## Checklist
- [x] Tests added or updated (existing 36 runtime tests still pass; `in_process_runtime_test::runtime_accepts_explicit_backend_bundle` migrated to the new API)
- [x] Backward compatibility considered (no external consumers of the removed shim types; only embedder in repo updated)
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (none yet)

## Validation
- `cargo test -p everruns-runtime` → 36 passed
- `cargo test -p everruns-core` → 1796 passed (2 pre-existing failures from unrelated external Anthropic Opus model availability, identical on `main`)
- `cargo clippy -p everruns-core -p everruns-runtime -p everruns-coding-cli --all-targets -- -D warnings` → clean
- `cargo fmt --check` → clean
- `cargo run -p everruns-runtime --example in_process_runtime` → success
- `cargo run -p everruns-runtime --example real_disk_agent_instructions` → success
- `cargo run -p everruns-runtime --example real_disk_file_system_tools` → success
- `bash scripts/lib/check-migration-ordering.sh` → sequential 001..044
- Rebased onto latest `origin/main` immediately before push
- **Net: -55 LOC workspace, -111 LOC in the runtime crate**

Note: `everruns-server` has a pre-existing compile error on `main` (`CommandError::Conflict` / `BadRequest` not found) that is unrelated to this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01And7sJrtt1oGFJUS9bVhF3)_