### PR TITLE
chore(docs): switch docs app to pnpm isolated linker

### DIFF
--- a/apps/docs/.npmrc
+++ b/apps/docs/.npmrc
@@ -1,2 +1,0 @@
-# pnpm: flat node_modules to match npm-compatible resolution.
-node-linker=hoisted

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -21,11 +21,12 @@
     "astro": "^6.3.7",
     "js-yaml": "^4.1.0",
     "marked": "^18.0.3",
-    "shiki": "^4.0.2",
     "sharp": "^0.34.5",
+    "shiki": "^4.0.2",
     "starlight-openapi": "^0.25.3",
     "starlight-sidebar-topics": "^0.7.1",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "zod": "^4.4.3"
   },
   "pnpm": {
     "overrides": {

--- a/apps/docs/pnpm-lock.yaml
+++ b/apps/docs/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
 
 packages:
 

--- a/apps/docs/pnpm-workspace.yaml
+++ b/apps/docs/pnpm-workspace.yaml
@@ -1,4 +1,3 @@
 packages: []
 minimumReleaseAge: 10080
 minimumReleaseAgeStrict: true
-nodeLinker: hoisted


### PR DESCRIPTION
## What
Switches `apps/docs` to pnpm's default isolated linker, completing the work #1950 did for `apps/ui`.

- Delete `apps/docs/.npmrc` (drops `node-linker=hoisted`).
- Drop `nodeLinker: hoisted` from `apps/docs/pnpm-workspace.yaml`. The `.npmrc` removal alone is insufficient — the workspace file also pinned the linker, asymmetric with `apps/ui/pnpm-workspace.yaml`.
- Declare `zod@^4.4.3` in `apps/docs/package.json` (imported by `src/content.config.ts`, previously only reachable transitively via `@astrojs/starlight`).
- `pnpm-lock.yaml`: add the `zod` direct-dep importer entry (package definition already present transitively).

Fixes [EVE-486](https://linear.app/everruns/issue/EVE-486/tighten-pnpm-node-linker-from-hoisted-to-strict).

## Why
Strict (isolated) linking gives real dependency boundaries: phantom imports fail at install/build time instead of silently working via the flat layout. #1950 already migrated `apps/ui`; this finishes the job for `apps/docs`.

The original scope of this PR was wider but everything else (`apps/ui` `.npmrc`, `remark-gfm` declaration, `jest.config.js` dual-layout pattern, `services.sh` symlink branch) has since landed via #1950 and follow-ups. This PR is now a focused docs-only delta.

## Risk
- Low. Config-only change in `apps/docs`. `zod@4.4.3` is the version that was already resolved transitively, so no new third-party code lands.
- Runtime/content build unchanged — verified with `astro check` and `astro build`.

## Security
- Threat categories reviewed: no security-relevant code changes. Dev-tooling/config only; no new dependency surface.
- Findings and resolutions: none.

## Follow-ups
- None.

## Checklist
- [x] Backward compatibility considered — internal dev config only.
- [x] Security review performed against relevant threat model categories.
- [ ] Final CI ran checks affected by this PR.
- [ ] All review comments addressed (code change or written reasoning).

## Validation
- `cd apps/docs && pnpm install --frozen-lockfile` (clean; `node_modules/.pnpm/` populated → isolated layout confirmed).
- `cd apps/docs && pnpm run check` (0 errors, 0 warnings).
- `cd apps/docs && pnpm run build` (356 pages built, postbuild notebook verification passes).
- `bash scripts/lib/pre-push.sh` (all 9 checks pass).
