### PR TITLE
feat(api): examples on Schedules, A2A channel, volume sources; floor 17%

### DIFF
--- a/crates/core/src/app.rs
+++ b/crates/core/src/app.rs
@@ -546,6 +546,10 @@ pub struct AppEndpointAuthRequirements {
 /// Inline auth config for one App endpoint/channel.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
+#[cfg_attr(
+    feature = "openapi",
+    schema(example = json!({"mode": "api_key", "requirements": {"login_required": false}}))
+)]
 pub struct AppEndpointAuthConfig {
     pub mode: AppEndpointAuthMode,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -672,6 +676,7 @@ fn default_fcp_response_timeout_seconds() -> u32 {
 /// How app-triggered invocations route into sessions.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
+#[cfg_attr(feature = "openapi", schema(example = "shared_session"))]
 #[serde(rename_all = "snake_case")]
 pub enum InvocationSessionMode {
     /// Reuse a single durable session for every invocation of the channel.

--- a/crates/core/src/app.rs
+++ b/crates/core/src/app.rs
@@ -548,7 +548,7 @@ pub struct AppEndpointAuthRequirements {
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 #[cfg_attr(
     feature = "openapi",
-    schema(example = json!({"mode": "api_key", "requirements": {"login_required": false}}))
+    schema(example = json!({"mode": "api_key", "requirements": {"audiences": ["everruns-api"], "scopes": ["app:invoke"]}}))
 )]
 pub struct AppEndpointAuthConfig {
     pub mode: AppEndpointAuthMode,

--- a/crates/server/src/api/apps.rs
+++ b/crates/server/src/api/apps.rs
@@ -458,7 +458,7 @@ pub async fn delete_channel(
 /// Request body for the `add_a2a_channel_http` operation.
 #[derive(Debug, serde::Deserialize, utoipa::ToSchema)]
 pub struct AddA2aChannelHttpRequest {
-    /// How a fresh session is opened for each invocation. Example shape is defined on `InvocationSessionMode`.
+    /// How invocations route into sessions (e.g. `shared_session` to reuse one durable session, or per-invocation modes). Example shape is defined on `InvocationSessionMode`.
     #[serde(default)]
     pub session_mode: everruns_core::app::InvocationSessionMode,
     /// First user message sent to the agent on each invocation; can reference incoming A2A payload via templating.

--- a/crates/server/src/api/apps.rs
+++ b/crates/server/src/api/apps.rs
@@ -458,14 +458,23 @@ pub async fn delete_channel(
 /// Request body for the `add_a2a_channel_http` operation.
 #[derive(Debug, serde::Deserialize, utoipa::ToSchema)]
 pub struct AddA2aChannelHttpRequest {
+    /// How a fresh session is opened for each invocation. Example shape is defined on `InvocationSessionMode`.
     #[serde(default)]
     pub session_mode: everruns_core::app::InvocationSessionMode,
+    /// First user message sent to the agent on each invocation; can reference incoming A2A payload via templating.
+    #[schema(example = "Process incoming A2A request and return a structured response.")]
     pub message: String,
+    /// Public agent card name advertised by the A2A endpoint. Defaults to the app name when omitted.
+    #[schema(example = "Support Triage Agent")]
     pub agent_card_name: Option<String>,
+    /// Public agent card description advertised by the A2A endpoint. Defaults to the app description when omitted.
+    #[schema(example = "Triages incoming support tickets and routes to the right team")]
     pub agent_card_description: Option<String>,
+    /// Optional endpoint auth. Example shape is defined on `AppEndpointAuthConfig`.
     #[serde(default)]
     pub auth: Option<everruns_core::AppEndpointAuthConfig>,
     /// Whether this resource is enabled.
+    #[schema(example = true)]
     pub enabled: Option<bool>,
 }
 

--- a/crates/server/src/api/schedules.rs
+++ b/crates/server/src/api/schedules.rs
@@ -182,7 +182,7 @@ pub struct CreateScheduleRequest {
     #[schema(example = 3)]
     pub max_catch_up: Option<u32>,
     /// Retry policy for failed executions (provider-specific JSON; see the durable engine's `RetryPolicy`).
-    #[schema(example = json!({"max_attempts": 3, "initial_backoff_secs": 30, "backoff_multiplier": 2.0}))]
+    /// Example: `{"max_attempts": 3, "initial_backoff_secs": 30, "backoff_multiplier": 2.0}`.
     pub retry_policy: Option<serde_json::Value>,
 }
 
@@ -221,7 +221,7 @@ pub struct UpdateScheduleRequest {
     #[schema(example = 3)]
     pub max_catch_up: Option<u32>,
     /// Retry policy (provider-specific JSON; see the durable engine's `RetryPolicy`).
-    #[schema(example = json!({"max_attempts": 3, "initial_backoff_secs": 30, "backoff_multiplier": 2.0}))]
+    /// Example: `{"max_attempts": 3, "initial_backoff_secs": 30, "backoff_multiplier": 2.0}`.
     pub retry_policy: Option<serde_json::Value>,
 }
 

--- a/crates/server/src/api/schedules.rs
+++ b/crates/server/src/api/schedules.rs
@@ -134,14 +134,18 @@ pub fn routes(state: ScheduleAppState) -> Router {
 
 /// Target for a schedule - either a workflow or activity
 #[derive(Debug, Deserialize, ToSchema)]
+#[schema(example = json!({"type": "workflow", "name": "session.run", "input": {"session_id": "session_01933b5a00007000800000000000001"}}))]
 pub struct ScheduleTarget {
     /// Target type: "workflow" or "activity"
     #[serde(rename = "type")]
+    #[schema(example = "workflow")]
     pub target_type: String,
     /// Workflow type name or activity type name
+    #[schema(example = "session.run")]
     pub name: String,
     /// Input JSON for the workflow/activity
     #[serde(default)]
+    #[schema(example = json!({"session_id": "session_01933b5a00007000800000000000001"}))]
     pub input: serde_json::Value,
 }
 
@@ -149,27 +153,36 @@ pub struct ScheduleTarget {
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct CreateScheduleRequest {
     /// Unique name for the schedule
+    #[schema(example = "nightly-triage")]
     pub name: String,
     /// Optional description
+    #[schema(example = "Fires the support-triage agent every night at 02:00 UTC")]
     pub description: Option<String>,
-    /// Cron expression (5-field or 7-field)
+    /// Cron expression (5-field or 7-field). Standard `min hour day-of-month month day-of-week` form.
+    #[schema(example = "0 2 * * *")]
     pub cron_expression: String,
-    /// Timezone (default: UTC)
+    /// Timezone (default: UTC). IANA name (e.g. `UTC`, `America/New_York`).
     #[serde(default = "default_timezone")]
+    #[schema(example = "UTC")]
     pub timezone: String,
-    /// Target to trigger
+    /// Target to trigger. Variant shape is defined on `ScheduleTarget`.
     pub target: ScheduleTarget,
     /// Whether schedule is enabled (default: true)
     #[serde(default = "default_enabled")]
+    #[schema(example = true)]
     pub enabled: bool,
-    /// Max concurrent executions
+    /// Max concurrent executions. Omit for no limit beyond the worker pool's concurrency.
+    #[schema(example = 1)]
     pub max_concurrent: Option<u32>,
     /// Whether to catch up missed triggers (default: false)
     #[serde(default)]
+    #[schema(example = false)]
     pub catch_up_missed: bool,
-    /// Max catch-up executions
+    /// Max catch-up executions when `catch_up_missed` is true. Older missed fires are dropped.
+    #[schema(example = 3)]
     pub max_catch_up: Option<u32>,
-    /// Retry policy for failed executions
+    /// Retry policy for failed executions (provider-specific JSON; see the durable engine's `RetryPolicy`).
+    #[schema(example = json!({"max_attempts": 3, "initial_backoff_secs": 30, "backoff_multiplier": 2.0}))]
     pub retry_policy: Option<serde_json::Value>,
 }
 
@@ -185,22 +198,30 @@ fn default_enabled() -> bool {
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct UpdateScheduleRequest {
     /// New description
+    #[schema(example = "Fires the support-triage agent every weekday at 08:00 UTC")]
     pub description: Option<String>,
-    /// New cron expression
+    /// New cron expression. Standard `min hour day-of-month month day-of-week` form.
+    #[schema(example = "0 8 * * 1-5")]
     pub cron_expression: Option<String>,
-    /// New timezone
+    /// New timezone (IANA name).
+    #[schema(example = "America/New_York")]
     pub timezone: Option<String>,
-    /// New target
+    /// New target. Variant shape is defined on `ScheduleTarget`.
     pub target: Option<ScheduleTarget>,
     /// Enable/disable
+    #[schema(example = true)]
     pub enabled: Option<bool>,
     /// Max concurrent executions
+    #[schema(example = 1)]
     pub max_concurrent: Option<u32>,
     /// Catch up missed triggers
+    #[schema(example = true)]
     pub catch_up_missed: Option<bool>,
     /// Max catch-up executions
+    #[schema(example = 3)]
     pub max_catch_up: Option<u32>,
-    /// Retry policy
+    /// Retry policy (provider-specific JSON; see the durable engine's `RetryPolicy`).
+    #[schema(example = json!({"max_attempts": 3, "initial_backoff_secs": 30, "backoff_multiplier": 2.0}))]
     pub retry_policy: Option<serde_json::Value>,
 }
 
@@ -422,22 +443,29 @@ pub struct TriggerResponse {
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct ListSchedulesQuery {
     /// Filter by enabled status
+    #[schema(example = true)]
     pub enabled: Option<bool>,
     /// Filter by target type ("workflow" or "activity")
+    #[schema(example = "workflow")]
     pub target_type: Option<String>,
     /// Pagination offset
+    #[schema(example = 0)]
     pub offset: Option<u32>,
     /// Pagination limit (default: 20, max: 100)
+    #[schema(example = 20)]
     pub limit: Option<u32>,
 }
 
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct ListExecutionsQuery {
     /// Filter by execution status
+    #[schema(example = "success")]
     pub status: Option<String>,
     /// Pagination offset
+    #[schema(example = 0)]
     pub offset: Option<u32>,
     /// Pagination limit (default: 20, max: 100)
+    #[schema(example = 20)]
     pub limit: Option<u32>,
 }
 

--- a/crates/server/src/domains/volumes/types.rs
+++ b/crates/server/src/domains/volumes/types.rs
@@ -140,28 +140,40 @@ pub struct GitVolumeSourceResponse {
 /// Request body for git hub volume source.
 #[derive(Debug, Clone, Deserialize, ToSchema)]
 pub struct GitHubVolumeSourceRequest {
+    /// GitHub repository in `owner/repo` form.
+    #[schema(example = "acme/design-docs")]
     pub repository: String,
+    /// Branch to sync. Defaults to the repository's default branch when omitted.
     #[serde(default)]
+    #[schema(example = "main")]
     pub branch: Option<String>,
+    /// Sub-directory within the repository to sync. Empty / omitted = whole tree.
     #[serde(default)]
+    #[schema(example = "docs/")]
     pub root_folder: Option<String>,
     /// Automatic resync interval in seconds. Omit or set 0 for manual-only; scheduled sync accepts 300 through 604800.
     #[serde(default)]
-    #[schema(maximum = 604800, minimum = 0)]
+    #[schema(maximum = 604800, minimum = 0, example = 3600)]
     pub sync_interval_secs: Option<u32>,
 }
 
 /// Request body for git volume source.
 #[derive(Debug, Clone, Deserialize, ToSchema)]
 pub struct GitVolumeSourceRequest {
+    /// Clonable git URL (SSH or HTTPS).
+    #[schema(example = "https://github.com/acme/design-docs.git")]
     pub url: String,
+    /// Branch to sync. Defaults to the repository's default branch when omitted.
     #[serde(default)]
+    #[schema(example = "main")]
     pub branch: Option<String>,
+    /// Sub-directory within the repository to sync. Empty / omitted = whole tree.
     #[serde(default)]
+    #[schema(example = "docs/")]
     pub root_folder: Option<String>,
     /// Automatic resync interval in seconds. Omit or set 0 for manual-only; scheduled sync accepts 300 through 604800.
     #[serde(default)]
-    #[schema(maximum = 604800, minimum = 0)]
+    #[schema(maximum = 604800, minimum = 0, example = 3600)]
     pub sync_interval_secs: Option<u32>,
 }
 

--- a/crates/server/src/domains/volumes/types.rs
+++ b/crates/server/src/domains/volumes/types.rs
@@ -111,7 +111,7 @@ pub enum VolumeSourceResponse {
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct ManualVolumeSourceResponse {}
 
-/// Response body for git hub volume source.
+/// Response body for GitHub volume source.
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct GitHubVolumeSourceResponse {
     pub repository: String,
@@ -137,7 +137,7 @@ pub struct GitVolumeSourceResponse {
     pub sync_interval_secs: Option<u32>,
 }
 
-/// Request body for git hub volume source.
+/// Request body for GitHub volume source.
 #[derive(Debug, Clone, Deserialize, ToSchema)]
 pub struct GitHubVolumeSourceRequest {
     /// GitHub repository in `owner/repo` form.

--- a/crates/server/tests/openapi_descriptions_test.rs
+++ b/crates/server/tests/openapi_descriptions_test.rs
@@ -22,7 +22,7 @@ const MIN_FIELD_DESC_PCT: u32 = 85;
 /// LLM to populate when it has seen one concrete instance. The floor starts
 /// low because the codebase only recently began adding `#[schema(example = …)]`
 /// — bump it as new annotations land, same rules as the description floors.
-const MIN_FIELD_EXAMPLE_PCT: u32 = 15;
+const MIN_FIELD_EXAMPLE_PCT: u32 = 17;
 
 fn spec_value() -> serde_json::Value {
     serde_json::from_str(&ApiDoc::openapi().to_pretty_json().unwrap())

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -11384,13 +11384,17 @@
             "type": [
               "string",
               "null"
-            ]
+            ],
+            "description": "Public agent card description advertised by the A2A endpoint. Defaults to the app description when omitted.",
+            "example": "Triages incoming support tickets and routes to the right team"
           },
           "agent_card_name": {
             "type": [
               "string",
               "null"
-            ]
+            ],
+            "description": "Public agent card name advertised by the A2A endpoint. Defaults to the app name when omitted.",
+            "example": "Support Triage Agent"
           },
           "auth": {
             "oneOf": [
@@ -11398,7 +11402,8 @@
                 "type": "null"
               },
               {
-                "$ref": "#/components/schemas/AppEndpointAuthConfig"
+                "$ref": "#/components/schemas/AppEndpointAuthConfig",
+                "description": "Optional endpoint auth. Example shape is defined on `AppEndpointAuthConfig`."
               }
             ]
           },
@@ -11407,13 +11412,17 @@
               "boolean",
               "null"
             ],
-            "description": "Whether this resource is enabled."
+            "description": "Whether this resource is enabled.",
+            "example": true
           },
           "message": {
-            "type": "string"
+            "type": "string",
+            "description": "First user message sent to the agent on each invocation; can reference incoming A2A payload via templating.",
+            "example": "Process incoming A2A request and return a structured response."
           },
           "session_mode": {
-            "$ref": "#/components/schemas/InvocationSessionMode"
+            "$ref": "#/components/schemas/InvocationSessionMode",
+            "description": "How a fresh session is opened for each invocation. Example shape is defined on `InvocationSessionMode`."
           }
         }
       },
@@ -12045,6 +12054,12 @@
           },
           "requirements": {
             "$ref": "#/components/schemas/AppEndpointAuthRequirements"
+          }
+        },
+        "example": {
+          "mode": "api_key",
+          "requirements": {
+            "login_required": false
           }
         }
       },
@@ -14253,22 +14268,26 @@
         "properties": {
           "catch_up_missed": {
             "type": "boolean",
-            "description": "Whether to catch up missed triggers (default: false)"
+            "description": "Whether to catch up missed triggers (default: false)",
+            "example": false
           },
           "cron_expression": {
             "type": "string",
-            "description": "Cron expression (5-field or 7-field)"
+            "description": "Cron expression (5-field or 7-field). Standard `min hour day-of-month month day-of-week` form.",
+            "example": "0 2 * * *"
           },
           "description": {
             "type": [
               "string",
               "null"
             ],
-            "description": "Optional description"
+            "description": "Optional description",
+            "example": "Fires the support-triage agent every night at 02:00 UTC"
           },
           "enabled": {
             "type": "boolean",
-            "description": "Whether schedule is enabled (default: true)"
+            "description": "Whether schedule is enabled (default: true)",
+            "example": true
           },
           "max_catch_up": {
             "type": [
@@ -14276,7 +14295,8 @@
               "null"
             ],
             "format": "int32",
-            "description": "Max catch-up executions",
+            "description": "Max catch-up executions when `catch_up_missed` is true. Older missed fires are dropped.",
+            "example": 3,
             "minimum": 0
           },
           "max_concurrent": {
@@ -14285,23 +14305,26 @@
               "null"
             ],
             "format": "int32",
-            "description": "Max concurrent executions",
+            "description": "Max concurrent executions. Omit for no limit beyond the worker pool's concurrency.",
+            "example": 1,
             "minimum": 0
           },
           "name": {
             "type": "string",
-            "description": "Unique name for the schedule"
+            "description": "Unique name for the schedule",
+            "example": "nightly-triage"
           },
           "retry_policy": {
-            "description": "Retry policy for failed executions"
+            "description": "Retry policy for failed executions (provider-specific JSON; see the durable engine's `RetryPolicy`)."
           },
           "target": {
             "$ref": "#/components/schemas/ScheduleTarget",
-            "description": "Target to trigger"
+            "description": "Target to trigger. Variant shape is defined on `ScheduleTarget`."
           },
           "timezone": {
             "type": "string",
-            "description": "Timezone (default: UTC)"
+            "description": "Timezone (default: UTC). IANA name (e.g. `UTC`, `America/New_York`).",
+            "example": "UTC"
           }
         }
       },
@@ -16046,16 +16069,22 @@
             "type": [
               "string",
               "null"
-            ]
+            ],
+            "description": "Branch to sync. Defaults to the repository's default branch when omitted.",
+            "example": "main"
           },
           "repository": {
-            "type": "string"
+            "type": "string",
+            "description": "GitHub repository in `owner/repo` form.",
+            "example": "acme/design-docs"
           },
           "root_folder": {
             "type": [
               "string",
               "null"
-            ]
+            ],
+            "description": "Sub-directory within the repository to sync. Empty / omitted = whole tree.",
+            "example": "docs/"
           },
           "sync_interval_secs": {
             "type": [
@@ -16064,6 +16093,7 @@
             ],
             "format": "int32",
             "description": "Automatic resync interval in seconds. Omit or set 0 for manual-only; scheduled sync accepts 300 through 604800.",
+            "example": 3600,
             "maximum": 604800,
             "minimum": 0
           }
@@ -16133,13 +16163,17 @@
             "type": [
               "string",
               "null"
-            ]
+            ],
+            "description": "Branch to sync. Defaults to the repository's default branch when omitted.",
+            "example": "main"
           },
           "root_folder": {
             "type": [
               "string",
               "null"
-            ]
+            ],
+            "description": "Sub-directory within the repository to sync. Empty / omitted = whole tree.",
+            "example": "docs/"
           },
           "sync_interval_secs": {
             "type": [
@@ -16148,11 +16182,14 @@
             ],
             "format": "int32",
             "description": "Automatic resync interval in seconds. Omit or set 0 for manual-only; scheduled sync accepts 300 through 604800.",
+            "example": 3600,
             "maximum": 604800,
             "minimum": 0
           },
           "url": {
-            "type": "string"
+            "type": "string",
+            "description": "Clonable git URL (SSH or HTTPS).",
+            "example": "https://github.com/acme/design-docs.git"
           }
         }
       },
@@ -16840,7 +16877,8 @@
         "enum": [
           "shared_session",
           "session_per_invocation"
-        ]
+        ],
+        "example": "shared_session"
       },
       "KeyValueInfo": {
         "type": "object",
@@ -17141,6 +17179,7 @@
             ],
             "format": "int32",
             "description": "Pagination limit (default: 20, max: 100)",
+            "example": 20,
             "minimum": 0
           },
           "offset": {
@@ -17150,6 +17189,7 @@
             ],
             "format": "int32",
             "description": "Pagination offset",
+            "example": 0,
             "minimum": 0
           },
           "status": {
@@ -17157,7 +17197,8 @@
               "string",
               "null"
             ],
-            "description": "Filter by execution status"
+            "description": "Filter by execution status",
+            "example": "success"
           }
         }
       },
@@ -19938,7 +19979,8 @@
               "boolean",
               "null"
             ],
-            "description": "Filter by enabled status"
+            "description": "Filter by enabled status",
+            "example": true
           },
           "limit": {
             "type": [
@@ -19947,6 +19989,7 @@
             ],
             "format": "int32",
             "description": "Pagination limit (default: 20, max: 100)",
+            "example": 20,
             "minimum": 0
           },
           "offset": {
@@ -19956,6 +19999,7 @@
             ],
             "format": "int32",
             "description": "Pagination offset",
+            "example": 0,
             "minimum": 0
           },
           "target_type": {
@@ -19963,7 +20007,8 @@
               "string",
               "null"
             ],
-            "description": "Filter by target type (\"workflow\" or \"activity\")"
+            "description": "Filter by target type (\"workflow\" or \"activity\")",
+            "example": "workflow"
           }
         }
       },
@@ -24398,12 +24443,21 @@
           },
           "name": {
             "type": "string",
-            "description": "Workflow type name or activity type name"
+            "description": "Workflow type name or activity type name",
+            "example": "session.run"
           },
           "type": {
             "type": "string",
-            "description": "Target type: \"workflow\" or \"activity\""
+            "description": "Target type: \"workflow\" or \"activity\"",
+            "example": "workflow"
           }
+        },
+        "example": {
+          "input": {
+            "session_id": "session_01933b5a00007000800000000000001"
+          },
+          "name": "session.run",
+          "type": "workflow"
         }
       },
       "ScheduleTargetResponse": {
@@ -27298,28 +27352,32 @@
               "boolean",
               "null"
             ],
-            "description": "Catch up missed triggers"
+            "description": "Catch up missed triggers",
+            "example": true
           },
           "cron_expression": {
             "type": [
               "string",
               "null"
             ],
-            "description": "New cron expression"
+            "description": "New cron expression. Standard `min hour day-of-month month day-of-week` form.",
+            "example": "0 8 * * 1-5"
           },
           "description": {
             "type": [
               "string",
               "null"
             ],
-            "description": "New description"
+            "description": "New description",
+            "example": "Fires the support-triage agent every weekday at 08:00 UTC"
           },
           "enabled": {
             "type": [
               "boolean",
               "null"
             ],
-            "description": "Enable/disable"
+            "description": "Enable/disable",
+            "example": true
           },
           "max_catch_up": {
             "type": [
@@ -27328,6 +27386,7 @@
             ],
             "format": "int32",
             "description": "Max catch-up executions",
+            "example": 3,
             "minimum": 0
           },
           "max_concurrent": {
@@ -27337,10 +27396,11 @@
             ],
             "format": "int32",
             "description": "Max concurrent executions",
+            "example": 1,
             "minimum": 0
           },
           "retry_policy": {
-            "description": "Retry policy"
+            "description": "Retry policy (provider-specific JSON; see the durable engine's `RetryPolicy`)."
           },
           "target": {
             "oneOf": [
@@ -27349,7 +27409,7 @@
               },
               {
                 "$ref": "#/components/schemas/ScheduleTarget",
-                "description": "New target"
+                "description": "New target. Variant shape is defined on `ScheduleTarget`."
               }
             ]
           },
@@ -27358,7 +27418,8 @@
               "string",
               "null"
             ],
-            "description": "New timezone"
+            "description": "New timezone (IANA name).",
+            "example": "America/New_York"
           }
         }
       },

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -11422,7 +11422,7 @@
           },
           "session_mode": {
             "$ref": "#/components/schemas/InvocationSessionMode",
-            "description": "How a fresh session is opened for each invocation. Example shape is defined on `InvocationSessionMode`."
+            "description": "How invocations route into sessions (e.g. `shared_session` to reuse one durable session, or per-invocation modes). Example shape is defined on `InvocationSessionMode`."
           }
         }
       },
@@ -12059,7 +12059,12 @@
         "example": {
           "mode": "api_key",
           "requirements": {
-            "login_required": false
+            "audiences": [
+              "everruns-api"
+            ],
+            "scopes": [
+              "app:invoke"
+            ]
           }
         }
       },
@@ -14315,7 +14320,7 @@
             "example": "nightly-triage"
           },
           "retry_policy": {
-            "description": "Retry policy for failed executions (provider-specific JSON; see the durable engine's `RetryPolicy`)."
+            "description": "Retry policy for failed executions (provider-specific JSON; see the durable engine's `RetryPolicy`).\nExample: `{\"max_attempts\": 3, \"initial_backoff_secs\": 30, \"backoff_multiplier\": 2.0}`."
           },
           "target": {
             "$ref": "#/components/schemas/ScheduleTarget",
@@ -16060,7 +16065,7 @@
       },
       "GitHubVolumeSourceRequest": {
         "type": "object",
-        "description": "Request body for git hub volume source.",
+        "description": "Request body for GitHub volume source.",
         "required": [
           "repository"
         ],
@@ -16101,7 +16106,7 @@
       },
       "GitHubVolumeSourceResponse": {
         "type": "object",
-        "description": "Response body for git hub volume source.",
+        "description": "Response body for GitHub volume source.",
         "required": [
           "repository",
           "branch"
@@ -27400,7 +27405,7 @@
             "minimum": 0
           },
           "retry_policy": {
-            "description": "Retry policy (provider-specific JSON; see the durable engine's `RetryPolicy`)."
+            "description": "Retry policy (provider-specific JSON; see the durable engine's `RetryPolicy`).\nExample: `{\"max_attempts\": 3, \"initial_backoff_secs\": 30, \"backoff_multiplier\": 2.0}`."
           },
           "target": {
             "oneOf": [


### PR DESCRIPTION
## What
Continuation of #1904 / #1915 — examples on three more high-value clusters:

- **Schedules**: `CreateScheduleRequest`, `UpdateScheduleRequest`, `ListSchedulesQuery`, `ListExecutionsQuery`, `ScheduleTarget` — concrete cron expressions (`0 2 * * *`, `0 8 * * 1-5`), IANA timezones, target shapes (`{"type": "workflow", "name": "session.run", "input": …}`), retry policies. Most schedule fields were entirely bare.
- **A2A channel**: `AddA2aChannelHttpRequest` — agent card name/description, session mode, enabled flag.
- **Volume sources**: `GitHubVolumeSourceRequest`, `GitVolumeSourceRequest` — concrete repository, URL, branch, root_folder, sync_interval examples.

Plus schema-level examples on:
- `InvocationSessionMode` (enum, `"shared_session"`) — referenced by `AddA2aChannelHttpRequest.session_mode`.
- `AppEndpointAuthConfig` (struct, `{"mode": "api_key", "requirements": {…}}`) — referenced by `.auth`.

Per the `$ref`-aware coverage gate from #1904, those propagate to every consumer.

## Why
Schedules in particular are a pain point for LLM toolcallers: cron expressions are an alien syntax and the per-tier `ScheduleTarget` shape is non-obvious from name alone. A2A channels are the newest channel kind and have zero in-the-wild examples to copy from. Volume source sub-types were the last gap from the `CreateVolumeRequest` annotations in #1904 (the wrapper carried an example but the variants themselves didn't).

## How
- Same `#[schema(example = …)]` / `json!(...)` pattern as the prior PRs.
- Coverage gate bumped: `MIN_FIELD_EXAMPLE_PCT` 15% → 17% to match the new actual (17%).
- OpenAPI spec regenerated.

## Risk
- **Negligible.** Pure documentation — no production code or wire-shape changes.
- All examples are valid against their schemas (cron expressions, IANA timezones, and the JSON shapes match the structs' field names).
- New gate floor matches the new actual coverage, so the gate passes today and stays forward-only.

## Security
- Threat categories reviewed: **none directly applicable.** Static literals in source, no runtime input handling. No secret-shaped placeholders in this batch (no API keys / tokens).

## Checklist
- [x] Tests added or updated (all 4 OpenAPI gates pass at 100/88/85/17%)
- [x] Backward compatibility considered (additive examples)
- [x] Security review performed against relevant threat model categories

---
_Generated by [Claude Code](https://claude.ai/code/session_01K7vXyQJ9St1tLHukPbJmGh)_