### PR TITLE
chore(release): prepare v0.8.34

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,79 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- New changes go here. Use `/prepare-release X.Y.Z` to generate draft from commits. -->
 
+## [0.8.34] - 2026-05-24
+
+### Highlights
+
+- **Coding-cli supports OpenRouter and Ollama** - The embedded coding CLI now talks to OpenRouter and Ollama in addition to the existing providers, broadening local and BYO-model setups.
+- **Capability-provided slash commands in the embedded CLI** - Capabilities can register their own slash commands inside the embedded coding CLI ([#1903](https://github.com/everruns/everruns/pull/1903)).
+- **Fingerprint-based loop detection** - Runtime now detects repeating-output loops via fingerprints and breaks them automatically.
+- **Stale tool result masking for cost control** - Compaction masks stale tool results so long sessions stay within budget without losing recent context.
+- **GitHub Scout blueprint** - New built-in GitHub Scout blueprint plus a fallback to the parent session token when the scout runs ([#1951](https://github.com/everruns/everruns/pull/1951)).
+- **Hypermedia pagination links** - Paginated API responses now include `next_url` / `prev_url` for HATEOAS-style navigation ([#1889](https://github.com/everruns/everruns/pull/1889)).
+- **OpenAPI examples expansion** - Examples and field descriptions added across Create*/Update* schemas, Schedules, A2A channel, volume sources, Memory + Knowledge clusters, and file/git/durable/tool-results endpoints; field-example floor ratcheted from 15% to 21% ([#1904](https://github.com/everruns/everruns/pull/1904), [#1915](https://github.com/everruns/everruns/pull/1915), [#1923](https://github.com/everruns/everruns/pull/1923), [#1949](https://github.com/everruns/everruns/pull/1949), [#1952](https://github.com/everruns/everruns/pull/1952)).
+
+### What's Changed
+
+- feat(api): examples on file ops, git, durable, tool-results; floor 21% ([#1952](https://github.com/everruns/everruns/pull/1952)) by [@chaliy](https://github.com/chaliy)
+- chore(ui): adopt Turbopack and drop hoisted-linker custom ([#1950](https://github.com/everruns/everruns/pull/1950)) by [@chaliy](https://github.com/chaliy)
+- fix(github): fallback to parent session token for scout ([#1951](https://github.com/everruns/everruns/pull/1951)) by [@chaliy](https://github.com/chaliy)
+- fix(ui): clean up jsx-a11y and react lint warnings ([#1955](https://github.com/everruns/everruns/pull/1955)) by [@chaliy](https://github.com/chaliy)
+- fix(ci): restore docker build triggers for rust inputs ([#1933](https://github.com/everruns/everruns/pull/1933)) by [@chaliy](https://github.com/chaliy)
+- fix(runtime): preserve CAS semantics in approval-gated writes ([#1930](https://github.com/everruns/everruns/pull/1930)) by [@chaliy](https://github.com/chaliy)
+- fix(coding-cli): bound write_todos transcript rendering ([#1932](https://github.com/everruns/everruns/pull/1932)) by [@chaliy](https://github.com/chaliy)
+- fix(coding-cli): redact credentials in git remote context ([#1931](https://github.com/everruns/everruns/pull/1931)) by [@chaliy](https://github.com/chaliy)
+- fix(core): bound infinity candidate load with max cap ([#1929](https://github.com/everruns/everruns/pull/1929)) by [@chaliy](https://github.com/chaliy)
+- fix(core): tighten token-efficient tool outputs ([#1954](https://github.com/everruns/everruns/pull/1954)) by [@chaliy](https://github.com/chaliy)
+- feat(events): persist opaque assistant reasoning items ([#1948](https://github.com/everruns/everruns/pull/1948)) by [@chaliy](https://github.com/chaliy)
+- feat(api): examples on Memory + Knowledge clusters; floor 19% ([#1949](https://github.com/everruns/everruns/pull/1949)) by [@chaliy](https://github.com/chaliy)
+- feat(ercode): store session artifacts in folders by [@chaliy](https://github.com/chaliy)
+- fix(core): keep model view masking capability-owned ([#1945](https://github.com/everruns/everruns/pull/1945)) by [@chaliy](https://github.com/chaliy)
+- feat(coding-cli): support OpenRouter and Ollama by [@chaliy](https://github.com/chaliy)
+- feat(context): attribute session usage sources by [@chaliy](https://github.com/chaliy)
+- feat(core): bound prompt tool output by default ([#1943](https://github.com/everruns/everruns/pull/1943)) by [@chaliy](https://github.com/chaliy)
+- feat(core): add fingerprint loop detection by [@chaliy](https://github.com/chaliy)
+- fix(cli): group consecutive tool output rows by [@chaliy](https://github.com/chaliy)
+- fix(coding-cli): support multiline TUI input by [@chaliy](https://github.com/chaliy)
+- chore(ui,docs): adopt pnpm for UI dev across all environments ([#1927](https://github.com/everruns/everruns/pull/1927)) by [@chaliy](https://github.com/chaliy)
+- feat(compaction): mask stale tool results for cost control by [@chaliy](https://github.com/chaliy)
+- feat(core): add utility llm service by [@chaliy](https://github.com/chaliy)
+- feat(api): examples on Schedules, A2A channel, volume sources; floor 17% ([#1923](https://github.com/everruns/everruns/pull/1923)) by [@chaliy](https://github.com/chaliy)
+- fix(runtime): avoid lossy in-process org id folding ([#1924](https://github.com/everruns/everruns/pull/1924)) by [@chaliy](https://github.com/chaliy)
+- fix(agents): bound automatic snapshots by [@chaliy](https://github.com/chaliy)
+- feat(github): add github scout blueprint by [@chaliy](https://github.com/chaliy)
+- perf(prompts): trim remaining capability prompts by [@chaliy](https://github.com/chaliy)
+- docs(crates): prepare published packages ([#1919](https://github.com/everruns/everruns/pull/1919)) by [@chaliy](https://github.com/chaliy)
+- fix(agent-handoff): require explicit target harness for child session ([#1921](https://github.com/everruns/everruns/pull/1921)) by [@chaliy](https://github.com/chaliy)
+- perf(prompts): trim hot capability and harness prompts ([#1913](https://github.com/everruns/everruns/pull/1913)) by [@chaliy](https://github.com/chaliy)
+- feat(api): examples on Update* request schemas; status enums; floor 15% ([#1915](https://github.com/everruns/everruns/pull/1915)) by [@chaliy](https://github.com/chaliy)
+- docs(capabilities): order overview first by [@chaliy](https://github.com/chaliy)
+- feat(events): summarize completed turns ([#1918](https://github.com/everruns/everruns/pull/1918)) by [@chaliy](https://github.com/chaliy)
+- fix(events): persist llm generation events ([#1917](https://github.com/everruns/everruns/pull/1917)) by [@chaliy](https://github.com/chaliy)
+- feat(ercode): inject environment context by [@chaliy](https://github.com/chaliy)
+- chore(deps): bump distroless/cc-debian12 from `e2d29ae` to `bd2899c` in /crates/server ([#1900](https://github.com/everruns/everruns/pull/1900)) by [@dependabot](https://github.com/dependabot)
+- fix(cli): hide assistant thinking in session logs by [@chaliy](https://github.com/chaliy)
+- fix(runtime): derive in-process org id from session org ([#1890](https://github.com/everruns/everruns/pull/1890)) by [@chaliy](https://github.com/chaliy)
+- fix(core): trim infinity context by token budget by [@chaliy](https://github.com/chaliy)
+- ci: filter postgres integration tests by [@chaliy](https://github.com/chaliy)
+- feat(api): examples on high-traffic Create*/Update* schemas; field-example gate ([#1904](https://github.com/everruns/everruns/pull/1904)) by [@chaliy](https://github.com/chaliy)
+- feat(coding-cli): persist bash output by [@chaliy](https://github.com/chaliy)
+- fix(coding-cli): tighten todo rendering by [@chaliy](https://github.com/chaliy)
+- chore(deps): bump distroless/cc-debian12 from `e2d29ae` to `bd2899c` in /crates/worker ([#1901](https://github.com/everruns/everruns/pull/1901)) by [@dependabot](https://github.com/dependabot)
+- chore(deps): bump distroless/cc-debian12 from `e2d29ae` to `bd2899c` in /docker ([#1902](https://github.com/everruns/everruns/pull/1902)) by [@dependabot](https://github.com/dependabot)
+- refactor(examples): move coding CLI capabilities by [@chaliy](https://github.com/chaliy)
+- refactor(coding-cli): split runtime wiring result by [@chaliy](https://github.com/chaliy)
+- chore(docs): slim agent instructions by [@chaliy](https://github.com/chaliy)
+- feat(coding-cli): improve turn progress rendering by [@chaliy](https://github.com/chaliy)
+- feat(core,runtime,examples): capability-provided slash commands in the embedded CLI ([#1903](https://github.com/everruns/everruns/pull/1903)) by [@chaliy](https://github.com/chaliy)
+- test(api): count utoipa oneOf-nested descriptions; ratchet field floor to 85% ([#1898](https://github.com/everruns/everruns/pull/1898)) by [@chaliy](https://github.com/chaliy)
+- feat(coding-cli): show live turn progress by [@chaliy](https://github.com/chaliy)
+- feat(api): hypermedia next_url / prev_url on paginated responses ([#1889](https://github.com/everruns/everruns/pull/1889)) by [@chaliy](https://github.com/chaliy)
+- feat(examples): coding-cli — seed event collector on resume ([#1896](https://github.com/everruns/everruns/pull/1896)) by [@chaliy](https://github.com/chaliy)
+- ci: bump actions/checkout to v5 (Node 24) ([#1893](https://github.com/everruns/everruns/pull/1893)) by [@chaliy](https://github.com/chaliy)
+- feat(runtime): SingleSessionBuilder::session_id setter ([#1894](https://github.com/everruns/everruns/pull/1894)) by [@chaliy](https://github.com/chaliy)
+- ci(publish-crates): allow manual dispatch + retry on rate limit ([#1895](https://github.com/everruns/everruns/pull/1895)) by [@chaliy](https://github.com/chaliy)
+
 ## [0.8.33] - 2026-05-19
 
 ### What's Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "a2a-client-lf"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b4ed8c8e815c4ca1947f9dcab76dd0d0878ab429d8f37875ce398fb0165982"
+checksum = "1da8f6ca9f460fc47231a78165abec30e9ab60886a6c62c599b6055f7f5429cc"
 dependencies = [
  "a2a-lf",
  "a2a-pb",
@@ -17,6 +17,7 @@ dependencies = [
  "pin-project-lite",
  "reqwest 0.12.28",
  "rustls",
+ "rustls-pemfile",
  "semver",
  "serde",
  "serde_json",
@@ -24,6 +25,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "uuid 1.23.1",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -63,9 +65,9 @@ dependencies = [
 
 [[package]]
 name = "a2a-server-lf"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ce4366a92d8be42bbd6d1057179d74d7c79fc8697f79f4072b5fc55579fa47"
+checksum = "5027f0f4919b0fea22831bd75521974efdf4561658c3df768d9a84dbe8313062"
 dependencies = [
  "a2a-lf",
  "a2a-pb",
@@ -421,9 +423,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
@@ -786,9 +788,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "byte-slice-cast"
@@ -1149,9 +1151,9 @@ dependencies = [
 
 [[package]]
 name = "const-hex"
-version = "1.19.0"
+version = "1.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20d9a563d167a9cce0f94153382b33cb6eded6dfabff03c69ad65a28ea1514e0"
+checksum = "33e2a781ebdf4467d1428dc4593067825fb646f6871475098d8577421af73558"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
@@ -1761,9 +1763,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 dependencies = [
  "serde",
 ]
@@ -1988,11 +1990,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-a2ui"
-version = "0.8.33"
+version = "0.8.34"
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.8.33"
+version = "0.8.34"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2008,7 +2010,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-cli"
-version = "0.8.33"
+version = "0.8.34"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2061,14 +2063,14 @@ dependencies = [
 
 [[package]]
 name = "everruns-config"
-version = "0.8.33"
+version = "0.8.34"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "everruns-container-sandbox"
-version = "0.8.33"
+version = "0.8.34"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2088,7 +2090,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.8.33"
+version = "0.8.34"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -2140,7 +2142,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-durable"
-version = "0.8.33"
+version = "0.8.34"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2165,7 +2167,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-gemini"
-version = "0.8.33"
+version = "0.8.34"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2179,7 +2181,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-brave-search"
-version = "0.8.33"
+version = "0.8.34"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2195,7 +2197,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-browserless"
-version = "0.8.33"
+version = "0.8.34"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2216,7 +2218,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-cursor"
-version = "0.8.33"
+version = "0.8.34"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2231,7 +2233,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.8.33"
+version = "0.8.34"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2247,7 +2249,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-deno"
-version = "0.8.33"
+version = "0.8.34"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2270,7 +2272,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-docker"
-version = "0.8.33"
+version = "0.8.34"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2285,7 +2287,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.8.33"
+version = "0.8.34"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2300,7 +2302,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-e2b"
-version = "0.8.33"
+version = "0.8.34"
 dependencies = [
  "async-trait",
  "buffa",
@@ -2327,7 +2329,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-github"
-version = "0.8.33"
+version = "0.8.34"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2344,7 +2346,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-parallel"
-version = "0.8.33"
+version = "0.8.34"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2356,7 +2358,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-sprites"
-version = "0.8.33"
+version = "0.8.34"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2372,7 +2374,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-internal-protocol"
-version = "0.8.33"
+version = "0.8.34"
 dependencies = [
  "chrono",
  "everruns-core",
@@ -2389,7 +2391,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-llm-tests"
-version = "0.8.33"
+version = "0.8.34"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2408,7 +2410,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-macros"
-version = "0.8.33"
+version = "0.8.34"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -2416,7 +2418,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.8.33"
+version = "0.8.34"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2436,11 +2438,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-openui"
-version = "0.8.33"
+version = "0.8.34"
 
 [[package]]
 name = "everruns-runtime"
-version = "0.8.33"
+version = "0.8.34"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2477,7 +2479,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-server"
-version = "0.8.33"
+version = "0.8.34"
 dependencies = [
  "aes-gcm",
  "ag-ui-core",
@@ -2565,7 +2567,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-session-sqldb"
-version = "0.8.33"
+version = "0.8.34"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2582,7 +2584,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-worker"
-version = "0.8.33"
+version = "0.8.34"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2995,9 +2997,9 @@ checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-timer"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"
@@ -4052,9 +4054,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.98"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -4511,9 +4513,9 @@ dependencies = [
 
 [[package]]
 name = "minijinja"
-version = "2.19.0"
+version = "2.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "805bfd7352166bae857ee569628b52bcd85a1cecf7810861ebceb1686b72b75d"
+checksum = "2929e494b2280e1e18959bb2e121da03347ae896896fdfaceaab43c88a02803f"
 dependencies = [
  "memo-map",
  "serde",
@@ -5676,9 +5678,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
+checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
 dependencies = [
  "bitflags 2.11.1",
  "memchr",
@@ -6450,6 +6452,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6725,9 +6736,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -8495,9 +8506,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -8508,9 +8519,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.71"
+version = "0.4.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -8518,9 +8529,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -8528,9 +8539,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -8541,9 +8552,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
@@ -8610,9 +8621,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.98"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.8.33"
+version = "0.8.34"
 edition = "2024"
 license = "MIT"
 authors = ["Everruns Contributors"]
@@ -132,7 +132,7 @@ futures-util = "0.3"
 
 # Everruns SDK
 everruns-sdk = "0.1.9"
-everruns-core = { path = "crates/core", version = "0.8.33" }
+everruns-core = { path = "crates/core", version = "0.8.34" }
 
 # A2A protocol
 a2a = { package = "a2a-lf", version = "0.3" }

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "everruns-ui",
-  "version": "0.8.33",
+  "version": "0.8.34",
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "exports": {

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -19,7 +19,7 @@ readme = "README.md"
 
 [dependencies]
 # Core dependencies
-everruns-config = { path = "../config", version = "0.8.33" }
+everruns-config = { path = "../config", version = "0.8.34" }
 anyhow.workspace = true
 thiserror.workspace = true
 async-trait.workspace = true
@@ -101,10 +101,10 @@ inventory.workspace = true
 llmsim = "0.3.0"
 
 # OpenUI component definitions and prompt generator
-everruns-openui = { path = "../openui", version = "0.8.33", optional = true }
+everruns-openui = { path = "../openui", version = "0.8.34", optional = true }
 
 # A2UI component catalog and prompt generator
-everruns-a2ui = { path = "../a2ui", version = "0.8.33", optional = true }
+everruns-a2ui = { path = "../a2ui", version = "0.8.34", optional = true }
 
 # A2A outbound agent delegation
 a2a.workspace = true


### PR DESCRIPTION
## Release v0.8.34

This PR prepares the v0.8.34 release.

### Checklist
- [ ] Review CHANGELOG.md entries
- [ ] Add highlights/screenshots if needed
- [ ] Verify version numbers updated
- [ ] CI passes

### Post-merge
After merging, the release workflow will automatically:
- Create git tag `v0.8.34`
- Create GitHub Release with notes from CHANGELOG.md
- Trigger Docker image build with version tag
- Publish CLI binaries and Homebrew formula
- Publish crates to crates.io


---
_Generated by [Claude Code](https://claude.ai/code/session_01WVG4yjvWxyTxYF9bGWLcFd)_