### PR TITLE
fix(ci): harden crates publish ref validation

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -1,20 +1,14 @@
 name: Publish Crates
 
 on:
-  release:
-    types: [published]
-  workflow_dispatch:
-    inputs:
-      tag:
-        description: 'Release tag (e.g., v0.8.31)'
-        required: true
-        type: string
+  repository_dispatch:
+    types: [publish-crates]
 
 permissions:
   contents: read
 
 concurrency:
-  group: publish-crates-${{ github.event.release.tag_name || inputs.tag || github.ref }}
+  group: publish-crates-${{ github.event.client_payload.tag || github.ref }}
   cancel-in-progress: false
 
 env:
@@ -27,26 +21,80 @@ jobs:
     steps:
       - name: Resolve release tag
         id: release
+        env:
+          DISPATCH_SHA: ${{ github.event.client_payload.sha || '' }}
+          DISPATCH_TAG: ${{ github.event.client_payload.tag || '' }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            TAG="${{ inputs.tag }}"
-          else
-            TAG="${{ github.event.release.tag_name }}"
+          set -euo pipefail
+
+          if [ "$EVENT_NAME" != "repository_dispatch" ]; then
+            echo "::error::Unsupported event for crates publish: $EVENT_NAME"
+            exit 1
           fi
+
+          TAG="$DISPATCH_TAG"
+
           if [ -z "$TAG" ]; then
             echo "::error::Release tag is required"
             exit 1
           fi
-          if [[ "$TAG" != v* ]]; then
-            echo "::error::Release tag must start with v: $TAG"
+
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z]+([.-][0-9A-Za-z]+)*)?$ ]]; then
+            echo "::error::Release tag must be a semantic version tag like v1.2.3 or v1.2.3-rc.1: $TAG"
             exit 1
           fi
+
+          if [[ ! "$DISPATCH_SHA" =~ ^[0-9a-fA-F]{40}$ ]]; then
+            echo "::error::repository_dispatch must include the 40-character release commit SHA"
+            exit 1
+          fi
+
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+          echo "expected_sha=$DISPATCH_SHA" >> "$GITHUB_OUTPUT"
 
       - uses: actions/checkout@v4
         with:
-          ref: ${{ steps.release.outputs.tag }}
+          ref: main
+          fetch-depth: 0
+
+      - name: Verify release tag is trusted
+        id: trusted_ref
+        env:
+          EXPECTED_SHA: ${{ steps.release.outputs.expected_sha }}
+          TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          set -euo pipefail
+
+          # The crates.io token may only publish code that was reviewed into main.
+          git fetch --force origin \
+            "refs/heads/main:refs/remotes/origin/main" \
+            "refs/tags/$TAG:refs/tags/$TAG"
+
+          if ! TAG_SHA="$(git rev-list -n 1 "$TAG^{commit}")"; then
+            echo "::error::Could not resolve release tag commit: $TAG"
+            exit 1
+          fi
+
+          if [ -n "$EXPECTED_SHA" ] && [ "$TAG_SHA" != "$EXPECTED_SHA" ]; then
+            echo "::error::Release tag $TAG resolves to $TAG_SHA, expected $EXPECTED_SHA"
+            exit 1
+          fi
+
+          if ! git merge-base --is-ancestor "$TAG_SHA" origin/main; then
+            echo "::error::Release tag $TAG ($TAG_SHA) is not reachable from origin/main"
+            exit 1
+          fi
+
+          echo "sha=$TAG_SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout trusted release commit
+        env:
+          TRUSTED_SHA: ${{ steps.trusted_ref.outputs.sha }}
+        run: |
+          set -euo pipefail
+          git -c advice.detachedHead=false checkout --detach "$TRUSTED_SHA"
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,7 +145,11 @@ jobs:
         run: |
           TAG="v${{ steps.version.outputs.version }}"
           echo "Triggering crates.io publish for tag $TAG..."
-          gh workflow run publish-crates.yml --ref "$TAG" -f "tag=$TAG"
+          gh api "repos/${{ github.repository }}/dispatches" \
+            --method POST \
+            --field event_type=publish-crates \
+            --field "client_payload[tag]=$TAG" \
+            --field "client_payload[sha]=${{ github.sha }}"
           echo "crates.io publish triggered for $TAG"
 
       - name: Trigger server & worker binary builds for release tag

--- a/specs/release-process.md
+++ b/specs/release-process.md
@@ -76,9 +76,10 @@ The workflow will extract release notes from CHANGELOG.md and create the GitHub 
 3. Release body: Extracted from CHANGELOG.md section for that version
 4. Docker images tagged with version (triggered via `workflow_dispatch` from Release workflow)
 5. Pre-built CLI binaries attached as release assets (triggered via `workflow_dispatch` from Release workflow)
+6. crates.io packages published from the trusted release commit (triggered via `repository_dispatch` from Release workflow)
 
 > **Note:** Tags created by `GITHUB_TOKEN` don't trigger other workflows (GitHub anti-recursion).
-> The Release workflow explicitly dispatches Docker Publish and CLI Binaries after creating the release.
+> The Release workflow explicitly dispatches Docker Publish, CLI Binaries, and crates.io publishing after creating the release. Crate publishing validates that the tag is a strict semver tag, resolves to the expected release SHA when dispatched internally, and is reachable from `origin/main` before the crates.io token is used.
 
 ### CLI Binary Assets
 


### PR DESCRIPTION
## What
Harden the crates.io publishing workflow so it no longer publishes from arbitrary manually supplied release tags.

## Why
The publish workflow used to accept a tag input, check out that ref, and publish with `CARGO_REGISTRY_TOKEN` after only version-string validation. A malicious tag with matching Cargo versions could reach the official crate publish path.

## How
- Replace manual `workflow_dispatch` for crates publishing with `repository_dispatch` from the Release workflow.
- Validate release tags with a strict semver pattern.
- Check out `main` before resolving any release tag.
- Fetch the release tag explicitly, verify the tag commit matches the internally dispatched release SHA when present, and require it to be reachable from `origin/main` before checkout/publish.
- Update the release-process spec with the trusted crates publish path.

## Risk
- Medium
- Release automation for crates.io could fail if the tag does not point at the release commit on `main`, which is the intended fail-closed behavior.

## Security
- Threat categories reviewed: supply-chain / CI secret use, TM-AUTHZ, TM-CRYPTO, TM-DOS.
- Findings and resolutions: the high-risk arbitrary-tag publish path is closed by removing external manual tag dispatch, validating tag format, binding internal dispatch to the expected SHA, and requiring main ancestry before the crates.io token is used. No new dependencies or runtime service surfaces were added.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

Validation:
- `just pre-push`
- `bash scripts/lib/check-migration-ordering.sh`
- YAML parse for `.github/workflows/publish-crates.yml` and `.github/workflows/release.yml`
- `git diff --check`
- Focused shell tests for tag resolution rejection/acceptance
- Local Git simulation proving non-main tags and mismatched dispatch SHAs are rejected
- Smoke test: skipped because this is a GitHub Actions/spec-only change with no local runtime path to exercise