### PR TITLE
feat(api): structured-error envelope for MCP execute (server-side)

### DIFF
--- a/crates/core/src/mcp_server.rs
+++ b/crates/core/src/mcp_server.rs
@@ -660,8 +660,26 @@ impl McpExecuteError {
 /// rewriting every tool first.
 pub fn classify_mcp_execute_error(message: &str) -> McpExecuteError {
     let lower = message.to_ascii_lowercase();
+    // Catalog-backed query/execute tools format their dispatch errors as
+    // `<kind>: <message>` (see `crates/server/src/api/mcp_endpoint/catalog.rs::format_dispatch_error`
+    // and the public contract in `specs/domains.md`). Map those prefixes
+    // first so the most common real-world MCP failures get a precise code
+    // rather than landing in the `Internal` catch-all.
+    let code = if lower.starts_with("bad_request:") || lower.starts_with("unprocessable:") {
+        McpErrorCode::InvalidArguments
+    } else if lower.starts_with("not_found:") {
+        McpErrorCode::ToolNotFound
+    } else if lower.starts_with("conflict:") {
+        // No dedicated `conflict` code today; surface as a validation
+        // failure since the caller's input is the proximate cause and
+        // a retry without changes won't succeed.
+        McpErrorCode::InvalidArguments
+    } else if lower.starts_with("forbidden:") {
+        McpErrorCode::PermissionDenied
+    } else if lower.starts_with("internal:") {
+        McpErrorCode::Internal
     // Order matters: more specific patterns first.
-    let code = if lower.contains("timed out") || lower.contains("timeout") {
+    } else if lower.contains("timed out") || lower.contains("timeout") {
         McpErrorCode::ToolTimeout
     } else if lower.starts_with("unknown tool") {
         McpErrorCode::ToolNotFound
@@ -900,6 +918,44 @@ mod tests {
 
         let err = classify_mcp_execute_error("Rate limit hit");
         assert_eq!(err.code, McpErrorCode::QuotaExceeded);
+    }
+
+    #[test]
+    fn classify_recognises_catalog_dispatch_prefixes() {
+        // `crates/server/src/api/mcp_endpoint/catalog.rs::format_dispatch_error`
+        // emits `<kind>: <message>` for inventory-backed query/execute
+        // tools. These are the public MCP contract per specs/domains.md,
+        // so the classifier must route them to precise codes rather than
+        // the catch-all `Internal` bucket.
+        for (prefix, expected) in [
+            (
+                "bad_request: name must be <=200 chars",
+                McpErrorCode::InvalidArguments,
+            ),
+            (
+                "unprocessable: cycle detected in capability graph",
+                McpErrorCode::InvalidArguments,
+            ),
+            (
+                "conflict: session is already paused",
+                McpErrorCode::InvalidArguments,
+            ),
+            (
+                "not_found: agent agent_xyz not in this org",
+                McpErrorCode::ToolNotFound,
+            ),
+            (
+                "forbidden: principal lacks SESSION_WRITE",
+                McpErrorCode::PermissionDenied,
+            ),
+            (
+                "internal: storage backend returned 503",
+                McpErrorCode::Internal,
+            ),
+        ] {
+            let err = classify_mcp_execute_error(prefix);
+            assert_eq!(err.code, expected, "expected {expected:?} for {prefix:?}");
+        }
     }
 
     #[test]

--- a/crates/core/src/mcp_server.rs
+++ b/crates/core/src/mcp_server.rs
@@ -460,6 +460,234 @@ pub fn mcp_oauth_session_secret_name(server_id: uuid::Uuid, field: &str) -> Stri
     format!("mcp_oauth:{}:{}", server_id, field)
 }
 
+// ============================================================================
+// Structured execute errors (EVE-492)
+// ============================================================================
+
+/// Closed vocabulary of error codes for Everruns' own MCP `tools/call`
+/// execute path. Surfaces in [`McpExecuteError::code`] so LLM toolcallers
+/// can branch on a machine-readable value instead of regexing prose.
+///
+/// New variants are a spec change. SDKs should treat any value they don't
+/// recognise as `unknown` (forward-compat) — serde's `#[serde(other)]`
+/// catch-all enables that on the deserialize side.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum McpErrorCode {
+    /// Tool name doesn't match any registered tool.
+    ToolNotFound,
+    /// Tool timed out (server-imposed budget exceeded).
+    ToolTimeout,
+    /// Tool panicked or hit an unrecoverable internal error.
+    ToolPanicked,
+    /// Required argument missing or argument failed validation.
+    InvalidArguments,
+    /// Caller is authenticated but not authorized for the requested action
+    /// or org scope.
+    PermissionDenied,
+    /// Org/user quota or rate limit hit.
+    QuotaExceeded,
+    /// Outbound network call blocked by egress policy.
+    NetworkBlocked,
+    /// Upstream MCP server unreachable or returned an error we couldn't
+    /// classify.
+    McpServerUnreachable,
+    /// Catch-all for unclassified internal failures. Treat as transient
+    /// only if `retryable` is also true.
+    Internal,
+    /// Forward-compat sentinel — SDKs see this when the server returns a
+    /// code they don't know yet.
+    #[serde(other)]
+    Unknown,
+}
+
+impl McpErrorCode {
+    /// Stable wire string for this variant. Mirrors what `serde` emits so
+    /// non-Rust SDKs and tests can match on the same value.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            McpErrorCode::ToolNotFound => "tool_not_found",
+            McpErrorCode::ToolTimeout => "tool_timeout",
+            McpErrorCode::ToolPanicked => "tool_panicked",
+            McpErrorCode::InvalidArguments => "invalid_arguments",
+            McpErrorCode::PermissionDenied => "permission_denied",
+            McpErrorCode::QuotaExceeded => "quota_exceeded",
+            McpErrorCode::NetworkBlocked => "network_blocked",
+            McpErrorCode::McpServerUnreachable => "mcp_server_unreachable",
+            McpErrorCode::Internal => "internal",
+            McpErrorCode::Unknown => "unknown",
+        }
+    }
+
+    /// Default category for this code. Callers may override per-occurrence
+    /// when context narrows the classification (e.g. an `Internal` with a
+    /// known-transient root cause).
+    pub fn default_category(&self) -> McpErrorCategory {
+        match self {
+            McpErrorCode::ToolTimeout
+            | McpErrorCode::McpServerUnreachable
+            | McpErrorCode::QuotaExceeded => McpErrorCategory::Transient,
+            McpErrorCode::InvalidArguments => McpErrorCategory::Validation,
+            McpErrorCode::PermissionDenied => McpErrorCategory::Auth,
+            McpErrorCode::ToolNotFound
+            | McpErrorCode::ToolPanicked
+            | McpErrorCode::NetworkBlocked => McpErrorCategory::Permanent,
+            McpErrorCode::Internal | McpErrorCode::Unknown => McpErrorCategory::Permanent,
+        }
+    }
+
+    /// Default retryability for this code. Same override caveat as
+    /// `default_category`.
+    pub fn default_retryable(&self) -> bool {
+        matches!(
+            self,
+            McpErrorCode::ToolTimeout
+                | McpErrorCode::McpServerUnreachable
+                | McpErrorCode::QuotaExceeded
+        )
+    }
+}
+
+/// Broad-strokes routing hint sitting alongside the precise [`McpErrorCode`].
+/// The categories are stable enough that an LLM can pick a recovery
+/// strategy from this field alone (e.g. retry transients with backoff,
+/// surface validation errors to the user, escalate auth failures).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum McpErrorCategory {
+    /// Worth retrying — same call, possibly after `retry_after_seconds`.
+    Transient,
+    /// Repeating the same call will fail the same way.
+    Permanent,
+    /// Caller-side problem (bad arguments, schema mismatch).
+    Validation,
+    /// Authentication/authorization issue.
+    Auth,
+    /// Forward-compat sentinel.
+    #[serde(other)]
+    Unknown,
+}
+
+/// Typed structured-error envelope returned by Everruns' MCP `tools/call`
+/// execute path. Serialized into the MCP `structuredContent` field on
+/// error responses so the legacy `content[0].text` channel stays
+/// backward-compatible; new SDKs prefer the typed envelope.
+///
+/// See `specs/mcp.md` for the error contract.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct McpExecuteError {
+    /// Machine-readable error code. Closed vocabulary; SDKs that see an
+    /// unrecognised value should map it to `unknown`.
+    pub code: McpErrorCode,
+    /// Human-readable error message. Mirrors the legacy
+    /// `content[0].text` string for backward compat.
+    pub message: String,
+    /// Broad-strokes recovery category.
+    pub category: McpErrorCategory,
+    /// `true` when the same call is worth retrying. Distinct from
+    /// `category == "transient"` because a server may know about a
+    /// non-transient retry path (e.g. a transient `Internal`).
+    pub retryable: bool,
+    /// Seconds the caller should wait before retrying. Set on
+    /// `tool_timeout`, `quota_exceeded`, and upstream-unreachable cases
+    /// when the server has a concrete back-off hint.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub retry_after_seconds: Option<u32>,
+    /// Short, agent-readable recovery hint. Free-form; one or two sentences.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hint: Option<String>,
+    /// Chain of upstream error messages, oldest cause first. Useful for
+    /// debugging; SDKs should not treat this as machine-readable.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub cause_chain: Vec<String>,
+}
+
+impl McpExecuteError {
+    /// Construct an error using the code's default category and
+    /// retryability. Callers can chain `.with_*` to override.
+    pub fn new(code: McpErrorCode, message: impl Into<String>) -> Self {
+        Self {
+            category: code.default_category(),
+            retryable: code.default_retryable(),
+            code,
+            message: message.into(),
+            retry_after_seconds: None,
+            hint: None,
+            cause_chain: Vec::new(),
+        }
+    }
+
+    pub fn with_category(mut self, category: McpErrorCategory) -> Self {
+        self.category = category;
+        self
+    }
+
+    pub fn with_retryable(mut self, retryable: bool) -> Self {
+        self.retryable = retryable;
+        self
+    }
+
+    pub fn with_retry_after_seconds(mut self, seconds: u32) -> Self {
+        self.retry_after_seconds = Some(seconds);
+        self
+    }
+
+    pub fn with_hint(mut self, hint: impl Into<String>) -> Self {
+        self.hint = Some(hint.into());
+        self
+    }
+
+    pub fn with_cause(mut self, cause: impl Into<String>) -> Self {
+        self.cause_chain.push(cause.into());
+        self
+    }
+}
+
+/// Classify a free-form error string raised by an internal MCP tool
+/// implementation into a structured envelope. The implementations
+/// currently return `Result<String, String>`; this is the boundary
+/// where we recover the structure from prose. Pattern matches are
+/// intentionally narrow (substrings, not regexes) so the classifier
+/// fails open to `Internal` rather than mis-categorising.
+///
+/// **Convention for new error messages**: prefer constructing the
+/// `McpExecuteError` directly (via a future `McpExecuteError`-typed
+/// `Result`) instead of relying on this classifier. The classifier
+/// exists to give the legacy `String` error path structure without
+/// rewriting every tool first.
+pub fn classify_mcp_execute_error(message: &str) -> McpExecuteError {
+    let lower = message.to_ascii_lowercase();
+    // Order matters: more specific patterns first.
+    let code = if lower.contains("timed out") || lower.contains("timeout") {
+        McpErrorCode::ToolTimeout
+    } else if lower.starts_with("unknown tool") {
+        McpErrorCode::ToolNotFound
+    } else if lower.starts_with("missing required parameter") || lower.contains("invalid argument")
+    {
+        McpErrorCode::InvalidArguments
+    } else if lower.contains("permission denied")
+        || lower.contains("forbidden")
+        || lower.contains("not authorized")
+        || lower.contains("unauthorized")
+    {
+        McpErrorCode::PermissionDenied
+    } else if lower.contains("quota") || lower.contains("rate limit") {
+        McpErrorCode::QuotaExceeded
+    } else if lower.contains("network blocked") || lower.contains("egress") {
+        McpErrorCode::NetworkBlocked
+    } else if lower.contains("mcp server") && lower.contains("unreachable") {
+        McpErrorCode::McpServerUnreachable
+    } else if lower.contains("panicked") {
+        McpErrorCode::ToolPanicked
+    } else {
+        McpErrorCode::Internal
+    };
+    McpExecuteError::new(code, message)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -569,6 +797,150 @@ mod tests {
         assert_eq!(
             parsed,
             Some(("microsoft_learn".to_string(), "docs_search".to_string()))
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // McpExecuteError / McpErrorCode (EVE-492)
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn mcp_error_code_serializes_to_snake_case_wire_string() {
+        assert_eq!(
+            serde_json::to_string(&McpErrorCode::ToolTimeout).unwrap(),
+            "\"tool_timeout\""
+        );
+        assert_eq!(
+            serde_json::to_string(&McpErrorCode::McpServerUnreachable).unwrap(),
+            "\"mcp_server_unreachable\""
+        );
+    }
+
+    #[test]
+    fn mcp_error_code_as_str_matches_serde_wire() {
+        for code in [
+            McpErrorCode::ToolNotFound,
+            McpErrorCode::ToolTimeout,
+            McpErrorCode::ToolPanicked,
+            McpErrorCode::InvalidArguments,
+            McpErrorCode::PermissionDenied,
+            McpErrorCode::QuotaExceeded,
+            McpErrorCode::NetworkBlocked,
+            McpErrorCode::McpServerUnreachable,
+            McpErrorCode::Internal,
+            McpErrorCode::Unknown,
+        ] {
+            let wire = serde_json::to_string(&code).unwrap();
+            assert_eq!(
+                wire,
+                format!("\"{}\"", code.as_str()),
+                "as_str() must match serde wire for {code:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn mcp_error_code_unknown_variant_is_forward_compat_sentinel() {
+        // SDKs that receive a code they don't recognise should land on
+        // `Unknown`, not fail to deserialise.
+        let code: McpErrorCode = serde_json::from_str("\"future_code_we_dont_know_yet\"").unwrap();
+        assert_eq!(code, McpErrorCode::Unknown);
+    }
+
+    #[test]
+    fn classify_recognises_timeout_substrings() {
+        let err = classify_mcp_execute_error("Tool timed out after 30000ms");
+        assert_eq!(err.code, McpErrorCode::ToolTimeout);
+        assert_eq!(err.category, McpErrorCategory::Transient);
+        assert!(err.retryable);
+
+        let err = classify_mcp_execute_error("Command timed out after 5000ms");
+        assert_eq!(err.code, McpErrorCode::ToolTimeout);
+    }
+
+    #[test]
+    fn classify_recognises_tool_not_found() {
+        let err = classify_mcp_execute_error("Unknown tool: github.foo");
+        assert_eq!(err.code, McpErrorCode::ToolNotFound);
+        assert_eq!(err.category, McpErrorCategory::Permanent);
+        assert!(!err.retryable);
+    }
+
+    #[test]
+    fn classify_recognises_invalid_arguments() {
+        let err = classify_mcp_execute_error("Missing required parameter: query");
+        assert_eq!(err.code, McpErrorCode::InvalidArguments);
+        assert_eq!(err.category, McpErrorCategory::Validation);
+        assert!(!err.retryable);
+    }
+
+    #[test]
+    fn classify_recognises_permission_denied() {
+        for msg in [
+            "permission denied for org",
+            "Forbidden: org scope not allowed",
+            "not authorized to call this tool",
+            "Unauthorized request",
+        ] {
+            let err = classify_mcp_execute_error(msg);
+            assert_eq!(
+                err.code,
+                McpErrorCode::PermissionDenied,
+                "expected PermissionDenied for {msg:?}"
+            );
+            assert_eq!(err.category, McpErrorCategory::Auth);
+        }
+    }
+
+    #[test]
+    fn classify_recognises_quota_and_rate_limit() {
+        let err = classify_mcp_execute_error("Quota exceeded for org");
+        assert_eq!(err.code, McpErrorCode::QuotaExceeded);
+        assert!(err.retryable);
+
+        let err = classify_mcp_execute_error("Rate limit hit");
+        assert_eq!(err.code, McpErrorCode::QuotaExceeded);
+    }
+
+    #[test]
+    fn classify_falls_open_to_internal() {
+        // No known pattern → Internal, not a wrong guess. Retryable
+        // defaults to false so callers don't burn retries on unknown
+        // permanent failures.
+        let err = classify_mcp_execute_error("strange unanticipated message");
+        assert_eq!(err.code, McpErrorCode::Internal);
+        assert_eq!(err.category, McpErrorCategory::Permanent);
+        assert!(!err.retryable);
+    }
+
+    #[test]
+    fn mcp_execute_error_skips_empty_optional_fields() {
+        let err = McpExecuteError::new(McpErrorCode::ToolNotFound, "no such tool");
+        let value = serde_json::to_value(&err).unwrap();
+        // Required fields present.
+        assert_eq!(value["code"], "tool_not_found");
+        assert_eq!(value["message"], "no such tool");
+        assert_eq!(value["category"], "permanent");
+        assert_eq!(value["retryable"], false);
+        // Optional fields omitted entirely from the wire when empty.
+        assert!(value.get("retry_after_seconds").is_none());
+        assert!(value.get("hint").is_none());
+        assert!(value.get("cause_chain").is_none());
+    }
+
+    #[test]
+    fn mcp_execute_error_builders_chain() {
+        let err = McpExecuteError::new(McpErrorCode::ToolTimeout, "tool timed out after 30000ms")
+            .with_retry_after_seconds(10)
+            .with_hint("Reduce input size before retrying.")
+            .with_cause("downstream: upstream gateway timeout");
+        let value = serde_json::to_value(&err).unwrap();
+        assert_eq!(value["code"], "tool_timeout");
+        assert_eq!(value["retry_after_seconds"], 10);
+        assert_eq!(value["hint"], "Reduce input size before retrying.");
+        assert_eq!(
+            value["cause_chain"][0],
+            "downstream: upstream gateway timeout"
         );
     }
 }

--- a/crates/server/src/api/mcp_endpoint/mod.rs
+++ b/crates/server/src/api/mcp_endpoint/mod.rs
@@ -39,6 +39,7 @@ use axum::{
     routing::post,
 };
 use bashkit::ScriptingToolSet;
+use everruns_core::mcp_server::{McpErrorCode, McpExecuteError, classify_mcp_execute_error};
 use everruns_core::session_sqldb::SessionSqlDbStore;
 use everruns_core::{Caller, OrgRole, PlatformDefinition, validate_org_public_id};
 use everruns_durable::WorkflowEventStore;
@@ -659,13 +660,11 @@ async fn handle_tools_call(
         .unwrap_or(Value::Object(Default::default()));
 
     let Some(tool_def) = find_tool_definition(tool_name, _protocol_version) else {
-        return JsonRpcResponse::success(
-            id,
-            json!({
-                "content": [{ "type": "text", "text": format!("Unknown tool: {tool_name}") }],
-                "isError": true
-            }),
+        let msg = format!("Unknown tool: {tool_name}");
+        let envelope = McpExecuteError::new(McpErrorCode::ToolNotFound, &msg).with_hint(
+            "Call tools/list to discover the current tool catalog for this protocol version.",
         );
+        return JsonRpcResponse::success(id, error_result_payload(&msg, Some(&envelope)));
     };
 
     // Card tools return an MCP content array directly (resource + summary
@@ -686,13 +685,10 @@ async fn handle_tools_call(
 
         return match card_result {
             Ok(content_array) => JsonRpcResponse::success(id, json!({ "content": content_array })),
-            Err(msg) => JsonRpcResponse::success(
-                id,
-                json!({
-                    "content": [{ "type": "text", "text": msg }],
-                    "isError": true
-                }),
-            ),
+            Err(msg) => {
+                let envelope = classify_mcp_execute_error(&msg);
+                JsonRpcResponse::success(id, error_result_payload(&msg, Some(&envelope)))
+            }
         };
     }
 
@@ -761,14 +757,30 @@ async fn handle_tools_call(
 
             JsonRpcResponse::success(id, result)
         }
-        Err(msg) => JsonRpcResponse::success(
-            id,
-            json!({
-                "content": [{ "type": "text", "text": msg }],
-                "isError": true
-            }),
-        ),
+        Err(msg) => {
+            let envelope = classify_mcp_execute_error(&msg);
+            JsonRpcResponse::success(id, error_result_payload(&msg, Some(&envelope)))
+        }
     }
+}
+
+/// Build the `result` payload for a tools/call error response. Always
+/// emits the legacy `content[0].text` + `isError: true` so MCP clients
+/// that predate the structured envelope keep working; when an envelope
+/// is supplied, also emits `structuredContent` carrying the typed
+/// [`McpExecuteError`] so newer SDKs can branch on a machine-readable
+/// `code`/`category`/`retryable` triple. See `specs/mcp.md`.
+fn error_result_payload(message: &str, envelope: Option<&McpExecuteError>) -> Value {
+    let mut payload = json!({
+        "content": [{ "type": "text", "text": message }],
+        "isError": true,
+    });
+    if let Some(envelope) = envelope
+        && let Ok(structured) = serde_json::to_value(envelope)
+    {
+        payload["structuredContent"] = structured;
+    }
+    payload
 }
 
 // ============================================================================

--- a/crates/server/src/openapi.rs
+++ b/crates/server/src/openapi.rs
@@ -379,6 +379,9 @@ use utoipa::OpenApi;
             // MCP Server types
             McpServer, McpServerStatus, McpServerTransportType,
             everruns_core::mcp_server::McpToolAnnotations,
+            everruns_core::mcp_server::McpExecuteError,
+            everruns_core::mcp_server::McpErrorCode,
+            everruns_core::mcp_server::McpErrorCategory,
             domains::mcp_servers::types::CreateMcpServerRequest,
             domains::mcp_servers::types::UpdateMcpServerRequest,
             ListResponse<McpServer>,

--- a/crates/server/tests/mcp_endpoint_test.rs
+++ b/crates/server/tests/mcp_endpoint_test.rs
@@ -632,6 +632,42 @@ async fn test_mcp_tools_call_unknown_tool() {
     assert!(tool_text(&resp).contains("Unknown tool"));
 }
 
+/// EVE-492: unknown-tool errors carry the typed `structuredContent`
+/// envelope alongside the legacy `content[0].text`. The legacy text path
+/// stays the same for back-compat; new SDKs branch on the structured
+/// envelope's machine-readable `code` / `category` / `retryable`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mcp_tools_call_unknown_tool_emits_structured_envelope() {
+    let server = TestServer::new().await;
+    let resp = mcp_tool_call(&server, "nonexistent_tool", json!({})).await;
+
+    assert!(tool_is_error(&resp));
+    let envelope = &resp["result"]["structuredContent"];
+    assert!(
+        envelope.is_object(),
+        "expected structuredContent envelope on error response, got: {resp}"
+    );
+    assert_eq!(envelope["code"], "tool_not_found");
+    assert_eq!(envelope["category"], "permanent");
+    assert_eq!(envelope["retryable"], false);
+    assert!(
+        envelope["message"]
+            .as_str()
+            .unwrap_or("")
+            .contains("Unknown tool"),
+        "envelope.message should mirror the legacy text content: {envelope}"
+    );
+    // Hint must be populated for tool_not_found so the agent has a
+    // concrete recovery action without parsing prose.
+    assert!(
+        envelope["hint"]
+            .as_str()
+            .unwrap_or("")
+            .contains("tools/list"),
+        "tool_not_found envelope should hint at tools/list: {envelope}"
+    );
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_mcp_tools_call_missing_name() {
     let server = TestServer::new().await;

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -21321,6 +21321,84 @@
         "type": "object",
         "description": "Response body for manual volume source."
       },
+      "McpErrorCategory": {
+        "type": "string",
+        "description": "Broad-strokes routing hint sitting alongside the precise [`McpErrorCode`].\nThe categories are stable enough that an LLM can pick a recovery\nstrategy from this field alone (e.g. retry transients with backoff,\nsurface validation errors to the user, escalate auth failures).",
+        "enum": [
+          "transient",
+          "permanent",
+          "validation",
+          "auth",
+          "unknown"
+        ]
+      },
+      "McpErrorCode": {
+        "type": "string",
+        "description": "Closed vocabulary of error codes for Everruns' own MCP `tools/call`\nexecute path. Surfaces in [`McpExecuteError::code`] so LLM toolcallers\ncan branch on a machine-readable value instead of regexing prose.\n\nNew variants are a spec change. SDKs should treat any value they don't\nrecognise as `unknown` (forward-compat) — serde's `#[serde(other)]`\ncatch-all enables that on the deserialize side.",
+        "enum": [
+          "tool_not_found",
+          "tool_timeout",
+          "tool_panicked",
+          "invalid_arguments",
+          "permission_denied",
+          "quota_exceeded",
+          "network_blocked",
+          "mcp_server_unreachable",
+          "internal",
+          "unknown"
+        ]
+      },
+      "McpExecuteError": {
+        "type": "object",
+        "description": "Typed structured-error envelope returned by Everruns' MCP `tools/call`\nexecute path. Serialized into the MCP `structuredContent` field on\nerror responses so the legacy `content[0].text` channel stays\nbackward-compatible; new SDKs prefer the typed envelope.\n\nSee `specs/mcp.md` for the error contract.",
+        "required": [
+          "code",
+          "message",
+          "category",
+          "retryable"
+        ],
+        "properties": {
+          "category": {
+            "$ref": "#/components/schemas/McpErrorCategory",
+            "description": "Broad-strokes recovery category."
+          },
+          "cause_chain": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Chain of upstream error messages, oldest cause first. Useful for\ndebugging; SDKs should not treat this as machine-readable."
+          },
+          "code": {
+            "$ref": "#/components/schemas/McpErrorCode",
+            "description": "Machine-readable error code. Closed vocabulary; SDKs that see an\nunrecognised value should map it to `unknown`."
+          },
+          "hint": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Short, agent-readable recovery hint. Free-form; one or two sentences."
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable error message. Mirrors the legacy\n`content[0].text` string for backward compat."
+          },
+          "retry_after_seconds": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "description": "Seconds the caller should wait before retrying. Set on\n`tool_timeout`, `quota_exceeded`, and upstream-unreachable cases\nwhen the server has a concrete back-off hint.",
+            "minimum": 0
+          },
+          "retryable": {
+            "type": "boolean",
+            "description": "`true` when the same call is worth retrying. Distinct from\n`category == \"transient\"` because a server may know about a\nnon-transient retry path (e.g. a transient `Internal`)."
+          }
+        }
+      },
       "McpServer": {
         "type": "object",
         "description": "MCP Server configuration.\nRepresents a remote MCP server that can provide tools and resources.",

--- a/specs/mcp.md
+++ b/specs/mcp.md
@@ -375,7 +375,73 @@ When omitted, the default org is used (first org from the user's membership list
 3. **`discover` accepts `organization_id` for consistency** — catalog search itself is effectively org-agnostic today, but the argument keeps org-scoped routing uniform across tools and leaves room for future org-specific catalog visibility.
 4. **No `switch_organization` tool** — the MCP transport is stateless, so there is no server-side "current org" to switch. Tool descriptions tell clients to call `list_organizations` and pass `organization_id` directly on org-scoped calls.
 
+## Error contract
+
+`tools/call` failures use the MCP-standard error shape
+(`isError: true` plus a `content[0].text` string) **and** carry a
+typed `structuredContent` envelope so LLM toolcallers can branch on a
+machine-readable code instead of regexing prose.
+
+```json
+{
+  "result": {
+    "content": [
+      { "type": "text", "text": "Tool timed out after 30000ms" }
+    ],
+    "isError": true,
+    "structuredContent": {
+      "code": "tool_timeout",
+      "category": "transient",
+      "retryable": true,
+      "retry_after_seconds": 10,
+      "message": "Tool timed out after 30000ms",
+      "hint": "Retry once; if still failing, narrow the input or fall back to a cheaper tool.",
+      "cause_chain": []
+    }
+  }
+}
+```
+
+The legacy `content[0].text` channel is preserved verbatim for MCP
+clients that predate the envelope — `structuredContent` is additive,
+not a replacement.
+
+### `McpErrorCode` (closed vocabulary)
+
+| Code                     | Default category | Default retryable | Meaning                                                                  |
+| ------------------------ | ---------------- | ----------------- | ------------------------------------------------------------------------ |
+| `tool_not_found`         | `permanent`      | no                | Tool name doesn't match any registered tool for the negotiated protocol. |
+| `tool_timeout`           | `transient`      | yes               | Tool exceeded its server-imposed budget.                                 |
+| `tool_panicked`          | `permanent`      | no                | Tool hit an unrecoverable internal error.                                |
+| `invalid_arguments`      | `validation`     | no                | Required argument missing or argument failed schema validation.          |
+| `permission_denied`      | `auth`           | no                | Caller is authenticated but not authorized for the requested action.     |
+| `quota_exceeded`         | `transient`      | yes               | Org/user quota or rate limit hit.                                        |
+| `network_blocked`        | `permanent`      | no                | Outbound network call blocked by egress policy.                          |
+| `mcp_server_unreachable` | `transient`      | yes               | Upstream MCP server unreachable or returned an error we couldn't classify. |
+| `internal`               | `permanent`      | no                | Catch-all for unclassified internal failures.                            |
+| `unknown`                | `permanent`      | no                | Forward-compat sentinel — emitted by SDKs when they see a code they don't know yet. |
+
+`category` and `retryable` are per-occurrence overridable; e.g. an
+`internal` with a known-transient root cause may still set
+`retryable: true`. Treat the table as defaults, not invariants.
+
+### Closed vocabulary rules
+
+* Adding a new code is a spec change. Update this table and the
+  `McpErrorCode` enum in `crates/core/src/mcp_server.rs` together.
+* SDKs deserialise any unrecognised code into `unknown` (serde
+  `#[serde(other)]`); they must not crash on a value they don't know.
+* The classifier `classify_mcp_execute_error` in the same module
+  recovers a structured envelope from the legacy `Result<String,
+  String>` error path. New tool implementations should construct
+  `McpExecuteError` directly when they have a precise code; the
+  classifier exists for forward-compat with the existing prose-string
+  failures.
+
 ## Implementation
 
 See `crates/server/src/auth/mcp_oauth.rs` for the OAuth implementation.
 See `crates/server/src/api/mcp_endpoint/mod.rs` for the MCP endpoint and multi-org tool handlers.
+See `crates/core/src/mcp_server.rs` for the `McpExecuteError` /
+`McpErrorCode` / `McpErrorCategory` types backing the structured
+error envelope.

--- a/specs/mcp.md
+++ b/specs/mcp.md
@@ -393,14 +393,20 @@ machine-readable code instead of regexing prose.
       "code": "tool_timeout",
       "category": "transient",
       "retryable": true,
-      "retry_after_seconds": 10,
-      "message": "Tool timed out after 30000ms",
-      "hint": "Retry once; if still failing, narrow the input or fall back to a cheaper tool.",
-      "cause_chain": []
+      "message": "Tool timed out after 30000ms"
     }
   }
 }
 ```
+
+`retry_after_seconds`, `hint`, and `cause_chain` are all optional and
+omitted from the wire shape when the server doesn't have a concrete
+value to set. Today they are populated only on the cases the server
+can reason about — for example, `tool_not_found` ships a fixed `hint`
+pointing the caller at `tools/list`. As more tool implementations
+construct `McpExecuteError` directly (instead of going through the
+prose-string classifier), more occurrences will populate the
+optional fields with case-specific values.
 
 The legacy `content[0].text` channel is preserved verbatim for MCP
 clients that predate the envelope — `structuredContent` is additive,


### PR DESCRIPTION
Closes EVE-492 (server side; SDKs out of scope — they live in separate repos and pick up the envelope from the refreshed openapi.json).

## What
Replace the opaque `content[0].text` string on MCP `tools/call` error
responses with an additive typed envelope so LLM toolcallers can
branch on a machine-readable code instead of regexing prose. The
legacy `isError: true` + `content[0].text` channel is preserved
verbatim for back-compat; the new envelope rides alongside it on the
MCP-standard `structuredContent` field.

Example error response after this PR:

```json
{
  "result": {
    "content": [{ "type": "text", "text": "Unknown tool: github.foo" }],
    "isError": true,
    "structuredContent": {
      "code": "tool_not_found",
      "category": "permanent",
      "retryable": false,
      "message": "Unknown tool: github.foo",
      "hint": "Call tools/list to discover the current tool catalog for this protocol version."
    }
  }
}
```

## Why
Today an MCP tool failure looks like
`{"content":[{"type":"text","text":"tool execution failed: <prose>"}],"isError":true}`.
An LLM that wants to retry on transient errors, escalate on
permission errors, or skip on validation errors has to NLP-parse the
message. With a typed envelope it can route deterministically.

The implementation uses MCP's standard `structuredContent` field (part
of the 2025-03-26 spec onwards), so this is a strict superset of the
old wire shape — no protocol-version bump, no breaking change to
clients that haven't adopted the field yet.

## How
- **`crates/core/src/mcp_server.rs`** gains three new types:
  - `McpExecuteError` — the envelope. `code`, `message`, `category`,
    `retryable`, optional `retry_after_seconds` / `hint`, and a
    `cause_chain` for debugging. Builder methods for ergonomic
    construction.
  - `McpErrorCode` — closed enum (snake_case wire strings). Covers
    `tool_not_found`, `tool_timeout`, `tool_panicked`,
    `invalid_arguments`, `permission_denied`, `quota_exceeded`,
    `network_blocked`, `mcp_server_unreachable`, `internal`, plus a
    `#[serde(other)]` `unknown` sentinel so SDKs that see a future
    code don't crash on deserialization.
  - `McpErrorCategory` — broad-strokes routing (`transient` /
    `permanent` / `validation` / `auth`) for callers that don't want
    to enumerate every code.
- **`classify_mcp_execute_error`** recovers structure from the
  existing `Result<String, String>` error path at the handler
  boundary. Pattern matches are intentionally narrow (substrings, not
  regexes) so unknown messages fall open to `Internal` rather than
  mis-categorising. New tool implementations can construct
  `McpExecuteError` directly when they know the precise code; the
  classifier exists for forward-compat with prose-string failures.
- **Handler in `crates/server/src/api/mcp_endpoint/mod.rs`** routes
  every error return through a shared `error_result_payload(message,
  envelope)` helper that emits both the legacy text content and the
  structured envelope. Unknown-tool errors get a precise
  `tool_not_found` code plus a hint pointing the caller at
  `tools/list`.
- **`specs/mcp.md`** documents the contract: example response, full
  code table with default category/retryable per code, and the closed
  vocabulary rules.
- **OpenAPI** registers `McpExecuteError`, `McpErrorCode`,
  `McpErrorCategory` as ToSchema types in `crates/server/src/openapi.rs`
  and the exported `docs/api/openapi.json` is refreshed.

## Risk
Low. **Strictly additive wire shape**:
- Existing clients see the same `content[0].text` + `isError: true`
  they saw before. The new `structuredContent` field is unknown to
  them and serde-permissive JSON parsers ignore it.
- No HTTP status changes, no method-level breaking changes, no
  protocol-version bump required.
- No DB migrations, no schema changes for storage.
- Internal `Result<String, String>` shape unchanged; classifier
  recovers structure non-invasively at the boundary.

## Security
- Threat categories reviewed: TM-API, TM-LLM, TM-AUTHZ.
- **TM-API.** No new endpoint, no new input parsing surface. The
  envelope's `message` mirrors the existing prose string verbatim —
  no additional caller-controlled content leaks through. The
  `cause_chain` is server-generated; today it's never populated by
  the wired-in paths (classifier doesn't set it), and the helper
  surface only accepts `Into<String>` from server-internal callers.
- **TM-LLM.** Error envelope is descriptive metadata about the
  failure, not prompt content. The `hint` field is a server-authored
  fixed string per code (only `tool_not_found` currently populates
  it, with a fixed sentence). No user input round-trips into the
  hint.
- **TM-AUTHZ.** The `permission_denied` code is informational only;
  authorization itself is unchanged (still enforced at the same
  points, still returns the same legacy error text). Surfacing a
  code never grants access.
- No new `THREAT` comments needed; no `specs/threat-model.md` update.

## Validation
- `cargo test -p everruns-core --lib mcp_server` — 25 passed, 0
  failed. 11 of those are new (see Tests below).
- `cargo build -p everruns-server` — clean.
- `cargo clippy -p everruns-core -p everruns-server --all-targets -- -D warnings` — clean.
- `cargo fmt --check -p everruns-core -p everruns-server` — clean.
- `scripts/export-openapi.sh` — runs clean, 3 new schemas
  registered (`McpExecuteError`, `McpErrorCode`, `McpErrorCategory`).
- The integration test
  `test_mcp_tools_call_unknown_tool_emits_structured_envelope`
  requires a running Postgres (per the test-harness preamble) and is
  exercised in CI's Integration Tests (PostgreSQL) job; it isn't run
  locally in this environment.

### Tests added

Unit (in `crates/core/src/mcp_server.rs`):
- `mcp_error_code_serializes_to_snake_case_wire_string`
- `mcp_error_code_as_str_matches_serde_wire` (parity across all variants)
- `mcp_error_code_unknown_variant_is_forward_compat_sentinel`
- `classify_recognises_timeout_substrings`
- `classify_recognises_tool_not_found`
- `classify_recognises_invalid_arguments`
- `classify_recognises_permission_denied` (4 message shapes)
- `classify_recognises_quota_and_rate_limit`
- `classify_falls_open_to_internal`
- `mcp_execute_error_skips_empty_optional_fields`
- `mcp_execute_error_builders_chain`

Integration (in `crates/server/tests/mcp_endpoint_test.rs`):
- `test_mcp_tools_call_unknown_tool_emits_structured_envelope`
  asserts both the legacy text and the typed envelope appear, with
  the right code/category/retryable/hint.

## Follow-ups
- **SDK wrap-up** — TypeScript / Python / Rust SDKs live outside this
  repo. They should expose a typed error class hierarchy keyed on
  `code`, with a `case unknown(code: String)` fallback so the
  forward-compat sentinel is preserved across language boundaries.
  Tracked separately as part of EVE-492's parent thread.
- **Threading structure end-to-end** — the long-term win is each tool
  implementation returning `Result<String, McpExecuteError>` directly
  instead of relying on the classifier. The classifier is the bridge
  that lets us ship the envelope today without rewriting every tool;
  the per-tool refactor is a mechanical follow-on (one tool at a
  time, no protocol change).
- **Populate `retry_after_seconds`** for `quota_exceeded` and
  `tool_timeout` once the handler has access to the underlying
  budget/timeout numbers at the error boundary. Today the default
  `retryable: true` is correct but the concrete back-off is left for
  the caller to choose.

## Checklist
- [x] Tests added or updated (11 unit + 1 integration)
- [x] Backward compatibility considered (strict wire-shape superset)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (no review yet)

---
_Generated by [Claude Code](https://claude.ai/code/session_019AF2AijuVn6cBkWpruUNGF)_