### PR TITLE
feat(core): bound prompt tool output by default

### DIFF
--- a/crates/container-sandbox/src/tools.rs
+++ b/crates/container-sandbox/src/tools.rs
@@ -8,7 +8,8 @@ use async_trait::async_trait;
 use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
 use everruns_core::ToolHints;
 use everruns_core::tool_output_sanitizer::{
-    clean_exec_output, output_verbosity_budget, priority_aware_truncate,
+    READ_FILE_DEFAULT_LIMIT, build_text_read_file_result, clean_exec_output,
+    output_verbosity_budget, parse_read_file_window_args, priority_aware_truncate,
 };
 use everruns_core::tools::{Tool, ToolExecutionResult};
 use everruns_core::traits::ToolContext;
@@ -322,6 +323,18 @@ impl Tool for SandboxReadFileTool {
                 "path": {
                     "type": "string",
                     "description": "Absolute path to the file inside the container"
+                },
+                "offset": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "default": 0,
+                    "description": "Zero-based line offset to start reading from"
+                },
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "default": READ_FILE_DEFAULT_LIMIT,
+                    "description": "Maximum number of lines to return"
                 }
             },
             "required": ["path"],
@@ -342,6 +355,10 @@ impl Tool for SandboxReadFileTool {
             Ok(p) => p,
             Err(e) => return e,
         };
+        let (offset, limit) = match parse_read_file_window_args(&arguments) {
+            Ok(window) => window,
+            Err(err) => return ToolExecutionResult::tool_error(err),
+        };
 
         let state = match get_sandbox_state(context).await {
             Ok(s) => s,
@@ -355,7 +372,14 @@ impl Tool for SandboxReadFileTool {
             Ok(bytes) => {
                 // Try to return as text, fall back to base64
                 match String::from_utf8(bytes.clone()) {
-                    Ok(text) => ToolExecutionResult::success(text),
+                    Ok(text) => ToolExecutionResult::success(build_text_read_file_result(
+                        "sandbox_read_file",
+                        &path,
+                        &text,
+                        "text",
+                        offset,
+                        limit,
+                    )),
                     Err(_) => ToolExecutionResult::success(format!(
                         "[Binary file, {} bytes]",
                         bytes.len()

--- a/crates/core/src/atoms/act.rs
+++ b/crates/core/src/atoms/act.rs
@@ -304,7 +304,10 @@ where
     /// Default final post-tool-exec hooks (infrastructure, always-on).
     /// These run after all capability-contributed hooks and cannot be removed.
     fn default_final_hooks() -> Vec<Arc<dyn act_hooks::PostToolExecHook>> {
-        vec![Arc::new(act_hooks::OutputHardLimitHook)]
+        vec![
+            Arc::new(crate::capabilities::PersistOutputHook),
+            Arc::new(act_hooks::OutputHardLimitHook),
+        ]
     }
 
     /// Set the SQL database store on this atom

--- a/crates/core/src/atoms/reason.rs
+++ b/crates/core/src/atoms/reason.rs
@@ -850,28 +850,24 @@ impl ReasonAtom {
         // 9. Patch dangling tool calls (add cancelled results for tool calls without responses)
         let patched_messages = patch_dangling_tool_calls(&messages);
 
-        // 9b. Apply cost-oriented masking before provider serialization.
-        // This keeps stale bulky tool results from being paid for repeatedly
-        // even when the model's context window is still large enough.
-        let context_messages = if let Some(ref config) = compaction_config {
-            let masking = crate::capabilities::apply_cost_control_masking(
-                &patched_messages,
-                config,
-                prior_usage.as_ref(),
+        // 9b. Build the prompt-facing model view from lossless stored
+        // messages. This keeps stale bulky tool results from being paid for
+        // repeatedly even when no compaction capability is configured.
+        let masking = crate::capabilities::build_model_view_messages(
+            &patched_messages,
+            compaction_config.as_ref(),
+            prior_usage.as_ref(),
+        );
+        if masking.masked_count > 0 {
+            tracing::info!(
+                session_id = %session_id,
+                masked_count = masking.masked_count,
+                tool_result_bytes_before = masking.tool_result_bytes_before,
+                tool_result_bytes_after = masking.tool_result_bytes_after,
+                "ReasonAtom: model-view cost-control masked stale tool results"
             );
-            if masking.masked_count > 0 {
-                tracing::info!(
-                    session_id = %session_id,
-                    masked_count = masking.masked_count,
-                    tool_result_bytes_before = masking.tool_result_bytes_before,
-                    tool_result_bytes_after = masking.tool_result_bytes_after,
-                    "ReasonAtom: cost-control masked stale tool results"
-                );
-            }
-            masking.messages
-        } else {
-            patched_messages
-        };
+        }
+        let context_messages = masking.messages;
 
         // 10. Resolve images from image_file references (if any)
         //

--- a/crates/core/src/capabilities/compaction.rs
+++ b/crates/core/src/capabilities/compaction.rs
@@ -735,6 +735,23 @@ pub struct CostControlMaskingResult {
     pub tool_result_bytes_after: usize,
 }
 
+static DEFAULT_MODEL_VIEW_COMPACTION_CONFIG: std::sync::LazyLock<CompactionConfig> =
+    std::sync::LazyLock::new(CompactionConfig::default);
+
+/// Build the bounded model-view messages from lossless stored messages.
+///
+/// Storage keeps full tool results. This helper defines the cheaper prompt
+/// view used for provider serialization, with cost control enabled by default
+/// even when the compaction capability itself is not configured.
+pub fn build_model_view_messages(
+    stored_messages: &[Message],
+    compaction_config: Option<&CompactionConfig>,
+    prior_usage: Option<&TokenUsage>,
+) -> CostControlMaskingResult {
+    let config = compaction_config.unwrap_or(&*DEFAULT_MODEL_VIEW_COMPACTION_CONFIG);
+    apply_cost_control_masking(stored_messages, config, prior_usage)
+}
+
 /// Apply cheap, generic cost-control masking to stored messages.
 ///
 /// This runs before converting messages to provider-specific LLM messages, so
@@ -919,7 +936,8 @@ fn summarize_tool_result(
     };
 
     match tool_name {
-        "read_file" | "daytona_read_file" | "sandbox_read_file" => {
+        "read_file" | "daytona_read_file" | "sandbox_read_file" | "e2b_read_file"
+        | "docker_read_file" | "deno_read_file" | "sprites_read_file" | "read_github_file" => {
             summarize_read_file_result(tool_name, object, value)
         }
         "bash" | "daytona_exec" | "sandbox_exec" | "e2b_exec" | "docker_exec" | "deno_exec" => {
@@ -1614,6 +1632,74 @@ mod tests {
     }
 
     #[test]
+    fn test_model_view_masks_without_compaction_config() {
+        let mut messages = vec![Message::user("inspect files repeatedly")];
+        for index in 0..9 {
+            messages.extend(make_message_tool_turn(
+                &format!("call_{index}"),
+                "read_file",
+                json!({
+                    "path": "/workspace/session_019e4c9dd1b17021af70ad3227361b16.jsonl",
+                    "content": format!("{}{}", "large transcript line\n".repeat(1000), index),
+                    "total_lines": 1000,
+                    "lines_shown": {"start": 1, "end": 1000},
+                    "truncated": false,
+                    "content_hash": format!("sha256:{index}")
+                }),
+            ));
+        }
+
+        let result = build_model_view_messages(&messages, None, None);
+
+        assert_eq!(result.masked_count, 7);
+        assert!(result.tool_result_bytes_after < result.tool_result_bytes_before / 4);
+        let first_tool = result.messages[2].tool_result_content().unwrap();
+        let masked = first_tool.result.as_ref().unwrap();
+        assert_eq!(masked["masked"], true);
+        assert!(masked["summary"].as_str().unwrap().contains("read_file"));
+        let last_tool = result
+            .messages
+            .last()
+            .unwrap()
+            .tool_result_content()
+            .unwrap();
+        assert!(last_tool.result.as_ref().unwrap().get("content").is_some());
+    }
+
+    #[test]
+    fn test_model_view_respects_disabled_cost_control_config() {
+        let mut messages = vec![Message::user("inspect files repeatedly")];
+        for index in 0..5 {
+            messages.extend(make_message_tool_turn(
+                &format!("call_{index}"),
+                "read_file",
+                json!({
+                    "path": "/workspace/src/lib.rs",
+                    "content": "line\n".repeat(400),
+                    "total_lines": 400,
+                    "lines_shown": {"start": 1, "end": 400},
+                    "truncated": false
+                }),
+            ));
+        }
+
+        let config = CompactionConfig::from_json(&json!({
+            "cost_control": {
+                "enabled": false,
+                "keep_recent_tool_results": 1,
+                "mask_after_tool_results": 2
+            }
+        }));
+        let result = build_model_view_messages(&messages, Some(&config), None);
+
+        assert_eq!(result.masked_count, 0);
+        assert_eq!(
+            result.tool_result_bytes_after,
+            result.tool_result_bytes_before
+        );
+    }
+
+    #[test]
     fn test_cost_control_uses_prior_usage_signal() {
         let mut messages = vec![Message::user("run commands")];
         for index in 0..3 {
@@ -1646,6 +1732,30 @@ mod tests {
             .as_str()
             .unwrap();
         assert!(summary.contains("bash exit=0"));
+    }
+
+    #[test]
+    fn test_model_view_uses_provider_cache_signal_by_default() {
+        let mut messages = vec![Message::user("run commands")];
+        for index in 0..3 {
+            messages.extend(make_message_tool_turn(
+                &format!("call_{index}"),
+                "bash",
+                json!({
+                    "stdout": "small output",
+                    "stderr": "",
+                    "exit_code": 0,
+                    "success": true
+                }),
+            ));
+        }
+        let usage = TokenUsage::with_cache(150_000, 100, Some(0), None);
+
+        let result = build_model_view_messages(&messages, None, Some(&usage));
+
+        assert_eq!(result.masked_count, 1);
+        let first_tool = result.messages[2].tool_result_content().unwrap();
+        assert_eq!(first_tool.result.as_ref().unwrap()["masked"], true);
     }
 
     #[test]

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -157,9 +157,9 @@ pub use compaction::{
     CompactionStrategy, CostControlConfig, CostControlMaskingResult, HierarchicalMemoryConfig,
     MaskingSummaryFormat, MemoryTier, ObservationMaskingConfig, ObservationMaskingResult,
     SessionCompactionMetrics, SummarizationConfig, aggressive_trim, apply_cost_control_masking,
-    apply_hierarchical_memory, apply_observation_masking, build_summarization_prompt,
-    build_summary_message, classify_memory_tiers, estimate_tokens, estimate_total_tokens,
-    format_messages_for_summarization, should_compact_proactively,
+    apply_hierarchical_memory, apply_observation_masking, build_model_view_messages,
+    build_summarization_prompt, build_summary_message, classify_memory_tiers, estimate_tokens,
+    estimate_total_tokens, format_messages_for_summarization, should_compact_proactively,
 };
 pub use current_time::{CurrentTimeCapability, GetCurrentTimeTool};
 pub use data_knowledge::DataKnowledgeCapability;
@@ -252,7 +252,7 @@ pub use subagents::SubagentCapability;
 pub use system_commands::{SYSTEM_COMMANDS_CAPABILITY_ID, SystemCommandsCapability};
 pub use test_math::{AddTool, DivideTool, MultiplyTool, SubtractTool, TestMathCapability};
 pub use test_weather::{GetForecastTool, GetWeatherTool, TestWeatherCapability};
-pub use tool_output_persistence::ToolOutputPersistenceCapability;
+pub use tool_output_persistence::{PersistOutputHook, ToolOutputPersistenceCapability};
 pub use virtual_bash::{BashTool, VirtualBashCapability};
 pub use web_fetch::{
     BotAuthPublicKey, WebFetchCapability, WebFetchTool, derive_bot_auth_public_key,

--- a/crates/core/src/capabilities/session_sandbox.rs
+++ b/crates/core/src/capabilities/session_sandbox.rs
@@ -10,8 +10,12 @@ use crate::session_sandbox::{
     ensure_session_sandbox_running, load_session_sandbox_state, pause_session_sandbox,
     session_sandbox_tool_hints,
 };
+use crate::tool_output_sanitizer::{
+    READ_FILE_DEFAULT_LIMIT, build_text_read_file_result, parse_read_file_window_args,
+};
 use crate::tools::{Tool, ToolExecutionResult};
 use crate::traits::ToolContext;
+use crate::truncation_info::TruncationInfo;
 use async_trait::async_trait;
 use serde_json::{Value, json};
 
@@ -123,6 +127,33 @@ fn build_sandbox_exec_result(
     } else {
         ToolExecutionResult::success(result)
     }
+}
+
+fn build_sandbox_read_file_result(
+    response: crate::SessionSandboxReadFileResponse,
+    offset: usize,
+    limit: usize,
+) -> ToolExecutionResult {
+    if response.encoding != "text" && response.encoding != "utf-8" {
+        let bytes_returned = response.content.len();
+        let mut result = json!({
+            "path": response.path,
+            "content": response.content,
+            "encoding": response.encoding,
+            "size_bytes": bytes_returned,
+        });
+        TruncationInfo::not_truncated(bytes_returned).attach(&mut result);
+        return ToolExecutionResult::success(result);
+    }
+
+    ToolExecutionResult::success(build_text_read_file_result(
+        "sandbox_read_file",
+        &response.path,
+        &response.content,
+        &response.encoding,
+        offset,
+        limit,
+    ))
 }
 
 #[derive(Clone)]
@@ -260,7 +291,19 @@ impl Tool for SandboxReadFileTool {
         json!({
             "type": "object",
             "properties": {
-                "path": { "type": "string", "description": "Path to read inside the sandbox" }
+                "path": { "type": "string", "description": "Path to read inside the sandbox" },
+                "offset": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "default": 0,
+                    "description": "Zero-based line offset to start reading from"
+                },
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "default": READ_FILE_DEFAULT_LIMIT,
+                    "description": "Maximum number of lines to return"
+                }
             },
             "required": ["path"],
             "additionalProperties": false
@@ -297,16 +340,16 @@ impl Tool for SandboxReadFileTool {
         let Some(path) = arguments.get("path").and_then(|v| v.as_str()) else {
             return ToolExecutionResult::tool_error("Missing required parameter: path");
         };
+        let (offset, limit) = match parse_read_file_window_args(&arguments) {
+            Ok(window) => window,
+            Err(err) => return ToolExecutionResult::tool_error(err),
+        };
 
         match provider
             .read_file(context, &config, &state.instance, path)
             .await
         {
-            Ok(response) => ToolExecutionResult::success(json!({
-                "path": response.path,
-                "content": response.content,
-                "encoding": response.encoding,
-            })),
+            Ok(response) => build_sandbox_read_file_result(response, offset, limit),
             Err(err) => err,
         }
     }
@@ -697,5 +740,53 @@ mod tests {
         assert_eq!(payload["exit_code"], 17);
         assert_eq!(payload["truncated"], true);
         assert_eq!(payload["hint"], "non-zero");
+    }
+
+    #[test]
+    fn sandbox_read_file_result_applies_line_window() {
+        let result = build_sandbox_read_file_result(
+            crate::SessionSandboxReadFileResponse {
+                path: "/workspace/src/lib.rs".to_string(),
+                content: "alpha\nbeta\ngamma\ndelta".to_string(),
+                encoding: "text".to_string(),
+            },
+            1,
+            2,
+        )
+        .into_tool_result("call_1", "sandbox_read_file");
+
+        let payload = result.result.unwrap();
+        assert_eq!(payload["path"], "/workspace/src/lib.rs");
+        assert_eq!(payload["content"], "2|beta\n3|gamma");
+        assert_eq!(payload["total_lines"], 4);
+        assert_eq!(payload["lines_shown"]["start"], 2);
+        assert_eq!(payload["lines_shown"]["end"], 3);
+        assert_eq!(payload["truncated"], true);
+        assert_eq!(payload["truncation"]["next_offset"], 3);
+        assert!(
+            payload["truncation"]["resume_hint"]
+                .as_str()
+                .unwrap()
+                .contains("sandbox_read_file")
+        );
+    }
+
+    #[test]
+    fn sandbox_read_file_result_marks_untruncated_window() {
+        let result = build_sandbox_read_file_result(
+            crate::SessionSandboxReadFileResponse {
+                path: "/workspace/src/lib.rs".to_string(),
+                content: "alpha\nbeta".to_string(),
+                encoding: "text".to_string(),
+            },
+            0,
+            10,
+        )
+        .into_tool_result("call_1", "sandbox_read_file");
+
+        let payload = result.result.unwrap();
+        assert_eq!(payload["content"], "1|alpha\n2|beta");
+        assert_eq!(payload["truncated"], false);
+        assert_eq!(payload["truncation"]["truncated"], false);
     }
 }

--- a/crates/core/src/capabilities/tool_output_persistence.rs
+++ b/crates/core/src/capabilities/tool_output_persistence.rs
@@ -13,7 +13,7 @@
 //   /.outputs/{safe_id}.stderr when stderr is persisted (session-scoped)
 // - Injects `output_files` array into result for agent to read selectively
 // - Graceful degradation: skip silently if file_store is unavailable
-// - Runs before FinalPostToolExecHook (EVE-225 hard limit)
+// - Runs as an always-on final hook before EVE-225 hard-limit truncation
 // - EVE-245: annotates truncated stdout with file reference so agent knows
 //   it can read_file the full output with offset/limit
 
@@ -166,7 +166,7 @@ impl Capability for ToolOutputPersistenceCapability {
 }
 
 /// Hook that persists tool output to VFS when `persist_output` hint is set.
-struct PersistOutputHook;
+pub struct PersistOutputHook;
 
 #[async_trait]
 impl PostToolExecHook for PersistOutputHook {
@@ -179,6 +179,15 @@ impl PostToolExecHook for PersistOutputHook {
     ) {
         // Only persist if tool declares persist_output hint
         if tool_def.hints().persist_output != Some(true) {
+            return;
+        }
+
+        if result
+            .result
+            .as_ref()
+            .and_then(|value| value.get("output_files"))
+            .is_some()
+        {
             return;
         }
 

--- a/crates/core/src/tool_output_sanitizer.rs
+++ b/crates/core/src/tool_output_sanitizer.rs
@@ -224,15 +224,32 @@ pub fn apply_read_file_hard_cap(result: &mut String) -> bool {
     true
 }
 
+#[derive(Debug)]
+struct FormattedReadFileWindow {
+    content: String,
+    total_lines: usize,
+    start_line: usize,
+    end_line: usize,
+    line_capped: bool,
+    size_capped: bool,
+}
+
 /// Format file content with compact line numbers: `N|content`.
 ///
-/// Applies offset/limit pagination. Returns (formatted_content, total_lines, truncated).
+/// Applies offset/limit pagination and the hard byte cap in one pass while
+/// preserving whether truncation was caused by the line window or byte budget.
 /// Line numbers are 1-based in output regardless of offset.
-/// Single-pass: counts total lines while only formatting the requested window.
-pub fn format_lines(content: &str, offset: usize, limit: usize) -> (String, usize, bool) {
+fn format_lines_with_metadata(
+    content: &str,
+    offset: usize,
+    limit: usize,
+) -> FormattedReadFileWindow {
     let window_end = offset.saturating_add(limit);
     let mut total_lines = 0;
     let mut result = String::new();
+    let mut start_line = 0;
+    let mut end_line = 0;
+    let mut size_capped = false;
 
     for (idx, line) in content.lines().enumerate() {
         total_lines = idx + 1;
@@ -241,26 +258,135 @@ pub fn format_lines(content: &str, offset: usize, limit: usize) -> (String, usiz
             continue;
         }
 
-        if !result.is_empty() {
-            result.push('\n');
+        if size_capped {
+            continue;
         }
 
         // 1-based line numbers
         let line_num = idx + 1;
-        result.push_str(&line_num.to_string());
-        result.push('|');
-        result.push_str(line);
+        if start_line == 0 {
+            start_line = line_num;
+        }
+
+        let separator = if result.is_empty() { "" } else { "\n" };
+        let formatted_line = format!("{separator}{line_num}|{line}");
+        let available = READ_FILE_HARD_BYTE_CAP.saturating_sub(result.len());
+
+        if formatted_line.len() <= available {
+            result.push_str(&formatted_line);
+            end_line = line_num;
+            continue;
+        }
+
+        let cut = utf8_floor(&formatted_line, available);
+        if cut > 0 {
+            result.push_str(&formatted_line[..cut]);
+            end_line = line_num;
+        }
+        size_capped = true;
     }
 
     let end = offset.saturating_add(limit).min(total_lines);
-    let truncated = end < total_lines;
+    let line_capped = end < total_lines;
 
-    // Apply hard byte cap
-    if apply_read_file_hard_cap(&mut result) {
-        return (result, total_lines, true);
+    FormattedReadFileWindow {
+        content: result,
+        total_lines,
+        start_line,
+        end_line,
+        line_capped,
+        size_capped,
     }
+}
 
-    (result, total_lines, truncated)
+/// Format file content with compact line numbers: `N|content`.
+///
+/// Applies offset/limit pagination. Returns (formatted_content, total_lines, truncated).
+/// Line numbers are 1-based in output regardless of offset.
+pub fn format_lines(content: &str, offset: usize, limit: usize) -> (String, usize, bool) {
+    let formatted = format_lines_with_metadata(content, offset, limit);
+    (
+        formatted.content,
+        formatted.total_lines,
+        formatted.line_capped || formatted.size_capped,
+    )
+}
+
+/// Parse standard read-file `offset`/`limit` arguments.
+pub fn parse_read_file_window_args(
+    arguments: &serde_json::Value,
+) -> Result<(usize, usize), String> {
+    let offset = arguments
+        .get("offset")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0) as usize;
+    let limit = arguments
+        .get("limit")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(READ_FILE_DEFAULT_LIMIT as u64) as usize;
+    if limit == 0 {
+        return Err("limit must be a positive integer".to_string());
+    }
+    Ok((offset, limit))
+}
+
+/// Build the standard structured response for a text read-file tool.
+pub fn build_text_read_file_result(
+    tool_name: &str,
+    path: &str,
+    content: &str,
+    encoding: &str,
+    offset: usize,
+    limit: usize,
+) -> serde_json::Value {
+    let formatted = format_lines_with_metadata(content, offset, limit);
+    let truncated = formatted.line_capped || formatted.size_capped;
+
+    let mut result = serde_json::json!({
+        "path": path,
+        "content": formatted.content,
+        "encoding": encoding,
+        "total_lines": formatted.total_lines,
+        "lines_shown": {
+            "start": formatted.start_line,
+            "end": formatted.end_line,
+        },
+        "truncated": truncated,
+        "size_bytes": content.len(),
+    });
+
+    let truncation = if truncated {
+        if formatted.size_capped {
+            crate::truncation_info::TruncationInfo::without_resume(
+                formatted.content.len(),
+                Some(content.len()),
+                crate::truncation_info::TruncationReason::SizeCap,
+            )
+        } else if formatted.line_capped {
+            crate::truncation_info::TruncationInfo::with_resume(
+                formatted.content.len(),
+                Some(content.len()),
+                formatted.end_line as u64,
+                format!(
+                    "call {tool_name} with offset={} to resume from line {}",
+                    formatted.end_line,
+                    formatted.end_line + 1,
+                ),
+                crate::truncation_info::TruncationReason::LineCap,
+            )
+        } else {
+            crate::truncation_info::TruncationInfo::without_resume(
+                formatted.content.len(),
+                Some(content.len()),
+                crate::truncation_info::TruncationReason::SizeCap,
+            )
+        }
+    } else {
+        crate::truncation_info::TruncationInfo::not_truncated(formatted.content.len())
+    };
+    truncation.attach(&mut result);
+
+    result
 }
 
 /// Full sanitization pipeline: strip ANSI → collapse CR → priority-aware truncate.
@@ -841,6 +967,43 @@ mod tests {
         assert_eq!(content, "1|hello");
         assert_eq!(total, 1);
         assert!(!truncated);
+    }
+
+    #[test]
+    fn test_build_text_read_file_result_window() {
+        let result =
+            build_text_read_file_result("read_file", "/workspace/a.txt", "a\nb\nc", "text", 1, 1);
+
+        assert_eq!(result["content"], "2|b");
+        assert_eq!(result["total_lines"], 3);
+        assert_eq!(result["lines_shown"]["start"], 2);
+        assert_eq!(result["lines_shown"]["end"], 2);
+        assert_eq!(result["truncated"], true);
+        assert_eq!(result["truncation"]["next_offset"], 2);
+    }
+
+    #[test]
+    fn test_build_text_read_file_result_hard_cap_has_no_resume() {
+        let big_line = "x".repeat(READ_FILE_HARD_BYTE_CAP + 128);
+        let result =
+            build_text_read_file_result("read_file", "/workspace/big.txt", &big_line, "text", 0, 1);
+
+        assert_eq!(result["total_lines"], 1);
+        assert_eq!(result["lines_shown"]["start"], 1);
+        assert_eq!(result["lines_shown"]["end"], 1);
+        assert_eq!(result["truncated"], true);
+        assert_eq!(result["truncation"]["reason"], "size_cap");
+        assert!(result["truncation"].get("next_offset").is_none());
+        assert!(
+            result["content"].as_str().unwrap().len() <= READ_FILE_HARD_BYTE_CAP,
+            "content exceeded hard byte cap"
+        );
+    }
+
+    #[test]
+    fn test_parse_read_file_window_rejects_zero_limit() {
+        let err = parse_read_file_window_args(&serde_json::json!({"limit": 0})).unwrap_err();
+        assert_eq!(err, "limit must be a positive integer");
     }
 
     // ====================================================================

--- a/integrations/daytona/src/tools.rs
+++ b/integrations/daytona/src/tools.rs
@@ -25,6 +25,9 @@ use everruns_core::resource_ownership::{
     list_owned_external_resource_ids, ownership_tracking_unavailable_error,
     require_owned_external_resource,
 };
+use everruns_core::tool_output_sanitizer::{
+    READ_FILE_DEFAULT_LIMIT, build_text_read_file_result, parse_read_file_window_args,
+};
 use everruns_core::tools::{Tool, ToolExecutionResult};
 use everruns_core::traits::ToolContext;
 
@@ -602,6 +605,18 @@ impl Tool for DaytonaReadFileTool {
                 "path": {
                     "type": "string",
                     "description": "Path to file in sandbox (e.g., '/home/daytona/main.py')"
+                },
+                "offset": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "default": 0,
+                    "description": "Zero-based line offset to start reading from"
+                },
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "default": READ_FILE_DEFAULT_LIMIT,
+                    "description": "Maximum number of lines to return"
                 }
             },
             "required": ["sandbox_id", "path"],
@@ -635,6 +650,10 @@ impl Tool for DaytonaReadFileTool {
             Ok(s) => s,
             Err(e) => return e,
         };
+        let (offset, limit) = match parse_read_file_window_args(&arguments) {
+            Ok(window) => window,
+            Err(err) => return ToolExecutionResult::tool_error(err),
+        };
 
         let api_key = match get_api_key(context).await {
             Ok(k) => k,
@@ -653,11 +672,25 @@ impl Tool for DaytonaReadFileTool {
                     return e;
                 }
                 let (content, encoding) = SessionFile::encode_content(&bytes);
-                ToolExecutionResult::success(json!({
-                    "path": path,
-                    "content": content,
-                    "encoding": encoding
-                }))
+                let mut result = if encoding == "text" || encoding == "utf-8" {
+                    build_text_read_file_result(
+                        "daytona_read_file",
+                        path,
+                        &content,
+                        &encoding,
+                        offset,
+                        limit,
+                    )
+                } else {
+                    json!({
+                        "path": path,
+                        "content": content,
+                        "encoding": encoding,
+                        "size_bytes": bytes.len()
+                    })
+                };
+                result["sandbox_id"] = json!(sandbox_id);
+                ToolExecutionResult::success(result)
             }
             Err(e) => ToolExecutionResult::tool_error(e),
         }

--- a/integrations/deno/src/tools.rs
+++ b/integrations/deno/src/tools.rs
@@ -5,6 +5,9 @@
 
 use async_trait::async_trait;
 use everruns_core::ToolHints;
+use everruns_core::tool_output_sanitizer::{
+    READ_FILE_DEFAULT_LIMIT, build_text_read_file_result, parse_read_file_window_args,
+};
 use everruns_core::tools::{Tool, ToolExecutionResult};
 use everruns_core::traits::ToolContext;
 use serde_json::{Value, json};
@@ -337,7 +340,19 @@ impl Tool for DenoReadFileTool {
             "type": "object",
             "properties": {
                 "sandbox_id": { "type": "string", "description": "Sandbox ID" },
-                "path": { "type": "string", "description": "Path to read" }
+                "path": { "type": "string", "description": "Path to read" },
+                "offset": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "default": 0,
+                    "description": "Zero-based line offset to start reading from"
+                },
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "default": READ_FILE_DEFAULT_LIMIT,
+                    "description": "Maximum number of lines to return"
+                }
             },
             "required": ["sandbox_id", "path"],
             "additionalProperties": false
@@ -370,6 +385,10 @@ impl Tool for DenoReadFileTool {
             Ok(value) => value,
             Err(error) => return error,
         };
+        let (offset, limit) = match parse_read_file_window_args(&arguments) {
+            Ok(window) => window,
+            Err(err) => return ToolExecutionResult::tool_error(err),
+        };
 
         let credentials = match get_credentials(context).await {
             Ok(credentials) => credentials,
@@ -389,10 +408,10 @@ impl Tool for DenoReadFileTool {
             return error;
         }
 
-        ToolExecutionResult::success(json!({
-            "path": path,
-            "content": content,
-        }))
+        let mut result =
+            build_text_read_file_result("deno_read_file", path, &content, "text", offset, limit);
+        result["sandbox_id"] = json!(sandbox_id);
+        ToolExecutionResult::success(result)
     }
 
     fn requires_context(&self) -> bool {

--- a/integrations/docker/src/lib.rs
+++ b/integrations/docker/src/lib.rs
@@ -20,6 +20,9 @@
 
 use everruns_core::ToolHints;
 use everruns_core::capabilities::{Capability, CapabilityStatus, IntegrationPlugin, RiskLevel};
+use everruns_core::tool_output_sanitizer::{
+    READ_FILE_DEFAULT_LIMIT, build_text_read_file_result, parse_read_file_window_args,
+};
 use everruns_core::tools::{Tool, ToolExecutionResult};
 use everruns_core::traits::ToolContext;
 
@@ -501,6 +504,18 @@ impl Tool for DockerReadFileTool {
                     "type": "string",
                     "description": "Absolute path to the file inside the container (e.g., '/workspace/main.py')"
                 },
+                "offset": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "default": 0,
+                    "description": "Zero-based line offset to start reading from"
+                },
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "default": READ_FILE_DEFAULT_LIMIT,
+                    "description": "Maximum number of lines to return"
+                },
                 "config": {
                     "type": "object",
                     "description": "Container configuration (image, working_dir). Usually provided by capability config.",
@@ -535,6 +550,10 @@ impl Tool for DockerReadFileTool {
         let path = match arguments.get("path").and_then(|v| v.as_str()) {
             Some(p) => p,
             None => return ToolExecutionResult::tool_error("Missing required parameter: path"),
+        };
+        let (offset, limit) = match parse_read_file_window_args(&arguments) {
+            Ok(window) => window,
+            Err(err) => return ToolExecutionResult::tool_error(err),
         };
 
         let config = arguments
@@ -574,11 +593,14 @@ impl Tool for DockerReadFileTool {
 
         let content = String::from_utf8_lossy(&output.stdout).to_string();
 
-        ToolExecutionResult::success(json!({
-            "path": path,
-            "content": content,
-            "size_bytes": content.len()
-        }))
+        ToolExecutionResult::success(build_text_read_file_result(
+            "docker_read_file",
+            path,
+            &content,
+            "text",
+            offset,
+            limit,
+        ))
     }
 
     fn requires_context(&self) -> bool {

--- a/integrations/e2b/src/tools.rs
+++ b/integrations/e2b/src/tools.rs
@@ -3,6 +3,9 @@
 use async_trait::async_trait;
 use everruns_core::ToolHints;
 use everruns_core::exec_tool_result::ExecToolResultPayload;
+use everruns_core::tool_output_sanitizer::{
+    READ_FILE_DEFAULT_LIMIT, build_text_read_file_result, parse_read_file_window_args,
+};
 use everruns_core::tools::{Tool, ToolExecutionResult};
 use everruns_core::traits::ToolContext;
 use serde_json::{Value, json};
@@ -360,7 +363,19 @@ impl Tool for E2BReadFileTool {
             "type": "object",
             "properties": {
                 "sandbox_id": {"type": "string"},
-                "path": {"type": "string"}
+                "path": {"type": "string"},
+                "offset": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "default": 0,
+                    "description": "Zero-based line offset to start reading from"
+                },
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "default": READ_FILE_DEFAULT_LIMIT,
+                    "description": "Maximum number of lines to return"
+                }
             },
             "required": ["sandbox_id", "path"],
             "additionalProperties": false
@@ -397,17 +412,28 @@ impl Tool for E2BReadFileTool {
             Ok(value) => value,
             Err(err) => return err,
         };
+        let (offset, limit) = match parse_read_file_window_args(&arguments) {
+            Ok(window) => window,
+            Err(err) => return ToolExecutionResult::tool_error(err),
+        };
         let state = match get_sandbox_state(context, sandbox_id).await {
             Ok(state) => state,
             Err(err) => return err,
         };
         let client = E2BClient::new(api_key);
         match client.read_file(&state, path).await {
-            Ok(content) => ToolExecutionResult::success(json!({
-                "sandbox_id": sandbox_id,
-                "path": path,
-                "content": content,
-            })),
+            Ok(content) => {
+                let mut result = build_text_read_file_result(
+                    "e2b_read_file",
+                    path,
+                    &content,
+                    "text",
+                    offset,
+                    limit,
+                );
+                result["sandbox_id"] = json!(sandbox_id);
+                ToolExecutionResult::success(result)
+            }
             Err(err) => ToolExecutionResult::tool_error(err),
         }
     }

--- a/integrations/github/src/tools.rs
+++ b/integrations/github/src/tools.rs
@@ -2,6 +2,9 @@
 
 use async_trait::async_trait;
 use everruns_core::ToolHints;
+use everruns_core::tool_output_sanitizer::{
+    READ_FILE_DEFAULT_LIMIT, build_text_read_file_result, parse_read_file_window_args,
+};
 use everruns_core::tools::{Tool, ToolExecutionResult};
 use everruns_core::traits::ToolContext;
 use serde_json::{Value, json};
@@ -265,6 +268,18 @@ impl Tool for ReadGitHubFileTool {
                 "ref": {
                     "type": "string",
                     "description": "Optional branch, tag, or commit SHA."
+                },
+                "offset": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "default": 0,
+                    "description": "Zero-based line offset to start reading from"
+                },
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "default": READ_FILE_DEFAULT_LIMIT,
+                    "description": "Maximum number of lines to return"
                 }
             },
             "required": ["repo", "path"],
@@ -310,6 +325,10 @@ impl Tool for ReadGitHubFileTool {
             );
         }
         let reference = arguments.get("ref").and_then(|v| v.as_str()).map(str::trim);
+        let (offset, limit) = match parse_read_file_window_args(&arguments) {
+            Ok(window) => window,
+            Err(err) => return ToolExecutionResult::tool_error(err),
+        };
 
         if let Err(e) = enforce_github_network_access(context) {
             return e;
@@ -321,15 +340,22 @@ impl Tool for ReadGitHubFileTool {
 
         match github_client(token).read_file(repo, path, reference).await {
             Ok(file) => match file.decoded_content() {
-                Ok(content) => ToolExecutionResult::success(json!({
-                    "repo": repo,
-                    "path": file.path,
-                    "name": file.name,
-                    "sha": file.sha,
-                    "url": file.html_url,
-                    "download_url": file.download_url,
-                    "content": content,
-                })),
+                Ok(content) => {
+                    let mut result = build_text_read_file_result(
+                        "read_github_file",
+                        &file.path,
+                        &content,
+                        "text",
+                        offset,
+                        limit,
+                    );
+                    result["repo"] = json!(repo);
+                    result["name"] = json!(file.name);
+                    result["sha"] = json!(file.sha);
+                    result["url"] = json!(file.html_url);
+                    result["download_url"] = json!(file.download_url);
+                    ToolExecutionResult::success(result)
+                }
                 Err(e) => ToolExecutionResult::tool_error(e),
             },
             Err(e) => ToolExecutionResult::tool_error(e),

--- a/integrations/sprites/src/tools.rs
+++ b/integrations/sprites/src/tools.rs
@@ -1,5 +1,8 @@
 //! Tool implementations for Sprites operations.
 
+use everruns_core::tool_output_sanitizer::{
+    READ_FILE_DEFAULT_LIMIT, build_text_read_file_result, parse_read_file_window_args,
+};
 use everruns_core::tool_types::ToolHints;
 use everruns_core::tools::{Tool, ToolExecutionResult};
 use everruns_core::traits::ToolContext;
@@ -341,6 +344,18 @@ impl Tool for SpritesReadFileTool {
                 "path": {
                     "type": "string",
                     "description": "Path to file (e.g., '/home/sprite/main.py')"
+                },
+                "offset": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "default": 0,
+                    "description": "Zero-based line offset to start reading from"
+                },
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "default": READ_FILE_DEFAULT_LIMIT,
+                    "description": "Maximum number of lines to return"
                 }
             },
             "required": ["sprite_name", "path"],
@@ -367,6 +382,10 @@ impl Tool for SpritesReadFileTool {
             Ok(s) => s,
             Err(e) => return e,
         };
+        let (offset, limit) = match parse_read_file_window_args(&arguments) {
+            Ok(window) => window,
+            Err(err) => return ToolExecutionResult::tool_error(err),
+        };
 
         let api_token = match get_api_token(context).await {
             Ok(t) => t,
@@ -385,10 +404,16 @@ impl Tool for SpritesReadFileTool {
                     return e;
                 }
                 let content = String::from_utf8_lossy(&bytes).to_string();
-                ToolExecutionResult::success(json!({
-                    "path": path,
-                    "content": content
-                }))
+                let mut result = build_text_read_file_result(
+                    "sprites_read_file",
+                    path,
+                    &content,
+                    "text",
+                    offset,
+                    limit,
+                );
+                result["sprite_name"] = json!(sprite_name);
+                ToolExecutionResult::success(result)
             }
             Err(e) => ToolExecutionResult::tool_error(e),
         }

--- a/specs/compaction.md
+++ b/specs/compaction.md
@@ -12,6 +12,14 @@ Context compaction manages conversations that exceed LLM context windows. Users 
 4. **Proactive, not reactive.** Compact before hitting limits, not after `RequestTooLarge`.
 5. **Users must know.** Every compaction emits events and renders in the UI.
 
+## Model View Versus Storage
+
+Session storage remains lossless: tool results, file reads, and exec outputs are stored as events/messages exactly as produced. Before provider serialization, `ReasonAtom` builds a separate **model view** from those stored messages.
+
+The model view always applies generic cost-control masking by default, even when the `compaction` capability is not configured. This masking replaces stale bulky tool results with compact summaries while preserving message/tool-call structure and the most recent tool results verbatim. A configured compaction capability can still tune or disable this via `cost_control`.
+
+Provider cache telemetry feeds this same model-view step. If the previous call reports high uncached input or a low cache-read ratio, the model view may mask older tool results earlier so repeated full-history prompts do not keep paying for cache misses.
+
 ## Current State
 
 ### What Exists

--- a/specs/tool-execution.md
+++ b/specs/tool-execution.md
@@ -95,7 +95,7 @@ Capability hooks involved:
 
 ### Reading-tool output contract
 
-Every reading tool attaches a shared `truncation` envelope to its JSON response so LLM callers can detect partial output, understand why it was cut, and resume or fall back without regex-matching human markers. The envelope is additive — existing flat fields like `truncated`, `total_lines`, and `row_count` stay in place for back-compat.
+Every reading tool attaches a shared `truncation` envelope to its JSON response so LLM callers can detect partial output, understand why it was cut, and resume or fall back without regex-matching human markers. The envelope is additive — existing flat fields like `truncated`, `total_lines`, and `row_count` stay in place for back-compat. File-reading tools, including session-sandbox-backed reads such as `sandbox_read_file`, accept `offset` and `limit` and return only that line window for text files.
 
 See [`crates/core/src/truncation_info.rs`](../crates/core/src/truncation_info.rs) for the source of truth: `TruncationInfo`, `TruncationReason`, and the `assert_conforms` conformance helper.
 
@@ -262,9 +262,10 @@ Two hook slots run in sequence:
 2. **Final hooks** (`final_post_tool_hooks`) — always-on infrastructure (e.g. EVE-225 hard limit)
 
 Current hooks:
-- **PersistOutputHook** (`tool_output_persistence` capability, included in Generic harness): When a tool declares `persist_output: true` in hints, writes stdout to `/.outputs/{tool_call_id}.stdout` and stderr to `/.outputs/{tool_call_id}.stderr` in session VFS, injecting `full_output`, `total_lines`, and `output_files` into the result. See `crates/core/src/capabilities/tool_output_persistence.rs`.
+- **PersistOutputHook** (`tool_output_persistence` capability; also installed as an always-on final hook): When a tool declares `persist_output: true` in hints, writes stdout to `/.outputs/{tool_call_id}.stdout` and stderr to `/.outputs/{tool_call_id}.stderr` in session VFS, injecting `full_output`, `total_lines`, and `output_files` into the result. It skips cleanly if no session file store is present, and skips if another hook already injected `output_files`. See `crates/core/src/capabilities/tool_output_persistence.rs`.
 
 Current final hooks (always-on, cannot be removed):
+- **PersistOutputHook**: Persists full output for any tool that declares `persist_output: true` before hard-limit truncation, independent of whether a harness explicitly enabled the persistence capability.
 - **OutputHardLimitHook** (EVE-225): Enforces a 64 KiB hard ceiling on serialized tool result text. Head-truncation with UTF-8 safety; appends an LLM-actionable suffix. Logs `tracing::warn!` with tool_name, tool_call_id, result_bytes, limit when truncating. Fires regardless of which capabilities are active. See `crates/core/src/atoms/act_hooks.rs`.
 
 ### Loop Detection (EVE-227)


### PR DESCRIPTION
## What
- Build a bounded model-view prompt from stored messages by default, independent of the compaction capability.
- Share read-file offset/limit windowing across core and integration read tools.
- Run full-output persistence as an always-on final hook for tools that declare persist_output.
- Document storage vs model view and generic read/persistence contracts.

## Why
Repeated full-history prompts were still possible when compaction was absent, so large file/tool outputs could be resent and re-billed across turns even though session storage already kept the full data.

## How
- Added build_model_view_messages() and wired ReasonAtom through it unconditionally while preserving cost_control.enabled=false opt-out.
- Added regression coverage for repeated read_file history, disabled cost-control config, and provider cache telemetry defaults.
- Added shared text read-file response helpers and wired them into session sandbox, Daytona, E2B, Docker, Deno, Sprites, GitHub, and container sandbox reads.
- Added PersistOutputHook to always-on final hooks before OutputHardLimitHook, with duplicate-output_files guard.

## Risk
- Medium
- Read-file output shape changes for several integration read tools from raw full content to structured line-windowed content. Backward compatibility considered: core fields path/content remain present, with additive metadata.
- Always-on persistence is guarded by persist_output hints and no-ops without a file store.

## Security
- Threat categories reviewed: TM-FS, TM-TOOL, TM-LLM, TM-DOS.
- Findings and resolutions: read-file changes reduce DoS/token exposure by applying line windows and a shared hard cap; no new filesystem authority is introduced. Prompt model-view masking preserves tool_result role boundaries. Persistence remains hint-gated, session-file-store scoped, and skips when output_files already exists. No threat-model update needed.

## Validation
- cargo test -p everruns-core tool_output_sanitizer::tests -- --nocapture
- cargo test -p everruns-core capabilities::compaction::tests::test_model_view -- --nocapture
- cargo test -p everruns-core capabilities::session_sandbox::tests::sandbox_read_file_result -- --nocapture
- cargo check -p everruns-integrations-github -p everruns-integrations-daytona -p everruns-integrations-e2b -p everruns-integrations-deno -p everruns-integrations-docker -p everruns-integrations-sprites -p everruns-container-sandbox
- cargo fmt --check
- bash scripts/lib/check-migration-ordering.sh
- just pre-push
- Smoke: dev-mode server started directly with PORT_PREFIX=272 and /health returned OK; stopped afterward. Full just start-dev UI/proxy smoke was limited because apps/ui/node_modules is not installed in this worktree.

## Follow-ups
- No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)