### PR TITLE
fix(core): tighten token-efficient tool outputs

### DIFF
--- a/crates/container-sandbox/src/tools.rs
+++ b/crates/container-sandbox/src/tools.rs
@@ -8,7 +8,7 @@ use async_trait::async_trait;
 use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
 use everruns_core::ToolHints;
 use everruns_core::tool_output_sanitizer::{
-    READ_FILE_DEFAULT_LIMIT, build_text_read_file_result, clean_exec_output,
+    READ_FILE_DEFAULT_LIMIT, build_bytes_read_file_result, clean_exec_output,
     output_verbosity_budget, parse_read_file_window_args, priority_aware_truncate,
 };
 use everruns_core::tools::{Tool, ToolExecutionResult};
@@ -369,23 +369,13 @@ impl Tool for SandboxReadFileTool {
         let client = docker_client(&config);
 
         match client.get_archive(&state.container_id, &path).await {
-            Ok(bytes) => {
-                // Try to return as text, fall back to base64
-                match String::from_utf8(bytes.clone()) {
-                    Ok(text) => ToolExecutionResult::success(build_text_read_file_result(
-                        "sandbox_read_file",
-                        &path,
-                        &text,
-                        "text",
-                        offset,
-                        limit,
-                    )),
-                    Err(_) => ToolExecutionResult::success(format!(
-                        "[Binary file, {} bytes]",
-                        bytes.len()
-                    )),
-                }
-            }
+            Ok(bytes) => ToolExecutionResult::success(build_bytes_read_file_result(
+                "sandbox_read_file",
+                &path,
+                &bytes,
+                offset,
+                limit,
+            )),
             Err(e) => ToolExecutionResult::tool_error(format!("Failed to read file: {e}")),
         }
     }

--- a/crates/core/src/atoms/reason.rs
+++ b/crates/core/src/atoms/reason.rs
@@ -1214,7 +1214,14 @@ impl ReasonAtom {
                         ContextCompactingData,
                     };
 
-                    let config = compaction_config.clone().unwrap_or_default();
+                    let Some(config) = compaction_config.clone() else {
+                        tracing::warn!(
+                            session_id = %session_id,
+                            turn_id = %context.turn_id,
+                            "ReasonAtom: context too large and compaction capability is not enabled"
+                        );
+                        return Err(e);
+                    };
                     let messages_before = llm_messages_for_call.len();
 
                     tracing::info!(

--- a/crates/core/src/capabilities/file_system.rs
+++ b/crates/core/src/capabilities/file_system.rs
@@ -14,6 +14,7 @@
 
 use super::{Capability, CapabilityStatus};
 use crate::session_file::SessionFile;
+use crate::tool_output_sanitizer::build_binary_read_file_result;
 use crate::tool_types::ToolHints;
 use crate::tools::{Tool, ToolExecutionResult, ToolResultImage};
 use crate::traits::ToolContext;
@@ -44,6 +45,10 @@ fn image_media_type(path: &str) -> Option<&'static str> {
 /// Workspace prefix used in file paths
 const WORKSPACE_PREFIX: &str = "/workspace";
 const MAX_EDIT_DIFF_CHARS: usize = 16_000;
+const LIST_DIRECTORY_DEFAULT_LIMIT: usize = 200;
+const LIST_DIRECTORY_MAX_LIMIT: usize = 1_000;
+const GREP_FILES_DEFAULT_LIMIT: usize = 200;
+const GREP_FILES_MAX_LIMIT: usize = 1_000;
 
 // ============================================================================
 // Content-type detection (EVE-249)
@@ -622,15 +627,16 @@ impl Tool for ReadFileTool {
                     Err(e) => return ToolExecutionResult::internal_error(e),
                 };
 
-                // Non-image binary files: return raw base64 without line formatting
+                // Non-image binary files: return metadata only. Base64 payloads
+                // are token-expensive and usually not useful to the model.
                 if file.encoding == "base64" {
-                    return ToolExecutionResult::success(json!({
-                        "path": display_path,
-                        "content": file.content.as_deref().unwrap_or(""),
-                        "encoding": "base64",
-                        "size_bytes": file.size_bytes,
-                        "content_hash": content_hash
-                    }));
+                    let mut result = build_binary_read_file_result(
+                        &display_path,
+                        file.size_bytes as usize,
+                        "base64",
+                    );
+                    result["content_hash"] = json!(content_hash);
+                    return ToolExecutionResult::success(result);
                 }
 
                 let raw_content = file.content.as_deref().unwrap_or("");
@@ -642,13 +648,13 @@ impl Tool for ReadFileTool {
 
                 // Metadata-only for known binary extensions
                 if read_mode == ReadMode::MetadataOnly {
-                    return ToolExecutionResult::success(json!({
-                        "path": display_path,
-                        "content_type": "binary",
-                        "size_bytes": file.size_bytes,
-                        "content_hash": content_hash,
-                        "note": "Binary file — use a different tool or download to inspect."
-                    }));
+                    let mut result = build_binary_read_file_result(
+                        &display_path,
+                        file.size_bytes as usize,
+                        "binary",
+                    );
+                    result["content_hash"] = json!(content_hash);
+                    return ToolExecutionResult::success(result);
                 }
 
                 // Apply content-type defaults when user didn't specify
@@ -1182,6 +1188,19 @@ impl Tool for ListDirectoryTool {
                     "type": "string",
                     "default": "/workspace",
                     "description": "Directory path to list (default: '/workspace')"
+                },
+                "offset": {
+                    "type": "integer",
+                    "description": "Starting item offset for large directories. Default: 0",
+                    "default": 0,
+                    "minimum": 0
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Max directory entries to return. Default: 200, maximum: 1000",
+                    "default": LIST_DIRECTORY_DEFAULT_LIMIT,
+                    "minimum": 1,
+                    "maximum": LIST_DIRECTORY_MAX_LIMIT
                 }
             },
             "additionalProperties": false
@@ -1209,6 +1228,15 @@ impl Tool for ListDirectoryTool {
             .get("path")
             .and_then(|v| v.as_str())
             .unwrap_or("/workspace");
+        let offset = arguments
+            .get("offset")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0) as usize;
+        let limit = match arguments.get("limit").and_then(|v| v.as_u64()) {
+            Some(0) => return ToolExecutionResult::tool_error("limit must be greater than 0"),
+            Some(value) => (value as usize).min(LIST_DIRECTORY_MAX_LIMIT),
+            None => LIST_DIRECTORY_DEFAULT_LIMIT,
+        };
 
         let file_store = match &context.file_store {
             Some(store) => store,
@@ -1228,8 +1256,11 @@ impl Tool for ListDirectoryTool {
             .await
         {
             Ok(files) => {
+                let total_count = files.len();
                 let entries: Vec<Value> = files
                     .iter()
+                    .skip(offset)
+                    .take(limit)
                     .map(|f| {
                         json!({
                             "name": f.name,
@@ -1244,17 +1275,31 @@ impl Tool for ListDirectoryTool {
                 let mut result = json!({
                     "path": display_path,
                     "entries": entries,
-                    "count": entries.len()
+                    "count": entries.len(),
+                    "total_count": total_count,
+                    "offset": offset,
+                    "limit": limit
                 });
-                // `list_directory` has no backend cap today — the contract is
-                // wired with `not_truncated` so the envelope is always present
-                // (EVE-339). If a cap is introduced later, switch to
-                // `without_resume(... ItemCap)`. `bytes_returned` measures the
-                // primary payload (`entries`), not the wrapping object.
                 let bytes_returned = serde_json::to_string(&entries)
                     .expect("list_directory entries always serialize")
                     .len();
-                TruncationInfo::not_truncated(bytes_returned).attach(&mut result);
+                let next_offset = offset.saturating_add(entries.len());
+                let truncation = if next_offset < total_count {
+                    TruncationInfo::with_resume(
+                        bytes_returned,
+                        None,
+                        next_offset as u64,
+                        format!(
+                            "call list_directory with offset={} to resume from item {}",
+                            next_offset,
+                            next_offset + 1
+                        ),
+                        TruncationReason::ItemCap,
+                    )
+                } else {
+                    TruncationInfo::not_truncated(bytes_returned)
+                };
+                truncation.attach(&mut result);
                 ToolExecutionResult::success(result)
             }
             Err(e) => {
@@ -1305,6 +1350,19 @@ impl Tool for GrepFilesTool {
                 "path_pattern": {
                     "type": "string",
                     "description": "Optional path pattern to filter files (e.g., '*.txt', '/workspace/docs/*')"
+                },
+                "offset": {
+                    "type": "integer",
+                    "description": "Starting match offset. Default: 0",
+                    "default": 0,
+                    "minimum": 0
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Max matches to return. Default: 200, maximum: 1000",
+                    "default": GREP_FILES_DEFAULT_LIMIT,
+                    "minimum": 1,
+                    "maximum": GREP_FILES_MAX_LIMIT
                 }
             },
             "required": ["pattern"],
@@ -1335,6 +1393,15 @@ impl Tool for GrepFilesTool {
         };
 
         let path_pattern = arguments.get("path_pattern").and_then(|v| v.as_str());
+        let offset = arguments
+            .get("offset")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0) as usize;
+        let limit = match arguments.get("limit").and_then(|v| v.as_u64()) {
+            Some(0) => return ToolExecutionResult::tool_error("limit must be greater than 0"),
+            Some(value) => (value as usize).min(GREP_FILES_MAX_LIMIT),
+            None => GREP_FILES_DEFAULT_LIMIT,
+        };
 
         let file_store = match &context.file_store {
             Some(store) => store,
@@ -1350,8 +1417,11 @@ impl Tool for GrepFilesTool {
             .await
         {
             Ok(matches) => {
+                let total_matches = matches.len();
                 let results: Vec<Value> = matches
                     .iter()
+                    .skip(offset)
+                    .take(limit)
                     .map(|m| {
                         json!({
                             "path": add_workspace_prefix(&m.path),
@@ -1364,18 +1434,31 @@ impl Tool for GrepFilesTool {
                 let mut result = json!({
                     "pattern": pattern,
                     "matches": results,
-                    "match_count": results.len()
+                    "match_count": results.len(),
+                    "total_matches": total_matches,
+                    "offset": offset,
+                    "limit": limit
                 });
-                // `grep_files` does not currently cap match count; the
-                // envelope is wired with `not_truncated` so the reading-tool
-                // contract is honoured uniformly (EVE-339). If a cap is
-                // introduced later, switch to `without_resume(... LineCap)`.
-                // `bytes_returned` measures the primary payload (`matches`),
-                // not the wrapping object.
                 let bytes_returned = serde_json::to_string(&results)
                     .expect("grep_files matches always serialize")
                     .len();
-                TruncationInfo::not_truncated(bytes_returned).attach(&mut result);
+                let next_offset = offset.saturating_add(results.len());
+                let truncation = if next_offset < total_matches {
+                    TruncationInfo::with_resume(
+                        bytes_returned,
+                        None,
+                        next_offset as u64,
+                        format!(
+                            "call grep_files with offset={} to resume from match {}",
+                            next_offset,
+                            next_offset + 1
+                        ),
+                        TruncationReason::LineCap,
+                    )
+                } else {
+                    TruncationInfo::not_truncated(bytes_returned)
+                };
+                truncation.attach(&mut result);
                 ToolExecutionResult::success(result)
             }
             Err(e) => {
@@ -1794,9 +1877,43 @@ mod tests {
         async fn list_directory(
             &self,
             _session_id: SessionId,
-            _path: &str,
+            path: &str,
         ) -> Result<Vec<FileInfo>> {
-            Ok(vec![])
+            let prefix = if path == "/" {
+                "/".to_string()
+            } else {
+                format!("{}/", path.trim_end_matches('/'))
+            };
+            let files = self.files.lock().unwrap();
+            let mut entries: Vec<FileInfo> = files
+                .iter()
+                .filter_map(|(entry_path, entry)| {
+                    if path != "/" && entry_path == path {
+                        return None;
+                    }
+                    let rest = entry_path.strip_prefix(&prefix)?;
+                    if rest.is_empty() || rest.contains('/') {
+                        return None;
+                    }
+                    Some(FileInfo {
+                        id: Uuid::new_v4(),
+                        session_id: Uuid::nil(),
+                        name: rest.to_string(),
+                        path: entry_path.clone(),
+                        is_directory: entry.is_directory,
+                        is_readonly: entry.is_readonly,
+                        size_bytes: entry
+                            .content
+                            .as_ref()
+                            .map(|content| content.len() as i64)
+                            .unwrap_or(0),
+                        created_at: entry.created_at,
+                        updated_at: entry.updated_at,
+                    })
+                })
+                .collect();
+            entries.sort_by(|a, b| a.path.cmp(&b.path));
+            Ok(entries)
         }
 
         async fn stat_file(&self, _session_id: SessionId, path: &str) -> Result<Option<FileStat>> {
@@ -1819,10 +1936,34 @@ mod tests {
         async fn grep_files(
             &self,
             _session_id: SessionId,
-            _pattern: &str,
+            pattern: &str,
             _path_pattern: Option<&str>,
         ) -> Result<Vec<GrepMatch>> {
-            Ok(vec![])
+            let files = self.files.lock().unwrap();
+            let mut matches = Vec::new();
+            for (path, entry) in files.iter() {
+                if entry.is_directory || entry.encoding != "text" {
+                    continue;
+                }
+                let Some(content) = entry.content.as_deref() else {
+                    continue;
+                };
+                for (idx, line) in content.lines().enumerate() {
+                    if line.contains(pattern) {
+                        matches.push(GrepMatch {
+                            path: path.clone(),
+                            line_number: idx + 1,
+                            line: line.to_string(),
+                        });
+                    }
+                }
+            }
+            matches.sort_by(|a, b| {
+                a.path
+                    .cmp(&b.path)
+                    .then_with(|| a.line_number.cmp(&b.line_number))
+            });
+            Ok(matches)
         }
 
         async fn create_directory(&self, _session_id: SessionId, path: &str) -> Result<FileInfo> {
@@ -2275,6 +2416,27 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_list_directory_applies_item_window() {
+        let store = Arc::new(MockFileStore::default());
+        store.add_text_file("/a.txt", "a");
+        store.add_text_file("/b.txt", "b");
+        store.add_text_file("/c.txt", "c");
+        let context = make_context(store);
+
+        let result = ListDirectoryTool
+            .execute_with_context(json!({"path": "/workspace", "limit": 2}), &context)
+            .await;
+        let value = expect_success(result);
+
+        crate::truncation_info::assert_conforms("list_directory", &value);
+        assert_eq!(value["count"], 2);
+        assert_eq!(value["total_count"], 3);
+        assert_eq!(value["truncation"]["truncated"], true);
+        assert_eq!(value["truncation"]["reason"], "item_cap");
+        assert_eq!(value["truncation"]["next_offset"], 2);
+    }
+
+    #[tokio::test]
     async fn test_grep_files_emits_truncation_envelope() {
         let store = Arc::new(MockFileStore::default());
         store.add_text_file("/notes.txt", "hello world");
@@ -2287,6 +2449,25 @@ mod tests {
 
         crate::truncation_info::assert_conforms("grep_files", &value);
         assert_eq!(value["truncation"]["truncated"], false);
+    }
+
+    #[tokio::test]
+    async fn test_grep_files_applies_match_window() {
+        let store = Arc::new(MockFileStore::default());
+        store.add_text_file("/notes.txt", "hello one\nhello two\nhello three");
+        let context = make_context(store);
+
+        let result = GrepFilesTool
+            .execute_with_context(json!({"pattern": "hello", "limit": 2}), &context)
+            .await;
+        let value = expect_success(result);
+
+        crate::truncation_info::assert_conforms("grep_files", &value);
+        assert_eq!(value["match_count"], 2);
+        assert_eq!(value["total_matches"], 3);
+        assert_eq!(value["truncation"]["truncated"], true);
+        assert_eq!(value["truncation"]["reason"], "line_cap");
+        assert_eq!(value["truncation"]["next_offset"], 2);
     }
 
     #[tokio::test]
@@ -2485,6 +2666,25 @@ mod tests {
             .await;
 
         assert!(expect_tool_error(result).contains("only supports text files"));
+    }
+
+    #[tokio::test]
+    async fn test_read_file_non_image_binary_omits_base64_content() {
+        let store = Arc::new(MockFileStore::default());
+        store.add_base64_file("/archive.zip", "UEsDBAoAAAAAAA==");
+        let context = make_context(store);
+
+        let result = ReadFileTool
+            .execute_with_context(json!({"path": "/workspace/archive.zip"}), &context)
+            .await;
+        let value = expect_success(result);
+
+        assert_eq!(value["content_type"], "binary");
+        assert_eq!(value["encoding"], "base64");
+        assert_eq!(value["truncation"]["truncated"], false);
+        assert_eq!(value["truncation"]["bytes_returned"], 0);
+        assert!(value.get("content").is_none());
+        assert!(value.get("content_hash").is_some());
     }
 
     #[tokio::test]

--- a/crates/core/src/capabilities/platform_management.rs
+++ b/crates/core/src/capabilities/platform_management.rs
@@ -24,6 +24,11 @@ use serde_json::{Value, json};
 #[cfg(all(feature = "embedded-platform-docs", everruns_has_workspace_docs))]
 use std::sync::Arc;
 
+const SESSION_READ_MESSAGES_DEFAULT_LIMIT: usize = 10;
+const SESSION_READ_MESSAGES_MAX_LIMIT: usize = 50;
+const SESSION_READ_MESSAGES_DEFAULT_CONTENT_LIMIT: usize = 12_000;
+const SESSION_READ_MESSAGES_MAX_CONTENT_LIMIT: usize = 50_000;
+
 // =============================================================================
 // Capability
 // =============================================================================
@@ -214,9 +219,52 @@ fn require_str<'a>(args: &'a Value, key: &str) -> Result<&'a str, ToolExecutionR
     })
 }
 
+fn parse_bounded_usize_arg(
+    args: &Value,
+    key: &str,
+    default: usize,
+    max: usize,
+) -> Result<usize, ToolExecutionResult> {
+    match args.get(key).and_then(|v| v.as_u64()) {
+        Some(0) => Err(ToolExecutionResult::tool_error(format!(
+            "{key} must be greater than 0"
+        ))),
+        Some(value) => Ok((value as usize).min(max)),
+        None => Ok(default),
+    }
+}
+
 fn parse_channel_type(value: &str, field: &str) -> Result<ChannelType, ToolExecutionResult> {
     serde_json::from_value(Value::String(value.to_string()))
         .map_err(|_| ToolExecutionResult::tool_error(format!("Invalid {field}: {value}")))
+}
+
+fn truncate_content_chars(content: &str, limit: usize) -> (String, bool, usize, usize) {
+    let mut end_byte = content.len();
+    let mut returned_chars = 0;
+    let mut total_chars = 0;
+
+    for (idx, (byte_idx, _)) in content.char_indices().enumerate() {
+        total_chars = idx + 1;
+        if idx == limit {
+            end_byte = byte_idx;
+        }
+        if idx < limit {
+            returned_chars = idx + 1;
+        }
+    }
+
+    let truncated = total_chars > limit;
+    if !truncated {
+        return (content.to_string(), false, total_chars, total_chars);
+    }
+
+    (
+        content[..end_byte].to_string(),
+        true,
+        total_chars,
+        returned_chars,
+    )
 }
 
 fn channel_json(channel: &AppChannel, include_config: bool) -> Value {
@@ -2138,7 +2186,17 @@ impl Tool for SessionReadMessagesTool {
                 },
                 "limit": {
                     "type": "integer",
-                    "description": "Optional max messages (default: 10)"
+                    "description": "Max messages to return. Default: 10, maximum: 50",
+                    "default": SESSION_READ_MESSAGES_DEFAULT_LIMIT,
+                    "minimum": 1,
+                    "maximum": SESSION_READ_MESSAGES_MAX_LIMIT
+                },
+                "content_limit": {
+                    "type": "integer",
+                    "description": "Max characters to return per message. Default: 12000, maximum: 50000",
+                    "default": SESSION_READ_MESSAGES_DEFAULT_CONTENT_LIMIT,
+                    "minimum": 1,
+                    "maximum": SESSION_READ_MESSAGES_MAX_CONTENT_LIMIT
                 }
             },
             "required": ["session_id"],
@@ -2181,28 +2239,54 @@ impl Tool for SessionReadMessagesTool {
             }
         };
 
-        let limit = arguments
-            .get("limit")
-            .and_then(|v| v.as_u64())
-            .map(|v| v as usize);
+        let limit = match parse_bounded_usize_arg(
+            &arguments,
+            "limit",
+            SESSION_READ_MESSAGES_DEFAULT_LIMIT,
+            SESSION_READ_MESSAGES_MAX_LIMIT,
+        ) {
+            Ok(value) => value,
+            Err(error) => return error,
+        };
+        let content_limit = match parse_bounded_usize_arg(
+            &arguments,
+            "content_limit",
+            SESSION_READ_MESSAGES_DEFAULT_CONTENT_LIMIT,
+            SESSION_READ_MESSAGES_MAX_CONTENT_LIMIT,
+        ) {
+            Ok(value) => value,
+            Err(error) => return error,
+        };
 
         let base_url = store.base_url();
 
-        match store.get_messages(session_id, limit).await {
+        match store.get_messages(session_id, Some(limit)).await {
             Ok(messages) => {
                 let items: Vec<Value> = messages
                     .iter()
                     .map(|m| {
+                        let (content, truncated, total_chars, returned_chars) =
+                            truncate_content_chars(&m.content, content_limit);
                         json!({
                             "role": m.role,
-                            "content": m.content,
+                            "content": content,
+                            "content_truncated": truncated,
+                            "content_total_chars": total_chars,
+                            "content_returned_chars": returned_chars,
                             "created_at": m.created_at.to_rfc3339(),
                         })
                     })
                     .collect();
+                let truncated_message_count = items
+                    .iter()
+                    .filter(|item| item["content_truncated"].as_bool().unwrap_or(false))
+                    .count();
                 ToolExecutionResult::success(json!({
                     "messages": items,
                     "count": items.len(),
+                    "limit": limit,
+                    "content_limit": content_limit,
+                    "truncated_message_count": truncated_message_count,
                     "session_id": session_id_str,
                     "ui_link": format!("{}/sessions/{}/chat", base_url, session_id),
                 }))
@@ -2483,6 +2567,16 @@ mod tests {
         assert!(names.contains(&"session_send_message"));
         assert!(names.contains(&"session_read_messages"));
         assert!(names.contains(&"session_read_response"));
+    }
+
+    #[test]
+    fn truncate_content_chars_respects_unicode_boundaries() {
+        let (content, truncated, total_chars, returned_chars) = truncate_content_chars("ab😀cd", 3);
+
+        assert_eq!(content, "ab😀");
+        assert!(truncated);
+        assert_eq!(total_chars, 5);
+        assert_eq!(returned_chars, 3);
     }
 
     // =========================================================================
@@ -3215,6 +3309,46 @@ mod tests {
                 assert_eq!(msgs[1]["role"], "agent");
             }
             other => panic!("expected success, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn read_messages_applies_content_limit() {
+        let ctx = mock_context();
+        let tool = SessionReadMessagesTool;
+        let result = tool
+            .execute_with_context(
+                json!({"session_id": SessionId::new().to_string(), "content_limit": 2}),
+                &ctx,
+            )
+            .await;
+        match result {
+            ToolExecutionResult::Success(v) => {
+                assert_eq!(v["content_limit"], 2);
+                assert_eq!(v["truncated_message_count"], 2);
+                let msgs = v["messages"].as_array().unwrap();
+                assert_eq!(msgs[0]["content"], "He");
+                assert_eq!(msgs[0]["content_truncated"], true);
+                assert_eq!(msgs[0]["content_total_chars"], 5);
+                assert_eq!(msgs[0]["content_returned_chars"], 2);
+            }
+            other => panic!("expected success, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn read_messages_rejects_zero_limits() {
+        let ctx = mock_context();
+        let tool = SessionReadMessagesTool;
+        let result = tool
+            .execute_with_context(
+                json!({"session_id": SessionId::new().to_string(), "limit": 0}),
+                &ctx,
+            )
+            .await;
+        match result {
+            ToolExecutionResult::ToolError(msg) => assert!(msg.contains("greater than 0")),
+            other => panic!("expected tool error, got: {other:?}"),
         }
     }
 

--- a/crates/core/src/capabilities/tool_output_persistence.rs
+++ b/crates/core/src/capabilities/tool_output_persistence.rs
@@ -24,7 +24,6 @@ use serde_json::json;
 
 use super::{Capability, CapabilityStatus};
 use crate::atoms::PostToolExecHook;
-use crate::tool_output_sanitizer::EXEC_OUTPUT_BUDGET;
 use crate::tool_types::{ToolCall, ToolDefinition, ToolResult};
 use crate::traits::{SessionFileSystem, ToolContext};
 use crate::typed_id::SessionId;
@@ -45,21 +44,20 @@ pub struct PersistResult {
     pub stdout_total_lines: usize,
 }
 
-/// Persist large exec output to session VFS when it exceeds the budget.
+/// Persist exec output to session VFS.
 ///
 /// Writes stdout to `/outputs/{safe_id}.stdout` and stderr to
 /// `/outputs/{safe_id}.stderr` (if non-empty). Returns paths and metadata.
 ///
 /// This is the shared helper that any sandbox tool or hook can call.
-pub async fn persist_large_output(
+pub async fn persist_output(
     file_store: &Arc<dyn SessionFileSystem>,
     session_id: SessionId,
     tool_call_id: &str,
     stdout: &str,
     stderr: &str,
 ) -> Option<PersistResult> {
-    // Only persist if stdout exceeds its budget or stderr exceeds 4096 bytes
-    if stdout.len() <= EXEC_OUTPUT_BUDGET && stderr.len() <= 4096 {
+    if stdout.is_empty() && stderr.is_empty() {
         return None;
     }
 
@@ -77,8 +75,8 @@ pub async fn persist_large_output(
         stdout_total_lines: 0,
     };
 
-    // Persist stdout
-    if stdout.len() > EXEC_OUTPUT_BUDGET {
+    // Persist stdout whenever present so verbosity-truncated results remain recoverable.
+    if !stdout.is_empty() {
         let stdout_to_persist = truncate_for_persistence(stdout, MAX_PERSISTED_STREAM_BYTES);
         let path = format!("{OUTPUT_DIR}/{safe_id}.stdout");
         result.stdout_total_lines = stdout.lines().count();
@@ -91,8 +89,8 @@ pub async fn persist_large_output(
         }
     }
 
-    // Persist stderr separately if large
-    if stderr.len() > 4096 {
+    // Persist stderr separately whenever present.
+    if !stderr.is_empty() {
         let stderr_to_persist = truncate_for_persistence(stderr, MAX_PERSISTED_STREAM_BYTES);
         let path = format!("{OUTPUT_DIR}/{safe_id}.stderr");
         if file_store
@@ -110,6 +108,19 @@ pub async fn persist_large_output(
     } else {
         None
     }
+}
+
+/// Back-compat wrapper for older callers. Despite the historical name, this now
+/// persists any non-empty opted-in output so verbosity-truncated results are
+/// recoverable through `read_file`.
+pub async fn persist_large_output(
+    file_store: &Arc<dyn SessionFileSystem>,
+    session_id: SessionId,
+    tool_call_id: &str,
+    stdout: &str,
+    stderr: &str,
+) -> Option<PersistResult> {
+    persist_output(file_store, session_id, tool_call_id, stdout, stderr).await
 }
 
 /// Truncate persisted stream content to a bounded size with a clear marker.
@@ -308,6 +319,7 @@ fn extract_output_text(json: &serde_json::Value) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::tool_output_sanitizer::EXEC_OUTPUT_BUDGET;
 
     #[test]
     fn test_extract_output_text_stdout_stderr() {
@@ -520,11 +532,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_persist_large_output_returns_none_below_budget() {
+    async fn test_persist_large_output_persists_stdout_below_budget() {
         let store: Arc<dyn SessionFileSystem> = Arc::new(MockFileStore::default());
         let small = "a".repeat(EXEC_OUTPUT_BUDGET);
         let result = persist_large_output(&store, test_session_id(), "call-1", &small, "").await;
-        assert!(result.is_none());
+        let r = result.expect("should persist non-empty stdout");
+        assert_eq!(r.stdout_path.as_deref(), Some("/outputs/call-1.stdout"));
     }
 
     #[tokio::test]
@@ -565,7 +578,7 @@ mod tests {
         let result =
             persist_large_output(&store, test_session_id(), "call-3", "small", &large_stderr).await;
         let r = result.expect("should persist stderr");
-        assert!(r.stdout_path.is_none());
+        assert_eq!(r.stdout_path.as_deref(), Some("/outputs/call-3.stdout"));
         assert_eq!(r.stderr_path.as_deref(), Some("/outputs/call-3.stderr"));
         assert_eq!(mock.content("/outputs/call-3.stderr").unwrap().len(), 4097);
     }

--- a/crates/core/src/tool_output_sanitizer.rs
+++ b/crates/core/src/tool_output_sanitizer.rs
@@ -48,7 +48,7 @@ pub fn output_verbosity_schema() -> serde_json::Value {
         "type": "string",
         "enum": ["silent", "concise", "normal", "verbose", "full"],
         "default": "concise",
-        "description": "Output verbosity: silent (~200B, truncated to exit code + minimal output), concise (~2KiB, default), normal (~8KiB), verbose (~16KiB), full (unlimited, capped by 64KiB hard limit). Full output always persisted to /outputs/{tool_call_id}.stdout and /outputs/{tool_call_id}.stderr — use read_file to retrieve."
+        "description": "Output verbosity: silent (~200B, truncated to exit code + minimal output), concise (~2KiB, default), normal (~8KiB), verbose (~16KiB), full (unlimited, capped by 64KiB hard limit). For tools with output persistence enabled, full output is saved to /outputs/{tool_call_id}.stdout and /outputs/{tool_call_id}.stderr — use read_file to retrieve."
     })
 }
 
@@ -56,7 +56,7 @@ pub fn output_verbosity_schema() -> serde_json::Value {
 /// Appended to each sandbox capability's `system_prompt_addition()` to guide
 /// the LLM toward less verbose command usage.
 pub const EXEC_OUTPUT_HINT: &str = "\n\n**Output economy:** Command output is truncated based on the `output` parameter (default: `concise` ~2 KiB). \
-Use `verbose` or `full` when debugging failures. Full output is always persisted — stdout to `/outputs/{tool_call_id}.stdout`, stderr to `/outputs/{tool_call_id}.stderr`. \
+Use `verbose` or `full` when debugging failures. Tools with output persistence enabled save full output — stdout to `/outputs/{tool_call_id}.stdout`, stderr to `/outputs/{tool_call_id}.stderr`. \
 When output exceeds the budget, the result includes an `output_files` array with paths you can `read_file` with offset/limit.\n\
 Available modes: `silent` (~200B), `concise` (~2KiB), `normal` (~8KiB), `verbose` (~16KiB), `full` (unlimited).\n\
 For build/install commands, the default `concise` is usually sufficient — check exit code first.\n\
@@ -387,6 +387,49 @@ pub fn build_text_read_file_result(
     truncation.attach(&mut result);
 
     result
+}
+
+/// Build the standard structured response for a binary read-file tool.
+pub fn build_binary_read_file_result(
+    path: &str,
+    size_bytes: usize,
+    encoding: &str,
+) -> serde_json::Value {
+    let mut result = serde_json::json!({
+        "path": path,
+        "content_type": "binary",
+        "encoding": encoding,
+        "size_bytes": size_bytes,
+        "note": "Binary file — use a different tool or download to inspect."
+    });
+    crate::truncation_info::TruncationInfo {
+        truncated: false,
+        bytes_returned: 0,
+        bytes_total: Some(size_bytes),
+        next_offset: None,
+        resume_hint: None,
+        reason: crate::truncation_info::TruncationReason::SizeCap,
+    }
+    .attach(&mut result);
+    result
+}
+
+/// Build the standard structured response for file bytes.
+///
+/// Valid UTF-8 bytes are returned through the standard line-windowed text
+/// formatter. Invalid UTF-8 returns metadata only so binary payloads do not
+/// leak into model context as lossy replacement text or base64.
+pub fn build_bytes_read_file_result(
+    tool_name: &str,
+    path: &str,
+    bytes: &[u8],
+    offset: usize,
+    limit: usize,
+) -> serde_json::Value {
+    match std::str::from_utf8(bytes) {
+        Ok(content) => build_text_read_file_result(tool_name, path, content, "text", offset, limit),
+        Err(_) => build_binary_read_file_result(path, bytes.len(), "binary"),
+    }
 }
 
 /// Full sanitization pipeline: strip ANSI → collapse CR → priority-aware truncate.
@@ -998,6 +1041,25 @@ mod tests {
             result["content"].as_str().unwrap().len() <= READ_FILE_HARD_BYTE_CAP,
             "content exceeded hard byte cap"
         );
+    }
+
+    #[test]
+    fn test_build_bytes_read_file_result_omits_binary_content() {
+        let result = build_bytes_read_file_result(
+            "sandbox_read_file",
+            "/workspace/archive.zip",
+            &[0xff, 0x00, 0xfe],
+            0,
+            READ_FILE_DEFAULT_LIMIT,
+        );
+
+        assert_eq!(result["content_type"], "binary");
+        assert_eq!(result["encoding"], "binary");
+        assert_eq!(result["size_bytes"], 3);
+        assert_eq!(result["truncation"]["truncated"], false);
+        assert_eq!(result["truncation"]["bytes_returned"], 0);
+        assert_eq!(result["truncation"]["bytes_total"], 3);
+        assert!(result.get("content").is_none());
     }
 
     #[test]

--- a/examples/coding-cli/README.md
+++ b/examples/coding-cli/README.md
@@ -35,9 +35,9 @@ depends on the public runtime crate the same way an external embedder would.
   - `web_fetch` — HTTP GET/HEAD with optional markdown/text conversion.
     Saved responses land on disk via the same `RealDiskFileStore` stack,
     so the blocklist and approval gate apply.
-  - `tool_output_persistence` — large bash output is summarized inline and
-    saved under `/outputs/` inside the current session folder so the agent
-    can inspect it with `read_file`.
+  - `tool_output_persistence` — bash output is summarized inline and the
+    full stdout/stderr streams are saved under `/outputs/` inside the current
+    session folder so the agent can inspect them with `read_file`.
 
 Note on parallel tool calls: independent tool calls already execute in
 parallel when the LLM provider batches them in one assistant turn (Anthropic
@@ -162,9 +162,11 @@ the platform-native user data directory:
 | macOS   | `~/Library/Application Support/ercode/sessions/<session_id>/` |
 | Windows | `%APPDATA%\ercode\sessions\<session_id>\`                   |
 
-The event log lives at `<session_folder>/events.jsonl`. Large tool output
-persisted by `tool_output_persistence` lives under
-`<session_folder>/outputs/`. The folder layout leaves room for other
+The event log lives at `<session_folder>/events.jsonl`. Tool output persisted
+by `tool_output_persistence` lives under `<session_folder>/outputs/`. On first
+resume after upgrading from the old flat-log layout, ercode copies
+`<sessions_dir>/<session_id>.jsonl` into the session folder if no
+`events.jsonl` exists yet. The folder layout leaves room for other
 session-scoped stores, such as key/value data, to sit beside the event log.
 
 One serialized `Event` per line, flushed after every write. On Unix the

--- a/examples/coding-cli/src/runtime.rs
+++ b/examples/coding-cli/src/runtime.rs
@@ -38,7 +38,9 @@ use everruns_runtime::{
     RealDiskFileStore, RuntimeBackends, WriteBlocklistFileStore,
 };
 
-use crate::session_log::{JsonlEventEmitter, replay, session_dir_path, session_log_path};
+use crate::session_log::{
+    JsonlEventEmitter, migrate_legacy_session_log, replay, session_dir_path, session_log_path,
+};
 use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
 
@@ -733,6 +735,7 @@ pub async fn build(
     let session_id = resume_session_id.unwrap_or_default();
     let session_dir = session_dir_path(&sessions_dir, session_id);
     let log_path = session_log_path(&session_dir);
+    let _legacy_log = migrate_legacy_session_log(&sessions_dir, &session_dir, session_id)?;
 
     // Replay anything already on disk for this id. Missing file → empty.
     // Pass `session_id` so events for any other session get skipped

--- a/examples/coding-cli/src/session_log.rs
+++ b/examples/coding-cli/src/session_log.rs
@@ -88,6 +88,41 @@ pub fn session_log_path(session_dir: &Path) -> PathBuf {
     session_dir.join("events.jsonl")
 }
 
+pub fn legacy_session_log_path(sessions_dir: &Path, session_id: SessionId) -> PathBuf {
+    sessions_dir.join(format!("{session_id}.jsonl"))
+}
+
+/// Copy a pre-folder-layout session log into the current session folder.
+///
+/// The old layout wrote `<sessions_dir>/<session_id>.jsonl`; the current
+/// layout writes `<sessions_dir>/<session_id>/events.jsonl`. Copying instead
+/// of renaming keeps older ercode binaries able to read the legacy file.
+pub fn migrate_legacy_session_log(
+    sessions_dir: &Path,
+    session_dir: &Path,
+    session_id: SessionId,
+) -> Result<Option<PathBuf>> {
+    let current = session_log_path(session_dir);
+    if current.exists() {
+        return Ok(None);
+    }
+    let legacy = legacy_session_log_path(sessions_dir, session_id);
+    if !legacy.exists() {
+        return Ok(None);
+    }
+    std::fs::create_dir_all(session_dir).map_err(|e| {
+        AgentLoopError::config(format!("create session dir {}: {e}", session_dir.display()))
+    })?;
+    std::fs::copy(&legacy, &current).map_err(|e| {
+        AgentLoopError::config(format!(
+            "migrate legacy session log {} to {}: {e}",
+            legacy.display(),
+            current.display()
+        ))
+    })?;
+    Ok(Some(legacy))
+}
+
 /// Result of replaying a JSONL session log from disk.
 #[derive(Debug, Default)]
 pub struct ReplayedSession {
@@ -459,6 +494,50 @@ mod tests {
         assert_eq!(collected.len(), 3, "seeded + 1 new");
         // New event sequence continues from start_sequence we opened with.
         assert_eq!(collected[2].sequence, Some(3));
+    }
+
+    #[test]
+    fn migrate_legacy_session_log_copies_flat_jsonl() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let session_id = SessionId::from_seed(48200);
+        let legacy_path = legacy_session_log_path(dir.path(), session_id);
+        std::fs::write(&legacy_path, "legacy event\n").expect("write legacy");
+
+        let session_dir = session_dir_path(dir.path(), session_id);
+        let migrated =
+            migrate_legacy_session_log(dir.path(), &session_dir, session_id).expect("migrate");
+        let current_path = session_log_path(&session_dir);
+
+        assert_eq!(migrated.as_deref(), Some(legacy_path.as_path()));
+        assert_eq!(
+            std::fs::read_to_string(&current_path).expect("read migrated"),
+            "legacy event\n"
+        );
+        assert!(
+            legacy_path.exists(),
+            "migration copies instead of renaming for old ercode compatibility"
+        );
+    }
+
+    #[test]
+    fn migrate_legacy_session_log_does_not_overwrite_current_log() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let session_id = SessionId::from_seed(48201);
+        let legacy_path = legacy_session_log_path(dir.path(), session_id);
+        std::fs::write(&legacy_path, "legacy event\n").expect("write legacy");
+        let session_dir = session_dir_path(dir.path(), session_id);
+        std::fs::create_dir_all(&session_dir).expect("create session dir");
+        let current_path = session_log_path(&session_dir);
+        std::fs::write(&current_path, "current event\n").expect("write current");
+
+        let migrated =
+            migrate_legacy_session_log(dir.path(), &session_dir, session_id).expect("migrate");
+
+        assert!(migrated.is_none());
+        assert_eq!(
+            std::fs::read_to_string(&current_path).expect("read current"),
+            "current event\n"
+        );
     }
 
     #[tokio::test]

--- a/integrations/browserless/src/tools.rs
+++ b/integrations/browserless/src/tools.rs
@@ -12,7 +12,7 @@
 //! When no session exists, each tool call uses a fresh browser via REST API.
 
 use everruns_core::ToolHints;
-use everruns_core::tools::{Tool, ToolExecutionResult};
+use everruns_core::tools::{Tool, ToolExecutionResult, ToolResultImage};
 use everruns_core::traits::ToolContext;
 use everruns_core::truncation_info::{TruncationInfo, TruncationReason};
 
@@ -72,6 +72,21 @@ fn truncate_html(html: String) -> (String, bool) {
     } else {
         (html, false)
     }
+}
+
+fn png_image_result(mut result: Value, base64: String, size_bytes: usize) -> ToolExecutionResult {
+    if let Some(obj) = result.as_object_mut() {
+        obj.insert("image_returned".to_string(), json!(true));
+        obj.insert("format".to_string(), json!("png"));
+        obj.insert("size_bytes".to_string(), json!(size_bytes));
+    }
+    ToolExecutionResult::success_with_images(
+        result,
+        vec![ToolResultImage {
+            base64,
+            media_type: "image/png".to_string(),
+        }],
+    )
 }
 
 fn validate_url(url: &str) -> Result<(), ToolExecutionResult> {
@@ -189,16 +204,22 @@ impl Tool for BrowserlessScreenshotTool {
             return match result {
                 Ok(b64) => {
                     use base64::Engine;
-                    let bytes = base64::engine::general_purpose::STANDARD
-                        .decode(&b64)
-                        .unwrap_or_default();
-                    ToolExecutionResult::Success(json!({
-                        "url": url,
-                        "format": "png",
-                        "size_bytes": bytes.len(),
-                        "image_base64": b64,
-                        "session": "cdp"
-                    }))
+                    let bytes = match base64::engine::general_purpose::STANDARD.decode(&b64) {
+                        Ok(bytes) => bytes,
+                        Err(e) => {
+                            return ToolExecutionResult::tool_error(format!(
+                                "CDP screenshot returned invalid base64: {e}"
+                            ));
+                        }
+                    };
+                    png_image_result(
+                        json!({
+                            "url": url,
+                            "session": "cdp"
+                        }),
+                        b64,
+                        bytes.len(),
+                    )
                 }
                 Err(e) => ToolExecutionResult::tool_error(format!("CDP screenshot failed: {e}")),
             };
@@ -230,12 +251,13 @@ impl Tool for BrowserlessScreenshotTool {
             Ok(bytes) => {
                 use base64::Engine;
                 let b64 = base64::engine::general_purpose::STANDARD.encode(&bytes);
-                ToolExecutionResult::Success(json!({
-                    "url": url,
-                    "format": "png",
-                    "size_bytes": bytes.len(),
-                    "image_base64": b64
-                }))
+                png_image_result(
+                    json!({
+                        "url": url,
+                    }),
+                    b64,
+                    bytes.len(),
+                )
             }
             Err(e) => ToolExecutionResult::tool_error(e),
         }
@@ -947,6 +969,7 @@ impl Tool for BrowserlessInteractTool {
                 "url": final_url,
                 "session": "cdp"
             });
+            let mut images = Vec::new();
             if suppress_content_for_secrets {
                 result["content_redacted"] = json!(true);
                 result["content_redaction_reason"] = json!("secrets_used_in_steps");
@@ -954,7 +977,24 @@ impl Tool for BrowserlessInteractTool {
             if want_screenshot {
                 match session.screenshot(true).await {
                     Ok(b64) => {
-                        result["screenshot"] = json!(b64);
+                        use base64::Engine;
+                        let bytes = match base64::engine::general_purpose::STANDARD.decode(&b64) {
+                            Ok(bytes) => bytes,
+                            Err(e) => {
+                                keep_session_alive(context, &mut session).await;
+                                session.disconnect().await;
+                                return ToolExecutionResult::tool_error(format!(
+                                    "CDP screenshot returned invalid base64: {e}"
+                                ));
+                            }
+                        };
+                        result["screenshot_returned"] = json!(true);
+                        result["screenshot_format"] = json!("png");
+                        result["screenshot_size_bytes"] = json!(bytes.len());
+                        images.push(ToolResultImage {
+                            base64: b64,
+                            media_type: "image/png".to_string(),
+                        });
                     }
                     Err(e) => {
                         keep_session_alive(context, &mut session).await;
@@ -968,7 +1008,11 @@ impl Tool for BrowserlessInteractTool {
             if want_content {
                 match session.get_content().await {
                     Ok(content) => {
+                        let total = content.len();
+                        let (content, was_truncated) = truncate_html(content);
                         result["content"] = json!(content);
+                        result["truncated"] = json!(was_truncated);
+                        attach_content_truncation(&mut result, &content, total, was_truncated);
                     }
                     Err(e) => {
                         keep_session_alive(context, &mut session).await;
@@ -980,7 +1024,11 @@ impl Tool for BrowserlessInteractTool {
 
             keep_session_alive(context, &mut session).await;
             session.disconnect().await;
-            return ToolExecutionResult::Success(result);
+            return if images.is_empty() {
+                ToolExecutionResult::Success(result)
+            } else {
+                ToolExecutionResult::success_with_images(result, images)
+            };
         }
 
         // Fallback: REST API
@@ -1000,6 +1048,8 @@ impl Tool for BrowserlessInteractTool {
                 if let Some(data_str) = result.get("data").and_then(|v| v.as_str()) {
                     match serde_json::from_str::<Value>(data_str) {
                         Ok(mut data) => {
+                            let mut images = Vec::new();
+                            let mut content_truncation: Option<(String, usize, bool)> = None;
                             // Extract and persist cookies (even empty — clears stale state)
                             if let Some(cookies) = data.get("__cookies").and_then(|v| v.as_array())
                                 && let Err(e) = save_cookies(context, cookies).await
@@ -1008,6 +1058,41 @@ impl Tool for BrowserlessInteractTool {
                             }
                             if let Some(obj) = data.as_object_mut() {
                                 obj.remove("__cookies");
+                                if let Some(content_value) = obj.get("content").cloned()
+                                    && let Some(content) = content_value.as_str()
+                                {
+                                    let total = content.len();
+                                    let (content, was_truncated) =
+                                        truncate_html(content.to_string());
+                                    obj.insert("content".to_string(), json!(content.clone()));
+                                    obj.insert("truncated".to_string(), json!(was_truncated));
+                                    content_truncation = Some((content, total, was_truncated));
+                                }
+                                if let Some(screenshot_value) = obj.remove("screenshot")
+                                    && let Some(b64) = screenshot_value.as_str()
+                                {
+                                    use base64::Engine;
+                                    let bytes = match base64::engine::general_purpose::STANDARD
+                                        .decode(b64)
+                                    {
+                                        Ok(bytes) => bytes,
+                                        Err(e) => {
+                                            return ToolExecutionResult::tool_error(format!(
+                                                "REST screenshot returned invalid base64: {e}"
+                                            ));
+                                        }
+                                    };
+                                    obj.insert("screenshot_returned".to_string(), json!(true));
+                                    obj.insert("screenshot_format".to_string(), json!("png"));
+                                    obj.insert(
+                                        "screenshot_size_bytes".to_string(),
+                                        json!(bytes.len()),
+                                    );
+                                    images.push(ToolResultImage {
+                                        base64: b64.to_string(),
+                                        media_type: "image/png".to_string(),
+                                    });
+                                }
                                 if suppress_content_for_secrets {
                                     obj.insert("content_redacted".to_string(), json!(true));
                                     obj.insert(
@@ -1016,7 +1101,19 @@ impl Tool for BrowserlessInteractTool {
                                     );
                                 }
                             }
-                            ToolExecutionResult::Success(data)
+                            if let Some((content, total, was_truncated)) = content_truncation {
+                                attach_content_truncation(
+                                    &mut data,
+                                    content.as_str(),
+                                    total,
+                                    was_truncated,
+                                );
+                            }
+                            if images.is_empty() {
+                                ToolExecutionResult::Success(data)
+                            } else {
+                                ToolExecutionResult::success_with_images(data, images)
+                            }
                         }
                         Err(_) => ToolExecutionResult::Success(json!({
                             "result": data_str

--- a/integrations/daytona/src/lib.rs
+++ b/integrations/daytona/src/lib.rs
@@ -101,7 +101,7 @@ static SYSTEM_PROMPT: LazyLock<String> = LazyLock::new(|| {
     let mut prompt = String::from(
         r#"Daytona sandboxes are isolated networked Linux environments. Create or select a sandbox before sandbox-scoped operations; inspect snapshots before creating custom environments. Sandboxes auto-stop/archive/delete, but delete them when done because stop leaves them visible in Daytona.
 
-Default workspace is `/home/daytona`. Clone repos under `/home/daytona/owner/repo`; connected GitHub accounts authenticate private clones. Configure sandbox git credentials before push/pull/fetch and refresh them if they expire."#,
+Workspace is `/home/daytona`. Clone repos under `/home/daytona/owner/repo`; connected GitHub accounts authenticate private clones. Configure sandbox git credentials before push/pull/fetch and refresh them if they expire."#,
     );
     prompt.push_str(everruns_core::tool_output_sanitizer::EXEC_OUTPUT_HINT);
     prompt

--- a/integrations/daytona/src/tools.rs
+++ b/integrations/daytona/src/tools.rs
@@ -26,7 +26,8 @@ use everruns_core::resource_ownership::{
     require_owned_external_resource,
 };
 use everruns_core::tool_output_sanitizer::{
-    READ_FILE_DEFAULT_LIMIT, build_text_read_file_result, parse_read_file_window_args,
+    READ_FILE_DEFAULT_LIMIT, build_binary_read_file_result, build_text_read_file_result,
+    parse_read_file_window_args,
 };
 use everruns_core::tools::{Tool, ToolExecutionResult};
 use everruns_core::traits::ToolContext;
@@ -682,12 +683,7 @@ impl Tool for DaytonaReadFileTool {
                         limit,
                     )
                 } else {
-                    json!({
-                        "path": path,
-                        "content": content,
-                        "encoding": encoding,
-                        "size_bytes": bytes.len()
-                    })
+                    build_binary_read_file_result(path, bytes.len(), &encoding)
                 };
                 result["sandbox_id"] = json!(sandbox_id);
                 ToolExecutionResult::success(result)

--- a/integrations/docker/src/lib.rs
+++ b/integrations/docker/src/lib.rs
@@ -21,7 +21,7 @@
 use everruns_core::ToolHints;
 use everruns_core::capabilities::{Capability, CapabilityStatus, IntegrationPlugin, RiskLevel};
 use everruns_core::tool_output_sanitizer::{
-    READ_FILE_DEFAULT_LIMIT, build_text_read_file_result, parse_read_file_window_args,
+    READ_FILE_DEFAULT_LIMIT, build_bytes_read_file_result, parse_read_file_window_args,
 };
 use everruns_core::tools::{Tool, ToolExecutionResult};
 use everruns_core::traits::ToolContext;
@@ -591,13 +591,10 @@ impl Tool for DockerReadFileTool {
             return ToolExecutionResult::tool_error(format!("Failed to read file: {}", stderr));
         }
 
-        let content = String::from_utf8_lossy(&output.stdout).to_string();
-
-        ToolExecutionResult::success(build_text_read_file_result(
+        ToolExecutionResult::success(build_bytes_read_file_result(
             "docker_read_file",
             path,
-            &content,
-            "text",
+            &output.stdout,
             offset,
             limit,
         ))

--- a/integrations/e2b/src/lib.rs
+++ b/integrations/e2b/src/lib.rs
@@ -41,7 +41,7 @@ pub const E2B_ENVD_PORT: u16 = 49_983;
 
 static SYSTEM_PROMPT: LazyLock<String> = LazyLock::new(|| {
     let mut prompt = String::from(
-        "E2B sandboxes are isolated networked Linux environments. Create or select a sandbox before sandbox-scoped operations, prefer `/home/user` as workspace root, and pause or delete sandboxes when done; delete for immediate cleanup.",
+        "E2B sandboxes are isolated networked Linux environments. Create or select a sandbox before sandbox-scoped operations, prefer `/home/user` as workspace root, and pause or delete sandboxes when done.",
     );
     prompt.push_str(everruns_core::tool_output_sanitizer::EXEC_OUTPUT_HINT);
     prompt

--- a/integrations/sprites/src/tools.rs
+++ b/integrations/sprites/src/tools.rs
@@ -1,7 +1,7 @@
 //! Tool implementations for Sprites operations.
 
 use everruns_core::tool_output_sanitizer::{
-    READ_FILE_DEFAULT_LIMIT, build_text_read_file_result, parse_read_file_window_args,
+    READ_FILE_DEFAULT_LIMIT, build_bytes_read_file_result, parse_read_file_window_args,
 };
 use everruns_core::tool_types::ToolHints;
 use everruns_core::tools::{Tool, ToolExecutionResult};
@@ -403,15 +403,8 @@ impl Tool for SpritesReadFileTool {
                 if let Err(e) = touch_sprite_lease(context, &state, None).await {
                     return e;
                 }
-                let content = String::from_utf8_lossy(&bytes).to_string();
-                let mut result = build_text_read_file_result(
-                    "sprites_read_file",
-                    path,
-                    &content,
-                    "text",
-                    offset,
-                    limit,
-                );
+                let mut result =
+                    build_bytes_read_file_result("sprites_read_file", path, &bytes, offset, limit);
                 result["sprite_name"] = json!(sprite_name);
                 ToolExecutionResult::success(result)
             }

--- a/specs/compaction.md
+++ b/specs/compaction.md
@@ -24,28 +24,23 @@ Provider cache telemetry feeds this same model-view step. If the previous call r
 
 ### What Exists
 
-**OpenResponses Protocol Compaction** (`crates/core/src/atoms/reason.rs:839-953`):
-- Reactive only — triggers on `RequestTooLarge` error
-- Calls `LlmDriver::compact()` — only OpenAI Responses API supports it today
-- Records `LlmCompactionInfo` as metadata on `llm.generation` event
-- No SSE event, no UI indicator, no TS types
+**Compaction capability** (`crates/core/src/capabilities/compaction.rs`):
+- Configured explicitly through the `compaction` capability.
+- Contributes the prompt-facing model-view provider that masks stale bulky tool results before provider serialization.
+- Supports proactive budget checks, reactive `RequestTooLarge` recovery, observation masking, native provider compaction when available, summarization, and last-resort trimming.
+- Emits `context.compacting` / `context.compacted` events and records `LlmCompactionInfo` on `llm.generation` when native provider compaction runs.
 
 **Infinity Context** (`crates/core/src/capabilities/infinity_context.rs`):
 - Separate, optional capability — not part of compaction. Trims messages + provides `query_history` tool.
 - Complementary to compaction but independent. See `specs/infinity-context.md`.
 
-### What's Missing
+### Current Caveats
 
 | Gap | Impact |
 |-----|--------|
-| No strategy selection | Users can't choose native vs our own |
-| No proactive compaction | Waits for error, adds latency |
-| No observation masking | Cheapest strategy not available |
-| No LLM summarization | Non-OpenAI providers have no fallback |
-| No SSE events | No real-time feedback |
-| No UI indicator | Users don't know compaction happened |
-| No TS types for `LlmCompactionInfo` | Frontend can't render compaction data |
-| `supports_compact()` not exposed | Users can't see what their provider supports |
+| Provider capability visibility | Users cannot yet see every provider's native compaction support in all product surfaces. |
+| UI polish | The backend emits compaction events, but timeline rendering may still need product-specific display work. |
+| Token telemetry precision | Some compaction events report message counts rather than exact token deltas when the strategy does not make a provider call. |
 
 ## Compaction Strategies
 
@@ -225,7 +220,9 @@ for the exact configuration fields and defaults.
 }
 ```
 
-**No compaction capability configured → existing behavior (reactive native-only on error).**
+**No compaction capability configured → no Everruns compaction or masking runs.**
+Provider `RequestTooLarge` errors propagate unless the agent/harness enables the
+`compaction` capability.
 
 ### Default Behavior
 
@@ -447,47 +444,28 @@ pub struct SessionCompactionMetrics {
 
 Displayed in session detail view and session list (as a subtle indicator when compaction has occurred).
 
-## Implementation Plan
+## Implementation Status
 
-### Phase 1: Compaction Capability + Events
+Implemented pieces live in the capability and runtime assembly paths:
 
-1. Create `CompactionConfig` types in `crates/core/src/capabilities/compaction.rs`
-2. Register `compaction` capability in `CapabilityRegistry`
-3. Add `context.compacting` / `context.compacted` event types to `crates/core/src/events.rs`
-4. Refactor `ReasonAtom` compaction flow to:
-   - Read compaction config from collected capabilities
-   - Emit SSE events
-   - Support strategy selection
-5. Add `LlmCompactionInfo` + event types to UI TypeScript types
-6. Render compaction divider in chat UI
+- `crates/core/src/capabilities/compaction.rs` owns config parsing,
+  cost-control model-view masking, observation masking, summarization helpers,
+  and compaction metrics types.
+- `crates/core/src/capabilities/mod.rs` exposes the generic
+  `ModelViewProvider` hook so compaction remains capability-owned.
+- `crates/core/src/atoms/reason.rs` invokes compaction only when the resolved
+  capability config includes `compaction`; without it, context-limit errors are
+  returned to the caller.
+- `crates/core/src/events.rs` defines compaction events and generation metadata.
 
-### Phase 2: Observation Masking
+Remaining product work should focus on UI presentation and provider capability
+visibility rather than changing the capability ownership model.
 
-1. Implement `ObservationMaskingFilter` in `crates/core/src/message_filter.rs`
-2. Wire into compaction capability's `message_filter_provider()`
-3. Add `observation_masking` as a strategy in `ReasonAtom`
-4. Integrate into `auto` cascade (runs before native/summarization)
+### Future Work
 
-### Phase 3: Proactive Compaction
-
-1. Add token estimation to message assembly in `ReasonAtom`
-2. Check against `budget_percent` threshold before LLM call
-3. Trigger cascade proactively instead of waiting for `RequestTooLarge`
-4. Keep reactive path as fallback (config: `proactive: false`)
-
-### Phase 4: Summarization
-
-1. Implement `SummarizationCompactor` — takes messages + config, returns summary
-2. Use agent's model by default, allow override via `summarization.model`
-3. Integrate as final cascade step in `auto` strategy
-4. Add as standalone strategy option
-
-### Phase 5: Hierarchical Memory + Metrics
-
-1. Implement hot/warm/cold tier management
-2. Wire cold tier to Infinity Context's `query_history` when both capabilities enabled
-3. Add `SessionCompactionMetrics` tracking
-4. Display metrics in session UI
+- Product UI for compaction timeline events and session-level metrics.
+- Provider capability visibility for native compaction support.
+- Deeper integration between hierarchical memory tiers and Infinity Context.
 
 ## References
 

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -946,6 +946,7 @@ When a bash script calls `bash` or `sh` or uses `eval`, bashkit re-invokes its o
 | TM-DOS-011 | Authenticated API key sprawl | Low | No server-side per-user API key quota; API key creation requires an authenticated user session and keys remain user-owned/revocable. Operators must monitor and clean up excessive key creation if they need stricter controls. | **ACCEPTED** |
 | TM-DOS-012 | Source-backed Volume repository storage abuse | Medium | Volume source sync performs shallow clones without tags, skips symlinks, excludes `.git`, and enforces configurable file-count, per-file byte, and total byte limits before replacing `volume_files`. Failed sync keeps the previous readable snapshot. | MITIGATED |
 | TM-DOS-013 | Hidden Agent snapshot storage growth | Medium | Automatic Agent draft snapshots are active only when `FEATURE_AGENT_VERSIONS` is enabled, skipped when the latest stored config hash already matches the draft, and pruned to a bounded per-Agent unpublished auto-snapshot window after each write. | MITIGATED |
+| TM-DOS-014 | Tool output context growth | Medium | Read-like tools use windowed responses and truncation envelopes (`read_file`, `list_directory`, `grep_files`, browser DOM content); platform message reads cap message count and per-message content; non-image binary reads return metadata instead of base64 or lossy UTF-8; opted-in exec tools persist full output under `/outputs/` so the inline prompt payload can stay bounded and recoverable. | MITIGATED |
 
 ### Mitigation Details
 

--- a/specs/tool-execution.md
+++ b/specs/tool-execution.md
@@ -95,7 +95,7 @@ Capability hooks involved:
 
 ### Reading-tool output contract
 
-Every reading tool attaches a shared `truncation` envelope to its JSON response so LLM callers can detect partial output, understand why it was cut, and resume or fall back without regex-matching human markers. The envelope is additive — existing flat fields like `truncated`, `total_lines`, and `row_count` stay in place for back-compat. File-reading tools, including session-sandbox-backed reads such as `sandbox_read_file`, accept `offset` and `limit` and return only that line window for text files.
+Every reading tool attaches a shared `truncation` envelope to its JSON response so LLM callers can detect partial output, understand why it was cut, and resume or fall back without regex-matching human markers. The envelope is additive — existing flat fields like `truncated`, `total_lines`, and `row_count` stay in place for back-compat. File-reading tools, including session-sandbox-backed reads such as `sandbox_read_file`, accept `offset` and `limit` and return only that line window for text files. Non-image binary file reads return metadata by default instead of raw base64 or lossy UTF-8.
 
 See [`crates/core/src/truncation_info.rs`](../crates/core/src/truncation_info.rs) for the source of truth: `TruncationInfo`, `TruncationReason`, and the `assert_conforms` conformance helper.
 
@@ -104,12 +104,14 @@ See [`crates/core/src/truncation_info.rs`](../crates/core/src/truncation_info.rs
 | Tool | Reason codes | Resume supported? |
 |------|--------------|-------------------|
 | `read_file` (session VFS + sandbox) | `line_cap` (with resume), `size_cap` (without resume) | Line cap only — `next_offset` = line number |
-| `list_directory` (session VFS + sandbox) | `item_cap` | No — narrow with `path` |
-| `grep_files` (session VFS + sandbox) | `line_cap` | No — narrow `pattern`/`path_pattern` |
+| `list_directory` (session VFS) | `item_cap` | Yes — `next_offset` = item offset |
+| `grep_files` (session VFS) | `line_cap` | Yes — `next_offset` = match offset |
 | `sql_query` | `row_cap` | No — narrow `WHERE`/`LIMIT` |
-| `browserless_content` | `size_cap` | No — narrow via `browserless_scrape` selectors or shrink the source page |
+| `browserless_content` / interaction DOM content | `size_cap` | No — narrow via `browserless_scrape` selectors or shrink the source page |
 
-`next_offset` units are tool-specific — `read_file` uses a line number today. Each tool documents its own unit via `resume_hint`.
+`next_offset` units are tool-specific — `read_file` uses a line number, `list_directory` uses an item offset, and `grep_files` uses a match offset. Each tool documents its own unit via `resume_hint`.
+
+Platform-management `session_read_messages` is not a filesystem reader, but it follows the same token-economy principle: returned message count and per-message content are bounded by defaults, with explicit caps for larger reads.
 
 Exec tools (`bash`, `*_exec`) keep their existing `truncated`/`total_lines`/`output_files` fields and the `exec_budget` reason is reserved for future migration; they are outside this envelope today because their truncation is priority-aware and persisted-output-backed.
 
@@ -160,7 +162,7 @@ All exec tools accept an `output` parameter controlling how much output is retur
 | `verbose` | ~16 KiB | Test failures, error investigation |
 | `full` | unlimited | Raw output, no truncation — when the LLM needs every line |
 
-Default is `concise`. Budgets apply to stdout; stderr is capped at `min(budget, 4096)` to keep error output proportional. Full output is always persisted to `/outputs/` via `tool_output_persistence` — stdout to `/outputs/{tool_call_id}.stdout`, stderr to `/outputs/{tool_call_id}.stderr` — and readable with `read_file`. See `crates/core/src/tool_output_sanitizer.rs` for budget constants and `output_verbosity_budget()`.
+Default is `concise`. Budgets apply to stdout; stderr is capped at `min(budget, 4096)` to keep error output proportional. Tools that set the `persist_output` hint persist non-empty full output to `/outputs/` via `tool_output_persistence` — stdout to `/outputs/{tool_call_id}.stdout`, stderr to `/outputs/{tool_call_id}.stderr` — and the files are readable with `read_file`. See `crates/core/src/tool_output_sanitizer.rs` for budget constants and `output_verbosity_budget()`.
 
 This is the tool's responsibility — each tool calls the helpers before constructing `ToolExecutionResult`. See `crates/core/src/tool_output_sanitizer.rs` for the primitives.
 


### PR DESCRIPTION
## What
Tightens token-efficient tool output behavior across core and integrations:

- Windowed `list_directory` and `grep_files` with `offset`/`limit`, total counts, and truncation envelopes.
- Metadata-only non-image binary reads for session VFS, container sandbox, Daytona, Docker, and Sprites instead of base64 or lossy UTF-8 payloads.
- Browserless screenshots/interact screenshots returned as native tool images, with DOM content truncation metadata.
- Platform `session_read_messages` caps message count and per-message content by default.
- Output persistence now persists non-empty opted-in streams so verbosity-truncated exec output remains recoverable under `/outputs/`.
- Coding CLI session logs migrate legacy flat JSONL paths into folder-backed `events.jsonl` logs.
- Compaction fallback no longer runs without the `compaction` capability configured.
- Specs and threat model updated for the new tool-output contract.

## Why
The original investigation showed small stored session logs could still produce very large cumulative model input because repeated tool outputs and full-history prompts were sent back into the model. This reduces inline payload size at the tool boundary, keeps full output recoverable where appropriate, and keeps compaction behavior capability-owned.

## How
Shared output helpers now produce line-windowed text responses or binary metadata. Read/list/search tools expose resumable windows. Browserless moves binary screenshots out of JSON and into native image parts. Platform session-message reads add explicit payload caps. Output persistence stores full opted-in streams before inline sanitizer budgets are applied.

## Risk
- Medium
- Tool result shape changes are additive for text/list/search paths, but binary file reads intentionally omit previous raw binary/base64 content from model-facing JSON. Callers that depended on inline binary payloads must use file/download-specific inspection paths instead.

## Security
- Threat categories reviewed: TM-DOS, TM-TOOL, TM-LLM, TM-FS
- Findings and resolutions: unbounded or bulky model-facing payloads were reduced with windows, caps, truncation envelopes, native image parts, metadata-only binary reads, and recoverable persisted exec output. No new auth, tenant, SQL, or network trust boundary was introduced.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

## Validation
- `cargo test -p everruns-core capabilities::file_system::tests --lib`
- `cargo test -p everruns-core capabilities::tool_output_persistence::tests --lib`
- `cargo test -p everruns-core capabilities::platform_management::tests::read_messages --lib`
- `cargo test -p everruns-core capabilities::platform_management::tests::truncate_content_chars_respects_unicode_boundaries --lib`
- `cargo test -p everruns-core tool_output_sanitizer::tests --lib`
- `cargo test -p everruns-coding-cli session_log::tests`
- `cargo test -p everruns-integrations-browserless --lib`
- `cargo test -p everruns-container-sandbox --lib`
- `cargo test -p everruns-integrations-daytona tools::tests::test_read_file_schema --lib`
- `cargo test -p everruns-integrations-docker --lib`
- `cargo test -p everruns-integrations-sprites --lib`
- `cargo test -p everruns-core test_collect_model_view_providers_respects_compaction_capability_boundary --lib`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `just pre-push`
- `bash scripts/lib/check-migration-ordering.sh`
- Smoke: `PORT_PREFIX=271 just start-dev --no-watch`, then `curl -fsS http://localhost:27101/health` returned `{"status":"ok","version":"0.8.33","auth_mode":"None"}`; services stopped afterward.
