### PR TITLE
feat(agents): add authenticated agent handoff

### DIFF
--- a/crates/core/src/capabilities/agent_handoff.rs
+++ b/crates/core/src/capabilities/agent_handoff.rs
@@ -1,0 +1,1180 @@
+// Agent handoff capability.
+//
+// Decision: handoff starts a real configured Agent in a child session instead
+// of using a code-defined blueprint. The source agent gets only handoff tools;
+// the target agent owns its own tools, capabilities, data, and runtime prompt.
+// Credentials are never accepted as tool arguments or config. Required
+// provider connections are resolved server-side before the child session starts.
+
+use super::{Capability, CapabilityStatus, RiskLevel, SystemPromptContext};
+use crate::platform_store::PlatformStore;
+use crate::session::SubagentStatus;
+use crate::session_resource::{
+    RegisterSessionResource, SessionResourceFilter, SessionResourceStatus,
+};
+use crate::tool_types::ToolHints;
+use crate::tools::{Tool, ToolExecutionResult};
+use crate::traits::{SessionResourceRegistry, ToolContext};
+use crate::typed_id::AgentId;
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+pub const AGENT_HANDOFF_CAPABILITY_ID: &str = "agent_handoff";
+const AGENT_HANDOFF_RESOURCE_KIND: &str = "agent_handoff";
+const DEFAULT_WAIT_TIMEOUT_SECS: u64 = 300;
+
+pub struct AgentHandoffCapability;
+
+#[async_trait]
+impl Capability for AgentHandoffCapability {
+    fn id(&self) -> &str {
+        AGENT_HANDOFF_CAPABILITY_ID
+    }
+
+    fn name(&self) -> &str {
+        "Agent Handoff"
+    }
+
+    fn description(&self) -> &str {
+        "Delegate work to configured first-party agents through an authenticated handoff gate."
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+
+    fn icon(&self) -> Option<&str> {
+        Some("user-round-check")
+    }
+
+    fn category(&self) -> Option<&str> {
+        Some("Orchestration")
+    }
+
+    fn features(&self) -> Vec<&'static str> {
+        vec!["agent_handoffs"]
+    }
+
+    fn risk_level(&self) -> RiskLevel {
+        RiskLevel::High
+    }
+
+    fn config_schema(&self) -> Option<Value> {
+        Some(json!({
+            "type": "object",
+            "properties": {
+                "targets": {
+                    "type": "array",
+                    "description": "Configured agents this agent may hand work off to.",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "id": {
+                                "type": "string",
+                                "description": "Stable target key used in start_agent_handoff."
+                            },
+                            "name": { "type": "string" },
+                            "description": { "type": "string" },
+                            "agent_id": {
+                                "type": "string",
+                                "description": "Public id of the configured target agent."
+                            },
+                            "required_connections": {
+                                "type": "array",
+                                "items": { "type": "string" },
+                                "description": "Provider connections required before handoff starts."
+                            },
+                            "required_scopes": {
+                                "type": "array",
+                                "items": { "type": "string" },
+                                "description": "Non-secret scope labels recorded for audit and resource metadata."
+                            }
+                        },
+                        "required": ["id", "name", "agent_id"],
+                        "additionalProperties": false
+                    },
+                    "default": []
+                }
+            },
+            "additionalProperties": false
+        }))
+    }
+
+    fn validate_config(&self, config: &Value) -> std::result::Result<(), String> {
+        let parsed = AgentHandoffConfig::from_value(config).map_err(|e| e.to_string())?;
+        parsed.validate()
+    }
+
+    fn tools_with_config(&self, config: &Value) -> Vec<Box<dyn Tool>> {
+        let config = AgentHandoffConfig::from_value(config).unwrap_or_default();
+        vec![
+            Box::new(StartAgentHandoffTool::new(config.clone())),
+            Box::new(GetAgentHandoffsTool),
+            Box::new(MessageAgentHandoffTool),
+        ]
+    }
+
+    fn tools(&self) -> Vec<Box<dyn Tool>> {
+        self.tools_with_config(&Value::Null)
+    }
+
+    async fn system_prompt_contribution_with_config(
+        &self,
+        _ctx: &SystemPromptContext,
+        config: &Value,
+    ) -> Option<String> {
+        let config = AgentHandoffConfig::from_value(config).unwrap_or_default();
+        let targets = config
+            .targets
+            .iter()
+            .map(|target| {
+                format!(
+                    "- {} ({}) — {}",
+                    target.name,
+                    target.id,
+                    target
+                        .description
+                        .as_deref()
+                        .unwrap_or("Configured handoff target")
+                )
+            })
+            .collect::<Vec<_>>();
+
+        Some(format!(
+            "<capability id=\"{}\">\n\
+Use start_agent_handoff to delegate work to configured first-party agents.\n\
+Never ask the user to paste provider tokens into chat or pass credentials in tool arguments.\n\
+If a required provider connection is missing, the handoff tool will return a connection_required result and the client should collect credentials through the Connections flow.\n\
+Available handoff targets:\n{}\n\
+</capability>",
+            self.id(),
+            if targets.is_empty() {
+                "- none configured".to_string()
+            } else {
+                targets.join("\n")
+            }
+        ))
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct AgentHandoffConfig {
+    #[serde(default)]
+    targets: Vec<AgentHandoffTargetConfig>,
+}
+
+impl AgentHandoffConfig {
+    fn from_value(value: &Value) -> serde_json::Result<Self> {
+        if value.is_null() {
+            Ok(Self::default())
+        } else {
+            serde_json::from_value(value.clone())
+        }
+    }
+
+    fn validate(&self) -> std::result::Result<(), String> {
+        let mut seen = std::collections::HashSet::new();
+        for target in &self.targets {
+            target.validate()?;
+            if !seen.insert(target.id.as_str()) {
+                return Err(format!("Duplicate handoff target id: {}", target.id));
+            }
+        }
+        Ok(())
+    }
+
+    fn target(&self, id: &str) -> Option<&AgentHandoffTargetConfig> {
+        self.targets.iter().find(|target| target.id == id)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct AgentHandoffTargetConfig {
+    id: String,
+    name: String,
+    #[serde(default)]
+    description: Option<String>,
+    agent_id: AgentId,
+    #[serde(default)]
+    required_connections: Vec<String>,
+    #[serde(default)]
+    required_scopes: Vec<String>,
+}
+
+impl AgentHandoffTargetConfig {
+    fn validate(&self) -> std::result::Result<(), String> {
+        if self.id.trim().is_empty() {
+            return Err("Agent handoff target id cannot be empty".to_string());
+        }
+        if self.name.trim().is_empty() {
+            return Err(format!(
+                "Agent handoff target {} name cannot be empty",
+                self.id
+            ));
+        }
+        for provider in &self.required_connections {
+            if provider.trim().is_empty() {
+                return Err(format!(
+                    "Agent handoff target {} has an empty required connection",
+                    self.id
+                ));
+            }
+        }
+        for scope in &self.required_scopes {
+            if scope.trim().is_empty() {
+                return Err(format!(
+                    "Agent handoff target {} has an empty required scope",
+                    self.id
+                ));
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+enum AgentHandoffMode {
+    Wait,
+}
+
+impl AgentHandoffMode {
+    fn parse(value: Option<&str>) -> std::result::Result<Self, String> {
+        match value.unwrap_or("wait") {
+            "wait" => Ok(Self::Wait),
+            other => Err(format!("Invalid mode: {other}. Only wait is supported")),
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Wait => "wait",
+        }
+    }
+}
+
+fn get_platform_store(context: &ToolContext) -> Result<&dyn PlatformStore, ToolExecutionResult> {
+    context
+        .platform_store
+        .as_ref()
+        .map(|store| store.as_ref())
+        .ok_or_else(|| {
+            ToolExecutionResult::tool_error("Agent handoff tools require platform_store context.")
+        })
+}
+
+fn require_str<'a>(args: &'a Value, field: &str) -> Result<&'a str, ToolExecutionResult> {
+    args.get(field)
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| {
+            ToolExecutionResult::tool_error(format!("Missing required parameter: {field}"))
+        })
+}
+
+fn child_task(task: &str, public_context: Option<&Value>) -> String {
+    let Some(public_context) = public_context else {
+        return task.to_string();
+    };
+    format!(
+        "{task}\n\n<public_handoff_context>\n{}\n</public_handoff_context>",
+        serde_json::to_string_pretty(public_context).unwrap_or_else(|_| "{}".to_string())
+    )
+}
+
+fn last_agent_message(messages: &[crate::platform_store::PlatformMessage]) -> Option<String> {
+    messages
+        .iter()
+        .rfind(|message| message.role == "agent" || message.role == "assistant")
+        .map(|message| message.content.clone())
+}
+
+async fn require_connections(
+    context: &ToolContext,
+    target: &AgentHandoffTargetConfig,
+) -> Result<(), ToolExecutionResult> {
+    if target.required_connections.is_empty() {
+        return Ok(());
+    }
+
+    let Some(resolver) = &context.connection_resolver else {
+        return Err(ToolExecutionResult::internal_error_msg(
+            "Agent handoff connection resolution is not available in this execution context.",
+        ));
+    };
+
+    for provider in &target.required_connections {
+        match resolver
+            .get_connection_token(context.session_id, provider)
+            .await
+        {
+            Ok(Some(_token)) => {}
+            Ok(None) => return Err(ToolExecutionResult::connection_required(provider.clone())),
+            Err(error) => return Err(ToolExecutionResult::internal_error(error)),
+        }
+    }
+    Ok(())
+}
+
+async fn register_handoff_resource(
+    registry: Option<&std::sync::Arc<dyn SessionResourceRegistry>>,
+    parent_session_id: crate::typed_id::SessionId,
+    child_session_id: crate::typed_id::SessionId,
+    target: &AgentHandoffTargetConfig,
+    mode: AgentHandoffMode,
+    status: SessionResourceStatus,
+) {
+    let Some(registry) = registry else {
+        return;
+    };
+    let _ = registry
+        .register(RegisterSessionResource {
+            session_id: parent_session_id,
+            resource_id: child_session_id.to_string(),
+            kind: AGENT_HANDOFF_RESOURCE_KIND.to_string(),
+            display_name: target.name.clone(),
+            status,
+            metadata: json!({
+                "target": target.id,
+                "target_agent_id": target.agent_id,
+                "required_connections": target.required_connections,
+                "required_scopes": target.required_scopes,
+                "mode": mode.as_str(),
+            }),
+        })
+        .await;
+}
+
+pub struct StartAgentHandoffTool {
+    config: AgentHandoffConfig,
+}
+
+impl StartAgentHandoffTool {
+    fn new(config: AgentHandoffConfig) -> Self {
+        Self { config }
+    }
+}
+
+#[async_trait]
+impl Tool for StartAgentHandoffTool {
+    fn name(&self) -> &str {
+        "start_agent_handoff"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("Start Agent Handoff")
+    }
+
+    fn description(&self) -> &str {
+        "Start an authenticated handoff to a configured first-party target agent. Credentials are resolved through Connections, never passed as arguments."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "target": {
+                    "type": "string",
+                    "description": "Configured handoff target id."
+                },
+                "task": {
+                    "type": "string",
+                    "description": "Work request for the target agent. Do not include credentials or bearer tokens."
+                },
+                "public_context": {
+                    "type": "object",
+                    "description": "Non-secret structured context to include with the task."
+                }
+            },
+            "required": ["target", "task"],
+            "additionalProperties": false
+        })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default().with_long_running(true)
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "start_agent_handoff requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let store = match get_platform_store(context) {
+            Ok(store) => store,
+            Err(error) => return error,
+        };
+
+        let target_id = match require_str(&arguments, "target") {
+            Ok(value) => value,
+            Err(error) => return error,
+        };
+        let task = match require_str(&arguments, "task") {
+            Ok(value) => value,
+            Err(error) => return error,
+        };
+        let mode = match AgentHandoffMode::parse(arguments.get("mode").and_then(Value::as_str)) {
+            Ok(mode) => mode,
+            Err(error) => return ToolExecutionResult::tool_error(error),
+        };
+
+        let Some(target) = self.config.target(target_id) else {
+            return ToolExecutionResult::tool_error(format!(
+                "Unknown handoff target: \"{target_id}\". Check configured targets."
+            ));
+        };
+
+        if let Err(error) = require_connections(context, target).await {
+            return error;
+        }
+
+        let parent_session = match store.get_session_by_id(context.session_id).await {
+            Ok(Some(session)) => session,
+            Ok(None) => return ToolExecutionResult::tool_error("Current session not found"),
+            Err(error) => return ToolExecutionResult::internal_error(error),
+        };
+
+        if parent_session.parent_session_id.is_some() {
+            return ToolExecutionResult::tool_error(
+                "Agent handoffs cannot be started from child sessions.",
+            );
+        }
+
+        let child_session = match store
+            .create_session(
+                parent_session.harness_id,
+                Some(target.agent_id),
+                Some(&target.name),
+                parent_session.locale.as_deref(),
+                None,
+                None,
+            )
+            .await
+        {
+            Ok(session) => session,
+            Err(error) => return ToolExecutionResult::internal_error(error),
+        };
+
+        let handoff_task = child_task(task, arguments.get("public_context"));
+        let child_session = match store
+            .set_subagent_metadata(
+                child_session.id,
+                context.session_id,
+                &target.name,
+                &handoff_task,
+                SubagentStatus::Running,
+            )
+            .await
+        {
+            Ok(session) => session,
+            Err(error) => return ToolExecutionResult::internal_error(error),
+        };
+
+        register_handoff_resource(
+            context.session_resource_registry.as_ref(),
+            context.session_id,
+            child_session.id,
+            target,
+            mode,
+            SessionResourceStatus::Active,
+        )
+        .await;
+
+        if let Err(error) = store.send_message(child_session.id, &handoff_task).await {
+            return ToolExecutionResult::internal_error(error);
+        }
+
+        let status = match store
+            .wait_for_idle(child_session.id, Some(DEFAULT_WAIT_TIMEOUT_SECS))
+            .await
+        {
+            Ok(status) => status,
+            Err(error) => {
+                if let Some(registry) = &context.session_resource_registry {
+                    let _ = registry
+                        .update_status(
+                            context.session_id,
+                            &child_session.id.to_string(),
+                            SessionResourceStatus::Failed,
+                        )
+                        .await;
+                }
+                return ToolExecutionResult::success(json!({
+                    "handoff_id": child_session.id.to_string(),
+                    "target": target.id,
+                    "target_agent_id": target.agent_id,
+                    "name": target.name,
+                    "status": "failed",
+                    "error": error.to_string(),
+                    "mode": "wait",
+                }));
+            }
+        };
+
+        let messages = match store.get_messages(child_session.id, Some(5)).await {
+            Ok(messages) => messages,
+            Err(error) => return ToolExecutionResult::internal_error(error),
+        };
+        let result = last_agent_message(&messages)
+            .unwrap_or_else(|| format!("Handoff completed with status: {status}"));
+
+        if let Some(registry) = &context.session_resource_registry {
+            let terminal = if status == "error" {
+                SessionResourceStatus::Failed
+            } else {
+                SessionResourceStatus::Completed
+            };
+            let _ = registry
+                .update_status(context.session_id, &child_session.id.to_string(), terminal)
+                .await;
+        }
+
+        let _ = store
+            .set_subagent_metadata(
+                child_session.id,
+                context.session_id,
+                &target.name,
+                &handoff_task,
+                if status == "error" {
+                    SubagentStatus::Failed
+                } else {
+                    SubagentStatus::Completed
+                },
+            )
+            .await;
+
+        ToolExecutionResult::success(json!({
+            "handoff_id": child_session.id.to_string(),
+            "target": target.id,
+            "target_agent_id": target.agent_id,
+            "name": target.name,
+            "status": status,
+            "result": result,
+            "mode": "wait",
+        }))
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+pub struct GetAgentHandoffsTool;
+
+#[async_trait]
+impl Tool for GetAgentHandoffsTool {
+    fn name(&self) -> &str {
+        "get_agent_handoffs"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("Get Agent Handoffs")
+    }
+
+    fn description(&self) -> &str {
+        "List agent handoffs started by the current session."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "handoff_id": {
+                    "type": "string",
+                    "description": "Optional child session id to retrieve."
+                }
+            },
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "get_agent_handoffs requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        if let Some(registry) = &context.session_resource_registry {
+            let filter = SessionResourceFilter {
+                kind: Some(AGENT_HANDOFF_RESOURCE_KIND.to_string()),
+                status: None,
+            };
+            let mut entries = match registry.list(context.session_id, Some(&filter)).await {
+                Ok(entries) => entries,
+                Err(error) => return ToolExecutionResult::internal_error(error),
+            };
+            if let Some(handoff_id) = arguments.get("handoff_id").and_then(Value::as_str) {
+                entries.retain(|entry| entry.resource_id == handoff_id);
+            }
+            return ToolExecutionResult::success(json!({ "handoffs": entries }));
+        }
+
+        let store = match get_platform_store(context) {
+            Ok(store) => store,
+            Err(error) => return error,
+        };
+        let sessions = match store.list_sessions(Some(100), None).await {
+            Ok(sessions) => sessions,
+            Err(error) => return ToolExecutionResult::internal_error(error),
+        };
+        let handoff_id = arguments.get("handoff_id").and_then(Value::as_str);
+        let handoffs = sessions
+            .into_iter()
+            .filter(|session| session.parent_session_id == Some(context.session_id))
+            .filter(|session| handoff_id.is_none_or(|id| session.id.to_string() == id))
+            .map(|session| {
+                json!({
+                    "handoff_id": session.id.to_string(),
+                    "name": session.subagent_name,
+                    "status": session.subagent_status,
+                    "target_agent_id": session.agent_id,
+                    "created_at": session.created_at,
+                    "updated_at": session.updated_at,
+                })
+            })
+            .collect::<Vec<_>>();
+        ToolExecutionResult::success(json!({ "handoffs": handoffs }))
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+pub struct MessageAgentHandoffTool;
+
+#[async_trait]
+impl Tool for MessageAgentHandoffTool {
+    fn name(&self) -> &str {
+        "message_agent_handoff"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("Message Agent Handoff")
+    }
+
+    fn description(&self) -> &str {
+        "Send follow-up input to an existing agent handoff child session."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "handoff_id": {
+                    "type": "string",
+                    "description": "Child session id returned by start_agent_handoff."
+                },
+                "message": {
+                    "type": "string",
+                    "description": "Follow-up message. Do not include credentials or bearer tokens."
+                }
+            },
+            "required": ["handoff_id", "message"],
+            "additionalProperties": false
+        })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default().with_long_running(true)
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "message_agent_handoff requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let store = match get_platform_store(context) {
+            Ok(store) => store,
+            Err(error) => return error,
+        };
+        let handoff_id = match require_str(&arguments, "handoff_id") {
+            Ok(value) => value,
+            Err(error) => return error,
+        };
+        let message = match require_str(&arguments, "message") {
+            Ok(value) => value,
+            Err(error) => return error,
+        };
+        let child_id = match handoff_id.parse::<crate::typed_id::SessionId>() {
+            Ok(id) => id,
+            Err(_) => {
+                return ToolExecutionResult::tool_error(format!(
+                    "Invalid handoff_id: {handoff_id}"
+                ));
+            }
+        };
+
+        let child = match store.get_session_by_id(child_id).await {
+            Ok(Some(session)) => session,
+            Ok(None) => return ToolExecutionResult::tool_error("Agent handoff not found"),
+            Err(error) => return ToolExecutionResult::internal_error(error),
+        };
+        if child.parent_session_id != Some(context.session_id) {
+            return ToolExecutionResult::tool_error(
+                "Agent handoff does not belong to the current session.",
+            );
+        }
+
+        if let Err(error) = store.send_message(child_id, message).await {
+            return ToolExecutionResult::internal_error(error);
+        }
+        let status = match store
+            .wait_for_idle(child_id, Some(DEFAULT_WAIT_TIMEOUT_SECS))
+            .await
+        {
+            Ok(status) => status,
+            Err(error) => return ToolExecutionResult::internal_error(error),
+        };
+        let messages = match store.get_messages(child_id, Some(5)).await {
+            Ok(messages) => messages,
+            Err(error) => return ToolExecutionResult::internal_error(error),
+        };
+        let result = last_agent_message(&messages)
+            .unwrap_or_else(|| format!("Handoff processed message with status: {status}"));
+
+        ToolExecutionResult::success(json!({
+            "handoff_id": child_id.to_string(),
+            "status": status,
+            "result": result,
+        }))
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Result;
+    use crate::platform_store::tests::MockPlatformStore;
+    use crate::session_resource::{SessionResourceEntry, SessionResourceFilter};
+    use crate::tools::{Tool, ToolExecutionResult};
+    use crate::traits::{SessionResourceRegistry, UserConnectionResolver};
+    use crate::typed_id::SessionId;
+    use std::collections::{HashMap, HashSet};
+    use std::sync::{Arc, Mutex};
+    use uuid::Uuid;
+
+    fn target_config(agent_id: AgentId, required_connections: Vec<&str>) -> Value {
+        json!({
+            "targets": [
+                {
+                    "id": "aws_operator",
+                    "name": "AWS Operator",
+                    "description": "Manage fake AWS infrastructure",
+                    "agent_id": agent_id,
+                    "required_connections": required_connections,
+                    "required_scopes": ["fake_aws:rds:create"]
+                }
+            ]
+        })
+    }
+
+    fn start_tool(config: Value) -> Box<dyn Tool> {
+        AgentHandoffCapability
+            .tools_with_config(&config)
+            .into_iter()
+            .find(|tool| tool.name() == "start_agent_handoff")
+            .expect("start_agent_handoff tool")
+    }
+
+    fn get_tool(config: Value) -> Box<dyn Tool> {
+        AgentHandoffCapability
+            .tools_with_config(&config)
+            .into_iter()
+            .find(|tool| tool.name() == "get_agent_handoffs")
+            .expect("get_agent_handoffs tool")
+    }
+
+    fn message_tool(config: Value) -> Box<dyn Tool> {
+        AgentHandoffCapability
+            .tools_with_config(&config)
+            .into_iter()
+            .find(|tool| tool.name() == "message_agent_handoff")
+            .expect("message_agent_handoff tool")
+    }
+
+    struct TestConnectionResolver {
+        providers: HashSet<String>,
+    }
+
+    #[async_trait]
+    impl UserConnectionResolver for TestConnectionResolver {
+        async fn get_connection_token(
+            &self,
+            _session_id: SessionId,
+            provider: &str,
+        ) -> Result<Option<String>> {
+            Ok(self
+                .providers
+                .contains(provider)
+                .then(|| "server-side-secret-token".to_string()))
+        }
+
+        async fn get_connection_user(
+            &self,
+            _session_id: SessionId,
+            _provider: &str,
+        ) -> Result<Option<Uuid>> {
+            Ok(None)
+        }
+
+        async fn get_connection_token_for_user(
+            &self,
+            _user_id: Uuid,
+            _provider: &str,
+        ) -> Result<Option<String>> {
+            Ok(None)
+        }
+    }
+
+    #[derive(Default)]
+    struct TestResourceRegistry {
+        entries: Mutex<HashMap<(SessionId, String), SessionResourceEntry>>,
+    }
+
+    #[async_trait]
+    impl SessionResourceRegistry for TestResourceRegistry {
+        async fn register(&self, entry: RegisterSessionResource) -> Result<SessionResourceEntry> {
+            let now = chrono::Utc::now();
+            let record = SessionResourceEntry {
+                resource_id: entry.resource_id,
+                session_id: entry.session_id,
+                kind: entry.kind,
+                display_name: entry.display_name,
+                status: entry.status,
+                metadata: entry.metadata,
+                created_at: now,
+                updated_at: now,
+            };
+            self.entries.lock().expect("registry mutex").insert(
+                (record.session_id, record.resource_id.clone()),
+                record.clone(),
+            );
+            Ok(record)
+        }
+
+        async fn update_status(
+            &self,
+            session_id: SessionId,
+            resource_id: &str,
+            status: SessionResourceStatus,
+        ) -> Result<Option<SessionResourceEntry>> {
+            let mut entries = self.entries.lock().expect("registry mutex");
+            let Some(entry) = entries.get_mut(&(session_id, resource_id.to_string())) else {
+                return Ok(None);
+            };
+            entry.status = status;
+            entry.updated_at = chrono::Utc::now();
+            Ok(Some(entry.clone()))
+        }
+
+        async fn get(
+            &self,
+            session_id: SessionId,
+            resource_id: &str,
+        ) -> Result<Option<SessionResourceEntry>> {
+            Ok(self
+                .entries
+                .lock()
+                .expect("registry mutex")
+                .get(&(session_id, resource_id.to_string()))
+                .cloned())
+        }
+
+        async fn list(
+            &self,
+            session_id: SessionId,
+            filter: Option<&SessionResourceFilter>,
+        ) -> Result<Vec<SessionResourceEntry>> {
+            let mut entries = self
+                .entries
+                .lock()
+                .expect("registry mutex")
+                .values()
+                .filter(|entry| entry.session_id == session_id)
+                .filter(|entry| {
+                    filter
+                        .and_then(|f| f.kind.as_ref())
+                        .is_none_or(|kind| &entry.kind == kind)
+                })
+                .filter(|entry| {
+                    filter
+                        .and_then(|f| f.status)
+                        .is_none_or(|status| entry.status == status)
+                })
+                .cloned()
+                .collect::<Vec<_>>();
+            entries.sort_by(|a, b| a.resource_id.cmp(&b.resource_id));
+            Ok(entries)
+        }
+
+        async fn deregister(&self, session_id: SessionId, resource_id: &str) -> Result<bool> {
+            Ok(self
+                .entries
+                .lock()
+                .expect("registry mutex")
+                .remove(&(session_id, resource_id.to_string()))
+                .is_some())
+        }
+    }
+
+    fn context(
+        store: Arc<MockPlatformStore>,
+        resolver: Option<Arc<dyn UserConnectionResolver>>,
+        registry: Option<Arc<dyn SessionResourceRegistry>>,
+    ) -> ToolContext {
+        let mut context = ToolContext::new(store.session.id);
+        context.platform_store = Some(store);
+        context.connection_resolver = resolver;
+        context.session_resource_registry = registry;
+        context
+    }
+
+    #[test]
+    fn capability_metadata_and_schema() {
+        let cap = AgentHandoffCapability;
+        assert_eq!(cap.id(), AGENT_HANDOFF_CAPABILITY_ID);
+        assert_eq!(cap.status(), CapabilityStatus::Available);
+        assert_eq!(cap.risk_level(), RiskLevel::High);
+        assert_eq!(cap.features(), vec!["agent_handoffs"]);
+
+        let schema = cap.config_schema().expect("config schema");
+        assert_eq!(schema["properties"]["targets"]["type"], "array");
+    }
+
+    #[test]
+    fn validate_config_rejects_duplicate_targets() {
+        let agent_id = AgentId::new();
+        let config = json!({
+            "targets": [
+                { "id": "dup", "name": "One", "agent_id": agent_id },
+                { "id": "dup", "name": "Two", "agent_id": AgentId::new() }
+            ]
+        });
+
+        let error = AgentHandoffCapability
+            .validate_config(&config)
+            .expect_err("duplicate targets should fail");
+        assert!(error.contains("Duplicate handoff target id"));
+    }
+
+    #[tokio::test]
+    async fn start_handoff_requires_configured_connection() {
+        let store = Arc::new(MockPlatformStore::new());
+        let config = target_config(store.agent.public_id, vec!["fake_aws"]);
+        let tool = start_tool(config);
+        let resolver = Arc::new(TestConnectionResolver {
+            providers: HashSet::new(),
+        });
+        let context = context(store, Some(resolver), None);
+
+        let result = tool
+            .execute_with_context(
+                json!({
+                    "target": "aws_operator",
+                    "task": "Create an RDS database named app-db"
+                }),
+                &context,
+            )
+            .await;
+
+        assert!(matches!(
+            result,
+            ToolExecutionResult::ConnectionRequired { provider } if provider == "fake_aws"
+        ));
+    }
+
+    #[tokio::test]
+    async fn start_handoff_without_connection_resolver_is_internal_error() {
+        let store = Arc::new(MockPlatformStore::new());
+        let config = target_config(store.agent.public_id, vec!["fake_aws"]);
+        let tool = start_tool(config);
+        let context = context(store, None, None);
+
+        let result = tool
+            .execute_with_context(
+                json!({
+                    "target": "aws_operator",
+                    "task": "Create an RDS database named app-db"
+                }),
+                &context,
+            )
+            .await;
+
+        assert!(matches!(result, ToolExecutionResult::InternalError(_)));
+    }
+
+    #[tokio::test]
+    async fn start_handoff_creates_child_session_for_target_agent() {
+        let store = Arc::new(MockPlatformStore::new());
+        let registry = Arc::new(TestResourceRegistry::default());
+        let resolver = Arc::new(TestConnectionResolver {
+            providers: HashSet::from(["fake_aws".to_string()]),
+        });
+        let config = target_config(store.agent.public_id, vec!["fake_aws"]);
+        let tool = start_tool(config);
+        let context = context(store.clone(), Some(resolver), Some(registry.clone()));
+
+        let result = tool
+            .execute_with_context(
+                json!({
+                    "target": "aws_operator",
+                    "task": "Create an RDS database named app-db",
+                    "public_context": { "region": "us-east-1" }
+                }),
+                &context,
+            )
+            .await;
+
+        let ToolExecutionResult::Success(value) = result else {
+            panic!("expected success, got {result:?}");
+        };
+        assert_eq!(value["target"], "aws_operator");
+        assert_eq!(value["target_agent_id"], json!(store.agent.public_id));
+        assert_eq!(value["result"], "Hi!");
+
+        let handoff_id = value["handoff_id"].as_str().expect("handoff_id");
+        let entry = registry
+            .get(context.session_id, handoff_id)
+            .await
+            .expect("registry get")
+            .expect("handoff resource");
+        assert_eq!(entry.kind, AGENT_HANDOFF_RESOURCE_KIND);
+        assert_eq!(entry.status, SessionResourceStatus::Completed);
+        assert_eq!(entry.metadata["target"], "aws_operator");
+        assert_eq!(entry.metadata["required_connections"], json!(["fake_aws"]));
+        assert_eq!(
+            entry.metadata["required_scopes"],
+            json!(["fake_aws:rds:create"])
+        );
+    }
+
+    #[tokio::test]
+    async fn get_handoffs_lists_registered_handoff_resources() {
+        let store = Arc::new(MockPlatformStore::new());
+        let registry = Arc::new(TestResourceRegistry::default());
+        let config = target_config(store.agent.public_id, vec![]);
+        let start = start_tool(config.clone());
+        let get = get_tool(config);
+        let context = context(store, None, Some(registry));
+
+        let start_result = start
+            .execute_with_context(
+                json!({
+                    "target": "aws_operator",
+                    "task": "Create an RDS database named app-db"
+                }),
+                &context,
+            )
+            .await;
+        assert!(start_result.is_success());
+
+        let result = get.execute_with_context(json!({}), &context).await;
+        let ToolExecutionResult::Success(value) = result else {
+            panic!("expected success, got {result:?}");
+        };
+        assert_eq!(value["handoffs"].as_array().expect("handoffs").len(), 1);
+        assert_eq!(value["handoffs"][0]["kind"], AGENT_HANDOFF_RESOURCE_KIND);
+        assert_eq!(value["handoffs"][0]["status"], "completed");
+    }
+
+    #[tokio::test]
+    async fn message_handoff_rejects_invalid_handoff_id() {
+        let store = Arc::new(MockPlatformStore::new());
+        let tool = message_tool(json!({}));
+        let context = context(store, None, None);
+
+        let result = tool
+            .execute_with_context(
+                json!({
+                    "handoff_id": "not-a-session-id",
+                    "message": "List RDS databases"
+                }),
+                &context,
+            )
+            .await;
+
+        assert!(
+            matches!(result, ToolExecutionResult::ToolError(message) if message.contains("Invalid handoff_id"))
+        );
+    }
+
+    #[tokio::test]
+    async fn message_handoff_rejects_non_child_session() {
+        let parent_id = SessionId::new();
+        let child_id = SessionId::new();
+        let mut store_value = MockPlatformStore::new();
+        store_value.session.id = child_id;
+        store_value.session.parent_session_id = None;
+        let store = Arc::new(store_value);
+        let tool = message_tool(json!({}));
+        let mut context = ToolContext::new(parent_id);
+        context.platform_store = Some(store);
+
+        let result = tool
+            .execute_with_context(
+                json!({
+                    "handoff_id": child_id.to_string(),
+                    "message": "List RDS databases"
+                }),
+                &context,
+            )
+            .await;
+
+        assert!(
+            matches!(result, ToolExecutionResult::ToolError(message) if message.contains("does not belong"))
+        );
+    }
+
+    #[tokio::test]
+    async fn message_handoff_sends_followup_to_owned_child_session() {
+        let parent_id = SessionId::new();
+        let child_id = SessionId::new();
+        let mut store_value = MockPlatformStore::new();
+        store_value.session.id = child_id;
+        store_value.session.parent_session_id = Some(parent_id);
+        let store = Arc::new(store_value);
+        let tool = message_tool(json!({}));
+        let mut context = ToolContext::new(parent_id);
+        context.platform_store = Some(store);
+
+        let result = tool
+            .execute_with_context(
+                json!({
+                    "handoff_id": child_id.to_string(),
+                    "message": "List RDS databases"
+                }),
+                &context,
+            )
+            .await;
+
+        let ToolExecutionResult::Success(value) = result else {
+            panic!("expected success, got {result:?}");
+        };
+        assert_eq!(value["handoff_id"], child_id.to_string());
+        assert_eq!(value["status"], "idle");
+        assert_eq!(value["result"], "Hi!");
+    }
+}

--- a/crates/core/src/capabilities/fake_aws.rs
+++ b/crates/core/src/capabilities/fake_aws.rs
@@ -20,6 +20,10 @@
 
 use super::{Capability, CapabilityStatus};
 use crate::SessionId;
+use crate::connection_provider::{
+    ConnectionFormSchema, ConnectionProvider, ConnectionProviderPlugin, ConnectionType,
+    ConnectionValidation, FieldType, FormField,
+};
 use crate::tool_types::ToolHints;
 use crate::tools::{Tool, ToolExecutionResult};
 use crate::traits::{SessionFileSystem, ToolContext};
@@ -28,6 +32,71 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::sync::OnceLock;
 use std::time::Duration;
+
+inventory::submit! {
+    ConnectionProviderPlugin {
+        experimental_only: true,
+        factory: || Box::new(FakeAwsConnectionProvider),
+    }
+}
+
+/// API-key style connection provider for the fake AWS tools.
+///
+/// The key is intentionally opaque to agents: it is captured through the normal
+/// Connections flow and resolved server-side by handoff gates or tools.
+pub struct FakeAwsConnectionProvider;
+
+#[async_trait]
+impl ConnectionProvider for FakeAwsConnectionProvider {
+    fn provider_id(&self) -> &str {
+        "fake_aws"
+    }
+
+    fn display_name(&self) -> &str {
+        "Fake AWS"
+    }
+
+    fn description(&self) -> &str {
+        "Demo AWS-style connection for authenticated handoff examples."
+    }
+
+    fn icon(&self) -> &str {
+        "cloud"
+    }
+
+    fn connection_type(&self) -> ConnectionType {
+        ConnectionType::ApiKey
+    }
+
+    fn form_schema(&self) -> Option<ConnectionFormSchema> {
+        Some(ConnectionFormSchema {
+            fields: vec![FormField {
+                name: "api_key".to_string(),
+                label: "Fake AWS API key".to_string(),
+                field_type: FieldType::Password,
+                required: true,
+                placeholder: Some("fake_aws_...".to_string()),
+                help_text: Some("Any non-empty value is accepted for local fake AWS testing.".to_string()),
+            }],
+            instructions_markdown:
+                "Use any non-empty value for local fake AWS handoff testing. Real providers should validate credentials against their upstream API."
+                    .to_string(),
+        })
+    }
+
+    async fn validate(&self, credential: &str) -> Result<ConnectionValidation, String> {
+        if credential.trim().is_empty() {
+            return Err("Fake AWS API key cannot be empty".to_string());
+        }
+        Ok(ConnectionValidation {
+            provider_username: Some("fake-aws-account".to_string()),
+            provider_metadata: Some(json!({
+                "account_alias": "fake-aws-account",
+                "provider": "fake_aws"
+            })),
+        })
+    }
+}
 
 // ============================================================================
 // Latency simulation

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -80,6 +80,7 @@ pub use crate::capability_types::{
 mod a2a_delegation;
 #[cfg(feature = "ui-capabilities")]
 mod a2ui;
+mod agent_handoff;
 mod agent_instructions;
 pub mod attach_skill;
 mod btw;
@@ -133,6 +134,10 @@ pub use a2a_delegation::{
 };
 #[cfg(feature = "ui-capabilities")]
 pub use a2ui::{A2UI_CAPABILITY_ID, A2UiCapability};
+pub use agent_handoff::{
+    AGENT_HANDOFF_CAPABILITY_ID, AgentHandoffCapability, GetAgentHandoffsTool,
+    MessageAgentHandoffTool, StartAgentHandoffTool,
+};
 pub use agent_instructions::{
     AGENT_INSTRUCTIONS_CAPABILITY_ID, AGENTS_MD_PATH, AgentInstructionsCapability,
     AgentInstructionsConfig, DEFAULT_AGENT_INSTRUCTIONS_FILE, MAX_AGENT_INSTRUCTIONS_FILES,
@@ -816,6 +821,7 @@ impl CapabilityRegistry {
 
         // Subagents (spawn child agent sessions, all environments)
         registry.register(SubagentCapability);
+        registry.register(AgentHandoffCapability);
         registry.register(A2aAgentDelegationCapability);
 
         // System commands (/clear, /status, /compact, /model)
@@ -1834,6 +1840,7 @@ mod tests {
             "prompt_caching",
             "skills",
             "subagents",
+            "agent_handoff",
             "a2a_agent_delegation",
             "system_commands",
             "sample_data",

--- a/crates/core/src/platform_store.rs
+++ b/crates/core/src/platform_store.rs
@@ -661,14 +661,17 @@ pub mod tests {
         }
         async fn create_session(
             &self,
-            _hid: HarnessId,
-            _aid: Option<crate::typed_id::AgentId>,
+            hid: HarnessId,
+            aid: Option<crate::typed_id::AgentId>,
             title: Option<&str>,
             locale: Option<&str>,
             blueprint_id: Option<&str>,
             blueprint_config: Option<&serde_json::Value>,
         ) -> Result<Session> {
             let mut s = self.session.clone();
+            s.id = SessionId::new();
+            s.harness_id = hid;
+            s.agent_id = aid;
             s.title = title.map(|t| t.to_string());
             s.locale = locale.map(|value| value.to_string());
             s.blueprint_id = blueprint_id.map(|b| b.to_string());

--- a/specs/agent-handoff.md
+++ b/specs/agent-handoff.md
@@ -1,0 +1,144 @@
+# Agent Handoff
+
+## Abstract
+
+Agent handoff lets one agent delegate work to another configured first-party
+Agent through an authorization and connection gate. Unlike blueprints, the
+target is a normal Agent resource with its own prompt, capabilities, MCP
+servers, mounted data, model defaults, and future identity bindings.
+
+The source agent receives only handoff tools. It does not receive the target
+agent's tools and never receives provider credentials.
+
+## Capability
+
+Capability id: `agent_handoff`.
+
+The capability is configured on the source agent with an allowlist of target
+agents:
+
+```json
+{
+  "targets": [
+    {
+      "id": "aws_operator",
+      "name": "AWS Operator",
+      "description": "Manage AWS infrastructure through fake AWS tools",
+      "agent_id": "agent_01933b5a000070008000000000000001",
+      "required_connections": ["fake_aws"],
+      "required_scopes": ["fake_aws:rds:create"]
+    }
+  ]
+}
+```
+
+Fields:
+
+| Field | Description |
+|---|---|
+| `id` | Stable target key used in tool calls. |
+| `name` | Human-readable target label and child-session title. |
+| `description` | Prompt-visible summary for target selection. |
+| `agent_id` | Public id of the configured target Agent. |
+| `required_connections` | Provider ids that must be connected before handoff starts. |
+| `required_scopes` | Non-secret audit labels recorded in resource metadata. |
+
+`required_scopes` are labels in the first implementation. Provider-specific
+tools that need hard authorization should enforce their own scoped grant checks
+before performing external writes.
+
+## Tools
+
+### `start_agent_handoff`
+
+Starts a child session using the configured target Agent.
+
+Parameters:
+
+| Field | Required | Description |
+|---|---:|---|
+| `target` | yes | Target key from capability config. |
+| `task` | yes | Work request for the target agent. Must not contain credentials. |
+| `public_context` | no | Non-secret structured context appended to the child task. |
+
+Behavior:
+
+1. Validate the target exists in capability config.
+2. Resolve required provider connections server-side through
+   `UserConnectionResolver`.
+3. If a connection is missing, return `connection_required(provider)`.
+4. Create a child session with the target `agent_id`.
+5. Persist parent/child metadata through the existing subagent session fields.
+6. Register a `session_resources.kind = "agent_handoff"` entry.
+7. Send the task to the child session.
+8. Block until the child session idles and return its last assistant message.
+
+### `get_agent_handoffs`
+
+Lists handoff resources for the current session. When the session resource
+registry is available, this uses `session_resources`; otherwise it falls back to
+child-session metadata.
+
+### `message_agent_handoff`
+
+Sends follow-up input to a child handoff session and waits for it to idle.
+
+## Security Contract
+
+Credentials must never be passed through handoff tool arguments, target config,
+messages, events, resource metadata, or prompt context. Required provider
+connections are checked inside the server process. Tools that need credentials
+resolve them lazily during execution via `UserConnectionResolver`.
+
+The source agent gets authority to request a handoff to configured targets. It
+does not get authority to call the target agent's tools directly.
+
+The first implementation is a configured-agent delegation gate. It does not yet
+create a separate durable scoped grant row. Provider tools that need
+fine-grained write protection should add scoped grant checks before production
+use against real external infrastructure.
+
+## Fake AWS Example
+
+Use this setup to test the flow locally:
+
+1. Create an `AWS Operator` agent with `fake_aws` enabled.
+2. Create a `Welcome` agent with `agent_handoff` enabled and config:
+
+```json
+{
+  "targets": [
+    {
+      "id": "aws_operator",
+      "name": "AWS Operator",
+      "agent_id": "<AWS_OPERATOR_AGENT_ID>",
+      "required_connections": ["fake_aws"],
+      "required_scopes": ["fake_aws:rds:create"]
+    }
+  ]
+}
+```
+
+3. Start a session with the `Welcome` agent and ask:
+
+```text
+Create an RDS database named app-db in us-east-1.
+```
+
+4. The first handoff should return `connection_required: "fake_aws"` if the
+   fake AWS connection is not configured.
+5. Add a Fake AWS connection in Settings → Connections. Any non-empty key is
+   accepted by the fake provider for local testing.
+6. Retry the user request. The welcome agent should call
+   `start_agent_handoff`, and the child AWS Operator session should receive the
+   task and use its own fake AWS tools.
+
+Background mode is intentionally not exposed until there is a durable lifecycle
+updater that can move handoff resources from `active` to a terminal status after
+the parent turn has returned.
+
+Focused verification:
+
+```bash
+cargo test -p everruns-core agent_handoff -- --nocapture
+```

--- a/specs/capabilities.md
+++ b/specs/capabilities.md
@@ -75,6 +75,14 @@ A Capability is an abstraction that defines added functionality for an Agent:
 2. **Tool Provision**: Tools made available to the agent during execution
 3. **Behavior Modification**: Influence on tool invocation and execution (future)
 
+### Agent Handoff Capability
+
+`agent_handoff` is a high-risk orchestration capability for delegating from one
+configured Agent to another configured Agent through an allowlist and connection
+gate. It is distinct from subagents and blueprints because the target is a
+normal Agent resource, not inherited runtime config and not a code-defined
+template. See [agent-handoff.md](agent-handoff.md).
+
 ### Architecture
 
 Capabilities are defined in **everruns-core** and resolved at the **API layer**:

--- a/specs/session-resources.md
+++ b/specs/session-resources.md
@@ -42,6 +42,7 @@ rather than duplicate.
 | Sandbox (Daytona, E2B, Deno) | `LeasedResourceStore.upsert_resource` | `sandbox`         | Leased resource public ID  |
 | Browser (Browserless)        | `LeasedResourceStore.upsert_resource` | `browser_session` | Leased resource public ID  |
 | Subagents                    | `spawn_subagent` tool                 | `subagent`        | Child session public ID    |
+| Agent handoff                | `start_agent_handoff` tool            | `agent_handoff`   | Child session public ID    |
 | Background tool runs         | `spawn_background` tool              | `background_run`  | Generated background run ID |
 | Sprites                      | `LeasedResourceStore.upsert_resource` | `sprite`          | Leased resource public ID  |
 | Voice Connections            | Voice bootstrap endpoints             | `voice_connection` | Voice connection public ID |

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -442,6 +442,7 @@ fn authorizer(action: AuthAction) -> Authorization {
 | TM-TOOL-018 | MCP server SSRF via configured server URL | High | MCP server URLs are validated on create/update and re-validated at execution time; private/internal hosts and metadata endpoints blocked | MITIGATED |
 | TM-TOOL-019 | MCP `query`/`execute` positional-arg rewrite injection | Low | Rewriter only inserts compile-time `--<flag>` tokens at statement-start boundaries, respects quotes/escapes/comments, and never modifies or reorders user bytes. Flag names come from the command registry, not user input. See EVE-323. | MITIGATED |
 | TM-TOOL-020 | Skill `` !`command` `` activation RCE on worker host | High | `ActivateSkillFromVfsTool::execute_with_context` never invokes `preprocess_command_injections` — the trust gate is forced off because no non-user-spoofable provenance signal exists on `SessionFile` today. Expansion is also capped at `MAX_COMMAND_PLACEHOLDERS_PER_SKILL` (32) with concurrency ≤ 4 in the expansion function itself. See EVE-388. | MITIGATED |
+| TM-TOOL-021 | Agent handoff credential leakage or unauthorized target delegation | High | `agent_handoff` delegates only to configured target Agent ids, requires server-side `UserConnectionResolver` checks before start, never accepts credentials in tool args/config/resource metadata, records only non-secret provider/scope labels in `session_resources`, and rejects follow-up messages unless the child session belongs to the current parent session. Provider tools must still enforce scoped grants before real external writes. | MITIGATED |
 
 ### Mitigation Details
 
@@ -471,6 +472,23 @@ SKILL.md content may contain `` !`command` `` placeholders that, if expanded by 
 6. Command execution MUST target the session sandbox (virtual bash via `bashkit`) against the session virtual filesystem, not the worker host shell. The current `ProcessCommandExecutor` (which spawns host `bash -c`) is dormant scaffolding only; re-enabling command substitution without also routing it through the session sandbox would still be RCE against the worker host. Any re-enable PR must both (a) introduce the provenance signal in (1) AND (b) replace host-bash execution with a sandbox-backed executor before flipping the gate.
 
 Follow-up work (tracked on EVE-388): (a) add a platform-controlled provenance field — e.g. a `mount_capability_id` column on `session_files` populated only by mount application code and rejected on all user-facing API paths, AND (b) replace `ProcessCommandExecutor` with a session-sandbox-backed executor (`bashkit` / managed session sandbox) so execution is confined to the session VFS. Both must land before the gate is flipped. See `specs/skills-registry.md` "Activation Substitution Pipeline" for the source/outcome matrix.
+
+**TM-TOOL-021 — Agent Handoff Delegation Gate:**
+`agent_handoff` is a high-risk orchestration tool because one agent can start a
+child session using another configured Agent's tools and data. The mitigation is
+to keep authority explicit and non-secret:
+
+1. Source agents can only target ids listed in their `agent_handoff` config.
+2. Required provider connections are resolved server-side through
+   `UserConnectionResolver`; bearer tokens are never accepted in tool arguments,
+   capability config, system prompt context, or session resource metadata.
+3. Handoff resources store only non-secret target id, target agent id, provider
+   ids, scope labels, and mode. Full task text and credentials are excluded.
+4. `message_agent_handoff` verifies the child session's `parent_session_id`
+   matches the current session before sending follow-up input.
+5. This gate proves the user has the required connection before delegation.
+   Real provider write tools still need scoped grant enforcement before mutating
+   external infrastructure.
 
 **TM-TOOL-011/012 — Skill Archive Validation:**
 ZIP archive extraction in `SkillService::create_from_archive()` enforces:

--- a/test_cases/agents/MANUAL_TEST_RESULTS_2026-05-19.md
+++ b/test_cases/agents/MANUAL_TEST_RESULTS_2026-05-19.md
@@ -1,0 +1,56 @@
+# Manual Agent Test Results - 2026-05-19
+
+## Environment
+
+- **Category:** `test_cases/agents/agent_handoff`
+- **Stack:** Not required for the automated capability-boundary run
+- **API smoke stack:** `PORT_PREFIX=281 just start-dev --no-watch`
+- **Auth Mode:** N/A for automated Rust validation
+- **Browser:** Not used
+- **Workspace:** repo root
+
+## Test Summary
+
+| Category | Tests | Pass | Fail/Partial | Issues |
+|----------|-------|------|--------------|--------|
+| agent_handoff | 1 | 1 | 0 | 0 |
+| **Total** | **1** | **1** | **0** | **0** |
+
+## Detailed Results
+
+### agent_handoff (1/1 PASS)
+
+- **TC001 Fake AWS Configured Agent Handoff**: PASS
+  - Added the manual agent workflow test case covering missing Fake AWS
+    connection gating, configured target Agent handoff, session resource
+    registration, child-session ownership, and secret exclusion.
+  - Ran focused automated coverage for the same behavior:
+    `cargo test -p everruns-core agent_handoff -- --nocapture`.
+  - Result: 9 handoff tests passed.
+  - Also ran `cargo fmt --check`.
+  - Smoke checked the running API:
+    - `GET /api/v1/capabilities?search=agent_handoff` returned
+      `agent_handoff	Agent Handoff	available`.
+    - `GET /api/v1/user/connections/providers` included
+      `fake_aws	Fake AWS	api_key`.
+
+## Issues Found
+
+None.
+
+## Evidence
+
+| Artifact | Location |
+|----------|----------|
+| Test case | `test_cases/agents/agent_handoff/TC001_fake_aws_configured_agent_handoff.md` |
+| Focused automated test | `cargo test -p everruns-core agent_handoff -- --nocapture` |
+| Format check | `cargo fmt --check` |
+| API smoke | `PORT_PREFIX=281 just start-dev --no-watch` plus capability and connection-provider curl checks |
+
+## Notes
+
+- This run validates the capability boundary deterministically in Rust and
+  verifies that the new capability/provider are visible through a running API.
+- The `/healthz` proxy smoke returned 502 because `apps/ui/node_modules` was
+  absent and the UI dev server did not start. The API endpoints required for
+  this feature were reachable through the proxy.

--- a/test_cases/agents/agent_handoff/TC001_fake_aws_configured_agent_handoff.md
+++ b/test_cases/agents/agent_handoff/TC001_fake_aws_configured_agent_handoff.md
@@ -1,0 +1,150 @@
+# TC001: Fake AWS Configured Agent Handoff
+
+## Description
+
+Verify that a source agent with the `agent_handoff` capability can delegate an
+AWS-style request to a configured target Agent only after the user has a
+required Fake AWS connection. The source agent must not receive Fake AWS tools
+or credentials directly. The target agent must run in a child session, the
+handoff must be registered as a session resource, and follow-up messages must be
+accepted only for child sessions owned by the source session.
+
+## Preconditions
+
+- Control-plane running (`PORT_PREFIX=271 just start-dev --no-watch` or
+  equivalent)
+- The active org has the built-in `generic` harness
+- The active org has a usable default model, or the agents are configured with a
+  deterministic `llmsim` model for local execution
+- The signed-in/dev user has no existing `fake_aws` connection at the start of
+  the negative-path check
+
+## Test Data
+
+| Field | Value |
+|-------|-------|
+| Target agent name | `aws-operator-handoff-tc001` |
+| Target agent display name | `AWS Operator Handoff TC001` |
+| Target capabilities | `fake_aws` |
+| Source agent name | `welcome-handoff-tc001` |
+| Source agent display name | `Welcome Handoff TC001` |
+| Source capabilities | `agent_handoff` |
+| Handoff target id | `aws_operator` |
+| Required connection | `fake_aws` |
+| Required scope label | `fake_aws:rds:create` |
+| Fake AWS key | `fake_aws_tc001_key` |
+| User request | `Create an RDS database named app-db in us-east-1.` |
+
+## Steps
+
+1. Create the target `AWS Operator Handoff TC001` agent on the `generic`
+   harness with the `fake_aws` capability and a system prompt that instructs it
+   to use Fake AWS tools for AWS infrastructure requests.
+
+2. Create the source `Welcome Handoff TC001` agent on the `generic` harness
+   with the `agent_handoff` capability configured with this target:
+
+   ```json
+   {
+     "targets": [
+       {
+         "id": "aws_operator",
+         "name": "AWS Operator",
+         "agent_id": "<TARGET_AGENT_ID>",
+         "required_connections": ["fake_aws"],
+         "required_scopes": ["fake_aws:rds:create"]
+       }
+     ]
+   }
+   ```
+
+3. Start a session with the source agent.
+
+4. Send the user request:
+
+   ```text
+   Create an RDS database named app-db in us-east-1.
+   ```
+
+5. Verify the first run requests connection setup instead of handing work off.
+
+6. Add a Fake AWS user connection through Settings > Connections or the API:
+
+   ```bash
+   curl -s -X POST "http://localhost:27100/api/v1/user/connections/fake_aws" \
+     -H "Content-Type: application/json" \
+     -d '{"api_key":"fake_aws_tc001_key"}'
+   ```
+
+7. Retry the user request in the same source session.
+
+8. Wait for the source session to idle.
+
+9. Inspect source session events and messages.
+
+10. Inspect session resources for the source session.
+
+11. Inspect the child session returned by the handoff resource.
+
+12. Send a follow-up through `message_agent_handoff`, for example:
+
+    ```text
+    List the RDS databases you can see now.
+    ```
+
+## Expected Result
+
+### Missing Connection Gate
+
+| Check | Expected |
+|-------|----------|
+| Missing connection result | Source turn includes a `connection_required` result for provider `fake_aws` |
+| No child session before connection | No `agent_handoff` session resource is registered |
+| No credential prompt | Source agent does not ask the user to paste an API key into chat |
+
+### Successful Handoff
+
+| Check | Expected |
+|-------|----------|
+| Handoff tool called | Source session includes a `start_agent_handoff` tool call |
+| Target allowlist enforced | Tool arguments use `target: "aws_operator"` |
+| Child session created | A child session exists with `parent_session_id` equal to the source session id |
+| Target agent selected | Child session `agent_id` equals `<TARGET_AGENT_ID>` |
+| Handoff resource registered | Source session has `session_resources.kind = "agent_handoff"` |
+| Resource id | Handoff resource `resource_id` equals the child session id |
+| Resource status | Handoff resource transitions from `active` to `completed` or `failed` |
+| Resource metadata | Metadata includes target id, target agent id, required connection ids, required scope labels, and mode |
+| Secret exclusion | Resource metadata does not include `fake_aws_tc001_key`, request credential text, or full task text |
+| Target tool ownership | Child session can call Fake AWS tools; source session does not receive Fake AWS tool definitions from the target |
+
+### Follow-up
+
+| Check | Expected |
+|-------|----------|
+| Follow-up ownership | `message_agent_handoff` accepts the child handoff id from this source session |
+| Cross-session guard | The same tool rejects an unrelated or non-child session id |
+| Follow-up result | Child session processes the follow-up and returns a non-empty assistant response |
+
+## Validation Commands
+
+```bash
+# Focused automated coverage for this setup:
+cargo test -p everruns-core agent_handoff -- --nocapture
+
+# Core regression coverage:
+cargo test -p everruns-core --lib -- --test-threads=1
+
+# Server compile check:
+cargo check -p everruns-server
+```
+
+## Failure Modes
+
+| Failure | What to look for |
+|---------|-----------------|
+| Handoff starts before connection | `required_connections` is not being resolved through `UserConnectionResolver` |
+| Source can use Fake AWS tools directly | Target capabilities leaked into the source runtime instead of remaining on the target Agent |
+| Credential appears in events/resource metadata | Tool args, prompt context, resource metadata, or event logging is persisting secrets |
+| Child session has wrong agent | `start_agent_handoff` is creating from inherited config or blueprint config instead of configured target `agent_id` |
+| Handoff cannot be listed | `session_resources.kind = "agent_handoff"` registration or filtering is broken |
+| Follow-up reaches wrong session | `message_agent_handoff` is missing the `parent_session_id` ownership check |


### PR DESCRIPTION
## What
Add a production-oriented `agent_handoff` capability that lets a source agent delegate work to configured first-party target Agents through a connection gate.

This also adds:
- Fake AWS API-key connection provider for local handoff testing, gated to experimental/dev deployments
- Agent handoff spec and threat-model entry
- Session resource registration for handoffs
- Agent workflow test case plus recorded run results

## Why
We need a generic welcoming/source agent to hand off privileged work to a separately configured target agent without using blueprints and without ever asking users to paste provider credentials into chat.

## How
- Adds `start_agent_handoff`, `get_agent_handoffs`, and `message_agent_handoff` tools.
- Requires targets to be explicitly allowlisted in `agent_handoff` config.
- Resolves required provider connections server-side through `UserConnectionResolver`.
- Creates child sessions using the configured target Agent id.
- Registers `session_resources.kind = "agent_handoff"` entries with non-secret metadata only.
- Supports synchronous wait-mode handoffs only; background mode is deferred until there is durable lifecycle status reconciliation.
- Adds Fake AWS as an experimental API-key connection provider for test setup.

## Risk
- Medium
- This touches high-risk orchestration/tool execution. Main risks are target authorization mistakes, credential leakage, child-session ownership bugs, and provider connection resolution regressions.
- Mitigations: target allowlist, server-side connection lookup, no credential-bearing args/config/resource metadata, parent/child ownership check, focused tests, API smoke, and threat-model update.

## Security
- Threat categories reviewed: TM-TOOL, TM-AUTHZ, TM-LLM, TM-API.
- Findings and resolutions:
  - Added `TM-TOOL-021` for agent handoff credential leakage / unauthorized target delegation.
  - Removed task preview from handoff session resource metadata and fallback listing to avoid persisting/returning user-supplied secret text.
  - Confirmed handoff config/tool schemas do not accept provider credentials.
  - Confirmed missing connection resolver is treated as execution-context misconfiguration, not a user auth prompt.
  - Confirmed follow-up messaging verifies child `parent_session_id` before sending input.
  - Fine-grained provider write scopes remain provider-tool responsibility before real infrastructure writes.

## Follow-ups
- Add durable scoped grant enforcement for real external provider write tools; safe to defer because this PR only adds the handoff gate and Fake AWS test provider, and the spec/threat model explicitly preserve the boundary.
- Add target agent identity binding when session creation supports passing `agent_identity_id`; safe to defer because current behavior uses the target Agent config and user-owned session connection resolution.
- Add durable lifecycle updater before exposing background handoff mode.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

Validation:
- `cargo fmt --check`
- `cargo test -p everruns-core agent_handoff -- --nocapture` (9 passed)
- `cargo test -p everruns-core --lib -- --test-threads=1` (1792 passed)
- `cargo check -p everruns-server`
- `PORT_PREFIX=281 just start-dev --no-watch` API smoke: `agent_handoff` capability available, `fake_aws` provider visible in dev/experimental mode
- `bash scripts/lib/check-migration-ordering.sh`
- `just pre-push`