### PR TITLE
ci(publish-crates): allow manual dispatch + retry on rate limit

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -3,12 +3,22 @@ name: Publish Crates
 on:
   repository_dispatch:
     types: [publish-crates]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to publish (e.g. v0.8.33)'
+        required: true
+        type: string
+      sha:
+        description: '40-char commit SHA the tag must resolve to'
+        required: true
+        type: string
 
 permissions:
   contents: read
 
 concurrency:
-  group: publish-crates-${{ github.event.client_payload.tag || github.ref }}
+  group: publish-crates-${{ github.event.client_payload.tag || github.event.inputs.tag || github.ref }}
   cancel-in-progress: false
 
 env:
@@ -22,13 +32,13 @@ jobs:
       - name: Resolve release tag
         id: release
         env:
-          DISPATCH_SHA: ${{ github.event.client_payload.sha || '' }}
-          DISPATCH_TAG: ${{ github.event.client_payload.tag || '' }}
+          DISPATCH_SHA: ${{ github.event.client_payload.sha || github.event.inputs.sha || '' }}
+          DISPATCH_TAG: ${{ github.event.client_payload.tag || github.event.inputs.tag || '' }}
           EVENT_NAME: ${{ github.event_name }}
         run: |
           set -euo pipefail
 
-          if [ "$EVENT_NAME" != "repository_dispatch" ]; then
+          if [ "$EVENT_NAME" != "repository_dispatch" ] && [ "$EVENT_NAME" != "workflow_dispatch" ]; then
             echo "::error::Unsupported event for crates publish: $EVENT_NAME"
             exit 1
           fi
@@ -233,6 +243,25 @@ jobs:
             return 1
           }
 
+          publish_one() {
+            # Retries on transient crates.io errors (esp. new-crate rate limit:
+            # 5 new crates / 10 min on a default token). Each retry waits
+            # ~11 minutes to clear the window before re-trying.
+            local crate="$1"
+            for attempt in 1 2 3; do
+              if CARGO_REGISTRY_TOKEN="${{ secrets.CARGO_REGISTRY_TOKEN }}" \
+                cargo publish --locked -p "$crate"; then
+                return 0
+              fi
+              if [ "$attempt" -lt 3 ]; then
+                echo "::warning::cargo publish $crate failed (attempt $attempt/3); sleeping 11 min before retry (covers new-crate rate-limit window)"
+                sleep 660
+              fi
+            done
+            echo "::error::cargo publish $crate failed after 3 attempts"
+            return 1
+          }
+
           for crate in "${CRATES[@]}"; do
             status="$(initial_publish_status "$crate" "$VERSION")"
             if [ "$status" = "published" ]; then
@@ -240,7 +269,7 @@ jobs:
             elif [ "$status" = "missing" ]; then
               echo "Publishing $crate $VERSION"
               cargo package --locked -p "$crate"
-              CARGO_REGISTRY_TOKEN="${{ secrets.CARGO_REGISTRY_TOKEN }}" cargo publish --locked -p "$crate"
+              publish_one "$crate"
             else
               echo "::error::Unexpected crates.io lookup status for $crate $VERSION: $status"
               exit 1


### PR DESCRIPTION
## Why

v0.8.33's `publish-crates` run pushed 6 new crates successfully (`everruns-config`, `everruns-openui`, `everruns-a2ui`, `everruns-core`, `everruns-openai`, `everruns-anthropic`) and then failed on the 7th (`everruns-integrations-duckduckgo`) with no transient retry. `everruns-runtime` never ran. crates.io enforces a new-crate rate limit of 5 per 10 minutes on default API tokens; back-to-back publishes of 6+ first-time crates will trip it.

Local `cargo package` and `cargo publish --dry-run` succeed on both missing crates, so the packages themselves are healthy — only the retry path is missing.

## Changes

- **`workflow_dispatch` trigger** with `tag` + `sha` inputs so we can re-run a release publish from the Actions UI without manufacturing a new commit. Mirrors the existing `repository_dispatch.client_payload` shape.
- **Retry `cargo publish`** up to 3 times per crate, sleeping ~11 min between attempts so the rate-limit window fully clears.
- **Event handling** now accepts either event when resolving the tag/sha.

## Recovery path

After this merges:

1. Open Actions → "Publish Crates" → "Run workflow"
2. Inputs: `tag = v0.8.33`, `sha = e96857ff9b2011670b1f96dbf798f93c746d9aeb`
3. The 6 already-published crates will be detected as `published` and skipped; only `everruns-integrations-duckduckgo` and `everruns-runtime` will be (re-)attempted, with retries on rate-limit failures.

## Test plan

- [x] YAML lints (workflow parses)
- [ ] Manual workflow_dispatch run finishes the v0.8.33 publish (validated post-merge)


---
_Generated by [Claude Code](https://claude.ai/code/session_019ELQRctyXB8rmoCMUDDxeK)_