### PR TITLE
fix(ui): remove deleted .npmrc from Docker build inputs

### DIFF
--- a/apps/ui/Dockerfile
+++ b/apps/ui/Dockerfile
@@ -13,7 +13,7 @@ WORKDIR /app
 RUN npm install -g pnpm@10.33.0
 
 # Install dependencies (fail if pnpm-lock.yaml is out of sync with package.json)
-COPY package.json pnpm-lock.yaml .npmrc ./
+COPY package.json pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile
 
 # Copy source and build


### PR DESCRIPTION
### Motivation
- The UI Docker build used `COPY package.json pnpm-lock.yaml .npmrc ./` but `apps/ui/.npmrc` was removed, causing Docker builds with `context: apps/ui` to fail due to a missing mandatory source file.

### Description
- Remove `.npmrc` from the dependency-install `COPY` in `apps/ui/Dockerfile`, keeping `pnpm install --frozen-lockfile` and the rest of the build unchanged.

### Testing
- Verified the UI workflow context and Dockerfile with `sed -n '260,300p' .github/workflows/docker-publish.yml` and `sed -n '1,80p' apps/ui/Dockerfile` which showed the `COPY` line referenced `.npmrc` and the workflow builds with `context: apps/ui`; these inspections succeeded.
- Confirmed `apps/ui/.npmrc` is absent with `test -f apps/ui/.npmrc; echo $?` which returned `1`.
- Confirmed the Dockerfile now copies only `package.json` and `pnpm-lock.yaml` with `nl -ba apps/ui/Dockerfile | sed -n '12,22p'`, and committed the change as `fix(ui): remove deleted .npmrc from Docker build inputs`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13b71cfbc4832b934cb7e41f605742)