### PR TITLE
feat(openapi): sandbox + harness + context + reporting fields (82% coverage)

### DIFF
--- a/crates/core/src/app.rs
+++ b/crates/core/src/app.rs
@@ -520,16 +520,22 @@ pub enum AppEndpointAuthProviderConfig {
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct AppEndpointAuthRequirements {
+    /// JWT `aud` values to require on inbound tokens. Empty list disables audience checking.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub audiences: Vec<String>,
+    /// OAuth scope strings to require (space-delimited per scope entry). Empty list disables scope checking.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub scopes: Vec<String>,
+    /// Arbitrary claim equality predicates. Empty map disables claim filtering.
     #[serde(default, skip_serializing_if = "serde_json::Map::is_empty")]
     pub claims: serde_json::Map<String, serde_json::Value>,
+    /// Allowlist of `sub` claim values. Empty list disables subject filtering.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub subjects: Vec<String>,
+    /// Allowlist of group memberships (from `groups` claim). Empty list disables group filtering.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub groups: Vec<String>,
+    /// Allowlist of email/identifier domains. Empty list disables domain filtering.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub domains: Vec<String>,
 }

--- a/crates/core/src/context_report.rs
+++ b/crates/core/src/context_report.rs
@@ -9,31 +9,46 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ContextReportSection {
+    /// Stable section key (e.g. `system_prompt`, `tools`, `history`). Used as a join key for contributions.
     pub key: String,
+    /// Human-readable section label suitable for UI display.
     pub label: String,
+    /// Total tokens this section contributes to the assembled context.
     pub tokens: u32,
+    /// Number of items this section comprises (messages, tool defs, etc.).
     pub items: u32,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ContextReportContribution {
+    /// Section this contribution rolls up into; matches `ContextReportSection.key`.
     pub section_key: String,
+    /// Stable id of the contributing source (capability id, tool name, message id, etc.).
     pub source_id: String,
+    /// Human-readable label suitable for UI display.
     pub label: String,
+    /// Tokens this single source contributes to the assembled context.
     pub tokens: u32,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct SessionContextReport {
+    /// Prefixed session identifier this report describes.
     pub session_id: String,
+    /// Model identifier the report's token estimates target (used to scope context-window math).
     pub model: String,
+    /// Total context window size in tokens for `model`. `None` if the model's profile lacks limits data.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub context_window_tokens: Option<u32>,
+    /// Estimated number of input tokens consumed by the next generation given the current context.
     pub estimated_input_tokens: u32,
+    /// Logical sections of the assembled context (system prompt, tool defs, message history, etc.) for inspection.
     pub sections: Vec<ContextReportSection>,
+    /// Per-source token contributions (per-tool, per-capability, per-message) for attribution.
     pub contributions: Vec<ContextReportContribution>,
+    /// Cumulative LLM usage observed across the session so far (token + cost rollup).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cumulative_usage: Option<TokenUsage>,
 }

--- a/crates/core/src/events.rs
+++ b/crates/core/src/events.rs
@@ -776,14 +776,20 @@ pub enum CapabilityUsageKind {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct CapabilityUsageRecord {
+    /// Capability id (prefixed or namespaced) attributing this usage.
     pub capability_id: String,
+    /// Capability display name for UI. `None` when the capability is unnamed.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub capability_name: Option<String>,
+    /// Discriminator for the kind of usage being recorded (e.g. `tool_call`, `subagent_spawn`).
     pub usage_kind: CapabilityUsageKind,
+    /// Concrete tool name when `usage_kind` is `tool_call`. `None` for non-tool usage kinds.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tool_name: Option<String>,
+    /// Number of distinct usages recorded in this record (count-style records). `None` for duration-style records.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub usage_count: Option<u64>,
+    /// Total wall-clock duration of the usage in milliseconds (duration-style records). `None` for count-style records.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub duration_ms: Option<u64>,
 }
@@ -1906,15 +1912,21 @@ pub struct VoiceSessionStartedData {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct VoiceTranscriptData {
+    /// Prefixed voice connection identifier this transcript belongs to.
     pub voice_connection_id: String,
+    /// Provider-specific identifier of the conversation item being transcribed. `None` when not yet assigned.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub item_id: Option<String>,
+    /// Provider-specific identifier of the response stream emitting this transcript. `None` for user-side transcripts.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub response_id: Option<String>,
+    /// Transcript phase: `user_partial`, `user_final`, `assistant_partial`, `assistant_final`. `None` when not yet classified.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub phase: Option<String>,
+    /// Newly transcribed text chunk delivered in this event. Empty for "final" events that only mark completion.
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub delta: String,
+    /// Full transcript accumulated for this item up to and including `delta`.
     pub accumulated: String,
 }
 

--- a/crates/core/src/reporting.rs
+++ b/crates/core/src/reporting.rs
@@ -27,16 +27,23 @@ pub struct ReportTimeRange {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ReportQuery {
+    /// Dataset name to query (see `GET /v1/reports/catalog` for the list of available datasets).
     pub dataset: String,
+    /// Time window for the query. The dataset selects which timestamp column the range applies to.
     pub time_range: ReportTimeRange,
+    /// Columns to group by. Empty list returns one aggregate row.
     #[serde(default)]
     pub dimensions: Vec<String>,
+    /// Aggregations to compute (count, sum, avg, etc.). Empty list returns row counts only.
     #[serde(default)]
     pub measures: Vec<String>,
+    /// Predicate filters applied before aggregation.
     #[serde(default)]
     pub filters: Vec<ReportFilter>,
+    /// Sort spec applied after aggregation. Empty list yields unspecified order.
     #[serde(default)]
     pub order_by: Vec<ReportOrderBy>,
+    /// Maximum number of rows to return (defaults to 100).
     #[serde(default = "default_report_limit")]
     pub limit: u32,
 }

--- a/crates/core/src/skill.rs
+++ b/crates/core/src/skill.rs
@@ -257,13 +257,18 @@ pub struct SkillUsage {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct SkillValidationResult {
+    /// `true` when the candidate SKILL.md parsed and passes all hard checks; `false` if any error was found.
     pub valid: bool,
+    /// Parsed skill slug from the front matter. `None` when the input could not be parsed enough to extract a name.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
+    /// Parsed skill description. `None` when not present in the input or unparseable.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    /// Hard validation errors. Non-empty if and only if `valid` is `false`.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub errors: Vec<String>,
+    /// Non-fatal warnings (style, deprecated patterns, optional fields missing). Emitted alongside a `valid` result.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub warnings: Vec<String>,
 }

--- a/crates/server/src/api/durable.rs
+++ b/crates/server/src/api/durable.rs
@@ -430,10 +430,15 @@ impl From<WorkerInfo> for WorkerResponse {
 /// Workers summary stats
 #[derive(Debug, Serialize, ToSchema)]
 pub struct WorkersSummaryResponse {
+    /// Workers in `running` state, accepting tasks.
     pub active: usize,
+    /// Workers in `draining` state, finishing in-flight tasks but not accepting new ones.
     pub draining: usize,
+    /// Workers in `stopped` state, neither running nor draining.
     pub stopped: usize,
+    /// Sum of `max_concurrency` across all `active` + `draining` workers.
     pub total_capacity: usize,
+    /// Total tasks currently in flight across all workers.
     pub total_load: usize,
 }
 

--- a/crates/server/src/api/session_sandbox.rs
+++ b/crates/server/src/api/session_sandbox.rs
@@ -48,56 +48,72 @@ pub enum SessionSandboxAction {
 /// Response body for the `get_session_sandbox` operation.
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct GetSessionSandboxResponse {
+    /// Whether the session's harness opts in to a managed sandbox at all.
     pub configured: bool,
+    /// Whether a sandbox instance currently exists for this session (within its lease).
     pub exists: bool,
+    /// Sandbox provider (`daytona`, `e2b`, `docker`, etc.) when one is configured.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub provider: Option<String>,
+    /// Current sandbox lifecycle status (`starting`, `ready`, `error`, `released`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub session_status: Option<SessionSandboxStatusValue>,
+    /// Provider-side sandbox identifier (workspace ID, container ID, etc.).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub external_id: Option<String>,
+    /// Human-readable sandbox label. Safe to render in user-facing messages.
     #[serde(skip_serializing_if = "Option::is_none")]
-    /// Human-readable display name. Safe to render in user-facing messages.
     pub display_name: Option<String>,
+    /// Absolute path of the sandbox workspace root (used to scope file operations).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub workspace_path: Option<String>,
+    /// Provider-specific metadata (URLs, ports, credentials envelopes).
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schema(value_type = Object)]
-    /// Free-form metadata attached to this resource.
     pub metadata: Option<serde_json::Value>,
+    /// Timestamp when sandbox initialization finished (RFC 3339); absent while still starting.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub init_completed_at: Option<String>,
+    /// Most recent initialization error message; cleared on successful re-init.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub last_init_error: Option<String>,
+    /// Timestamp when this sandbox record was created (RFC 3339).
     #[serde(skip_serializing_if = "Option::is_none")]
-    /// Timestamp when this resource was created (RFC 3339).
     pub created_at: Option<String>,
+    /// Timestamp when this sandbox record was last updated (RFC 3339).
     #[serde(skip_serializing_if = "Option::is_none")]
-    /// Timestamp when this resource was last updated (RFC 3339).
     pub updated_at: Option<String>,
 }
 
 /// Request body for the `manage_session_sandbox` operation.
 #[derive(Debug, Clone, Deserialize, ToSchema)]
 pub struct ManageSessionSandboxRequest {
+    /// Action to take on the sandbox (`reset`, `delete`, etc.).
     pub action: SessionSandboxAction,
 }
 
 /// Response body for the `manage_session_sandbox` operation.
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct ManageSessionSandboxResponse {
+    /// Action that was taken.
     pub action: SessionSandboxAction,
+    /// Whether a sandbox instance still exists after the action.
     pub exists: bool,
+    /// Whether the action deleted the sandbox (`true` after a successful `delete`).
     pub deleted: bool,
+    /// Sandbox provider (`daytona`, `e2b`, `docker`, etc.).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub provider: Option<String>,
+    /// Current sandbox lifecycle status after the action.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub session_status: Option<SessionSandboxStatusValue>,
+    /// Provider-side sandbox identifier.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub external_id: Option<String>,
+    /// Human-readable sandbox label.
     #[serde(skip_serializing_if = "Option::is_none")]
-    /// Human-readable display name. Safe to render in user-facing messages.
     pub display_name: Option<String>,
+    /// Absolute path of the sandbox workspace root.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub workspace_path: Option<String>,
 }

--- a/crates/server/src/domains/harnesses/types.rs
+++ b/crates/server/src/domains/harnesses/types.rs
@@ -70,21 +70,27 @@ pub struct UpdateHarnessRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     /// Human-readable description. Safe to render in user-facing messages.
     pub description: Option<String>,
+    /// New system prompt the harness contributes to sessions; omit to leave unchanged.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub system_prompt: Option<String>,
+    /// New parent harness for inheritance. Outer `None` leaves unchanged; inner `None` removes inheritance (becomes a root harness).
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schema(value_type = Option<String>, nullable = true)]
     pub parent_harness_id: Option<Option<HarnessId>>,
+    /// New default model selected when sessions inherit from this harness; omit to leave unchanged.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schema(value_type = Option<String>)]
     pub default_model_id: Option<ModelId>,
+    /// Replace the tag list entirely; omit to leave unchanged.
     #[serde(skip_serializing_if = "Option::is_none")]
-    /// Free-form tags attached to this resource.
     pub tags: Option<Vec<String>>,
+    /// Replace the capability list entirely; omit to leave unchanged.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub capabilities: Option<Vec<AgentCapabilityConfig>>,
+    /// Replace the initial-files list entirely; omit to leave unchanged.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub initial_files: Option<Vec<InitialFile>>,
+    /// Replace the scoped MCP server set entirely; omit to leave unchanged.
     #[serde(
         default,
         rename = "mcpServers",

--- a/crates/server/src/domains/reporting/types.rs
+++ b/crates/server/src/domains/reporting/types.rs
@@ -100,11 +100,17 @@ fn default_export_format() -> ReportExportFormat {
 
 #[derive(Debug, Clone, Serialize, ToSchema)]
 pub struct ReportExport {
+    /// Export format (currently `csv`).
     pub format: ReportExportFormat,
+    /// Suggested filename for the download (includes the extension matching `format`).
     pub filename: String,
+    /// MIME type matching `format` (`text/csv` for CSV exports).
     pub content_type: String,
+    /// Serialized payload as a UTF-8 string. Caller streams this to the client.
     pub content: String,
+    /// Timestamp the underlying data was materialized (RFC 3339). Useful for "as of" footers.
     pub as_of: DateTime<Utc>,
+    /// How stale the data is relative to `now()`, in milliseconds. `None` when freshness can't be determined.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub freshness_lag_ms: Option<i64>,
 }
@@ -127,34 +133,47 @@ pub struct DatasetProjectorLag {
 
 #[derive(Debug, Clone, Serialize, ToSchema)]
 pub struct ReportingOutboxDiagnostics {
+    /// Outbox rows waiting to be claimed by a projector.
     pub pending: i64,
+    /// Outbox rows currently being processed.
     pub processing: i64,
+    /// Outbox rows that have failed (exceeded retry limit).
     pub failed: i64,
+    /// Outbox rows that have completed processing successfully.
     pub completed: i64,
+    /// Timestamp of the oldest `pending` row (RFC 3339). `None` if no rows are pending.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub oldest_pending_at: Option<DateTime<Utc>>,
+    /// Sample of the most recent failed rows for operator inspection.
     pub failed_rows: Vec<FailedReportingOutboxRow>,
 }
 
 #[derive(Debug, Clone, Serialize, ToSchema)]
 pub struct FailedReportingOutboxRow {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Outbox row UUID.
     pub id: Uuid,
-    /// Owning organization's prefixed public identifier.
+    /// Owning organization's internal numeric id.
     pub org_id: i64,
+    /// Discriminator for the outbox source (`event`, `session`, `llm_generation`, `usage_ledger`).
     pub source_type: String,
+    /// Source-specific row identifier (event id, session id, etc.).
     pub source_id: String,
+    /// Number of processing attempts made before this row was marked failed.
     pub attempts: i32,
+    /// Most recent error message from a processing attempt.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub last_error: Option<String>,
-    /// Timestamp when this resource was last updated (RFC 3339).
+    /// Timestamp when this row was last updated (RFC 3339).
     pub updated_at: DateTime<Utc>,
 }
 
 #[derive(Debug, Clone, Serialize, ToSchema)]
 pub struct ProjectorRunResult {
+    /// Number of outbox rows claimed by this run.
     pub claimed: usize,
+    /// Number of claimed rows that completed successfully.
     pub completed: usize,
+    /// Number of claimed rows that failed and will be retried (or moved to `failed` after retry limit).
     pub failed: usize,
 }
 
@@ -170,9 +189,14 @@ fn default_backfill_limit() -> i64 {
 
 #[derive(Debug, Clone, Default, Serialize, ToSchema)]
 pub struct ReportingBackfillResult {
+    /// Total number of outbox rows enqueued across all source types.
     pub enqueued: i64,
+    /// Number of `event` outbox rows enqueued.
     pub events: i64,
+    /// Number of `session` outbox rows enqueued.
     pub sessions: i64,
+    /// Number of `llm_generation` outbox rows enqueued.
     pub llm_generations: i64,
+    /// Number of `usage_ledger` outbox rows enqueued.
     pub usage_ledger: i64,
 }

--- a/crates/server/src/domains/session_git/service.rs
+++ b/crates/server/src/domains/session_git/service.rs
@@ -25,11 +25,17 @@ use uuid::Uuid;
 /// A commit entry in the log
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct GitCommitInfo {
+    /// Full git object identifier (40-char hex SHA-1).
     pub oid: String,
+    /// Commit message as authored.
     pub message: String,
+    /// Author display name from the commit.
     pub author_name: String,
+    /// Author email from the commit.
     pub author_email: String,
+    /// Commit timestamp (RFC 3339, normalised to UTC).
     pub timestamp: DateTime<Utc>,
+    /// Parent commit object identifiers. Length 0 for the initial commit, 1 for ordinary commits, 2+ for merge commits.
     pub parent_oids: Vec<String>,
 }
 

--- a/crates/server/src/domains/volumes/types.rs
+++ b/crates/server/src/domains/volumes/types.rs
@@ -19,12 +19,18 @@ pub struct VolumeResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     /// Human-readable description. Safe to render in user-facing messages.
     pub description: Option<String>,
+    /// Source kind discriminator (`manual`, `git`, `github`). Determines which `source` variant is populated.
     pub source_type: String,
+    /// Source-specific configuration (git remote, github repo, manual upload).
     pub source: VolumeSourceResponse,
+    /// Whether the volume is mounted read-only into sessions. Read-only volumes accept no writes from the session sandbox.
     pub is_readonly: bool,
+    /// Current sync status (`idle`, `syncing`, `succeeded`, `failed`). Only meaningful when `source_type` is `git` or `github`.
     pub sync_status: String,
+    /// Timestamp of the most recent successful sync (RFC 3339). `None` if never synced.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub last_synced_at: Option<DateTime<Utc>>,
+    /// Most recent sync error message; cleared on the next successful sync.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub last_sync_error: Option<String>,
     #[serde(skip)]

--- a/crates/server/tests/openapi_descriptions_test.rs
+++ b/crates/server/tests/openapi_descriptions_test.rs
@@ -16,7 +16,7 @@ use utoipa::OpenApi;
 /// Lowest acceptable coverage. Bump up when you fix a batch.
 const MIN_OP_DESC_PCT: u32 = 100;
 const MIN_SCHEMA_DESC_PCT: u32 = 88;
-const MIN_FIELD_DESC_PCT: u32 = 75;
+const MIN_FIELD_DESC_PCT: u32 = 82;
 
 fn spec_value() -> serde_json::Value {
     serde_json::from_str(&ApiDoc::openapi().to_pretty_json().unwrap())

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -12205,10 +12205,12 @@
             "type": "array",
             "items": {
               "type": "string"
-            }
+            },
+            "description": "JWT `aud` values to require on inbound tokens. Empty list disables audience checking."
           },
           "claims": {
             "type": "object",
+            "description": "Arbitrary claim equality predicates. Empty map disables claim filtering.",
             "additionalProperties": {},
             "propertyNames": {
               "type": "string"
@@ -12218,25 +12220,29 @@
             "type": "array",
             "items": {
               "type": "string"
-            }
+            },
+            "description": "Allowlist of email/identifier domains. Empty list disables domain filtering."
           },
           "groups": {
             "type": "array",
             "items": {
               "type": "string"
-            }
+            },
+            "description": "Allowlist of group memberships (from `groups` claim). Empty list disables group filtering."
           },
           "scopes": {
             "type": "array",
             "items": {
               "type": "string"
-            }
+            },
+            "description": "OAuth scope strings to require (space-delimited per scope entry). Empty list disables scope checking."
           },
           "subjects": {
             "type": "array",
             "items": {
               "type": "string"
-            }
+            },
+            "description": "Allowlist of `sub` claim values. Empty list disables subject filtering."
           }
         }
       },
@@ -12712,13 +12718,15 @@
         ],
         "properties": {
           "capability_id": {
-            "type": "string"
+            "type": "string",
+            "description": "Capability id (prefixed or namespaced) attributing this usage."
           },
           "capability_name": {
             "type": [
               "string",
               "null"
-            ]
+            ],
+            "description": "Capability display name for UI. `None` when the capability is unnamed."
           },
           "duration_ms": {
             "type": [
@@ -12726,13 +12734,15 @@
               "null"
             ],
             "format": "int64",
+            "description": "Total wall-clock duration of the usage in milliseconds (duration-style records). `None` for count-style records.",
             "minimum": 0
           },
           "tool_name": {
             "type": [
               "string",
               "null"
-            ]
+            ],
+            "description": "Concrete tool name when `usage_kind` is `tool_call`. `None` for non-tool usage kinds."
           },
           "usage_count": {
             "type": [
@@ -12740,10 +12750,12 @@
               "null"
             ],
             "format": "int64",
+            "description": "Number of distinct usages recorded in this record (count-style records). `None` for duration-style records.",
             "minimum": 0
           },
           "usage_kind": {
-            "$ref": "#/components/schemas/CapabilityUsageKind"
+            "$ref": "#/components/schemas/CapabilityUsageKind",
+            "description": "Discriminator for the kind of usage being recorded (e.g. `tool_call`, `subagent_spawn`)."
           }
         }
       },
@@ -13219,17 +13231,21 @@
         ],
         "properties": {
           "label": {
-            "type": "string"
+            "type": "string",
+            "description": "Human-readable label suitable for UI display."
           },
           "section_key": {
-            "type": "string"
+            "type": "string",
+            "description": "Section this contribution rolls up into; matches `ContextReportSection.key`."
           },
           "source_id": {
-            "type": "string"
+            "type": "string",
+            "description": "Stable id of the contributing source (capability id, tool name, message id, etc.)."
           },
           "tokens": {
             "type": "integer",
             "format": "int32",
+            "description": "Tokens this single source contributes to the assembled context.",
             "minimum": 0
           }
         }
@@ -13246,17 +13262,21 @@
           "items": {
             "type": "integer",
             "format": "int32",
+            "description": "Number of items this section comprises (messages, tool defs, etc.).",
             "minimum": 0
           },
           "key": {
-            "type": "string"
+            "type": "string",
+            "description": "Stable section key (e.g. `system_prompt`, `tools`, `history`). Used as a join key for contributions."
           },
           "label": {
-            "type": "string"
+            "type": "string",
+            "description": "Human-readable section label suitable for UI display."
           },
           "tokens": {
             "type": "integer",
             "format": "int32",
+            "description": "Total tokens this section contributes to the assembled context.",
             "minimum": 0
           }
         }
@@ -15485,34 +15505,38 @@
         "properties": {
           "attempts": {
             "type": "integer",
-            "format": "int32"
+            "format": "int32",
+            "description": "Number of processing attempts made before this row was marked failed."
           },
           "id": {
             "type": "string",
             "format": "uuid",
-            "description": "Prefixed public identifier (see `specs/id-schema.md`)."
+            "description": "Outbox row UUID."
           },
           "last_error": {
             "type": [
               "string",
               "null"
-            ]
+            ],
+            "description": "Most recent error message from a processing attempt."
           },
           "org_id": {
             "type": "integer",
             "format": "int64",
-            "description": "Owning organization's prefixed public identifier."
+            "description": "Owning organization's internal numeric id."
           },
           "source_id": {
-            "type": "string"
+            "type": "string",
+            "description": "Source-specific row identifier (event id, session id, etc.)."
           },
           "source_type": {
-            "type": "string"
+            "type": "string",
+            "description": "Discriminator for the outbox source (`event`, `session`, `llm_generation`, `usage_ledger`)."
           },
           "updated_at": {
             "type": "string",
             "format": "date-time",
-            "description": "Timestamp when this resource was last updated (RFC 3339)."
+            "description": "Timestamp when this row was last updated (RFC 3339)."
           }
         }
       },
@@ -15719,52 +15743,58 @@
         ],
         "properties": {
           "configured": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Whether the session's harness opts in to a managed sandbox at all."
           },
           "created_at": {
             "type": [
               "string",
               "null"
             ],
-            "description": "Timestamp when this resource was created (RFC 3339)."
+            "description": "Timestamp when this sandbox record was created (RFC 3339)."
           },
           "display_name": {
             "type": [
               "string",
               "null"
             ],
-            "description": "Human-readable display name. Safe to render in user-facing messages."
+            "description": "Human-readable sandbox label. Safe to render in user-facing messages."
           },
           "exists": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Whether a sandbox instance currently exists for this session (within its lease)."
           },
           "external_id": {
             "type": [
               "string",
               "null"
-            ]
+            ],
+            "description": "Provider-side sandbox identifier (workspace ID, container ID, etc.)."
           },
           "init_completed_at": {
             "type": [
               "string",
               "null"
-            ]
+            ],
+            "description": "Timestamp when sandbox initialization finished (RFC 3339); absent while still starting."
           },
           "last_init_error": {
             "type": [
               "string",
               "null"
-            ]
+            ],
+            "description": "Most recent initialization error message; cleared on successful re-init."
           },
           "metadata": {
             "type": "object",
-            "description": "Free-form metadata attached to this resource."
+            "description": "Provider-specific metadata (URLs, ports, credentials envelopes)."
           },
           "provider": {
             "type": [
               "string",
               "null"
-            ]
+            ],
+            "description": "Sandbox provider (`daytona`, `e2b`, `docker`, etc.) when one is configured."
           },
           "session_status": {
             "oneOf": [
@@ -15772,7 +15802,8 @@
                 "type": "null"
               },
               {
-                "$ref": "#/components/schemas/SessionSandboxStatusValue"
+                "$ref": "#/components/schemas/SessionSandboxStatusValue",
+                "description": "Current sandbox lifecycle status (`starting`, `ready`, `error`, `released`)."
               }
             ]
           },
@@ -15781,13 +15812,14 @@
               "string",
               "null"
             ],
-            "description": "Timestamp when this resource was last updated (RFC 3339)."
+            "description": "Timestamp when this sandbox record was last updated (RFC 3339)."
           },
           "workspace_path": {
             "type": [
               "string",
               "null"
-            ]
+            ],
+            "description": "Absolute path of the sandbox workspace root (used to scope file operations)."
           }
         }
       },
@@ -15804,26 +15836,32 @@
         ],
         "properties": {
           "author_email": {
-            "type": "string"
+            "type": "string",
+            "description": "Author email from the commit."
           },
           "author_name": {
-            "type": "string"
+            "type": "string",
+            "description": "Author display name from the commit."
           },
           "message": {
-            "type": "string"
+            "type": "string",
+            "description": "Commit message as authored."
           },
           "oid": {
-            "type": "string"
+            "type": "string",
+            "description": "Full git object identifier (40-char hex SHA-1)."
           },
           "parent_oids": {
             "type": "array",
             "items": {
               "type": "string"
-            }
+            },
+            "description": "Parent commit object identifiers. Length 0 for the initial commit, 1 for ordinary commits, 2+ for merge commits."
           },
           "timestamp": {
             "type": "string",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Commit timestamp (RFC 3339, normalised to UTC)."
           }
         }
       },
@@ -18618,37 +18656,43 @@
                   "example": "vol_01933b5a000070008000000000000001"
                 },
                 "is_readonly": {
-                  "type": "boolean"
+                  "type": "boolean",
+                  "description": "Whether the volume is mounted read-only into sessions. Read-only volumes accept no writes from the session sandbox."
                 },
                 "last_sync_error": {
                   "type": [
                     "string",
                     "null"
-                  ]
+                  ],
+                  "description": "Most recent sync error message; cleared on the next successful sync."
                 },
                 "last_synced_at": {
                   "type": [
                     "string",
                     "null"
                   ],
-                  "format": "date-time"
+                  "format": "date-time",
+                  "description": "Timestamp of the most recent successful sync (RFC 3339). `None` if never synced."
                 },
                 "name": {
                   "type": "string",
                   "description": "Human-readable name. Safe to render in user-facing messages."
                 },
                 "source": {
-                  "$ref": "#/components/schemas/VolumeSourceResponse"
+                  "$ref": "#/components/schemas/VolumeSourceResponse",
+                  "description": "Source-specific configuration (git remote, github repo, manual upload)."
                 },
                 "source_type": {
-                  "type": "string"
+                  "type": "string",
+                  "description": "Source kind discriminator (`manual`, `git`, `github`). Determines which `source` variant is populated."
                 },
                 "status": {
                   "type": "string",
                   "description": "Current lifecycle status."
                 },
                 "sync_status": {
-                  "type": "string"
+                  "type": "string",
+                  "description": "Current sync status (`idle`, `syncing`, `succeeded`, `failed`). Only meaningful when `source_type` is `git` or `github`."
                 },
                 "updated_at": {
                   "type": "string",
@@ -20648,7 +20692,8 @@
         ],
         "properties": {
           "action": {
-            "$ref": "#/components/schemas/SessionSandboxAction"
+            "$ref": "#/components/schemas/SessionSandboxAction",
+            "description": "Action to take on the sandbox (`reset`, `delete`, etc.)."
           }
         }
       },
@@ -20662,32 +20707,37 @@
         ],
         "properties": {
           "action": {
-            "$ref": "#/components/schemas/SessionSandboxAction"
+            "$ref": "#/components/schemas/SessionSandboxAction",
+            "description": "Action that was taken."
           },
           "deleted": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Whether the action deleted the sandbox (`true` after a successful `delete`)."
           },
           "display_name": {
             "type": [
               "string",
               "null"
             ],
-            "description": "Human-readable display name. Safe to render in user-facing messages."
+            "description": "Human-readable sandbox label."
           },
           "exists": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Whether a sandbox instance still exists after the action."
           },
           "external_id": {
             "type": [
               "string",
               "null"
-            ]
+            ],
+            "description": "Provider-side sandbox identifier."
           },
           "provider": {
             "type": [
               "string",
               "null"
-            ]
+            ],
+            "description": "Sandbox provider (`daytona`, `e2b`, `docker`, etc.)."
           },
           "session_status": {
             "oneOf": [
@@ -20695,7 +20745,8 @@
                 "type": "null"
               },
               {
-                "$ref": "#/components/schemas/SessionSandboxStatusValue"
+                "$ref": "#/components/schemas/SessionSandboxStatusValue",
+                "description": "Current sandbox lifecycle status after the action."
               }
             ]
           },
@@ -20703,7 +20754,8 @@
             "type": [
               "string",
               "null"
-            ]
+            ],
+            "description": "Absolute path of the sandbox workspace root."
           }
         }
       },
@@ -23037,14 +23089,17 @@
         "properties": {
           "claimed": {
             "type": "integer",
+            "description": "Number of outbox rows claimed by this run.",
             "minimum": 0
           },
           "completed": {
             "type": "integer",
+            "description": "Number of claimed rows that completed successfully.",
             "minimum": 0
           },
           "failed": {
             "type": "integer",
+            "description": "Number of claimed rows that failed and will be retried (or moved to `failed` after retry limit).",
             "minimum": 0
           }
         }
@@ -23330,26 +23385,32 @@
         "properties": {
           "as_of": {
             "type": "string",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Timestamp the underlying data was materialized (RFC 3339). Useful for \"as of\" footers."
           },
           "content": {
-            "type": "string"
+            "type": "string",
+            "description": "Serialized payload as a UTF-8 string. Caller streams this to the client."
           },
           "content_type": {
-            "type": "string"
+            "type": "string",
+            "description": "MIME type matching `format` (`text/csv` for CSV exports)."
           },
           "filename": {
-            "type": "string"
+            "type": "string",
+            "description": "Suggested filename for the download (includes the extension matching `format`)."
           },
           "format": {
-            "$ref": "#/components/schemas/ReportExportFormat"
+            "$ref": "#/components/schemas/ReportExportFormat",
+            "description": "Export format (currently `csv`)."
           },
           "freshness_lag_ms": {
             "type": [
               "integer",
               "null"
             ],
-            "format": "int64"
+            "format": "int64",
+            "description": "How stale the data is relative to `now()`, in milliseconds. `None` when freshness can't be determined."
           }
         }
       },
@@ -23424,39 +23485,46 @@
         ],
         "properties": {
           "dataset": {
-            "type": "string"
+            "type": "string",
+            "description": "Dataset name to query (see `GET /v1/reports/catalog` for the list of available datasets)."
           },
           "dimensions": {
             "type": "array",
             "items": {
               "type": "string"
-            }
+            },
+            "description": "Columns to group by. Empty list returns one aggregate row."
           },
           "filters": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ReportFilter"
-            }
+            },
+            "description": "Predicate filters applied before aggregation."
           },
           "limit": {
             "type": "integer",
             "format": "int32",
+            "description": "Maximum number of rows to return (defaults to 100).",
             "minimum": 0
           },
           "measures": {
             "type": "array",
             "items": {
               "type": "string"
-            }
+            },
+            "description": "Aggregations to compute (count, sum, avg, etc.). Empty list returns row counts only."
           },
           "order_by": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ReportOrderBy"
-            }
+            },
+            "description": "Sort spec applied after aggregation. Empty list yields unspecified order."
           },
           "time_range": {
-            "$ref": "#/components/schemas/ReportTimeRange"
+            "$ref": "#/components/schemas/ReportTimeRange",
+            "description": "Time window for the query. The dataset selects which timestamp column the range applies to."
           }
         }
       },
@@ -23529,23 +23597,28 @@
         "properties": {
           "enqueued": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "description": "Total number of outbox rows enqueued across all source types."
           },
           "events": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "description": "Number of `event` outbox rows enqueued."
           },
           "llm_generations": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "description": "Number of `llm_generation` outbox rows enqueued."
           },
           "sessions": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "description": "Number of `session` outbox rows enqueued."
           },
           "usage_ledger": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "description": "Number of `usage_ledger` outbox rows enqueued."
           }
         }
       },
@@ -23584,32 +23657,38 @@
         "properties": {
           "completed": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "description": "Outbox rows that have completed processing successfully."
           },
           "failed": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "description": "Outbox rows that have failed (exceeded retry limit)."
           },
           "failed_rows": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/FailedReportingOutboxRow"
-            }
+            },
+            "description": "Sample of the most recent failed rows for operator inspection."
           },
           "oldest_pending_at": {
             "type": [
               "string",
               "null"
             ],
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Timestamp of the oldest `pending` row (RFC 3339). `None` if no rows are pending."
           },
           "pending": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "description": "Outbox rows waiting to be claimed by a projector."
           },
           "processing": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "description": "Outbox rows currently being processed."
           }
         }
       },
@@ -24581,13 +24660,15 @@
               "null"
             ],
             "format": "int32",
+            "description": "Total context window size in tokens for `model`. `None` if the model's profile lacks limits data.",
             "minimum": 0
           },
           "contributions": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ContextReportContribution"
-            }
+            },
+            "description": "Per-source token contributions (per-tool, per-capability, per-message) for attribution."
           },
           "cumulative_usage": {
             "oneOf": [
@@ -24595,26 +24676,31 @@
                 "type": "null"
               },
               {
-                "$ref": "#/components/schemas/TokenUsage"
+                "$ref": "#/components/schemas/TokenUsage",
+                "description": "Cumulative LLM usage observed across the session so far (token + cost rollup)."
               }
             ]
           },
           "estimated_input_tokens": {
             "type": "integer",
             "format": "int32",
+            "description": "Estimated number of input tokens consumed by the next generation given the current context.",
             "minimum": 0
           },
           "model": {
-            "type": "string"
+            "type": "string",
+            "description": "Model identifier the report's token estimates target (used to scope context-window math)."
           },
           "sections": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ContextReportSection"
-            }
+            },
+            "description": "Logical sections of the assembled context (system prompt, tool defs, message history, etc.) for inspection."
           },
           "session_id": {
-            "type": "string"
+            "type": "string",
+            "description": "Prefixed session identifier this report describes."
           }
         }
       },
@@ -25079,28 +25165,33 @@
             "type": [
               "string",
               "null"
-            ]
+            ],
+            "description": "Parsed skill description. `None` when not present in the input or unparseable."
           },
           "errors": {
             "type": "array",
             "items": {
               "type": "string"
-            }
+            },
+            "description": "Hard validation errors. Non-empty if and only if `valid` is `false`."
           },
           "name": {
             "type": [
               "string",
               "null"
-            ]
+            ],
+            "description": "Parsed skill slug from the front matter. `None` when the input could not be parsed enough to extract a name."
           },
           "valid": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "`true` when the candidate SKILL.md parsed and passes all hard checks; `false` if any error was found."
           },
           "warnings": {
             "type": "array",
             "items": {
               "type": "string"
-            }
+            },
+            "description": "Non-fatal warnings (style, deprecated patterns, optional fields missing). Emitted alongside a `valid` result."
           }
         }
       },
@@ -26336,13 +26427,15 @@
             ],
             "items": {
               "$ref": "#/components/schemas/AgentCapabilityConfig"
-            }
+            },
+            "description": "Replace the capability list entirely; omit to leave unchanged."
           },
           "default_model_id": {
             "type": [
               "string",
               "null"
-            ]
+            ],
+            "description": "New default model selected when sessions inherit from this harness; omit to leave unchanged."
           },
           "description": {
             "type": [
@@ -26366,7 +26459,8 @@
             ],
             "items": {
               "$ref": "#/components/schemas/InitialFile"
-            }
+            },
+            "description": "Replace the initial-files list entirely; omit to leave unchanged."
           },
           "mcpServers": {
             "oneOf": [
@@ -26374,7 +26468,8 @@
                 "type": "null"
               },
               {
-                "$ref": "#/components/schemas/BTreeMap"
+                "$ref": "#/components/schemas/BTreeMap",
+                "description": "Replace the scoped MCP server set entirely; omit to leave unchanged."
               }
             ]
           },
@@ -26401,7 +26496,8 @@
             "type": [
               "string",
               "null"
-            ]
+            ],
+            "description": "New parent harness for inheritance. Outer `None` leaves unchanged; inner `None` removes inheritance (becomes a root harness)."
           },
           "status": {
             "oneOf": [
@@ -26418,7 +26514,8 @@
             "type": [
               "string",
               "null"
-            ]
+            ],
+            "description": "New system prompt the harness contributes to sessions; omit to leave unchanged."
           },
           "tags": {
             "type": [
@@ -26428,7 +26525,7 @@
             "items": {
               "type": "string"
             },
-            "description": "Free-form tags attached to this resource."
+            "description": "Replace the tag list entirely; omit to leave unchanged."
           }
         }
       },
@@ -27523,31 +27620,37 @@
         ],
         "properties": {
           "accumulated": {
-            "type": "string"
+            "type": "string",
+            "description": "Full transcript accumulated for this item up to and including `delta`."
           },
           "delta": {
-            "type": "string"
+            "type": "string",
+            "description": "Newly transcribed text chunk delivered in this event. Empty for \"final\" events that only mark completion."
           },
           "item_id": {
             "type": [
               "string",
               "null"
-            ]
+            ],
+            "description": "Provider-specific identifier of the conversation item being transcribed. `None` when not yet assigned."
           },
           "phase": {
             "type": [
               "string",
               "null"
-            ]
+            ],
+            "description": "Transcript phase: `user_partial`, `user_final`, `assistant_partial`, `assistant_final`. `None` when not yet classified."
           },
           "response_id": {
             "type": [
               "string",
               "null"
-            ]
+            ],
+            "description": "Provider-specific identifier of the response stream emitting this transcript. `None` for user-side transcripts."
           },
           "voice_connection_id": {
-            "type": "string"
+            "type": "string",
+            "description": "Prefixed voice connection identifier this transcript belongs to."
           }
         }
       },
@@ -27600,37 +27703,43 @@
             "example": "vol_01933b5a000070008000000000000001"
           },
           "is_readonly": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Whether the volume is mounted read-only into sessions. Read-only volumes accept no writes from the session sandbox."
           },
           "last_sync_error": {
             "type": [
               "string",
               "null"
-            ]
+            ],
+            "description": "Most recent sync error message; cleared on the next successful sync."
           },
           "last_synced_at": {
             "type": [
               "string",
               "null"
             ],
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Timestamp of the most recent successful sync (RFC 3339). `None` if never synced."
           },
           "name": {
             "type": "string",
             "description": "Human-readable name. Safe to render in user-facing messages."
           },
           "source": {
-            "$ref": "#/components/schemas/VolumeSourceResponse"
+            "$ref": "#/components/schemas/VolumeSourceResponse",
+            "description": "Source-specific configuration (git remote, github repo, manual upload)."
           },
           "source_type": {
-            "type": "string"
+            "type": "string",
+            "description": "Source kind discriminator (`manual`, `git`, `github`). Determines which `source` variant is populated."
           },
           "status": {
             "type": "string",
             "description": "Current lifecycle status."
           },
           "sync_status": {
-            "type": "string"
+            "type": "string",
+            "description": "Current sync status (`idle`, `syncing`, `succeeded`, `failed`). Only meaningful when `source_type` is `git` or `github`."
           },
           "updated_at": {
             "type": "string",
@@ -29933,22 +30042,27 @@
         "properties": {
           "active": {
             "type": "integer",
+            "description": "Workers in `running` state, accepting tasks.",
             "minimum": 0
           },
           "draining": {
             "type": "integer",
+            "description": "Workers in `draining` state, finishing in-flight tasks but not accepting new ones.",
             "minimum": 0
           },
           "stopped": {
             "type": "integer",
+            "description": "Workers in `stopped` state, neither running nor draining.",
             "minimum": 0
           },
           "total_capacity": {
             "type": "integer",
+            "description": "Sum of `max_concurrency` across all `active` + `draining` workers.",
             "minimum": 0
           },
           "total_load": {
             "type": "integer",
+            "description": "Total tasks currently in flight across all workers.",
             "minimum": 0
           }
         }


### PR DESCRIPTION
## What
Stacks on #1873. Field coverage **75.6% → 82.3%** (1268/1540). Bumps `MIN_FIELD_DESC_PCT` from 75 to 82.

Annotations for the next batch of agent-callable types:

- **`UpdateHarnessRequest`** — outer/inner `Option<Option<>>` semantics for the parent inheritance + per-field "leaves unchanged" vs "replaces entirely" clarification.
- **`GetSessionSandboxResponse` + `ManageSessionSandboxResponse` + `ManageSessionSandboxRequest`** — sandbox provider, lifecycle status, workspace path, init/error tracking.
- **`SessionContextReport` + `ContextReportSection` + `ContextReportContribution`** — token budget breakdown by section and per-source attribution.
- **`ReportQuery`** — datasets, dimensions, measures, filters, order_by, limit. Plus `ReportExport`, `ReportingOutboxDiagnostics`, `FailedReportingOutboxRow`, `ProjectorRunResult`, `ReportingBackfillResult`.
- **`VolumeResponse`** — sync semantics, read-only mount.
- **`GitCommitInfo`** — oid, message, author, parent oids.
- **`AppEndpointAuthRequirements`** — OIDC/JWT claim filters (audiences, scopes, claims, subjects, groups, domains).
- **`CapabilityUsageRecord`** — count-style vs duration-style record discriminator.
- **`VoiceTranscriptData`** — phase, delta, accumulated, ids.
- **`SkillValidationResult`** — valid + errors/warnings split.
- **`WorkersSummaryResponse`** — active/draining/stopped breakdown.

## Why
Same theme as #1873 — continuing to close the prose gap on agent-facing types so the OpenAPI is a sufficient tool catalog. Operator surfaces (`SessionContextReport`, reporting diagnostics, sandbox management) are the highest-leverage gaps remaining.

## How
Direct `///` doc comments on the relevant struct fields. No behavior change.

## Risk
- **Low.** Documentation-only PR. No code paths touched.
- OpenAPI diff is the bulk of the changes (+326 lines), almost entirely added `description` properties.

## Security
- Threat categories reviewed: none directly applicable. Prose changes don't widen any surface.
- `AppEndpointAuthRequirements` descriptions document JWT claim filtering semantics already implemented; no new behavior, no new exposure.

## Follow-ups
- Remaining clusters: `Session` (5/39 — large but mostly already documented), `MemoryResponse` (5/10), `LlmModelProfile` nested types. A follow-up can push to ~88-90%.
- `example` injection is still ~11% across the board — separate effort.

## Checklist
- [x] Tests added or updated (ratchet floor bumped 75 → 82)
- [x] Backward compatibility considered (no wire shape changes)
- [x] Security review performed against relevant threat model categories

---
_Generated by [Claude Code](https://claude.ai/code/session_01K7vXyQJ9St1tLHukPbJmGh)_