### PR TITLE
fix(cli): hide assistant thinking in session logs

### DIFF
--- a/examples/coding-cli/src/app.rs
+++ b/examples/coding-cli/src/app.rs
@@ -692,7 +692,7 @@ pub fn lines_for_event(event: &RuntimeEvent) -> Vec<ChatLine> {
                 Vec::new()
             }
         }
-        EventData::OutputMessageCompleted(data) => thinking_lines_for_message(&data.message),
+        EventData::OutputMessageCompleted(_) => Vec::new(),
         EventData::ToolCompleted(data) => {
             if data.tool_name == "write_todos" {
                 return todo_lines_for_result(data);
@@ -726,24 +726,6 @@ pub fn lines_for_event(event: &RuntimeEvent) -> Vec<ChatLine> {
         }
         _ => Vec::new(),
     }
-}
-
-fn thinking_lines_for_message(message: &everruns_core::Message) -> Vec<ChatLine> {
-    if message.role != MessageRole::Agent || !message.has_tool_calls() {
-        return Vec::new();
-    }
-    message
-        .thinking
-        .as_deref()
-        .map(str::trim)
-        .filter(|thinking| !thinking.is_empty())
-        .map(|thinking| {
-            vec![ChatLine {
-                author: Author::Assistant,
-                text: thinking.to_string(),
-            }]
-        })
-        .unwrap_or_default()
 }
 
 pub fn status_for_event(event: &RuntimeEvent) -> Option<ActivityStatus> {
@@ -1730,7 +1712,7 @@ mod tests {
     }
 
     #[test]
-    fn lines_for_event_surfaces_output_message_thinking() {
+    fn lines_for_event_hides_output_message_thinking() {
         let mut message = everruns_core::Message::assistant_with_tools(
             "",
             vec![ToolCall {
@@ -1750,12 +1732,7 @@ mod tests {
 
         let lines = lines_for_event(&event);
 
-        assert_eq!(lines.len(), 1);
-        assert!(matches!(lines[0].author, Author::Assistant));
-        assert_eq!(
-            lines[0].text,
-            "**Inspecting package files**\n\nI should read the package manifest first."
-        );
+        assert!(lines.is_empty(), "thinking must not be rendered: {lines:?}");
     }
 
     #[test]

--- a/examples/coding-cli/src/session_log.rs
+++ b/examples/coding-cli/src/session_log.rs
@@ -19,6 +19,10 @@
 //   (`input.message`, `output.message.completed`, `tool.completed`).
 //   Streaming `*.delta` events have no replay value and would otherwise
 //   inflate the log O(n²) for long streamed responses.
+// * Assistant `thinking` / `thinking_signature` fields are stripped before
+//   JSONL persistence. The CLI keeps the live runtime event unchanged, but
+//   session logs are user-facing durable history and must not expose hidden
+//   model reasoning material.
 // * Replay rejects events whose `session_id` doesn't match the resumed
 //   session — guards against accidentally merging logs across sessions.
 // * On open, if the file does not end with `\n` (previous run crashed
@@ -43,7 +47,7 @@ use everruns_core::events::{
     Event, EventData, EventRequest, INPUT_MESSAGE, OUTPUT_MESSAGE_COMPLETED,
     OutputMessageCompletedData, TOOL_COMPLETED,
 };
-use everruns_core::message::{ContentPart, Message};
+use everruns_core::message::{ContentPart, Message, MessageRole};
 use everruns_core::tools::ToolResultImage;
 use everruns_core::traits::EventEmitter;
 use everruns_core::typed_id::EventId;
@@ -278,7 +282,8 @@ impl EventEmitter for JsonlEventEmitter {
         self.events.write().await.push(event.clone());
 
         if is_replay_relevant(&event.event_type) {
-            let line = serde_json::to_string(&event).map_err(|e| {
+            let persisted_event = event_for_session_log(&event);
+            let line = serde_json::to_string(&persisted_event).map_err(|e| {
                 AgentLoopError::config(format!("serialize event for session log: {e}"))
             })?;
             let mut file = self.file.lock().await;
@@ -288,6 +293,21 @@ impl EventEmitter for JsonlEventEmitter {
                 .map_err(|e| AgentLoopError::config(format!("flush session log: {e}")))?;
         }
         Ok(event)
+    }
+}
+
+fn event_for_session_log(event: &Event) -> Event {
+    let mut persisted = event.clone();
+    if let EventData::OutputMessageCompleted(data) = &mut persisted.data {
+        strip_hidden_thinking(&mut data.message);
+    }
+    persisted
+}
+
+fn strip_hidden_thinking(message: &mut Message) {
+    if message.role == MessageRole::Agent {
+        message.thinking = None;
+        message.thinking_signature = None;
     }
 }
 
@@ -358,7 +378,7 @@ fn tool_completed_to_message(data: everruns_core::events::ToolCompletedData) -> 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use everruns_core::events::{EventContext, InputMessageData};
+    use everruns_core::events::{EventContext, InputMessageData, OutputMessageCompletedData};
     use everruns_core::message::Message;
 
     fn input_event(session_id: SessionId, text: &str) -> Event {
@@ -419,5 +439,49 @@ mod tests {
         assert_eq!(collected.len(), 3, "seeded + 1 new");
         // New event sequence continues from start_sequence we opened with.
         assert_eq!(collected[2].sequence, Some(3));
+    }
+
+    #[tokio::test]
+    async fn output_message_thinking_is_not_written_to_session_log() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let session_id = SessionId::from_seed(4821);
+        let path = session_log_path(dir.path(), session_id);
+        let emitter = JsonlEventEmitter::open(&path, 1).expect("open");
+
+        let mut message = Message::assistant("I will inspect the files.");
+        message.thinking = Some("private model reasoning".to_string());
+        message.thinking_signature = Some("encrypted-thinking-token".to_string());
+        let req = EventRequest::new(
+            session_id,
+            EventContext::default(),
+            OutputMessageCompletedData::new(message),
+        );
+
+        emitter.emit(req).await.expect("emit");
+
+        let on_disk = std::fs::read_to_string(&path).expect("read");
+        assert!(
+            !on_disk.contains("private model reasoning"),
+            "session log must not persist assistant thinking: {on_disk}"
+        );
+        assert!(
+            !on_disk.contains("thinking_signature"),
+            "session log must not persist thinking signatures: {on_disk}"
+        );
+        let replayed = replay(&path, session_id).expect("replay");
+        let replayed_message = replayed.messages.first().expect("message replayed");
+        assert!(replayed_message.thinking.is_none());
+        assert!(replayed_message.thinking_signature.is_none());
+
+        let collected = emitter.collected_events().await;
+        match &collected[0].data {
+            EventData::OutputMessageCompleted(data) => {
+                assert_eq!(
+                    data.message.thinking.as_deref(),
+                    Some("private model reasoning")
+                );
+            }
+            other => panic!("unexpected event data: {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
## What
- Stop persisting assistant `thinking` and `thinking_signature` fields in coding CLI JSONL session logs.
- Stop rendering output-message thinking as visible assistant transcript lines in the coding CLI TUI.
- Add regression tests for session-log scrubbing and UI hiding behavior.

## Why
The inspected session log showed hidden assistant reasoning serialized into `output.message.completed.data.message.thinking`, and the TUI path could surface the same field as user-visible text during tool-call turns.

## How
- Persist a scrubbed clone of replay-relevant output-message events while keeping the live in-memory runtime event unchanged.
- Remove the TUI helper that converted `Message.thinking` into transcript lines.
- Cover the durable log and rendering paths with tests.

## Risk
- Low
- Could affect replay/debug visibility for hidden model reasoning in coding CLI logs, intentionally. Normal assistant messages, tool calls, tool results, and replay-relevant event structure remain unchanged.

## Security
- Threat categories reviewed: TM-LLM, TM-FS, TM-OBS, TM-DOS.
- Findings and resolutions: The diff touches model reasoning handling and local durable session logs. The prior behavior could expose hidden model reasoning in session JSONL and visible TUI output; this PR strips those fields before disk persistence and hides them in UI rendering. No new inputs, dependencies, auth paths, shell execution, or unbounded resource behavior were introduced.

## Validation
- `cargo fmt --check --package everruns-coding-cli`
- `cargo test -p everruns-coding-cli`
- `cargo clippy -p everruns-coding-cli --all-targets --all-features -- -D warnings`
- `cargo run -p everruns-coding-cli -- --provider llmsim --session-dir <tmpdir> -p "hi"`
- `just pre-push` (UI format/lint skipped by script because this worktree has no `node_modules`; Rust, migration, specs, and author checks passed.)
- Rebased onto latest `origin/main`; final pre-merge migration diff check found no migration changes on either side since merge base, and `bash scripts/lib/check-migration-ordering.sh` passed.
- GitHub checks passed: Build Check, CI Opt-Out Policy, Migration Immutability, CodeQL. Broad matrix jobs were skipped by repository change detection with no `ci:skip-*` labels present.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)
