### PR TITLE
fix(coding-cli): confine output chmod walk to /outputs subtree

### DIFF
--- a/examples/coding-cli/src/runtime.rs
+++ b/examples/coding-cli/src/runtime.rs
@@ -197,6 +197,10 @@ impl CodingCliSessionFileStore {
         let outputs_root = self.session_dir.join("outputs");
         let mut current = absolute.parent();
         while let Some(dir) = current {
+            if !dir.starts_with(&outputs_root) {
+                break;
+            }
+
             std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o700)).map_err(|e| {
                 AgentLoopError::config(format!(
                     "set private permissions on session output dir {}: {e}",
@@ -1207,6 +1211,40 @@ mod tests {
         assert_eq!(mode_of("outputs/run/log"), 0o700);
         assert_eq!(mode_of("outputs/run"), 0o700);
         assert_eq!(mode_of("outputs"), 0o700);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn coding_cli_file_store_output_root_does_not_chmod_session_ancestors() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let workspace = tempfile::tempdir().expect("workspace");
+        let session = tempfile::tempdir().expect("session");
+        let store = CodingCliSessionFileStore::new(workspace.path().into(), session.path().into())
+            .expect("store");
+        let session_id = SessionId::from_seed(5);
+
+        let session_mode_before = std::fs::metadata(session.path())
+            .expect("session metadata")
+            .permissions()
+            .mode()
+            & 0o777;
+
+        store
+            .write_file(session_id, "/outputs", "not a nested artifact", "text")
+            .await
+            .expect("write output root path");
+
+        let mode_of = |path: &std::path::Path| -> u32 {
+            std::fs::metadata(path)
+                .expect("metadata")
+                .permissions()
+                .mode()
+                & 0o777
+        };
+
+        assert_eq!(mode_of(session.path()), session_mode_before);
+        assert_eq!(mode_of(&session.path().join("outputs")), 0o600);
     }
     #[test]
     fn openai_input_message_carries_reasoning_effort() {


### PR DESCRIPTION
### Motivation

- Prevent an upward chmod traversal when a caller writes to the exact `/outputs` path that could change permissions of directories above the session `outputs/` subtree.

### Description

- Add a containment guard in `secure_session_artifact_path` so the directory chmod loop breaks if the current ancestor is not under the session `outputs` root using `starts_with` against `outputs_root`.
- Preserve existing behavior for nested paths under `/outputs/...` by still walking up to and including `<session_dir>/outputs` and setting directories to `0o700` and files to `0o600` on Unix.
- Add a Unix-only regression test `coding_cli_file_store_output_root_does_not_chmod_session_ancestors` that writes to `/outputs` and asserts session ancestor permissions are unchanged while the written path is hardened.

### Testing

- Ran `cargo test -p everruns-coding-cli coding_cli_file_store_secures_output_permissions` and it passed.
- Ran `cargo test -p everruns-coding-cli coding_cli_file_store_secures_nested_output_directories` and it passed.
- Ran `cargo test -p everruns-coding-cli coding_cli_file_store_output_root_does_not_chmod_session_ancestors` (new regression test) and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1522541b24832b8c8c10cfa5933af8)