### PR TITLE
fix(github): fallback to parent session token for scout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2331,6 +2331,7 @@ version = "0.8.33"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
+ "chrono",
  "everruns-core",
  "inventory",
  "reqwest 0.13.3",

--- a/integrations/github/Cargo.toml
+++ b/integrations/github/Cargo.toml
@@ -33,3 +33,4 @@ github-live-tests = []
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }
 wiremock = "0.6"
+chrono.workspace = true

--- a/integrations/github/src/tools.rs
+++ b/integrations/github/src/tools.rs
@@ -17,30 +17,62 @@ const DEFAULT_LIMIT: u32 = 10;
 const MAX_LIMIT: u32 = 30;
 
 async fn get_github_token(context: &ToolContext) -> Result<String, ToolExecutionResult> {
+    let mut token_session_ids = vec![context.session_id];
+    if let Some(session_store) = context.session_store.as_ref() {
+        match session_store.get_session(context.session_id).await {
+            Ok(Some(session)) => {
+                if let Some(parent_session_id) = session.parent_session_id
+                    && !token_session_ids.contains(&parent_session_id)
+                {
+                    token_session_ids.push(parent_session_id);
+                }
+            }
+            Ok(None) => {
+                debug!(
+                    "GitHub token resolver: session_store returned no session for {} — no parent fallback",
+                    context.session_id
+                );
+            }
+            Err(e) => debug!(
+                "GitHub token resolver: session_store lookup failed; no parent fallback: {e}"
+            ),
+        }
+    }
+
     if let Some(resolver) = context.connection_resolver.as_ref() {
-        match resolver
-            .get_connection_token(context.session_id, GITHUB_CONNECTION_PROVIDER)
-            .await
-        {
-            Ok(Some(token)) if !token.trim().is_empty() => return Ok(token),
-            Ok(_) => {}
-            Err(e) => debug!("GitHub connection resolver failed: {e}"),
+        for session_id in &token_session_ids {
+            match resolver
+                .get_connection_token(*session_id, GITHUB_CONNECTION_PROVIDER)
+                .await
+            {
+                Ok(Some(token)) if !token.trim().is_empty() => return Ok(token),
+                Ok(_) => {}
+                Err(e) => debug!("GitHub connection resolver failed: {e}"),
+            }
         }
     }
 
     if let Some(storage) = context.storage_store.as_ref() {
-        match storage
-            .get_secret(context.session_id, GITHUB_TOKEN_SECRET)
-            .await
-        {
-            Ok(Some(token)) if !token.trim().is_empty() => return Ok(token),
-            Ok(_) => {}
-            Err(e) => {
-                error!("Failed to read {GITHUB_TOKEN_SECRET} session secret: {e}");
-                return Err(ToolExecutionResult::internal_error_msg(
-                    "Failed to read GitHub token",
-                ));
+        let mut last_error: Option<String> = None;
+        for session_id in &token_session_ids {
+            match storage.get_secret(*session_id, GITHUB_TOKEN_SECRET).await {
+                Ok(Some(token)) if !token.trim().is_empty() => return Ok(token),
+                Ok(_) => {}
+                Err(e) => {
+                    debug!(
+                        "Failed to read {GITHUB_TOKEN_SECRET} session secret for {session_id}: {e}"
+                    );
+                    last_error = Some(e.to_string());
+                }
             }
+        }
+        if let Some(err) = last_error {
+            error!(
+                "Failed to read {GITHUB_TOKEN_SECRET} session secret across all candidate sessions; last error: {err}"
+            );
+            return Err(ToolExecutionResult::internal_error_msg(
+                "Failed to read GitHub token",
+            ));
         }
     }
 
@@ -475,26 +507,30 @@ impl Tool for SearchGitHubIssuesTool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::Utc;
     use everruns_core::error::Result;
-    use everruns_core::traits::{KeyInfo, SecretInfo, SessionStorageStore, UserConnectionResolver};
+    use everruns_core::traits::{
+        KeyInfo, SecretInfo, SessionStorageStore, SessionStore, UserConnectionResolver,
+    };
     use everruns_core::typed_id::SessionId;
+    use everruns_core::{HarnessId, ModelId, PrincipalId, Session, SessionStatus};
     use std::collections::HashMap;
     use std::sync::Arc;
     use tokio::sync::Mutex;
 
     struct MockConnectionResolver {
-        token: Option<String>,
+        tokens: HashMap<SessionId, String>,
     }
 
     #[async_trait]
     impl UserConnectionResolver for MockConnectionResolver {
         async fn get_connection_token(
             &self,
-            _session_id: SessionId,
+            session_id: SessionId,
             provider: &str,
         ) -> Result<Option<String>> {
             assert_eq!(provider, GITHUB_CONNECTION_PROVIDER);
-            Ok(self.token.clone())
+            Ok(self.tokens.get(&session_id).cloned())
         }
     }
 
@@ -514,6 +550,26 @@ mod tests {
                 .lock()
                 .await
                 .insert(format!("{session_id}:{name}"), value.to_string());
+        }
+    }
+
+    struct MockSessionStore {
+        session: Session,
+    }
+
+    #[async_trait]
+    impl SessionStore for MockSessionStore {
+        async fn get_session(&self, session_id: SessionId) -> Result<Option<Session>> {
+            if self.session.id == session_id {
+                return Ok(Some(self.session.clone()));
+            }
+            if self.session.parent_session_id == Some(session_id) {
+                let mut parent = self.session.clone();
+                parent.id = session_id;
+                parent.parent_session_id = None;
+                return Ok(Some(parent));
+            }
+            Ok(None)
         }
     }
 
@@ -558,11 +614,10 @@ mod tests {
 
     #[tokio::test]
     async fn token_prefers_connection_resolver() {
-        let context = ToolContext::new(SessionId::new()).with_connection_resolver(Arc::new(
-            MockConnectionResolver {
-                token: Some("connection-token".into()),
-            },
-        ));
+        let session_id = SessionId::new();
+        let tokens = HashMap::from([(session_id, "connection-token".into())]);
+        let context = ToolContext::new(session_id)
+            .with_connection_resolver(Arc::new(MockConnectionResolver { tokens }));
         assert_eq!(
             get_github_token(&context).await.unwrap(),
             "connection-token"
@@ -589,6 +644,64 @@ mod tests {
             }
             other => panic!("expected connection required, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn token_falls_back_to_parent_session_connection() {
+        let session_id = SessionId::new();
+        let parent_session_id = SessionId::new();
+        let session = Session {
+            id: session_id,
+            organization_id: "org_00000000000000000000000000000001".to_string(),
+            harness_id: HarnessId::new(),
+            agent_id: None,
+            agent_version_id: None,
+            agent_identity_id: None,
+            owner_principal_id: PrincipalId::from_seed(1),
+            resolved_owner_user_id: None,
+            owner: None,
+            effective_owner: None,
+            title: Some("child".to_string()),
+            locale: None,
+            preview: None,
+            output_preview: None,
+            tags: vec![],
+            model_id: Some(ModelId::new()),
+            capabilities: vec![],
+            tools: vec![],
+            mcp_servers: Default::default(),
+            system_prompt: None,
+            initial_files: vec![],
+            hints: None,
+            network_access: None,
+            max_iterations: None,
+            status: SessionStatus::Idle,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            started_at: None,
+            finished_at: None,
+            usage: None,
+            is_pinned: None,
+            active_schedule_count: None,
+            features: vec![],
+            parent_session_id: Some(parent_session_id),
+            subagent_name: None,
+            subagent_task: None,
+            subagent_status: None,
+            blueprint_id: None,
+            blueprint_config: None,
+        };
+
+        let context = ToolContext::new(session_id)
+            .with_session_store(Arc::new(MockSessionStore { session }))
+            .with_connection_resolver(Arc::new(MockConnectionResolver {
+                tokens: HashMap::from([(parent_session_id, "parent-connection-token".into())]),
+            }));
+
+        assert_eq!(
+            get_github_token(&context).await.unwrap(),
+            "parent-connection-token"
+        );
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Blueprint-created child sessions were unable to resolve a parent user's GitHub connection because `get_github_token` only looked up tokens by the child `session_id`, and the gRPC blueprint path creates system-owned child sessions with no `resolved_owner_user_id`.
- The change restores expected availability for the GitHub Scout blueprint without altering credential precedence.

### Description
- Update `get_github_token` in `integrations/github/src/tools.rs` to collect `session_id` and, when available, the `parent_session_id` via the `SessionStore` and try both session IDs when resolving connection tokens from the `UserConnectionResolver`.
- Apply the same child→parent lookup when falling back to session secrets via `SessionStorageStore`, preserving the original precedence (resolver first, then session secret).
- Add a focused unit test `token_falls_back_to_parent_session_connection` that exercises the child→parent resolver fallback using lightweight `MockSessionStore` and `MockConnectionResolver` mocks in `integrations/github/src/tools.rs` tests.
- Add `chrono` to `integrations/github` dev-dependencies to construct realistic `Session` timestamps used in the new test.

### Testing
- Ran `cargo test -p everruns-integrations-github token_` and the targeted test suite completed successfully with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f87524444832b8e1fadfd04b8b6f8)