### PR TITLE
feat(core): add utility llm service

### DIFF
--- a/crates/core/src/atoms/act.rs
+++ b/crates/core/src/atoms/act.rs
@@ -162,6 +162,8 @@ where
     image_store: Option<Arc<dyn crate::traits::ImageArtifactStore>>,
     /// Optional provider credential store for tool-side API clients
     provider_credential_store: Option<Arc<dyn crate::traits::ProviderCredentialStore>>,
+    /// Optional utility LLM service for capability internals
+    utility_llm_service: Option<Arc<dyn crate::UtilityLlmService>>,
     /// Optional resolver for user connection tokens
     connection_resolver: Option<Arc<dyn crate::traits::UserConnectionResolver>>,
     /// Optional session store for session metadata reads
@@ -221,6 +223,7 @@ where
             storage_store: None,
             image_store: None,
             provider_credential_store: None,
+            utility_llm_service: None,
             connection_resolver: None,
             session_store: None,
             session_mutator: None,
@@ -257,6 +260,7 @@ where
             storage_store: None,
             image_store: None,
             provider_credential_store: None,
+            utility_llm_service: None,
             connection_resolver: None,
             session_store: None,
             session_mutator: None,
@@ -327,6 +331,12 @@ where
         store: Arc<dyn crate::traits::ProviderCredentialStore>,
     ) -> Self {
         self.provider_credential_store = Some(store);
+        self
+    }
+
+    /// Set the utility LLM service on this atom.
+    pub fn with_utility_llm_service(mut self, service: Arc<dyn crate::UtilityLlmService>) -> Self {
+        self.utility_llm_service = Some(service);
         self
     }
 
@@ -926,6 +936,9 @@ where
         if let Some(ref store) = self.provider_credential_store {
             tool_context.provider_credential_store = Some(store.clone());
         }
+        if let Some(ref service) = self.utility_llm_service {
+            tool_context.utility_llm_service = Some(service.clone());
+        }
         if let Some(ref resolver) = self.connection_resolver {
             tool_context.connection_resolver = Some(resolver.clone());
         }
@@ -1200,6 +1213,48 @@ mod tests {
         }
     }
 
+    struct UtilityLlmContextProbeTool;
+
+    #[async_trait]
+    impl crate::tools::Tool for UtilityLlmContextProbeTool {
+        fn name(&self) -> &str {
+            "utility_llm_context_probe"
+        }
+
+        fn description(&self) -> &str {
+            "checks whether the utility LLM service is present in tool context"
+        }
+
+        fn parameters_schema(&self) -> serde_json::Value {
+            json!({
+                "type": "object",
+                "properties": {}
+            })
+        }
+
+        async fn execute(&self, _arguments: serde_json::Value) -> crate::ToolExecutionResult {
+            crate::ToolExecutionResult::tool_error("context required")
+        }
+
+        async fn execute_with_context(
+            &self,
+            _arguments: serde_json::Value,
+            context: &crate::traits::ToolContext,
+        ) -> crate::ToolExecutionResult {
+            crate::ToolExecutionResult::success(json!({
+                "utility_llm_service": context.utility_llm_service.is_some(),
+                "configured": context
+                    .utility_llm_service
+                    .as_ref()
+                    .is_some_and(|service| service.is_configured()),
+            }))
+        }
+
+        fn requires_context(&self) -> bool {
+            true
+        }
+    }
+
     #[tokio::test]
     async fn test_act_atom_empty_tool_calls() {
         let executor = ToolRegistry::with_defaults();
@@ -1225,6 +1280,51 @@ mod tests {
         assert!(result.results.is_empty());
         assert_eq!(result.success_count, 0);
         assert_eq!(result.error_count, 0);
+    }
+
+    #[tokio::test]
+    async fn test_act_atom_threads_utility_llm_service_to_tool_context() {
+        let mut executor = ToolRegistry::with_defaults();
+        executor.register(UtilityLlmContextProbeTool);
+        let event_emitter = NoopEventEmitter;
+        let atom = ActAtom::new(executor, event_emitter)
+            .with_utility_llm_service(Arc::new(crate::DisabledUtilityLlmService));
+
+        let context = AtomContext::new(SessionId::new(), TurnId::new(), MessageId::new());
+        let input = ActInput {
+            org_id: Some(1),
+            context,
+            harness_id: HarnessId::from_seed(1),
+            agent_id: Some(AgentId::new()),
+            tool_calls: vec![ToolCall {
+                id: "call_1".to_string(),
+                name: "utility_llm_context_probe".to_string(),
+                arguments: json!({}),
+            }],
+            tool_definitions: vec![ToolDefinition::Builtin(crate::BuiltinTool {
+                name: "utility_llm_context_probe".to_string(),
+                display_name: None,
+                description: "checks context".to_string(),
+                parameters: json!({
+                    "type": "object",
+                    "properties": {}
+                }),
+                policy: Default::default(),
+                category: None,
+                deferrable: Default::default(),
+                hints: crate::tool_types::ToolHints::default(),
+            })],
+            locale: None,
+            blueprint_id: None,
+            network_access: None,
+        };
+
+        let result = atom.execute(input).await.unwrap();
+
+        assert_eq!(result.success_count, 1);
+        let payload = result.results[0].result.result.as_ref().unwrap();
+        assert_eq!(payload["utility_llm_service"], true);
+        assert_eq!(payload["configured"], false);
     }
 
     #[tokio::test]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -39,6 +39,7 @@ pub mod tool_types;
 pub mod deployment;
 pub mod email;
 pub mod exec_tool_result;
+pub mod utility_llm;
 
 // Feature flags
 pub mod feature_flags;
@@ -225,6 +226,10 @@ pub use email::{
     EmailTag, EmailTemplate, GenericEmailTemplate, NoopEmailSender, RenderedEmail,
     ResendEmailConfig, ResendEmailSender, SYSTEM_EMAIL_FROM, SentEmail, SystemEmailConfig,
     system_email_from,
+};
+pub use utility_llm::{
+    DisabledUtilityLlmService, OpenAiUtilityLlmService, SystemUtilityLlmConfig, UTILITY_LLM_MODEL,
+    UTILITY_OPENAI_API_KEY_ENV, UtilityLlmReasoningEffort, UtilityLlmRequest, UtilityLlmService,
 };
 
 // LLM driver types re-exports

--- a/crates/core/src/platform_definition.rs
+++ b/crates/core/src/platform_definition.rs
@@ -12,7 +12,7 @@
 
 use crate::{
     Capability, CapabilityRegistry, ConnectionProvider, ConnectionProviderRegistry, DriverRegistry,
-    EmailSender,
+    EmailSender, UtilityLlmService,
     traits::{DisabledSessionFileSystemFactory, SessionFileSystemFactory},
 };
 use serde_json::Value;
@@ -186,6 +186,7 @@ pub struct PlatformDefinition {
     connection_providers: ConnectionProviderRegistry,
     built_in_harnesses: Vec<BuiltInHarnessDefinition>,
     email_sender: Arc<dyn EmailSender>,
+    utility_llm_service: Arc<dyn UtilityLlmService>,
     session_file_system_factory: Arc<dyn SessionFileSystemFactory>,
 }
 
@@ -198,6 +199,7 @@ impl PlatformDefinition {
             connection_providers: ConnectionProviderRegistry::new(),
             built_in_harnesses: Vec::new(),
             email_sender: Arc::new(crate::DisabledEmailSender),
+            utility_llm_service: Arc::new(crate::DisabledUtilityLlmService),
             session_file_system_factory: Arc::new(DisabledSessionFileSystemFactory),
         }
     }
@@ -252,6 +254,11 @@ impl PlatformDefinition {
         self.email_sender.clone()
     }
 
+    /// System-wide utility LLM service for capability internals.
+    pub fn utility_llm_service(&self) -> Arc<dyn UtilityLlmService> {
+        self.utility_llm_service.clone()
+    }
+
     /// Factory for the platform-selected session filesystem implementation.
     pub fn session_file_system_factory(&self) -> Arc<dyn SessionFileSystemFactory> {
         self.session_file_system_factory.clone()
@@ -283,6 +290,7 @@ impl std::fmt::Debug for PlatformDefinition {
             .field("connection_providers", &self.connection_providers)
             .field("built_in_harnesses", &harness_keys)
             .field("email_sender", &self.email_sender.name())
+            .field("utility_llm_service", &self.utility_llm_service.name())
             .field(
                 "session_file_system_factory",
                 &self.session_file_system_factory.name(),
@@ -352,6 +360,12 @@ impl PlatformDefinitionBuilder {
     /// Set the system-wide email sender.
     pub fn email_sender(mut self, sender: Arc<dyn EmailSender>) -> Self {
         self.platform.email_sender = sender;
+        self
+    }
+
+    /// Set the system-wide utility LLM service.
+    pub fn utility_llm_service(mut self, service: Arc<dyn UtilityLlmService>) -> Self {
+        self.platform.utility_llm_service = service;
         self
     }
 

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -855,6 +855,9 @@ pub struct ToolContext {
     /// Optional provider credential store for tool-side API clients.
     pub provider_credential_store: Option<Arc<dyn ProviderCredentialStore>>,
 
+    /// Optional system utility LLM service for capability internals.
+    pub utility_llm_service: Option<Arc<dyn crate::UtilityLlmService>>,
+
     /// Optional session SQL database store
     pub sqldb_store: Option<SessionSqlDbStoreRef>,
 
@@ -933,6 +936,7 @@ impl ToolContext {
             storage_store: None,
             image_store: None,
             provider_credential_store: None,
+            utility_llm_service: None,
             sqldb_store: None,
             message_retriever: None,
             session_store: None,
@@ -965,6 +969,7 @@ impl ToolContext {
             storage_store: None,
             image_store: None,
             provider_credential_store: None,
+            utility_llm_service: None,
             sqldb_store: None,
             message_retriever: None,
             session_store: None,
@@ -1000,6 +1005,7 @@ impl ToolContext {
             storage_store: Some(storage_store),
             image_store: None,
             provider_credential_store: None,
+            utility_llm_service: None,
             sqldb_store: None,
             message_retriever: None,
             session_store: None,
@@ -1037,6 +1043,7 @@ impl ToolContext {
             sqldb_store: None,
             image_store: None,
             provider_credential_store: None,
+            utility_llm_service: None,
             message_retriever: None,
             session_store: None,
             session_mutator: None,
@@ -1110,6 +1117,7 @@ impl ToolContext {
             storage_store: None,
             image_store: Some(image_store),
             provider_credential_store: None,
+            utility_llm_service: None,
             sqldb_store: None,
             message_retriever: None,
             session_store: None,
@@ -1140,6 +1148,12 @@ impl ToolContext {
         store: Arc<dyn ProviderCredentialStore>,
     ) -> Self {
         self.provider_credential_store = Some(store);
+        self
+    }
+
+    /// Set the utility LLM service on this context.
+    pub fn with_utility_llm_service(mut self, service: Arc<dyn crate::UtilityLlmService>) -> Self {
+        self.utility_llm_service = Some(service);
         self
     }
 
@@ -1285,6 +1299,7 @@ impl std::fmt::Debug for ToolContext {
                 "provider_credential_store",
                 &self.provider_credential_store.is_some(),
             )
+            .field("utility_llm_service", &self.utility_llm_service.is_some())
             .field("sqldb_store", &self.sqldb_store.is_some())
             .field("message_retriever", &self.message_retriever.is_some())
             .field("session_store", &self.session_store.is_some())

--- a/crates/core/src/utility_llm.rs
+++ b/crates/core/src/utility_llm.rs
@@ -1,0 +1,298 @@
+//! System utility LLM service.
+//!
+//! This is a host-owned service for capability internals, not an agent-visible
+//! model provider. It is configured once per deployment and deliberately keeps
+//! the model fixed so call sites cannot turn it into a user-selectable model.
+
+use crate::{
+    AgentLoopError, LlmCallConfig, LlmDriver, LlmMessage, LlmResponse, LlmResponseStream,
+    OpenResponsesProtocolLlmDriver, Result,
+};
+use async_trait::async_trait;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+pub const UTILITY_LLM_MODEL: &str = "gpt-5.5";
+pub const UTILITY_OPENAI_API_KEY_ENV: &str = "UTILITY_OPENAI_API_KEY";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UtilityLlmReasoningEffort {
+    Low,
+    Medium,
+    High,
+}
+
+impl UtilityLlmReasoningEffort {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Low => "low",
+            Self::Medium => "medium",
+            Self::High => "high",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct UtilityLlmRequest {
+    pub messages: Vec<LlmMessage>,
+    pub reasoning_effort: Option<UtilityLlmReasoningEffort>,
+    pub temperature: Option<f32>,
+    pub max_tokens: Option<u32>,
+    pub metadata: HashMap<String, String>,
+}
+
+impl UtilityLlmRequest {
+    pub fn new(messages: Vec<LlmMessage>) -> Self {
+        Self {
+            messages,
+            reasoning_effort: None,
+            temperature: None,
+            max_tokens: None,
+            metadata: HashMap::new(),
+        }
+    }
+
+    pub fn user_text(prompt: impl Into<String>) -> Self {
+        Self::new(vec![LlmMessage::text(
+            crate::LlmMessageRole::User,
+            prompt.into(),
+        )])
+    }
+
+    pub fn with_reasoning_effort(mut self, effort: UtilityLlmReasoningEffort) -> Self {
+        self.reasoning_effort = Some(effort);
+        self
+    }
+
+    pub fn with_temperature(mut self, temperature: f32) -> Self {
+        self.temperature = Some(temperature);
+        self
+    }
+
+    pub fn with_max_tokens(mut self, max_tokens: u32) -> Self {
+        self.max_tokens = Some(max_tokens);
+        self
+    }
+
+    pub fn with_metadata(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.metadata.insert(key.into(), value.into());
+        self
+    }
+
+    fn into_parts(self) -> Result<(Vec<LlmMessage>, LlmCallConfig)> {
+        if self.messages.is_empty() {
+            return Err(AgentLoopError::llm(
+                "utility LLM request must include at least one message",
+            ));
+        }
+
+        let config = LlmCallConfig {
+            model: UTILITY_LLM_MODEL.to_string(),
+            temperature: self.temperature,
+            max_tokens: self.max_tokens,
+            tools: Vec::new(),
+            reasoning_effort: self
+                .reasoning_effort
+                .map(|effort| effort.as_str().to_string()),
+            metadata: self.metadata,
+            previous_response_id: None,
+            tool_search: None,
+            prompt_cache: None,
+        };
+        Ok((self.messages, config))
+    }
+}
+
+#[async_trait]
+pub trait UtilityLlmService: Send + Sync {
+    fn is_configured(&self) -> bool;
+
+    async fn chat_completion(&self, request: UtilityLlmRequest) -> Result<LlmResponse>;
+
+    async fn chat_completion_stream(&self, request: UtilityLlmRequest)
+    -> Result<LlmResponseStream>;
+
+    fn name(&self) -> &'static str {
+        "UtilityLlmService"
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct DisabledUtilityLlmService;
+
+#[async_trait]
+impl UtilityLlmService for DisabledUtilityLlmService {
+    fn is_configured(&self) -> bool {
+        false
+    }
+
+    async fn chat_completion(&self, _request: UtilityLlmRequest) -> Result<LlmResponse> {
+        Err(AgentLoopError::llm("utility LLM service is disabled"))
+    }
+
+    async fn chat_completion_stream(
+        &self,
+        _request: UtilityLlmRequest,
+    ) -> Result<LlmResponseStream> {
+        Err(AgentLoopError::llm("utility LLM service is disabled"))
+    }
+
+    fn name(&self) -> &'static str {
+        "DisabledUtilityLlmService"
+    }
+}
+
+#[derive(Clone)]
+pub struct OpenAiUtilityLlmService {
+    driver: OpenResponsesProtocolLlmDriver,
+}
+
+impl std::fmt::Debug for OpenAiUtilityLlmService {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OpenAiUtilityLlmService")
+            .field("model", &UTILITY_LLM_MODEL)
+            .field("configured", &true)
+            .finish()
+    }
+}
+
+impl OpenAiUtilityLlmService {
+    pub fn new(api_key: impl Into<String>) -> Self {
+        // THREAT[TM-LLM-021]: Utility LLM credentials must not become agent- or
+        // session-configurable. Keep the key inside this host service.
+        Self {
+            driver: OpenResponsesProtocolLlmDriver::new(api_key),
+        }
+    }
+}
+
+#[async_trait]
+impl UtilityLlmService for OpenAiUtilityLlmService {
+    fn is_configured(&self) -> bool {
+        true
+    }
+
+    async fn chat_completion(&self, request: UtilityLlmRequest) -> Result<LlmResponse> {
+        let (messages, config) = request.into_parts()?;
+        self.driver.chat_completion(messages, &config).await
+    }
+
+    async fn chat_completion_stream(
+        &self,
+        request: UtilityLlmRequest,
+    ) -> Result<LlmResponseStream> {
+        let (messages, config) = request.into_parts()?;
+        self.driver.chat_completion_stream(messages, &config).await
+    }
+
+    fn name(&self) -> &'static str {
+        "OpenAiUtilityLlmService"
+    }
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub enum SystemUtilityLlmConfig {
+    Disabled,
+    OpenAi { api_key: String },
+}
+
+impl std::fmt::Debug for SystemUtilityLlmConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Disabled => f.debug_struct("SystemUtilityLlmConfig::Disabled").finish(),
+            Self::OpenAi { .. } => f
+                .debug_struct("SystemUtilityLlmConfig::OpenAi")
+                .field("api_key", &"<redacted>")
+                .finish(),
+        }
+    }
+}
+
+impl SystemUtilityLlmConfig {
+    pub fn from_env() -> Self {
+        match env_opt(UTILITY_OPENAI_API_KEY_ENV) {
+            Some(api_key) => Self::OpenAi { api_key },
+            None => Self::Disabled,
+        }
+    }
+
+    pub fn into_service(self) -> Arc<dyn UtilityLlmService> {
+        match self {
+            Self::Disabled => Arc::new(DisabledUtilityLlmService),
+            Self::OpenAi { api_key } => Arc::new(OpenAiUtilityLlmService::new(api_key)),
+        }
+    }
+}
+
+fn env_opt(name: &str) -> Option<String> {
+    std::env::var(name).ok().filter(|value| !value.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::LlmMessageRole;
+
+    #[tokio::test]
+    async fn disabled_service_reports_not_configured() {
+        let service = DisabledUtilityLlmService;
+
+        assert!(!service.is_configured());
+        let error = service
+            .chat_completion(UtilityLlmRequest::user_text("summarize this"))
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("disabled"));
+    }
+
+    #[test]
+    fn request_builds_hardcoded_model_without_reasoning_by_default() {
+        let request = UtilityLlmRequest::user_text("summarize this");
+        let (messages, config) = request.into_parts().unwrap();
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(config.model, UTILITY_LLM_MODEL);
+        assert_eq!(config.reasoning_effort, None);
+        assert!(config.tools.is_empty());
+        assert!(config.tool_search.is_none());
+    }
+
+    #[test]
+    fn request_accepts_supported_reasoning_efforts() {
+        for (effort, expected) in [
+            (UtilityLlmReasoningEffort::Low, "low"),
+            (UtilityLlmReasoningEffort::Medium, "medium"),
+            (UtilityLlmReasoningEffort::High, "high"),
+        ] {
+            let (_, config) = UtilityLlmRequest::new(vec![LlmMessage::text(
+                LlmMessageRole::User,
+                "classify this",
+            )])
+            .with_reasoning_effort(effort)
+            .into_parts()
+            .unwrap();
+
+            assert_eq!(config.reasoning_effort.as_deref(), Some(expected));
+        }
+    }
+
+    #[test]
+    fn request_requires_messages() {
+        let error = UtilityLlmRequest::new(vec![]).into_parts().unwrap_err();
+
+        assert!(error.to_string().contains("at least one message"));
+    }
+
+    #[test]
+    fn system_config_debug_redacts_api_key() {
+        let debug = format!(
+            "{:?}",
+            SystemUtilityLlmConfig::OpenAi {
+                api_key: "sk-secret-value".to_string(),
+            }
+        );
+
+        assert!(debug.contains("<redacted>"));
+        assert!(!debug.contains("sk-secret-value"));
+    }
+}

--- a/crates/runtime/src/host.rs
+++ b/crates/runtime/src/host.rs
@@ -26,7 +26,7 @@ use everruns_core::traits::{
 use everruns_core::typed_id::{AgentId, HarnessId, MessageId, SessionId, TurnId};
 use everruns_core::{
     Agent, CapabilityRegistry, DependencyBlocker, DriverRegistry, Harness, Session, TokenUsage,
-    ToolDefinition, ToolRegistry, UserFacingError, org_public_id_from_internal,
+    ToolDefinition, ToolRegistry, UserFacingError, UtilityLlmService, org_public_id_from_internal,
     resolve_runtime_capabilities,
 };
 use std::sync::Arc;
@@ -108,6 +108,10 @@ pub trait RuntimeHostAdapter: Send + Sync + Clone + 'static {
     }
 
     fn provider_credential_store(&self, _org_id: i64) -> Option<Arc<dyn ProviderCredentialStore>> {
+        None
+    }
+
+    fn utility_llm_service(&self) -> Option<Arc<dyn UtilityLlmService>> {
         None
     }
 
@@ -669,6 +673,9 @@ pub async fn execute_act_activity<A: RuntimeHostAdapter>(
     }
     if let Some(provider_credential_store) = adapter.provider_credential_store(org_id) {
         atom = atom.with_provider_credential_store(provider_credential_store);
+    }
+    if let Some(utility_llm_service) = adapter.utility_llm_service() {
+        atom = atom.with_utility_llm_service(utility_llm_service);
     }
     if let Some(memory_store) = adapter.memory_store(org_id) {
         atom = atom.with_memory_store(memory_store);

--- a/crates/runtime/src/runtime.rs
+++ b/crates/runtime/src/runtime.rs
@@ -813,6 +813,10 @@ impl RuntimeHostAdapter for InProcessRuntime {
         Some(self.storage_store.clone())
     }
 
+    fn utility_llm_service(&self) -> Option<Arc<dyn everruns_core::UtilityLlmService>> {
+        Some(self.platform_definition.utility_llm_service())
+    }
+
     fn memory_store(&self, _org_id: i64) -> Option<Arc<dyn MemoryStoreBackend>> {
         Some(self.memory_store.clone())
     }

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -100,6 +100,8 @@ pub struct ServerContext {
     pub platform_definition: Arc<PlatformDefinition>,
     /// System-wide email sender from the platform profile.
     pub email_sender: Arc<dyn everruns_core::EmailSender>,
+    /// System-wide utility LLM service from the platform profile.
+    pub utility_llm_service: Arc<dyn everruns_core::UtilityLlmService>,
     /// Vendor-neutral embedder-provided error reporter. Always present;
     /// defaults to a no-op when no embedder has installed one.
     pub error_reporter: SharedErrorReporter,
@@ -1389,6 +1391,7 @@ impl ServerAppBuilder {
             driver_registry: driver_registry.clone(),
             platform_definition: platform_definition.clone(),
             email_sender: platform_definition.email_sender(),
+            utility_llm_service: platform_definition.utility_llm_service(),
             error_reporter: error_reporter.clone(),
         };
 
@@ -1653,6 +1656,7 @@ impl ServerAppBuilder {
                 .with_encryption(encryption.clone())
                 .with_workflow_store(durable_store.clone())
                 .with_permission_resolver(auth_state.permission_resolver.clone())
+                .with_utility_llm_service(platform_definition.utility_llm_service())
                 .with_virtual_registry(virtual_registry.clone())
                 .with_storage_store(session_storage_store)
                 .with_runner(runner.clone());

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -21,7 +21,7 @@ use everruns_core::typed_id::{AgentId, HarnessId, MessageId, SessionId};
 use everruns_core::{
     Agent, AgentStatus, Caller, ContentPart, DriverRegistry, EventData, Harness, HarnessStatus,
     LlmProviderType, Message, MessageRole, Session, SessionStatus, ToolDefinition,
-    ToolResultContentPart, merge_harness,
+    ToolResultContentPart, UtilityLlmService, merge_harness,
 };
 use everruns_worker::mcp_executor::McpServerInfo;
 use everruns_worker::worker_adapters::{TurnContext, WorkerAdapters};
@@ -269,6 +269,7 @@ pub struct DirectWorkerAdapters {
     mcp_server_service: Arc<McpServerService>,
     capability_registry: CapabilityRegistry,
     driver_registry: DriverRegistry,
+    utility_llm_service: Option<Arc<dyn UtilityLlmService>>,
     sqldb_store: everruns_core::traits::SessionSqlDbStoreRef,
     storage_store: Option<Arc<dyn everruns_core::traits::SessionStorageStore>>,
     connection_resolver: Option<Arc<dyn everruns_core::traits::UserConnectionResolver>>,
@@ -299,6 +300,7 @@ impl DirectWorkerAdapters {
             mcp_server_service,
             capability_registry,
             driver_registry,
+            utility_llm_service: None,
             sqldb_store,
             storage_store: None,
             connection_resolver: None,
@@ -364,6 +366,11 @@ impl DirectWorkerAdapters {
 
     pub fn with_permission_resolver(mut self, resolver: Arc<dyn PermissionResolver>) -> Self {
         self.permission_resolver = resolver;
+        self
+    }
+
+    pub fn with_utility_llm_service(mut self, service: Arc<dyn UtilityLlmService>) -> Self {
+        self.utility_llm_service = Some(service);
         self
     }
 
@@ -1391,6 +1398,10 @@ impl WorkerAdapters for DirectWorkerAdapters {
             llm_resolver: self.llm_resolver.clone(),
             org_id,
         })
+    }
+
+    fn utility_llm_service(&self) -> Option<Arc<dyn UtilityLlmService>> {
+        self.utility_llm_service.clone()
     }
 
     fn connection_resolver(&self) -> Arc<dyn everruns_core::traits::UserConnectionResolver> {

--- a/crates/server/src/platform.rs
+++ b/crates/server/src/platform.rs
@@ -10,6 +10,7 @@ use everruns_core::connection_provider::{ConnectionProviderPlugin, ConnectionPro
 use everruns_core::deployment::DeploymentGrade;
 use everruns_core::{
     BuiltInHarnessDefinition, CapabilityRegistry, PlatformDefinition, SystemEmailConfig,
+    SystemUtilityLlmConfig,
 };
 use std::sync::Arc;
 
@@ -26,6 +27,7 @@ pub fn oss_platform_definition_for_grade(grade: DeploymentGrade) -> PlatformDefi
     let email_sender = SystemEmailConfig::from_env()
         .expect("Invalid system email configuration")
         .into_sender();
+    let utility_llm_service = SystemUtilityLlmConfig::from_env().into_service();
 
     PlatformDefinition::builder()
         .capability_registry(capability_registry)
@@ -33,6 +35,7 @@ pub fn oss_platform_definition_for_grade(grade: DeploymentGrade) -> PlatformDefi
         .connection_providers(connection_providers)
         .built_in_harnesses(oss_built_in_harnesses())
         .email_sender(email_sender)
+        .utility_llm_service(utility_llm_service)
         .session_file_system_factory(Arc::new(
             crate::domains::session_files::StorageSessionFileSystemFactory,
         ))

--- a/crates/worker/src/grpc_worker_adapters.rs
+++ b/crates/worker/src/grpc_worker_adapters.rs
@@ -15,7 +15,9 @@ use everruns_core::traits::{
 use everruns_core::typed_id::{
     AgentId, HarnessId, LeasedResourceId, MessageId, ModelId, SessionId,
 };
-use everruns_core::{Agent, DriverRegistry, Harness, Message, PlatformDefinition, Session};
+use everruns_core::{
+    Agent, DriverRegistry, Harness, Message, PlatformDefinition, Session, UtilityLlmService,
+};
 use std::collections::HashMap;
 use std::sync::Arc;
 use uuid::Uuid;
@@ -387,6 +389,10 @@ impl WorkerAdapters for GrpcWorkerAdapters {
             self.client.clone(),
             org_id,
         ))
+    }
+
+    fn utility_llm_service(&self) -> Option<Arc<dyn UtilityLlmService>> {
+        Some(self.platform_definition.utility_llm_service())
     }
 
     fn platform_store(

--- a/crates/worker/src/platform.rs
+++ b/crates/worker/src/platform.rs
@@ -5,7 +5,9 @@
 //! The worker default only includes capabilities and LLM drivers because
 //! connection providers and harness templates are server-owned by default.
 
-use everruns_core::{CapabilityRegistry, DeploymentGrade, PlatformDefinition};
+use everruns_core::{
+    CapabilityRegistry, DeploymentGrade, PlatformDefinition, SystemUtilityLlmConfig,
+};
 
 /// Build the default worker-side platform definition for the current deployment grade.
 pub fn default_platform_definition() -> PlatformDefinition {
@@ -17,5 +19,6 @@ pub fn default_platform_definition_for_grade(grade: DeploymentGrade) -> Platform
     PlatformDefinition::builder()
         .capability_registry(CapabilityRegistry::with_builtins_for_grade(grade))
         .driver_registry(crate::create_driver_registry())
+        .utility_llm_service(SystemUtilityLlmConfig::from_env().into_service())
         .build()
 }

--- a/crates/worker/src/runtime_host.rs
+++ b/crates/worker/src/runtime_host.rs
@@ -9,7 +9,9 @@ use everruns_core::traits::{
     PaymentAuthority, ProviderCredentialStore, SessionFileSystem, SessionMutator, SessionStore,
 };
 use everruns_core::typed_id::{AgentId, HarnessId, SessionId};
-use everruns_core::{Agent, CapabilityRegistry, DriverRegistry, Harness, Session, SessionStatus};
+use everruns_core::{
+    Agent, CapabilityRegistry, DriverRegistry, Harness, Session, SessionStatus, UtilityLlmService,
+};
 use everruns_runtime::{RuntimeHostAdapter, RuntimeHostTurnContext};
 use std::sync::Arc;
 
@@ -136,6 +138,10 @@ impl<A: WorkerAdapters> RuntimeHostAdapter for WorkerRuntimeHost<A> {
 
     fn provider_credential_store(&self, org_id: i64) -> Option<Arc<dyn ProviderCredentialStore>> {
         Some(self.adapters.provider_credential_store(org_id))
+    }
+
+    fn utility_llm_service(&self) -> Option<Arc<dyn UtilityLlmService>> {
+        self.adapters.utility_llm_service()
     }
 
     fn storage_store(&self) -> Option<Arc<dyn everruns_core::traits::SessionStorageStore>> {

--- a/crates/worker/src/worker_adapters.rs
+++ b/crates/worker/src/worker_adapters.rs
@@ -21,7 +21,9 @@ use everruns_core::traits::{
 use everruns_core::typed_id::{
     AgentId, HarnessId, LeasedResourceId, MessageId, ModelId, SessionId,
 };
-use everruns_core::{Agent, DriverRegistry, Harness, Message, Session, ToolDefinition};
+use everruns_core::{
+    Agent, DriverRegistry, Harness, Message, Session, ToolDefinition, UtilityLlmService,
+};
 use std::collections::HashMap;
 use std::sync::Arc;
 use uuid::Uuid;
@@ -237,6 +239,9 @@ pub trait WorkerAdapters: Send + Sync + Clone + 'static {
 
     /// Get the provider credential store for tool-side provider auth lookup.
     fn provider_credential_store(&self, org_id: i64) -> Arc<dyn ProviderCredentialStore>;
+
+    /// Get the system utility LLM service for capability internals.
+    fn utility_llm_service(&self) -> Option<Arc<dyn UtilityLlmService>>;
 
     /// Get the platform store for org-level management tools.
     /// Takes org_id so the store is scoped to the current session's organization.

--- a/specs/README.md
+++ b/specs/README.md
@@ -92,6 +92,7 @@ Specs capture the "why" and "what", not exhaustive source detail. Link to code f
 - `specs/localization.md` - Locale/timezone resolution and backend localization rules
 - `specs/notifications.md` - Generic user notifications
 - `specs/email.md` - Internal email delivery abstraction
+- `specs/utility-llm.md` - Internal utility LLM service for capability internals
 - `specs/voice.md` - Voice Sessions
 - `specs/volumes.md` - Workspace Volumes
 

--- a/specs/embedding.md
+++ b/specs/embedding.md
@@ -23,6 +23,7 @@ This spec defines the contract for embedding. See `crates/core/src/platform_defi
 - Connection-provider registry
 - Built-in harness templates
 - System email sender
+- System utility LLM service
 - Session filesystem factory
 
 The type lives in `everruns-core` so any binary can construct or mutate it without depending on `everruns-server`.

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -560,6 +560,7 @@ The shared validator blocks loopback, RFC1918, link-local, and cloud metadata ta
 | TM-LLM-007 | Indirect prompt injection | High | Tool results and user messages are role-separated; no complete mitigation exists for LLM-level prompt injection | **ACCEPTED** |
 | TM-LLM-008 | Cost runaway via agent loop | Medium | Max 10 iterations per agent turn; configurable | MITIGATED |
 | TM-LLM-020 | Client-supplied privileged message roles in AG-UI input | Medium | Anonymous AG-UI/CopilotKit clients could send `role: "system"` / `developer` / `tool` messages that flow into the LLM context alongside the agent's real system prompt. Mitigated in `crates/server/src/api/ag_ui.rs::validate_input_messages` by rejecting any non-{user,assistant} role at the runtime trust boundary with a generic 400 `invalid_request`, and by rejecting duplicate message ids. | MITIGATED |
+| TM-LLM-021 | Utility LLM key exposed through agent model configuration | High | The utility LLM uses deployment env secret `UTILITY_OPENAI_API_KEY`, is carried as a host service on `PlatformDefinition`, and is threaded only into capability `ToolContext`. It is not stored in provider records, exposed through model selection, or accepted from session/agent config. | MITIGATED |
 
 ### Mitigation Details
 
@@ -583,6 +584,12 @@ Indirect prompt injection via tool results or user messages is an inherent LLM l
 - Max iteration limit prevents infinite loops
 - No automatic code execution without registered tool
 - Monitoring via usage tracking
+
+**TM-LLM-021 — Utility LLM Service:**
+The utility LLM exists for capability internals only. It is configured from the
+host environment, defaults to disabled, fixes the model in code, and reaches
+capabilities through `ToolContext` rather than through agent model/provider
+configuration.
 
 ## 9. Durable Execution Engine (TM-DURABLE)
 

--- a/specs/utility-llm.md
+++ b/specs/utility-llm.md
@@ -1,0 +1,51 @@
+# Utility LLM Service
+
+## Intent
+
+Provide a system-owned LLM service for built-in capability internals.
+
+The utility model is not an agent model provider, public API, UI option, or
+session/agent configuration surface. It is a host service exposed through
+capability execution context so capabilities can perform bounded internal model
+work without reusing user-configured model providers or session secrets.
+
+## Core Contract
+
+`everruns-core` owns the service abstraction:
+
+- `UtilityLlmService` is the async trait used by capability internals.
+- `UtilityLlmRequest` is the provider-neutral request shape.
+- `UtilityLlmReasoningEffort` allows `low`, `medium`, and `high` when a caller
+  explicitly needs reasoning.
+- `UtilityLlmService::is_configured()` reports whether the deployment has the
+  service enabled.
+- `PlatformDefinition` carries the active service as part of the platform
+  profile.
+- Runtime tool execution threads the service into `ToolContext`.
+
+The model is hardcoded to `gpt-5.5`. Requests do not expose tools, tool search,
+previous response IDs, model overrides, or provider credentials. By default the
+service sends no reasoning parameter; callers can opt into `low`, `medium`, or
+`high`.
+
+## System Configuration
+
+The service is configured from process environment:
+
+- `UTILITY_OPENAI_API_KEY`
+
+When the variable is unset or empty, the service is disabled. Disabled
+deployments should call `is_configured()` before attempting optional utility
+work, or handle the configuration error returned by completion methods.
+
+The default server and worker platform profiles resolve
+`SystemUtilityLlmConfig::from_env()` during platform construction. Embedders can
+bypass env-based setup by constructing a custom `PlatformDefinition` and calling
+`PlatformDefinition::builder().utility_llm_service(...)`.
+
+## Non-Goals
+
+- No user-facing model picker entry.
+- No REST API endpoint for ad hoc utility LLM calls.
+- No per-organization or per-session utility model configuration.
+- No access from ordinary agent model selection or provider records.


### PR DESCRIPTION
## What
Add a system-owned utility LLM service for capability internals.

## Why
Capabilities need a provider-neutral internal LLM service that is configured by deployment env rather than by agent/session model provider records.

## How
- Added `UtilityLlmService`, `UtilityLlmRequest`, disabled/OpenAI implementations, and `SystemUtilityLlmConfig` using `UTILITY_OPENAI_API_KEY`.
- Hardcoded utility calls to `gpt-5.5`, with no reasoning by default and explicit `low`, `medium`, or `high` reasoning options.
- Carried the service through `PlatformDefinition`, server/worker platform construction, runtime host adapters, `ActAtom`, and capability `ToolContext`.
- Added specs and a threat-model entry for the new system utility LLM secret surface.

## Risk
- Medium
- Platform construction, worker adapter wiring, or capability tool context could regress if the service is not defaulted correctly. The service defaults disabled, and tests cover disabled config plus ToolContext threading.

## Security
- Threat categories reviewed: TM-LLM, TM-TOOL, TM-DOS, TM-OBS.
- Findings and resolutions: Added TM-LLM-021 for the utility LLM key exposure/cost surface. The key stays in deployment env, is represented as a host service, is not stored in model provider records, and is only threaded into capability `ToolContext`. No key values are logged or exposed in errors.

## Validation
- `cargo check -p everruns-core -p everruns-runtime -p everruns-worker -p everruns-server`
- `cargo test -p everruns-core utility_llm`
- `just start-dev --no-watch`, then `curl -fsS http://localhost:27100/health` returned `{"status":"ok","version":"0.8.33","auth_mode":"None"}`; services stopped afterward.
- `just pre-push`

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)