### PR TITLE
fix(llm): avoid mixing previous_response_id with full transcript

### DIFF
--- a/crates/core/src/openresponses_protocol.rs
+++ b/crates/core/src/openresponses_protocol.rs
@@ -515,6 +515,12 @@ impl OpenResponsesProtocolLlmDriver {
     /// Handles the conversion of:
     /// - Assistant messages with tool_calls into separate FunctionCall items
     /// - Assistant messages with thinking into Reasoning items (for o-series/GPT-5 models)
+    ///
+    /// Note: this function always reconstructs the FULL transcript from the supplied
+    /// messages. The caller is responsible for trimming to a delta window when a
+    /// `previous_response_id` is in play — see [`compute_delta_input_items`]. The
+    /// stateful Responses invariant is: a request must not mix `previous_response_id`
+    /// with prior transcript input the provider already holds server-side.
     fn build_input(
         messages: &[LlmMessage],
         supports_phases: bool,
@@ -588,6 +594,44 @@ impl OpenResponsesProtocolLlmDriver {
     }
 }
 
+/// Trim input items to the "delta" window for a stateful Responses continuation.
+///
+/// When a request carries `previous_response_id`, OpenAI already holds the prior
+/// transcript server-side. Re-sending it in `input` double-counts context (charges
+/// the user twice and inflates prompt-cache keys). The invariant is:
+///
+///   **A request must not mix `previous_response_id` with prior transcript input.**
+///
+/// "Delta" is everything strictly after the last item that belonged to a prior
+/// assistant turn. Items that belong to a prior assistant turn are: assistant
+/// `Message`, `Reasoning`, and `FunctionCall` (the assistant's own tool calls).
+/// What remains as delta is typically `FunctionCallOutput` items (tool results
+/// the client produced) plus any fresh user `Message`s.
+///
+/// Defensive behavior: if no prior-assistant item is found (e.g., the caller
+/// passed only fresh user input), all items are treated as delta and kept. An
+/// empty input is also valid — the provider can resume purely from
+/// `previous_response_id`.
+fn compute_delta_input_items(items: Vec<ResponsesInputItem>) -> Vec<ResponsesInputItem> {
+    // Find the index of the last item that is part of a prior assistant turn.
+    let last_assistant_turn_idx = items
+        .iter()
+        .enumerate()
+        .rev()
+        .find_map(|(i, item)| match item {
+            ResponsesInputItem::Message { role, .. } if role == "assistant" => Some(i),
+            ResponsesInputItem::Reasoning { .. } => Some(i),
+            ResponsesInputItem::FunctionCall { .. } => Some(i),
+            _ => None,
+        });
+
+    match last_assistant_turn_idx {
+        Some(idx) => items.into_iter().skip(idx + 1).collect(),
+        // No prior-assistant items in input — defensive: keep all items as delta.
+        None => items,
+    }
+}
+
 #[async_trait]
 impl LlmDriver for OpenResponsesProtocolLlmDriver {
     async fn chat_completion_stream(
@@ -604,6 +648,16 @@ impl LlmDriver for OpenResponsesProtocolLlmDriver {
         .is_some_and(|p| p.supports_phases);
 
         let (instructions, input_items) = Self::build_input(&messages, supports_phases);
+
+        // Stateful Responses continuations must not mix `previous_response_id` with
+        // the prior transcript input the provider already holds server-side. When a
+        // continuation handle is present, trim `input_items` to the delta window so
+        // the request only carries new tool results / user messages.
+        let input_items = if config.previous_response_id.is_some() {
+            compute_delta_input_items(input_items)
+        } else {
+            input_items
+        };
 
         let tools = if config.tools.is_empty() {
             None
@@ -2237,6 +2291,232 @@ mod tests {
         let json = serde_json::to_value(&input[2]).unwrap();
         assert_eq!(json["type"], "function_call");
         assert_eq!(json["call_id"], "call_abc");
+    }
+
+    // ========================================================================
+    // EVE-488: Stateful Responses continuations must not double-send context.
+    //
+    // When `previous_response_id` is set, the OpenAI Responses provider already
+    // holds the prior transcript server-side. Re-sending it in `input` causes
+    // double-counting. These tests pin the invariant that the delta-trim helper
+    // only keeps items strictly after the most recent assistant turn, and
+    // that the request-building path applies the trim when (and only when) a
+    // continuation handle is present.
+    // ========================================================================
+
+    /// Issue reproducer: a stateful continuation must not carry the full prior
+    /// transcript in `input` alongside `previous_response_id`. After trimming,
+    /// only the new tool result and any fresh user input should remain.
+    #[test]
+    fn openresponses_requests_should_not_mix_previous_response_id_with_full_transcript() {
+        use crate::tool_types::ToolCall;
+
+        // Simulate a multi-turn transcript: system + user + assistant(tool_call) + tool result.
+        // This is the exact shape that gets reconstructed on a follow-up turn when
+        // the runtime has a `previous_response_id` from the prior assistant turn.
+        let messages = vec![
+            LlmMessage::text(LlmMessageRole::System, "You are helpful"),
+            LlmMessage::text(LlmMessageRole::User, "What time is it?"),
+            LlmMessage {
+                role: LlmMessageRole::Assistant,
+                content: LlmMessageContent::Text("Let me check.".to_string()),
+                tool_calls: Some(vec![ToolCall {
+                    id: "call_xyz789".to_string(),
+                    name: "get_current_time".to_string(),
+                    arguments: json!({"timezone": "UTC"}),
+                }]),
+                tool_call_id: None,
+                phase: None,
+                thinking: None,
+                thinking_signature: None,
+            },
+            LlmMessage {
+                role: LlmMessageRole::Tool,
+                content: LlmMessageContent::Text("2025-01-19T10:30:00Z".to_string()),
+                tool_calls: None,
+                tool_call_id: Some("call_xyz789".to_string()),
+                phase: None,
+                thinking: None,
+                thinking_signature: None,
+            },
+        ];
+
+        // Build the full transcript the same way the driver does.
+        let (instructions, full_input) =
+            OpenResponsesProtocolLlmDriver::build_input(&messages, false);
+
+        // Without trimming the full transcript leaks user + assistant + function_call
+        // + function_call_output — exactly the bug.
+        assert!(
+            full_input.len() > 1,
+            "sanity: full transcript has multi items"
+        );
+
+        // The trim performed when `previous_response_id` is present in the request
+        // path must drop everything up to and including the last prior-assistant item.
+        let delta = compute_delta_input_items(full_input);
+
+        // Only the tool result (function_call_output) should remain.
+        assert_eq!(
+            delta.len(),
+            1,
+            "stateful continuation must only send delta items; got {} items",
+            delta.len()
+        );
+        let json = serde_json::to_value(&delta[0]).unwrap();
+        assert_eq!(json["type"], "function_call_output");
+        assert_eq!(json["call_id"], "call_xyz789");
+        assert_eq!(json["output"], "2025-01-19T10:30:00Z");
+
+        // Instructions (system message) are NOT part of `input`; they're still sent
+        // separately and that is correct — they don't count toward the invariant.
+        assert_eq!(instructions, Some("You are helpful".to_string()));
+    }
+
+    /// Stateless mode (no previous_response_id): all input items are kept.
+    /// The trim helper is only invoked by the call path when previous_response_id
+    /// is set; this test pins that the helper produces correct delta output
+    /// regardless, leaving the fresh user message that follows the assistant turn.
+    #[test]
+    fn compute_delta_keeps_tail_after_assistant_message() {
+        let items = vec![
+            ResponsesInputItem::Message {
+                r#type: "message".to_string(),
+                role: "user".to_string(),
+                content: ResponsesContent::Text("hi".to_string()),
+                phase: None,
+            },
+            ResponsesInputItem::Message {
+                r#type: "message".to_string(),
+                role: "assistant".to_string(),
+                content: ResponsesContent::Text("hello".to_string()),
+                phase: None,
+            },
+            ResponsesInputItem::Message {
+                r#type: "message".to_string(),
+                role: "user".to_string(),
+                content: ResponsesContent::Text("follow up".to_string()),
+                phase: None,
+            },
+        ];
+        let trimmed = compute_delta_input_items(items);
+        assert_eq!(trimmed.len(), 1);
+        let json = serde_json::to_value(&trimmed[0]).unwrap();
+        assert_eq!(json["role"], "user");
+        assert_eq!(
+            json["content"], "follow up",
+            "trim keeps the fresh user message that arrived after the assistant turn"
+        );
+    }
+
+    /// Stateful continuation with parallel tool calls: every tool output that
+    /// follows the prior assistant's function_call items is kept. The function_call
+    /// items themselves belong to server-side state and are dropped.
+    #[test]
+    fn compute_delta_keeps_tool_results_after_last_assistant_turn() {
+        let items = vec![
+            ResponsesInputItem::Message {
+                r#type: "message".to_string(),
+                role: "user".to_string(),
+                content: ResponsesContent::Text("do two things".to_string()),
+                phase: None,
+            },
+            ResponsesInputItem::Message {
+                r#type: "message".to_string(),
+                role: "assistant".to_string(),
+                content: ResponsesContent::Text("ok".to_string()),
+                phase: None,
+            },
+            ResponsesInputItem::FunctionCall {
+                r#type: "function_call".to_string(),
+                call_id: "call_a".to_string(),
+                name: "tool_a".to_string(),
+                arguments: "{}".to_string(),
+            },
+            ResponsesInputItem::FunctionCall {
+                r#type: "function_call".to_string(),
+                call_id: "call_b".to_string(),
+                name: "tool_b".to_string(),
+                arguments: "{}".to_string(),
+            },
+            ResponsesInputItem::FunctionCallOutput {
+                r#type: "function_call_output".to_string(),
+                call_id: "call_a".to_string(),
+                output: "a result".to_string(),
+            },
+            ResponsesInputItem::FunctionCallOutput {
+                r#type: "function_call_output".to_string(),
+                call_id: "call_b".to_string(),
+                output: "b result".to_string(),
+            },
+        ];
+
+        let trimmed = compute_delta_input_items(items);
+
+        // The function_call items live in server-side state. The delta carries
+        // only the tool outputs the client produced for them.
+        assert_eq!(trimmed.len(), 2);
+        for item in &trimmed {
+            let json = serde_json::to_value(item).unwrap();
+            assert_eq!(json["type"], "function_call_output");
+        }
+    }
+
+    /// Empty input with previous_response_id is valid: the provider can resume
+    /// purely from the continuation handle, no input needed.
+    #[test]
+    fn compute_delta_allows_empty_input_for_stateful_continuation() {
+        let trimmed = compute_delta_input_items(vec![]);
+        assert!(trimmed.is_empty());
+    }
+
+    /// Defensive: if no prior-assistant item is present (caller passed only fresh
+    /// user input), all items are kept as delta.
+    #[test]
+    fn compute_delta_keeps_all_items_when_no_assistant_turn_present() {
+        let items = vec![
+            ResponsesInputItem::Message {
+                r#type: "message".to_string(),
+                role: "user".to_string(),
+                content: ResponsesContent::Text("one".to_string()),
+                phase: None,
+            },
+            ResponsesInputItem::Message {
+                r#type: "message".to_string(),
+                role: "user".to_string(),
+                content: ResponsesContent::Text("two".to_string()),
+                phase: None,
+            },
+        ];
+        let trimmed = compute_delta_input_items(items);
+        assert_eq!(trimmed.len(), 2);
+    }
+
+    /// Reasoning items from a prior assistant turn are also dropped by the trim.
+    #[test]
+    fn compute_delta_drops_prior_reasoning_items() {
+        let items = vec![
+            ResponsesInputItem::Reasoning {
+                r#type: "reasoning".to_string(),
+                id: "rs_00000001".to_string(),
+                encrypted_content: "encrypted-blob".to_string(),
+            },
+            ResponsesInputItem::Message {
+                r#type: "message".to_string(),
+                role: "assistant".to_string(),
+                content: ResponsesContent::Text("prior".to_string()),
+                phase: None,
+            },
+            ResponsesInputItem::FunctionCallOutput {
+                r#type: "function_call_output".to_string(),
+                call_id: "call_z".to_string(),
+                output: "result".to_string(),
+            },
+        ];
+        let trimmed = compute_delta_input_items(items);
+        assert_eq!(trimmed.len(), 1);
+        let json = serde_json::to_value(&trimmed[0]).unwrap();
+        assert_eq!(json["type"], "function_call_output");
     }
 
     // ========================================================================

--- a/crates/core/src/openresponses_protocol.rs
+++ b/crates/core/src/openresponses_protocol.rs
@@ -632,6 +632,21 @@ fn compute_delta_input_items(items: Vec<ResponsesInputItem>) -> Vec<ResponsesInp
     }
 }
 
+/// The single decision point for whether a Responses request `input` should be
+/// trimmed to the delta window. Extracted so the call path can be regression-tested
+/// without spinning up an HTTP mock — protects against accidentally removing the
+/// `previous_response_id.is_some()` guard that enforces the stateful invariant.
+fn finalize_input_for_request(
+    input_items: Vec<ResponsesInputItem>,
+    previous_response_id: &Option<String>,
+) -> Vec<ResponsesInputItem> {
+    if previous_response_id.is_some() {
+        compute_delta_input_items(input_items)
+    } else {
+        input_items
+    }
+}
+
 #[async_trait]
 impl LlmDriver for OpenResponsesProtocolLlmDriver {
     async fn chat_completion_stream(
@@ -653,11 +668,7 @@ impl LlmDriver for OpenResponsesProtocolLlmDriver {
         // the prior transcript input the provider already holds server-side. When a
         // continuation handle is present, trim `input_items` to the delta window so
         // the request only carries new tool results / user messages.
-        let input_items = if config.previous_response_id.is_some() {
-            compute_delta_input_items(input_items)
-        } else {
-            input_items
-        };
+        let input_items = finalize_input_for_request(input_items, &config.previous_response_id);
 
         let tools = if config.tools.is_empty() {
             None
@@ -1744,8 +1755,14 @@ enum ResponsesInputItem {
         output: String,
     },
     /// Reasoning item for o-series and GPT-5 models
-    /// Contains encrypted reasoning content that must be included in subsequent API calls
-    /// to preserve reasoning context across turns (similar to Anthropic's thinking signature)
+    /// Contains encrypted reasoning content that preserves reasoning context across turns
+    /// (similar to Anthropic's thinking signature).
+    ///
+    /// Stateless requests must re-send prior `Reasoning` items in `input` so the model can
+    /// continue from them. Stateful continuations (those carrying `previous_response_id`)
+    /// rely on OpenAI to hold the prior reasoning chain server-side, so [`compute_delta_input_items`]
+    /// intentionally drops `Reasoning` items that belong to a prior assistant turn — re-sending
+    /// them alongside `previous_response_id` would violate the no-mixing invariant.
     Reasoning {
         r#type: String,
         /// Unique ID for this reasoning item
@@ -2517,6 +2534,76 @@ mod tests {
         assert_eq!(trimmed.len(), 1);
         let json = serde_json::to_value(&trimmed[0]).unwrap();
         assert_eq!(json["type"], "function_call_output");
+    }
+
+    // ------------------------------------------------------------------------
+    // Request-builder integration: `finalize_input_for_request` is the single
+    // gate that chooses whether the request `input` is trimmed. These tests
+    // pin the exact decision the call path makes — they catch regressions
+    // where the `previous_response_id`-presence check is accidentally dropped
+    // or inverted, which is what would re-introduce the bug even if the trim
+    // helper itself stays correct.
+    // ------------------------------------------------------------------------
+
+    fn sample_full_transcript_items() -> Vec<ResponsesInputItem> {
+        vec![
+            ResponsesInputItem::Message {
+                r#type: "message".to_string(),
+                role: "user".to_string(),
+                content: ResponsesContent::Text("first request".to_string()),
+                phase: None,
+            },
+            ResponsesInputItem::Message {
+                r#type: "message".to_string(),
+                role: "assistant".to_string(),
+                content: ResponsesContent::Text("first reply".to_string()),
+                phase: None,
+            },
+            ResponsesInputItem::Message {
+                r#type: "message".to_string(),
+                role: "user".to_string(),
+                content: ResponsesContent::Text("follow-up".to_string()),
+                phase: None,
+            },
+        ]
+    }
+
+    #[test]
+    fn finalize_input_skips_trim_when_previous_response_id_is_none() {
+        let items = sample_full_transcript_items();
+        let original_len = items.len();
+        let out = finalize_input_for_request(items, &None);
+        assert_eq!(
+            out.len(),
+            original_len,
+            "stateless mode keeps the full transcript so the model has context"
+        );
+    }
+
+    #[test]
+    fn finalize_input_trims_when_previous_response_id_is_set() {
+        let items = sample_full_transcript_items();
+        let out = finalize_input_for_request(items, &Some("resp_prev_42".to_string()));
+        assert_eq!(
+            out.len(),
+            1,
+            "stateful continuation must drop everything up to and including the prior assistant message"
+        );
+        let json = serde_json::to_value(&out[0]).unwrap();
+        assert_eq!(json["type"], "message");
+        assert_eq!(json["role"], "user");
+        // Only the post-assistant follow-up survives.
+        let txt = json["content"].as_str().unwrap_or("");
+        assert_eq!(txt, "follow-up");
+    }
+
+    #[test]
+    fn finalize_input_allows_empty_input_with_previous_response_id() {
+        let out = finalize_input_for_request(vec![], &Some("resp_anything".to_string()));
+        assert!(
+            out.is_empty(),
+            "empty delta is valid — the provider can resume purely from the response id"
+        );
     }
 
     // ========================================================================

--- a/specs/llm-drivers.md
+++ b/specs/llm-drivers.md
@@ -265,6 +265,14 @@ The OpenAI crate provides two driver implementations:
 
 Both drivers share the same base URL handling and can work with OpenAI-compatible endpoints.
 
+### Stateful Continuation Invariant
+
+When a request to the OpenAI Responses API sets `previous_response_id`, the provider already holds the prior transcript server-side. The request must NOT also carry the full reconstructed transcript in `input` — that double-counts context and inflates prompt-cache keys.
+
+Invariant: **a request with `previous_response_id` only carries delta items in `input`** — typically tool results (`function_call_output`) for the prior assistant turn plus any fresh user messages. Prior assistant messages, reasoning items, and the assistant's own function calls are dropped because they live in server-side state. `instructions` (system message) is sent separately and is exempt. Empty `input` is allowed.
+
+`OpenResponsesProtocolLlmDriver` enforces this by trimming `input` via `compute_delta_input_items` whenever `previous_response_id` is `Some(_)` (see `crates/core/src/openresponses_protocol.rs`).
+
 ## Automatic Retry for Transient Errors
 
 LLM drivers implement automatic retry with exponential backoff for transient errors. This follows official SDK behavior from OpenAI and Anthropic.


### PR DESCRIPTION
## What
Enforces the invariant that OpenAI Responses requests never mix `previous_response_id` (stateful continuation handle) with a full prior transcript in `input`. When a continuation handle is set, only "delta" items (anything after the last prior assistant turn — tool results and fresh user messages) are sent.

Linear: [EVE-488](https://linear.app/everruns/issue/EVE-488/avoid-double-sending-openai-responses-context)

## Why
Long ercode sessions were paying twice for context: the OpenAI server holds prior state via `previous_response_id`, while Everruns also reconstructed and resent the full message history in `input`. The analyzed session `session_019e5782139d70329de9933055799369` showed a late "Try continue" turn ballooning to 265k input tokens while doing mostly CI polling. The mixed request shape was a structural issue independent of that session.

## How
- New helper `compute_delta_input_items(items) -> Vec<ResponsesInputItem>` in `crates/core/src/openresponses_protocol.rs` finds the last item belonging to a prior assistant turn (assistant `Message`, `Reasoning`, or `FunctionCall`) and keeps only items strictly after it.
- The request builder invokes the helper only when `config.previous_response_id` is `Some(_)`. Stateless requests pass through unchanged (full transcript preserved).
- `instructions` (system message) remains sent independently — it is not part of `input` and is not subject to the invariant.
- Defensive cases preserved: empty input and input with no prior-assistant item are both allowed (kept as-is).
- Spec `specs/llm-drivers.md` updated with a "Stateful Continuation Invariant" subsection under the OpenAI driver section documenting the contract.

## Risk
- Low / Medium / High: **Medium**
- What can break: provider request shaping for OpenAI Responses continuations. The trim only activates when `previous_response_id` is set, so stateless behavior is unchanged. Tool-call loops are exercised by tests (tool results after last assistant turn are kept).

## Security
- Threat categories reviewed: TM-LLM, TM-DOS
- Findings and resolutions: this change shrinks the request payload on stateful continuations, reducing the unbounded-input surface (TM-DOS positive). No new secret handling, tool execution, auth, or tenant boundary changes. No changes to logging or error surfaces that could leak prior messages.

## Validation
- 6 new tests in `crates/core/src/openresponses_protocol.rs::tests`:
  - `openresponses_requests_should_not_mix_previous_response_id_with_full_transcript` (the issue's reproducer, now passing non-ignored)
  - `compute_delta_keeps_tail_after_assistant_message`
  - `compute_delta_keeps_tool_results_after_last_assistant_turn`
  - `compute_delta_allows_empty_input_for_stateful_continuation`
  - `compute_delta_keeps_all_items_when_no_assistant_turn_present`
  - `compute_delta_drops_prior_reasoning_items`
- `cargo test -p everruns-core` — green (one pre-existing unrelated failure in `test_subagent_capability_registration` confirmed on `origin/main`).
- `cargo test -p everruns-runtime` — green.
- `just pre-push` — green after `cargo fmt`.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)


---
_Generated by [Claude Code](https://claude.ai/code/session_019B9LRrNNvnXo2G9NcfZurY)_