### PR TITLE
fix(ui): clean up jsx-a11y and react lint warnings

### DIFF
--- a/apps/ui/src/__tests__/agent-detail-model.test.tsx
+++ b/apps/ui/src/__tests__/agent-detail-model.test.tsx
@@ -28,7 +28,7 @@ jest.mock("@/components/ui/prompt-editor", () => ({
     <div data-testid="markdown">{content}</div>
   ),
   PromptEditor: ({ value, onChange }: { value: string; onChange: (v: string) => void }) => (
-    <textarea value={value} onChange={(e) => onChange(e.target.value)} />
+    <textarea aria-label="Prompt" value={value} onChange={(e) => onChange(e.target.value)} />
   ),
 }));
 

--- a/apps/ui/src/app/(main)/agents/page.tsx
+++ b/apps/ui/src/app/(main)/agents/page.tsx
@@ -89,6 +89,7 @@ export default function AgentsPage() {
             onChange={handleFileChange}
             accept=".md,.yaml,.yml,.json"
             className="hidden"
+            aria-label="Import agent file"
           />
           <Button variant="outline" onClick={handleImportClick} disabled={importAgent.isPending}>
             <Upload className="w-4 h-4 mr-2" />

--- a/apps/ui/src/app/(main)/apps/[appId]/page.tsx
+++ b/apps/ui/src/app/(main)/apps/[appId]/page.tsx
@@ -2446,6 +2446,7 @@ function AppDetailPageLegacy({ params }: { params: Promise<{ appId: string }> })
                         setShowAddChannel(false);
                       }}
                       aria-pressed={selected}
+                      aria-label={`Select channel ${summary.target}`}
                       className={cn(
                         "w-full rounded-md border border-border p-3 text-left transition-colors outline-none hover:bg-muted/50 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50",
                         selected && "bg-muted",

--- a/apps/ui/src/app/(main)/apps/page.tsx
+++ b/apps/ui/src/app/(main)/apps/page.tsx
@@ -112,7 +112,7 @@ function AppCard({ app }: { app: App }) {
             </div>
           )}
 
-          {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
+          {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions, jsx-a11y/no-noninteractive-element-interactions -- group container only suppresses click propagation; nested actions own interactivity */}
           <div
             className="flex gap-2 pt-2"
             role="group"

--- a/apps/ui/src/app/(main)/durable/queues/enqueue-dialog.tsx
+++ b/apps/ui/src/app/(main)/durable/queues/enqueue-dialog.tsx
@@ -84,6 +84,7 @@ export function EnqueueDialog({
               }}
               className="flex min-h-[100px] w-full border border-input bg-background px-3 py-2 text-sm font-mono ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
               placeholder='{"key": "value"}'
+              aria-label="Input JSON"
             />
             {jsonError && <p className="text-sm text-destructive">{jsonError}</p>}
           </div>

--- a/apps/ui/src/app/(main)/memory-stores/page.tsx
+++ b/apps/ui/src/app/(main)/memory-stores/page.tsx
@@ -755,6 +755,7 @@ function CreateStoreDialog({
               type="checkbox"
               checked={isDefault}
               onChange={(e) => setIsDefault(e.target.checked)}
+              aria-label="Make this the default store for the organization"
             />
             Make this the default store for the organization
           </label>
@@ -847,6 +848,7 @@ function EditStoreDialog({
               checked={isDefault}
               disabled={disableDefaultToggle}
               onChange={(e) => setIsDefault(e.target.checked)}
+              aria-label="Make this the default store for the organization"
             />
             Make this the default store for the organization
             {disableDefaultToggle && (

--- a/apps/ui/src/app/(main)/skills/skills-page-client.tsx
+++ b/apps/ui/src/app/(main)/skills/skills-page-client.tsx
@@ -207,6 +207,7 @@ function UploadSkillDialog({
               id="skill-file"
               type="file"
               accept=".zip"
+              aria-label="Skill ZIP archive"
               onChange={(e) => setFile(e.target.files?.[0] ?? null)}
               className="block w-full text-sm text-muted-foreground file:mr-4 file:py-2 file:px-4 file:border-0 file:text-sm file:font-medium file:bg-primary file:text-primary-foreground hover:file:bg-primary/90"
             />

--- a/apps/ui/src/app/dev/session-card/page.tsx
+++ b/apps/ui/src/app/dev/session-card/page.tsx
@@ -296,6 +296,7 @@ export default function DevSessionCardPage() {
                   <button
                     className="p-2 hover:bg-muted text-muted-foreground hover:text-foreground"
                     type="button"
+                    aria-label="Delete session"
                   >
                     <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                       <path

--- a/apps/ui/src/components/agents/capability-dialog.tsx
+++ b/apps/ui/src/components/agents/capability-dialog.tsx
@@ -118,11 +118,13 @@ export function CapabilityDialog({
         <div className="relative">
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
           <Input
+            // eslint-disable-next-line jsx-a11y/no-autofocus -- search-input inside an opened dialog is a deliberate focus target
+            autoFocus
             placeholder="Search capabilities..."
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
             className="pl-9"
-            autoFocus
+            aria-label="Search capabilities"
           />
         </div>
 

--- a/apps/ui/src/components/ai-elements/file-tree.tsx
+++ b/apps/ui/src/components/ai-elements/file-tree.tsx
@@ -257,6 +257,7 @@ const stopPropagation = (e: React.SyntheticEvent) => e.stopPropagation();
 export const FileTreeActions = ({ className, children, ...props }: FileTreeActionsProps) => (
   // biome-ignore lint/a11y/noNoninteractiveElementInteractions: stopPropagation required for nested interactions
   // biome-ignore lint/a11y/useSemanticElements: fieldset doesn't fit this UI pattern
+  // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions -- group container only stops event propagation; nested controls own interactivity
   <div
     className={cn(
       "ml-auto flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity",

--- a/apps/ui/src/components/apps/channel-row.tsx
+++ b/apps/ui/src/components/apps/channel-row.tsx
@@ -144,7 +144,12 @@ export function ChannelRow({
   return (
     <div className="border bg-card">
       <div className="grid gap-3 p-4 md:grid-cols-[minmax(0,1fr)_140px_120px_120px_48px] md:items-center">
-        <button type="button" onClick={onToggle} className="min-w-0 text-left">
+        <button
+          type="button"
+          onClick={onToggle}
+          className="min-w-0 text-left"
+          aria-label={`Toggle ${channelName(channel)} details`}
+        >
           <div className="flex min-w-0 items-start gap-3">
             <span className="flex size-9 shrink-0 items-center justify-center border bg-background">
               <Icon className="size-4" />

--- a/apps/ui/src/components/chat/a2ui-renderer.tsx
+++ b/apps/ui/src/components/chat/a2ui-renderer.tsx
@@ -95,6 +95,7 @@ class A2UIErrorBoundary extends Component<EBProps, EBState> {
   }
   componentDidUpdate(prevProps: EBProps) {
     if (this.state.hasError && prevProps.children !== this.props.children) {
+      // eslint-disable-next-line react/no-did-update-set-state -- ErrorBoundary reset on new children is the standard React pattern
       this.setState({ hasError: false });
     }
   }

--- a/apps/ui/src/components/chat/chat-composer.tsx
+++ b/apps/ui/src/components/chat/chat-composer.tsx
@@ -153,6 +153,7 @@ export function ChatComposer({
           multiple
           className="hidden"
           onChange={handleFileChange}
+          aria-label="Attach images"
         />
 
         {hasImages && <ImageAttachments images={pendingImages} onRemove={removeImage} />}

--- a/apps/ui/src/components/chat/openui-renderer.tsx
+++ b/apps/ui/src/components/chat/openui-renderer.tsx
@@ -83,6 +83,7 @@ class OpenUIErrorBoundary extends Component<EBProps, EBState> {
   componentDidUpdate(prevProps: EBProps) {
     // Reset when children change (new code / streaming update)
     if (this.state.hasError && prevProps.children !== this.props.children) {
+      // eslint-disable-next-line react/no-did-update-set-state -- ErrorBoundary reset on new children is the standard React pattern
       this.setState({ hasError: false });
     }
   }

--- a/apps/ui/src/components/command-palette.tsx
+++ b/apps/ui/src/components/command-palette.tsx
@@ -171,6 +171,7 @@ export function CommandPalette() {
                 onChange={(e) => setQuery(e.target.value)}
                 placeholder="Search pages, organizations, agents..."
                 className="flex-1 bg-transparent py-3.5 text-sm outline-none placeholder:text-muted-foreground"
+                aria-label="Search pages, organizations, agents"
               />
               <kbd className="hidden sm:inline-flex h-5 items-center gap-1 border bg-muted px-1.5 font-mono text-[10px] font-medium text-muted-foreground">
                 ESC

--- a/apps/ui/src/components/files/file-browser.tsx
+++ b/apps/ui/src/components/files/file-browser.tsx
@@ -464,6 +464,7 @@ export function FileBrowser({
               placeholder="File content (optional)"
               value={newFileContent}
               onChange={(e) => setNewFileContent(e.target.value)}
+              aria-label="File content (optional)"
             />
           </div>
           <DialogFooter>

--- a/apps/ui/src/components/files/file-previews.tsx
+++ b/apps/ui/src/components/files/file-previews.tsx
@@ -396,6 +396,7 @@ export function ImagePreview({
   return (
     <ScrollArea className="h-full">
       <div className="p-4 flex items-center justify-center min-h-full">
+        {/* eslint-disable-next-line @next/next/no-img-element -- preview source is a data: URL from user-uploaded bytes; next/image's optimizer/loaders do not handle data: URLs */}
         <img
           src={dataUrl}
           alt={fileName}

--- a/apps/ui/src/components/files/file-viewer.tsx
+++ b/apps/ui/src/components/files/file-viewer.tsx
@@ -186,6 +186,7 @@ export function FileViewer({ sessionId, file, onClose }: FileViewerProps) {
             value={editContent}
             onChange={(e) => setEditContent(e.target.value)}
             spellCheck={false}
+            aria-label="File content editor"
           />
         ) : !fileData?.content && fileData?.content !== "" ? (
           <div className="flex flex-col items-center justify-center h-full text-muted-foreground">

--- a/apps/ui/src/components/initial-files-editor.tsx
+++ b/apps/ui/src/components/initial-files-editor.tsx
@@ -239,6 +239,7 @@ export function InitialFilesEditor({
           type="file"
           multiple
           className="hidden"
+          aria-label="Upload files"
           onChange={(event) => {
             void addUploadedFiles(event.target.files);
             event.target.value = "";
@@ -371,6 +372,7 @@ export function InitialFilesEditor({
                         type="file"
                         className="hidden"
                         disabled={disabled}
+                        aria-label="Replace selected file with upload"
                         onChange={(event) => {
                           void replaceWithUpload(selectedIndex!, event.target.files);
                           event.target.value = "";

--- a/apps/ui/src/components/ui/combobox.tsx
+++ b/apps/ui/src/components/ui/combobox.tsx
@@ -21,8 +21,6 @@ interface ComboboxProps {
   clearable?: boolean;
 }
 
-const listboxId = "combobox-listbox";
-
 export function Combobox({
   options,
   value,
@@ -33,6 +31,7 @@ export function Combobox({
   className,
   clearable = true,
 }: ComboboxProps) {
+  const listboxId = React.useId();
   const [open, setOpen] = React.useState(false);
   const [search, setSearch] = React.useState("");
   const [highlightIndex, setHighlightIndex] = React.useState(0);
@@ -176,6 +175,7 @@ export function Combobox({
               onKeyDown={handleKeyDown}
               placeholder={searchPlaceholder}
               aria-controls={listboxId}
+              aria-label={searchPlaceholder}
               className="bg-transparent w-full text-sm outline-none placeholder:text-muted-foreground"
             />
           </div>
@@ -189,9 +189,16 @@ export function Combobox({
                 <div
                   key={option.value}
                   role="option"
+                  tabIndex={-1}
                   aria-selected={option.value === value}
                   data-combobox-item
                   onClick={() => handleSelect(option.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      handleSelect(option.value);
+                    }
+                  }}
                   className={cn(
                     "flex cursor-default items-center px-2 py-1.5 text-sm select-none",
                     idx === highlightIndex && "bg-muted text-foreground",

--- a/apps/ui/src/components/ui/switch.tsx
+++ b/apps/ui/src/components/ui/switch.tsx
@@ -9,6 +9,8 @@ interface SwitchProps {
   disabled?: boolean;
   className?: string;
   id?: string;
+  "aria-label"?: string;
+  "aria-labelledby"?: string;
 }
 
 function Switch({
@@ -17,12 +19,16 @@ function Switch({
   disabled = false,
   className,
   id,
+  "aria-label": ariaLabel,
+  "aria-labelledby": ariaLabelledby,
 }: SwitchProps) {
   return (
     <button
       type="button"
       role="switch"
       aria-checked={checked}
+      aria-label={ariaLabel}
+      aria-labelledby={ariaLabelledby}
       id={id}
       disabled={disabled}
       onClick={() => onCheckedChange?.(!checked)}


### PR DESCRIPTION
## What
Resolves all 25 oxlint warnings in `apps/ui` surfaced during the
npm → pnpm migration (EVE-487). `cd apps/ui && pnpm run lint` is now
clean.

## Why
The pile of warnings makes new regressions invisible in PR diffs. With
the queue empty, regressions stand out, and the team can later promote
the addressed rules from `warn` to `error` (see Follow-ups).

## How — by rule

- **`jsx-a11y/control-has-associated-label`** — added explicit
  `aria-label` on:
  - Icon-only buttons (`session-card/page.tsx`, `apps/[appId]/page.tsx`
    channel-select tile, `channel-row.tsx` row-toggle).
  - Hidden / restyled file inputs (`agents/page.tsx`,
    `chat/chat-composer.tsx`, `initial-files-editor.tsx` x2,
    `skills/skills-page-client.tsx`).
  - Dialog search / form inputs that have an associated
    `<Label htmlFor=...>` but no attribute the linter can statically
    detect (`command-palette.tsx`, `combobox.tsx`,
    `durable/queues/enqueue-dialog.tsx`, `agents/capability-dialog.tsx`).
  - Textareas in dialogs (`files/file-viewer.tsx`,
    `files/file-browser.tsx`).
  - "Make this the default store" checkboxes in `memory-stores/page.tsx`
    (the surrounding `<label>` text is also kept; aria-label gives the
    linter what it wants).
  - `Switch` now forwards optional `aria-label` / `aria-labelledby`
    props so callers can label it; the rule no longer fires inside the
    primitive itself.
  - The mock `PromptEditor` textarea in
    `__tests__/agent-detail-model.test.tsx`.

- **`jsx-a11y/no-noninteractive-element-interactions`** — documented
  intentional propagation-stopping containers (file-tree actions in
  `components/ai-elements/file-tree.tsx`, apps page CTA group in
  `app/(main)/apps/page.tsx`) with an inline disable + rationale.

- **`jsx-a11y/no-autofocus`** — kept on the capability dialog's search
  input (`agents/capability-dialog.tsx`) since opening the dialog is a
  deliberate focus target. Disable + rationale inline; also added an
  `aria-label`.

- **`jsx-a11y/click-events-have-key-events`** /
  **`jsx-a11y/interactive-supports-focus`** — `combobox.tsx` option
  rows now carry `tabIndex={-1}` plus an Enter/Space `onKeyDown` that
  mirrors the existing click selection.

- **`react/no-did-update-set-state`** — documented disable on the two
  error boundaries (`a2ui-renderer.tsx`, `openui-renderer.tsx`) that
  reset `hasError` when `children` change. This is the standard React
  ErrorBoundary recovery pattern.

- **`@next/next/no-img-element`** — documented disable on the
  file-preview `<img>` in `files/file-previews.tsx` that renders from
  a `data:` URL of user-uploaded bytes; `next/image`'s loaders do not
  handle `data:` URLs.

## Risk
- Low. Pure a11y attribute additions and documented disables; no
  control flow, no styling, no behavior changes. `Switch`'s new props
  are optional and default to `undefined`.

## Security
- Threat categories reviewed: none directly applicable. Pure
  attribute / static-string additions to TSX; no new input parsing,
  network, auth, tenant, or filesystem surface.

## Follow-ups
- Consider promoting the addressed rules from `warn` to `error` in
  `apps/ui/oxlint.json` so regressions block CI. Deferred — wants
  team consensus on the documented disables first. Linear: EVE-487
  optional follow-on already calls this out.

## Checklist
- [x] Tests added or updated (no behavior change; existing
      `agent-detail-model.test.tsx` still passes)
- [x] Backward compatibility considered (additive `Switch` props,
      additive aria attributes)
- [x] Security review performed against relevant threat model
      categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

## Validation
- `cd apps/ui && pnpm run lint` — 0 warnings (was 25 on `origin/main`).
- `cd apps/ui && pnpm run format:check` — clean.
- `cd apps/ui && pnpm jest src/__tests__/agent-detail-model.test.tsx`
  — 16 passed.
- `bash scripts/lib/pre-push.sh` — all 9 gates pass (fmt, clippy,
  Cargo.lock, UI fmt, UI lint, migrations sequential / immutable,
  specs index, commit attribution).

Closes [EVE-487](https://linear.app/everruns/issue/EVE-487/clean-up-pre-existing-ui-lint-warnings-jsx-a11y-nextno-img-element).

---
_Generated by [Claude Code](https://claude.ai/code/session_01BjAAH5Gxw1gMhvga4hDqfv)_