### PR TITLE
feat(goal): add /goal lifecycle command and capability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,6 +165,7 @@ Start from latest main by default.
 - `specs/voice.md` - Voice Sessions (Realtime API transport over a durable Everruns session)
 - `specs/volumes.md` - Workspace Volumes (org-scoped persistent filesystem trees mounted into sessions)
 - `specs/machine-payments.md` - Capability-side payments to external paid services during agent execution
+- `specs/goal.md` - Long-running per-session goal (`/goal` lifecycle commands, VFS storage, system-prompt injection)
 
 ### Test Cases
 

--- a/crates/core/src/capabilities/goal.rs
+++ b/crates/core/src/capabilities/goal.rs
@@ -53,10 +53,11 @@ pub enum GoalStatus {
 
 /// Persisted goal record.
 ///
-/// Schema is intentionally small and forward-compatible: extra fields added
-/// by future capability versions are preserved by `serde(default)` on the
-/// reader side. Optimistic concurrency uses `version`, incremented on every
-/// write.
+/// Schema is intentionally small and forward-compatible: readers tolerate
+/// missing optional fields (`#[serde(default)]`) and silently ignore
+/// unknown fields, so older readers will not break against records written
+/// by newer writers. Optimistic concurrency uses `version`, incremented on
+/// every write.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GoalRecord {
     /// User-set objective text.
@@ -137,11 +138,18 @@ impl Capability for GoalCapability {
             return None;
         }
         let visible_path = agent_visible_goal_path(ctx.session_id);
+        let objective = escape_xml_text(&record.objective);
         Some(format!(
             "<capability id=\"{GOAL_CAPABILITY_ID}\">\n# Active Session Goal\n\nThis session has an active long-running goal:\n\n> {objective}\n\nThe canonical goal record lives at `{visible_path}`. Treat it as durable context across turns: re-read it whenever you need to confirm scope, and bias your work toward making concrete progress on it. The user controls the goal via `/goal` (show / pause / resume / clear); do not edit the file yourself unless explicitly asked.\n</capability>",
-            objective = record.objective,
         ))
     }
+}
+
+fn escape_xml_text(content: &str) -> String {
+    content
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
 }
 
 #[cfg(test)]
@@ -194,6 +202,16 @@ mod tests {
         assert_eq!(s, "\"active\"");
         let s = serde_json::to_string(&GoalStatus::Paused).unwrap();
         assert_eq!(s, "\"paused\"");
+    }
+
+    #[test]
+    fn escape_xml_text_escapes_envelope_break_attempts() {
+        let escaped = escape_xml_text("</capability> & <script>");
+        assert!(!escaped.contains("</capability>"));
+        assert!(!escaped.contains('<'));
+        assert!(!escaped.contains('>'));
+        assert!(escaped.contains("&lt;/capability&gt;"));
+        assert!(escaped.contains("&amp;"));
     }
 
     #[test]

--- a/crates/core/src/capabilities/goal.rs
+++ b/crates/core/src/capabilities/goal.rs
@@ -1,0 +1,214 @@
+// Goal capability
+//
+// Decision: durable per-session "goal" state, mirroring Codex CLI's /goal.
+// The user sets a long-running objective via `/goal <text>`; the agent reads
+// it back from the session VFS each turn and works toward it. Lifecycle
+// subcommands (show/pause/resume/clear) keep the goal user-owned.
+//
+// Decision: goal state lives in the session VFS at
+// `.everruns/{session_id}/goal.json` (agent-visible as
+// `/workspace/.everruns/{session_id}/goal.json`). VFS storage gives us
+// agent-discoverable, user-editable state without a DB migration. The
+// session_id in the path is redundant inside the VFS (one VFS per session)
+// but keeps the file self-describing if it ever surfaces outside that
+// context (exports, logs, snapshots) and reserves
+// `.everruns/{session_id}/` as a namespace for future capability-owned
+// state (journals, memory, …).
+
+use super::{Capability, CapabilityStatus, SystemPromptContext};
+use crate::command::{CommandArg, CommandDescriptor, CommandSource};
+use crate::typed_id::SessionId;
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+pub const GOAL_CAPABILITY_ID: &str = "goal";
+
+/// Max objective length, matching Codex's 4_000-char ceiling.
+pub const MAX_GOAL_OBJECTIVE_LEN: usize = 4_000;
+
+/// File-store-relative directory for goal state (no `/workspace` prefix).
+pub fn goal_dir(session_id: SessionId) -> String {
+    format!(".everruns/{session_id}")
+}
+
+/// File-store-relative path to the goal JSON.
+pub fn goal_file_path(session_id: SessionId) -> String {
+    format!("{}/goal.json", goal_dir(session_id))
+}
+
+/// Agent-visible path (under `/workspace`) used in system-prompt copy.
+pub fn agent_visible_goal_path(session_id: SessionId) -> String {
+    format!("/workspace/.everruns/{session_id}/goal.json")
+}
+
+/// Lifecycle state for a goal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GoalStatus {
+    Active,
+    Paused,
+    Completed,
+    Cleared,
+}
+
+/// Persisted goal record.
+///
+/// Schema is intentionally small and forward-compatible: extra fields added
+/// by future capability versions are preserved by `serde(default)` on the
+/// reader side. Optimistic concurrency uses `version`, incremented on every
+/// write.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GoalRecord {
+    /// User-set objective text.
+    pub objective: String,
+    /// Current lifecycle state.
+    pub status: GoalStatus,
+    /// Monotonic version, incremented on every write.
+    #[serde(default)]
+    pub version: u64,
+    /// ISO-8601 timestamp when the goal was first set.
+    pub set_at: String,
+    /// ISO-8601 timestamp of the last status/objective change.
+    pub updated_at: String,
+}
+
+pub struct GoalCapability;
+
+#[async_trait]
+impl Capability for GoalCapability {
+    fn id(&self) -> &str {
+        GOAL_CAPABILITY_ID
+    }
+
+    fn name(&self) -> &str {
+        "Goal"
+    }
+
+    fn description(&self) -> &str {
+        "Long-running session objective with /goal lifecycle commands."
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+
+    fn icon(&self) -> Option<&str> {
+        Some("target")
+    }
+
+    fn category(&self) -> Option<&str> {
+        Some("Productivity")
+    }
+
+    fn commands(&self) -> Vec<CommandDescriptor> {
+        vec![CommandDescriptor {
+            name: "goal".to_string(),
+            description:
+                "Set, view, pause, resume, or clear a long-running objective for this session."
+                    .to_string(),
+            source: CommandSource::System,
+            args: vec![CommandArg {
+                name: "subcommand_or_objective".to_string(),
+                description: "Subcommand (show, pause, resume, clear) or new objective text."
+                    .to_string(),
+                required: false,
+            }],
+        }]
+    }
+
+    async fn system_prompt_contribution(&self, ctx: &SystemPromptContext) -> Option<String> {
+        let file_store = ctx.file_store.as_ref()?;
+        let path = goal_file_path(ctx.session_id);
+        let file = match file_store.read_file(ctx.session_id, &path).await {
+            Ok(Some(f)) => f,
+            Ok(None) => return None,
+            Err(error) => {
+                tracing::warn!(
+                    %error,
+                    session_id = %ctx.session_id,
+                    "Failed to read goal file, skipping system-prompt contribution"
+                );
+                return None;
+            }
+        };
+        let content = file.content.as_deref()?;
+        let record: GoalRecord = serde_json::from_str(content).ok()?;
+        if record.status != GoalStatus::Active {
+            return None;
+        }
+        let visible_path = agent_visible_goal_path(ctx.session_id);
+        Some(format!(
+            "<capability id=\"{GOAL_CAPABILITY_ID}\">\n# Active Session Goal\n\nThis session has an active long-running goal:\n\n> {objective}\n\nThe canonical goal record lives at `{visible_path}`. Treat it as durable context across turns: re-read it whenever you need to confirm scope, and bias your work toward making concrete progress on it. The user controls the goal via `/goal` (show / pause / resume / clear); do not edit the file yourself unless explicitly asked.\n</capability>",
+            objective = record.objective,
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::typed_id::SessionId;
+    use uuid::Uuid;
+
+    fn fixture_session_id() -> SessionId {
+        SessionId::from(Uuid::nil())
+    }
+
+    #[test]
+    fn capability_metadata() {
+        let cap = GoalCapability;
+        assert_eq!(cap.id(), GOAL_CAPABILITY_ID);
+        assert_eq!(cap.name(), "Goal");
+        assert_eq!(cap.status(), CapabilityStatus::Available);
+        assert_eq!(cap.icon(), Some("target"));
+        assert_eq!(cap.category(), Some("Productivity"));
+    }
+
+    #[test]
+    fn registers_goal_command_with_optional_arg() {
+        let cap = GoalCapability;
+        let commands = cap.commands();
+        assert_eq!(commands.len(), 1);
+        assert_eq!(commands[0].name, "goal");
+        assert_eq!(commands[0].source, CommandSource::System);
+        assert_eq!(commands[0].args.len(), 1);
+        assert!(!commands[0].args[0].required);
+    }
+
+    #[test]
+    fn path_helpers_include_session_id() {
+        let sid = fixture_session_id();
+        let dir = goal_dir(sid);
+        let file = goal_file_path(sid);
+        let visible = agent_visible_goal_path(sid);
+        assert!(dir.starts_with(".everruns/"));
+        assert!(dir.contains(&sid.to_string()));
+        assert!(file.ends_with("/goal.json"));
+        assert!(visible.starts_with("/workspace/.everruns/"));
+        assert!(visible.contains(&sid.to_string()));
+    }
+
+    #[test]
+    fn status_serialises_snake_case() {
+        let s = serde_json::to_string(&GoalStatus::Active).unwrap();
+        assert_eq!(s, "\"active\"");
+        let s = serde_json::to_string(&GoalStatus::Paused).unwrap();
+        assert_eq!(s, "\"paused\"");
+    }
+
+    #[test]
+    fn record_roundtrips() {
+        let record = GoalRecord {
+            objective: "ship it".to_string(),
+            status: GoalStatus::Active,
+            version: 1,
+            set_at: "2026-05-20T00:00:00Z".to_string(),
+            updated_at: "2026-05-20T00:00:00Z".to_string(),
+        };
+        let json = serde_json::to_string(&record).unwrap();
+        let back: GoalRecord = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.objective, "ship it");
+        assert_eq!(back.status, GoalStatus::Active);
+        assert_eq!(back.version, 1);
+    }
+}

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -1839,6 +1839,7 @@ mod tests {
             "virtual_bash",
             "session_schedule",
             "btw",
+            "goal",
             "infinity_context",
             "compaction",
             "memory",

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -94,6 +94,7 @@ mod fake_crm;
 mod fake_financial;
 mod fake_warehouse;
 mod file_system;
+mod goal;
 mod human_intent;
 mod infinity_context;
 mod knowledge_base;
@@ -190,6 +191,10 @@ pub use fake_warehouse::{
 pub use file_system::{
     DeleteFileTool, EditFileTool, FileSystemCapability, GrepFilesTool, ListDirectoryTool,
     ReadFileTool, StatFileTool, WriteFileTool,
+};
+pub use goal::{
+    GOAL_CAPABILITY_ID, GoalCapability, GoalRecord, GoalStatus, MAX_GOAL_OBJECTIVE_LEN,
+    agent_visible_goal_path, goal_dir, goal_file_path,
 };
 pub use human_intent::{HUMAN_INTENT_CAPABILITY_ID, HumanIntentCapability};
 pub use infinity_context::{
@@ -805,6 +810,7 @@ impl CapabilityRegistry {
         registry.register(VirtualBashCapability);
         registry.register(SessionScheduleCapability);
         registry.register(BtwCapability);
+        registry.register(GoalCapability);
         registry.register(InfinityContextCapability);
         registry.register(budgeting::BudgetingCapability);
         registry.register(SelfBudgetCapability);

--- a/crates/server/src/domains/session_commands/service.rs
+++ b/crates/server/src/domains/session_commands/service.rs
@@ -12,6 +12,7 @@ use crate::errors::{BadRequestError, ResourceNotFoundError};
 use crate::services::{EventService, LlmResolverService};
 use crate::storage::StorageBackend;
 use anyhow::{Result, anyhow};
+use everruns_core::capabilities::{GoalRecord, GoalStatus, MAX_GOAL_OBJECTIVE_LEN, goal_file_path};
 use everruns_core::command::{CommandDescriptor, CommandResult, ExecuteCommandRequest};
 use everruns_core::llm_driver_registry::{
     LlmCallConfigBuilder, LlmMessage, LlmMessageContent, LlmMessageRole, ProviderConfig,
@@ -34,6 +35,7 @@ use uuid::Uuid;
 
 const BTW_COMMAND_NAME: &str = "btw";
 const BTW_SYSTEM_PROMPT: &str = "You are answering an ephemeral side question about the current session. Use the existing conversation as context, answer exactly once, and do not call tools or ask follow-up questions.";
+const GOAL_COMMAND_NAME: &str = "goal";
 
 pub struct SessionCommandService {
     db: Arc<StorageBackend>,
@@ -128,11 +130,105 @@ impl SessionCommandService {
 
         match command.name.as_str() {
             BTW_COMMAND_NAME => self.execute_btw(caller.org_id, session_id, req).await,
+            GOAL_COMMAND_NAME => self.execute_goal(session_id, req).await,
             _ => Err(BadRequestError::new(format!(
                 "Unsupported system command: /{}",
                 command.name
             ))
             .into()),
+        }
+    }
+
+    async fn execute_goal(
+        &self,
+        session_id: SessionId,
+        req: ExecuteCommandRequest,
+    ) -> Result<CommandResult> {
+        let adapters = self.adapters();
+        let file_store = AdapterSessionFileStore::new(adapters);
+        let path = goal_file_path(session_id);
+        let arg = req
+            .arguments
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty());
+
+        let existing = read_goal_record(&file_store, session_id, &path).await?;
+
+        let action = parse_goal_action(arg);
+        match action {
+            GoalAction::Show => Ok(goal_show_result(existing.as_ref())),
+            GoalAction::Set(objective) => {
+                if objective.len() > MAX_GOAL_OBJECTIVE_LEN {
+                    return Err(BadRequestError::new(format!(
+                        "Goal objective exceeds {MAX_GOAL_OBJECTIVE_LEN}-character limit"
+                    ))
+                    .into());
+                }
+                let now = chrono::Utc::now().to_rfc3339();
+                let (set_at, version) = match &existing {
+                    Some(prev) => (prev.set_at.clone(), prev.version),
+                    None => (now.clone(), 0),
+                };
+                let record = GoalRecord {
+                    objective: objective.clone(),
+                    status: GoalStatus::Active,
+                    version: version.saturating_add(1),
+                    set_at,
+                    updated_at: now,
+                };
+                write_goal_record(&file_store, session_id, &path, &record).await?;
+                Ok(CommandResult {
+                    success: true,
+                    message: format!(
+                        "Goal set:\n\n> {objective}\n\nThe agent will treat this as durable context across turns. Use `/goal` to view, `/goal pause`, `/goal resume`, or `/goal clear`."
+                    ),
+                    error_code: None,
+                    error_fields: None,
+                })
+            }
+            GoalAction::Pause | GoalAction::Resume | GoalAction::Clear => {
+                let Some(mut record) = existing else {
+                    return Ok(CommandResult {
+                        success: false,
+                        message:
+                            "No goal is set for this session. Use `/goal <objective>` to set one."
+                                .to_string(),
+                        error_code: None,
+                        error_fields: None,
+                    });
+                };
+                let new_status = match action {
+                    GoalAction::Pause => GoalStatus::Paused,
+                    GoalAction::Resume => GoalStatus::Active,
+                    GoalAction::Clear => GoalStatus::Cleared,
+                    _ => unreachable!(),
+                };
+                if record.status == new_status {
+                    return Ok(CommandResult {
+                        success: true,
+                        message: format!("Goal already in state `{}`.", status_label(new_status)),
+                        error_code: None,
+                        error_fields: None,
+                    });
+                }
+                record.status = new_status;
+                record.version = record.version.saturating_add(1);
+                record.updated_at = chrono::Utc::now().to_rfc3339();
+                write_goal_record(&file_store, session_id, &path, &record).await?;
+                let verb = match new_status {
+                    GoalStatus::Paused => "paused",
+                    GoalStatus::Active => "resumed",
+                    GoalStatus::Cleared => "cleared",
+                    GoalStatus::Completed => "marked completed",
+                };
+                Ok(CommandResult {
+                    success: true,
+                    message: format!("Goal {verb}.\n\nObjective: {}", record.objective),
+                    error_code: None,
+                    error_fields: None,
+                })
+            }
         }
     }
 
@@ -341,6 +437,90 @@ impl SessionCommandService {
     }
 }
 
+#[derive(Debug, PartialEq, Eq)]
+enum GoalAction {
+    Show,
+    Set(String),
+    Pause,
+    Resume,
+    Clear,
+}
+
+fn parse_goal_action(arg: Option<&str>) -> GoalAction {
+    let Some(text) = arg else {
+        return GoalAction::Show;
+    };
+    match text.to_ascii_lowercase().as_str() {
+        "show" | "status" => GoalAction::Show,
+        "pause" => GoalAction::Pause,
+        "resume" => GoalAction::Resume,
+        "clear" | "cancel" | "stop" => GoalAction::Clear,
+        _ => GoalAction::Set(text.to_string()),
+    }
+}
+
+fn status_label(status: GoalStatus) -> &'static str {
+    match status {
+        GoalStatus::Active => "active",
+        GoalStatus::Paused => "paused",
+        GoalStatus::Completed => "completed",
+        GoalStatus::Cleared => "cleared",
+    }
+}
+
+fn goal_show_result(existing: Option<&GoalRecord>) -> CommandResult {
+    let message = match existing {
+        Some(record) => format!(
+            "Goal status: {status}\n\n> {objective}\n\nSet at {set_at}, updated {updated_at}.",
+            status = status_label(record.status),
+            objective = record.objective,
+            set_at = record.set_at,
+            updated_at = record.updated_at,
+        ),
+        None => "No goal is set for this session. Use `/goal <objective>` to set one.".to_string(),
+    };
+    CommandResult {
+        success: true,
+        message,
+        error_code: None,
+        error_fields: None,
+    }
+}
+
+async fn read_goal_record(
+    file_store: &dyn everruns_core::traits::SessionFileSystem,
+    session_id: SessionId,
+    path: &str,
+) -> Result<Option<GoalRecord>> {
+    let Some(file) = file_store.read_file(session_id, path).await? else {
+        return Ok(None);
+    };
+    let Some(content) = file.content else {
+        return Ok(None);
+    };
+    match serde_json::from_str::<GoalRecord>(&content) {
+        Ok(record) => Ok(Some(record)),
+        Err(error) => {
+            tracing::warn!(%error, %session_id, "Failed to parse goal.json, treating as missing");
+            Ok(None)
+        }
+    }
+}
+
+async fn write_goal_record(
+    file_store: &dyn everruns_core::traits::SessionFileSystem,
+    session_id: SessionId,
+    path: &str,
+    record: &GoalRecord,
+) -> Result<()> {
+    let content = serde_json::to_string_pretty(record)
+        .map_err(|e| anyhow!("Failed to serialise goal record: {e}"))?;
+    file_store
+        .write_file(session_id, path, &content, "utf-8")
+        .await?;
+    Ok(())
+}
+
 async fn run_btw_completion(
     driver_registry: &DriverRegistry,
     provider: &ProviderConfig,
@@ -497,6 +677,54 @@ mod tests {
 
         assert!(!result.success);
         assert_eq!(result.error_code.as_deref(), Some("processing_error"));
+    }
+
+    #[test]
+    fn parse_goal_action_empty_arg_is_show() {
+        assert_eq!(parse_goal_action(None), GoalAction::Show);
+    }
+
+    #[test]
+    fn parse_goal_action_lifecycle_keywords() {
+        assert_eq!(parse_goal_action(Some("show")), GoalAction::Show);
+        assert_eq!(parse_goal_action(Some("status")), GoalAction::Show);
+        assert_eq!(parse_goal_action(Some("pause")), GoalAction::Pause);
+        assert_eq!(parse_goal_action(Some("Pause")), GoalAction::Pause);
+        assert_eq!(parse_goal_action(Some("resume")), GoalAction::Resume);
+        assert_eq!(parse_goal_action(Some("clear")), GoalAction::Clear);
+        assert_eq!(parse_goal_action(Some("cancel")), GoalAction::Clear);
+        assert_eq!(parse_goal_action(Some("stop")), GoalAction::Clear);
+    }
+
+    #[test]
+    fn parse_goal_action_arbitrary_text_is_set() {
+        assert_eq!(
+            parse_goal_action(Some("ship the migration safely")),
+            GoalAction::Set("ship the migration safely".to_string())
+        );
+    }
+
+    #[test]
+    fn goal_show_result_handles_missing_goal() {
+        let result = goal_show_result(None);
+        assert!(result.success);
+        assert!(result.message.contains("No goal"));
+    }
+
+    #[test]
+    fn goal_show_result_renders_active_goal() {
+        let record = GoalRecord {
+            objective: "finish the rebase".to_string(),
+            status: GoalStatus::Active,
+            version: 3,
+            set_at: "2026-05-20T10:00:00Z".to_string(),
+            updated_at: "2026-05-20T11:00:00Z".to_string(),
+        };
+        let result = goal_show_result(Some(&record));
+        assert!(result.success);
+        assert!(result.message.contains("active"));
+        assert!(result.message.contains("finish the rebase"));
+        assert!(result.message.contains("2026-05-20T10:00:00Z"));
     }
 
     #[test]

--- a/crates/server/src/domains/session_commands/service.rs
+++ b/crates/server/src/domains/session_commands/service.rs
@@ -190,7 +190,7 @@ impl SessionCommandService {
             GoalAction::Pause | GoalAction::Resume | GoalAction::Clear => {
                 let Some(mut record) = existing else {
                     return Ok(CommandResult {
-                        success: false,
+                        success: true,
                         message:
                             "No goal is set for this session. Use `/goal <objective>` to set one."
                                 .to_string(),

--- a/crates/server/src/harnesses/generic.rs
+++ b/crates/server/src/harnesses/generic.rs
@@ -23,6 +23,7 @@ pub fn definition() -> BuiltInHarnessDefinition {
         BuiltInCapabilityDefinition::new("session"),
         BuiltInCapabilityDefinition::new("session_schedule"),
         BuiltInCapabilityDefinition::new("btw"),
+        BuiltInCapabilityDefinition::new("goal"),
         BuiltInCapabilityDefinition::new("agent_instructions"),
         BuiltInCapabilityDefinition::new("skills"),
         BuiltInCapabilityDefinition::new("infinity_context"),

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -2380,7 +2380,7 @@ mod tests {
             .expect("Generic harness should exist");
 
         let cap_ids: Vec<&str> = generic.capabilities.iter().map(|c| c.id.as_str()).collect();
-        assert_eq!(cap_ids.len(), 16);
+        assert_eq!(cap_ids.len(), 17);
         assert!(cap_ids.contains(&"human_intent"));
         assert!(cap_ids.contains(&"session_file_system"));
         assert!(cap_ids.contains(&"virtual_bash"));
@@ -2389,6 +2389,7 @@ mod tests {
         assert!(cap_ids.contains(&"session"));
         assert!(cap_ids.contains(&"session_schedule"));
         assert!(cap_ids.contains(&"btw"));
+        assert!(cap_ids.contains(&"goal"));
         assert!(cap_ids.contains(&"agent_instructions"));
         assert!(cap_ids.contains(&"skills"));
         assert!(cap_ids.contains(&"infinity_context"));

--- a/crates/server/tests/api_integration_test.rs
+++ b/crates/server/tests/api_integration_test.rs
@@ -1921,8 +1921,8 @@ async fn test_get_generic_harness() {
         .collect();
     assert_eq!(
         cap_ids.len(),
-        16,
-        "Generic harness should have 16 capabilities"
+        17,
+        "Generic harness should have 17 capabilities"
     );
     assert!(
         cap_ids.contains(&"human_intent"),
@@ -2456,8 +2456,8 @@ async fn test_copy_seed_generic_harness() {
     // Generic harness capabilities should be preserved on copy
     assert_eq!(
         copied.capabilities.len(),
-        16,
-        "Copied harness should have same 16 capabilities"
+        17,
+        "Copied harness should have same 17 capabilities"
     );
     assert!(
         copied

--- a/specs/goal.md
+++ b/specs/goal.md
@@ -1,0 +1,209 @@
+# Goal
+
+Per-session long-running objective, inspired by Codex CLI's `/goal`. The user
+sets a durable goal via `/goal <objective>`; the agent reads it back from the
+session VFS each turn and treats it as standing context across many turns.
+Lifecycle subcommands (show / pause / resume / clear) keep the goal
+user-owned.
+
+This spec covers **v1**: storage, system-prompt injection, and the `/goal`
+lifecycle commands. **v2** (deferred): autonomous post-FinalAnswer validator
+and continuation loop, plus the agent-owned progress journal.
+
+## Concepts
+
+A **goal** is a user-set objective bigger than one prompt but smaller than
+an open-ended backlog. It persists across turns of the same session and
+gives the agent durable scope it can return to whenever it would otherwise
+ask "what next?".
+
+A goal has:
+
+- **objective** — free-form text describing what to accomplish (≤4_000
+  chars, matching Codex's ceiling).
+- **status** — one of `active`, `paused`, `completed`, `cleared`.
+- **version** — monotonic counter, incremented on every write. Reserved
+  for optimistic concurrency in v2.
+- **set_at** / **updated_at** — RFC 3339 timestamps.
+
+Goals are session-scoped. They do not span sessions, agents, or
+organizations.
+
+## Storage
+
+Goal state lives in the session VFS at the file-store-relative path:
+
+```
+.everruns/{session_id}/goal.json
+```
+
+Agent-visible (under `/workspace`):
+
+```
+/workspace/.everruns/{session_id}/goal.json
+```
+
+### Why the VFS, not session metadata or a dedicated table
+
+- **Agent-discoverable.** The agent can read the file with its existing
+  file tools. No new "read goal" API to wire.
+- **User-editable in place.** Any tool that exposes the VFS lets the user
+  inspect or hand-edit the goal.
+- **Composable with future capability state.** `.everruns/{session_id}/`
+  reserves a namespace for sibling capability files (progress journal,
+  memory, …) without per-feature placement decisions.
+- **No DB migration.** Goal lifecycle is a thin layer over file
+  read/write.
+
+### Why session_id is in the path
+
+The VFS is already per-session, so the `{session_id}` segment is
+redundant inside that scope. We include it anyway for three reasons:
+
+1. **Self-describing.** If the file is exported, snapshotted, surfaced
+   in logs, or otherwise leaves the VFS context, the path identifies
+   the session.
+2. **Future-proofing.** Reserves a stable, per-session namespace for
+   capability-owned state; siblings (`.everruns/{session_id}/journal.md`
+   etc.) get the same prefix from day one.
+3. **Convention parity.** Matches the prefixed-ID style used elsewhere
+   in the codebase (`specs/id-schema.md`).
+
+### Why `.everruns/`, not the VFS root
+
+Dotfile-style hides the capability state from casual workspace listings
+without making it inaccessible. Mirrors existing precedent
+(`/workspace/.outputs/` from `gpt_image_gen`).
+
+### Schema
+
+`goal.json` is a single JSON object (pretty-printed for human edits):
+
+```json
+{
+  "objective": "Finish the 0042 migration and keep tests green",
+  "status": "active",
+  "version": 3,
+  "set_at": "2026-05-20T10:00:00Z",
+  "updated_at": "2026-05-20T11:23:11Z"
+}
+```
+
+Readers must ignore unknown fields so future versions can extend the
+record without breaking older code paths. The Rust type lives in
+`crates/core/src/capabilities/goal.rs` as `GoalRecord`.
+
+## `GoalCapability`
+
+Defined in `crates/core/src/capabilities/goal.rs`. ID: `"goal"`.
+
+Contributes:
+
+- The `/goal` system command (no tools, no MCP servers, no mounts).
+- A dynamic `system_prompt_contribution()` that reads `goal.json` and
+  injects active-goal context. When the goal is missing, paused,
+  completed, or cleared, the contribution returns `None` — the agent
+  only carries goal context while it is `active`.
+
+The `Generic` harness opts into `goal` by default
+(`crates/server/src/harnesses/generic.rs`).
+
+### System-prompt injection
+
+When the goal is `active`, the capability injects a `<capability
+id="goal">` block containing:
+
+- The objective text inline.
+- The agent-visible path to `goal.json` so the agent can re-read the
+  authoritative copy.
+- A note that the goal is user-owned and `/goal` commands are the
+  supported edit surface.
+
+Injection is lazy: the capability does **not** stuff the goal into the
+prompt at session creation. It is read on every system-prompt build,
+ensuring the agent always sees the live state.
+
+## `/goal` command
+
+System command (`CommandSource::System`), dispatched in
+`SessionCommandService::execute_goal`. Single optional argument; the
+handler parses subcommands:
+
+| Invocation | Effect |
+|---|---|
+| `/goal` | Show the current goal (or "no goal set"). |
+| `/goal show` / `/goal status` | Same as `/goal`. |
+| `/goal <text>` | Set the objective to `<text>`, status `active`. Replaces any prior goal. |
+| `/goal pause` | Set status to `paused`. |
+| `/goal resume` | Set status back to `active`. |
+| `/goal clear` / `/goal cancel` / `/goal stop` | Set status to `cleared`. |
+
+Returns a `CommandResult` (overlay-style, no chat message persisted).
+`success: false` is reserved for usage errors that the UI surfaces inline
+(e.g. unknown subcommand or objective too long). The 4_000-char limit on
+new objectives is enforced server-side and matches Codex's ceiling.
+
+### Notes on state transitions
+
+- Setting a new objective on top of an existing goal **replaces**
+  it, increments `version`, and preserves `set_at`.
+- `pause`/`resume`/`clear` on a missing goal returns a friendly
+  "no goal set" response, not an error.
+- `clear` does not delete `goal.json`; it sets `status: "cleared"`. This
+  keeps the audit trail and version counter monotonic. v2 may grow a
+  separate `/goal forget` to delete the file outright.
+
+## Out of scope (v1)
+
+The following are intentionally **not** in v1 and will be added in
+follow-up PRs:
+
+- **Autonomous continuation loop.** Codex's `/goal` keeps the agent
+  working across many turns without user input. v2 adds a goal-gate
+  execution-phase step that runs after `FinalAnswer`, calls a cheap
+  validator LLM, and either accepts the FinalAnswer or synthesizes a
+  user-role continuation message inside the durable workflow (see
+  `specs/durable-execution-engine.md` — the loop is checkpointed for
+  free).
+- **Progress journal.** `.everruns/{session_id}/goal-journal.md` for
+  agent-written notes about what's been tried. v2 wires this into the
+  validator so the agent doesn't repeat itself across iterations.
+- **Iteration / budget caps.** A hard ceiling on how many auto-continued
+  turns a single goal can drive before requiring user check-in, plus
+  integration with `specs/budgeting.md` to auto-pause on budget
+  exhaustion.
+- **Pause-on-restart.** When a worker restarts mid-loop, sweep `active`
+  goals with stale `updated_at` to `paused(reason: "worker_restart")`.
+
+## Threat model touchpoints
+
+- **User-owned state.** The goal is user-controlled. The agent **can**
+  write to `goal.json` via normal file tools (we don't ACL it) but the
+  capability's system prompt instructs the agent not to. Misbehaviour is
+  contained the same way the rest of the agent loop is: tool-use audit,
+  iteration caps (v2), and validator cross-check (v2). Choosing not to
+  ACL the file keeps user hand-edits cheap; the integrity tradeoff is
+  no worse than the existing tool-use trust model.
+- **Prompt-injection content.** The objective text flows into the
+  system prompt verbatim. The capability wraps it in a `<capability
+  id="goal">` XML envelope per the existing
+  `specs/xml-prompt-formatting.md` convention; downstream injection
+  guards apply unchanged.
+
+## Tests
+
+- `crates/core/src/capabilities/goal.rs` — metadata, command schema,
+  path helpers, record serialisation.
+- `crates/server/src/domains/session_commands/service.rs` —
+  subcommand parsing and `goal_show_result` rendering.
+
+## References
+
+- Codex CLI `/goal` docs (external):
+  `developers.openai.com/codex/use-cases/follow-goals`,
+  `developers.openai.com/codex/cli/slash-commands`.
+- `specs/commands.md` — slash-command system this builds on.
+- `specs/session-filesystem.md` — VFS layout and `/workspace` path
+  convention.
+- `specs/durable-execution-engine.md` — the substrate v2's continuation
+  loop will run inside.


### PR DESCRIPTION
## What
Adds the `/goal` slash command and `GoalCapability` — a durable per-session long-running objective, modeled on Codex CLI's `/goal`. The user sets an objective via `/goal <text>`; the capability persists it in the session VFS and injects active-goal context into the agent's system prompt on every turn. Lifecycle subcommands (`show`, `pause`, `resume`, `clear`) keep the goal user-owned.

## Why
Codex CLI's `/goal` lets users set a durable objective the agent works toward across many turns. Our existing `/ship`, `/maintenance` etc. are single-shot prompt expansions — no equivalent for "carry this objective forward across the next N turns until done." This PR adds the v1 piece (storage + context injection + lifecycle commands). The autonomous validator/continuation loop is intentionally deferred to v2 so the storage and UX shape can settle first.

## How
- New `GoalCapability` (`crates/core/src/capabilities/goal.rs`):
  - Registers `/goal` as `CommandSource::System` with a single optional argument.
  - Async `system_prompt_contribution()` reads `.everruns/{session_id}/goal.json` from the session VFS and injects an `<capability id="goal">` block only when status is `active`.
- New handler in `SessionCommandService::execute_goal`:
  - Parses subcommands: empty / `show` / `status` → view; `pause` / `resume` / `clear` / `cancel` / `stop` → lifecycle transitions; anything else → set a new objective.
  - 4_000-char cap on objectives (Codex parity).
  - Persists via the existing `SessionFileSystem` trait — no new file abstractions.
- Generic harness opts into `goal` by default.
- `specs/goal.md` documents storage rationale (VFS, dotfile-style, session_id in path for self-description and namespacing), schema, lifecycle, threat-model touchpoints, and exactly what is deferred to v2.

## Risk
Low. Purely additive: new capability, new system-command match arm, single dynamic prompt injection path. No DB migrations, no schema changes, no changes to existing capabilities or API contracts. Falls back to "no goal" cleanly when the file is missing, malformed, or unreadable.

## Validation
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `./scripts/lib/pre-push.sh` all clean.
- 5 new unit tests in `crates/core/src/capabilities/goal.rs` (capability metadata, command schema, path helpers, status serialisation, record roundtrip).
- 5 new unit tests in `crates/server/src/domains/session_commands/service.rs` (subcommand parsing across all keywords, empty-arg behaviour, show-rendering for present/absent goals).
- Smoke tested end-to-end against `just start-dev`: created a session on the Generic harness, confirmed `/goal` appears in `GET /v1/sessions/{id}/commands`, then exercised the full lifecycle via `POST /v1/sessions/{id}/commands/execute`:
  - `/goal` (empty) → "no goal set"
  - `/goal ship the migration safely` → goal active, version 1
  - `/goal show` → returns active status with timestamps
  - `/goal pause` → paused
  - `/goal resume` → active again
  - `/goal clear` → cleared
  - `/goal` after clear → reports cleared status with monotonic timestamps
- Goal file roundtrip is exercised by every show/set/transition; timestamps and version evolve correctly across writes.

## Security
Threat categories reviewed: TM-API, TM-AUTHZ, TM-FS, TM-LLM, TM-TENANT, TM-DOS.

Findings and resolutions:
- **TM-API** — New `/goal` system command dispatched via the existing `SessionCommandService::execute` arm. Input is the existing `ExecuteCommandRequest.arguments` string. Subcommands matched by lowercase exact-match; the set-objective path takes the original text. Auth via the existing `SESSION_VIEW` policy on `/v1/sessions/{id}/commands/execute`. No new endpoint surface.
- **TM-AUTHZ** — No new policy paths or principals. Same gate as `/btw`.
- **TM-FS** — Server-constructed path `.everruns/{session_id}/goal.json`; no user-controlled path components, no traversal vector. Writes go through `SessionFileSystem`, which enforces per-session scoping.
- **TM-LLM** — User objective is interpolated into the system prompt verbatim inside a `<capability id="goal">` envelope (per `specs/xml-prompt-formatting.md`). This is the same trust posture as other VFS-sourced prompt content (e.g. AGENTS.md via `agent_instructions`). The user is the trust source for their own session; downstream prompt-injection handling is unchanged.
- **TM-TENANT** — Storage is per-session via `SessionFileSystem`. No cross-org, cross-session, or cross-user exposure.
- **TM-DOS** — 4_000-char ceiling on objectives, O(1) file writes per command, no iteration loops in v1.

No new `THREAT` comments added (no new mitigation contracts beyond the existing capability/command surface). No `specs/threat-model.md` update required for v1.

## Follow-ups
v2 work is intentionally out of scope and documented in `specs/goal.md`:
- Autonomous post-FinalAnswer validator and synthetic-user continuation, implemented as steps inside the existing durable execution workflow (crash recovery comes free from `specs/durable-execution-engine.md`).
- Agent-owned progress journal at `.everruns/{session_id}/goal-journal.md` so the continuation loop doesn't repeat itself.
- Iteration / budget caps and a worker-restart pause-sweep.

Smaller items considered and deferred with reason:
- UI badge for active goal — depends on UI work outside this PR; the existing capability surface is enough for follow-up UI to read goal state.
- `/goal forget` to delete the file (vs `clear` which sets status) — wait for actual demand; keeping the monotonic version trail is more useful than cleanup right now.

## Checklist
- [x] Tests added (5 core + 5 server)
- [x] Backward compatibility considered (purely additive)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (no review yet)

---
_Generated by [Claude Code](https://claude.ai/code/session_011nuxn4ob56EA7JWxZDfkqP)_