### PR TITLE
chore(release): prepare v0.8.32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,75 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- New changes go here. Use `/prepare-release X.Y.Z` to generate draft from commits. -->
 
+## [0.8.32] - 2026-05-19
+
+### Highlights
+
+- **Reporting product surface** - Completes the async reporting subsystem with finalized analytics, saved reports, and export flows.
+- **Agent versions with automatic draft snapshots** - Immutable agent configuration snapshots are now captured automatically as drafts to enable audit, rollback, forks, and pinned App deployments.
+- **RFC 9457 Problem Details API errors** - HTTP error responses now follow RFC 9457 with structured `CommandError` extensions ([#1834](https://github.com/everruns/everruns/pull/1834)).
+- **Coding-cli example** - New TUI coding agent example built on `everruns-runtime` with JSONL session log, `--session` resume, and proper harness system prompt ([#1839](https://github.com/everruns/everruns/pull/1839), [#1870](https://github.com/everruns/everruns/pull/1870), [#1871](https://github.com/everruns/everruns/pull/1871)).
+- **Runtime FileSystem policy decorators** - Filesystem access in the runtime now ships with composable policy decorators for ACL enforcement and pluggable real-disk `SessionFileStore` (EVE-478) ([#1857](https://github.com/everruns/everruns/pull/1857), [#1886](https://github.com/everruns/everruns/pull/1886)).
+- **OpenAPI surface expansion** - Health, agent versions, skills, schedules ([#1873](https://github.com/everruns/everruns/pull/1873)), and payments/LLM/durable field descriptions ([#1851](https://github.com/everruns/everruns/pull/1851)) are now documented in the OpenAPI spec.
+
+### What's Changed
+
+- feat(examples): coding-cli — JSONL session log + --session resume ([#1871](https://github.com/everruns/everruns/pull/1871)) by [@chaliy](https://github.com/chaliy)
+- feat(examples): coding-cli — proper system prompt for the harness ([#1870](https://github.com/everruns/everruns/pull/1870)) by [@chaliy](https://github.com/chaliy)
+- chore(ci): add affected CI opt-out labels ([#1887](https://github.com/everruns/everruns/pull/1887)) by [@chaliy](https://github.com/chaliy)
+- chore(test-cases): ignore manual test results by [@chaliy](https://github.com/chaliy)
+- feat(runtime): ship FileSystem policy decorators (EVE-478) ([#1886](https://github.com/everruns/everruns/pull/1886)) by [@chaliy](https://github.com/chaliy)
+- fix(runtime): reject symlink workspace paths ([#1876](https://github.com/everruns/everruns/pull/1876)) by [@chaliy](https://github.com/chaliy)
+- fix(core): pin fetchkit to 0.2.0 to enforce egress ACL ([#1881](https://github.com/everruns/everruns/pull/1881)) by [@chaliy](https://github.com/chaliy)
+- fix(server): harden app run history window parsing ([#1878](https://github.com/everruns/everruns/pull/1878)) by [@chaliy](https://github.com/chaliy)
+- fix(openai): cap prompt cache key length by [@chaliy](https://github.com/chaliy)
+- fix(runtime): preserve ACLs in single-session builder ([#1877](https://github.com/everruns/everruns/pull/1877)) by [@chaliy](https://github.com/chaliy)
+- chore(deps): remove unused integration dependencies by [@chaliy](https://github.com/chaliy)
+- feat(agents): add authenticated agent handoff by [@chaliy](https://github.com/chaliy)
+- ci: narrow docker build trigger by [@chaliy](https://github.com/chaliy)
+- refactor(runtime): resolve filesystem from platform by [@chaliy](https://github.com/chaliy)
+- feat(openapi): health + agent versions + skills + schedules ([#1873](https://github.com/everruns/everruns/pull/1873)) by [@chaliy](https://github.com/chaliy)
+- refactor(runtime): InProcessRuntime drives turns via host activity functions ([#1874](https://github.com/everruns/everruns/pull/1874)) by [@chaliy](https://github.com/chaliy)
+- fix(ci): harden crates publish ref validation by [@chaliy](https://github.com/chaliy)
+- feat(coding-cli): add model command suggestions by [@chaliy](https://github.com/chaliy)
+- chore(release): publish provider crates by [@chaliy](https://github.com/chaliy)
+- refactor(runtime): drop store shim wrappers, add EventBus + in_memory() ([#1872](https://github.com/everruns/everruns/pull/1872)) by [@chaliy](https://github.com/chaliy)
+- feat(openapi): payments + LLM + durable field descriptions ([#1851](https://github.com/everruns/everruns/pull/1851)) by [@chaliy](https://github.com/chaliy)
+- feat(api): RFC 9457 Problem Details + CommandError extensions ([#1834](https://github.com/everruns/everruns/pull/1834)) by [@chaliy](https://github.com/chaliy)
+- chore(deps): bump fetchkit to 0.3.0 ([#1865](https://github.com/everruns/everruns/pull/1865)) by [@chaliy](https://github.com/chaliy)
+- feat(examples): add coding-cli — TUI coding agent on everruns-runtime ([#1839](https://github.com/everruns/everruns/pull/1839)) by [@chaliy](https://github.com/chaliy)
+- feat(agents): add automatic draft snapshots by [@chaliy](https://github.com/chaliy)
+- chore(deps): bump brace-expansion from 5.0.5 to 5.0.6 in /.deepsec ([#1864](https://github.com/everruns/everruns/pull/1864)) by [@dependabot](https://github.com/dependabot)
+- refactor(runtime): add session filesystem factory by [@chaliy](https://github.com/chaliy)
+- feat(core): configure agent instruction files by [@chaliy](https://github.com/chaliy)
+- chore(deps): bump bashkit to 0.6.0 by [@chaliy](https://github.com/chaliy)
+- feat(runtime): add embedder builders by [@chaliy](https://github.com/chaliy)
+- feat(runtime): pluggable real-disk SessionFileStore + capability examples ([#1857](https://github.com/everruns/everruns/pull/1857)) by [@chaliy](https://github.com/chaliy)
+- chore(release): publish public crates by [@chaliy](https://github.com/chaliy)
+- fix(fcp): resume sessions by cookie id ([#1840](https://github.com/everruns/everruns/pull/1840)) by [@chaliy](https://github.com/chaliy)
+- fix(apps): add app run history endpoint by [@chaliy](https://github.com/chaliy)
+- fix(a2a): bind signing HMAC to app channel scope ([#1830](https://github.com/everruns/everruns/pull/1830)) by [@chaliy](https://github.com/chaliy)
+- chore(deps): bump typescript to 6 in apps/docs ([#1855](https://github.com/everruns/everruns/pull/1855)) by [@chaliy](https://github.com/chaliy)
+- chore(deps): bump marked to 18 ([#1854](https://github.com/everruns/everruns/pull/1854)) by [@chaliy](https://github.com/chaliy)
+- chore(deps): bump lucide-react to 1.16 ([#1853](https://github.com/everruns/everruns/pull/1853)) by [@chaliy](https://github.com/chaliy)
+- chore(specs): remove dash-gap-analysis.md ([#1852](https://github.com/everruns/everruns/pull/1852)) by [@chaliy](https://github.com/chaliy)
+- chore(deps): bump tokio-tungstenite to 0.29 ([#1847](https://github.com/everruns/everruns/pull/1847)) by [@chaliy](https://github.com/chaliy)
+- chore(deps): bump @openuidev/react-{lang,ui} to 0.2 / 0.11 ([#1850](https://github.com/everruns/everruns/pull/1850)) by [@chaliy](https://github.com/chaliy)
+- chore(deps): bump governor to 0.10 ([#1848](https://github.com/everruns/everruns/pull/1848)) by [@chaliy](https://github.com/chaliy)
+- chore(deps): bump rstest to 0.26 ([#1845](https://github.com/everruns/everruns/pull/1845)) by [@chaliy](https://github.com/chaliy)
+- chore(deps): bump async-nats to 0.48 ([#1844](https://github.com/everruns/everruns/pull/1844)) by [@chaliy](https://github.com/chaliy)
+- chore(deps): bump a2a stack to 0.3 ([#1842](https://github.com/everruns/everruns/pull/1842)) by [@chaliy](https://github.com/chaliy)
+- chore(deps): refresh Cargo.lock within semver ([#1836](https://github.com/everruns/everruns/pull/1836)) by [@chaliy](https://github.com/chaliy)
+- chore(deps): bump @astrojs/starlight to 0.39.2 ([#1837](https://github.com/everruns/everruns/pull/1837)) by [@chaliy](https://github.com/chaliy)
+- chore: index 6 missing specs in AGENTS.md ([#1838](https://github.com/everruns/everruns/pull/1838)) by [@chaliy](https://github.com/chaliy)
+- chore(deps): override @anthropic-ai/sdk to 0.91.1+ in .deepsec ([#1835](https://github.com/everruns/everruns/pull/1835)) by [@chaliy](https://github.com/chaliy)
+- feat(reporting): complete reporting product surface by [@chaliy](https://github.com/chaliy)
+- fix(ui): standardize organization label by [@chaliy](https://github.com/chaliy)
+- fix(memory): wire memory store for grpc workers by [@chaliy](https://github.com/chaliy)
+- chore(specs): add maintenance completeness checks by [@chaliy](https://github.com/chaliy)
+- docs(railway): update release template guidance by [@chaliy](https://github.com/chaliy)
+- feat(ui): add provider model counts and edit page by [@chaliy](https://github.com/chaliy)
+
 ## [0.8.31] - 2026-05-17
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1143,7 +1143,7 @@ checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "unicode-width 0.2.0",
+ "unicode-width 0.2.2",
  "windows-sys 0.61.2",
 ]
 
@@ -1410,9 +1410,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
 ]
@@ -1508,9 +1508,9 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "6.1.0"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -1656,7 +1656,7 @@ checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
  "const-oid 0.10.2",
- "crypto-common 0.2.1",
+ "crypto-common 0.2.2",
  "ctutils",
 ]
 
@@ -1988,11 +1988,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-a2ui"
-version = "0.8.31"
+version = "0.8.32"
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.8.31"
+version = "0.8.32"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2008,7 +2008,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-cli"
-version = "0.8.31"
+version = "0.8.32"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2059,14 +2059,14 @@ dependencies = [
 
 [[package]]
 name = "everruns-config"
-version = "0.8.31"
+version = "0.8.32"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "everruns-container-sandbox"
-version = "0.8.31"
+version = "0.8.32"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2086,7 +2086,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.8.31"
+version = "0.8.32"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -2138,7 +2138,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-durable"
-version = "0.8.31"
+version = "0.8.32"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2163,7 +2163,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-gemini"
-version = "0.8.31"
+version = "0.8.32"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2177,7 +2177,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-brave-search"
-version = "0.8.31"
+version = "0.8.32"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2193,7 +2193,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-browserless"
-version = "0.8.31"
+version = "0.8.32"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2214,7 +2214,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-cursor"
-version = "0.8.31"
+version = "0.8.32"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2229,7 +2229,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.8.31"
+version = "0.8.32"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2245,7 +2245,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-deno"
-version = "0.8.31"
+version = "0.8.32"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2268,7 +2268,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-docker"
-version = "0.8.31"
+version = "0.8.32"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2283,7 +2283,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.8.31"
+version = "0.8.32"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2298,7 +2298,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-e2b"
-version = "0.8.31"
+version = "0.8.32"
 dependencies = [
  "async-trait",
  "buffa",
@@ -2325,7 +2325,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-parallel"
-version = "0.8.31"
+version = "0.8.32"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2337,7 +2337,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-sprites"
-version = "0.8.31"
+version = "0.8.32"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2353,7 +2353,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-internal-protocol"
-version = "0.8.31"
+version = "0.8.32"
 dependencies = [
  "chrono",
  "everruns-core",
@@ -2370,7 +2370,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-llm-tests"
-version = "0.8.31"
+version = "0.8.32"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2389,7 +2389,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-macros"
-version = "0.8.31"
+version = "0.8.32"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -2397,7 +2397,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.8.31"
+version = "0.8.32"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2417,11 +2417,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-openui"
-version = "0.8.31"
+version = "0.8.32"
 
 [[package]]
 name = "everruns-runtime"
-version = "0.8.31"
+version = "0.8.32"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2457,7 +2457,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-server"
-version = "0.8.31"
+version = "0.8.32"
 dependencies = [
  "aes-gcm",
  "ag-ui-core",
@@ -2544,7 +2544,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-session-sqldb"
-version = "0.8.31"
+version = "0.8.32"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2561,7 +2561,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-worker"
-version = "0.8.31"
+version = "0.8.32"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3758,7 +3758,7 @@ checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
 dependencies = [
  "console",
  "portable-atomic",
- "unicode-width 0.2.0",
+ "unicode-width 0.2.2",
  "unit-prefix",
  "web-time",
 ]
@@ -4726,9 +4726,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-derive"
@@ -5047,7 +5047,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad5fd71b79026fb918650dde6d125000a233764f1c2f1659a1c71118e33ea08f"
 dependencies = [
- "unicode-width 0.2.0",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -5926,7 +5926,7 @@ dependencies = [
  "thiserror 2.0.18",
  "unicode-segmentation",
  "unicode-truncate",
- "unicode-width 0.2.0",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -5977,7 +5977,7 @@ dependencies = [
  "strum 0.27.2",
  "time",
  "unicode-segmentation",
- "unicode-width 0.2.0",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -7417,9 +7417,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
-version = "0.4.45"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",
@@ -7510,7 +7510,7 @@ checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
 dependencies = [
  "smawk",
  "unicode-linebreak",
- "unicode-width 0.2.0",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -7936,9 +7936,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.10"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "async-compression",
  "bitflags 2.11.1",
@@ -8248,7 +8248,7 @@ checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
 dependencies = [
  "itertools",
  "unicode-segmentation",
- "unicode-width 0.2.0",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -8259,9 +8259,9 @@ checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.8.31"
+version = "0.8.32"
 edition = "2024"
 license = "MIT"
 authors = ["Everruns Contributors"]
@@ -131,7 +131,7 @@ futures-util = "0.3"
 
 # Everruns SDK
 everruns-sdk = "0.1.9"
-everruns-core = { path = "crates/core", version = "0.8.31" }
+everruns-core = { path = "crates/core", version = "0.8.32" }
 
 # A2A protocol
 a2a = { package = "a2a-lf", version = "0.3" }

--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "everruns-ui",
-  "version": "0.8.31",
+  "version": "0.8.32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "everruns-ui",
-      "version": "0.8.31",
+      "version": "0.8.32",
       "dependencies": {
         "@base-ui/react": "^1.2.0",
         "@openuidev/react-lang": "^0.2.4",
@@ -11823,6 +11823,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "everruns-ui",
-  "version": "0.8.31",
+  "version": "0.8.32",
   "private": true,
   "exports": {
     "./route-manifest": "./src/lib/ui-route-manifest.ts",


### PR DESCRIPTION
## Release v0.8.32

This PR prepares the v0.8.32 patch release.

### Highlights

- **Reporting product surface** - Completes the async reporting subsystem with finalized analytics, saved reports, and export flows.
- **Agent versions with automatic draft snapshots** - Immutable agent configuration snapshots are now captured automatically as drafts to enable audit, rollback, forks, and pinned App deployments.
- **RFC 9457 Problem Details API errors** - HTTP error responses now follow RFC 9457 with structured `CommandError` extensions ([#1834](https://github.com/everruns/everruns/pull/1834)).
- **Coding-cli example** - New TUI coding agent example built on `everruns-runtime` with JSONL session log, `--session` resume, and proper harness system prompt ([#1839](https://github.com/everruns/everruns/pull/1839), [#1870](https://github.com/everruns/everruns/pull/1870), [#1871](https://github.com/everruns/everruns/pull/1871)).
- **Runtime FileSystem policy decorators** - Filesystem access in the runtime now ships with composable policy decorators for ACL enforcement and pluggable real-disk `SessionFileStore` (EVE-478) ([#1857](https://github.com/everruns/everruns/pull/1857), [#1886](https://github.com/everruns/everruns/pull/1886)).
- **OpenAPI surface expansion** - Health, agent versions, skills, schedules ([#1873](https://github.com/everruns/everruns/pull/1873)), and payments/LLM/durable field descriptions ([#1851](https://github.com/everruns/everruns/pull/1851)) are now documented in the OpenAPI spec.

### Checklist
- [x] Review CHANGELOG.md entries
- [x] Verify version numbers updated
- [ ] CI passes

### Post-merge
After merging, the release workflow will automatically:
- Create git tag `v0.8.32`
- Create GitHub Release with notes from CHANGELOG.md
- Trigger Docker image build with version tag
- Publish CLI binaries and update Homebrew formula


---
_Generated by [Claude Code](https://claude.ai/code/session_019ELQRctyXB8rmoCMUDDxeK)_