### PR TITLE
docs(api): describe Voice/Report/GitDiff fields; floor 92%

### DIFF
--- a/crates/core/src/reporting.rs
+++ b/crates/core/src/reporting.rs
@@ -62,6 +62,8 @@ pub struct ReportFilter {
     /// Field to filter on. Must be a filter field exposed by the dataset (see `filter_fields` in the catalog).
     #[cfg_attr(feature = "openapi", schema(example = "status"))]
     pub field: String,
+    /// Comparison operator. Determines the expected shape of `value`
+    /// (scalar for `eq`/`neq`/`gt`/`gte`/`lt`/`lte`, array for `in`).
     pub op: ReportFilterOp,
     /// Comparison value. Type depends on `op`: a scalar for `eq`/`neq`/`gt`/`gte`/`lt`/`lte`,
     /// an array for `in`. Example for `op = in`: `["completed", "failed"]`.
@@ -112,10 +114,20 @@ pub enum ReportOrderDirection {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ReportResult {
+    /// Timestamp the underlying data was materialized (RFC 3339). Useful as
+    /// an "as of" footer when rendering — distinct from when the query ran.
     pub as_of: DateTime<Utc>,
+    /// How stale the data is relative to the server's wall clock at query
+    /// time, in milliseconds. `None` when freshness can't be determined
+    /// (e.g. backends that don't track projector lag).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub freshness_lag_ms: Option<i64>,
+    /// Column metadata in the same order as the entries of each row in
+    /// `rows`. Use the `kind` field to tell dimensions from measures.
     pub columns: Vec<ReportColumn>,
+    /// Result rows. Each row is a JSON object keyed by column name; cell
+    /// types match the underlying dataset (numbers for measures, strings
+    /// or numbers for dimensions). Length is capped by `ReportQuery.limit`.
     pub rows: Vec<Value>,
 }
 
@@ -125,6 +137,8 @@ pub struct ReportColumn {
     /// Column name as it appears in `rows`.
     #[cfg_attr(feature = "openapi", schema(example = "session_count"))]
     pub name: String,
+    /// Whether this column is a grouping `dimension` or an aggregate
+    /// `measure` — the same distinction made on `ReportQuery`.
     pub kind: ReportColumnKind,
 }
 

--- a/crates/server/src/api/voice.rs
+++ b/crates/server/src/api/voice.rs
@@ -259,6 +259,7 @@ pub struct VoiceAttachResponse {
 /// Response body for voice end.
 #[derive(Debug, Clone, Serialize, ToSchema)]
 pub struct VoiceEndResponse {
+    /// Prefixed public identifier of the voice connection that was ended.
     pub voice_connection_id: String,
     /// Current lifecycle status.
     pub status: String,
@@ -266,7 +267,12 @@ pub struct VoiceEndResponse {
 
 #[derive(Debug, Clone, Serialize, ToSchema)]
 pub struct VoiceSessionResponse<T> {
+    /// The session this voice connection is attached to. Returned alongside
+    /// the voice payload so a caller has a single round-trip view of both.
     pub session: everruns_core::Session,
+    /// Voice connection details — concrete shape depends on the endpoint
+    /// (e.g. `VoiceCallResponse` for `/voice/call`, `VoiceAttachResponse`
+    /// for `/voice/attach`).
     pub voice: T,
 }
 

--- a/crates/server/src/domains/reporting/types.rs
+++ b/crates/server/src/domains/reporting/types.rs
@@ -19,7 +19,12 @@ pub struct SavedReport {
     #[serde(skip_serializing_if = "Option::is_none")]
     /// Human-readable description. Safe to render in user-facing messages.
     pub description: Option<String>,
+    /// The query this report executes when run or exported. Same shape as the
+    /// `body` of `POST /v1/reports/query` — see `ReportQuery` for the field
+    /// breakdown.
     pub query: ReportQuery,
+    /// Optional dashboard placement metadata. `None` means the report is
+    /// "library-only" and not pinned to a dashboard layout.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub dashboard: Option<SavedReportDashboardMetadata>,
     /// Timestamp when this resource was created (RFC 3339).
@@ -33,10 +38,18 @@ pub struct SavedReportDashboardMetadata {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     /// Human-readable title. Safe to render in user-facing messages.
     pub title: Option<String>,
+    /// Dashboard section/group this report belongs to (free-form bucket name
+    /// like `"Operations"` or `"Finance"`). Used to cluster related reports
+    /// in the UI.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub section: Option<String>,
+    /// Rendering hint for the UI (e.g. `"line"`, `"bar"`, `"table"`,
+    /// `"big_number"`). Free-form string — the server doesn't enforce a
+    /// closed set so new chart types can roll out client-side first.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub chart_type: Option<String>,
+    /// Sort key within `section`. Lower values render first. `None` means
+    /// "place at the end".
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub position: Option<i32>,
 }
@@ -53,7 +66,11 @@ pub struct CreateSavedReportRequest {
         example = "Rolling 30-day count of agents with at least one session per day, grouped by org."
     )]
     pub description: Option<String>,
+    /// The query this report executes when run or exported. See `ReportQuery`
+    /// for the full field breakdown.
     pub query: ReportQuery,
+    /// Optional dashboard placement metadata. Omit to create a library-only
+    /// report that isn't pinned to any dashboard layout.
     #[serde(default)]
     pub dashboard: Option<SavedReportDashboardMetadata>,
 }
@@ -69,9 +86,14 @@ pub struct UpdateSavedReportRequest {
     #[serde(default, deserialize_with = "deserialize_nullable_update_field")]
     #[schema(value_type = Option<String>, nullable = true, example = "Rolling 60-day window; widened from 30d after the Q3 product launch.")]
     pub description: UpdateField<String>,
+    /// Replace the saved report's query wholesale. Omit to keep the existing
+    /// query; send a new `ReportQuery` to swap it.
     #[serde(default, deserialize_with = "deserialize_nullable_update_field")]
     #[schema(value_type = ReportQuery, nullable = false)]
     pub query: UpdateField<ReportQuery>,
+    /// Replace dashboard placement metadata. Omit to keep current placement;
+    /// send `null` to detach the report from its dashboard; send an object
+    /// to overwrite the placement.
     #[serde(default, deserialize_with = "deserialize_nullable_update_field")]
     #[schema(value_type = Option<SavedReportDashboardMetadata>, nullable = true)]
     pub dashboard: UpdateField<SavedReportDashboardMetadata>,
@@ -87,6 +109,8 @@ pub enum ReportExportFormat {
 /// Request body for the `export_report_query` operation.
 #[derive(Debug, Clone, Deserialize, ToSchema)]
 pub struct ExportReportQueryRequest {
+    /// Ad-hoc query to materialize and export. Same shape as the body of
+    /// `POST /v1/reports/query` — see `ReportQuery` for the field breakdown.
     pub query: ReportQuery,
     /// Export format. Defaults to `csv` when omitted.
     #[serde(default = "default_export_format")]
@@ -124,8 +148,15 @@ pub struct ReportExport {
 
 #[derive(Debug, Clone, Serialize, ToSchema)]
 pub struct ReportingDiagnostics {
+    /// Server-side wall-clock timestamp when this snapshot was assembled
+    /// (RFC 3339). Use as the "as-of" for any displayed lag metrics.
     pub generated_at: DateTime<Utc>,
+    /// Per-dataset projector freshness. One entry per active reporting
+    /// dataset; missing datasets mean the projector hasn't produced any
+    /// rows yet.
     pub projector_lag: Vec<DatasetProjectorLag>,
+    /// Reporting outbox health — counts of pending/processing/failed/
+    /// completed rows plus a sample of the most recent failures.
     pub outbox: ReportingOutboxDiagnostics,
 }
 

--- a/crates/server/src/domains/session_git/service.rs
+++ b/crates/server/src/domains/session_git/service.rs
@@ -42,25 +42,40 @@ pub struct GitCommitInfo {
 /// A diff entry between two commits
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct GitDiffEntry {
+    /// File path on the "new" side of the diff (the post-change path). For
+    /// a rename, the pre-rename path is in `old_path`. Repo-root-relative,
+    /// forward-slash separated.
     pub path: String,
     /// Current lifecycle status.
     pub status: String, // "added", "modified", "deleted", "renamed"
+    /// Pre-change path. Only set when `status == "renamed"`; otherwise
+    /// `None` (including for `added`/`deleted`/`modified`).
     pub old_path: Option<String>,
 }
 
 /// A diff with full patch output
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct GitDiff {
+    /// Per-file change records. Empty when the two trees are identical.
     pub entries: Vec<GitDiffEntry>,
+    /// Unified-diff patch text covering all `entries`. `None` when the
+    /// caller requested a name-only diff (no `+`/`-` lines computed).
     pub patch: Option<String>,
+    /// Aggregate line/file counts across `entries`.
     pub stats: GitDiffStats,
 }
 
 /// Diff statistics
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct GitDiffStats {
+    /// Number of files with at least one changed line (matches the length
+    /// of `GitDiff.entries`).
     pub files_changed: usize,
+    /// Total added lines summed across all files (the `+` count in a
+    /// unified diff).
     pub insertions: usize,
+    /// Total removed lines summed across all files (the `-` count in a
+    /// unified diff).
     pub deletions: usize,
 }
 

--- a/crates/server/src/domains/session_git/service.rs
+++ b/crates/server/src/domains/session_git/service.rs
@@ -58,8 +58,10 @@ pub struct GitDiffEntry {
 pub struct GitDiff {
     /// Per-file change records. Empty when the two trees are identical.
     pub entries: Vec<GitDiffEntry>,
-    /// Unified-diff patch text covering all `entries`. `None` when the
-    /// caller requested a name-only diff (no `+`/`-` lines computed).
+    /// Unified-diff patch text covering all `entries`, truncated to ~64 KiB
+    /// (with a trailing `... (truncated)` marker when the cap is hit).
+    /// `None` when the diff produced no patch text — typically because the
+    /// two trees are identical.
     pub patch: Option<String>,
     /// Aggregate line/file counts across `entries`.
     pub stats: GitDiffStats,

--- a/crates/server/tests/openapi_descriptions_test.rs
+++ b/crates/server/tests/openapi_descriptions_test.rs
@@ -16,7 +16,7 @@ use utoipa::OpenApi;
 /// Lowest acceptable coverage. Bump up when you fix a batch.
 const MIN_OP_DESC_PCT: u32 = 100;
 const MIN_SCHEMA_DESC_PCT: u32 = 88;
-const MIN_FIELD_DESC_PCT: u32 = 85;
+const MIN_FIELD_DESC_PCT: u32 = 92;
 /// Field example coverage is an AI-friendliness signal in its own right:
 /// even an accurately described `Vec<ToolDefinition>` is far easier for an
 /// LLM to populate when it has seen one concrete instance. The floor starts

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -16093,7 +16093,7 @@
               "string",
               "null"
             ],
-            "description": "Unified-diff patch text covering all `entries`. `None` when the\ncaller requested a name-only diff (no `+`/`-` lines computed)."
+            "description": "Unified-diff patch text covering all `entries`, truncated to ~64 KiB\n(with a trailing `... (truncated)` marker when the cap is hit).\n`None` when the diff produced no patch text — typically because the\ntwo trees are identical."
           },
           "stats": {
             "$ref": "#/components/schemas/GitDiffStats",

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -14305,7 +14305,8 @@
                 "type": "null"
               },
               {
-                "$ref": "#/components/schemas/SavedReportDashboardMetadata"
+                "$ref": "#/components/schemas/SavedReportDashboardMetadata",
+                "description": "Optional dashboard placement metadata. Omit to create a library-only\nreport that isn't pinned to any dashboard layout."
               }
             ]
           },
@@ -14323,7 +14324,8 @@
             "example": "Weekly active agents — last 30 days"
           },
           "query": {
-            "$ref": "#/components/schemas/ReportQuery"
+            "$ref": "#/components/schemas/ReportQuery",
+            "description": "The query this report executes when run or exported. See `ReportQuery`\nfor the full field breakdown."
           }
         }
       },
@@ -15489,7 +15491,8 @@
             "description": "Export format. Defaults to `csv` when omitted."
           },
           "query": {
-            "$ref": "#/components/schemas/ReportQuery"
+            "$ref": "#/components/schemas/ReportQuery",
+            "description": "Ad-hoc query to materialize and export. Same shape as the body of\n`POST /v1/reports/query` — see `ReportQuery` for the field breakdown."
           }
         }
       },
@@ -16082,16 +16085,19 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/GitDiffEntry"
-            }
+            },
+            "description": "Per-file change records. Empty when the two trees are identical."
           },
           "patch": {
             "type": [
               "string",
               "null"
-            ]
+            ],
+            "description": "Unified-diff patch text covering all `entries`. `None` when the\ncaller requested a name-only diff (no `+`/`-` lines computed)."
           },
           "stats": {
-            "$ref": "#/components/schemas/GitDiffStats"
+            "$ref": "#/components/schemas/GitDiffStats",
+            "description": "Aggregate line/file counts across `entries`."
           }
         }
       },
@@ -16107,10 +16113,12 @@
             "type": [
               "string",
               "null"
-            ]
+            ],
+            "description": "Pre-change path. Only set when `status == \"renamed\"`; otherwise\n`None` (including for `added`/`deleted`/`modified`)."
           },
           "path": {
-            "type": "string"
+            "type": "string",
+            "description": "File path on the \"new\" side of the diff (the post-change path). For\na rename, the pre-rename path is in `old_path`. Repo-root-relative,\nforward-slash separated."
           },
           "status": {
             "type": "string",
@@ -16129,14 +16137,17 @@
         "properties": {
           "deletions": {
             "type": "integer",
+            "description": "Total removed lines summed across all files (the `-` count in a\nunified diff).",
             "minimum": 0
           },
           "files_changed": {
             "type": "integer",
+            "description": "Number of files with at least one changed line (matches the length\nof `GitDiff.entries`).",
             "minimum": 0
           },
           "insertions": {
             "type": "integer",
+            "description": "Total added lines summed across all files (the `+` count in a\nunified diff).",
             "minimum": 0
           }
         }
@@ -18602,7 +18613,8 @@
                       "type": "null"
                     },
                     {
-                      "$ref": "#/components/schemas/SavedReportDashboardMetadata"
+                      "$ref": "#/components/schemas/SavedReportDashboardMetadata",
+                      "description": "Optional dashboard placement metadata. `None` means the report is\n\"library-only\" and not pinned to a dashboard layout."
                     }
                   ]
                 },
@@ -18623,7 +18635,8 @@
                   "description": "Human-readable name. Safe to render in user-facing messages."
                 },
                 "query": {
-                  "$ref": "#/components/schemas/ReportQuery"
+                  "$ref": "#/components/schemas/ReportQuery",
+                  "description": "The query this report executes when run or exported. Same shape as the\n`body` of `POST /v1/reports/query` — see `ReportQuery` for the field\nbreakdown."
                 },
                 "updated_at": {
                   "type": "string",
@@ -23758,7 +23771,8 @@
         ],
         "properties": {
           "kind": {
-            "$ref": "#/components/schemas/ReportColumnKind"
+            "$ref": "#/components/schemas/ReportColumnKind",
+            "description": "Whether this column is a grouping `dimension` or an aggregate\n`measure` — the same distinction made on `ReportQuery`."
           },
           "name": {
             "type": "string",
@@ -23836,7 +23850,8 @@
             "example": "status"
           },
           "op": {
-            "$ref": "#/components/schemas/ReportFilterOp"
+            "$ref": "#/components/schemas/ReportFilterOp",
+            "description": "Comparison operator. Determines the expected shape of `value`\n(scalar for `eq`/`neq`/`gt`/`gte`/`lt`/`lte`, array for `in`)."
           },
           "value": {
             "description": "Comparison value. Type depends on `op`: a scalar for `eq`/`neq`/`gt`/`gte`/`lt`/`lte`,\nan array for `in`. Example for `op = in`: `[\"completed\", \"failed\"]`."
@@ -23948,24 +23963,28 @@
         "properties": {
           "as_of": {
             "type": "string",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Timestamp the underlying data was materialized (RFC 3339). Useful as\nan \"as of\" footer when rendering — distinct from when the query ran."
           },
           "columns": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ReportColumn"
-            }
+            },
+            "description": "Column metadata in the same order as the entries of each row in\n`rows`. Use the `kind` field to tell dimensions from measures."
           },
           "freshness_lag_ms": {
             "type": [
               "integer",
               "null"
             ],
-            "format": "int64"
+            "format": "int64",
+            "description": "How stale the data is relative to the server's wall clock at query\ntime, in milliseconds. `None` when freshness can't be determined\n(e.g. backends that don't track projector lag)."
           },
           "rows": {
             "type": "array",
-            "items": {}
+            "items": {},
+            "description": "Result rows. Each row is a JSON object keyed by column name; cell\ntypes match the underlying dataset (numbers for measures, strings\nor numbers for dimensions). Length is capped by `ReportQuery.limit`."
           }
         }
       },
@@ -24048,16 +24067,19 @@
         "properties": {
           "generated_at": {
             "type": "string",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Server-side wall-clock timestamp when this snapshot was assembled\n(RFC 3339). Use as the \"as-of\" for any displayed lag metrics."
           },
           "outbox": {
-            "$ref": "#/components/schemas/ReportingOutboxDiagnostics"
+            "$ref": "#/components/schemas/ReportingOutboxDiagnostics",
+            "description": "Reporting outbox health — counts of pending/processing/failed/\ncompleted rows plus a sample of the most recent failures."
           },
           "projector_lag": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/DatasetProjectorLag"
-            }
+            },
+            "description": "Per-dataset projector freshness. One entry per active reporting\ndataset; missing datasets mean the projector hasn't produced any\nrows yet."
           }
         }
       },
@@ -24312,7 +24334,8 @@
                 "type": "null"
               },
               {
-                "$ref": "#/components/schemas/SavedReportDashboardMetadata"
+                "$ref": "#/components/schemas/SavedReportDashboardMetadata",
+                "description": "Optional dashboard placement metadata. `None` means the report is\n\"library-only\" and not pinned to a dashboard layout."
               }
             ]
           },
@@ -24333,7 +24356,8 @@
             "description": "Human-readable name. Safe to render in user-facing messages."
           },
           "query": {
-            "$ref": "#/components/schemas/ReportQuery"
+            "$ref": "#/components/schemas/ReportQuery",
+            "description": "The query this report executes when run or exported. Same shape as the\n`body` of `POST /v1/reports/query` — see `ReportQuery` for the field\nbreakdown."
           },
           "updated_at": {
             "type": "string",
@@ -24349,20 +24373,23 @@
             "type": [
               "string",
               "null"
-            ]
+            ],
+            "description": "Rendering hint for the UI (e.g. `\"line\"`, `\"bar\"`, `\"table\"`,\n`\"big_number\"`). Free-form string — the server doesn't enforce a\nclosed set so new chart types can roll out client-side first."
           },
           "position": {
             "type": [
               "integer",
               "null"
             ],
-            "format": "int32"
+            "format": "int32",
+            "description": "Sort key within `section`. Lower values render first. `None` means\n\"place at the end\"."
           },
           "section": {
             "type": [
               "string",
               "null"
-            ]
+            ],
+            "description": "Dashboard section/group this report belongs to (free-form bucket name\nlike `\"Operations\"` or `\"Finance\"`). Used to cluster related reports\nin the UI."
           },
           "title": {
             "type": [
@@ -27608,7 +27635,8 @@
                 "type": "null"
               },
               {
-                "$ref": "#/components/schemas/SavedReportDashboardMetadata"
+                "$ref": "#/components/schemas/SavedReportDashboardMetadata",
+                "description": "Replace dashboard placement metadata. Omit to keep current placement;\nsend `null` to detach the report from its dashboard; send an object\nto overwrite the placement."
               }
             ]
           },
@@ -27629,7 +27657,8 @@
             "example": "Weekly active agents — last 60 days"
           },
           "query": {
-            "$ref": "#/components/schemas/ReportQuery"
+            "$ref": "#/components/schemas/ReportQuery",
+            "description": "Replace the saved report's query wholesale. Omit to keep the existing\nquery; send a new `ReportQuery` to swap it."
           }
         }
       },
@@ -28084,7 +28113,8 @@
             "description": "Current lifecycle status."
           },
           "voice_connection_id": {
-            "type": "string"
+            "type": "string",
+            "description": "Prefixed public identifier of the voice connection that was ended."
           }
         }
       },
@@ -28185,7 +28215,8 @@
         ],
         "properties": {
           "session": {
-            "$ref": "#/components/schemas/Session"
+            "$ref": "#/components/schemas/Session",
+            "description": "The session this voice connection is attached to. Returned alongside\nthe voice payload so a caller has a single round-trip view of both."
           },
           "voice": {
             "type": "object",


### PR DESCRIPTION
## What
Follow-up to #1958 — closes the description gaps on the three clusters called out in its follow-ups section.

- **GitDiff** (`crates/server/src/domains/session_git/service.rs`): `GitDiff`, `GitDiffEntry`, `GitDiffStats` — all eight bare fields described (entries/patch/stats, path/old_path, files_changed/insertions/deletions).
- **Voice** (`crates/server/src/api/voice.rs`): `VoiceEndResponse.voice_connection_id`, `VoiceSessionResponse.{session,voice}`.
- **Report** (`crates/server/src/domains/reporting/types.rs` + `crates/core/src/reporting.rs`): the 19 previously-bare fields on `SavedReport`, `Create/UpdateSavedReportRequest`, `ExportReportQueryRequest`, `SavedReportDashboardMetadata`, `ReportingDiagnostics`, `ReportFilter.op`, `ReportColumn.kind`, `ReportResult.{as_of,columns,freshness_lag_ms,rows}`.

## Why
These were the last three clusters flagged in #1958&#39;s &#34;follow-ups&#34; as the natural lift to push the field-description floor from 85% to 90%+. Without these the OpenAPI consumer (the LLM toolcaller) sees a `$ref: GitDiffEntry` or a `type: integer` field with no inline context — they have to follow the ref or guess what a `freshness_lag_ms` of `null` means vs zero. One sentence per field collapses that.

## How
Plain `///` field-level doc comments. utoipa picks them up for primitive types (`usize`, `DateTime`) and array properties (`Vec<T>`); for bare `$ref` fields like `ReportFilter.op` the field-level description is rendered as a sibling alongside the `$ref` (utoipa wraps with `allOf` under the hood when there&#39;s extra metadata). All 29 target fields landed in the regenerated spec.

`MIN_FIELD_DESC_PCT` bumped 85 → 92 to match the new actual (1445/1567 = 92.2%). OpenAPI spec regenerated.

## Risk
- **Negligible.** Pure documentation — no production code, wire-shape, or schema-type changes. No new `#[schema(...)]` annotations beyond doc comments.
- New gate floor matches the new actual coverage.

## Security
- Threat categories reviewed: **TM-API** (request/response schema docs only — no parsing/handler changes). No other categories applicable.
- No secrets, credentials, or PII in any doc string.

## Follow-ups
- Schema-description floor (`MIN_SCHEMA_DESC_PCT = 88`) — there&#39;s still some headroom there if a future pass wants to fully describe every `ToSchema` struct.
- Longer-horizon items from the #1958 handoff still open: MCP execute structured-error wire bump and hypermedia for entity actions.

## Checklist
- [x] Tests added or updated (all 4 OpenAPI gates pass at 100/88/92/24%)
- [x] Backward compatibility considered (additive descriptions, no schema-type changes)
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jx7aHhsynabhrKB9gDMAVq)_