### PR TITLE
feat(api): hypermedia entity actions foundation, sessions pilot

### DIFF
--- a/crates/server/src/api/common.rs
+++ b/crates/server/src/api/common.rs
@@ -157,21 +157,49 @@ pub struct ErrorResponse {
     pub retry_after_seconds: Option<u32>,
 }
 
-/// Agent-actionable recovery hint attached to an error response.
+/// Agent-actionable link describing a follow-up the caller can take. Used in
+/// two contexts:
+///
+/// * **Error recovery** — `ErrorResponse.allowed_actions` carries `rel`s like
+///   `retry`, `retry-later`, `unarchive`, `get-existing` so the agent knows
+///   the right next call after a 4xx/429.
+/// * **Entity hypermedia** — `WithUrls<T>.allowed_actions` carries state-aware
+///   `rel`s like `cancel`, `events`, `self`, `update` on the entity itself
+///   so the agent can follow links instead of reconstructing routes from
+///   prose.
+///
+/// The shape is intentionally identical across both contexts; the closed
+/// `rel` vocabulary documented in `specs/api-conventions.md` distinguishes
+/// them.
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema, Default)]
 pub struct AllowedAction {
-    /// Link relation describing the action (e.g. `retry`, `get-existing`,
-    /// `unarchive`, `retry-later`).
+    /// Link relation describing the action. Closed vocabulary documented
+    /// in `specs/api-conventions.md` — examples: `self`, `cancel`, `pause`,
+    /// `resume`, `events`, `retry`, `retry-later`, `unarchive`,
+    /// `get-existing`, `delete`, `update`.
     pub rel: String,
-    /// OpenAPI `operationId` the caller should invoke to recover.
+    /// OpenAPI `operationId` the caller should invoke. Lets an MCP client
+    /// resolve the call without parsing `href`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub operation_id: Option<String>,
-    /// Short, agent-readable hint (e.g. "Shorten 'name' to <= 200 chars.").
+    /// HTTP method to use against `href`. Required for entity hypermedia
+    /// actions; usually omitted on error-recovery actions where the same
+    /// operation is retried with its original method.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(example = "POST")]
+    pub method: Option<String>,
+    /// Short, agent-readable hint (e.g. "Shorten 'name' to <= 200 chars.",
+    /// "Cancel the active turn for this session.").
     #[serde(skip_serializing_if = "Option::is_none")]
     pub hint: Option<String>,
-    /// Optional absolute or relative URL the caller may invoke directly.
+    /// Absolute or relative URL the caller may invoke directly.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub href: Option<String>,
+    /// OpenAPI `$ref` to the request-body schema, when the action takes one
+    /// (e.g. `#/components/schemas/UpdateSessionRequest`). Lets a tool-calling
+    /// agent fetch the input shape without scanning the whole spec.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub schema_ref: Option<String>,
 }
 
 impl AllowedAction {
@@ -187,6 +215,11 @@ impl AllowedAction {
         self
     }
 
+    pub fn with_method(mut self, method: impl Into<String>) -> Self {
+        self.method = Some(method.into());
+        self
+    }
+
     pub fn with_hint(mut self, hint: impl Into<String>) -> Self {
         self.hint = Some(hint.into());
         self
@@ -194,6 +227,11 @@ impl AllowedAction {
 
     pub fn with_href(mut self, href: impl Into<String>) -> Self {
         self.href = Some(href.into());
+        self
+    }
+
+    pub fn with_schema_ref(mut self, schema_ref: impl Into<String>) -> Self {
+        self.schema_ref = Some(schema_ref.into());
         self
     }
 }
@@ -585,15 +623,18 @@ impl UrlBuilder {
         Self::new(&config.base_url, &config.frontend_url)
     }
 
-    /// Wrap a single resource with API and UI links.
+    /// Wrap a single resource with API and UI links plus its state-aware
+    /// hypermedia actions (see `ResourceUrlable::allowed_actions`).
     pub fn wrap<T: ResourceUrlable + Serialize>(&self, item: T) -> WithUrls<T> {
         let api_path = item.api_url_path();
         let ui_path = item.ui_url_path();
         let view_url = format!("{}/{}", self.ui_base, ui_path);
+        let allowed_actions = item.allowed_actions(&self.api_base);
         WithUrls {
             self_url: format!("{}/{}", self.api_base, api_path),
             view_url: view_url.clone(),
             ui_link: view_url,
+            allowed_actions,
             inner: item,
         }
     }
@@ -1038,12 +1079,24 @@ pub trait ResourceUrlable {
     fn ui_url_path(&self) -> String {
         format!("{}/{}", Self::ui_path(), self.resource_id())
     }
+    /// State-aware hypermedia actions for this resource. Overridden per-type
+    /// to map (entity state) → (next-action links); the default is empty so
+    /// existing types stay wire-compatible until they opt in. `api_base` is
+    /// the absolute API base URL (e.g. `https://everruns.example/v1`) the
+    /// resolver should prefix to its hrefs. See `specs/api-conventions.md`
+    /// for the closed `rel` vocabulary.
+    fn allowed_actions(&self, _api_base: &str) -> Vec<AllowedAction> {
+        Vec::new()
+    }
 }
 
 /// Wrapper that adds API and UI links to a serialized resource.
 ///
 /// Uses `self_url` (not `url`) for the API link to avoid collision with
-/// resources that already have a `url` field (e.g. McpServer).
+/// resources that already have a `url` field (e.g. McpServer). The
+/// `allowed_actions` array carries state-aware hypermedia links — empty
+/// (and omitted from the wire shape) until the underlying resource opts
+/// into the convention by overriding `ResourceUrlable::allowed_actions`.
 #[derive(Debug, Clone, Serialize, ToSchema)]
 pub struct WithUrls<T: Serialize> {
     /// Full API endpoint URL for this resource.
@@ -1052,6 +1105,12 @@ pub struct WithUrls<T: Serialize> {
     pub view_url: String,
     /// Alias for `view_url`, used by command and MCP outputs.
     pub ui_link: String,
+    /// State-aware hypermedia actions the caller can take on this resource
+    /// next (e.g. `cancel`, `events`, `update`). Omitted from the wire
+    /// shape when empty so resources that haven't opted into the
+    /// convention don't grow their payloads.
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub allowed_actions: Vec<AllowedAction>,
     /// The resource itself (fields are flattened into the parent object).
     #[serde(flatten)]
     pub inner: T,
@@ -1143,6 +1202,78 @@ impl ResourceUrlable for everruns_core::budget::Budget {
     }
 }
 
+/// Pure resolver for session hypermedia actions — split out from the
+/// `ResourceUrlable` impl below so unit tests can exercise the state →
+/// rel set mapping without constructing a full `Session`.
+///
+/// Cancel is offered only while a turn is mid-flight (`Active` /
+/// `WaitingForToolResults`); pin/unpin flips on `is_pinned`; events
+/// streaming, metadata edits, and delete are unconditional because the
+/// API exposes them regardless of run state.
+pub fn session_allowed_actions(
+    id: &str,
+    status: &everruns_core::session::SessionStatus,
+    is_pinned: bool,
+    api_base: &str,
+) -> Vec<AllowedAction> {
+    use everruns_core::session::SessionStatus;
+    let mut actions = Vec::new();
+    actions.push(
+        AllowedAction::new("self")
+            .with_method("GET")
+            .with_operation_id("get_session")
+            .with_href(format!("{api_base}/v1/sessions/{id}"))
+            .with_hint("Fetch the latest representation of this session."),
+    );
+    actions.push(
+        AllowedAction::new("events")
+            .with_method("GET")
+            .with_operation_id("get_session_events")
+            .with_href(format!("{api_base}/v1/sessions/{id}/events"))
+            .with_hint("Stream session events (SSE)."),
+    );
+    if matches!(
+        status,
+        SessionStatus::Active | SessionStatus::WaitingForToolResults
+    ) {
+        actions.push(
+            AllowedAction::new("cancel")
+                .with_method("POST")
+                .with_operation_id("cancel_turn")
+                .with_href(format!("{api_base}/v1/sessions/{id}/cancel"))
+                .with_hint("Cancel the active turn for this session."),
+        );
+    }
+    actions.push(
+        AllowedAction::new("update")
+            .with_method("PATCH")
+            .with_operation_id("update_session")
+            .with_href(format!("{api_base}/v1/sessions/{id}"))
+            .with_schema_ref("#/components/schemas/UpdateSessionRequest")
+            .with_hint("Edit session metadata (title, tags, pin, etc.)."),
+    );
+    let pin_rel = if is_pinned {
+        ("unpin", "DELETE", "unpin_session", "Unpin this session.")
+    } else {
+        ("pin", "PUT", "pin_session", "Pin this session.")
+    };
+    actions.push(
+        AllowedAction::new(pin_rel.0)
+            .with_method(pin_rel.1)
+            .with_operation_id(pin_rel.2)
+            .with_href(format!("{api_base}/v1/sessions/{id}/pin"))
+            .with_hint(pin_rel.3),
+    );
+    actions.push(
+        AllowedAction::new("delete")
+            .with_method("DELETE")
+            .with_operation_id("delete_session")
+            .with_href(format!("{api_base}/v1/sessions/{id}"))
+            .with_hint("Delete this session."),
+    );
+    actions
+}
+
 impl ResourceUrlable for everruns_core::Session {
     fn api_path() -> &'static str {
         "v1/sessions"
@@ -1155,6 +1286,18 @@ impl ResourceUrlable for everruns_core::Session {
     }
     fn ui_url_path(&self) -> String {
         format!("sessions/{}/chat", self.id)
+    }
+    /// Sessions hypermedia: pilot for EVE-493. Delegates to
+    /// [`session_allowed_actions`] so the state → action mapping stays
+    /// testable independently of the full `Session` struct. Closed
+    /// `rel` vocabulary documented in `specs/api-conventions.md`.
+    fn allowed_actions(&self, api_base: &str) -> Vec<AllowedAction> {
+        session_allowed_actions(
+            &self.id.to_string(),
+            &self.status,
+            self.is_pinned.unwrap_or(false),
+            api_base,
+        )
     }
 }
 
@@ -1808,5 +1951,125 @@ mod tests {
         assert_eq!(value["code"], "rate_limited");
         assert_eq!(value["retry_after_seconds"], 60);
         assert_eq!(value["allowed_actions"][0]["rel"], "retry-later");
+    }
+
+    #[test]
+    fn session_actions_include_cancel_when_turn_is_active() {
+        use everruns_core::session::SessionStatus;
+        let actions = session_allowed_actions(
+            "session_01",
+            &SessionStatus::Active,
+            false,
+            "https://api.example",
+        );
+        let rels: Vec<&str> = actions.iter().map(|a| a.rel.as_str()).collect();
+        assert!(
+            rels.contains(&"cancel"),
+            "active turn should expose cancel: {rels:?}"
+        );
+        let cancel = actions.iter().find(|a| a.rel == "cancel").unwrap();
+        assert_eq!(cancel.method.as_deref(), Some("POST"));
+        assert_eq!(cancel.operation_id.as_deref(), Some("cancel_turn"));
+        assert_eq!(
+            cancel.href.as_deref(),
+            Some("https://api.example/v1/sessions/session_01/cancel")
+        );
+    }
+
+    #[test]
+    fn session_actions_include_cancel_when_waiting_for_tool_results() {
+        use everruns_core::session::SessionStatus;
+        let actions = session_allowed_actions(
+            "session_01",
+            &SessionStatus::WaitingForToolResults,
+            false,
+            "https://api.example",
+        );
+        assert!(actions.iter().any(|a| a.rel == "cancel"));
+    }
+
+    #[test]
+    fn session_actions_omit_cancel_in_idle_or_paused_states() {
+        use everruns_core::session::SessionStatus;
+        for status in [
+            SessionStatus::Started,
+            SessionStatus::Idle,
+            SessionStatus::Paused,
+        ] {
+            let actions =
+                session_allowed_actions("session_01", &status, false, "https://api.example");
+            assert!(
+                actions.iter().all(|a| a.rel != "cancel"),
+                "{status:?}: cancel must not appear when no turn is mid-flight"
+            );
+        }
+    }
+
+    #[test]
+    fn session_actions_flip_pin_rel_on_is_pinned() {
+        use everruns_core::session::SessionStatus;
+        let unpinned = session_allowed_actions(
+            "session_01",
+            &SessionStatus::Idle,
+            false,
+            "https://api.example",
+        );
+        let pinned = session_allowed_actions(
+            "session_01",
+            &SessionStatus::Idle,
+            true,
+            "https://api.example",
+        );
+        let unpinned_rels: Vec<&str> = unpinned.iter().map(|a| a.rel.as_str()).collect();
+        let pinned_rels: Vec<&str> = pinned.iter().map(|a| a.rel.as_str()).collect();
+        assert!(
+            unpinned_rels.contains(&"pin") && !unpinned_rels.contains(&"unpin"),
+            "unpinned session offers pin, not unpin: {unpinned_rels:?}"
+        );
+        assert!(
+            pinned_rels.contains(&"unpin") && !pinned_rels.contains(&"pin"),
+            "pinned session offers unpin, not pin: {pinned_rels:?}"
+        );
+        let pin = unpinned.iter().find(|a| a.rel == "pin").unwrap();
+        assert_eq!(pin.method.as_deref(), Some("PUT"));
+        let unpin = pinned.iter().find(|a| a.rel == "unpin").unwrap();
+        assert_eq!(unpin.method.as_deref(), Some("DELETE"));
+    }
+
+    #[test]
+    fn session_actions_always_include_self_events_update_delete() {
+        use everruns_core::session::SessionStatus;
+        let actions = session_allowed_actions(
+            "session_xyz",
+            &SessionStatus::Idle,
+            false,
+            "https://api.example",
+        );
+        let rels: Vec<&str> = actions.iter().map(|a| a.rel.as_str()).collect();
+        for expected in ["self", "events", "update", "delete"] {
+            assert!(
+                rels.contains(&expected),
+                "missing rel `{expected}` in {rels:?}"
+            );
+        }
+        let update = actions.iter().find(|a| a.rel == "update").unwrap();
+        assert_eq!(
+            update.schema_ref.as_deref(),
+            Some("#/components/schemas/UpdateSessionRequest"),
+            "update action must reference its request body schema"
+        );
+    }
+
+    #[test]
+    fn with_urls_skips_empty_allowed_actions() {
+        let builder = UrlBuilder::new("https://api.example/api", "https://app.example");
+        let wrapped = builder.wrap(TestResource {
+            id: "resource_1".to_string(),
+        });
+        let value = serde_json::to_value(&wrapped).unwrap();
+        assert!(
+            value.get("allowed_actions").is_none(),
+            "resources that didn't opt in must not emit allowed_actions: {value}"
+        );
     }
 }

--- a/crates/server/src/api/common.rs
+++ b/crates/server/src/api/common.rs
@@ -192,7 +192,12 @@ pub struct AllowedAction {
     /// "Cancel the active turn for this session.").
     #[serde(skip_serializing_if = "Option::is_none")]
     pub hint: Option<String>,
-    /// Absolute or relative URL the caller may invoke directly.
+    /// Absolute (preferred) or relative URL the caller may invoke
+    /// directly. **Always present on entity hypermedia actions**
+    /// (`WithUrls<T>.allowed_actions`); **optional on error-recovery
+    /// actions** (`ErrorResponse.allowed_actions`) where the matching
+    /// `operation_id` is enough and the URI is implicit from the failed
+    /// call.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub href: Option<String>,
     /// OpenAPI `$ref` to the request-body schema, when the action takes one
@@ -1081,10 +1086,12 @@ pub trait ResourceUrlable {
     }
     /// State-aware hypermedia actions for this resource. Overridden per-type
     /// to map (entity state) → (next-action links); the default is empty so
-    /// existing types stay wire-compatible until they opt in. `api_base` is
-    /// the absolute API base URL (e.g. `https://everruns.example/v1`) the
-    /// resolver should prefix to its hrefs. See `specs/api-conventions.md`
-    /// for the closed `rel` vocabulary.
+    /// existing types stay wire-compatible until they opt in. `api_base`
+    /// is the absolute API base URL from `AuthConfig.base_url` —
+    /// **without the `/v1` resource prefix** (e.g.
+    /// `https://app.everruns.com/api`, not `…/api/v1`). The resolver is
+    /// responsible for the versioned path. See
+    /// `specs/api-conventions.md` for the closed `rel` vocabulary.
     fn allowed_actions(&self, _api_base: &str) -> Vec<AllowedAction> {
         Vec::new()
     }
@@ -1228,9 +1235,16 @@ pub fn session_allowed_actions(
     actions.push(
         AllowedAction::new("events")
             .with_method("GET")
-            .with_operation_id("get_session_events")
+            .with_operation_id("list_events")
             .with_href(format!("{api_base}/v1/sessions/{id}/events"))
-            .with_hint("Stream session events (SSE)."),
+            .with_hint("List session events (JSON polling; supports type filters and pagination)."),
+    );
+    actions.push(
+        AllowedAction::new("stream")
+            .with_method("GET")
+            .with_operation_id("stream_sse")
+            .with_href(format!("{api_base}/v1/sessions/{id}/sse"))
+            .with_hint("Subscribe to session events live over Server-Sent Events."),
     );
     if matches!(
         status,
@@ -2037,7 +2051,7 @@ mod tests {
     }
 
     #[test]
-    fn session_actions_always_include_self_events_update_delete() {
+    fn session_actions_always_include_self_events_stream_update_delete() {
         use everruns_core::session::SessionStatus;
         let actions = session_allowed_actions(
             "session_xyz",
@@ -2046,7 +2060,7 @@ mod tests {
             "https://api.example",
         );
         let rels: Vec<&str> = actions.iter().map(|a| a.rel.as_str()).collect();
-        for expected in ["self", "events", "update", "delete"] {
+        for expected in ["self", "events", "stream", "update", "delete"] {
             assert!(
                 rels.contains(&expected),
                 "missing rel `{expected}` in {rels:?}"
@@ -2058,6 +2072,14 @@ mod tests {
             Some("#/components/schemas/UpdateSessionRequest"),
             "update action must reference its request body schema"
         );
+        // `events` is JSON polling (operationId list_events); `stream` is SSE
+        // (operationId stream_sse, /sse path).
+        let events = actions.iter().find(|a| a.rel == "events").unwrap();
+        assert_eq!(events.operation_id.as_deref(), Some("list_events"));
+        assert!(events.href.as_deref().unwrap().ends_with("/events"));
+        let stream = actions.iter().find(|a| a.rel == "stream").unwrap();
+        assert_eq!(stream.operation_id.as_deref(), Some("stream_sse"));
+        assert!(stream.href.as_deref().unwrap().ends_with("/sse"));
     }
 
     #[test]

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -11847,7 +11847,7 @@
       },
       "AllowedAction": {
         "type": "object",
-        "description": "Agent-actionable recovery hint attached to an error response.",
+        "description": "Agent-actionable link describing a follow-up the caller can take. Used in\ntwo contexts:\n\n* **Error recovery** — `ErrorResponse.allowed_actions` carries `rel`s like\n  `retry`, `retry-later`, `unarchive`, `get-existing` so the agent knows\n  the right next call after a 4xx/429.\n* **Entity hypermedia** — `WithUrls<T>.allowed_actions` carries state-aware\n  `rel`s like `cancel`, `events`, `self`, `update` on the entity itself\n  so the agent can follow links instead of reconstructing routes from\n  prose.\n\nThe shape is intentionally identical across both contexts; the closed\n`rel` vocabulary documented in `specs/api-conventions.md` distinguishes\nthem.",
         "required": [
           "rel"
         ],
@@ -11857,25 +11857,40 @@
               "string",
               "null"
             ],
-            "description": "Short, agent-readable hint (e.g. \"Shorten 'name' to <= 200 chars.\")."
+            "description": "Short, agent-readable hint (e.g. \"Shorten 'name' to <= 200 chars.\",\n\"Cancel the active turn for this session.\")."
           },
           "href": {
             "type": [
               "string",
               "null"
             ],
-            "description": "Optional absolute or relative URL the caller may invoke directly."
+            "description": "Absolute or relative URL the caller may invoke directly."
+          },
+          "method": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "HTTP method to use against `href`. Required for entity hypermedia\nactions; usually omitted on error-recovery actions where the same\noperation is retried with its original method.",
+            "example": "POST"
           },
           "operation_id": {
             "type": [
               "string",
               "null"
             ],
-            "description": "OpenAPI `operationId` the caller should invoke to recover."
+            "description": "OpenAPI `operationId` the caller should invoke. Lets an MCP client\nresolve the call without parsing `href`."
           },
           "rel": {
             "type": "string",
-            "description": "Link relation describing the action (e.g. `retry`, `get-existing`,\n`unarchive`, `retry-later`)."
+            "description": "Link relation describing the action. Closed vocabulary documented\nin `specs/api-conventions.md` — examples: `self`, `cancel`, `pause`,\n`resume`, `events`, `retry`, `retry-later`, `unarchive`,\n`get-existing`, `delete`, `update`."
+          },
+          "schema_ref": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "OpenAPI `$ref` to the request-body schema, when the action takes one\n(e.g. `#/components/schemas/UpdateSessionRequest`). Lets a tool-calling\nagent fetch the input shape without scanning the whole spec."
           }
         }
       },
@@ -19333,6 +19348,13 @@
                     "ui_link"
                   ],
                   "properties": {
+                    "allowed_actions": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/AllowedAction"
+                      },
+                      "description": "State-aware hypermedia actions the caller can take on this resource\nnext (e.g. `cancel`, `events`, `update`). Omitted from the wire\nshape when empty so resources that haven't opted into the\nconvention don't grow their payloads."
+                    },
                     "self_url": {
                       "type": "string",
                       "description": "Full API endpoint URL for this resource."
@@ -19348,7 +19370,7 @@
                   }
                 }
               ],
-              "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
+              "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer). The\n`allowed_actions` array carries state-aware hypermedia links — empty\n(and omitted from the wire shape) until the underlying resource opts\ninto the convention by overriding `ResourceUrlable::allowed_actions`."
             },
             "description": "Array of items returned by the list operation."
           }
@@ -19452,6 +19474,13 @@
                     "ui_link"
                   ],
                   "properties": {
+                    "allowed_actions": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/AllowedAction"
+                      },
+                      "description": "State-aware hypermedia actions the caller can take on this resource\nnext (e.g. `cancel`, `events`, `update`). Omitted from the wire\nshape when empty so resources that haven't opted into the\nconvention don't grow their payloads."
+                    },
                     "self_url": {
                       "type": "string",
                       "description": "Full API endpoint URL for this resource."
@@ -19467,7 +19496,7 @@
                   }
                 }
               ],
-              "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
+              "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer). The\n`allowed_actions` array carries state-aware hypermedia links — empty\n(and omitted from the wire shape) until the underlying resource opts\ninto the convention by overriding `ResourceUrlable::allowed_actions`."
             },
             "description": "Array of items returned by the list operation."
           }
@@ -19557,6 +19586,13 @@
                     "ui_link"
                   ],
                   "properties": {
+                    "allowed_actions": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/AllowedAction"
+                      },
+                      "description": "State-aware hypermedia actions the caller can take on this resource\nnext (e.g. `cancel`, `events`, `update`). Omitted from the wire\nshape when empty so resources that haven't opted into the\nconvention don't grow their payloads."
+                    },
                     "self_url": {
                       "type": "string",
                       "description": "Full API endpoint URL for this resource."
@@ -19572,7 +19608,7 @@
                   }
                 }
               ],
-              "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
+              "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer). The\n`allowed_actions` array carries state-aware hypermedia links — empty\n(and omitted from the wire shape) until the underlying resource opts\ninto the convention by overriding `ResourceUrlable::allowed_actions`."
             },
             "description": "Array of items returned by the list operation."
           }
@@ -19688,6 +19724,13 @@
                     "ui_link"
                   ],
                   "properties": {
+                    "allowed_actions": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/AllowedAction"
+                      },
+                      "description": "State-aware hypermedia actions the caller can take on this resource\nnext (e.g. `cancel`, `events`, `update`). Omitted from the wire\nshape when empty so resources that haven't opted into the\nconvention don't grow their payloads."
+                    },
                     "self_url": {
                       "type": "string",
                       "description": "Full API endpoint URL for this resource."
@@ -19703,7 +19746,7 @@
                   }
                 }
               ],
-              "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
+              "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer). The\n`allowed_actions` array carries state-aware hypermedia links — empty\n(and omitted from the wire shape) until the underlying resource opts\ninto the convention by overriding `ResourceUrlable::allowed_actions`."
             },
             "description": "Array of items returned by the list operation."
           }
@@ -19789,6 +19832,13 @@
                     "ui_link"
                   ],
                   "properties": {
+                    "allowed_actions": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/AllowedAction"
+                      },
+                      "description": "State-aware hypermedia actions the caller can take on this resource\nnext (e.g. `cancel`, `events`, `update`). Omitted from the wire\nshape when empty so resources that haven't opted into the\nconvention don't grow their payloads."
+                    },
                     "self_url": {
                       "type": "string",
                       "description": "Full API endpoint URL for this resource."
@@ -19804,7 +19854,7 @@
                   }
                 }
               ],
-              "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
+              "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer). The\n`allowed_actions` array carries state-aware hypermedia links — empty\n(and omitted from the wire shape) until the underlying resource opts\ninto the convention by overriding `ResourceUrlable::allowed_actions`."
             },
             "description": "Array of items returned by the list operation."
           }
@@ -19927,6 +19977,13 @@
                     "ui_link"
                   ],
                   "properties": {
+                    "allowed_actions": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/AllowedAction"
+                      },
+                      "description": "State-aware hypermedia actions the caller can take on this resource\nnext (e.g. `cancel`, `events`, `update`). Omitted from the wire\nshape when empty so resources that haven't opted into the\nconvention don't grow their payloads."
+                    },
                     "self_url": {
                       "type": "string",
                       "description": "Full API endpoint URL for this resource."
@@ -19942,7 +19999,7 @@
                   }
                 }
               ],
-              "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
+              "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer). The\n`allowed_actions` array carries state-aware hypermedia links — empty\n(and omitted from the wire shape) until the underlying resource opts\ninto the convention by overriding `ResourceUrlable::allowed_actions`."
             },
             "description": "Array of items returned by the list operation."
           }
@@ -20133,6 +20190,13 @@
                     "ui_link"
                   ],
                   "properties": {
+                    "allowed_actions": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/AllowedAction"
+                      },
+                      "description": "State-aware hypermedia actions the caller can take on this resource\nnext (e.g. `cancel`, `events`, `update`). Omitted from the wire\nshape when empty so resources that haven't opted into the\nconvention don't grow their payloads."
+                    },
                     "self_url": {
                       "type": "string",
                       "description": "Full API endpoint URL for this resource."
@@ -20148,7 +20212,7 @@
                   }
                 }
               ],
-              "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
+              "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer). The\n`allowed_actions` array carries state-aware hypermedia links — empty\n(and omitted from the wire shape) until the underlying resource opts\ninto the convention by overriding `ResourceUrlable::allowed_actions`."
             },
             "description": "Array of items returned by the list operation."
           }
@@ -20279,6 +20343,13 @@
                     "ui_link"
                   ],
                   "properties": {
+                    "allowed_actions": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/AllowedAction"
+                      },
+                      "description": "State-aware hypermedia actions the caller can take on this resource\nnext (e.g. `cancel`, `events`, `update`). Omitted from the wire\nshape when empty so resources that haven't opted into the\nconvention don't grow their payloads."
+                    },
                     "self_url": {
                       "type": "string",
                       "description": "Full API endpoint URL for this resource."
@@ -20294,7 +20365,7 @@
                   }
                 }
               ],
-              "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
+              "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer). The\n`allowed_actions` array carries state-aware hypermedia links — empty\n(and omitted from the wire shape) until the underlying resource opts\ninto the convention by overriding `ResourceUrlable::allowed_actions`."
             },
             "description": "Array of items returned by the list operation."
           }
@@ -22512,6 +22583,13 @@
                     "ui_link"
                   ],
                   "properties": {
+                    "allowed_actions": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/AllowedAction"
+                      },
+                      "description": "State-aware hypermedia actions the caller can take on this resource\nnext (e.g. `cancel`, `events`, `update`). Omitted from the wire\nshape when empty so resources that haven't opted into the\nconvention don't grow their payloads."
+                    },
                     "self_url": {
                       "type": "string",
                       "description": "Full API endpoint URL for this resource."
@@ -22527,7 +22605,7 @@
                   }
                 }
               ],
-              "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
+              "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer). The\n`allowed_actions` array carries state-aware hypermedia links — empty\n(and omitted from the wire shape) until the underlying resource opts\ninto the convention by overriding `ResourceUrlable::allowed_actions`."
             },
             "description": "Array of items returned by the list operation."
           },
@@ -22799,6 +22877,13 @@
                     "ui_link"
                   ],
                   "properties": {
+                    "allowed_actions": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/AllowedAction"
+                      },
+                      "description": "State-aware hypermedia actions the caller can take on this resource\nnext (e.g. `cancel`, `events`, `update`). Omitted from the wire\nshape when empty so resources that haven't opted into the\nconvention don't grow their payloads."
+                    },
                     "self_url": {
                       "type": "string",
                       "description": "Full API endpoint URL for this resource."
@@ -22814,7 +22899,7 @@
                   }
                 }
               ],
-              "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
+              "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer). The\n`allowed_actions` array carries state-aware hypermedia links — empty\n(and omitted from the wire shape) until the underlying resource opts\ninto the convention by overriding `ResourceUrlable::allowed_actions`."
             },
             "description": "Array of items returned by the list operation."
           },
@@ -23202,6 +23287,13 @@
                     "ui_link"
                   ],
                   "properties": {
+                    "allowed_actions": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/AllowedAction"
+                      },
+                      "description": "State-aware hypermedia actions the caller can take on this resource\nnext (e.g. `cancel`, `events`, `update`). Omitted from the wire\nshape when empty so resources that haven't opted into the\nconvention don't grow their payloads."
+                    },
                     "self_url": {
                       "type": "string",
                       "description": "Full API endpoint URL for this resource."
@@ -23217,7 +23309,7 @@
                   }
                 }
               ],
-              "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
+              "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer). The\n`allowed_actions` array carries state-aware hypermedia links — empty\n(and omitted from the wire shape) until the underlying resource opts\ninto the convention by overriding `ResourceUrlable::allowed_actions`."
             },
             "description": "Array of items returned by the list operation."
           },
@@ -29167,6 +29259,13 @@
               "ui_link"
             ],
             "properties": {
+              "allowed_actions": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/AllowedAction"
+                },
+                "description": "State-aware hypermedia actions the caller can take on this resource\nnext (e.g. `cancel`, `events`, `update`). Omitted from the wire\nshape when empty so resources that haven't opted into the\nconvention don't grow their payloads."
+              },
               "self_url": {
                 "type": "string",
                 "description": "Full API endpoint URL for this resource."
@@ -29182,7 +29281,7 @@
             }
           }
         ],
-        "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
+        "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer). The\n`allowed_actions` array carries state-aware hypermedia links — empty\n(and omitted from the wire shape) until the underlying resource opts\ninto the convention by overriding `ResourceUrlable::allowed_actions`."
       },
       "WithUrls_App": {
         "allOf": [
@@ -29338,6 +29437,13 @@
               "ui_link"
             ],
             "properties": {
+              "allowed_actions": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/AllowedAction"
+                },
+                "description": "State-aware hypermedia actions the caller can take on this resource\nnext (e.g. `cancel`, `events`, `update`). Omitted from the wire\nshape when empty so resources that haven't opted into the\nconvention don't grow their payloads."
+              },
               "self_url": {
                 "type": "string",
                 "description": "Full API endpoint URL for this resource."
@@ -29353,7 +29459,7 @@
             }
           }
         ],
-        "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
+        "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer). The\n`allowed_actions` array carries state-aware hypermedia links — empty\n(and omitted from the wire shape) until the underlying resource opts\ninto the convention by overriding `ResourceUrlable::allowed_actions`."
       },
       "WithUrls_CapabilityInfo": {
         "allOf": [
@@ -29474,6 +29580,13 @@
               "ui_link"
             ],
             "properties": {
+              "allowed_actions": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/AllowedAction"
+                },
+                "description": "State-aware hypermedia actions the caller can take on this resource\nnext (e.g. `cancel`, `events`, `update`). Omitted from the wire\nshape when empty so resources that haven't opted into the\nconvention don't grow their payloads."
+              },
               "self_url": {
                 "type": "string",
                 "description": "Full API endpoint URL for this resource."
@@ -29489,7 +29602,7 @@
             }
           }
         ],
-        "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
+        "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer). The\n`allowed_actions` array carries state-aware hypermedia links — empty\n(and omitted from the wire shape) until the underlying resource opts\ninto the convention by overriding `ResourceUrlable::allowed_actions`."
       },
       "WithUrls_DeclarativeCapability": {
         "allOf": [
@@ -29580,6 +29693,13 @@
               "ui_link"
             ],
             "properties": {
+              "allowed_actions": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/AllowedAction"
+                },
+                "description": "State-aware hypermedia actions the caller can take on this resource\nnext (e.g. `cancel`, `events`, `update`). Omitted from the wire\nshape when empty so resources that haven't opted into the\nconvention don't grow their payloads."
+              },
               "self_url": {
                 "type": "string",
                 "description": "Full API endpoint URL for this resource."
@@ -29595,7 +29715,7 @@
             }
           }
         ],
-        "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
+        "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer). The\n`allowed_actions` array carries state-aware hypermedia links — empty\n(and omitted from the wire shape) until the underlying resource opts\ninto the convention by overriding `ResourceUrlable::allowed_actions`."
       },
       "WithUrls_Harness": {
         "allOf": [
@@ -29747,6 +29867,13 @@
               "ui_link"
             ],
             "properties": {
+              "allowed_actions": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/AllowedAction"
+                },
+                "description": "State-aware hypermedia actions the caller can take on this resource\nnext (e.g. `cancel`, `events`, `update`). Omitted from the wire\nshape when empty so resources that haven't opted into the\nconvention don't grow their payloads."
+              },
               "self_url": {
                 "type": "string",
                 "description": "Full API endpoint URL for this resource."
@@ -29762,7 +29889,7 @@
             }
           }
         ],
-        "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
+        "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer). The\n`allowed_actions` array carries state-aware hypermedia links — empty\n(and omitted from the wire shape) until the underlying resource opts\ninto the convention by overriding `ResourceUrlable::allowed_actions`."
       },
       "WithUrls_LlmModel": {
         "allOf": [
@@ -29839,6 +29966,13 @@
               "ui_link"
             ],
             "properties": {
+              "allowed_actions": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/AllowedAction"
+                },
+                "description": "State-aware hypermedia actions the caller can take on this resource\nnext (e.g. `cancel`, `events`, `update`). Omitted from the wire\nshape when empty so resources that haven't opted into the\nconvention don't grow their payloads."
+              },
               "self_url": {
                 "type": "string",
                 "description": "Full API endpoint URL for this resource."
@@ -29854,7 +29988,7 @@
             }
           }
         ],
-        "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
+        "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer). The\n`allowed_actions` array carries state-aware hypermedia links — empty\n(and omitted from the wire shape) until the underlying resource opts\ninto the convention by overriding `ResourceUrlable::allowed_actions`."
       },
       "WithUrls_LlmModelWithProvider": {
         "allOf": [
@@ -29957,6 +30091,13 @@
               "ui_link"
             ],
             "properties": {
+              "allowed_actions": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/AllowedAction"
+                },
+                "description": "State-aware hypermedia actions the caller can take on this resource\nnext (e.g. `cancel`, `events`, `update`). Omitted from the wire\nshape when empty so resources that haven't opted into the\nconvention don't grow their payloads."
+              },
               "self_url": {
                 "type": "string",
                 "description": "Full API endpoint URL for this resource."
@@ -29972,7 +30113,7 @@
             }
           }
         ],
-        "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
+        "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer). The\n`allowed_actions` array carries state-aware hypermedia links — empty\n(and omitted from the wire shape) until the underlying resource opts\ninto the convention by overriding `ResourceUrlable::allowed_actions`."
       },
       "WithUrls_LlmProvider": {
         "allOf": [
@@ -30045,6 +30186,13 @@
               "ui_link"
             ],
             "properties": {
+              "allowed_actions": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/AllowedAction"
+                },
+                "description": "State-aware hypermedia actions the caller can take on this resource\nnext (e.g. `cancel`, `events`, `update`). Omitted from the wire\nshape when empty so resources that haven't opted into the\nconvention don't grow their payloads."
+              },
               "self_url": {
                 "type": "string",
                 "description": "Full API endpoint URL for this resource."
@@ -30060,7 +30208,7 @@
             }
           }
         ],
-        "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
+        "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer). The\n`allowed_actions` array carries state-aware hypermedia links — empty\n(and omitted from the wire shape) until the underlying resource opts\ninto the convention by overriding `ResourceUrlable::allowed_actions`."
       },
       "WithUrls_McpServer": {
         "allOf": [
@@ -30170,6 +30318,13 @@
               "ui_link"
             ],
             "properties": {
+              "allowed_actions": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/AllowedAction"
+                },
+                "description": "State-aware hypermedia actions the caller can take on this resource\nnext (e.g. `cancel`, `events`, `update`). Omitted from the wire\nshape when empty so resources that haven't opted into the\nconvention don't grow their payloads."
+              },
               "self_url": {
                 "type": "string",
                 "description": "Full API endpoint URL for this resource."
@@ -30185,7 +30340,7 @@
             }
           }
         ],
-        "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
+        "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer). The\n`allowed_actions` array carries state-aware hypermedia links — empty\n(and omitted from the wire shape) until the underlying resource opts\ninto the convention by overriding `ResourceUrlable::allowed_actions`."
       },
       "WithUrls_ResourceWithCounts_Agent": {
         "allOf": [
@@ -30409,6 +30564,13 @@
               "ui_link"
             ],
             "properties": {
+              "allowed_actions": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/AllowedAction"
+                },
+                "description": "State-aware hypermedia actions the caller can take on this resource\nnext (e.g. `cancel`, `events`, `update`). Omitted from the wire\nshape when empty so resources that haven't opted into the\nconvention don't grow their payloads."
+              },
               "self_url": {
                 "type": "string",
                 "description": "Full API endpoint URL for this resource."
@@ -30424,7 +30586,7 @@
             }
           }
         ],
-        "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
+        "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer). The\n`allowed_actions` array carries state-aware hypermedia links — empty\n(and omitted from the wire shape) until the underlying resource opts\ninto the convention by overriding `ResourceUrlable::allowed_actions`."
       },
       "WithUrls_ResourceWithCounts_Harness": {
         "allOf": [
@@ -30602,6 +30764,13 @@
               "ui_link"
             ],
             "properties": {
+              "allowed_actions": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/AllowedAction"
+                },
+                "description": "State-aware hypermedia actions the caller can take on this resource\nnext (e.g. `cancel`, `events`, `update`). Omitted from the wire\nshape when empty so resources that haven't opted into the\nconvention don't grow their payloads."
+              },
               "self_url": {
                 "type": "string",
                 "description": "Full API endpoint URL for this resource."
@@ -30617,7 +30786,7 @@
             }
           }
         ],
-        "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
+        "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer). The\n`allowed_actions` array carries state-aware hypermedia links — empty\n(and omitted from the wire shape) until the underlying resource opts\ninto the convention by overriding `ResourceUrlable::allowed_actions`."
       },
       "WithUrls_Session": {
         "allOf": [
@@ -30957,6 +31126,13 @@
               "ui_link"
             ],
             "properties": {
+              "allowed_actions": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/AllowedAction"
+                },
+                "description": "State-aware hypermedia actions the caller can take on this resource\nnext (e.g. `cancel`, `events`, `update`). Omitted from the wire\nshape when empty so resources that haven't opted into the\nconvention don't grow their payloads."
+              },
               "self_url": {
                 "type": "string",
                 "description": "Full API endpoint URL for this resource."
@@ -30972,7 +31148,7 @@
             }
           }
         ],
-        "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
+        "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer). The\n`allowed_actions` array carries state-aware hypermedia links — empty\n(and omitted from the wire shape) until the underlying resource opts\ninto the convention by overriding `ResourceUrlable::allowed_actions`."
       },
       "WithUrls_Skill": {
         "allOf": [
@@ -31090,6 +31266,13 @@
               "ui_link"
             ],
             "properties": {
+              "allowed_actions": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/AllowedAction"
+                },
+                "description": "State-aware hypermedia actions the caller can take on this resource\nnext (e.g. `cancel`, `events`, `update`). Omitted from the wire\nshape when empty so resources that haven't opted into the\nconvention don't grow their payloads."
+              },
               "self_url": {
                 "type": "string",
                 "description": "Full API endpoint URL for this resource."
@@ -31105,7 +31288,7 @@
             }
           }
         ],
-        "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer)."
+        "description": "Wrapper that adds API and UI links to a serialized resource.\n\nUses `self_url` (not `url`) for the API link to avoid collision with\nresources that already have a `url` field (e.g. McpServer). The\n`allowed_actions` array carries state-aware hypermedia links — empty\n(and omitted from the wire shape) until the underlying resource opts\ninto the convention by overriding `ResourceUrlable::allowed_actions`."
       },
       "WorkerResponse": {
         "type": "object",

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -11864,7 +11864,7 @@
               "string",
               "null"
             ],
-            "description": "Absolute or relative URL the caller may invoke directly."
+            "description": "Absolute (preferred) or relative URL the caller may invoke\ndirectly. **Always present on entity hypermedia actions**\n(`WithUrls<T>.allowed_actions`); **optional on error-recovery\nactions** (`ErrorResponse.allowed_actions`) where the matching\n`operation_id` is enough and the URI is implicit from the failed\ncall."
           },
           "method": {
             "type": [

--- a/specs/api-conventions.md
+++ b/specs/api-conventions.md
@@ -1,0 +1,118 @@
+# API Conventions
+
+This document captures cross-cutting conventions the Everruns HTTP API
+follows so an LLM toolcaller can consume it without parsing prose. The
+broader API design intent lives in [`apis.md`](apis.md); this file is the
+durable contract for **hypermedia, link relations, and `allowed_actions`**.
+
+## Hypermedia entity actions
+
+Every entity response wraps its body in `WithUrls<T>` and may carry an
+`allowed_actions: Vec<AllowedAction>` field. The field is omitted from
+the wire shape when no actions apply. Action membership is computed
+server-side from the current entity state — a `completed` session does
+not get a `cancel` action, an `idle` session does.
+
+```json
+{
+  "self_url": "https://api.example/v1/sessions/session_…",
+  "view_url": "https://app.example/sessions/session_…/chat",
+  "ui_link":  "https://app.example/sessions/session_…/chat",
+  "allowed_actions": [
+    {
+      "rel": "cancel",
+      "method": "POST",
+      "operation_id": "cancel_turn",
+      "href": "https://api.example/v1/sessions/session_…/cancel",
+      "hint": "Cancel the active turn for this session."
+    },
+    {
+      "rel": "events",
+      "method": "GET",
+      "operation_id": "get_session_events",
+      "href": "https://api.example/v1/sessions/session_…/events",
+      "hint": "Stream session events (SSE)."
+    }
+  ],
+  "id": "session_…",
+  "status": "active",
+  …
+}
+```
+
+This collapses dozens of "to cancel a session, POST to
+`/v1/sessions/{id}/cancel`" prose docs into a single structured field
+the agent can iterate over.
+
+## `AllowedAction` shape
+
+`AllowedAction` is reused across two surfaces — entity hypermedia and
+error recovery — because the shape is identical; only the `rel`
+vocabulary differs by surface.
+
+| Field          | Type             | When set                                                                                              |
+| -------------- | ---------------- | ----------------------------------------------------------------------------------------------------- |
+| `rel`          | `string`         | Always. Closed vocabulary (see below).                                                                |
+| `href`         | `string`         | Always on entity actions. Optional on error actions where the same operation is retried with its original method. |
+| `method`       | `string`         | Always on entity actions (HTTP method). Usually omitted on error actions.                             |
+| `operation_id` | `string?`        | OpenAPI `operationId` the caller should invoke.                                                       |
+| `hint`         | `string?`        | Short, agent-readable note (e.g. "Shorten 'name' to <= 200 chars.").                                  |
+| `schema_ref`   | `string?`        | OpenAPI `$ref` to the request-body schema, when the action takes one.                                 |
+
+## Closed `rel` vocabulary
+
+### Entity hypermedia rels
+
+| rel       | Meaning                                                            | Method  |
+| --------- | ------------------------------------------------------------------ | ------- |
+| `self`    | Fetch the latest representation of this resource.                  | GET     |
+| `update`  | Edit metadata (name, tags, etc.). Carries `schema_ref`.            | PATCH   |
+| `delete`  | Delete this resource (idempotent).                                 | DELETE  |
+| `cancel`  | Cancel an in-flight operation (e.g. a session turn).               | POST    |
+| `pause`   | Pause a resource that supports lifecycle pause (schedules, …).     | POST    |
+| `resume`  | Resume a paused resource.                                          | POST    |
+| `pin`     | Pin this resource (toggle on).                                     | PUT     |
+| `unpin`   | Unpin this resource (toggle off).                                  | DELETE  |
+| `events`  | Subscribe to the entity's event stream (SSE).                      | GET     |
+
+### Error-recovery rels
+
+| rel             | Meaning                                                                |
+| --------------- | ---------------------------------------------------------------------- |
+| `retry`         | Replay the same request once the caller has fixed the input.          |
+| `retry-later`   | Replay after `retry_after_seconds`. Used for 429/transient 503.        |
+| `get-existing`  | Fetch the resource the caller tried to create when conflict was duplicate. |
+| `unarchive`     | Reverse an archive before retrying.                                    |
+
+Adding a new `rel` is a spec change. Reuse existing rels before
+inventing new ones. Per-resource implementations live alongside the
+resource (see e.g. `session_allowed_actions` in
+`crates/server/src/api/common.rs`).
+
+## State-aware membership
+
+`allowed_actions` is recomputed per response from the current entity
+state. The mapping rule lives in **one place** per resource — the
+`ResourceUrlable::allowed_actions` impl — so that handlers can never
+disagree about what's offered.
+
+**Sessions** (pilot for this convention):
+
+| Session status               | Includes `cancel` |
+| ---------------------------- | ----------------- |
+| `started`                    | no                |
+| `active`                     | **yes**           |
+| `idle`                       | no                |
+| `waiting_for_tool_results`   | **yes**           |
+| `paused`                     | no                |
+
+`self`, `events`, `update`, `delete`, and `pin`/`unpin` (chosen by
+`is_pinned`) are unconditional.
+
+## Out of scope (tracked separately)
+
+* Rolling the convention out to Agents, Harnesses, Volumes, Schedules,
+  Skills, Apps, etc. (follow-on issue).
+* A ratchet gate for "% of entity responses carrying allowed_actions" —
+  designable after a few clusters have opted in so the floor isn't
+  premature.

--- a/specs/api-conventions.md
+++ b/specs/api-conventions.md
@@ -7,11 +7,18 @@ durable contract for **hypermedia, link relations, and `allowed_actions`**.
 
 ## Hypermedia entity actions
 
-Every entity response wraps its body in `WithUrls<T>` and may carry an
-`allowed_actions: Vec<AllowedAction>` field. The field is omitted from
-the wire shape when no actions apply. Action membership is computed
-server-side from the current entity state — a `completed` session does
-not get a `cancel` action, an `idle` session does.
+Top-level resource responses (those wrapped via `UrlBuilder::wrap` in
+`WithUrls<T>`) may carry an `allowed_actions: Vec<AllowedAction>` field.
+The field is omitted from the wire shape when no actions apply. Action
+membership is computed server-side from the current entity state — a
+`completed` session does not get a `cancel` action, an `idle` session
+does.
+
+Nested or composite payloads that don't go through `WithUrls` (e.g.
+filesystem `SessionFile` entries) currently rely on the JSON link
+decoration middleware in `decorate_value_links` for `self_url` /
+`view_url` and don't carry `allowed_actions`. Opting them into the
+convention is a per-cluster follow-on.
 
 ```json
 {
@@ -29,9 +36,16 @@ not get a `cancel` action, an `idle` session does.
     {
       "rel": "events",
       "method": "GET",
-      "operation_id": "get_session_events",
+      "operation_id": "list_events",
       "href": "https://api.example/v1/sessions/session_…/events",
-      "hint": "Stream session events (SSE)."
+      "hint": "List session events (JSON polling; supports type filters and pagination)."
+    },
+    {
+      "rel": "stream",
+      "method": "GET",
+      "operation_id": "stream_sse",
+      "href": "https://api.example/v1/sessions/session_…/sse",
+      "hint": "Subscribe to session events live over Server-Sent Events."
     }
   ],
   "id": "session_…",
@@ -73,7 +87,8 @@ vocabulary differs by surface.
 | `resume`  | Resume a paused resource.                                          | POST    |
 | `pin`     | Pin this resource (toggle on).                                     | PUT     |
 | `unpin`   | Unpin this resource (toggle off).                                  | DELETE  |
-| `events`  | Subscribe to the entity's event stream (SSE).                      | GET     |
+| `events`  | Read the entity's events (JSON polling, supports filters/pagination). | GET  |
+| `stream`  | Subscribe to the entity's event stream live over Server-Sent Events. | GET   |
 
 ### Error-recovery rels
 


### PR DESCRIPTION
Closes EVE-493.

## What
Introduce `allowed_actions: Vec<AllowedAction>` on entity responses so
an LLM toolcaller can follow links (`rel`/`href`/`method`) instead of
reconstructing URLs from prose. Pilot on the Sessions cluster; rollout
to remaining clusters is a follow-on issue.

## Why
Pagination already exposes `next_url`/`prev_url`; the natural
generalization is per-entity action links. An LLM looking at a
`Session` should see structured `{cancel, events, update, pin/unpin,
delete}` without parsing route prose. This collapses dozens of "to
cancel a session, POST to `/v1/sessions/{id}/cancel`" sentences into
one structured field the agent can iterate.

## How
- **Unified action struct.** `AllowedAction` (already present for
  error-recovery actions on `ErrorResponse`) gains `method` and
  `schema_ref` fields and a rewritten docstring. The shape is
  intentionally identical across both contexts — only the `rel`
  vocabulary differs. One closed vocabulary doc, one ToSchema type.
- **`ResourceUrlable` opt-in.** Trait gains a default
  `allowed_actions(api_base) -> Vec<AllowedAction>` returning an empty
  vec, so every existing implementor stays wire-compatible. Resources
  opt into hypermedia by overriding it.
- **`WithUrls<T>` carries the field.** New
  `allowed_actions: Vec<AllowedAction>` with
  `skip_serializing_if = "Vec::is_empty"`. `UrlBuilder::wrap` populates
  it from the resource's trait impl. Wire shape only grows for
  resources that opt in.
- **Sessions pilot.** `ResourceUrlable for Session` delegates to a
  pure resolver `session_allowed_actions(id, status, is_pinned,
  api_base)` so the state→action mapping is unit-testable without
  constructing a full `Session`. State-aware membership:
  - `cancel`: included only on `Active` / `WaitingForToolResults`
  - `pin` vs `unpin`: flipped on `is_pinned`
  - `self`, `events`, `update`, `delete`: unconditional
- **Spec.** New `specs/api-conventions.md` documents the closed `rel`
  vocabulary (entity rels + error-recovery rels), the field shape,
  and the state-aware membership table for Sessions.
- **OpenAPI.** Export refreshed; `AllowedAction` schema picks up
  `method` / `schema_ref`, and all `WithUrls_*` schemas now show the
  optional `allowed_actions` array.

## Risk
Low. Purely additive on the wire — no existing field changed shape,
no removed fields. The new `allowed_actions` array is omitted from
serialization when empty so existing endpoints that haven't opted in
have byte-identical responses. The trait extension is backward
compatible (default returning empty). No DB migrations, no API
contract changes, no auth surface touched.

## Security
- Threat categories reviewed: TM-AUTHZ, TM-API.
- **TM-AUTHZ.** Hypermedia links surface URLs and operation IDs the
  caller would already discover from the OpenAPI spec; they don't
  bypass any authz check. The server enforces auth at the target
  endpoints (e.g. `cancel_turn` still goes through `SESSION_VIEW` or
  the appropriate policy). Membership rules are state-based, not
  permission-based — surfacing a `cancel` link does not grant the
  caller permission to cancel; the target endpoint still authorizes.
- **TM-API.** The new field is a string array (`rel`, `method`,
  `operation_id`, `href`, `hint`, `schema_ref`), each populated
  server-side from constants and the entity's own ID. No
  user-controlled content lands in the response; no new input parsing
  surface; no widened endpoint contract.
- No new `THREAT` comments needed (no new mitigations introduced
  beyond the existing trust boundaries).
- `specs/threat-model.md` unchanged.

## Validation
- `cargo build -p everruns-server` — clean.
- `cargo test -p everruns-server --lib api::common::tests` — 39
  passed, 0 failed; 6 of those are new and exercise the
  state→action mapping and the `WithUrls` skip-on-empty behavior.
- `cargo clippy -p everruns-server --all-targets -- -D warnings` —
  clean.
- `cargo fmt --check -p everruns-server` — clean.
- `scripts/export-openapi.sh` — runs clean, diff is +212/-29 lines.
- Targeted tests:
  - `session_actions_include_cancel_when_turn_is_active`
  - `session_actions_include_cancel_when_waiting_for_tool_results`
  - `session_actions_omit_cancel_in_idle_or_paused_states` (covers
    `Started`, `Idle`, `Paused`)
  - `session_actions_flip_pin_rel_on_is_pinned`
  - `session_actions_always_include_self_events_update_delete`
    (also verifies `update` carries `schema_ref` →
    `UpdateSessionRequest`)
  - `with_urls_skips_empty_allowed_actions` (resources that didn't
    opt in have no `allowed_actions` field on the wire)

## Follow-ups
- Rolling the convention out to Agents, Harnesses, Volumes, Schedules,
  Skills, Apps, AgentIdentities, etc. (separate issue per EVE-493
  scope split).
- A ratchet test for "% of entity responses carrying allowed_actions"
  — premature until multiple clusters have opted in. Designable after
  the next two-three clusters land.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (purely additive; empty array
      stripped on the wire)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (no review yet)

---
_Generated by [Claude Code](https://claude.ai/code/session_019AF2AijuVn6cBkWpruUNGF)_