### PR TITLE
ci: filter postgres integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
       docs: ${{ steps.core_filter.outputs.docs }}
       docs_notebooks: ${{ steps.core_filter.outputs.docs_notebooks }}
       docker: ${{ steps.core_filter.outputs.docker }}
+      postgres_integration: ${{ steps.core_filter.outputs.postgres_integration }}
       brave_search_integration: ${{ steps.core_filter.outputs.brave_search_integration }}
       duckduckgo_integration: ${{ steps.core_filter.outputs.duckduckgo_integration }}
       parallel_integration: ${{ steps.core_filter.outputs.parallel_integration }}
@@ -151,6 +152,24 @@ jobs:
               - '.dockerignore'
               - '.github/workflows/ci.yml'
               - '.github/workflows/docker-publish.yml'
+            # PostgreSQL integration tests cover the server persistence/API
+            # surface, durable engine stores, and provider live tests that
+            # currently run inside the same CI job. Keep this narrower than the
+            # general Rust filter so unrelated crates do not start PostgreSQL.
+            postgres_integration:
+              - 'crates/server/**'
+              - 'crates/durable/**'
+              - 'crates/core/**'
+              - 'crates/config/**'
+              - 'crates/session-sqldb/**'
+              - 'crates/llm-tests/**'
+              - 'crates/openai/**'
+              - 'crates/anthropic/**'
+              - 'crates/gemini/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'rust-toolchain.toml'
+              - '.github/workflows/ci.yml'
             brave_search_integration:
               - 'integrations/brave-search/**'
             duckduckgo_integration:
@@ -457,7 +476,7 @@ jobs:
     name: Integration Tests (PostgreSQL)
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true' && needs.changes.outputs.skip_slow_rust != 'true' && needs.changes.outputs.skip_postgres_integration != 'true'
+    if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.postgres_integration == 'true' && needs.changes.outputs.skip_slow_rust != 'true' && needs.changes.outputs.skip_postgres_integration != 'true'
     services:
       postgres:
         image: postgres:17-alpine
@@ -1199,7 +1218,7 @@ jobs:
           fi
 
           require_if_affected "ci:skip-slow-rust" "${{ needs.changes.outputs.skip_slow_rust }}" "$slow_rust_affected" "slow Rust, release-binary-dependent, OpenAPI, and SDK checks"
-          require_if_affected "ci:skip-postgres-integration" "${{ needs.changes.outputs.skip_postgres_integration }}" "${{ needs.changes.outputs.rust }}" "PostgreSQL integration tests"
+          require_if_affected "ci:skip-postgres-integration" "${{ needs.changes.outputs.skip_postgres_integration }}" "${{ needs.changes.outputs.postgres_integration }}" "PostgreSQL integration tests"
           require_if_affected "ci:skip-sdk-compat" "${{ needs.changes.outputs.skip_sdk_compat }}" "${{ needs.changes.outputs.sdk_compat }}" "SDK compatibility checks"
           require_if_affected "ci:skip-ui-e2e" "${{ needs.changes.outputs.skip_ui_e2e }}" "${{ needs.changes.outputs.ui }}" "UI Playwright smoke"
           require_if_affected "ci:skip-docs-notebooks" "${{ needs.changes.outputs.skip_docs_notebooks }}" "${{ needs.changes.outputs.docs_notebooks }}" "docs notebook execution"

--- a/specs/code-organization.md
+++ b/specs/code-organization.md
@@ -73,6 +73,10 @@ Tests are organized by dependency requirements and execution speed:
 | CLI E2E | `cli-e2e-test` | Server (DEV_MODE) | ~2min | `./scripts/cli-e2e-test.sh` |
 | LLM | (manual) | API keys | varies | `just test-llm` |
 
+`integration-test` is path-filtered in CI and runs when PostgreSQL-backed
+surfaces, provider live-test crates bundled into that job, workspace dependency
+files, the Rust toolchain pin, or the CI workflow itself change.
+
 ### Unit Tests (Pure)
 
 **Goal:** Fast feedback on logic errors without infrastructure.


### PR DESCRIPTION
## What
Add a dedicated `postgres_integration` path-filter output for the main PostgreSQL integration CI job and use it for both the job gate and the CI opt-out policy.

## Why
The PostgreSQL integration job previously ran for any Rust change through the broad `rust` filter. That made unrelated Rust-only changes start PostgreSQL and run the full DB-backed integration suite.

## How
The new filter covers the server persistence/API surface, durable engine, storage-adjacent shared crates, provider live-test crates currently bundled into the job, workspace dependency files, and the CI workflow itself. The test organization spec now documents that `integration-test` is path-filtered.

## Risk
- Low
- The main risk is an overly narrow path filter skipping PostgreSQL integration tests for a relevant change. The filter intentionally includes the workflow itself, workspace dependency files, and the crates directly covered by the job.

## Security
- Threat categories reviewed: CI/configuration surface; no runtime TM-* application categories touched.
- Findings and resolutions: no secrets, permissions, auth, SQL, tenant-boundary, or runtime request handling changed. The `ci:skip-postgres-integration` policy now keys off the same `postgres_integration` affected signal as the job, so opt-out enforcement remains aligned with the filtered check.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)
