### PR TITLE
docs(api): SSE event-type catalog in OpenAPI (session stream)

### DIFF
--- a/crates/server/src/api/events.rs
+++ b/crates/server/src/api/events.rs
@@ -274,7 +274,22 @@ pub fn routes(state: AppState) -> Router {
         EventsQuery
     ),
     responses(
-        (status = 200, description = "Event stream. Includes 'connected' on open, domain events during streaming, and 'disconnecting' before graceful close.", content_type = "text/event-stream"),
+        (
+            status = 200,
+            description = "Server-Sent Events stream. Each SSE message has the wire \
+                shape `event: <type>\\nid: <sequence>\\ndata: <json>\\n\\n`, where \
+                `<type>` is one of the event types in the `EventData` catalog \
+                (`turn.started`, `tool.completed`, `reason.thinking.delta`, …), \
+                `<sequence>` is a monotonically increasing per-session sequence id \
+                (usable as `since_id` on reconnect), and `<json>` is the body \
+                schema below — a serialized `Event` whose `data` field carries \
+                the event-type-specific payload defined in `EventData`. Lifecycle \
+                framing events (`connected`, `disconnecting`) use the same SSE \
+                shape but carry a minimal JSON object in `data` rather than a \
+                full `Event`. See `specs/api-streaming.md` for the SSE convention.",
+            body = Event,
+            content_type = "text/event-stream",
+        ),
         (status = 400, description = "Invalid session ID"),
         (status = 404, description = "Session not found"),
         (status = 500, description = "Internal server error")

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -10077,9 +10077,13 @@
         ],
         "responses": {
           "200": {
-            "description": "Event stream. Includes 'connected' on open, domain events during streaming, and 'disconnecting' before graceful close.",
+            "description": "Server-Sent Events stream. Each SSE message has the wire shape `event: <type>\\nid: <sequence>\\ndata: <json>\\n\\n`, where `<type>` is one of the event types in the `EventData` catalog (`turn.started`, `tool.completed`, `reason.thinking.delta`, …), `<sequence>` is a monotonically increasing per-session sequence id (usable as `since_id` on reconnect), and `<json>` is the body schema below — a serialized `Event` whose `data` field carries the event-type-specific payload defined in `EventData`. Lifecycle framing events (`connected`, `disconnecting`) use the same SSE shape but carry a minimal JSON object in `data` rather than a full `Event`. See `specs/api-streaming.md` for the SSE convention.",
             "content": {
-              "text/event-stream": {}
+              "text/event-stream": {
+                "schema": {
+                  "$ref": "#/components/schemas/Event"
+                }
+              }
             }
           },
           "400": {

--- a/specs/api-streaming.md
+++ b/specs/api-streaming.md
@@ -1,0 +1,142 @@
+# Streaming APIs
+
+Cross-cutting conventions for Server-Sent Events (SSE) endpoints in
+the Everruns HTTP API. Companion to [`apis.md`](apis.md) and
+[`api-conventions.md`](api-conventions.md); the durable contract for
+**how SSE responses are described in OpenAPI** so an LLM toolcaller
+can subscribe and dispatch by event-type without parsing prose.
+
+## SSE wire format
+
+Every SSE endpoint serves `Content-Type: text/event-stream` and
+follows the standard SSE framing
+([RFC mdn](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events)):
+
+```
+event: <type>
+id: <sequence>
+retry: <ms>
+data: <json>
+
+event: <type>
+id: <sequence>
+data: <json>
+
+```
+
+* `event:` — the **event type discriminator**. Maps directly to the
+  IANA-style dot-notation type strings used throughout Everruns
+  (`turn.started`, `tool.completed`, `reason.thinking.delta`, …).
+  Lifecycle framing events (`connected`, `disconnecting`) use the
+  same field but carry a minimal framing payload rather than an
+  `Event`.
+* `id:` — monotonic per-session sequence id. Reconnecting clients
+  pass it back as the `since_id` query parameter to resume without
+  missing events.
+* `retry:` — server-suggested reconnect delay in milliseconds; see
+  the per-endpoint description for the cycling policy.
+* `data:` — the per-event JSON body. The shape depends on the
+  `event:` value (see "Event-type catalog" below).
+
+Streams are **automatically cycled** at a per-endpoint interval (5 min
+for session events, 1 min for durable workflow snapshots) so proxies
+and load balancers don't drop the connection silently. The server
+emits a `disconnecting` event before closing; clients should
+reconnect immediately using `since_id`.
+
+## Event-type catalog
+
+### `GET /v1/sessions/{session_id}/sse`
+
+The body schema is the **`Event`** ToSchema (see `crates/core/src/events.rs`).
+Each `data:` line is a serialized `Event`, whose `type` field matches
+the SSE `event:` discriminator and whose `data` field carries the
+event-type-specific payload defined by the `EventData` enum.
+
+Closed `event:` vocabulary (all `text/event-stream` framing values
+the server may emit on this endpoint):
+
+| `event:` value                  | `data:` shape                                                              |
+| ------------------------------- | -------------------------------------------------------------------------- |
+| `connected`                     | `{"status": "connected"}` (lifecycle; no `Event` wrapper)                  |
+| `disconnecting`                 | `{"reason": "connection_cycle", "retry_ms": 100}` (lifecycle)              |
+| `input.message`                 | `Event` (`data` = `InputMessageData`)                                      |
+| `output.message.started`        | `Event` (`data` = `OutputMessageStartedData`)                              |
+| `output.message.delta`          | `Event` (`data` = `OutputMessageDeltaData`)                                |
+| `output.message.completed`      | `Event` (`data` = `OutputMessageCompletedData`)                            |
+| `output.message.replaced`       | `Event` (`data` = `OutputMessageReplacedData`)                             |
+| `turn.started`                  | `Event` (`data` = `TurnStartedData`)                                       |
+| `turn.completed`                | `Event` (`data` = `TurnCompletedData`)                                     |
+| `turn.failed`                   | `Event` (`data` = `TurnFailedData`)                                        |
+| `turn.cancelled`                | `Event` (`data` = `TurnCancelledData`)                                     |
+| `reason.started`                | `Event` (`data` = `ReasonStartedData`)                                     |
+| `reason.completed`              | `Event` (`data` = `ReasonCompletedData`)                                   |
+| `reason.thinking.started`       | `Event` (`data` = `ReasonThinkingStartedData`)                             |
+| `reason.thinking.delta`         | `Event` (`data` = `ReasonThinkingDeltaData`)                               |
+| `reason.thinking.completed`     | `Event` (`data` = `ReasonThinkingCompletedData`)                           |
+| `reason.item`                   | `Event` (`data` = `ReasonItemData`)                                        |
+| `act.started`                   | `Event` (`data` = `ActStartedData`)                                        |
+| `act.completed`                 | `Event` (`data` = `ActCompletedData`)                                      |
+| `tool.started`                  | `Event` (`data` = `ToolStartedData`)                                       |
+| `tool.progress`                 | `Event` (`data` = `ToolProgressData`)                                      |
+| `tool.completed`                | `Event` (`data` = `ToolCompletedData`)                                     |
+| `tool.output.delta`             | `Event` (`data` = `ToolOutputDeltaData`)                                   |
+| `tool.call_requested`           | `Event` (`data` = `ToolCallRequestedData`)                                 |
+| `llm.generation`                | `Event` (`data` = `LlmGenerationData`)                                     |
+| `capability.usage`              | `Event` (`data` = `CapabilityUsageData`)                                   |
+| `session.started`               | `Event` (`data` = `SessionStartedData`)                                    |
+| `session.activated`             | `Event` (`data` = `SessionActivatedData`)                                  |
+| `session.idled`                 | `Event` (`data` = `SessionIdledData`)                                      |
+| `subagent.spawned`              | `Event` (`data` = `SubagentEventData`)                                     |
+| `subagent.completed`            | `Event` (`data` = `SubagentEventData`)                                     |
+| `subagent.failed`               | `Event` (`data` = `SubagentEventData`)                                     |
+| `subagent.cancelled`            | `Event` (`data` = `SubagentEventData`)                                     |
+| `context.compacting`            | `Event` (`data` = `ContextCompactingData`)                                 |
+| `context.compacted`             | `Event` (`data` = `ContextCompactedData`)                                  |
+| `file.written`                  | `Event` (`data` = `FileWrittenData`)                                       |
+| `budget.warning`                | `Event` (`data` = `BudgetEventData`)                                       |
+| `budget.paused`                 | `Event` (`data` = `BudgetEventData`)                                       |
+| `budget.exhausted`              | `Event` (`data` = `BudgetEventData`)                                       |
+| `budget.resumed`                | `Event` (`data` = `BudgetEventData`)                                       |
+| `voice.session.started`         | `Event` (`data` = `VoiceSessionStartedData`)                               |
+| `voice.input.transcript.delta`  | `Event` (`data` = `VoiceTranscriptData`)                                   |
+| `voice.input.transcript.completed`  | `Event` (`data` = `VoiceTranscriptData`)                               |
+| `voice.output.transcript.delta` | `Event` (`data` = `VoiceTranscriptData`)                                   |
+| `voice.output.transcript.completed` | `Event` (`data` = `VoiceTranscriptData`)                               |
+| `voice.session.ended`           | `Event` (`data` = `VoiceSessionEndedData`)                                 |
+| `voice.session.failed`          | `Event` (`data` = `VoiceSessionFailedData`)                                |
+
+The set is exhaustive — events whose type isn't in this list are
+filtered out before transmission. Clients should treat any future
+unknown `event:` value as informational only.
+
+### `GET /v1/durable/sse` and `GET /v1/durable/workflows/{id}/sse`
+
+These streams emit **snapshots**, not `Event`s. The closed `event:`
+vocabulary is `{connected, snapshot, disconnecting}`:
+
+| `event:` value  | `data:` shape                                                  |
+| --------------- | -------------------------------------------------------------- |
+| `connected`     | `{"status": "connected"}`                                      |
+| `snapshot`      | Workflow/queue state snapshot — shape varies; treat as opaque  |
+|                 | JSON until a typed snapshot schema lands.                      |
+| `disconnecting` | `{"reason": "connection_cycle", "retry_ms": …}`                |
+
+The snapshot endpoints poll the durable store at a fixed interval
+and re-emit whenever the snapshot hash changes. They don't fan out
+domain `Event`s — for the per-workflow domain event stream, use the
+JSON polling endpoint `GET /v1/durable/workflows/{id}/events`.
+
+## Adding new SSE endpoints
+
+When wiring up a new SSE handler:
+
+1. Decide whether the stream carries `Event`s (use the per-session
+   pattern above) or a snapshot type (use the durable pattern).
+2. Declare the response in `#[utoipa::path]` as
+   `(status = 200, body = <Type>, content_type = "text/event-stream", …)`.
+3. Document the closed `event:` vocabulary in this file under a new
+   subsection.
+4. The on-the-wire framing (`event:`/`id:`/`retry:`/`data:`) is
+   the same for every endpoint and is documented once here — don't
+   re-explain it per endpoint.


### PR DESCRIPTION
First wave of EVE-497 — covers the per-session SSE endpoint. Durable workflow streams emit opaque snapshots (not domain `Event`s) and need a typed-snapshot schema first; tracked as follow-on.

## What
Replace the opaque `text/event-stream: {}` declaration on
`GET /v1/sessions/{session_id}/sse` with a body-schema reference to
`Event`, and stand up `specs/api-streaming.md` as the durable
contract for how SSE responses are described in OpenAPI. The
event-type catalog enumerates every `event:` value the server may
emit on this endpoint along with the corresponding `EventData`
payload variant.

## Why
Today the streaming endpoints appear in `docs/api/openapi.json` as
`text/event-stream: {}` — completely opaque. An LLM that wants to
consume the stream has to read prose docs to discover which event
types it can receive and what shape each payload is. With the
catalog and the `body = Event` schema reference inline:

- A typed-SDK generator can produce a tagged union per stream.
- An LLM client can dispatch by the `event:` discriminator with the
  payload shape already in hand.

## How
- `crates/server/src/api/events.rs::stream_sse`: the `responses(…)`
  block now declares `body = Event` alongside
  `content_type = "text/event-stream"`. The response description
  spells out the SSE wire framing (`event:`/`id:`/`retry:`/`data:`)
  with a pointer to the spec doc, so spec consumers see the framing
  inline without reading prose.
- `specs/api-streaming.md` (new) — durable contract:
  - **SSE wire format** documented once (referenced from each
    endpoint).
  - **Event-type catalog for the session stream** — full closed
    vocabulary of `event:` values mapped to the
    corresponding `EventData` payload variant (e.g.
    `tool.completed` → `Event` with `data = ToolCompletedData`).
    Lifecycle framing values (`connected`, `disconnecting`) are
    distinguished from domain events.
  - **Event-type catalog for the durable streams** —
    `{connected, snapshot, disconnecting}` only; documented that
    they emit opaque workflow snapshots, with a forward-pointer to
    `GET /v1/durable/workflows/{id}/events` for the JSON-polling
    domain-event surface.
  - **Adding new SSE endpoints** — checklist so future stream
    handlers follow the pattern.
- `docs/api/openapi.json` regenerated — the
  `/v1/sessions/{session_id}/sse` `200` response now declares
  `schema: { $ref: "#/components/schemas/Event" }` under
  `text/event-stream`.

## Risk
Trivial. Schema-only change — no behavior change, no wire-shape
change. The `Event` schema was already in the OpenAPI components
list (registered as a top-level type); only the response-content
`$ref` is new. Existing stream consumers (UI, CLI, integration
tests) are unaffected because the SSE bytes on the network are
identical.

## Security
- Threat categories reviewed: none directly applicable. Schema
  documentation only; no runtime code path touched, no auth surface
  changed, no new input parsing. The `Event` schema describes
  payloads the server was already emitting.
- `specs/threat-model.md` unchanged.

## Validation
- `cargo build -p everruns-server` — clean.
- `cargo fmt --check -p everruns-server` — clean.
- `cargo clippy -p everruns-server --lib -- -D warnings` — clean.
- `cargo test -p everruns-server --test openapi_descriptions_test`
  — all 4 OpenAPI gate tests still pass (no schema regression).
- `scripts/export-openapi.sh` — runs clean; the only diff is the new
  `schema: { $ref }` block on the SSE 200 response.

## Follow-ups
- **Durable workflow streams** —
  `GET /v1/durable/sse` and `GET /v1/durable/workflows/{id}/sse`
  emit workflow/queue **snapshots**, not `Event`s. They need a
  typed snapshot schema (e.g. `WorkflowStateSnapshot`) before the
  same treatment can apply. Tracked as follow-on; the spec doc
  documents the current `{connected, snapshot, disconnecting}`
  vocabulary so consumers aren't blocked in the meantime.
- **Discriminated union of `EventData`** — today the OpenAPI Event
  schema documents `event_type: string` + `data: EventData` where
  `EventData` is `#[serde(untagged)]` (its schema lists every
  variant as part of a `oneOf`). A future tagged-union refactor
  (matching the SSE `event:` discriminator on the wire) would let
  utoipa generate a `discriminator` block instead, giving SDK
  generators a clean enum to dispatch on. That's a larger change
  with serde tag semantics; deferred.
- **Spec assertion test** — a small integration test that the
  catalog in `api-streaming.md` covers every variant of `EventData`
  (so the spec doc can't drift from the code). Useful once the
  catalog has been stable through a few iterations; deferred.

## Checklist
- [x] Tests added or updated (no new tests; existing 4 OpenAPI gates
      still pass)
- [x] Backward compatibility considered (schema doc change only;
      wire shape unchanged)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (no review yet)

---
_Generated by [Claude Code](https://claude.ai/code/session_019AF2AijuVn6cBkWpruUNGF)_