### PR TITLE
feat(ercode): store session artifacts in folders

### DIFF
--- a/crates/core/src/capabilities/tool_output_persistence.rs
+++ b/crates/core/src/capabilities/tool_output_persistence.rs
@@ -9,8 +9,8 @@
 // - Implemented as PostToolExecHook, not baked into each tool — VFS
 //   persistence is a cross-cutting concern the tool shouldn't know about
 // - Reads `persist_output` hint from ToolDefinition to decide what to persist
-// - Writes stdout to /.outputs/{safe_id}.stdout, stderr to
-//   /.outputs/{safe_id}.stderr when stderr is persisted (session-scoped)
+// - Writes stdout to /outputs/{safe_id}.stdout, stderr to
+//   /outputs/{safe_id}.stderr when stderr is persisted (session-scoped)
 // - Injects `output_files` array into result for agent to read selectively
 // - Graceful degradation: skip silently if file_store is unavailable
 // - Runs as an always-on final hook before EVE-225 hard-limit truncation
@@ -31,11 +31,12 @@ use crate::typed_id::SessionId;
 
 /// Max bytes persisted per output stream file to avoid storage exhaustion.
 const MAX_PERSISTED_STREAM_BYTES: usize = 1024 * 1024; // 1 MiB
+const OUTPUT_DIR: &str = "/outputs";
 
 /// Result of persisting large exec output to session VFS.
 pub struct PersistResult {
     /// Path to the persisted stdout file in session VFS form
-    /// (e.g. `/.outputs/{safe_id}.stdout`).
+    /// (e.g. `/outputs/{safe_id}.stdout`).
     pub stdout_path: Option<String>,
     /// Path to the persisted stderr file in session VFS form, if non-empty
     /// stderr was persisted.
@@ -46,8 +47,8 @@ pub struct PersistResult {
 
 /// Persist large exec output to session VFS when it exceeds the budget.
 ///
-/// Writes stdout to `/.outputs/{safe_id}.stdout` and stderr to
-/// `/.outputs/{safe_id}.stderr` (if non-empty). Returns paths and metadata.
+/// Writes stdout to `/outputs/{safe_id}.stdout` and stderr to
+/// `/outputs/{safe_id}.stderr` (if non-empty). Returns paths and metadata.
 ///
 /// This is the shared helper that any sandbox tool or hook can call.
 pub async fn persist_large_output(
@@ -79,7 +80,7 @@ pub async fn persist_large_output(
     // Persist stdout
     if stdout.len() > EXEC_OUTPUT_BUDGET {
         let stdout_to_persist = truncate_for_persistence(stdout, MAX_PERSISTED_STREAM_BYTES);
-        let path = format!("/.outputs/{safe_id}.stdout");
+        let path = format!("{OUTPUT_DIR}/{safe_id}.stdout");
         result.stdout_total_lines = stdout.lines().count();
         if file_store
             .write_file(session_id, &path, &stdout_to_persist, "utf-8")
@@ -93,7 +94,7 @@ pub async fn persist_large_output(
     // Persist stderr separately if large
     if stderr.len() > 4096 {
         let stderr_to_persist = truncate_for_persistence(stderr, MAX_PERSISTED_STREAM_BYTES);
-        let path = format!("/.outputs/{safe_id}.stderr");
+        let path = format!("{OUTPUT_DIR}/{safe_id}.stderr");
         if file_store
             .write_file(session_id, &path, &stderr_to_persist, "utf-8")
             .await
@@ -393,16 +394,16 @@ mod tests {
     #[test]
     fn test_annotate_truncated_output() {
         let annotated =
-            annotate_truncated_output("truncated text...", "/.outputs/abc.stdout", 50 * 1024);
+            annotate_truncated_output("truncated text...", "/outputs/abc.stdout", 50 * 1024);
         assert!(annotated.contains("truncated text..."));
-        assert!(annotated.contains("/workspace/.outputs/abc.stdout"));
+        assert!(annotated.contains("/workspace/outputs/abc.stdout"));
         assert!(annotated.contains("50 KiB"));
         assert!(annotated.contains("read_file"));
     }
 
     #[test]
     fn test_annotate_truncated_output_small() {
-        let annotated = annotate_truncated_output("short", "/.outputs/x.stdout", 1024);
+        let annotated = annotate_truncated_output("short", "/outputs/x.stdout", 1024);
         assert!(annotated.contains("1 KiB"));
         assert!(annotated.contains("read_file with offset/limit"));
     }
@@ -534,12 +535,12 @@ mod tests {
         let result = persist_large_output(&store, test_session_id(), "call-2", &large, "").await;
         let r = result.expect("should persist");
         assert!(r.stdout_path.is_some());
-        assert_eq!(r.stdout_path.as_deref(), Some("/.outputs/call-2.stdout"));
+        assert_eq!(r.stdout_path.as_deref(), Some("/outputs/call-2.stdout"));
         assert!(r.stderr_path.is_none());
         assert_eq!(r.stdout_total_lines, 1);
         // Verify content was written
         assert_eq!(
-            mock.content("/.outputs/call-2.stdout").unwrap().len(),
+            mock.content("/outputs/call-2.stdout").unwrap().len(),
             large.len()
         );
     }
@@ -551,7 +552,7 @@ mod tests {
         let huge = "x".repeat(MAX_PERSISTED_STREAM_BYTES + 2048);
         let result = persist_large_output(&store, test_session_id(), "call-cap", &huge, "").await;
         assert!(result.is_some());
-        let persisted = mock.content("/.outputs/call-cap.stdout").unwrap();
+        let persisted = mock.content("/outputs/call-cap.stdout").unwrap();
         assert!(persisted.len() < huge.len());
         assert!(persisted.contains("output truncated before persistence"));
     }
@@ -565,8 +566,8 @@ mod tests {
             persist_large_output(&store, test_session_id(), "call-3", "small", &large_stderr).await;
         let r = result.expect("should persist stderr");
         assert!(r.stdout_path.is_none());
-        assert_eq!(r.stderr_path.as_deref(), Some("/.outputs/call-3.stderr"));
-        assert_eq!(mock.content("/.outputs/call-3.stderr").unwrap().len(), 4097);
+        assert_eq!(r.stderr_path.as_deref(), Some("/outputs/call-3.stderr"));
+        assert_eq!(mock.content("/outputs/call-3.stderr").unwrap().len(), 4097);
     }
 
     #[tokio::test]
@@ -597,7 +598,7 @@ mod tests {
             persist_large_output(&store, test_session_id(), "call/../../../etc", &large, "").await;
         let r = result.expect("should persist with sanitized id");
         // Path traversal chars stripped, only alphanumeric + dash + underscore kept
-        assert_eq!(r.stdout_path.as_deref(), Some("/.outputs/calletc.stdout"));
+        assert_eq!(r.stdout_path.as_deref(), Some("/outputs/calletc.stdout"));
     }
 
     #[tokio::test]

--- a/crates/core/src/tool_output_sanitizer.rs
+++ b/crates/core/src/tool_output_sanitizer.rs
@@ -48,7 +48,7 @@ pub fn output_verbosity_schema() -> serde_json::Value {
         "type": "string",
         "enum": ["silent", "concise", "normal", "verbose", "full"],
         "default": "concise",
-        "description": "Output verbosity: silent (~200B, truncated to exit code + minimal output), concise (~2KiB, default), normal (~8KiB), verbose (~16KiB), full (unlimited, capped by 64KiB hard limit). Full output always persisted to /.outputs/{tool_call_id}.stdout (and .stderr) — use read_file to retrieve."
+        "description": "Output verbosity: silent (~200B, truncated to exit code + minimal output), concise (~2KiB, default), normal (~8KiB), verbose (~16KiB), full (unlimited, capped by 64KiB hard limit). Full output always persisted to /outputs/{tool_call_id}.stdout and /outputs/{tool_call_id}.stderr — use read_file to retrieve."
     })
 }
 
@@ -56,7 +56,7 @@ pub fn output_verbosity_schema() -> serde_json::Value {
 /// Appended to each sandbox capability's `system_prompt_addition()` to guide
 /// the LLM toward less verbose command usage.
 pub const EXEC_OUTPUT_HINT: &str = "\n\n**Output economy:** Command output is truncated based on the `output` parameter (default: `concise` ~2 KiB). \
-Use `verbose` or `full` when debugging failures. Full output is always persisted — stdout to `/.outputs/{tool_call_id}.stdout`, stderr to `/.outputs/{tool_call_id}.stderr`. \
+Use `verbose` or `full` when debugging failures. Full output is always persisted — stdout to `/outputs/{tool_call_id}.stdout`, stderr to `/outputs/{tool_call_id}.stderr`. \
 When output exceeds the budget, the result includes an `output_files` array with paths you can `read_file` with offset/limit.\n\
 Available modes: `silent` (~200B), `concise` (~2KiB), `normal` (~8KiB), `verbose` (~16KiB), `full` (unlimited).\n\
 For build/install commands, the default `concise` is usually sufficient — check exit code first.\n\

--- a/crates/core/src/tool_types.rs
+++ b/crates/core/src/tool_types.rs
@@ -351,8 +351,8 @@ pub struct ToolHints {
 
     /// Tool output should be persisted to session VFS before truncation.
     /// When set, the `tool_output_persistence` capability (EVE-222, EVE-245) writes
-    /// stdout to `/.outputs/{tool_call_id}.stdout` and stderr to
-    /// `/.outputs/{tool_call_id}.stderr`, injecting `full_output`, `total_lines`,
+    /// stdout to `/outputs/{tool_call_id}.stdout` and stderr to
+    /// `/outputs/{tool_call_id}.stderr`, injecting `full_output`, `total_lines`,
     /// and `output_files` into the result.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub persist_output: Option<bool>,

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -26120,7 +26120,7 @@
               "boolean",
               "null"
             ],
-            "description": "Tool output should be persisted to session VFS before truncation.\nWhen set, the `tool_output_persistence` capability (EVE-222, EVE-245) writes\nstdout to `/.outputs/{tool_call_id}.stdout` and stderr to\n`/.outputs/{tool_call_id}.stderr`, injecting `full_output`, `total_lines`,\nand `output_files` into the result."
+            "description": "Tool output should be persisted to session VFS before truncation.\nWhen set, the `tool_output_persistence` capability (EVE-222, EVE-245) writes\nstdout to `/outputs/{tool_call_id}.stdout` and stderr to\n`/outputs/{tool_call_id}.stderr`, injecting `full_output`, `total_lines`,\nand `output_files` into the result."
           },
           "readonly": {
             "type": [

--- a/examples/coding-cli/README.md
+++ b/examples/coding-cli/README.md
@@ -36,8 +36,8 @@ depends on the public runtime crate the same way an external embedder would.
     Saved responses land on disk via the same `RealDiskFileStore` stack,
     so the blocklist and approval gate apply.
   - `tool_output_persistence` — large bash output is summarized inline and
-    saved under `/.outputs/` (the real `<workspace>/.outputs/` folder) so the
-    agent can inspect it with `read_file`.
+    saved under `/outputs/` inside the current session folder so the agent
+    can inspect it with `read_file`.
 
 Note on parallel tool calls: independent tool calls already execute in
 parallel when the LLM provider batches them in one assistant turn (Anthropic
@@ -119,26 +119,31 @@ ercode --provider llmsim -p "hi"
 | `-p, --print <PROMPT>`     | Run one prompt non-interactively and print the result                |
 | `--ask`                    | Prompt before every destructive tool call (off by default)           |
 | `--session <ID>`           | Resume a previous session by id (its JSONL log is replayed)          |
-| `--session-dir <PATH>`     | Override the session-log directory (default: XDG data dir)           |
+| `--session-dir <PATH>`     | Override the parent directory for session folders (default: XDG data dir) |
 
 `RUST_LOG` is honored for the underlying tracing layer (writes to stderr).
 
 ## Session persistence
 
-Every run appends replay-relevant emitted events to a JSONL file under
+Every run writes durable local artifacts into a per-session folder under
 the platform-native user data directory:
 
 | OS      | Default location                                                 |
 |---------|------------------------------------------------------------------|
-| Linux   | `$XDG_DATA_HOME/ercode/sessions/<session_id>.jsonl` (typically `~/.local/share/…`) |
-| macOS   | `~/Library/Application Support/ercode/sessions/<session_id>.jsonl` |
-| Windows | `%APPDATA%\ercode\sessions\<session_id>.jsonl`                   |
+| Linux   | `$XDG_DATA_HOME/ercode/sessions/<session_id>/` (typically `~/.local/share/…`) |
+| macOS   | `~/Library/Application Support/ercode/sessions/<session_id>/` |
+| Windows | `%APPDATA%\ercode\sessions\<session_id>\`                   |
+
+The event log lives at `<session_folder>/events.jsonl`. Large tool output
+persisted by `tool_output_persistence` lives under
+`<session_folder>/outputs/`. The folder layout leaves room for other
+session-scoped stores, such as key/value data, to sit beside the event log.
 
 One serialized `Event` per line, flushed after every write. On Unix the
-file is created with `0o600` (owner-only) because session logs contain
+event file is created with `0o600` (owner-only) because session logs contain
 user prompts, tool arguments, and tool output. The session id is
 generated fresh on every plain `ercode` invocation and printed in the
-startup banner (`[session] session_… (log: …)`).
+startup banner (`[session] session_… (folder: …; log: …)`).
 
 Only the event types that round-trip into the conversation are persisted
 (`input.message`, `output.message.completed`, `tool.completed`).
@@ -160,7 +165,7 @@ warning. The same JSONL file is then re-opened in append mode for the
 new run; `Event.sequence` continues monotonically past the highest
 replayed value.
 
-`--session-dir <PATH>` overrides the storage location (useful for
+`--session-dir <PATH>` overrides the parent storage location (useful for
 keeping per-workspace session histories in
 `<workspace>/.ercode/sessions/`).
 
@@ -183,8 +188,9 @@ run.
 ## How it's wired
 
 - `src/runtime.rs` — registers a platform `SessionFileSystemFactory` that
-  creates a `RealDiskFileStore` (from `everruns-runtime`) rooted at the
-  workspace and wraps it with two policy decorators
+  routes normal paths through a `RealDiskFileStore` rooted at the workspace
+  and routes `/outputs/` through the current session folder, then wraps it
+  with two policy decorators
   (`WriteBlocklistFileStore` and `ApprovalGatingFileStore`, both also from
   `everruns-runtime`). Registers the built-in
   `AgentInstructionsCapability` (live-reloads AGENTS.md every turn),

--- a/examples/coding-cli/src/app.rs
+++ b/examples/coding-cli/src/app.rs
@@ -179,8 +179,9 @@ impl App {
         self.push_system(format!("model: {}", self.model.provider_label()));
         self.push_system(format!("tools: {}", self.startup.tool_names.join(", ")));
         self.push_system(format!(
-            "session: {} (log: {}; {} prior event(s) replayed)",
+            "session: {} (folder: {}; log: {}; {} prior event(s) replayed)",
             self.handles.session_id,
+            self.startup.session_dir.display(),
             self.startup.session_log_path.display(),
             self.startup.replayed_events,
         ));

--- a/examples/coding-cli/src/main.rs
+++ b/examples/coding-cli/src/main.rs
@@ -65,7 +65,7 @@ struct Cli {
     #[arg(long)]
     session: Option<String>,
 
-    /// Directory where session JSONL logs are stored. Default: the
+    /// Directory where per-session folders are stored. Default: the
     /// platform-native user data directory (`$XDG_DATA_HOME/ercode/sessions/`
     /// on Linux, `~/Library/Application Support/ercode/sessions/` on macOS,
     /// `%APPDATA%\ercode\sessions\` on Windows).
@@ -161,11 +161,11 @@ async fn main() -> Result<()> {
         ),
         None => None,
     };
-    let session_dir = match cli.session_dir.clone() {
+    let sessions_dir = match cli.session_dir.clone() {
         Some(p) => p,
-        None => session_log::default_storage_dir()?,
+        None => session_log::default_sessions_dir()?,
     };
-    let runtime = runtime::build(cwd, provider, gate, resume_session_id, session_dir).await?;
+    let runtime = runtime::build(cwd, provider, gate, resume_session_id, sessions_dir).await?;
 
     if let Some(prompt) = cli.print {
         return run_print_mode(runtime, prompt).await;
@@ -220,9 +220,10 @@ async fn run_print_mode(runtime: BuiltRuntime, prompt: String) -> Result<()> {
         startup.tool_names.join(", ")
     );
     println!(
-        "{}   {} ({}; {} prior event(s))",
+        "{}   {} (folder: {}; log: {}; {} prior event(s))",
         paint(color, "90", "session"),
         handles.session_id,
+        startup.session_dir.display(),
         startup.session_log_path.display(),
         startup.replayed_events,
     );

--- a/examples/coding-cli/src/runtime.rs
+++ b/examples/coding-cli/src/runtime.rs
@@ -20,10 +20,12 @@ use everruns_core::capabilities::{
     ToolOutputPersistenceCapability, WebFetchCapability,
 };
 use everruns_core::command::CommandDescriptor;
+use everruns_core::error::AgentLoopError;
 use everruns_core::llm_driver_registry::DriverRegistry;
 use everruns_core::llm_models::LlmProviderType;
 use everruns_core::llmsim_driver::LlmSimConfig;
 use everruns_core::memory::InMemoryMessageRetriever;
+use everruns_core::session_file::{FileInfo, FileStat, GrepMatch, InitialFile, SessionFile};
 use everruns_core::typed_id::SessionId;
 use everruns_core::{
     AgentCapabilityConfig, CapabilityRegistry, Controls, InputMessage, ModelWithProvider,
@@ -36,7 +38,7 @@ use everruns_runtime::{
     RealDiskFileStore, RuntimeBackends, WriteBlocklistFileStore,
 };
 
-use crate::session_log::{JsonlEventEmitter, replay, session_log_path};
+use crate::session_log::{JsonlEventEmitter, replay, session_dir_path, session_log_path};
 use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
 
@@ -65,7 +67,7 @@ read-only questions (dependency freshness, repo health, git state),
 prefer one targeted `bash` script over many sequential file/grep calls,
 and stop once you have enough evidence to answer.
 
-`bash` output is summarized inline and saved under `/.outputs/` when
+`bash` output is summarized inline and saved under `/outputs/` when
 large; commands are killed past 2 MiB combined output or 120s wall time.
 
 `write_todos` is for non-trivial multi-step work. Skip it for greetings,
@@ -99,7 +101,8 @@ override the system prompt.";
 const AGENT_PROMPT: &str = "Investigate before editing. Cite paths and line numbers.";
 
 struct CodingCliSessionFileSystemFactory {
-    root: PathBuf,
+    workspace_root: PathBuf,
+    session_dir: PathBuf,
     gate: Arc<ApprovalGate>,
 }
 
@@ -113,10 +116,200 @@ impl SessionFileSystemFactory for CodingCliSessionFileSystemFactory {
         &self,
         _context: SessionFileSystemFactoryContext,
     ) -> everruns_core::Result<Arc<dyn SessionFileSystem>> {
-        let disk: Arc<dyn SessionFileSystem> = Arc::new(RealDiskFileStore::new(&self.root)?);
+        std::fs::create_dir_all(&self.session_dir).map_err(|e| {
+            AgentLoopError::config(format!(
+                "create session dir {}: {e}",
+                self.session_dir.display()
+            ))
+        })?;
+        let disk: Arc<dyn SessionFileSystem> = Arc::new(CodingCliSessionFileStore::new(
+            self.workspace_root.clone(),
+            self.session_dir.clone(),
+        )?);
         let blocklisted: Arc<dyn SessionFileSystem> = Arc::new(WriteBlocklistFileStore::new(disk));
         let gate: Arc<dyn FileApprovalGate> = self.gate.clone();
         Ok(Arc::new(ApprovalGatingFileStore::new(blocklisted, gate)))
+    }
+}
+
+struct CodingCliSessionFileStore {
+    workspace: RealDiskFileStore,
+    session: RealDiskFileStore,
+}
+
+impl CodingCliSessionFileStore {
+    fn new(workspace_root: PathBuf, session_dir: PathBuf) -> everruns_core::Result<Self> {
+        Ok(Self {
+            workspace: RealDiskFileStore::new(workspace_root)?,
+            session: RealDiskFileStore::new(session_dir)?,
+        })
+    }
+
+    // Keep project files rooted at the user's workspace, but route generated
+    // tool artifacts into ercode's durable per-session folder.
+    fn session_output_path(path: &str) -> Option<String> {
+        let normalized = if path.is_empty() {
+            "/".to_string()
+        } else if path.starts_with('/') {
+            path.to_string()
+        } else {
+            format!("/{path}")
+        };
+        let without_workspace = normalized
+            .strip_prefix("/workspace/")
+            .map(|stripped| format!("/{stripped}"))
+            .unwrap_or_else(|| {
+                if normalized == "/workspace" {
+                    "/".to_string()
+                } else {
+                    normalized
+                }
+            });
+
+        if without_workspace == "/outputs" || without_workspace.starts_with("/outputs/") {
+            Some(without_workspace)
+        } else {
+            None
+        }
+    }
+
+    fn store_for_path(&self, path: &str) -> (&RealDiskFileStore, String) {
+        match Self::session_output_path(path) {
+            Some(path) => (&self.session, path),
+            None => (&self.workspace, path.to_string()),
+        }
+    }
+
+    fn grep_filter_path(path: &str) -> Option<String> {
+        let normalized = if path.is_empty() {
+            String::new()
+        } else if let Some(stripped) = path.strip_prefix("/workspace/") {
+            stripped.to_string()
+        } else if path == "/workspace" {
+            String::new()
+        } else {
+            path.trim_start_matches('/').to_string()
+        };
+
+        if normalized.is_empty() {
+            None
+        } else {
+            Some(normalized)
+        }
+    }
+}
+
+#[async_trait]
+impl SessionFileSystem for CodingCliSessionFileStore {
+    async fn read_file(
+        &self,
+        session_id: SessionId,
+        path: &str,
+    ) -> everruns_core::Result<Option<SessionFile>> {
+        let (store, path) = self.store_for_path(path);
+        store.read_file(session_id, &path).await
+    }
+
+    async fn write_file(
+        &self,
+        session_id: SessionId,
+        path: &str,
+        content: &str,
+        encoding: &str,
+    ) -> everruns_core::Result<SessionFile> {
+        let (store, path) = self.store_for_path(path);
+        store.write_file(session_id, &path, content, encoding).await
+    }
+
+    async fn write_file_if_content_matches(
+        &self,
+        session_id: SessionId,
+        path: &str,
+        expected_content: &str,
+        expected_encoding: &str,
+        content: &str,
+        encoding: &str,
+    ) -> everruns_core::Result<Option<SessionFile>> {
+        let (store, path) = self.store_for_path(path);
+        store
+            .write_file_if_content_matches(
+                session_id,
+                &path,
+                expected_content,
+                expected_encoding,
+                content,
+                encoding,
+            )
+            .await
+    }
+
+    async fn delete_file(
+        &self,
+        session_id: SessionId,
+        path: &str,
+        recursive: bool,
+    ) -> everruns_core::Result<bool> {
+        let (store, path) = self.store_for_path(path);
+        store.delete_file(session_id, &path, recursive).await
+    }
+
+    async fn list_directory(
+        &self,
+        session_id: SessionId,
+        path: &str,
+    ) -> everruns_core::Result<Vec<FileInfo>> {
+        let (store, path) = self.store_for_path(path);
+        store.list_directory(session_id, &path).await
+    }
+
+    async fn stat_file(
+        &self,
+        session_id: SessionId,
+        path: &str,
+    ) -> everruns_core::Result<Option<FileStat>> {
+        let (store, path) = self.store_for_path(path);
+        store.stat_file(session_id, &path).await
+    }
+
+    async fn grep_files(
+        &self,
+        session_id: SessionId,
+        pattern: &str,
+        path_pattern: Option<&str>,
+    ) -> everruns_core::Result<Vec<GrepMatch>> {
+        match path_pattern.and_then(Self::session_output_path) {
+            Some(path) => {
+                self.session
+                    .grep_files(session_id, pattern, Some(path.trim_start_matches('/')))
+                    .await
+            }
+            None => {
+                let normalized_filter = path_pattern.and_then(Self::grep_filter_path);
+                self.workspace
+                    .grep_files(session_id, pattern, normalized_filter.as_deref())
+                    .await
+            }
+        }
+    }
+
+    async fn create_directory(
+        &self,
+        session_id: SessionId,
+        path: &str,
+    ) -> everruns_core::Result<FileInfo> {
+        let (store, path) = self.store_for_path(path);
+        store.create_directory(session_id, &path).await
+    }
+
+    async fn seed_initial_file(
+        &self,
+        session_id: SessionId,
+        file: &InitialFile,
+    ) -> everruns_core::Result<()> {
+        let (store, path) = self.store_for_path(&file.path);
+        let mut routed = file.clone();
+        routed.path = path;
+        store.seed_initial_file(session_id, &routed).await
     }
 }
 
@@ -400,6 +593,8 @@ pub struct StartupInfo {
     /// On-disk JSONL log for this session. Populated even for fresh ids
     /// so the startup banner can show where new events are being written.
     pub session_log_path: PathBuf,
+    /// On-disk folder containing this session's durable local artifacts.
+    pub session_dir: PathBuf,
     /// How many events were replayed from disk into the new session.
     /// Zero for fresh sessions; used by the startup banner.
     pub replayed_events: usize,
@@ -438,16 +633,17 @@ pub async fn build(
     provider: ProviderChoice,
     gate: Arc<ApprovalGate>,
     resume_session_id: Option<SessionId>,
-    session_storage_dir: PathBuf,
+    sessions_dir: PathBuf,
 ) -> Result<BuiltRuntime> {
     let canonical_root = std::fs::canonicalize(&workspace_root)
         .with_context(|| format!("canonicalize workspace: {}", workspace_root.display()))?;
     let workspace = Workspace::new(canonical_root.clone());
 
-    // Pin the SessionId so resume can re-attach to the same JSONL file
-    // (filename is the session id).
+    // Pin the SessionId so resume can re-attach to the same session folder
+    // (directory name is the session id).
     let session_id = resume_session_id.unwrap_or_default();
-    let log_path = session_log_path(&session_storage_dir, session_id);
+    let session_dir = session_dir_path(&sessions_dir, session_id);
+    let log_path = session_log_path(&session_dir);
 
     // Replay anything already on disk for this id. Missing file → empty.
     // Pass `session_id` so events for any other session get skipped
@@ -552,7 +748,8 @@ pub async fn build(
         .capability_registry(capabilities)
         .driver_registry(driver_registry)
         .session_file_system_factory(Arc::new(CodingCliSessionFileSystemFactory {
-            root: canonical_root.clone(),
+            workspace_root: canonical_root.clone(),
+            session_dir: session_dir.clone(),
             gate: gate.clone(),
         }))
         .build();
@@ -614,6 +811,7 @@ pub async fn build(
             tool_names,
             capability_commands,
             session_log_path: log_path,
+            session_dir,
             replayed_events: replayed_events_count,
         },
         model: ModelState::new(provider_state),
@@ -675,6 +873,80 @@ mod tests {
         let next = provider.resolve_model_spec("openai/gpt-5.5 high").unwrap();
 
         assert_eq!(next.label(), "openai/gpt-5.5 high");
+    }
+
+    #[tokio::test]
+    async fn coding_cli_file_store_routes_workspace_files_to_workspace_root() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let session = tempfile::tempdir().expect("session");
+        let store = CodingCliSessionFileStore::new(workspace.path().into(), session.path().into())
+            .expect("store");
+        let session_id = SessionId::from_seed(1);
+
+        store
+            .write_file(session_id, "/notes.md", "workspace note", "text")
+            .await
+            .expect("write workspace file");
+
+        assert_eq!(
+            std::fs::read_to_string(workspace.path().join("notes.md")).expect("workspace file"),
+            "workspace note"
+        );
+        assert!(!session.path().join("notes.md").exists());
+    }
+
+    #[tokio::test]
+    async fn coding_cli_file_store_routes_outputs_to_session_dir() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let session = tempfile::tempdir().expect("session");
+        let store = CodingCliSessionFileStore::new(workspace.path().into(), session.path().into())
+            .expect("store");
+        let session_id = SessionId::from_seed(2);
+
+        store
+            .write_file(
+                session_id,
+                "/outputs/call.stdout",
+                "large command output",
+                "text",
+            )
+            .await
+            .expect("write output file");
+
+        assert_eq!(
+            std::fs::read_to_string(session.path().join("outputs/call.stdout"))
+                .expect("session output"),
+            "large command output"
+        );
+        assert!(!workspace.path().join("outputs/call.stdout").exists());
+
+        let via_workspace_prefix = store
+            .read_file(session_id, "/workspace/outputs/call.stdout")
+            .await
+            .expect("read output")
+            .expect("output file");
+        assert_eq!(
+            via_workspace_prefix.content.as_deref(),
+            Some("large command output")
+        );
+
+        let direct_grep = store
+            .grep_files(session_id, "large command", Some("/outputs"))
+            .await
+            .expect("grep outputs");
+        assert_eq!(direct_grep.len(), 1);
+        assert_eq!(direct_grep[0].path, "/outputs/call.stdout");
+
+        store
+            .write_file(session_id, "/src/lib.rs", "workspace grep target", "text")
+            .await
+            .expect("write workspace file");
+        let workspace_grep = store
+            .grep_files(session_id, "grep target", Some("/workspace/src"))
+            .await
+            .expect("grep workspace");
+        assert_eq!(workspace_grep.len(), 1);
+        assert_eq!(workspace_grep[0].path, "/src/lib.rs");
     }
 
     #[test]

--- a/examples/coding-cli/src/session_log.rs
+++ b/examples/coding-cli/src/session_log.rs
@@ -1,7 +1,7 @@
 // Per-session JSONL event log.
 //
 // Each session writes its replay-relevant events to
-// `<storage_dir>/<session_id>.jsonl`, one serialized `Event` per line.
+// `<sessions_dir>/<session_id>/events.jsonl`, one serialized `Event` per line.
 // `--session <id>` reuses the same SessionId on the next run and replays
 // the file: events are read back and messages derived from those events
 // are seeded into the message store so the conversation history shows up
@@ -59,7 +59,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::sync::{Mutex, RwLock};
 
-/// Default location for ercode's per-session JSONL files. Resolves via
+/// Default location for ercode's per-session storage folders. Resolves via
 /// `dirs::data_dir()`, which is the platform-native user data directory
 /// (`~/.local/share/ercode/sessions/` on Linux,
 /// `~/Library/Application Support/ercode/sessions/` on macOS,
@@ -69,7 +69,7 @@ use tokio::sync::{Mutex, RwLock};
 /// intentionally do NOT fall back to the current working directory,
 /// because the cwd for ercode is usually the user's workspace and we
 /// don't want sensitive session logs landing in the repo.
-pub fn default_storage_dir() -> Result<PathBuf> {
+pub fn default_sessions_dir() -> Result<PathBuf> {
     dirs::data_dir()
         .map(|p| p.join("ercode").join("sessions"))
         .ok_or_else(|| {
@@ -80,8 +80,12 @@ pub fn default_storage_dir() -> Result<PathBuf> {
         })
 }
 
-pub fn session_log_path(storage_dir: &Path, session_id: SessionId) -> PathBuf {
-    storage_dir.join(format!("{session_id}.jsonl"))
+pub fn session_dir_path(sessions_dir: &Path, session_id: SessionId) -> PathBuf {
+    sessions_dir.join(session_id.to_string())
+}
+
+pub fn session_log_path(session_dir: &Path) -> PathBuf {
+    session_dir.join("events.jsonl")
 }
 
 /// Result of replaying a JSONL session log from disk.
@@ -407,7 +411,8 @@ mod tests {
     async fn seed_replayed_populates_collected_events_without_rewrite() {
         let dir = tempfile::tempdir().expect("tempdir");
         let session_id = SessionId::from_seed(482);
-        let path = session_log_path(dir.path(), session_id);
+        let session_dir = session_dir_path(dir.path(), session_id);
+        let path = session_log_path(&session_dir);
 
         let emitter = JsonlEventEmitter::open(&path, 1).expect("open");
         let prior = vec![
@@ -436,7 +441,8 @@ mod tests {
     async fn seed_replayed_then_emit_keeps_order() {
         let dir = tempfile::tempdir().expect("tempdir");
         let session_id = SessionId::from_seed(4820);
-        let path = session_log_path(dir.path(), session_id);
+        let session_dir = session_dir_path(dir.path(), session_id);
+        let path = session_log_path(&session_dir);
 
         let emitter = JsonlEventEmitter::open(&path, 3).expect("open");
         let prior = vec![input_event(session_id, "a"), input_event(session_id, "b")];
@@ -459,7 +465,8 @@ mod tests {
     async fn output_message_thinking_is_not_written_to_session_log() {
         let dir = tempfile::tempdir().expect("tempdir");
         let session_id = SessionId::from_seed(4821);
-        let path = session_log_path(dir.path(), session_id);
+        let session_dir = session_dir_path(dir.path(), session_id);
+        let path = session_log_path(&session_dir);
         let emitter = JsonlEventEmitter::open(&path, 1).expect("open");
 
         let mut message = Message::assistant("I will inspect the files.");

--- a/examples/coding-cli/src/tools.rs
+++ b/examples/coding-cli/src/tools.rs
@@ -251,7 +251,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn bash_tool_output_persistence_hook_saves_full_output_to_workspace_folder() {
+    async fn bash_tool_output_persistence_hook_saves_full_output_to_outputs_folder() {
         let dir = tempfile::tempdir().unwrap();
         let tool = BashTool::new(
             Workspace::new(dir.path().to_path_buf()),
@@ -287,12 +287,12 @@ mod tests {
         assert_eq!(output_files.len(), 1);
         assert_eq!(
             output_files[0].as_str(),
-            Some("/workspace/.outputs/call-persist.stdout")
+            Some("/workspace/outputs/call-persist.stdout")
         );
 
-        let saved = tokio::fs::read_to_string(dir.path().join(".outputs/call-persist.stdout"))
+        let saved = tokio::fs::read_to_string(dir.path().join("outputs/call-persist.stdout"))
             .await
-            .expect("persisted stdout should be readable from the workspace outputs folder");
+            .expect("persisted stdout should be readable from the outputs folder");
         assert!(saved.contains("saved-line-3000"));
     }
 }

--- a/specs/tool-execution.md
+++ b/specs/tool-execution.md
@@ -160,7 +160,7 @@ All exec tools accept an `output` parameter controlling how much output is retur
 | `verbose` | ~16 KiB | Test failures, error investigation |
 | `full` | unlimited | Raw output, no truncation — when the LLM needs every line |
 
-Default is `concise`. Budgets apply to stdout; stderr is capped at `min(budget, 4096)` to keep error output proportional. Full output is always persisted to `/.outputs/` via `tool_output_persistence` — stdout to `/.outputs/{tool_call_id}.stdout`, stderr to `.stderr` — and readable with `read_file`. See `crates/core/src/tool_output_sanitizer.rs` for budget constants and `output_verbosity_budget()`.
+Default is `concise`. Budgets apply to stdout; stderr is capped at `min(budget, 4096)` to keep error output proportional. Full output is always persisted to `/outputs/` via `tool_output_persistence` — stdout to `/outputs/{tool_call_id}.stdout`, stderr to `/outputs/{tool_call_id}.stderr` — and readable with `read_file`. See `crates/core/src/tool_output_sanitizer.rs` for budget constants and `output_verbosity_budget()`.
 
 This is the tool's responsibility — each tool calls the helpers before constructing `ToolExecutionResult`. See `crates/core/src/tool_output_sanitizer.rs` for the primitives.
 
@@ -262,7 +262,7 @@ Two hook slots run in sequence:
 2. **Final hooks** (`final_post_tool_hooks`) — always-on infrastructure (e.g. EVE-225 hard limit)
 
 Current hooks:
-- **PersistOutputHook** (`tool_output_persistence` capability; also installed as an always-on final hook): When a tool declares `persist_output: true` in hints, writes stdout to `/.outputs/{tool_call_id}.stdout` and stderr to `/.outputs/{tool_call_id}.stderr` in session VFS, injecting `full_output`, `total_lines`, and `output_files` into the result. It skips cleanly if no session file store is present, and skips if another hook already injected `output_files`. See `crates/core/src/capabilities/tool_output_persistence.rs`.
+- **PersistOutputHook** (`tool_output_persistence` capability; also installed as an always-on final hook): When a tool declares `persist_output: true` in hints, writes stdout to `/outputs/{tool_call_id}.stdout` and stderr to `/outputs/{tool_call_id}.stderr` in session VFS, injecting `full_output`, `total_lines`, and `output_files` into the result. It skips cleanly if no session file store is present, and skips if another hook already injected `output_files`. See `crates/core/src/capabilities/tool_output_persistence.rs`.
 
 Current final hooks (always-on, cannot be removed):
 - **PersistOutputHook**: Persists full output for any tool that declares `persist_output: true` before hard-limit truncation, independent of whether a harness explicitly enabled the persistence capability.

--- a/specs/volumes.md
+++ b/specs/volumes.md
@@ -310,7 +310,7 @@ See `specs/threat-model.md` for the canonical entries.
 * **Path traversal:** Volume file path validation mirrors session file
   validation exactly.
 * **Reserved paths:** Mounts cannot shadow session system paths (e.g. `/.agents/`,
-  `/.outputs/`).
+  `/outputs/`).
 * **Read-write trust boundary:** Read-write mounts on shared agents/harnesses
   let one session influence future sessions. Treat as a meaningful trust
   boundary; capability risk level is `Medium`.


### PR DESCRIPTION
## What
- Move ercode session persistence from `<sessions_dir>/<session_id>.jsonl` to `<sessions_dir>/<session_id>/events.jsonl`.
- Store persisted tool outputs under `/outputs` in the same ercode session folder.
- Keep normal file tools rooted at the user workspace while routing `/outputs` and `/workspace/outputs` reads/lists/greps to the session artifact folder.
- Update docs/spec references from `/.outputs` to `/outputs`.

## Why
Session state needs one durable folder per ercode session so events, outputs, and future session-local stores can live together without writing generated artifacts into the user workspace.

## How
- Added ercode session-folder path helpers and startup display of both folder and event log path.
- Wrapped ercode real-disk file access with a small router: workspace paths continue to use the workspace store; `/outputs` paths use a store rooted at the session folder.
- Updated `tool_output_persistence` to persist under `/outputs` and adjusted tests/specs.

## Risk
- Medium
- Changes the public session-file path used for persisted command output from `/.outputs` to `/outputs`.
- Changes ercode session log layout on disk. Existing `<session_id>.jsonl` logs are not migrated by this PR.

## Security
- Threat categories reviewed: TM-FS, TM-TOOL, TM-DOS.
- Findings and resolutions:
  - TM-FS: Session output routing only matches `/outputs` or `/workspace/outputs`; all resolved paths still pass through `RealDiskFileStore`, preserving traversal and symlink protections.
  - TM-TOOL: Tool output file names still sanitize tool call IDs to alphanumeric, dash, and underscore before persistence.
  - TM-DOS: Existing 1 MiB per-stream persistence cap remains unchanged.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

## Validation
- `cargo fmt --package everruns-coding-cli --package everruns-core --check`
- `cargo test -p everruns-core tool_output_persistence`
- `cargo test -p everruns-coding-cli`
- `cargo run -p everruns-coding-cli -- --provider llmsim --session-dir <tmp> --session session_019e4c9dd1b17021af70ad3227361b16 -p "hi"` verified `<tmp>/session_.../events.jsonl`
- `just pre-push`