### PR TITLE
chore(ci): add affected CI opt-out labels

### DIFF
--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -27,7 +27,14 @@ Use this skill when the user asks to:
 1. The branch state is safe.
    - Do not ship from `main` or `master`.
    - The working tree must be clean before the final push.
-   - Rebase onto the latest `origin/main` before merge.
+   - Prefer rebasing onto the latest `origin/main` before merge.
+   - Merging without the latest rebase is acceptable when saving another CI cycle is more valuable and migration risk is absent. Before doing this, fetch `origin/main` and check that neither `origin/main` nor the PR changed `crates/server/migrations/` since their merge base. If either side changed migrations, rebase and run `bash scripts/lib/check-migration-ordering.sh`.
+     ```bash
+     git fetch origin main
+     base="$(git merge-base HEAD origin/main)"
+     git diff --name-only "$base"..HEAD -- crates/server/migrations/
+     git diff --name-only "$base"..origin/main -- crates/server/migrations/
+     ```
    - **After rebasing**, run `bash scripts/lib/check-migration-ordering.sh` to verify `crates/server/migrations/` numbers are strictly sequential. Migrations are the most common conflict source — multiple branches often add the same next number, and rebase silently keeps both. If the check fails, renumber your migration to the next available number.
    - **Immediately before `gh pr merge`** (after CI is green and review threads are resolved), re-run `bash scripts/lib/check-migration-ordering.sh`. Other PRs may have merged a colliding number while yours was in review.
 2. The requested goal is achieved with evidence.
@@ -55,6 +62,8 @@ Use this skill when the user asks to:
 7. The PR is mergeable and merged safely.
    - Push the branch.
    - Create or update the PR with `.github/pull_request_template.md`.
+   - Temporary CI opt-out labels (`ci:skip-docker`, `ci:skip-slow-rust`, `ci:skip-postgres-integration`, `ci:skip-sdk-compat`, `ci:skip-ui-e2e`, `ci:skip-docs-notebooks`, `ci:skip-integration-workflows`) may be used only for interim pushes after checking the skipped surface is not useful for that iteration.
+   - Before final merge readiness, remove any `ci:skip-*` label that suppresses CI affected by the PR diff and rerun CI on the latest PR commit. The `CI Opt-Out Policy` job must pass; do not merge with affected CI still skipped by opt-out.
    - Check the PR conversation, review threads, and review state from all reviewers, including bots.
    - After each push and again after CI turns green, wait at least 2 minutes for async reviewer bots to finish, then re-check for new comments before merge.
    - **Address every review comment** — including low-confidence suggestions, nits, non-blocking ones (COMMENTED state), and bot suggestions. Non-blocking comments often contain valid improvements (UX, robustness, doc clarity). For each comment: analyze the concern, reason about whether a code change is warranted, and either apply the fix or reply with a clear explanation of why the current code is correct. Do not dismiss comments without reasoning.
@@ -62,6 +71,7 @@ Use this skill when the user asks to:
    - Do not merge while any review comment is unresolved. Every thread must be explicitly addressed (code change or written resolution) before merge.
    - Wait for CI to go green.
    - Merge with squash only after CI is green, all review threads are resolved, and the final review/comment sweep above is clean.
+   - After merging, monitor main CI for the merge commit. If it fails, treat it as an active shipping regression and fix or revert promptly.
 
 ## Operating Model
 
@@ -69,6 +79,7 @@ Use this skill when the user asks to:
 - Choose the highest-signal path first: targeted diff review, focused tests, relevant builds, then smoke tests if gaps remain.
 - "Fix and ship" means implement first, then switch into shipping mode.
 - Docs or config-only changes can skip code tests when you explain why and run the relevant docs, lint, or build proof.
+- CI is slow enough that reducing unnecessary cycles is important. Use CI opt-out labels only to conserve interim CI time, not to weaken merge evidence. Prefer `ci:skip-docker` while iterating on non-container changes that still touch Rust/UI paths, `ci:skip-slow-rust` for early pushes where local targeted Rust evidence already covers the change, `ci:skip-postgres-integration` when only the PostgreSQL integration job is low-signal for the current push, `ci:skip-sdk-compat` when SDK contracts are unaffected, `ci:skip-ui-e2e` when UI smoke coverage is not relevant to the push, `ci:skip-docs-notebooks` when executable tutorial behavior is unchanged, and `ci:skip-integration-workflows` when the standalone integration workflow surface is unaffected. Before merge, remove opt-outs that suppress affected checks and rerun CI.
 - Do not use auto-merge or `gh pr merge --auto`; merge manually only after the final review sweep is clean because async review bots can post after the last push or after CI turns green.
 - If `just fmt` can auto-fix a failing formatting check, use it once and retry.
 - Stop only for blockers you cannot safely resolve alone: merge conflicts, missing credentials, ambiguous product intent, or CI failures you cannot reproduce or fix.
@@ -132,6 +143,7 @@ Pick only what matches the changed surface:
 - In the PR body, explain what changed, why it changed, how it was validated, notable risks, and an explicit **Follow-ups** section (or "No follow-ups." if none). Prefer implementing follow-ups in this PR; only defer when the work is genuinely out of scope or too large, and say so per item.
 - Use `gh pr view --json url` to detect an existing PR.
 - Create a PR with `gh pr create` if needed.
+- Use `gh pr edit --add-label <label>` only for interim CI opt-outs, and `gh pr edit --remove-label <label>` before final CI. If label removal does not trigger the expected workflow, rerun the workflow or push an empty final commit only after confirming that is the repo's intended practice.
 - Use `gh pr view --comments` to inspect the PR conversation, including bot comments.
 - Use `gh pr view --json reviews,latestReviews` to inspect reviewer state.
 - If review-thread status is unclear, inspect the review threads in the GitHub UI or via `gh api graphql` before merge.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -22,4 +22,5 @@ List anything intentionally deferred with a one-line rationale, or write "No fol
 - [ ] Tests added or updated
 - [ ] Backward compatibility considered
 - [ ] Security review performed against relevant threat model categories
+- [ ] Final CI ran checks affected by this PR
 - [ ] All review comments addressed (code change or written reasoning)

--- a/.github/workflows/brave-search-integration.yml
+++ b/.github/workflows/brave-search-integration.yml
@@ -7,6 +7,7 @@ on:
       - 'integrations/brave-search/**'
   pull_request:
     branches: [main]
+    types: [opened, reopened, synchronize, labeled, unlabeled]
     paths:
       - 'integrations/brave-search/**'
 
@@ -27,6 +28,7 @@ jobs:
   integration-test:
     name: Brave Search API Tests
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || (((github.event.action != 'labeled' && github.event.action != 'unlabeled') || github.event.label.name == 'ci:skip-integration-workflows') && !contains(github.event.pull_request.labels.*.name, 'ci:skip-integration-workflows'))
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    types: [opened, reopened, synchronize, labeled, unlabeled]
 
 # Cancel in-progress runs for the same PR/branch on new pushes.
 # On main, let every run finish so merged commits aren't silently skipped.
@@ -27,6 +28,7 @@ jobs:
     name: Detect Changes
     runs-on: ubuntu-latest
     outputs:
+      run_ci: ${{ steps.ci_event.outputs.run_ci }}
       rust: ${{ steps.core_filter.outputs.rust }}
       daytona: ${{ steps.live_filter.outputs.daytona }}
       deno: ${{ steps.live_filter.outputs.deno }}
@@ -39,8 +41,69 @@ jobs:
       docs: ${{ steps.core_filter.outputs.docs }}
       docs_notebooks: ${{ steps.core_filter.outputs.docs_notebooks }}
       docker: ${{ steps.core_filter.outputs.docker }}
+      brave_search_integration: ${{ steps.core_filter.outputs.brave_search_integration }}
+      duckduckgo_integration: ${{ steps.core_filter.outputs.duckduckgo_integration }}
+      parallel_integration: ${{ steps.core_filter.outputs.parallel_integration }}
+      skip_slow_rust: ${{ steps.ci_opt_outs.outputs.skip_slow_rust }}
+      skip_postgres_integration: ${{ steps.ci_opt_outs.outputs.skip_postgres_integration }}
+      skip_sdk_compat: ${{ steps.ci_opt_outs.outputs.skip_sdk_compat }}
+      skip_ui_e2e: ${{ steps.ci_opt_outs.outputs.skip_ui_e2e }}
+      skip_docs_notebooks: ${{ steps.ci_opt_outs.outputs.skip_docs_notebooks }}
+      skip_docker: ${{ steps.ci_opt_outs.outputs.skip_docker }}
+      skip_integration_workflows: ${{ steps.ci_opt_outs.outputs.skip_integration_workflows }}
     steps:
       - uses: actions/checkout@v4
+
+      - name: Resolve CI event gate
+        id: ci_event
+        env:
+          EVENT_ACTION: ${{ github.event.action }}
+          LABEL_NAME: ${{ github.event.label.name }}
+        run: |
+          set -euo pipefail
+
+          if [ "${GITHUB_EVENT_NAME}" = "pull_request" ] && \
+             { [ "${EVENT_ACTION}" = "labeled" ] || [ "${EVENT_ACTION}" = "unlabeled" ]; }; then
+            case "${LABEL_NAME}" in
+              ci:skip-docker|ci:skip-slow-rust|ci:skip-postgres-integration|ci:skip-sdk-compat|ci:skip-ui-e2e|ci:skip-docs-notebooks|ci:skip-integration-workflows)
+                echo "run_ci=true" >> "$GITHUB_OUTPUT"
+                ;;
+              *)
+                echo "run_ci=false" >> "$GITHUB_OUTPUT"
+                ;;
+            esac
+          else
+            echo "run_ci=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Resolve CI opt-out labels
+        id: ci_opt_outs
+        env:
+          LABELS_JSON: ${{ toJson(github.event.pull_request.labels.*.name) }}
+        run: |
+          set -euo pipefail
+
+          has_label() {
+            [[ "$LABELS_JSON" == *"\"$1\""* ]]
+          }
+
+          set_output() {
+            local name="$1"
+            local label="$2"
+            if has_label "$label"; then
+              echo "$name=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "$name=false" >> "$GITHUB_OUTPUT"
+            fi
+          }
+
+          set_output skip_slow_rust "ci:skip-slow-rust"
+          set_output skip_postgres_integration "ci:skip-postgres-integration"
+          set_output skip_sdk_compat "ci:skip-sdk-compat"
+          set_output skip_ui_e2e "ci:skip-ui-e2e"
+          set_output skip_docs_notebooks "ci:skip-docs-notebooks"
+          set_output skip_docker "ci:skip-docker"
+          set_output skip_integration_workflows "ci:skip-integration-workflows"
 
       - uses: dorny/paths-filter@v3
         id: core_filter
@@ -88,6 +151,12 @@ jobs:
               - '.dockerignore'
               - '.github/workflows/ci.yml'
               - '.github/workflows/docker-publish.yml'
+            brave_search_integration:
+              - 'integrations/brave-search/**'
+            duckduckgo_integration:
+              - 'integrations/duckduckgo/**'
+            parallel_integration:
+              - 'integrations/parallel/**'
 
       # Exclusion filters need `predicate-quantifier: every`; with the default
       # `some`, a rule like `!integrations/foo/**/*.md` matches almost every
@@ -122,7 +191,7 @@ jobs:
     name: Format Check
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.rust == 'true'
+    if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true'
     steps:
       - uses: actions/checkout@v4
 
@@ -138,7 +207,7 @@ jobs:
     name: Lockfile Check
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.rust == 'true'
+    if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true'
     steps:
       - uses: actions/checkout@v4
 
@@ -151,7 +220,8 @@ jobs:
   migration-immutability:
     name: Migration Immutability
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    needs: changes
+    if: needs.changes.outputs.run_ci == 'true' && github.event_name == 'pull_request'
 
     steps:
       - uses: actions/checkout@v4
@@ -165,7 +235,7 @@ jobs:
     name: Clippy Lints
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.rust == 'true'
+    if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true'
 
     steps:
       - uses: actions/checkout@v4
@@ -189,7 +259,7 @@ jobs:
     name: Unit Tests (Pure)
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.rust == 'true'
+    if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true'
 
     steps:
       - uses: actions/checkout@v4
@@ -225,7 +295,7 @@ jobs:
     name: Worker Tests (Durable Execution)
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.rust == 'true'
+    if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true'
 
     steps:
       - uses: actions/checkout@v4
@@ -245,7 +315,7 @@ jobs:
     name: Shell Tests (Repo Scripts)
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.shell == 'true'
+    if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.shell == 'true'
 
     steps:
       - uses: actions/checkout@v4
@@ -281,7 +351,7 @@ jobs:
     name: Daytona Live API Tests
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.daytona == 'true' && github.event_name == 'push'
+    if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.daytona == 'true' && github.event_name == 'push'
     timeout-minutes: 10
 
     steps:
@@ -306,7 +376,7 @@ jobs:
     name: Browserless Live API Tests
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.browserless == 'true' && github.event_name == 'push'
+    if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.browserless == 'true' && github.event_name == 'push'
     timeout-minutes: 10
 
     steps:
@@ -331,7 +401,7 @@ jobs:
     name: E2B Live API Tests
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.e2b == 'true' && github.event_name == 'push'
+    if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.e2b == 'true' && github.event_name == 'push'
     timeout-minutes: 10
 
     steps:
@@ -356,7 +426,7 @@ jobs:
     name: Deno Live API Tests
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.deno == 'true' && github.event_name == 'push'
+    if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.deno == 'true' && github.event_name == 'push'
     timeout-minutes: 10
     env:
       DENO_SANDBOX_REGION: ams
@@ -384,7 +454,7 @@ jobs:
     name: Integration Tests (PostgreSQL)
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.rust == 'true'
+    if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true' && needs.changes.outputs.skip_slow_rust != 'true' && needs.changes.outputs.skip_postgres_integration != 'true'
     services:
       postgres:
         image: postgres:17-alpine
@@ -501,7 +571,7 @@ jobs:
     name: Build Release Binaries
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.rust == 'true'
+    if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true' && needs.changes.outputs.skip_slow_rust != 'true'
 
     steps:
       - uses: actions/checkout@v4
@@ -548,7 +618,10 @@ jobs:
   workflow-test:
     name: Workflow Tests (Server + Worker)
     runs-on: ubuntu-latest
-    needs: build-binaries
+    needs:
+      - changes
+      - build-binaries
+    if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true' && needs.changes.outputs.skip_slow_rust != 'true'
     services:
       postgres:
         image: postgres:17-alpine
@@ -673,7 +746,10 @@ jobs:
   cli-e2e-test:
     name: CLI E2E Tests
     runs-on: ubuntu-latest
-    needs: build-binaries
+    needs:
+      - changes
+      - build-binaries
+    if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true' && needs.changes.outputs.skip_slow_rust != 'true'
     timeout-minutes: 10
 
     env:
@@ -737,7 +813,7 @@ jobs:
     name: SDK Compat Matrix
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.sdk_compat == 'true'
+    if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.sdk_compat == 'true' && needs.changes.outputs.skip_sdk_compat != 'true' && needs.changes.outputs.skip_slow_rust != 'true'
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
     steps:
@@ -754,7 +830,7 @@ jobs:
       - changes
       - build-binaries
       - sdk-compat-matrix
-    if: needs.changes.outputs.sdk_compat == 'true'
+    if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.sdk_compat == 'true' && needs.changes.outputs.skip_sdk_compat != 'true' && needs.changes.outputs.skip_slow_rust != 'true'
     timeout-minutes: 20
     strategy:
       fail-fast: false
@@ -831,7 +907,10 @@ jobs:
   openapi-check:
     name: OpenAPI Spec Freshness
     runs-on: ubuntu-latest
-    needs: build-binaries
+    needs:
+      - changes
+      - build-binaries
+    if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true' && needs.changes.outputs.skip_slow_rust != 'true'
 
     steps:
       - uses: actions/checkout@v4
@@ -866,7 +945,7 @@ jobs:
     name: UI Build, Lint & Test
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.ui == 'true'
+    if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.ui == 'true'
 
     defaults:
       run:
@@ -913,7 +992,7 @@ jobs:
     name: UI Playwright Smoke
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.ui == 'true'
+    if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.ui == 'true' && needs.changes.outputs.skip_ui_e2e != 'true'
 
     defaults:
       run:
@@ -961,7 +1040,7 @@ jobs:
     name: Docs Build & Check
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.docs == 'true'
+    if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.docs == 'true'
 
     defaults:
       run:
@@ -1000,7 +1079,7 @@ jobs:
         run: npm run prepare-content
 
       - name: Execute notebook tutorials
-        if: needs.changes.outputs.docs_notebooks == 'true'
+        if: needs.changes.outputs.docs_notebooks == 'true' && needs.changes.outputs.skip_docs_notebooks != 'true'
         working-directory: .
         env:
           ADDR: 127.0.0.1:9301
@@ -1048,7 +1127,7 @@ jobs:
     name: Docker Build
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.docker == 'true'
+    if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.docker == 'true' && needs.changes.outputs.skip_docker != 'true'
 
     steps:
       - uses: actions/checkout@v4
@@ -1078,6 +1157,63 @@ jobs:
           cache-from: type=gha,scope=docker-rust
           cache-to: type=gha,mode=max,scope=docker-rust
 
+  ci-opt-out-policy:
+    name: CI Opt-Out Policy
+    runs-on: ubuntu-latest
+    if: needs.changes.outputs.run_ci == 'true' && github.event_name == 'pull_request'
+    needs: changes
+    steps:
+      - name: Require affected CI before merge
+        run: |
+          set -euo pipefail
+
+          blocked=0
+
+          require_if_affected() {
+            local label="$1"
+            local label_present="$2"
+            local affected="$3"
+            local check_name="$4"
+
+            if [ "$label_present" = "true" ] && [ "$affected" = "true" ]; then
+              echo "::error title=Affected CI skipped::$label suppresses affected CI: $check_name"
+              blocked=1
+            fi
+          }
+
+          if [ "${{ needs.changes.outputs.rust }}" = "true" ] || [ "${{ needs.changes.outputs.sdk_compat }}" = "true" ]; then
+            slow_rust_affected=true
+          else
+            slow_rust_affected=false
+          fi
+
+          if [ "${{ needs.changes.outputs.brave_search_integration }}" = "true" ] || \
+             [ "${{ needs.changes.outputs.duckduckgo_integration }}" = "true" ] || \
+             [ "${{ needs.changes.outputs.parallel_integration }}" = "true" ]; then
+            standalone_integration_affected=true
+          else
+            standalone_integration_affected=false
+          fi
+
+          require_if_affected "ci:skip-slow-rust" "${{ needs.changes.outputs.skip_slow_rust }}" "$slow_rust_affected" "slow Rust, release-binary-dependent, OpenAPI, and SDK checks"
+          require_if_affected "ci:skip-postgres-integration" "${{ needs.changes.outputs.skip_postgres_integration }}" "${{ needs.changes.outputs.rust }}" "PostgreSQL integration tests"
+          require_if_affected "ci:skip-sdk-compat" "${{ needs.changes.outputs.skip_sdk_compat }}" "${{ needs.changes.outputs.sdk_compat }}" "SDK compatibility checks"
+          require_if_affected "ci:skip-ui-e2e" "${{ needs.changes.outputs.skip_ui_e2e }}" "${{ needs.changes.outputs.ui }}" "UI Playwright smoke"
+          require_if_affected "ci:skip-docs-notebooks" "${{ needs.changes.outputs.skip_docs_notebooks }}" "${{ needs.changes.outputs.docs_notebooks }}" "docs notebook execution"
+          require_if_affected "ci:skip-docker" "${{ needs.changes.outputs.skip_docker }}" "${{ needs.changes.outputs.docker }}" "Docker image build validation"
+          require_if_affected "ci:skip-integration-workflows" "${{ needs.changes.outputs.skip_integration_workflows }}" "$standalone_integration_affected" "standalone Brave Search, DuckDuckGo, or Parallel MCP integration workflows"
+
+          if [ "$blocked" -ne 0 ]; then
+            cat <<'MSG'
+          Opt-outs are allowed for interim pushes to save CI time, but before
+          merge they must not suppress CI checks affected by this PR. Remove the
+          relevant ci:skip-* label(s) and rerun CI on the final PR commit.
+          MSG
+            exit "$blocked"
+          fi
+
+          echo "No CI opt-out labels suppress affected checks."
+
   # Aggregation gate for branch protection.
   ci-success:
     name: Build Check
@@ -1102,6 +1238,7 @@ jobs:
       - ui-e2e
       - docs-build
       - docker-build
+      - ci-opt-out-policy
       - browserless-live-test
       - daytona-live-test
       - e2b-live-test

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -24,7 +24,7 @@ on:
   # push SHA-tagged images to GHCR (pre-existing behavior) — these are
   # traceability artifacts, not a consumer-facing channel.
   pull_request:
-    types: [opened, reopened, synchronize]
+    types: [opened, reopened, synchronize, labeled, unlabeled]
     paths:
       - 'docker/**'
       - 'apps/ui/Dockerfile'
@@ -46,6 +46,7 @@ jobs:
   build-rust-images:
     name: Build Rust Images
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || (((github.event.action != 'labeled' && github.event.action != 'unlabeled') || github.event.label.name == 'ci:skip-docker') && !contains(github.event.pull_request.labels.*.name, 'ci:skip-docker'))
     permissions:
       contents: read
       packages: write
@@ -198,6 +199,7 @@ jobs:
   build-ui-image:
     name: Build UI Image
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || (((github.event.action != 'labeled' && github.event.action != 'unlabeled') || github.event.label.name == 'ci:skip-docker') && !contains(github.event.pull_request.labels.*.name, 'ci:skip-docker'))
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/duckduckgo-integration.yml
+++ b/.github/workflows/duckduckgo-integration.yml
@@ -7,6 +7,7 @@ on:
       - 'integrations/duckduckgo/**'
   pull_request:
     branches: [main]
+    types: [opened, reopened, synchronize, labeled, unlabeled]
     paths:
       - 'integrations/duckduckgo/**'
 
@@ -26,6 +27,7 @@ jobs:
   integration-test:
     name: DuckDuckGo API Tests
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || (((github.event.action != 'labeled' && github.event.action != 'unlabeled') || github.event.label.name == 'ci:skip-integration-workflows') && !contains(github.event.pull_request.labels.*.name, 'ci:skip-integration-workflows'))
     timeout-minutes: 5
 
     steps:

--- a/.github/workflows/parallel-integration.yml
+++ b/.github/workflows/parallel-integration.yml
@@ -7,6 +7,7 @@ on:
       - 'integrations/parallel/**'
   pull_request:
     branches: [main]
+    types: [opened, reopened, synchronize, labeled, unlabeled]
     paths:
       - 'integrations/parallel/**'
 
@@ -26,6 +27,7 @@ jobs:
   integration-test:
     name: Parallel MCP Tests
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || (((github.event.action != 'labeled' && github.event.action != 'unlabeled') || github.event.label.name == 'ci:skip-integration-workflows') && !contains(github.event.pull_request.labels.*.name, 'ci:skip-integration-workflows'))
     timeout-minutes: 5
 
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,12 +42,13 @@ Fix root cause. Unsure: read more code; if stuck, ask w/ short options. Unrecogn
 
 ### Branch Base
 
-Always make sure you are working on top of latest main from remote.
+Start from latest main by default.
 
 - Start by syncing: `git fetch origin main`
 - Branch or rebase onto `origin/main` before edits, especially before shipping
 - In worktrees, do not assume `HEAD` tracks a branch; verify with `git status --branch` or `git worktree list`
 - **After every rebase**, check `crates/server/migrations/` for duplicate version numbers. Migrations are the most common conflict source — multiple branches often add the next sequential number. Renumber your migration to the next available number if a conflict exists. See [`specs/migrations.md`](specs/migrations.md) for the full migration process.
+- Before merge, prefer rebasing onto latest `origin/main`. It is acceptable to merge without the latest rebase when avoiding another CI cycle is more valuable and migration risk is absent: check that neither `origin/main` nor the PR changed `crates/server/migrations/` since their merge base. If either side changed migrations, rebase and run `bash scripts/lib/check-migration-ordering.sh`. If merging without latest rebase, monitor main CI after merge and fix any regression immediately.
 
 ### Principles
 
@@ -184,7 +185,7 @@ behavioral change. See `docs/sre/environment-variables.md` for `NATS_URL` detail
 
 #### Worktrees
 
-Always make sure you are working on top of latest main from remote.
+Start worktrees from latest main by default.
 
 Worktrees are often detached or stale. Before making changes, start from the latest remote base:
 
@@ -237,6 +238,20 @@ cd apps/ui
 
 If checks fail, auto-fix with `just fmt`, then re-run `just pre-push`.
 
+### CI Opt-Out Labels
+
+Long CI jobs can be skipped on interim PR pushes with temporary labels:
+
+- `ci:skip-docker` skips PR Docker image builds.
+- `ci:skip-slow-rust` skips PostgreSQL integration tests, release binary builds, workflow tests, CLI E2E, OpenAPI freshness, and dependent SDK checks.
+- `ci:skip-postgres-integration` skips only the main PostgreSQL integration test job.
+- `ci:skip-sdk-compat` skips SDK compatibility checks only.
+- `ci:skip-ui-e2e` skips Playwright smoke tests; UI build/lint/unit tests still run.
+- `ci:skip-docs-notebooks` skips executable docs notebooks; docs check/build still run.
+- `ci:skip-integration-workflows` skips the standalone PR integration workflows for Brave Search, DuckDuckGo, and Parallel MCP.
+
+CI is slow enough that reducing unnecessary cycles matters. Use these labels to save iteration time after deciding the skipped surface is low-signal for the current push. The `CI Opt-Out Policy` job fails only when an opt-out label suppresses CI affected by the PR diff. Before merge, remove any CI opt-out label that blocks affected checks and rerun CI on the final PR commit so the affected checks run green.
+
 ### Shipping
 
 "Ship" means: achieve the requested goal, produce enough evidence that it works, perform a structured security review, create a mergeable PR, address every review comment, and merge only after CI is green.
@@ -259,7 +274,7 @@ Use the smallest set that gives high confidence. `/ship` should pick from this m
 4. `npm run lint` and `npm run build` in `apps/ui/` for UI changes
 5. `./scripts/export-openapi.sh` when API surface changes
 6. `npm run build` in `apps/docs/` when docs change
-7. `git fetch origin main && git rebase origin/main` before merge
+7. Prefer `git fetch origin main && git rebase origin/main` before merge; if skipping the final rebase, verify no migration changes exist on either side since the merge base and monitor main CI after merge
 8. Smoke test impacted flows in `just start-dev` or `just start-all` as risk dictates
 9. Review performance impact: indexes, scans, N+1 patterns, pagination, and bounded result sets
 10. Capture UI screenshots for UI changes in validation or PR comments only

--- a/specs/shipping.md
+++ b/specs/shipping.md
@@ -32,13 +32,13 @@ Relevant references:
 
 **Every shipped change MUST satisfy ALL of these outcomes. These are mandatory requirements, not optional suggestions. Do not skip or weaken any requirement.**
 
-1. Safe branch state: no shipping from `main` or `master`; working tree clean before final push; rebased onto the latest `origin/main` before merge. After rebasing, run `bash scripts/lib/check-migration-ordering.sh` to verify `crates/server/migrations/` numbers are strictly sequential — migrations are the most common conflict source. Re-run the same check immediately before `gh pr merge`, since other PRs may have merged a colliding number while yours was in review. Renumber your migration if a conflict exists.
+1. Safe branch state: no shipping from `main` or `master`; working tree clean before final push; prefer rebasing onto the latest `origin/main` before merge. Merging without the latest rebase is allowed when saving another CI cycle is more valuable and migration risk is absent: fetch `origin/main`, verify neither `origin/main` nor the PR changed `crates/server/migrations/` since their merge base, and monitor main CI after merge. If either side changed migrations, rebase and run `bash scripts/lib/check-migration-ordering.sh` to verify migration numbers are strictly sequential. Re-run the same check immediately before `gh pr merge`, since other PRs may have merged a colliding number while yours was in review. Renumber your migration if a conflict exists.
 2. Goal achieved with evidence: the requested behavior is implemented and validated with proof that matches the risk.
 3. Merge-ready code: touched code is reviewed for avoidable complexity and performance risk. A structured security review is performed against the relevant threat model categories from `specs/threat-model.md` (see the Security Review section in the ship skill). Issues found during review are addressed or explicitly blocked.
 4. Synced artifacts: only the affected artifacts are updated, including specs, threat model, docs, OpenAPI, test cases, and agent instructions when relevant. Specs touched by the change must not contain implementation details that duplicate code (struct fields, enum variants, exhaustive tables, code snippets) — replace with links to source files per the spec content principle in `AGENTS.md`.
 5. Smoke test impacted functionality: always smoke test the flows affected by the change end-to-end. This is mandatory, not conditional on risk assessment. Docs-only or config-only changes that do not affect runtime behavior may skip smoke testing with explicit justification.
 6. Follow-ups surfaced: the agent actively looks for in-scope work that risks being silently dropped (TODOs, partial fixes, declined suggestions, missed edge cases, spec/doc drift) and prefers to implement them in this PR. Anything deferred is listed under a **Follow-ups** section in the PR body with a one-line rationale; if nothing is deferred, the PR body must explicitly state "No follow-ups." so readers can distinguish completeness from omission.
-7. Safe merge: the PR uses the repo template, CI is green, **every** review comment from all reviewers (including async bot reviewers and low-confidence suggestions) is explicitly analyzed, reasoned about, and resolved — either with a code change or a written explanation — after a final post-green sweep, and merge happens with squash only.
+7. Safe merge: the PR uses the repo template, CI is green, no temporary `ci:skip-*` opt-out label suppresses CI affected by the PR diff, **every** review comment from all reviewers (including async bot reviewers and low-confidence suggestions) is explicitly analyzed, reasoned about, and resolved — either with a code change or a written explanation — after a final post-green sweep, merge happens with squash only, and main CI is monitored after merge.
 
 ## Constraints
 
@@ -46,6 +46,8 @@ Relevant references:
 - Validation should start with the smallest high-signal proof and deepen only when risk or weak signals require it.
 - Bug fixes should prefer a failing test before the fix when practical, but the validation strategy may vary when a smaller or stronger proof exists.
 - Docs-only or config-only changes may skip code tests if that choice is justified and the relevant docs or build checks were run.
+- CI is slow enough that reducing unnecessary cycles is important. Temporary CI opt-out labels may skip expensive interim PR checks to conserve CI capacity, but they are not merge evidence for affected surfaces. Before merge, opt-outs must not suppress CI checks affected by the PR diff, and merge must wait for those affected checks to pass.
+- A latest-main rebase is preferred but not mandatory when migration risk is absent. If merging without it, explicitly verify no migration changes exist on either side since the merge base and watch main CI after merge.
 - Security review is mandatory for all code, configuration, and infrastructure changes. The review must identify relevant threat model categories, check the diff against them, and document findings. Perceived low risk does not justify skipping the review.
 - Every review comment must be explicitly addressed before merge — including low-confidence suggestions, nits, and bot comments. For each comment, the agent must analyze the concern, reason about whether a change is warranted, and either apply a fix or reply with a clear explanation. Dismissing or ignoring comments without reasoning is not permitted.
 - Auto-merge must not bypass the final review pass; shipping should give async reviewer bots time to comment after the last push and after CI turns green, then re-check before merge.
@@ -58,7 +60,8 @@ Shipping output should make it easy to evaluate readiness:
 - what changed
 - what evidence was gathered
 - security review: which threat categories were checked, any findings, and how they were resolved
-- what was skipped and why
+- what was skipped during iteration and why, plus confirmation that final merge CI ran the checks affected by the PR diff
+- whether the PR was rebased onto latest main; if not, the migration-change check and main-CI monitoring outcome
 - review comments: how each comment was addressed (code change or written reasoning)
 - follow-ups: what was deferred and why (or an explicit "No follow-ups." statement)
 - what blockers or residual risks remain


### PR DESCRIPTION
## What
Add temporary PR CI opt-out labels for long-running checks, plus an affected-check policy gate that only blocks merge when an opt-out suppresses CI relevant to the current diff.

## Why
CI is slow enough that avoiding unnecessary interim cycles matters, especially around Docker and other expensive validation. The final merge bar should require affected checks, not every possible check.

## How
- Add label detection in CI for Docker, slow Rust, PostgreSQL integration, SDK compatibility, UI E2E, docs notebooks, and standalone integration workflows.
- Gate the matching jobs on those labels.
- Add a path-aware `CI Opt-Out Policy` job that fails only when an opt-out skips affected CI.
- Teach `AGENTS.md`, the ship skill, the shipping spec, and the PR checklist how to use the labels.
- Preserve the latest main Docker path-filter changes while rebasing.

## Risk
- Low / Medium / High: Medium
- What can break: CI label expressions or path filters could skip or block the wrong job. Mitigated with workflow YAML parsing, local policy-logic checks, and `just pre-push`.

## Security
- Threat categories reviewed: No security-relevant runtime code changes. CI configuration and agent guidance only.
- Findings and resolutions: No new app/runtime trust boundary. The policy remains conservative for affected checks.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)