### PR TITLE
docs: remove internal spec references from public docs

### DIFF
--- a/crates/core/src/agent.rs
+++ b/crates/core/src/agent.rs
@@ -90,7 +90,7 @@ impl From<&str> for AgentVersionChangeKind {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct AgentVersion {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     #[serde(rename = "id")]
     #[cfg_attr(feature = "openapi", schema(value_type = String, example = "agentver_01933b5a000070008000000000000001"))]
     pub public_id: AgentVersionId,

--- a/crates/core/src/llm_models.rs
+++ b/crates/core/src/llm_models.rs
@@ -118,7 +118,7 @@ impl std::str::FromStr for LlmModelSource {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct LlmProvider {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     #[cfg_attr(feature = "openapi", schema(value_type = String, example = "provider_01933b5a00007000800000000000001"))]
     pub id: ProviderId,
     /// Human-readable provider name. Safe to render in user-facing messages.
@@ -145,7 +145,7 @@ pub struct LlmProvider {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct LlmModel {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     #[cfg_attr(feature = "openapi", schema(value_type = String, example = "model_01933b5a00007000800000000000001"))]
     pub id: ModelId,
     /// Owning provider's prefixed public identifier.
@@ -173,7 +173,7 @@ pub struct LlmModel {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct LlmModelWithProvider {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     #[cfg_attr(feature = "openapi", schema(value_type = String, example = "model_01933b5a00007000800000000000001"))]
     pub id: ModelId,
     /// Owning provider's prefixed public identifier.

--- a/crates/core/src/payment.rs
+++ b/crates/core/src/payment.rs
@@ -141,7 +141,7 @@ impl From<&str> for PaymentStatus {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct PaymentAccount {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: PaymentAccountId,
     /// Owning organization's prefixed public identifier.
     pub organization_id: String,
@@ -168,7 +168,7 @@ pub struct PaymentAccount {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct PaymentPolicy {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: PaymentPolicyId,
     /// Owning organization's prefixed public identifier.
     pub organization_id: String,
@@ -205,7 +205,7 @@ pub struct PaymentPolicy {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct PaymentAttempt {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: PaymentAttemptId,
     /// Owning organization's prefixed public identifier.
     pub organization_id: String,

--- a/crates/core/src/skill.rs
+++ b/crates/core/src/skill.rs
@@ -89,7 +89,7 @@ impl From<&str> for SkillStatus {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct Skill {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     #[cfg_attr(feature = "openapi", schema(value_type = String, example = "skill_01933b5a00007000800000000000001"))]
     pub id: SkillId,
     /// Stable kebab-case slug used to invoke the skill (e.g. `/pdf-processing` in chat). Safe to render in user-facing messages.

--- a/crates/server/src/api/durable.rs
+++ b/crates/server/src/api/durable.rs
@@ -364,7 +364,7 @@ impl HealthResponse {
 /// Worker response
 #[derive(Debug, Serialize, ToSchema)]
 pub struct WorkerResponse {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: String,
     /// Logical group this worker belongs to (used for routing). `None` for ungrouped workers.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -455,7 +455,7 @@ pub struct WorkersListResponse {
 /// Workflow response
 #[derive(Debug, Serialize, ToSchema)]
 pub struct WorkflowResponse {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: Uuid,
     pub workflow_type: String,
     /// Current lifecycle status.
@@ -504,7 +504,7 @@ pub struct WorkflowsListResponse {
 /// Workflow event response
 #[derive(Debug, Serialize, ToSchema)]
 pub struct WorkflowEventResponse {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: i64,
     /// Durable workflow's identifier.
     pub workflow_id: Uuid,
@@ -540,7 +540,7 @@ pub struct WorkflowEventsListResponse {
 /// Task response
 #[derive(Debug, Serialize, ToSchema)]
 pub struct TaskResponse {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: Uuid,
     /// Owning workflow's identifier. `None` for one-off tasks not tied to a workflow.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -610,7 +610,7 @@ pub struct TasksListResponse {
 /// DLQ entry response
 #[derive(Debug, Serialize, ToSchema)]
 pub struct DlqEntryResponse {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: Uuid,
     /// Task ID that was originally retried and ultimately failed (matches the `tasks` record before its move to the DLQ).
     pub original_task_id: Uuid,

--- a/crates/server/src/api/durable.rs
+++ b/crates/server/src/api/durable.rs
@@ -364,7 +364,7 @@ impl HealthResponse {
 /// Worker response
 #[derive(Debug, Serialize, ToSchema)]
 pub struct WorkerResponse {
-    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
+    /// Opaque durable worker identifier (defaults to `worker-<uuid>`).
     pub id: String,
     /// Logical group this worker belongs to (used for routing). `None` for ungrouped workers.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -455,7 +455,7 @@ pub struct WorkersListResponse {
 /// Workflow response
 #[derive(Debug, Serialize, ToSchema)]
 pub struct WorkflowResponse {
-    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
+    /// UUID of the workflow.
     pub id: Uuid,
     pub workflow_type: String,
     /// Current lifecycle status.
@@ -504,7 +504,7 @@ pub struct WorkflowsListResponse {
 /// Workflow event response
 #[derive(Debug, Serialize, ToSchema)]
 pub struct WorkflowEventResponse {
-    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
+    /// Monotonically-assigned internal event identifier.
     pub id: i64,
     /// Durable workflow's identifier.
     pub workflow_id: Uuid,
@@ -540,7 +540,7 @@ pub struct WorkflowEventsListResponse {
 /// Task response
 #[derive(Debug, Serialize, ToSchema)]
 pub struct TaskResponse {
-    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
+    /// UUID of the task.
     pub id: Uuid,
     /// Owning workflow's identifier. `None` for one-off tasks not tied to a workflow.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -610,7 +610,7 @@ pub struct TasksListResponse {
 /// DLQ entry response
 #[derive(Debug, Serialize, ToSchema)]
 pub struct DlqEntryResponse {
-    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
+    /// UUID of the DLQ entry.
     pub id: Uuid,
     /// Task ID that was originally retried and ultimately failed (matches the `tasks` record before its move to the DLQ).
     pub original_task_id: Uuid,

--- a/crates/server/src/api/images.rs
+++ b/crates/server/src/api/images.rs
@@ -49,7 +49,7 @@ pub(crate) const ALLOWED_CONTENT_TYPES: &[&str] =
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct ImageInfo {
     #[schema(value_type = String, example = "img_01933b5a00007000800000000000001")]
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: ImageId,
     pub filename: String,
     pub content_type: String,
@@ -64,7 +64,7 @@ pub struct ImageInfo {
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct ImageUploadResponse {
     #[schema(value_type = String, example = "img_01933b5a00007000800000000000001")]
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: ImageId,
     pub filename: String,
     pub content_type: String,

--- a/crates/server/src/api/notifications.rs
+++ b/crates/server/src/api/notifications.rs
@@ -33,7 +33,7 @@ use futures::{
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct Notification {
     #[schema(value_type = String, example = "notification_01933b5a00007000800000000000001")]
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: NotificationId,
     /// Discriminator selecting the variant of this resource.
     pub kind: String,

--- a/crates/server/src/api/resolver.rs
+++ b/crates/server/src/api/resolver.rs
@@ -52,8 +52,8 @@ pub struct ResolveOrgResponse {
 /// Returns the owning organization only when it is one the authenticated
 /// caller already belongs to. For every other case (unknown id, unknown
 /// prefix, resource belongs to a non-member org) the endpoint returns 404 —
-/// this preserves the existing org-enumeration guarantee documented in
-/// specs/multitenancy.md.
+/// this preserves the org-enumeration guarantee: callers cannot use this
+/// endpoint to probe for the existence of resources outside their own orgs.
 #[utoipa::path(
     get,
     path = "/v1/resolve-org",

--- a/crates/server/src/api/schedules.rs
+++ b/crates/server/src/api/schedules.rs
@@ -232,7 +232,7 @@ pub struct UpdateScheduleRequest {
 /// Schedule response
 #[derive(Debug, Serialize, ToSchema)]
 pub struct ScheduleResponse {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: Uuid,
     /// Human-readable name. Safe to render in user-facing messages.
     pub name: String,
@@ -323,7 +323,7 @@ pub struct SchedulesListResponse {
 /// Schedule execution response
 #[derive(Debug, Serialize, ToSchema)]
 pub struct ScheduleExecutionResponse {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: Uuid,
     /// Schedule's prefixed public identifier.
     pub schedule_id: Uuid,

--- a/crates/server/src/api/schedules.rs
+++ b/crates/server/src/api/schedules.rs
@@ -232,7 +232,7 @@ pub struct UpdateScheduleRequest {
 /// Schedule response
 #[derive(Debug, Serialize, ToSchema)]
 pub struct ScheduleResponse {
-    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
+    /// UUID of the schedule.
     pub id: Uuid,
     /// Human-readable name. Safe to render in user-facing messages.
     pub name: String,
@@ -323,9 +323,9 @@ pub struct SchedulesListResponse {
 /// Schedule execution response
 #[derive(Debug, Serialize, ToSchema)]
 pub struct ScheduleExecutionResponse {
-    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
+    /// UUID of the schedule execution.
     pub id: Uuid,
-    /// Schedule's prefixed public identifier.
+    /// UUID of the owning schedule.
     pub schedule_id: Uuid,
     /// Timestamp when this resource is scheduled to run (RFC 3339).
     pub scheduled_at: DateTime<Utc>,

--- a/crates/server/src/api/users.rs
+++ b/crates/server/src/api/users.rs
@@ -37,7 +37,7 @@ impl_auth_state!(UsersState);
 /// User response for listing
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct User {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: String,
     pub email: String,
     /// Human-readable name. Safe to render in user-facing messages.
@@ -87,7 +87,7 @@ pub struct UpdateProfileRequest {
 /// Response from profile update
 #[derive(Debug, Clone, Serialize, ToSchema)]
 pub struct ProfileResponse {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: String,
     pub email: String,
     /// Human-readable name. Safe to render in user-facing messages.
@@ -105,7 +105,7 @@ pub struct DeleteAccountResponse {
 /// Exported user profile data
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct ExportedUserProfile {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: String,
     pub email: String,
     /// Human-readable name. Safe to render in user-facing messages.
@@ -126,7 +126,7 @@ pub struct ExportedUserProfile {
 pub struct ExportedOrganization {
     /// Owning organization's prefixed public identifier.
     pub org_id: i64,
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub public_id: String,
     /// Human-readable name. Safe to render in user-facing messages.
     pub name: String,
@@ -136,7 +136,7 @@ pub struct ExportedOrganization {
 /// Exported API key metadata (no sensitive data)
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct ExportedApiKey {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: String,
     /// Human-readable name. Safe to render in user-facing messages.
     pub name: String,

--- a/crates/server/src/api/voice.rs
+++ b/crates/server/src/api/voice.rs
@@ -200,7 +200,7 @@ pub struct VoiceEndRequest {
 /// Response body for voice client secret.
 #[derive(Debug, Clone, Serialize, ToSchema)]
 pub struct VoiceClientSecretResponse {
-    /// Prefixed public identifier of the voice connection (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub voice_connection_id: String,
     /// Realtime provider routing this connection (e.g. `openai`).
     pub provider: String,
@@ -219,7 +219,7 @@ pub struct VoiceClientSecretResponse {
 /// Response body for voice call.
 #[derive(Debug, Clone, Serialize, ToSchema)]
 pub struct VoiceCallResponse {
-    /// Prefixed public identifier of the voice connection.
+    /// Prefixed public identifier of the voice connection. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub voice_connection_id: String,
     /// Provider-side call identifier once issued. `None` until the realtime call is established.
     pub provider_call_id: Option<String>,
@@ -240,7 +240,7 @@ pub struct VoiceCallResponse {
 /// Response body for voice attach.
 #[derive(Debug, Clone, Serialize, ToSchema)]
 pub struct VoiceAttachResponse {
-    /// Prefixed public identifier of the voice connection.
+    /// Prefixed public identifier of the voice connection. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub voice_connection_id: String,
     /// Provider-side call identifier of the connected realtime call.
     pub provider_call_id: String,

--- a/crates/server/src/api/voice.rs
+++ b/crates/server/src/api/voice.rs
@@ -200,7 +200,7 @@ pub struct VoiceEndRequest {
 /// Response body for voice client secret.
 #[derive(Debug, Clone, Serialize, ToSchema)]
 pub struct VoiceClientSecretResponse {
-    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
+    /// Prefixed public identifier of the voice connection. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub voice_connection_id: String,
     /// Realtime provider routing this connection (e.g. `openai`).
     pub provider: String,

--- a/crates/server/src/auth/api_key_routes.rs
+++ b/crates/server/src/auth/api_key_routes.rs
@@ -43,7 +43,7 @@ impl FromRef<ApiKeyState> for AuthState {
 /// API key response (shown only once at creation)
 #[derive(Debug, Serialize, ToSchema)]
 pub struct ApiKeyResponse {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: String,
     /// Human-readable name. Safe to render in user-facing messages.
     pub name: String,
@@ -58,7 +58,7 @@ pub struct ApiKeyResponse {
 /// API key list item (without full key)
 #[derive(Debug, Serialize, ToSchema)]
 pub struct ApiKeyListItem {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: String,
     /// Human-readable name. Safe to render in user-facing messages.
     pub name: String,

--- a/crates/server/src/auth/cli_auth.rs
+++ b/crates/server/src/auth/cli_auth.rs
@@ -118,7 +118,7 @@ pub struct CliExchangeResponse {
 /// User info returned from CLI exchange
 #[derive(Debug, Serialize, ToSchema)]
 pub struct CliUserInfo {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: String,
     pub email: String,
     /// Human-readable name. Safe to render in user-facing messages.

--- a/crates/server/src/auth/routes.rs
+++ b/crates/server/src/auth/routes.rs
@@ -151,7 +151,7 @@ pub struct TokenResponse {
 /// Organization membership in user response
 #[derive(Debug, Serialize, ToSchema)]
 pub struct OrgMembershipResponse {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub public_id: String,
     /// Human-readable name. Safe to render in user-facing messages.
     pub name: String,
@@ -161,7 +161,7 @@ pub struct OrgMembershipResponse {
 /// User info response
 #[derive(Debug, Serialize, ToSchema)]
 pub struct UserInfoResponse {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: String,
     pub email: String,
     /// Human-readable name. Safe to render in user-facing messages.

--- a/crates/server/src/domains/agent_identities/commands.rs
+++ b/crates/server/src/domains/agent_identities/commands.rs
@@ -144,7 +144,7 @@ inventory::submit! { CommandDescriptor::of::<ListAgentIdentities>() }
 /// Get a single agent identity by ID.
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct GetAgentIdentity {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: String,
 }
 
@@ -191,7 +191,7 @@ inventory::submit! { CommandDescriptor::of::<GetAgentIdentity>() }
 /// Update an agent identity. Only provided fields are changed.
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct UpdateAgentIdentityCmd {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: String,
     #[serde(flatten)]
     pub req: UpdateAgentIdentityRequest,
@@ -289,7 +289,7 @@ inventory::submit! { CommandDescriptor::of::<UpdateAgentIdentityCmd>() }
 /// Archive an agent identity (soft delete).
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct DeleteAgentIdentity {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: String,
 }
 
@@ -354,7 +354,7 @@ inventory::submit! { CommandDescriptor::of::<DeleteAgentIdentity>() }
 /// Permanently delete an agent identity.
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct DestroyAgentIdentity {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: String,
 }
 

--- a/crates/server/src/domains/agents/commands.rs
+++ b/crates/server/src/domains/agents/commands.rs
@@ -336,7 +336,7 @@ inventory::submit! { CommandDescriptor::of::<ListAgents>() }
 /// Get a single agent by ID or name.
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct GetAgent {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: String,
 }
 
@@ -378,7 +378,7 @@ inventory::submit! { CommandDescriptor::of::<GetAgent>() }
 /// Update an agent. Only provided fields are changed.
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct UpdateAgentCmd {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: String,
     #[serde(flatten)]
     pub req: UpdateAgentRequest,
@@ -562,7 +562,7 @@ inventory::submit! { CommandDescriptor::of::<UpdateAgentCmd>() }
 /// Archive an agent (soft delete).
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct DeleteAgent {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: String,
 }
 
@@ -625,7 +625,7 @@ inventory::submit! { CommandDescriptor::of::<DeleteAgent>() }
 /// Upsert agent — create or update by ID.
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct UpsertAgent {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: String,
     #[serde(flatten)]
     pub req: CreateAgentRequest,
@@ -766,7 +766,7 @@ inventory::submit! { CommandDescriptor::of::<UpsertAgent>() }
 /// Copy an agent. Generates a unique name ({name}-copy, -copy-2, etc.)
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct CopyAgent {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: String,
 }
 
@@ -831,7 +831,7 @@ inventory::submit! { CommandDescriptor::of::<CopyAgent>() }
 /// Get agent data for export.
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct ExportAgent {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: String,
 }
 
@@ -2142,7 +2142,7 @@ mod tests {
 /// Permanently delete an archived agent.
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct DestroyAgent {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: String,
 }
 

--- a/crates/server/src/domains/apps/commands.rs
+++ b/crates/server/src/domains/apps/commands.rs
@@ -1732,7 +1732,7 @@ inventory::submit! { CommandDescriptor::of::<ListApps>() }
 /// Get a single app by ID.
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct GetApp {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: String,
 }
 
@@ -2119,7 +2119,7 @@ fn bucket_app_runs_by_hour(runs: &[AppRunEvent]) -> Vec<AppRunBucket> {
 /// Update an app. Only provided fields are changed.
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct UpdateAppCmd {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: String,
     #[serde(flatten)]
     pub req: UpdateAppRequest,
@@ -2319,7 +2319,7 @@ inventory::submit! { CommandDescriptor::of::<UpdateAppCmd>() }
 /// Archive an app (soft delete).
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct DeleteApp {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: String,
 }
 
@@ -2385,7 +2385,7 @@ inventory::submit! { CommandDescriptor::of::<DeleteApp>() }
 /// Permanently delete an archived app.
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct DestroyApp {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: String,
 }
 
@@ -2456,7 +2456,7 @@ inventory::submit! { CommandDescriptor::of::<DestroyApp>() }
 /// Publish an app (start accepting requests).
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct PublishApp {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: String,
 }
 
@@ -2528,7 +2528,7 @@ inventory::submit! { CommandDescriptor::of::<PublishApp>() }
 /// Unpublish an app (stop accepting requests).
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct UnpublishApp {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: String,
 }
 

--- a/crates/server/src/domains/audit_logs/types.rs
+++ b/crates/server/src/domains/audit_logs/types.rs
@@ -12,7 +12,7 @@ pub use crate::storage::models::{AuditLogQuery, AuditLogRow};
 /// shape returned by the HTTP and MCP adapters.
 #[derive(Debug, Clone, Serialize, ToSchema)]
 pub struct AuditLogEntry {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: String,
     pub domain: String,
     pub action: String,

--- a/crates/server/src/domains/capabilities/commands.rs
+++ b/crates/server/src/domains/capabilities/commands.rs
@@ -98,7 +98,7 @@ inventory::submit! { CommandDescriptor::of::<ListCapabilities>() }
 /// Get a specific capability by ID.
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct GetCapability {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: String,
 }
 
@@ -243,7 +243,7 @@ inventory::submit! { CommandDescriptor::of::<ListDeclarativeCapabilities>() }
 
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct GetDeclarativeCapability {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: String,
 }
 
@@ -278,7 +278,7 @@ inventory::submit! { CommandDescriptor::of::<GetDeclarativeCapability>() }
 
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct UpdateDeclarativeCapabilityCmd {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: String,
     #[serde(flatten)]
     pub req: UpdateDeclarativeCapabilityRequest,
@@ -357,7 +357,7 @@ inventory::submit! { CommandDescriptor::of::<UpdateDeclarativeCapabilityCmd>() }
 
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct DeleteDeclarativeCapability {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: String,
 }
 
@@ -400,7 +400,7 @@ inventory::submit! { CommandDescriptor::of::<DeleteDeclarativeCapability>() }
 
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct DestroyDeclarativeCapability {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: String,
 }
 

--- a/crates/server/src/domains/harnesses/commands.rs
+++ b/crates/server/src/domains/harnesses/commands.rs
@@ -269,7 +269,7 @@ inventory::submit! { CommandDescriptor::of::<ListHarnesses>() }
 /// Get a single harness by ID or name.
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct GetHarness {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: String,
 }
 
@@ -311,7 +311,7 @@ inventory::submit! { CommandDescriptor::of::<GetHarness>() }
 /// Update a harness. Only provided fields are changed.
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct UpdateHarnessCmd {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: String,
     #[serde(flatten)]
     pub req: UpdateHarnessRequest,
@@ -501,7 +501,7 @@ inventory::submit! { CommandDescriptor::of::<UpdateHarnessCmd>() }
 /// Archive a harness (soft delete).
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct DeleteHarness {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: String,
 }
 
@@ -574,7 +574,7 @@ inventory::submit! { CommandDescriptor::of::<DeleteHarness>() }
 /// Permanently delete an archived harness.
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct DestroyHarness {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: String,
 }
 
@@ -660,7 +660,7 @@ inventory::submit! { CommandDescriptor::of::<DestroyHarness>() }
 /// Copy a harness. Generates a unique name ({name}-copy, -copy-2, etc.)
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct CopyHarness {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: String,
 }
 

--- a/crates/server/src/domains/images/commands.rs
+++ b/crates/server/src/domains/images/commands.rs
@@ -46,7 +46,7 @@ inventory::submit! { CommandDescriptor::of::<ListImages>() }
 
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct GetImage {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: String,
 }
 

--- a/crates/server/src/domains/knowledge_bases/types.rs
+++ b/crates/server/src/domains/knowledge_bases/types.rs
@@ -15,7 +15,7 @@ pub use crate::storage::models::{
 #[derive(Debug, Clone, Serialize, ToSchema)]
 pub struct KnowledgeBaseResponse {
     #[schema(value_type = String, example = "kb_01933b5a000070008000000000000001")]
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: KnowledgeBaseId,
     /// Human-readable name. Safe to render in user-facing messages.
     pub name: String,
@@ -94,7 +94,7 @@ pub fn knowledge_base_response(row: KnowledgeBaseRow) -> anyhow::Result<Knowledg
 #[derive(Debug, Clone, Serialize, ToSchema)]
 pub struct KnowledgeEntryResponse {
     #[schema(value_type = String, example = "kbe_01933b5a000070008000000000000001")]
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: KnowledgeEntryId,
     #[schema(value_type = String, example = "kb_01933b5a000070008000000000000001")]
     /// Knowledge base's prefixed public identifier.

--- a/crates/server/src/domains/llm_models/commands.rs
+++ b/crates/server/src/domains/llm_models/commands.rs
@@ -151,7 +151,7 @@ inventory::submit! { CommandDescriptor::of::<ListModels>() }
 
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct GetModel {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: String,
 }
 
@@ -190,7 +190,7 @@ inventory::submit! { CommandDescriptor::of::<GetModel>() }
 
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct UpdateModel {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: String,
     /// LLM provider's prefixed public identifier.
     pub provider_id: Option<String>,
@@ -255,7 +255,7 @@ inventory::submit! { CommandDescriptor::of::<UpdateModel>() }
 
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct DeleteModel {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: String,
 }
 

--- a/crates/server/src/domains/llm_providers/commands.rs
+++ b/crates/server/src/domains/llm_providers/commands.rs
@@ -96,7 +96,7 @@ inventory::submit! { CommandDescriptor::of::<ListProviders>() }
 
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct GetProvider {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: String,
 }
 
@@ -135,7 +135,7 @@ inventory::submit! { CommandDescriptor::of::<GetProvider>() }
 
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct UpdateProvider {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: String,
     /// Human-readable name. Safe to render in user-facing messages.
     pub name: Option<String>,
@@ -187,7 +187,7 @@ inventory::submit! { CommandDescriptor::of::<UpdateProvider>() }
 
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct DeleteProvider {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: String,
 }
 
@@ -229,7 +229,7 @@ inventory::submit! { CommandDescriptor::of::<DeleteProvider>() }
 
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct SyncProviderModels {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: String,
 }
 

--- a/crates/server/src/domains/mcp_servers/commands.rs
+++ b/crates/server/src/domains/mcp_servers/commands.rs
@@ -198,7 +198,7 @@ inventory::submit! { CommandDescriptor::of::<ListMcpServers>() }
 /// Get a single MCP server by ID.
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct GetMcpServer {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: String,
 }
 
@@ -245,7 +245,7 @@ inventory::submit! { CommandDescriptor::of::<GetMcpServer>() }
 /// Update an MCP server. Only provided fields are changed.
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct UpdateMcpServerCmd {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: String,
     #[serde(flatten)]
     pub req: UpdateMcpServerRequest,
@@ -381,7 +381,7 @@ inventory::submit! { CommandDescriptor::of::<UpdateMcpServerCmd>() }
 /// Archive an MCP server (soft delete).
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct DeleteMcpServer {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: String,
 }
 
@@ -435,7 +435,7 @@ inventory::submit! { CommandDescriptor::of::<DeleteMcpServer>() }
 /// Permanently delete an archived MCP server.
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct DestroyMcpServer {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: String,
 }
 

--- a/crates/server/src/domains/memory_stores/types.rs
+++ b/crates/server/src/domains/memory_stores/types.rs
@@ -9,7 +9,7 @@ pub use crate::storage::models::{MemoryDbRow, MemoryStoreDbRow};
 #[derive(Debug, Clone, Serialize, ToSchema)]
 pub struct MemoryStoreResponse {
     #[schema(value_type = String, example = "mst_01933b5a000070008000000000000001")]
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: MemoryStoreId,
     /// Human-readable name. Safe to render in user-facing messages.
     pub name: String,
@@ -50,7 +50,7 @@ pub struct UpdateMemoryStoreRequest {
 #[derive(Debug, Clone, Serialize, ToSchema)]
 pub struct MemoryResponse {
     #[schema(value_type = String, example = "mem_01933b5a000070008000000000000001")]
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: MemoryId,
     #[schema(value_type = String, example = "mst_01933b5a000070008000000000000001")]
     pub store_id: MemoryStoreId,

--- a/crates/server/src/domains/organizations/commands.rs
+++ b/crates/server/src/domains/organizations/commands.rs
@@ -92,7 +92,7 @@ inventory::submit! { CommandDescriptor::of::<GetOrg>() }
 // (Cross-Org Resource Resolution).
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct ResolveOrg {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: String,
 }
 

--- a/crates/server/src/domains/reporting/types.rs
+++ b/crates/server/src/domains/reporting/types.rs
@@ -12,7 +12,7 @@ use uuid::Uuid;
 
 #[derive(Debug, Clone, Serialize, ToSchema)]
 pub struct SavedReport {
-    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
+    /// UUID of the saved report.
     pub id: Uuid,
     /// Human-readable name. Safe to render in user-facing messages.
     pub name: String,

--- a/crates/server/src/domains/reporting/types.rs
+++ b/crates/server/src/domains/reporting/types.rs
@@ -12,7 +12,7 @@ use uuid::Uuid;
 
 #[derive(Debug, Clone, Serialize, ToSchema)]
 pub struct SavedReport {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: Uuid,
     /// Human-readable name. Safe to render in user-facing messages.
     pub name: String,

--- a/crates/server/src/domains/skills/commands.rs
+++ b/crates/server/src/domains/skills/commands.rs
@@ -160,7 +160,7 @@ inventory::submit! { CommandDescriptor::of::<ListSkills>() }
 /// Get a single skill by ID.
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct GetSkill {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: String,
 }
 
@@ -212,7 +212,7 @@ inventory::submit! { CommandDescriptor::of::<GetSkill>() }
 /// Get full skill content (SKILL.md + files).
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct GetSkillContent {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: String,
 }
 
@@ -310,7 +310,7 @@ inventory::submit! { CommandDescriptor::of::<GetSkillContent>() }
 /// Update a skill. Only provided fields are changed.
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct UpdateSkillCmd {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: String,
     #[serde(flatten)]
     pub req: UpdateSkillRequest,
@@ -453,7 +453,7 @@ inventory::submit! { CommandDescriptor::of::<UpdateSkillCmd>() }
 /// Archive a skill (soft delete).
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct DeleteSkill {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: String,
 }
 
@@ -510,7 +510,7 @@ inventory::submit! { CommandDescriptor::of::<DeleteSkill>() }
 /// Permanently delete an archived skill.
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct DestroySkill {
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: String,
 }
 

--- a/crates/server/src/domains/volumes/types.rs
+++ b/crates/server/src/domains/volumes/types.rs
@@ -12,7 +12,7 @@ pub use crate::storage::models::{CreateVolumeRow, UpdateVolume, VolumeRow};
 #[derive(Debug, Clone, Serialize, ToSchema)]
 pub struct VolumeResponse {
     #[schema(value_type = String, example = "vol_01933b5a000070008000000000000001")]
-    /// Prefixed public identifier (see `specs/id-schema.md`).
+    /// Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).
     pub id: VolumeId,
     /// Human-readable name. Safe to render in user-facing messages.
     pub name: String,

--- a/docs/advanced/id-schema.md
+++ b/docs/advanced/id-schema.md
@@ -27,7 +27,7 @@ Example:
 agent_5c7f3a91b24e48d6a0e91f3b7c4d2e85
 ```
 
-Identifiers must match the regular expression `^{prefix}_[0-9a-f]{32}$`. The API rejects malformed values with `400 Bad Request`.
+Identifiers match a fixed pattern: the resource's prefix, an underscore, then exactly 32 lowercase hexadecimal characters. For an `agent`, the literal regex is `^agent_[0-9a-f]{32}$`. The API rejects malformed values with `400 Bad Request`.
 
 ## Treat the suffix as opaque
 
@@ -39,16 +39,11 @@ The suffix carries no public meaning. In particular:
 
 This decoupling is intentional. The internal database key for a resource and its public ID are deliberately separate concepts — clients only ever see the public ID.
 
-## Client-Supplied IDs and Upsert
+## Client-Supplied IDs
 
-You can supply your own `id` when creating a resource, as long as it matches the format above and uses the correct prefix for the resource type. If you omit `id`, the server assigns one.
+For resources that accept client-supplied IDs on create, you can pass your own `id` as long as it matches the format above and uses the correct prefix for the resource type. If you omit `id`, the server assigns one.
 
-Because IDs are stable and unique per organization, `PUT /v1/{resource}/{id}` performs an upsert:
-
-- If no resource with that ID exists, it is created (`201 Created`).
-- If one already exists, it is updated in place (`200 OK`).
-
-This makes idempotent provisioning straightforward — replay the same `PUT` and the end state is identical.
+A subset of resources additionally expose `PUT /v1/{resource}/{id}` as an upsert: the same call creates the resource if it does not exist (`201 Created`) and updates it in place if it does (`200 OK`). Where supported, this makes idempotent provisioning straightforward — replay the same `PUT` and the end state is identical. The OpenAPI reference is the source of truth for which resources support this; not every resource has a `PUT` route.
 
 ## Serialization
 
@@ -65,19 +60,21 @@ IDs are always serialized as JSON strings. The field name is `id` for the resour
 
 The prefix is part of the public contract for each resource. The most common ones are listed below; the canonical list lives in the OpenAPI specification.
 
+The prefix in the table below is the token that appears before the `_` separator — an `agent` resource has IDs that start with `agent_`.
+
 | Resource | Prefix |
 |----------|--------|
-| Agent | `agent_` |
-| Agent version | `agentver_` |
-| Session | `session_` |
-| Skill | `skill_` |
-| Knowledge base | `kb_` |
-| Volume | `vol_` |
-| MCP server | `mcp_` |
-| Schedule | `sched_` |
-| Image | `img_` |
-| User | `user_` |
-| Organization | `org_` |
+| Agent | `agent` |
+| Agent version | `agentver` |
+| Session | `session` |
+| Skill | `skill` |
+| Knowledge base | `kb` |
+| Volume | `vol` |
+| MCP server | `mcp` |
+| Schedule | `sched` |
+| Image | `img` |
+| User | `user` |
+| Organization | `org` |
 
 ## Design Notes
 

--- a/docs/advanced/id-schema.md
+++ b/docs/advanced/id-schema.md
@@ -1,13 +1,13 @@
 ---
 title: ID Schema
-description: How Everruns formats and validates public resource identifiers (Stripe-style prefixed IDs backed by UUIDv7)
+description: How Everruns formats and validates public resource identifiers — Stripe-style prefixed IDs.
 sidebar:
   order: 40
 ---
 
-Every resource in the Everruns API — agents, sessions, skills, knowledge bases, and so on — is identified by a **prefixed public ID**. The prefix tells you at a glance what kind of resource you are looking at; the suffix is a UUIDv7 rendered as 32 lowercase hex characters with no dashes.
+Every resource in the Everruns API — agents, sessions, skills, knowledge bases, and so on — is identified by a **prefixed public ID**. The prefix tells you at a glance what kind of resource you are looking at; the suffix is an opaque 32-character token.
 
-This pattern was popularized by Stripe (`cus_`, `sub_`, `pi_`) and formalized by the [TypeID spec](https://github.com/jetpack-io/typeid). Everruns uses hex encoding (32 characters) instead of TypeID's base32 (26 characters) for simpler debugging and direct UUID compatibility.
+This pattern was popularized by Stripe (`cus_`, `sub_`, `pi_`). Treat the suffix as a meaningless string — do not parse it, sort by it, or infer information from it. The only guarantees the API makes about an ID are its format, its uniqueness within an organization, and its stability over the lifetime of the resource.
 
 ## Format
 
@@ -19,23 +19,29 @@ All resource identifiers use the same shape:
 
 - `{prefix}` is a short lowercase token that identifies the resource type (for example `agent`, `session`, `skill`).
 - `_` separates the prefix from the suffix.
-- `{32-hex-chars}` is a UUIDv7 serialized as lowercase hex with no dashes.
+- `{32-hex-chars}` is an opaque 32-character lowercase hexadecimal token.
 
 Example:
 
 ```
-agent_01933b5a00007000800000000000001
+agent_5c7f3a91b24e48d6a0e91f3b7c4d2e85
 ```
 
 Identifiers must match the regular expression `^{prefix}_[0-9a-f]{32}$`. The API rejects malformed values with `400 Bad Request`.
 
-## Why UUIDv7?
+## Treat the suffix as opaque
 
-UUIDv7 embeds a millisecond timestamp in its leading bits, so IDs sort roughly in creation order. That makes paginated listings stable, makes log lines easier to scan chronologically, and avoids the index fragmentation that random UUIDv4 keys cause.
+The suffix carries no public meaning. In particular:
+
+- **Do not sort by it.** Use `created_at` (or whatever timestamp field the resource exposes) for chronological ordering.
+- **Do not infer age, ordering, or shard placement from it.** The encoding may change without notice.
+- **Do not parse it as a UUID.** The hex format is a transport convenience; future resources may use different internal schemes while keeping the same wire format.
+
+This decoupling is intentional. The internal database key for a resource and its public ID are deliberately separate concepts — clients only ever see the public ID.
 
 ## Client-Supplied IDs and Upsert
 
-You can supply your own `id` when creating a resource as long as it matches the format above and uses the correct prefix for the resource type. If you omit `id`, the server generates one.
+You can supply your own `id` when creating a resource, as long as it matches the format above and uses the correct prefix for the resource type. If you omit `id`, the server assigns one.
 
 Because IDs are stable and unique per organization, `PUT /v1/{resource}/{id}` performs an upsert:
 
@@ -50,8 +56,8 @@ IDs are always serialized as JSON strings. The field name is `id` for the resour
 
 ```json
 {
-  "id": "agent_01933b5a00007000800000000000001",
-  "session_id": "session_01933b5a00007000800000000000003"
+  "id": "agent_5c7f3a91b24e48d6a0e91f3b7c4d2e85",
+  "session_id": "session_2b8a4d12c673491fae058b7d9c1f6a40"
 }
 ```
 
@@ -78,6 +84,6 @@ The prefix is part of the public contract for each resource. The most common one
 | Question | Answer |
 |----------|--------|
 | Why prefixed IDs? | They make IDs self-describing and prevent accidentally passing, say, an agent ID where a session ID is expected. |
-| Why UUIDv7? | Time-ordered, globally unique, index-friendly. |
+| Why opaque suffixes? | Decoupling the wire format from internal storage gives the platform room to evolve without breaking clients, and prevents callers from leaning on accidental properties (ordering, creation time) that aren't part of the contract. |
 | Why lowercase hex? | Case-insensitive matching, URL-safe, easy to copy and paste. |
 | Are IDs unique across organizations? | Each ID is unique within its owning organization. The same `id` value could in principle appear in two different orgs, but you only ever see IDs scoped to orgs you belong to. |

--- a/docs/advanced/id-schema.md
+++ b/docs/advanced/id-schema.md
@@ -1,0 +1,83 @@
+---
+title: ID Schema
+description: How Everruns formats and validates public resource identifiers (Stripe-style prefixed IDs backed by UUIDv7)
+sidebar:
+  order: 40
+---
+
+Every resource in the Everruns API — agents, sessions, skills, knowledge bases, and so on — is identified by a **prefixed public ID**. The prefix tells you at a glance what kind of resource you are looking at; the suffix is a UUIDv7 rendered as 32 lowercase hex characters with no dashes.
+
+This pattern was popularized by Stripe (`cus_`, `sub_`, `pi_`) and formalized by the [TypeID spec](https://github.com/jetpack-io/typeid). Everruns uses hex encoding (32 characters) instead of TypeID's base32 (26 characters) for simpler debugging and direct UUID compatibility.
+
+## Format
+
+All resource identifiers use the same shape:
+
+```
+{prefix}_{32-hex-chars}
+```
+
+- `{prefix}` is a short lowercase token that identifies the resource type (for example `agent`, `session`, `skill`).
+- `_` separates the prefix from the suffix.
+- `{32-hex-chars}` is a UUIDv7 serialized as lowercase hex with no dashes.
+
+Example:
+
+```
+agent_01933b5a00007000800000000000001
+```
+
+Identifiers must match the regular expression `^{prefix}_[0-9a-f]{32}$`. The API rejects malformed values with `400 Bad Request`.
+
+## Why UUIDv7?
+
+UUIDv7 embeds a millisecond timestamp in its leading bits, so IDs sort roughly in creation order. That makes paginated listings stable, makes log lines easier to scan chronologically, and avoids the index fragmentation that random UUIDv4 keys cause.
+
+## Client-Supplied IDs and Upsert
+
+You can supply your own `id` when creating a resource as long as it matches the format above and uses the correct prefix for the resource type. If you omit `id`, the server generates one.
+
+Because IDs are stable and unique per organization, `PUT /v1/{resource}/{id}` performs an upsert:
+
+- If no resource with that ID exists, it is created (`201 Created`).
+- If one already exists, it is updated in place (`200 OK`).
+
+This makes idempotent provisioning straightforward — replay the same `PUT` and the end state is identical.
+
+## Serialization
+
+IDs are always serialized as JSON strings. The field name is `id` for the resource itself and `{resource}_id` when referenced from another resource:
+
+```json
+{
+  "id": "agent_01933b5a00007000800000000000001",
+  "session_id": "session_01933b5a00007000800000000000003"
+}
+```
+
+## Prefix Reference
+
+The prefix is part of the public contract for each resource. The most common ones are listed below; the canonical list lives in the OpenAPI specification.
+
+| Resource | Prefix |
+|----------|--------|
+| Agent | `agent_` |
+| Agent version | `agentver_` |
+| Session | `session_` |
+| Skill | `skill_` |
+| Knowledge base | `kb_` |
+| Volume | `vol_` |
+| MCP server | `mcp_` |
+| Schedule | `sched_` |
+| Image | `img_` |
+| User | `user_` |
+| Organization | `org_` |
+
+## Design Notes
+
+| Question | Answer |
+|----------|--------|
+| Why prefixed IDs? | They make IDs self-describing and prevent accidentally passing, say, an agent ID where a session ID is expected. |
+| Why UUIDv7? | Time-ordered, globally unique, index-friendly. |
+| Why lowercase hex? | Case-insensitive matching, URL-safe, easy to copy and paste. |
+| Are IDs unique across organizations? | Each ID is unique within its owning organization. The same `id` value could in principle appear in two different orgs, but you only ever see IDs scoped to orgs you belong to. |

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -7924,7 +7924,7 @@
           "users"
         ],
         "summary": "GET /v1/resolve-org — resolve the owning org for a resource id.",
-        "description": "Returns the owning organization only when it is one the authenticated\ncaller already belongs to. For every other case (unknown id, unknown\nprefix, resource belongs to a non-member org) the endpoint returns 404 —\nthis preserves the existing org-enumeration guarantee documented in\nspecs/multitenancy.md.",
+        "description": "Returns the owning organization only when it is one the authenticated\ncaller already belongs to. For every other case (unknown id, unknown\nprefix, resource belongs to a non-member org) the endpoint returns 404 —\nthis preserves the org-enumeration guarantee: callers cannot use this\nendpoint to probe for the existence of resources outside their own orgs.",
         "operationId": "resolve_org",
         "parameters": [
           {
@@ -11720,7 +11720,7 @@
           },
           "id": {
             "type": "string",
-            "description": "Prefixed public identifier (see `specs/id-schema.md`).",
+            "description": "Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).",
             "example": "agentver_01933b5a000070008000000000000001"
           },
           "is_published": {
@@ -14964,7 +14964,7 @@
           "id": {
             "type": "string",
             "format": "uuid",
-            "description": "Prefixed public identifier (see `specs/id-schema.md`)."
+            "description": "Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/)."
           },
           "input": {
             "description": "Task input payload at the time of failure (used for inspection and replay)."
@@ -15559,7 +15559,7 @@
           },
           "id": {
             "type": "string",
-            "description": "Prefixed public identifier (see `specs/id-schema.md`)."
+            "description": "Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/)."
           },
           "key_prefix": {
             "type": "string"
@@ -15599,7 +15599,7 @@
           },
           "public_id": {
             "type": "string",
-            "description": "Prefixed public identifier (see `specs/id-schema.md`)."
+            "description": "Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/)."
           },
           "role": {
             "type": "string"
@@ -15643,7 +15643,7 @@
           },
           "id": {
             "type": "string",
-            "description": "Prefixed public identifier (see `specs/id-schema.md`)."
+            "description": "Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/)."
           },
           "name": {
             "type": "string",
@@ -16769,7 +16769,7 @@
           },
           "id": {
             "type": "string",
-            "description": "Prefixed public identifier (see `specs/id-schema.md`).",
+            "description": "Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).",
             "example": "img_01933b5a00007000800000000000001"
           },
           "metadata": {
@@ -16805,7 +16805,7 @@
           },
           "id": {
             "type": "string",
-            "description": "Prefixed public identifier (see `specs/id-schema.md`).",
+            "description": "Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).",
             "example": "img_01933b5a00007000800000000000001"
           },
           "size_bytes": {
@@ -17034,7 +17034,7 @@
           },
           "id": {
             "type": "string",
-            "description": "Prefixed public identifier (see `specs/id-schema.md`).",
+            "description": "Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).",
             "example": "kb_01933b5a000070008000000000000001"
           },
           "name": {
@@ -17076,7 +17076,7 @@
           },
           "id": {
             "type": "string",
-            "description": "Prefixed public identifier (see `specs/id-schema.md`).",
+            "description": "Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).",
             "example": "kbe_01933b5a000070008000000000000001"
           },
           "kb_id": {
@@ -18166,7 +18166,7 @@
                 },
                 "id": {
                   "type": "string",
-                  "description": "Prefixed public identifier (see `specs/id-schema.md`).",
+                  "description": "Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).",
                   "example": "kb_01933b5a000070008000000000000001"
                 },
                 "name": {
@@ -18221,7 +18221,7 @@
                 },
                 "id": {
                   "type": "string",
-                  "description": "Prefixed public identifier (see `specs/id-schema.md`).",
+                  "description": "Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).",
                   "example": "kbe_01933b5a000070008000000000000001"
                 },
                 "kb_id": {
@@ -18398,7 +18398,7 @@
                 },
                 "id": {
                   "type": "string",
-                  "description": "Prefixed public identifier (see `specs/id-schema.md`).",
+                  "description": "Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).",
                   "example": "mst_01933b5a000070008000000000000001"
                 },
                 "is_default": {
@@ -18616,7 +18616,7 @@
                 "id": {
                   "type": "string",
                   "format": "uuid",
-                  "description": "Prefixed public identifier (see `specs/id-schema.md`)."
+                  "description": "Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/)."
                 },
                 "name": {
                   "type": "string",
@@ -18741,7 +18741,7 @@
                 },
                 "id": {
                   "type": "string",
-                  "description": "Prefixed public identifier (see `specs/id-schema.md`).",
+                  "description": "Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).",
                   "example": "skill_01933b5a00007000800000000000001"
                 },
                 "license": {
@@ -18833,7 +18833,7 @@
                 },
                 "id": {
                   "type": "string",
-                  "description": "Prefixed public identifier (see `specs/id-schema.md`)."
+                  "description": "Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/)."
                 },
                 "name": {
                   "type": "string",
@@ -18905,7 +18905,7 @@
                 },
                 "id": {
                   "type": "string",
-                  "description": "Prefixed public identifier (see `specs/id-schema.md`).",
+                  "description": "Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).",
                   "example": "vol_01933b5a000070008000000000000001"
                 },
                 "is_readonly": {
@@ -19309,7 +19309,7 @@
                     },
                     "id": {
                       "type": "string",
-                      "description": "Prefixed public identifier (see `specs/id-schema.md`).",
+                      "description": "Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).",
                       "example": "model_01933b5a00007000800000000000001"
                     },
                     "is_favorite": {
@@ -19421,7 +19421,7 @@
                     },
                     "id": {
                       "type": "string",
-                      "description": "Prefixed public identifier (see `specs/id-schema.md`).",
+                      "description": "Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).",
                       "example": "model_01933b5a00007000800000000000001"
                     },
                     "is_favorite": {
@@ -19538,7 +19538,7 @@
                     },
                     "id": {
                       "type": "string",
-                      "description": "Prefixed public identifier (see `specs/id-schema.md`).",
+                      "description": "Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).",
                       "example": "provider_01933b5a00007000800000000000001"
                     },
                     "last_synced_at": {
@@ -19999,7 +19999,7 @@
                     },
                     "id": {
                       "type": "string",
-                      "description": "Prefixed public identifier (see `specs/id-schema.md`).",
+                      "description": "Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).",
                       "example": "skill_01933b5a00007000800000000000001"
                     },
                     "license": {
@@ -20387,7 +20387,7 @@
           },
           "id": {
             "type": "string",
-            "description": "Prefixed public identifier (see `specs/id-schema.md`).",
+            "description": "Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).",
             "example": "model_01933b5a00007000800000000000001"
           },
           "is_favorite": {
@@ -20691,7 +20691,7 @@
           },
           "id": {
             "type": "string",
-            "description": "Prefixed public identifier (see `specs/id-schema.md`).",
+            "description": "Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).",
             "example": "model_01933b5a00007000800000000000001"
           },
           "is_favorite": {
@@ -20793,7 +20793,7 @@
           },
           "id": {
             "type": "string",
-            "description": "Prefixed public identifier (see `specs/id-schema.md`).",
+            "description": "Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).",
             "example": "provider_01933b5a00007000800000000000001"
           },
           "last_synced_at": {
@@ -21209,7 +21209,7 @@
           },
           "id": {
             "type": "string",
-            "description": "Prefixed public identifier (see `specs/id-schema.md`).",
+            "description": "Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).",
             "example": "mem_01933b5a000070008000000000000001"
           },
           "importance": {
@@ -21261,7 +21261,7 @@
           },
           "id": {
             "type": "string",
-            "description": "Prefixed public identifier (see `specs/id-schema.md`).",
+            "description": "Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).",
             "example": "mst_01933b5a000070008000000000000001"
           },
           "is_default": {
@@ -22980,7 +22980,7 @@
           },
           "id": {
             "$ref": "#/components/schemas/payacctId",
-            "description": "Prefixed public identifier (see `specs/id-schema.md`)."
+            "description": "Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/)."
           },
           "label": {
             "type": "string",
@@ -23066,7 +23066,7 @@
           },
           "id": {
             "$ref": "#/components/schemas/payattId",
-            "description": "Prefixed public identifier (see `specs/id-schema.md`)."
+            "description": "Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/)."
           },
           "operation": {
             "type": "string",
@@ -23177,7 +23177,7 @@
           },
           "id": {
             "$ref": "#/components/schemas/paypolId",
-            "description": "Prefixed public identifier (see `specs/id-schema.md`)."
+            "description": "Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/)."
           },
           "max_amount_usd_per_day": {
             "type": [
@@ -23406,7 +23406,7 @@
           },
           "id": {
             "type": "string",
-            "description": "Prefixed public identifier (see `specs/id-schema.md`)."
+            "description": "Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/)."
           },
           "name": {
             "type": "string",
@@ -24326,7 +24326,7 @@
           "id": {
             "type": "string",
             "format": "uuid",
-            "description": "Prefixed public identifier (see `specs/id-schema.md`)."
+            "description": "Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/)."
           },
           "name": {
             "type": "string",
@@ -24415,7 +24415,7 @@
           "id": {
             "type": "string",
             "format": "uuid",
-            "description": "Prefixed public identifier (see `specs/id-schema.md`)."
+            "description": "Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/)."
           },
           "schedule_id": {
             "type": "string",
@@ -24518,7 +24518,7 @@
           "id": {
             "type": "string",
             "format": "uuid",
-            "description": "Prefixed public identifier (see `specs/id-schema.md`)."
+            "description": "Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/)."
           },
           "last_triggered_at": {
             "type": [
@@ -25469,7 +25469,7 @@
           },
           "id": {
             "type": "string",
-            "description": "Prefixed public identifier (see `specs/id-schema.md`).",
+            "description": "Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).",
             "example": "skill_01933b5a00007000800000000000001"
           },
           "license": {
@@ -25888,7 +25888,7 @@
           "id": {
             "type": "string",
             "format": "uuid",
-            "description": "Prefixed public identifier (see `specs/id-schema.md`)."
+            "description": "Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/)."
           },
           "last_error": {
             "type": [
@@ -27845,7 +27845,7 @@
           },
           "id": {
             "type": "string",
-            "description": "Prefixed public identifier (see `specs/id-schema.md`)."
+            "description": "Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/)."
           },
           "name": {
             "type": "string",
@@ -27932,7 +27932,7 @@
           },
           "voice_connection_id": {
             "type": "string",
-            "description": "Prefixed public identifier of the voice connection."
+            "description": "Prefixed public identifier of the voice connection. See [ID Schema](https://docs.everruns.com/advanced/id-schema/)."
           }
         }
       },
@@ -28002,7 +28002,7 @@
           },
           "voice_connection_id": {
             "type": "string",
-            "description": "Prefixed public identifier of the voice connection."
+            "description": "Prefixed public identifier of the voice connection. See [ID Schema](https://docs.everruns.com/advanced/id-schema/)."
           }
         }
       },
@@ -28053,7 +28053,7 @@
           },
           "voice_connection_id": {
             "type": "string",
-            "description": "Prefixed public identifier of the voice connection (see `specs/id-schema.md`)."
+            "description": "Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/)."
           }
         }
       },
@@ -28234,7 +28234,7 @@
               },
               "voice_connection_id": {
                 "type": "string",
-                "description": "Prefixed public identifier of the voice connection."
+                "description": "Prefixed public identifier of the voice connection. See [ID Schema](https://docs.everruns.com/advanced/id-schema/)."
               }
             }
           }
@@ -28366,7 +28366,7 @@
           },
           "id": {
             "type": "string",
-            "description": "Prefixed public identifier (see `specs/id-schema.md`).",
+            "description": "Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).",
             "example": "vol_01933b5a000070008000000000000001"
           },
           "is_readonly": {
@@ -29310,7 +29310,7 @@
               },
               "id": {
                 "type": "string",
-                "description": "Prefixed public identifier (see `specs/id-schema.md`).",
+                "description": "Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).",
                 "example": "model_01933b5a00007000800000000000001"
               },
               "is_favorite": {
@@ -29409,7 +29409,7 @@
               },
               "id": {
                 "type": "string",
-                "description": "Prefixed public identifier (see `specs/id-schema.md`).",
+                "description": "Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).",
                 "example": "model_01933b5a00007000800000000000001"
               },
               "is_favorite": {
@@ -29513,7 +29513,7 @@
               },
               "id": {
                 "type": "string",
-                "description": "Prefixed public identifier (see `specs/id-schema.md`).",
+                "description": "Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).",
                 "example": "provider_01933b5a00007000800000000000001"
               },
               "last_synced_at": {
@@ -30488,7 +30488,7 @@
               },
               "id": {
                 "type": "string",
-                "description": "Prefixed public identifier (see `specs/id-schema.md`).",
+                "description": "Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).",
                 "example": "skill_01933b5a00007000800000000000001"
               },
               "license": {
@@ -30617,7 +30617,7 @@
           },
           "id": {
             "type": "string",
-            "description": "Prefixed public identifier (see `specs/id-schema.md`)."
+            "description": "Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/)."
           },
           "last_heartbeat_at": {
             "type": "string",
@@ -30758,7 +30758,7 @@
           "id": {
             "type": "integer",
             "format": "int64",
-            "description": "Prefixed public identifier (see `specs/id-schema.md`)."
+            "description": "Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/)."
           },
           "sequence_num": {
             "type": "integer",
@@ -30823,7 +30823,7 @@
           "id": {
             "type": "string",
             "format": "uuid",
-            "description": "Prefixed public identifier (see `specs/id-schema.md`)."
+            "description": "Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/)."
           },
           "input": {},
           "result": {},

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -14964,7 +14964,7 @@
           "id": {
             "type": "string",
             "format": "uuid",
-            "description": "Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/)."
+            "description": "UUID of the DLQ entry."
           },
           "input": {
             "description": "Task input payload at the time of failure (used for inspection and replay)."
@@ -18616,7 +18616,7 @@
                 "id": {
                   "type": "string",
                   "format": "uuid",
-                  "description": "Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/)."
+                  "description": "UUID of the saved report."
                 },
                 "name": {
                   "type": "string",
@@ -24326,7 +24326,7 @@
           "id": {
             "type": "string",
             "format": "uuid",
-            "description": "Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/)."
+            "description": "UUID of the saved report."
           },
           "name": {
             "type": "string",
@@ -24415,12 +24415,12 @@
           "id": {
             "type": "string",
             "format": "uuid",
-            "description": "Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/)."
+            "description": "UUID of the schedule execution."
           },
           "schedule_id": {
             "type": "string",
             "format": "uuid",
-            "description": "Schedule's prefixed public identifier."
+            "description": "UUID of the owning schedule."
           },
           "scheduled_at": {
             "type": "string",
@@ -24518,7 +24518,7 @@
           "id": {
             "type": "string",
             "format": "uuid",
-            "description": "Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/)."
+            "description": "UUID of the schedule."
           },
           "last_triggered_at": {
             "type": [
@@ -25888,7 +25888,7 @@
           "id": {
             "type": "string",
             "format": "uuid",
-            "description": "Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/)."
+            "description": "UUID of the task."
           },
           "last_error": {
             "type": [
@@ -28053,7 +28053,7 @@
           },
           "voice_connection_id": {
             "type": "string",
-            "description": "Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/)."
+            "description": "Prefixed public identifier of the voice connection. See [ID Schema](https://docs.everruns.com/advanced/id-schema/)."
           }
         }
       },
@@ -30617,7 +30617,7 @@
           },
           "id": {
             "type": "string",
-            "description": "Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/)."
+            "description": "Opaque durable worker identifier (defaults to `worker-<uuid>`)."
           },
           "last_heartbeat_at": {
             "type": "string",
@@ -30758,7 +30758,7 @@
           "id": {
             "type": "integer",
             "format": "int64",
-            "description": "Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/)."
+            "description": "Monotonically-assigned internal event identifier."
           },
           "sequence_num": {
             "type": "integer",
@@ -30823,7 +30823,7 @@
           "id": {
             "type": "string",
             "format": "uuid",
-            "description": "Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/)."
+            "description": "UUID of the workflow."
           },
           "input": {},
           "result": {},

--- a/docs/capabilities/prompt-canary-guardrail.md
+++ b/docs/capabilities/prompt-canary-guardrail.md
@@ -19,7 +19,7 @@ This is intentionally narrow: a single substring match against one normalized ne
 
 ## Tools
 
-None — this capability hooks the streaming output via [`output_guardrails()`](/specs/capabilities/#output-guardrails).
+None — this capability hooks the streaming output via the capability framework's output-guardrail extension point.
 
 ## How It Works
 
@@ -84,7 +84,7 @@ Do **not** rely on this for:
 
 - General-purpose data-loss prevention (PII, secrets in tool output, etc.) — those need their own surfaces
 - Defense against paraphrased or summarized prompt leaks — the canary only catches verbatim or near-verbatim copies of the first sentence
-- Tool output or extended-thinking surfaces — the canary only inspects assistant text. See [the spec](/specs/capabilities/#output-guardrails) for surface scope
+- Tool output or extended-thinking surfaces — the canary only inspects assistant text
 
 ## Limitations
 
@@ -94,5 +94,5 @@ Do **not** rely on this for:
 
 ## See Also
 
-- [Output Guardrails](/specs/capabilities/#output-guardrails) — the underlying extension point
-- [`output.message.replaced` event](/specs/events/#outputmessagereplaced) — the wire format clients need to handle
+- [Events](/features/events/) — the streaming event protocol that carries `output.message.replaced`
+- [Capabilities](/features/capabilities/) — the extension model these guardrails plug into

--- a/docs/capabilities/sub-agents.md
+++ b/docs/capabilities/sub-agents.md
@@ -54,7 +54,7 @@ Send a follow-up message to an existing subagent. Use this to steer a running su
 
 ## See Also
 
-- [GitHub Scout](./github-scout.md) — blueprint-only GitHub repository exploration
-- [Session](./session.md) — session metadata and lifecycle
-- [Platform Management](./platform-management.md) — agent and platform configuration
-- [Capabilities Overview](./index.md) — full list of available capabilities
+- [GitHub Scout](/capabilities/github-scout/) — blueprint-only GitHub repository exploration
+- [Session](/capabilities/session/) — session metadata and lifecycle
+- [Platform Management](/capabilities/platform-management/) — agent and platform configuration
+- [Capabilities Overview](/capabilities/) — full list of available capabilities

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -59,8 +59,6 @@ Everruns is organization-scoped end-to-end:
 - Sessions are isolated at the database row level — there is no cross-session filesystem or key-value access.
 - Secrets are encrypted at rest with an organization-scoped key chain.
 
-The threat model is documented in [`specs/threat-model.md`](https://github.com/everruns/everruns/blob/main/specs/threat-model.md).
-
 ## Where the boundaries are
 
 Things the control plane owns: auth, durable task queue, event log, virtual filesystem, key-value storage, capability registry, MCP catalog.

--- a/docs/explanation/durable-execution.md
+++ b/docs/explanation/durable-execution.md
@@ -65,4 +65,3 @@ For deployments that outgrow a single primary, the migration path is to a sharde
 
 - [The agentic loop](/explanation/agentic-loop/) — what each step inside a turn looks like.
 - [Architecture](/explanation/architecture/) — how the control plane and workers interact.
-- [`specs/durable-execution-engine.md`](https://github.com/everruns/everruns/blob/main/specs/durable-execution-engine.md) — internal specification.

--- a/docs/features/apps.md
+++ b/docs/features/apps.md
@@ -29,7 +29,7 @@ The same agent can back multiple apps (e.g., a Slack deployment and a webhook de
 | WhatsApp | Planned | — |
 | Web Widget | Planned | — |
 
-See [Slack Integration](/integrations/slack/) for the Slack-side setup, and [app invocation channels](https://github.com/everruns/everruns/blob/main/specs/app-invocation-channels.md) for the spec on schedule/webhook channels.
+See [Slack Integration](/integrations/slack/) for the Slack-side setup.
 
 ## Session routing
 

--- a/docs/features/capabilities.md
+++ b/docs/features/capabilities.md
@@ -52,5 +52,4 @@ The full list of built-in capabilities, organised by category, lives in the refe
 
 ## See also
 
-- [MCP servers as virtual capabilities](https://github.com/everruns/everruns/blob/main/specs/mcp-servers.md) — internal spec on remote MCP integration.
 - [Concepts](/explanation/concepts/) — the entity model in full.

--- a/docs/features/events.md
+++ b/docs/features/events.md
@@ -105,4 +105,3 @@ Your deserializer should ignore unknown fields, ignore unknown event types, and 
 
 - [Event Reference](/event-reference/) — complete event type catalog with payloads.
 - [Events as the primary store](/explanation/events/) — design rationale.
-- [`specs/events.md`](https://github.com/everruns/everruns/blob/main/specs/events.md) — internal spec with the full compatibility contract.

--- a/docs/features/skills-registry.md
+++ b/docs/features/skills-registry.md
@@ -38,8 +38,6 @@ Registry skills automatically depend on `session_file_system` so bundled resourc
 - Skill names are unique per organization.
 - Disabled skills are hidden from listings.
 
-See [TM-TOOL-010 through TM-TOOL-014](https://github.com/everruns/everruns/blob/main/specs/threat-model.md) in the threat model for the detailed analysis.
-
 ## Do something
 
 - [Publish a skill to the registry](/how-to/publish-a-skill-to-the-registry/) — full upload, validate, assign flow.

--- a/docs/how-to/migrate-providers.md
+++ b/docs/how-to/migrate-providers.md
@@ -83,7 +83,7 @@ A safe migration sequence:
 
 1. Add the new provider and verify discovered models.
 2. Create a test agent that mirrors production, with `default_model_id` set to a model on the new provider.
-3. Run an evaluation suite against the test agent (see [Evals](https://github.com/everruns/everruns/blob/main/specs/evals.md)).
+3. Run an evaluation suite against the test agent.
 4. Once happy, update the production agent's `default_model_id` — new sessions migrate over.
 5. Leave old sessions on the old model; they age out naturally.
 

--- a/docs/how-to/publish-a-skill-to-the-registry.md
+++ b/docs/how-to/publish-a-skill-to-the-registry.md
@@ -100,8 +100,6 @@ Deleting a skill hides it from capability listings. Agents that reference it via
 - Skill names are unique per organization.
 - Disabled skills are hidden from listings.
 
-See [TM-TOOL-010 through TM-TOOL-014](https://github.com/everruns/everruns/blob/main/specs/threat-model.md) in the threat model for the detailed analysis.
-
 ## See also
 
 - [Skills Registry feature](/features/skills-registry/)

--- a/docs/how-to/publish-to-slack.md
+++ b/docs/how-to/publish-to-slack.md
@@ -72,4 +72,3 @@ Set this on the app's `agent_version_mode` field.
 
 - [Apps feature](/features/apps/)
 - [Slack Integration](/integrations/slack/) — the prerequisite Slack-side configuration.
-- [App invocation channels](https://github.com/everruns/everruns/blob/main/specs/app-invocation-channels.md) — webhook and schedule channels.

--- a/docs/observability/index.md
+++ b/docs/observability/index.md
@@ -1,0 +1,17 @@
+---
+title: Observability
+description: Send Everruns session traces, token usage, and tool-call timings to your observability platform of choice.
+sidebar:
+  order: 0
+---
+
+Everruns emits structured events for every agent turn — model calls, tool invocations, retries, token usage, latency. The integrations in this section forward those signals to dedicated observability platforms so you can monitor agents in production, evaluate prompt changes, and debug failures with full trace context.
+
+## Available Integrations
+
+- [Braintrust](/observability/braintrust/) — LLM observability, evaluation, and trace visualization. Turn traces are grouped by session, with token usage, time-to-first-token, and tool execution times.
+
+## Related
+
+- [Events](/features/events/) — the streaming event protocol that backs every observability export.
+- [Environment Variables](/sre/environment-variables/) — configure exporters, sampling, and OTLP endpoints.

--- a/docs/sre/environment-variables.md
+++ b/docs/sre/environment-variables.md
@@ -312,7 +312,6 @@ RESEND_API_KEY=re_...
 - Set these on the control-plane process that performs system email sends.
 - The sender is fixed in code as `Everruns <no-replay@everruns.com>`.
 - The Resend account must have `everruns.com` verified and enabled for sending.
-- See `specs/email.md` for the internal abstraction and provider contract.
 
 ## UI API Proxy Architecture
 


### PR DESCRIPTION
## What
- Strip `(see specs/...)` and `[…](github.com/…/specs/…)` references from public docs and from rustdoc that feeds `docs/api/openapi.json`.
- Add `docs/advanced/id-schema.md` as the public home for the prefixed-ID contract; rustdoc on `Prefixed public identifier` fields now links there instead of citing `specs/id-schema.md`.
- Correct rustdoc on durable, schedule, DLQ, task, workflow, workflow-event, and saved-report response `id` fields — they are UUIDs/i64, not prefixed public IDs.
- Rephrase the `resolve_org` rustdoc so it no longer cites `specs/multitenancy.md`.
- Regenerate `docs/api/openapi.json` — 0 `specs/*` references remain.
- Fix three docs-site 404s flagged in Search Console:
  - `docs/observability/index.md` added (section root previously 404'd).
  - `docs/capabilities/sub-agents.md` relative `./session.md`-style links rewritten to absolute `/capabilities/session/` URLs (these were the source of `/capabilities/sub-agents/session.md` 404s).
  - `docs/capabilities/prompt-canary-guardrail.md` `/specs/capabilities/` and `/specs/events/` links replaced with public-doc equivalents.

## Why
`AGENTS.md` is explicit: "Public product documentation lives in `docs/`. Internal proposals, durable design intent, and temporary investigations do not belong there." The `specs/` directory is internal; the references were leaking into both `docs/*.md` prose and the published OpenAPI surface, which broke clicks and exposed an internal taxonomy.

The id-schema doc is also written to describe the suffix as an opaque token. The whole point of the public ID is to hide the sequential, time-ordered nature of the internal key, so the public contract should not advertise UUIDv7.

## How
- `sed` over rustdoc `Prefixed public identifier (see \`specs/id-schema.md\`).` to `Prefixed public identifier. See [ID Schema](https://docs.everruns.com/advanced/id-schema/).` across 28 source files.
- Manual edits where the field type isn't actually a prefixed ID (durable, schedule, reporting response IDs).
- Manual edits for the single `specs/multitenancy.md` reference in `crates/server/src/api/resolver.rs`.
- Per-file edits to remove the "See [`specs/...`](github.com/.../specs/...)" footers from `docs/*.md`.
- Regenerated `docs/api/openapi.json` via `./scripts/export-openapi.sh`.
- Verified `pnpm run build` and `pnpm run check` in `apps/docs` pass — 355 pages built, 0 errors.

## Risk
- Low. Doc-comment edits do not affect compiled behavior. `openapi.json` diff is purely description-string rewrites.
- The id-schema doc is new and discoverable in the sidebar via Starlight's autogenerate.

## Security
- Threat categories reviewed: no security-relevant code changes. The diff only modifies rustdoc strings, prose in `docs/*.md`, the generated OpenAPI descriptions derived from those rustdoc strings, and one new public docs page. No runtime, auth, query, validation, or sandbox code paths are touched.
- Findings and resolutions: none.

## Follow-ups
- The current `TypedId<T>::new()` implementation derives the public ID suffix from a UUIDv7. The new public docs deliberately describe the suffix as opaque, so the contract is intact, but the implementation still leaks creation-time ordering through the hex bytes. Worth a separate code change to switch to a non-time-ordered random suffix while keeping internal `id` as UUIDv7.
- ~30 other `///` rustdoc comments in `crates/` still reference `specs/*.md` but currently don't surface in `docs/api/openapi.json` (they're on internal items). Worth a follow-up pass if/when those items become public.

## Checklist
- [x] Tests added or updated — N/A (docs-only change; no behavior changed)
- [x] Backward compatibility considered — public OpenAPI field descriptions changed text only; no field names, types, or paths changed
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)