### PR TITLE
docs(api): per-operation request/response example pairs (foundation)

### DIFF
--- a/crates/server/src/api/sessions.rs
+++ b/crates/server/src/api/sessions.rs
@@ -398,10 +398,46 @@ pub async fn session_config(
 #[utoipa::path(
     post,
     path = "/v1/sessions",
-    request_body = CreateSessionRequest,
+    request_body(
+        content = CreateSessionRequest,
+        example = json!({
+            "harness_name": "generic",
+            "title": "Debug login issue",
+            "tags": ["debugging", "urgent"]
+        })
+    ),
     responses(
-        (status = 201, description = "Session created successfully", body = WithUrls<Session>),
-        (status = 404, description = "Harness, Agent, or Model not found"),
+        (
+            status = 201,
+            description = "Session created successfully",
+            body = WithUrls<Session>,
+            example = json!({
+                "self_url": "https://app.everruns.com/api/v1/sessions/session_01933b5a00007000800000000000001",
+                "view_url": "https://app.everruns.com/sessions/session_01933b5a00007000800000000000001/chat",
+                "ui_link":  "https://app.everruns.com/sessions/session_01933b5a00007000800000000000001/chat",
+                "id": "session_01933b5a00007000800000000000001",
+                "status": "started",
+                "organization_id": "org_00000000000000000000000000000001",
+                "harness_id": "harness_01933b5a00007000800000000000001",
+                "owner_principal_id": "principal_01933b5a000070008000000000000001",
+                "title": "Debug login issue",
+                "tags": ["debugging", "urgent"],
+                "created_at": "2026-05-27T15:24:00Z",
+                "updated_at": "2026-05-27T15:24:00Z"
+            })
+        ),
+        (
+            status = 404,
+            description = "Harness, Agent, or Model not found",
+            body = ErrorResponse,
+            example = json!({
+                "type": "https://docs.everruns.com/errors/harness_not_found",
+                "title": "Not Found",
+                "status": 404,
+                "detail": "Harness 'generic' not found in org org_00000000000000000000000000000001.",
+                "code": "harness_not_found"
+            })
+        ),
         (status = 500, description = "Internal server error")
     ),
     extensions(
@@ -688,9 +724,29 @@ pub async fn unpin_session(
         ("session_id" = String, Path, description = "Session ID (prefixed, e.g., session_...)")
     ),
     responses(
-        (status = 200, description = "Turn cancelled successfully (or no-op if idle)", body = CancelTurnResponse),
+        (
+            status = 200,
+            description = "Turn cancelled successfully (or no-op if idle)",
+            body = CancelTurnResponse,
+            example = json!({
+                "session_id": "session_01933b5a00007000800000000000001",
+                "status": "idle",
+                "cancelled_turn_id": "turn_01933b5a00007000800000000000001"
+            })
+        ),
+        (
+            status = 404,
+            description = "Session not found",
+            body = ErrorResponse,
+            example = json!({
+                "type": "https://docs.everruns.com/errors/session_not_found",
+                "title": "Not Found",
+                "status": 404,
+                "detail": "Session session_01933b5a000070008000000000000001 not found in org org_00000000000000000000000000000001.",
+                "code": "session_not_found"
+            })
+        ),
         (status = 400, description = "Invalid session ID"),
-        (status = 404, description = "Session not found"),
         (status = 500, description = "Internal server error")
     ),
     tag = "sessions"

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -8050,6 +8050,14 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/CreateSessionRequest"
+              },
+              "example": {
+                "harness_name": "generic",
+                "tags": [
+                  "debugging",
+                  "urgent"
+                ],
+                "title": "Debug login issue"
               }
             }
           },
@@ -8062,12 +8070,43 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/WithUrls_Session"
+                },
+                "example": {
+                  "created_at": "2026-05-27T15:24:00Z",
+                  "harness_id": "harness_01933b5a00007000800000000000001",
+                  "id": "session_01933b5a00007000800000000000001",
+                  "organization_id": "org_00000000000000000000000000000001",
+                  "owner_principal_id": "principal_01933b5a000070008000000000000001",
+                  "self_url": "https://app.everruns.com/api/v1/sessions/session_01933b5a00007000800000000000001",
+                  "status": "started",
+                  "tags": [
+                    "debugging",
+                    "urgent"
+                  ],
+                  "title": "Debug login issue",
+                  "ui_link": "https://app.everruns.com/sessions/session_01933b5a00007000800000000000001/chat",
+                  "updated_at": "2026-05-27T15:24:00Z",
+                  "view_url": "https://app.everruns.com/sessions/session_01933b5a00007000800000000000001/chat"
                 }
               }
             }
           },
           "404": {
-            "description": "Harness, Agent, or Model not found"
+            "description": "Harness, Agent, or Model not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "code": "harness_not_found",
+                  "detail": "Harness 'generic' not found in org org_00000000000000000000000000000001.",
+                  "status": 404,
+                  "title": "Not Found",
+                  "type": "https://docs.everruns.com/errors/harness_not_found"
+                }
+              }
+            }
           },
           "500": {
             "description": "Internal server error"
@@ -8325,6 +8364,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/CancelTurnResponse"
+                },
+                "example": {
+                  "cancelled_turn_id": "turn_01933b5a00007000800000000000001",
+                  "session_id": "session_01933b5a00007000800000000000001",
+                  "status": "idle"
                 }
               }
             }
@@ -8333,7 +8377,21 @@
             "description": "Invalid session ID"
           },
           "404": {
-            "description": "Session not found"
+            "description": "Session not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "code": "session_not_found",
+                  "detail": "Session session_01933b5a000070008000000000000001 not found in org org_00000000000000000000000000000001.",
+                  "status": 404,
+                  "title": "Not Found",
+                  "type": "https://docs.everruns.com/errors/session_not_found"
+                }
+              }
+            }
           },
           "500": {
             "description": "Internal server error"

--- a/specs/api-examples.md
+++ b/specs/api-examples.md
@@ -1,0 +1,125 @@
+# Per-operation request/response examples
+
+Convention for **operation-level** examples on every `#[utoipa::path]`
+handler so an LLM toolcaller sees concrete payloads at the operation
+level, not just per-field literals. Companion to
+[`api-conventions.md`](api-conventions.md) (hypermedia) and
+[`api-llm-extensions.md`](api-llm-extensions.md) (cost/safety
+metadata).
+
+## What
+Per-field `#[schema(example = …)]` (gate-tracked separately) tells an
+LLM **what literal to put in one field**. Per-operation examples tell
+an LLM:
+
+- **How fields combine** into a valid request payload.
+- **What an error response actually looks like** for that specific
+  operation, complete with the right `code`/`detail` shape.
+
+## Wire format
+utoipa emits the operation-level example directly into the response
+content:
+
+```yaml
+responses:
+  "201":
+    description: Session created successfully
+    content:
+      application/json:
+        schema:
+          $ref: "#/components/schemas/WithUrls_Session"
+        example:
+          self_url: https://api.example/v1/sessions/session_…
+          view_url: https://app.example/sessions/session_…/chat
+          id: session_…
+          status: started
+          …
+```
+
+## Authoring
+
+Add `example = json!(…)` to the `responses(…)` and `request_body(…)`
+entries in `#[utoipa::path]`. Keep examples **realistic**: use IDs
+that match the documented prefix format, populate optional fields the
+LLM is likely to set, and stick to one example per
+(status × content type) pair to avoid utoipa's
+non-deterministic `examples` map ordering (same caveat as
+`extensions`, see `api-llm-extensions.md`).
+
+### Single example per response
+
+```rust
+#[utoipa::path(
+    post,
+    path = "/v1/sessions",
+    request_body(
+        content = CreateSessionRequest,
+        example = json!({
+            "harness_name": "generic",
+            "title": "Debug login issue",
+            "tags": ["debugging", "urgent"]
+        })
+    ),
+    responses(
+        (
+            status = 201,
+            description = "Session created successfully",
+            body = WithUrls<Session>,
+            example = json!({
+                "self_url": "https://api.example/v1/sessions/session_01933…",
+                "view_url": "https://app.example/sessions/session_01933…/chat",
+                "ui_link":  "https://app.example/sessions/session_01933…/chat",
+                "id": "session_01933b5a00007000800000000000001",
+                "status": "started",
+                "organization_id": "org_00000000000000000000000000000001",
+                "harness_id": "harness_01933b5a00007000800000000000001",
+                "title": "Debug login issue",
+                "tags": ["debugging", "urgent"],
+                "created_at": "2026-05-27T15:24:00Z",
+                "updated_at": "2026-05-27T15:24:00Z"
+            })
+        ),
+        (
+            status = 404,
+            description = "Harness, Agent, or Model not found",
+            body = ErrorResponse,
+            example = json!({
+                "type": "https://docs.everruns.com/errors/harness_not_found",
+                "title": "Not Found",
+                "status": 404,
+                "detail": "Harness 'generic' not found in org org_00000000000000000000000000000001.",
+                "code": "harness_not_found"
+            })
+        ),
+    ),
+    tag = "sessions"
+)]
+```
+
+## When to add an example
+
+* **Always for `POST` / `PATCH` / `PUT`** that mutate non-trivial
+  state — the LLM needs to see the realistic payload shape, not
+  just inferred from the schema.
+* **Always on the canonical success response** (`200` / `201`).
+* **On every `4xx` that the operation can specifically emit** —
+  e.g. `409 Conflict` for already-archived, `429 Too Many Requests`
+  with `retry_after_seconds`. Generic `500` doesn't usually need one.
+* **`GET` is optional** — listing endpoints benefit most when there
+  are nested objects (`messages`, `events`) so the LLM can see the
+  envelope shape.
+
+## Out of scope
+
+* Per-field examples — tracked separately by EVE-491.
+* OpenAPI `examples` (multi-example map) — deferred until utoipa
+  switches to a deterministic container; the single `example`
+  attribute is stable.
+* Coverage ratchet — designable after the rollout reaches enough
+  endpoints; otherwise the floor would be premature.
+
+## First-wave rollout
+
+This convention lands with examples on a small first wave of
+high-traffic endpoints so the convention can settle. A follow-on
+issue tracks the per-endpoint sweep.


### PR DESCRIPTION
Foundation for EVE-495 — convention doc + utoipa wiring + a minimal first wave on two sessions endpoints. The per-endpoint sweep across the remaining ~28 endpoints is tracked as follow-on so the convention can settle first.

## What
Attach **request_body + response examples** to `#[utoipa::path]`
handlers so an LLM toolcaller sees concrete full-payload examples
at the operation level, not just per-field literals. Convention doc
`specs/api-examples.md` documents the pattern; two pilot endpoints
demonstrate it.

## Why
After EVE-491 lifted per-field example coverage to 44%, an LLM can
populate single fields with reasonable literals. But the LLM still
has to guess at:

- The **combined** request shape (which optional fields go
  together).
- The **operation-specific error envelope** (which `code` values a
  given endpoint can emit, what the `detail` actually looks like).

Per-operation examples close that gap — the LLM sees a realistic
full payload at the call site without scanning every nested schema.

## How
- **`specs/api-examples.md`** (new) — convention doc:
  - When to add an example (always POST/PATCH/PUT canonical
    success + every operation-specific 4xx).
  - utoipa syntax for `request_body(content = T, example = …)` and
    `responses((… body = T, example = …))`.
  - Single-`example`-per-response constraint (utoipa's `examples`
    multi-example map has the same non-deterministic ordering
    issue as `extensions`; documented inline). Multi-example
    support deferred until utoipa switches to a deterministic
    container.

- **`POST /v1/sessions` (`create_session`)** —
  - **request_body** example with realistic `harness_name` +
    `title` + `tags`.
  - **201 example** showing the full `WithUrls<Session>` shape
    (self_url, view_url, ui_link, prefixed IDs, status,
    timestamps).
  - **404 example** with `code: harness_not_found`, prefixed IDs,
    realistic `detail` and `type` URI.

- **`POST /v1/sessions/{session_id}/cancel` (`cancel_turn`)** —
  - **200 example** showing `cancelled_turn_id` + new `status`.
  - **404 example** with `code: session_not_found` envelope.

- `docs/api/openapi.json` regenerated; verified by running
  `export-openapi.sh` twice and diffing — output is stable
  (BTreeMap ordering throughout, no spec-freshness flake).

## Risk
Trivial. Pure additive metadata; standard OpenAPI consumers ignore
unknown content fields, consumers that read `example` get a richer
payload preview. No wire-shape changes, no schema changes, no new
endpoints, no auth surface touched.

## Security
- Threat categories reviewed: none directly applicable. The added
  examples are server-authored fixed JSON values surfaced in the
  public OpenAPI; no user input pathway, no auth surface changed.
- `specs/threat-model.md` unchanged.

## Validation
- `cargo build -p everruns-server` — clean.
- `cargo fmt --check -p everruns-server` — clean.
- `cargo clippy -p everruns-server --lib -- -D warnings` — clean.
- `cargo test -p everruns-server --test openapi_descriptions_test`
  — all 4 OpenAPI gate tests still pass.
- `bash scripts/export-openapi.sh` re-run twice and diffed: output
  is deterministic; OpenAPI Spec Freshness CI gate will pass.

## Follow-ups
- **Per-endpoint sweep** — apply request/response examples to the
  remaining ~28 endpoints called out in the EVE-495 issue body
  (every POST/PATCH + canonical 4xx). Splitting so the convention
  can settle first.
- **utoipa `examples` map** — multi-example syntax deferred until
  utoipa switches to a deterministic container (same constraint
  documented in `api-llm-extensions.md`).
- **Coverage ratchet** — designable after the per-endpoint sweep
  reaches enough density; otherwise the floor would be premature.

## Checklist
- [x] Tests added or updated (no new tests; existing 4 OpenAPI
      gates still pass)
- [x] Backward compatibility considered (purely additive OpenAPI
      example annotations)
- [x] Security review performed against relevant threat model
      categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (no review yet)

---
_Generated by [Claude Code](https://claude.ai/code/session_019AF2AijuVn6cBkWpruUNGF)_