### PR TITLE
fix(agent-handoff): require explicit target harness for child session

### DIFF
--- a/crates/core/src/capabilities/agent_handoff.rs
+++ b/crates/core/src/capabilities/agent_handoff.rs
@@ -15,7 +15,7 @@ use crate::session_resource::{
 use crate::tool_types::ToolHints;
 use crate::tools::{Tool, ToolExecutionResult};
 use crate::traits::{SessionResourceRegistry, ToolContext};
-use crate::typed_id::AgentId;
+use crate::typed_id::{AgentId, HarnessId};
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
@@ -80,6 +80,10 @@ impl Capability for AgentHandoffCapability {
                                 "type": "string",
                                 "description": "Public id of the configured target agent."
                             },
+                            "harness_id": {
+                                "type": "string",
+                                "description": "Public id of the configured target harness."
+                            },
                             "required_connections": {
                                 "type": "array",
                                 "items": { "type": "string" },
@@ -91,7 +95,7 @@ impl Capability for AgentHandoffCapability {
                                 "description": "Non-secret scope labels recorded for audit and resource metadata."
                             }
                         },
-                        "required": ["id", "name", "agent_id"],
+                        "required": ["id", "name", "agent_id", "harness_id"],
                         "additionalProperties": false
                     },
                     "default": []
@@ -196,6 +200,7 @@ struct AgentHandoffTargetConfig {
     #[serde(default)]
     description: Option<String>,
     agent_id: AgentId,
+    harness_id: HarnessId,
     #[serde(default)]
     required_connections: Vec<String>,
     #[serde(default)]
@@ -449,7 +454,7 @@ impl Tool for StartAgentHandoffTool {
 
         let child_session = match store
             .create_session(
-                parent_session.harness_id,
+                target.harness_id,
                 Some(target.agent_id),
                 Some(&target.name),
                 parent_session.locale.as_deref(),
@@ -776,7 +781,11 @@ mod tests {
     use std::sync::{Arc, Mutex};
     use uuid::Uuid;
 
-    fn target_config(agent_id: AgentId, required_connections: Vec<&str>) -> Value {
+    fn target_config(
+        agent_id: AgentId,
+        harness_id: HarnessId,
+        required_connections: Vec<&str>,
+    ) -> Value {
         json!({
             "targets": [
                 {
@@ -784,6 +793,7 @@ mod tests {
                     "name": "AWS Operator",
                     "description": "Manage fake AWS infrastructure",
                     "agent_id": agent_id,
+                    "harness_id": harness_id,
                     "required_connections": required_connections,
                     "required_scopes": ["fake_aws:rds:create"]
                 }
@@ -967,10 +977,11 @@ mod tests {
     #[test]
     fn validate_config_rejects_duplicate_targets() {
         let agent_id = AgentId::new();
+        let harness_id = HarnessId::new();
         let config = json!({
             "targets": [
-                { "id": "dup", "name": "One", "agent_id": agent_id },
-                { "id": "dup", "name": "Two", "agent_id": AgentId::new() }
+                { "id": "dup", "name": "One", "agent_id": agent_id, "harness_id": harness_id },
+                { "id": "dup", "name": "Two", "agent_id": AgentId::new(), "harness_id": HarnessId::new() }
             ]
         });
 
@@ -983,7 +994,11 @@ mod tests {
     #[tokio::test]
     async fn start_handoff_requires_configured_connection() {
         let store = Arc::new(MockPlatformStore::new());
-        let config = target_config(store.agent.public_id, vec!["fake_aws"]);
+        let config = target_config(
+            store.agent.public_id,
+            store.session.harness_id,
+            vec!["fake_aws"],
+        );
         let tool = start_tool(config);
         let resolver = Arc::new(TestConnectionResolver {
             providers: HashSet::new(),
@@ -1009,7 +1024,11 @@ mod tests {
     #[tokio::test]
     async fn start_handoff_without_connection_resolver_is_internal_error() {
         let store = Arc::new(MockPlatformStore::new());
-        let config = target_config(store.agent.public_id, vec!["fake_aws"]);
+        let config = target_config(
+            store.agent.public_id,
+            store.session.harness_id,
+            vec!["fake_aws"],
+        );
         let tool = start_tool(config);
         let context = context(store, None, None);
 
@@ -1033,7 +1052,11 @@ mod tests {
         let resolver = Arc::new(TestConnectionResolver {
             providers: HashSet::from(["fake_aws".to_string()]),
         });
-        let config = target_config(store.agent.public_id, vec!["fake_aws"]);
+        let config = target_config(
+            store.agent.public_id,
+            store.session.harness_id,
+            vec!["fake_aws"],
+        );
         let tool = start_tool(config);
         let context = context(store.clone(), Some(resolver), Some(registry.clone()));
 
@@ -1075,7 +1098,7 @@ mod tests {
     async fn get_handoffs_lists_registered_handoff_resources() {
         let store = Arc::new(MockPlatformStore::new());
         let registry = Arc::new(TestResourceRegistry::default());
-        let config = target_config(store.agent.public_id, vec![]);
+        let config = target_config(store.agent.public_id, store.session.harness_id, vec![]);
         let start = start_tool(config.clone());
         let get = get_tool(config);
         let context = context(store, None, Some(registry));

--- a/crates/core/src/capabilities/agent_handoff.rs
+++ b/crates/core/src/capabilities/agent_handoff.rs
@@ -1094,6 +1094,58 @@ mod tests {
         );
     }
 
+    /// Regression for the confused-deputy issue this PR fixes: the child
+    /// session must be created with the *target's* harness, not the
+    /// parent session's harness. If a future refactor reintroduces
+    /// `parent_session.harness_id` here, the child would inherit the
+    /// parent's mounts/capabilities while gaining the target's tools.
+    #[tokio::test]
+    async fn start_handoff_uses_target_harness_not_parent() {
+        let store = Arc::new(MockPlatformStore::new());
+        let registry = Arc::new(TestResourceRegistry::default());
+        let resolver = Arc::new(TestConnectionResolver {
+            providers: HashSet::from(["fake_aws".to_string()]),
+        });
+        let target_harness_id = HarnessId::new();
+        // Sanity: the target harness must differ from the parent's,
+        // otherwise the assertion below cannot distinguish them.
+        assert_ne!(store.session.harness_id, target_harness_id);
+
+        let config = target_config(store.agent.public_id, target_harness_id, vec!["fake_aws"]);
+        let tool = start_tool(config);
+        let context = context(store.clone(), Some(resolver), Some(registry));
+
+        let result = tool
+            .execute_with_context(
+                json!({
+                    "target": "aws_operator",
+                    "task": "Create an RDS database named app-db"
+                }),
+                &context,
+            )
+            .await;
+        assert!(result.is_success(), "expected success, got {result:?}");
+
+        let recorded = store
+            .created_session_harness_ids
+            .lock()
+            .expect("recorder lock")
+            .clone();
+        assert_eq!(
+            recorded.len(),
+            1,
+            "expected exactly one child create_session call, got {recorded:?}"
+        );
+        assert_eq!(
+            recorded[0], target_harness_id,
+            "child session must inherit the target harness, not the parent's",
+        );
+        assert_ne!(
+            recorded[0], store.session.harness_id,
+            "child session must NOT inherit the parent harness (confused-deputy regression)",
+        );
+    }
+
     #[tokio::test]
     async fn get_handoffs_lists_registered_handoff_resources() {
         let store = Arc::new(MockPlatformStore::new());

--- a/crates/core/src/platform_store.rs
+++ b/crates/core/src/platform_store.rs
@@ -288,6 +288,10 @@ pub mod tests {
         pub app: App,
         pub app_channel: AppChannel,
         pub session: Session,
+        /// Records the `harness_id` argument of every `create_session`
+        /// call so tests can assert which harness a child session was
+        /// created against. See `start_handoff_uses_target_harness_not_parent`.
+        pub created_session_harness_ids: std::sync::Mutex<Vec<HarnessId>>,
     }
 
     impl Default for MockPlatformStore {
@@ -422,6 +426,7 @@ pub mod tests {
                     blueprint_id: None,
                     blueprint_config: None,
                 },
+                created_session_harness_ids: std::sync::Mutex::new(Vec::new()),
             }
         }
     }
@@ -668,6 +673,9 @@ pub mod tests {
             blueprint_id: Option<&str>,
             blueprint_config: Option<&serde_json::Value>,
         ) -> Result<Session> {
+            if let Ok(mut recorder) = self.created_session_harness_ids.lock() {
+                recorder.push(hid);
+            }
             let mut s = self.session.clone();
             s.id = SessionId::new();
             s.harness_id = hid;


### PR DESCRIPTION
### Motivation
- Prevent confused-deputy privilege composition where a handoff child session inherited the parent session's harness (files/capabilities) while gaining the target agent's tools, enabling exfiltration or privileged actions.
- Enforce an explicit target harness to make the target execution environment deliberate and isolated.

### Description
- Require `harness_id` in the `agent_handoff` config schema and add a `HarnessId` field to `AgentHandoffTargetConfig` so each target declares its execution harness explicitly.
- Use `target.harness_id` (instead of `parent_session.harness_id`) when creating the child session in `start_agent_handoff` to avoid inheriting source-harness mounts/capabilities.
- Update unit-test helpers and tests to provide `harness_id` for handoff targets and keep coverage for existing handoff behavior under the new contract.
- Backward compatibility note: existing handoff configs missing `harness_id` will fail validation and must be migrated.

### Testing
- Ran `cargo test -p everruns-core agent_handoff -- --nocapture`, and all handoff-related tests passed (`9 passed; 0 failed`).
- Existing unit tests for `agent_handoff` were updated and executed successfully as part of the run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c120b7ac8832bac500f6d5f377b7d)