### PR TITLE
fix(core): keep model view masking capability-owned

### DIFF
--- a/crates/core/src/atoms/reason.rs
+++ b/crates/core/src/atoms/reason.rs
@@ -850,24 +850,18 @@ impl ReasonAtom {
         // 9. Patch dangling tool calls (add cancelled results for tool calls without responses)
         let patched_messages = patch_dangling_tool_calls(&messages);
 
-        // 9b. Build the prompt-facing model view from lossless stored
-        // messages. This keeps stale bulky tool results from being paid for
-        // repeatedly even when no compaction capability is configured.
-        let masking = crate::capabilities::build_model_view_messages(
-            &patched_messages,
-            compaction_config.as_ref(),
-            prior_usage.as_ref(),
+        // 9b. Let enabled capabilities build a prompt-facing model view from
+        // lossless stored messages. Storage remains unchanged.
+        let model_view_providers = crate::capabilities::collect_model_view_providers(
+            &resolved_capability_configs,
+            &self.capability_registry,
         );
-        if masking.masked_count > 0 {
-            tracing::info!(
-                session_id = %session_id,
-                masked_count = masking.masked_count,
-                tool_result_bytes_before = masking.tool_result_bytes_before,
-                tool_result_bytes_after = masking.tool_result_bytes_after,
-                "ReasonAtom: model-view cost-control masked stale tool results"
-            );
-        }
-        let context_messages = masking.messages;
+        let model_view_context = crate::capabilities::ModelViewContext {
+            session_id,
+            prior_usage: prior_usage.as_ref(),
+        };
+        let context_messages =
+            model_view_providers.apply_model_view(patched_messages, &model_view_context);
 
         // 10. Resolve images from image_file references (if any)
         //

--- a/crates/core/src/capabilities/compaction.rs
+++ b/crates/core/src/capabilities/compaction.rs
@@ -10,7 +10,7 @@
 //! - The `auto` cascade: observation masking → native → summarization
 //! - Proactive compaction at a configurable budget threshold, not just on error
 
-use super::{Capability, CapabilityStatus};
+use super::{Capability, CapabilityStatus, ModelViewContext, ModelViewProvider};
 use crate::events::TokenUsage;
 use crate::message::{ContentPart, Message, MessageRole};
 use crate::message_filter::MessageFilterProvider;
@@ -289,6 +289,38 @@ Choose between native provider compaction (e.g., OpenAI /responses/compact), obs
 
     fn message_filter_provider(&self) -> Option<Arc<dyn MessageFilterProvider>> {
         Some(Arc::new(CompactionFilterProvider))
+    }
+
+    fn model_view_provider(&self) -> Option<Arc<dyn ModelViewProvider>> {
+        Some(Arc::new(CompactionModelViewProvider))
+    }
+}
+
+struct CompactionModelViewProvider;
+
+impl ModelViewProvider for CompactionModelViewProvider {
+    fn apply_model_view(
+        &self,
+        messages: Vec<Message>,
+        config: &serde_json::Value,
+        context: &ModelViewContext<'_>,
+    ) -> Vec<Message> {
+        let config = CompactionConfig::from_json(config);
+        let masking = build_model_view_messages_owned(messages, &config, context.prior_usage);
+        if masking.masked_count > 0 {
+            tracing::info!(
+                session_id = %context.session_id,
+                masked_count = masking.masked_count,
+                tool_result_bytes_before = masking.tool_result_bytes_before,
+                tool_result_bytes_after = masking.tool_result_bytes_after,
+                "CompactionCapability: masked stale tool results for model view"
+            );
+        }
+        masking.messages
+    }
+
+    fn priority(&self) -> i32 {
+        50
     }
 }
 
@@ -735,21 +767,28 @@ pub struct CostControlMaskingResult {
     pub tool_result_bytes_after: usize,
 }
 
-static DEFAULT_MODEL_VIEW_COMPACTION_CONFIG: std::sync::LazyLock<CompactionConfig> =
-    std::sync::LazyLock::new(CompactionConfig::default);
-
 /// Build the bounded model-view messages from lossless stored messages.
 ///
 /// Storage keeps full tool results. This helper defines the cheaper prompt
-/// view used for provider serialization, with cost control enabled by default
-/// even when the compaction capability itself is not configured.
+/// view used for provider serialization when the compaction capability is
+/// configured.
 pub fn build_model_view_messages(
     stored_messages: &[Message],
-    compaction_config: Option<&CompactionConfig>,
+    compaction_config: &CompactionConfig,
     prior_usage: Option<&TokenUsage>,
 ) -> CostControlMaskingResult {
-    let config = compaction_config.unwrap_or(&*DEFAULT_MODEL_VIEW_COMPACTION_CONFIG);
-    apply_cost_control_masking(stored_messages, config, prior_usage)
+    apply_cost_control_masking(stored_messages, compaction_config, prior_usage)
+}
+
+/// Build the bounded model-view messages from owned stored messages.
+///
+/// This avoids cloning the message list when masking does not apply.
+pub fn build_model_view_messages_owned(
+    stored_messages: Vec<Message>,
+    compaction_config: &CompactionConfig,
+    prior_usage: Option<&TokenUsage>,
+) -> CostControlMaskingResult {
+    apply_cost_control_masking_owned(stored_messages, compaction_config, prior_usage)
 }
 
 /// Apply cheap, generic cost-control masking to stored messages.
@@ -765,13 +804,21 @@ pub fn apply_cost_control_masking(
     config: &CompactionConfig,
     prior_usage: Option<&TokenUsage>,
 ) -> CostControlMaskingResult {
+    apply_cost_control_masking_owned(messages.to_vec(), config, prior_usage)
+}
+
+fn apply_cost_control_masking_owned(
+    messages: Vec<Message>,
+    config: &CompactionConfig,
+    prior_usage: Option<&TokenUsage>,
+) -> CostControlMaskingResult {
     let cost_config = &config.cost_control;
     let tool_indices: Vec<usize> = messages
         .iter()
         .enumerate()
         .filter(|(_, message)| {
             message.role == MessageRole::ToolResult
-                && !is_protected_message_tool_result(messages, message)
+                && !is_protected_message_tool_result(&messages, message)
         })
         .map(|(index, _)| index)
         .collect();
@@ -790,7 +837,7 @@ pub fn apply_cost_control_masking(
         )
     {
         return CostControlMaskingResult {
-            messages: messages.to_vec(),
+            messages,
             masked_count: 0,
             tool_result_bytes_before,
             tool_result_bytes_after: tool_result_bytes_before,
@@ -801,16 +848,24 @@ pub fn apply_cost_control_masking(
     let to_mask_count = tool_indices.len().saturating_sub(keep_recent);
     let indices_to_mask: std::collections::HashSet<usize> =
         tool_indices[..to_mask_count].iter().copied().collect();
+    let tool_names: std::collections::HashMap<usize, String> = indices_to_mask
+        .iter()
+        .map(|index| {
+            (
+                *index,
+                find_message_tool_call_name(&messages, &messages[*index]),
+            )
+        })
+        .collect();
 
     let mut masked_count = 0;
     let mut masked_messages = Vec::with_capacity(messages.len());
-    for (index, message) in messages.iter().enumerate() {
-        if indices_to_mask.contains(&index) {
-            let tool_name = find_message_tool_call_name(messages, message);
-            masked_messages.push(mask_tool_result_message(message, &tool_name));
+    for (index, message) in messages.into_iter().enumerate() {
+        if let Some(tool_name) = tool_names.get(&index) {
+            masked_messages.push(mask_tool_result_message(&message, tool_name));
             masked_count += 1;
         } else {
-            masked_messages.push(message.clone());
+            masked_messages.push(message);
         }
     }
 
@@ -1632,7 +1687,7 @@ mod tests {
     }
 
     #[test]
-    fn test_model_view_masks_without_compaction_config() {
+    fn test_model_view_masks_with_compaction_config() {
         let mut messages = vec![Message::user("inspect files repeatedly")];
         for index in 0..9 {
             messages.extend(make_message_tool_turn(
@@ -1649,7 +1704,8 @@ mod tests {
             ));
         }
 
-        let result = build_model_view_messages(&messages, None, None);
+        let config = CompactionConfig::default();
+        let result = build_model_view_messages(&messages, &config, None);
 
         assert_eq!(result.masked_count, 7);
         assert!(result.tool_result_bytes_after < result.tool_result_bytes_before / 4);
@@ -1663,6 +1719,37 @@ mod tests {
             .unwrap()
             .tool_result_content()
             .unwrap();
+        assert!(last_tool.result.as_ref().unwrap().get("content").is_some());
+    }
+
+    #[test]
+    fn test_compaction_capability_contributes_model_view_provider() {
+        let mut messages = vec![Message::user("inspect files repeatedly")];
+        for index in 0..9 {
+            messages.extend(make_message_tool_turn(
+                &format!("call_{index}"),
+                "read_file",
+                json!({
+                    "path": "/workspace/src/lib.rs",
+                    "content": format!("{}{}", "large file line\n".repeat(1000), index),
+                    "total_lines": 1000,
+                    "lines_shown": {"start": 1, "end": 1000},
+                    "truncated": false
+                }),
+            ));
+        }
+
+        let capability = CompactionCapability;
+        let provider = capability.model_view_provider().unwrap();
+        let context = ModelViewContext {
+            session_id: crate::typed_id::SessionId::new(),
+            prior_usage: None,
+        };
+        let result = provider.apply_model_view(messages, &json!({}), &context);
+
+        let first_tool = result[2].tool_result_content().unwrap();
+        assert_eq!(first_tool.result.as_ref().unwrap()["masked"], true);
+        let last_tool = result.last().unwrap().tool_result_content().unwrap();
         assert!(last_tool.result.as_ref().unwrap().get("content").is_some());
     }
 
@@ -1690,7 +1777,7 @@ mod tests {
                 "mask_after_tool_results": 2
             }
         }));
-        let result = build_model_view_messages(&messages, Some(&config), None);
+        let result = build_model_view_messages(&messages, &config, None);
 
         assert_eq!(result.masked_count, 0);
         assert_eq!(
@@ -1735,7 +1822,7 @@ mod tests {
     }
 
     #[test]
-    fn test_model_view_uses_provider_cache_signal_by_default() {
+    fn test_model_view_uses_provider_cache_signal_from_compaction_config() {
         let mut messages = vec![Message::user("run commands")];
         for index in 0..3 {
             messages.extend(make_message_tool_turn(
@@ -1751,7 +1838,8 @@ mod tests {
         }
         let usage = TokenUsage::with_cache(150_000, 100, Some(0), None);
 
-        let result = build_model_view_messages(&messages, None, Some(&usage));
+        let config = CompactionConfig::default();
+        let result = build_model_view_messages(&messages, &config, Some(&usage));
 
         assert_eq!(result.masked_count, 1);
         let first_tool = result.messages[2].tool_result_content().unwrap();

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -22,7 +22,9 @@ use crate::command::{
     CommandDescriptor, CommandExecutionContext, CommandResult, ExecuteCommandRequest,
 };
 use crate::deployment::DeploymentGrade;
+use crate::events::TokenUsage;
 use crate::mcp_server::{ScopedMcpServers, merge_scoped_mcp_servers};
+use crate::message::Message;
 use crate::message_filter::MessageFilterProvider;
 use crate::runtime_agent::RuntimeAgent;
 use crate::tool_types::{ToolCall, ToolDefinition};
@@ -546,6 +548,17 @@ pub trait Capability: Send + Sync {
         None
     }
 
+    /// Returns a provider that can build a prompt-facing model view from
+    /// lossless stored messages before provider serialization.
+    ///
+    /// This is for capability-owned context transformations such as compaction
+    /// cost-control masking. Storage messages remain unchanged.
+    ///
+    /// By default, returns None (no model-view transformation).
+    fn model_view_provider(&self) -> Option<Arc<dyn ModelViewProvider>> {
+        None
+    }
+
     /// Returns post-tool execution hooks provided by this capability.
     ///
     /// These hooks run after each individual tool completes execution.
@@ -1054,6 +1067,30 @@ impl Default for CapabilityRegistryBuilder {
 // Collect Capabilities Helper
 // ============================================================================
 
+/// Context available to capability-owned model-view transforms.
+pub struct ModelViewContext<'a> {
+    pub session_id: SessionId,
+    pub prior_usage: Option<&'a TokenUsage>,
+}
+
+/// Provider-side hook for building prompt-facing model views.
+///
+/// Providers receive the output of earlier providers and return the messages
+/// that should be sent into provider serialization. Lower priority providers
+/// run earlier.
+pub trait ModelViewProvider: Send + Sync {
+    fn apply_model_view(
+        &self,
+        messages: Vec<Message>,
+        config: &serde_json::Value,
+        context: &ModelViewContext<'_>,
+    ) -> Vec<Message>;
+
+    fn priority(&self) -> i32 {
+        0
+    }
+}
+
 /// Collected data from capabilities before applying to config.
 ///
 /// This intermediate struct allows sharing the capability collection logic
@@ -1142,6 +1179,12 @@ pub struct CollectedMessageFilters {
     pub message_filter_providers: Vec<(Arc<dyn MessageFilterProvider>, serde_json::Value)>,
 }
 
+/// Lightweight result containing only model-view providers.
+pub struct CollectedModelViewProviders {
+    /// Model-view providers with their configs (in priority order).
+    pub model_view_providers: Vec<(Arc<dyn ModelViewProvider>, serde_json::Value)>,
+}
+
 // Note: apply_message_filters/apply_post_load_filters mirror the same methods
 // on CollectedCapabilities. The duplication is intentional — extracting a trait
 // would add indirection for 3 lines of loop body, and the two structs serve
@@ -1160,6 +1203,20 @@ impl CollectedMessageFilters {
         for (provider, config) in &self.message_filter_providers {
             provider.post_load(messages, config);
         }
+    }
+}
+
+impl CollectedModelViewProviders {
+    /// Apply all collected model-view providers in priority order.
+    pub fn apply_model_view(
+        &self,
+        mut messages: Vec<Message>,
+        context: &ModelViewContext<'_>,
+    ) -> Vec<Message> {
+        for (provider, config) in &self.model_view_providers {
+            messages = provider.apply_model_view(messages, config, context);
+        }
+        messages
     }
 }
 
@@ -1191,6 +1248,32 @@ pub fn collect_message_filters_only(
 
     CollectedMessageFilters {
         message_filter_providers,
+    }
+}
+
+/// Collect only model-view providers from capabilities.
+pub fn collect_model_view_providers(
+    capability_configs: &[AgentCapabilityConfig],
+    registry: &CapabilityRegistry,
+) -> CollectedModelViewProviders {
+    let mut model_view_providers: Vec<(Arc<dyn ModelViewProvider>, serde_json::Value)> = Vec::new();
+
+    for cap_config in capability_configs {
+        let cap_id = cap_config.capability_ref.as_str();
+        if let Some(capability) = registry.get(cap_id) {
+            if capability.status() != CapabilityStatus::Available {
+                continue;
+            }
+            if let Some(provider) = capability.model_view_provider() {
+                model_view_providers.push((provider, cap_config.config.clone()));
+            }
+        }
+    }
+
+    model_view_providers.sort_by_key(|(p, _)| p.priority());
+
+    CollectedModelViewProviders {
+        model_view_providers,
     }
 }
 
@@ -3088,6 +3171,70 @@ mod tests {
         // post_load reversed the messages
         assert_eq!(messages[0].text(), Some("second"));
         assert_eq!(messages[1].text(), Some("first"));
+    }
+
+    #[test]
+    fn test_collect_model_view_providers_respects_compaction_capability_boundary() {
+        use crate::tool_types::ToolCall;
+
+        fn tool_heavy_messages() -> Vec<Message> {
+            let mut messages = vec![Message::user("inspect files repeatedly")];
+            for index in 0..9 {
+                let call_id = format!("call_{index}");
+                messages.push(Message::assistant_with_tools(
+                    "",
+                    vec![ToolCall {
+                        id: call_id.clone(),
+                        name: "read_file".to_string(),
+                        arguments: serde_json::json!({"path": "/workspace/src/lib.rs"}),
+                    }],
+                ));
+                messages.push(Message::tool_result(
+                    call_id,
+                    Some(serde_json::json!({
+                        "path": "/workspace/src/lib.rs",
+                        "content": format!("{}{}", "large file line\n".repeat(1000), index),
+                        "total_lines": 1000,
+                        "lines_shown": {"start": 1, "end": 1000},
+                        "truncated": false
+                    })),
+                    None,
+                ));
+            }
+            messages
+        }
+
+        fn first_tool_result_is_masked(messages: &[Message]) -> bool {
+            messages[2]
+                .tool_result_content()
+                .and_then(|result| result.result.as_ref())
+                .and_then(|result| result.get("masked"))
+                .and_then(|masked| masked.as_bool())
+                .unwrap_or(false)
+        }
+
+        let mut registry = CapabilityRegistry::new();
+        registry.register(CompactionCapability);
+        let context = ModelViewContext {
+            session_id: SessionId::new(),
+            prior_usage: None,
+        };
+
+        let no_compaction = collect_model_view_providers(&[], &registry);
+        let unmasked = no_compaction.apply_model_view(tool_heavy_messages(), &context);
+        assert!(!first_tool_result_is_masked(&unmasked));
+
+        let compaction = collect_model_view_providers(
+            &[AgentCapabilityConfig {
+                capability_ref: CapabilityId::new(COMPACTION_CAPABILITY_ID),
+                config: serde_json::json!({}),
+            }],
+            &registry,
+        );
+        let masked = compaction.apply_model_view(tool_heavy_messages(), &context);
+        assert!(first_tool_result_is_masked(&masked));
+        let last_tool = masked.last().unwrap().tool_result_content().unwrap();
+        assert!(last_tool.result.as_ref().unwrap().get("content").is_some());
     }
 
     // =========================================================================

--- a/specs/compaction.md
+++ b/specs/compaction.md
@@ -14,9 +14,9 @@ Context compaction manages conversations that exceed LLM context windows. Users 
 
 ## Model View Versus Storage
 
-Session storage remains lossless: tool results, file reads, and exec outputs are stored as events/messages exactly as produced. Before provider serialization, `ReasonAtom` builds a separate **model view** from those stored messages.
+Session storage remains lossless: tool results, file reads, and exec outputs are stored as events/messages exactly as produced. When the `compaction` capability is configured, it contributes a model-view provider that builds a separate **model view** from those stored messages before provider serialization.
 
-The model view always applies generic cost-control masking by default, even when the `compaction` capability is not configured. This masking replaces stale bulky tool results with compact summaries while preserving message/tool-call structure and the most recent tool results verbatim. A configured compaction capability can still tune or disable this via `cost_control`.
+The model view applies generic cost-control masking according to the configured `compaction` capability. This masking replaces stale bulky tool results with compact summaries while preserving message/tool-call structure and the most recent tool results verbatim. Builders can tune or disable this via `cost_control`.
 
 Provider cache telemetry feeds this same model-view step. If the previous call reports high uncached input or a low cache-read ratio, the model view may mask older tool results earlier so repeated full-history prompts do not keep paying for cache misses.
 


### PR DESCRIPTION
## What
Move prompt-facing model-view transformations behind a generic capability-owned hook.

## Why
Model-view cost-control masking should not be hard-coded in `ReasonAtom`. The behavior belongs to the `compaction` capability so sessions only get compaction model-view masking when that capability is configured.

## How
- Added a `ModelViewProvider` extension point and collector to the capability system.
- Updated `ReasonAtom` to apply collected model-view providers generically after dangling tool-call patching.
- Made `CompactionCapability` contribute the model-view provider and own config parsing, masking, and logging.
- Updated `specs/compaction.md` to document capability-owned model views.

## Risk
- Low / Medium / High: Medium
- What can break: prompt assembly for sessions using the `compaction` capability. Sessions without `compaction` now skip model-view masking, which is the intended behavior.

## Security
- Threat categories reviewed: TM-LLM, TM-DOS
- Findings and resolutions: No new external input, auth, filesystem, SQL, or network surface. The change narrows prompt transformation authority to enabled capabilities. Resource behavior remains bounded by existing compaction cost-control limits; no new unbounded loops or allocations beyond applying collected providers in configured capability order.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

Validation so far:
- `cargo test -p everruns-core capabilities::compaction::tests -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
- `just pre-push`
- `PORT_PREFIX=274 just start-dev --no-watch`, then `curl -fsS http://localhost:27400/health`