### PR TITLE
fix(core): pin fetchkit to 0.2.0 to enforce egress ACL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2667,21 +2667,21 @@ dependencies = [
 
 [[package]]
 name = "fetchkit"
-version = "0.3.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830662c4a2b95832e4dd411706f2999f6e241eccd9b9f1afcab8b2f498b0faa9"
+checksum = "3e551cfcd0082a9acbe9be3dc068f368ef6b5ea6546c47fdd76eb3216ddbf686"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
  "bytes",
  "ed25519-dalek",
  "futures",
- "rand 0.10.1",
+ "rand 0.8.6",
  "reqwest 0.13.3",
  "schemars",
  "serde",
  "serde_json",
- "sha2 0.11.0",
+ "sha2 0.10.9",
  "thiserror 2.0.18",
  "tokio",
  "tower",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -62,7 +62,7 @@ similar = "2"
 url = "2"
 
 # Web fetching
-fetchkit = { version = "0.3.0", features = ["bot-auth"] }
+fetchkit = { version = "0.2.0", features = ["bot-auth"] }
 
 # Ed25519 key derivation (bot-auth public key registration)
 ed25519-dalek = { version = "2", features = ["rand_core"] }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -62,7 +62,7 @@ similar = "2"
 url = "2"
 
 # Web fetching
-fetchkit = { version = "0.2.0", features = ["bot-auth"] }
+fetchkit = { version = "=0.2.0", features = ["bot-auth"] }
 
 # Ed25519 key derivation (bot-auth public key registration)
 ed25519-dalek = { version = "2", features = ["rand_core"] }

--- a/specs/fetchkit.md
+++ b/specs/fetchkit.md
@@ -1,6 +1,6 @@
 # fetchkit
 
-External library ([github.com/everruns/fetchkit](https://github.com/everruns/fetchkit)) powering the `web_fetch` capability. Provides HTTP fetching, HTML-to-markdown conversion, SSRF protection, file download, and source-specific fetchers.
+External library ([github.com/everruns/fetchkit](https://github.com/everruns/fetchkit)) powering the `web_fetch` capability. Provides HTTP fetching, HTML-to-markdown conversion, SSRF protection, and file download.
 
 ## Integration
 
@@ -9,14 +9,6 @@ External library ([github.com/everruns/fetchkit](https://github.com/everruns/fet
 - All metadata (description, system prompt, input schema) comes from `fetchkit::ToolBuilder`, not constants
 - SSRF: `DnsPolicy::block_private_ips()` (default) blocks loopback, RFC1918, link-local, cloud metadata
 - See `crates/core/src/capabilities/web_fetch.rs`
-
-## Specialized fetchers
-
-`fetchkit::Tool` auto-registers a `FetcherRegistry::with_defaults()` chain at execute time. URLs are matched in priority order, falling back to `DefaultFetcher` for anything unmatched. Built-ins (v0.3+):
-
-GitHub code/issue/repo → Twitter/X → Stack Exchange → package registries (PyPI, crates.io, npm) → Wikipedia → YouTube → ArXiv → Hacker News → RSS/Atom → llms.txt / docs sites → `DefaultFetcher` (generic HTML → markdown).
-
-Specialized fetchers produce cleaner, AI-friendly extracts (e.g. Q&A structure for Stack Exchange, README + metadata for GitHub repos) without any caller code change. SSRF protection is uniform: every fetcher resolves through the same `DnsPolicy`.
 
 ## File download (`FileSaver`)
 


### PR DESCRIPTION
### Motivation
- A security scan found that `fetchkit` 0.3.0 introduces source-specific specialized fetchers that may issue secondary outbound requests which are not checked against Everruns' per-context `network_access` ACL, enabling an egress-policy bypass. 
- The change pins `fetchkit` to `0.2.0` to remove the specialized-fetch chain until ACL hooks/callbacks are available to enforce policy on all internal requests.

### Description
- Downgrade `fetchkit` in `crates/core/Cargo.toml` to `fetchkit = { version = "0.2.0", features = ["bot-auth"] }` to avoid the specialized-fetcher behavior introduced in 0.3.0. 
- Regenerated workspace `Cargo.lock` so the resolved `fetchkit` package is `0.2.0` and dependent transitive versions align. 
- Updated `specs/fetchkit.md` to remove the documented v0.3 specialized-fetcher section so documentation matches runtime behavior. 
- No runtime logic in `crates/core/src/capabilities/web_fetch.rs` was changed; this is a minimal dependency/documentation remediation to eliminate the bypass path.

### Testing
- Ran `cargo update -p fetchkit --precise 0.2.0` to adjust the lockfile, which completed successfully. 
- Ran `cargo check -p everruns-core --locked`, which completed successfully (build/check finished). 
- No automated unit tests were modified in this PR; existing `everruns-core` checks passed locally with the pinned dependency.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bdb1b4aa0832b8221ca518e7af835)