### PR TITLE
fix(cli): group consecutive tool output rows

### DIFF
--- a/examples/coding-cli/src/app.rs
+++ b/examples/coding-cli/src/app.rs
@@ -1208,7 +1208,9 @@ fn should_insert_chat_gap(current: &Author, next: Option<&Author>) -> bool {
 
     !matches!(
         (current, next),
-        (&Author::Tool, &Author::ToolDetail) | (&Author::ToolDetail, &Author::ToolDetail)
+        (&Author::Tool, &Author::Tool)
+            | (&Author::Tool, &Author::ToolDetail)
+            | (&Author::ToolDetail, &Author::ToolDetail)
     )
 }
 
@@ -1962,7 +1964,8 @@ mod tests {
     }
 
     #[test]
-    fn should_not_insert_chat_gap_inside_todo_blocks() {
+    fn should_not_insert_chat_gap_inside_tool_blocks() {
+        assert!(!should_insert_chat_gap(&Author::Tool, Some(&Author::Tool)));
         assert!(!should_insert_chat_gap(
             &Author::Tool,
             Some(&Author::ToolDetail)

--- a/examples/coding-cli/src/app.rs
+++ b/examples/coding-cli/src/app.rs
@@ -1210,6 +1210,7 @@ fn should_insert_chat_gap(current: &Author, next: Option<&Author>) -> bool {
         (current, next),
         (&Author::Tool, &Author::Tool)
             | (&Author::Tool, &Author::ToolDetail)
+            | (&Author::ToolDetail, &Author::Tool)
             | (&Author::ToolDetail, &Author::ToolDetail)
     )
 }
@@ -1969,6 +1970,10 @@ mod tests {
         assert!(!should_insert_chat_gap(
             &Author::Tool,
             Some(&Author::ToolDetail)
+        ));
+        assert!(!should_insert_chat_gap(
+            &Author::ToolDetail,
+            Some(&Author::Tool)
         ));
         assert!(!should_insert_chat_gap(
             &Author::ToolDetail,


### PR DESCRIPTION
## What
Group adjacent coding CLI tool transcript rows without an inserted blank line, including tool detail rows followed by another tool completion.

## Why
Consecutive tool completions are part of the same transcript block, and the extra spacer makes the CLI output look unintentionally sparse.

## How
Treat `Tool -> Tool`, `Tool -> ToolDetail`, `ToolDetail -> Tool`, and `ToolDetail -> ToolDetail` adjacency as one contiguous TUI chat block, and update the focused unit test.

## Risk
- Low
- Affects only visual spacing in the example coding CLI transcript renderer.

## Security
- Threat categories reviewed: No security-relevant code changes. This only changes local terminal row grouping and does not add inputs, trust boundaries, execution paths, persistence, or network behavior.
- Findings and resolutions: No findings.

## Follow-ups
No follow-ups.

## Validation
- `cargo test -p everruns-coding-cli should_not_insert_chat_gap_inside_tool_blocks`
- `cargo fmt --check -p everruns-coding-cli`
- `cargo run -p everruns-coding-cli -- --provider llmsim --session-dir target/ercode-smoke --print "Say exactly: smoke ok"`
- `git fetch origin main && git rebase origin/main && bash scripts/lib/check-migration-ordering.sh`
- `just pre-push`
- Final PR CI/checks passed: Detect Changes, Build Check, CI Opt-Out Policy, Migration Immutability, CodeQL, Analyze (actions), Analyze (python), Analyze (javascript-typescript); unrelated suites were skipped by change detection with no `ci:skip-*` labels.
- Final review sweep after the post-green wait found one Copilot thread; it was fixed, replied to, and resolved.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)