### PR TITLE
feat(ercode): inject environment context

### DIFF
--- a/examples/coding-cli/README.md
+++ b/examples/coding-cli/README.md
@@ -16,6 +16,8 @@ depends on the public runtime crate the same way an external embedder would.
   `list_directory`, `grep_files`, `delete_file`, `stat_file`.
 - **Plus a custom `bash`** tool that runs `bash -lc` from the workspace root.
 - **Curated built-in capabilities** wired beyond filesystem:
+  - `environment_context` — injects the current workspace root, shell, local
+    date/timezone, and Git identity/branch into the model context.
   - `agent_instructions` — re-reads `AGENTS.md` every turn (live reload).
   - `skills` — discovers `SKILL.md` files under `/.agents/skills/{name}/`;
     exposes `list_skills` / `activate_skill`.

--- a/examples/coding-cli/README.md
+++ b/examples/coding-cli/README.md
@@ -15,9 +15,9 @@ depends on the public runtime crate the same way an external embedder would.
   on top of `RealDiskFileStore`: `read_file`, `write_file`, `edit_file`,
   `list_directory`, `grep_files`, `delete_file`, `stat_file`.
 - **Plus a custom `bash`** tool that runs `bash -lc` from the workspace root.
-- **Curated built-in capabilities** wired beyond filesystem:
-  - `environment_context` — injects the current workspace root, shell, local
-    date/timezone, and Git identity/branch into the model context.
+- **Curated built-in and CLI-owned capabilities** wired beyond filesystem:
+  - `coding_cli_environment_context` — CLI-owned context injection for the
+    current workspace root, shell, local date/timezone, and Git identity/branch.
   - `agent_instructions` — re-reads `AGENTS.md` every turn (live reload).
   - `skills` — discovers `SKILL.md` files under `/.agents/skills/{name}/`;
     exposes `list_skills` / `activate_skill`.

--- a/examples/coding-cli/src/capabilities.rs
+++ b/examples/coding-cli/src/capabilities.rs
@@ -8,14 +8,169 @@ use crate::approval::ApprovalGate;
 use crate::runtime::ProviderChoice;
 use crate::tools::{BashTool, Workspace};
 use async_trait::async_trait;
-use everruns_core::capabilities::{Capability, CapabilityStatus};
+use chrono::Local;
+use everruns_core::capabilities::{Capability, CapabilityStatus, SystemPromptContext};
 use everruns_core::command::{
     CommandArg, CommandDescriptor, CommandExecutionContext, CommandResult, CommandSource,
     ExecuteCommandRequest,
 };
 use everruns_core::tools::Tool;
 use everruns_runtime::RuntimeProviderStore;
+use std::path::{Path, PathBuf};
+use std::process::Command;
 use std::sync::{Arc, RwLock};
+
+// ---------- environment context ----------
+
+pub(crate) const ENVIRONMENT_CONTEXT_CAPABILITY_ID: &str = "coding_cli_environment_context";
+
+pub(crate) struct CodingCliEnvironmentCapability {
+    pub(crate) workspace_root: PathBuf,
+}
+
+#[async_trait]
+impl Capability for CodingCliEnvironmentCapability {
+    fn id(&self) -> &str {
+        ENVIRONMENT_CONTEXT_CAPABILITY_ID
+    }
+    fn name(&self) -> &str {
+        "Coding CLI Environment Context"
+    }
+    fn description(&self) -> &str {
+        "Adds current workspace, shell, date, timezone, and Git context to the prompt."
+    }
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+    fn category(&self) -> Option<&str> {
+        Some("Examples")
+    }
+    async fn system_prompt_contribution(&self, _ctx: &SystemPromptContext) -> Option<String> {
+        Some(render_environment_context(&EnvironmentContext::collect(
+            &self.workspace_root,
+        )))
+    }
+    fn system_prompt_preview(&self) -> Option<String> {
+        Some(render_environment_context(&EnvironmentContext::collect(
+            &self.workspace_root,
+        )))
+    }
+}
+
+#[derive(Debug)]
+struct EnvironmentContext {
+    cwd: String,
+    shell: String,
+    current_date: String,
+    timezone: String,
+    git_repo: Option<String>,
+    git_user: Option<String>,
+    git_email: Option<String>,
+    git_current_branch: Option<String>,
+}
+
+impl EnvironmentContext {
+    fn collect(workspace_root: &Path) -> Self {
+        Self {
+            cwd: workspace_root.display().to_string(),
+            shell: shell_name(),
+            current_date: Local::now().format("%Y-%m-%d").to_string(),
+            timezone: local_timezone(),
+            git_repo: git_output(workspace_root, &["config", "--get", "remote.origin.url"])
+                .or_else(|| git_output(workspace_root, &["rev-parse", "--show-toplevel"])),
+            git_user: git_output(workspace_root, &["config", "--get", "user.name"]),
+            git_email: git_output(workspace_root, &["config", "--get", "user.email"]),
+            git_current_branch: git_current_branch(workspace_root),
+        }
+    }
+}
+
+fn render_environment_context(context: &EnvironmentContext) -> String {
+    let mut out = String::new();
+    out.push_str("<environment_context>\n");
+    push_xml_field(&mut out, "cwd", &context.cwd);
+    push_xml_field(&mut out, "shell", &context.shell);
+    push_xml_field(&mut out, "current_date", &context.current_date);
+    push_xml_field(&mut out, "timezone", &context.timezone);
+    if let Some(value) = &context.git_repo {
+        push_xml_field(&mut out, "git_repo", value);
+    }
+    if let Some(value) = &context.git_user {
+        push_xml_field(&mut out, "git_user", value);
+    }
+    if let Some(value) = &context.git_email {
+        push_xml_field(&mut out, "git_email", value);
+    }
+    if let Some(value) = &context.git_current_branch {
+        push_xml_field(&mut out, "git_current_branch", value);
+    }
+    out.push_str("</environment_context>");
+    out
+}
+
+fn push_xml_field(out: &mut String, name: &str, value: &str) {
+    out.push_str("  <");
+    out.push_str(name);
+    out.push('>');
+    out.push_str(&xml_escape(value));
+    out.push_str("</");
+    out.push_str(name);
+    out.push_str(">\n");
+}
+
+fn xml_escape(value: &str) -> String {
+    value
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}
+
+fn shell_name() -> String {
+    std::env::var("SHELL")
+        .ok()
+        .and_then(|shell| {
+            Path::new(&shell)
+                .file_name()
+                .map(|name| name.to_string_lossy().to_string())
+        })
+        .filter(|shell| !shell.is_empty())
+        .unwrap_or_else(|| "sh".to_string())
+}
+
+fn local_timezone() -> String {
+    if let Ok(tz) = std::env::var("TZ")
+        && !tz.trim().is_empty()
+    {
+        return tz;
+    }
+    if let Ok(target) = std::fs::read_link("/etc/localtime") {
+        let target = target.to_string_lossy();
+        if let Some((_, timezone)) = target.split_once("/zoneinfo/") {
+            return timezone.to_string();
+        }
+    }
+    "local".to_string()
+}
+
+fn git_current_branch(workspace_root: &Path) -> Option<String> {
+    git_output(workspace_root, &["branch", "--show-current"])
+        .filter(|branch| !branch.is_empty())
+        .or_else(|| git_output(workspace_root, &["rev-parse", "--short", "HEAD"]))
+}
+
+fn git_output(workspace_root: &Path, args: &[&str]) -> Option<String> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(workspace_root)
+        .args(args)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let text = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    (!text.is_empty()).then_some(text)
+}
 
 // ---------- bash ----------
 
@@ -175,5 +330,40 @@ fn failed_result(message: String) -> CommandResult {
         message,
         error_code: None,
         error_fields: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn environment_context_renders_requested_fields() {
+        let rendered = render_environment_context(&EnvironmentContext {
+            cwd: "/repo".to_string(),
+            shell: "zsh".to_string(),
+            current_date: "2026-05-20".to_string(),
+            timezone: "America/Chicago".to_string(),
+            git_repo: Some("https://github.com/everruns/everruns.git".to_string()),
+            git_user: Some("Chal & Yi".to_string()),
+            git_email: Some("chalyi@example.com".to_string()),
+            git_current_branch: Some("feature<context>".to_string()),
+        });
+
+        assert!(rendered.starts_with("<environment_context>\n"));
+        assert!(rendered.contains("  <cwd>/repo</cwd>\n"));
+        assert!(rendered.contains("  <shell>zsh</shell>\n"));
+        assert!(rendered.contains("  <current_date>2026-05-20</current_date>\n"));
+        assert!(rendered.contains("  <timezone>America/Chicago</timezone>\n"));
+        assert!(
+            rendered.contains("  <git_repo>https://github.com/everruns/everruns.git</git_repo>\n")
+        );
+        assert!(rendered.contains("  <git_user>Chal &amp; Yi</git_user>\n"));
+        assert!(rendered.contains("  <git_email>chalyi@example.com</git_email>\n"));
+        assert!(
+            rendered
+                .contains("  <git_current_branch>feature&lt;context&gt;</git_current_branch>\n")
+        );
+        assert!(rendered.ends_with("</environment_context>"));
     }
 }

--- a/examples/coding-cli/src/capabilities.rs
+++ b/examples/coding-cli/src/capabilities.rs
@@ -25,7 +25,15 @@ use std::sync::{Arc, RwLock};
 pub(crate) const ENVIRONMENT_CONTEXT_CAPABILITY_ID: &str = "coding_cli_environment_context";
 
 pub(crate) struct CodingCliEnvironmentCapability {
-    pub(crate) workspace_root: PathBuf,
+    base: EnvironmentContextBase,
+}
+
+impl CodingCliEnvironmentCapability {
+    pub(crate) fn new(workspace_root: PathBuf) -> Self {
+        Self {
+            base: EnvironmentContextBase::collect(workspace_root),
+        }
+    }
 }
 
 #[async_trait]
@@ -46,14 +54,51 @@ impl Capability for CodingCliEnvironmentCapability {
         Some("Examples")
     }
     async fn system_prompt_contribution(&self, _ctx: &SystemPromptContext) -> Option<String> {
-        Some(render_environment_context(&EnvironmentContext::collect(
-            &self.workspace_root,
+        Some(render_environment_context(&EnvironmentContext::from_base(
+            &self.base,
         )))
     }
     fn system_prompt_preview(&self) -> Option<String> {
-        Some(render_environment_context(&EnvironmentContext::collect(
-            &self.workspace_root,
-        )))
+        Some(
+            "\
+<environment_context>
+  <cwd>/path/to/workspace</cwd>
+  <shell>zsh</shell>
+  <current_date>YYYY-MM-DD</current_date>
+  <timezone>Region/City</timezone>
+  <git_repo>git remote or workspace root</git_repo>
+  <git_user>Git user name</git_user>
+  <git_email>Git user email</git_email>
+  <git_current_branch>branch or short commit</git_current_branch>
+</environment_context>"
+                .to_string(),
+        )
+    }
+}
+
+#[derive(Debug)]
+struct EnvironmentContextBase {
+    cwd: String,
+    shell: String,
+    timezone: String,
+    git_repo: Option<String>,
+    git_user: Option<String>,
+    git_email: Option<String>,
+    workspace_root: PathBuf,
+}
+
+impl EnvironmentContextBase {
+    fn collect(workspace_root: PathBuf) -> Self {
+        Self {
+            cwd: workspace_root.display().to_string(),
+            shell: shell_name(),
+            timezone: local_timezone(),
+            git_repo: git_output(&workspace_root, &["config", "--get", "remote.origin.url"])
+                .or_else(|| git_output(&workspace_root, &["rev-parse", "--show-toplevel"])),
+            git_user: git_output(&workspace_root, &["config", "--get", "user.name"]),
+            git_email: git_output(&workspace_root, &["config", "--get", "user.email"]),
+            workspace_root,
+        }
     }
 }
 
@@ -70,17 +115,16 @@ struct EnvironmentContext {
 }
 
 impl EnvironmentContext {
-    fn collect(workspace_root: &Path) -> Self {
+    fn from_base(base: &EnvironmentContextBase) -> Self {
         Self {
-            cwd: workspace_root.display().to_string(),
-            shell: shell_name(),
+            cwd: base.cwd.clone(),
+            shell: base.shell.clone(),
             current_date: Local::now().format("%Y-%m-%d").to_string(),
-            timezone: local_timezone(),
-            git_repo: git_output(workspace_root, &["config", "--get", "remote.origin.url"])
-                .or_else(|| git_output(workspace_root, &["rev-parse", "--show-toplevel"])),
-            git_user: git_output(workspace_root, &["config", "--get", "user.name"]),
-            git_email: git_output(workspace_root, &["config", "--get", "user.email"]),
-            git_current_branch: git_current_branch(workspace_root),
+            timezone: base.timezone.clone(),
+            git_repo: base.git_repo.clone(),
+            git_user: base.git_user.clone(),
+            git_email: base.git_email.clone(),
+            git_current_branch: git_current_branch(&base.workspace_root),
         }
     }
 }
@@ -141,7 +185,7 @@ fn local_timezone() -> String {
     if let Ok(tz) = std::env::var("TZ")
         && !tz.trim().is_empty()
     {
-        return tz;
+        return tz.trim().to_string();
     }
     if let Ok(target) = std::fs::read_link("/etc/localtime") {
         let target = target.to_string_lossy();

--- a/examples/coding-cli/src/runtime.rs
+++ b/examples/coding-cli/src/runtime.rs
@@ -555,9 +555,7 @@ pub async fn build(
     capabilities.register(ToolOutputPersistenceCapability);
     capabilities.register(DuckDuckGoCapability);
     capabilities.register(WebFetchCapability::from_env());
-    capabilities.register(CodingCliEnvironmentCapability {
-        workspace_root: canonical_root.clone(),
-    });
+    capabilities.register(CodingCliEnvironmentCapability::new(canonical_root.clone()));
     // `/model` (below) is the example's capability-sourced slash command —
     // it implements `Capability::execute_command` end to end. We deliberately
     // do NOT register `BtwCapability` here: the server's `/btw` flow has its

--- a/examples/coding-cli/src/runtime.rs
+++ b/examples/coding-cli/src/runtime.rs
@@ -6,7 +6,8 @@
 
 use crate::approval::ApprovalGate;
 use crate::capabilities::{
-    CodingBashCapability, MODEL_SWITCHER_CAPABILITY_ID, ModelSwitcherCapability,
+    CodingBashCapability, CodingCliEnvironmentCapability, ENVIRONMENT_CONTEXT_CAPABILITY_ID,
+    MODEL_SWITCHER_CAPABILITY_ID, ModelSwitcherCapability,
 };
 use crate::tools::Workspace;
 use anyhow::{Context, Result, anyhow};
@@ -375,6 +376,7 @@ fn normalize_openai_reasoning_effort(reasoning_effort: Option<String>) -> Option
 
 fn coding_harness_capabilities() -> Vec<AgentCapabilityConfig> {
     vec![
+        AgentCapabilityConfig::new(ENVIRONMENT_CONTEXT_CAPABILITY_ID),
         // Pick up CLAUDE.md / .agents.md alongside AGENTS.md, live-reloaded.
         AgentCapabilityConfig::with_config(
             AGENT_INSTRUCTIONS_CAPABILITY_ID,
@@ -553,6 +555,9 @@ pub async fn build(
     capabilities.register(ToolOutputPersistenceCapability);
     capabilities.register(DuckDuckGoCapability);
     capabilities.register(WebFetchCapability::from_env());
+    capabilities.register(CodingCliEnvironmentCapability {
+        workspace_root: canonical_root.clone(),
+    });
     // `/model` (below) is the example's capability-sourced slash command —
     // it implements `Capability::execute_command` end to end. We deliberately
     // do NOT register `BtwCapability` here: the server's `/btw` flow has its


### PR DESCRIPTION
## What
Add an `environment_context` capability to the coding CLI example. It injects the current workspace root, shell, local date/timezone, and Git repo/user/email/branch into the model context.

## Why
`ercode` already runs tools from the configured workspace root, but the model did not see the concrete cwd. That made it easy for the agent to assume container paths like `/workspace` and waste tokens on failed discovery.

## How
- Add `CodingCliEnvironmentCapability` with a dynamic system prompt contribution.
- Register the capability in the default coding CLI harness.
- XML-escape dynamic values before prompt insertion.
- Document the capability in the coding CLI README.

## Risk
- Low
- The main risk is exposing local Git identity to the selected model provider. This is intentional for this change and limited to the local coding CLI prompt context.
- No filesystem or bash execution boundaries changed.

## Security
- Threat categories reviewed: TM-LLM, TM-FS, TM-BASH, TM-TOOL.
- Findings and resolutions: Dynamic prompt values are XML-escaped; Git commands use fixed argument lists through `git -C <workspace>` rather than shell interpolation; no new tools, auth paths, sandbox behavior, or write paths were added.

## Validation
- `cargo fmt --check -p everruns-coding-cli`
- `cargo test -p everruns-coding-cli`
- `cargo clippy -p everruns-coding-cli --all-targets -- -D warnings`
- `cargo run -p everruns-coding-cli -- --provider llmsim --session-dir "$tmpdir" -p "hi"`
- `just pre-push`
- GitHub PR checks passed; unrelated jobs were skipped by change detection and `CI Opt-Out Policy` passed.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)
