### PR TITLE
fix(ci): stop fork PRs from reading Doppler + LLM keys via env

### DIFF
--- a/.github/workflows/brave-search-integration.yml
+++ b/.github/workflows/brave-search-integration.yml
@@ -1,6 +1,7 @@
 name: Brave Search Integration
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
     paths:
@@ -22,14 +23,43 @@ env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
   CARGO_INCREMENTAL: 0
-  DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+  # DOPPLER_TOKEN is intentionally NOT exposed at workflow scope so it
+  # cannot reach the PR-triggered unit-test job (which runs untrusted
+  # code). It is scoped to live-test below, which only runs on push.
 
 jobs:
-  integration-test:
-    name: Brave Search API Tests
+  unit-test:
+    name: Brave Search Unit Tests
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request' || (((github.event.action != 'labeled' && github.event.action != 'unlabeled') || github.event.label.name == 'ci:skip-integration-workflows') && !contains(github.event.pull_request.labels.*.name, 'ci:skip-integration-workflows'))
     timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "debug"
+
+      - name: Run unit tests
+        run: cargo test -p everruns-integrations-brave-search
+
+  # Live tests hit the real Brave Search API and need DOPPLER_TOKEN.
+  # Restricted to push/workflow_dispatch so the secret is never available
+  # in a fork-PR context where untrusted code (build.rs, proc-macros,
+  # tests) could exfiltrate it. The weekly `integration-live-sweep.yml`
+  # backstop catches shared-crate regressions that slip past this gate.
+  live-test:
+    name: Brave Search Live API Tests
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    timeout-minutes: 10
+    env:
+      DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/brave-search-integration.yml
+++ b/.github/workflows/brave-search-integration.yml
@@ -25,7 +25,8 @@ env:
   CARGO_INCREMENTAL: 0
   # DOPPLER_TOKEN is intentionally NOT exposed at workflow scope so it
   # cannot reach the PR-triggered unit-test job (which runs untrusted
-  # code). It is scoped to live-test below, which only runs on push.
+  # code). It is scoped to live-test below, which only runs on push or
+  # workflow_dispatch.
 
 jobs:
   unit-test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,10 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
-  DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+  # DOPPLER_TOKEN is intentionally NOT exposed at workflow scope: PR code
+  # would inherit it and could exfiltrate the whole Doppler vault via
+  # build.rs, proc-macros, or tests. Inject it per step under a push-only
+  # gate (see Slack + live-test jobs below).
 
 jobs:
   # Detect which parts of the codebase changed to skip irrelevant jobs
@@ -383,6 +386,8 @@ jobs:
     needs: changes
     if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.daytona == 'true' && github.event_name == 'push'
     timeout-minutes: 10
+    env:
+      DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
 
     steps:
       - uses: actions/checkout@v5
@@ -408,6 +413,8 @@ jobs:
     needs: changes
     if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.browserless == 'true' && github.event_name == 'push'
     timeout-minutes: 10
+    env:
+      DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
 
     steps:
       - uses: actions/checkout@v5
@@ -433,6 +440,8 @@ jobs:
     needs: changes
     if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.e2b == 'true' && github.event_name == 'push'
     timeout-minutes: 10
+    env:
+      DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
 
     steps:
       - uses: actions/checkout@v5
@@ -460,6 +469,7 @@ jobs:
     timeout-minutes: 10
     env:
       DENO_SANDBOX_REGION: ams
+      DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
 
     steps:
       - uses: actions/checkout@v5
@@ -577,12 +587,17 @@ jobs:
       - name: Run durable failpoint tests
         run: cargo test -p everruns-durable --test failure_injection_test --features "failpoints,postgres-tests" -- --test-threads=1
 
+      # Slack live tests need DOPPLER_TOKEN. Restrict to push events so the
+      # token is never instantiated in a fork-PR context where untrusted
+      # code (build.rs, proc-macros, test bodies) would see it via env.
       - name: Install Doppler CLI
-        if: env.DOPPLER_TOKEN != ''
+        if: github.event_name == 'push'
         uses: dopplerhq/cli-action@v3
 
       - name: Run Slack integration tests (real API via Doppler)
-        if: env.DOPPLER_TOKEN != ''
+        if: github.event_name == 'push'
+        env:
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
         run: doppler run --preserve-env="DATABASE_URL" -- cargo test -p everruns-server --test slack_integration_test -- --test-threads=1
 
       - name: Run LLM integration tests (skips providers without API keys)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -512,10 +512,13 @@ jobs:
 
     env:
       DATABASE_URL: postgres://everruns:everruns@localhost:5432/everruns_test
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
       SECRETS_ENCRYPTION_KEY: kek-v1:8B3uCQ4Znx45hl5nB+PKVriRrj/KtEVM+wBZ2VGa9vY=
+      # LLM provider keys are intentionally NOT exposed at job scope:
+      # this job runs PR-controlled cargo test (and therefore arbitrary
+      # build.rs / proc-macro / test code) which would otherwise be able
+      # to read the keys from process env. The single step that needs
+      # them (Run LLM integration tests) is gated to push events and
+      # sets them via step env below.
 
     steps:
       - uses: actions/checkout@v5
@@ -600,7 +603,11 @@ jobs:
           DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
         run: doppler run --preserve-env="DATABASE_URL" -- cargo test -p everruns-server --test slack_integration_test -- --test-threads=1
 
+      # Gated to push events so PR-controlled cargo test cannot exfiltrate
+      # the LLM provider keys via env. PR coverage of the LLM matrix is
+      # still provided by `unit-test` (mocked) and the weekly live sweep.
       - name: Run LLM integration tests (skips providers without API keys)
+        if: github.event_name == 'push'
         timeout-minutes: 10
         # Gemini cases chronically hit 429 `RESOURCE_EXHAUSTED` on the shared
         # CI key regardless of the 2 in-test retries. Skip the `gemini` provider
@@ -609,6 +616,9 @@ jobs:
         # regressions, not upstream quota pressure. Revisit when quota is raised.
         env:
           SKIP_LLM_INTEGRATION_TESTS_PROVIDERS: gemini
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
         run: cargo test -p everruns-llm-tests --test agent_run_basic --test agent_run_with_thinking --all-features
 
   # Build release binaries and upload as artifacts for E2E jobs and openapi-check
@@ -660,13 +670,18 @@ jobs:
           path: target/release/export-openapi
           retention-days: 1
 
+  # Gated to push events: this job launches PR-built `everruns-server` and
+  # `everruns-worker` binaries with ANTHROPIC/OPENAI/GEMINI keys in env, so
+  # running it on fork PRs would let attacker-controlled binary code exfil
+  # the keys. PR coverage of the binaries is still provided by build-binaries
+  # (compile-time) and the workflow tests run on push to main.
   workflow-test:
     name: Workflow Tests (Server + Worker)
     runs-on: ubuntu-latest
     needs:
       - changes
       - build-binaries
-    if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true' && needs.changes.outputs.skip_slow_rust != 'true'
+    if: github.event_name == 'push' && needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true' && needs.changes.outputs.skip_slow_rust != 'true'
     services:
       postgres:
         image: postgres:17-alpine
@@ -788,13 +803,18 @@ jobs:
           echo "=== Worker logs ==="
           cat worker.log 2>/dev/null || echo "No worker log"
 
+  # Gated to push events: this job launches the PR-built `everruns-server`
+  # binary with DEFAULT_*_API_KEY in env (which map to the same secrets as
+  # workflow-test), so running it on fork PRs would let attacker-controlled
+  # binary code exfil the keys. PR coverage of the CLI is still provided by
+  # the CLI integration tests under `unit-test` (which run without keys).
   cli-e2e-test:
     name: CLI E2E Tests
     runs-on: ubuntu-latest
     needs:
       - changes
       - build-binaries
-    if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true' && needs.changes.outputs.skip_slow_rust != 'true'
+    if: github.event_name == 'push' && needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true' && needs.changes.outputs.skip_slow_rust != 'true'
     timeout-minutes: 10
 
     env:

--- a/.github/workflows/cursor-integration.yml
+++ b/.github/workflows/cursor-integration.yml
@@ -26,7 +26,8 @@ env:
   CARGO_INCREMENTAL: 0
   # DOPPLER_TOKEN is intentionally NOT exposed at workflow scope so it
   # cannot reach the PR-triggered unit-test job (which runs untrusted
-  # code). It is scoped to live-test below, which only runs on push.
+  # code). It is scoped to live-test below, which only runs on push or
+  # workflow_dispatch.
 
 jobs:
   unit-test:

--- a/.github/workflows/cursor-integration.yml
+++ b/.github/workflows/cursor-integration.yml
@@ -24,7 +24,9 @@ env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
   CARGO_INCREMENTAL: 0
-  DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+  # DOPPLER_TOKEN is intentionally NOT exposed at workflow scope so it
+  # cannot reach the PR-triggered unit-test job (which runs untrusted
+  # code). It is scoped to live-test below, which only runs on push.
 
 jobs:
   unit-test:
@@ -51,6 +53,8 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     timeout-minutes: 10
+    env:
+      DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/sprites-integration.yml
+++ b/.github/workflows/sprites-integration.yml
@@ -26,7 +26,9 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
-  DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+  # DOPPLER_TOKEN is intentionally NOT exposed at workflow scope so it
+  # cannot reach the PR-triggered unit-test job (which runs untrusted
+  # code). It is scoped to live-test below, which only runs on push.
 
 jobs:
   unit-test:
@@ -56,6 +58,8 @@ jobs:
     # immediately after Doppler changes without waiting for the weekly sweep.
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     timeout-minutes: 10
+    env:
+      DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/sprites-integration.yml
+++ b/.github/workflows/sprites-integration.yml
@@ -28,7 +28,8 @@ env:
   RUST_BACKTRACE: 1
   # DOPPLER_TOKEN is intentionally NOT exposed at workflow scope so it
   # cannot reach the PR-triggered unit-test job (which runs untrusted
-  # code). It is scoped to live-test below, which only runs on push.
+  # code). It is scoped to live-test below, which only runs on push or
+  # workflow_dispatch.
 
 jobs:
   unit-test:

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -1201,6 +1201,34 @@ And on update, the preserved-secrets merger reinjects the existing encrypted tok
 **TM-FCP-008 — Session ownership invariant:**
 `SessionService::create_from_app` sets `session.owner_principal_id = app.owner_principal_id` and tags every session with `fcp:app:<app_public_id>`. The reuse path (`find_app_session_by_tags`) requires the `org_id`, `app.internal_id`, AND the routing tag to all match — so even an attacker who guesses a victim app's id and forges a cookie cannot adopt a session owned by a different org or app.
 
+## 24. CI / Build Pipeline (TM-CI)
+
+GitHub Actions workflows in `.github/workflows/` are part of the trust boundary because they execute on push to `main` and on fork pull requests once the first-time-contributor approval is granted. After that one-time approval, every subsequent PR from the same fork runs CI automatically; the only barrier between attacker-controlled code and the repo's secrets is the per-workflow secret scoping.
+
+Key GitHub guarantee: for `pull_request` triggers, the workflow YAML is read from the BASE branch, so a fork PR cannot directly add an exfiltration step to a workflow. The risk is indirect — workflow YAML in the base branch may execute PR-controlled code (cargo build/test runs `build.rs`, proc-macros, and test bodies; PR-built server/worker/CLI binaries execute) with secrets injected into the process env. Any secret available to that code is exfiltratable.
+
+| ID | Threat | Severity | Mitigation | Status |
+|----|--------|----------|------------|--------|
+| TM-CI-001 | Workflow-level `DOPPLER_TOKEN` exfil via PR-controlled cargo build/test | Critical | `DOPPLER_TOKEN` is no longer declared at workflow `env:` in `ci.yml`, `brave-search-integration.yml`, `cursor-integration.yml`, or `sprites-integration.yml`. It is injected only into jobs/steps gated on `github.event_name == 'push'` (live-test jobs in ci.yml + per-integration live-test jobs). The Slack step in `integration-test` was changed from `if: env.DOPPLER_TOKEN != ''` to `if: github.event_name == 'push'` with step-scoped env | MITIGATED |
+| TM-CI-002 | LLM provider keys (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`) exfil from `integration-test` job env via PR-controlled cargo test | High | Three keys removed from `integration-test` job env. The single step that needs them (`Run LLM integration tests`) gates on `github.event_name == 'push'` and sets them via step env | MITIGATED |
+| TM-CI-003 | LLM provider keys exfil from PR-built `everruns-server`/`everruns-worker` binaries in `workflow-test` | High | `workflow-test` job condition now requires `github.event_name == 'push'`. Compile-time PR coverage of the binaries is preserved via `build-binaries` | MITIGATED |
+| TM-CI-004 | LLM provider keys exfil via `DEFAULT_*_API_KEY` from PR-built CLI in `cli-e2e-test` | High | `cli-e2e-test` job condition now requires `github.event_name == 'push'`. PR-side CLI coverage continues via `unit-test`'s CLI integration tests, which run without keys | MITIGATED |
+| TM-CI-005 | Brave Search live tests exposing Doppler vault on fork PRs | High | `brave-search-integration.yml` split into a PR-safe `unit-test` job (no secrets) and a push-only `live-test` job. Weekly `integration-live-sweep.yml` backstops shared-crate regression coverage | MITIGATED |
+| TM-CI-006 | First-time-contributor approval grants persistent CI access | Medium | GitHub setting "Require approval for all outside collaborators" recommended at the org/repo level. Not enforced in this repo's workflows; orthogonal to the per-secret scoping above | **OPERATIONAL** |
+| TM-CI-007 | `GITHUB_TOKEN` exfil on PR | Low | GitHub scopes the fork-PR `GITHUB_TOKEN` to read-only by default. `docker-publish.yml` uses it only on `push`/tag jobs; PR-validation jobs do not log in to GHCR | MITIGATED |
+
+### Mitigation Details
+
+**TM-CI-001 / TM-CI-002 / TM-CI-003 / TM-CI-004 — `pull_request` vs `push` gating:**
+The four workflows touched in this category previously declared secrets at workflow `env:` or at job `env:` on jobs that ran on `pull_request`. After the fix, every step that has any secret in its env satisfies one of:
+- The enclosing job condition includes `github.event_name == 'push'` (or `workflow_dispatch`), or
+- The step itself has an `if: github.event_name == 'push'` guard, and the secret is set at step `env:` only.
+
+This ensures GitHub never instantiates the secret value into a runner that is executing fork-PR-controlled code (build.rs, proc-macros, test bodies, or PR-built binaries).
+
+**TM-CI-006 — Outside-collaborator approval gate:**
+Even with per-secret scoping, an attacker who controls a previously-approved fork can submit malicious PRs that the workflow base-branch YAML still runs. The remaining defense layer is the GitHub org setting "Require approval for all outside collaborators" under Actions → General → Fork pull request workflows. This is a repo/org-level operational control, not a workflow change, and is therefore tracked here for visibility.
+
 ## Vulnerability Summary
 
 ### Open Threats (Require Action)
@@ -1298,6 +1326,7 @@ And on update, the preserved-secrets merger reinjects the existing encrypted tok
 | A2A Agent Card disclosure | TM-A2A-009 | Card never echoes API key / hash / internal IDs; only published while app is live and channel enabled |
 | A2A runaway client DoS | TM-A2A-013 | Configurable per-app, per-IP cap (`A2aChannelConfig::rate_limit_per_minute`) enforced after API key check via shared `ChannelRateLimiter` (in-memory governor or Valkey) |
 | A2A replay of captured request | TM-A2A-010 | Opt-in scope-bound HMAC signing (`A2aChannelConfig::signing_secret`) — basestring `v0:{ts}:{app_id}:{channel_id}:{body}` so signatures are non-reusable across channels; 5-minute timestamp window plus signature-keyed dedup; in-memory or Valkey backend |
+| CI secret scoping | TM-CI-001..005 | No `secrets.*` at workflow `env:`; secrets are injected only into jobs/steps gated on `github.event_name == 'push'` (or `workflow_dispatch`) so fork-PR-controlled cargo/binary code cannot read them from process env |
 
 ## References
 


### PR DESCRIPTION
## What
Move every CI secret (`DOPPLER_TOKEN`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`) out of workflow-level / job-level `env:` on PR-triggered jobs. Secrets are now injected only into jobs or steps gated on `github.event_name == 'push'` (or `workflow_dispatch`). Adds a `TM-CI` section to the threat model documenting the surface and mitigations.

Files touched:
- `.github/workflows/ci.yml`
- `.github/workflows/brave-search-integration.yml`
- `.github/workflows/cursor-integration.yml`
- `.github/workflows/sprites-integration.yml`
- `specs/threat-model.md`

## Why
GitHub's "Require approval for first-time contributors" gate is one-time only. After approval, every subsequent fork PR runs CI automatically. The workflow YAML itself is read from the base branch (so a fork PR cannot directly add an exfil step), but the base-branch workflow can — and did — inject secrets at `env:` while running PR-controlled code: `cargo build`/`cargo test` runs `build.rs`, proc-macros, and test bodies; `workflow-test`/`cli-e2e-test` start PR-built `everruns-server`/`everruns-worker`/`everruns` binaries. Any of those code paths can read process env and POST it out. A leaked `DOPPLER_TOKEN` compromises the entire Doppler vault (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GITHUB_TOKEN`, `LINEAR_API_KEY`, etc.).

## How
Three changes in three commits:

1. **`fix(ci): scope DOPPLER_TOKEN to push-only jobs`** — Remove `DOPPLER_TOKEN` from workflow-level `env:` in `ci.yml`, `cursor-integration.yml`, `sprites-integration.yml` (cursor/sprites already had push-only live-test jobs; just moved the env to job scope on those). For `brave-search-integration.yml`, split the single job into a PR-safe `unit-test` and a push-only `live-test`. In `ci.yml`, the Slack step is now `if: github.event_name == 'push'` with step-scoped `DOPPLER_TOKEN`.

2. **`fix(ci): scope LLM provider keys to push-only execution`** — Remove the three LLM keys from `integration-test` job env; the `Run LLM integration tests` step now gates on `github.event_name == 'push'` and sets them via step env. `workflow-test` and `cli-e2e-test` job conditions get `&& github.event_name == 'push'` because they run PR-built binaries with the keys in env and have no clean step-scope fix.

3. **`docs(threat-model): add TM-CI`** — Seven new threat IDs (TM-CI-001..007) with mitigation status and a Security Controls Matrix row.

## Risk
- **Medium.**
- PR coverage **lost** (still covered by push-to-main + the weekly `integration-live-sweep.yml`):
  - LLM integration tests (`crates/llm-tests` agent matrix)
  - `workflow-test` (server+worker end-to-end against real LLMs)
  - `cli-e2e-test`
  - Brave Search live API tests
- **Watch on first PR after merge:** any test still in `integration-test` that silently relied on the three LLM keys via job env will start failing on PR. Likely candidates: `evals_integration_test`, `ag_ui_integration_test`, `client_side_tools_test`, `llm_model_default_test`. Fix is to either make them skip on absent keys (existing `everruns-llm-tests` pattern) or move them to a push-only sibling job.
- Aggregator `ci-success` already treats skipped as OK (only fails on `failure`/`cancelled`), so branch protection still passes for PRs from `main`-side contributors.

## Security
- Threat categories reviewed: **TM-CI** (new), TM-LLM (key exposure), TM-TOOL (no surface change).
- Findings and resolutions: this PR _is_ the resolution. The exfil paths are closed by the per-step gating documented in TM-CI-001..005. TM-CI-006 (org-level "Require approval for all outside collaborators" setting) is operational and tracked but not fixable in code.
- No new runtime/code paths; only workflow YAML and threat-model doc.

## Follow-ups
- **TM-CI-006:** turn on org/repo Actions setting **"Require approval for all outside collaborators"** (Settings → Actions → General → Fork pull request workflows). Cannot be set via code; needs operator action.
- If any of the suspected key-dependent tests in `integration-test` start failing on PR, split them into a push-only sibling job mirroring the LLM-integration-tests pattern. Not pre-emptively done because behavior is uncertain without running CI.
- Consider GitHub deployment environments with required reviewers for any future workflow that must run untrusted code with secrets (defense-in-depth beyond push-gating).

## Checklist
- [x] Tests added or updated — N/A; YAML-only + spec doc. YAML validated locally with `python3 -c "import yaml; yaml.safe_load(...)"`.
- [x] Backward compatibility considered — main-branch maintainers and push-to-main runs are unaffected; only PR-from-fork runs lose live-test coverage (explicitly intended).
- [x] Security review performed against relevant threat model categories.
- [ ] Final CI ran checks affected by this PR — pending this PR's CI cycle.
- [ ] All review comments addressed — pending.


---
_Generated by [Claude Code](https://claude.ai/code/session_015daMTyTJZTbH8TUyPjomUe)_