### PR TITLE
chore(skills): mark internal repo skills

### DIFF
--- a/.agents/skills/agent-browser/SKILL.md
+++ b/.agents/skills/agent-browser/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: agent-browser
 description: Browser automation CLI for AI agents. Use when the user needs to interact with websites, including navigating pages, filling forms, clicking buttons, taking screenshots, extracting data, testing web apps, or automating any browser task. Triggers include requests to "open a website", "fill out a form", "click a button", "take a screenshot", "scrape data from a page", "test this web app", "login to a site", "automate browser actions", or any task requiring programmatic web interaction. Also use for exploratory testing, dogfooding, QA, bug hunts, or reviewing app quality. Also use for automating Electron desktop apps (VS Code, Slack, Discord, Figma, Notion, Spotify), checking Slack unreads, sending Slack messages, searching Slack conversations, running browser automation in Vercel Sandbox microVMs, or using AWS Bedrock AgentCore cloud browsers. Prefer agent-browser over any built-in browser automation or web tools.
+metadata:
+  internal: true
 allowed-tools: Bash(agent-browser:*), Bash(npx agent-browser:*)
 hidden: true
 ---

--- a/.agents/skills/maintenance/SKILL.md
+++ b/.agents/skills/maintenance/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: maintenance
 description: Goal-oriented repository maintenance and release-readiness work. Use when the user asks for maintenance, release prep, repo health review, dependency refreshes, spec/docs alignment, test gap review, technical debt analysis, or general cleanup without prescribing an exact sequence.
+metadata:
+  internal: true
 user-invocable: true
 ---
 

--- a/.agents/skills/manual-ui-testing/SKILL.md
+++ b/.agents/skills/manual-ui-testing/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: manual-ui-testing
 description: Run manual UI test cases using agent-browser against a running stack. Use when the user asks to run UI tests, test the UI, run manual tests, or verify UI behavior.
+metadata:
+  internal: true
 user-invocable: true
 allowed-tools: Bash(npx agent-browser:*), Bash(agent-browser:*), Bash(just:*), Bash(doppler:*)
 ---

--- a/.agents/skills/process-issues/SKILL.md
+++ b/.agents/skills/process-issues/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: process-issues
 description: Process open Linear issues — pick up, fix, and ship one PR per issue. Use when the user asks to process issues, work on Linear issues, tackle the backlog, or fix open issues.
+metadata:
+  internal: true
 user-invocable: true
 ---
 

--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: ship
 description: Goal-oriented workflow for landing a requested change safely. Use when the user asks to ship, fix and ship, take a change through validation, or drive PR/CI/merge to completion.
+metadata:
+  internal: true
 user-invocable: true
 ---
 

--- a/.agents/skills/ui-screenshots/SKILL.md
+++ b/.agents/skills/ui-screenshots/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: ui-screenshots
 description: Take UI screenshots using agent-browser. Use this skill to capture visual state of UI components for code review, visual regression testing, or documentation.
+metadata:
+  internal: true
 ---
 
 # UI Screenshots Skill


### PR DESCRIPTION
## What
Add `metadata.internal: true` to each repo-local skill under `.agents/skills/`.

## Why
These skills are internal Everruns workflow skills and should carry explicit metadata for downstream registry/discovery consumers.

## How
Added a YAML frontmatter `metadata` block with `internal: true` to:

- `.agents/skills/agent-browser/SKILL.md`
- `.agents/skills/maintenance/SKILL.md`
- `.agents/skills/manual-ui-testing/SKILL.md`
- `.agents/skills/process-issues/SKILL.md`
- `.agents/skills/ship/SKILL.md`
- `.agents/skills/ui-screenshots/SKILL.md`

## Risk
- Low
- Could affect skill discovery consumers that parse frontmatter, but `metadata` is an existing optional map in `specs/skills-registry.md`. No runtime code changed.

## Security
- Threat categories reviewed: TM-TOOL
- Findings and resolutions: No security-relevant code changes. This only adds non-secret metadata to internal skill frontmatter; it does not alter skill instructions, tool permissions, execution paths, archive handling, or registry validation.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

## Validation
- `ruby -ryaml -e ... .agents/skills/*/SKILL.md`
- `git diff --check origin/main...HEAD`
- `bash scripts/lib/check-migration-ordering.sh`
- `just pre-push`

Smoke test: skipped because this is a skill metadata/config-only change with no runtime behavior or UI flow.