### PR TITLE
fix(tests): tolerate Daytona /sandbox pagination shape

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2244,6 +2244,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
+ "urlencoding",
  "wiremock",
 ]
 

--- a/integrations/daytona/Cargo.toml
+++ b/integrations/daytona/Cargo.toml
@@ -32,3 +32,4 @@ daytona-live-tests = []
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }
 wiremock = "0.6"
+urlencoding = "2"

--- a/integrations/daytona/tests/live_api_test.rs
+++ b/integrations/daytona/tests/live_api_test.rs
@@ -754,17 +754,56 @@ async fn test_live_api_call_sandbox_lifecycle_with_labels() {
     assert!(files.is_array(), "Expected array of files, got: {files}");
     eprintln!("[test] Toolbox file listing works via api_call");
 
-    // List all sandboxes via api_call, verify ours appears
-    let all = client
-        .api_call(reqwest::Method::GET, "/sandbox", None)
-        .await
-        .expect("api_call GET /sandbox failed");
-    let found = all
-        .as_array()
-        .unwrap()
-        .iter()
-        .any(|s| s["id"].as_str() == Some(sandbox_id));
-    assert!(found, "Sandbox {sandbox_id} not found in list");
+    // List all sandboxes via api_call, verify ours appears.
+    //
+    // Daytona's `GET /sandbox` historically returned a bare array but has
+    // since started wrapping results in `{ items: [...], next_cursor: ... }`
+    // when pagination is in play (EVE-490). Accept either shape so the test
+    // stays resilient. If pagination is active and our sandbox is not in the
+    // first page, follow the cursor until it shows up or the stream ends —
+    // sandbox creation/listing is eventually consistent and one or two
+    // follow-on pages is usually all we need.
+    let mut next: Option<String> = None;
+    let mut found = false;
+    let mut pages_scanned: usize = 0;
+    loop {
+        let path = match &next {
+            Some(cursor) => format!("/sandbox?cursor={cursor}"),
+            None => "/sandbox".to_string(),
+        };
+        let page = client
+            .api_call(reqwest::Method::GET, &path, None)
+            .await
+            .expect("api_call GET /sandbox failed");
+
+        let items = page
+            .as_array()
+            .or_else(|| page["items"].as_array())
+            .or_else(|| page["data"].as_array())
+            .unwrap_or_else(|| {
+                panic!(
+                    "expected /sandbox response to be a bare array or a wrapped {{ items: [...] }} object, got: {page}"
+                )
+            });
+        pages_scanned += 1;
+        if items.iter().any(|s| s["id"].as_str() == Some(sandbox_id)) {
+            found = true;
+            break;
+        }
+        next = page["next_cursor"]
+            .as_str()
+            .or_else(|| page["nextCursor"].as_str())
+            .filter(|s| !s.is_empty())
+            .map(String::from);
+        // Cap follow-on pages so a runaway listing never makes the test hang.
+        if next.is_none() || pages_scanned >= 5 {
+            break;
+        }
+    }
+    assert!(
+        found,
+        "Sandbox {sandbox_id} not found in {pages_scanned} listed page(s)"
+    );
 
     // Delete via api_call
     let del = client

--- a/integrations/daytona/tests/live_api_test.rs
+++ b/integrations/daytona/tests/live_api_test.rs
@@ -768,7 +768,10 @@ async fn test_live_api_call_sandbox_lifecycle_with_labels() {
     let mut pages_scanned: usize = 0;
     loop {
         let path = match &next {
-            Some(cursor) => format!("/sandbox?cursor={cursor}"),
+            // Cursors are opaque server-issued strings and can contain
+            // reserved characters (`+`, `=`, `&`, `/`); percent-encode the
+            // value before splicing it into the query string.
+            Some(cursor) => format!("/sandbox?cursor={}", urlencoding::encode(cursor)),
             None => "/sandbox".to_string(),
         };
         let page = client
@@ -782,7 +785,7 @@ async fn test_live_api_call_sandbox_lifecycle_with_labels() {
             .or_else(|| page["data"].as_array())
             .unwrap_or_else(|| {
                 panic!(
-                    "expected /sandbox response to be a bare array or a wrapped {{ items: [...] }} object, got: {page}"
+                    "expected /sandbox response to be a bare array or a wrapped {{ items: [...] }} / {{ data: [...] }} object, got: {page}"
                 )
             });
         pages_scanned += 1;


### PR DESCRIPTION
## What
Makes `test_live_api_call_sandbox_lifecycle_with_labels` tolerant of Daytona's `GET /sandbox` shape change. The endpoint started returning `{ items: [...], next_cursor: ... }` instead of a bare array, breaking the existing `.as_array().unwrap()` on the response. The test now accepts either the bare-array or the wrapped `{ items: [...] }` shape (also tolerates a `data` field) and follows up to four extra pages when pagination is in play.

Linear: [EVE-490](https://linear.app/everruns/issue/EVE-490/daytona-live-test-test-live-api-call-sandbox-lifecycle-with-labels)

## Why
Main CI on the EVE-489 merge commit (`0bc3fc83`) failed on the daytona live test for the first time since the API drift. The same test passed on the previous daytona-touching commit (`961ce158`, 2026-05-22) and now fails consistently across reruns at the same point — `as_array().unwrap()` on a non-array response. The drift is on Daytona's side, not in our code.

## How
- Accept `as_array()` first (legacy shape), then `page["items"].as_array()` (new wrapped shape), then `page["data"].as_array()` (defensive). If none match, panic with the full response payload so the next drift is debuggable instead of a bare `unwrap`.
- Read `next_cursor` (or `nextCursor`) from the response and re-issue the listing if our sandbox isn't on the first page. Eventually-consistent listings sometimes need one or two extra reads.
- Cap follow-on pages at 5 so a runaway cursor cannot make the test hang.

## Risk
- Low / Medium / High: **Low**
- What can break: the listing-side assertion now follows cursors, which adds one or two extra Daytona requests in the (uncommon) case where the sandbox is not on the first page. The body of the test is otherwise unchanged.

## Security
- No security-relevant code changes. Test-only diff against a live integration test; no production code paths or trust boundaries touched.

## Validation
- `cargo check -p everruns-integrations-daytona --tests --features daytona-live-tests` — green.
- `just pre-push` — all 9 checks pass.
- The live run will validate on PR CI; the daytona path filter triggers `Daytona Live API Tests` for this branch.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (legacy bare-array shape still accepted)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)


---
_Generated by [Claude Code](https://claude.ai/code/session_019B9LRrNNvnXo2G9NcfZurY)_