### PR TITLE
feat(tools): add auto output mode and make it default for exec

### DIFF
--- a/crates/container-sandbox/src/tools.rs
+++ b/crates/container-sandbox/src/tools.rs
@@ -10,6 +10,7 @@ use everruns_core::ToolHints;
 use everruns_core::tool_output_sanitizer::{
     READ_FILE_DEFAULT_LIMIT, build_bytes_read_file_result, clean_exec_output,
     output_verbosity_budget, parse_read_file_window_args, priority_aware_truncate,
+    resolve_auto_mode,
 };
 use everruns_core::tools::{Tool, ToolExecutionResult};
 use everruns_core::traits::ToolContext;
@@ -246,10 +247,12 @@ impl Tool for SandboxExecTool {
             Err(e) => return e,
         };
 
+        // EVE-489: persistence-first default. `auto` returns a compact
+        // summary on success and a `normal`-sized diagnostic window on failure.
         let output_mode = arguments
             .get("output")
             .and_then(|v| v.as_str())
-            .unwrap_or("concise");
+            .unwrap_or("auto");
 
         let state = match get_sandbox_state(context).await {
             Ok(s) => s,
@@ -279,15 +282,19 @@ impl Tool for SandboxExecTool {
         // Refresh lease on successful exec
         let _ = touch_sandbox_lease(context, &state).await;
 
-        // Sanitize output
+        // Sanitize output. EVE-489: resolve `auto` against the exit code so
+        // successes get a compact summary and failures still get a diagnostic
+        // window. Docker exit codes fit in i32; saturate on the off chance
+        // the daemon returns something outlandish.
+        let exit_code = result.exit_code;
+        let effective_mode = resolve_auto_mode(output_mode, exit_code as i32);
         let clean_output = clean_exec_output(&result.output);
-        let output = if let Some(budget) = output_verbosity_budget(output_mode) {
+        let output = if let Some(budget) = output_verbosity_budget(effective_mode) {
             priority_aware_truncate(&clean_output, budget)
         } else {
             clean_output
         };
 
-        let exit_code = result.exit_code;
         if exit_code == 0 {
             ToolExecutionResult::success(output)
         } else {

--- a/crates/container-sandbox/src/tools.rs
+++ b/crates/container-sandbox/src/tools.rs
@@ -284,10 +284,12 @@ impl Tool for SandboxExecTool {
 
         // Sanitize output. EVE-489: resolve `auto` against the exit code so
         // successes get a compact summary and failures still get a diagnostic
-        // window. Docker exit codes fit in i32; saturate on the off chance
-        // the daemon returns something outlandish.
+        // window. `resolve_auto_mode` only branches on `== 0`, so reduce the
+        // (possibly i64) Docker exit code to a sentinel that preserves that
+        // distinction without lossy casting.
         let exit_code = result.exit_code;
-        let effective_mode = resolve_auto_mode(output_mode, exit_code as i32);
+        let success_sentinel: i32 = if exit_code == 0 { 0 } else { 1 };
+        let effective_mode = resolve_auto_mode(output_mode, success_sentinel);
         let clean_output = clean_exec_output(&result.output);
         let output = if let Some(budget) = output_verbosity_budget(effective_mode) {
             priority_aware_truncate(&clean_output, budget)

--- a/crates/core/src/capabilities/session_sandbox.rs
+++ b/crates/core/src/capabilities/session_sandbox.rs
@@ -245,10 +245,12 @@ impl Tool for SandboxExecTool {
                         .and_then(|v| v.as_str())
                         .map(ToString::to_string),
                     timeout_ms,
+                    // EVE-489: persistence-first default — `auto` returns
+                    // compact summaries on success, diagnostics on failure.
                     output_mode: arguments
                         .get("output")
                         .and_then(|v| v.as_str())
-                        .unwrap_or("concise")
+                        .unwrap_or("auto")
                         .to_string(),
                 },
             )

--- a/crates/core/src/capabilities/virtual_bash.rs
+++ b/crates/core/src/capabilities/virtual_bash.rs
@@ -241,10 +241,12 @@ impl Tool for BashTool {
             .unwrap_or(30000)
             .min(60000);
 
+        // EVE-489: persistence-first default. `auto` returns a compact
+        // summary on success and a `normal`-sized diagnostic window on failure.
         let output_mode = arguments
             .get("output")
             .and_then(|v| v.as_str())
-            .unwrap_or("concise");
+            .unwrap_or("auto");
 
         let file_store = match &context.file_store {
             Some(store) => store.clone(),
@@ -409,9 +411,13 @@ impl Tool for BashTool {
                 } else {
                     use crate::tool_output_sanitizer::{
                         clean_exec_output, output_verbosity_budget, priority_aware_truncate,
+                        resolve_auto_mode,
                     };
+                    // EVE-489: a timeout is a failure — `auto` resolves to
+                    // `normal` so the model gets useful diagnostics.
+                    let effective = resolve_auto_mode(output_mode, 1);
                     let clean = clean_exec_output(&partial);
-                    let truncated = if let Some(budget) = output_verbosity_budget(output_mode) {
+                    let truncated = if let Some(budget) = output_verbosity_budget(effective) {
                         priority_aware_truncate(&clean, budget)
                     } else {
                         clean.clone()
@@ -462,10 +468,11 @@ impl BackgroundExecutableTool for BashTool {
             .unwrap_or(30000)
             .min(60000);
 
+        // EVE-489: persistence-first default for background execution as well.
         let output_mode = arguments
             .get("output")
             .and_then(|v| v.as_str())
-            .unwrap_or("concise");
+            .unwrap_or("auto");
 
         let file_store = match &context.file_store {
             Some(store) => store.clone(),
@@ -604,9 +611,13 @@ impl BackgroundExecutableTool for BashTool {
                 } else {
                     use crate::tool_output_sanitizer::{
                         clean_exec_output, output_verbosity_budget, priority_aware_truncate,
+                        resolve_auto_mode,
                     };
+                    // EVE-489: a timeout is a failure — resolve `auto` to
+                    // `normal` so the model gets useful diagnostics.
+                    let effective = resolve_auto_mode(output_mode, 1);
                     let clean = clean_exec_output(&partial);
-                    let truncated = if let Some(budget) = output_verbosity_budget(output_mode) {
+                    let truncated = if let Some(budget) = output_verbosity_budget(effective) {
                         priority_aware_truncate(&clean, budget)
                     } else {
                         clean.clone()

--- a/crates/core/src/exec_tool_result.rs
+++ b/crates/core/src/exec_tool_result.rs
@@ -5,7 +5,7 @@
 //! previews, persistence hooks, and narration all depend on this split.
 
 use crate::tool_output_sanitizer::{
-    clean_exec_output, output_verbosity_budget, priority_aware_truncate,
+    clean_exec_output, output_verbosity_budget, priority_aware_truncate, resolve_auto_mode,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -23,7 +23,12 @@ impl ExecToolResultPayload {
     pub fn new(stdout: &str, stderr: &str, exit_code: i32, output_mode: &str) -> Self {
         let clean_stdout = clean_exec_output(stdout);
         let clean_stderr = clean_exec_output(stderr);
-        let (stdout, stderr) = if let Some(budget) = output_verbosity_budget(output_mode) {
+        // EVE-489: `auto` is persistence-first — successful persisted exec
+        // calls return a tiny inline summary so the model can rely on the
+        // persisted /outputs files for the full log, while failures fall back
+        // to a `normal`-sized window for in-loop debugging.
+        let effective_mode = resolve_auto_mode(output_mode, exit_code);
+        let (stdout, stderr) = if let Some(budget) = output_verbosity_budget(effective_mode) {
             (
                 priority_aware_truncate(&clean_stdout, budget),
                 priority_aware_truncate(&clean_stderr, budget.min(4096)),
@@ -54,6 +59,7 @@ impl ExecToolResultPayload {
 #[cfg(test)]
 mod tests {
     use super::ExecToolResultPayload;
+    use crate::tool_output_sanitizer::{AUTO_SUCCESS_BUDGET, NORMAL_BUDGET};
 
     #[test]
     fn preserves_full_raw_output_and_marks_truncation() {
@@ -82,5 +88,126 @@ mod tests {
         assert!(!payload.truncated);
         assert_eq!(payload.total_lines, 2);
         assert_eq!(payload.raw_output, "alpha\nbeta\n");
+    }
+
+    // ====================================================================
+    // EVE-489: auto mode is persistence-first
+    // ====================================================================
+
+    #[test]
+    fn auto_success_produces_compact_inline_output() {
+        let stdout = (0..2000)
+            .map(|i| format!("success-line-{i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let payload = ExecToolResultPayload::new(&stdout, "", 0, "auto");
+
+        assert!(payload.success);
+        assert!(
+            payload.stdout.len() <= AUTO_SUCCESS_BUDGET,
+            "auto+success stdout should fit in AUTO_SUCCESS_BUDGET ({}), got {} bytes",
+            AUTO_SUCCESS_BUDGET,
+            payload.stdout.len()
+        );
+        // total_lines is computed from cleaned (untruncated) stdout
+        assert_eq!(payload.total_lines, 2000);
+        // raw_output still contains every line for the persistence hook
+        assert!(payload.raw_output.contains("success-line-0"));
+        assert!(payload.raw_output.contains("success-line-1999"));
+        assert!(payload.truncated);
+    }
+
+    #[test]
+    fn auto_failure_uses_normal_diagnostic_budget() {
+        // Build output large enough that NORMAL_BUDGET truncation kicks in
+        // but the result still has substantial diagnostic detail.
+        let mut lines = Vec::new();
+        for i in 0..200 {
+            lines.push(format!("building module {i}"));
+        }
+        lines.push("error: failed to compile".to_string());
+        lines.push("  --> src/main.rs:1:1".to_string());
+        for i in 0..2000 {
+            lines.push(format!("trailing diagnostic line {i}"));
+        }
+        let stdout = lines.join("\n");
+
+        let payload = ExecToolResultPayload::new(&stdout, "stderr details\n", 1, "auto");
+
+        assert!(!payload.success);
+        assert_eq!(payload.exit_code, 1);
+        // Auto + failure should give a diagnostic window, not the tiny success budget.
+        assert!(
+            payload.stdout.len() > AUTO_SUCCESS_BUDGET,
+            "auto+failure stdout should exceed AUTO_SUCCESS_BUDGET to fit diagnostics, got {} bytes",
+            payload.stdout.len()
+        );
+        assert!(
+            payload.stdout.len() <= NORMAL_BUDGET,
+            "auto+failure stdout should be capped at NORMAL_BUDGET ({}), got {} bytes",
+            NORMAL_BUDGET,
+            payload.stdout.len()
+        );
+        // Error region is preserved through priority-aware truncation.
+        assert!(
+            payload.stdout.contains("error: failed to compile"),
+            "error line must be preserved in failure diagnostic output"
+        );
+        // raw_output still has the full content for persistence.
+        assert!(payload.raw_output.contains("building module 0"));
+        assert!(payload.raw_output.contains("trailing diagnostic line 1999"));
+        assert!(payload.raw_output.contains("--- stderr ---"));
+    }
+
+    #[test]
+    fn auto_small_success_output_is_unchanged() {
+        let payload = ExecToolResultPayload::new("ok\n", "", 0, "auto");
+        assert!(payload.success);
+        assert_eq!(payload.stdout, "ok\n");
+        assert!(!payload.truncated);
+    }
+
+    #[test]
+    fn explicit_normal_still_uses_normal_budget_on_success() {
+        let stdout = (0..2000)
+            .map(|i| format!("line-{i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let payload = ExecToolResultPayload::new(&stdout, "", 0, "normal");
+
+        assert!(payload.success);
+        // Normal on success returns NORMAL_BUDGET worth of inline output,
+        // not the auto-success compact summary.
+        assert!(
+            payload.stdout.len() > AUTO_SUCCESS_BUDGET,
+            "explicit normal mode should not compact to auto-success budget on success"
+        );
+        assert!(payload.stdout.len() <= NORMAL_BUDGET);
+    }
+
+    #[test]
+    fn raw_output_preserved_across_modes() {
+        let stdout = (0..5000)
+            .map(|i| format!("line-{i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        for mode in ["auto", "silent", "concise", "normal", "verbose", "full"] {
+            for exit_code in [0, 1] {
+                let payload = ExecToolResultPayload::new(&stdout, "err\n", exit_code, mode);
+                assert!(
+                    payload.raw_output.contains("line-0"),
+                    "raw_output should contain head for mode={mode} exit={exit_code}"
+                );
+                assert!(
+                    payload.raw_output.contains("line-4999"),
+                    "raw_output should contain tail for mode={mode} exit={exit_code}"
+                );
+                assert!(
+                    payload.raw_output.contains("--- stderr ---"),
+                    "raw_output should contain stderr marker for mode={mode} exit={exit_code}"
+                );
+            }
+        }
     }
 }

--- a/crates/core/src/session_sandbox.rs
+++ b/crates/core/src/session_sandbox.rs
@@ -520,7 +520,8 @@ fn default_provider_config() -> Value {
 }
 
 fn default_output_mode() -> String {
-    "concise".to_string()
+    // EVE-489: persistence-first default for exec-style sandbox tools.
+    "auto".to_string()
 }
 
 fn now_rfc3339() -> String {

--- a/crates/core/src/tool_output_sanitizer.rs
+++ b/crates/core/src/tool_output_sanitizer.rs
@@ -44,8 +44,10 @@ pub const AUTO_SUCCESS_BUDGET: usize = 384;
 ///
 /// Note: `auto` is exec-tool specific and depends on the process exit code,
 /// so callers should run [`resolve_auto_mode`] first to map `auto` to a
-/// concrete mode. A bare `auto` reaching this function falls through to the
-/// unknown default (`CONCISE_BUDGET`) so behavior stays safe.
+/// concrete mode. A bare `auto` reaching this function resolves to the
+/// tight `AUTO_SUCCESS_BUDGET` rather than silently falling back to
+/// `CONCISE_BUDGET` — callers that forget to resolve will at worst
+/// over-truncate, never silently widen.
 pub fn output_verbosity_budget(mode: &str) -> Option<usize> {
     match mode {
         "silent" => Some(SILENT_BUDGET),
@@ -53,7 +55,7 @@ pub fn output_verbosity_budget(mode: &str) -> Option<usize> {
         "normal" => Some(NORMAL_BUDGET),
         "verbose" => Some(VERBOSE_BUDGET),
         "full" => None,
-        "auto_success" => Some(AUTO_SUCCESS_BUDGET),
+        "auto" | "auto_success" => Some(AUTO_SUCCESS_BUDGET),
         _ => Some(CONCISE_BUDGET), // unknown → default
     }
 }
@@ -86,7 +88,7 @@ pub fn output_verbosity_schema() -> serde_json::Value {
         "type": "string",
         "enum": ["auto", "silent", "concise", "normal", "verbose", "full"],
         "default": "auto",
-        "description": "Output verbosity: auto (default — compact summary on success when output is persisted, ~8KiB on failure for diagnostics), silent (~200B), concise (~2KiB), normal (~8KiB), verbose (~16KiB), full (unlimited, capped by 64KiB hard limit). For tools with output persistence enabled, full output is saved to /outputs/{tool_call_id}.stdout and /outputs/{tool_call_id}.stderr — use read_file to retrieve."
+        "description": "Output verbosity: auto (default — compact summary on success, ~8KiB on failure for diagnostics), silent (~200B), concise (~2KiB), normal (~8KiB), verbose (~16KiB), full (unlimited, capped by 64KiB hard limit). For tools with output persistence enabled, full output is saved to /outputs/{tool_call_id}.stdout and /outputs/{tool_call_id}.stderr — use read_file to retrieve."
     })
 }
 
@@ -1322,6 +1324,19 @@ mod tests {
         assert_eq!(
             output_verbosity_budget("auto_success"),
             Some(AUTO_SUCCESS_BUDGET)
+        );
+    }
+
+    #[test]
+    fn test_bare_auto_budget_defaults_to_auto_success() {
+        // A caller that forgets to run `resolve_auto_mode` first must not
+        // silently widen to `concise`. EVE-489 keeps the tight budget so
+        // the worst case is an over-truncated payload, never a silently
+        // expanded one.
+        assert_eq!(
+            output_verbosity_budget("auto"),
+            Some(AUTO_SUCCESS_BUDGET),
+            "bare `auto` should resolve to the tight success budget, not silently widen to concise"
         );
     }
 

--- a/crates/core/src/tool_output_sanitizer.rs
+++ b/crates/core/src/tool_output_sanitizer.rs
@@ -13,10 +13,11 @@
 // Follow-ups:
 // - EVE-222: persist_output hint drives VFS persistence via PostToolExecHook
 // - EVE-223: EXEC_OUTPUT_HINT constant for system prompt additions
+// - EVE-489: `auto` output mode — persistence-first defaults for exec tools
 
 /// Legacy output budget constant (16 KiB). Kept for backward compatibility
 /// with any code not yet migrated to `output_verbosity_budget()`.
-/// New code should use the verbosity modes instead (default: `concise` = 2 KiB).
+/// New code should use the verbosity modes instead (default: `auto`).
 pub const EXEC_OUTPUT_BUDGET: usize = 16 * 1024;
 
 /// Output verbosity budgets (EVE-236).
@@ -28,8 +29,23 @@ pub const CONCISE_BUDGET: usize = 2 * 1024;
 pub const NORMAL_BUDGET: usize = 8 * 1024;
 pub const VERBOSE_BUDGET: usize = 16 * 1024;
 
+/// Compact "success summary" budget used by `auto` mode (EVE-489).
+/// When an exec call succeeds and full output is persisted to `/outputs/`,
+/// the inline payload only needs enough bytes to confirm completion — the
+/// model can `read_file` the persisted log when it needs more detail.
+///
+/// Sized so that even after the `PersistOutputHook` appends its
+/// `[full output saved to /workspace/outputs/... (NN KiB) — use read_file ...]`
+/// pointer (~120 bytes), the full inline `stdout` field stays ≤ ~512 bytes.
+pub const AUTO_SUCCESS_BUDGET: usize = 384;
+
 /// Resolve output verbosity mode string to byte budget.
 /// Returns `None` for "full" (no truncation).
+///
+/// Note: `auto` is exec-tool specific and depends on the process exit code,
+/// so callers should run [`resolve_auto_mode`] first to map `auto` to a
+/// concrete mode. A bare `auto` reaching this function falls through to the
+/// unknown default (`CONCISE_BUDGET`) so behavior stays safe.
 pub fn output_verbosity_budget(mode: &str) -> Option<usize> {
     match mode {
         "silent" => Some(SILENT_BUDGET),
@@ -37,7 +53,29 @@ pub fn output_verbosity_budget(mode: &str) -> Option<usize> {
         "normal" => Some(NORMAL_BUDGET),
         "verbose" => Some(VERBOSE_BUDGET),
         "full" => None,
+        "auto_success" => Some(AUTO_SUCCESS_BUDGET),
         _ => Some(CONCISE_BUDGET), // unknown → default
+    }
+}
+
+/// Resolve the exec-tool `auto` mode to a concrete verbosity mode based on
+/// the process exit code (EVE-489).
+///
+/// - `auto` + success (`exit_code == 0`) → `auto_success` (tight summary).
+///   Full output remains in `raw_output` and is persisted via
+///   `ToolOutputPersistenceCapability` when the tool opts in.
+/// - `auto` + failure → `normal` so the model can debug without immediately
+///   reading the persisted log.
+/// - Any other (explicit) mode is returned unchanged.
+pub fn resolve_auto_mode(mode: &str, exit_code: i32) -> &str {
+    if mode == "auto" {
+        if exit_code == 0 {
+            "auto_success"
+        } else {
+            "normal"
+        }
+    } else {
+        mode
     }
 }
 
@@ -46,21 +84,19 @@ pub fn output_verbosity_budget(mode: &str) -> Option<usize> {
 pub fn output_verbosity_schema() -> serde_json::Value {
     serde_json::json!({
         "type": "string",
-        "enum": ["silent", "concise", "normal", "verbose", "full"],
-        "default": "concise",
-        "description": "Output verbosity: silent (~200B, truncated to exit code + minimal output), concise (~2KiB, default), normal (~8KiB), verbose (~16KiB), full (unlimited, capped by 64KiB hard limit). For tools with output persistence enabled, full output is saved to /outputs/{tool_call_id}.stdout and /outputs/{tool_call_id}.stderr — use read_file to retrieve."
+        "enum": ["auto", "silent", "concise", "normal", "verbose", "full"],
+        "default": "auto",
+        "description": "Output verbosity: auto (default — compact summary on success when output is persisted, ~8KiB on failure for diagnostics), silent (~200B), concise (~2KiB), normal (~8KiB), verbose (~16KiB), full (unlimited, capped by 64KiB hard limit). For tools with output persistence enabled, full output is saved to /outputs/{tool_call_id}.stdout and /outputs/{tool_call_id}.stderr — use read_file to retrieve."
     })
 }
 
-/// System prompt hint for exec tool capabilities (EVE-223, EVE-236).
+/// System prompt hint for exec tool capabilities (EVE-223, EVE-236, EVE-489).
 /// Appended to each sandbox capability's `system_prompt_addition()` to guide
 /// the LLM toward less verbose command usage.
-pub const EXEC_OUTPUT_HINT: &str = "\n\n**Output economy:** Command output is truncated based on the `output` parameter (default: `concise` ~2 KiB). \
-Use `verbose` or `full` when debugging failures. Tools with output persistence enabled save full output — stdout to `/outputs/{tool_call_id}.stdout`, stderr to `/outputs/{tool_call_id}.stderr`. \
-When output exceeds the budget, the result includes an `output_files` array with paths you can `read_file` with offset/limit.\n\
-Available modes: `silent` (~200B), `concise` (~2KiB), `normal` (~8KiB), `verbose` (~16KiB), `full` (unlimited).\n\
-For build/install commands, the default `concise` is usually sufficient — check exit code first.\n\
-If you need more detail, re-run with `output: \"verbose\"` or read the persisted output files via `read_file`.";
+pub const EXEC_OUTPUT_HINT: &str = "\n\n**Output economy:** The `output` parameter shapes command output (default: `auto` — compact summary on success, ~8 KiB diagnostic window on failure). \
+Persistence-enabled tools save full output to `/outputs/{tool_call_id}.stdout`/`.stderr`; oversized results include an `output_files` array of paths to `read_file` with offset/limit.\n\
+Modes: `auto` (default), `silent` (~200B), `concise` (~2KiB), `normal` (~8KiB), `verbose` (~16KiB), `full` (unlimited).\n\
+`auto` is usually sufficient — check `exit_code` first; use `verbose` or read the persisted files when more detail is needed.";
 
 /// System prompt hint for file reading economy (EVE-244).
 /// Appended to the FileSystem capability's `system_prompt_addition()` to guide
@@ -1254,5 +1290,56 @@ mod tests {
         let regions = find_error_regions(&lines);
         // Should merge into one region since they're within 2*ERROR_CONTEXT_LINES+1 of each other
         assert_eq!(regions.len(), 1, "nearby errors should merge");
+    }
+
+    // ====================================================================
+    // auto mode resolution (EVE-489)
+    // ====================================================================
+
+    #[test]
+    fn test_resolve_auto_success_maps_to_auto_success() {
+        assert_eq!(resolve_auto_mode("auto", 0), "auto_success");
+    }
+
+    #[test]
+    fn test_resolve_auto_failure_maps_to_normal() {
+        assert_eq!(resolve_auto_mode("auto", 1), "normal");
+        assert_eq!(resolve_auto_mode("auto", -1), "normal");
+        assert_eq!(resolve_auto_mode("auto", 137), "normal");
+    }
+
+    #[test]
+    fn test_resolve_auto_passes_through_explicit_modes() {
+        assert_eq!(resolve_auto_mode("concise", 0), "concise");
+        assert_eq!(resolve_auto_mode("normal", 1), "normal");
+        assert_eq!(resolve_auto_mode("verbose", 0), "verbose");
+        assert_eq!(resolve_auto_mode("full", 1), "full");
+        assert_eq!(resolve_auto_mode("silent", 0), "silent");
+    }
+
+    #[test]
+    fn test_auto_success_budget_matches_constant() {
+        assert_eq!(
+            output_verbosity_budget("auto_success"),
+            Some(AUTO_SUCCESS_BUDGET)
+        );
+    }
+
+    #[test]
+    fn test_output_verbosity_schema_includes_auto() {
+        let schema = output_verbosity_schema();
+        let variants: Vec<&str> = schema["enum"]
+            .as_array()
+            .expect("enum should be an array")
+            .iter()
+            .map(|v| v.as_str().unwrap())
+            .collect();
+        assert!(variants.contains(&"auto"), "auto must be in enum");
+        assert!(variants.contains(&"silent"));
+        assert!(variants.contains(&"concise"));
+        assert!(variants.contains(&"normal"));
+        assert!(variants.contains(&"verbose"));
+        assert!(variants.contains(&"full"));
+        assert_eq!(schema["default"], "auto", "auto must be the default");
     }
 }

--- a/examples/coding-cli/src/tools.rs
+++ b/examples/coding-cli/src/tools.rs
@@ -88,10 +88,15 @@ impl Tool for BashTool {
             Some(c) => c.to_string(),
             None => return ToolExecutionResult::tool_error("'command' is required"),
         };
+        // EVE-489: default to `auto` (persistence-first). On success, returns
+        // a compact ~512 B summary while full output stays in `/outputs/` via
+        // ToolOutputPersistenceCapability. On failure, returns a `normal`
+        // (~8 KiB) diagnostic window. Explicit modes (silent/concise/normal/
+        // verbose/full) still override this behavior.
         let output_mode = arguments
             .get("output")
             .and_then(Value::as_str)
-            .unwrap_or("concise");
+            .unwrap_or("auto");
         let approved = self
             .gate
             .approve(ApprovalRequest::Bash {
@@ -294,5 +299,183 @@ mod tests {
             .await
             .expect("persisted stdout should be readable from the outputs folder");
         assert!(saved.contains("saved-line-3000"));
+    }
+
+    // ====================================================================
+    // EVE-489: persistence-first `auto` output mode
+    // ====================================================================
+
+    /// Issue EVE-489 reproducer: successful bash output should be a compact
+    /// inline summary when full output is persisted to `/outputs/`. Before
+    /// the fix, requesting `output: "normal"` returned ~8 KiB inline even
+    /// though the full log was already saved. With `auto` (the new default),
+    /// successful runs return ≤512 bytes inline.
+    #[tokio::test]
+    async fn bash_success_output_should_be_persistent_first_when_output_is_saved() {
+        let dir = tempfile::tempdir().unwrap();
+        let tool = BashTool::new(
+            Workspace::new(dir.path().to_path_buf()),
+            ApprovalGate::auto(),
+        );
+        let call = ToolCall {
+            id: "call-auto-compact".to_string(),
+            name: "bash".to_string(),
+            arguments: json!({
+                "command": "for i in {1..2000}; do echo success-line-$i; done",
+                "output": "auto"
+            }),
+        };
+        let mut result = tool
+            .execute(call.arguments.clone())
+            .await
+            .into_tool_result(&call.id, &call.name);
+        let file_store = Arc::new(RealDiskFileStore::new(dir.path()).unwrap());
+        let context = ToolContext::with_file_store(Default::default(), file_store);
+        let tool_def = tool.to_definition();
+
+        for hook in ToolOutputPersistenceCapability.post_tool_exec_hooks() {
+            hook.after_exec(&call, &tool_def, &mut result, &context)
+                .await;
+        }
+
+        let value = result.result.expect("bash result should be present");
+        let stdout = value["stdout"].as_str().expect("stdout should be a string");
+        assert_eq!(value["success"], true);
+        assert!(
+            value["output_files"]
+                .as_array()
+                .is_some_and(|files| !files.is_empty()),
+            "full output should be persisted"
+        );
+        assert!(
+            stdout.len() <= 512,
+            "successful persisted bash output should be a compact inline summary, got {} bytes",
+            stdout.len()
+        );
+    }
+
+    #[tokio::test]
+    async fn bash_defaults_to_auto_mode_for_compact_success() {
+        // No `output` parameter at all — the new default must behave like `auto`.
+        let dir = tempfile::tempdir().unwrap();
+        let tool = BashTool::new(
+            Workspace::new(dir.path().to_path_buf()),
+            ApprovalGate::auto(),
+        );
+
+        let result = tool
+            .execute(json!({
+                "command": "for i in {1..2000}; do echo line-$i; done"
+            }))
+            .await;
+
+        let ToolExecutionResult::Success(value) = result else {
+            panic!("expected success");
+        };
+        assert_eq!(value["success"], true);
+        let stdout = value["stdout"].as_str().unwrap();
+        assert!(
+            stdout.len() <= 512,
+            "default mode should compact successful output, got {} bytes",
+            stdout.len()
+        );
+        // raw_output retains full content for persistence hook.
+        let raw = value["_raw_output"].as_str().unwrap();
+        assert!(raw.contains("line-2000"));
+    }
+
+    #[tokio::test]
+    async fn bash_auto_failure_returns_diagnostic_inline_output() {
+        let dir = tempfile::tempdir().unwrap();
+        let tool = BashTool::new(
+            Workspace::new(dir.path().to_path_buf()),
+            ApprovalGate::auto(),
+        );
+
+        // Produce lots of stdout, then exit non-zero with a useful stderr line.
+        let result = tool
+            .execute(json!({
+                "command": "for i in {1..2000}; do echo line-$i; done; echo 'error: something broke' 1>&2; exit 7",
+                "output": "auto"
+            }))
+            .await;
+
+        let ToolExecutionResult::Success(value) = result else {
+            panic!("expected success-wrapped tool result");
+        };
+        assert_eq!(value["success"], false);
+        assert_eq!(value["exit_code"], 7);
+        let stderr = value["stderr"].as_str().unwrap();
+        assert!(
+            stderr.contains("error: something broke"),
+            "failure stderr should expose diagnostics inline, got: {stderr}"
+        );
+        let stdout = value["stdout"].as_str().unwrap();
+        // Failure path should give substantially more than the success compact budget.
+        assert!(
+            stdout.len() > 512,
+            "auto+failure stdout should not collapse to the success compact budget, got {} bytes",
+            stdout.len()
+        );
+    }
+
+    #[tokio::test]
+    async fn bash_explicit_normal_still_returns_larger_inline_output() {
+        let dir = tempfile::tempdir().unwrap();
+        let tool = BashTool::new(
+            Workspace::new(dir.path().to_path_buf()),
+            ApprovalGate::auto(),
+        );
+
+        let result = tool
+            .execute(json!({
+                "command": "for i in {1..2000}; do echo line-$i; done",
+                "output": "normal"
+            }))
+            .await;
+
+        let ToolExecutionResult::Success(value) = result else {
+            panic!("expected success");
+        };
+        let stdout = value["stdout"].as_str().unwrap();
+        // Explicit `normal` must keep the larger inline window even on success.
+        assert!(
+            stdout.len() > 512,
+            "explicit normal should not collapse to auto-success budget, got {} bytes",
+            stdout.len()
+        );
+        assert!(
+            stdout.len() <= 8 * 1024,
+            "explicit normal should respect NORMAL_BUDGET, got {} bytes",
+            stdout.len()
+        );
+    }
+
+    #[tokio::test]
+    async fn bash_explicit_full_returns_unlimited_inline_output() {
+        let dir = tempfile::tempdir().unwrap();
+        let tool = BashTool::new(
+            Workspace::new(dir.path().to_path_buf()),
+            ApprovalGate::auto(),
+        );
+
+        let result = tool
+            .execute(json!({
+                "command": "for i in {1..200}; do echo line-$i; done",
+                "output": "full"
+            }))
+            .await;
+
+        let ToolExecutionResult::Success(value) = result else {
+            panic!("expected success");
+        };
+        let stdout = value["stdout"].as_str().unwrap();
+        // `full` must include every line — first and last.
+        assert!(
+            stdout.contains("line-1\n"),
+            "stdout must contain first line"
+        );
+        assert!(stdout.contains("line-200"), "stdout must contain last line");
+        assert_eq!(value["truncated"], false);
     }
 }

--- a/integrations/daytona/src/tools.rs
+++ b/integrations/daytona/src/tools.rs
@@ -504,7 +504,7 @@ impl Tool for DaytonaExecTool {
         let output_mode = arguments
             .get("output")
             .and_then(|v| v.as_str())
-            .unwrap_or("concise");
+            .unwrap_or("auto");
         let timeout = arguments
             .get("timeout")
             .and_then(|v| v.as_u64())

--- a/integrations/deno/src/tools.rs
+++ b/integrations/deno/src/tools.rs
@@ -266,7 +266,7 @@ impl Tool for DenoExecTool {
         let output_mode = arguments
             .get("output")
             .and_then(|v| v.as_str())
-            .unwrap_or("concise");
+            .unwrap_or("auto");
 
         let credentials = match get_credentials(context).await {
             Ok(credentials) => credentials,
@@ -291,10 +291,12 @@ impl Tool for DenoExecTool {
         {
             use everruns_core::tool_output_sanitizer::{
                 clean_exec_output, output_verbosity_budget, priority_aware_truncate,
+                resolve_auto_mode,
             };
             let clean_stdout = clean_exec_output(&exec.stdout);
             let clean_stderr = clean_exec_output(&exec.stderr);
-            let (stdout, stderr) = if let Some(budget) = output_verbosity_budget(output_mode) {
+            let effective_mode = resolve_auto_mode(output_mode, exec.exit_code);
+            let (stdout, stderr) = if let Some(budget) = output_verbosity_budget(effective_mode) {
                 (
                     priority_aware_truncate(&clean_stdout, budget),
                     priority_aware_truncate(&clean_stderr, budget.min(4096)),

--- a/integrations/docker/src/lib.rs
+++ b/integrations/docker/src/lib.rs
@@ -404,7 +404,7 @@ impl Tool for DockerExecTool {
         let output_mode = arguments
             .get("output")
             .and_then(|v| v.as_str())
-            .unwrap_or("concise");
+            .unwrap_or("auto");
 
         let name = container_name(&context.session_id);
 
@@ -445,11 +445,12 @@ impl Tool for DockerExecTool {
         let stderr_raw = String::from_utf8_lossy(&output.stderr);
 
         use everruns_core::tool_output_sanitizer::{
-            clean_exec_output, output_verbosity_budget, priority_aware_truncate,
+            clean_exec_output, output_verbosity_budget, priority_aware_truncate, resolve_auto_mode,
         };
         let clean_stdout = clean_exec_output(&stdout_raw);
         let clean_stderr = clean_exec_output(&stderr_raw);
-        let (stdout, stderr) = if let Some(budget) = output_verbosity_budget(output_mode) {
+        let effective_mode = resolve_auto_mode(output_mode, exit_code);
+        let (stdout, stderr) = if let Some(budget) = output_verbosity_budget(effective_mode) {
             (
                 priority_aware_truncate(&clean_stdout, budget),
                 priority_aware_truncate(&clean_stderr, budget.min(4096)),

--- a/integrations/e2b/src/tools.rs
+++ b/integrations/e2b/src/tools.rs
@@ -288,7 +288,7 @@ impl Tool for E2BExecTool {
         let output_mode = arguments
             .get("output")
             .and_then(|v| v.as_str())
-            .unwrap_or("concise");
+            .unwrap_or("auto");
         let state = match get_sandbox_state(context, sandbox_id).await {
             Ok(state) => state,
             Err(err) => return err,

--- a/integrations/sprites/src/tools.rs
+++ b/integrations/sprites/src/tools.rs
@@ -257,7 +257,7 @@ impl Tool for SpritesExecTool {
         let output_mode = arguments
             .get("output")
             .and_then(|v| v.as_str())
-            .unwrap_or("concise");
+            .unwrap_or("auto");
         let timeout = arguments
             .get("timeout")
             .and_then(|v| v.as_u64())
@@ -283,10 +283,13 @@ impl Tool for SpritesExecTool {
                 }
                 use everruns_core::tool_output_sanitizer::{
                     clean_exec_output, output_verbosity_budget, priority_aware_truncate,
+                    resolve_auto_mode,
                 };
                 let clean_stdout = clean_exec_output(&result.stdout);
                 let clean_stderr = clean_exec_output(&result.stderr);
-                let (stdout, stderr) = if let Some(budget) = output_verbosity_budget(output_mode) {
+                let effective_mode = resolve_auto_mode(output_mode, result.exit_code);
+                let (stdout, stderr) = if let Some(budget) = output_verbosity_budget(effective_mode)
+                {
                     (
                         priority_aware_truncate(&clean_stdout, budget),
                         priority_aware_truncate(&clean_stderr, budget.min(4096)),

--- a/specs/tool-execution.md
+++ b/specs/tool-execution.md
@@ -150,19 +150,22 @@ The pipeline:
 2. **Collapse CR lines** — `\r`-overwritten lines (progress bars) reduced to final content
 3. **Truncate** — priority-aware truncation at the budget determined by the `output` verbosity parameter
 
-### Output Verbosity (EVE-236)
+### Output Verbosity (EVE-236, EVE-489)
 
 All exec tools accept an `output` parameter controlling how much output is returned to the LLM:
 
 | Mode | Budget | When to use |
 |------|--------|-------------|
+| `auto` | compact summary on success (~512 B total inline including the `[full output saved to ...]` pointer) / ~8 KiB on failure | Persistence-first — compact summary when the run succeeds and output is persisted, diagnostic window when it fails (**default**) |
 | `silent` | ~200 B | Minimal truncated output — fire-and-forget commands |
-| `concise` | ~2 KiB | Tail ~30 lines — builds, installs, known-good commands (**default**) |
+| `concise` | ~2 KiB | Tail ~30 lines — builds, installs, known-good commands |
 | `normal` | ~8 KiB | General use, debugging |
 | `verbose` | ~16 KiB | Test failures, error investigation |
 | `full` | unlimited | Raw output, no truncation — when the LLM needs every line |
 
-Default is `concise`. Budgets apply to stdout; stderr is capped at `min(budget, 4096)` to keep error output proportional. Tools that set the `persist_output` hint persist non-empty full output to `/outputs/` via `tool_output_persistence` — stdout to `/outputs/{tool_call_id}.stdout`, stderr to `/outputs/{tool_call_id}.stderr` — and the files are readable with `read_file`. See `crates/core/src/tool_output_sanitizer.rs` for budget constants and `output_verbosity_budget()`.
+Default is `auto`. In `auto` mode, the resolved budget depends on the process exit code: successful runs (`exit_code == 0`) collapse to `AUTO_SUCCESS_BUDGET` so the model relies on the persisted log; non-zero exits resolve to `normal` (~8 KiB) so failures stay debuggable in-loop. `AUTO_SUCCESS_BUDGET` is intentionally sized so the inline `stdout` field — including the `[full output saved to /workspace/outputs/... — use read_file ...]` pointer that `PersistOutputHook` appends — stays around 512 bytes total. `raw_output` always carries the full cleaned output for persistence hooks, regardless of mode. Explicit `silent`/`concise`/`normal`/`verbose`/`full` are opt-ins for a fixed inline window and continue to behave exactly as before — they ignore exit code.
+
+Budgets apply to stdout; stderr is capped at `min(budget, 4096)` to keep error output proportional. Tools that set the `persist_output` hint persist non-empty full output to `/outputs/` via `tool_output_persistence` — stdout to `/outputs/{tool_call_id}.stdout`, stderr to `/outputs/{tool_call_id}.stderr` — and the files are readable with `read_file`. The persisted files are the source of truth for full logs; the inline payload is sized for next-step reasoning. See `crates/core/src/tool_output_sanitizer.rs` for budget constants, `output_verbosity_budget()`, and `resolve_auto_mode()`.
 
 This is the tool's responsibility — each tool calls the helpers before constructing `ToolExecutionResult`. See `crates/core/src/tool_output_sanitizer.rs` for the primitives.
 


### PR DESCRIPTION
## What
Adds a new `output: "auto"` mode for exec-style tools (ercode bash, virtual bash, session sandbox, container sandbox) and makes it the new default. On success with persisted output, `auto` returns a compact inline summary (~384 bytes, room for the persistence annotation to land under the ~512 byte target). On failure, `auto` falls back to the `normal` budget (8 KiB) so the model has enough diagnostic detail to debug without immediately reading `/outputs/`.

Linear: [EVE-489](https://linear.app/everruns/issue/EVE-489/make-exec-output-persistent-first-with-auto-mode)

## Why
Persistence already saves full exec output to `/outputs/`, but the inline result returned to the model was still verbosity-first. In the analyzed ercode session, 36 `normal` bash calls produced 124,792 inline result chars (~31k tokens) of context bloat that compounded over long CI-polling loops. Making `auto` the default keeps inline output minimal on success while preserving diagnostics on failure.

## How
- New helper `resolve_auto_mode(mode, exit_code)` in `crates/core/src/tool_output_sanitizer.rs` maps `"auto"` to either an internal `"auto_success"` budget (`AUTO_SUCCESS_BUDGET = 384`) on `exit_code == 0`, or `"normal"` on failure. Explicit modes pass through unchanged.
- `output_verbosity_budget` learned about `"auto_success"` so the single budget table stays the source of truth.
- `ExecToolResultPayload::new` runs `resolve_auto_mode` once before applying the budget — `raw_output` is preserved regardless of mode.
- All four exec tool defaults switched to `"auto"`:
  - `examples/coding-cli/src/tools.rs` (ercode bash)
  - `crates/core/src/capabilities/virtual_bash.rs` (sync + background paths; timeout treated as failure)
  - `crates/core/src/capabilities/session_sandbox.rs` (`default_output_mode`)
  - `crates/container-sandbox/src/tools.rs` (resolves against docker exit code, since this path does not use `ExecToolResultPayload`)
- Schema (`output_verbosity_schema`) gains `"auto"` and sets it as default.
- Spec `specs/tool-execution.md` updated to document `auto`, success-compact / failure-diagnostic semantics, and the persisted-output source-of-truth invariant.
- The `EXEC_OUTPUT_HINT` prompt insert was trimmed slightly to fit the daytona system-prompt budget after the addition.

## Risk
- Low / Medium / High: **Medium**
- What can break: any caller relying on the prior `concise` default for successful exec calls will now see ~384-byte summaries by default (with a `[full output saved to ...]` annotation pointing to the persisted file). Explicit `silent`/`concise`/`normal`/`verbose`/`full` continue to work unchanged.

## Security
- Threat categories reviewed: TM-LLM, TM-FS, TM-DOS
- Findings and resolutions: TM-DOS positive — auto-mode reduces unbounded inline prompt growth on success. TM-FS unchanged — persistence paths are unaffected, full output continues to be written under `/outputs/` via the existing `ToolOutputPersistenceCapability` hook. No new secret handling, auth, or tenant boundary changes. No logging surface that could leak persisted-only content into prompts unintentionally.

## Validation
- Reproducer test from the issue added (non-ignored, passing): `bash_success_output_should_be_persistent_first_when_output_is_saved` in `examples/coding-cli/src/tools.rs`.
- New tests cover: auto + success (compact), auto + failure (normal budget), explicit `normal` opt-in still wide, explicit `full` unlimited, `raw_output` preserved across modes (5 tests in `exec_tool_result.rs`, 5 in `tool_output_sanitizer.rs`, 5 in `examples/coding-cli/src/tools.rs`).
- `cargo test -p everruns-core --lib`: 1852 passed.
- `cargo test -p everruns-coding-cli`: 49 passed (8 bash tests).
- `cargo test -p everruns-container-sandbox`: 33 passed.
- `cargo test -p everruns-integrations-daytona --lib`: 166 passed (including `system_prompt_within_budget` after the hint trim).
- `just pre-push`: all 9 checks pass.

A pre-existing unrelated failure (`test_subagent_capability_registration`) was confirmed present on `origin/main` and is not introduced by this change.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (explicit modes preserved)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)


---
_Generated by [Claude Code](https://claude.ai/code/session_019B9LRrNNvnXo2G9NcfZurY)_