### PR TITLE
docs(capabilities): order overview first

### DIFF
--- a/docs/capabilities/index.md
+++ b/docs/capabilities/index.md
@@ -1,6 +1,8 @@
 ---
 title: Capabilities Overview
 description: Modular capabilities that extend agent behavior with tools, system prompts, and execution features. Browse all built-in and custom capabilities available.
+sidebar:
+  order: 1
 ---
 
 Capabilities are modular units that extend what an agent can do. Each capability can contribute:


### PR DESCRIPTION
## What
Add an explicit sidebar order to the capabilities overview page so it appears first in the Built-ins > Capabilities side navigation.

## Why
The overview page was being sorted after capability pages that already had explicit `sidebar.order` values, which made the active overview item appear in the middle of the sidepanel.

## How
Set `sidebar.order: 1` in `docs/capabilities/index.md`.

## Risk
- Low
- Docs navigation ordering only; runtime behavior is unchanged.

## Security
- Threat categories reviewed: No security-relevant code changes. This changes Markdown frontmatter for docs sidebar ordering only.
- Findings and resolutions: No findings.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

Validation:
- `cd apps/docs && npm run build`
- `just pre-push`
- CI: Docs Build & Check, Build Check, Migration Immutability, CodeQL, Cloudflare Pages, and CI Opt-Out Policy passed.

Smoke test: skipped runtime smoke testing because this is docs-only frontmatter with no application runtime path. The generated docs HTML was inspected to confirm the overview link renders first in the Capabilities sidebar.