### PR TITLE
fix(events): persist llm generation events

### DIFF
--- a/crates/core/src/events.rs
+++ b/crates/core/src/events.rs
@@ -78,7 +78,6 @@ fn is_ephemeral_event_type(event_type: &str) -> bool {
         OUTPUT_MESSAGE_DELTA
             | REASON_THINKING_DELTA
             | TOOL_OUTPUT_DELTA
-            | LLM_GENERATION
             | VOICE_INPUT_TRANSCRIPT_DELTA
             | VOICE_OUTPUT_TRANSCRIPT_DELTA
     )
@@ -388,7 +387,7 @@ impl Event {
         self.event_type == INPUT_MESSAGE || self.event_type == OUTPUT_MESSAGE_COMPLETED
     }
 
-    /// Whether this event is ephemeral. Ephemeral events may be delivered to
+    /// Whether this event is ephemeral. Delta events may be delivered to
     /// listeners without ever being inserted into the `events` table, so any
     /// downstream storage that holds an FK to `events.id` must treat the
     /// reference as best-effort and skip it for ephemeral sources.
@@ -2452,9 +2451,9 @@ impl EventRequest {
         self
     }
 
-    /// Whether this event is ephemeral (high-frequency streaming data that
-    /// doesn't need durable storage). Ephemeral events are delivered via
-    /// pub/sub only — they skip PostgreSQL INSERT entirely.
+    /// Whether this event is ephemeral (high-frequency streaming deltas that
+    /// don't need durable storage). Delivery backends that support ephemeral
+    /// routing can publish these events without inserting them into PostgreSQL.
     ///
     /// The authoritative content lives in the corresponding "completed" event
     /// (e.g. `output.message.completed` has the full text), so missing a delta
@@ -2759,6 +2758,65 @@ mod tests {
 
         let event_data: EventData = data.into();
         assert_eq!(event_data.event_type(), LLM_GENERATION);
+    }
+
+    #[test]
+    fn test_llm_generation_is_durable_not_ephemeral() {
+        let session_id = SessionId::new();
+        let data = LlmGenerationData::success(
+            vec![Message::user("test")],
+            vec![],
+            Some("response".to_string()),
+            vec![],
+            "model".to_string(),
+            None,
+            None,
+            None,
+            None,
+        );
+
+        let request = EventRequest::new(session_id, EventContext::empty(), data);
+        assert!(!request.is_ephemeral());
+    }
+
+    #[test]
+    fn test_delta_events_are_ephemeral() {
+        let session_id = SessionId::new();
+        let turn_id = TurnId::new();
+
+        let output_delta = EventRequest::new(
+            session_id,
+            EventContext::empty(),
+            OutputMessageDeltaData {
+                turn_id,
+                delta: "hel".to_string(),
+                accumulated: "hel".to_string(),
+            },
+        );
+        assert!(output_delta.is_ephemeral());
+
+        let thinking_delta = EventRequest::new(
+            session_id,
+            EventContext::empty(),
+            ReasonThinkingDeltaData {
+                turn_id,
+                delta: "step".to_string(),
+                accumulated: "step".to_string(),
+            },
+        );
+        assert!(thinking_delta.is_ephemeral());
+
+        let tool_delta = EventRequest::new(
+            session_id,
+            EventContext::empty(),
+            ToolOutputDeltaData {
+                tool_call_id: "call_123".to_string(),
+                tool_name: "bash".to_string(),
+                delta: "line".to_string(),
+                stream: "stdout".to_string(),
+            },
+        );
+        assert!(tool_delta.is_ephemeral());
     }
 
     #[test]

--- a/crates/server/src/domains/budgets/service.rs
+++ b/crates/server/src/domains/budgets/service.rs
@@ -289,12 +289,10 @@ impl BudgetService {
         }
 
         let total_tokens = input_tokens + output_tokens;
-        // Ephemeral events (e.g. `llm.generation`) may not be persisted to the
-        // `events` table when the ephemeral-skip delivery path is active (NATS),
-        // so storing their id in `usage_journal.event_id` would violate the FK.
-        // The public id is still preserved via `source_type`/`source_id` for
-        // traceability — `event_id` is the durable FK reference only.
-        let event_id = (!event.is_ephemeral()).then(|| event.id.uuid());
+        // Only persisted events have a sequence allocated by the events table.
+        // Synthetic listener inputs preserve traceability via source_id but must
+        // not write an FK to usage_journal.event_id.
+        let event_id = event.sequence.map(|_| event.id.uuid());
         let journal = match self
             .db
             .create_usage_journal_entry(CreateUsageJournalRow {

--- a/crates/server/src/domains/budgets/tests.rs
+++ b/crates/server/src/domains/budgets/tests.rs
@@ -1186,17 +1186,15 @@ fn test_row_to_ledger_entry_dto() {
 }
 
 // ========================================================================
-// Listener: ephemeral llm.generation event journaling (regression: EVE-416)
+// Listener: unpersisted llm.generation event journaling (regression: EVE-416)
 // ========================================================================
 
 #[tokio::test]
-async fn test_llm_generation_listener_omits_event_id_for_ephemeral_events() {
-    // Regression for EVE-416: `llm.generation` is ephemeral and may skip the
-    // `events` table insert when NATS-backed delivery is active. The budget
-    // listener used to write `usage_journal.event_id = <ephemeral event id>`,
-    // which violated the FK on `events(id)`. The listener must now omit the
-    // FK reference for ephemeral source events while still journaling the
-    // generation. The public id is preserved via `source_type`/`source_id`.
+async fn test_llm_generation_listener_omits_event_id_for_unpersisted_events() {
+    // Regression for EVE-416: listener inputs without an events-table sequence
+    // do not have a durable FK target. The listener must omit the FK reference
+    // while still journaling the generation. The public id is preserved via
+    // `source_type`/`source_id`.
     let db = make_db();
     let svc = BudgetService::new(db.clone());
 
@@ -1232,10 +1230,7 @@ async fn test_llm_generation_listener_omits_event_id_for_ephemeral_events() {
     let event = Event::new(session_id, EventContext::empty(), data);
     let public_event_id = event.id.to_string();
 
-    assert!(
-        event.is_ephemeral(),
-        "llm.generation must remain ephemeral for this regression to apply"
-    );
+    assert!(event.sequence.is_none(), "test input must be unpersisted");
 
     svc.on_event(&event).await;
 
@@ -1257,7 +1252,7 @@ async fn test_llm_generation_listener_omits_event_id_for_ephemeral_events() {
 
     assert!(
         journal.event_id.is_none(),
-        "usage_journal.event_id must be NULL for ephemeral source events to avoid FK violation, got {:?}",
+        "usage_journal.event_id must be NULL for unpersisted source events to avoid FK violation, got {:?}",
         journal.event_id
     );
     assert_eq!(journal.kind, "llm_generation");

--- a/crates/server/src/services/event.rs
+++ b/crates/server/src/services/event.rs
@@ -4,9 +4,9 @@
 // This service is the central entry point for event ingestion from both
 // HTTP API and gRPC service.
 //
-// Decision: Ephemeral events (deltas, LLM generation) skip PostgreSQL
-// only when NATS-backed EventDelivery is active (NATS_URL set). Without
-// NATS, all events persist to PG as before — zero behavioral change.
+// Decision: Ephemeral delta events skip PostgreSQL only when NATS-backed
+// EventDelivery is active (NATS_URL set). Without NATS, all events persist
+// to PG as before — zero behavioral change.
 // Durable events always go to PG AND EventDelivery.
 // SSE streams subscribe to EventDelivery instead of polling PG.
 //
@@ -137,7 +137,7 @@ impl EventService {
     /// Emit a typed event request.
     ///
     /// Routing:
-    /// - **Ephemeral** events (deltas, LLM generation) when NATS is active:
+    /// - **Ephemeral** delta events when NATS is active:
     ///   published to EventDelivery only. No PG write, no sequence allocation.
     /// - **All events** when NATS is not active (InMemory mode): stored in PG
     ///   as before. No behavioral change without explicit NATS opt-in.
@@ -151,7 +151,7 @@ impl EventService {
         self.attach_agent_version_metadata(&mut request).await;
         Self::validate_event_type_consistency(&request)?;
 
-        // Only skip PG for ephemeral events when the delivery backend supports it
+        // Only skip PG for delta events when the delivery backend supports it
         // (NATS provides durable pub/sub with replay). InMemory mode persists
         // everything to PG — zero behavioral change without NATS_URL.
         if request.is_ephemeral() && self.event_delivery.supports_ephemeral_skip() {
@@ -283,7 +283,7 @@ impl EventService {
     }
 
     /// Emit a batch of typed event requests.
-    /// Ephemeral events skip PG only when NATS is active; otherwise all go to PG.
+    /// Ephemeral delta events skip PG only when NATS is active; otherwise all go to PG.
     /// Returns the count of successfully processed events.
     ///
     /// # Errors

--- a/crates/server/tests/workflow_test.rs
+++ b/crates/server/tests/workflow_test.rs
@@ -4015,7 +4015,7 @@ async fn test_agent_execution_multiple_tool_calls() {
 /// This test verifies that:
 /// 1. `output.message.started` event is emitted when LLM starts generating (durable, persisted)
 /// 2. `output.message.delta` events are ephemeral (may not appear in PG events list)
-/// 3. `llm.generation` events are ephemeral (may not appear in PG events list)
+/// 3. `llm.generation` events are durable and appear in PG events list
 ///
 /// Note: This test uses LlmSim which simulates streaming but does not produce
 /// extended thinking events (reason.thinking.delta, reason.thinking.completed).
@@ -4302,14 +4302,14 @@ async fn test_streaming_events_emitted() {
     );
 
     // Check for llm.generation event with time_to_first_token_ms
-    // Note: llm.generation is ephemeral (skip PG persistence). May be absent from PG events.
     let llm_events: Vec<_> = events
         .iter()
         .filter(|e| e["type"] == "llm.generation")
         .collect();
-    println!(
-        "Found {} llm.generation events (ephemeral — may be 0 in PG)",
-        llm_events.len()
+    println!("Found {} llm.generation events", llm_events.len());
+    assert!(
+        !llm_events.is_empty(),
+        "Expected at least one durable llm.generation event"
     );
 
     if let Some(llm_event) = llm_events.first() {

--- a/specs/architecture.md
+++ b/specs/architecture.md
@@ -54,10 +54,10 @@ Events are classified as **ephemeral** or **durable**:
 
 | Category | Examples | Storage | Delivery |
 |---|---|---|---|
-| Ephemeral | `output.message.delta`, `reason.thinking.delta`, `tool.output.delta`, `llm.generation` | None (skip PG) | EventDelivery only |
-| Durable | `output.message.completed`, `turn.started`, `tool.completed` | PostgreSQL | PG + EventDelivery |
+| Ephemeral | `output.message.delta`, `reason.thinking.delta`, `tool.output.delta` | EventDelivery-only when the backend supports ephemeral skip; otherwise PostgreSQL + EventDelivery | EventDelivery only |
+| Durable | `llm.generation`, `output.message.completed`, `turn.started`, `tool.completed` | PostgreSQL | PG + EventDelivery |
 
-`EventService.emit()` routes automatically based on `EventRequest::is_ephemeral()`. Ephemeral events (~80% of volume) never hit PostgreSQL, reducing write pressure significantly. SSE reconnection replays durable events from PG; missed deltas are acceptable since the completed event has the full content.
+`EventService.emit()` routes automatically based on `EventRequest::is_ephemeral()`. With NATS-backed delivery, ephemeral delta events skip PostgreSQL, reducing write pressure significantly. In-memory dev delivery still persists events to PG. SSE reconnection replays durable events from PG; missed deltas are acceptable since the completed event has the full content.
 
 Durable events and usage rows can also feed asynchronous analytical projections
 for built-in reporting. Reporting is not part of the hot event delivery path;

--- a/specs/events.md
+++ b/specs/events.md
@@ -1328,7 +1328,7 @@ Both the SSE (`/v1/sessions/{id}/sse`) and JSON (`/v1/sessions/{id}/events`) end
 
 **Examples:**
 - Only turn lifecycle: `?types=turn.started&types=turn.completed`
-- Everything except deltas: `?exclude=output.message.delta&exclude=reason.thinking.delta`
+- Everything except deltas: `?exclude=output.message.delta&exclude=reason.thinking.delta&exclude=tool.output.delta&exclude=voice.input_transcript.delta&exclude=voice.output_transcript.delta`
 - Turn events but not failures: `?types=turn.started&types=turn.completed&types=turn.failed&exclude=turn.failed`
 
 **Validation:**


### PR DESCRIPTION
## What
Persist `llm.generation` events durably instead of treating them as ephemeral. Delta events remain ephemeral and continue to skip PostgreSQL when NATS-backed event delivery supports that path.

## Why
Session exports and event history should include the full LLM generation record for audit/replay and Codex-style session comparison. Previously these records could be delivered live but skipped durable storage.

## How
- Removed `llm.generation` from the shared ephemeral event classifier.
- Kept output, thinking, tool-output, and voice transcript deltas ephemeral.
- Updated the budget listener to treat only events with an allocated event-table sequence as safe FK targets.
- Updated workflow expectations and architecture/event specs.
- Added focused tests for durable `llm.generation` and ephemeral delta behavior.

## Risk
- Medium
- More `llm.generation` data is retained in the durable events table, increasing event storage volume and export surface. Existing org-scoped event access controls still apply.
- Budget journaling could regress if listener-only synthetic events wrote invalid event FKs; covered by the updated listener test.

## Security
- Threat categories reviewed: TM-OBS, TM-TENANT, TM-DOS.
- Findings and resolutions:
  - TM-OBS: Durable `llm.generation` increases retained observability data. This is intentional for session record fidelity; access remains through existing org-scoped event APIs, and plaintext event retention risk is already tracked in the threat model.
  - TM-TENANT: No new endpoint or authorization path. Existing session/event org scoping remains unchanged.
  - TM-DOS: Event write volume increases by one durable event per LLM call. High-frequency delta events still skip PG, preserving the main write-pressure mitigation.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

## Validation
- `bash scripts/lib/check-migration-ordering.sh`
- `cargo fmt --check`
- `cargo test -p everruns-core test_llm_generation_is_durable_not_ephemeral`
- `cargo test -p everruns-core test_delta_events_are_ephemeral`
- `cargo test -p everruns-server test_llm_generation_listener_omits_event_id_for_unpersisted_events`
- Smoke: `just start-dev --no-watch`, then API-created LlmSim session produced `llm.generation=1`, `output.message.delta=1`, `output.message.completed=1`
- `just pre-push`
