### PR TITLE
ci: narrow docker build trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,11 +85,9 @@ jobs:
               - 'docs/tutorials/**'
             docker:
               - 'docker/**'
-              - 'crates/**'
-              - 'integrations/**'
-              - 'Cargo.toml'
-              - 'Cargo.lock'
+              - '.dockerignore'
               - '.github/workflows/ci.yml'
+              - '.github/workflows/docker-publish.yml'
 
       # Exclusion filters need `predicate-quantifier: every`; with the default
       # `some`, a rule like `!integrations/foo/**/*.md` matches almost every


### PR DESCRIPTION
## What
Narrow the CI Docker build path filter so the server/worker Docker image build runs only for files that can affect that job.

## Why
Rust and integration source-only PRs were still triggering Docker builds, which made normal PRs slower despite the release process documenting Docker PR validation as Docker-path-only.

## How
Removed Rust source and Cargo manifest paths from the `docker` filter in `.github/workflows/ci.yml`. The CI Docker build remains triggered by server/worker Docker inputs and related workflow changes: `docker/**`, root `.dockerignore`, `ci.yml`, and `docker-publish.yml`. UI Docker image validation remains owned by `docker-publish.yml`, which already path-filters UI Dockerfile changes.

## Risk
- Low
- Source-only changes will no longer validate container image construction on every PR. This matches `specs/release-process.md`; release tag builds still validate source changes in images before release.

## Security
- Threat categories reviewed: CI/CD configuration; no application threat-model categories touched.
- Findings and resolutions: no secrets, permissions, auth, runtime code, dependencies, or deployment credentials changed. The change only narrows when an existing CI job runs.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (code change or written reasoning)

Validation:
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "ci.yml parsed"'`\n- `bash scripts/lib/check-migration-ordering.sh`\n- `just pre-push`\n\nSmoke testing:\n- Skipped: CI workflow path-filter-only change; no runtime behavior or user flow is affected.