### PR TITLE
feat(core): add outbound egress service

### DIFF
--- a/crates/core/src/atoms/act.rs
+++ b/crates/core/src/atoms/act.rs
@@ -167,6 +167,8 @@ where
     provider_credential_store: Option<Arc<dyn crate::traits::ProviderCredentialStore>>,
     /// Optional utility LLM service for capability internals
     utility_llm_service: Option<Arc<dyn crate::UtilityLlmService>>,
+    /// Optional outbound egress service for HTTP/API traffic.
+    egress_service: Option<Arc<dyn crate::EgressService>>,
     /// Optional resolver for user connection tokens
     connection_resolver: Option<Arc<dyn crate::traits::UserConnectionResolver>>,
     /// Optional session store for session metadata reads
@@ -227,6 +229,7 @@ where
             image_store: None,
             provider_credential_store: None,
             utility_llm_service: None,
+            egress_service: None,
             connection_resolver: None,
             session_store: None,
             session_mutator: None,
@@ -264,6 +267,7 @@ where
             image_store: None,
             provider_credential_store: None,
             utility_llm_service: None,
+            egress_service: None,
             connection_resolver: None,
             session_store: None,
             session_mutator: None,
@@ -343,6 +347,12 @@ where
     /// Set the utility LLM service on this atom.
     pub fn with_utility_llm_service(mut self, service: Arc<dyn crate::UtilityLlmService>) -> Self {
         self.utility_llm_service = Some(service);
+        self
+    }
+
+    /// Set the outbound egress service on this atom.
+    pub fn with_egress_service(mut self, service: Arc<dyn crate::EgressService>) -> Self {
+        self.egress_service = Some(service);
         self
     }
 
@@ -950,6 +960,9 @@ where
         }
         if let Some(ref service) = self.utility_llm_service {
             tool_context.utility_llm_service = Some(service.clone());
+        }
+        if let Some(ref service) = self.egress_service {
+            tool_context.egress_service = Some(service.clone());
         }
         if let Some(ref resolver) = self.connection_resolver {
             tool_context.connection_resolver = Some(resolver.clone());

--- a/crates/core/src/egress.rs
+++ b/crates/core/src/egress.rs
@@ -1,0 +1,422 @@
+//! Host-owned outbound network boundary.
+//!
+//! `EgressService` is the runtime contract for traffic that leaves an
+//! Everruns deployment. Provider drivers, capabilities, toolkit integrations,
+//! and system services should depend on this trait instead of constructing
+//! transport clients directly.
+
+use crate::network_access::NetworkAccessList;
+use async_trait::async_trait;
+use futures::{Stream, StreamExt};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::pin::Pin;
+use std::time::Duration;
+use thiserror::Error;
+
+const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
+
+pub type EgressResult<T> = std::result::Result<T, EgressError>;
+pub type EgressByteStream = Pin<Box<dyn Stream<Item = EgressResult<Vec<u8>>> + Send>>;
+
+#[derive(Debug, Error)]
+pub enum EgressError {
+    #[error("Invalid egress request: {0}")]
+    InvalidRequest(String),
+
+    #[error("Outbound request blocked by network access policy: {url}")]
+    NetworkAccessDenied { url: String },
+
+    #[error("Outbound request signing is not configured")]
+    SigningUnavailable,
+
+    #[error("Outbound transport error: {0}")]
+    Transport(String),
+}
+
+impl EgressError {
+    fn invalid(message: impl Into<String>) -> Self {
+        Self::InvalidRequest(message.into())
+    }
+}
+
+/// Logical owner of an outbound request.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EgressRequestKind {
+    LlmProvider,
+    Capability,
+    Integration,
+    SystemEmail,
+    UtilityLlm,
+    Other(String),
+}
+
+/// Request signing behavior requested by the caller.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EgressSigning {
+    Disabled,
+    PlatformDefault,
+    Required,
+}
+
+/// Provider-neutral HTTP request carried over the egress boundary.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EgressRequest {
+    pub method: String,
+    pub url: String,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub headers: BTreeMap<String, String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub body: Vec<u8>,
+    pub kind: EgressRequestKind,
+    #[serde(default = "default_signing")]
+    pub signing: EgressSigning,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub network_access: Option<NetworkAccessList>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timeout_ms: Option<u64>,
+}
+
+impl EgressRequest {
+    pub fn new(method: impl Into<String>, url: impl Into<String>, kind: EgressRequestKind) -> Self {
+        Self {
+            method: method.into(),
+            url: url.into(),
+            headers: BTreeMap::new(),
+            body: Vec::new(),
+            kind,
+            signing: EgressSigning::Disabled,
+            network_access: None,
+            timeout_ms: None,
+        }
+    }
+
+    pub fn header(mut self, name: impl Into<String>, value: impl Into<String>) -> Self {
+        self.headers.insert(name.into(), value.into());
+        self
+    }
+
+    pub fn body(mut self, body: impl Into<Vec<u8>>) -> Self {
+        self.body = body.into();
+        self
+    }
+
+    pub fn signing(mut self, signing: EgressSigning) -> Self {
+        self.signing = signing;
+        self
+    }
+
+    pub fn network_access(mut self, network_access: Option<NetworkAccessList>) -> Self {
+        self.network_access = network_access;
+        self
+    }
+
+    pub fn timeout_ms(mut self, timeout_ms: u64) -> Self {
+        self.timeout_ms = Some(timeout_ms);
+        self
+    }
+}
+
+/// Provider-neutral HTTP response returned by the egress boundary.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EgressResponse {
+    pub status: u16,
+    pub headers: BTreeMap<String, String>,
+    pub body: Vec<u8>,
+}
+
+pub struct EgressStreamResponse {
+    pub status: u16,
+    pub headers: BTreeMap<String, String>,
+    pub body: EgressByteStream,
+}
+
+#[async_trait]
+pub trait EgressService: Send + Sync {
+    async fn send(&self, request: EgressRequest) -> EgressResult<EgressResponse>;
+
+    async fn send_stream(&self, request: EgressRequest) -> EgressResult<EgressStreamResponse>;
+
+    fn name(&self) -> &'static str {
+        "EgressService"
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct DisabledEgressService;
+
+#[async_trait]
+impl EgressService for DisabledEgressService {
+    async fn send(&self, _request: EgressRequest) -> EgressResult<EgressResponse> {
+        Err(EgressError::Transport(
+            "outbound egress service is disabled".to_string(),
+        ))
+    }
+
+    async fn send_stream(&self, _request: EgressRequest) -> EgressResult<EgressStreamResponse> {
+        Err(EgressError::Transport(
+            "outbound egress service is disabled".to_string(),
+        ))
+    }
+
+    fn name(&self) -> &'static str {
+        "DisabledEgressService"
+    }
+}
+
+#[derive(Clone)]
+pub struct DirectEgressService {
+    client: reqwest::Client,
+}
+
+impl std::fmt::Debug for DirectEgressService {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DirectEgressService")
+            .finish_non_exhaustive()
+    }
+}
+
+impl Default for DirectEgressService {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DirectEgressService {
+    pub fn new() -> Self {
+        Self {
+            client: reqwest::Client::builder()
+                .connect_timeout(DEFAULT_CONNECT_TIMEOUT)
+                .timeout(DEFAULT_REQUEST_TIMEOUT)
+                .build()
+                .expect("build direct egress HTTP client"),
+        }
+    }
+
+    pub fn with_client(client: reqwest::Client) -> Self {
+        Self { client }
+    }
+
+    fn validate_request(request: &EgressRequest) -> EgressResult<()> {
+        if request.method.trim().is_empty() {
+            return Err(EgressError::invalid("method is required"));
+        }
+        let parsed = reqwest::Url::parse(&request.url)
+            .map_err(|error| EgressError::invalid(format!("invalid URL: {error}")))?;
+        match parsed.scheme() {
+            "http" | "https" => {}
+            scheme => {
+                return Err(EgressError::invalid(format!(
+                    "URL must use http or https, got '{scheme}'"
+                )));
+            }
+        }
+        if let Some(acl) = &request.network_access
+            && !acl.is_url_allowed(&request.url)
+        {
+            return Err(EgressError::NetworkAccessDenied {
+                url: request.url.clone(),
+            });
+        }
+        Ok(())
+    }
+
+    fn build_request(&self, request: EgressRequest) -> EgressResult<reqwest::RequestBuilder> {
+        Self::validate_request(&request)?;
+        if request.signing == EgressSigning::Required {
+            return Err(EgressError::SigningUnavailable);
+        }
+
+        let method = reqwest::Method::from_bytes(request.method.as_bytes())
+            .map_err(|error| EgressError::invalid(format!("invalid HTTP method: {error}")))?;
+        let mut builder = self.client.request(method, &request.url);
+        for (name, value) in request.headers {
+            builder = builder.header(name, value);
+        }
+        if let Some(timeout_ms) = request.timeout_ms {
+            builder = builder.timeout(Duration::from_millis(timeout_ms));
+        }
+        if !request.body.is_empty() {
+            builder = builder.body(request.body);
+        }
+        Ok(builder)
+    }
+}
+
+#[async_trait]
+impl EgressService for DirectEgressService {
+    async fn send(&self, request: EgressRequest) -> EgressResult<EgressResponse> {
+        let response = self
+            .build_request(request)?
+            .send()
+            .await
+            .map_err(|error| EgressError::Transport(error.to_string()))?;
+        let status = response.status().as_u16();
+        let headers = response
+            .headers()
+            .iter()
+            .filter_map(|(name, value)| {
+                value
+                    .to_str()
+                    .ok()
+                    .map(|value| (name.as_str().to_string(), value.to_string()))
+            })
+            .collect();
+        let body = response
+            .bytes()
+            .await
+            .map_err(|error| EgressError::Transport(error.to_string()))?
+            .to_vec();
+
+        Ok(EgressResponse {
+            status,
+            headers,
+            body,
+        })
+    }
+
+    async fn send_stream(&self, request: EgressRequest) -> EgressResult<EgressStreamResponse> {
+        let response = self
+            .build_request(request)?
+            .send()
+            .await
+            .map_err(|error| EgressError::Transport(error.to_string()))?;
+        let status = response.status().as_u16();
+        let headers = response
+            .headers()
+            .iter()
+            .filter_map(|(name, value)| {
+                value
+                    .to_str()
+                    .ok()
+                    .map(|value| (name.as_str().to_string(), value.to_string()))
+            })
+            .collect();
+        let body = response.bytes_stream().map(|chunk| {
+            chunk
+                .map(|bytes| bytes.to_vec())
+                .map_err(|error| EgressError::Transport(error.to_string()))
+        });
+
+        Ok(EgressStreamResponse {
+            status,
+            headers,
+            body: Box::pin(body),
+        })
+    }
+
+    fn name(&self) -> &'static str {
+        "DirectEgressService"
+    }
+}
+
+fn default_signing() -> EgressSigning {
+    EgressSigning::Disabled
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::StreamExt;
+    use serde_json::json;
+    use wiremock::matchers::{body_json, header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[tokio::test]
+    async fn direct_service_sends_json_request() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/test"))
+            .and(header("Authorization", "Bearer test"))
+            .and(body_json(json!({"ok": true})))
+            .respond_with(ResponseTemplate::new(201).set_body_json(json!({
+                "id": "response_123"
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let response = DirectEgressService::new()
+            .send(
+                EgressRequest::new(
+                    "POST",
+                    format!("{}/v1/test", server.uri()),
+                    EgressRequestKind::Capability,
+                )
+                .header("Authorization", "Bearer test")
+                .header("Content-Type", "application/json")
+                .body(serde_json::to_vec(&json!({"ok": true})).unwrap()),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status, 201);
+        assert_eq!(
+            serde_json::from_slice::<serde_json::Value>(&response.body).unwrap()["id"],
+            "response_123"
+        );
+    }
+
+    #[tokio::test]
+    async fn direct_service_enforces_network_access() {
+        let error = DirectEgressService::new()
+            .send(
+                EgressRequest::new(
+                    "GET",
+                    "https://blocked.example.com/path",
+                    EgressRequestKind::Capability,
+                )
+                .network_access(Some(NetworkAccessList::allow_only(["allowed.example.com"]))),
+            )
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, EgressError::NetworkAccessDenied { .. }));
+    }
+
+    #[tokio::test]
+    async fn required_signing_fails_when_no_signer_is_configured() {
+        let error = DirectEgressService::new()
+            .send(
+                EgressRequest::new("GET", "https://example.com", EgressRequestKind::Capability)
+                    .signing(EgressSigning::Required),
+            )
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, EgressError::SigningUnavailable));
+    }
+
+    #[tokio::test]
+    async fn direct_service_streams_response_body() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/stream"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("data: one\n\ndata: two\n\n"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let mut response = DirectEgressService::new()
+            .send_stream(EgressRequest::new(
+                "GET",
+                format!("{}/stream", server.uri()),
+                EgressRequestKind::LlmProvider,
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status, 200);
+        let mut body = Vec::new();
+        while let Some(chunk) = response.body.next().await {
+            body.extend(chunk.unwrap());
+        }
+        assert_eq!(
+            String::from_utf8(body).unwrap(),
+            "data: one\n\ndata: two\n\n"
+        );
+    }
+}

--- a/crates/core/src/email.rs
+++ b/crates/core/src/email.rs
@@ -51,10 +51,6 @@ impl EmailError {
     fn invalid(message: impl Into<String>) -> Self {
         Self::InvalidRequest(message.into())
     }
-
-    fn transport(error: reqwest::Error) -> Self {
-        Self::Transport(error.to_string())
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -334,9 +330,19 @@ impl SystemEmailConfig {
     }
 
     pub fn into_sender(self) -> Arc<dyn EmailSender> {
+        self.into_sender_with_egress(Arc::new(crate::DirectEgressService::default()))
+    }
+
+    pub fn into_sender_with_egress(
+        self,
+        egress_service: Arc<dyn crate::EgressService>,
+    ) -> Arc<dyn EmailSender> {
         match self {
             Self::Disabled => Arc::new(DisabledEmailSender),
-            Self::Resend(config) => Arc::new(ResendEmailSender::new(config)),
+            Self::Resend(config) => Arc::new(ResendEmailSender::with_egress_service(
+                config,
+                egress_service,
+            )),
         }
     }
 }

--- a/crates/core/src/email/resend.rs
+++ b/crates/core/src/email/resend.rs
@@ -4,18 +4,17 @@
 // capability. Resend credentials are process-level deployment configuration.
 
 use async_trait::async_trait;
-use reqwest::Client;
 use serde::{Deserialize, Serialize};
-use std::time::Duration;
+use std::sync::Arc;
 
 use super::{
     EmailAddress, EmailError, EmailMessage, EmailResult, EmailSender, EmailTag, RenderedEmail,
     SentEmail, system_email_from,
 };
+use crate::{EgressError, EgressRequest, EgressRequestKind, EgressService};
 
 const RESEND_API_BASE_URL: &str = "https://api.resend.com";
-const RESEND_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
-const RESEND_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+const RESEND_REQUEST_TIMEOUT_MS: u64 = 30_000;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ResendEmailConfig {
@@ -58,7 +57,7 @@ impl ResendEmailConfig {
 
 #[derive(Clone)]
 pub struct ResendEmailSender {
-    client: Client,
+    egress_service: Arc<dyn EgressService>,
     config: ResendEmailConfig,
 }
 
@@ -72,12 +71,15 @@ impl std::fmt::Debug for ResendEmailSender {
 
 impl ResendEmailSender {
     pub fn new(config: ResendEmailConfig) -> Self {
+        Self::with_egress_service(config, Arc::new(crate::DirectEgressService::default()))
+    }
+
+    pub fn with_egress_service(
+        config: ResendEmailConfig,
+        egress_service: Arc<dyn EgressService>,
+    ) -> Self {
         Self {
-            client: Client::builder()
-                .connect_timeout(RESEND_CONNECT_TIMEOUT)
-                .timeout(RESEND_REQUEST_TIMEOUT)
-                .build()
-                .expect("build Resend HTTP client"),
+            egress_service,
             config,
         }
     }
@@ -92,31 +94,39 @@ impl EmailSender for ResendEmailSender {
     async fn send_email(&self, message: EmailMessage) -> EmailResult<SentEmail> {
         let rendered = message.validate()?;
         let request = ResendSendEmailRequest::from_message(system_email_from(), message, rendered);
-        let mut builder = self
-            .client
-            .post(format!("{}/emails", self.config.api_base_url))
-            .header("Authorization", format!("Bearer {}", self.config.api_key))
-            .header("Content-Type", "application/json");
+        let mut egress_request = EgressRequest::new(
+            "POST",
+            format!("{}/emails", self.config.api_base_url),
+            EgressRequestKind::SystemEmail,
+        )
+        .header("Authorization", format!("Bearer {}", self.config.api_key))
+        .header("Content-Type", "application/json")
+        .timeout_ms(RESEND_REQUEST_TIMEOUT_MS)
+        .body(serde_json::to_vec(&request).map_err(|error| {
+            EmailError::Transport(format!("failed to encode Resend request: {error}"))
+        })?);
 
         if let Some(key) = &request.idempotency_key {
-            builder = builder.header("Idempotency-Key", key);
+            egress_request = egress_request.header("Idempotency-Key", key);
         }
 
-        let response = builder
-            .json(&request)
-            .send()
+        let response = self
+            .egress_service
+            .send(egress_request)
             .await
-            .map_err(EmailError::transport)?;
-        let status = response.status();
-        if !status.is_success() {
+            .map_err(EmailError::egress)?;
+        if !(200..300).contains(&response.status) {
             return Err(EmailError::Provider {
                 provider: "resend",
-                status: status.as_u16(),
-                body: response.text().await.unwrap_or_default(),
+                status: response.status,
+                body: String::from_utf8_lossy(&response.body).into_owned(),
             });
         }
 
-        let body: ResendSendEmailResponse = response.json().await.map_err(EmailError::transport)?;
+        let body: ResendSendEmailResponse =
+            serde_json::from_slice(&response.body).map_err(|error| {
+                EmailError::Transport(format!("failed to decode Resend response: {error}"))
+            })?;
         Ok(SentEmail {
             provider: "resend",
             id: body.id,
@@ -125,6 +135,12 @@ impl EmailSender for ResendEmailSender {
 
     fn name(&self) -> &'static str {
         "ResendEmailSender"
+    }
+}
+
+impl EmailError {
+    fn egress(error: EgressError) -> Self {
+        Self::Transport(error.to_string())
     }
 }
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -38,6 +38,7 @@ pub mod tool_types;
 
 // Deployment configuration
 pub mod deployment;
+pub mod egress;
 pub mod email;
 pub mod exec_tool_result;
 pub mod utility_llm;
@@ -219,6 +220,13 @@ pub use event_listeners::{CompositeEventListener, EventListener, NoopEventListen
 // Error reporter re-exports
 pub use error_reporter::{
     ErrorReport, ErrorReporter, ErrorScope, ErrorSeverity, NoopErrorReporter, SharedErrorReporter,
+};
+
+// Outbound egress service re-exports
+pub use egress::{
+    DirectEgressService, DisabledEgressService, EgressByteStream, EgressError, EgressRequest,
+    EgressRequestKind, EgressResponse, EgressResult, EgressService, EgressSigning,
+    EgressStreamResponse,
 };
 
 // System email re-exports

--- a/crates/core/src/platform_definition.rs
+++ b/crates/core/src/platform_definition.rs
@@ -12,7 +12,7 @@
 
 use crate::{
     Capability, CapabilityRegistry, ConnectionProvider, ConnectionProviderRegistry, DriverRegistry,
-    EmailSender, UtilityLlmService,
+    EgressService, EmailSender, UtilityLlmService,
     traits::{DisabledSessionFileSystemFactory, SessionFileSystemFactory},
 };
 use serde_json::Value;
@@ -185,6 +185,7 @@ pub struct PlatformDefinition {
     driver_registry: DriverRegistry,
     connection_providers: ConnectionProviderRegistry,
     built_in_harnesses: Vec<BuiltInHarnessDefinition>,
+    egress_service: Arc<dyn EgressService>,
     email_sender: Arc<dyn EmailSender>,
     utility_llm_service: Arc<dyn UtilityLlmService>,
     session_file_system_factory: Arc<dyn SessionFileSystemFactory>,
@@ -198,6 +199,7 @@ impl PlatformDefinition {
             driver_registry,
             connection_providers: ConnectionProviderRegistry::new(),
             built_in_harnesses: Vec::new(),
+            egress_service: Arc::new(crate::DirectEgressService::default()),
             email_sender: Arc::new(crate::DisabledEmailSender),
             utility_llm_service: Arc::new(crate::DisabledUtilityLlmService),
             session_file_system_factory: Arc::new(DisabledSessionFileSystemFactory),
@@ -249,6 +251,11 @@ impl PlatformDefinition {
         &mut self.built_in_harnesses
     }
 
+    /// System-wide outbound network boundary.
+    pub fn egress_service(&self) -> Arc<dyn EgressService> {
+        self.egress_service.clone()
+    }
+
     /// System-wide email sender for product and operational flows.
     pub fn email_sender(&self) -> Arc<dyn EmailSender> {
         self.email_sender.clone()
@@ -289,6 +296,7 @@ impl std::fmt::Debug for PlatformDefinition {
             .field("drivers", &self.driver_registry.registered_providers())
             .field("connection_providers", &self.connection_providers)
             .field("built_in_harnesses", &harness_keys)
+            .field("egress_service", &self.egress_service.name())
             .field("email_sender", &self.email_sender.name())
             .field("utility_llm_service", &self.utility_llm_service.name())
             .field(
@@ -354,6 +362,12 @@ impl PlatformDefinitionBuilder {
     /// Append a built-in harness template.
     pub fn add_built_in_harness(mut self, harness: BuiltInHarnessDefinition) -> Self {
         self.platform.built_in_harnesses.push(harness);
+        self
+    }
+
+    /// Set the system-wide outbound egress service.
+    pub fn egress_service(mut self, service: Arc<dyn EgressService>) -> Self {
+        self.platform.egress_service = service;
         self
     }
 

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -858,6 +858,9 @@ pub struct ToolContext {
     /// Optional system utility LLM service for capability internals.
     pub utility_llm_service: Option<Arc<dyn crate::UtilityLlmService>>,
 
+    /// Optional outbound egress service for HTTP/API traffic.
+    pub egress_service: Option<Arc<dyn crate::EgressService>>,
+
     /// Optional session SQL database store
     pub sqldb_store: Option<SessionSqlDbStoreRef>,
 
@@ -937,6 +940,7 @@ impl ToolContext {
             image_store: None,
             provider_credential_store: None,
             utility_llm_service: None,
+            egress_service: None,
             sqldb_store: None,
             message_retriever: None,
             session_store: None,
@@ -970,6 +974,7 @@ impl ToolContext {
             image_store: None,
             provider_credential_store: None,
             utility_llm_service: None,
+            egress_service: None,
             sqldb_store: None,
             message_retriever: None,
             session_store: None,
@@ -1006,6 +1011,7 @@ impl ToolContext {
             image_store: None,
             provider_credential_store: None,
             utility_llm_service: None,
+            egress_service: None,
             sqldb_store: None,
             message_retriever: None,
             session_store: None,
@@ -1044,6 +1050,7 @@ impl ToolContext {
             image_store: None,
             provider_credential_store: None,
             utility_llm_service: None,
+            egress_service: None,
             message_retriever: None,
             session_store: None,
             session_mutator: None,
@@ -1118,6 +1125,7 @@ impl ToolContext {
             image_store: Some(image_store),
             provider_credential_store: None,
             utility_llm_service: None,
+            egress_service: None,
             sqldb_store: None,
             message_retriever: None,
             session_store: None,
@@ -1154,6 +1162,12 @@ impl ToolContext {
     /// Set the utility LLM service on this context.
     pub fn with_utility_llm_service(mut self, service: Arc<dyn crate::UtilityLlmService>) -> Self {
         self.utility_llm_service = Some(service);
+        self
+    }
+
+    /// Set the outbound egress service on this context.
+    pub fn with_egress_service(mut self, service: Arc<dyn crate::EgressService>) -> Self {
+        self.egress_service = Some(service);
         self
     }
 
@@ -1300,6 +1314,7 @@ impl std::fmt::Debug for ToolContext {
                 &self.provider_credential_store.is_some(),
             )
             .field("utility_llm_service", &self.utility_llm_service.is_some())
+            .field("egress_service", &self.egress_service.is_some())
             .field("sqldb_store", &self.sqldb_store.is_some())
             .field("message_retriever", &self.message_retriever.is_some())
             .field("session_store", &self.session_store.is_some())

--- a/crates/runtime/src/host.rs
+++ b/crates/runtime/src/host.rs
@@ -25,9 +25,9 @@ use everruns_core::traits::{
 };
 use everruns_core::typed_id::{AgentId, HarnessId, MessageId, SessionId, TurnId};
 use everruns_core::{
-    Agent, CapabilityRegistry, DependencyBlocker, DriverRegistry, Harness, Session, TokenUsage,
-    ToolDefinition, ToolRegistry, UserFacingError, UtilityLlmService, org_public_id_from_internal,
-    resolve_runtime_capabilities,
+    Agent, CapabilityRegistry, DependencyBlocker, DriverRegistry, EgressService, Harness, Session,
+    TokenUsage, ToolDefinition, ToolRegistry, UserFacingError, UtilityLlmService,
+    org_public_id_from_internal, resolve_runtime_capabilities,
 };
 use std::sync::Arc;
 use tracing::warn;
@@ -112,6 +112,10 @@ pub trait RuntimeHostAdapter: Send + Sync + Clone + 'static {
     }
 
     fn utility_llm_service(&self) -> Option<Arc<dyn UtilityLlmService>> {
+        None
+    }
+
+    fn egress_service(&self) -> Option<Arc<dyn EgressService>> {
         None
     }
 
@@ -676,6 +680,9 @@ pub async fn execute_act_activity<A: RuntimeHostAdapter>(
     }
     if let Some(utility_llm_service) = adapter.utility_llm_service() {
         atom = atom.with_utility_llm_service(utility_llm_service);
+    }
+    if let Some(egress_service) = adapter.egress_service() {
+        atom = atom.with_egress_service(egress_service);
     }
     if let Some(memory_store) = adapter.memory_store(org_id) {
         atom = atom.with_memory_store(memory_store);

--- a/crates/runtime/src/runtime.rs
+++ b/crates/runtime/src/runtime.rs
@@ -817,6 +817,10 @@ impl RuntimeHostAdapter for InProcessRuntime {
         Some(self.platform_definition.utility_llm_service())
     }
 
+    fn egress_service(&self) -> Option<Arc<dyn everruns_core::EgressService>> {
+        Some(self.platform_definition.egress_service())
+    }
+
     fn memory_store(&self, _org_id: i64) -> Option<Arc<dyn MemoryStoreBackend>> {
         Some(self.memory_store.clone())
     }

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -100,6 +100,8 @@ pub struct ServerContext {
     pub platform_definition: Arc<PlatformDefinition>,
     /// System-wide email sender from the platform profile.
     pub email_sender: Arc<dyn everruns_core::EmailSender>,
+    /// System-wide outbound egress service from the platform profile.
+    pub egress_service: Arc<dyn everruns_core::EgressService>,
     /// System-wide utility LLM service from the platform profile.
     pub utility_llm_service: Arc<dyn everruns_core::UtilityLlmService>,
     /// Vendor-neutral embedder-provided error reporter. Always present;
@@ -1391,6 +1393,7 @@ impl ServerAppBuilder {
             driver_registry: driver_registry.clone(),
             platform_definition: platform_definition.clone(),
             email_sender: platform_definition.email_sender(),
+            egress_service: platform_definition.egress_service(),
             utility_llm_service: platform_definition.utility_llm_service(),
             error_reporter: error_reporter.clone(),
         };
@@ -1657,6 +1660,7 @@ impl ServerAppBuilder {
                 .with_workflow_store(durable_store.clone())
                 .with_permission_resolver(auth_state.permission_resolver.clone())
                 .with_utility_llm_service(platform_definition.utility_llm_service())
+                .with_egress_service(platform_definition.egress_service())
                 .with_virtual_registry(virtual_registry.clone())
                 .with_storage_store(session_storage_store)
                 .with_runner(runner.clone());

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -19,8 +19,8 @@ use everruns_core::traits::{
 };
 use everruns_core::typed_id::{AgentId, HarnessId, MessageId, SessionId};
 use everruns_core::{
-    Agent, AgentStatus, Caller, ContentPart, DriverRegistry, EventData, Harness, HarnessStatus,
-    LlmProviderType, Message, MessageRole, Session, SessionStatus, ToolDefinition,
+    Agent, AgentStatus, Caller, ContentPart, DriverRegistry, EgressService, EventData, Harness,
+    HarnessStatus, LlmProviderType, Message, MessageRole, Session, SessionStatus, ToolDefinition,
     ToolResultContentPart, UtilityLlmService, merge_harness,
 };
 use everruns_worker::mcp_executor::McpServerInfo;
@@ -270,6 +270,7 @@ pub struct DirectWorkerAdapters {
     capability_registry: CapabilityRegistry,
     driver_registry: DriverRegistry,
     utility_llm_service: Option<Arc<dyn UtilityLlmService>>,
+    egress_service: Option<Arc<dyn EgressService>>,
     sqldb_store: everruns_core::traits::SessionSqlDbStoreRef,
     storage_store: Option<Arc<dyn everruns_core::traits::SessionStorageStore>>,
     connection_resolver: Option<Arc<dyn everruns_core::traits::UserConnectionResolver>>,
@@ -301,6 +302,7 @@ impl DirectWorkerAdapters {
             capability_registry,
             driver_registry,
             utility_llm_service: None,
+            egress_service: None,
             sqldb_store,
             storage_store: None,
             connection_resolver: None,
@@ -371,6 +373,11 @@ impl DirectWorkerAdapters {
 
     pub fn with_utility_llm_service(mut self, service: Arc<dyn UtilityLlmService>) -> Self {
         self.utility_llm_service = Some(service);
+        self
+    }
+
+    pub fn with_egress_service(mut self, service: Arc<dyn EgressService>) -> Self {
+        self.egress_service = Some(service);
         self
     }
 
@@ -1402,6 +1409,10 @@ impl WorkerAdapters for DirectWorkerAdapters {
 
     fn utility_llm_service(&self) -> Option<Arc<dyn UtilityLlmService>> {
         self.utility_llm_service.clone()
+    }
+
+    fn egress_service(&self) -> Option<Arc<dyn EgressService>> {
+        self.egress_service.clone()
     }
 
     fn connection_resolver(&self) -> Arc<dyn everruns_core::traits::UserConnectionResolver> {

--- a/crates/server/src/platform.rs
+++ b/crates/server/src/platform.rs
@@ -9,8 +9,8 @@
 use everruns_core::connection_provider::{ConnectionProviderPlugin, ConnectionProviderRegistry};
 use everruns_core::deployment::DeploymentGrade;
 use everruns_core::{
-    BuiltInHarnessDefinition, CapabilityRegistry, PlatformDefinition, SystemEmailConfig,
-    SystemUtilityLlmConfig,
+    BuiltInHarnessDefinition, CapabilityRegistry, DirectEgressService, PlatformDefinition,
+    SystemEmailConfig, SystemUtilityLlmConfig,
 };
 use std::sync::Arc;
 
@@ -24,9 +24,10 @@ pub fn oss_platform_definition_for_grade(grade: DeploymentGrade) -> PlatformDefi
     let capability_registry = CapabilityRegistry::with_builtins_for_grade(grade);
     let driver_registry = everruns_worker::create_driver_registry();
     let connection_providers = oss_connection_provider_registry_for_grade(grade);
+    let egress_service = Arc::new(DirectEgressService::default());
     let email_sender = SystemEmailConfig::from_env()
         .expect("Invalid system email configuration")
-        .into_sender();
+        .into_sender_with_egress(egress_service.clone());
     let utility_llm_service = SystemUtilityLlmConfig::from_env().into_service();
 
     PlatformDefinition::builder()
@@ -34,6 +35,7 @@ pub fn oss_platform_definition_for_grade(grade: DeploymentGrade) -> PlatformDefi
         .driver_registry(driver_registry)
         .connection_providers(connection_providers)
         .built_in_harnesses(oss_built_in_harnesses())
+        .egress_service(egress_service)
         .email_sender(email_sender)
         .utility_llm_service(utility_llm_service)
         .session_file_system_factory(Arc::new(

--- a/crates/worker/src/grpc_worker_adapters.rs
+++ b/crates/worker/src/grpc_worker_adapters.rs
@@ -16,7 +16,8 @@ use everruns_core::typed_id::{
     AgentId, HarnessId, LeasedResourceId, MessageId, ModelId, SessionId,
 };
 use everruns_core::{
-    Agent, DriverRegistry, Harness, Message, PlatformDefinition, Session, UtilityLlmService,
+    Agent, DriverRegistry, EgressService, Harness, Message, PlatformDefinition, Session,
+    UtilityLlmService,
 };
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -393,6 +394,10 @@ impl WorkerAdapters for GrpcWorkerAdapters {
 
     fn utility_llm_service(&self) -> Option<Arc<dyn UtilityLlmService>> {
         Some(self.platform_definition.utility_llm_service())
+    }
+
+    fn egress_service(&self) -> Option<Arc<dyn EgressService>> {
+        Some(self.platform_definition.egress_service())
     }
 
     fn platform_store(

--- a/crates/worker/src/runtime_host.rs
+++ b/crates/worker/src/runtime_host.rs
@@ -10,7 +10,8 @@ use everruns_core::traits::{
 };
 use everruns_core::typed_id::{AgentId, HarnessId, SessionId};
 use everruns_core::{
-    Agent, CapabilityRegistry, DriverRegistry, Harness, Session, SessionStatus, UtilityLlmService,
+    Agent, CapabilityRegistry, DriverRegistry, EgressService, Harness, Session, SessionStatus,
+    UtilityLlmService,
 };
 use everruns_runtime::{RuntimeHostAdapter, RuntimeHostTurnContext};
 use std::sync::Arc;
@@ -142,6 +143,10 @@ impl<A: WorkerAdapters> RuntimeHostAdapter for WorkerRuntimeHost<A> {
 
     fn utility_llm_service(&self) -> Option<Arc<dyn UtilityLlmService>> {
         self.adapters.utility_llm_service()
+    }
+
+    fn egress_service(&self) -> Option<Arc<dyn EgressService>> {
+        self.adapters.egress_service()
     }
 
     fn storage_store(&self) -> Option<Arc<dyn everruns_core::traits::SessionStorageStore>> {

--- a/crates/worker/src/worker_adapters.rs
+++ b/crates/worker/src/worker_adapters.rs
@@ -22,7 +22,8 @@ use everruns_core::typed_id::{
     AgentId, HarnessId, LeasedResourceId, MessageId, ModelId, SessionId,
 };
 use everruns_core::{
-    Agent, DriverRegistry, Harness, Message, Session, ToolDefinition, UtilityLlmService,
+    Agent, DriverRegistry, EgressService, Harness, Message, Session, ToolDefinition,
+    UtilityLlmService,
 };
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -242,6 +243,9 @@ pub trait WorkerAdapters: Send + Sync + Clone + 'static {
 
     /// Get the system utility LLM service for capability internals.
     fn utility_llm_service(&self) -> Option<Arc<dyn UtilityLlmService>>;
+
+    /// Get the outbound egress service for HTTP/API traffic.
+    fn egress_service(&self) -> Option<Arc<dyn EgressService>>;
 
     /// Get the platform store for org-level management tools.
     /// Takes org_id so the store is scoped to the current session's organization.

--- a/specs/README.md
+++ b/specs/README.md
@@ -92,6 +92,7 @@ Specs capture the "why" and "what", not exhaustive source detail. Link to code f
 - `specs/localization.md` - Locale/timezone resolution and backend localization rules
 - `specs/notifications.md` - Generic user notifications
 - `specs/email.md` - Internal email delivery abstraction
+- `specs/egress.md` - Host-owned outbound network boundary and future gateway
 - `specs/utility-llm.md` - Internal utility LLM service for capability internals
 - `specs/voice.md` - Voice Sessions
 - `specs/volumes.md` - Workspace Volumes

--- a/specs/architecture.md
+++ b/specs/architecture.md
@@ -23,6 +23,7 @@ graph TB
     subgraph Workers
         Worker[TaskWorker]
         Atoms[Atoms<br/>Input/Reason/Act]
+        Egress[Egress Service]
         LLM[LLM Providers]
     end
 
@@ -35,7 +36,8 @@ graph TB
     Worker -->|gRPC only| GRPC
     REST -->|Queue Task| Services
     Worker --> Atoms
-    Atoms --> LLM
+    Atoms --> Egress
+    Egress --> LLM
 ```
 
 **Key Design Decision**: Workers communicate with the control-plane **exclusively via gRPC** (port 9001). Workers have no direct database access - all storage operations go through the gRPC service layer. This provides:
@@ -91,7 +93,7 @@ Production event routing therefore prefers:
 2. **Crate Separation** (folder → package name):
    - `server/` → `everruns-server` - **Control plane**: HTTP API (axum) + gRPC server (tonic), SSE streaming, database layer
    - `worker/` → `everruns-worker` - TaskWorker, WorkerAdapters, activities, gRPC adapters, durable task execution
-   - `core/` → `everruns-core` - Core agent abstractions (traits, atoms, tools, events, capabilities, LLM drivers, internal system services, shared types)
+   - `core/` → `everruns-core` - Core agent abstractions (traits, atoms, tools, events, capabilities, LLM drivers, egress service, internal system services, shared types)
    - `runtime/` → `everruns-runtime` - Public in-process runtime plus reusable host-phase execution for embedded and durable/server-backed execution
    - `internal-protocol/` → `everruns-internal-protocol` - gRPC protocol for worker ↔ server
    - `durable/` → `everruns-durable` - PostgreSQL-backed durable execution engine
@@ -168,6 +170,7 @@ Everruns runtime composition is centered on `PlatformDefinition` in `crates/core
 - Connection providers
 - Built-in harness templates
 - System email sender
+- Outbound egress service
 
 The server and worker builders both accept an explicit `PlatformDefinition`. If none is supplied, they fall back to crate-local presets:
 
@@ -298,6 +301,7 @@ sequenceDiagram
     participant W as Worker
     participant CP as Control Plane (gRPC)
     participant DB as PostgreSQL
+    participant EG as Egress Service
     participant LLM as LLM Provider
 
     W->>CP: ClaimDurableTasks
@@ -314,8 +318,10 @@ sequenceDiagram
         end
     and Task Execution
         loop Reason-Act Loop
-            W->>LLM: Generate completion
-            LLM-->>W: Response + Tool calls
+            W->>EG: Generate completion request
+            EG->>LLM: Provider HTTP request
+            LLM-->>EG: Response + Tool calls
+            EG-->>W: Provider response stream
             W->>CP: EmitEvent(llm.generation)
 
             opt Tool Execution

--- a/specs/capabilities.md
+++ b/specs/capabilities.md
@@ -244,6 +244,14 @@ capabilities. The backend remains authoritative for config semantics through
 `validate_config(config)`, which is called on capability write paths before
 config is persisted.
 
+##### Outbound Network Calls
+
+Capabilities that call external HTTP/API endpoints must use `ToolContext`'s
+`EgressService` and must pass `ToolContext.network_access` when the destination
+URL is authored by the agent, session, capability config, or user input. New
+capabilities must not construct direct external HTTP clients in tool execution.
+See [egress.md](egress.md) and [network-access.md](network-access.md).
+
 ##### Collection Functions
 
 - **`collect_capabilities()`** — Sync. Collects tools, mounts, static prompts.

--- a/specs/egress.md
+++ b/specs/egress.md
@@ -1,0 +1,146 @@
+# Egress Service
+
+## Intent
+
+Provide one host-owned boundary for outbound network traffic.
+
+The egress service owns HTTP/API traffic that leaves an Everruns deployment:
+LLM provider calls, capability HTTP calls, toolkit integrations, system email,
+utility LLM calls, sandbox-provider APIs, and future outbound protocols that can
+be represented over HTTP. Workers and the control plane must not create direct
+external HTTP clients at runtime once a call path has been migrated.
+
+## Terminology
+
+The service name is **Egress Service**. The future physical deployment component
+is the **Egress Gateway**.
+
+Reasoning:
+
+- "egress" is the standard infrastructure term for outbound traffic.
+- "service" fits the existing `EmailSender` and `UtilityLlmService` platform
+  service pattern.
+- "gateway" is reserved for the future process or network component that both
+  control-plane and workers call inside an airgapped deployment.
+
+## Goals
+
+1. Give every outbound call site the same policy, audit, signing, retry, and
+   observability boundary.
+2. Keep provider credentials and signing keys inside host-owned services, not
+   agent/session/tool configuration.
+3. Support a default direct implementation for local/dev/self-hosted use.
+4. Support a future remote gateway implementation so workers and control-plane
+   processes can run without direct internet egress.
+5. Preserve existing network access allowlist/blocklist semantics for
+   agent-authored URLs.
+6. Allow requests to opt into platform-managed signing.
+
+## Core Contract
+
+`everruns-core` owns the abstraction:
+
+- `EgressService` is the async trait.
+- `EgressRequest` is the provider-neutral outbound HTTP request.
+- `EgressResponse` is the provider-neutral response body, status, and headers.
+- `EgressStreamResponse` is the streaming response body used by LLM SSE and
+  other long-lived HTTP responses.
+- `EgressRequestKind` labels traffic as `llm_provider`, `capability`,
+  `integration`, `system_email`, `utility_llm`, or `other`.
+- `EgressSigning` expresses whether signing is disabled, optional via platform
+  default, or required.
+- `EgressError` separates invalid requests, network access denial, unavailable
+  signing, and transport failures.
+- `PlatformDefinition` carries the active `Arc<dyn EgressService>`.
+- Runtime tool execution threads the service into `ToolContext`.
+
+The default platform service is `DirectEgressService`, which performs outbound
+HTTP directly. `DisabledEgressService` is available for embedded hosts that want
+hard airgap behavior before installing a remote gateway implementation.
+
+## Required Usage
+
+New outbound runtime code must use `EgressService` instead of constructing
+`reqwest::Client`, provider SDK clients, or toolkit-specific HTTP transports
+directly.
+
+This applies to:
+
+- LLM drivers and model discovery.
+- capability tools, including library-backed tools such as fetchkit and bashkit
+  HTTP support.
+- integration crates for external provider APIs.
+- internal system services such as email and utility LLM.
+- background tasks that call external APIs.
+
+Exceptions:
+
+- inbound HTTP servers and gRPC servers are not egress.
+- loopback-only test servers and unit-test clients may use direct HTTP clients
+  inside tests.
+- database, NATS, Valkey, and control-plane worker gRPC links are internal
+  infrastructure traffic, not internet egress.
+
+## Network Access
+
+Agent/session `NetworkAccessList` remains a runtime policy, not an egress
+implementation detail. Call sites that send agent-authored or
+capability-configured URLs must pass the merged access list into
+`EgressRequest.network_access`.
+
+The egress service enforces the policy before making the request. Individual
+capabilities may still perform earlier validation when they need better
+user-facing errors, but the egress boundary is the final enforcement point.
+
+System-owned fixed endpoints, such as a configured email provider or model
+provider URL, do not use the agent/session network access list unless that
+endpoint is derived from agent/session/user input.
+
+## Signing
+
+Requests can set:
+
+- `disabled` — send without signatures.
+- `platform_default` — sign when the platform has an egress signer configured.
+- `required` — fail if the platform cannot sign the request.
+
+V1 keeps the request shape provider-neutral. The concrete signer can implement
+HTTP Message Signatures, vendor-specific signatures, or both. Existing fetchkit
+bot-auth signing should move behind the egress service rather than remain a
+capability-local signing path.
+
+## Future Egress Gateway
+
+The remote implementation will replace direct internet egress in workers and
+control-plane processes:
+
+```mermaid
+graph LR
+    CP["Control Plane"] -->|internal RPC| EG["Egress Gateway"]
+    W["Workers"] -->|internal RPC| EG
+    EG --> LLM["LLM Providers"]
+    EG --> API["External APIs"]
+    EG --> WEB["HTTP/Web"]
+```
+
+Deployment properties:
+
+- CP and workers need only internal network access to the gateway.
+- The gateway owns outbound allowlists, signatures, proxy configuration, audit
+  logs, and provider-specific transport policy.
+- In airgapped deployments, the gateway can be disabled, replaced with an
+  approved relay, or bound to a preapproved network route.
+
+## Migration Order
+
+1. Introduce `EgressService` and platform/runtime threading.
+2. Move internal system services onto it. `EmailSender` is migrated first;
+   `UtilityLlmService` follows with provider-driver migration.
+3. Move fetchkit/web_fetch and any future bashkit HTTP hooks onto it.
+4. Move LLM drivers and model discovery onto it.
+5. Move integration provider clients onto it.
+6. Add the remote Egress Gateway implementation and make worker/CP direct
+   internet egress removable by deployment policy.
+
+Each migration should leave tests that prove the call path uses injected egress
+instead of a direct client.

--- a/specs/email.md
+++ b/specs/email.md
@@ -23,6 +23,8 @@ Email is not an agent capability, public API, or UI surface. It is a host servic
 - `EmailError` separates configuration, request validation, transport, and provider failures.
 - Platform/application state stores the sender as `Arc<dyn EmailSender>` when it must be shared across services.
 - `PlatformDefinition` carries the active system email sender as part of the platform profile.
+- Concrete senders use `EgressService` for provider HTTP; email remains a
+  domain-specific service above the outbound transport boundary.
 
 Messages support:
 

--- a/specs/fetchkit.md
+++ b/specs/fetchkit.md
@@ -8,6 +8,9 @@ External library ([github.com/everruns/fetchkit](https://github.com/everruns/fet
 - `WebFetchTool` wraps `fetchkit::Tool` — delegates schema, description, llmtxt, and execution
 - All metadata (description, system prompt, input schema) comes from `fetchkit::ToolBuilder`, not constants
 - SSRF: `DnsPolicy::block_private_ips()` (default) blocks loopback, RFC1918, link-local, cloud metadata
+- Outbound HTTP must migrate behind `EgressService`; fetchkit should become a
+  request/response adapter at the Everruns boundary rather than owning final
+  network transport inside workers.
 - See `crates/core/src/capabilities/web_fetch.rs`
 
 ## File download (`FileSaver`)
@@ -40,7 +43,7 @@ Server-wide via environment variables:
 | `BOT_AUTH_AGENT_FQDN` | no | FQDN for `Signature-Agent` header (key discovery) |
 | `BOT_AUTH_VALIDITY_SECS` | no | signature validity window, default 300 |
 
-When `BOT_AUTH_SIGNING_KEY_SEED` is set, all `web_fetch` HTTP requests are signed. When unset, signing is disabled (no crypto dependencies loaded at runtime).
+When `BOT_AUTH_SIGNING_KEY_SEED` is set, all `web_fetch` HTTP requests are signed. When unset, signing is disabled (no crypto dependencies loaded at runtime). This is the existing implementation; new signing work should put signing policy behind `EgressService` so web_fetch, LLM drivers, and integrations share the same outbound signing path.
 
 Generate a seed: `python3 -c "import os, base64; print(base64.urlsafe_b64encode(os.urandom(32)).rstrip(b'=').decode())"`
 

--- a/specs/llm-drivers.md
+++ b/specs/llm-drivers.md
@@ -20,6 +20,10 @@ graph TD
         Gemini[everruns-gemini]
     end
 
+    subgraph Host
+        Egress[EgressService]
+    end
+
     subgraph Consumer
         ReasonAtom[ReasonAtom]
     end
@@ -31,6 +35,9 @@ graph TD
     Anthropic -->|registers| Registry
     Gemini -->|registers| Registry
     ReasonAtom -->|uses| Registry
+    OpenAI -->|outbound HTTP| Egress
+    Anthropic -->|outbound HTTP| Egress
+    Gemini -->|outbound HTTP| Egress
     ReasonAtom -->|handles| Errors
 ```
 
@@ -67,6 +74,15 @@ Each driver MUST implement provider-specific error detection to classify context
 ### Driver Registry
 
 Provider crates register factories at startup. Drivers created on-demand from `ProviderConfig`. All real providers require API keys; `LlmSim` exempted for testing. See `crates/core/src/llm_driver_registry.rs` for `DriverRegistry`.
+
+### Egress Boundary
+
+Provider drivers and model discovery must route outbound HTTP through
+`EgressService` (see `specs/egress.md`). Drivers still own provider-specific
+request construction, streaming parse logic, retry classification, and error
+mapping, but they should not create direct external HTTP clients as the final
+transport. This keeps workers and control-plane processes compatible with a
+future remote Egress Gateway and airgapped deployments.
 
 ### Message Types
 

--- a/specs/network-access.md
+++ b/specs/network-access.md
@@ -47,17 +47,24 @@ Merge function: `network_access::merge_network_access(parent, child)`
 
 ## Enforcement
 
+All outbound HTTP/API call paths must use the host `EgressService` described in
+`specs/egress.md`. The egress service is the final enforcement point for
+requests that carry a `NetworkAccessList`.
+
 Merged `NetworkAccessList` flows through:
 1. `ReasonAtom` merges harness + agent + session → stores on `RuntimeAgent.network_access`
 2. `ReasonResult.network_access` carries it to `ActInput`
 3. `ActAtom` sets `ToolContext.network_access`
-4. `WebFetchTool.execute_with_context()` checks URL before fetching (THREAT[TM-AGENT-018])
+4. Tools that send agent-authored or capability-configured URLs pass the list
+   to `EgressRequest.network_access`
+5. `EgressService` denies blocked/disallowed URLs before making the outbound
+   request (THREAT[TM-AGENT-018])
 
 ### Bashkit
 
 Bashkit has no network builtins (TM-BASH-003: curl/wget not available).
-No enforcement needed today. If bashkit gains HTTP support, it must check
-`ToolContext.network_access`.
+No enforcement needed today. If bashkit gains HTTP support, it must route HTTP
+through `EgressService` with `ToolContext.network_access`.
 
 ## API
 

--- a/specs/utility-llm.md
+++ b/specs/utility-llm.md
@@ -22,6 +22,8 @@ work without reusing user-configured model providers or session secrets.
 - `PlatformDefinition` carries the active service as part of the platform
   profile.
 - Runtime tool execution threads the service into `ToolContext`.
+- Concrete implementations must use `EgressService` for provider HTTP once
+  migrated; the utility LLM service remains the capability-facing typed API.
 
 The model is hardcoded to `gpt-5.5`. Requests do not expose tools, tool search,
 previous response IDs, model overrides, or provider credentials. By default the


### PR DESCRIPTION
## What
Add a host-owned outbound egress service contract and thread it through the platform, runtime host, direct worker adapters, and external worker adapters. Migrate Resend system email onto the injected egress service and add unit coverage for direct, disabled, ACL-denied, required-signing, and streaming behavior.

## Why
Workers and control-plane components need a single outbound network boundary so future deployments can move all internet access behind a physical gateway and eventually run workers/control plane without direct internet egress.

## How
- Added `EgressService`, `DirectEgressService`, `DisabledEgressService`, `EgressRequest`, response, streaming, request-kind, signing, timeout, and network-access policy support in core.
- Carried the active service through `PlatformDefinition`, `ToolContext`, `ActAtom`, runtime hosts, worker adapters, and server app context.
- Reused one platform `DirectEgressService` for system email and the runtime platform profile.
- Added `specs/egress.md` plus integration notes in architecture, capabilities, email, fetchkit, LLM drivers, network access, and utility LLM specs.

## Risk
- Medium
- Runtime/worker context construction could miss the egress service and leave future capabilities without the intended boundary.
- Resend delivery now depends on the egress request adapter instead of a private reqwest client.
- The default direct implementation keeps existing network behavior; remote gateway behavior is specified but not implemented in this PR.

## Security
- Threat categories reviewed: TM-API, TM-TOOL, TM-LLM, TM-DURABLE, TM-OBS, TM-DOS.
- Findings and resolutions: direct egress validates HTTP/HTTPS URLs and enforces supplied `NetworkAccessList` before transport; required signing fails closed when no signer exists; API keys are still supplied only by existing callers and are not newly logged or exposed; worker/control-plane gRPC auth semantics are unchanged. No new public API endpoint or unauthenticated ingress was added.

## Follow-ups
- Migrate LLM provider drivers to `EgressService`; safe to defer because this PR first establishes and threads the shared contract without changing provider streaming semantics.
- Migrate fetchkit/web-fetch and capability HTTP clients to `EgressService`; safe to defer because existing fetchkit SSRF controls stay unchanged while the new boundary is introduced.
- Migrate integration clients and MCP outbound HTTP to `EgressService`; safe to defer because those clients have provider-specific streaming/upload behavior that needs focused follow-up tests.
- Implement the remote Egress Gateway and platform signing backend; safe to defer because this PR preserves direct egress behavior while defining the replacement contract.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)