### PR TITLE
ci(release): use homebrew tap token

### DIFF
--- a/.github/workflows/cli-binaries.yml
+++ b/.github/workflows/cli-binaries.yml
@@ -166,8 +166,12 @@ jobs:
           TAG="${{ inputs.tag }}"
           VERSION="${TAG#v}"
 
-          # Fetch the GitHub PAT from Doppler (has push access to homebrew-tap)
+          # Fetch the Homebrew tap PAT from Doppler (has push access to homebrew-tap)
           GH_PAT=$(doppler secrets get HOMEBREW_TAP_GITHUB_TOKEN --plain)
+          if [[ -z "${GH_PAT}" ]]; then
+            echo "::error::HOMEBREW_TAP_GITHUB_TOKEN is missing or empty in Doppler."
+            exit 1
+          fi
           echo "::add-mask::${GH_PAT}"
 
           # Use askpass instead of embedding credentials in the clone URL

--- a/.github/workflows/cli-binaries.yml
+++ b/.github/workflows/cli-binaries.yml
@@ -167,7 +167,7 @@ jobs:
           VERSION="${TAG#v}"
 
           # Fetch the GitHub PAT from Doppler (has push access to homebrew-tap)
-          GH_PAT=$(doppler secrets get GITHUB_TOKEN --plain)
+          GH_PAT=$(doppler secrets get HOMEBREW_TAP_GITHUB_TOKEN --plain)
           echo "::add-mask::${GH_PAT}"
 
           # Use askpass instead of embedding credentials in the clone URL

--- a/specs/release-process.md
+++ b/specs/release-process.md
@@ -98,7 +98,7 @@ Each archive contains the `everruns` binary. SHA-256 checksums (`.sha256` files)
 
 After all CLI binaries are built and uploaded, the `Publish CLI Binaries` workflow automatically updates the Homebrew formula at `everruns/homebrew-tap`. It downloads the SHA-256 checksums from the release, generates an updated `Formula/everruns.rb`, and pushes it to the tap repository.
 
-**Auth:** Uses the `GITHUB_TOKEN` PAT from Doppler (via `DOPPLER_TOKEN` secret), which has push access to `everruns/homebrew-tap`.
+**Auth:** Uses the `HOMEBREW_TAP_GITHUB_TOKEN` PAT from Doppler (via `DOPPLER_TOKEN` secret), which has push access to `everruns/homebrew-tap`.
 
 ### Docker Image Tagging
 


### PR DESCRIPTION
## What
Update the CLI binaries publish workflow so the Homebrew tap push reads `HOMEBREW_TAP_GITHUB_TOKEN` from Doppler instead of the general `GITHUB_TOKEN`. Update `specs/release-process.md` to document the dedicated token.

## Why
The Homebrew tap write path should use a token scoped specifically for `everruns/homebrew-tap`, reducing reliance on the broader GitHub token.

## How
The `Push formula to homebrew-tap` step now fetches `HOMEBREW_TAP_GITHUB_TOKEN` and continues to pass it through the existing `GIT_ASKPASS` flow. The release-process spec mirrors the workflow behavior.

## Risk
- Low
- If the Doppler secret is missing or lacks tap push access, the Homebrew formula update job will fail at release time. The failure is explicit before credentials are used for `git push`.

## Security
- Threat categories reviewed: TM-AUTH, TM-OBS
- Findings and resolutions: This change narrows the release credential used for the cross-repo Homebrew tap write. The existing masking and `GIT_ASKPASS` handling are preserved, so the PAT is not embedded in the clone URL or intentionally logged. No new runtime trust boundary is introduced.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated (N/A: workflow/spec only; validation run)
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

Validation run locally before push:
- `git diff --check`
- `ruby -ryaml -e 'YAML.load_file(".github/workflows/cli-binaries.yml"); puts "workflow yaml parsed"'`\n- `rg -n 'doppler secrets get (GITHUB_TOKEN|HOMEBREW_TAP_GITHUB_TOKEN)|HOMEBREW_TAP_GITHUB_TOKEN|GITHUB_TOKEN PAT from Doppler' .github/workflows/cli-binaries.yml specs/release-process.md`\n- `just pre-push`\n\nSmoke test: skipped because this is a GitHub Actions workflow/spec-only change with no local runtime behavior. CI is the end-to-end validation for the affected path.