### PR TITLE
feat(openapi): health + agent versions + skills + schedules (75% coverage)

### DIFF
--- a/crates/core/src/agent.rs
+++ b/crates/core/src/agent.rs
@@ -87,38 +87,54 @@ impl From<&str> for AgentVersionChangeKind {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct AgentVersion {
+    /// Prefixed public identifier (see `specs/id-schema.md`).
     #[serde(rename = "id")]
     #[cfg_attr(feature = "openapi", schema(value_type = String, example = "agentver_01933b5a000070008000000000000001"))]
     pub public_id: AgentVersionId,
+    /// Internal database UUID. Not part of the public identifier surface; skipped during serialization.
     #[serde(skip, default = "uuid::Uuid::nil")]
     pub internal_id: uuid::Uuid,
+    /// Owning agent's prefixed public identifier.
     #[cfg_attr(feature = "openapi", schema(value_type = String, example = "agent_01933b5a000070008000000000000001"))]
     pub agent_id: AgentId,
+    /// Monotonic per-agent version sequence number (1, 2, 3, ...). Increments on every snapshot.
     pub version_number: i32,
+    /// Semantic version major component.
     pub semver_major: i32,
+    /// Semantic version minor component.
     pub semver_minor: i32,
+    /// Semantic version patch component.
     pub semver_patch: i32,
+    /// Combined semver string for display (e.g. `1.4.2`).
     pub version: String,
-    /// Published versions are user-controlled semver releases. Unpublished rows
-    /// are automatic draft snapshots kept for audit and rollback.
+    /// Whether this version was explicitly published by a user. Published versions are user-controlled semver releases; unpublished rows are automatic draft snapshots kept for audit and rollback.
     pub is_published: bool,
+    /// Version this one was forked or branched from, if any.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "openapi", schema(value_type = Option<String>))]
     pub parent_version_id: Option<AgentVersionId>,
+    /// When this version is a copy of another version (e.g. a manual rollback), the original source. `None` for ordinary snapshots.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "openapi", schema(value_type = Option<String>))]
     pub source_version_id: Option<AgentVersionId>,
+    /// Identity of the principal (user or agent identity) that created this version. `None` for system-generated snapshots.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "openapi", schema(value_type = Option<String>))]
     pub created_by_principal_id: Option<PrincipalId>,
+    /// Classification of why this version was created (manual publish, automatic draft, rollback, fork, etc.).
     pub change_kind: AgentVersionChangeKind,
+    /// Human-readable summary of changes in this version (release notes). `None` if not provided.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub summary: Option<String>,
+    /// Stable hash of `resolved_config` used to deduplicate adjacent identical snapshots.
     pub config_hash: String,
+    /// User-authored agent configuration JSON, exactly as submitted. Capabilities, MCP refs, model selection live here.
     #[cfg_attr(feature = "openapi", schema(value_type = Object))]
     pub authored_config: serde_json::Value,
+    /// Resolved configuration after applying harness, capability, and platform layers. This is what the runtime executes against.
     #[cfg_attr(feature = "openapi", schema(value_type = Object))]
     pub resolved_config: serde_json::Value,
+    /// Timestamp when this version was created (RFC 3339).
     pub created_at: DateTime<Utc>,
 }
 

--- a/crates/core/src/session_file.rs
+++ b/crates/core/src/session_file.rs
@@ -15,14 +15,23 @@ use utoipa::ToSchema;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct FileInfo {
+    /// Internal database UUID for this file entry.
     pub id: Uuid,
+    /// UUID of the owning session.
     pub session_id: Uuid,
+    /// Absolute path within the session workspace (e.g. `/notes.md`).
     pub path: String,
+    /// File or directory name (the last segment of `path`).
     pub name: String,
+    /// `true` when this entry represents a directory; `false` for a regular file.
     pub is_directory: bool,
+    /// Whether the entry was marked read-only at creation. Read-only entries cannot be edited or deleted by the session.
     pub is_readonly: bool,
+    /// File size in bytes. `0` for directories.
     pub size_bytes: i64,
+    /// Timestamp when this entry was created (RFC 3339).
     pub created_at: DateTime<Utc>,
+    /// Timestamp when this entry was last updated (RFC 3339).
     pub updated_at: DateTime<Utc>,
 }
 
@@ -51,20 +60,29 @@ impl FileInfo {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct SessionFile {
+    /// Internal database UUID for this file entry.
     pub id: Uuid,
+    /// UUID of the owning session.
     pub session_id: Uuid,
+    /// Absolute path within the session workspace (e.g. `/notes.md`).
     pub path: String,
+    /// File or directory name (the last segment of `path`).
     pub name: String,
-    /// Base64-encoded content for binary files, plain text for text files
+    /// File content. Encoding is controlled by the `encoding` field: plain UTF-8 text for `text`, base64-encoded bytes for `base64`. `None` for directories and when this is a metadata-only listing.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub content: Option<String>,
-    /// Content encoding: "text" or "base64"
+    /// Content encoding for the `content` field: `text` (UTF-8) or `base64` (binary).
     #[serde(default = "default_encoding")]
     pub encoding: String,
+    /// `true` when this entry represents a directory; `false` for a regular file.
     pub is_directory: bool,
+    /// Whether the entry was marked read-only at creation. Read-only entries cannot be edited or deleted by the session.
     pub is_readonly: bool,
+    /// File size in bytes. `0` for directories.
     pub size_bytes: i64,
+    /// Timestamp when this entry was created (RFC 3339).
     pub created_at: DateTime<Utc>,
+    /// Timestamp when this entry was last updated (RFC 3339).
     pub updated_at: DateTime<Utc>,
 }
 
@@ -121,12 +139,19 @@ impl SessionFile {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct FileStat {
+    /// Absolute path within the session workspace.
     pub path: String,
+    /// File or directory name (last segment of `path`).
     pub name: String,
+    /// `true` when this entry represents a directory.
     pub is_directory: bool,
+    /// Whether the entry is read-only.
     pub is_readonly: bool,
+    /// File size in bytes. `0` for directories.
     pub size_bytes: i64,
+    /// Timestamp when this entry was created (RFC 3339).
     pub created_at: DateTime<Utc>,
+    /// Timestamp when this entry was last updated (RFC 3339).
     pub updated_at: DateTime<Utc>,
 }
 

--- a/crates/core/src/skill.rs
+++ b/crates/core/src/skill.rs
@@ -89,36 +89,50 @@ impl From<&str> for SkillStatus {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct Skill {
+    /// Prefixed public identifier (see `specs/id-schema.md`).
     #[cfg_attr(feature = "openapi", schema(value_type = String, example = "skill_01933b5a00007000800000000000001"))]
     pub id: SkillId,
+    /// Stable kebab-case slug used to invoke the skill (e.g. `/pdf-processing` in chat). Safe to render in user-facing messages.
     #[cfg_attr(feature = "openapi", schema(example = "pdf-processing"))]
     pub name: String,
+    /// Short, agent- and user-readable summary of what the skill does and when to use it.
     #[cfg_attr(
         feature = "openapi",
         schema(example = "Extract text and tables from PDF files.")
     )]
     pub description: String,
+    /// License string as declared by the skill author (e.g. `MIT`, `Apache-2.0`). Informational; not enforced.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub license: Option<String>,
+    /// Compatibility marker describing host-runtime requirements declared by the skill (e.g. min platform version). Informational.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub compatibility: Option<String>,
+    /// Free-form metadata declared by the skill author.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub metadata: HashMap<String, serde_json::Value>,
+    /// Comma-separated list of tool patterns this skill may invoke. `None` means inherit from the harness.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub allowed_tools: Option<String>,
+    /// How the skill content is sourced (filesystem, URL, embedded). Determines reload semantics.
     pub source_type: SkillSourceType,
+    /// Current lifecycle status (`active`, `archived`, `deleted`).
     pub status: SkillStatus,
+    /// Semver string declared by the skill author. Free-form; sorted lexicographically when comparing.
     pub version: String,
-    /// Whether this skill appears as a /slash command for users
+    /// Whether this skill appears as a `/`-prefixed slash command for end users in chat UIs.
     #[serde(default = "default_true")]
     pub user_invocable: bool,
-    /// Whether the model is prevented from auto-invoking this skill
+    /// When `true`, the LLM is prevented from auto-invoking this skill; only the user can trigger it explicitly.
     #[serde(default)]
     pub disable_model_invocation: bool,
+    /// Timestamp when this skill was created (RFC 3339).
     pub created_at: DateTime<Utc>,
+    /// Timestamp when this skill was last updated (RFC 3339).
     pub updated_at: DateTime<Utc>,
+    /// Timestamp when this skill was archived, if any (RFC 3339). Archived skills are hidden from default list views.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub archived_at: Option<DateTime<Utc>>,
+    /// Timestamp when this skill was hard-deleted, if any (RFC 3339).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub deleted_at: Option<DateTime<Utc>>,
 }

--- a/crates/server/src/api/common.rs
+++ b/crates/server/src/api/common.rs
@@ -36,20 +36,35 @@ pub type ApiResult<T> = Result<Json<T>, (StatusCode, Json<ErrorResponse>)>;
 /// Response body for resource stats.
 #[derive(Debug, Clone, Serialize, ToSchema)]
 pub struct ResourceStatsResponse {
+    /// Total number of sessions ever created for this resource.
     pub session_count: u64,
+    /// Sessions in a running state right now.
     pub active_session_count: u64,
+    /// Sessions in an idle state right now (created but no recent activity).
     pub idle_session_count: u64,
+    /// Sessions that have started at least one turn.
     pub started_session_count: u64,
+    /// Sessions currently paused waiting for client-side tool results.
     pub waiting_for_tool_results_session_count: u64,
+    /// Total number of agent executions (turns) recorded across all sessions for this resource.
     pub execution_count: u64,
+    /// Cumulative session wall-clock duration in milliseconds across all sessions.
     pub total_session_duration_ms: u64,
+    /// Average session duration in milliseconds. `None` when `session_count` is 0.
     pub avg_session_duration_ms: Option<u64>,
+    /// Cumulative LLM input tokens billed across all sessions.
     pub total_input_tokens: u64,
+    /// Cumulative LLM output tokens billed across all sessions.
     pub total_output_tokens: u64,
+    /// Cumulative cache-read tokens across all sessions (where the provider supports prompt caching).
     pub total_cache_read_tokens: u64,
+    /// Cumulative cache-write tokens across all sessions (charged when first writing a cache entry).
     pub total_cache_creation_tokens: u64,
+    /// Timestamp of the first session for this resource (RFC 3339). `None` if no sessions exist.
     pub first_session_at: Option<DateTime<Utc>>,
+    /// Timestamp of the most recent session for this resource (RFC 3339). `None` if no sessions exist.
     pub last_session_at: Option<DateTime<Utc>>,
+    /// Timestamp of the most recent execution (turn) for this resource (RFC 3339). `None` if no executions exist.
     pub last_execution_at: Option<DateTime<Utc>>,
 }
 

--- a/crates/server/src/api/durable.rs
+++ b/crates/server/src/api/durable.rs
@@ -245,26 +245,43 @@ pub fn routes(state: AppState) -> Router {
 /// System health response
 #[derive(Debug, Serialize, ToSchema)]
 pub struct HealthResponse {
-    /// Current lifecycle status.
+    /// Aggregate system status: `healthy`, `degraded`, or `unhealthy`. Derived from worker availability, load, and queue depths.
     pub status: String,
+    /// Total number of workers registered (heartbeating in the last window).
     pub total_workers: usize,
+    /// Number of workers in the `running` state, ready to claim tasks.
     pub active_workers: usize,
+    /// Number of workers currently accepting new task assignments (subset of `active_workers`; drains/backpressure excluded).
     pub workers_accepting: usize,
+    /// Sum of `max_concurrency` across all workers (the upper bound on concurrent task execution).
     pub total_capacity: usize,
+    /// Total tasks currently in flight across all workers.
     pub current_load: usize,
+    /// `current_load / total_capacity * 100`. 0.0 when no workers are registered.
     pub load_percentage: f64,
+    /// Tasks waiting to be claimed (gauge).
     pub pending_tasks: usize,
+    /// Tasks currently claimed by a worker (gauge).
     pub claimed_tasks: usize,
+    /// Cumulative count of tasks that completed successfully (monotonic counter).
     pub completed_tasks: usize,
+    /// Cumulative count of tasks that failed terminally or were sent to the DLQ (monotonic counter).
     pub failed_tasks: usize,
+    /// Cumulative count of tasks claimed at least once (monotonic counter).
     pub started_tasks: usize,
+    /// Workflows currently executing (gauge).
     pub running_workflows: usize,
+    /// Workflows waiting to be claimed (gauge).
     pub pending_workflows: usize,
+    /// Cumulative count of workflows that completed successfully (monotonic counter).
     pub completed_workflows: usize,
+    /// Cumulative count of workflows that ended in failure (monotonic counter).
     pub failed_workflows: usize,
+    /// Cumulative count of workflows that started (monotonic counter).
     pub started_workflows: usize,
+    /// Size of the dead-letter queue (gauge). High values indicate stuck activities.
     pub dlq_size: usize,
-    /// Event delivery backend: "nats" or "in_memory"
+    /// Event-delivery backend in use: `nats` for distributed deployments, `in_memory` for single-instance. `None` if the field was omitted by an older server.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub event_delivery: Option<String>,
 }

--- a/crates/server/src/api/schedules.rs
+++ b/crates/server/src/api/schedules.rs
@@ -218,20 +218,29 @@ pub struct ScheduleResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     /// Human-readable description. Safe to render in user-facing messages.
     pub description: Option<String>,
+    /// Cron expression in the standard `min hour day-of-month month day-of-week` form (6 fields with seconds optional). Evaluated in `timezone`.
     pub cron_expression: String,
+    /// IANA timezone name used to interpret `cron_expression` (e.g. `UTC`, `America/New_York`).
     pub timezone: String,
+    /// What the schedule invokes when it fires (a session, an agent, an app channel, etc.).
     pub target: ScheduleTargetResponse,
-    /// Whether this resource is enabled.
+    /// When `false`, the schedule is paused — kept in storage but never fires until re-enabled.
     pub enabled: bool,
+    /// Maximum number of overlapping executions allowed. `None` means no limit beyond the worker pool's concurrency.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_concurrent: Option<u32>,
+    /// When `true`, missed fires (while the scheduler was down, paused, or unreachable) are queued and run after recovery, subject to `max_catch_up`.
     pub catch_up_missed: bool,
+    /// Maximum number of missed fires to replay when `catch_up_missed` is `true`. Older missed fires are dropped. `None` means no cap.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_catch_up: Option<u32>,
+    /// Optional retry policy for failed runs (provider-specific JSON; see the durable engine's `RetryPolicy`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub retry_policy: Option<serde_json::Value>,
+    /// Timestamp of the most recent fire (RFC 3339). `None` if never triggered.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub last_triggered_at: Option<DateTime<Utc>>,
+    /// Timestamp of the next scheduled fire (RFC 3339). `None` when the schedule is disabled or the cron expression has no upcoming match.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub next_trigger_at: Option<DateTime<Utc>>,
     /// Timestamp when this resource was created (RFC 3339).
@@ -359,12 +368,18 @@ pub struct ScheduleExecutionsListResponse {
 /// Schedule stats response
 #[derive(Debug, Serialize, ToSchema)]
 pub struct ScheduleStatsResponse {
+    /// Total number of executions recorded for this schedule (sum of successful + failed + skipped).
     pub total_executions: u64,
+    /// Count of executions that completed successfully.
     pub successful_executions: u64,
+    /// Count of executions that ended in failure (after exhausting retries).
     pub failed_executions: u64,
+    /// Count of fires that were intentionally skipped (e.g. blocked by `max_concurrent` or disabled mid-fire).
     pub skipped_executions: u64,
+    /// Average execution duration in milliseconds across `total_executions`. `None` when no executions exist yet.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub avg_duration_ms: Option<u64>,
+    /// Status of the most recent execution (`succeeded`, `failed`, `skipped`, `running`). `None` if the schedule has never fired.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub last_execution_status: Option<String>,
 }

--- a/crates/server/src/api/voice.rs
+++ b/crates/server/src/api/voice.rs
@@ -189,37 +189,59 @@ pub struct VoiceEndRequest {
 /// Response body for voice client secret.
 #[derive(Debug, Clone, Serialize, ToSchema)]
 pub struct VoiceClientSecretResponse {
+    /// Prefixed public identifier of the voice connection (see `specs/id-schema.md`).
     pub voice_connection_id: String,
+    /// Realtime provider routing this connection (e.g. `openai`).
     pub provider: String,
+    /// Provider-side model identifier used for the realtime session.
     pub model: String,
+    /// Realtime voice preset selected for the connection (provider-specific).
     pub voice: String,
+    /// Reasoning effort tier for thinking-capable models (`none`, `minimal`, `low`, `medium`, `high`).
     pub reasoning_effort: String,
+    /// Timestamp when the client secret expires (RFC 3339). The client must establish the realtime connection before this.
     pub expires_at: chrono::DateTime<chrono::Utc>,
+    /// Provider-specific ephemeral credential payload the client uses to authenticate the realtime connection.
     pub client_secret: Value,
 }
 
 /// Response body for voice call.
 #[derive(Debug, Clone, Serialize, ToSchema)]
 pub struct VoiceCallResponse {
+    /// Prefixed public identifier of the voice connection.
     pub voice_connection_id: String,
+    /// Provider-side call identifier once issued. `None` until the realtime call is established.
     pub provider_call_id: Option<String>,
+    /// Realtime provider routing this connection.
     pub provider: String,
+    /// Provider-side model identifier used for the realtime session.
     pub model: String,
+    /// Realtime voice preset selected for the connection.
     pub voice: String,
+    /// Reasoning effort tier for thinking-capable models.
     pub reasoning_effort: String,
+    /// Timestamp when the call's lease expires (RFC 3339).
     pub expires_at: chrono::DateTime<chrono::Utc>,
+    /// Server-generated SDP answer to send back to the client to complete the WebRTC handshake.
     pub answer_sdp: String,
 }
 
 /// Response body for voice attach.
 #[derive(Debug, Clone, Serialize, ToSchema)]
 pub struct VoiceAttachResponse {
+    /// Prefixed public identifier of the voice connection.
     pub voice_connection_id: String,
+    /// Provider-side call identifier of the connected realtime call.
     pub provider_call_id: String,
+    /// Realtime provider routing this connection.
     pub provider: String,
+    /// Provider-side model identifier used for the realtime session.
     pub model: String,
+    /// Realtime voice preset selected for the connection.
     pub voice: String,
+    /// Reasoning effort tier for thinking-capable models.
     pub reasoning_effort: String,
+    /// Timestamp when the connection's lease expires (RFC 3339).
     pub expires_at: chrono::DateTime<chrono::Utc>,
 }
 

--- a/crates/server/tests/openapi_descriptions_test.rs
+++ b/crates/server/tests/openapi_descriptions_test.rs
@@ -16,7 +16,7 @@ use utoipa::OpenApi;
 /// Lowest acceptable coverage. Bump up when you fix a batch.
 const MIN_OP_DESC_PCT: u32 = 100;
 const MIN_SCHEMA_DESC_PCT: u32 = 88;
-const MIN_FIELD_DESC_PCT: u32 = 67;
+const MIN_FIELD_DESC_PCT: u32 = 75;
 
 fn spec_value() -> serde_json::Value {
     serde_json::from_str(&ApiDoc::openapi().to_pretty_json().unwrap())

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -11675,74 +11675,90 @@
         "properties": {
           "agent_id": {
             "type": "string",
+            "description": "Owning agent's prefixed public identifier.",
             "example": "agent_01933b5a000070008000000000000001"
           },
           "authored_config": {
-            "type": "object"
+            "type": "object",
+            "description": "User-authored agent configuration JSON, exactly as submitted. Capabilities, MCP refs, model selection live here."
           },
           "change_kind": {
-            "$ref": "#/components/schemas/AgentVersionChangeKind"
+            "$ref": "#/components/schemas/AgentVersionChangeKind",
+            "description": "Classification of why this version was created (manual publish, automatic draft, rollback, fork, etc.)."
           },
           "config_hash": {
-            "type": "string"
+            "type": "string",
+            "description": "Stable hash of `resolved_config` used to deduplicate adjacent identical snapshots."
           },
           "created_at": {
             "type": "string",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Timestamp when this version was created (RFC 3339)."
           },
           "created_by_principal_id": {
             "type": [
               "string",
               "null"
-            ]
+            ],
+            "description": "Identity of the principal (user or agent identity) that created this version. `None` for system-generated snapshots."
           },
           "id": {
             "type": "string",
+            "description": "Prefixed public identifier (see `specs/id-schema.md`).",
             "example": "agentver_01933b5a000070008000000000000001"
           },
           "is_published": {
             "type": "boolean",
-            "description": "Published versions are user-controlled semver releases. Unpublished rows\nare automatic draft snapshots kept for audit and rollback."
+            "description": "Whether this version was explicitly published by a user. Published versions are user-controlled semver releases; unpublished rows are automatic draft snapshots kept for audit and rollback."
           },
           "parent_version_id": {
             "type": [
               "string",
               "null"
-            ]
+            ],
+            "description": "Version this one was forked or branched from, if any."
           },
           "resolved_config": {
-            "type": "object"
+            "type": "object",
+            "description": "Resolved configuration after applying harness, capability, and platform layers. This is what the runtime executes against."
           },
           "semver_major": {
             "type": "integer",
-            "format": "int32"
+            "format": "int32",
+            "description": "Semantic version major component."
           },
           "semver_minor": {
             "type": "integer",
-            "format": "int32"
+            "format": "int32",
+            "description": "Semantic version minor component."
           },
           "semver_patch": {
             "type": "integer",
-            "format": "int32"
+            "format": "int32",
+            "description": "Semantic version patch component."
           },
           "source_version_id": {
             "type": [
               "string",
               "null"
-            ]
+            ],
+            "description": "When this version is a copy of another version (e.g. a manual rollback), the original source. `None` for ordinary snapshots."
           },
           "summary": {
             "type": [
               "string",
               "null"
-            ]
+            ],
+            "description": "Human-readable summary of changes in this version (release notes). `None` if not provided."
           },
           "version": {
-            "type": "string"
+            "type": "string",
+            "description": "Combined semver string for display (e.g. `1.4.2`)."
           },
           "version_number": {
             "type": "integer",
-            "format": "int32"
+            "format": "int32",
+            "description": "Monotonic per-agent version sequence number (1, 2, 3, ...). Increments on every snapshot."
           }
         }
       },
@@ -15517,35 +15533,44 @@
         "properties": {
           "created_at": {
             "type": "string",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Timestamp when this entry was created (RFC 3339)."
           },
           "id": {
             "type": "string",
-            "format": "uuid"
+            "format": "uuid",
+            "description": "Internal database UUID for this file entry."
           },
           "is_directory": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "`true` when this entry represents a directory; `false` for a regular file."
           },
           "is_readonly": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Whether the entry was marked read-only at creation. Read-only entries cannot be edited or deleted by the session."
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "description": "File or directory name (the last segment of `path`)."
           },
           "path": {
-            "type": "string"
+            "type": "string",
+            "description": "Absolute path within the session workspace (e.g. `/notes.md`)."
           },
           "session_id": {
             "type": "string",
-            "format": "uuid"
+            "format": "uuid",
+            "description": "UUID of the owning session."
           },
           "size_bytes": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "description": "File size in bytes. `0` for directories."
           },
           "updated_at": {
             "type": "string",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Timestamp when this entry was last updated (RFC 3339)."
           }
         }
       },
@@ -15564,27 +15589,34 @@
         "properties": {
           "created_at": {
             "type": "string",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Timestamp when this entry was created (RFC 3339)."
           },
           "is_directory": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "`true` when this entry represents a directory."
           },
           "is_readonly": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Whether the entry is read-only."
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "description": "File or directory name (last segment of `path`)."
           },
           "path": {
-            "type": "string"
+            "type": "string",
+            "description": "Absolute path within the session workspace."
           },
           "size_bytes": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "description": "File size in bytes. `0` for directories."
           },
           "updated_at": {
             "type": "string",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Timestamp when this entry was last updated (RFC 3339)."
           }
         }
       },
@@ -16311,26 +16343,32 @@
         "properties": {
           "active_workers": {
             "type": "integer",
+            "description": "Number of workers in the `running` state, ready to claim tasks.",
             "minimum": 0
           },
           "claimed_tasks": {
             "type": "integer",
+            "description": "Tasks currently claimed by a worker (gauge).",
             "minimum": 0
           },
           "completed_tasks": {
             "type": "integer",
+            "description": "Cumulative count of tasks that completed successfully (monotonic counter).",
             "minimum": 0
           },
           "completed_workflows": {
             "type": "integer",
+            "description": "Cumulative count of workflows that completed successfully (monotonic counter).",
             "minimum": 0
           },
           "current_load": {
             "type": "integer",
+            "description": "Total tasks currently in flight across all workers.",
             "minimum": 0
           },
           "dlq_size": {
             "type": "integer",
+            "description": "Size of the dead-letter queue (gauge). High values indicate stuck activities.",
             "minimum": 0
           },
           "event_delivery": {
@@ -16338,54 +16376,65 @@
               "string",
               "null"
             ],
-            "description": "Event delivery backend: \"nats\" or \"in_memory\""
+            "description": "Event-delivery backend in use: `nats` for distributed deployments, `in_memory` for single-instance. `None` if the field was omitted by an older server."
           },
           "failed_tasks": {
             "type": "integer",
+            "description": "Cumulative count of tasks that failed terminally or were sent to the DLQ (monotonic counter).",
             "minimum": 0
           },
           "failed_workflows": {
             "type": "integer",
+            "description": "Cumulative count of workflows that ended in failure (monotonic counter).",
             "minimum": 0
           },
           "load_percentage": {
             "type": "number",
-            "format": "double"
+            "format": "double",
+            "description": "`current_load / total_capacity * 100`. 0.0 when no workers are registered."
           },
           "pending_tasks": {
             "type": "integer",
+            "description": "Tasks waiting to be claimed (gauge).",
             "minimum": 0
           },
           "pending_workflows": {
             "type": "integer",
+            "description": "Workflows waiting to be claimed (gauge).",
             "minimum": 0
           },
           "running_workflows": {
             "type": "integer",
+            "description": "Workflows currently executing (gauge).",
             "minimum": 0
           },
           "started_tasks": {
             "type": "integer",
+            "description": "Cumulative count of tasks claimed at least once (monotonic counter).",
             "minimum": 0
           },
           "started_workflows": {
             "type": "integer",
+            "description": "Cumulative count of workflows that started (monotonic counter).",
             "minimum": 0
           },
           "status": {
             "type": "string",
-            "description": "Current lifecycle status."
+            "description": "Aggregate system status: `healthy`, `degraded`, or `unhealthy`. Derived from worker availability, load, and queue depths."
           },
           "total_capacity": {
             "type": "integer",
+            "description": "Sum of `max_concurrency` across all workers (the upper bound on concurrent task execution).",
             "minimum": 0
           },
           "total_workers": {
             "type": "integer",
+            "description": "Total number of workers registered (heartbeating in the last window).",
             "minimum": 0
           },
           "workers_accepting": {
             "type": "integer",
+            "description": "Number of workers currently accepting new task assignments (subset of `active_workers`; drains/backpressure excluded).",
             "minimum": 0
           }
         }
@@ -17518,35 +17567,44 @@
               "properties": {
                 "created_at": {
                   "type": "string",
-                  "format": "date-time"
+                  "format": "date-time",
+                  "description": "Timestamp when this entry was created (RFC 3339)."
                 },
                 "id": {
                   "type": "string",
-                  "format": "uuid"
+                  "format": "uuid",
+                  "description": "Internal database UUID for this file entry."
                 },
                 "is_directory": {
-                  "type": "boolean"
+                  "type": "boolean",
+                  "description": "`true` when this entry represents a directory; `false` for a regular file."
                 },
                 "is_readonly": {
-                  "type": "boolean"
+                  "type": "boolean",
+                  "description": "Whether the entry was marked read-only at creation. Read-only entries cannot be edited or deleted by the session."
                 },
                 "name": {
-                  "type": "string"
+                  "type": "string",
+                  "description": "File or directory name (the last segment of `path`)."
                 },
                 "path": {
-                  "type": "string"
+                  "type": "string",
+                  "description": "Absolute path within the session workspace (e.g. `/notes.md`)."
                 },
                 "session_id": {
                   "type": "string",
-                  "format": "uuid"
+                  "format": "uuid",
+                  "description": "UUID of the owning session."
                 },
                 "size_bytes": {
                   "type": "integer",
-                  "format": "int64"
+                  "format": "int64",
+                  "description": "File size in bytes. `0` for directories."
                 },
                 "updated_at": {
                   "type": "string",
-                  "format": "date-time"
+                  "format": "date-time",
+                  "description": "Timestamp when this entry was last updated (RFC 3339)."
                 }
               }
             },
@@ -18350,52 +18408,61 @@
                   "type": [
                     "string",
                     "null"
-                  ]
+                  ],
+                  "description": "Comma-separated list of tool patterns this skill may invoke. `None` means inherit from the harness."
                 },
                 "archived_at": {
                   "type": [
                     "string",
                     "null"
                   ],
-                  "format": "date-time"
+                  "format": "date-time",
+                  "description": "Timestamp when this skill was archived, if any (RFC 3339). Archived skills are hidden from default list views."
                 },
                 "compatibility": {
                   "type": [
                     "string",
                     "null"
-                  ]
+                  ],
+                  "description": "Compatibility marker describing host-runtime requirements declared by the skill (e.g. min platform version). Informational."
                 },
                 "created_at": {
                   "type": "string",
-                  "format": "date-time"
+                  "format": "date-time",
+                  "description": "Timestamp when this skill was created (RFC 3339)."
                 },
                 "deleted_at": {
                   "type": [
                     "string",
                     "null"
                   ],
-                  "format": "date-time"
+                  "format": "date-time",
+                  "description": "Timestamp when this skill was hard-deleted, if any (RFC 3339)."
                 },
                 "description": {
                   "type": "string",
+                  "description": "Short, agent- and user-readable summary of what the skill does and when to use it.",
                   "example": "Extract text and tables from PDF files."
                 },
                 "disable_model_invocation": {
                   "type": "boolean",
-                  "description": "Whether the model is prevented from auto-invoking this skill"
+                  "description": "When `true`, the LLM is prevented from auto-invoking this skill; only the user can trigger it explicitly."
                 },
                 "id": {
                   "type": "string",
+                  "description": "Prefixed public identifier (see `specs/id-schema.md`).",
                   "example": "skill_01933b5a00007000800000000000001"
                 },
                 "license": {
                   "type": [
                     "string",
                     "null"
-                  ]
+                  ],
+                  "description": "License string as declared by the skill author (e.g. `MIT`, `Apache-2.0`). Informational; not enforced."
                 },
                 "metadata": {
                   "type": "object",
+                  "description": "Free-form metadata declared by the skill author.",
                   "additionalProperties": {},
                   "propertyNames": {
                     "type": "string"
@@ -18403,24 +18470,29 @@
                 },
                 "name": {
                   "type": "string",
+                  "description": "Stable kebab-case slug used to invoke the skill (e.g. `/pdf-processing` in chat). Safe to render in user-facing messages.",
                   "example": "pdf-processing"
                 },
                 "source_type": {
-                  "$ref": "#/components/schemas/SkillSourceType"
+                  "$ref": "#/components/schemas/SkillSourceType",
+                  "description": "How the skill content is sourced (filesystem, URL, embedded). Determines reload semantics."
                 },
                 "status": {
-                  "$ref": "#/components/schemas/SkillStatus"
+                  "$ref": "#/components/schemas/SkillStatus",
+                  "description": "Current lifecycle status (`active`, `archived`, `deleted`)."
                 },
                 "updated_at": {
                   "type": "string",
-                  "format": "date-time"
+                  "format": "date-time",
+                  "description": "Timestamp when this skill was last updated (RFC 3339)."
                 },
                 "user_invocable": {
                   "type": "boolean",
-                  "description": "Whether this skill appears as a /slash command for users"
+                  "description": "Whether this skill appears as a `/`-prefixed slash command for end users in chat UIs."
                 },
                 "version": {
-                  "type": "string"
+                  "type": "string",
+                  "description": "Semver string declared by the skill author. Free-form; sorted lexicographically when comparing."
                 }
               }
             },
@@ -19588,52 +19660,61 @@
                       "type": [
                         "string",
                         "null"
-                      ]
+                      ],
+                      "description": "Comma-separated list of tool patterns this skill may invoke. `None` means inherit from the harness."
                     },
                     "archived_at": {
                       "type": [
                         "string",
                         "null"
                       ],
-                      "format": "date-time"
+                      "format": "date-time",
+                      "description": "Timestamp when this skill was archived, if any (RFC 3339). Archived skills are hidden from default list views."
                     },
                     "compatibility": {
                       "type": [
                         "string",
                         "null"
-                      ]
+                      ],
+                      "description": "Compatibility marker describing host-runtime requirements declared by the skill (e.g. min platform version). Informational."
                     },
                     "created_at": {
                       "type": "string",
-                      "format": "date-time"
+                      "format": "date-time",
+                      "description": "Timestamp when this skill was created (RFC 3339)."
                     },
                     "deleted_at": {
                       "type": [
                         "string",
                         "null"
                       ],
-                      "format": "date-time"
+                      "format": "date-time",
+                      "description": "Timestamp when this skill was hard-deleted, if any (RFC 3339)."
                     },
                     "description": {
                       "type": "string",
+                      "description": "Short, agent- and user-readable summary of what the skill does and when to use it.",
                       "example": "Extract text and tables from PDF files."
                     },
                     "disable_model_invocation": {
                       "type": "boolean",
-                      "description": "Whether the model is prevented from auto-invoking this skill"
+                      "description": "When `true`, the LLM is prevented from auto-invoking this skill; only the user can trigger it explicitly."
                     },
                     "id": {
                       "type": "string",
+                      "description": "Prefixed public identifier (see `specs/id-schema.md`).",
                       "example": "skill_01933b5a00007000800000000000001"
                     },
                     "license": {
                       "type": [
                         "string",
                         "null"
-                      ]
+                      ],
+                      "description": "License string as declared by the skill author (e.g. `MIT`, `Apache-2.0`). Informational; not enforced."
                     },
                     "metadata": {
                       "type": "object",
+                      "description": "Free-form metadata declared by the skill author.",
                       "additionalProperties": {},
                       "propertyNames": {
                         "type": "string"
@@ -19641,24 +19722,29 @@
                     },
                     "name": {
                       "type": "string",
+                      "description": "Stable kebab-case slug used to invoke the skill (e.g. `/pdf-processing` in chat). Safe to render in user-facing messages.",
                       "example": "pdf-processing"
                     },
                     "source_type": {
-                      "$ref": "#/components/schemas/SkillSourceType"
+                      "$ref": "#/components/schemas/SkillSourceType",
+                      "description": "How the skill content is sourced (filesystem, URL, embedded). Determines reload semantics."
                     },
                     "status": {
-                      "$ref": "#/components/schemas/SkillStatus"
+                      "$ref": "#/components/schemas/SkillStatus",
+                      "description": "Current lifecycle status (`active`, `archived`, `deleted`)."
                     },
                     "updated_at": {
                       "type": "string",
-                      "format": "date-time"
+                      "format": "date-time",
+                      "description": "Timestamp when this skill was last updated (RFC 3339)."
                     },
                     "user_invocable": {
                       "type": "boolean",
-                      "description": "Whether this skill appears as a /slash command for users"
+                      "description": "Whether this skill appears as a `/`-prefixed slash command for end users in chat UIs."
                     },
                     "version": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "Semver string declared by the skill author. Free-form; sorted lexicographically when comparing."
                     }
                   }
                 },
@@ -23584,6 +23670,7 @@
           "active_session_count": {
             "type": "integer",
             "format": "int64",
+            "description": "Sessions in a running state right now.",
             "minimum": 0
           },
           "avg_session_duration_ms": {
@@ -23592,11 +23679,13 @@
               "null"
             ],
             "format": "int64",
+            "description": "Average session duration in milliseconds. `None` when `session_count` is 0.",
             "minimum": 0
           },
           "execution_count": {
             "type": "integer",
             "format": "int64",
+            "description": "Total number of agent executions (turns) recorded across all sessions for this resource.",
             "minimum": 0
           },
           "first_session_at": {
@@ -23604,11 +23693,13 @@
               "string",
               "null"
             ],
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Timestamp of the first session for this resource (RFC 3339). `None` if no sessions exist."
           },
           "idle_session_count": {
             "type": "integer",
             "format": "int64",
+            "description": "Sessions in an idle state right now (created but no recent activity).",
             "minimum": 0
           },
           "last_execution_at": {
@@ -23616,53 +23707,63 @@
               "string",
               "null"
             ],
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Timestamp of the most recent execution (turn) for this resource (RFC 3339). `None` if no executions exist."
           },
           "last_session_at": {
             "type": [
               "string",
               "null"
             ],
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Timestamp of the most recent session for this resource (RFC 3339). `None` if no sessions exist."
           },
           "session_count": {
             "type": "integer",
             "format": "int64",
+            "description": "Total number of sessions ever created for this resource.",
             "minimum": 0
           },
           "started_session_count": {
             "type": "integer",
             "format": "int64",
+            "description": "Sessions that have started at least one turn.",
             "minimum": 0
           },
           "total_cache_creation_tokens": {
             "type": "integer",
             "format": "int64",
+            "description": "Cumulative cache-write tokens across all sessions (charged when first writing a cache entry).",
             "minimum": 0
           },
           "total_cache_read_tokens": {
             "type": "integer",
             "format": "int64",
+            "description": "Cumulative cache-read tokens across all sessions (where the provider supports prompt caching).",
             "minimum": 0
           },
           "total_input_tokens": {
             "type": "integer",
             "format": "int64",
+            "description": "Cumulative LLM input tokens billed across all sessions.",
             "minimum": 0
           },
           "total_output_tokens": {
             "type": "integer",
             "format": "int64",
+            "description": "Cumulative LLM output tokens billed across all sessions.",
             "minimum": 0
           },
           "total_session_duration_ms": {
             "type": "integer",
             "format": "int64",
+            "description": "Cumulative session wall-clock duration in milliseconds across all sessions.",
             "minimum": 0
           },
           "waiting_for_tool_results_session_count": {
             "type": "integer",
             "format": "int64",
+            "description": "Sessions currently paused waiting for client-side tool results.",
             "minimum": 0
           }
         }
@@ -23892,7 +23993,8 @@
         ],
         "properties": {
           "catch_up_missed": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "When `true`, missed fires (while the scheduler was down, paused, or unreachable) are queued and run after recovery, subject to `max_catch_up`."
           },
           "created_at": {
             "type": "string",
@@ -23900,7 +24002,8 @@
             "description": "Timestamp when this resource was created (RFC 3339)."
           },
           "cron_expression": {
-            "type": "string"
+            "type": "string",
+            "description": "Cron expression in the standard `min hour day-of-month month day-of-week` form (6 fields with seconds optional). Evaluated in `timezone`."
           },
           "description": {
             "type": [
@@ -23911,7 +24014,7 @@
           },
           "enabled": {
             "type": "boolean",
-            "description": "Whether this resource is enabled."
+            "description": "When `false`, the schedule is paused — kept in storage but never fires until re-enabled."
           },
           "id": {
             "type": "string",
@@ -23923,7 +24026,8 @@
               "string",
               "null"
             ],
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Timestamp of the most recent fire (RFC 3339). `None` if never triggered."
           },
           "max_catch_up": {
             "type": [
@@ -23931,6 +24035,7 @@
               "null"
             ],
             "format": "int32",
+            "description": "Maximum number of missed fires to replay when `catch_up_missed` is `true`. Older missed fires are dropped. `None` means no cap.",
             "minimum": 0
           },
           "max_concurrent": {
@@ -23939,6 +24044,7 @@
               "null"
             ],
             "format": "int32",
+            "description": "Maximum number of overlapping executions allowed. `None` means no limit beyond the worker pool's concurrency.",
             "minimum": 0
           },
           "name": {
@@ -23950,14 +24056,19 @@
               "string",
               "null"
             ],
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Timestamp of the next scheduled fire (RFC 3339). `None` when the schedule is disabled or the cron expression has no upcoming match."
           },
-          "retry_policy": {},
+          "retry_policy": {
+            "description": "Optional retry policy for failed runs (provider-specific JSON; see the durable engine's `RetryPolicy`)."
+          },
           "target": {
-            "$ref": "#/components/schemas/ScheduleTargetResponse"
+            "$ref": "#/components/schemas/ScheduleTargetResponse",
+            "description": "What the schedule invokes when it fires (a session, an agent, an app channel, etc.)."
           },
           "timezone": {
-            "type": "string"
+            "type": "string",
+            "description": "IANA timezone name used to interpret `cron_expression` (e.g. `UTC`, `America/New_York`)."
           },
           "updated_at": {
             "type": "string",
@@ -23982,32 +24093,38 @@
               "null"
             ],
             "format": "int64",
+            "description": "Average execution duration in milliseconds across `total_executions`. `None` when no executions exist yet.",
             "minimum": 0
           },
           "failed_executions": {
             "type": "integer",
             "format": "int64",
+            "description": "Count of executions that ended in failure (after exhausting retries).",
             "minimum": 0
           },
           "last_execution_status": {
             "type": [
               "string",
               "null"
-            ]
+            ],
+            "description": "Status of the most recent execution (`succeeded`, `failed`, `skipped`, `running`). `None` if the schedule has never fired."
           },
           "skipped_executions": {
             "type": "integer",
             "format": "int64",
+            "description": "Count of fires that were intentionally skipped (e.g. blocked by `max_concurrent` or disabled mid-fire).",
             "minimum": 0
           },
           "successful_executions": {
             "type": "integer",
             "format": "int64",
+            "description": "Count of executions that completed successfully.",
             "minimum": 0
           },
           "total_executions": {
             "type": "integer",
             "format": "int64",
+            "description": "Total number of executions recorded for this schedule (sum of successful + failed + skipped).",
             "minimum": 0
           }
         }
@@ -24521,43 +24638,52 @@
               "string",
               "null"
             ],
-            "description": "Base64-encoded content for binary files, plain text for text files"
+            "description": "File content. Encoding is controlled by the `encoding` field: plain UTF-8 text for `text`, base64-encoded bytes for `base64`. `None` for directories and when this is a metadata-only listing."
           },
           "created_at": {
             "type": "string",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Timestamp when this entry was created (RFC 3339)."
           },
           "encoding": {
             "type": "string",
-            "description": "Content encoding: \"text\" or \"base64\""
+            "description": "Content encoding for the `content` field: `text` (UTF-8) or `base64` (binary)."
           },
           "id": {
             "type": "string",
-            "format": "uuid"
+            "format": "uuid",
+            "description": "Internal database UUID for this file entry."
           },
           "is_directory": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "`true` when this entry represents a directory; `false` for a regular file."
           },
           "is_readonly": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Whether the entry was marked read-only at creation. Read-only entries cannot be edited or deleted by the session."
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "description": "File or directory name (the last segment of `path`)."
           },
           "path": {
-            "type": "string"
+            "type": "string",
+            "description": "Absolute path within the session workspace (e.g. `/notes.md`)."
           },
           "session_id": {
             "type": "string",
-            "format": "uuid"
+            "format": "uuid",
+            "description": "UUID of the owning session."
           },
           "size_bytes": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "description": "File size in bytes. `0` for directories."
           },
           "updated_at": {
             "type": "string",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Timestamp when this entry was last updated (RFC 3339)."
           }
         }
       },
@@ -24781,52 +24907,61 @@
             "type": [
               "string",
               "null"
-            ]
+            ],
+            "description": "Comma-separated list of tool patterns this skill may invoke. `None` means inherit from the harness."
           },
           "archived_at": {
             "type": [
               "string",
               "null"
             ],
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Timestamp when this skill was archived, if any (RFC 3339). Archived skills are hidden from default list views."
           },
           "compatibility": {
             "type": [
               "string",
               "null"
-            ]
+            ],
+            "description": "Compatibility marker describing host-runtime requirements declared by the skill (e.g. min platform version). Informational."
           },
           "created_at": {
             "type": "string",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Timestamp when this skill was created (RFC 3339)."
           },
           "deleted_at": {
             "type": [
               "string",
               "null"
             ],
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Timestamp when this skill was hard-deleted, if any (RFC 3339)."
           },
           "description": {
             "type": "string",
+            "description": "Short, agent- and user-readable summary of what the skill does and when to use it.",
             "example": "Extract text and tables from PDF files."
           },
           "disable_model_invocation": {
             "type": "boolean",
-            "description": "Whether the model is prevented from auto-invoking this skill"
+            "description": "When `true`, the LLM is prevented from auto-invoking this skill; only the user can trigger it explicitly."
           },
           "id": {
             "type": "string",
+            "description": "Prefixed public identifier (see `specs/id-schema.md`).",
             "example": "skill_01933b5a00007000800000000000001"
           },
           "license": {
             "type": [
               "string",
               "null"
-            ]
+            ],
+            "description": "License string as declared by the skill author (e.g. `MIT`, `Apache-2.0`). Informational; not enforced."
           },
           "metadata": {
             "type": "object",
+            "description": "Free-form metadata declared by the skill author.",
             "additionalProperties": {},
             "propertyNames": {
               "type": "string"
@@ -24834,24 +24969,29 @@
           },
           "name": {
             "type": "string",
+            "description": "Stable kebab-case slug used to invoke the skill (e.g. `/pdf-processing` in chat). Safe to render in user-facing messages.",
             "example": "pdf-processing"
           },
           "source_type": {
-            "$ref": "#/components/schemas/SkillSourceType"
+            "$ref": "#/components/schemas/SkillSourceType",
+            "description": "How the skill content is sourced (filesystem, URL, embedded). Determines reload semantics."
           },
           "status": {
-            "$ref": "#/components/schemas/SkillStatus"
+            "$ref": "#/components/schemas/SkillStatus",
+            "description": "Current lifecycle status (`active`, `archived`, `deleted`)."
           },
           "updated_at": {
             "type": "string",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Timestamp when this skill was last updated (RFC 3339)."
           },
           "user_invocable": {
             "type": "boolean",
-            "description": "Whether this skill appears as a /slash command for users"
+            "description": "Whether this skill appears as a `/`-prefixed slash command for end users in chat UIs."
           },
           "version": {
-            "type": "string"
+            "type": "string",
+            "description": "Semver string declared by the skill author. Free-form; sorted lexicographically when comparing."
           }
         }
       },
@@ -27033,25 +27173,32 @@
         "properties": {
           "expires_at": {
             "type": "string",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Timestamp when the connection's lease expires (RFC 3339)."
           },
           "model": {
-            "type": "string"
+            "type": "string",
+            "description": "Provider-side model identifier used for the realtime session."
           },
           "provider": {
-            "type": "string"
+            "type": "string",
+            "description": "Realtime provider routing this connection."
           },
           "provider_call_id": {
-            "type": "string"
+            "type": "string",
+            "description": "Provider-side call identifier of the connected realtime call."
           },
           "reasoning_effort": {
-            "type": "string"
+            "type": "string",
+            "description": "Reasoning effort tier for thinking-capable models."
           },
           "voice": {
-            "type": "string"
+            "type": "string",
+            "description": "Realtime voice preset selected for the connection."
           },
           "voice_connection_id": {
-            "type": "string"
+            "type": "string",
+            "description": "Prefixed public identifier of the voice connection."
           }
         }
       },
@@ -27088,32 +27235,40 @@
         ],
         "properties": {
           "answer_sdp": {
-            "type": "string"
+            "type": "string",
+            "description": "Server-generated SDP answer to send back to the client to complete the WebRTC handshake."
           },
           "expires_at": {
             "type": "string",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Timestamp when the call's lease expires (RFC 3339)."
           },
           "model": {
-            "type": "string"
+            "type": "string",
+            "description": "Provider-side model identifier used for the realtime session."
           },
           "provider": {
-            "type": "string"
+            "type": "string",
+            "description": "Realtime provider routing this connection."
           },
           "provider_call_id": {
             "type": [
               "string",
               "null"
-            ]
+            ],
+            "description": "Provider-side call identifier once issued. `None` until the realtime call is established."
           },
           "reasoning_effort": {
-            "type": "string"
+            "type": "string",
+            "description": "Reasoning effort tier for thinking-capable models."
           },
           "voice": {
-            "type": "string"
+            "type": "string",
+            "description": "Realtime voice preset selected for the connection."
           },
           "voice_connection_id": {
-            "type": "string"
+            "type": "string",
+            "description": "Prefixed public identifier of the voice connection."
           }
         }
       },
@@ -27138,25 +27293,33 @@
           "client_secret"
         ],
         "properties": {
-          "client_secret": {},
+          "client_secret": {
+            "description": "Provider-specific ephemeral credential payload the client uses to authenticate the realtime connection."
+          },
           "expires_at": {
             "type": "string",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Timestamp when the client secret expires (RFC 3339). The client must establish the realtime connection before this."
           },
           "model": {
-            "type": "string"
+            "type": "string",
+            "description": "Provider-side model identifier used for the realtime session."
           },
           "provider": {
-            "type": "string"
+            "type": "string",
+            "description": "Realtime provider routing this connection (e.g. `openai`)."
           },
           "reasoning_effort": {
-            "type": "string"
+            "type": "string",
+            "description": "Reasoning effort tier for thinking-capable models (`none`, `minimal`, `low`, `medium`, `high`)."
           },
           "voice": {
-            "type": "string"
+            "type": "string",
+            "description": "Realtime voice preset selected for the connection (provider-specific)."
           },
           "voice_connection_id": {
-            "type": "string"
+            "type": "string",
+            "description": "Prefixed public identifier of the voice connection (see `specs/id-schema.md`)."
           }
         }
       },
@@ -27284,32 +27447,40 @@
             ],
             "properties": {
               "answer_sdp": {
-                "type": "string"
+                "type": "string",
+                "description": "Server-generated SDP answer to send back to the client to complete the WebRTC handshake."
               },
               "expires_at": {
                 "type": "string",
-                "format": "date-time"
+                "format": "date-time",
+                "description": "Timestamp when the call's lease expires (RFC 3339)."
               },
               "model": {
-                "type": "string"
+                "type": "string",
+                "description": "Provider-side model identifier used for the realtime session."
               },
               "provider": {
-                "type": "string"
+                "type": "string",
+                "description": "Realtime provider routing this connection."
               },
               "provider_call_id": {
                 "type": [
                   "string",
                   "null"
-                ]
+                ],
+                "description": "Provider-side call identifier once issued. `None` until the realtime call is established."
               },
               "reasoning_effort": {
-                "type": "string"
+                "type": "string",
+                "description": "Reasoning effort tier for thinking-capable models."
               },
               "voice": {
-                "type": "string"
+                "type": "string",
+                "description": "Realtime voice preset selected for the connection."
               },
               "voice_connection_id": {
-                "type": "string"
+                "type": "string",
+                "description": "Prefixed public identifier of the voice connection."
               }
             }
           }
@@ -29499,52 +29670,61 @@
                 "type": [
                   "string",
                   "null"
-                ]
+                ],
+                "description": "Comma-separated list of tool patterns this skill may invoke. `None` means inherit from the harness."
               },
               "archived_at": {
                 "type": [
                   "string",
                   "null"
                 ],
-                "format": "date-time"
+                "format": "date-time",
+                "description": "Timestamp when this skill was archived, if any (RFC 3339). Archived skills are hidden from default list views."
               },
               "compatibility": {
                 "type": [
                   "string",
                   "null"
-                ]
+                ],
+                "description": "Compatibility marker describing host-runtime requirements declared by the skill (e.g. min platform version). Informational."
               },
               "created_at": {
                 "type": "string",
-                "format": "date-time"
+                "format": "date-time",
+                "description": "Timestamp when this skill was created (RFC 3339)."
               },
               "deleted_at": {
                 "type": [
                   "string",
                   "null"
                 ],
-                "format": "date-time"
+                "format": "date-time",
+                "description": "Timestamp when this skill was hard-deleted, if any (RFC 3339)."
               },
               "description": {
                 "type": "string",
+                "description": "Short, agent- and user-readable summary of what the skill does and when to use it.",
                 "example": "Extract text and tables from PDF files."
               },
               "disable_model_invocation": {
                 "type": "boolean",
-                "description": "Whether the model is prevented from auto-invoking this skill"
+                "description": "When `true`, the LLM is prevented from auto-invoking this skill; only the user can trigger it explicitly."
               },
               "id": {
                 "type": "string",
+                "description": "Prefixed public identifier (see `specs/id-schema.md`).",
                 "example": "skill_01933b5a00007000800000000000001"
               },
               "license": {
                 "type": [
                   "string",
                   "null"
-                ]
+                ],
+                "description": "License string as declared by the skill author (e.g. `MIT`, `Apache-2.0`). Informational; not enforced."
               },
               "metadata": {
                 "type": "object",
+                "description": "Free-form metadata declared by the skill author.",
                 "additionalProperties": {},
                 "propertyNames": {
                   "type": "string"
@@ -29552,24 +29732,29 @@
               },
               "name": {
                 "type": "string",
+                "description": "Stable kebab-case slug used to invoke the skill (e.g. `/pdf-processing` in chat). Safe to render in user-facing messages.",
                 "example": "pdf-processing"
               },
               "source_type": {
-                "$ref": "#/components/schemas/SkillSourceType"
+                "$ref": "#/components/schemas/SkillSourceType",
+                "description": "How the skill content is sourced (filesystem, URL, embedded). Determines reload semantics."
               },
               "status": {
-                "$ref": "#/components/schemas/SkillStatus"
+                "$ref": "#/components/schemas/SkillStatus",
+                "description": "Current lifecycle status (`active`, `archived`, `deleted`)."
               },
               "updated_at": {
                 "type": "string",
-                "format": "date-time"
+                "format": "date-time",
+                "description": "Timestamp when this skill was last updated (RFC 3339)."
               },
               "user_invocable": {
                 "type": "boolean",
-                "description": "Whether this skill appears as a /slash command for users"
+                "description": "Whether this skill appears as a `/`-prefixed slash command for end users in chat UIs."
               },
               "version": {
-                "type": "string"
+                "type": "string",
+                "description": "Semver string declared by the skill author. Free-form; sorted lexicographically when comparing."
               }
             }
           },


### PR DESCRIPTION
## What
Next slice on the OpenAPI prose ratchet. Field coverage **67% → 75.6%** (1164/1540 fields). Bumps `MIN_FIELD_DESC_PCT` floor from 67 to 75.

Hand-written descriptions for the largest remaining clusters:

- **`HealthResponse`** — durable engine operator surface. Distinguishes gauges (running/pending/active) from monotonic counters (completed/failed/started), explains `load_percentage` derivation and `event_delivery` backend marker.
- **`AgentVersion`** — versioning entity. `is_published` vs automatic-snapshot semantics, `change_kind` classification, `parent_version_id` (forked from) vs `source_version_id` (rollback copy of), authored-vs-resolved config split.
- **`ResourceStatsResponse`** — shared aggregate stats. Distinguishes status-bucket counts from cumulative totals; cache tokens; `avg_*` derivation.
- **`Skill`** — slash-command surface. `name` as the user-typed slug, `user_invocable` vs `disable_model_invocation`, lifecycle timestamps.
- **`SessionFile` + `FileInfo` + `FileStat`** — content encoding (text vs base64), read-only semantics, directory vs file.
- **`VoiceClientSecretResponse` / `VoiceCallResponse` / `VoiceAttachResponse`** — `client_secret` opaque payload, WebRTC `answer_sdp`, lease expiry.
- **`ScheduleResponse` + `ScheduleStatsResponse`** — cron expression format, timezone interpretation, catch-up semantics, success/fail/skip breakdown.

## Why
Continuing the AI-friendly OpenAPI push from #1834 and #1851. At 67% coverage, agents still hit gaps where a missing description means "guess what this field means" — especially on operator surfaces where wrong assumptions can mask actual system state (`HealthResponse`, `ScheduleStatsResponse`) and on lifecycle entities (`AgentVersion`, `Skill`) where the wrong mental model produces incorrect tool calls.

## How
Direct `///` doc comments on the relevant struct fields. No behavior change — only prose. OpenAPI export regenerated. Ratchet floor bumped to lock the new level.

## Risk
- **Low.** Documentation-only PR. No code paths touched.
- OpenAPI diff is the bulk of the changes (+473 lines), almost entirely added `description` properties.

## Security
- Threat categories reviewed: none directly applicable. Prose changes don't widen any surface.
- The `VoiceClientSecretResponse.client_secret` description re-emphasizes it's an ephemeral credential payload the client must protect; no new disclosure.
- `AgentVersion.authored_config` and `resolved_config` already serialize as opaque JSON; new prose doesn't expose any internal detail.

## Follow-ups
- Remaining unannotated clusters: `UpdateHarnessRequest` (8), `GetSessionSandboxResponse` (8), `ManageSessionSandboxResponse` (7), `SessionContextReport` (7), `ReportQuery` (7), `VolumeResponse` (6 of 14), nested deep structs. A focused PR can push to ~85%.
- `example` injection is still ~11% across the board — a separate effort.

## Checklist
- [x] Tests added or updated (ratchet floor bumped 67 → 75)
- [x] Backward compatibility considered (no wire shape changes)
- [x] Security review performed against relevant threat model categories

---
_Generated by [Claude Code](https://claude.ai/code/session_01K7vXyQJ9St1tLHukPbJmGh)_