### PR TITLE
fix(core): type-dispatch Event and EventRequest deserialization

### DIFF
--- a/crates/core/src/events.rs
+++ b/crates/core/src/events.rs
@@ -326,7 +326,6 @@ pub struct Event {
     pub sequence: Option<i32>,
 }
 
-
 #[derive(Debug, Deserialize)]
 struct RawEvent {
     id: EventId,
@@ -2615,7 +2614,6 @@ pub struct EventRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tags: Option<Vec<String>>,
 }
-
 
 #[derive(Debug, Deserialize)]
 struct RawEventRequest {

--- a/crates/core/src/events.rs
+++ b/crates/core/src/events.rs
@@ -19,7 +19,7 @@
 // observability into session execution.
 
 use chrono::{DateTime, Utc};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 use uuid::Uuid;
@@ -288,7 +288,7 @@ impl EventContext {
 /// - `data`: Event-specific payload (typed via EventData enum)
 /// - `metadata`: Optional arbitrary metadata
 /// - `tags`: Optional list of tags for filtering
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct Event {
     /// Unique event identifier (format: event_{32-hex})
@@ -324,6 +324,42 @@ pub struct Event {
     /// Sequence number within session (for ordering)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sequence: Option<i32>,
+}
+
+
+#[derive(Debug, Deserialize)]
+struct RawEvent {
+    id: EventId,
+    #[serde(rename = "type")]
+    event_type: String,
+    ts: DateTime<Utc>,
+    session_id: SessionId,
+    context: EventContext,
+    data: serde_json::Value,
+    metadata: Option<serde_json::Value>,
+    tags: Option<Vec<String>>,
+    sequence: Option<i32>,
+}
+
+impl<'de> Deserialize<'de> for Event {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let raw = RawEvent::deserialize(deserializer)?;
+        let data = deserialize_event_data(&raw.event_type, raw.data);
+        Ok(Self {
+            id: raw.id,
+            event_type: raw.event_type,
+            ts: raw.ts,
+            session_id: raw.session_id,
+            context: raw.context,
+            data,
+            metadata: raw.metadata,
+            tags: raw.tags,
+            sequence: raw.sequence,
+        })
+    }
 }
 
 impl Event {
@@ -2552,7 +2588,7 @@ impl EventData {
 /// This is the input type for event ingestion. It contains all the data
 /// needed to create an event, but without the `id` and `sequence` fields
 /// which are assigned by the storage layer.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct EventRequest {
     /// Event type in dot notation
@@ -2578,6 +2614,38 @@ pub struct EventRequest {
     /// Tags for filtering and categorization
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tags: Option<Vec<String>>,
+}
+
+
+#[derive(Debug, Deserialize)]
+struct RawEventRequest {
+    #[serde(rename = "type")]
+    event_type: String,
+    ts: DateTime<Utc>,
+    session_id: SessionId,
+    context: EventContext,
+    data: serde_json::Value,
+    metadata: Option<serde_json::Value>,
+    tags: Option<Vec<String>>,
+}
+
+impl<'de> Deserialize<'de> for EventRequest {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let raw = RawEventRequest::deserialize(deserializer)?;
+        let data = deserialize_event_data(&raw.event_type, raw.data);
+        Ok(Self {
+            event_type: raw.event_type,
+            ts: raw.ts,
+            session_id: raw.session_id,
+            context: raw.context,
+            data,
+            metadata: raw.metadata,
+            tags: raw.tags,
+        })
+    }
 }
 
 impl EventRequest {
@@ -3290,6 +3358,66 @@ mod tests {
         assert!(json.contains("rs_abc"));
         assert!(json.contains("OPAQUE_BLOB"));
         assert!(json.contains("safe summary"));
+    }
+
+    #[test]
+    fn test_event_deserialize_reason_item_uses_event_type_dispatch() {
+        let turn_id = TurnId::from_uuid(Uuid::now_v7());
+        let payload = serde_json::json!({
+            "id": EventId::new().to_string(),
+            "type": REASON_ITEM,
+            "ts": Utc::now().to_rfc3339(),
+            "session_id": SessionId::from_uuid(Uuid::now_v7()).to_string(),
+            "context": {"trace_id": "t", "span_id": "s", "parent_span_id": null},
+            "data": {
+                "turn_id": turn_id.to_string(),
+                "provider": "openai",
+                "model": "gpt-5",
+                "item_id": "rs_event",
+                "encrypted_content": "ENC",
+                "summary": ["safe"],
+                "token_count": 9
+            }
+        });
+
+        let event: Event = serde_json::from_value(payload).expect("event deserializes");
+        match event.data {
+            EventData::ReasonItem(data) => {
+                assert_eq!(data.turn_id, turn_id);
+                assert_eq!(data.provider, "openai");
+                assert_eq!(data.item_id, "rs_event");
+                assert_eq!(data.token_count, Some(9));
+            }
+            other => panic!("expected reason.item data, got {}", other.event_type()),
+        }
+    }
+
+    #[test]
+    fn test_event_request_deserialize_reason_item_uses_event_type_dispatch() {
+        let turn_id = TurnId::from_uuid(Uuid::now_v7());
+        let payload = serde_json::json!({
+            "type": REASON_ITEM,
+            "ts": Utc::now().to_rfc3339(),
+            "session_id": SessionId::from_uuid(Uuid::now_v7()).to_string(),
+            "context": {"trace_id": "t", "span_id": "s", "parent_span_id": null},
+            "data": {
+                "turn_id": turn_id.to_string(),
+                "provider": "openai",
+                "item_id": "rs_request",
+                "encrypted_content": "ENC",
+                "summary": ["safe"]
+            }
+        });
+
+        let req: EventRequest = serde_json::from_value(payload).expect("request deserializes");
+        match req.data {
+            EventData::ReasonItem(data) => {
+                assert_eq!(data.turn_id, turn_id);
+                assert_eq!(data.provider, "openai");
+                assert_eq!(data.item_id, "rs_request");
+            }
+            other => panic!("expected reason.item data, got {}", other.event_type()),
+        }
     }
 
     #[test]

--- a/crates/core/src/events.rs
+++ b/crates/core/src/events.rs
@@ -2480,6 +2480,14 @@ pub fn deserialize_event_data(event_type: &str, data: serde_json::Value) -> Even
                 .map(EventData::VoiceSessionEnded),
             VOICE_SESSION_FAILED => serde_json::from_value::<VoiceSessionFailedData>(data.clone())
                 .map(EventData::VoiceSessionFailed),
+            SUBAGENT_SPAWNED => serde_json::from_value::<SubagentEventData>(data.clone())
+                .map(EventData::SubagentSpawned),
+            SUBAGENT_COMPLETED => serde_json::from_value::<SubagentEventData>(data.clone())
+                .map(EventData::SubagentCompleted),
+            SUBAGENT_FAILED => serde_json::from_value::<SubagentEventData>(data.clone())
+                .map(EventData::SubagentFailed),
+            SUBAGENT_CANCELLED => serde_json::from_value::<SubagentEventData>(data.clone())
+                .map(EventData::SubagentCancelled),
             _ => {
                 // Unknown event type - return as unsupported with warning
                 return EventData::unsupported(event_type.to_string(), data);
@@ -3415,6 +3423,35 @@ mod tests {
                 assert_eq!(data.item_id, "rs_request");
             }
             other => panic!("expected reason.item data, got {}", other.event_type()),
+        }
+    }
+
+    #[test]
+    fn test_event_deserialize_subagent_uses_event_type_dispatch() {
+        let subagent_session_id = SessionId::from_uuid(Uuid::now_v7());
+        let payload = serde_json::json!({
+            "id": EventId::new().to_string(),
+            "type": SUBAGENT_COMPLETED,
+            "ts": Utc::now().to_rfc3339(),
+            "session_id": SessionId::from_uuid(Uuid::now_v7()).to_string(),
+            "context": {"trace_id": "t", "span_id": "s", "parent_span_id": null},
+            "data": {
+                "subagent_session_id": subagent_session_id.to_string(),
+                "subagent_name": "researcher",
+                "task": "summarize docs",
+                "status": "completed",
+                "result": "done"
+            }
+        });
+
+        let event: Event = serde_json::from_value(payload).expect("event deserializes");
+        match event.data {
+            EventData::SubagentCompleted(data) => {
+                assert_eq!(data.subagent_session_id, subagent_session_id);
+                assert_eq!(data.subagent_name, "researcher");
+                assert_eq!(data.status, "completed");
+            }
+            other => panic!("expected subagent.completed, got {}", other.event_type()),
         }
     }
 


### PR DESCRIPTION
### Motivation
- An untagged `EventData` enum with overlapping shapes allowed a `reason.item` payload to deserialize as `output.message.started` when `Event`/`EventRequest` were derived `Deserialize`, causing silent field loss for `provider`, `item_id`, `encrypted_content`, `summary`, and `token_count`.
- The intent is to ensure canonical parsing uses the outer `type` to select the correct `EventData` variant and preserve payload integrity for newly added events like `reason.item`.

### Description
- Removed derived `Deserialize` for `Event` and `EventRequest` and kept `Serialize` so wire output is unchanged while input parsing is custom.
- Added internal `RawEvent` and `RawEventRequest` structs and custom `impl Deserialize` that first parse the outer `type` and then call `deserialize_event_data(&event_type, data)` to construct the typed `data` variant.
- Kept `metadata`, `tags`, and other optional fields intact when round-tripping and preserved the public structs and their `Serialize` behavior.
- Added regression tests that deserialize full JSON `Event` and `EventRequest` payloads for `REASON_ITEM` and assert the parsed `data` is `EventData::ReasonItem`.

### Testing
- Ran `cargo test -p everruns-core --lib test_event_deserialize_reason_item_uses_event_type_dispatch` and the test passed.
- Ran `cargo test -p everruns-core --lib test_event_request_deserialize_reason_item_uses_event_type_dispatch` and the test passed.
- Verified the new custom deserializers preserve optional `metadata`/`tags` fields and existing `Serialize` behavior via existing unit tests that remained green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13b71db0b4832b8348f125036c3d5d)