### PR TITLE
fix(core): harden edit_file placeholders

### DIFF
--- a/crates/core/src/capabilities/file_system.rs
+++ b/crates/core/src/capabilities/file_system.rs
@@ -286,14 +286,25 @@ struct PlannedEdit {
 }
 
 fn parse_text_edits(arguments: &Value) -> std::result::Result<Vec<TextEdit>, String> {
-    let has_single = arguments.get("old_text").is_some() || arguments.get("new_text").is_some();
+    let old_text_arg = arguments.get("old_text");
+    let new_text_arg = arguments.get("new_text");
+    let has_single = old_text_arg.is_some() || new_text_arg.is_some();
     let has_batch = arguments.get("edits").is_some();
 
     if has_single && has_batch {
-        return Err("Provide either old_text/new_text or edits, not both".to_string());
+        let has_empty_single_placeholders = matches!(
+            (
+                old_text_arg.and_then(Value::as_str),
+                new_text_arg.and_then(Value::as_str)
+            ),
+            (Some(""), Some(""))
+        );
+        if !has_empty_single_placeholders {
+            return Err("Provide either old_text/new_text or edits, not both".to_string());
+        }
     }
 
-    if has_single {
+    if has_single && !has_batch {
         let old_text = arguments
             .get("old_text")
             .and_then(Value::as_str)
@@ -2551,6 +2562,37 @@ mod tests {
         assert_eq!(store.content("/batch.txt").unwrap(), "ONE\ntwo\nTHREE\n");
         assert_eq!(value["applied_edits"], 2);
         assert_eq!(value["first_changed_line"], 1);
+    }
+
+    #[tokio::test]
+    async fn test_edit_file_batch_replace_ignores_empty_single_placeholders() {
+        let store = Arc::new(MockFileStore::default());
+        store.add_text_file("/batch-placeholders.txt", "one\ntwo\nthree\n");
+        let context = make_context(store.clone());
+        let expected_hash = read_hash(&context, "/workspace/batch-placeholders.txt").await;
+
+        let result = EditFileTool
+            .execute_with_context(
+                json!({
+                    "path": "/workspace/batch-placeholders.txt",
+                    "expected_hash": expected_hash,
+                    "edits": [
+                        {"old_text": "one", "new_text": "ONE"},
+                        {"old_text": "three", "new_text": "THREE"}
+                    ],
+                    "old_text": "",
+                    "new_text": ""
+                }),
+                &context,
+            )
+            .await;
+        let value = expect_success(result);
+
+        assert_eq!(
+            store.content("/batch-placeholders.txt").unwrap(),
+            "ONE\ntwo\nTHREE\n"
+        );
+        assert_eq!(value["applied_edits"], 2);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What
Allow `session_file_system` `edit_file` batch edits to ignore top-level `old_text: ""` / `new_text: ""` placeholders.

## Why
Models can emit a valid `edits` batch together with empty single-edit placeholders. The old parser treated field presence as conflicting modes and rejected the batch, causing repeated tool failures.

## How
`parse_text_edits` now accepts mixed-mode arguments only when `edits` is present and both top-level single-edit fields are present as empty strings. Non-empty or malformed mixed-mode arguments still return `Provide either old_text/new_text or edits, not both`.

Added a regression test that runs the full `EditFileTool::execute_with_context` batch edit path with empty top-level placeholders.

## Risk
- Low
- What can break: `edit_file` argument validation. Existing mixed-mode rejection, stale hash rejection, ambiguous match rejection, overlapping edit rejection, and readonly protections remain covered by existing tests.

## Security
- Threat categories reviewed: TM-FS, TM-TOOL
- Findings and resolutions: No new file path, authorization, storage, network, or tool registration surface. The change only narrows parser rejection for empty placeholder fields while preserving the content hash, text-only, readonly, ambiguous match, and overlap safeguards.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)
