### PR TITLE
feat(coding-cli): support OpenRouter and Ollama

### DIFF
--- a/examples/coding-cli/README.md
+++ b/examples/coding-cli/README.md
@@ -56,13 +56,16 @@ and OpenAI both do). No capability needed.
   The `bash` tool also accepts an `output` verbosity argument matching the
   built-in sandbox exec tools.
 - **Provider selection** via env vars: `OPENAI_API_KEY` → OpenAI (`gpt-5.5`),
-  `ANTHROPIC_API_KEY` → Anthropic (`claude-sonnet-4-5`), otherwise falls back
-  to `llmsim` (offline). OpenAI is preferred when both keys are present so the
-  default model stays `gpt-5.5`.
+  `ANTHROPIC_API_KEY` → Anthropic (`claude-sonnet-4-5`), `OPENROUTER_API_KEY`
+  → OpenRouter (`openai/gpt-5.2`), `OLLAMA_BASE_URL` or `OLLAMA_API_KEY` →
+  Ollama (`llama3.2`), otherwise falls back to `llmsim` (offline). OpenAI is
+  preferred when multiple provider env vars are present so the default model
+  stays `gpt-5.5`.
 - **Slash commands** (TUI): `/help`, `/tools`, `/cwd`, `/model <provider>/<id>`, `/clear`, `/quit`.
   Typing `/` opens suggestions; Tab accepts the first suggestion. `/model`
   with no argument shows the current model and suggested model IDs, while
-  `/model openai/gpt-5.5`, `/model anthropic/claude-sonnet-4-5`, or
+  `/model openai/gpt-5.5`, `/model anthropic/claude-sonnet-4-5`,
+  `/model openrouter/openai/gpt-5.2`, `/model ollama/llama3.2`, or
   `/model llmsim/llmsim-coding-cli` changes the active provider/model for
   subsequent turns. Bare model IDs still target the current provider.
 - **`--print`** one-shot mode for CI smoke tests
@@ -109,12 +112,24 @@ Offline (no API key required):
 ercode --provider llmsim -p "hi"
 ```
 
+OpenRouter, using its OpenAI-compatible Responses endpoint:
+
+```bash
+OPENROUTER_API_KEY=sk-or-... ercode --provider openrouter -m openai/gpt-5.2 -p "hi"
+```
+
+Local Ollama, using its OpenAI-compatible Responses endpoint:
+
+```bash
+OLLAMA_BASE_URL=http://localhost:11434/v1 ercode --provider ollama -m llama3.2 -p "hi"
+```
+
 ## Flags
 
 | Flag                       | Description                                                          |
 | -------------------------- | -------------------------------------------------------------------- |
 | `-C, --cwd <PATH>`         | Workspace root (default: current dir)                                |
-| `--provider <P>`           | Force `anthropic`, `openai`, or `llmsim` (default: env-detected)     |
+| `--provider <P>`           | Force `anthropic`, `openai`, `openrouter`, `ollama`, or `llmsim`     |
 | `-m, --model <ID>`         | Override the model id for the chosen provider                        |
 | `-p, --print <PROMPT>`     | Run one prompt non-interactively and print the result                |
 | `--ask`                    | Prompt before every destructive tool call (off by default)           |
@@ -122,6 +137,19 @@ ercode --provider llmsim -p "hi"
 | `--session-dir <PATH>`     | Override the session-log directory (default: XDG data dir)           |
 
 `RUST_LOG` is honored for the underlying tracing layer (writes to stderr).
+
+Provider env vars:
+
+| Env var                         | Description                                                 |
+| ------------------------------- | ----------------------------------------------------------- |
+| `OPENAI_API_KEY`                | Select OpenAI unless `--provider` overrides it              |
+| `ANTHROPIC_API_KEY`             | Select Anthropic when OpenAI is not configured              |
+| `OPENROUTER_API_KEY`            | Select OpenRouter when OpenAI/Anthropic are not configured  |
+| `OPENROUTER_BASE_URL`           | Optional, defaults to `https://openrouter.ai/api/v1`        |
+| `OLLAMA_BASE_URL`               | Select Ollama, defaults to `http://localhost:11434/v1`      |
+| `OLLAMA_API_KEY`                | Optional, defaults to `ollama` for local Ollama             |
+| `EVERRUNS_CLI_MODEL`            | Override the auto-selected default model                    |
+| `EVERRUNS_CLI_REASONING_EFFORT` | OpenAI-only reasoning effort override                       |
 
 ## Session persistence
 

--- a/examples/coding-cli/src/main.rs
+++ b/examples/coding-cli/src/main.rs
@@ -77,6 +77,8 @@ struct Cli {
 enum ProviderArg {
     Anthropic,
     Openai,
+    Openrouter,
+    Ollama,
     #[value(name = "llmsim", alias = "sim")]
     Sim,
 }
@@ -94,6 +96,26 @@ fn pick_provider(cli: &Cli) -> ProviderChoice {
                     .unwrap_or_else(|| "medium".to_string()),
             ),
         },
+        Some(ProviderArg::Openrouter) => ProviderChoice::OpenRouter {
+            model: std::env::var("EVERRUNS_CLI_MODEL")
+                .ok()
+                .filter(|value| !value.is_empty())
+                .unwrap_or_else(|| "openai/gpt-5.2".to_string()),
+            base_url: std::env::var("OPENROUTER_BASE_URL")
+                .ok()
+                .filter(|value| !value.is_empty())
+                .unwrap_or_else(|| "https://openrouter.ai/api/v1".to_string()),
+        },
+        Some(ProviderArg::Ollama) => ProviderChoice::Ollama {
+            model: std::env::var("EVERRUNS_CLI_MODEL")
+                .ok()
+                .filter(|value| !value.is_empty())
+                .unwrap_or_else(|| "llama3.2".to_string()),
+            base_url: std::env::var("OLLAMA_BASE_URL")
+                .ok()
+                .filter(|value| !value.is_empty())
+                .unwrap_or_else(|| "http://localhost:11434/v1".to_string()),
+        },
         Some(ProviderArg::Sim) => ProviderChoice::Sim,
         None => ProviderChoice::from_env(),
     };
@@ -108,6 +130,12 @@ fn pick_provider(cli: &Cli) -> ProviderChoice {
             model: m,
             reasoning_effort: cli.reasoning_effort.clone().or(reasoning_effort),
         },
+        (ProviderChoice::OpenRouter { base_url, .. }, Some(m)) => {
+            ProviderChoice::OpenRouter { model: m, base_url }
+        }
+        (ProviderChoice::Ollama { base_url, .. }, Some(m)) => {
+            ProviderChoice::Ollama { model: m, base_url }
+        }
         (other, _) => other,
     };
     match (selected, cli.reasoning_effort.clone()) {

--- a/examples/coding-cli/src/runtime.rs
+++ b/examples/coding-cli/src/runtime.rs
@@ -125,6 +125,11 @@ impl SessionFileSystemFactory for CodingCliSessionFileSystemFactory {
 const DEFAULT_OPENAI_MODEL: &str = "gpt-5.5";
 const DEFAULT_OPENAI_REASONING_EFFORT: &str = "medium";
 const DEFAULT_ANTHROPIC_MODEL: &str = "claude-sonnet-4-5";
+const DEFAULT_OPENROUTER_MODEL: &str = "openai/gpt-5.2";
+const DEFAULT_OPENROUTER_BASE_URL: &str = "https://openrouter.ai/api/v1";
+const DEFAULT_OLLAMA_MODEL: &str = "llama3.2";
+const DEFAULT_OLLAMA_BASE_URL: &str = "http://localhost:11434/v1";
+const DEFAULT_OLLAMA_API_KEY: &str = "ollama";
 
 #[derive(Clone, Debug)]
 pub enum ProviderChoice {
@@ -135,6 +140,14 @@ pub enum ProviderChoice {
         model: String,
         reasoning_effort: Option<String>,
     },
+    OpenRouter {
+        model: String,
+        base_url: String,
+    },
+    Ollama {
+        model: String,
+        base_url: String,
+    },
     Sim,
 }
 
@@ -143,26 +156,30 @@ impl ProviderChoice {
     /// OpenAI is preferred when both keys are present so the out-of-the-box
     /// default model stays `gpt-5.5`.
     pub fn from_env() -> Self {
-        if std::env::var("OPENAI_API_KEY")
-            .ok()
-            .is_some_and(|v| !v.is_empty())
-        {
+        if env_non_empty("OPENAI_API_KEY").is_some() {
             return Self::OpenAi {
-                model: std::env::var("EVERRUNS_CLI_MODEL")
-                    .unwrap_or_else(|_| DEFAULT_OPENAI_MODEL.to_string()),
-                reasoning_effort: Some(
-                    std::env::var("EVERRUNS_CLI_REASONING_EFFORT")
-                        .unwrap_or_else(|_| DEFAULT_OPENAI_REASONING_EFFORT.to_string()),
-                ),
+                model: env_or_default("EVERRUNS_CLI_MODEL", DEFAULT_OPENAI_MODEL),
+                reasoning_effort: Some(env_or_default(
+                    "EVERRUNS_CLI_REASONING_EFFORT",
+                    DEFAULT_OPENAI_REASONING_EFFORT,
+                )),
             };
         }
-        if std::env::var("ANTHROPIC_API_KEY")
-            .ok()
-            .is_some_and(|v| !v.is_empty())
-        {
+        if env_non_empty("ANTHROPIC_API_KEY").is_some() {
             return Self::Anthropic {
-                model: std::env::var("EVERRUNS_CLI_MODEL")
-                    .unwrap_or_else(|_| DEFAULT_ANTHROPIC_MODEL.to_string()),
+                model: env_or_default("EVERRUNS_CLI_MODEL", DEFAULT_ANTHROPIC_MODEL),
+            };
+        }
+        if env_non_empty("OPENROUTER_API_KEY").is_some() {
+            return Self::OpenRouter {
+                model: env_or_default("EVERRUNS_CLI_MODEL", DEFAULT_OPENROUTER_MODEL),
+                base_url: env_or_default("OPENROUTER_BASE_URL", DEFAULT_OPENROUTER_BASE_URL),
+            };
+        }
+        if env_non_empty("OLLAMA_BASE_URL").is_some() || env_non_empty("OLLAMA_API_KEY").is_some() {
+            return Self::Ollama {
+                model: env_or_default("EVERRUNS_CLI_MODEL", DEFAULT_OLLAMA_MODEL),
+                base_url: env_or_default("OLLAMA_BASE_URL", DEFAULT_OLLAMA_BASE_URL),
             };
         }
         Self::Sim
@@ -178,6 +195,8 @@ impl ProviderChoice {
                 Some(effort) => format!("openai/{model} {effort}"),
                 None => format!("openai/{model}"),
             },
+            Self::OpenRouter { model, .. } => format!("openrouter/{model}"),
+            Self::Ollama { model, .. } => format!("ollama/{model}"),
             Self::Sim => "llmsim/llmsim-coding-cli".to_string(),
         }
     }
@@ -189,6 +208,8 @@ impl ProviderChoice {
             "openai/gpt-5.4-mini",
             "openai/gpt-5.3-codex",
             "openai/gpt-5.2",
+            "openrouter/openai/gpt-5.2",
+            "ollama/llama3.2",
             "anthropic/claude-sonnet-4-5",
             "anthropic/claude-opus-4-5",
             "anthropic/claude-haiku-4-5",
@@ -231,6 +252,28 @@ impl ProviderChoice {
                 model: model.to_string(),
                 reasoning_effort: normalize_openai_reasoning_effort(reasoning_effort),
             }),
+            "openrouter" => {
+                if reasoning_effort.is_some() {
+                    return Err(anyhow!(
+                        "openrouter model switching does not accept reasoning effort"
+                    ));
+                }
+                Ok(Self::OpenRouter {
+                    model: model.to_string(),
+                    base_url: env_or_default("OPENROUTER_BASE_URL", DEFAULT_OPENROUTER_BASE_URL),
+                })
+            }
+            "ollama" => {
+                if reasoning_effort.is_some() {
+                    return Err(anyhow!(
+                        "ollama model switching does not accept reasoning effort"
+                    ));
+                }
+                Ok(Self::Ollama {
+                    model: model.to_string(),
+                    base_url: env_or_default("OLLAMA_BASE_URL", DEFAULT_OLLAMA_BASE_URL),
+                })
+            }
             "llmsim" | "sim" => {
                 if reasoning_effort.is_some() {
                     return Err(anyhow!("offline llmsim does not support reasoning effort"));
@@ -265,6 +308,28 @@ impl ProviderChoice {
                 model,
                 reasoning_effort: normalize_openai_reasoning_effort(reasoning_effort),
             }),
+            Self::OpenRouter { base_url, .. } => {
+                if reasoning_effort.is_some() {
+                    return Err(anyhow!(
+                        "openrouter model switching does not accept reasoning effort"
+                    ));
+                }
+                Ok(Self::OpenRouter {
+                    model,
+                    base_url: base_url.clone(),
+                })
+            }
+            Self::Ollama { base_url, .. } => {
+                if reasoning_effort.is_some() {
+                    return Err(anyhow!(
+                        "ollama model switching does not accept reasoning effort"
+                    ));
+                }
+                Ok(Self::Ollama {
+                    model,
+                    base_url: base_url.clone(),
+                })
+            }
             Self::Sim => {
                 if reasoning_effort.is_some() {
                     return Err(anyhow!("offline llmsim does not support reasoning effort"));
@@ -300,6 +365,22 @@ impl ProviderChoice {
                     base_url: None,
                 })
             }
+            ProviderChoice::OpenRouter { model, base_url } => {
+                let key = env_non_empty("OPENROUTER_API_KEY")
+                    .ok_or_else(|| anyhow!("OPENROUTER_API_KEY not set"))?;
+                Ok(ModelWithProvider {
+                    model: model.clone(),
+                    provider_type: LlmProviderType::Openai,
+                    api_key: Some(key),
+                    base_url: Some(base_url.clone()),
+                })
+            }
+            ProviderChoice::Ollama { model, base_url } => Ok(ModelWithProvider {
+                model: model.clone(),
+                provider_type: LlmProviderType::Openai,
+                api_key: Some(env_or_default("OLLAMA_API_KEY", DEFAULT_OLLAMA_API_KEY)),
+                base_url: Some(base_url.clone()),
+            }),
             ProviderChoice::Sim => Ok(ModelWithProvider {
                 model: "llmsim-coding-cli".into(),
                 provider_type: LlmProviderType::LlmSim,
@@ -325,6 +406,14 @@ impl ProviderChoice {
         }
         input
     }
+}
+
+fn env_non_empty(name: &str) -> Option<String> {
+    std::env::var(name).ok().filter(|value| !value.is_empty())
+}
+
+fn env_or_default(name: &str, default: &str) -> String {
+    env_non_empty(name).unwrap_or_else(|| default.to_string())
 }
 
 fn normalize_openai_reasoning_effort(reasoning_effort: Option<String>) -> Option<String> {
@@ -537,9 +626,10 @@ pub async fn build(
     everruns_anthropic::register_driver(&mut driver_registry);
     everruns_openai::register_driver(&mut driver_registry);
     let default_model = match &provider {
-        ProviderChoice::Anthropic { .. } | ProviderChoice::OpenAi { .. } => {
-            provider.model_with_provider()?
-        }
+        ProviderChoice::Anthropic { .. }
+        | ProviderChoice::OpenAi { .. }
+        | ProviderChoice::OpenRouter { .. }
+        | ProviderChoice::Ollama { .. } => provider.model_with_provider()?,
         ProviderChoice::Sim => ModelWithProvider {
             model: "llmsim-coding-cli".into(),
             provider_type: LlmProviderType::LlmSim,
@@ -667,6 +757,50 @@ mod tests {
             .unwrap();
 
         assert_eq!(next.label(), "llmsim/llmsim-coding-cli");
+    }
+
+    #[test]
+    fn model_spec_accepts_openrouter_provider_name() {
+        let provider = ProviderChoice::Sim;
+        let next = provider
+            .resolve_model_spec("openrouter/openai/gpt-5.2")
+            .unwrap();
+
+        assert_eq!(next.label(), "openrouter/openai/gpt-5.2");
+    }
+
+    #[test]
+    fn model_spec_accepts_ollama_provider_name() {
+        let provider = ProviderChoice::Sim;
+        let next = provider.resolve_model_spec("ollama/llama3.2").unwrap();
+
+        assert_eq!(next.label(), "ollama/llama3.2");
+    }
+
+    #[test]
+    fn openrouter_uses_openai_responses_driver_with_base_url() {
+        let provider = ProviderChoice::OpenRouter {
+            model: "openai/gpt-5.2".to_string(),
+            base_url: DEFAULT_OPENROUTER_BASE_URL.to_string(),
+        };
+
+        let err = provider.model_with_provider().unwrap_err();
+
+        assert_eq!(err.to_string(), "OPENROUTER_API_KEY not set");
+    }
+
+    #[test]
+    fn ollama_uses_openai_responses_driver_with_local_base_url() {
+        let provider = ProviderChoice::Ollama {
+            model: "llama3.2".to_string(),
+            base_url: DEFAULT_OLLAMA_BASE_URL.to_string(),
+        };
+
+        let model = provider.model_with_provider().unwrap();
+
+        assert_eq!(model.provider_type, LlmProviderType::Openai);
+        assert_eq!(model.api_key, Some(DEFAULT_OLLAMA_API_KEY.to_string()));
+        assert_eq!(model.base_url, Some(DEFAULT_OLLAMA_BASE_URL.to_string()));
     }
 
     #[test]


### PR DESCRIPTION
## What
Add OpenRouter and Ollama provider support to the standalone `examples/coding-cli` binary.

## Why
The coding CLI already supports OpenAI, Anthropic, and offline llmsim. OpenRouter and local Ollama are both useful OpenAI-compatible options for testing and local development, and both now expose Responses-compatible endpoints.

## How
- Add `--provider openrouter` and `--provider ollama`.
- Auto-detect `OPENROUTER_API_KEY`, then `OLLAMA_BASE_URL` / `OLLAMA_API_KEY`, after OpenAI and Anthropic.
- Route OpenRouter and Ollama through the existing OpenAI Responses driver with provider-specific base URLs.
- Document provider env vars and add focused provider-selection tests.

## Risk
- Low
- Risk is limited to the example coding CLI provider-selection path. Existing OpenAI, Anthropic, and llmsim behavior remains ordered ahead of the new providers except when explicitly using `--provider`.
- Misconfigured OpenRouter/Ollama env vars can select a provider that later fails at request time; this matches existing key-based provider selection behavior.

## Security
- Threat categories reviewed: TM-LLM, TM-DOS
- Findings and resolutions:
  - API key handling remains env-only and is passed into the existing provider config path; no keys are logged or written by this change.
  - Base URL values are env-configured in a local example CLI, not accepted from remote users or persisted server-side. No new multi-tenant trust boundary is introduced.
  - No new dependencies, network fetch logic, command execution, auth, or filesystem sandbox changes.

## Evidence
- `cargo test -p everruns-coding-cli`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `just pre-push`
- Smoke test: `ercode --provider openrouter -m moonshotai/kimi-k2.5 -p ...` returned `kimi-openrouter-ok` via OpenRouter Responses.
- Smoke test: `ercode --provider openrouter -m moonshotai/kimi-k2.5 -p ...` read `examples/coding-cli/src/runtime.rs` and correctly summarized provider precedence/env vars.
- Rebased onto latest `origin/main`; migration ordering check passed (`001..044`).
- CI selected checks passed: Build Check, Migration Immutability, CodeQL, Analyze jobs, Detect Changes, CI Opt-Out Policy.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)
