### PR TITLE
docs(crates): prepare published packages

### DIFF
--- a/crates/a2ui/Cargo.toml
+++ b/crates/a2ui/Cargo.toml
@@ -16,6 +16,7 @@ homepage.workspace = true
 repository.workspace = true
 documentation = "https://docs.rs/everruns-a2ui"
 description = "A2UI component catalog and prompt generator for Everruns"
+readme = "README.md"
 
 [dependencies]
 

--- a/crates/a2ui/README.md
+++ b/crates/a2ui/README.md
@@ -1,0 +1,33 @@
+# everruns-a2ui
+
+A2UI component catalog and prompt generation for Everruns generative UI.
+
+This crate is part of the [Everruns](https://everruns.com) ecosystem. It gives
+LLMs a compact catalog of A2UI JSON components and rules for emitting `a2ui`
+fenced blocks that Everruns clients can render.
+
+## Quick Example
+
+```rust
+use everruns_a2ui::{PromptOptions, default_catalog, generate_prompt};
+
+let prompt = generate_prompt(
+    default_catalog(),
+    &PromptOptions {
+        additional_rules: vec!["Use action buttons only for clear next steps.".into()],
+        ..PromptOptions::default()
+    },
+);
+
+assert!(prompt.contains("```a2ui"));
+```
+
+## What It Provides
+
+- A default A2UI catalog
+- Prompt generation for JSON component trees
+- Component and prop metadata for renderer-compatible output
+
+## License
+
+MIT. See the repository-level `LICENSE` file.

--- a/crates/a2ui/src/lib.rs
+++ b/crates/a2ui/src/lib.rs
@@ -1,11 +1,22 @@
-//! A2UI Component Catalog and Prompt Generator
+//! A2UI component catalog and prompt generator for Everruns.
 //!
 //! Produces system prompts that instruct LLMs to emit A2UI JSON component trees.
 //! The JSON is transported in ```a2ui fenced code blocks and rendered by the UI
 //! using native shadcn/ui primitives.
 //!
+//! This crate is part of the [Everruns](https://everruns.com) ecosystem.
+//!
+//! # Example
+//!
+//! ```
+//! use everruns_a2ui::{PromptOptions, default_catalog, generate_prompt};
+//!
+//! let prompt = generate_prompt(default_catalog(), &PromptOptions::default());
+//! assert!(prompt.contains("```a2ui"));
+//! ```
+//!
 //! Ref: specs/a2ui.md
-//! Ref: https://github.com/google/a2ui
+//! Ref: <https://github.com/google/a2ui>
 
 mod catalog;
 mod components;

--- a/crates/anthropic/Cargo.toml
+++ b/crates/anthropic/Cargo.toml
@@ -12,6 +12,7 @@ homepage.workspace = true
 repository.workspace = true
 documentation = "https://docs.rs/everruns-anthropic"
 description = "Anthropic Claude provider implementation for Everruns"
+readme = "README.md"
 
 [dependencies]
 # Core dependencies

--- a/crates/anthropic/README.md
+++ b/crates/anthropic/README.md
@@ -1,0 +1,32 @@
+# everruns-anthropic
+
+Anthropic Claude LLM provider implementation for Everruns.
+
+This crate is part of the [Everruns](https://everruns.com) ecosystem. It
+registers an Anthropic driver with `everruns-core` so the same agent loop can
+run against Claude models through the provider-neutral Everruns driver trait.
+
+## Quick Example
+
+```rust
+use everruns_anthropic::{AnthropicLlmDriver, register_driver};
+use everruns_core::DriverRegistry;
+
+let driver = AnthropicLlmDriver::new("your-api-key");
+
+let mut registry = DriverRegistry::new();
+register_driver(&mut registry);
+
+assert!(format!("{driver:?}").contains("AnthropicLlmDriver"));
+```
+
+## What It Provides
+
+- Claude Messages API streaming
+- Registration into the Everruns `DriverRegistry`
+- Provider-specific error mapping into Everruns runtime errors
+- Support for provider-neutral messages, tools, and reasoning metadata
+
+## License
+
+MIT. See the repository-level `LICENSE` file.

--- a/crates/anthropic/src/lib.rs
+++ b/crates/anthropic/src/lib.rs
@@ -1,12 +1,26 @@
-// Anthropic Driver Implementation
-//
-// This crate provides an Anthropic Claude LLM driver implementation.
-// It implements the LlmDriver trait from everruns-core, enabling
-// the agent loop to communicate with Anthropic's Messages API.
-//
-// Design: This crate depends on everruns-core and registers its driver
-// at application startup via register_driver(). This enables dependency
-// inversion - core has no knowledge of specific provider implementations.
+//! Anthropic Claude provider driver for Everruns.
+//!
+//! `everruns-anthropic` is part of the [Everruns](https://everruns.com)
+//! ecosystem. It implements the [`LlmDriver`] contract from `everruns-core` and
+//! registers Anthropic's Messages API driver into a [`DriverRegistry`].
+//!
+//! Provider crates depend on `everruns-core`; `everruns-core` does not depend on
+//! provider implementations. Hosts register whichever drivers they want to make
+//! available.
+//!
+//! # Example
+//!
+//! ```
+//! use everruns_anthropic::{AnthropicLlmDriver, register_driver};
+//! use everruns_core::DriverRegistry;
+//!
+//! let driver = AnthropicLlmDriver::new("your-api-key");
+//!
+//! let mut registry = DriverRegistry::new();
+//! register_driver(&mut registry);
+//!
+//! assert!(format!("{driver:?}").contains("AnthropicLlmDriver"));
+//! ```
 
 mod driver;
 

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -14,6 +14,7 @@ homepage.workspace = true
 repository.workspace = true
 documentation = "https://docs.rs/everruns-config"
 description = "Shared configuration loading helpers for Everruns"
+readme = "README.md"
 
 [dependencies]
 thiserror.workspace = true

--- a/crates/config/README.md
+++ b/crates/config/README.md
@@ -1,0 +1,34 @@
+# everruns-config
+
+Small configuration helpers shared across the Everruns Rust crates.
+
+This crate is part of the [Everruns](https://everruns.com) ecosystem. It keeps
+environment-variable parsing consistent for services, workers, integrations,
+and embedders without pulling in the larger runtime crates.
+
+## Quick Example
+
+```rust
+use std::time::Duration;
+
+use everruns_config::{env_bool, env_duration_secs, env_required, env_string};
+
+let bind_addr = env_string("EVERRUNS_BIND_ADDR", "127.0.0.1:8080");
+let allow_dev = env_bool("EVERRUNS_ALLOW_DEV", false);
+let timeout = env_duration_secs("EVERRUNS_REQUEST_TIMEOUT_SECS", Duration::from_secs(30));
+let database_url: String = env_required("DATABASE_URL")?;
+
+println!("{bind_addr} {allow_dev} {timeout:?} {database_url}");
+# Ok::<(), everruns_config::ConfigError>(())
+```
+
+## What It Provides
+
+- Optional and required env-var readers
+- Typed parsing with default values
+- Duration helpers for seconds and milliseconds
+- A shared `ConfigError` type for missing or invalid required values
+
+## License
+
+MIT. See the repository-level `LICENSE` file.

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1,12 +1,34 @@
-// Shared configuration helpers
-//
-// Decision: Helper functions over traits — configs are too heterogeneous for a
-// single trait to add value. Composable functions give the same deduplication
-// with zero abstraction overhead.
-//
-// Decision: No derive macro — the complexity of a proc macro isn't justified
-// for ~49 structs with varying patterns. Plain functions are transparent and
-// easy to audit.
+//! Shared configuration helpers for Everruns crates.
+//!
+//! `everruns-config` is a small leaf crate in the
+//! [Everruns](https://everruns.com) ecosystem. It centralizes common
+//! environment-variable loading patterns so services, workers, integrations,
+//! and embedding hosts parse configuration the same way.
+//!
+//! The API is intentionally function-based. Config structs across Everruns are
+//! heterogeneous, so composable helpers are clearer than a shared trait or
+//! derive macro.
+//!
+//! # Example
+//!
+//! ```
+//! use std::time::Duration;
+//!
+//! use everruns_config::{env_bool, env_duration_secs, env_or, env_string};
+//!
+//! let port = env_or("EVERRUNS_CONFIG_DOC_TEST_PORT", 8080_u16);
+//! let bind_addr = env_string("EVERRUNS_CONFIG_DOC_TEST_BIND_ADDR", "127.0.0.1");
+//! let enabled = env_bool("EVERRUNS_CONFIG_DOC_TEST_FEATURE_ENABLED", false);
+//! let timeout = env_duration_secs(
+//!     "EVERRUNS_CONFIG_DOC_TEST_TIMEOUT_SECS",
+//!     Duration::from_secs(30),
+//! );
+//!
+//! assert_eq!(port, 8080);
+//! assert_eq!(bind_addr, "127.0.0.1");
+//! assert!(!enabled);
+//! assert_eq!(timeout, Duration::from_secs(30));
+//! ```
 
 mod env;
 mod error;

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -15,6 +15,7 @@ homepage.workspace = true
 repository.workspace = true
 documentation = "https://docs.rs/everruns-core"
 description = "Core agent abstractions for Everruns - agent loop, events, tools, LLM providers"
+readme = "README.md"
 
 [dependencies]
 # Core dependencies

--- a/crates/core/README.md
+++ b/crates/core/README.md
@@ -1,0 +1,36 @@
+# everruns-core
+
+Core agent abstractions for Everruns: agents, sessions, events, tools,
+capabilities, LLM driver traits, runtime context assembly, and shared domain
+types.
+
+This crate is part of the [Everruns](https://everruns.com) ecosystem. Provider
+crates such as `everruns-openai` and host crates such as `everruns-runtime`
+build on these contracts instead of depending on server internals.
+
+## Quick Example
+
+```rust
+use everruns_core::{CapabilityRegistry, DriverRegistry, PlatformDefinition};
+use everruns_core::capabilities::TestMathCapability;
+
+let mut capabilities = CapabilityRegistry::new();
+capabilities.register(TestMathCapability);
+
+let drivers = DriverRegistry::new();
+let platform = PlatformDefinition::new(capabilities, drivers);
+
+assert!(platform.capability_registry().get("test_math").is_some());
+```
+
+## What It Provides
+
+- Agent, harness, session, message, event, and typed ID models
+- Capability and tool traits
+- LLM driver registry and provider-neutral message types
+- Context assembly used by embedded, worker, and server execution paths
+- In-memory helpers and deterministic LLM simulation for tests
+
+## License
+
+MIT. See the repository-level `LICENSE` file.

--- a/crates/core/src/capability_dto.rs
+++ b/crates/core/src/capability_dto.rs
@@ -72,6 +72,7 @@ pub struct CapabilityInfo {
     /// Number of active harnesses referencing this capability in the org.
     #[serde(default, skip_serializing_if = "is_zero_u64")]
     pub harness_count: u64,
+    #[allow(rustdoc::bare_urls)]
     /// Slug under https://dev.everruns.com/capabilities/ when public docs exist.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub docs_slug: Option<String>,
@@ -87,6 +88,7 @@ fn is_zero_u64(v: &u64) -> bool {
     *v == 0
 }
 
+#[allow(rustdoc::bare_urls)]
 /// Mapping from built-in capability ID to its docs slug under
 /// https://dev.everruns.com/capabilities/. Returns None for IDs that
 /// have no published documentation page.

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,20 +1,35 @@
-// Agent Loop Abstraction
-//
-// This crate provides a DB-agnostic, streamable, and decomposable implementation
-// of an agentic loop (LLM call → tool execution → repeat).
-
-//
-// Key design decisions:
-// - Uses traits (MessageRetriever, ToolExecutor) for pluggable backends
-// - MessageRetriever is retrieval-only; messages are stored via EventEmitter
-// - Can be decomposed into steps for durable activity execution
-// - Configuration via RuntimeAgent (can be built from Agent entity or created directly)
-// - Tools are defined via a Tool trait for flexibility (function-style tools)
-// - ToolRegistry implements ToolExecutor for easy tool management
-// - Error handling distinguishes between user-visible and internal errors
-// - Capabilities provide modular functionality units for composing agent behavior
-// - Domain entity types (Agent, Session, LlmProvider, etc.) are defined here
-// - Tool types are defined here as runtime types
+//! Core agent abstractions for Everruns.
+//!
+//! `everruns-core` is the shared contract crate for the
+//! [Everruns](https://everruns.com) ecosystem. It defines the runtime-facing
+//! types used by embedded hosts, workers, provider drivers, integrations, and
+//! the control plane.
+//!
+//! The crate is deliberately storage-agnostic. Agent execution is expressed in
+//! terms of traits such as [`MessageRetriever`], [`ToolExecutor`],
+//! [`EventEmitter`], and [`LlmProviderStore`], while host crates decide whether
+//! those traits are backed by memory, PostgreSQL, gRPC, or another system.
+//!
+//! # Main Surfaces
+//!
+//! - Agent, harness, session, message, event, and typed ID models
+//! - Capability and tool traits for composing agent behavior
+//! - Provider-neutral LLM messages, streams, and driver registration
+//! - Context assembly for the shared `input -> reason -> act` execution flow
+//! - In-memory helpers and `llmsim` for deterministic tests and examples
+//!
+//! # Example
+//!
+//! ```ignore
+//! use everruns_core::{CapabilityRegistry, DriverRegistry, PlatformDefinition};
+//! use everruns_core::capabilities::TestMathCapability;
+//!
+//! let mut capabilities = CapabilityRegistry::new();
+//! capabilities.register(TestMathCapability);
+//!
+//! let platform = PlatformDefinition::new(capabilities, DriverRegistry::new());
+//! assert!(platform.capability_registry().get("test_math").is_some());
+//! ```
 
 // Runtime types (tool definitions, capability types)
 pub mod capability_types;

--- a/crates/core/src/llm_driver_registry.rs
+++ b/crates/core/src/llm_driver_registry.rs
@@ -304,7 +304,7 @@ impl LlmMessage {
 
     /// Prepend a prefix to the first text content.
     ///
-    /// Used by ReasonAtom to inject external actor identity (e.g. "[Alice] ")
+    /// Used by ReasonAtom to inject external actor identity (e.g. `"[Alice] "`)
     /// into user messages from external channels.
     pub fn prepend_text_prefix(&mut self, prefix: &str) {
         match &mut self.content {

--- a/crates/core/src/mcp_server.rs
+++ b/crates/core/src/mcp_server.rs
@@ -261,7 +261,7 @@ pub struct McpToolDefinition {
     #[serde(rename = "inputSchema")]
     pub input_schema: Value,
     /// MCP tool annotations (behavioral hints).
-    /// See: https://spec.modelcontextprotocol.io
+    /// See: <https://spec.modelcontextprotocol.io>
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub annotations: Option<McpToolAnnotations>,
 }

--- a/crates/core/src/outline.rs
+++ b/crates/core/src/outline.rs
@@ -17,7 +17,7 @@ pub struct OutlineItem {
     pub kind: &'static str,
     /// Name of the declaration
     pub name: String,
-    /// Full signature text (e.g. "fn process(input: &Input) -> Result<Output>")
+    /// Full signature text (e.g. `"fn process(input: &Input) -> Result<Output>"`)
     pub signature: String,
     /// 1-based line number
     pub line: usize,

--- a/crates/core/src/skill.rs
+++ b/crates/core/src/skill.rs
@@ -184,7 +184,7 @@ pub struct ParsedSkillMd {
     pub user_invocable: bool,
     /// Whether the model is prevented from auto-invoking this skill (default: false)
     pub disable_model_invocation: bool,
-    /// Hint string for autocomplete (e.g., "<issue-number>")
+    /// Hint string for autocomplete (e.g., `"<issue-number>"`)
     pub argument_hint: Option<String>,
     /// Execution context: inline (default) or fork (subagent)
     pub context: SkillContext,
@@ -806,7 +806,7 @@ const COMMAND_EXECUTION_CONCURRENCY: usize = 4;
 /// its stdout. Execution is bounded: at most
 /// [`MAX_COMMAND_PLACEHOLDERS_PER_SKILL`] placeholders are expanded per call
 /// (extras are replaced with `[Too many command placeholders: limit is N]`
-/// sentinels), and at most [`COMMAND_EXECUTION_CONCURRENCY`] commands run
+/// sentinels), and at most `COMMAND_EXECUTION_CONCURRENCY` commands run
 /// concurrently.
 ///
 /// Substitution pipeline order (caller is responsible for prior steps):

--- a/crates/openai/Cargo.toml
+++ b/crates/openai/Cargo.toml
@@ -12,6 +12,7 @@ homepage.workspace = true
 repository.workspace = true
 documentation = "https://docs.rs/everruns-openai"
 description = "OpenAI provider implementation for Everruns"
+readme = "README.md"
 
 [dependencies]
 # Core dependencies

--- a/crates/openai/README.md
+++ b/crates/openai/README.md
@@ -1,0 +1,60 @@
+# everruns-openai
+
+OpenAI LLM provider implementation for Everruns.
+
+This crate is part of the [Everruns](https://everruns.com) ecosystem. It
+registers OpenAI drivers with `everruns-core`, including the recommended
+Responses API driver and a Chat Completions compatibility driver.
+
+## Quick Example: Agent With OpenAI
+
+```rust,no_run
+use everruns_core::{
+    CapabilityRegistry, DriverRegistry, LlmProviderType, ModelWithProvider, PlatformDefinition,
+};
+use everruns_runtime::InProcessRuntimeBuilder;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut drivers = DriverRegistry::new();
+    everruns_openai::register_driver(&mut drivers);
+
+    let platform = PlatformDefinition::new(CapabilityRegistry::new(), drivers);
+    let runtime = InProcessRuntimeBuilder::new()
+        .platform_definition(platform)
+        .default_model(ModelWithProvider {
+            model: "gpt-5.4-mini".into(),
+            provider_type: LlmProviderType::Openai,
+            api_key: Some(std::env::var("OPENAI_API_KEY")?),
+            base_url: None,
+        })
+        .single_session(|s| {
+            s.harness("assistant", "You are a helpful assistant.")
+                .agent("openai-agent", "Answer clearly and concisely.")
+                .session_title("OpenAI example")
+        })
+        .build()
+        .await?;
+
+    let session_id = runtime.default_session_id().expect("single_session id");
+    let result = runtime
+        .run_text_turn(session_id, "Write one sentence about reliable agents.")
+        .await?;
+
+    println!("{}", result.response);
+    Ok(())
+}
+```
+
+## Driver-Only Example
+
+```rust
+use everruns_openai::OpenAILlmDriver;
+
+let driver = OpenAILlmDriver::new("your-api-key");
+assert!(!driver.uses_custom_url());
+```
+
+## License
+
+MIT. See the repository-level `LICENSE` file.

--- a/crates/openai/src/lib.rs
+++ b/crates/openai/src/lib.rs
@@ -1,16 +1,56 @@
-// OpenAI Driver Implementation
-//
-// This crate provides OpenAI LLM driver implementations:
-//
-// - OpenAILlmDriver: Uses Open Responses API (https://www.openresponses.org/)
-//   Recommended for new projects with better performance.
-//
-// - OpenAICompletionsLlmDriver: Uses Chat Completions API
-//   For backward compatibility with /v1/chat/completions endpoint.
-//
-// Design: This crate depends on everruns-core and registers its drivers
-// at application startup via register_driver(). This enables dependency
-// inversion - core has no knowledge of specific provider implementations.
+//! OpenAI provider drivers for Everruns.
+//!
+//! `everruns-openai` is part of the [Everruns](https://everruns.com)
+//! ecosystem. It implements the [`LlmDriver`] contract from `everruns-core` and
+//! registers OpenAI providers into a [`DriverRegistry`].
+//!
+//! The crate exposes two drivers:
+//!
+//! - [`OpenAILlmDriver`], the recommended Responses API driver.
+//! - [`OpenAICompletionsLlmDriver`], a Chat Completions compatibility driver.
+//!
+//! # Registering the Driver
+//!
+//! ```
+//! use everruns_core::DriverRegistry;
+//! use everruns_openai::register_driver;
+//!
+//! let mut registry = DriverRegistry::new();
+//! register_driver(&mut registry);
+//! ```
+//!
+//! # Embedded Agent Example
+//!
+//! ```ignore
+//! use everruns_core::{
+//!     CapabilityRegistry, DriverRegistry, LlmProviderType, ModelWithProvider, PlatformDefinition,
+//! };
+//! use everruns_runtime::InProcessRuntimeBuilder;
+//!
+//! let mut drivers = DriverRegistry::new();
+//! everruns_openai::register_driver(&mut drivers);
+//!
+//! let platform = PlatformDefinition::new(CapabilityRegistry::new(), drivers);
+//! let runtime = InProcessRuntimeBuilder::new()
+//!     .platform_definition(platform)
+//!     .default_model(ModelWithProvider {
+//!         model: "gpt-5.4-mini".into(),
+//!         provider_type: LlmProviderType::Openai,
+//!         api_key: Some(std::env::var("OPENAI_API_KEY")?),
+//!         base_url: None,
+//!     })
+//!     .single_session(|s| {
+//!         s.harness("assistant", "You are a helpful assistant.")
+//!             .agent("openai-agent", "Answer clearly and concisely.")
+//!     })
+//!     .build()
+//!     .await?;
+//!
+//! let session_id = runtime.default_session_id().expect("single_session id");
+//! let result = runtime.run_text_turn(session_id, "Write a one-line status update.").await?;
+//! println!("{}", result.response);
+//! # Ok::<(), Box<dyn std::error::Error>>(())
+//! ```
 
 mod driver;
 mod image_capability;

--- a/crates/openui/Cargo.toml
+++ b/crates/openui/Cargo.toml
@@ -15,6 +15,7 @@ homepage.workspace = true
 repository.workspace = true
 documentation = "https://docs.rs/everruns-openui"
 description = "OpenUI component definitions and prompt generator for Everruns"
+readme = "README.md"
 
 [dependencies]
 

--- a/crates/openui/README.md
+++ b/crates/openui/README.md
@@ -1,0 +1,33 @@
+# everruns-openui
+
+OpenUI component definitions and prompt generation for Everruns generative UI.
+
+This crate is part of the [Everruns](https://everruns.com) ecosystem. It builds
+the system-prompt text that teaches an LLM to produce `openui` fenced blocks for
+rendering in clients that understand OpenUI Lang.
+
+## Quick Example
+
+```rust
+use everruns_openui::{PromptOptions, default_library, generate_prompt};
+
+let prompt = generate_prompt(
+    default_library(),
+    &PromptOptions {
+        additional_rules: vec!["Prefer compact tables for operational data.".into()],
+        ..PromptOptions::default()
+    },
+);
+
+assert!(prompt.contains("```openui"));
+```
+
+## What It Provides
+
+- A static OpenUI component library
+- Prompt generation for OpenUI Lang output
+- Custom prompt options for extra rules and examples
+
+## License
+
+MIT. See the repository-level `LICENSE` file.

--- a/crates/openui/src/lib.rs
+++ b/crates/openui/src/lib.rs
@@ -1,4 +1,4 @@
-//! OpenUI Component Library and Prompt Generator
+//! OpenUI component library and prompt generator for Everruns.
 //!
 //! Rust reimplementation of the OpenUI component definitions and prompt generator.
 //! Produces system prompts that instruct LLMs to generate OpenUI Lang code.
@@ -6,7 +6,18 @@
 //! The generated prompt is compatible with `@openuidev/react-lang` and `@openuidev/react-ui`
 //! — the React runtime parses the LLM output and renders it into interactive components.
 //!
-//! Ref: https://github.com/thesysdev/openui
+//! This crate is part of the [Everruns](https://everruns.com) ecosystem.
+//!
+//! # Example
+//!
+//! ```
+//! use everruns_openui::{PromptOptions, default_library, generate_prompt};
+//!
+//! let prompt = generate_prompt(default_library(), &PromptOptions::default());
+//! assert!(prompt.contains("```openui"));
+//! ```
+//!
+//! Ref: <https://github.com/thesysdev/openui>
 //! - Component definitions: packages/react-ui/src/genui-lib/
 //! - Prompt generator: packages/react-lang/src/parser/prompt.ts
 //! - Library/types: packages/react-lang/src/library.ts

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -12,6 +12,7 @@ homepage.workspace = true
 repository.workspace = true
 documentation = "https://docs.rs/everruns-runtime"
 description = "Public in-process runtime for embedding Everruns harnesses"
+readme = "README.md"
 
 [dependencies]
 async-trait.workspace = true

--- a/crates/runtime/README.md
+++ b/crates/runtime/README.md
@@ -1,0 +1,65 @@
+# everruns-runtime
+
+Public in-process runtime for embedding Everruns harnesses.
+
+This crate is part of the [Everruns](https://everruns.com) ecosystem. It runs
+Everruns sessions in your process with in-memory stores by default, while using
+the same core `input -> reason -> act` flow as worker-backed execution.
+
+## Quick Example
+
+```rust
+use everruns_core::{
+    CapabilityRegistry, DriverRegistry, LlmProviderType, ModelWithProvider, PlatformDefinition,
+};
+use everruns_core::capabilities::TestMathCapability;
+use everruns_runtime::InProcessRuntimeBuilder;
+
+# async fn example() -> Result<(), Box<dyn std::error::Error>> {
+let mut capabilities = CapabilityRegistry::new();
+capabilities.register(TestMathCapability);
+
+let platform = PlatformDefinition::new(capabilities, DriverRegistry::new());
+let runtime = InProcessRuntimeBuilder::new()
+    .platform_definition(platform)
+    .llm_sim(everruns_core::llmsim_driver::LlmSimConfig::fixed("4"))
+    .default_model(ModelWithProvider {
+        model: "llmsim-model".into(),
+        provider_type: LlmProviderType::LlmSim,
+        api_key: Some("fake-key".into()),
+        base_url: None,
+    })
+    .single_session(|s| {
+        s.harness("math", "You are a calculator.")
+            .with_capability("test_math")
+            .agent("math-agent", "Use tools when useful.")
+            .session_title("Math example")
+    })
+    .build()
+    .await?;
+
+let session_id = runtime.default_session_id().expect("single_session id");
+let result = runtime.run_text_turn(session_id, "What is 2 + 2?").await?;
+
+assert!(result.success);
+# Ok(())
+# }
+```
+
+Runnable examples:
+
+```text
+cargo run -p everruns-runtime --example in_process_runtime
+cargo run -p everruns-runtime --example inspect_context
+```
+
+## What It Provides
+
+- `InProcessRuntimeBuilder` for embedding sessions
+- In-memory stores for local and test usage
+- Real-disk workspace wiring for file-backed agents
+- Host phase helpers reused by durable and server-backed execution
+
+## License
+
+MIT. See the repository-level `LICENSE` file.

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -3,6 +3,7 @@
 //! The runtime crate exposes an in-memory execution surface that runs the same
 //! core atoms (`input`, `reason`, `act`) used elsewhere in the system, but
 //! without the durable engine, gRPC worker boundary, or control-plane server.
+//! It is part of the [Everruns](https://everruns.com) ecosystem.
 //!
 //! This is the intended public entrypoint for embedders who want to:
 //!
@@ -73,7 +74,7 @@
 //! Embedders who want built-in capabilities (`file_system`,
 //! `agent_instructions`, `skills`, ...) to read and write a real directory
 //! on disk can configure [`RealDiskSessionFileSystemFactory`] on their
-//! [`PlatformDefinition`]. Every capability that goes through
+//! [`PlatformDefinition`](everruns_core::PlatformDefinition). Every capability that goes through
 //! `ToolContext.file_store` or `SystemPromptContext.file_store` picks it up
 //! automatically.
 //!

--- a/integrations/duckduckgo/Cargo.toml
+++ b/integrations/duckduckgo/Cargo.toml
@@ -13,6 +13,7 @@ homepage.workspace = true
 repository.workspace = true
 documentation = "https://docs.rs/everruns-integrations-duckduckgo"
 description = "DuckDuckGo Instant Answer search integration for Everruns"
+readme = "README.md"
 
 [dependencies]
 everruns-core.workspace = true

--- a/integrations/duckduckgo/README.md
+++ b/integrations/duckduckgo/README.md
@@ -1,0 +1,30 @@
+# everruns-integrations-duckduckgo
+
+DuckDuckGo Instant Answer search integration for Everruns agents.
+
+This crate is part of the [Everruns](https://everruns.com) ecosystem. It adds a
+small no-key network capability for quick facts, abstracts, definitions, and
+related topics from the DuckDuckGo Instant Answer API.
+
+## Quick Example
+
+```rust
+use everruns_core::capabilities::Capability;
+use everruns_integrations_duckduckgo::DuckDuckGoCapability;
+
+let capability = DuckDuckGoCapability;
+
+assert_eq!(capability.id(), "duckduckgo");
+assert_eq!(capability.tools().len(), 1);
+```
+
+## What It Provides
+
+- `duckduckgo_search` tool registration
+- No API-key setup
+- Stateless instant-answer lookup for agents
+- Inventory-based Everruns integration registration
+
+## License
+
+MIT. See the repository-level `LICENSE` file.

--- a/integrations/duckduckgo/src/lib.rs
+++ b/integrations/duckduckgo/src/lib.rs
@@ -1,8 +1,21 @@
-//! DuckDuckGo Integration (Experimental)
+//! DuckDuckGo Instant Answer integration for Everruns.
 //!
 //! Instant answers via DuckDuckGo Instant Answer API.
 //! Provides `duckduckgo_search` tool for agents to get instant answers,
 //! abstracts, related topics, and definitions.
+//!
+//! This crate is part of the [Everruns](https://everruns.com) ecosystem.
+//!
+//! # Example
+//!
+//! ```
+//! use everruns_core::capabilities::Capability;
+//! use everruns_integrations_duckduckgo::DuckDuckGoCapability;
+//!
+//! let capability = DuckDuckGoCapability;
+//! assert_eq!(capability.id(), "duckduckgo");
+//! assert_eq!(capability.tools().len(), 1);
+//! ```
 //!
 //! Decision: External integration crate, auto-registered via inventory plugin system
 //! Decision: No API key required — DuckDuckGo Instant Answer API is free


### PR DESCRIPTION
## What
Adds publish-facing README files and README metadata for the crates currently published by `.github/workflows/publish-crates.yml`:

- `everruns-config`
- `everruns-openui`
- `everruns-a2ui`
- `everruns-core`
- `everruns-openai`
- `everruns-anthropic`
- `everruns-integrations-duckduckgo`
- `everruns-runtime`

Also improves crate-root rustdocs for those crates and fixes rustdoc warnings in public `everruns-core` docs so docs.rs-style builds can run with warnings denied.

## Why
Published crates should be useful from crates.io/docs.rs without requiring readers to inspect the monorepo. Each package now has a short purpose statement, quick example, Everruns ecosystem context, an `everruns.com` link, and license guidance.

## How
- Added crate-local `README.md` files with concise usage notes and examples.
- Added `readme = "README.md"` to each published crate manifest.
- Converted plain crate comments into crate-level rustdoc where docs.rs would otherwise show little context.
- Cleaned existing public rustdoc issues found by `RUSTDOCFLAGS='-D warnings'`.

## Risk
- Low
- Docs and package metadata only; no runtime behavior changes.
- Main risk is stale or misleading examples. Mitigated with focused doctests and warning-denied docs builds.

## Security
- Threat categories reviewed: No security-relevant code changes. This PR changes crate READMEs, crate-level docs, rustdoc formatting, and crates.io README metadata only; it does not alter auth, authorization, API handlers, tool execution, tenant isolation, secrets, network access, filesystem access, SQL, or command execution behavior.
- Findings and resolutions: No findings.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

## Validation
- `cargo fmt --check`
- `just pre-push`
- `cargo test --doc -p everruns-config -p everruns-openui -p everruns-a2ui -p everruns-core -p everruns-openai -p everruns-anthropic -p everruns-integrations-duckduckgo -p everruns-runtime`
- `RUSTDOCFLAGS='-D warnings' cargo doc --no-deps -p everruns-config -p everruns-openui -p everruns-a2ui -p everruns-core -p everruns-openai -p everruns-anthropic -p everruns-integrations-duckduckgo -p everruns-runtime`
- `cargo package --locked --allow-dirty --no-verify -p ...` for all eight crates above
- `bash scripts/lib/check-migration-ordering.sh`

Smoke test: skipped because this is docs/package metadata only and does not affect runtime behavior.

Packaging note: full `cargo package --locked` verification passed for seven crates locally. `everruns-runtime` full verification is blocked on this branch because Cargo verifies against the already-published registry `everruns-core v0.8.33`, which lacks APIs from this checkout. The release workflow publishes and waits for `everruns-core` before `everruns-runtime`, so the local package check used `--no-verify` to validate tarball assembly/README inclusion without the registry-version skew.
