### PR TITLE
fix(runtime): preserve ACLs in single-session builder

### DIFF
--- a/crates/runtime/src/builders.rs
+++ b/crates/runtime/src/builders.rs
@@ -70,6 +70,11 @@ impl HarnessBuilder {
         self.id
     }
 
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.name = name.into();
+        self
+    }
+
     pub fn display_name(mut self, display_name: impl Into<String>) -> Self {
         self.display_name = Some(display_name.into());
         self
@@ -244,6 +249,11 @@ impl AgentBuilder {
     /// Return the id currently assigned to this builder.
     pub fn agent_id(&self) -> AgentId {
         self.id
+    }
+
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.name = name.into();
+        self
     }
 
     pub fn display_name(mut self, display_name: impl Into<String>) -> Self {
@@ -637,22 +647,22 @@ impl Default for SingleSessionBuilder {
 }
 
 impl SingleSessionBuilder {
-    /// Configure the seeded harness.
+    /// Configure the seeded harness. Mutates the existing `HarnessBuilder`
+    /// in place so previously configured fields (e.g. `network_access`) are
+    /// preserved regardless of call order.
     pub fn harness(mut self, name: impl Into<String>, system_prompt: impl Into<String>) -> Self {
         let harness_id = self.harness.harness_id();
-        self.harness.id = harness_id;
-        self.harness.name = name.into();
-        self.harness.system_prompt = system_prompt.into();
+        self.harness = self.harness.name(name).system_prompt(system_prompt);
         self.session = self.session.harness(harness_id);
         self
     }
 
-    /// Configure the seeded agent.
+    /// Configure the seeded agent. Mutates the existing `AgentBuilder` in
+    /// place so previously configured fields (e.g. `network_access`) are
+    /// preserved regardless of call order.
     pub fn agent(mut self, name: impl Into<String>, system_prompt: impl Into<String>) -> Self {
         let agent_id = self.agent.agent_id();
-        self.agent.id = agent_id;
-        self.agent.name = name.into();
-        self.agent.system_prompt = system_prompt.into();
+        self.agent = self.agent.name(name).system_prompt(system_prompt);
         self.session = self.session.agent(agent_id);
         self
     }

--- a/crates/runtime/src/builders.rs
+++ b/crates/runtime/src/builders.rs
@@ -640,7 +640,9 @@ impl SingleSessionBuilder {
     /// Configure the seeded harness.
     pub fn harness(mut self, name: impl Into<String>, system_prompt: impl Into<String>) -> Self {
         let harness_id = self.harness.harness_id();
-        self.harness = HarnessBuilder::new(name, system_prompt).id(harness_id);
+        self.harness.id = harness_id;
+        self.harness.name = name.into();
+        self.harness.system_prompt = system_prompt.into();
         self.session = self.session.harness(harness_id);
         self
     }
@@ -648,7 +650,9 @@ impl SingleSessionBuilder {
     /// Configure the seeded agent.
     pub fn agent(mut self, name: impl Into<String>, system_prompt: impl Into<String>) -> Self {
         let agent_id = self.agent.agent_id();
-        self.agent = AgentBuilder::new(name, system_prompt).id(agent_id);
+        self.agent.id = agent_id;
+        self.agent.name = name.into();
+        self.agent.system_prompt = system_prompt.into();
         self.session = self.session.agent(agent_id);
         self
     }

--- a/crates/runtime/tests/in_process_runtime_test.rs
+++ b/crates/runtime/tests/in_process_runtime_test.rs
@@ -3,6 +3,7 @@ use chrono::{TimeZone, Utc};
 use everruns_core::capabilities::TestMathCapability;
 use everruns_core::llm_driver_registry::DriverRegistry;
 use everruns_core::llmsim_driver::LlmSimConfig;
+use everruns_core::network_access::NetworkAccessList;
 use everruns_core::{
     Agent, CapabilityRegistry, Harness, InitialFile, LlmProviderType, MessageRole,
     ModelWithProvider, PlatformDefinition, Session, SessionFileSystem, SessionFileSystemFactory,
@@ -206,6 +207,56 @@ async fn single_session_builder_seeds_runnable_runtime() {
         .await
         .unwrap();
     assert!(result.success);
+}
+
+#[tokio::test]
+async fn single_session_builder_preserves_harness_acl_when_order_changes() {
+    let runtime = InProcessRuntimeBuilder::new()
+        .platform_definition(minimal_platform())
+        .llm_sim(LlmSimConfig::fixed("ok"))
+        .single_session(|s| {
+            s.harness_network_access(NetworkAccessList::allow_only(["example.com"]))
+                .harness("math", "You are a math assistant.")
+        })
+        .build()
+        .await
+        .unwrap();
+
+    let session_id = runtime.default_session_id().expect("default session id");
+    let context = runtime.load_context(session_id).await.unwrap();
+    assert_eq!(
+        context
+            .harness_chain
+            .last()
+            .and_then(|h| h.network_access.as_ref())
+            .map(|acl| acl.allowed.clone()),
+        Some(vec!["example.com".to_string()])
+    );
+}
+
+#[tokio::test]
+async fn single_session_builder_preserves_agent_acl_when_order_changes() {
+    let runtime = InProcessRuntimeBuilder::new()
+        .platform_definition(minimal_platform())
+        .llm_sim(LlmSimConfig::fixed("ok"))
+        .single_session(|s| {
+            s.agent_network_access(NetworkAccessList::allow_only(["example.com"]))
+                .agent("math-agent", "Use tools when needed.")
+        })
+        .build()
+        .await
+        .unwrap();
+
+    let session_id = runtime.default_session_id().expect("default session id");
+    let context = runtime.load_context(session_id).await.unwrap();
+    assert_eq!(
+        context
+            .agent
+            .as_ref()
+            .and_then(|a| a.network_access.as_ref())
+            .map(|acl| acl.allowed.clone()),
+        Some(vec!["example.com".to_string()])
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
### Motivation
- Prevent order-dependent loss of network ACLs in `SingleSessionBuilder` where calls to `harness(...)` or `agent(...)` replaced their entire sub-builders and discarded previously-set `network_access` (fail-open security risk). 

### Description
- `SingleSessionBuilder::harness(...)` now mutates the existing `HarnessBuilder` fields (`name` and `system_prompt`) instead of replacing the sub-builder, preserving previously configured fields such as `network_access`. 
- `SingleSessionBuilder::agent(...)` now mutates the existing `AgentBuilder` fields (`name` and `system_prompt`) instead of replacing the sub-builder, preserving previously configured fields such as `network_access`. 
- Added regression tests that assert ACLs survive the call order for both harness and agent and added the necessary `NetworkAccessList` import in the test file. 
- Files changed: `crates/runtime/src/builders.rs` and `crates/runtime/tests/in_process_runtime_test.rs`. 

### Testing
- Ran `cargo test -p everruns-runtime single_session_builder_preserves_*` and the two new tests (`single_session_builder_preserves_harness_acl_when_order_changes` and `single_session_builder_preserves_agent_acl_when_order_changes`) passed. 
- Built and ran the `everruns-runtime` tests which completed successfully for the targeted test set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b1f88b268832ba162b607b8ce5b35)