### PR TITLE
ci: bump actions/checkout to v5 (Node 24)

### DIFF
--- a/.github/workflows/brave-search-integration.yml
+++ b/.github/workflows/brave-search-integration.yml
@@ -32,7 +32,7 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
       skip_docker: ${{ steps.ci_opt_outs.outputs.skip_docker }}
       skip_integration_workflows: ${{ steps.ci_opt_outs.outputs.skip_integration_workflows }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Resolve CI event gate
         id: ci_event
@@ -193,7 +193,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -209,7 +209,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -224,7 +224,7 @@ jobs:
     if: needs.changes.outputs.run_ci == 'true' && github.event_name == 'pull_request'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -238,7 +238,7 @@ jobs:
     if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -262,7 +262,7 @@ jobs:
     if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -298,7 +298,7 @@ jobs:
     if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -318,7 +318,7 @@ jobs:
     if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.shell == 'true'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install shell test dependencies
         run: |
@@ -355,7 +355,7 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Doppler CLI
         uses: dopplerhq/cli-action@v3
@@ -380,7 +380,7 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Doppler CLI
         uses: dopplerhq/cli-action@v3
@@ -405,7 +405,7 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Doppler CLI
         uses: dopplerhq/cli-action@v3
@@ -432,7 +432,7 @@ jobs:
       DENO_SANDBOX_REGION: ams
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Doppler CLI
         uses: dopplerhq/cli-action@v3
@@ -478,7 +478,7 @@ jobs:
       SECRETS_ENCRYPTION_KEY: kek-v1:8B3uCQ4Znx45hl5nB+PKVriRrj/KtEVM+wBZ2VGa9vY=
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -574,7 +574,7 @@ jobs:
     if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true' && needs.changes.outputs.skip_slow_rust != 'true'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -648,7 +648,7 @@ jobs:
       RATE_LIMIT_API_REQUESTS_PER_MINUTE: "0"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -764,7 +764,7 @@ jobs:
       RATE_LIMIT_API_REQUESTS_PER_MINUTE: "0"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install jq
         run: sudo apt-get update && sudo apt-get install -y jq
@@ -817,7 +817,7 @@ jobs:
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Resolve SDK version matrix
         id: matrix
@@ -846,7 +846,7 @@ jobs:
       EVERRUNS_BASE_URL: http://localhost:9000
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Node.js
         if: matrix.language == 'typescript'
@@ -913,7 +913,7 @@ jobs:
     if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true' && needs.changes.outputs.skip_slow_rust != 'true'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Download export-openapi binary
         uses: actions/download-artifact@v4
@@ -952,7 +952,7 @@ jobs:
         working-directory: apps/ui
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -999,7 +999,7 @@ jobs:
         working-directory: apps/ui
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -1047,7 +1047,7 @@ jobs:
         working-directory: apps/docs
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -1130,7 +1130,7 @@ jobs:
     if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.docker == 'true' && needs.changes.outputs.skip_docker != 'true'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/cli-binaries.yml
+++ b/.github/workflows/cli-binaries.yml
@@ -32,7 +32,7 @@ jobs:
             archive: everruns-x86_64-unknown-linux-gnu.tar.gz
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ inputs.tag }}
 

--- a/.github/workflows/container-sandbox-integration.yml
+++ b/.github/workflows/container-sandbox-integration.yml
@@ -29,7 +29,7 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -64,7 +64,7 @@ jobs:
       CONTAINER_SANDBOX_DOCKER_HOST: http://localhost:2375
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/cursor-integration.yml
+++ b/.github/workflows/cursor-integration.yml
@@ -33,7 +33,7 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -53,7 +53,7 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Doppler CLI
         uses: dopplerhq/cli-action@v3

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -52,7 +52,7 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # QEMU needed for multi-arch builds (ARM64 cross-compilation)
       - name: Set up QEMU
@@ -205,7 +205,7 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up QEMU
         if: github.event_name != 'pull_request'

--- a/.github/workflows/duckduckgo-integration.yml
+++ b/.github/workflows/duckduckgo-integration.yml
@@ -31,7 +31,7 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/integration-live-sweep.yml
+++ b/.github/workflows/integration-live-sweep.yml
@@ -52,7 +52,7 @@ jobs:
             command: cargo test -p everruns-integrations-brave-search --features integration
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Doppler CLI
         uses: dopplerhq/cli-action@v3
@@ -87,7 +87,7 @@ jobs:
             command: cargo test -p everruns-integrations-parallel --features integration
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -118,7 +118,7 @@ jobs:
       CONTAINER_SANDBOX_DOCKER_HOST: http://localhost:2375
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/licenses.yml
+++ b/.github/workflows/licenses.yml
@@ -31,7 +31,7 @@ jobs:
     name: Check Dependency Licenses
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/parallel-integration.yml
+++ b/.github/workflows/parallel-integration.yml
@@ -31,7 +31,7 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -54,7 +54,7 @@ jobs:
           echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
           echo "expected_sha=$DISPATCH_SHA" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: main
           fetch-depth: 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/server-worker-binaries.yml
+++ b/.github/workflows/server-worker-binaries.yml
@@ -43,7 +43,7 @@ jobs:
             archive: everruns-worker-aarch64-unknown-linux-gnu.tar.gz
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ inputs.tag }}
 

--- a/.github/workflows/sprites-integration.yml
+++ b/.github/workflows/sprites-integration.yml
@@ -35,7 +35,7 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -58,7 +58,7 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Doppler CLI
         uses: dopplerhq/cli-action@v3


### PR DESCRIPTION
## What
Bump `actions/checkout@v4` → `actions/checkout@v5` across all 14 workflow files (42 occurrences).

## Why
GitHub Actions surfaces a deprecation warning on every run that uses `actions/checkout@v4`:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026.

`actions/checkout@v5` ships on Node 24 and clears the warning. Without this bump the action will eventually stop working when Node 20 is removed from runners.

## How
`sed`-based bump of the version pin across `.github/workflows/*.yml`. No other action versions or workflow logic touched — other `@v4` actions in use (`cache`, `upload-artifact`, `download-artifact`, `setup-node`) update their bundled Node runtime via patch releases and are not currently surfacing the warning, so they are left alone for a focused diff.

## Risk
- Low.
- v5 has the same input API as v4; the bump only changes the bundled Node runtime. CI itself will exercise the new action on every job.

## Security
- Threat categories reviewed: No security-relevant code changes. This is a CI workflow version bump to a first-party `actions/checkout` major. No application code, configuration, runtime behavior, or dependency surface is altered.
- Findings and resolutions: None.

## Follow-ups
- Bump other Node-20-bundled `@v4` actions (`actions/cache`, `actions/upload-artifact`, `actions/download-artifact`, `actions/setup-node`) and `setup-python@v5` to their next majors when those start surfacing the same warning. Deferred because they are not currently warning and bumping them now would expand diff scope without resolving an observed issue.

## Checklist
- [x] Tests added or updated — N/A, CI itself exercises the change
- [x] Backward compatibility considered — v5 has same input API as v4
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning) — none received