### PR TITLE
fix(api): correct schedule execution status example

### DIFF
--- a/crates/server/src/api/schedules.rs
+++ b/crates/server/src/api/schedules.rs
@@ -459,7 +459,7 @@ pub struct ListSchedulesQuery {
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct ListExecutionsQuery {
     /// Filter by execution status
-    #[schema(example = "success")]
+    #[schema(example = "completed")]
     pub status: Option<String>,
     /// Pagination offset
     #[schema(example = 0)]

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -20236,7 +20236,7 @@
         "description": "Metadata about an LLM generation",
         "required": [
           "model",
-          "completed"
+          "success"
         ],
         "properties": {
           "compaction": {
@@ -20316,7 +20316,7 @@
               }
             ]
           },
-          "completed": {
+          "success": {
             "type": "boolean",
             "description": "Whether the generation was successful"
           },
@@ -23473,7 +23473,7 @@
         "type": "object",
         "description": "Data for reason.completed event",
         "required": [
-          "completed",
+          "success",
           "has_tool_calls",
           "tool_call_count"
         ],
@@ -23498,7 +23498,7 @@
             "type": "boolean",
             "description": "Whether tool calls were requested"
           },
-          "completed": {
+          "success": {
             "type": "boolean",
             "description": "Whether the LLM call succeeded"
           },
@@ -25797,7 +25797,7 @@
         "type": "object",
         "description": "Response from switch org endpoint",
         "required": [
-          "completed",
+          "success",
           "org_id"
         ],
         "properties": {
@@ -25805,7 +25805,7 @@
             "type": "string",
             "description": "The organization ID that was switched to"
           },
-          "completed": {
+          "success": {
             "type": "boolean",
             "description": "Whether the switch was successful"
           }
@@ -25836,7 +25836,7 @@
               "status": {
                 "type": "string",
                 "enum": [
-                  "completed"
+                  "success"
                 ]
               },
               "updated": {
@@ -26130,7 +26130,7 @@
         "required": [
           "tool_call_id",
           "tool_name",
-          "completed",
+          "success",
           "status"
         ],
         "properties": {
@@ -26192,7 +26192,7 @@
             "type": "string",
             "description": "Status: \"success\", \"error\", \"timeout\", \"cancelled\""
           },
-          "completed": {
+          "success": {
             "type": "boolean",
             "description": "Whether the tool call succeeded"
           },

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -17294,7 +17294,7 @@
               "null"
             ],
             "description": "Filter by execution status",
-            "example": "success"
+            "example": "completed"
           }
         }
       },
@@ -20236,7 +20236,7 @@
         "description": "Metadata about an LLM generation",
         "required": [
           "model",
-          "success"
+          "completed"
         ],
         "properties": {
           "compaction": {
@@ -20316,7 +20316,7 @@
               }
             ]
           },
-          "success": {
+          "completed": {
             "type": "boolean",
             "description": "Whether the generation was successful"
           },
@@ -23473,7 +23473,7 @@
         "type": "object",
         "description": "Data for reason.completed event",
         "required": [
-          "success",
+          "completed",
           "has_tool_calls",
           "tool_call_count"
         ],
@@ -23498,7 +23498,7 @@
             "type": "boolean",
             "description": "Whether tool calls were requested"
           },
-          "success": {
+          "completed": {
             "type": "boolean",
             "description": "Whether the LLM call succeeded"
           },
@@ -25797,7 +25797,7 @@
         "type": "object",
         "description": "Response from switch org endpoint",
         "required": [
-          "success",
+          "completed",
           "org_id"
         ],
         "properties": {
@@ -25805,7 +25805,7 @@
             "type": "string",
             "description": "The organization ID that was switched to"
           },
-          "success": {
+          "completed": {
             "type": "boolean",
             "description": "Whether the switch was successful"
           }
@@ -25836,7 +25836,7 @@
               "status": {
                 "type": "string",
                 "enum": [
-                  "success"
+                  "completed"
                 ]
               },
               "updated": {
@@ -26130,7 +26130,7 @@
         "required": [
           "tool_call_id",
           "tool_name",
-          "success",
+          "completed",
           "status"
         ],
         "properties": {
@@ -26192,7 +26192,7 @@
             "type": "string",
             "description": "Status: \"success\", \"error\", \"timeout\", \"cancelled\""
           },
-          "success": {
+          "completed": {
             "type": "boolean",
             "description": "Whether the tool call succeeded"
           },


### PR DESCRIPTION
### Motivation
- Fix a documentation mismatch where the OpenAPI example for `ListExecutionsQuery.status` advertised `"success"` while server-side parsing accepts only `pending`, `running`, `completed`, `failed`, or `skipped`, which caused clients following the docs to receive HTTP 400 errors.

### Description
- Replace the invalid schema example `#[schema(example = "success")]` with `#[schema(example = "completed")]` in `crates/server/src/api/schedules.rs`.
- Update the generated OpenAPI artifact `docs/api/openapi.json` so the published example is `"completed"` and stays in sync with server behavior.
- Commit created as `fix(api): correct schedule execution status example` to record the documentation-only correction.

### Testing
- No unit or integration tests were changed because this is a documentation-only fix; no automated test failures were expected or introduced.
- Verified the change via automated repository searches: `rg -n 'ListExecutionsQuery|Filter by execution status' crates/server/src/api/schedules.rs docs/api/openapi.json` and `rg -n 'success|completed' crates/server/src/api/schedules.rs docs/api/openapi.json`, which confirmed the example value was updated to `"completed"`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10db8b2818832bb31681787b3e71a9)