### PR TITLE
fix(container-sandbox): persist raw output in auto success

### DIFF
--- a/crates/container-sandbox/src/tools.rs
+++ b/crates/container-sandbox/src/tools.rs
@@ -298,7 +298,7 @@ impl Tool for SandboxExecTool {
         };
 
         if exit_code == 0 {
-            ToolExecutionResult::success(output)
+            ToolExecutionResult::success_with_raw_output(output, clean_output)
         } else {
             ToolExecutionResult::success(format!("Exit code: {exit_code}\n\n{output}"))
         }

--- a/crates/container-sandbox/src/tools.rs
+++ b/crates/container-sandbox/src/tools.rs
@@ -294,7 +294,7 @@ impl Tool for SandboxExecTool {
         let output = if let Some(budget) = output_verbosity_budget(effective_mode) {
             priority_aware_truncate(&clean_output, budget)
         } else {
-            clean_output
+            clean_output.clone()
         };
 
         if exit_code == 0 {

--- a/crates/core/src/tools.rs
+++ b/crates/core/src/tools.rs
@@ -109,9 +109,19 @@ impl ToolExecutionResult {
     /// The raw output is transferred to `ToolResult.raw_output` during `into_tool_result()`.
     pub fn success_with_raw_output(value: impl Into<Value>, raw_output: String) -> Self {
         let mut value = value.into();
-        // Embed raw output in a sidecar key — extracted in into_tool_result()
-        if let Some(obj) = value.as_object_mut() {
-            obj.insert("_raw_output".to_string(), Value::String(raw_output));
+        // Embed raw output in a sidecar key — extracted in into_tool_result().
+        // Non-object values are wrapped in a scalar carrier so raw_output still
+        // flows through; the carrier is unwrapped on extraction.
+        match value.as_object_mut() {
+            Some(obj) => {
+                obj.insert("_raw_output".to_string(), Value::String(raw_output));
+            }
+            None => {
+                value = serde_json::json!({
+                    "_raw_output_scalar": value,
+                    "_raw_output": raw_output,
+                });
+            }
         }
         ToolExecutionResult::Success(value)
     }
@@ -182,9 +192,14 @@ impl ToolExecutionResult {
                     .as_object_mut()
                     .and_then(|obj| obj.remove("_raw_output"))
                     .and_then(|v| v.as_str().map(|s| s.to_string()));
+                // Unwrap scalar carrier (set by success_with_raw_output for non-object inputs)
+                let result_value = value
+                    .as_object_mut()
+                    .and_then(|obj| obj.remove("_raw_output_scalar"))
+                    .unwrap_or(value);
                 ToolResult {
                     tool_call_id: tool_call_id.to_string(),
-                    result: Some(value),
+                    result: Some(result_value),
                     images: None,
                     error: None,
                     connection_required: None,
@@ -2339,6 +2354,41 @@ mod tests {
 
         let def = tool.to_definition();
         assert_eq!(def.display_name(), Some("Get Current Time"));
+    }
+
+    #[test]
+    fn test_success_with_raw_output_object_preserves_shape() {
+        let res = ToolExecutionResult::success_with_raw_output(
+            serde_json::json!({"stdout": "hello"}),
+            "raw stdout bytes".to_string(),
+        );
+        let tr = res.into_tool_result("call_1", "demo");
+        assert_eq!(tr.result.as_ref().unwrap()["stdout"], "hello");
+        assert!(
+            tr.result
+                .as_ref()
+                .unwrap()
+                .as_object()
+                .unwrap()
+                .get("_raw_output")
+                .is_none(),
+            "sidecar key must not leak to the LLM-visible result"
+        );
+        assert_eq!(tr.raw_output.as_deref(), Some("raw stdout bytes"));
+    }
+
+    #[test]
+    fn test_success_with_raw_output_scalar_unwraps_to_string() {
+        let res = ToolExecutionResult::success_with_raw_output(
+            "compact summary".to_string(),
+            "full output bytes".to_string(),
+        );
+        let tr = res.into_tool_result("call_1", "demo");
+        assert_eq!(
+            tr.result,
+            Some(serde_json::Value::String("compact summary".into()))
+        );
+        assert_eq!(tr.raw_output.as_deref(), Some("full output bytes"));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- `sandbox_exec` was defaulting to `auto` and returning a truncated inline string on success without providing the pre-truncation `raw_output`, which can cause the persist-output hook to skip saving the full output.

### Description
- Update the success path in `crates/container-sandbox/src/tools.rs` to return `ToolExecutionResult::success_with_raw_output(output, clean_output)` so the compact inline summary is preserved while the full cleaned output is provided to the persistence hook.

### Testing
- Attempted `cargo test -p everruns-container-sandbox --lib`, the build started and dependencies compiled but the test run did not complete within the session (inconclusive).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13b71dd558832ba36c019f66417cf6)