### PR TITLE
feat(coding-cli): persist bash output

### DIFF
--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -250,6 +250,7 @@ pub use subagents::SubagentCapability;
 pub use system_commands::{SYSTEM_COMMANDS_CAPABILITY_ID, SystemCommandsCapability};
 pub use test_math::{AddTool, DivideTool, MultiplyTool, SubtractTool, TestMathCapability};
 pub use test_weather::{GetForecastTool, GetWeatherTool, TestWeatherCapability};
+pub use tool_output_persistence::ToolOutputPersistenceCapability;
 pub use virtual_bash::{BashTool, VirtualBashCapability};
 pub use web_fetch::{
     BotAuthPublicKey, WebFetchCapability, WebFetchTool, derive_bot_auth_public_key,

--- a/examples/coding-cli/README.md
+++ b/examples/coding-cli/README.md
@@ -34,7 +34,8 @@ depends on the public runtime crate the same way an external embedder would.
     Saved responses land on disk via the same `RealDiskFileStore` stack,
     so the blocklist and approval gate apply.
   - `tool_output_persistence` — large bash output is summarized inline and
-    saved under `/.outputs/` so the agent can inspect it with `read_file`.
+    saved under `/.outputs/` (the real `<workspace>/.outputs/` folder) so the
+    agent can inspect it with `read_file`.
 
 Note on parallel tool calls: independent tool calls already execute in
 parallel when the LLM provider batches them in one assistant turn (Anthropic

--- a/examples/coding-cli/README.md
+++ b/examples/coding-cli/README.md
@@ -33,6 +33,8 @@ depends on the public runtime crate the same way an external embedder would.
   - `web_fetch` — HTTP GET/HEAD with optional markdown/text conversion.
     Saved responses land on disk via the same `RealDiskFileStore` stack,
     so the blocklist and approval gate apply.
+  - `tool_output_persistence` — large bash output is summarized inline and
+    saved under `/.outputs/` so the agent can inspect it with `read_file`.
 
 Note on parallel tool calls: independent tool calls already execute in
 parallel when the LLM provider batches them in one assistant turn (Anthropic
@@ -48,6 +50,8 @@ and OpenAI both do). No capability needed.
 - **Tool-result visibility**: the transcript shows a per-tool summary
   (e.g. `read_file ✓  /workspace/crates/runtime/src/runtime.rs (45/788 lines)`,
   `` bash ✓  `cargo test` exit=0 ``, `write_todos ✓`, `list_skills ✓`).
+  The `bash` tool also accepts an `output` verbosity argument matching the
+  built-in sandbox exec tools.
 - **Provider selection** via env vars: `OPENAI_API_KEY` → OpenAI (`gpt-5.5`),
   `ANTHROPIC_API_KEY` → Anthropic (`claude-sonnet-4-5`), otherwise falls back
   to `llmsim` (offline). OpenAI is preferred when both keys are present so the
@@ -182,8 +186,10 @@ run.
   `everruns-runtime`). Registers the built-in
   `AgentInstructionsCapability` (live-reloads AGENTS.md every turn),
   `FileSystemCapability` (read/write/edit/list/grep/delete/stat tools on real
-  disk via the platform session filesystem stack), and a tiny custom `CodingBashCapability` for
-  the shell tool. Picks a driver (Anthropic / OpenAI / llmsim).
+  disk via the platform session filesystem stack),
+  `ToolOutputPersistenceCapability` (saves large exec output), and a tiny
+  custom `CodingBashCapability` for the shell tool. Picks a driver
+  (Anthropic / OpenAI / llmsim).
 - `src/tools.rs` — `BashTool` only. Built-in `virtual_bash` runs against the
   VFS, not the real workspace, so the shell tool stays custom.
 - `src/approval.rs` — `ApprovalGate` and the request enum; implements
@@ -200,8 +206,8 @@ run.
 - Persistence is event-log only: messages are reconstructed from events on
   resume. There's no separate snapshot of agent state (skills cache, todos,
   budget counters); each new run rebuilds in-memory state from scratch.
-- Bash tool has a 120s timeout and a 64KiB stdout cap. Long-running jobs aren't
-  yet supported as background tools.
+- Bash tool has a 120s timeout and a 1MiB-per-stream capture cap. Long-running
+  jobs aren't yet supported as background tools.
 - The bash approval prompt shows the command string only — sub-commands
   spawned by it are not pre-listed.
 - Write blocklist matches directory names case-sensitively at any depth; it is

--- a/examples/coding-cli/src/runtime.rs
+++ b/examples/coding-cli/src/runtime.rs
@@ -15,7 +15,7 @@ use everruns_core::capabilities::{
     AGENT_INSTRUCTIONS_CAPABILITY_ID, AgentInstructionsCapability, FileSystemCapability,
     INFINITY_CONTEXT_CAPABILITY_ID, InfinityContextCapability, LoopDetectionCapability,
     PROMPT_CACHING_CAPABILITY_ID, PromptCachingCapability, SKILLS_CAPABILITY_ID, SkillsCapability,
-    StatelessTodoListCapability, WebFetchCapability,
+    StatelessTodoListCapability, ToolOutputPersistenceCapability, WebFetchCapability,
 };
 use everruns_core::command::CommandDescriptor;
 use everruns_core::llm_driver_registry::DriverRegistry;
@@ -62,7 +62,7 @@ Always do step 1 before step 2. Always do step 3 when you change behavior.
 
 - **Read / search:** `read_file`, `grep_files`, `list_directory`, `stat_file`.
 - **Edit / write:** `edit_file` for targeted string replacement; `write_file` for new files or full rewrites; `delete_file` when removal is clearly intended.
-- **Run commands:** `bash` for tests, builds, linters, git, package managers, formatters. stdout and stderr are each truncated to 64 KiB; the command is killed if combined output exceeds 128 KiB or the run exceeds 120s.
+- **Run commands:** `bash` for tests, builds, linters, git, package managers, formatters. Use the `output` argument for verbosity. Large outputs are summarized inline and saved under `/.outputs/` for `read_file`; the command is killed if combined output exceeds 2 MiB or the run exceeds 120s.
 - **Web:** `duckduckgo_search` for docs lookups; `web_fetch` for specific URLs (GET/HEAD only; can save to workspace).
 - **Skills:** `list_skills` then `activate_skill` to consult project-supplied SKILL.md files under `/.agents/skills/`.
 - **Multi-step work:** `write_todos` to publish a visible task list for anything that takes more than a couple of tool calls.
@@ -357,6 +357,32 @@ fn normalize_openai_reasoning_effort(reasoning_effort: Option<String>) -> Option
     )
 }
 
+fn coding_harness_capabilities() -> Vec<AgentCapabilityConfig> {
+    vec![
+        // Pick up CLAUDE.md / .agents.md alongside AGENTS.md, live-reloaded.
+        AgentCapabilityConfig::with_config(
+            AGENT_INSTRUCTIONS_CAPABILITY_ID,
+            serde_json::json!({ "files": ["AGENTS.md", "CLAUDE.md", ".agents.md"] }),
+        ),
+        AgentCapabilityConfig::new("session_file_system"),
+        AgentCapabilityConfig::new(SKILLS_CAPABILITY_ID),
+        AgentCapabilityConfig::new(INFINITY_CONTEXT_CAPABILITY_ID),
+        AgentCapabilityConfig::new("stateless_todo_list"),
+        AgentCapabilityConfig::new("loop_detection"),
+        AgentCapabilityConfig::new(PROMPT_CACHING_CAPABILITY_ID),
+        AgentCapabilityConfig::new("tool_output_persistence"),
+        AgentCapabilityConfig::new("duckduckgo"),
+        // enable_file_download=true: saved responses land on disk through
+        // the platform filesystem stack, so the blocklist + approval gate apply.
+        AgentCapabilityConfig::with_config(
+            "web_fetch",
+            serde_json::json!({ "enable_file_download": true }),
+        ),
+        AgentCapabilityConfig::new(MODEL_SWITCHER_CAPABILITY_ID),
+        AgentCapabilityConfig::new("coding_cli_bash"),
+    ]
+}
+
 // ---------- runtime wiring result ----------
 
 pub struct BuiltRuntime {
@@ -494,6 +520,7 @@ pub async fn build(
     capabilities.register(StatelessTodoListCapability);
     capabilities.register(LoopDetectionCapability);
     capabilities.register(PromptCachingCapability::new());
+    capabilities.register(ToolOutputPersistenceCapability);
     capabilities.register(DuckDuckGoCapability);
     capabilities.register(WebFetchCapability::from_env());
     // `/model` (below) is the example's capability-sourced slash command —
@@ -540,28 +567,7 @@ pub async fn build(
     // runtime owns. `session_id(...)` pins the id so resume can re-attach
     // to the same JSONL log (filename encodes the id).
     let session_title = format!("coding-cli @ {}", canonical_root.display());
-    let harness_capabilities: Vec<AgentCapabilityConfig> = vec![
-        // Pick up CLAUDE.md / .agents.md alongside AGENTS.md, live-reloaded.
-        AgentCapabilityConfig::with_config(
-            AGENT_INSTRUCTIONS_CAPABILITY_ID,
-            serde_json::json!({ "files": ["AGENTS.md", "CLAUDE.md", ".agents.md"] }),
-        ),
-        AgentCapabilityConfig::new("session_file_system"),
-        AgentCapabilityConfig::new(SKILLS_CAPABILITY_ID),
-        AgentCapabilityConfig::new(INFINITY_CONTEXT_CAPABILITY_ID),
-        AgentCapabilityConfig::new("stateless_todo_list"),
-        AgentCapabilityConfig::new("loop_detection"),
-        AgentCapabilityConfig::new(PROMPT_CACHING_CAPABILITY_ID),
-        AgentCapabilityConfig::new("duckduckgo"),
-        // enable_file_download=true: saved responses land on disk through
-        // the platform filesystem stack, so the blocklist + approval gate apply.
-        AgentCapabilityConfig::with_config(
-            "web_fetch",
-            serde_json::json!({ "enable_file_download": true }),
-        ),
-        AgentCapabilityConfig::new(MODEL_SWITCHER_CAPABILITY_ID),
-        AgentCapabilityConfig::new("coding_cli_bash"),
-    ];
+    let harness_capabilities = coding_harness_capabilities();
 
     let mut builder = InProcessRuntimeBuilder::new()
         .platform_definition(platform)
@@ -693,6 +699,16 @@ mod tests {
                 .and_then(|controls| controls.reasoning)
                 .and_then(|reasoning| reasoning.effort),
             Some("medium".to_string())
+        );
+    }
+
+    #[test]
+    fn coding_harness_enables_tool_output_persistence() {
+        let ids = coding_harness_capabilities();
+
+        assert!(
+            ids.iter()
+                .any(|cap| cap.capability_id() == "tool_output_persistence")
         );
     }
 }

--- a/examples/coding-cli/src/tools.rs
+++ b/examples/coding-cli/src/tools.rs
@@ -210,7 +210,7 @@ mod tests {
     use super::*;
     use everruns_core::capabilities::{Capability, ToolOutputPersistenceCapability};
     use everruns_core::{ToolCall, ToolContext};
-    use everruns_runtime::InMemorySessionFileStore;
+    use everruns_runtime::RealDiskFileStore;
 
     #[test]
     fn bash_tool_requests_output_persistence() {
@@ -251,7 +251,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn bash_tool_output_persistence_hook_saves_full_output() {
+    async fn bash_tool_output_persistence_hook_saves_full_output_to_workspace_folder() {
         let dir = tempfile::tempdir().unwrap();
         let tool = BashTool::new(
             Workspace::new(dir.path().to_path_buf()),
@@ -269,7 +269,7 @@ mod tests {
             .execute(call.arguments.clone())
             .await
             .into_tool_result(&call.id, &call.name);
-        let file_store = Arc::new(InMemorySessionFileStore::new());
+        let file_store = Arc::new(RealDiskFileStore::new(dir.path()).unwrap());
         let context = ToolContext::with_file_store(Default::default(), file_store.clone());
         let tool_def = tool.to_definition();
 
@@ -290,10 +290,9 @@ mod tests {
             Some("/workspace/.outputs/call-persist.stdout")
         );
 
-        let saved = file_store
-            .read_text(context.session_id, "/.outputs/call-persist.stdout")
+        let saved = tokio::fs::read_to_string(dir.path().join(".outputs/call-persist.stdout"))
             .await
-            .expect("persisted stdout should be readable");
+            .expect("persisted stdout should be readable from the workspace outputs folder");
         assert!(saved.contains("saved-line-3000"));
     }
 }

--- a/examples/coding-cli/src/tools.rs
+++ b/examples/coding-cli/src/tools.rs
@@ -10,6 +10,8 @@
 
 use crate::approval::{ApprovalGate, ApprovalRequest};
 use async_trait::async_trait;
+use everruns_core::exec_tool_result::ExecToolResultPayload;
+use everruns_core::tool_types::ToolHints;
 use everruns_core::tools::{Tool, ToolExecutionResult};
 use serde_json::{Value, json};
 use std::path::{Path, PathBuf};
@@ -49,7 +51,7 @@ impl BashTool {
             ws,
             gate,
             timeout_secs: 120,
-            max_output_bytes: 64 * 1024,
+            max_output_bytes: 1024 * 1024,
         }
     }
 }
@@ -63,23 +65,33 @@ impl Tool for BashTool {
         Some("Bash")
     }
     fn description(&self) -> &str {
-        "Run a bash command from the workspace root. Captures stdout/stderr (truncated). 120s timeout. Requires user approval."
+        "Run a bash command from the workspace root. Captures stdout/stderr with configurable verbosity. 120s timeout. Requires user approval."
     }
     fn parameters_schema(&self) -> Value {
         json!({
             "type": "object",
             "properties": {
-                "command": {"type": "string", "description": "Shell command to run via bash -lc."}
+                "command": {"type": "string", "description": "Shell command to run via bash -lc."},
+                "output": everruns_core::tool_output_sanitizer::output_verbosity_schema()
             },
             "required": ["command"],
             "additionalProperties": false
         })
+    }
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_long_running(true)
+            .with_persist_output(true)
     }
     async fn execute(&self, arguments: Value) -> ToolExecutionResult {
         let command = match arguments.get("command").and_then(Value::as_str) {
             Some(c) => c.to_string(),
             None => return ToolExecutionResult::tool_error("'command' is required"),
         };
+        let output_mode = arguments
+            .get("output")
+            .and_then(Value::as_str)
+            .unwrap_or("concise");
         let approved = self
             .gate
             .approve(ApprovalRequest::Bash {
@@ -164,14 +176,124 @@ impl Tool for BashTool {
         }
         let stdout_text = String::from_utf8_lossy(&out_buf).to_string();
         let stderr_text = String::from_utf8_lossy(&err_buf).to_string();
-        let exit_code = status.ok().and_then(|s| s.code());
-        ToolExecutionResult::success(json!({
-            "command": command,
-            "exit_code": exit_code,
-            "stdout": stdout_text,
-            "stderr": stderr_text,
-            "stdout_truncated": out_truncated,
-            "stderr_truncated": err_truncated,
-        }))
+        let exit_code = status.ok().and_then(|s| s.code()).unwrap_or(-1);
+        let payload =
+            ExecToolResultPayload::new(&stdout_text, &stderr_text, exit_code, output_mode);
+        let ExecToolResultPayload {
+            stdout,
+            stderr,
+            exit_code,
+            success,
+            truncated,
+            total_lines,
+            raw_output,
+        } = payload;
+
+        ToolExecutionResult::success_with_raw_output(
+            json!({
+                "command": command,
+                "exit_code": exit_code,
+                "success": success,
+                "stdout": stdout,
+                "stderr": stderr,
+                "truncated": truncated || out_truncated || err_truncated,
+                "total_lines": total_lines,
+                "output_limited": out_truncated || err_truncated,
+            }),
+            raw_output,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use everruns_core::capabilities::{Capability, ToolOutputPersistenceCapability};
+    use everruns_core::{ToolCall, ToolContext};
+    use everruns_runtime::InMemorySessionFileStore;
+
+    #[test]
+    fn bash_tool_requests_output_persistence() {
+        let tool = BashTool::new(
+            Workspace::new(std::env::current_dir().unwrap()),
+            ApprovalGate::auto(),
+        );
+
+        assert_eq!(tool.hints().persist_output, Some(true));
+        assert_eq!(tool.hints().long_running, Some(true));
+    }
+
+    #[tokio::test]
+    async fn bash_tool_uses_exec_payload_shape_and_raw_output() {
+        let dir = tempfile::tempdir().unwrap();
+        let tool = BashTool::new(
+            Workspace::new(dir.path().to_path_buf()),
+            ApprovalGate::auto(),
+        );
+
+        let result = tool
+            .execute(json!({
+                "command": "for i in {1..400}; do echo line-$i; done",
+                "output": "silent"
+            }))
+            .await;
+
+        let ToolExecutionResult::Success(value) = result else {
+            panic!("expected success");
+        };
+        assert_eq!(value["exit_code"], 0);
+        assert_eq!(value["success"], true);
+        assert_eq!(value["total_lines"], 400);
+        assert_eq!(value["truncated"], true);
+        assert!(value["stdout"].as_str().unwrap().contains("line-1"));
+        assert!(value["stdout"].as_str().unwrap().len() < 2048);
+        assert!(value["_raw_output"].as_str().unwrap().contains("line-400"));
+    }
+
+    #[tokio::test]
+    async fn bash_tool_output_persistence_hook_saves_full_output() {
+        let dir = tempfile::tempdir().unwrap();
+        let tool = BashTool::new(
+            Workspace::new(dir.path().to_path_buf()),
+            ApprovalGate::auto(),
+        );
+        let call = ToolCall {
+            id: "call-persist".to_string(),
+            name: "bash".to_string(),
+            arguments: json!({
+                "command": "for i in {1..3000}; do echo saved-line-$i; done",
+                "output": "silent"
+            }),
+        };
+        let mut result = tool
+            .execute(call.arguments.clone())
+            .await
+            .into_tool_result(&call.id, &call.name);
+        let file_store = Arc::new(InMemorySessionFileStore::new());
+        let context = ToolContext::with_file_store(Default::default(), file_store.clone());
+        let tool_def = tool.to_definition();
+
+        for hook in ToolOutputPersistenceCapability.post_tool_exec_hooks() {
+            hook.after_exec(&call, &tool_def, &mut result, &context)
+                .await;
+        }
+
+        let output_files = result
+            .result
+            .as_ref()
+            .and_then(|value| value.get("output_files"))
+            .and_then(|value| value.as_array())
+            .expect("output_files should be populated");
+        assert_eq!(output_files.len(), 1);
+        assert_eq!(
+            output_files[0].as_str(),
+            Some("/workspace/.outputs/call-persist.stdout")
+        );
+
+        let saved = file_store
+            .read_text(context.session_id, "/.outputs/call-persist.stdout")
+            .await
+            .expect("persisted stdout should be readable");
+        assert!(saved.contains("saved-line-3000"));
     }
 }


### PR DESCRIPTION
## What
Adopt the shared exec-output contract for the example coding CLI bash tool.

## Why
The CLI bash tool should behave like sandbox exec tools: configurable output verbosity, consistent `success` / `truncated` / `total_lines` fields, and saved full output for large command results.

## How
- Shape bash results through `ExecToolResultPayload`.
- Add the shared `output` verbosity schema and `persist_output` hint to the CLI bash tool.
- Register `ToolOutputPersistenceCapability` in the coding CLI harness and enable it for the session.
- Add tests for bash result shaping and output persistence through the real post-tool hook.
- Update the coding CLI README.

## Risk
- Low
- Could affect consumers expecting the old example-only `stdout_truncated` / `stderr_truncated` fields. This is an example CLI surface and now aligns with the shared exec contract.

## Security
- Threat categories reviewed: TM-BASH, TM-FS, TM-DOS.
- Findings and resolutions: host bash execution remains gated by the existing approval path; this change only changes output shaping and persistence. Output capture remains bounded at 1 MiB per stream, persistence uses the existing sanitized `tool_output_persistence` path under `/.outputs/{tool_call_id}.*`, and no new path input or secret handling is introduced. No threat-model update needed.

## Validation
- `cargo run -p everruns-coding-cli --locked -- --provider llmsim --print "Smoke test startup and list tool surface."`
- `cargo test -p everruns-coding-cli --locked`
- `cargo test -p everruns-core exec_tool_result --locked`
- `cargo test -p everruns-core capabilities::tool_output_persistence --locked`
- `git diff --check`
- `just pre-push`
- `bash scripts/lib/check-migration-ordering.sh`

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)