### PR TITLE
docs(api): describe Reporting/Payment/Voice/list-query schemas; floor 99%

### DIFF
--- a/crates/core/src/context_report.rs
+++ b/crates/core/src/context_report.rs
@@ -8,6 +8,8 @@ use crate::tool_types::ToolDefinition;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
+/// One logical section of the assembled LLM context (system prompt, tool
+/// definitions, message history, etc.) with its rolled-up token budget.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ContextReportSection {
@@ -21,6 +23,9 @@ pub struct ContextReportSection {
     pub items: u32,
 }
 
+/// Single-source token contribution within a `ContextReportSection` — the
+/// per-tool / per-capability / per-message attribution that lets operators
+/// see which source is eating the context window.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ContextReportContribution {
@@ -34,6 +39,10 @@ pub struct ContextReportContribution {
     pub tokens: u32,
 }
 
+/// Token-budget report for a session — a model-aware breakdown of the
+/// context window into named sections plus per-source contributions, so
+/// callers can answer "what's filling the context?" without reverse-
+/// engineering the prompt assembly.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct SessionContextReport {

--- a/crates/core/src/payment.rs
+++ b/crates/core/src/payment.rs
@@ -94,6 +94,9 @@ impl From<&str> for PaymentOwnerType {
     }
 }
 
+/// Lifecycle state of a payment account, policy, or attempt. The shared
+/// vocabulary keeps account/policy admin and attempt settlement on the
+/// same status taxonomy.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 #[serde(rename_all = "snake_case")]
@@ -138,6 +141,9 @@ impl From<&str> for PaymentStatus {
     }
 }
 
+/// A payment account — the org-scoped source of funds for paid agent calls.
+/// Each account binds an owning principal (user, agent identity, or org)
+/// to one settlement rail and tracks its provisioning lifecycle.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct PaymentAccount {
@@ -165,6 +171,9 @@ pub struct PaymentAccount {
     pub updated_at: DateTime<Utc>,
 }
 
+/// A payment policy — the binding between a paying account and a subject
+/// (agent identity, session) that controls which paid calls are
+/// authorized and at what spend caps.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct PaymentPolicy {
@@ -202,6 +211,9 @@ pub struct PaymentPolicy {
     pub updated_at: DateTime<Utc>,
 }
 
+/// A single paid-call settlement attempt — the durable record of one
+/// authorization+settlement cycle issued through the payment authority.
+/// Persisted regardless of outcome so failed attempts remain auditable.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct PaymentAttempt {

--- a/crates/core/src/principal.rs
+++ b/crates/core/src/principal.rs
@@ -15,6 +15,9 @@ use crate::typed_id::PrincipalId;
 #[cfg(feature = "openapi")]
 use utoipa::ToSchema;
 
+/// Class of principal that can hold permissions or own resources. `system`
+/// is reserved for platform-internal callers and is never minted via the
+/// public API.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 #[serde(rename_all = "snake_case")]
@@ -73,6 +76,9 @@ impl From<&str> for PrincipalStatus {
     }
 }
 
+/// Compact view of a principal — id + kind + the subject-id pointer back
+/// into the user/agent-identity row. Used wherever a full `Principal`
+/// would be redundant (e.g. as a sub-field of a session or audit record).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct PrincipalSummary {

--- a/crates/core/src/reporting.rs
+++ b/crates/core/src/reporting.rs
@@ -17,6 +17,8 @@ pub struct ReportScope {
     pub caller: Caller,
 }
 
+/// Half-open time window applied to the dataset's primary timestamp column
+/// during a report query. `from` is inclusive, `to` is exclusive.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ReportTimeRange {
@@ -28,6 +30,9 @@ pub struct ReportTimeRange {
     pub to: DateTime<Utc>,
 }
 
+/// Semantic query a caller submits to the reporting layer. The backend
+/// compiles this to its native query language, scopes it to the calling
+/// org, and returns a `ReportResult`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ReportQuery {
@@ -56,6 +61,8 @@ fn default_report_limit() -> u32 {
     100
 }
 
+/// One predicate filter applied to the dataset before aggregation.
+/// Combined with other filters via logical AND.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ReportFilter {
@@ -70,6 +77,8 @@ pub struct ReportFilter {
     pub value: Value,
 }
 
+/// Comparison operator used in a `ReportFilter`. The `In` variant takes a
+/// JSON array as its value; all others take a scalar.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
@@ -83,6 +92,8 @@ pub enum ReportFilterOp {
     Lte,
 }
 
+/// One sort clause applied to the aggregated result. Either `dimension`
+/// OR `measure` is set (mutually exclusive), never both.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ReportOrderBy {
@@ -103,6 +114,7 @@ fn default_order_direction() -> ReportOrderDirection {
     ReportOrderDirection::Asc
 }
 
+/// Sort direction for a `ReportOrderBy` clause.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
@@ -111,6 +123,8 @@ pub enum ReportOrderDirection {
     Desc,
 }
 
+/// Materialized result of a report query — column metadata, rows, and the
+/// freshness of the underlying data.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ReportResult {
@@ -131,6 +145,8 @@ pub struct ReportResult {
     pub rows: Vec<Value>,
 }
 
+/// One column header in a `ReportResult`. The ordered `columns` list
+/// declares the key set of each row in `rows`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ReportColumn {
@@ -142,6 +158,7 @@ pub struct ReportColumn {
     pub kind: ReportColumnKind,
 }
 
+/// Whether a `ReportColumn` is a grouping dimension or an aggregate measure.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
@@ -150,18 +167,27 @@ pub enum ReportColumnKind {
     Measure,
 }
 
+/// Listing of every dataset the reporting layer can answer queries over.
+/// Returned from `GET /v1/reports/catalog`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct DatasetCatalog {
+    /// All datasets the caller has access to, in stable alphabetical order.
     pub datasets: Vec<DatasetCatalogEntry>,
 }
 
+/// A single dataset entry in the reporting catalog — the set of dimensions,
+/// measures, and filter fields the dataset exposes to query authors.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct DatasetCatalogEntry {
+    /// Dataset identifier as passed to `ReportQuery.dataset`.
     pub name: String,
+    /// Dimensions available to group by.
     pub dimensions: Vec<String>,
+    /// Measures available to aggregate.
     pub measures: Vec<String>,
+    /// Fields valid as the `field` of a `ReportFilter`.
     pub filter_fields: Vec<String>,
 }
 

--- a/crates/server/src/api/apps.rs
+++ b/crates/server/src/api/apps.rs
@@ -339,6 +339,8 @@ pub async fn unpublish_app(
         .await
 }
 
+/// Query parameters for listing recent app invocation runs — a relative
+/// time window and an optional bucketing hint for the dashboard.
 #[derive(Debug, Default, Deserialize, IntoParams, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct ListAppRunsQuery {

--- a/crates/server/src/api/reporting.rs
+++ b/crates/server/src/api/reporting.rs
@@ -61,6 +61,8 @@ impl AppState {
 impl_auth_state!(AppState);
 impl_dispatchable!(AppState);
 
+/// Query parameters for a manual `POST /v1/reports/projector/run` invocation —
+/// the cap on how many outbox rows one run is allowed to claim.
 #[derive(Debug, Clone, Deserialize, IntoParams, ToSchema)]
 pub struct ProjectorRunQuery {
     #[serde(default = "default_projector_limit")]

--- a/crates/server/src/api/schedules.rs
+++ b/crates/server/src/api/schedules.rs
@@ -440,6 +440,8 @@ pub struct TriggerResponse {
 // Query parameters
 // ============================================================================
 
+/// Query parameters for `GET /v1/schedules` — optional enabled/target-type
+/// filters plus standard offset/limit paging.
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct ListSchedulesQuery {
     /// Filter by enabled status
@@ -456,6 +458,8 @@ pub struct ListSchedulesQuery {
     pub limit: Option<u32>,
 }
 
+/// Query parameters for listing executions of a schedule — optional status
+/// filter plus offset/limit paging.
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct ListExecutionsQuery {
     /// Filter by execution status

--- a/crates/server/src/api/session_sandbox.rs
+++ b/crates/server/src/api/session_sandbox.rs
@@ -21,6 +21,8 @@ use utoipa::ToSchema;
 
 use super::common::{ApiResult, impl_auth_state};
 
+/// Wire-facing status of a session sandbox. Mirrors
+/// `everruns_core::SessionSandboxStatus` for the public API.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum SessionSandboxStatusValue {
@@ -37,6 +39,9 @@ impl From<everruns_core::SessionSandboxStatus> for SessionSandboxStatusValue {
     }
 }
 
+/// Operator action to take against a session's managed sandbox. `Pause`
+/// suspends the instance, `Resume` restarts it, `Delete` releases the
+/// lease.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum SessionSandboxAction {

--- a/crates/server/src/api/voice.rs
+++ b/crates/server/src/api/voice.rs
@@ -144,10 +144,12 @@ pub fn routes(state: AppState) -> Router {
         .with_state(state)
 }
 
-/// Realtime-session knobs shared by every voice endpoint
-/// (`/voice/client-secret`, `/voice/calls`, `/voice/attach`,
-/// `/voice/sessions`). All fields are optional; omitted ones fall back to
-/// the agent's or provider's default.
+/// Realtime-session knobs flattened into the voice request bodies that
+/// create or attach a realtime connection — `VoiceClientSecretRequest`,
+/// `VoiceCallRequest`, and `VoiceAttachRequest`. The `/voice/.../end`
+/// endpoint takes `VoiceEndRequest` and does not accept these options.
+/// All fields are optional; omitted ones fall back to the agent's or
+/// provider's default.
 #[derive(Debug, Clone, Deserialize, ToSchema)]
 pub struct VoiceSessionOptions {
     /// Provider-side realtime model identifier. When omitted the server picks the agent's configured default.

--- a/crates/server/src/api/voice.rs
+++ b/crates/server/src/api/voice.rs
@@ -144,6 +144,10 @@ pub fn routes(state: AppState) -> Router {
         .with_state(state)
 }
 
+/// Realtime-session knobs shared by every voice endpoint
+/// (`/voice/client-secret`, `/voice/calls`, `/voice/attach`,
+/// `/voice/sessions`). All fields are optional; omitted ones fall back to
+/// the agent's or provider's default.
 #[derive(Debug, Clone, Deserialize, ToSchema)]
 pub struct VoiceSessionOptions {
     /// Provider-side realtime model identifier. When omitted the server picks the agent's configured default.
@@ -265,6 +269,10 @@ pub struct VoiceEndResponse {
     pub status: String,
 }
 
+/// Generic envelope returned by the agent/chat voice-session endpoints that
+/// create-or-attach a session and a voice connection in one round trip.
+/// `T` is the per-endpoint voice payload (`VoiceCallResponse`,
+/// `VoiceAttachResponse`).
 #[derive(Debug, Clone, Serialize, ToSchema)]
 pub struct VoiceSessionResponse<T> {
     /// The session this voice connection is attached to. Returned alongside

--- a/crates/server/src/domains/capabilities/types.rs
+++ b/crates/server/src/domains/capabilities/types.rs
@@ -15,6 +15,9 @@ pub use crate::storage::models::{
     CreateDeclarativeCapabilityRow, DeclarativeCapabilityRow, UpdateDeclarativeCapability,
 };
 
+/// Persisted, org-scoped declarative capability — a YAML/JSON-defined
+/// bundle of skills, files, and tool defs that an agent or harness can
+/// reference by `capability_id` or name.
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct DeclarativeCapability {
     /// Public resource ID for this persisted declarative capability.

--- a/crates/server/src/domains/events/commands.rs
+++ b/crates/server/src/domains/events/commands.rs
@@ -305,13 +305,18 @@ impl Command for ListEvents {
 
 inventory::submit! { CommandDescriptor::of::<ListEvents>() }
 
+/// One row of `EventsSummaryResult.by_type` — the per-event-type count
+/// produced by the events summary query.
 #[derive(Debug, Serialize, ToSchema)]
 pub struct EventTypeCountOut {
+    /// Event-type discriminator (e.g. `turn.started`, `tool.completed`).
     pub event_type: String,
     /// Count of items matching the query.
     pub count: i64,
 }
 
+/// Aggregate result of the events summary query — total count, per-type
+/// breakdown, and a few convenience rollups (turn count, failure count).
 #[derive(Debug, Serialize, ToSchema)]
 pub struct EventsSummaryResult {
     /// Total event count across all types.

--- a/crates/server/src/domains/knowledge_bases/types.rs
+++ b/crates/server/src/domains/knowledge_bases/types.rs
@@ -64,6 +64,8 @@ pub struct UpdateKnowledgeBaseRequest {
     pub description: UpdateField<String>,
 }
 
+/// Query parameters for `GET /v1/knowledge-bases` — optional name/desc
+/// search plus a flag to include archived knowledge bases.
 #[derive(Debug, Clone, Deserialize, IntoParams, ToSchema)]
 pub struct ListKnowledgeBasesQuery {
     /// Substring filter applied to knowledge-base name and description.
@@ -174,6 +176,8 @@ pub struct UpdateKnowledgeEntryRequest {
     pub tags: Option<Vec<String>>,
 }
 
+/// Query parameters for listing entries inside a knowledge base — optional
+/// text search and tag filter.
 #[derive(Debug, Clone, Deserialize, IntoParams, ToSchema)]
 pub struct ListKnowledgeEntriesQuery {
     /// Substring filter applied to entry title and body.

--- a/crates/server/src/domains/memory_stores/types.rs
+++ b/crates/server/src/domains/memory_stores/types.rs
@@ -77,6 +77,8 @@ pub struct ListMemoriesResponse {
     pub total: i64,
 }
 
+/// Query parameters for listing memories within a store — optional content
+/// search and kind filter.
 #[derive(Debug, Clone, Default, Deserialize, IntoParams, ToSchema)]
 pub struct ListMemoriesQuery {
     /// Substring filter applied to memory content.

--- a/crates/server/src/domains/reporting/types.rs
+++ b/crates/server/src/domains/reporting/types.rs
@@ -158,7 +158,7 @@ pub struct ReportExport {
 
 /// Point-in-time health snapshot of the reporting layer — projector
 /// freshness plus outbox processing health. Returned from
-/// `GET /v1/reports/diagnostics`.
+/// `GET /v1/reports/admin/diagnostics`.
 #[derive(Debug, Clone, Serialize, ToSchema)]
 pub struct ReportingDiagnostics {
     /// Server-side wall-clock timestamp when this snapshot was assembled

--- a/crates/server/src/domains/reporting/types.rs
+++ b/crates/server/src/domains/reporting/types.rs
@@ -10,6 +10,8 @@ use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 use uuid::Uuid;
 
+/// A user-saved report definition — a named, persistable wrapper around a
+/// `ReportQuery` with optional dashboard placement metadata.
 #[derive(Debug, Clone, Serialize, ToSchema)]
 pub struct SavedReport {
     /// UUID of the saved report.
@@ -33,6 +35,8 @@ pub struct SavedReport {
     pub updated_at: DateTime<Utc>,
 }
 
+/// Dashboard placement metadata attached to a `SavedReport`. Captures how
+/// and where to render the report in the operator dashboard UI.
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct SavedReportDashboardMetadata {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -99,6 +103,9 @@ pub struct UpdateSavedReportRequest {
     pub dashboard: UpdateField<SavedReportDashboardMetadata>,
 }
 
+/// Output format for a report export. `Csv` emits a header row plus one
+/// row per result; `Json` emits an envelope with the same shape as
+/// `ReportResult`.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum ReportExportFormat {
@@ -129,6 +136,9 @@ fn default_export_format() -> ReportExportFormat {
     ReportExportFormat::Csv
 }
 
+/// Serialized export of a report's data, ready to stream to a caller as a
+/// download. Carries the rendered payload plus the MIME/filename metadata
+/// a client needs to save it.
 #[derive(Debug, Clone, Serialize, ToSchema)]
 pub struct ReportExport {
     /// Export format (currently `csv`).
@@ -146,6 +156,9 @@ pub struct ReportExport {
     pub freshness_lag_ms: Option<i64>,
 }
 
+/// Point-in-time health snapshot of the reporting layer — projector
+/// freshness plus outbox processing health. Returned from
+/// `GET /v1/reports/diagnostics`.
 #[derive(Debug, Clone, Serialize, ToSchema)]
 pub struct ReportingDiagnostics {
     /// Server-side wall-clock timestamp when this snapshot was assembled
@@ -160,15 +173,26 @@ pub struct ReportingDiagnostics {
     pub outbox: ReportingOutboxDiagnostics,
 }
 
+/// Per-dataset projector freshness telemetry. One entry per active dataset
+/// the reporting projector is materializing.
 #[derive(Debug, Clone, Serialize, ToSchema)]
 pub struct DatasetProjectorLag {
+    /// Dataset name (matches `ReportQuery.dataset`).
     pub dataset: String,
+    /// Wall-clock timestamp of the newest fact the projector has
+    /// materialized for this dataset (RFC 3339). `None` if the projector
+    /// hasn't produced any rows yet.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub latest_projected_at: Option<DateTime<Utc>>,
+    /// Gap between `latest_projected_at` and the diagnostic's
+    /// `generated_at`, in milliseconds. `None` when freshness can't be
+    /// determined.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub freshness_lag_ms: Option<i64>,
 }
 
+/// Aggregate health of the reporting outbox — the queue of source rows
+/// waiting to be projected into fact tables.
 #[derive(Debug, Clone, Serialize, ToSchema)]
 pub struct ReportingOutboxDiagnostics {
     /// Outbox rows waiting to be claimed by a projector.
@@ -186,6 +210,9 @@ pub struct ReportingOutboxDiagnostics {
     pub failed_rows: Vec<FailedReportingOutboxRow>,
 }
 
+/// One failed reporting-outbox row, surfaced in
+/// `ReportingOutboxDiagnostics.failed_rows` so operators can triage
+/// projector failures without dropping to SQL.
 #[derive(Debug, Clone, Serialize, ToSchema)]
 pub struct FailedReportingOutboxRow {
     /// Outbox row UUID.
@@ -205,6 +232,9 @@ pub struct FailedReportingOutboxRow {
     pub updated_at: DateTime<Utc>,
 }
 
+/// Outcome of one projector run — how many outbox rows it claimed,
+/// completed, and failed. Returned by manual `POST /v1/reports/projector/run`
+/// calls and useful for backfill scripting.
 #[derive(Debug, Clone, Serialize, ToSchema)]
 pub struct ProjectorRunResult {
     /// Number of outbox rows claimed by this run.
@@ -215,6 +245,8 @@ pub struct ProjectorRunResult {
     pub failed: usize,
 }
 
+/// Request body for the `reporting_backfill` operation — enqueues source
+/// rows into the reporting outbox for the projector to re-materialize.
 #[derive(Debug, Clone, Deserialize, ToSchema)]
 pub struct ReportingBackfillRequest {
     /// Maximum number of outbox rows to enqueue across all source types. Defaults to 1000.
@@ -227,6 +259,8 @@ fn default_backfill_limit() -> i64 {
     1_000
 }
 
+/// Result of a `reporting_backfill` call — per-source counts of outbox rows
+/// enqueued for re-projection.
 #[derive(Debug, Clone, Default, Serialize, ToSchema)]
 pub struct ReportingBackfillResult {
     /// Total number of outbox rows enqueued across all source types.

--- a/crates/server/src/domains/volumes/types.rs
+++ b/crates/server/src/domains/volumes/types.rs
@@ -81,6 +81,8 @@ pub struct UpdateVolumeRequest {
     pub source: Option<CreateVolumeSourceRequest>,
 }
 
+/// Query parameters for `GET /v1/volumes` — optional name search and a
+/// flag to include archived volumes in the listing.
 #[derive(Debug, Clone, Deserialize, IntoParams, ToSchema)]
 pub struct ListVolumesQuery {
     #[serde(default)]

--- a/crates/server/tests/openapi_descriptions_test.rs
+++ b/crates/server/tests/openapi_descriptions_test.rs
@@ -15,7 +15,7 @@ use utoipa::OpenApi;
 
 /// Lowest acceptable coverage. Bump up when you fix a batch.
 const MIN_OP_DESC_PCT: u32 = 100;
-const MIN_SCHEMA_DESC_PCT: u32 = 88;
+const MIN_SCHEMA_DESC_PCT: u32 = 99;
 const MIN_FIELD_DESC_PCT: u32 = 92;
 /// Field example coverage is an AI-friendliness signal in its own right:
 /// even an accurately described `Vec<ToolDefinition>` is far easier for an

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -24107,7 +24107,7 @@
       },
       "ReportingDiagnostics": {
         "type": "object",
-        "description": "Point-in-time health snapshot of the reporting layer — projector\nfreshness plus outbox processing health. Returned from\n`GET /v1/reports/diagnostics`.",
+        "description": "Point-in-time health snapshot of the reporting layer — projector\nfreshness plus outbox processing health. Returned from\n`GET /v1/reports/admin/diagnostics`.",
         "required": [
           "generated_at",
           "projector_lag",
@@ -28227,7 +28227,7 @@
       },
       "VoiceSessionOptions": {
         "type": "object",
-        "description": "Realtime-session knobs shared by every voice endpoint\n(`/voice/client-secret`, `/voice/calls`, `/voice/attach`,\n`/voice/sessions`). All fields are optional; omitted ones fall back to\nthe agent's or provider's default.",
+        "description": "Realtime-session knobs flattened into the voice request bodies that\ncreate or attach a realtime connection — `VoiceClientSecretRequest`,\n`VoiceCallRequest`, and `VoiceAttachRequest`. The `/voice/.../end`\nendpoint takes `VoiceEndRequest` and does not accept these options.\nAll fields are optional; omitted ones fall back to the agent's or\nprovider's default.",
         "properties": {
           "instructions": {
             "type": [

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -13260,6 +13260,7 @@
       },
       "ContextReportContribution": {
         "type": "object",
+        "description": "Single-source token contribution within a `ContextReportSection` — the\nper-tool / per-capability / per-message attribution that lets operators\nsee which source is eating the context window.",
         "required": [
           "section_key",
           "source_id",
@@ -13289,6 +13290,7 @@
       },
       "ContextReportSection": {
         "type": "object",
+        "description": "One logical section of the assembled LLM context (system prompt, tool\ndefinitions, message history, etc.) with its rolled-up token budget.",
         "required": [
           "key",
           "label",
@@ -14710,6 +14712,7 @@
       },
       "DatasetCatalog": {
         "type": "object",
+        "description": "Listing of every dataset the reporting layer can answer queries over.\nReturned from `GET /v1/reports/catalog`.",
         "required": [
           "datasets"
         ],
@@ -14718,12 +14721,14 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/DatasetCatalogEntry"
-            }
+            },
+            "description": "All datasets the caller has access to, in stable alphabetical order."
           }
         }
       },
       "DatasetCatalogEntry": {
         "type": "object",
+        "description": "A single dataset entry in the reporting catalog — the set of dimensions,\nmeasures, and filter fields the dataset exposes to query authors.",
         "required": [
           "name",
           "dimensions",
@@ -14735,52 +14740,61 @@
             "type": "array",
             "items": {
               "type": "string"
-            }
+            },
+            "description": "Dimensions available to group by."
           },
           "filter_fields": {
             "type": "array",
             "items": {
               "type": "string"
-            }
+            },
+            "description": "Fields valid as the `field` of a `ReportFilter`."
           },
           "measures": {
             "type": "array",
             "items": {
               "type": "string"
-            }
+            },
+            "description": "Measures available to aggregate."
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "description": "Dataset identifier as passed to `ReportQuery.dataset`."
           }
         }
       },
       "DatasetProjectorLag": {
         "type": "object",
+        "description": "Per-dataset projector freshness telemetry. One entry per active dataset\nthe reporting projector is materializing.",
         "required": [
           "dataset"
         ],
         "properties": {
           "dataset": {
-            "type": "string"
+            "type": "string",
+            "description": "Dataset name (matches `ReportQuery.dataset`)."
           },
           "freshness_lag_ms": {
             "type": [
               "integer",
               "null"
             ],
-            "format": "int64"
+            "format": "int64",
+            "description": "Gap between `latest_projected_at` and the diagnostic's\n`generated_at`, in milliseconds. `None` when freshness can't be\ndetermined."
           },
           "latest_projected_at": {
             "type": [
               "string",
               "null"
             ],
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Wall-clock timestamp of the newest fact the projector has\nmaterialized for this dataset (RFC 3339). `None` if the projector\nhasn't produced any rows yet."
           }
         }
       },
       "DeclarativeCapability": {
         "type": "object",
+        "description": "Persisted, org-scoped declarative capability — a YAML/JSON-defined\nbundle of skills, files, and tool defs that an agent or harness can\nreference by `capability_id` or name.",
         "required": [
           "id",
           "capability_id",
@@ -15407,6 +15421,7 @@
       },
       "EventTypeCountOut": {
         "type": "object",
+        "description": "One row of `EventsSummaryResult.by_type` — the per-event-type count\nproduced by the events summary query.",
         "required": [
           "event_type",
           "count"
@@ -15418,12 +15433,14 @@
             "description": "Count of items matching the query."
           },
           "event_type": {
-            "type": "string"
+            "type": "string",
+            "description": "Event-type discriminator (e.g. `turn.started`, `tool.completed`)."
           }
         }
       },
       "EventsSummaryResult": {
         "type": "object",
+        "description": "Aggregate result of the events summary query — total count, per-type\nbreakdown, and a few convenience rollups (turn count, failure count).",
         "required": [
           "total",
           "by_type",
@@ -15699,6 +15716,7 @@
       },
       "FailedReportingOutboxRow": {
         "type": "object",
+        "description": "One failed reporting-outbox row, surfaced in\n`ReportingOutboxDiagnostics.failed_rows` so operators can triage\nprojector failures without dropping to SQL.",
         "required": [
           "id",
           "org_id",
@@ -17248,6 +17266,7 @@
       },
       "ListAppRunsQuery": {
         "type": "object",
+        "description": "Query parameters for listing recent app invocation runs — a relative\ntime window and an optional bucketing hint for the dashboard.",
         "properties": {
           "groupBy": {
             "type": [
@@ -17267,6 +17286,7 @@
       },
       "ListExecutionsQuery": {
         "type": "object",
+        "description": "Query parameters for listing executions of a schedule — optional status\nfilter plus offset/limit paging.",
         "properties": {
           "limit": {
             "type": [
@@ -17300,6 +17320,7 @@
       },
       "ListKnowledgeBasesQuery": {
         "type": "object",
+        "description": "Query parameters for `GET /v1/knowledge-bases` — optional name/desc\nsearch plus a flag to include archived knowledge bases.",
         "properties": {
           "include_archived": {
             "type": [
@@ -17321,6 +17342,7 @@
       },
       "ListKnowledgeEntriesQuery": {
         "type": "object",
+        "description": "Query parameters for listing entries inside a knowledge base — optional\ntext search and tag filter.",
         "properties": {
           "kind": {
             "type": [
@@ -17342,6 +17364,7 @@
       },
       "ListMemoriesQuery": {
         "type": "object",
+        "description": "Query parameters for listing memories within a store — optional content\nsearch and kind filter.",
         "properties": {
           "include_inactive": {
             "type": [
@@ -18594,6 +18617,7 @@
             "type": "array",
             "items": {
               "type": "object",
+              "description": "A user-saved report definition — a named, persistable wrapper around a\n`ReportQuery` with optional dashboard placement metadata.",
               "required": [
                 "id",
                 "name",
@@ -19168,6 +19192,7 @@
               "allOf": [
                 {
                   "type": "object",
+                  "description": "Persisted, org-scoped declarative capability — a YAML/JSON-defined\nbundle of skills, files, and tool defs that an agent or harness can\nreference by `capability_id` or name.",
                   "required": [
                     "id",
                     "capability_id",
@@ -20089,6 +20114,7 @@
       },
       "ListSchedulesQuery": {
         "type": "object",
+        "description": "Query parameters for `GET /v1/schedules` — optional enabled/target-type\nfilters plus standard offset/limit paging.",
         "properties": {
           "enabled": {
             "type": [
@@ -20143,6 +20169,7 @@
       },
       "ListVolumesQuery": {
         "type": "object",
+        "description": "Query parameters for `GET /v1/volumes` — optional name search and a\nflag to include archived volumes in the listing.",
         "properties": {
           "include_archived": {
             "type": [
@@ -22973,6 +23000,7 @@
       },
       "PaymentAccount": {
         "type": "object",
+        "description": "A payment account — the org-scoped source of funds for paid agent calls.\nEach account binds an owning principal (user, agent identity, or org)\nto one settlement rail and tracks its provisioning lifecycle.",
         "required": [
           "id",
           "organization_id",
@@ -23038,6 +23066,7 @@
       },
       "PaymentAttempt": {
         "type": "object",
+        "description": "A single paid-call settlement attempt — the durable record of one\nauthorization+settlement cycle issued through the payment authority.\nPersisted regardless of outcome so failed attempts remain auditable.",
         "required": [
           "id",
           "organization_id",
@@ -23154,6 +23183,7 @@
       },
       "PaymentPolicy": {
         "type": "object",
+        "description": "A payment policy — the binding between a paying account and a subject\n(agent identity, session) that controls which paid calls are\nauthorized and at what spend caps.",
         "required": [
           "id",
           "organization_id",
@@ -23271,6 +23301,7 @@
       },
       "PaymentStatus": {
         "type": "string",
+        "description": "Lifecycle state of a payment account, policy, or attempt. The shared\nvocabulary keeps account/policy admin and attempt settlement on the\nsame status taxonomy.",
         "enum": [
           "active",
           "disabled",
@@ -23369,6 +23400,7 @@
       },
       "PrincipalKind": {
         "type": "string",
+        "description": "Class of principal that can hold permissions or own resources. `system`\nis reserved for platform-internal callers and is never minted via the\npublic API.",
         "enum": [
           "user",
           "agent_identity",
@@ -23377,6 +23409,7 @@
       },
       "PrincipalSummary": {
         "type": "object",
+        "description": "Compact view of a principal — id + kind + the subject-id pointer back\ninto the user/agent-identity row. Used wherever a full `Principal`\nwould be redundant (e.g. as a sub-field of a session or audit record).",
         "required": [
           "id",
           "kind"
@@ -23429,6 +23462,7 @@
       },
       "ProjectorRunQuery": {
         "type": "object",
+        "description": "Query parameters for a manual `POST /v1/reports/projector/run` invocation —\nthe cap on how many outbox rows one run is allowed to claim.",
         "properties": {
           "limit": {
             "type": "integer",
@@ -23439,6 +23473,7 @@
       },
       "ProjectorRunResult": {
         "type": "object",
+        "description": "Outcome of one projector run — how many outbox rows it claimed,\ncompleted, and failed. Returned by manual `POST /v1/reports/projector/run`\ncalls and useful for backfill scripting.",
         "required": [
           "claimed",
           "completed",
@@ -23765,6 +23800,7 @@
       },
       "ReportColumn": {
         "type": "object",
+        "description": "One column header in a `ReportResult`. The ordered `columns` list\ndeclares the key set of each row in `rows`.",
         "required": [
           "name",
           "kind"
@@ -23783,6 +23819,7 @@
       },
       "ReportColumnKind": {
         "type": "string",
+        "description": "Whether a `ReportColumn` is a grouping dimension or an aggregate measure.",
         "enum": [
           "dimension",
           "measure"
@@ -23790,6 +23827,7 @@
       },
       "ReportExport": {
         "type": "object",
+        "description": "Serialized export of a report's data, ready to stream to a caller as a\ndownload. Carries the rendered payload plus the MIME/filename metadata\na client needs to save it.",
         "required": [
           "format",
           "filename",
@@ -23831,6 +23869,7 @@
       },
       "ReportExportFormat": {
         "type": "string",
+        "description": "Output format for a report export. `Csv` emits a header row plus one\nrow per result; `Json` emits an envelope with the same shape as\n`ReportResult`.",
         "enum": [
           "csv",
           "json"
@@ -23838,6 +23877,7 @@
       },
       "ReportFilter": {
         "type": "object",
+        "description": "One predicate filter applied to the dataset before aggregation.\nCombined with other filters via logical AND.",
         "required": [
           "field",
           "op",
@@ -23860,6 +23900,7 @@
       },
       "ReportFilterOp": {
         "type": "string",
+        "description": "Comparison operator used in a `ReportFilter`. The `In` variant takes a\nJSON array as its value; all others take a scalar.",
         "enum": [
           "eq",
           "neq",
@@ -23872,6 +23913,7 @@
       },
       "ReportOrderBy": {
         "type": "object",
+        "description": "One sort clause applied to the aggregated result. Either `dimension`\nOR `measure` is set (mutually exclusive), never both.",
         "properties": {
           "dimension": {
             "type": [
@@ -23897,6 +23939,7 @@
       },
       "ReportOrderDirection": {
         "type": "string",
+        "description": "Sort direction for a `ReportOrderBy` clause.",
         "enum": [
           "asc",
           "desc"
@@ -23904,6 +23947,7 @@
       },
       "ReportQuery": {
         "type": "object",
+        "description": "Semantic query a caller submits to the reporting layer. The backend\ncompiles this to its native query language, scopes it to the calling\norg, and returns a `ReportResult`.",
         "required": [
           "dataset",
           "time_range"
@@ -23955,6 +23999,7 @@
       },
       "ReportResult": {
         "type": "object",
+        "description": "Materialized result of a report query — column metadata, rows, and the\nfreshness of the underlying data.",
         "required": [
           "as_of",
           "columns",
@@ -23990,6 +24035,7 @@
       },
       "ReportTimeRange": {
         "type": "object",
+        "description": "Half-open time window applied to the dataset's primary timestamp column\nduring a report query. `from` is inclusive, `to` is exclusive.",
         "required": [
           "from",
           "to"
@@ -24011,6 +24057,7 @@
       },
       "ReportingBackfillRequest": {
         "type": "object",
+        "description": "Request body for the `reporting_backfill` operation — enqueues source\nrows into the reporting outbox for the projector to re-materialize.",
         "properties": {
           "limit": {
             "type": "integer",
@@ -24022,6 +24069,7 @@
       },
       "ReportingBackfillResult": {
         "type": "object",
+        "description": "Result of a `reporting_backfill` call — per-source counts of outbox rows\nenqueued for re-projection.",
         "required": [
           "enqueued",
           "events",
@@ -24059,6 +24107,7 @@
       },
       "ReportingDiagnostics": {
         "type": "object",
+        "description": "Point-in-time health snapshot of the reporting layer — projector\nfreshness plus outbox processing health. Returned from\n`GET /v1/reports/diagnostics`.",
         "required": [
           "generated_at",
           "projector_lag",
@@ -24085,6 +24134,7 @@
       },
       "ReportingOutboxDiagnostics": {
         "type": "object",
+        "description": "Aggregate health of the reporting outbox — the queue of source rows\nwaiting to be projected into fact tables.",
         "required": [
           "pending",
           "processing",
@@ -24315,6 +24365,7 @@
       },
       "SavedReport": {
         "type": "object",
+        "description": "A user-saved report definition — a named, persistable wrapper around a\n`ReportQuery` with optional dashboard placement metadata.",
         "required": [
           "id",
           "name",
@@ -24368,6 +24419,7 @@
       },
       "SavedReportDashboardMetadata": {
         "type": "object",
+        "description": "Dashboard placement metadata attached to a `SavedReport`. Captures how\nand where to render the report in the operator dashboard UI.",
         "properties": {
           "chart_type": {
             "type": [
@@ -25106,6 +25158,7 @@
       },
       "SessionContextReport": {
         "type": "object",
+        "description": "Token-budget report for a session — a model-aware breakdown of the\ncontext window into named sections plus per-source contributions, so\ncallers can answer \"what's filling the context?\" without reverse-\nengineering the prompt assembly.",
         "required": [
           "session_id",
           "model",
@@ -25325,6 +25378,7 @@
       },
       "SessionSandboxAction": {
         "type": "string",
+        "description": "Operator action to take against a session's managed sandbox. `Pause`\nsuspends the instance, `Resume` restarts it, `Delete` releases the\nlease.",
         "enum": [
           "pause",
           "resume",
@@ -25333,6 +25387,7 @@
       },
       "SessionSandboxStatusValue": {
         "type": "string",
+        "description": "Wire-facing status of a session sandbox. Mirrors\n`everruns_core::SessionSandboxStatus` for the public API.",
         "enum": [
           "running",
           "paused"
@@ -28172,6 +28227,7 @@
       },
       "VoiceSessionOptions": {
         "type": "object",
+        "description": "Realtime-session knobs shared by every voice endpoint\n(`/voice/client-secret`, `/voice/calls`, `/voice/attach`,\n`/voice/sessions`). All fields are optional; omitted ones fall back to\nthe agent's or provider's default.",
         "properties": {
           "instructions": {
             "type": [
@@ -28209,6 +28265,7 @@
       },
       "VoiceSessionResponse_VoiceCallResponse": {
         "type": "object",
+        "description": "Generic envelope returned by the agent/chat voice-session endpoints that\ncreate-or-attach a session and a voice connection in one round trip.\n`T` is the per-endpoint voice payload (`VoiceCallResponse`,\n`VoiceAttachResponse`).",
         "required": [
           "session",
           "voice"
@@ -29046,6 +29103,7 @@
         "allOf": [
           {
             "type": "object",
+            "description": "Persisted, org-scoped declarative capability — a YAML/JSON-defined\nbundle of skills, files, and tool defs that an agent or harness can\nreference by `capability_id` or name.",
             "required": [
               "id",
               "capability_id",


### PR DESCRIPTION
## What
Follow-up to #1965 — closes 46 of the 47 bare `ToSchema` types so an OpenAPI consumer sees a one-sentence summary on every schema component.

Cluster breakdown:
- **Reporting (~22)**: `ReportTimeRange`, `ReportQuery`, `ReportFilter`, `ReportFilterOp`, `ReportOrderBy`, `ReportOrderDirection`, `ReportResult`, `ReportColumn`, `ReportColumnKind`, `DatasetCatalog`, `DatasetCatalogEntry`, `SavedReport`, `SavedReportDashboardMetadata`, `ReportExportFormat`, `ReportExport`, `ReportingDiagnostics`, `DatasetProjectorLag`, `ReportingOutboxDiagnostics`, `FailedReportingOutboxRow`, `ProjectorRunResult`, `ProjectorRunQuery`, `ReportingBackfillRequest`, `ReportingBackfillResult`.
- **Payment (4)**: `PaymentStatus`, `PaymentAccount`, `PaymentPolicy`, `PaymentAttempt`.
- **Voice (2)**: `VoiceSessionOptions`, `VoiceSessionResponse`.
- **Principal (2)**: `PrincipalKind`, `PrincipalSummary`.
- **Context report (3)**: `ContextReportSection`, `ContextReportContribution`, `SessionContextReport`.
- **Session sandbox (2)**: `SessionSandboxStatusValue`, `SessionSandboxAction`.
- **List-query (7)**: `ListAppRunsQuery`, `ListSchedulesQuery`, `ListExecutionsQuery`, `ListVolumesQuery`, `ListKnowledgeBasesQuery`, `ListKnowledgeEntriesQuery`, `ListMemoriesQuery`.
- **Misc (3)**: `DeclarativeCapability`, `EventTypeCountOut`, `EventsSummaryResult`.

## Why
The schema-description coverage gate was lagging behind reality — floor at 88% but actual at 88%, with 47 bare types in clusters that an LLM toolcaller hits regularly (reporting query authoring, payment policy setup, voice session options, list endpoint paging). One sentence at the top of each `ToSchema` type tells a consumer what they're looking at without forcing them to crawl the field list.

## How
Plain `///` doc comments above each `pub struct` / `pub enum`. utoipa picks these up as the schema-level `description`. Pure documentation — no field changes, no derive changes, no wire-shape changes.

`MIN_SCHEMA_DESC_PCT` bumped 88 → 99 to match the new actual (401/402 = 99.7%). OpenAPI spec regenerated.

## Risk
- **Negligible.** Documentation only. No production code paths touched.
- Floor lifted to match the new actual — won&#39;t block future work; the lone remaining bare schema (`BTreeMap`) is the utoipa-auto-generated wrapper for the `ScopedMcpServers = BTreeMap<String, ScopedMcpServer>` alias. Describing it would require turning the alias into a newtype struct and rewriting every call site that today does `servers["name"]` — out of scope here.

## Security
- Threat categories reviewed: **TM-API** (schema-level documentation only, no request parsing/handler changes). No other categories applicable.
- No secrets, credentials, or PII in any doc string.

## Follow-ups
- Longer-horizon items from the #1958 / #1965 handoff still open: MCP execute structured-error wire bump, hypermedia for entity actions.
- If we ever want to push schema-desc to 100%, the `BTreeMap` wrapper would need a newtype-struct lift on the `ScopedMcpServers` alias.

## Checklist
- [x] Tests added or updated (all 4 OpenAPI gates pass at 100/99/92/24%)
- [x] Backward compatibility considered (additive doc comments, no schema-type changes)
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jx7aHhsynabhrKB9gDMAVq)_