### PR TITLE
refactor(coding-cli): split runtime wiring result

### DIFF
--- a/examples/coding-cli/src/app.rs
+++ b/examples/coding-cli/src/app.rs
@@ -5,7 +5,7 @@
 // channel so the UI stays responsive while the model is thinking.
 
 use crate::approval::ApprovalRequest;
-use crate::runtime::RuntimeBundle;
+use crate::runtime::{BuiltRuntime, ModelState, RuntimeHandles, StartupInfo};
 use anyhow::Result;
 use crossterm::event::{
     self, Event as CrosstermEvent, KeyCode, KeyEvent, KeyEventKind, KeyModifiers, MouseEvent,
@@ -22,7 +22,6 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
 use serde_json::Value;
 use std::collections::HashSet;
-use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::{mpsc, oneshot};
 
@@ -114,7 +113,9 @@ const COMMANDS: &[CommandSpec] = &[
 ];
 
 pub struct App {
-    bundle: Arc<RuntimeBundle>,
+    handles: RuntimeHandles,
+    startup: StartupInfo,
+    model: ModelState,
     pub lines: Vec<ChatLine>,
     pub input: String,
     pub busy: bool,
@@ -147,9 +148,11 @@ enum TurnEvent {
 }
 
 impl App {
-    pub fn new(bundle: Arc<RuntimeBundle>, approval_rx: ApprovalRx) -> Self {
+    pub fn new(runtime: BuiltRuntime, approval_rx: ApprovalRx) -> Self {
         let mut app = Self {
-            bundle,
+            handles: runtime.handles,
+            startup: runtime.startup,
+            model: runtime.model,
             lines: Vec::new(),
             input: String::new(),
             busy: false,
@@ -170,19 +173,19 @@ impl App {
     fn emit_system_banner(&mut self) {
         self.push_system(format!(
             "workspace: {}",
-            self.bundle.workspace_root.display()
+            self.startup.workspace_root.display()
         ));
-        self.push_system(format!("model: {}", self.bundle.provider_label()));
-        self.push_system(format!("tools: {}", self.bundle.tool_names.join(", ")));
+        self.push_system(format!("model: {}", self.model.provider_label()));
+        self.push_system(format!("tools: {}", self.startup.tool_names.join(", ")));
         self.push_system(format!(
             "session: {} (log: {}; {} prior event(s) replayed)",
-            self.bundle.session_id,
-            self.bundle.session_log_path.display(),
-            self.bundle.replayed_events,
+            self.handles.session_id,
+            self.startup.session_log_path.display(),
+            self.startup.replayed_events,
         ));
-        if !self.bundle.capability_commands.is_empty() {
+        if !self.startup.capability_commands.is_empty() {
             let names: Vec<String> = self
-                .bundle
+                .startup
                 .capability_commands
                 .iter()
                 .map(|c| format!("/{}", c.name))
@@ -414,7 +417,7 @@ impl App {
     }
 
     fn suggestions(&self) -> Vec<CommandSuggestion> {
-        command_suggestions(&self.input, &self.bundle.capability_commands)
+        command_suggestions(&self.input, &self.startup.capability_commands)
     }
 
     async fn handle_command(&mut self, cmd: &str) {
@@ -431,9 +434,9 @@ impl App {
                         .collect::<Vec<_>>()
                         .join(" · "),
                 );
-                if !self.bundle.capability_commands.is_empty() {
+                if !self.startup.capability_commands.is_empty() {
                     let caps = self
-                        .bundle
+                        .startup
                         .capability_commands
                         .iter()
                         .map(capability_command_usage)
@@ -448,12 +451,12 @@ impl App {
                 self.push_system("approvals: y allow · n / Esc deny · exit: Esc / Ctrl-D".into());
             }
             "tools" => {
-                self.push_system(format!("tools: {}", self.bundle.tool_names.join(", ")));
+                self.push_system(format!("tools: {}", self.startup.tool_names.join(", ")));
             }
             "cwd" => {
                 self.push_system(format!(
                     "workspace root: {}",
-                    self.bundle.workspace_root.display()
+                    self.startup.workspace_root.display()
                 ));
             }
             "clear" => {
@@ -463,7 +466,7 @@ impl App {
             "quit" | "exit" => self.should_quit = true,
             other => {
                 if let Some(descriptor) = self
-                    .bundle
+                    .startup
                     .capability_commands
                     .iter()
                     .find(|c| c.name == other)
@@ -518,9 +521,9 @@ impl App {
                     controls: None,
                 };
                 let result = self
-                    .bundle
+                    .handles
                     .runtime
-                    .execute_command(self.bundle.session_id, request)
+                    .execute_command(self.handles.session_id, request)
                     .await;
                 match result {
                     Ok(result) => {
@@ -543,15 +546,16 @@ impl App {
     }
 
     fn start_turn(&mut self, prompt: String) {
-        let bundle = self.bundle.clone();
+        let handles = self.handles.clone();
+        let model = self.model.clone();
         let (tx, rx) = mpsc::unbounded_channel::<TurnEvent>();
         self.rx = Some(rx);
         self.busy = true;
         self.turn_activity = None;
 
         tokio::spawn(async move {
-            let session_id = bundle.session_id;
-            let before = match bundle.runtime.messages(session_id).await {
+            let session_id = handles.session_id;
+            let before = match handles.runtime.messages(session_id).await {
                 Ok(m) => m.len(),
                 Err(e) => {
                     let _ = tx.send(TurnEvent::Failed(format!("load history: {e}")));
@@ -559,17 +563,17 @@ impl App {
                     return;
                 }
             };
-            let events_before = match bundle.runtime.events().await {
+            let events_before = match handles.runtime.events().await {
                 Ok(e) => e.len(),
                 Err(_) => 0,
             };
 
-            let input = bundle.input_message(prompt);
-            let runtime = bundle.runtime.clone();
+            let input = model.input_message(prompt);
+            let runtime = handles.runtime.clone();
             let turn = tokio::spawn(async move { runtime.run_turn(session_id, input).await });
             let mut emitted_events = HashSet::new();
             while !turn.is_finished() {
-                emit_new_turn_events(&bundle, events_before, &mut emitted_events, &tx).await;
+                emit_new_turn_events(&handles, events_before, &mut emitted_events, &tx).await;
                 tokio::time::sleep(Duration::from_millis(120)).await;
             }
 
@@ -581,7 +585,7 @@ impl App {
                     return;
                 }
             };
-            emit_new_turn_events(&bundle, events_before, &mut emitted_events, &tx).await;
+            emit_new_turn_events(&handles, events_before, &mut emitted_events, &tx).await;
             let response = match result {
                 Ok(r) => r,
                 Err(e) => {
@@ -591,12 +595,12 @@ impl App {
                 }
             };
 
-            let messages = bundle
+            let messages = handles
                 .runtime
                 .messages(session_id)
                 .await
                 .unwrap_or_default();
-            let events = bundle.runtime.events().await.unwrap_or_default();
+            let events = handles.runtime.events().await.unwrap_or_default();
 
             let mut out = Vec::new();
             // Catch any final tool events missed by the polling loop.
@@ -645,12 +649,12 @@ impl App {
 }
 
 async fn emit_new_turn_events(
-    bundle: &RuntimeBundle,
+    handles: &RuntimeHandles,
     events_before: usize,
     emitted_events: &mut HashSet<String>,
     tx: &mpsc::UnboundedSender<TurnEvent>,
 ) {
-    let events = bundle.runtime.events().await.unwrap_or_default();
+    let events = handles.runtime.events().await.unwrap_or_default();
     let mut lines = Vec::new();
     for event in events.iter().skip(events_before) {
         let event_id = event.id.to_string();
@@ -1535,8 +1539,8 @@ fn thinking_title(frame: u64, activity: &str) -> Line<'static> {
 fn draw_status(f: &mut ratatui::Frame, area: Rect, app: &App) {
     let status = format!(
         " {} · {} · {}msgs ",
-        app.bundle.provider_label(),
-        app.bundle.workspace_root.display(),
+        app.model.provider_label(),
+        app.startup.workspace_root.display(),
         app.lines.len()
     );
     let para = Paragraph::new(Span::styled(status, Style::default().fg(Color::DarkGray)));

--- a/examples/coding-cli/src/main.rs
+++ b/examples/coding-cli/src/main.rs
@@ -20,10 +20,9 @@ use crossterm::terminal::{
 use everruns_core::message::MessageRole;
 use ratatui::Terminal;
 use ratatui::backend::CrosstermBackend;
-use runtime::{ProviderChoice, RuntimeBundle};
+use runtime::{BuiltRuntime, ProviderChoice};
 use std::io::{self, IsTerminal};
 use std::path::PathBuf;
-use std::sync::Arc;
 
 #[derive(Parser, Debug)]
 #[command(
@@ -165,17 +164,16 @@ async fn main() -> Result<()> {
         Some(p) => p,
         None => session_log::default_storage_dir()?,
     };
-    let bundle = runtime::build(cwd, provider, gate, resume_session_id, session_dir).await?;
-    let bundle = Arc::new(bundle);
+    let runtime = runtime::build(cwd, provider, gate, resume_session_id, session_dir).await?;
 
     if let Some(prompt) = cli.print {
-        return run_print_mode(bundle, prompt).await;
+        return run_print_mode(runtime, prompt).await;
     }
-    run_tui(bundle, approval_rx).await
+    run_tui(runtime, approval_rx).await
 }
 
 async fn run_tui(
-    bundle: Arc<RuntimeBundle>,
+    runtime: BuiltRuntime,
     approval_rx: tokio::sync::mpsc::UnboundedReceiver<(
         approval::ApprovalRequest,
         tokio::sync::oneshot::Sender<bool>,
@@ -187,7 +185,7 @@ async fn run_tui(
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
 
-    let mut app = App::new(bundle, approval_rx);
+    let mut app = App::new(runtime, approval_rx);
     let result = app.run(&mut terminal).await;
 
     disable_raw_mode()?;
@@ -196,34 +194,39 @@ async fn run_tui(
     result
 }
 
-async fn run_print_mode(bundle: Arc<RuntimeBundle>, prompt: String) -> Result<()> {
+async fn run_print_mode(runtime: BuiltRuntime, prompt: String) -> Result<()> {
+    let BuiltRuntime {
+        handles,
+        startup,
+        model,
+    } = runtime;
     let color = io::stdout().is_terminal();
     println!("{}", paint(color, "90", &format!("› {prompt}")));
     println!();
     println!(
         "{} {}",
         paint(color, "90", "workspace"),
-        bundle.workspace_root.display()
+        startup.workspace_root.display()
     );
     println!(
         "{}  {}",
         paint(color, "90", "provider"),
-        paint(color, "96", &bundle.provider_label())
+        paint(color, "96", &model.provider_label())
     );
     println!(
         "{}     {}",
         paint(color, "90", "tools"),
-        bundle.tool_names.join(", ")
+        startup.tool_names.join(", ")
     );
     println!(
         "{}   {} ({}; {} prior event(s))",
         paint(color, "90", "session"),
-        bundle.session_id,
-        bundle.session_log_path.display(),
-        bundle.replayed_events,
+        handles.session_id,
+        startup.session_log_path.display(),
+        startup.replayed_events,
     );
-    if !bundle.capability_commands.is_empty() {
-        let names: Vec<String> = bundle
+    if !startup.capability_commands.is_empty() {
+        let names: Vec<String> = startup
             .capability_commands
             .iter()
             .map(|c| format!("/{}", c.name))
@@ -232,20 +235,20 @@ async fn run_print_mode(bundle: Arc<RuntimeBundle>, prompt: String) -> Result<()
     }
     println!();
 
-    let before_events = bundle.runtime.events().await.map(|e| e.len()).unwrap_or(0);
-    let before_msgs = bundle
+    let before_events = handles.runtime.events().await.map(|e| e.len()).unwrap_or(0);
+    let before_msgs = handles
         .runtime
-        .messages(bundle.session_id)
+        .messages(handles.session_id)
         .await
         .map(|m| m.len())
         .unwrap_or(0);
 
-    let input = bundle.input_message(prompt);
-    let result = bundle.runtime.run_turn(bundle.session_id, input).await?;
-    let events = bundle.runtime.events().await.unwrap_or_default();
-    let messages = bundle
+    let input = model.input_message(prompt);
+    let result = handles.runtime.run_turn(handles.session_id, input).await?;
+    let events = handles.runtime.events().await.unwrap_or_default();
+    let messages = handles
         .runtime
-        .messages(bundle.session_id)
+        .messages(handles.session_id)
         .await
         .unwrap_or_default();
 

--- a/examples/coding-cli/src/runtime.rs
+++ b/examples/coding-cli/src/runtime.rs
@@ -162,8 +162,8 @@ impl Capability for CodingBashCapability {
 //
 // Demonstrates the `Capability::execute_command` hook: `/model` lives entirely
 // outside the TUI's `handle_command` branches now. The capability owns the
-// runtime provider store and shares an Arc<RwLock<ProviderChoice>> with the
-// `RuntimeBundle` so the banner label stays in sync after a switch.
+// runtime provider store and shares provider state with the UI-facing
+// `ModelState` so the banner label stays in sync after a switch.
 
 pub(crate) const MODEL_SWITCHER_CAPABILITY_ID: &str = "coding_cli_model_switcher";
 
@@ -519,11 +519,21 @@ fn normalize_openai_reasoning_effort(reasoning_effort: Option<String>) -> Option
     )
 }
 
-// ---------- runtime bundle ----------
+// ---------- runtime wiring result ----------
 
-pub struct RuntimeBundle {
+pub struct BuiltRuntime {
+    pub handles: RuntimeHandles,
+    pub startup: StartupInfo,
+    pub model: ModelState,
+}
+
+#[derive(Clone)]
+pub struct RuntimeHandles {
     pub runtime: Arc<InProcessRuntime>,
     pub session_id: SessionId,
+}
+
+pub struct StartupInfo {
     pub workspace_root: PathBuf,
     pub tool_names: Vec<String>,
     /// Slash commands contributed by registered capabilities (via
@@ -538,13 +548,21 @@ pub struct RuntimeBundle {
     /// How many events were replayed from disk into the new session.
     /// Zero for fresh sessions; used by the startup banner.
     pub replayed_events: usize,
+}
+
+#[derive(Clone)]
+pub struct ModelState {
     /// Shared with [`ModelSwitcherCapability`] so a successful `/model`
     /// invocation through `runtime.execute_command` immediately updates the
     /// banner label.
     provider: Arc<RwLock<ProviderChoice>>,
 }
 
-impl RuntimeBundle {
+impl ModelState {
+    fn new(provider: Arc<RwLock<ProviderChoice>>) -> Self {
+        Self { provider }
+    }
+
     pub fn provider_label(&self) -> String {
         self.provider
             .read()
@@ -566,7 +584,7 @@ pub async fn build(
     gate: Arc<ApprovalGate>,
     resume_session_id: Option<SessionId>,
     session_storage_dir: PathBuf,
-) -> Result<RuntimeBundle> {
+) -> Result<BuiltRuntime> {
     let canonical_root = std::fs::canonicalize(&workspace_root)
         .with_context(|| format!("canonicalize workspace: {}", workspace_root.display()))?;
     let workspace = Workspace::new(canonical_root.clone());
@@ -609,8 +627,8 @@ pub async fn build(
     let backends = RuntimeBackends::in_memory()
         .with_event_bus(event_bus)
         .with_message_store(message_store);
-    // Shared between the bundle (for banner labels) and the
-    // ModelSwitcherCapability (which mutates it on a successful `/model`).
+    // Shared between `ModelState` (for banner labels) and
+    // `ModelSwitcherCapability` (which mutates it on a successful `/model`).
     let provider_state = Arc::new(RwLock::new(provider.clone()));
     let provider_store = backends.provider_store.clone();
 
@@ -749,15 +767,19 @@ pub async fn build(
         .collect();
     let capability_commands = runtime.list_commands(session_id).await?;
 
-    Ok(RuntimeBundle {
-        runtime: Arc::new(runtime),
-        session_id,
-        workspace_root: canonical_root,
-        tool_names,
-        capability_commands,
-        session_log_path: log_path,
-        replayed_events: replayed_events_count,
-        provider: provider_state,
+    Ok(BuiltRuntime {
+        handles: RuntimeHandles {
+            runtime: Arc::new(runtime),
+            session_id,
+        },
+        startup: StartupInfo {
+            workspace_root: canonical_root,
+            tool_names,
+            capability_commands,
+            session_log_path: log_path,
+            replayed_events: replayed_events_count,
+        },
+        model: ModelState::new(provider_state),
     })
 }
 


### PR DESCRIPTION
## What
Split the coding CLI runtime build result into focused app-facing pieces instead of passing a single `RuntimeBundle` through the TUI and print paths.

## Why
`RuntimeBundle` mixed execution handles, startup/banner metadata, command descriptors, and mutable model state. The model-selection command now lives behind capability command dispatch, so the CLI can keep those responsibilities separate.

## How
- Added `BuiltRuntime`, `RuntimeHandles`, `StartupInfo`, and `ModelState` in `examples/coding-cli/src/runtime.rs`.
- Updated the TUI to use runtime handles for turns/commands, startup info for banner/autocomplete metadata, and model state for provider label/input controls.
- Updated print mode to destructure the build result and preserve OpenAI reasoning controls through `ModelState::input_message`.

## Risk
- Low
- Example CLI wiring could regress provider display, `/model` discovery, print mode, or turn execution.

## Security
- Threat categories reviewed: TM-LLM, TM-TOOL, TM-DOS.
- Findings and resolutions: no new trust boundary, API key path, tool execution behavior, input parsing rule, or resource limit changed. This is an example-local refactor that preserves existing model controls and capability command dispatch.

## Follow-ups
No follow-ups.

## Validation
- `bash scripts/lib/check-migration-ordering.sh`
- `cargo fmt --manifest-path examples/coding-cli/Cargo.toml`
- `cargo check --manifest-path examples/coding-cli/Cargo.toml`
- `cargo test --manifest-path examples/coding-cli/Cargo.toml`
- `cargo clippy --manifest-path examples/coding-cli/Cargo.toml -- -D warnings`
- `cargo run --manifest-path examples/coding-cli/Cargo.toml -- --provider llmsim --print "Smoke test the split runtime wiring."`
- `just pre-push`
- GitHub CI for PR #1908

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)