### PR TITLE
chore(deps): bump bashkit to 0.7.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -571,14 +571,15 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bashkit"
-version = "0.6.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bec5470c94eddec899a8048070259e6209f04b367c4f05a455ed0a0c9075ceca"
+checksum = "fa7892a1440c479f5b70dfddf760fe9671c5436d4c7b5ba39bb05216e2e3f301"
 dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.22.1",
  "bigdecimal",
+ "bitflags 2.11.1",
  "chrono",
  "clap",
  "fancy-regex 0.18.0",
@@ -594,7 +595,6 @@ dependencies = [
  "num-traits",
  "os_display",
  "regex",
- "schemars",
  "serde",
  "serde_json",
  "sha1 0.11.0",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -69,7 +69,7 @@ fetchkit = { version = "=0.2.0", features = ["bot-auth"] }
 ed25519-dalek = { version = "2", features = ["rand_core"] }
 
 # Virtual bash interpreter
-bashkit = { version = "0.6.0", features = ["jq"] }
+bashkit = { version = "0.7.2", features = ["jq"] }
 
 # Tree-sitter for structural outlines (EVE-248)
 tree-sitter = { version = "0.24", optional = true }

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -71,7 +71,7 @@ mime_guess = "2"
 tokio-tungstenite.workspace = true
 futures-util.workspace = true
 
-bashkit = { version = "0.6.0", features = ["scripted_tool", "jq"] }
+bashkit = { version = "0.7.2", features = ["scripted_tool", "jq"] }
 
 everruns-config = { path = "../config" }
 everruns-core = { path = "../core", features = ["embedded-platform-docs", "openapi", "sqlx", "tree-sitter-outlines", "ui-capabilities"] }


### PR DESCRIPTION
## What
Bump `bashkit` from 0.6.0 to 0.7.2 in `crates/core` and `crates/server`.

## Why
Pick up the latest virtual-bash interpreter (0.7.x line) for our `virtual_bash` and `scripted_tool` capabilities. Keeps us aligned with upstream fixes.

## How
- `crates/core/Cargo.toml`: `bashkit = "0.7.2"` (features unchanged: `jq`).
- `crates/server/Cargo.toml`: `bashkit = "0.7.2"` (features unchanged: `scripted_tool`, `jq`).
- `cargo update -p bashkit` to refresh `Cargo.lock`.

Feature set is identical between 0.6.0 and 0.7.2 — no API surface changes required on our side. `cargo check` is clean for `everruns-core` and `everruns-server`.

## Risk
- Low. Single-dep version bump on a workspace dependency we already use.
- Behavioral change is bounded to whatever bashkit changed between 0.6 and 0.7.x; both consumers compile clean without source changes.

## Security
- Threat categories reviewed: No security-relevant code changes — pure dependency version bump, no new features pulled in, feature flags unchanged. The crate (`bashkit`) is the same `everruns/bashkit` repo we already depend on.
- Findings and resolutions: None.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated (n/a — dep bump; existing tests cover bashkit-backed capabilities)
- [x] Backward compatibility considered (no API surface changes)
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)