### PR TITLE
perf(prompts): trim remaining capability prompts

### DIFF
--- a/crates/core/src/capabilities/budgeting.rs
+++ b/crates/core/src/capabilities/budgeting.rs
@@ -60,18 +60,7 @@ impl Capability for BudgetingCapability {
     }
 }
 
-const BUDGET_SYSTEM_PROMPT: &str = "\
-## Budget Awareness
-
-This session has budget constraints. You should be mindful of token usage and cost.
-
-**Guidelines:**
-- Use the `check_budget` tool to see remaining budget before starting expensive operations.
-- If budget is running low (< 20% remaining), prioritize completing the current task efficiently.
-- Avoid unnecessary verbose output when budget is constrained.
-- If budget is exhausted, the session will be paused or stopped automatically.
-
-Use the `check_budget` tool to check current budget status at any time.";
+const BUDGET_SYSTEM_PROMPT: &str = "This session may have enforced budgets. Check budget before expensive work; when remaining budget is low, finish the core task efficiently and avoid unnecessary output. Exhaustion may pause or stop the session.";
 
 // ============================================================================
 // Tool: check_budget
@@ -176,7 +165,7 @@ mod tests {
         assert!(
             cap.system_prompt_addition()
                 .unwrap()
-                .contains("Budget Awareness")
+                .contains("enforced budgets")
         );
     }
 

--- a/crates/core/src/capabilities/data_knowledge.rs
+++ b/crates/core/src/capabilities/data_knowledge.rs
@@ -74,12 +74,7 @@ impl Capability for DataKnowledgeCapability {
 
     fn system_prompt_addition(&self) -> Option<&str> {
         Some(
-            r#"Curated data knowledge is available in /knowledge/:
-- /knowledge/tables/ — schema docs, column semantics, gotchas
-- /knowledge/business/ — metric definitions, business rules
-- /knowledge/queries/ — validated SQL templates
-
-Read these files before writing SQL. They are curated ground truth."#,
+            "Curated data knowledge is mounted at `/knowledge/{tables,business,queries}`. Read it before writing SQL; it is ground truth for schema semantics, metrics, and validated query patterns.",
         )
     }
 
@@ -130,9 +125,8 @@ mod tests {
     fn test_has_system_prompt() {
         let cap = DataKnowledgeCapability;
         let prompt = cap.system_prompt_addition().unwrap();
-        assert!(prompt.contains("/knowledge/tables/"));
-        assert!(prompt.contains("/knowledge/business/"));
-        assert!(prompt.contains("/knowledge/queries/"));
+        assert!(prompt.contains("/knowledge/{tables,business,queries}"));
+        assert!(prompt.contains("ground truth"));
     }
 
     #[test]

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -151,6 +151,7 @@ pub use attach_skill::{
     parse_skill_capability_id, reconstruct_skill_md, skill_capability_id,
 };
 pub use btw::{BTW_CAPABILITY_ID, BtwCapability};
+pub use budgeting::BudgetingCapability;
 pub use compaction::{
     COMPACTION_CAPABILITY_ID, CompactionCapability, CompactionConfig, CompactionStep,
     CompactionStrategy, HierarchicalMemoryConfig, MaskingSummaryFormat, MemoryTier,

--- a/crates/core/src/capabilities/persistent_memory.rs
+++ b/crates/core/src/capabilities/persistent_memory.rs
@@ -106,12 +106,7 @@ impl Capability for MemoryCapability {
     }
 }
 
-const MEMORY_SYSTEM_PROMPT: &str = r#"## Persistent Memory
-
-You have persistent memory across sessions via `remember`, `recall`, and `forget` tools.
-Use `remember` to save important facts, user preferences, corrections, or procedures.
-Use `recall` to search your memory before answering questions where prior context may help.
-Use `forget` to remove outdated or incorrect memories."#;
+const MEMORY_SYSTEM_PROMPT: &str = "Persistent memory survives across sessions. Save durable facts, preferences, corrections, and procedures; recall when prior context may help; remove stale or wrong memories.";
 
 // ============================================================================
 // Capability Config

--- a/crates/core/src/capabilities/sample_data.rs
+++ b/crates/core/src/capabilities/sample_data.rs
@@ -124,12 +124,7 @@ impl Capability for SampleDataCapability {
 
     fn system_prompt_addition(&self) -> Option<&str> {
         Some(
-            r#"Sample data files are available in the /samples directory. These include:
-- /samples/users.json - Example user data in JSON format
-- /samples/config.yaml - Example configuration in YAML format
-- /samples/README.md - Documentation about the sample files
-
-These files are read-only and can be used for learning, testing, or as templates."#,
+            "Read-only sample files are mounted at `/samples` (`users.json`, `config.yaml`, `README.md`) for demos, tests, and templates.",
         )
     }
 

--- a/crates/core/src/capabilities/self_budget.rs
+++ b/crates/core/src/capabilities/self_budget.rs
@@ -54,41 +54,7 @@ impl Capability for SelfBudgetCapability {
     }
 }
 
-const SELF_BUDGET_SYSTEM_PROMPT: &str = "\
-## Self-Managed Budget
-
-If the user gives you an indicative budget (e.g. \"you have $7\" or \"keep this under 20k tokens\"), \
-treat it as an **agent-managed soft target**, not as a platform-enforced limit.
-
-**This is different from platform budgets.** The Everruns platform may also enforce \
-session-level budgets — those are authoritative and will pause or stop the session \
-automatically. A self-managed budget is a goal *you* are trying to respect on the \
-user's behalf. Do not conflate the two when reporting progress or remaining spend.
-
-**How to track it:**
-
-- Use `get_session_info` to read cumulative session usage (tokens, and cost where \
-  available) as the source of truth for current spend.
-- Decide for yourself when to start tracking, when to re-check, and when to stop. \
-  You do not need to check on every turn — re-check around expensive or long-running \
-  work, or before kicking off a new phase.
-- Avoid claiming exact cost certainty when only token counts or partial pricing \
-  information are available. Qualify estimates (\"roughly\", \"on the order of\").
-
-**How to adapt as the budget tightens:**
-
-- Prefer shorter, more direct outputs over verbose narration.
-- Reduce retries and exploratory tool calls; commit to a plan sooner.
-- Narrow the scope — finish the core request well rather than covering every adjacent \
-  concern.
-- Skip redundant confirmations and intermediate summaries unless the user asked for them.
-
-**What not to do:**
-
-- Do not create, modify, or delete platform budgets in response to a self-managed \
-  target. Self-managed budgets live only in this conversation.
-- Do not refuse work solely because a self-managed target is close to exhausted; \
-  inform the user and offer a scoped-down option instead.";
+const SELF_BUDGET_SYSTEM_PROMPT: &str = "User-stated budgets are agent-managed soft targets, not platform-enforced limits. Track spend with `get_session_info` around expensive phases, qualify estimates when pricing is partial, and tighten scope/output as the target nears. Do not create, modify, delete, or report them as platform budgets; if close to exhausted, inform the user and continue with a scoped-down path.";
 
 #[cfg(test)]
 mod tests {
@@ -115,10 +81,9 @@ mod tests {
     fn test_capability_has_system_prompt() {
         let cap = SelfBudgetCapability;
         let prompt = cap.system_prompt_addition().expect("prompt present");
-        assert!(prompt.contains("Self-Managed Budget"));
-        assert!(prompt.contains("agent-managed soft target"));
+        assert!(prompt.contains("agent-managed soft targets"));
         assert!(prompt.contains("get_session_info"));
-        assert!(prompt.contains("different from platform budgets"));
+        assert!(prompt.contains("platform-enforced limits"));
     }
 
     #[test]

--- a/crates/core/src/capabilities/session_sandbox.rs
+++ b/crates/core/src/capabilities/session_sandbox.rs
@@ -44,10 +44,7 @@ impl Capability for SessionSandboxCapability {
 
     fn system_prompt_addition(&self) -> Option<&str> {
         Some(
-            "Use the managed sandbox tools for code execution and filesystem access. \
-             You do not need to create or pick a sandbox: this session owns a single managed sandbox. \
-             Use `sandbox_exec` for shell commands, `sandbox_read_file`/`sandbox_write_file` for file I/O, \
-             `sandbox_status` to inspect lifecycle state, and `sandbox_manage` for pause/resume/delete.",
+            "This session owns one managed sandbox. Use sandbox tools for commands and sandbox file I/O; inspect lifecycle state before lifecycle-sensitive work and pause/resume/delete only when requested or cleaning up.",
         )
     }
 

--- a/crates/core/src/capabilities/subagents.rs
+++ b/crates/core/src/capabilities/subagents.rs
@@ -68,20 +68,7 @@ impl Capability for SubagentCapability {
     }
 }
 
-const SUBAGENT_SYSTEM_PROMPT: &str = r#"Delegate tasks to subagents running in their own context window.
-
-When to spawn a subagent:
-- Move noisy/verbose work off the main conversation (test runs, large searches).
-- Fan out across independent items — spawn multiple subagents in the same response.
-- Isolate an independent workstream that does not need to share state with the main thread.
-
-When NOT to spawn a subagent:
-- Do not spawn a subagent for work you can complete directly in this response (e.g. editing a function you can already see).
-- Do not spawn a subagent for a single sequential step that needs the main context.
-
-Other rules:
-- Subagents cannot spawn other subagents (no nesting).
-- Use the `blueprint` parameter to spawn specialist agents with their own tools and model."#;
+const SUBAGENT_SYSTEM_PROMPT: &str = "Spawn subagents only for independent workstreams that benefit from parallelism or a separate context window. Do not delegate immediate sequential steps you can complete directly. No nested subagents. Use blueprints for specialist agents with their own tools and model.";
 
 // =============================================================================
 // Helper: get platform store from context

--- a/crates/core/tests/prompt_budget.rs
+++ b/crates/core/tests/prompt_budget.rs
@@ -12,8 +12,10 @@
 // always fine.
 
 use everruns_core::capabilities::{
-    Capability, FileSystemCapability, InfinityContextCapability, SkillsCapability,
-    StatelessTodoListCapability, SystemPromptContext, WebFetchCapability,
+    BudgetingCapability, Capability, DataKnowledgeCapability, FileSystemCapability,
+    InfinityContextCapability, MemoryCapability, SampleDataCapability, SelfBudgetCapability,
+    SessionSandboxCapability, SkillsCapability, StatelessTodoListCapability, SubagentCapability,
+    SystemPromptContext, WebFetchCapability,
 };
 use everruns_core::typed_id::SessionId;
 
@@ -51,6 +53,37 @@ async fn infinity_context_prompt_within_budget() {
 #[tokio::test]
 async fn skills_static_prompt_within_budget() {
     assert_contribution_under(&SkillsCapability, 250).await;
+}
+
+#[tokio::test]
+async fn memory_prompt_within_budget() {
+    assert_contribution_under(&MemoryCapability, 275).await;
+}
+
+#[tokio::test]
+async fn subagents_prompt_within_budget() {
+    assert_contribution_under(&SubagentCapability, 350).await;
+}
+
+#[tokio::test]
+async fn budgeting_prompt_within_budget() {
+    assert_contribution_under(&BudgetingCapability, 300).await;
+}
+
+#[tokio::test]
+async fn self_budget_prompt_within_budget() {
+    assert_contribution_under(&SelfBudgetCapability, 475).await;
+}
+
+#[tokio::test]
+async fn session_sandbox_prompt_within_budget() {
+    assert_contribution_under(&SessionSandboxCapability, 300).await;
+}
+
+#[tokio::test]
+async fn mounted_data_prompts_within_budget() {
+    assert_contribution_under(&SampleDataCapability, 250).await;
+    assert_contribution_under(&DataKnowledgeCapability, 300).await;
 }
 
 #[tokio::test]

--- a/crates/openai/src/image_capability.rs
+++ b/crates/openai/src/image_capability.rs
@@ -36,19 +36,11 @@ inventory::submit! {
 }
 
 static SYSTEM_PROMPT: LazyLock<String> = LazyLock::new(|| {
-    r#"Use `generate_image` for raster image generation and `edit_image` to transform existing images.
-If the user asks for image generation or editing and those tools are present in the tool list, call them directly.
-Do not claim the tools are unavailable when `generate_image` or `edit_image` are listed as available tools.
-For straightforward image requests, avoid unrelated metadata or bookkeeping tools before the image tool call.
-When the user asks for multiple new images, make one `generate_image` call per requested concept unless they explicitly ask for a batch in one call.
-Unless the user says otherwise, set `save_to_session_fs` to true, keep `persist_artifact` enabled, and save under `/workspace/.outputs/images`.
-Prefer PNG output and rely on the capability default quality unless the user requests a specific quality.
-For single-image requests, streaming progress updates may arrive before the final image; wait for the completed tool result before describing the finished output.
-Do not stop at writing prompts, suggesting external tools, or describing environment limitations unless an actual image tool call fails.
+    r#"When image tools are listed, call them directly for generation/editing requests; do not claim they are unavailable or stop at writing prompts unless a tool call fails. Avoid unrelated bookkeeping before straightforward image calls.
 
-Store per-session OpenAI overrides in `secret_store` under `OPENAI_API_KEY` and optionally `OPENAI_BASE_URL`.
-When saving files, write under `/workspace/.outputs/images` unless the user requests another directory.
-Prefer medium quality unless the user explicitly asks for higher fidelity."#
+For multiple new images, make one generation call per requested concept unless the user asks for batching. Save session files under `/workspace/.outputs/images` by default, rely on the configured quality unless the user requests another, and wait for the completed result before describing a single-image output.
+
+Per-session OpenAI overrides belong in `secret_store` as `OPENAI_API_KEY` and optionally `OPENAI_BASE_URL`."#
         .to_string()
 });
 
@@ -1385,8 +1377,20 @@ mod tests {
     fn system_prompt_marks_image_tools_as_directly_invokable() {
         let prompt = GptImageGenCapability.system_prompt_addition().unwrap();
         assert!(prompt.contains("call them directly"));
-        assert!(prompt.contains("Do not claim the tools are unavailable"));
-        assert!(prompt.contains("Do not stop at writing prompts"));
+        assert!(prompt.contains("do not claim they are unavailable"));
+        assert!(prompt.contains("stop at writing prompts"));
+    }
+
+    #[tokio::test]
+    async fn image_system_prompt_within_budget() {
+        let ctx = everruns_core::capabilities::SystemPromptContext::without_file_store(
+            everruns_core::SessionId::new(),
+        );
+        let prompt = GptImageGenCapability
+            .system_prompt_contribution(&ctx)
+            .await
+            .unwrap();
+        assert!(prompt.len() <= 850, "prompt is {} bytes", prompt.len());
     }
 
     #[test]

--- a/integrations/brave-search/src/lib.rs
+++ b/integrations/brave-search/src/lib.rs
@@ -80,16 +80,7 @@ impl Capability for BraveSearchCapability {
 
     fn system_prompt_addition(&self) -> Option<&str> {
         Some(
-            r#"## Brave Search (Experimental)
-
-Web search via Brave Search API. Use this to find current information, research topics, and look up documentation.
-
-Prerequisite: Brave Search API key must be configured in Settings > Connections, or set as session secret `BRAVE_SEARCH_API_KEY`.
-
-Tools:
-- `brave_web_search` - Search the web and return relevant results
-
-Get a free API key at https://brave.com/search/api/"#,
+            "`brave_web_search` performs current web search via Brave Search; use it for recent facts, research, and documentation lookups.",
         )
     }
 
@@ -136,8 +127,17 @@ mod tests {
         let cap = BraveSearchCapability;
         let prompt = cap.system_prompt_addition().unwrap();
         assert!(prompt.contains("brave_web_search"));
-        assert!(prompt.contains("Brave Search"));
-        assert!(prompt.contains("Experimental"));
+        assert!(prompt.contains("current web search"));
+    }
+
+    #[tokio::test]
+    async fn system_prompt_within_budget() {
+        let cap = BraveSearchCapability;
+        let ctx = everruns_core::capabilities::SystemPromptContext::without_file_store(
+            everruns_core::SessionId::new(),
+        );
+        let prompt = cap.system_prompt_contribution(&ctx).await.unwrap();
+        assert!(prompt.len() <= 250, "prompt is {} bytes", prompt.len());
     }
 
     #[test]

--- a/integrations/browserless/src/lib.rs
+++ b/integrations/browserless/src/lib.rs
@@ -134,65 +134,7 @@ impl Capability for BrowserlessCapability {
 
     fn system_prompt_addition(&self) -> Option<&str> {
         Some(
-            r#"## Browserless
-
-Cloud browser automation via Browserless. Two modes of operation:
-
-### Stateless Mode (default)
-Each tool call uses a fresh browser session that is automatically destroyed after completion.
-No resources are left behind.
-
-### Persistent Session Mode (CDP)
-Use `browserless_open_browser` to create a persistent browser session via Chrome DevTools Protocol.
-The browser stays alive between tool calls, preserving login state, cookies, and navigation history.
-Use `browserless_close_browser` when done to release the browser.
-Persistent sessions also appear in the session Resources tab so users can see
-what may be cleaned automatically after inactivity.
-
-When a persistent session is active, the navigate/screenshot/content/interact tools will
-automatically use it instead of creating fresh browsers.
-
-Authentication: Browserless API token is resolved automatically from Settings > Connections > Browserless.
-If not configured, guide the user to set up their token in Settings > Connections.
-
-### Session Management Tools
-- `browserless_open_browser` - Open a persistent browser session (stays alive between tool calls)
-- `browserless_close_browser` - Close the persistent browser session and release resources
-
-### Browser Tools
-- `browserless_navigate` - Open a URL and get page metadata (title, links, headings, meta tags)
-- `browserless_screenshot` - Take a PNG screenshot of a page (full page or specific element)
-- `browserless_content` - Get the fully rendered HTML/DOM of a page (including JS-rendered content)
-- `browserless_scrape` - Extract structured data using CSS selectors
-- `browserless_interact` - Multi-step interactions: click, type, keyboard, mouse, touch, scroll, then capture result
-
-### Typical Workflows
-
-**One-shot (no persistent session needed):**
-1. `browserless_navigate` to explore a page and discover its structure
-2. `browserless_screenshot` to capture the visual state
-3. `browserless_content` or `browserless_scrape` to read specific content
-
-**Login-protected pages (use persistent session):**
-1. `browserless_open_browser` with the login page URL
-2. `browserless_interact` to fill in credentials and submit the form
-3. `browserless_navigate` to browse authenticated pages
-4. `browserless_screenshot` / `browserless_content` to inspect pages
-5. `browserless_close_browser` when done
-
-### Interaction Actions (browserless_interact)
-- `click` - Click by CSS selector or x,y coordinates
-- `type` - Type text into an input field (selector + value)
-- `keyboard` - Press a key (Enter, Tab, Escape, etc.)
-- `mouse_move` - Move mouse to x,y coordinates
-- `touch` - Tap an element (mobile touch simulation)
-- `scroll` - Scroll the page by a pixel amount
-- `wait` - Wait for milliseconds
-- `wait_for_selector` - Wait for a CSS selector to appear
-- `navigate` - Navigate to a different URL mid-interaction
-
-Set `return_screenshot: true` on `browserless_interact` to get a screenshot after all steps,
-or leave it false to get the DOM content instead."#,
+            "Browserless tools use fresh browsers by default. Open a persistent browser only for login/stateful flows; active persistent sessions are reused automatically and should be closed when done. Use screenshots for visual state and DOM/content/scrape tools for text or structured data.",
         )
     }
 
@@ -288,16 +230,20 @@ mod tests {
     fn test_capability_has_system_prompt() {
         let cap = BrowserlessCapability;
         let prompt = cap.system_prompt_addition().unwrap();
-        assert!(prompt.contains("browserless_open_browser"));
-        assert!(prompt.contains("browserless_close_browser"));
-        assert!(prompt.contains("browserless_navigate"));
-        assert!(prompt.contains("browserless_screenshot"));
-        assert!(prompt.contains("browserless_content"));
-        assert!(prompt.contains("browserless_scrape"));
-        assert!(prompt.contains("browserless_interact"));
-        assert!(prompt.contains("Settings > Connections"));
-        assert!(prompt.contains("Persistent Session Mode"));
-        assert!(prompt.contains("CDP"));
+        assert!(prompt.contains("fresh browsers"));
+        assert!(prompt.contains("persistent browser"));
+        assert!(prompt.contains("closed when done"));
+        assert!(prompt.contains("screenshots for visual state"));
+    }
+
+    #[tokio::test]
+    async fn system_prompt_within_budget() {
+        let cap = BrowserlessCapability;
+        let ctx = everruns_core::capabilities::SystemPromptContext::without_file_store(
+            everruns_core::SessionId::new(),
+        );
+        let prompt = cap.system_prompt_contribution(&ctx).await.unwrap();
+        assert!(prompt.len() <= 400, "prompt is {} bytes", prompt.len());
     }
 
     #[test]

--- a/integrations/cursor/src/lib.rs
+++ b/integrations/cursor/src/lib.rs
@@ -80,23 +80,7 @@ impl Capability for CursorCapability {
 
     fn system_prompt_addition(&self) -> Option<&str> {
         Some(
-            r#"## Cursor Cloud Agents
-
-Use Cursor tools to delegate coding work to asynchronous Cursor Cloud Agents.
-
-Prerequisites:
-- Cursor Cloud Agents API key configured in Settings > Connections (or a per-session `CURSOR_API_KEY` session secret).
-- Cursor GitHub app must have access to the target repository.
-
-Recommended workflow:
-1. Use `cursor_list_models` only when the user asks for a specific model; otherwise omit model and let Cursor choose automatically.
-2. Use `cursor_launch_agent` with a precise repository, base ref, task prompt, and optional branch name.
-3. Use `cursor_get_agent` or `cursor_list_agents` to track status.
-4. Use `cursor_add_followup` for additional instructions while an agent is running.
-5. Use `cursor_get_conversation` to inspect the transcript before summarizing results.
-6. Use `cursor_delete_agent` only when the user asks to remove the agent record.
-
-Cursor agents run in Cursor-managed remote environments and can push branches or create PRs depending on the request."#,
+            "Delegate async coding work to Cursor Cloud Agents when a remote repository task should run outside this session. Launch with a precise repo, base ref, task, and optional branch; track status, send follow-ups while running, inspect the transcript before summarizing, and delete agent records only when asked. Omit model unless the user specifies one.",
         )
     }
 
@@ -233,5 +217,15 @@ mod tests {
         assert!(names.contains(&"cursor_add_followup"));
         assert!(names.contains(&"cursor_get_conversation"));
         assert!(names.contains(&"cursor_list_repositories"));
+    }
+
+    #[tokio::test]
+    async fn system_prompt_within_budget() {
+        let cap = CursorCapability;
+        let ctx = everruns_core::capabilities::SystemPromptContext::without_file_store(
+            everruns_core::SessionId::new(),
+        );
+        let prompt = cap.system_prompt_contribution(&ctx).await.unwrap();
+        assert!(prompt.len() <= 475, "prompt is {} bytes", prompt.len());
     }
 }

--- a/integrations/daytona/src/lib.rs
+++ b/integrations/daytona/src/lib.rs
@@ -99,29 +99,9 @@ const LEASE_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(3 * 60);
 
 static SYSTEM_PROMPT: LazyLock<String> = LazyLock::new(|| {
     let mut prompt = String::from(
-        r#"## Daytona
+        r#"Daytona sandboxes are isolated networked Linux environments. Create or select a sandbox before sandbox-scoped operations; inspect snapshots before creating custom environments. Sandboxes auto-stop/archive/delete, but delete them when done because stop leaves them visible in Daytona.
 
-Cloud-based sandboxes via Daytona. Each sandbox is an isolated environment with full Linux and network access.
-
-Authentication: Daytona API key is resolved automatically from Settings > Connections > Daytona.
-If not configured, guide the user to set up their key in Settings > Connections.
-
-All tools except `daytona_create_sandbox`, `daytona_list_sandboxes`, and `daytona_list_snapshots` require a `sandbox_id`.
-Use `daytona_list_snapshots` to discover available snapshots and their resource specs before creating sandboxes.
-Sandboxes auto-stop after 5 min of inactivity, auto-archive after 30 min, and auto-delete after 60 min.
-Stopped sandboxes are also cleaned up by the control plane after 20 min.
-Always DELETE sandboxes when done (stop leaves them on the dashboard).
-Active sandboxes also appear in the session Resources tab so users can see what
-may be cleaned automatically later.
-
-Git cloning: Use `daytona_git_clone` to clone repositories into `/home/daytona/owner/repo`.
-If the user has connected their GitHub account (Settings > Connections), private repos
-are automatically authenticated. For public repos, no credentials are needed.
-Supports "user/repo" shorthand. Working directory is `/home/daytona`.
-
-Git push/pull/fetch: After cloning, call `daytona_git_credentials` once to configure
-credentials in the sandbox. Then use `daytona_exec` for any git command (push, pull,
-fetch, rebase, etc.) — they authenticate automatically. Call again to refresh (~1h expiry)."#,
+Default workspace is `/home/daytona`. Clone repos under `/home/daytona/owner/repo`; connected GitHub accounts authenticate private clones. Configure sandbox git credentials before push/pull/fetch and refresh them if they expire."#,
     );
     prompt.push_str(everruns_core::tool_output_sanitizer::EXEC_OUTPUT_HINT);
     prompt
@@ -220,13 +200,7 @@ impl Capability for DaytonaCapability {
         let base = self.system_prompt_addition()?;
         if is_api_calling_enabled(config) {
             let api_calling_addition = format!(
-                "\n\n### Direct API Access\n\n\
-                 Direct Daytona API calling is enabled. Use `daytona_api_call` to call any \
-                 Daytona REST API endpoint not covered by the dedicated tools.\n\
-                 The full OpenAPI spec is mounted at `{DAYTONA_OPENAPI_MOUNT_PATH}` — \
-                 read it to discover endpoints, parameters, and schemas.\n\
-                 Resources created via `daytona_api_call` (e.g. POST /sandbox) are \
-                 automatically tracked for cleanup."
+                "\n\nDirect Daytona API access is enabled. Read `{DAYTONA_OPENAPI_MOUNT_PATH}` before calling endpoints not covered by dedicated tools; resources created this way are tracked for cleanup."
             );
             Some(format!(
                 "<capability id=\"{}\">\n{}{}\n</capability>",
@@ -296,11 +270,17 @@ mod tests {
         let cap = DaytonaCapability;
         let prompt = cap.system_prompt_addition().unwrap();
         assert!(prompt.contains("Daytona"));
-        assert!(prompt.contains("Settings > Connections"));
-        // Tool names referenced in usage context (not as a tool list)
-        assert!(prompt.contains("daytona_create_sandbox"));
-        assert!(prompt.contains("daytona_git_clone"));
-        assert!(prompt.contains("daytona_git_credentials"));
+        assert!(prompt.contains("/home/daytona"));
+        assert!(prompt.contains("delete them when done"));
+        assert!(prompt.contains("sandbox git credentials"));
+    }
+
+    #[tokio::test]
+    async fn system_prompt_within_budget() {
+        let cap = DaytonaCapability;
+        let ctx = SystemPromptContext::without_file_store(everruns_core::SessionId::new());
+        let prompt = cap.system_prompt_contribution(&ctx).await.unwrap();
+        assert!(prompt.len() <= 1300, "prompt is {} bytes", prompt.len());
     }
 
     #[test]
@@ -391,9 +371,8 @@ mod tests {
             .system_prompt_contribution_with_config(&ctx, &json!({"enable_api_calling": true}))
             .await
             .unwrap();
-        assert!(prompt.contains("daytona_api_call"));
         assert!(prompt.contains(DAYTONA_OPENAPI_MOUNT_PATH));
-        assert!(prompt.contains("Direct API Access"));
+        assert!(prompt.contains("Direct Daytona API access"));
     }
 
     #[tokio::test]
@@ -404,8 +383,7 @@ mod tests {
             .system_prompt_contribution_with_config(&ctx, &json!({}))
             .await
             .unwrap();
-        assert!(!prompt.contains("daytona_api_call"));
-        assert!(!prompt.contains("Direct API Access"));
+        assert!(!prompt.contains("Direct Daytona API access"));
         // Still has the base prompt
         assert!(prompt.contains("Daytona"));
     }

--- a/integrations/deno/src/lib.rs
+++ b/integrations/deno/src/lib.rs
@@ -55,18 +55,7 @@ const DENO_WORKSPACE_PATH: &str = "/home/app";
 
 static SYSTEM_PROMPT: LazyLock<String> = LazyLock::new(|| {
     let mut prompt = String::from(
-        r#"## Deno Sandboxes
-
-Cloud-based sandboxes via Deno. Each sandbox is an isolated Linux microVM with network access.
-
-Authentication: Deno access token is resolved automatically from Settings > Connections > Deno Deploy.
-If not configured, guide the user to set it up in Settings > Connections.
-
-All tools except `deno_create_sandbox` and `deno_list_sandboxes` require a `sandbox_id`.
-Sandboxes are created with a fixed timeout because Everruns closes the create connection after each tool.
-Always DELETE sandboxes when done to avoid resource leaks.
-
-Use `deno_exec` for shell commands, `deno_write_file` / `deno_read_file` for files, and `deno_manage_sandbox` with action=`delete` for cleanup."#,
+        "Deno sandboxes are isolated networked microVMs. Create or select a sandbox before sandbox-scoped operations, use `/home/app` as the default workspace, and delete sandboxes when done to avoid leaks.",
     );
     prompt.push_str(everruns_core::tool_output_sanitizer::EXEC_OUTPUT_HINT);
     prompt
@@ -155,5 +144,15 @@ mod tests {
         assert!(names.contains(&"deno_write_file"));
         assert!(names.contains(&"deno_list_sandboxes"));
         assert!(names.contains(&"deno_manage_sandbox"));
+    }
+
+    #[tokio::test]
+    async fn system_prompt_within_budget() {
+        let cap = DenoCapability;
+        let ctx = everruns_core::capabilities::SystemPromptContext::without_file_store(
+            everruns_core::SessionId::new(),
+        );
+        let prompt = cap.system_prompt_contribution(&ctx).await.unwrap();
+        assert!(prompt.len() <= 1000, "prompt is {} bytes", prompt.len());
     }
 }

--- a/integrations/docker/src/lib.rs
+++ b/integrations/docker/src/lib.rs
@@ -95,28 +95,7 @@ impl Default for DockerContainerConfig {
 
 static SYSTEM_PROMPT: LazyLock<String> = LazyLock::new(|| {
     let mut prompt = String::from(
-        r#"## Docker Container (Experimental)
-
-You have access to a Docker container for executing commands and managing files.
-The container is tied to this session and persists across tool calls.
-
-IMPORTANT: This is an EXPERIMENTAL capability. The container uses host networking.
-
-Tools:
-- `docker_exec` - Execute a shell command inside the container. Returns stdout, stderr, and exit code.
-- `docker_read_file` - Read a file from the container filesystem.
-- `docker_write_file` - Write content to a file in the container filesystem.
-- `docker_logs` - Get logs from the container. Useful for debugging long-running processes.
-- `docker_stop` - Stop and remove the container (for cleanup or to reset state).
-
-The container is lazily started on first tool use. Subsequent calls reuse the same container.
-
-Best practices:
-- Use `docker_exec` with `bash -c "..."` for complex commands
-- Check exit codes to verify command success
-- The working directory defaults to /workspace
-- Files written persist for the session duration
-- Use `docker_stop` to clean up when done or to reset container state"#,
+        "This session has one lazily-started Docker container with host networking. Calls reuse the same container; default working directory is `/workspace`, files persist for the session, and stopping removes/resets it. Check exit codes and clean up when done.",
     );
     prompt.push_str(everruns_core::tool_output_sanitizer::EXEC_OUTPUT_HINT);
     prompt
@@ -1057,12 +1036,20 @@ mod tests {
     fn test_capability_has_system_prompt() {
         let cap = DockerContainerCapability;
         let prompt = cap.system_prompt_addition().unwrap();
-        assert!(prompt.contains("docker_exec"));
-        assert!(prompt.contains("docker_read_file"));
-        assert!(prompt.contains("docker_write_file"));
-        assert!(prompt.contains("docker_logs"));
-        assert!(prompt.contains("docker_stop"));
-        assert!(prompt.contains("EXPERIMENTAL"));
+        assert!(prompt.contains("lazily-started Docker container"));
+        assert!(prompt.contains("host networking"));
+        assert!(prompt.contains("/workspace"));
+        assert!(prompt.contains("stopping removes/resets it"));
+    }
+
+    #[tokio::test]
+    async fn system_prompt_within_budget() {
+        let cap = DockerContainerCapability;
+        let ctx = everruns_core::capabilities::SystemPromptContext::without_file_store(
+            everruns_core::SessionId::new(),
+        );
+        let prompt = cap.system_prompt_contribution(&ctx).await.unwrap();
+        assert!(prompt.len() <= 1150, "prompt is {} bytes", prompt.len());
     }
 
     #[test]

--- a/integrations/e2b/src/lib.rs
+++ b/integrations/e2b/src/lib.rs
@@ -41,13 +41,7 @@ pub const E2B_ENVD_PORT: u16 = 49_983;
 
 static SYSTEM_PROMPT: LazyLock<String> = LazyLock::new(|| {
     let mut prompt = String::from(
-        r#"## E2B
-
-Cloud sandboxes via E2B. Each sandbox is an isolated Linux environment with network access.
-
-Use `e2b_create_sandbox` first, then `e2b_exec`, `e2b_read_file`, and `e2b_write_file` against the returned `sandbox_id`.
-Prefer `/home/user` as the workspace root.
-Always pause or delete sandboxes when done. Deleted sandboxes are cleaned up immediately; paused sandboxes may still consume platform quota until resumed or deleted."#,
+        "E2B sandboxes are isolated networked Linux environments. Create or select a sandbox before sandbox-scoped operations, prefer `/home/user` as workspace root, and pause or delete sandboxes when done; delete for immediate cleanup.",
     );
     prompt.push_str(everruns_core::tool_output_sanitizer::EXEC_OUTPUT_HINT);
     prompt
@@ -136,5 +130,15 @@ mod tests {
         assert!(names.contains(&"e2b_write_file".to_string()));
         assert!(names.contains(&"e2b_list_sandboxes".to_string()));
         assert!(names.contains(&"e2b_manage_sandbox".to_string()));
+    }
+
+    #[tokio::test]
+    async fn system_prompt_within_budget() {
+        let cap = E2BCapability;
+        let ctx = everruns_core::capabilities::SystemPromptContext::without_file_store(
+            everruns_core::SessionId::new(),
+        );
+        let prompt = cap.system_prompt_contribution(&ctx).await.unwrap();
+        assert!(prompt.len() <= 1000, "prompt is {} bytes", prompt.len());
     }
 }

--- a/integrations/sprites/src/lib.rs
+++ b/integrations/sprites/src/lib.rs
@@ -64,28 +64,7 @@ const SPRITES_WORKSPACE_PATH: &str = "/home/sprite";
 
 static SYSTEM_PROMPT: LazyLock<String> = LazyLock::new(|| {
     let mut prompt = String::from(
-        r#"## Sprites
-
-Persistent, hardware-isolated Linux microVMs (Firecracker) via Sprites. Each sprite is
-a full Linux computer with a persistent ext4 filesystem that survives between sessions.
-
-Authentication: Sprites API token is resolved automatically from Settings > Connections > Sprites.
-If not configured, guide the user to set up their token in Settings > Connections.
-
-All tools except `sprites_create_sprite` and `sprites_list_sprites` require a `sprite_name`.
-Sprites persist indefinitely — they hibernate when idle (no compute charges) and wake instantly.
-Always DELETE sprites when done to avoid storage charges.
-
-Key differences from ephemeral sandboxes:
-- **Persistent filesystem**: Data survives idle/sleep, backed to durable object storage.
-- **Checkpoints**: Use `sprites_checkpoint` to snapshot state before risky operations,
-  `sprites_restore_checkpoint` to roll back. Checkpoints complete in ~300ms.
-- **HTTP services**: Each sprite has a unique public URL. Listen on port 8080 inside
-  the sprite and it's accessible at the sprite's URL. Use `sprites_service_url` to get
-  the URL for sharing or testing.
-- **Instant wake**: Sprites wake from hibernation in <1s when you execute a command.
-
-Working directory is `/home/sprite`."#,
+        "Sprites are persistent Firecracker Linux VMs. Create or select a sprite before sprite-scoped operations; data survives idle/sleep, checkpoints can protect risky changes, services should listen on port 8080 for the public URL, and deleting avoids storage charges. Working directory is `/home/sprite`.",
     );
     prompt.push_str(everruns_core::tool_output_sanitizer::EXEC_OUTPUT_HINT);
     prompt
@@ -193,10 +172,20 @@ mod tests {
         let cap = SpritesCapability;
         let prompt = cap.system_prompt_addition().unwrap();
         assert!(prompt.contains("Sprites"));
-        assert!(prompt.contains("Settings > Connections"));
-        assert!(prompt.contains("sprites_create_sprite"));
-        assert!(prompt.contains("sprites_checkpoint"));
-        assert!(prompt.contains("HTTP services"));
+        assert!(prompt.contains("persistent Firecracker"));
+        assert!(prompt.contains("checkpoints"));
+        assert!(prompt.contains("port 8080"));
+        assert!(prompt.contains("/home/sprite"));
+    }
+
+    #[tokio::test]
+    async fn system_prompt_within_budget() {
+        let cap = SpritesCapability;
+        let ctx = everruns_core::capabilities::SystemPromptContext::without_file_store(
+            everruns_core::SessionId::new(),
+        );
+        let prompt = cap.system_prompt_contribution(&ctx).await.unwrap();
+        assert!(prompt.len() <= 1200, "prompt is {} bytes", prompt.len());
     }
 
     #[test]

--- a/specs/capabilities.md
+++ b/specs/capabilities.md
@@ -203,6 +203,33 @@ System prompt additions must **not duplicate** information already present in to
 
 If every piece of information in the prompt is already covered by tool definitions, return `None`. Listing tool names and descriptions in the system prompt is redundant because the model receives tool definitions as structured metadata alongside the prompt.
 
+Prompt contributions are paid on every model call, so capability prompts are
+budgeted product surface, not documentation. Authors should keep prompt text to
+the smallest stable behavior contract:
+
+- Prefer one or two dense sentences over headings, catalogs, examples, and
+  step-by-step tutorials.
+- Do not include setup instructions, marketing copy, tool inventories, or
+  parameter/action lists when capability metadata, tool descriptions, schemas,
+  config schemas, or tool errors already carry that information.
+- Do not paste external toolkit `llmtxt`/help output into the runtime prompt
+  unless the model needs that grammar on every turn. Long previews may be
+  exposed through `system_prompt_preview()` or docs instead.
+- Config-aware prompts must describe only behavior that changes with config, and
+  must not mention options that are not actually enabled in the current config.
+- When a larger prompt is unavoidable (for example, UI component grammars or
+  machine-readable output catalogs), document why it cannot live in schemas,
+  mounted files, previews, or a tool result.
+
+Prompt-size tests should measure the **actual assembled contribution** using
+`system_prompt_contribution(ctx)` or
+`system_prompt_contribution_with_config(ctx, config)`, including the
+`<capability id="…">` wrapper and config-specific branches. Any capability that
+adds or materially changes a runtime prompt should add or update a byte-budget
+ratchet test in the same PR. Lowering a budget is always acceptable; raising a
+budget requires an explicit code change and a short justification in the commit
+or PR description.
+
 ##### Config-Aware Methods
 
 - **`tools_with_config(config)`** — Returns tools adapted to per-capability config. Default delegates to `tools()`. Example: `WebFetchCapability` enables `save_to_file` when config has `enable_file_download: true`.


### PR DESCRIPTION
## What
Trim remaining verbose capability system prompts across core, OpenAI image generation, and integration capabilities. Add prompt budget ratchets for the newly covered prompt contributors and document the prompt-authoring contract in `specs/capabilities.md`.

## Why
PR #1913 reduced the hottest prompt contributors, but several other capabilities still paid for tool catalogs, setup notes, and long workflow guidance every turn. These prompts are runtime product surface and should contain only behavior the tool schemas cannot express.

## How
- Condensed prompt text for memory, subagents, budgeting, self-budget, session sandbox, mounted data, OpenAI image generation, and selected integrations.
- Added byte-budget tests for additional core capabilities and touched integration/image prompts.
- Updated the capabilities spec to require concise prompts, config-aware prompt accuracy, and actual assembled byte-budget tests.

## Risk
- Low
- Could weaken model guidance if an essential behavior was removed; preserved non-schema behavior such as cleanup expectations, workspace paths, persistent browser/session semantics, and budget distinctions.

## Security
- Threat categories reviewed: TM-LLM.
- Findings and resolutions: Prompt-only changes. No tool schema, tool execution, auth, secret handling, filesystem boundary, sandbox runtime, or outbound network behavior changed. No new threat-model entries needed.

## Follow-ups
No follow-ups.

## Validation
- `git rebase origin/main --autostash`
- `bash scripts/lib/check-migration-ordering.sh`
- `cargo fmt --check`
- `cargo test -p everruns-core --test prompt_budget -- --nocapture`
- `cargo test -p everruns-core -p everruns-openai -p everruns-integrations-brave-search -p everruns-integrations-browserless -p everruns-integrations-cursor -p everruns-integrations-daytona -p everruns-integrations-deno -p everruns-integrations-docker -p everruns-integrations-e2b -p everruns-integrations-sprites system_prompt -- --nocapture`
- `just pre-push`

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)