### PR TITLE
fix(runtime): derive in-process org id from session org

### DIFF
--- a/crates/runtime/src/runtime.rs
+++ b/crates/runtime/src/runtime.rs
@@ -48,23 +48,36 @@ use std::sync::Arc;
 /// org id is absent or invalid.
 const IN_PROCESS_ORG_ID_FALLBACK: i64 = everruns_core::DEFAULT_ORG_ID;
 
+/// Derive an internal `i64` org id from the public `org_<32hex>` form on a
+/// [`Session`].
+///
+/// Round-trip with [`everruns_core::org_public_id_from_internal`]: when the
+/// public id was produced by that helper (i.e. the upper bits are zero and
+/// the value fits in a positive `i64`), this returns the original internal
+/// id unchanged. High-entropy UUID-style ids that do not fit in `i64` are
+/// folded deterministically into `[2, i64::MAX]`, leaving `1` reserved for
+/// [`everruns_core::DEFAULT_ORG_ID`].
 fn in_process_internal_org_id(public_org_id: &str) -> i64 {
     if public_org_id == everruns_core::DEFAULT_ORG_PUBLIC_ID {
         return everruns_core::DEFAULT_ORG_ID;
     }
 
-    if public_org_id.parse::<OrgId>().is_err() {
+    let Ok(parsed) = public_org_id.parse::<OrgId>() else {
+        return IN_PROCESS_ORG_ID_FALLBACK;
+    };
+    let raw: u128 = parsed.uuid().as_u128();
+    if raw == 0 {
         return IN_PROCESS_ORG_ID_FALLBACK;
     }
 
-    let Some(hex) = public_org_id.strip_prefix("org_") else {
-        return IN_PROCESS_ORG_ID_FALLBACK;
-    };
-    let Ok(raw) = u128::from_str_radix(hex, 16) else {
-        return IN_PROCESS_ORG_ID_FALLBACK;
-    };
+    // Synthetic ids from `org_public_id_from_internal(i64)` always fit here,
+    // so the in-process runtime sees the same `org_id` the server used.
+    if raw <= i64::MAX as u128 {
+        return raw as i64;
+    }
 
-    // Stable deterministic fold to positive i64; reserve 1 for default org.
+    // UUID-style ids exceed `i64`; fold deterministically into [2, i64::MAX].
+    // We avoid `0` (invalid) and `1` (DEFAULT_ORG_ID, handled above).
     ((raw % ((i64::MAX - 1) as u128)) as i64) + 2
 }
 
@@ -905,5 +918,92 @@ fn tool_completed_to_message(data: ToolCompletedData) -> Message {
         Message::tool_result(&data.tool_call_id, result, data.error)
     } else {
         Message::tool_result_with_images(&data.tool_call_id, result, images)
+    }
+}
+
+#[cfg(test)]
+mod org_id_mapping_tests {
+    use super::*;
+    use everruns_core::{DEFAULT_ORG_ID, DEFAULT_ORG_PUBLIC_ID, org_public_id_from_internal};
+
+    #[test]
+    fn default_public_id_maps_to_default_org() {
+        assert_eq!(
+            in_process_internal_org_id(DEFAULT_ORG_PUBLIC_ID),
+            DEFAULT_ORG_ID
+        );
+    }
+
+    #[test]
+    fn invalid_public_id_falls_back_to_default() {
+        for invalid in [
+            "",
+            "not-an-org",
+            "org_short",
+            "org_ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ",
+            "ORG_00000000000000000000000000000001",
+        ] {
+            assert_eq!(
+                in_process_internal_org_id(invalid),
+                IN_PROCESS_ORG_ID_FALLBACK,
+                "invalid input {invalid:?} should fall back"
+            );
+        }
+    }
+
+    #[test]
+    fn zero_public_id_falls_back_to_default() {
+        // org_public_id_from_internal never produces this; a hand-crafted
+        // all-zeros id is treated as invalid (raw == 0).
+        assert_eq!(
+            in_process_internal_org_id("org_00000000000000000000000000000000"),
+            IN_PROCESS_ORG_ID_FALLBACK
+        );
+    }
+
+    #[test]
+    fn synthetic_public_id_round_trips_with_internal_helper() {
+        for internal in [1_i64, 2, 42, 1_000_000, i64::MAX - 1, i64::MAX] {
+            let public = org_public_id_from_internal(internal);
+            assert_eq!(
+                in_process_internal_org_id(&public),
+                internal,
+                "round-trip failed for internal={internal}"
+            );
+        }
+    }
+
+    #[test]
+    fn distinct_synthetic_ids_map_to_distinct_internal_ids() {
+        let a = org_public_id_from_internal(7);
+        let b = org_public_id_from_internal(8);
+        assert_ne!(a, b);
+        assert_ne!(
+            in_process_internal_org_id(&a),
+            in_process_internal_org_id(&b)
+        );
+    }
+
+    #[test]
+    fn high_entropy_uuid_style_id_folds_into_reserved_range() {
+        // First valid UUID-style id whose raw u128 exceeds i64::MAX
+        // (top bit of the u128 set). It must fold to a positive i64 that
+        // is neither 0 nor DEFAULT_ORG_ID.
+        let high = "org_80000000000000000000000000000000";
+        let mapped = in_process_internal_org_id(high);
+        assert!(mapped >= 2, "folded id {mapped} must be >= 2");
+        assert_ne!(mapped, DEFAULT_ORG_ID);
+
+        // Mapping is deterministic.
+        assert_eq!(mapped, in_process_internal_org_id(high));
+    }
+
+    #[test]
+    fn high_entropy_ids_are_isolated_from_each_other() {
+        let a = in_process_internal_org_id("org_80000000000000000000000000000001");
+        let b = in_process_internal_org_id("org_80000000000000000000000000000002");
+        assert_ne!(a, b);
+        assert_ne!(a, DEFAULT_ORG_ID);
+        assert_ne!(b, DEFAULT_ORG_ID);
     }
 }

--- a/crates/runtime/src/runtime.rs
+++ b/crates/runtime/src/runtime.rs
@@ -37,19 +37,36 @@ use everruns_core::traits::{
     SessionStorageStore, SessionStore,
 };
 use everruns_core::turn::{TurnAction, TurnContext, TurnOutcome, TurnStateMachine};
-use everruns_core::typed_id::{AgentId, HarnessId, SessionId};
+use everruns_core::typed_id::{AgentId, HarnessId, OrgId, SessionId};
 use everruns_core::{
     InputMessage, MemoryStoreBackend, MessageRetriever, SessionFileSystem,
     SessionFileSystemFactoryContext,
 };
 use std::sync::Arc;
 
-/// Internal org id used by the in-process runtime when calling host
-/// activity functions. The in-process runtime does not multi-tenant; this
-/// matches `everruns_core::DEFAULT_ORG_ID` so the public-id mapping in
-/// `org_public_id_from_internal` resolves to `DEFAULT_ORG_PUBLIC_ID` and
-/// the org id `ActAtom` sees matches the prior (pre-host-activity) wiring.
-const IN_PROCESS_ORG_ID: i64 = everruns_core::DEFAULT_ORG_ID;
+/// Internal org id fallback used by the in-process runtime when a session
+/// org id is absent or invalid.
+const IN_PROCESS_ORG_ID_FALLBACK: i64 = everruns_core::DEFAULT_ORG_ID;
+
+fn in_process_internal_org_id(public_org_id: &str) -> i64 {
+    if public_org_id == everruns_core::DEFAULT_ORG_PUBLIC_ID {
+        return everruns_core::DEFAULT_ORG_ID;
+    }
+
+    if public_org_id.parse::<OrgId>().is_err() {
+        return IN_PROCESS_ORG_ID_FALLBACK;
+    }
+
+    let Some(hex) = public_org_id.strip_prefix("org_") else {
+        return IN_PROCESS_ORG_ID_FALLBACK;
+    };
+    let Ok(raw) = u128::from_str_radix(hex, 16) else {
+        return IN_PROCESS_ORG_ID_FALLBACK;
+    };
+
+    // Stable deterministic fold to positive i64; reserve 1 for default org.
+    ((raw % ((i64::MAX - 1) as u128)) as i64) + 2
+}
 
 #[derive(Debug, Clone)]
 pub struct TurnResult {
@@ -438,7 +455,7 @@ impl InProcessRuntime {
         let synthetic_agent_id = session
             .agent_id
             .unwrap_or_else(|| AgentId::from_uuid(session.id.uuid()));
-        let org_id: i64 = IN_PROCESS_ORG_ID;
+        let org_id = in_process_internal_org_id(&session.organization_id);
         let mut state_machine = TurnStateMachine::new(
             TurnContext::new(session_id, input_message.id, synthetic_agent_id, org_id),
             assembled.runtime_agent.max_iterations,


### PR DESCRIPTION
## What
Fix a regression in the in-process runtime where every host-activity invocation used the same `DEFAULT_ORG_ID`, collapsing org-scoped persistent memory stores across sessions with different `Session.organization_id` values.

The in-process runtime now derives an internal `i64` org id from `session.organization_id` and propagates it through the `input → reason → act` host activities (and into the `TurnContext`).

## Why
After the refactor in #1874, `InProcessRuntime` drives turns through the host activity functions, which take an explicit `org_id` parameter. The constant-only wiring (`IN_PROCESS_ORG_ID = DEFAULT_ORG_ID`) meant the `direct_worker_adapters` path — which populates `session.organization_id` via `org_public_id_from_internal(self.org_id)` — silently lost the per-session org binding, breaking memory store isolation in any deployment that drives multiple orgs through the in-process runtime.

## How
- New helper `in_process_internal_org_id(public_org_id: &str) -> i64` in `crates/runtime/src/runtime.rs`:
  - `DEFAULT_ORG_PUBLIC_ID` → `DEFAULT_ORG_ID` (fast path).
  - Otherwise `parse::<OrgId>()` once and read the raw `u128` via `parsed.uuid().as_u128()`.
  - **Round-trip preserved** with `org_public_id_from_internal`: when the raw value fits in a positive `i64`, return it as-is. This is the case the server's direct-worker adapter exercises (`crates/server/src/direct_worker_adapters.rs:2031`).
  - UUID-style high-entropy ids that exceed `i64::MAX` fold deterministically into `[2, i64::MAX]`, leaving `1` reserved for `DEFAULT_ORG_ID`.
  - Invalid input and the all-zeros id fall back to `IN_PROCESS_ORG_ID_FALLBACK = DEFAULT_ORG_ID`.
- `run_turn` calls the helper once per turn and threads the result into `TurnContext`, `execute_input_activity`, `execute_reason_activity`, and `execute_act_activity` (unchanged from the initial commit).

## Validation
- `cargo fmt --check`
- `cargo clippy -p everruns-runtime --all-targets --all-features -- -D warnings`
- New unit tests `cargo test -p everruns-runtime --lib org_id_mapping`:
  - `default_public_id_maps_to_default_org`
  - `invalid_public_id_falls_back_to_default`
  - `zero_public_id_falls_back_to_default`
  - `synthetic_public_id_round_trips_with_internal_helper` (covers `1, 2, 42, 1_000_000, i64::MAX-1, i64::MAX`)
  - `distinct_synthetic_ids_map_to_distinct_internal_ids`
  - `high_entropy_uuid_style_id_folds_into_reserved_range`
  - `high_entropy_ids_are_isolated_from_each_other`
- Existing host activity coverage: `cargo test -p everruns-runtime --test runtime_host_test act_activity_passes_public_org_id_to_memory_tools` — already asserts that the internal `org_id` propagates through to the memory store key.

## Risk
Low. Single-file change behind a deterministic helper with full unit coverage. Round-trip preservation means downstream consumers of `session.organization_id` (the server adapter at `direct_worker_adapters.rs:2031` populating `Session.organization_id` from an internal `org_id`) see the same internal id they constructed with. UUID-style ids that don't fit in `i64` fold deterministically but cannot collide with `DEFAULT_ORG_ID`.

## Security
Threat categories reviewed: **TM-TENANT, TM-AUTHZ**.

- **TM-TENANT** — This change *restores* tenant isolation for persistent memory stores in the in-process runtime. Before this PR, all sessions shared `DEFAULT_ORG_ID` for host-activity-backed memory, regardless of `Session.organization_id`. After: distinct `organization_id` values yield distinct internal `org_id` values, which is what `MemoryStore` keys on.
- **TM-AUTHZ** — No new authorization paths. The helper is pure; authorization decisions upstream of `run_turn` are unchanged.
- Collision surface: the fold for UUID-style ids uses modulo, which is deterministic but in principle allows targeted collisions if `session.organization_id` is attacker-controlled. In practice, `session.organization_id` is server-populated from authenticated org context; the in-process runtime is not directly exposed to untrusted public ids. Synthetic ids (the production path) bypass the fold entirely via the `raw <= i64::MAX` fast path, so no collision is possible there.
- No new `THREAT` comments needed (no new mitigation contracts beyond the existing host activity wiring); no `specs/threat-model.md` update required.

## Follow-ups
No follow-ups. The mapping is deterministic, round-trip-stable for the server-adapter path, and fully unit-tested. UUID-style ids that exceed `i64::MAX` are a theoretical surface not exercised today; if a future deployment routes such ids through the in-process runtime and needs per-id stability across processes, switching to a keyed hash (HMAC with a process-constant salt) is a small, contained change at that point.

## Checklist
- [x] Tests added (7 unit tests in `org_id_mapping_tests`)
- [x] Backward compatibility considered (`DEFAULT_ORG_PUBLIC_ID` still maps to `DEFAULT_ORG_ID`; synthetic ids round-trip)
- [x] Security review performed against relevant threat model categories
- [x] All review comments addressed (3 Copilot review threads replied + resolved)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bf0014de0832b99d0c69c536b20f9)