### PR TITLE
fix(agents): bound automatic snapshots

### DIFF
--- a/crates/server/src/api/agents.rs
+++ b/crates/server/src/api/agents.rs
@@ -155,6 +155,7 @@ impl AppState {
             None,
             self.auth.permission_resolver.clone(),
         )
+        .with_feature_flags(FeatureFlags::from_env(&self.grade))
     }
 }
 

--- a/crates/server/src/domains/agents/commands.rs
+++ b/crates/server/src/domains/agents/commands.rs
@@ -29,6 +29,8 @@ use crate::api::validation::{
     MAX_AGENT_SYSTEM_PROMPT_BYTES, MAX_INITIAL_FILES, MAX_INITIAL_FILES_TOTAL_BYTES,
 };
 
+const MAX_AUTO_SNAPSHOTS_PER_AGENT: i64 = 50;
+
 fn validate_create_limits(req: &CreateAgentRequest) -> Result<(), CommandError> {
     if req.name.len() > MAX_AGENT_NAME_BYTES
         || req
@@ -439,6 +441,15 @@ impl Command for UpdateAgentCmd {
         }
 
         let internal_id = existing.id;
+        let previous_config_hash = if ctx.feature_flags.agent_versions {
+            let caps = q::get_capabilities(&ctx.db, ctx.org_id(), internal_id.uuid())
+                .await
+                .map_err(classify_anyhow)?;
+            let agent = q::row_to_agent(existing.clone(), caps);
+            Some(q::config_hash(&q::authored_config(&agent)))
+        } else {
+            None
+        };
         if let Some(ref name) = req.name {
             q::ensure_name_available(&ctx.db, ctx.org_id(), name, Some(internal_id)).await?;
         }
@@ -530,7 +541,13 @@ impl Command for UpdateAgentCmd {
         };
 
         let agent = q::row_to_agent(row, caps);
-        create_auto_snapshot_from_agent(ctx, &agent).await?;
+        let current_config_hash = q::config_hash(&q::authored_config(&agent));
+        if previous_config_hash
+            .as_ref()
+            .is_none_or(|hash| hash != &current_config_hash)
+        {
+            create_auto_snapshot_from_agent(ctx, &agent).await?;
+        }
 
         Ok(agent)
     }
@@ -645,6 +662,7 @@ impl Command for UpsertAgent {
 
     async fn execute(self, ctx: &Ctx) -> Result<UpsertResult, CommandError> {
         let req = self.req;
+        let public_id = self.id;
 
         // Validate (same checks as CreateAgent)
         validate_name("Agent", &req.name)?;
@@ -671,9 +689,27 @@ impl Command for UpsertAgent {
         let default_model_id = q::validate_model_id(&ctx.db, ctx.org_id(), req.default_model_id)
             .await
             .map_err(classify_anyhow)?;
+        let previous_config_hash = if ctx.feature_flags.agent_versions {
+            if let Some(existing) = ctx
+                .db
+                .get_agent_by_public_id(ctx.org_id(), &public_id)
+                .await
+                .map_err(classify_anyhow)?
+            {
+                let caps = q::get_capabilities(&ctx.db, ctx.org_id(), existing.id.uuid())
+                    .await
+                    .map_err(classify_anyhow)?;
+                let agent = q::row_to_agent(existing, caps);
+                Some(q::config_hash(&q::authored_config(&agent)))
+            } else {
+                None
+            }
+        } else {
+            None
+        };
 
         let input = CreateAgentRow {
-            public_id: self.id,
+            public_id: public_id.clone(),
             name: req.name,
             display_name: req.display_name,
             description: req.description,
@@ -708,7 +744,12 @@ impl Command for UpsertAgent {
         };
 
         let agent = q::row_to_agent(row, final_caps);
-        if !was_created {
+        let current_config_hash = q::config_hash(&q::authored_config(&agent));
+        if !was_created
+            && previous_config_hash
+                .as_ref()
+                .is_none_or(|hash| hash != &current_config_hash)
+        {
             create_auto_snapshot_from_agent(ctx, &agent).await?;
         }
 
@@ -1009,16 +1050,42 @@ async fn create_version_from_agent(
     Ok(q::row_to_agent_version(row))
 }
 
-async fn create_auto_snapshot_from_agent(
-    ctx: &Ctx,
-    agent: &Agent,
-) -> Result<AgentVersion, CommandError> {
+async fn create_auto_snapshot_from_agent(ctx: &Ctx, agent: &Agent) -> Result<(), CommandError> {
+    if !ctx.feature_flags.agent_versions {
+        return Ok(());
+    }
+
+    let agent_id = AgentId::from_uuid(agent.internal_id);
+    let authored_config = q::authored_config(agent);
+    let config_hash = q::config_hash(&authored_config);
+    if ctx
+        .db
+        .get_latest_agent_snapshot(ctx.org_id(), agent_id)
+        .await
+        .map_err(classify_anyhow)?
+        .is_some_and(|row| row.config_hash == config_hash)
+    {
+        return Ok(());
+    }
+
+    // THREAT[TM-DOS-013]: Repeated no-op Agent updates can grow hidden snapshot rows.
+    // Mitigation: automatic snapshots are feature-gated, deduplicated by latest config hash, and retained to a bounded per-Agent window.
     let mut last_conflict = None;
     for _ in 0..3 {
         match create_version_from_agent(ctx, agent, AgentVersionChangeKind::Auto, None, None, false)
             .await
         {
-            Ok(version) => return Ok(version),
+            Ok(_) => {
+                ctx.db
+                    .prune_agent_auto_snapshots(
+                        ctx.org_id(),
+                        agent_id,
+                        MAX_AUTO_SNAPSHOTS_PER_AGENT,
+                    )
+                    .await
+                    .map_err(classify_anyhow)?;
+                return Ok(());
+            }
             Err(CommandError {
                 kind: CommandErrorKind::Conflict(message),
                 ..
@@ -1563,7 +1630,8 @@ mod tests {
     use crate::services::CapabilityService;
     use crate::storage::StorageBackend;
     use everruns_core::{
-        Caller, DEFAULT_ORG_ID, DEFAULT_ORG_PUBLIC_ID, DefaultPermissionResolver, OrgRole,
+        Caller, DEFAULT_ORG_ID, DEFAULT_ORG_PUBLIC_ID, DefaultPermissionResolver, FeatureFlags,
+        OrgRole,
     };
     use std::sync::Arc;
     use uuid::Uuid;
@@ -1577,7 +1645,11 @@ mod tests {
         assert_eq!(version, "0.1.0");
     }
 
-    fn ctx_with_role(db: Arc<StorageBackend>, role: OrgRole) -> Ctx {
+    fn ctx_with_role_and_flags(
+        db: Arc<StorageBackend>,
+        role: OrgRole,
+        feature_flags: FeatureFlags,
+    ) -> Ctx {
         let capability_service = Arc::new(CapabilityService::new(db.clone(), None));
         Ctx::new(
             Caller {
@@ -1592,6 +1664,18 @@ mod tests {
             capability_service,
             None,
             Arc::new(DefaultPermissionResolver),
+        )
+        .with_feature_flags(feature_flags)
+    }
+
+    fn ctx_with_role(db: Arc<StorageBackend>, role: OrgRole) -> Ctx {
+        ctx_with_role_and_flags(
+            db,
+            role,
+            FeatureFlags {
+                agent_versions: true,
+                ..FeatureFlags::default()
+            },
         )
     }
 
@@ -1722,6 +1806,102 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn update_agent_skips_auto_snapshot_when_versions_disabled() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let ctx = ctx_with_role_and_flags(db, OrgRole::Owner, FeatureFlags::default());
+        let agent = CreateAgent(basic_agent_request("auto-snapshot-disabled-agent"))
+            .run(&ctx)
+            .await
+            .expect("agent is created");
+
+        UpdateAgentCmd {
+            id: agent.public_id.to_string(),
+            req: update_prompt_request("updated prompt"),
+        }
+        .run(&ctx)
+        .await
+        .expect("agent is updated");
+
+        let snapshots = ListAgentVersions {
+            agent_id: agent.public_id.to_string(),
+        }
+        .run(&ctx)
+        .await
+        .expect("versions are listed");
+        assert!(snapshots.is_empty());
+    }
+
+    #[tokio::test]
+    async fn update_agent_skips_auto_snapshot_for_unchanged_config() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let ctx = ctx_with_role(db, OrgRole::Owner);
+        let agent = CreateAgent(basic_agent_request("auto-snapshot-noop-agent"))
+            .run(&ctx)
+            .await
+            .expect("agent is created");
+
+        UpdateAgentCmd {
+            id: agent.public_id.to_string(),
+            req: UpdateAgentRequest {
+                name: None,
+                display_name: None,
+                description: None,
+                system_prompt: None,
+                default_model_id: None,
+                tags: None,
+                capabilities: None,
+                initial_files: None,
+                status: None,
+                tools: None,
+                mcp_servers: None,
+                network_access: None,
+                max_iterations: None,
+            },
+        }
+        .run(&ctx)
+        .await
+        .expect("no-op update succeeds");
+
+        let snapshots = ListAgentVersions {
+            agent_id: agent.public_id.to_string(),
+        }
+        .run(&ctx)
+        .await
+        .expect("versions are listed");
+        assert!(snapshots.is_empty());
+    }
+
+    #[tokio::test]
+    async fn update_agent_prunes_old_auto_snapshots() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let ctx = ctx_with_role(db, OrgRole::Owner);
+        let agent = CreateAgent(basic_agent_request("auto-snapshot-pruned-agent"))
+            .run(&ctx)
+            .await
+            .expect("agent is created");
+
+        for i in 0..(MAX_AUTO_SNAPSHOTS_PER_AGENT + 2) {
+            UpdateAgentCmd {
+                id: agent.public_id.to_string(),
+                req: update_prompt_request(&format!("updated prompt {i}")),
+            }
+            .run(&ctx)
+            .await
+            .expect("agent is updated");
+        }
+
+        let snapshots = ListAgentVersions {
+            agent_id: agent.public_id.to_string(),
+        }
+        .run(&ctx)
+        .await
+        .expect("versions are listed");
+        assert_eq!(snapshots.len(), MAX_AUTO_SNAPSHOTS_PER_AGENT as usize);
+        assert_eq!(snapshots[0].version, "draft.52");
+        assert_eq!(snapshots.last().unwrap().version, "draft.3");
+    }
+
+    #[tokio::test]
     async fn upsert_agent_update_creates_unpublished_auto_snapshot() {
         let db = Arc::new(StorageBackend::in_memory());
         let ctx = ctx_with_role(db, OrgRole::Owner);
@@ -1761,6 +1941,37 @@ mod tests {
             snapshots[0].authored_config["system_prompt"],
             "updated upsert prompt"
         );
+    }
+
+    #[tokio::test]
+    async fn upsert_agent_skips_auto_snapshot_for_unchanged_config() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let ctx = ctx_with_role(db, OrgRole::Owner);
+        let agent_id = AgentId::new();
+        let req = basic_agent_request("upsert-auto-snapshot-noop-agent");
+
+        UpsertAgent {
+            id: agent_id.to_string(),
+            req: req.clone(),
+        }
+        .run(&ctx)
+        .await
+        .expect("agent is created by upsert");
+        UpsertAgent {
+            id: agent_id.to_string(),
+            req,
+        }
+        .run(&ctx)
+        .await
+        .expect("agent is upserted without changes");
+
+        let snapshots = ListAgentVersions {
+            agent_id: agent_id.to_string(),
+        }
+        .run(&ctx)
+        .await
+        .expect("versions are listed");
+        assert!(snapshots.is_empty());
     }
 
     #[tokio::test]

--- a/crates/server/src/domains/common.rs
+++ b/crates/server/src/domains/common.rs
@@ -8,7 +8,7 @@ use axum::Json;
 use axum::http::StatusCode;
 #[cfg(test)]
 use everruns_core::DefaultPermissionResolver;
-use everruns_core::{Caller, PermissionResolver, Policy, PolicyError};
+use everruns_core::{Caller, FeatureFlags, PermissionResolver, Policy, PolicyError};
 use everruns_durable::WorkflowEventStore;
 use serde::{Serialize, de::DeserializeOwned};
 use serde_json::Value;
@@ -299,6 +299,7 @@ pub struct Ctx {
     // hardcodes `DefaultPermissionResolver`.
     pub permission_resolver: Arc<dyn PermissionResolver>,
     pub db: Arc<StorageBackend>,
+    pub feature_flags: FeatureFlags,
     pub capability_service: Arc<crate::services::CapabilityService>,
     pub encryption: Option<Arc<crate::storage::encryption::EncryptionService>>,
     pub session_service: Option<Arc<crate::domains::sessions::SessionService>>,
@@ -350,6 +351,7 @@ impl Ctx {
             caller,
             permission_resolver,
             db,
+            feature_flags: FeatureFlags::current(),
             capability_service,
             encryption,
             session_service: None,
@@ -407,6 +409,11 @@ impl Ctx {
     /// code should pass the resolver to `Ctx::new` directly.
     pub fn with_permission_resolver(mut self, resolver: Arc<dyn PermissionResolver>) -> Self {
         self.permission_resolver = resolver;
+        self
+    }
+
+    pub fn with_feature_flags(mut self, feature_flags: FeatureFlags) -> Self {
+        self.feature_flags = feature_flags;
         self
     }
 

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -481,6 +481,15 @@ impl StorageBackend {
         dispatch!(self, get_latest_agent_snapshot, org_id, agent_id)
     }
 
+    pub async fn prune_agent_auto_snapshots(
+        &self,
+        org_id: i64,
+        agent_id: AgentId,
+        keep: i64,
+    ) -> Result<u64> {
+        dispatch!(self, prune_agent_auto_snapshots, org_id, agent_id, keep)
+    }
+
     // ============================================
     // Harnesses
     // ============================================

--- a/crates/server/src/storage/memory/agents.rs
+++ b/crates/server/src/storage/memory/agents.rs
@@ -515,6 +515,36 @@ impl InMemoryDatabase {
             .next())
     }
 
+    pub async fn prune_agent_auto_snapshots(
+        &self,
+        org_id: i64,
+        agent_id: AgentId,
+        keep: i64,
+    ) -> Result<u64> {
+        let keep = keep.max(0) as usize;
+        let mut rows: Vec<_> = self
+            .agent_versions
+            .read()
+            .values()
+            .filter(|row| {
+                row.org_id == org_id
+                    && row.agent_id == agent_id
+                    && !row.is_published
+                    && row.change_kind == "auto"
+            })
+            .cloned()
+            .collect();
+        rows.sort_by_key(|row| std::cmp::Reverse(row.version_number));
+
+        let ids_to_remove: Vec<_> = rows.into_iter().skip(keep).map(|row| row.id).collect();
+        let removed = ids_to_remove.len() as u64;
+        let mut versions = self.agent_versions.write();
+        for id in ids_to_remove {
+            versions.remove(&id);
+        }
+        Ok(removed)
+    }
+
     // ============================================
     // Agent Capabilities
     // ============================================

--- a/crates/server/src/storage/repositories/agents.rs
+++ b/crates/server/src/storage/repositories/agents.rs
@@ -554,6 +554,37 @@ impl Database {
         .await?)
     }
 
+    pub async fn prune_agent_auto_snapshots(
+        &self,
+        org_id: i64,
+        agent_id: AgentId,
+        keep: i64,
+    ) -> Result<u64> {
+        let keep = keep.max(0);
+        let result = sqlx::query(
+            r#"
+            DELETE FROM agent_versions
+            WHERE id IN (
+                SELECT id
+                FROM agent_versions
+                WHERE org_id = $1
+                    AND agent_id = $2
+                    AND is_published = FALSE
+                    AND change_kind = 'auto'
+                ORDER BY version_number DESC
+                OFFSET $3
+            )
+            "#,
+        )
+        .bind(org_id)
+        .bind(agent_id)
+        .bind(keep)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(result.rows_affected())
+    }
+
     // ============================================
     // Agent Capabilities
     // ============================================

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -938,6 +938,7 @@ When a bash script calls `bash` or `sh` or uses `eval`, bashkit re-invokes its o
 | TM-DOS-010 | Rate limit bypass via Valkey failure | Low | Fail-open design: if Valkey is down, requests are allowed without rate limiting | **ACCEPTED** |
 | TM-DOS-011 | Authenticated API key sprawl | Low | No server-side per-user API key quota; API key creation requires an authenticated user session and keys remain user-owned/revocable. Operators must monitor and clean up excessive key creation if they need stricter controls. | **ACCEPTED** |
 | TM-DOS-012 | Source-backed Volume repository storage abuse | Medium | Volume source sync performs shallow clones without tags, skips symlinks, excludes `.git`, and enforces configurable file-count, per-file byte, and total byte limits before replacing `volume_files`. Failed sync keeps the previous readable snapshot. | MITIGATED |
+| TM-DOS-013 | Hidden Agent snapshot storage growth | Medium | Automatic Agent draft snapshots are active only when `FEATURE_AGENT_VERSIONS` is enabled, skipped when the latest stored config hash already matches the draft, and pruned to a bounded per-Agent unpublished auto-snapshot window after each write. | MITIGATED |
 
 ### Mitigation Details
 


### PR DESCRIPTION
## What
Bound automatic Agent draft snapshots and stop creating hidden snapshot rows when they are disabled or unchanged.

## Why
Repeated no-op Agent updates could create unbounded unpublished `agent_versions` rows containing full authored and resolved config. This could grow database storage even when `FEATURE_AGENT_VERSIONS` was disabled.

## How
- Thread API-resolved feature flags into domain `Ctx` for Agent routes.
- Skip automatic snapshots when `agent_versions` is disabled.
- Compare pre/post authored config hashes for update/upsert paths and skip no-op config changes.
- Deduplicate against the latest snapshot config hash before inserting.
- Prune unpublished automatic snapshots to the latest 50 per Agent.
- Clamp PostgreSQL retention input before using it in `OFFSET`, matching the in-memory backend.
- Document the mitigation as `TM-DOS-013`.

## Risk
- Medium
- Snapshot history beyond the latest 50 automatic draft snapshots is pruned. Published versions are not pruned.
- Existing deployments with `FEATURE_AGENT_VERSIONS=false` will stop writing automatic snapshot rows, matching the documented feature gate.

## Security
- Threat categories reviewed: TM-DOS, TM-SQL, TM-TENANT, TM-API.
- Findings and resolutions: added feature gating, no-op/dedup checks, bounded retention, and a clamped retention input for hidden snapshot writes. SQL deletion remains org- and agent-scoped, uses bind parameters, and only targets unpublished `change_kind = 'auto'` rows. No new dependencies or secret-handling changes.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

## Validation
- `cargo fmt --check`
- `cargo test -p everruns-server domains::agents::commands::tests:: -- --nocapture`
- `cargo clippy -p everruns-server --all-targets --all-features -- -D warnings`
- `git diff --check`
- `PORT_PREFIX=279 AUTH_MODE=none FEATURE_AGENT_VERSIONS=true just start-all --no-watch --no-ui` plus API smoke: create Agent, no-op PATCH creates 0 snapshots, changed PATCH creates 1 auto snapshot, second no-op remains at 1 snapshot.
- `just pre-push`
- Final GitHub CI run is green, including PostgreSQL integration, workflow tests, release binaries, clippy, unit tests, CodeQL, SDK compatibility, and CI opt-out policy.
