### PR TITLE
feat(api): examples on payments, reports, voice, misc; floor 24%

### DIFF
--- a/crates/core/src/agent.rs
+++ b/crates/core/src/agent.rs
@@ -40,8 +40,10 @@ pub enum AgentStatus {
 }
 
 /// Reason a version was created. Stored as lower_snake_case text.
+/// One of `auto`, `manual`, `patch`, `minor`, `major`, `import`, `rollback`, `fork`.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
+#[cfg_attr(feature = "openapi", schema(example = "manual"))]
 #[serde(rename_all = "snake_case")]
 pub enum AgentVersionChangeKind {
     Auto,

--- a/crates/core/src/events.rs
+++ b/crates/core/src/events.rs
@@ -2010,10 +2010,23 @@ pub struct BudgetEventData {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct VoiceSessionStartedData {
+    /// Prefixed voice connection identifier for the started session.
+    #[cfg_attr(
+        feature = "openapi",
+        schema(example = "voice_01933b5a00007000800000000000001")
+    )]
     pub voice_connection_id: String,
+    /// Provider-side realtime model identifier negotiated for this session.
+    #[cfg_attr(feature = "openapi", schema(example = "gpt-realtime"))]
     pub model: String,
+    /// Realtime voice preset selected for this session.
+    #[cfg_attr(feature = "openapi", schema(example = "alloy"))]
     pub voice: String,
+    /// Reasoning effort applied to the realtime model. One of `low`, `medium`, `high`.
+    #[cfg_attr(feature = "openapi", schema(example = "medium"))]
     pub reasoning_effort: String,
+    /// Transport carrying the audio stream. One of `webrtc`, `sip`, `websocket`.
+    #[cfg_attr(feature = "openapi", schema(example = "webrtc"))]
     pub transport: String,
 }
 
@@ -2043,10 +2056,20 @@ pub struct VoiceTranscriptData {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct VoiceSessionEndedData {
+    /// Prefixed voice connection identifier for the ended session.
+    #[cfg_attr(
+        feature = "openapi",
+        schema(example = "voice_01933b5a00007000800000000000001")
+    )]
     pub voice_connection_id: String,
+    /// Free-text end reason captured from the client or server. `None` when no reason was supplied.
+    /// Example: `User hung up after refund confirmed.`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reason: Option<String>,
+    /// Total wall-clock duration of the connection in milliseconds. `None` when the connection
+    /// never completed an audio handshake.
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "openapi", schema(example = 184_500_u64))]
     pub duration_ms: Option<u64>,
 }
 
@@ -2054,7 +2077,17 @@ pub struct VoiceSessionEndedData {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct VoiceSessionFailedData {
+    /// Prefixed voice connection identifier for the failed session.
+    #[cfg_attr(
+        feature = "openapi",
+        schema(example = "voice_01933b5a00007000800000000000001")
+    )]
     pub voice_connection_id: String,
+    /// Error message captured at failure. Provider-formatted; not stable for parsing.
+    #[cfg_attr(
+        feature = "openapi",
+        schema(example = "realtime provider closed stream: 1011 internal_error")
+    )]
     pub error: String,
 }
 

--- a/crates/core/src/events.rs
+++ b/crates/core/src/events.rs
@@ -2063,8 +2063,11 @@ pub struct VoiceSessionEndedData {
     )]
     pub voice_connection_id: String,
     /// Free-text end reason captured from the client or server. `None` when no reason was supplied.
-    /// Example: `User hung up after refund confirmed.`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(
+        feature = "openapi",
+        schema(example = "User hung up after refund confirmed.")
+    )]
     pub reason: Option<String>,
     /// Total wall-clock duration of the connection in milliseconds. `None` when the connection
     /// never completed an audio handshake.

--- a/crates/core/src/reporting.rs
+++ b/crates/core/src/reporting.rs
@@ -20,7 +20,11 @@ pub struct ReportScope {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ReportTimeRange {
+    /// Start of the window (RFC 3339, inclusive).
+    #[cfg_attr(feature = "openapi", schema(example = "2026-04-24T00:00:00Z"))]
     pub from: DateTime<Utc>,
+    /// End of the window (RFC 3339, exclusive).
+    #[cfg_attr(feature = "openapi", schema(example = "2026-05-24T00:00:00Z"))]
     pub to: DateTime<Utc>,
 }
 
@@ -55,8 +59,12 @@ fn default_report_limit() -> u32 {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ReportFilter {
+    /// Field to filter on. Must be a filter field exposed by the dataset (see `filter_fields` in the catalog).
+    #[cfg_attr(feature = "openapi", schema(example = "status"))]
     pub field: String,
     pub op: ReportFilterOp,
+    /// Comparison value. Type depends on `op`: a scalar for `eq`/`neq`/`gt`/`gte`/`lt`/`lte`,
+    /// an array for `in`. Example for `op = in`: `["completed", "failed"]`.
     pub value: Value,
 }
 
@@ -76,10 +84,15 @@ pub enum ReportFilterOp {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ReportOrderBy {
+    /// Dimension name to sort by. Mutually exclusive with `measure`.
     #[serde(default)]
+    #[cfg_attr(feature = "openapi", schema(example = "org_id"))]
     pub dimension: Option<String>,
+    /// Measure name to sort by. Mutually exclusive with `dimension`.
     #[serde(default)]
+    #[cfg_attr(feature = "openapi", schema(example = "session_count"))]
     pub measure: Option<String>,
+    /// Sort direction (`asc` or `desc`). Defaults to `asc`.
     #[serde(default = "default_order_direction")]
     pub direction: ReportOrderDirection,
 }
@@ -109,6 +122,8 @@ pub struct ReportResult {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ReportColumn {
+    /// Column name as it appears in `rows`.
+    #[cfg_attr(feature = "openapi", schema(example = "session_count"))]
     pub name: String,
     pub kind: ReportColumnKind,
 }

--- a/crates/server/src/api/session_databases.rs
+++ b/crates/server/src/api/session_databases.rs
@@ -29,7 +29,8 @@ use super::common::{ListResponse, impl_auth_state};
 /// Request body for creating a database.
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct CreateDatabaseRequest {
-    /// Database name (alphanumeric + underscores, max 64 chars)
+    /// Database name (alphanumeric + underscores, max 64 chars).
+    #[schema(example = "refund_history")]
     pub name: String,
 }
 

--- a/crates/server/src/api/session_storage.rs
+++ b/crates/server/src/api/session_storage.rs
@@ -50,7 +50,9 @@ pub struct SecretInfo {
 /// Batch secret set request
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct BatchSetSecretsRequest {
-    /// Map of secret names to values
+    /// Map of secret names to values. Names are case-sensitive; values are stored encrypted
+    /// and never returned by list/read endpoints. Existing keys are overwritten.
+    /// Example: `{"OPENAI_API_KEY": "sk-...", "GITHUB_TOKEN": "ghp_..."}`.
     pub secrets: HashMap<String, String>,
 }
 

--- a/crates/server/src/api/skills.rs
+++ b/crates/server/src/api/skills.rs
@@ -43,7 +43,10 @@ const MAX_ARCHIVE_UPLOAD: usize = 11 * 1024 * 1024;
 /// Request to validate a SKILL.md
 #[derive(Debug, Clone, Deserialize, ToSchema)]
 pub struct ValidateSkillRequest {
-    /// SKILL.md content to validate
+    /// Full SKILL.md content to validate, including the YAML frontmatter and the markdown body.
+    #[schema(
+        example = "---\nname: refund-policy\ndescription: Issue refunds inside the policy window.\n---\n\nUse this when a customer asks for a refund within 30 days of purchase."
+    )]
     pub skill_md: String,
 }
 

--- a/crates/server/src/api/voice.rs
+++ b/crates/server/src/api/voice.rs
@@ -147,21 +147,21 @@ pub fn routes(state: AppState) -> Router {
 #[derive(Debug, Clone, Deserialize, ToSchema)]
 pub struct VoiceSessionOptions {
     /// Provider-side realtime model identifier. When omitted the server picks the agent's configured default.
-    /// Example: `gpt-realtime`.
     #[serde(default)]
+    #[schema(example = "gpt-realtime")]
     pub model: Option<String>,
     /// Realtime voice preset (provider-specific). When omitted the server picks the agent's configured default.
-    /// Example: `alloy`.
     #[serde(default)]
+    #[schema(example = "alloy")]
     pub voice: Option<String>,
     /// Reasoning effort hint passed through to the realtime model. One of `low`, `medium`, `high`.
     /// When omitted the server picks the provider's default.
-    /// Example: `medium`.
     #[serde(default)]
+    #[schema(example = "medium")]
     pub reasoning_effort: Option<String>,
     /// Extra system instructions appended to the realtime session prompt.
-    /// Example: `Always confirm before placing an order.`.
     #[serde(default)]
+    #[schema(example = "Always confirm before placing an order.")]
     pub instructions: Option<String>,
 }
 
@@ -192,8 +192,8 @@ pub struct VoiceAttachRequest {
 #[derive(Debug, Clone, Deserialize, ToSchema)]
 pub struct VoiceEndRequest {
     /// Free-text reason recorded with the session-ended event. Useful for operator forensics.
-    /// Example: `User hung up after refund confirmed.`.
     #[serde(default)]
+    #[schema(example = "User hung up after refund confirmed.")]
     pub reason: Option<String>,
 }
 

--- a/crates/server/src/api/voice.rs
+++ b/crates/server/src/api/voice.rs
@@ -146,12 +146,21 @@ pub fn routes(state: AppState) -> Router {
 
 #[derive(Debug, Clone, Deserialize, ToSchema)]
 pub struct VoiceSessionOptions {
+    /// Provider-side realtime model identifier. When omitted the server picks the agent's configured default.
+    /// Example: `gpt-realtime`.
     #[serde(default)]
     pub model: Option<String>,
+    /// Realtime voice preset (provider-specific). When omitted the server picks the agent's configured default.
+    /// Example: `alloy`.
     #[serde(default)]
     pub voice: Option<String>,
+    /// Reasoning effort hint passed through to the realtime model. One of `low`, `medium`, `high`.
+    /// When omitted the server picks the provider's default.
+    /// Example: `medium`.
     #[serde(default)]
     pub reasoning_effort: Option<String>,
+    /// Extra system instructions appended to the realtime session prompt.
+    /// Example: `Always confirm before placing an order.`.
     #[serde(default)]
     pub instructions: Option<String>,
 }
@@ -182,6 +191,8 @@ pub struct VoiceAttachRequest {
 /// Request body for voice end.
 #[derive(Debug, Clone, Deserialize, ToSchema)]
 pub struct VoiceEndRequest {
+    /// Free-text reason recorded with the session-ended event. Useful for operator forensics.
+    /// Example: `User hung up after refund confirmed.`.
     #[serde(default)]
     pub reason: Option<String>,
 }

--- a/crates/server/src/domains/agents/types.rs
+++ b/crates/server/src/domains/agents/types.rs
@@ -145,8 +145,12 @@ pub struct UpdateAgentRequest {
 /// Request body for the `create_agent_version` operation.
 #[derive(Debug, Clone, Deserialize, ToSchema)]
 pub struct CreateAgentVersionRequest {
+    /// Free-text summary of what changed in this version. Shown in the version timeline.
     #[serde(default)]
+    #[schema(example = "Tightened the refund-window check and added a regression test.")]
     pub summary: Option<String>,
+    /// Reason this version was created. See `AgentVersionChangeKind` for the allowed values.
+    /// Defaults to `manual` when omitted.
     #[serde(default)]
     pub change_kind: Option<everruns_core::AgentVersionChangeKind>,
 }
@@ -154,9 +158,14 @@ pub struct CreateAgentVersionRequest {
 /// Request body for the `rollback_agent_version` operation.
 #[derive(Debug, Clone, Deserialize, ToSchema)]
 pub struct RollbackAgentVersionRequest {
+    /// When true, snapshot the current agent state as a new version before rolling back.
+    /// Use this to preserve the in-flight work alongside the recovery point.
     #[serde(default)]
+    #[schema(example = true)]
     pub save_version: bool,
+    /// Free-text summary attached to the rollback. Shown in the version timeline.
     #[serde(default)]
+    #[schema(example = "Reverting refund-window change — false positives in production.")]
     pub summary: Option<String>,
 }
 

--- a/crates/server/src/domains/harnesses/types.rs
+++ b/crates/server/src/domains/harnesses/types.rs
@@ -115,13 +115,21 @@ pub struct UpdateHarnessRequest {
 /// Request to preview harness shape with capabilities applied
 #[derive(Debug, Clone, Deserialize, ToSchema)]
 pub struct PreviewHarnessRequest {
+    /// System prompt to render as the base prompt for the preview.
     #[schema(example = "You are a research assistant.")]
     pub system_prompt: String,
+    /// Parent harness to extend. When set, its prompt, capabilities, and MCP servers are
+    /// merged with the fields in this request before rendering.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schema(value_type = Option<String>, example = "harness_01933b5a000070008000000000000602")]
     pub parent_harness_id: Option<HarnessId>,
+    /// Capability configurations to layer onto the preview. Empty list means none.
+    /// Example: `[{"id": "web.search", "enabled": true}]`.
     #[serde(default)]
     pub capabilities: Vec<AgentCapabilityConfig>,
+    /// MCP servers scoped to this preview. Use the camelCase key `mcpServers` (preferred) or
+    /// the snake_case alias `mcp_servers`. Empty by default.
+    /// Example: `{"shared": [{"name": "filesystem", "transport": "stdio", "command": "mcp-fs"}]}`.
     #[serde(default, rename = "mcpServers", alias = "mcp_servers")]
     pub mcp_servers: ScopedMcpServers,
 }

--- a/crates/server/src/domains/harnesses/types.rs
+++ b/crates/server/src/domains/harnesses/types.rs
@@ -124,13 +124,13 @@ pub struct PreviewHarnessRequest {
     #[schema(value_type = Option<String>, example = "harness_01933b5a000070008000000000000602")]
     pub parent_harness_id: Option<HarnessId>,
     /// Capability configurations to layer onto the preview. Empty list means none.
-    /// Example: `[{"id": "web.search", "enabled": true}]`.
     #[serde(default)]
+    #[schema(example = json!([{"ref": "web.search", "config": {}}, {"ref": "filesystem.read", "config": {"root": "/workspace"}}]))]
     pub capabilities: Vec<AgentCapabilityConfig>,
-    /// MCP servers scoped to this preview. Use the camelCase key `mcpServers` (preferred) or
-    /// the snake_case alias `mcp_servers`. Empty by default.
-    /// Example: `{"shared": [{"name": "filesystem", "transport": "stdio", "command": "mcp-fs"}]}`.
+    /// MCP servers scoped to this preview, keyed by scope (`shared` / per-agent / etc.).
+    /// Use the camelCase key `mcpServers` (preferred) or the snake_case alias `mcp_servers`. Empty by default.
     #[serde(default, rename = "mcpServers", alias = "mcp_servers")]
+    #[schema(example = json!({"shared": {"name": "filesystem", "transport": "stdio", "command": "mcp-fs", "args": ["--root", "/workspace"]}}))]
     pub mcp_servers: ScopedMcpServers,
 }
 

--- a/crates/server/src/domains/payments/types.rs
+++ b/crates/server/src/domains/payments/types.rs
@@ -5,10 +5,13 @@ use utoipa::{IntoParams, ToSchema};
 #[derive(Debug, Clone, Deserialize, ToSchema)]
 pub struct CreatePaymentAccountRequest {
     /// Principal class that owns the account. One of: `user`, `agent_identity`, `organization`.
+    /// The prefix on `owner_id` must match this: `user` → `user_…`, `agent_identity` → `identity_…`,
+    /// `organization` → `org_…`.
     #[schema(example = "agent_identity")]
     pub owner_type: String,
-    /// Prefixed identifier of the owning principal (e.g. `user_…`, `agent_…`, `org_…`).
-    #[schema(example = "agent_01933b5a00007000800000000000001")]
+    /// Prefixed identifier of the owning principal. Must use the prefix that matches `owner_type`
+    /// (see above). Example below pairs with `owner_type = "agent_identity"`.
+    #[schema(example = "identity_01933b5a00007000800000000000001")]
     pub owner_id: String,
     /// Settlement rail this account operates on. One of: `mpp_tempo`, `x402_base`.
     #[schema(example = "x402_base")]
@@ -21,8 +24,9 @@ pub struct CreatePaymentAccountRequest {
     #[schema(example = "0x742d35Cc6634C0532925a3b844Bc454e4438f44e")]
     pub public_address: Option<String>,
     /// Private key material for the rail. Stored encrypted; never returned in responses.
+    /// Example shown as an obvious placeholder — supply a real 32-byte hex value at create time.
     #[serde(default)]
-    #[schema(example = "0x4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318")]
+    #[schema(example = "0x<your-32-byte-hex-private-key>")]
     pub private_key: Option<String>,
     /// Free-form metadata attached to this account (caller-defined; opaque to the platform).
     /// Example: `{"team": "support", "cost_center": "ops"}`.
@@ -39,7 +43,8 @@ pub struct UpdatePaymentAccountRequest {
     /// New public address. The outer `Option` indicates whether to update; the inner allows clearing the field.
     pub public_address: Option<Option<String>>,
     /// New private key material. Set to `Some(...)` to rotate; omit to leave unchanged.
-    #[schema(example = "0x4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318")]
+    /// Example shown as an obvious placeholder — supply a real 32-byte hex value when rotating.
+    #[schema(example = "0x<your-32-byte-hex-private-key>")]
     pub private_key: Option<String>,
     /// New lifecycle status. Valid values: `active`, `disabled`.
     #[schema(example = "disabled")]
@@ -60,14 +65,18 @@ pub struct ListPaymentAccountsQuery {
 /// Request body for the `create_payment_policy` operation.
 #[derive(Debug, Clone, Deserialize, ToSchema)]
 pub struct CreatePaymentPolicyRequest {
-    /// Payment account this policy authorizes spending from.
-    #[schema(example = "pay_account_01933b5a00007000800000000000001")]
+    /// Payment account this policy authorizes spending from. Accepts a prefixed `payacct_…`
+    /// identifier or a bare UUID.
+    #[schema(example = "payacct_01933b5a00007000800000000000001")]
     pub payment_account_id: String,
     /// Class of subject this policy binds to. One of: `user`, `agent_identity`, `agent`, `app`, `session`, `org`.
+    /// The prefix on `subject_id` must match: `user`→`user_…`, `agent_identity`→`identity_…`,
+    /// `agent`→`agent_…`, `app`→`app_…`, `session`→`session_…`, `org`→`org_…`.
     #[schema(example = "agent_identity")]
     pub subject_type: String,
-    /// Prefixed identifier of the bound subject.
-    #[schema(example = "agent_01933b5a00007000800000000000001")]
+    /// Prefixed identifier of the bound subject. Must use the prefix matching `subject_type`
+    /// (see above). Example below pairs with `subject_type = "agent_identity"`.
+    #[schema(example = "identity_01933b5a00007000800000000000001")]
     pub subject_id: String,
     /// Capability IDs this policy permits paid calls for. Empty list means no capability gating.
     #[serde(default)]

--- a/crates/server/src/domains/payments/types.rs
+++ b/crates/server/src/domains/payments/types.rs
@@ -4,21 +4,28 @@ use utoipa::{IntoParams, ToSchema};
 /// Request body for the `create_payment_account` operation.
 #[derive(Debug, Clone, Deserialize, ToSchema)]
 pub struct CreatePaymentAccountRequest {
-    /// Principal class that owns the account (user, agent identity, or organization).
+    /// Principal class that owns the account. One of: `user`, `agent_identity`, `organization`.
+    #[schema(example = "agent_identity")]
     pub owner_type: String,
     /// Prefixed identifier of the owning principal (e.g. `user_…`, `agent_…`, `org_…`).
+    #[schema(example = "agent_01933b5a00007000800000000000001")]
     pub owner_id: String,
-    /// Settlement rail this account operates on (e.g. `mpp_tempo`, `x402_base`).
+    /// Settlement rail this account operates on. One of: `mpp_tempo`, `x402_base`.
+    #[schema(example = "x402_base")]
     pub rail: String,
     /// Human-readable label. Safe to render in user-facing messages.
+    #[schema(example = "Refund agent · USDC on Base")]
     pub label: String,
     /// Public address on the rail (chain address, account number, etc.). Optional; can be filled in later.
     #[serde(default)]
+    #[schema(example = "0x742d35Cc6634C0532925a3b844Bc454e4438f44e")]
     pub public_address: Option<String>,
     /// Private key material for the rail. Stored encrypted; never returned in responses.
     #[serde(default)]
+    #[schema(example = "0x4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318")]
     pub private_key: Option<String>,
     /// Free-form metadata attached to this account (caller-defined; opaque to the platform).
+    /// Example: `{"team": "support", "cost_center": "ops"}`.
     #[serde(default)]
     pub metadata: Option<serde_json::Value>,
 }
@@ -27,14 +34,18 @@ pub struct CreatePaymentAccountRequest {
 #[derive(Debug, Clone, Deserialize, ToSchema)]
 pub struct UpdatePaymentAccountRequest {
     /// New label, if changing.
+    #[schema(example = "Refund agent · USDC on Base (prod)")]
     pub label: Option<String>,
     /// New public address. The outer `Option` indicates whether to update; the inner allows clearing the field.
     pub public_address: Option<Option<String>>,
     /// New private key material. Set to `Some(...)` to rotate; omit to leave unchanged.
+    #[schema(example = "0x4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318")]
     pub private_key: Option<String>,
     /// New lifecycle status. Valid values: `active`, `disabled`.
+    #[schema(example = "disabled")]
     pub status: Option<String>,
     /// New free-form metadata. Replaces the existing metadata blob entirely when set.
+    /// Example: `{"team": "support", "cost_center": "ops-2026"}`.
     pub metadata: Option<serde_json::Value>,
 }
 
@@ -50,29 +61,40 @@ pub struct ListPaymentAccountsQuery {
 #[derive(Debug, Clone, Deserialize, ToSchema)]
 pub struct CreatePaymentPolicyRequest {
     /// Payment account this policy authorizes spending from.
+    #[schema(example = "pay_account_01933b5a00007000800000000000001")]
     pub payment_account_id: String,
-    /// Class of subject this policy binds to (e.g. `agent_identity`, `session`).
+    /// Class of subject this policy binds to. One of: `user`, `agent_identity`, `agent`, `app`, `session`, `org`.
+    #[schema(example = "agent_identity")]
     pub subject_type: String,
     /// Prefixed identifier of the bound subject.
+    #[schema(example = "agent_01933b5a00007000800000000000001")]
     pub subject_id: String,
     /// Capability IDs this policy permits paid calls for. Empty list means no capability gating.
     #[serde(default)]
+    #[schema(example = json!(["weather.lookup", "shipping.quote"]))]
     pub allowed_capabilities: Vec<String>,
     /// HTTP host allowlist for paid outbound calls. Empty list means no host gating.
     #[serde(default)]
+    #[schema(example = json!(["api.shippo.com", "api.openweathermap.org"]))]
     pub allowed_hosts: Vec<String>,
     /// Preferred settlement rails in priority order; the authority picks the first available.
     #[serde(default)]
+    #[schema(example = json!(["x402_base", "mpp_tempo"]))]
     pub rail_preference: Vec<String>,
     /// Maximum amount (USD) any single paid request may settle for. **Enforced** by the payment authority at policy selection. `None` means no per-request cap.
+    #[schema(example = 5.0)]
     pub max_amount_usd_per_request: Option<f64>,
     /// Maximum cumulative amount (USD) per agent turn. **Advisory only — not yet enforced.** Stored for forward compatibility; the authority currently checks only `max_amount_usd_per_request`. `None` means no per-turn cap.
+    #[schema(example = 20.0)]
     pub max_amount_usd_per_turn: Option<f64>,
     /// Maximum cumulative amount (USD) per UTC day. **Advisory only — not yet enforced.** Stored for forward compatibility; the authority currently checks only `max_amount_usd_per_request`. `None` means no per-day cap.
+    #[schema(example = 100.0)]
     pub max_amount_usd_per_day: Option<f64>,
     /// Threshold (USD) above which a request would require explicit human approval. **Advisory only — not yet enforced.** Stored for forward compatibility; no approval gate is wired up yet. `None` disables the (future) gate.
+    #[schema(example = 10.0)]
     pub require_approval_above_usd: Option<f64>,
     /// Free-form metadata attached to this policy.
+    /// Example: `{"owner_team": "ops", "ticket": "OPS-1248"}`.
     #[serde(default)]
     pub metadata: Option<serde_json::Value>,
 }
@@ -81,10 +103,13 @@ pub struct CreatePaymentPolicyRequest {
 #[derive(Debug, Clone, Deserialize, ToSchema)]
 pub struct UpdatePaymentPolicyRequest {
     /// New capability allowlist. Outer `None` leaves the field unchanged.
+    #[schema(example = json!(["weather.lookup", "shipping.quote", "currency.convert"]))]
     pub allowed_capabilities: Option<Vec<String>>,
     /// New host allowlist. Outer `None` leaves the field unchanged.
+    #[schema(example = json!(["api.shippo.com", "api.openweathermap.org", "api.exchangerate.host"]))]
     pub allowed_hosts: Option<Vec<String>>,
     /// New rail preference order. Outer `None` leaves the field unchanged.
+    #[schema(example = json!(["mpp_tempo", "x402_base"]))]
     pub rail_preference: Option<Vec<String>>,
     /// New per-request cap (USD). **Enforced** by the payment authority. Outer `None` leaves the field unchanged; inner `None` clears the cap.
     pub max_amount_usd_per_request: Option<Option<f64>>,
@@ -95,8 +120,10 @@ pub struct UpdatePaymentPolicyRequest {
     /// New approval threshold (USD). **Advisory only — not yet enforced.** Outer `None` leaves the field unchanged; inner `None` disables the (future) gate.
     pub require_approval_above_usd: Option<Option<f64>>,
     /// New lifecycle status. Valid values: `active`, `disabled`.
+    #[schema(example = "disabled")]
     pub status: Option<String>,
     /// New free-form metadata. Replaces the existing metadata blob entirely when set.
+    /// Example: `{"owner_team": "ops", "ticket": "OPS-1248", "review_due": "2026-09-01"}`.
     pub metadata: Option<serde_json::Value>,
 }
 

--- a/crates/server/src/domains/reporting/types.rs
+++ b/crates/server/src/domains/reporting/types.rs
@@ -45,9 +45,13 @@ pub struct SavedReportDashboardMetadata {
 #[derive(Debug, Clone, Deserialize, ToSchema)]
 pub struct CreateSavedReportRequest {
     /// Human-readable name. Safe to render in user-facing messages.
+    #[schema(example = "Weekly active agents — last 30 days")]
     pub name: String,
-    #[serde(default)]
     /// Human-readable description. Safe to render in user-facing messages.
+    #[serde(default)]
+    #[schema(
+        example = "Rolling 30-day count of agents with at least one session per day, grouped by org."
+    )]
     pub description: Option<String>,
     pub query: ReportQuery,
     #[serde(default)]
@@ -57,12 +61,13 @@ pub struct CreateSavedReportRequest {
 /// Request body for the `update_saved_report` operation.
 #[derive(Debug, Clone, Deserialize, ToSchema)]
 pub struct UpdateSavedReportRequest {
-    #[serde(default)]
     /// Human-readable name. Safe to render in user-facing messages.
+    #[serde(default)]
+    #[schema(example = "Weekly active agents — last 60 days")]
     pub name: Option<String>,
-    #[serde(default, deserialize_with = "deserialize_nullable_update_field")]
-    #[schema(value_type = Option<String>, nullable = true)]
     /// Human-readable description. Safe to render in user-facing messages.
+    #[serde(default, deserialize_with = "deserialize_nullable_update_field")]
+    #[schema(value_type = Option<String>, nullable = true, example = "Rolling 60-day window; widened from 30d after the Q3 product launch.")]
     pub description: UpdateField<String>,
     #[serde(default, deserialize_with = "deserialize_nullable_update_field")]
     #[schema(value_type = ReportQuery, nullable = false)]
@@ -83,6 +88,7 @@ pub enum ReportExportFormat {
 #[derive(Debug, Clone, Deserialize, ToSchema)]
 pub struct ExportReportQueryRequest {
     pub query: ReportQuery,
+    /// Export format. Defaults to `csv` when omitted.
     #[serde(default = "default_export_format")]
     pub format: ReportExportFormat,
 }
@@ -90,6 +96,7 @@ pub struct ExportReportQueryRequest {
 /// Request body for the `export_saved_report` operation.
 #[derive(Debug, Clone, Deserialize, ToSchema)]
 pub struct ExportSavedReportRequest {
+    /// Export format. Defaults to `csv` when omitted.
     #[serde(default = "default_export_format")]
     pub format: ReportExportFormat,
 }
@@ -179,7 +186,9 @@ pub struct ProjectorRunResult {
 
 #[derive(Debug, Clone, Deserialize, ToSchema)]
 pub struct ReportingBackfillRequest {
+    /// Maximum number of outbox rows to enqueue across all source types. Defaults to 1000.
     #[serde(default = "default_backfill_limit")]
+    #[schema(example = 5000)]
     pub limit: i64,
 }
 

--- a/crates/server/tests/openapi_descriptions_test.rs
+++ b/crates/server/tests/openapi_descriptions_test.rs
@@ -22,7 +22,7 @@ const MIN_FIELD_DESC_PCT: u32 = 85;
 /// LLM to populate when it has seen one concrete instance. The floor starts
 /// low because the codebase only recently began adding `#[schema(example = …)]`
 /// — bump it as new annotations land, same rules as the description floors.
-const MIN_FIELD_EXAMPLE_PCT: u32 = 21;
+const MIN_FIELD_EXAMPLE_PCT: u32 = 24;
 
 fn spec_value() -> serde_json::Value {
     serde_json::from_str(&ApiDoc::openapi().to_pretty_json().unwrap())

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -11780,7 +11780,7 @@
       },
       "AgentVersionChangeKind": {
         "type": "string",
-        "description": "Reason a version was created. Stored as lower_snake_case text.",
+        "description": "Reason a version was created. Stored as lower_snake_case text.\nOne of `auto`, `manual`, `patch`, `minor`, `major`, `import`, `rollback`, `fork`.",
         "enum": [
           "auto",
           "manual",
@@ -11790,7 +11790,8 @@
           "import",
           "rollback",
           "fork"
-        ]
+        ],
+        "example": "manual"
       },
       "AgentVersionDiffResponse": {
         "type": "object",
@@ -12459,7 +12460,7 @@
         "properties": {
           "secrets": {
             "type": "object",
-            "description": "Map of secret names to values",
+            "description": "Map of secret names to values. Names are case-sensitive; values are stored encrypted\nand never returned by list/read endpoints. Existing keys are overwritten.\nExample: `{\"OPENAI_API_KEY\": \"sk-...\", \"GITHUB_TOKEN\": \"ghp_...\"}`.",
             "additionalProperties": {
               "type": "string"
             },
@@ -13562,7 +13563,8 @@
                 "type": "null"
               },
               {
-                "$ref": "#/components/schemas/AgentVersionChangeKind"
+                "$ref": "#/components/schemas/AgentVersionChangeKind",
+                "description": "Reason this version was created. See `AgentVersionChangeKind` for the allowed values.\nDefaults to `manual` when omitted."
               }
             ]
           },
@@ -13570,7 +13572,9 @@
             "type": [
               "string",
               "null"
-            ]
+            ],
+            "description": "Free-text summary of what changed in this version. Shown in the version timeline.",
+            "example": "Tightened the refund-window check and added a regression test."
           }
         }
       },
@@ -13676,7 +13680,8 @@
         "properties": {
           "name": {
             "type": "string",
-            "description": "Database name (alphanumeric + underscores, max 64 chars)"
+            "description": "Database name (alphanumeric + underscores, max 64 chars).",
+            "example": "refund_history"
           }
         }
       },
@@ -14149,36 +14154,42 @@
         "properties": {
           "label": {
             "type": "string",
-            "description": "Human-readable label. Safe to render in user-facing messages."
+            "description": "Human-readable label. Safe to render in user-facing messages.",
+            "example": "Refund agent · USDC on Base"
           },
           "metadata": {
-            "description": "Free-form metadata attached to this account (caller-defined; opaque to the platform)."
+            "description": "Free-form metadata attached to this account (caller-defined; opaque to the platform).\nExample: `{\"team\": \"support\", \"cost_center\": \"ops\"}`."
           },
           "owner_id": {
             "type": "string",
-            "description": "Prefixed identifier of the owning principal (e.g. `user_…`, `agent_…`, `org_…`)."
+            "description": "Prefixed identifier of the owning principal (e.g. `user_…`, `agent_…`, `org_…`).",
+            "example": "agent_01933b5a00007000800000000000001"
           },
           "owner_type": {
             "type": "string",
-            "description": "Principal class that owns the account (user, agent identity, or organization)."
+            "description": "Principal class that owns the account. One of: `user`, `agent_identity`, `organization`.",
+            "example": "agent_identity"
           },
           "private_key": {
             "type": [
               "string",
               "null"
             ],
-            "description": "Private key material for the rail. Stored encrypted; never returned in responses."
+            "description": "Private key material for the rail. Stored encrypted; never returned in responses.",
+            "example": "0x4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318"
           },
           "public_address": {
             "type": [
               "string",
               "null"
             ],
-            "description": "Public address on the rail (chain address, account number, etc.). Optional; can be filled in later."
+            "description": "Public address on the rail (chain address, account number, etc.). Optional; can be filled in later.",
+            "example": "0x742d35Cc6634C0532925a3b844Bc454e4438f44e"
           },
           "rail": {
             "type": "string",
-            "description": "Settlement rail this account operates on (e.g. `mpp_tempo`, `x402_base`)."
+            "description": "Settlement rail this account operates on. One of: `mpp_tempo`, `x402_base`.",
+            "example": "x402_base"
           }
         }
       },
@@ -14196,14 +14207,22 @@
             "items": {
               "type": "string"
             },
-            "description": "Capability IDs this policy permits paid calls for. Empty list means no capability gating."
+            "description": "Capability IDs this policy permits paid calls for. Empty list means no capability gating.",
+            "example": [
+              "weather.lookup",
+              "shipping.quote"
+            ]
           },
           "allowed_hosts": {
             "type": "array",
             "items": {
               "type": "string"
             },
-            "description": "HTTP host allowlist for paid outbound calls. Empty list means no host gating."
+            "description": "HTTP host allowlist for paid outbound calls. Empty list means no host gating.",
+            "example": [
+              "api.shippo.com",
+              "api.openweathermap.org"
+            ]
           },
           "max_amount_usd_per_day": {
             "type": [
@@ -14211,7 +14230,8 @@
               "null"
             ],
             "format": "double",
-            "description": "Maximum cumulative amount (USD) per UTC day. **Advisory only — not yet enforced.** Stored for forward compatibility; the authority currently checks only `max_amount_usd_per_request`. `None` means no per-day cap."
+            "description": "Maximum cumulative amount (USD) per UTC day. **Advisory only — not yet enforced.** Stored for forward compatibility; the authority currently checks only `max_amount_usd_per_request`. `None` means no per-day cap.",
+            "example": 100.0
           },
           "max_amount_usd_per_request": {
             "type": [
@@ -14219,7 +14239,8 @@
               "null"
             ],
             "format": "double",
-            "description": "Maximum amount (USD) any single paid request may settle for. **Enforced** by the payment authority at policy selection. `None` means no per-request cap."
+            "description": "Maximum amount (USD) any single paid request may settle for. **Enforced** by the payment authority at policy selection. `None` means no per-request cap.",
+            "example": 5.0
           },
           "max_amount_usd_per_turn": {
             "type": [
@@ -14227,21 +14248,27 @@
               "null"
             ],
             "format": "double",
-            "description": "Maximum cumulative amount (USD) per agent turn. **Advisory only — not yet enforced.** Stored for forward compatibility; the authority currently checks only `max_amount_usd_per_request`. `None` means no per-turn cap."
+            "description": "Maximum cumulative amount (USD) per agent turn. **Advisory only — not yet enforced.** Stored for forward compatibility; the authority currently checks only `max_amount_usd_per_request`. `None` means no per-turn cap.",
+            "example": 20.0
           },
           "metadata": {
-            "description": "Free-form metadata attached to this policy."
+            "description": "Free-form metadata attached to this policy.\nExample: `{\"owner_team\": \"ops\", \"ticket\": \"OPS-1248\"}`."
           },
           "payment_account_id": {
             "type": "string",
-            "description": "Payment account this policy authorizes spending from."
+            "description": "Payment account this policy authorizes spending from.",
+            "example": "pay_account_01933b5a00007000800000000000001"
           },
           "rail_preference": {
             "type": "array",
             "items": {
               "type": "string"
             },
-            "description": "Preferred settlement rails in priority order; the authority picks the first available."
+            "description": "Preferred settlement rails in priority order; the authority picks the first available.",
+            "example": [
+              "x402_base",
+              "mpp_tempo"
+            ]
           },
           "require_approval_above_usd": {
             "type": [
@@ -14249,15 +14276,18 @@
               "null"
             ],
             "format": "double",
-            "description": "Threshold (USD) above which a request would require explicit human approval. **Advisory only — not yet enforced.** Stored for forward compatibility; no approval gate is wired up yet. `None` disables the (future) gate."
+            "description": "Threshold (USD) above which a request would require explicit human approval. **Advisory only — not yet enforced.** Stored for forward compatibility; no approval gate is wired up yet. `None` disables the (future) gate.",
+            "example": 10.0
           },
           "subject_id": {
             "type": "string",
-            "description": "Prefixed identifier of the bound subject."
+            "description": "Prefixed identifier of the bound subject.",
+            "example": "agent_01933b5a00007000800000000000001"
           },
           "subject_type": {
             "type": "string",
-            "description": "Class of subject this policy binds to (e.g. `agent_identity`, `session`)."
+            "description": "Class of subject this policy binds to. One of: `user`, `agent_identity`, `agent`, `app`, `session`, `org`.",
+            "example": "agent_identity"
           }
         }
       },
@@ -14284,11 +14314,13 @@
               "string",
               "null"
             ],
-            "description": "Human-readable description. Safe to render in user-facing messages."
+            "description": "Human-readable description. Safe to render in user-facing messages.",
+            "example": "Rolling 30-day count of agents with at least one session per day, grouped by org."
           },
           "name": {
             "type": "string",
-            "description": "Human-readable name. Safe to render in user-facing messages."
+            "description": "Human-readable name. Safe to render in user-facing messages.",
+            "example": "Weekly active agents — last 30 days"
           },
           "query": {
             "$ref": "#/components/schemas/ReportQuery"
@@ -15453,7 +15485,8 @@
         ],
         "properties": {
           "format": {
-            "$ref": "#/components/schemas/ReportExportFormat"
+            "$ref": "#/components/schemas/ReportExportFormat",
+            "description": "Export format. Defaults to `csv` when omitted."
           },
           "query": {
             "$ref": "#/components/schemas/ReportQuery"
@@ -15465,7 +15498,8 @@
         "description": "Request body for the `export_saved_report` operation.",
         "properties": {
           "format": {
-            "$ref": "#/components/schemas/ReportExportFormat"
+            "$ref": "#/components/schemas/ReportExportFormat",
+            "description": "Export format. Defaults to `csv` when omitted."
           }
         }
       },
@@ -23286,20 +23320,24 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/AgentCapabilityConfig"
-            }
+            },
+            "description": "Capability configurations to layer onto the preview. Empty list means none.\nExample: `[{\"id\": \"web.search\", \"enabled\": true}]`."
           },
           "mcpServers": {
-            "$ref": "#/components/schemas/BTreeMap"
+            "$ref": "#/components/schemas/BTreeMap",
+            "description": "MCP servers scoped to this preview. Use the camelCase key `mcpServers` (preferred) or\nthe snake_case alias `mcp_servers`. Empty by default.\nExample: `{\"shared\": [{\"name\": \"filesystem\", \"transport\": \"stdio\", \"command\": \"mcp-fs\"}]}`."
           },
           "parent_harness_id": {
             "type": [
               "string",
               "null"
             ],
+            "description": "Parent harness to extend. When set, its prompt, capabilities, and MCP servers are\nmerged with the fields in this request before rendering.",
             "example": "harness_01933b5a000070008000000000000602"
           },
           "system_prompt": {
             "type": "string",
+            "description": "System prompt to render as the base prompt for the preview.",
             "example": "You are a research assistant."
           }
         }
@@ -23711,7 +23749,9 @@
             "$ref": "#/components/schemas/ReportColumnKind"
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "description": "Column name as it appears in `rows`.",
+            "example": "session_count"
           }
         }
       },
@@ -23779,12 +23819,16 @@
         ],
         "properties": {
           "field": {
-            "type": "string"
+            "type": "string",
+            "description": "Field to filter on. Must be a filter field exposed by the dataset (see `filter_fields` in the catalog).",
+            "example": "status"
           },
           "op": {
             "$ref": "#/components/schemas/ReportFilterOp"
           },
-          "value": {}
+          "value": {
+            "description": "Comparison value. Type depends on `op`: a scalar for `eq`/`neq`/`gt`/`gte`/`lt`/`lte`,\nan array for `in`. Example for `op = in`: `[\"completed\", \"failed\"]`."
+          }
         }
       },
       "ReportFilterOp": {
@@ -23806,16 +23850,21 @@
             "type": [
               "string",
               "null"
-            ]
+            ],
+            "description": "Dimension name to sort by. Mutually exclusive with `measure`.",
+            "example": "org_id"
           },
           "direction": {
-            "$ref": "#/components/schemas/ReportOrderDirection"
+            "$ref": "#/components/schemas/ReportOrderDirection",
+            "description": "Sort direction (`asc` or `desc`). Defaults to `asc`."
           },
           "measure": {
             "type": [
               "string",
               "null"
-            ]
+            ],
+            "description": "Measure name to sort by. Mutually exclusive with `dimension`.",
+            "example": "session_count"
           }
         }
       },
@@ -23917,11 +23966,15 @@
         "properties": {
           "from": {
             "type": "string",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Start of the window (RFC 3339, inclusive).",
+            "example": "2026-04-24T00:00:00Z"
           },
           "to": {
             "type": "string",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "End of the window (RFC 3339, exclusive).",
+            "example": "2026-05-24T00:00:00Z"
           }
         }
       },
@@ -23930,7 +23983,9 @@
         "properties": {
           "limit": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "description": "Maximum number of outbox rows to enqueue across all source types. Defaults to 1000.",
+            "example": 5000
           }
         }
       },
@@ -24210,13 +24265,17 @@
         "description": "Request body for the `rollback_agent_version` operation.",
         "properties": {
           "save_version": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "When true, snapshot the current agent state as a new version before rolling back.\nUse this to preserve the in-flight work alongside the recovery point.",
+            "example": true
           },
           "summary": {
             "type": [
               "string",
               "null"
-            ]
+            ],
+            "description": "Free-text summary attached to the rollback. Shown in the version timeline.",
+            "example": "Reverting refund-window change — false positives in production."
           }
         }
       },
@@ -27389,17 +27448,19 @@
               "string",
               "null"
             ],
-            "description": "New label, if changing."
+            "description": "New label, if changing.",
+            "example": "Refund agent · USDC on Base (prod)"
           },
           "metadata": {
-            "description": "New free-form metadata. Replaces the existing metadata blob entirely when set."
+            "description": "New free-form metadata. Replaces the existing metadata blob entirely when set.\nExample: `{\"team\": \"support\", \"cost_center\": \"ops-2026\"}`."
           },
           "private_key": {
             "type": [
               "string",
               "null"
             ],
-            "description": "New private key material. Set to `Some(...)` to rotate; omit to leave unchanged."
+            "description": "New private key material. Set to `Some(...)` to rotate; omit to leave unchanged.",
+            "example": "0x4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318"
           },
           "public_address": {
             "type": [
@@ -27413,7 +27474,8 @@
               "string",
               "null"
             ],
-            "description": "New lifecycle status. Valid values: `active`, `disabled`."
+            "description": "New lifecycle status. Valid values: `active`, `disabled`.",
+            "example": "disabled"
           }
         }
       },
@@ -27429,7 +27491,12 @@
             "items": {
               "type": "string"
             },
-            "description": "New capability allowlist. Outer `None` leaves the field unchanged."
+            "description": "New capability allowlist. Outer `None` leaves the field unchanged.",
+            "example": [
+              "weather.lookup",
+              "shipping.quote",
+              "currency.convert"
+            ]
           },
           "allowed_hosts": {
             "type": [
@@ -27439,7 +27506,12 @@
             "items": {
               "type": "string"
             },
-            "description": "New host allowlist. Outer `None` leaves the field unchanged."
+            "description": "New host allowlist. Outer `None` leaves the field unchanged.",
+            "example": [
+              "api.shippo.com",
+              "api.openweathermap.org",
+              "api.exchangerate.host"
+            ]
           },
           "max_amount_usd_per_day": {
             "type": [
@@ -27466,7 +27538,7 @@
             "description": "New per-turn cap (USD). **Advisory only — not yet enforced.** Outer `None` leaves the field unchanged; inner `None` clears the cap."
           },
           "metadata": {
-            "description": "New free-form metadata. Replaces the existing metadata blob entirely when set."
+            "description": "New free-form metadata. Replaces the existing metadata blob entirely when set.\nExample: `{\"owner_team\": \"ops\", \"ticket\": \"OPS-1248\", \"review_due\": \"2026-09-01\"}`."
           },
           "rail_preference": {
             "type": [
@@ -27476,7 +27548,11 @@
             "items": {
               "type": "string"
             },
-            "description": "New rail preference order. Outer `None` leaves the field unchanged."
+            "description": "New rail preference order. Outer `None` leaves the field unchanged.",
+            "example": [
+              "mpp_tempo",
+              "x402_base"
+            ]
           },
           "require_approval_above_usd": {
             "type": [
@@ -27491,7 +27567,8 @@
               "string",
               "null"
             ],
-            "description": "New lifecycle status. Valid values: `active`, `disabled`."
+            "description": "New lifecycle status. Valid values: `active`, `disabled`.",
+            "example": "disabled"
           }
         }
       },
@@ -27528,14 +27605,16 @@
               "string",
               "null"
             ],
-            "description": "Human-readable description. Safe to render in user-facing messages."
+            "description": "Human-readable description. Safe to render in user-facing messages.",
+            "example": "Rolling 60-day window; widened from 30d after the Q3 product launch."
           },
           "name": {
             "type": [
               "string",
               "null"
             ],
-            "description": "Human-readable name. Safe to render in user-facing messages."
+            "description": "Human-readable name. Safe to render in user-facing messages.",
+            "example": "Weekly active agents — last 60 days"
           },
           "query": {
             "$ref": "#/components/schemas/ReportQuery"
@@ -27777,7 +27856,8 @@
         "properties": {
           "skill_md": {
             "type": "string",
-            "description": "SKILL.md content to validate"
+            "description": "Full SKILL.md content to validate, including the YAML frontmatter and the markdown body.",
+            "example": "---\nname: refund-policy\ndescription: Issue refunds inside the policy window.\n---\n\nUse this when a customer asks for a refund within 30 days of purchase."
           }
         }
       },
@@ -27973,7 +28053,8 @@
             "type": [
               "string",
               "null"
-            ]
+            ],
+            "description": "Free-text reason recorded with the session-ended event. Useful for operator forensics.\nExample: `User hung up after refund confirmed.`."
           }
         }
       },
@@ -28007,16 +28088,21 @@
               "null"
             ],
             "format": "int64",
+            "description": "Total wall-clock duration of the connection in milliseconds. `None` when the connection\nnever completed an audio handshake.",
+            "example": 184500,
             "minimum": 0
           },
           "reason": {
             "type": [
               "string",
               "null"
-            ]
+            ],
+            "description": "Free-text end reason captured from the client or server. `None` when no reason was supplied.\nExample: `User hung up after refund confirmed.`."
           },
           "voice_connection_id": {
-            "type": "string"
+            "type": "string",
+            "description": "Prefixed voice connection identifier for the ended session.",
+            "example": "voice_01933b5a00007000800000000000001"
           }
         }
       },
@@ -28029,10 +28115,14 @@
         ],
         "properties": {
           "error": {
-            "type": "string"
+            "type": "string",
+            "description": "Error message captured at failure. Provider-formatted; not stable for parsing.",
+            "example": "realtime provider closed stream: 1011 internal_error"
           },
           "voice_connection_id": {
-            "type": "string"
+            "type": "string",
+            "description": "Prefixed voice connection identifier for the failed session.",
+            "example": "voice_01933b5a00007000800000000000001"
           }
         }
       },
@@ -28043,25 +28133,29 @@
             "type": [
               "string",
               "null"
-            ]
+            ],
+            "description": "Extra system instructions appended to the realtime session prompt.\nExample: `Always confirm before placing an order.`."
           },
           "model": {
             "type": [
               "string",
               "null"
-            ]
+            ],
+            "description": "Provider-side realtime model identifier. When omitted the server picks the agent's configured default.\nExample: `gpt-realtime`."
           },
           "reasoning_effort": {
             "type": [
               "string",
               "null"
-            ]
+            ],
+            "description": "Reasoning effort hint passed through to the realtime model. One of `low`, `medium`, `high`.\nWhen omitted the server picks the provider's default.\nExample: `medium`."
           },
           "voice": {
             "type": [
               "string",
               "null"
-            ]
+            ],
+            "description": "Realtime voice preset (provider-specific). When omitted the server picks the agent's configured default.\nExample: `alloy`."
           }
         }
       },
@@ -28140,19 +28234,29 @@
         ],
         "properties": {
           "model": {
-            "type": "string"
+            "type": "string",
+            "description": "Provider-side realtime model identifier negotiated for this session.",
+            "example": "gpt-realtime"
           },
           "reasoning_effort": {
-            "type": "string"
+            "type": "string",
+            "description": "Reasoning effort applied to the realtime model. One of `low`, `medium`, `high`.",
+            "example": "medium"
           },
           "transport": {
-            "type": "string"
+            "type": "string",
+            "description": "Transport carrying the audio stream. One of `webrtc`, `sip`, `websocket`.",
+            "example": "webrtc"
           },
           "voice": {
-            "type": "string"
+            "type": "string",
+            "description": "Realtime voice preset selected for this session.",
+            "example": "alloy"
           },
           "voice_connection_id": {
-            "type": "string"
+            "type": "string",
+            "description": "Prefixed voice connection identifier for the started session.",
+            "example": "voice_01933b5a00007000800000000000001"
           }
         }
       },

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -14162,12 +14162,12 @@
           },
           "owner_id": {
             "type": "string",
-            "description": "Prefixed identifier of the owning principal (e.g. `user_…`, `agent_…`, `org_…`).",
-            "example": "agent_01933b5a00007000800000000000001"
+            "description": "Prefixed identifier of the owning principal. Must use the prefix that matches `owner_type`\n(see above). Example below pairs with `owner_type = \"agent_identity\"`.",
+            "example": "identity_01933b5a00007000800000000000001"
           },
           "owner_type": {
             "type": "string",
-            "description": "Principal class that owns the account. One of: `user`, `agent_identity`, `organization`.",
+            "description": "Principal class that owns the account. One of: `user`, `agent_identity`, `organization`.\nThe prefix on `owner_id` must match this: `user` → `user_…`, `agent_identity` → `identity_…`,\n`organization` → `org_…`.",
             "example": "agent_identity"
           },
           "private_key": {
@@ -14175,8 +14175,8 @@
               "string",
               "null"
             ],
-            "description": "Private key material for the rail. Stored encrypted; never returned in responses.",
-            "example": "0x4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318"
+            "description": "Private key material for the rail. Stored encrypted; never returned in responses.\nExample shown as an obvious placeholder — supply a real 32-byte hex value at create time.",
+            "example": "0x<your-32-byte-hex-private-key>"
           },
           "public_address": {
             "type": [
@@ -14256,8 +14256,8 @@
           },
           "payment_account_id": {
             "type": "string",
-            "description": "Payment account this policy authorizes spending from.",
-            "example": "pay_account_01933b5a00007000800000000000001"
+            "description": "Payment account this policy authorizes spending from. Accepts a prefixed `payacct_…`\nidentifier or a bare UUID.",
+            "example": "payacct_01933b5a00007000800000000000001"
           },
           "rail_preference": {
             "type": "array",
@@ -14281,12 +14281,12 @@
           },
           "subject_id": {
             "type": "string",
-            "description": "Prefixed identifier of the bound subject.",
-            "example": "agent_01933b5a00007000800000000000001"
+            "description": "Prefixed identifier of the bound subject. Must use the prefix matching `subject_type`\n(see above). Example below pairs with `subject_type = \"agent_identity\"`.",
+            "example": "identity_01933b5a00007000800000000000001"
           },
           "subject_type": {
             "type": "string",
-            "description": "Class of subject this policy binds to. One of: `user`, `agent_identity`, `agent`, `app`, `session`, `org`.",
+            "description": "Class of subject this policy binds to. One of: `user`, `agent_identity`, `agent`, `app`, `session`, `org`.\nThe prefix on `subject_id` must match: `user`→`user_…`, `agent_identity`→`identity_…`,\n`agent`→`agent_…`, `app`→`app_…`, `session`→`session_…`, `org`→`org_…`.",
             "example": "agent_identity"
           }
         }
@@ -23321,11 +23321,23 @@
             "items": {
               "$ref": "#/components/schemas/AgentCapabilityConfig"
             },
-            "description": "Capability configurations to layer onto the preview. Empty list means none.\nExample: `[{\"id\": \"web.search\", \"enabled\": true}]`."
+            "description": "Capability configurations to layer onto the preview. Empty list means none.",
+            "example": [
+              {
+                "config": {},
+                "ref": "web.search"
+              },
+              {
+                "config": {
+                  "root": "/workspace"
+                },
+                "ref": "filesystem.read"
+              }
+            ]
           },
           "mcpServers": {
             "$ref": "#/components/schemas/BTreeMap",
-            "description": "MCP servers scoped to this preview. Use the camelCase key `mcpServers` (preferred) or\nthe snake_case alias `mcp_servers`. Empty by default.\nExample: `{\"shared\": [{\"name\": \"filesystem\", \"transport\": \"stdio\", \"command\": \"mcp-fs\"}]}`."
+            "description": "MCP servers scoped to this preview, keyed by scope (`shared` / per-agent / etc.).\nUse the camelCase key `mcpServers` (preferred) or the snake_case alias `mcp_servers`. Empty by default."
           },
           "parent_harness_id": {
             "type": [
@@ -27459,8 +27471,8 @@
               "string",
               "null"
             ],
-            "description": "New private key material. Set to `Some(...)` to rotate; omit to leave unchanged.",
-            "example": "0x4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318"
+            "description": "New private key material. Set to `Some(...)` to rotate; omit to leave unchanged.\nExample shown as an obvious placeholder — supply a real 32-byte hex value when rotating.",
+            "example": "0x<your-32-byte-hex-private-key>"
           },
           "public_address": {
             "type": [
@@ -28054,7 +28066,8 @@
               "string",
               "null"
             ],
-            "description": "Free-text reason recorded with the session-ended event. Useful for operator forensics.\nExample: `User hung up after refund confirmed.`."
+            "description": "Free-text reason recorded with the session-ended event. Useful for operator forensics.",
+            "example": "User hung up after refund confirmed."
           }
         }
       },
@@ -28097,7 +28110,8 @@
               "string",
               "null"
             ],
-            "description": "Free-text end reason captured from the client or server. `None` when no reason was supplied.\nExample: `User hung up after refund confirmed.`."
+            "description": "Free-text end reason captured from the client or server. `None` when no reason was supplied.",
+            "example": "User hung up after refund confirmed."
           },
           "voice_connection_id": {
             "type": "string",
@@ -28134,28 +28148,32 @@
               "string",
               "null"
             ],
-            "description": "Extra system instructions appended to the realtime session prompt.\nExample: `Always confirm before placing an order.`."
+            "description": "Extra system instructions appended to the realtime session prompt.",
+            "example": "Always confirm before placing an order."
           },
           "model": {
             "type": [
               "string",
               "null"
             ],
-            "description": "Provider-side realtime model identifier. When omitted the server picks the agent's configured default.\nExample: `gpt-realtime`."
+            "description": "Provider-side realtime model identifier. When omitted the server picks the agent's configured default.",
+            "example": "gpt-realtime"
           },
           "reasoning_effort": {
             "type": [
               "string",
               "null"
             ],
-            "description": "Reasoning effort hint passed through to the realtime model. One of `low`, `medium`, `high`.\nWhen omitted the server picks the provider's default.\nExample: `medium`."
+            "description": "Reasoning effort hint passed through to the realtime model. One of `low`, `medium`, `high`.\nWhen omitted the server picks the provider's default.",
+            "example": "medium"
           },
           "voice": {
             "type": [
               "string",
               "null"
             ],
-            "description": "Realtime voice preset (provider-specific). When omitted the server picks the agent's configured default.\nExample: `alloy`."
+            "description": "Realtime voice preset (provider-specific). When omitted the server picks the agent's configured default.",
+            "example": "alloy"
           }
         }
       },


### PR DESCRIPTION
## What
Continuation of #1904 / #1915 / #1923 / #1949 / #1952 — examples on four previously-bare clusters bundled into one larger PR.

- **Payments** (`crates/server/src/domains/payments/types.rs`): `Create/UpdatePaymentAccountRequest`, `Create/UpdatePaymentPolicyRequest`. Examples use CHECK-constraint-valid values for `owner_type`/`rail`/`subject_type`/`status` (per `migrations/036_machine_payments.sql`).
- **Reports** (`crates/server/src/domains/reporting/types.rs` + `crates/core/src/reporting.rs`): `Create/UpdateSavedReportRequest`, `ExportSavedReportRequest`, `ExportReportQueryRequest`, `ReportingBackfillRequest`; plus the shared `ReportColumn`, `ReportFilter`, `ReportOrderBy`, `ReportTimeRange`.
- **Voice** (`crates/server/src/api/voice.rs` + `crates/core/src/events.rs`): `VoiceSessionOptions`, `VoiceEndRequest`, `VoiceSession{Started,Ended,Failed}Data`.
- **Misc**: `Create/RollbackAgentVersionRequest` (with the example placed on the `AgentVersionChangeKind` enum itself to work around the `Option<Enum>` field-level drop), `PreviewHarnessRequest`, `BatchSetSecretsRequest`, `ValidateSkillRequest`, `CreateDatabaseRequest`.

## Why
These clusters are the LLM-facing surfaces an agent toolcaller needs to reason about during everyday operation: setting up payment policies, exporting reports, opening voice sessions, snapshotting agent versions, batch-setting secrets. Without examples a toolcaller has to guess at allowed `kind`/`rail`/`status` values, the shape of a `ReportFilter.value`, the snake_case taxonomy of `AgentVersionChangeKind`, etc. One concrete example collapses each guess.

Per the recent shift to larger PRs, this bundles four cluster slices that would historically have been four separate PRs.

## How
Same `#[schema(example = …)]` / `json!(...)` pattern as the prior PRs. For the known utoipa quirks (carried over from previous PRs' watch-outs):
- `Option<serde_json::Value>` and `HashMap` fields: example inlined into the `///` doc comment (utoipa drops field-level examples for these unconditionally).
- `Option<Enum>` fields: example placed on the enum definition (`AgentVersionChangeKind`) so `$ref` resolution surfaces it.
- `Option<Option<T>>` "tri-state" fields in `UpdatePaymentPolicyRequest`: left bare — the dispatch shape isn't well-represented by a single literal example, and the doc comment already explains the semantics.

Coverage gate bumped: `MIN_FIELD_EXAMPLE_PCT` 21% → 24% to match the new actual (383/1567 = 24%). OpenAPI spec regenerated.

## Risk
- **Negligible.** Pure documentation — no production code, wire-shape, or schema-type changes (no `value_type` overrides this time).
- All examples are valid against their schemas and respect DB CHECK constraints.
- New gate floor matches the new actual coverage.

## Security
- Threat categories reviewed: **TM-API** (request schema docs only — no parsing/handler changes), **none others applicable**.
- Static literals in source. Sample private key + chain address values are well-known test/throwaway literals from public docs; no real secrets.
- The `BatchSetSecretsRequest` example uses obviously-placeholder values (`sk-...`, `ghp_...`) that won't be mistaken for real secrets.

## Follow-ups
No follow-ups in this PR. Next candidate clusters (still bare on `main` as of this commit): the longer-horizon items from the handoff — MCP execute structured-error wire bump, hypermedia for entity actions, description gaps on Voice/Report/GitDiff clusters (would push field-desc floor 85 → 90%).

## Checklist
- [x] Tests added or updated (all 4 OpenAPI gates pass at 100/88/85/24%)
- [x] Backward compatibility considered (additive examples, no schema-type changes)
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jx7aHhsynabhrKB9gDMAVq)_