### PR TITLE
feat(coding-cli): add model command suggestions

### DIFF
--- a/examples/coding-cli/README.md
+++ b/examples/coding-cli/README.md
@@ -52,7 +52,12 @@ and OpenAI both do). No capability needed.
   `ANTHROPIC_API_KEY` → Anthropic (`claude-sonnet-4-5`), otherwise falls back
   to `llmsim` (offline). OpenAI is preferred when both keys are present so the
   default model stays `gpt-5.5`.
-- **Slash commands** (TUI): `/help`, `/tools`, `/cwd`, `/model`, `/clear`, `/quit`
+- **Slash commands** (TUI): `/help`, `/tools`, `/cwd`, `/model <provider>/<id>`, `/clear`, `/quit`.
+  Typing `/` opens suggestions; Tab accepts the first suggestion. `/model`
+  with no argument shows the current model and suggested model IDs, while
+  `/model openai/gpt-5.5`, `/model anthropic/claude-sonnet-4-5`, or
+  `/model llmsim/llmsim-coding-cli` changes the active provider/model for
+  subsequent turns. Bare model IDs still target the current provider.
 - **`--print`** one-shot mode for CI smoke tests
 
 ## Install
@@ -94,7 +99,7 @@ doppler run -- ercode -p "Show me the runtime spec."
 Offline (no API key required):
 
 ```bash
-ercode --provider sim -p "hi"
+ercode --provider llmsim -p "hi"
 ```
 
 ## Flags
@@ -102,7 +107,7 @@ ercode --provider sim -p "hi"
 | Flag                       | Description                                                          |
 | -------------------------- | -------------------------------------------------------------------- |
 | `-C, --cwd <PATH>`         | Workspace root (default: current dir)                                |
-| `--provider <P>`           | Force `anthropic`, `openai`, or `sim` (default: env-detected)        |
+| `--provider <P>`           | Force `anthropic`, `openai`, or `llmsim` (default: env-detected)     |
 | `-m, --model <ID>`         | Override the model id for the chosen provider                        |
 | `-p, --print <PROMPT>`     | Run one prompt non-interactively and print the result                |
 | `--ask`                    | Prompt before every destructive tool call (off by default)           |

--- a/examples/coding-cli/src/app.rs
+++ b/examples/coding-cli/src/app.rs
@@ -66,6 +66,52 @@ struct PendingApproval {
     responder: oneshot::Sender<bool>,
 }
 
+#[derive(Clone, Copy)]
+struct CommandSpec {
+    name: &'static str,
+    usage: &'static str,
+    description: &'static str,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct CommandSuggestion {
+    completion: String,
+    label: String,
+}
+
+const COMMANDS: &[CommandSpec] = &[
+    CommandSpec {
+        name: "help",
+        usage: "/help",
+        description: "show commands",
+    },
+    CommandSpec {
+        name: "tools",
+        usage: "/tools",
+        description: "list available tools",
+    },
+    CommandSpec {
+        name: "cwd",
+        usage: "/cwd",
+        description: "show workspace root",
+    },
+    CommandSpec {
+        name: "model",
+        usage: "/model <provider>/<id>",
+        description: "show or change the active provider/model",
+    },
+    CommandSpec {
+        name: "clear",
+        usage: "/clear",
+        description: "clear transcript",
+    },
+    CommandSpec {
+        name: "quit",
+        usage: "/quit",
+        description: "exit",
+    },
+];
+
 pub struct App {
     bundle: Arc<RuntimeBundle>,
     pub lines: Vec<ChatLine>,
@@ -114,7 +160,7 @@ impl App {
             "workspace: {}",
             self.bundle.workspace_root.display()
         ));
-        self.push_system(format!("model: {}", self.bundle.provider_label));
+        self.push_system(format!("model: {}", self.bundle.provider_label()));
         self.push_system(format!("tools: {}", self.bundle.tool_names.join(", ")));
         if !self.bundle.instruction_files.is_empty() {
             self.push_system(format!(
@@ -283,6 +329,11 @@ impl App {
             KeyCode::Backspace => {
                 self.input.pop();
             }
+            KeyCode::Tab => {
+                if let Some(suggestion) = self.suggestions().first() {
+                    self.input = suggestion.completion.clone();
+                }
+            }
             KeyCode::Char(c) => self.input.push(c),
             KeyCode::Enter => {
                 let text = std::mem::take(&mut self.input);
@@ -291,7 +342,7 @@ impl App {
                     return;
                 }
                 if let Some(rest) = text.strip_prefix('/') {
-                    self.handle_command(rest);
+                    self.handle_command(rest).await;
                     return;
                 }
                 self.push_user(text.clone());
@@ -327,12 +378,24 @@ impl App {
         self.last_total_lines.saturating_sub(self.last_chat_height)
     }
 
-    fn handle_command(&mut self, cmd: &str) {
-        let parts: Vec<&str> = cmd.splitn(2, ' ').collect();
-        let head = parts[0];
+    fn suggestions(&self) -> Vec<CommandSuggestion> {
+        command_suggestions(&self.input, self.bundle.model_suggestions())
+    }
+
+    async fn handle_command(&mut self, cmd: &str) {
+        let cmd = cmd.trim();
+        let mut parts = cmd.splitn(2, char::is_whitespace);
+        let head = parts.next().unwrap_or_default();
+        let arg = parts.next().unwrap_or_default().trim();
         match head {
             "help" => {
-                self.push_system("/help · /tools · /cwd · /model · /clear · /quit".into());
+                self.push_system(
+                    COMMANDS
+                        .iter()
+                        .map(|cmd| cmd.usage)
+                        .collect::<Vec<_>>()
+                        .join(" · "),
+                );
                 self.push_system(
                     "scroll: ↑/↓ line · PgUp/PgDn half-page · Home/End top/bottom · mouse wheel"
                         .into(),
@@ -349,7 +412,18 @@ impl App {
                 ));
             }
             "model" => {
-                self.push_system(format!("model: {}", self.bundle.provider_label));
+                if arg.is_empty() {
+                    self.push_system(format!("model: {}", self.bundle.provider_label()));
+                    self.push_system(format!(
+                        "usage: /model <provider>/<id>; suggestions: {}",
+                        self.bundle.model_suggestions().join(", ")
+                    ));
+                } else {
+                    match self.bundle.set_model(arg).await {
+                        Ok(label) => self.push_system(format!("model changed: {label}")),
+                        Err(err) => self.push_system(format!("model change failed: {err}")),
+                    }
+                }
             }
             "clear" => {
                 self.lines.clear();
@@ -461,6 +535,46 @@ impl App {
     }
 }
 
+fn command_suggestions(input: &str, model_suggestions: &[&str]) -> Vec<CommandSuggestion> {
+    let Some(rest) = input.strip_prefix('/') else {
+        return Vec::new();
+    };
+
+    if let Some(model_prefix) = rest.strip_prefix("model ") {
+        return model_suggestions
+            .iter()
+            .filter(|model| model.starts_with(model_prefix.trim_start()))
+            .take(5)
+            .map(|model| CommandSuggestion {
+                completion: format!("/model {model}"),
+                label: format!("/model {model}    change active provider/model"),
+            })
+            .collect();
+    }
+
+    if rest == "model" {
+        return vec![CommandSuggestion {
+            completion: "/model ".to_string(),
+            label: "/model <provider>/<id>    show or change the active provider/model".to_string(),
+        }];
+    }
+
+    COMMANDS
+        .iter()
+        .filter(|cmd| cmd.name.starts_with(rest))
+        .take(5)
+        .map(|cmd| CommandSuggestion {
+            completion: cmd
+                .usage
+                .split_whitespace()
+                .next()
+                .unwrap_or(cmd.usage)
+                .to_string(),
+            label: format!("{}    {}", cmd.usage, cmd.description),
+        })
+        .collect()
+}
+
 // ---------- helpers for surfacing tool results ----------
 
 fn result_value(data: &ToolCompletedData) -> Option<Value> {
@@ -565,12 +679,22 @@ fn first_line(s: &str, max: usize) -> String {
 
 fn draw(f: &mut ratatui::Frame, app: &mut App) {
     let has_approval = app.pending.is_some();
+    let suggestions = if !app.busy && !has_approval {
+        app.suggestions()
+    } else {
+        Vec::new()
+    };
+    let has_suggestions = !suggestions.is_empty();
     let input_height: u16 = 3;
     let approval_height: u16 = if has_approval { 3 } else { 0 };
+    let suggestions_height: u16 = if has_suggestions { 3 } else { 0 };
 
     let mut constraints = vec![Constraint::Min(3)];
     if has_approval {
         constraints.push(Constraint::Length(approval_height));
+    }
+    if has_suggestions {
+        constraints.push(Constraint::Length(suggestions_height));
     }
     constraints.push(Constraint::Length(input_height));
     constraints.push(Constraint::Length(1));
@@ -585,6 +709,10 @@ fn draw(f: &mut ratatui::Frame, app: &mut App) {
     idx += 1;
     if has_approval {
         draw_approval(f, chunks[idx], &*app);
+        idx += 1;
+    }
+    if has_suggestions {
+        draw_suggestions(f, chunks[idx], &suggestions);
         idx += 1;
     }
     draw_input(f, chunks[idx], &*app);
@@ -666,6 +794,22 @@ fn draw_approval(f: &mut ratatui::Frame, area: Rect, app: &App) {
     f.render_widget(para, area);
 }
 
+fn draw_suggestions(f: &mut ratatui::Frame, area: Rect, suggestions: &[CommandSuggestion]) {
+    let text = suggestions
+        .iter()
+        .map(|suggestion| suggestion.label.as_str())
+        .collect::<Vec<_>>()
+        .join("  ·  ");
+    let para = Paragraph::new(text)
+        .style(Style::default().fg(Color::LightBlue))
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(" suggestions (Tab to accept) "),
+        );
+    f.render_widget(para, area);
+}
+
 fn draw_input(f: &mut ratatui::Frame, area: Rect, app: &App) {
     let title = if app.pending.is_some() {
         " approval pending — answer y / n above "
@@ -687,10 +831,57 @@ fn draw_input(f: &mut ratatui::Frame, area: Rect, app: &App) {
 fn draw_status(f: &mut ratatui::Frame, area: Rect, app: &App) {
     let status = format!(
         " {} · {} · {}msgs ",
-        app.bundle.provider_label,
+        app.bundle.provider_label(),
         app.bundle.workspace_root.display(),
         app.lines.len()
     );
     let para = Paragraph::new(Span::styled(status, Style::default().fg(Color::DarkGray)));
     f.render_widget(para, area);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn command_suggestions_list_commands_for_slash() {
+        let suggestions = command_suggestions("/", &["openai/gpt-5.5"]);
+
+        assert!(suggestions.iter().any(|s| s.completion == "/help"));
+        assert!(suggestions.iter().any(|s| s.completion == "/model"));
+    }
+
+    #[test]
+    fn command_suggestions_complete_model_command_before_args() {
+        let suggestions = command_suggestions("/model", &["openai/gpt-5.5"]);
+
+        assert_eq!(
+            suggestions,
+            vec![CommandSuggestion {
+                completion: "/model ".to_string(),
+                label: "/model <provider>/<id>    show or change the active provider/model"
+                    .to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn command_suggestions_filter_models_by_prefix() {
+        let suggestions = command_suggestions(
+            "/model openai/gpt-5.",
+            &[
+                "openai/gpt-5.5",
+                "openai/gpt-5.4-mini",
+                "anthropic/claude-sonnet-4-5",
+            ],
+        );
+
+        assert_eq!(
+            suggestions
+                .iter()
+                .map(|s| s.completion.as_str())
+                .collect::<Vec<_>>(),
+            vec!["/model openai/gpt-5.5", "/model openai/gpt-5.4-mini"]
+        );
+    }
 }

--- a/examples/coding-cli/src/main.rs
+++ b/examples/coding-cli/src/main.rs
@@ -61,6 +61,7 @@ struct Cli {
 enum ProviderArg {
     Anthropic,
     Openai,
+    #[value(name = "llmsim", alias = "sim")]
     Sim,
 }
 
@@ -148,7 +149,7 @@ async fn run_tui(
 
 async fn run_print_mode(bundle: Arc<RuntimeBundle>, prompt: String) -> Result<()> {
     println!("[workspace] {}", bundle.workspace_root.display());
-    println!("[provider]  {}", bundle.provider_label);
+    println!("[provider]  {}", bundle.provider_label());
     println!("[tools]     {}", bundle.tool_names.join(", "));
     if !bundle.instruction_files.is_empty() {
         println!(

--- a/examples/coding-cli/src/runtime.rs
+++ b/examples/coding-cli/src/runtime.rs
@@ -24,10 +24,11 @@ use everruns_core::{
 };
 use everruns_integrations_duckduckgo::DuckDuckGoCapability;
 use everruns_runtime::{
-    InProcessRuntime, InProcessRuntimeBuilder, RealDiskFileStore, RuntimeBackends, RuntimeFileStore,
+    InProcessRuntime, InProcessRuntimeBuilder, RealDiskFileStore, RuntimeBackends,
+    RuntimeFileStore, RuntimeProviderStore,
 };
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
 const HARNESS_PROMPT: &str = "You are a precise, terse coding assistant. \
     Make minimal, surgical changes. Always explain non-obvious decisions briefly.";
@@ -111,7 +112,101 @@ impl ProviderChoice {
         match self {
             Self::Anthropic { model } => format!("anthropic/{model}"),
             Self::OpenAi { model } => format!("openai/{model}"),
-            Self::Sim => "llmsim (no API key)".to_string(),
+            Self::Sim => "llmsim/llmsim-coding-cli".to_string(),
+        }
+    }
+
+    pub fn model_suggestions() -> &'static [&'static str] {
+        &[
+            "openai/gpt-5.5",
+            "openai/gpt-5.4",
+            "openai/gpt-5.4-mini",
+            "openai/gpt-5.3-codex",
+            "openai/gpt-5.2",
+            "anthropic/claude-sonnet-4-5",
+            "anthropic/claude-opus-4-5",
+            "anthropic/claude-haiku-4-5",
+            "anthropic/claude-sonnet-4-6",
+            "anthropic/claude-opus-4-6",
+            "llmsim/llmsim-coding-cli",
+        ]
+    }
+
+    fn resolve_model_spec(&self, spec: &str) -> Result<Self> {
+        let spec = spec.trim();
+        if let Some((provider, model)) = spec.split_once('/') {
+            return Self::from_provider_model(provider, model);
+        }
+        self.with_current_provider_model(spec.to_string())
+    }
+
+    fn from_provider_model(provider: &str, model: &str) -> Result<Self> {
+        let model = model.trim();
+        if model.is_empty() {
+            return Err(anyhow!("model id is required"));
+        }
+        match provider.trim().to_ascii_lowercase().as_str() {
+            "anthropic" => Ok(Self::Anthropic {
+                model: model.to_string(),
+            }),
+            "openai" => Ok(Self::OpenAi {
+                model: model.to_string(),
+            }),
+            "llmsim" | "sim" => {
+                if model == "llmsim-coding-cli" {
+                    Ok(Self::Sim)
+                } else {
+                    Err(anyhow!("offline llmsim only supports llmsim-coding-cli"))
+                }
+            }
+            other => Err(anyhow!(
+                "unknown provider {other}; expected openai, anthropic, or llmsim"
+            )),
+        }
+    }
+
+    fn with_current_provider_model(&self, model: String) -> Result<Self> {
+        match self {
+            Self::Anthropic { .. } => Ok(Self::Anthropic { model }),
+            Self::OpenAi { .. } => Ok(Self::OpenAi { model }),
+            Self::Sim => {
+                if model == "llmsim-coding-cli" {
+                    Ok(Self::Sim)
+                } else {
+                    Err(anyhow!("offline llmsim only supports llmsim-coding-cli"))
+                }
+            }
+        }
+    }
+
+    fn model_with_provider(&self) -> Result<ModelWithProvider> {
+        match self {
+            ProviderChoice::Anthropic { model } => {
+                let key = std::env::var("ANTHROPIC_API_KEY")
+                    .map_err(|_| anyhow!("ANTHROPIC_API_KEY not set"))?;
+                Ok(ModelWithProvider {
+                    model: model.clone(),
+                    provider_type: LlmProviderType::Anthropic,
+                    api_key: Some(key),
+                    base_url: None,
+                })
+            }
+            ProviderChoice::OpenAi { model } => {
+                let key = std::env::var("OPENAI_API_KEY")
+                    .map_err(|_| anyhow!("OPENAI_API_KEY not set"))?;
+                Ok(ModelWithProvider {
+                    model: model.clone(),
+                    provider_type: LlmProviderType::Openai,
+                    api_key: Some(key),
+                    base_url: None,
+                })
+            }
+            ProviderChoice::Sim => Ok(ModelWithProvider {
+                model: "llmsim-coding-cli".into(),
+                provider_type: LlmProviderType::LlmSim,
+                api_key: Some("fake-key".into()),
+                base_url: None,
+            }),
         }
     }
 }
@@ -122,9 +217,41 @@ pub struct RuntimeBundle {
     pub runtime: Arc<InProcessRuntime>,
     pub session_id: SessionId,
     pub workspace_root: PathBuf,
-    pub provider_label: String,
     pub instruction_files: Vec<String>,
     pub tool_names: Vec<String>,
+    provider: RwLock<ProviderChoice>,
+    provider_store: Arc<dyn RuntimeProviderStore>,
+}
+
+impl RuntimeBundle {
+    pub fn provider_label(&self) -> String {
+        self.provider
+            .read()
+            .expect("provider lock poisoned")
+            .label()
+    }
+
+    pub fn model_suggestions(&self) -> &'static [&'static str] {
+        ProviderChoice::model_suggestions()
+    }
+
+    pub async fn set_model(&self, model: &str) -> Result<String> {
+        let model = model.trim();
+        if model.is_empty() {
+            return Err(anyhow!("model id is required"));
+        }
+        let next = self
+            .provider
+            .read()
+            .expect("provider lock poisoned")
+            .resolve_model_spec(model)?;
+        self.provider_store
+            .set_default_model(next.model_with_provider()?)
+            .await?;
+        let label = next.label();
+        *self.provider.write().expect("provider lock poisoned") = next;
+        Ok(label)
+    }
 }
 
 pub async fn build(
@@ -145,6 +272,7 @@ pub async fn build(
 
     // The rest of the backends stay in memory.
     let backends = RuntimeBackends::in_memory().with_file_store(file_store);
+    let provider_store = backends.provider_store.clone();
 
     // Register a curated set of built-in capabilities (no opinionated bundle
     // — we want a tight, predictable surface for the coding-CLI) plus our
@@ -178,45 +306,18 @@ pub async fn build(
     });
 
     let mut driver_registry = DriverRegistry::new();
-    let mut llm_sim: Option<LlmSimConfig> = None;
+    everruns_anthropic::register_driver(&mut driver_registry);
+    everruns_openai::register_driver(&mut driver_registry);
     let default_model = match &provider {
-        ProviderChoice::Anthropic { model } => {
-            let key = std::env::var("ANTHROPIC_API_KEY")
-                .map_err(|_| anyhow!("ANTHROPIC_API_KEY not set"))?;
-            everruns_anthropic::register_driver(&mut driver_registry);
-            ModelWithProvider {
-                model: model.clone(),
-                provider_type: LlmProviderType::Anthropic,
-                api_key: Some(key),
-                base_url: None,
-            }
+        ProviderChoice::Anthropic { .. } | ProviderChoice::OpenAi { .. } => {
+            provider.model_with_provider()?
         }
-        ProviderChoice::OpenAi { model } => {
-            let key =
-                std::env::var("OPENAI_API_KEY").map_err(|_| anyhow!("OPENAI_API_KEY not set"))?;
-            everruns_openai::register_driver(&mut driver_registry);
-            ModelWithProvider {
-                model: model.clone(),
-                provider_type: LlmProviderType::Openai,
-                api_key: Some(key),
-                base_url: None,
-            }
-        }
-        ProviderChoice::Sim => {
-            llm_sim = Some(
-                LlmSimConfig::fixed(
-                    "I'm running in offline mode (llmsim — no API key set). \
-                     Set ANTHROPIC_API_KEY or OPENAI_API_KEY for real responses.",
-                )
-                .with_model("llmsim-coding-cli"),
-            );
-            ModelWithProvider {
-                model: "llmsim-coding-cli".into(),
-                provider_type: LlmProviderType::LlmSim,
-                api_key: Some("fake-key".into()),
-                base_url: None,
-            }
-        }
+        ProviderChoice::Sim => ModelWithProvider {
+            model: "llmsim-coding-cli".into(),
+            provider_type: LlmProviderType::LlmSim,
+            api_key: Some("fake-key".into()),
+            base_url: None,
+        },
     };
 
     let platform = PlatformDefinition::new(capabilities, driver_registry);
@@ -269,9 +370,13 @@ pub async fn build(
             }
             s
         });
-    if let Some(cfg) = llm_sim {
-        builder = builder.llm_sim(cfg);
-    }
+    builder = builder.llm_sim(
+        LlmSimConfig::fixed(
+            "I'm running in offline mode (llmsim — no API key set). \
+             Set ANTHROPIC_API_KEY or OPENAI_API_KEY for real responses.",
+        )
+        .with_model("llmsim-coding-cli"),
+    );
     let runtime = builder.build().await?;
     let session_id = runtime
         .default_session_id()
@@ -298,8 +403,56 @@ pub async fn build(
         runtime: Arc::new(runtime),
         session_id,
         workspace_root: canonical_root,
-        provider_label: provider.label(),
         instruction_files,
         tool_names,
+        provider: RwLock::new(provider),
+        provider_store,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn model_spec_can_switch_to_openai() {
+        let provider = ProviderChoice::Sim;
+        let next = provider.resolve_model_spec("openai/gpt-5.5").unwrap();
+
+        assert_eq!(next.label(), "openai/gpt-5.5");
+    }
+
+    #[test]
+    fn model_spec_can_switch_to_anthropic() {
+        let provider = ProviderChoice::OpenAi {
+            model: "gpt-5.5".to_string(),
+        };
+        let next = provider
+            .resolve_model_spec("anthropic/claude-sonnet-4-5")
+            .unwrap();
+
+        assert_eq!(next.label(), "anthropic/claude-sonnet-4-5");
+    }
+
+    #[test]
+    fn model_spec_uses_current_provider_without_prefix() {
+        let provider = ProviderChoice::OpenAi {
+            model: "gpt-5.5".to_string(),
+        };
+        let next = provider.resolve_model_spec("gpt-5.4").unwrap();
+
+        assert_eq!(next.label(), "openai/gpt-5.4");
+    }
+
+    #[test]
+    fn model_spec_accepts_llmsim_provider_name() {
+        let provider = ProviderChoice::OpenAi {
+            model: "gpt-5.5".to_string(),
+        };
+        let next = provider
+            .resolve_model_spec("llmsim/llmsim-coding-cli")
+            .unwrap();
+
+        assert_eq!(next.label(), "llmsim/llmsim-coding-cli");
+    }
 }


### PR DESCRIPTION
## What
Add visible slash-command suggestions to the example coding CLI and extend `/model` so it can switch the active provider/model with combined specs such as `/model openai/gpt-5.5`, `/model anthropic/claude-sonnet-4-5`, and `/model llmsim/llmsim-coding-cli`.

## Why
The example CLI had basic slash commands, but `/model` only reported the current model and there was no discoverable command completion. Provider switching also required restarting the CLI.

## How
- Add a bounded suggestions bar in the TUI and Tab completion for the first suggestion.
- Parse `/model <provider>/<id>` and update the in-process runtime default model for subsequent turns.
- Register OpenAI, Anthropic, and llmsim drivers up front so provider switches can happen at runtime.
- Make `llmsim` the canonical offline provider spelling while keeping `sim` as a CLI alias.
- Cover command suggestion filtering and provider/model spec parsing with unit tests.

## Risk
- Low
- Possible breakage would be limited to the standalone `examples/coding-cli` command handling or startup provider parsing.

## Security
- Threat categories reviewed: TM-LLM, TM-DOS
- Findings and resolutions: API keys remain env-sourced and are not displayed in command suggestions, status lines, or errors. Provider/model input is parsed only into existing runtime provider selection and does not introduce shell execution, filesystem access, or network endpoints. Suggestions are static and capped to five rendered entries to avoid unbounded UI work.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)
