### PR TITLE
feat(mcp): route MCP client traffic through EgressService

### DIFF
--- a/crates/core/src/egress.rs
+++ b/crates/core/src/egress.rs
@@ -50,6 +50,7 @@ pub enum EgressRequestKind {
     Integration,
     SystemEmail,
     UtilityLlm,
+    Mcp,
     Other(String),
 }
 

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -780,15 +780,21 @@ impl ServerAppBuilder {
             platform_definition.as_ref(),
             event_delivery.clone(),
         );
-        let capability_service = Arc::new(services::CapabilityService::with_registry(
-            db.clone(),
-            encryption.clone(),
-            platform_definition.capability_registry().clone(),
-        ));
-        let mcp_server_service = Arc::new(crate::domains::mcp_servers::McpServerService::new(
-            db.clone(),
-            encryption.clone(),
-        ));
+        let capability_service = Arc::new(
+            services::CapabilityService::with_registry(
+                db.clone(),
+                encryption.clone(),
+                platform_definition.capability_registry().clone(),
+            )
+            .with_mcp_egress_service(platform_definition.egress_service()),
+        );
+        let mcp_server_service = Arc::new(
+            crate::domains::mcp_servers::McpServerService::with_egress_service(
+                db.clone(),
+                encryption.clone(),
+                platform_definition.egress_service(),
+            ),
+        );
         let command_service = Arc::new(
             crate::domains::session_commands::SessionCommandService::new(
                 db.clone(),
@@ -1622,11 +1628,13 @@ impl ServerAppBuilder {
                 tracing::info!("DEV MODE: Starting task worker for in-process execution");
 
                 // Reuse the shared llm_resolver from Phase 5
-                let mcp_server_service =
-                    Arc::new(crate::domains::mcp_servers::McpServerService::new(
+                let mcp_server_service = Arc::new(
+                    crate::domains::mcp_servers::McpServerService::with_egress_service(
                         db.clone(),
                         encryption.clone(),
-                    ));
+                        platform_definition.egress_service(),
+                    ),
+                );
                 let session_storage_store: Arc<dyn everruns_core::traits::SessionStorageStore> =
                     match db.as_ref() {
                         crate::storage::StorageBackend::Postgres(database) => {

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -1312,10 +1312,15 @@ impl WorkerAdapters for DirectWorkerAdapters {
                 tracing::warn!(error = %error, "Invalid scoped MCP server config, skipping");
                 vec![]
             } else {
+                let egress = self
+                    .egress_service
+                    .clone()
+                    .unwrap_or_else(|| Arc::new(everruns_core::DirectEgressService::default()));
                 build_scoped_mcp_tool_definitions(
                     &effective,
                     Some(session.id),
                     self.connection_resolver.as_ref(),
+                    egress.as_ref(),
                 )
                 .await
                 .unwrap_or_else(|error| {
@@ -1540,6 +1545,7 @@ impl WorkerAdapters for DirectWorkerAdapters {
                 encryption: self.encryption.clone(),
                 workflow_store: self.workflow_store.clone(),
                 permission_resolver: self.permission_resolver.clone(),
+                egress_service: self.egress_service.clone(),
             },
         ))
     }
@@ -1884,6 +1890,7 @@ struct DirectPlatformStoreDeps {
     encryption: Option<Arc<EncryptionService>>,
     workflow_store: Option<Arc<dyn WorkflowEventStore + Send + Sync>>,
     permission_resolver: Arc<dyn PermissionResolver>,
+    egress_service: Option<Arc<dyn EgressService>>,
 }
 
 pub struct DirectPlatformStore {
@@ -1907,11 +1914,15 @@ impl DirectPlatformStore {
         db: Arc<StorageBackend>,
         deps: DirectPlatformStoreDeps,
     ) -> Self {
-        let capability_service = Arc::new(crate::services::CapabilityService::with_registry(
+        let mut capability_service = crate::services::CapabilityService::with_registry(
             db.clone(),
             deps.encryption.clone(),
             deps.capability_registry.clone(),
-        ));
+        );
+        if let Some(egress) = &deps.egress_service {
+            capability_service = capability_service.with_mcp_egress_service(egress.clone());
+        }
+        let capability_service = Arc::new(capability_service);
         let session_service = Arc::new(SessionService::with_registry(
             db.clone(),
             deps.capability_registry.clone(),
@@ -3155,6 +3166,7 @@ mod tests {
                 encryption: None,
                 workflow_store: None,
                 permission_resolver: adapters.permission_resolver.clone(),
+                egress_service: adapters.egress_service.clone(),
             },
         )
     }

--- a/crates/server/src/domains/agents/commands.rs
+++ b/crates/server/src/domains/agents/commands.rs
@@ -1546,6 +1546,7 @@ impl Command for PreviewAgent {
                 &self.mcp_servers,
                 None,
                 None,
+                ctx.capability_service.egress_service().as_ref(),
             )
             .await
             .map_err(classify_anyhow)?,

--- a/crates/server/src/domains/harnesses/commands.rs
+++ b/crates/server/src/domains/harnesses/commands.rs
@@ -794,6 +794,7 @@ impl Command for PreviewHarness {
                 &effective_mcp_servers,
                 None,
                 None,
+                ctx.capability_service.egress_service().as_ref(),
             )
             .await
             .map_err(classify_anyhow)?,

--- a/crates/server/src/domains/mcp_servers/scoped_mcp.rs
+++ b/crates/server/src/domains/mcp_servers/scoped_mcp.rs
@@ -10,8 +10,8 @@ use everruns_core::capabilities::{CapabilityRegistry, collect_capability_mcp_ser
 use everruns_core::mcp_server::sanitize_mcp_server_name;
 use everruns_core::traits::UserConnectionResolver;
 use everruns_core::{
-    Agent, Capability, Harness, McpCapability, McpServerAuthMode, ScopedMcpServers, Session,
-    SessionId, ToolDefinition, merge_scoped_mcp_servers, resolve_runtime_capabilities,
+    Agent, Capability, EgressService, Harness, McpCapability, McpServerAuthMode, ScopedMcpServers,
+    Session, SessionId, ToolDefinition, merge_scoped_mcp_servers, resolve_runtime_capabilities,
     validate_safe_url,
 };
 use std::collections::{HashMap, HashSet};
@@ -151,6 +151,7 @@ pub async fn build_scoped_mcp_tool_definitions(
     servers: &ScopedMcpServers,
     session_id: Option<SessionId>,
     connection_resolver: Option<&Arc<dyn UserConnectionResolver>>,
+    egress_service: &dyn EgressService,
 ) -> Result<Vec<ToolDefinition>> {
     let mut definitions = Vec::new();
 
@@ -189,18 +190,24 @@ pub async fn build_scoped_mcp_tool_definitions(
             continue;
         }
 
-        let tools =
-            match fetch_mcp_tools(&server.url, bearer_token.as_deref(), &server.headers).await {
-                Ok(tools) => tools,
-                Err(error) => {
-                    tracing::warn!(
-                        server_name = %name,
-                        error = %error,
-                        "Failed to discover scoped MCP tools, skipping server"
-                    );
-                    continue;
-                }
-            };
+        let tools = match fetch_mcp_tools(
+            egress_service,
+            &server.url,
+            bearer_token.as_deref(),
+            &server.headers,
+        )
+        .await
+        {
+            Ok(tools) => tools,
+            Err(error) => {
+                tracing::warn!(
+                    server_name = %name,
+                    error = %error,
+                    "Failed to discover scoped MCP tools, skipping server"
+                );
+                continue;
+            }
+        };
         let capability_id = session_id
             .map(|id| scoped_mcp_server_uuid(id.uuid(), name))
             .unwrap_or_else(Uuid::nil);

--- a/crates/server/src/domains/mcp_servers/service.rs
+++ b/crates/server/src/domains/mcp_servers/service.rs
@@ -18,8 +18,9 @@ use anyhow::{Result, anyhow};
 use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64_STANDARD};
 use chrono::{DateTime, Utc};
 use everruns_core::{
-    Caller, McpServer, McpServerAuthMode, McpServerStatus, McpServerTransportType,
-    McpToolDefinition, McpToolsListRequest, McpToolsListResponse, mcp_oauth_provider_id_for_uuid,
+    Caller, DirectEgressService, EgressRequest, EgressRequestKind, EgressService, McpServer,
+    McpServerAuthMode, McpServerStatus, McpServerTransportType, McpToolDefinition,
+    McpToolsListRequest, McpToolsListResponse, mcp_oauth_provider_id_for_uuid,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -40,6 +41,7 @@ const MCP_CLIENT_TIMEOUT: Duration = Duration::from_secs(30);
 pub struct McpServerService {
     db: Arc<StorageBackend>,
     encryption: Option<Arc<EncryptionService>>,
+    egress_service: Arc<dyn EgressService>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -70,7 +72,27 @@ pub struct McpServerOAuthSettings {
 
 impl McpServerService {
     pub fn new(db: Arc<StorageBackend>, encryption: Option<Arc<EncryptionService>>) -> Self {
-        Self { db, encryption }
+        Self::with_egress_service(db, encryption, Arc::new(DirectEgressService::default()))
+    }
+
+    pub fn with_egress_service(
+        db: Arc<StorageBackend>,
+        encryption: Option<Arc<EncryptionService>>,
+        egress_service: Arc<dyn EgressService>,
+    ) -> Self {
+        Self {
+            db,
+            encryption,
+            egress_service,
+        }
+    }
+
+    pub fn egress_service(&self) -> Arc<dyn EgressService> {
+        self.egress_service.clone()
+    }
+
+    pub fn encryption(&self) -> Option<Arc<EncryptionService>> {
+        self.encryption.clone()
     }
 
     pub fn oauth_provider_id(server_id: Uuid) -> String {
@@ -372,7 +394,13 @@ impl McpServerService {
         }
 
         // Fetch tools from MCP server
-        let tools = fetch_mcp_tools(&row.url, api_key.as_deref(), &headers).await?;
+        let tools = fetch_mcp_tools(
+            self.egress_service.as_ref(),
+            &row.url,
+            api_key.as_deref(),
+            &headers,
+        )
+        .await?;
 
         // Cache tools in database
         let cached_tools = serde_json::to_value(&tools)?;
@@ -396,7 +424,13 @@ impl McpServerService {
             .ok_or_else(|| anyhow!("MCP server not found"))?;
         let headers: HashMap<String, String> =
             serde_json::from_value(row.headers.clone()).unwrap_or_default();
-        let tools = fetch_mcp_tools(&row.url, Some(token), &headers).await?;
+        let tools = fetch_mcp_tools(
+            self.egress_service.as_ref(),
+            &row.url,
+            Some(token),
+            &headers,
+        )
+        .await?;
         let cached_tools = serde_json::to_value(&tools)?;
         self.db
             .update_mcp_server_tools(caller.org_id, id, UpdateMcpServerTools { cached_tools })
@@ -582,43 +616,46 @@ pub struct McpServerResolved {
     pub headers: HashMap<String, String>,
 }
 
-/// Fetch tools from an MCP server using JSON-RPC over HTTP
+/// Fetch tools from an MCP server using JSON-RPC over HTTP via the platform
+/// `EgressService` (spec: `specs/egress.md`).
 pub(crate) async fn fetch_mcp_tools(
+    egress_service: &dyn EgressService,
     url: &str,
     api_key: Option<&str>,
     headers: &HashMap<String, String>,
 ) -> Result<Vec<McpToolDefinition>> {
-    // Re-validate URL at fetch time (SSRF defense-in-depth)
+    // Re-validate URL at fetch time (SSRF defense-in-depth). This runs before
+    // the egress request is constructed so unsafe URLs never reach the boundary.
     validate_safe_url(url).map_err(|e| anyhow!("MCP server URL blocked: {}", e))?;
 
-    let client = reqwest::Client::builder()
-        .timeout(MCP_CLIENT_TIMEOUT)
-        .build()?;
+    let request_body = serde_json::to_vec(&McpToolsListRequest::default())?;
 
-    let request = McpToolsListRequest::default();
+    let mut egress_request = EgressRequest::new("POST", url, EgressRequestKind::Mcp)
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json, text/event-stream")
+        .timeout_ms(MCP_CLIENT_TIMEOUT.as_millis() as u64)
+        .body(request_body);
 
-    let mut req_builder = client.post(url).json(&request);
-
-    // Add API key if provided
     if let Some(key) = api_key {
-        req_builder = req_builder.header("Authorization", format!("Bearer {}", key));
+        egress_request = egress_request.header("Authorization", format!("Bearer {}", key));
     }
-
-    // Add custom headers
     for (name, value) in headers {
-        req_builder = req_builder.header(name, value);
+        egress_request = egress_request.header(name, value);
     }
 
-    let response = req_builder.send().await?;
+    let response = egress_service
+        .send(egress_request)
+        .await
+        .map_err(|e| anyhow!("MCP server egress error: {}", e))?;
 
-    if !response.status().is_success() {
+    if !(200..300).contains(&response.status) {
         return Err(anyhow!(
             "MCP server returned error status: {}",
-            response.status()
+            response.status
         ));
     }
 
-    let mcp_response: McpToolsListResponse = response.json().await?;
+    let mcp_response: McpToolsListResponse = serde_json::from_slice(&response.body)?;
 
     if let Some(error) = mcp_response.error {
         return Err(anyhow!(
@@ -872,24 +909,34 @@ mod tests {
 
     // --- SSRF: fetch_mcp_tools blocks unsafe URLs ---
 
+    fn test_egress() -> DirectEgressService {
+        DirectEgressService::default()
+    }
+
     #[tokio::test]
     async fn fetch_tools_blocks_localhost() {
+        let egress = test_egress();
         let result =
-            super::fetch_mcp_tools("http://localhost:9999/mcp", None, &HashMap::new()).await;
+            super::fetch_mcp_tools(&egress, "http://localhost:9999/mcp", None, &HashMap::new())
+                .await;
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("blocked"));
     }
 
     #[tokio::test]
     async fn fetch_tools_blocks_private_ip() {
-        let result = super::fetch_mcp_tools("http://10.0.0.1/mcp", None, &HashMap::new()).await;
+        let egress = test_egress();
+        let result =
+            super::fetch_mcp_tools(&egress, "http://10.0.0.1/mcp", None, &HashMap::new()).await;
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("blocked"));
     }
 
     #[tokio::test]
     async fn fetch_tools_blocks_metadata_endpoint() {
+        let egress = test_egress();
         let result = super::fetch_mcp_tools(
+            &egress,
             "http://169.254.169.254/latest/meta-data/",
             None,
             &HashMap::new(),

--- a/crates/server/src/grpc_service/mod.rs
+++ b/crates/server/src/grpc_service/mod.rs
@@ -450,7 +450,11 @@ impl WorkerServiceImpl {
         };
         let llm_resolver_service = llm_resolver_service
             .unwrap_or_else(|| Arc::new(LlmResolverService::new(db.clone(), encryption.clone())));
-        let mcp_server_service = McpServerService::new(db.clone(), encryption.clone());
+        let mcp_server_service = McpServerService::with_egress_service(
+            db.clone(),
+            encryption.clone(),
+            platform_definition.egress_service(),
+        );
         let capability_service = Arc::new(CapabilityService::with_registry(
             db.clone(),
             encryption.clone(),

--- a/crates/server/src/grpc_service/worker_service_impl.rs
+++ b/crates/server/src/grpc_service/worker_service_impl.rs
@@ -297,6 +297,7 @@ impl WorkerService for WorkerServiceImpl {
                     &effective,
                     Some(session.id),
                     self.connection_resolver.as_ref(),
+                    self.mcp_server_service.egress_service().as_ref(),
                 )
                 .await
                 .map(|defs| {

--- a/crates/server/src/services/capability.rs
+++ b/crates/server/src/services/capability.rs
@@ -64,8 +64,27 @@ impl CapabilityService {
         }
     }
 
+    /// Replace the embedded `McpServerService` so outbound MCP traffic flows
+    /// through the platform's shared egress boundary (spec: `specs/egress.md`).
+    pub fn with_mcp_egress_service(
+        mut self,
+        egress_service: Arc<dyn everruns_core::EgressService>,
+    ) -> Self {
+        let db = self.db.clone();
+        let encryption = self.mcp_service.encryption();
+        self.mcp_service = McpServerService::with_egress_service(db, encryption, egress_service);
+        self
+    }
+
     pub fn registry(&self) -> &CapabilityRegistry {
         &self.registry
+    }
+
+    /// Egress service used by the embedded `McpServerService` for outbound
+    /// HTTP to remote MCP servers. Surfaced so command handlers that need to
+    /// discover scoped MCP tools can share the platform's egress boundary.
+    pub fn egress_service(&self) -> Arc<dyn everruns_core::EgressService> {
+        self.mcp_service.egress_service()
     }
 
     /// Invalidate the cached skill list for an org. Called by skill mutation
@@ -491,6 +510,7 @@ impl CapabilityService {
                 &collected.mcp_servers,
                 None,
                 None,
+                self.mcp_service.egress_service().as_ref(),
             )
             .await?,
         );

--- a/crates/worker/src/mcp_executor.rs
+++ b/crates/worker/src/mcp_executor.rs
@@ -9,9 +9,10 @@ use anyhow::{Result, anyhow};
 use async_trait::async_trait;
 use everruns_core::traits::{ToolContext, ToolExecutor};
 use everruns_core::{
-    McpContent, McpServerAuthMode, McpToolCallRequest, McpToolCallResponse, ToolCall,
-    ToolDefinition, ToolResult, ToolResultImage, is_mcp_tool, mcp_oauth_session_secret_name,
-    parse_mcp_tool_name, validate_safe_url,
+    DirectEgressService, EgressRequest, EgressRequestKind, EgressService, McpContent,
+    McpServerAuthMode, McpToolCallRequest, McpToolCallResponse, ToolCall, ToolDefinition,
+    ToolResult, ToolResultImage, is_mcp_tool, mcp_oauth_session_secret_name, parse_mcp_tool_name,
+    validate_safe_url,
 };
 use serde_json::json;
 use std::collections::HashMap;
@@ -41,14 +42,29 @@ pub struct McpToolExecutor {
     org_id: i64,
     /// Cache of MCP server info by session scope + server name prefix.
     server_cache: tokio::sync::RwLock<HashMap<String, McpServerInfo>>,
+    /// Shared outbound HTTP boundary (spec: `specs/egress.md`).
+    egress_service: Arc<dyn EgressService>,
 }
 
 impl McpToolExecutor {
     pub fn new(grpc_client: GrpcClient, org_id: i64) -> Self {
+        Self::with_egress_service(
+            grpc_client,
+            org_id,
+            Arc::new(DirectEgressService::default()),
+        )
+    }
+
+    pub fn with_egress_service(
+        grpc_client: GrpcClient,
+        org_id: i64,
+        egress_service: Arc<dyn EgressService>,
+    ) -> Self {
         Self {
             grpc_client,
             org_id,
             server_cache: tokio::sync::RwLock::new(HashMap::new()),
+            egress_service,
         }
     }
 
@@ -84,6 +100,7 @@ impl McpToolExecutor {
         }
 
         let (result, images) = call_mcp_tool(
+            self.egress_service.as_ref(),
             &server_info,
             &original_tool_name,
             tool_call.arguments.clone(),
@@ -181,15 +198,20 @@ impl McpToolExecutor {
     }
 }
 
-/// Call an MCP server's tools/call endpoint.
+/// Call an MCP server's tools/call endpoint via the platform `EgressService`
+/// (spec: `specs/egress.md`).
+///
 /// Returns (json_result, images) where images are extracted from MCP image content.
 async fn call_mcp_tool(
+    egress_service: &dyn EgressService,
     server_info: &McpServerInfo,
     tool_name: &str,
     arguments: serde_json::Value,
     authorization_header: Option<&str>,
 ) -> Result<(serde_json::Value, Vec<ToolResultImage>)> {
-    // Re-validate URL at execution time to catch TOCTOU / post-registration changes
+    // Re-validate URL at execution time to catch TOCTOU / post-registration
+    // changes. Runs before the egress request is built so unsafe URLs never
+    // reach the boundary.
     validate_safe_url(&server_info.url).map_err(|e| {
         tracing::warn!(
             mcp_server = %server_info.name,
@@ -200,27 +222,24 @@ async fn call_mcp_tool(
         anyhow!("MCP server URL blocked: {}", e)
     })?;
 
-    let client = reqwest::Client::builder()
-        .timeout(MCP_TOOL_TIMEOUT)
-        .build()?;
-
-    // Create JSON-RPC request
     let request = McpToolCallRequest::new(
         1, // Request ID
         tool_name.to_string(),
         Some(arguments),
     );
+    let request_body = serde_json::to_vec(&request)?;
 
-    let mut req_builder = client.post(&server_info.url).json(&request);
+    let mut egress_request = EgressRequest::new("POST", &server_info.url, EgressRequestKind::Mcp)
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json, text/event-stream")
+        .timeout_ms(MCP_TOOL_TIMEOUT.as_millis() as u64)
+        .body(request_body);
 
-    // Add Authorization header (API key, OAuth token, etc.) if provided
     if let Some(auth_header) = authorization_header {
-        req_builder = req_builder.header("Authorization", auth_header);
+        egress_request = egress_request.header("Authorization", auth_header);
     }
-
-    // Add custom headers
     for (name, value) in &server_info.headers {
-        req_builder = req_builder.header(name, value);
+        egress_request = egress_request.header(name, value);
     }
 
     tracing::debug!(
@@ -229,7 +248,7 @@ async fn call_mcp_tool(
         "Calling MCP server"
     );
 
-    let response = req_builder.send().await.map_err(|e| {
+    let response = egress_service.send(egress_request).await.map_err(|e| {
         tracing::error!(
             mcp_server = %server_info.name,
             tool_name = %tool_name,
@@ -239,21 +258,23 @@ async fn call_mcp_tool(
         anyhow!("Failed to call MCP server: {}", e)
     })?;
 
-    if !response.status().is_success() {
-        let status = response.status();
-        let body = response.text().await.unwrap_or_default();
+    if !(200..300).contains(&response.status) {
+        let body = String::from_utf8_lossy(&response.body).into_owned();
         tracing::error!(
             mcp_server = %server_info.name,
             tool_name = %tool_name,
-            status = %status,
+            status = %response.status,
             body = %body,
             "MCP server returned error"
         );
-        return Err(anyhow!("MCP server returned error: {} - {}", status, body));
+        return Err(anyhow!(
+            "MCP server returned error: {} - {}",
+            response.status,
+            body
+        ));
     }
 
-    // Parse response - handle both plain JSON and SSE (Server-Sent Events) formats
-    let response_text = response.text().await.map_err(|e| {
+    let response_text = String::from_utf8(response.body).map_err(|e| {
         tracing::error!(
             mcp_server = %server_info.name,
             tool_name = %tool_name,
@@ -553,6 +574,10 @@ data: {"result":{"tools":[{"name":"search","description":"Search docs"}]},"id":1
 
     // --- SSRF validation at execution time ---
 
+    fn test_egress() -> DirectEgressService {
+        DirectEgressService::default()
+    }
+
     #[tokio::test]
     async fn ssrf_blocks_localhost_at_execution_time() {
         let server = McpServerInfo {
@@ -564,7 +589,9 @@ data: {"result":{"tools":[{"name":"search","description":"Search docs"}]},"id":1
             auth_mode: McpServerAuthMode::None,
             oauth_provider_id: None,
         };
-        let result = call_mcp_tool(&server, "test_tool", serde_json::json!({}), None).await;
+        let egress = test_egress();
+        let result =
+            call_mcp_tool(&egress, &server, "test_tool", serde_json::json!({}), None).await;
         assert!(result.is_err());
         let err_msg = result.unwrap_err().to_string();
         assert!(
@@ -584,7 +611,9 @@ data: {"result":{"tools":[{"name":"search","description":"Search docs"}]},"id":1
             auth_mode: McpServerAuthMode::None,
             oauth_provider_id: None,
         };
-        let result = call_mcp_tool(&server, "test_tool", serde_json::json!({}), None).await;
+        let egress = test_egress();
+        let result =
+            call_mcp_tool(&egress, &server, "test_tool", serde_json::json!({}), None).await;
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("blocked"));
     }
@@ -600,7 +629,9 @@ data: {"result":{"tools":[{"name":"search","description":"Search docs"}]},"id":1
             auth_mode: McpServerAuthMode::None,
             oauth_provider_id: None,
         };
-        let result = call_mcp_tool(&server, "test_tool", serde_json::json!({}), None).await;
+        let egress = test_egress();
+        let result =
+            call_mcp_tool(&egress, &server, "test_tool", serde_json::json!({}), None).await;
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("blocked"));
     }
@@ -616,7 +647,9 @@ data: {"result":{"tools":[{"name":"search","description":"Search docs"}]},"id":1
             auth_mode: McpServerAuthMode::None,
             oauth_provider_id: None,
         };
-        let result = call_mcp_tool(&server, "test_tool", serde_json::json!({}), None).await;
+        let egress = test_egress();
+        let result =
+            call_mcp_tool(&egress, &server, "test_tool", serde_json::json!({}), None).await;
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("blocked"));
     }

--- a/specs/README.md
+++ b/specs/README.md
@@ -20,6 +20,8 @@ Specs capture the "why" and "what", not exhaustive source detail. Link to code f
 ## APIs and execution
 
 - `specs/apis.md` - HTTP API endpoints, error handling
+- `specs/api-conventions.md` - Cross-cutting HTTP API conventions
+- `specs/api-streaming.md` - SSE streaming conventions for API endpoints
 - `specs/public-endpoints.md` - Public endpoints, error sanitization contract, stable public code set
 - `specs/events.md` - Event types, SSE streaming, contract and compatibility guarantees
 - `specs/execution-phases.md` - Execution phases (Commentary/FinalAnswer) for multi-step tool flows

--- a/specs/egress.md
+++ b/specs/egress.md
@@ -46,7 +46,7 @@ Reasoning:
 - `EgressStreamResponse` is the streaming response body used by LLM SSE and
   other long-lived HTTP responses.
 - `EgressRequestKind` labels traffic as `llm_provider`, `capability`,
-  `integration`, `system_email`, `utility_llm`, or `other`.
+  `integration`, `system_email`, `utility_llm`, `mcp`, or `other`.
 - `EgressSigning` expresses whether signing is disabled, optional via platform
   default, or required.
 - `EgressError` separates invalid requests, network access denial, unavailable
@@ -71,6 +71,7 @@ This applies to:
   HTTP support.
 - integration crates for external provider APIs.
 - internal system services such as email and utility LLM.
+- remote MCP servers (tool discovery and tool execution).
 - background tasks that call external APIs.
 
 Exceptions:


### PR DESCRIPTION
## What
Routes the MCP **client** integration — tool discovery (`fetch_mcp_tools`) and tool execution (`call_mcp_tool`) — through the platform's `EgressService` instead of constructing ad-hoc `reqwest::Client` instances per call. Adds an `Mcp` variant to `EgressRequestKind` so MCP traffic is labelled at the boundary.

## Why
`specs/egress.md` requires that "new outbound runtime code must use `EgressService` instead of constructing `reqwest::Client`, provider SDK clients, or toolkit-specific HTTP transports directly" so a future Egress Gateway deployment can move all internet egress behind a physical boundary. The MCP client paths were the largest remaining `reqwest::Client::builder()` sites that the spec applies to — they now share the platform's boundary like the LLM, system-email, and capability paths.

## How
- Added `EgressRequestKind::Mcp` (`crates/core/src/egress.rs`) and updated `specs/egress.md`.
- `fetch_mcp_tools` and `call_mcp_tool` now take `&dyn EgressService` and build `EgressRequest`s with `Content-Type`, `Accept`, the per-call timeout (`MCP_CLIENT_TIMEOUT` / `MCP_TOOL_TIMEOUT`), auth header, and custom headers.
- `McpServerService` holds an `Arc<dyn EgressService>`. `new(...)` falls back to `DirectEgressService::default()` for ergonomics in tests; production paths use the new `with_egress_service(...)` constructor.
- `build_scoped_mcp_tool_definitions` threads the egress service through callers (worker adapters, gRPC worker service, agent/harness preview commands, capability preview).
- `CapabilityService` exposes `egress_service()` and a `with_mcp_egress_service(...)` builder so command handlers can share the platform's egress via the service they already have a handle to.
- `app_builder.rs`, `grpc_service/mod.rs`, and `direct_worker_adapters.rs` wire `platform_definition.egress_service()` into both `McpServerService` and `CapabilityService`.
- SSRF validation continues to run **before** request construction so unsafe URLs never reach the boundary. Existing SSRF tests updated to pass an egress service.

A follow-up commit (`chore(specs)`) adds two pre-existing unindexed specs (`specs/api-conventions.md`, `specs/api-streaming.md`) to `specs/README.md` so `just pre-push` passes.

## Risk
- **Medium.** Touches every MCP discovery and tool-execution call. The wire-level request shape is unchanged (POST, JSON body, Authorization + custom headers), the SSRF defense-in-depth check still runs first, and timeouts are preserved (`timeout_ms` on `EgressRequest`). The largest non-functional change is that a long-lived `reqwest::Client` is now reused via `DirectEgressService` (connection pooling actually works), instead of a fresh client per call.
- Test/dev adapters that don't pass through `platform_definition.egress_service()` (e.g. `direct_worker_adapters::test_adapters`, `DirectPlatformStore` constructed without `egress_service`) fall back to a fresh `DirectEgressService::default()`, preserving previous behaviour.

## Security
- **Threat categories reviewed:** TM-TOOL (MCP server interaction), with reference to TM-DOS (timeouts) and TM-TENANT (per-call auth headers).
- **Findings and resolutions:**
  - TM-TOOL-002 (MCP response poisoning) — parsing path unchanged: response bytes → text → SSE/JSON extraction → `McpToolCallResponse` / `McpToolsListResponse` `serde_json::from_slice`. Same defensive parsing as before.
  - TM-TOOL-004 (MCP server timeout abuse) — preserved via `EgressRequest::timeout_ms(MCP_*_TIMEOUT.as_millis())`. No request can outlive the existing per-kind cap.
  - TM-TOOL-006 (Disabled MCP server still callable) — unaffected; status check happens above this layer.
  - TM-TOOL-007 (MCP API key exposure) — API keys still passed only via `Authorization: Bearer …` headers, encrypted at rest, decrypted at runtime.
  - SSRF — `validate_safe_url(...)` runs **before** building the egress request in both `fetch_mcp_tools` and `call_mcp_tool`, so localhost / private IPv4-IPv6 / link-local / cloud-metadata URLs never reach the boundary. Covered by `ssrf_blocks_localhost_at_execution_time`, `ssrf_blocks_private_ip_at_execution_time`, `ssrf_blocks_metadata_endpoint_at_execution_time`, `ssrf_blocks_ipv6_loopback_at_execution_time` in `mcp_executor.rs`, plus `fetch_tools_blocks_*` in `mcp_servers::service`.
  - No new trust boundary introduced; the migration is policy-positive in that all MCP traffic is now visible to and routable through the host's egress (signing, future gateway, policy, observability).

## Follow-ups
- The default `McpServerService::new(...)` and test adapters still construct a fresh `DirectEgressService::default()`. This matches the existing pattern across the codebase (e.g. `CapabilityService::new`) but means tests don't share the platform's egress instance. Migrating those constructors to require an egress service is out of scope for this PR; the production paths are wired.
- `mcp_executor::CompositeToolExecutor` / `McpToolExecutor` appear to be unused outside of their own module; investigating whether they can be removed is left for a separate cleanup PR.
- `EgressRequest.network_access` (per-session ACL) is not populated for MCP requests — neither was the previous code path. Threading the session/agent `NetworkAccessList` into the MCP call paths is a separate enhancement; right now `validate_safe_url` is the SSRF backstop.

## Checklist
- [x] Tests added or updated (SSRF tests now pass an egress service)
- [x] Backward compatibility considered (no public API removed; `McpServerService::new` keeps its existing signature via fallback)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR (pending)
- [ ] All review comments addressed (pending)


---
_Generated by [Claude Code](https://claude.ai/code/session_01E72Dd1aknM8gvdmUjZEqwB)_