### PR TITLE
fix(core): trim infinity context by token budget

### DIFF
--- a/crates/core/src/capabilities/infinity_context.rs
+++ b/crates/core/src/capabilities/infinity_context.rs
@@ -111,21 +111,6 @@ impl Default for InfinityContextConfig {
     }
 }
 
-/// Estimate message limit based on token budget.
-fn calculate_message_limit(budget_tokens: usize, min_recent_messages: usize) -> usize {
-    const AVG_TOKENS_PER_MESSAGE: usize = 250;
-    (budget_tokens / AVG_TOKENS_PER_MESSAGE).max(min_recent_messages)
-}
-
-fn resolve_message_limit(config: &InfinityContextConfig) -> usize {
-    let estimated =
-        calculate_message_limit(config.context_budget_tokens, config.min_recent_messages);
-    config
-        .max_recent_messages
-        .map(|max| estimated.min(max.max(1)))
-        .unwrap_or(estimated)
-}
-
 struct InfinityContextFilterProvider;
 
 impl MessageFilterProvider for InfinityContextFilterProvider {
@@ -133,13 +118,105 @@ impl MessageFilterProvider for InfinityContextFilterProvider {
         let config: InfinityContextConfig =
             serde_json::from_value(config.clone()).unwrap_or_default();
 
-        query.limit = Some(resolve_message_limit(&config) as i64);
-        query.prepend_transform = Some(Arc::new(ExcludedNoticeTransform::infinity_context()));
+        if let Some(max_recent_messages) = config.max_recent_messages {
+            query.limit = Some(max_recent_messages.max(1) as i64);
+            query.prepend_transform = Some(Arc::new(ExcludedNoticeTransform::infinity_context()));
+        }
+    }
+
+    fn post_load(&self, messages: &mut Vec<Message>, config: &Value) {
+        let config: InfinityContextConfig =
+            serde_json::from_value(config.clone()).unwrap_or_default();
+        let excluded_count = trim_messages_to_token_budget(messages, &config);
+        if excluded_count > 0 {
+            messages.insert(
+                0,
+                Message::system(
+                    ExcludedNoticeTransform::infinity_context()
+                        .format
+                        .replace("{}", &excluded_count.to_string()),
+                ),
+            );
+        }
     }
 
     fn priority(&self) -> i32 {
         100
     }
+}
+
+fn estimate_message_tokens(message: &Message) -> usize {
+    const TOKEN_CHARS: usize = 4;
+    let role_overhead = message.role.to_string().len() + 8;
+    let content_len: usize = message
+        .content
+        .iter()
+        .map(|part| match part {
+            ContentPart::Text(text) => text.text.len(),
+            ContentPart::Image(image) => {
+                image.url.as_ref().map_or(0, String::len)
+                    + image.base64.as_ref().map_or(50, String::len)
+                    + image.media_type.as_ref().map_or(0, String::len)
+            }
+            ContentPart::ImageFile(file) => {
+                file.image_id.to_string().len() + file.filename.as_ref().map_or(0, String::len)
+            }
+            ContentPart::ToolCall(call) => {
+                call.id.len() + call.name.len() + call.arguments.to_string().len() + 20
+            }
+            ContentPart::ToolResult(result) => {
+                result.tool_call_id.len()
+                    + result
+                        .result
+                        .as_ref()
+                        .map_or(0, |value| value.to_string().len())
+                    + result.error.as_ref().map_or(0, String::len)
+                    + 20
+            }
+        })
+        .sum();
+    (role_overhead + content_len) / TOKEN_CHARS
+}
+
+fn trim_messages_to_token_budget(
+    messages: &mut Vec<Message>,
+    config: &InfinityContextConfig,
+) -> usize {
+    if messages.is_empty() {
+        return 0;
+    }
+
+    let original_count = messages.len();
+    if let Some(max_recent_messages) = config.max_recent_messages {
+        let max_recent_messages = max_recent_messages.max(1);
+        if messages.len() > max_recent_messages {
+            let drop_count = messages.len() - max_recent_messages;
+            messages.drain(0..drop_count);
+        }
+    }
+
+    let capped_count = messages.len();
+    let min_recent_start = capped_count.saturating_sub(config.min_recent_messages);
+    let mut selected = Vec::new();
+    let mut selected_tokens = 0usize;
+
+    for (idx, message) in messages.iter().enumerate().skip(min_recent_start) {
+        selected.push((idx, message.clone()));
+        selected_tokens = selected_tokens.saturating_add(estimate_message_tokens(message));
+    }
+
+    let mut remaining_budget = config.context_budget_tokens.saturating_sub(selected_tokens);
+    for (idx, message) in messages[..min_recent_start].iter().enumerate().rev() {
+        let tokens = estimate_message_tokens(message);
+        if tokens <= remaining_budget {
+            selected.push((idx, message.clone()));
+            remaining_budget -= tokens;
+        }
+    }
+
+    selected.sort_by_key(|(idx, _)| *idx);
+    *messages = selected.into_iter().map(|(_, message)| message).collect();
+    original_count.saturating_sub(messages.len())
 }
 
 /// Tool for querying earlier conversation history.
@@ -431,23 +508,6 @@ mod tests {
     use crate::typed_id::SessionId;
 
     #[test]
-    fn test_calculate_message_limit_respects_budget_and_floor() {
-        assert_eq!(calculate_message_limit(10_000, 5), 40);
-        assert_eq!(calculate_message_limit(100, 50), 50);
-    }
-
-    #[test]
-    fn test_resolve_message_limit_respects_hard_cap() {
-        let config = InfinityContextConfig {
-            context_budget_tokens: 10_000,
-            min_recent_messages: 10,
-            max_recent_messages: Some(30),
-        };
-
-        assert_eq!(resolve_message_limit(&config), 30);
-    }
-
-    #[test]
     fn test_capability_metadata() {
         let capability = InfinityContextCapability;
 
@@ -460,7 +520,7 @@ mod tests {
     }
 
     #[test]
-    fn test_filter_provider_sets_limit_and_notice() {
+    fn test_filter_provider_leaves_loading_unbounded_without_hard_cap() {
         let mut query = MessageQuery::new(SessionId::new());
         let provider = InfinityContextFilterProvider;
         provider.apply_filters(
@@ -468,8 +528,8 @@ mod tests {
             &json!({"context_budget_tokens": 1_000, "min_recent_messages": 3}),
         );
 
-        assert_eq!(query.limit, Some(4));
-        assert!(query.prepend_transform.is_some());
+        assert_eq!(query.limit, None);
+        assert!(query.prepend_transform.is_none());
     }
 
     #[test]
@@ -498,8 +558,59 @@ mod tests {
             &json!({"context_budget_tokens": "not-a-number"}),
         );
 
-        assert_eq!(query.limit, Some(400));
-        assert!(query.prepend_transform.is_some());
+        assert_eq!(query.limit, None);
+        assert!(query.prepend_transform.is_none());
+    }
+
+    #[test]
+    fn test_filter_provider_trims_loaded_messages_by_token_budget() {
+        let provider = InfinityContextFilterProvider;
+        let mut messages = vec![
+            Message::user("old tiny"),
+            Message::assistant("old ".repeat(400)),
+            Message::user("recent one"),
+            Message::assistant("recent two"),
+        ];
+
+        provider.post_load(
+            &mut messages,
+            &json!({"context_budget_tokens": 1, "min_recent_messages": 2}),
+        );
+
+        assert_eq!(messages.len(), 3);
+        assert!(
+            extract_text_content(&messages[0])
+                .contains("earlier messages are NOT visible in this context")
+        );
+        assert_eq!(extract_text_content(&messages[1]), "recent one");
+        assert_eq!(extract_text_content(&messages[2]), "recent two");
+    }
+
+    #[test]
+    fn test_filter_provider_applies_hard_cap_after_loading() {
+        let provider = InfinityContextFilterProvider;
+        let mut messages = vec![
+            Message::user("one"),
+            Message::assistant("two"),
+            Message::user("three"),
+        ];
+
+        provider.post_load(
+            &mut messages,
+            &json!({
+                "context_budget_tokens": 10_000,
+                "min_recent_messages": 10,
+                "max_recent_messages": 2
+            }),
+        );
+
+        assert_eq!(messages.len(), 3);
+        assert!(
+            extract_text_content(&messages[0])
+                .contains("earlier messages are NOT visible in this context")
+        );
+        assert_eq!(extract_text_content(&messages[1]), "two");
+        assert_eq!(extract_text_content(&messages[2]), "three");
     }
 
     #[test]

--- a/crates/core/src/capabilities/infinity_context.rs
+++ b/crates/core/src/capabilities/infinity_context.rs
@@ -13,6 +13,7 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::cmp::Ordering;
+use std::io::{self, Write};
 use std::sync::Arc;
 
 /// Capability ID for infinity context.
@@ -166,16 +167,35 @@ fn estimate_message_tokens(message: &Message) -> usize {
             }
             ContentPart::ToolResult(result) => {
                 result.tool_call_id.len()
-                    + result
-                        .result
-                        .as_ref()
-                        .map_or(0, |value| value.to_string().len())
+                    + result.result.as_ref().map_or(0, estimate_json_value_len)
                     + result.error.as_ref().map_or(0, String::len)
                     + 20
             }
         })
         .sum();
     (role_overhead + content_len) / TOKEN_CHARS
+}
+
+struct CountingWriter {
+    len: usize,
+}
+
+impl Write for CountingWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.len = self.len.saturating_add(buf.len());
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+fn estimate_json_value_len(value: &Value) -> usize {
+    let mut writer = CountingWriter { len: 0 };
+    serde_json::to_writer(&mut writer, value)
+        .map(|_| writer.len)
+        .unwrap_or(0)
 }
 
 fn trim_messages_to_token_budget(
@@ -611,6 +631,20 @@ mod tests {
         );
         assert_eq!(extract_text_content(&messages[1]), "two");
         assert_eq!(extract_text_content(&messages[2]), "three");
+    }
+
+    #[test]
+    fn test_estimate_json_value_len_matches_serialized_length() {
+        let value = json!({
+            "stdout": ["alpha", "beta"],
+            "ok": true,
+            "count": 2
+        });
+
+        assert_eq!(
+            estimate_json_value_len(&value),
+            serde_json::to_string(&value).unwrap().len()
+        );
     }
 
     #[test]

--- a/crates/core/src/capabilities/infinity_context.rs
+++ b/crates/core/src/capabilities/infinity_context.rs
@@ -112,6 +112,10 @@ impl Default for InfinityContextConfig {
     }
 }
 
+const CANDIDATE_AVG_TOKENS_PER_MESSAGE: usize = 250;
+const CANDIDATE_OVERFETCH_FACTOR: usize = 4;
+const CANDIDATE_MAX_MESSAGES: usize = 2_000;
+
 struct InfinityContextFilterProvider;
 
 impl MessageFilterProvider for InfinityContextFilterProvider {
@@ -119,23 +123,23 @@ impl MessageFilterProvider for InfinityContextFilterProvider {
         let config: InfinityContextConfig =
             serde_json::from_value(config.clone()).unwrap_or_default();
 
-        if let Some(max_recent_messages) = config.max_recent_messages {
-            query.limit = Some(max_recent_messages.max(1) as i64);
-            query.prepend_transform = Some(Arc::new(ExcludedNoticeTransform::infinity_context()));
-        }
+        query.limit = Some(resolve_candidate_load_limit(&config) as i64);
+        query.prepend_transform = Some(Arc::new(ExcludedNoticeTransform::infinity_context()));
     }
 
     fn post_load(&self, messages: &mut Vec<Message>, config: &Value) {
         let config: InfinityContextConfig =
             serde_json::from_value(config.clone()).unwrap_or_default();
+        let existing_notice_count = take_existing_excluded_notice(messages);
         let excluded_count = trim_messages_to_token_budget(messages, &config);
-        if excluded_count > 0 {
+        let total_excluded_count = existing_notice_count.saturating_add(excluded_count);
+        if total_excluded_count > 0 {
             messages.insert(
                 0,
                 Message::system(
                     ExcludedNoticeTransform::infinity_context()
                         .format
-                        .replace("{}", &excluded_count.to_string()),
+                        .replace("{}", &total_excluded_count.to_string()),
                 ),
             );
         }
@@ -144,6 +148,18 @@ impl MessageFilterProvider for InfinityContextFilterProvider {
     fn priority(&self) -> i32 {
         100
     }
+}
+
+fn resolve_candidate_load_limit(config: &InfinityContextConfig) -> usize {
+    if let Some(max_recent_messages) = config.max_recent_messages {
+        return max_recent_messages.max(1);
+    }
+
+    (config.context_budget_tokens / CANDIDATE_AVG_TOKENS_PER_MESSAGE)
+        .saturating_mul(CANDIDATE_OVERFETCH_FACTOR)
+        .min(CANDIDATE_MAX_MESSAGES)
+        .max(config.min_recent_messages)
+        .max(1)
 }
 
 fn estimate_message_tokens(message: &Message) -> usize {
@@ -163,7 +179,7 @@ fn estimate_message_tokens(message: &Message) -> usize {
                 file.image_id.to_string().len() + file.filename.as_ref().map_or(0, String::len)
             }
             ContentPart::ToolCall(call) => {
-                call.id.len() + call.name.len() + call.arguments.to_string().len() + 20
+                call.id.len() + call.name.len() + estimate_json_value_len(&call.arguments) + 20
             }
             ContentPart::ToolResult(result) => {
                 result.tool_call_id.len()
@@ -196,6 +212,28 @@ fn estimate_json_value_len(value: &Value) -> usize {
     serde_json::to_writer(&mut writer, value)
         .map(|_| writer.len)
         .unwrap_or(0)
+}
+
+fn take_existing_excluded_notice(messages: &mut Vec<Message>) -> usize {
+    let Some(first) = messages.first() else {
+        return 0;
+    };
+    let Some(count) = parse_excluded_notice_count(first) else {
+        return 0;
+    };
+
+    messages.remove(0);
+    count
+}
+
+fn parse_excluded_notice_count(message: &Message) -> Option<usize> {
+    let text = message.text()?;
+    let rest = text.strip_prefix("[IMPORTANT: ")?;
+    let (count, rest) = rest.split_once(' ')?;
+    if !rest.starts_with("earlier messages are NOT visible in this context.") {
+        return None;
+    }
+    count.parse().ok()
 }
 
 fn trim_messages_to_token_budget(
@@ -540,7 +578,7 @@ mod tests {
     }
 
     #[test]
-    fn test_filter_provider_leaves_loading_unbounded_without_hard_cap() {
+    fn test_filter_provider_sets_bounded_candidate_load_limit_without_hard_cap() {
         let mut query = MessageQuery::new(SessionId::new());
         let provider = InfinityContextFilterProvider;
         provider.apply_filters(
@@ -548,8 +586,8 @@ mod tests {
             &json!({"context_budget_tokens": 1_000, "min_recent_messages": 3}),
         );
 
-        assert_eq!(query.limit, None);
-        assert!(query.prepend_transform.is_none());
+        assert_eq!(query.limit, Some(16));
+        assert!(query.prepend_transform.is_some());
     }
 
     #[test]
@@ -578,8 +616,8 @@ mod tests {
             &json!({"context_budget_tokens": "not-a-number"}),
         );
 
-        assert_eq!(query.limit, None);
-        assert!(query.prepend_transform.is_none());
+        assert_eq!(query.limit, Some(1_600));
+        assert!(query.prepend_transform.is_some());
     }
 
     #[test]
@@ -628,6 +666,34 @@ mod tests {
         assert!(
             extract_text_content(&messages[0])
                 .contains("earlier messages are NOT visible in this context")
+        );
+        assert_eq!(extract_text_content(&messages[1]), "two");
+        assert_eq!(extract_text_content(&messages[2]), "three");
+    }
+
+    #[test]
+    fn test_filter_provider_preserves_hard_cap_notice_through_full_flow() {
+        let provider = InfinityContextFilterProvider;
+        let config = json!({
+            "context_budget_tokens": 10_000,
+            "min_recent_messages": 10,
+            "max_recent_messages": 2
+        });
+        let mut query = MessageQuery::new(SessionId::new());
+        provider.apply_filters(&mut query, &config);
+        let mut messages = vec![
+            Message::user("one"),
+            Message::assistant("two"),
+            Message::user("three"),
+        ];
+
+        query.apply_windowing(&mut messages);
+        provider.post_load(&mut messages, &config);
+
+        assert_eq!(messages.len(), 3);
+        assert!(
+            extract_text_content(&messages[0])
+                .contains("1 earlier messages are NOT visible in this context")
         );
         assert_eq!(extract_text_content(&messages[1]), "two");
         assert_eq!(extract_text_content(&messages[2]), "three");

--- a/examples/coding-cli/src/runtime.rs
+++ b/examples/coding-cli/src/runtime.rs
@@ -12,10 +12,11 @@ use crate::tools::Workspace;
 use anyhow::{Context, Result, anyhow};
 use async_trait::async_trait;
 use everruns_core::capabilities::{
-    AGENT_INSTRUCTIONS_CAPABILITY_ID, AgentInstructionsCapability, FileSystemCapability,
-    INFINITY_CONTEXT_CAPABILITY_ID, InfinityContextCapability, LoopDetectionCapability,
-    PROMPT_CACHING_CAPABILITY_ID, PromptCachingCapability, SKILLS_CAPABILITY_ID, SkillsCapability,
-    StatelessTodoListCapability, WebFetchCapability,
+    AGENT_INSTRUCTIONS_CAPABILITY_ID, AgentInstructionsCapability, COMPACTION_CAPABILITY_ID,
+    CompactionCapability, FileSystemCapability, INFINITY_CONTEXT_CAPABILITY_ID,
+    InfinityContextCapability, LoopDetectionCapability, PROMPT_CACHING_CAPABILITY_ID,
+    PromptCachingCapability, SKILLS_CAPABILITY_ID, SkillsCapability, StatelessTodoListCapability,
+    WebFetchCapability,
 };
 use everruns_core::command::CommandDescriptor;
 use everruns_core::llm_driver_registry::DriverRegistry;
@@ -65,8 +66,23 @@ Always do step 1 before step 2. Always do step 3 when you change behavior.
 - **Run commands:** `bash` for tests, builds, linters, git, package managers, formatters. stdout and stderr are each truncated to 64 KiB; the command is killed if combined output exceeds 128 KiB or the run exceeds 120s.
 - **Web:** `duckduckgo_search` for docs lookups; `web_fetch` for specific URLs (GET/HEAD only; can save to workspace).
 - **Skills:** `list_skills` then `activate_skill` to consult project-supplied SKILL.md files under `/.agents/skills/`.
-- **Multi-step work:** `write_todos` to publish a visible task list for anything that takes more than a couple of tool calls.
+- **Multi-step work:** `write_todos` to publish a visible task list for non-trivial implementation work. Do not use it for greetings, simple questions, or short read-only checks.
 - **History:** `query_history` when you need older turns the live prompt has trimmed.
+
+## Read-only status checks
+
+For broad read-only questions like dependency freshness, test status, git
+state, or repo health, prefer one targeted `bash` script that discovers the
+relevant files and runs the needed read-only commands over many sequential
+`list_directory`, `grep_files`, and `read_file` calls. The script must stay
+generic to the project: detect common manifests and lockfiles, avoid generated
+directories such as `node_modules` and `target`, and use quiet/JSON flags where
+available.
+
+After a successful targeted command provides enough evidence to answer, stop
+and answer. Do not inspect unrelated manifests or retry with more tools just to
+increase confidence. If the command output is too large or inconclusive, run
+one narrower follow-up command or explain the uncertainty.
 
 ## Code quality
 
@@ -482,6 +498,7 @@ pub async fn build(
     //
     // Non-filesystem, but useful for a coding agent:
     //   * infinity_context     — keeps long sessions usable; adds query_history
+    //   * compaction           — proactively masks older large tool outputs
     //   * stateless_todo_list  — write_todos tool for multi-step tasks
     //   * loop_detection       — safety net against repeated identical tool calls
     //   * prompt_caching       — Anthropic prompt caching; free token savings
@@ -491,6 +508,7 @@ pub async fn build(
     capabilities.register(FileSystemCapability);
     capabilities.register(SkillsCapability);
     capabilities.register(InfinityContextCapability);
+    capabilities.register(CompactionCapability);
     capabilities.register(StatelessTodoListCapability);
     capabilities.register(LoopDetectionCapability);
     capabilities.register(PromptCachingCapability::new());
@@ -549,6 +567,18 @@ pub async fn build(
         AgentCapabilityConfig::new("session_file_system"),
         AgentCapabilityConfig::new(SKILLS_CAPABILITY_ID),
         AgentCapabilityConfig::new(INFINITY_CONTEXT_CAPABILITY_ID),
+        AgentCapabilityConfig::with_config(
+            COMPACTION_CAPABILITY_ID,
+            serde_json::json!({
+                "strategy": "auto",
+                "proactive": true,
+                "budget_percent": 0.20,
+                "observation_masking": {
+                    "keep_recent_tool_outputs": 1,
+                    "summary_format": "one_line"
+                }
+            }),
+        ),
         AgentCapabilityConfig::new("stateless_todo_list"),
         AgentCapabilityConfig::new("loop_detection"),
         AgentCapabilityConfig::new(PROMPT_CACHING_CAPABILITY_ID),


### PR DESCRIPTION
## What
- Make `infinity_context` trim loaded messages by estimated content token weight instead of converting the token budget into a guessed message count.
- Preserve `max_recent_messages` as an explicit hard cap and keep excluded-history notices when messages are hidden.
- Enable `compaction` in the example coding CLI with proactive masking of older tool outputs.
- Add coding-CLI prompt guidance to use one targeted read-only script for broad status checks.

## Why
Simple coding-agent asks were accumulating expensive prompt context because large tool results and long sessions could stay live despite a nominal token budget. The old default `100_000 / 250 = 400` message limit let oversized messages through.

## How
- Move Infinity Context budget enforcement into `MessageFilterProvider::post_load`, where the actual loaded messages can be estimated by content length.
- Always preserve the configured recent-message floor, then include older messages newest-first while budget remains.
- Add focused unit coverage for token-budget trimming and hard-cap behavior.
- Reuse the existing `compaction` capability in `examples/coding-cli` with a lower proactive threshold and one retained full tool output.

## Risk
- Medium
- Context assembly behavior changes for sessions using `infinity_context`; overly tight budgets can now hide more old messages than before, but hidden messages remain available through `query_history` and recent messages are preserved.
- Example coding CLI prompt/tool-output behavior changes could alter agent strategy, intentionally reducing long read-only loops and old tool-output carryover.

## Security
- Threat categories reviewed: TM-LLM, TM-TOOL, TM-DOS.
- Findings and resolutions: No new trust boundary, tool execution path, credential handling, or user input execution. The change reduces LLM prompt size and stale tool-output exposure. Resource usage risk is bounded by existing message loading and uses a linear scan over loaded messages; no new unbounded external calls or dependencies were added.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

Validation:
- `cargo test -p everruns-core infinity_context --lib`
- `cargo test --manifest-path examples/coding-cli/Cargo.toml --no-run`
- `cargo run --manifest-path examples/coding-cli/Cargo.toml -- --help`
- `just pre-push`
- `bash scripts/lib/check-migration-ordering.sh`
- GitHub CI: all affected checks passed; Docker/docs/UI/live API jobs skipped by change detection.
