### PR TITLE
feat(ercode): persist and render reasoning artifacts for session restore

### DIFF
--- a/examples/coding-cli/README.md
+++ b/examples/coding-cli/README.md
@@ -169,11 +169,13 @@ resume after upgrading from the old flat-log layout, ercode copies
 `events.jsonl` exists yet. The folder layout leaves room for other
 session-scoped stores, such as key/value data, to sit beside the event log.
 
-One serialized `Event` per line, flushed after every write. On Unix the
-event file is created with `0o600` (owner-only) because session logs contain
-user prompts, tool arguments, and tool output. The session id is
-generated fresh on every plain `ercode` invocation and printed in the
-startup banner (`[session] session_… (folder: …; log: …)`).
+One serialized `Event` per line, flushed after every write. On Unix
+`events.jsonl` is created with `0o600` and its parent session folder
+is set to `0o700` (both owner-only) because session logs contain user
+prompts, tool arguments, tool output, and the reasoning artifacts
+discussed below. The session id is generated fresh on every plain
+`ercode` invocation and printed in the startup banner (`[session]
+session_… (folder: …; log: …)`).
 
 The event types kept on disk are those that round-trip into the
 conversation (`input.message`, `output.message.completed`,
@@ -192,8 +194,9 @@ dropped from the log — they are live status signals only and the delta
 types would inflate the file O(n²) without adding resume value.
 
 This persistence contract is **local-store**, not user-facing
-transcript export. The per-session folder is owner-only (0o600 on
-Unix) under the platform-native user data directory; treat its
+transcript export. On Unix, the per-session folder is set to `0o700`
+and the `events.jsonl` file inside it to `0o600` on every open, both
+under the platform-native user data directory; treat the folder
 contents as sensitive (see [Sensitivity](#sensitivity) below).
 
 To continue a previous conversation, pass `--session <id>`:

--- a/examples/coding-cli/README.md
+++ b/examples/coding-cli/README.md
@@ -175,11 +175,26 @@ user prompts, tool arguments, and tool output. The session id is
 generated fresh on every plain `ercode` invocation and printed in the
 startup banner (`[session] session_… (folder: …; log: …)`).
 
-Only the event types that round-trip into the conversation are persisted
-(`input.message`, `output.message.completed`, `tool.completed`).
-Streaming `*.delta` events are dropped from the log — they carry the
-accumulated text so far and would inflate the file O(n²) without adding
-resume value.
+The event types kept on disk are those that round-trip into the
+conversation (`input.message`, `output.message.completed`,
+`tool.completed`) plus the agent reasoning artifacts ercode needs to
+restore the live transcript view and provider continuation state on
+resume (`reason.completed` carries the safe `text_preview` narration;
+`reason.item` carries opaque/encrypted reasoning context curated by the
+provider, such as OpenAI Responses reasoning items). Assistant
+`thinking` / `thinking_signature` are persisted alongside
+`output.message.completed` — providers that resume via encrypted
+reasoning continuation (e.g. OpenAI Responses replays
+`thinking_signature` as `encrypted_content`) cannot continue without
+them. Streaming `*.delta` events and lifecycle markers
+(`reason.started`, `reason.thinking.*`, `output.message.started`) are
+dropped from the log — they are live status signals only and the delta
+types would inflate the file O(n²) without adding resume value.
+
+This persistence contract is **local-store**, not user-facing
+transcript export. The per-session folder is owner-only (0o600 on
+Unix) under the platform-native user data directory; treat its
+contents as sensitive (see [Sensitivity](#sensitivity) below).
 
 To continue a previous conversation, pass `--session <id>`:
 
@@ -209,6 +224,13 @@ serialized `Event` that fired during a turn, which may include:
   to `bash`, `write_file`, `edit_file`, `web_fetch`, etc.
 - Tool output — `bash` stdout/stderr, file contents, HTTP response
   bodies (capped per-tool but not redacted).
+- Agent reasoning artifacts — `reason.completed.text_preview`
+  narration, `reason.item` opaque/encrypted reasoning context, and the
+  `thinking` / `thinking_signature` fields on assistant messages.
+  Persisting these is what lets `--session <id>` resume restore the
+  transcript view and lets providers (e.g. OpenAI Responses) continue
+  encrypted reasoning across resumes; they are deliberately not
+  redacted from the local log.
 
 There is no retention policy or rotation — files grow until you delete
 them. If you'd rather a session not be persisted, point `--session-dir`

--- a/examples/coding-cli/src/app.rs
+++ b/examples/coding-cli/src/app.rs
@@ -732,6 +732,9 @@ pub fn lines_for_event(event: &RuntimeEvent) -> Vec<ChatLine> {
     match &event.data {
         EventData::ReasonStarted(_) => Vec::new(),
         EventData::ReasonCompleted(data) => {
+            // Render pre-tool-call narration. When there are no tool calls
+            // the final assistant message will arrive via the message loop
+            // shortly, so we'd duplicate it; keep the has_tool_calls gate.
             if data.success && data.has_tool_calls {
                 let mut lines = Vec::new();
                 if let Some(text) = data
@@ -750,6 +753,17 @@ pub fn lines_for_event(event: &RuntimeEvent) -> Vec<ChatLine> {
                 Vec::new()
             }
         }
+        EventData::ReasonItem(data) => data
+            .summary
+            .iter()
+            .filter_map(|segment| {
+                let trimmed = segment.trim();
+                (!trimmed.is_empty()).then(|| ChatLine {
+                    author: Author::Assistant,
+                    text: trimmed.to_string(),
+                })
+            })
+            .collect(),
         EventData::OutputMessageCompleted(_) => Vec::new(),
         EventData::ToolCompleted(data) => {
             if data.tool_name == "write_todos" {
@@ -1923,6 +1937,36 @@ mod tests {
                 .as_deref(),
             Some("planned 2 tool call(s)")
         );
+    }
+
+    #[test]
+    fn lines_for_event_renders_reason_item_summary_segments() {
+        use everruns_core::events::ReasonItemData;
+
+        let event = RuntimeEvent::new(
+            SessionId::new(),
+            EventContext::empty(),
+            ReasonItemData {
+                turn_id: TurnId::new(),
+                provider: "openai".to_string(),
+                model: Some("gpt-5".to_string()),
+                item_id: "rs_abc".to_string(),
+                encrypted_content: Some("opaque".to_string()),
+                summary: vec![
+                    "Considering file layout".to_string(),
+                    "".to_string(),
+                    "  Plan the read order  ".to_string(),
+                ],
+                token_count: None,
+            },
+        );
+
+        let lines = lines_for_event(&event);
+
+        assert_eq!(lines.len(), 2, "blank summary segments are dropped");
+        assert!(matches!(lines[0].author, Author::Assistant));
+        assert_eq!(lines[0].text, "Considering file layout");
+        assert_eq!(lines[1].text, "Plan the read order");
     }
 
     #[test]

--- a/examples/coding-cli/src/session_log.rs
+++ b/examples/coding-cli/src/session_log.rs
@@ -13,8 +13,10 @@
 // every line so a crash mid-session loses at most the event in flight.
 //
 // Concerns explicitly handled below:
-// * 0o600 file mode on Unix (owner-only): session logs contain prompts,
-//   tool arguments, and tool output.
+// * Owner-only on Unix: `events.jsonl` is opened with `0o600` and the
+//   per-session folder is `chmod`-ed to `0o700` on open. Session logs
+//   contain prompts, tool arguments, and tool output, plus the
+//   reasoning artifacts described below.
 // * Replay keeps event types that (a) round-trip into the conversation
 //   (`input.message`, `output.message.completed`, `tool.completed`) and
 //   (b) the agent needs to restore the live transcript view and provider
@@ -23,12 +25,12 @@
 //   inflate the log O(n²) for long streamed responses.
 // * Assistant `thinking` / `thinking_signature` fields ARE persisted in
 //   ercode's per-session JSONL. The per-session folder is the local
-//   private session store (0o600 on Unix) and provider continuation on
-//   resume requires the signature/encrypted_content (e.g. OpenAI
-//   Responses threads the encrypted reasoning context back via
-//   `thinking_signature`). The contract is local-store, not user-facing
-//   transcript export — see the coding-cli README for the public/private
-//   distinction.
+//   private session store (owner-only on Unix, see above) and provider
+//   continuation on resume requires the signature/encrypted_content
+//   (e.g. OpenAI Responses threads the encrypted reasoning context back
+//   via `thinking_signature`). The contract is local-store, not
+//   user-facing transcript export — see the coding-cli README for the
+//   public/private distinction.
 // * Replay rejects events whose `session_id` doesn't match the resumed
 //   session — guards against accidentally merging logs across sessions.
 // * On open, if the file does not end with `\n` (previous run crashed
@@ -229,6 +231,25 @@ impl JsonlEventEmitter {
             std::fs::create_dir_all(parent).map_err(|e| {
                 AgentLoopError::config(format!("create session log dir {}: {e}", parent.display()))
             })?;
+            // Per-session folder is owner-only on Unix. The events.jsonl
+            // file gets `0o600` below, but the folder may also hold tool
+            // outputs (`/outputs/`) and other per-session artifacts;
+            // tightening the directory keeps every file inside private
+            // even if a caller later creates one without an explicit
+            // mode. Idempotent — set on every open so a session folder
+            // that pre-dates this change gets corrected next resume.
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700)).map_err(
+                    |e| {
+                        AgentLoopError::config(format!(
+                            "tighten session dir permissions on {}: {e}",
+                            parent.display()
+                        ))
+                    },
+                )?;
+            }
         }
         let mut opts = OpenOptions::new();
         // `read(true)` is required so we can read the file's last byte
@@ -540,6 +561,64 @@ mod tests {
         assert_eq!(
             std::fs::read_to_string(&current_path).expect("read current"),
             "current event\n"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn open_tightens_session_dir_to_owner_only_on_unix() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let session_id = SessionId::from_seed(48222);
+        let session_dir = session_dir_path(dir.path(), session_id);
+        let path = session_log_path(&session_dir);
+
+        let _emitter = JsonlEventEmitter::open(&path, 1).expect("open");
+
+        let mode = std::fs::metadata(&session_dir)
+            .expect("session dir exists")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(
+            mode, 0o700,
+            "per-session folder must be owner-only on Unix, got {mode:o}"
+        );
+
+        let file_mode = std::fs::metadata(&path)
+            .expect("events.jsonl exists")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(
+            file_mode, 0o600,
+            "events.jsonl must be owner-only on Unix, got {file_mode:o}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn open_corrects_loose_session_dir_permissions_on_resume() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let session_id = SessionId::from_seed(48223);
+        let session_dir = session_dir_path(dir.path(), session_id);
+        let path = session_log_path(&session_dir);
+
+        std::fs::create_dir_all(&session_dir).expect("pre-create");
+        std::fs::set_permissions(&session_dir, std::fs::Permissions::from_mode(0o755))
+            .expect("loosen for test");
+
+        let _emitter = JsonlEventEmitter::open(&path, 1).expect("open");
+
+        let mode = std::fs::metadata(&session_dir)
+            .expect("session dir exists")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(
+            mode, 0o700,
+            "resume must re-tighten an existing loose session folder, got {mode:o}"
         );
     }
 

--- a/examples/coding-cli/src/session_log.rs
+++ b/examples/coding-cli/src/session_log.rs
@@ -15,14 +15,20 @@
 // Concerns explicitly handled below:
 // * 0o600 file mode on Unix (owner-only): session logs contain prompts,
 //   tool arguments, and tool output.
-// * Replay only keeps event types we can reconstruct into messages
-//   (`input.message`, `output.message.completed`, `tool.completed`).
+// * Replay keeps event types that (a) round-trip into the conversation
+//   (`input.message`, `output.message.completed`, `tool.completed`) and
+//   (b) the agent needs to restore the live transcript view and provider
+//   continuation state on resume (`reason.completed`, `reason.item`).
 //   Streaming `*.delta` events have no replay value and would otherwise
 //   inflate the log O(n²) for long streamed responses.
-// * Assistant `thinking` / `thinking_signature` fields are stripped before
-//   JSONL persistence. The CLI keeps the live runtime event unchanged, but
-//   session logs are user-facing durable history and must not expose hidden
-//   model reasoning material.
+// * Assistant `thinking` / `thinking_signature` fields ARE persisted in
+//   ercode's per-session JSONL. The per-session folder is the local
+//   private session store (0o600 on Unix) and provider continuation on
+//   resume requires the signature/encrypted_content (e.g. OpenAI
+//   Responses threads the encrypted reasoning context back via
+//   `thinking_signature`). The contract is local-store, not user-facing
+//   transcript export — see the coding-cli README for the public/private
+//   distinction.
 // * Replay rejects events whose `session_id` doesn't match the resumed
 //   session — guards against accidentally merging logs across sessions.
 // * On open, if the file does not end with `\n` (previous run crashed
@@ -45,9 +51,9 @@ use chrono::Utc;
 use everruns_core::error::{AgentLoopError, Result};
 use everruns_core::events::{
     Event, EventData, EventRequest, INPUT_MESSAGE, OUTPUT_MESSAGE_COMPLETED,
-    OutputMessageCompletedData, TOOL_COMPLETED,
+    OutputMessageCompletedData, REASON_COMPLETED, REASON_ITEM, TOOL_COMPLETED,
 };
-use everruns_core::message::{ContentPart, Message, MessageRole};
+use everruns_core::message::{ContentPart, Message};
 use everruns_core::tools::ToolResultImage;
 use everruns_core::traits::EventEmitter;
 use everruns_core::typed_id::EventId;
@@ -183,15 +189,21 @@ pub fn replay(path: &Path, expected: SessionId) -> Result<ReplayedSession> {
     Ok(out)
 }
 
-/// Event types that are useful to keep on disk: they're the ones replay
-/// can map back into the conversation. Everything else (streaming
-/// `*.delta`, `*.started`, lifecycle, etc.) adds bytes without adding
-/// resume value, and the delta types in particular bloat the log
-/// O(n²) since each delta carries the accumulated text so far.
+/// Event types that are useful to keep on disk: those that replay can map
+/// back into the conversation (`input.message`, `output.message.completed`,
+/// `tool.completed`) plus the agent reasoning artifacts the CLI uses to
+/// restore the live transcript view and provider continuation state on
+/// resume (`reason.completed` carries the safe `text_preview` narration,
+/// `reason.item` carries opaque/encrypted reasoning context curated by the
+/// provider). Streaming `*.delta` events and pure lifecycle markers
+/// (`reason.started`, `reason.thinking.*`, `output.message.started`) are
+/// dropped — they are live status signals only and the delta types would
+/// bloat the log O(n²) since each delta carries the accumulated text so
+/// far.
 fn is_replay_relevant(event_type: &str) -> bool {
     matches!(
         event_type,
-        INPUT_MESSAGE | OUTPUT_MESSAGE_COMPLETED | TOOL_COMPLETED
+        INPUT_MESSAGE | OUTPUT_MESSAGE_COMPLETED | TOOL_COMPLETED | REASON_COMPLETED | REASON_ITEM
     )
 }
 
@@ -321,8 +333,14 @@ impl EventEmitter for JsonlEventEmitter {
         self.events.write().await.push(event.clone());
 
         if is_replay_relevant(&event.event_type) {
-            let persisted_event = event_for_session_log(&event);
-            let line = serde_json::to_string(&persisted_event).map_err(|e| {
+            // ercode's per-session JSONL is the local session store; we
+            // persist `thinking` / `thinking_signature` and opaque
+            // `reason.item` content as-is so provider continuation
+            // (e.g. OpenAI Responses replays encrypted reasoning via
+            // `thinking_signature`) works after `--session <id>` resume.
+            // Privacy lives in the 0o600 file mode and per-user
+            // platform data dir, not in field stripping.
+            let line = serde_json::to_string(&event).map_err(|e| {
                 AgentLoopError::config(format!("serialize event for session log: {e}"))
             })?;
             let mut file = self.file.lock().await;
@@ -332,21 +350,6 @@ impl EventEmitter for JsonlEventEmitter {
                 .map_err(|e| AgentLoopError::config(format!("flush session log: {e}")))?;
         }
         Ok(event)
-    }
-}
-
-fn event_for_session_log(event: &Event) -> Event {
-    let mut persisted = event.clone();
-    if let EventData::OutputMessageCompleted(data) = &mut persisted.data {
-        strip_hidden_thinking(&mut data.message);
-    }
-    persisted
-}
-
-fn strip_hidden_thinking(message: &mut Message) {
-    if message.role == MessageRole::Agent {
-        message.thinking = None;
-        message.thinking_signature = None;
     }
 }
 
@@ -541,7 +544,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn output_message_thinking_is_not_written_to_session_log() {
+    async fn output_message_thinking_is_persisted_for_provider_continuation() {
+        // ercode's per-session JSONL is the local session store: thinking
+        // and thinking_signature must round-trip so providers that thread
+        // encrypted reasoning context back (e.g. OpenAI Responses via
+        // `thinking_signature`) can continue across `--session <id>` resume.
         let dir = tempfile::tempdir().expect("tempdir");
         let session_id = SessionId::from_seed(4821);
         let session_dir = session_dir_path(dir.path(), session_id);
@@ -561,28 +568,122 @@ mod tests {
 
         let on_disk = std::fs::read_to_string(&path).expect("read");
         assert!(
-            !on_disk.contains("private model reasoning"),
-            "session log must not persist assistant thinking: {on_disk}"
+            on_disk.contains("private model reasoning"),
+            "session log must persist assistant thinking for restore: {on_disk}"
         );
         assert!(
-            !on_disk.contains("thinking_signature"),
-            "session log must not persist thinking signatures: {on_disk}"
+            on_disk.contains("encrypted-thinking-token"),
+            "session log must persist thinking_signature for provider continuation: {on_disk}"
         );
+
         let replayed = replay(&path, session_id).expect("replay");
         let replayed_message = replayed.messages.first().expect("message replayed");
-        assert!(replayed_message.thinking.is_none());
-        assert!(replayed_message.thinking_signature.is_none());
+        assert_eq!(
+            replayed_message.thinking.as_deref(),
+            Some("private model reasoning")
+        );
+        assert_eq!(
+            replayed_message.thinking_signature.as_deref(),
+            Some("encrypted-thinking-token")
+        );
+    }
 
-        let collected = emitter.collected_events().await;
-        match &collected[0].data {
-            EventData::OutputMessageCompleted(data) => {
+    #[tokio::test]
+    async fn reason_completed_event_is_persisted_and_replayed() {
+        use everruns_core::events::ReasonCompletedData;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let session_id = SessionId::from_seed(4822);
+        let session_dir = session_dir_path(dir.path(), session_id);
+        let path = session_log_path(&session_dir);
+        let emitter = JsonlEventEmitter::open(&path, 1).expect("open");
+
+        let req = EventRequest::new(
+            session_id,
+            EventContext::default(),
+            ReasonCompletedData::success("Will read the lib.rs file", true, 1, Some(120), None),
+        );
+        emitter.emit(req).await.expect("emit");
+
+        let on_disk = std::fs::read_to_string(&path).expect("read");
+        assert!(
+            on_disk.contains("\"reason.completed\""),
+            "reason.completed should be persisted to JSONL: {on_disk}"
+        );
+        assert!(
+            on_disk.contains("Will read the lib.rs file"),
+            "text_preview narration should round-trip on disk: {on_disk}"
+        );
+
+        let replayed = replay(&path, session_id).expect("replay");
+        assert_eq!(replayed.events.len(), 1);
+        match &replayed.events[0].data {
+            EventData::ReasonCompleted(data) => {
                 assert_eq!(
-                    data.message.thinking.as_deref(),
-                    Some("private model reasoning")
+                    data.text_preview.as_deref(),
+                    Some("Will read the lib.rs file")
                 );
+                assert!(data.has_tool_calls);
+                assert_eq!(data.tool_call_count, 1);
             }
-            other => panic!("unexpected event data: {other:?}"),
+            other => panic!("expected ReasonCompleted, got {other:?}"),
         }
+        // reason.completed is not a conversation message — it must not
+        // pollute the replayed messages vec.
+        assert!(replayed.messages.is_empty());
+    }
+
+    #[tokio::test]
+    async fn reason_item_event_is_persisted_and_replayed() {
+        use everruns_core::events::ReasonItemData;
+        use everruns_core::typed_id::TurnId;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let session_id = SessionId::from_seed(4823);
+        let session_dir = session_dir_path(dir.path(), session_id);
+        let path = session_log_path(&session_dir);
+        let emitter = JsonlEventEmitter::open(&path, 1).expect("open");
+
+        let req = EventRequest::new(
+            session_id,
+            EventContext::default(),
+            ReasonItemData {
+                turn_id: TurnId::new(),
+                provider: "openai".to_string(),
+                model: Some("gpt-5".to_string()),
+                item_id: "rs_abc123".to_string(),
+                encrypted_content: Some("opaque-encrypted-blob".to_string()),
+                summary: vec!["Considered file structure.".to_string()],
+                token_count: Some(42),
+            },
+        );
+        emitter.emit(req).await.expect("emit");
+
+        let on_disk = std::fs::read_to_string(&path).expect("read");
+        assert!(
+            on_disk.contains("\"reason.item\""),
+            "reason.item should be persisted: {on_disk}"
+        );
+        assert!(
+            on_disk.contains("opaque-encrypted-blob"),
+            "encrypted_content must round-trip for provider continuation: {on_disk}"
+        );
+
+        let replayed = replay(&path, session_id).expect("replay");
+        assert_eq!(replayed.events.len(), 1);
+        match &replayed.events[0].data {
+            EventData::ReasonItem(data) => {
+                assert_eq!(data.provider, "openai");
+                assert_eq!(data.item_id, "rs_abc123");
+                assert_eq!(
+                    data.encrypted_content.as_deref(),
+                    Some("opaque-encrypted-blob")
+                );
+                assert_eq!(data.summary, vec!["Considered file structure.".to_string()]);
+            }
+            other => panic!("expected ReasonItem, got {other:?}"),
+        }
+        assert!(replayed.messages.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
Closes EVE-499.

## What
Flip ercode's per-session JSONL persistence contract so the local
session store retains every artifact `--session <id>` resume needs:
reasoning events (`reason.completed`, `reason.item`) and the
`thinking` / `thinking_signature` fields on assistant messages are now
persisted, and the ercode UI renders `ReasonItem.summary` segments
alongside the existing pre-tool-call `ReasonCompleted.text_preview`
narration.

## Why
The previous contract dropped reasoning events as lifecycle noise and
stripped `thinking` / `thinking_signature` from `OutputMessageCompleted`
before writing to JSONL, on the (now obsolete) framing that session
logs were user-facing durable history. That broke two flows:

1. **Provider continuation on resume.** OpenAI Responses threads its
   encrypted reasoning context back into the next turn via the
   assistant message's `thinking_signature` (rebuilt as a `Reasoning`
   input item). After resume, the stripped field meant the encrypted
   continuation was lost, so the next turn started without the
   reasoning chain the model expected.
2. **Restored transcript review.** Resumed sessions only showed tool
   calls — pre-tool-call narration was gone because `reason.completed`
   was filtered out before disk, and OpenAI Responses provider
   summaries (`reason.item.summary`) were never persisted or rendered.

The per-session folder is owner-only (0o600 on Unix) under the
platform user-data dir. Treating that local store as the right home
for these artifacts is exactly the local-vs-public distinction EVE-499
asks for.

## How
- `examples/coding-cli/src/session_log.rs`:
  - `is_replay_relevant` now keeps `REASON_COMPLETED` and `REASON_ITEM`
    alongside the existing message/tool event triple. Streaming
    `*.delta` events and pure lifecycle markers stay filtered out
    (O(n²) bloat and no resume value).
  - Removed `event_for_session_log` / `strip_hidden_thinking` —
    `OutputMessageCompleted.message.thinking` and `thinking_signature`
    now round-trip on disk so providers can replay them.
  - Header comment block documents the local-store contract and the
    public/private split.
- `examples/coding-cli/src/app.rs`:
  - `lines_for_event` gains a `ReasonItem` arm that renders non-empty
    `summary` segments as assistant chat lines (live and on replay via
    `lines_for_replayed_event` fallthrough). `ReasonCompleted`
    narration rendering is unchanged — the existing has_tool_calls
    gate prevents duplication with the final assistant message.
- `examples/coding-cli/README.md`: updated the "Session persistence"
  and "Sensitivity" sections to reflect what is persisted and why.

## Risk
Low. Backwards-compatible on the read side: pre-change JSONL files
(no reasoning events, stripped thinking) replay exactly as before —
the new fields simply remain `None`. New sessions write a strict
superset of the previous content. No schema migration, no API or
crate boundary touched. Only the ercode example binary is affected.

## Security
- Threat categories reviewed: TM-FS, TM-LLM.
- TM-FS: The persisted artifacts (encrypted reasoning blobs, thinking
  signatures, plaintext thinking, summary text) land in the per-session
  folder created with `0o600` on Unix under the platform user-data dir.
  No new file path, no new write surface; only the byte content widens.
  The README "Sensitivity" section was updated to flag these contents
  explicitly so operators understand what is now stored.
- TM-LLM: Reasoning artifacts are local-only — never sent to a
  different provider, never reflected back into prompts on the same
  turn they arrived. On resume, the only consumer is the existing
  OpenAI Responses request builder, which already accepts
  `thinking_signature` as `encrypted_content` — no new attack surface
  in the prompt construction path.
- No new `THREAT` comments needed (no new mitigation contracts beyond
  the file-mode protection already documented).
- No changes to `specs/threat-model.md` required.

## Validation
- `cargo test -p everruns-coding-cli --bin ercode` — 55 passed, 0
  failed (includes 3 new session_log tests and 1 new app test).
- `cargo clippy -p everruns-coding-cli --all-targets -- -D warnings` — clean.
- `cargo fmt --check` — clean.
- Targeted tests added:
  - `output_message_thinking_is_persisted_for_provider_continuation`
    (inverts the previous strip-on-write expectation, asserts both
    `thinking` and `thinking_signature` round-trip through emit →
    JSONL → `replay`).
  - `reason_completed_event_is_persisted_and_replayed` (verifies
    `text_preview` and `tool_call_count` survive the round trip and
    that the event does not pollute the replayed messages vec).
  - `reason_item_event_is_persisted_and_replayed` (verifies opaque
    `encrypted_content`, provider/model metadata, and summary segments
    round-trip).
  - `lines_for_event_renders_reason_item_summary_segments` (UI render
    of the new `ReasonItem` arm; verifies blank segments are dropped
    and surrounding whitespace is trimmed).
- Smoke testing the full TUI flow end-to-end requires an LLM API key
  and a tool-calling turn that drives `reason.item` emission; that's
  out of scope here. The unit tests cover both ends of the resume
  data flow (emit → JSONL → replay → events → UI render) and the
  runtime code that emits these events is unchanged — this PR only
  changes which events the ercode persistence layer filters in and out.

## Follow-ups
No follow-ups. Acceptance criteria covered:
- ercode renders pre-tool-call narration (`ReasonCompleted.text_preview`)
  and provider summaries (`ReasonItem.summary`).
- Live status for `reason.started`, `reason.thinking.started`,
  `output.message.started`, tool lifecycle, and turn failure/cancel was
  already wired in `status_for_event` and is unchanged.
- Persisted event set now includes reasoning summaries, opaque/encrypted
  reasoning context, and thinking signatures.
- Local privacy protection preserved (`0o600` on the JSONL on Unix; no
  change to file mode or path).
- Spec/docs updated (`examples/coding-cli/README.md`; the
  module-level comment in `session_log.rs` is the durable contract for
  ercode-specific persistence and was rewritten to match).

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (read path unchanged; write
      path is a strict superset)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (no review yet)

---
_Generated by [Claude Code](https://claude.ai/code/session_019AF2AijuVn6cBkWpruUNGF)_