### PR TITLE
fix(openai): cap prompt cache key length

### DIFF
--- a/crates/core/src/openresponses_protocol.rs
+++ b/crates/core/src/openresponses_protocol.rs
@@ -43,6 +43,8 @@ use crate::openresponses_types::{self as types, StreamingEvent};
 use crate::tool_types::{ToolCall, ToolDefinition};
 
 const DEFAULT_API_URL: &str = "https://api.openai.com/v1/responses";
+const OPENAI_PROMPT_CACHE_KEY_MAX_LEN: usize = 64;
+const PROMPT_CACHE_KEY_PREFIX: &str = "everruns:";
 
 /// Open Responses Protocol Driver (OpenAI implementation)
 ///
@@ -331,7 +333,12 @@ impl OpenResponsesProtocolLlmDriver {
             "tools": tools,
         });
         let payload = serde_json::to_vec(&fingerprint).ok()?;
-        Some(format!("everruns:{:x}", Sha256::digest(payload)))
+        let digest = format!("{:x}", Sha256::digest(payload));
+        let digest_len = OPENAI_PROMPT_CACHE_KEY_MAX_LEN - PROMPT_CACHE_KEY_PREFIX.len();
+        Some(format!(
+            "{PROMPT_CACHE_KEY_PREFIX}{}",
+            &digest[..digest_len]
+        ))
     }
 
     /// Compact a conversation to reduce context size
@@ -1869,6 +1876,45 @@ mod tests {
 
         assert!(key.is_some());
         assert!(key.unwrap().starts_with("everruns:"));
+    }
+
+    #[test]
+    fn test_build_prompt_cache_key_stays_within_openai_limit() {
+        let config = LlmCallConfig {
+            model: "gpt-5.5".to_string(),
+            temperature: None,
+            max_tokens: None,
+            tools: vec![],
+            reasoning_effort: None,
+            metadata: std::collections::HashMap::new(),
+            previous_response_id: None,
+            tool_search: None,
+            prompt_cache: Some(crate::llm_driver_registry::PromptCacheConfig {
+                enabled: true,
+                strategy: crate::llm_driver_registry::PromptCacheStrategy::Auto,
+                gemini_cached_content: None,
+            }),
+        };
+        let input = vec![ResponsesInputItem::Message {
+            r#type: "message".to_string(),
+            role: "user".to_string(),
+            content: ResponsesContent::Text("fetch chalyi.name for me".to_string()),
+            phase: None,
+        }];
+
+        let key = OpenResponsesProtocolLlmDriver::build_prompt_cache_key(
+            &config,
+            &input,
+            &Some("You are helpful".to_string()),
+            &None,
+        )
+        .unwrap();
+
+        assert!(
+            key.len() <= 64,
+            "OpenAI prompt_cache_key limit is 64 characters, got {}",
+            key.len()
+        );
     }
 
     #[test]

--- a/specs/llm-drivers.md
+++ b/specs/llm-drivers.md
@@ -98,7 +98,7 @@ Prompt caching is modeled as request intent on `LlmCallConfig.prompt_cache`. Dri
 
 Current provider mappings:
 
-- **OpenAI Responses API** — derives a deterministic `prompt_cache_key`
+- **OpenAI Responses API** — derives a deterministic `prompt_cache_key` within OpenAI's 64-character request limit
 - **Anthropic** — adds `cache_control: { type: "ephemeral" }` to eligible text blocks
 - **Gemini** — uses `cachedContent` when the config includes an existing cached-content resource name; otherwise the request remains in implicit/default Gemini behavior
 


### PR DESCRIPTION
## What
Cap OpenAI Responses `prompt_cache_key` generation at the provider's 64-character request limit and document that limit in the LLM driver spec.

## Why
OpenAI rejects overlong `prompt_cache_key` values with `400 Bad Request`. The previous key was `everruns:` plus a full SHA-256 hex digest, producing 73 characters.

## How
- Keep the `everruns:` namespace prefix.
- Truncate the SHA-256 hex digest to the remaining allowed length.
- Add a regression test that reproduces the 73-character failure and asserts the OpenAI limit.

Validation:
- Reproduced with new failing regression test: `cargo test -p everruns-core openresponses_protocol::tests::test_build_prompt_cache_key_stays_within_openai_limit` failed with `got 73` before the fix.
- `cargo test -p everruns-core openresponses_protocol::tests::test_build_prompt_cache_key`
- `cargo fmt --check`
- `bash scripts/lib/check-migration-ordering.sh`
- `just pre-push`
- API smoke: `PORT_PREFIX=452 ... ./scripts/lib/services.sh server`, then `GET /health` on `127.0.0.1:45201`.

## Risk
- Low
- Prompt cache keys remain deterministic but use 55 hex digest characters instead of 64. That still leaves 220 bits of hash material, so collision risk remains negligible for this use.

## Security
- Threat categories reviewed: TM-LLM, TM-DOS
- Findings and resolutions: The change only constrains a provider request parameter length. It does not add prompt content, credentials, logging, authorization, network targets, dependencies, or unbounded resource use. No threat model update needed.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
