### PR TITLE
test(api): count utoipa oneOf-nested descriptions; ratchet field floor to 85%

### DIFF
--- a/crates/server/tests/openapi_descriptions_test.rs
+++ b/crates/server/tests/openapi_descriptions_test.rs
@@ -16,7 +16,7 @@ use utoipa::OpenApi;
 /// Lowest acceptable coverage. Bump up when you fix a batch.
 const MIN_OP_DESC_PCT: u32 = 100;
 const MIN_SCHEMA_DESC_PCT: u32 = 88;
-const MIN_FIELD_DESC_PCT: u32 = 82;
+const MIN_FIELD_DESC_PCT: u32 = 85;
 
 fn spec_value() -> serde_json::Value {
     serde_json::from_str(&ApiDoc::openapi().to_pretty_json().unwrap())
@@ -63,6 +63,28 @@ fn schema_description_coverage(spec: &serde_json::Value) -> (u32, u32) {
     (with_desc, total)
 }
 
+/// A field counts as described when there's a `description` either at the
+/// property root or on any branch of a `oneOf` / `anyOf` / `allOf` envelope.
+/// utoipa renders `Option<ComplexType>` as `oneOf: [{type: null}, {$ref, description}]`,
+/// putting the doc comment on the non-null branch rather than the property root.
+/// The description is still visible to an AI consumer parsing the spec, so
+/// counting only the root would undercount actual coverage.
+fn field_has_description(field: &serde_json::Value) -> bool {
+    if field.get("description").is_some() {
+        return true;
+    }
+    for key in ["oneOf", "anyOf", "allOf"] {
+        if let Some(branches) = field.get(key).and_then(|v| v.as_array()) {
+            for branch in branches {
+                if branch.get("description").is_some() {
+                    return true;
+                }
+            }
+        }
+    }
+    false
+}
+
 fn field_description_coverage(spec: &serde_json::Value) -> (u32, u32) {
     let mut total = 0u32;
     let mut with_desc = 0u32;
@@ -75,7 +97,7 @@ fn field_description_coverage(spec: &serde_json::Value) -> (u32, u32) {
         };
         for field in props.values() {
             total += 1;
-            if field.get("description").is_some() {
+            if field_has_description(field) {
                 with_desc += 1;
             }
         }


### PR DESCRIPTION
## What
The OpenAPI field-description gate was undercounting documented fields by 4pp because of a utoipa rendering quirk.

When a field is `Option<ComplexType>` (e.g. `Option<NetworkAccessList>`, `Option<TokenUsage>`, `Option<PrincipalSummary>`), utoipa emits:

```json
{
  "oneOf": [
    { "type": "null" },
    { "$ref": "#/components/schemas/NetworkAccessList", "description": "Network access list controlling…" }
  ]
}
```

The doc comment lives on the non-null branch instead of the property root. The previous coverage check only inspected `field.description`, so these 60 fields were counted as undocumented even though the description was emitted into the spec and is fully visible to LLM consumers.

Fix: teach `field_description_coverage` to recognize descriptions on any branch of `oneOf` / `anyOf` / `allOf`. Bump `MIN_FIELD_DESC_PCT` from **82% → 85%** to reflect the true coverage (now 86% with 1pp headroom).

## Why
The ratcheting floor only does its job if it counts real coverage. Two practical effects:

1. The current 82% floor was a low-confidence reading — it under-credited types like `Session`, `Agent`, `Harness`, `App`, `LlmModelProfile`, etc., whose `Option<…>` fields *are* documented.
2. Future contributors adding `Option<ComplexType>` fields with `///` doc comments will see their description show up in the spec; previously the gate would have suggested otherwise, encouraging redundant `#[schema(description = "…")]` overrides.

## How
Single-file change in `crates/server/tests/openapi_descriptions_test.rs`:

- New helper `field_has_description` that checks the root *and* every branch of `oneOf` / `anyOf` / `allOf`.
- `MIN_FIELD_DESC_PCT` raised from 82 to 85.
- Comment block on the helper explains the utoipa rendering rule so the next reader doesn't re-discover it.

No production code changes. No schema changes. OpenAPI spec at `docs/api/openapi.json` is unchanged.

## Risk
- **Negligible.** Test-only change. The new counting rule is strictly more permissive than the old one (a field counted before still counts now), so this can never falsely fail.
- The floor goes up by 3pp, but the actual coverage with the new rule is 86%, so the gate passes with 1pp headroom.
- If a contributor later removes a `///` doc comment from an `Option<ComplexType>` field, the gate now correctly catches that regression (it would have silently slipped past before).

## Security
- Threat categories reviewed: none directly applicable. This is a test-coverage gate that reads the generated OpenAPI spec from memory; no new endpoints, no new data paths, no auth changes.

## Checklist
- [x] Tests added or updated (the test itself is the change; ran `cargo test -p everruns-server --test openapi_descriptions_test` — all 3 pass)
- [x] Backward compatibility considered (test-only; strictly more permissive counting)
- [x] Security review performed against relevant threat model categories

---
_Generated by [Claude Code](https://claude.ai/code/session_01K7vXyQJ9St1tLHukPbJmGh)_