### PR TITLE
chore(deps): bump llmsim from 0.3.0 to 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4277,9 +4277,9 @@ checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "llmsim"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd8de8212fda25a8c24b7b487be7ee790190b6402a13acd8613b2fc4998c9a41"
+checksum = "bdf2c7d8ebf2b6c24175cb89658e4818ca04b98b69a39ee3b5a110d0e7187f80"
 dependencies = [
  "async-stream",
  "axum",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -98,7 +98,7 @@ eventsource-stream = "0.2"
 inventory.workspace = true
 
 # LLM simulation for testing
-llmsim = "0.3.0"
+llmsim = "0.4.0"
 
 # OpenUI component definitions and prompt generator
 everruns-openui = { path = "../openui", version = "0.8.35", optional = true }


### PR DESCRIPTION
## What
Bump `llmsim` from 0.3.0 to 0.4.0 in `crates/core`.

## Why
Pick up upstream improvements (scripted-response mode, streaming/WS hardening, bounded per-model stats). 0.4.0 is the latest release on crates.io and is documented as backward-compatible with 0.3.0.

## How
Updated `crates/core/Cargo.toml` and ran `cargo update -p llmsim`. The API surface used by `llmsim_driver` (`llmsim::generator`, `llmsim::latency`, `llmsim::openai`, `llmsim::stream::TokenStreamBuilder`) is unchanged in 0.4.0.

Verification:
- `cargo build -p everruns-core` — clean.
- `cargo test -p everruns-core --lib llmsim_driver` — 18/18 pass.

## Risk
- Low
- `llmsim` is declared under `[dependencies]` (not `[dev-dependencies]`): `llmsim_driver` is exported from `everruns-core`, registered as the `LlmProviderType::LlmSim` driver, seeded by the server, and used by runtime examples and integration tests. So this is a normal runtime dependency/API-compatibility bump, not a dev-only one. The upstream release is documented as non-breaking, and the API symbols we depend on still compile and pass tests.
- Failure modes would be compile breakage or behavior drift in the simulated provider, both covered by the build and the unit tests above.

## Security
- Threat categories reviewed: TM-LLM (LLM provider driver paths). The bump adds upstream hardening (stream/WS finalization on drops, WS capacity caps, bounded per-model stats to mitigate memory DoS). No new threat surface introduced in `everruns`; the symbols we import are unchanged.
- Findings and resolutions: None.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated (existing `llmsim_driver` tests cover the API surface; all 18 pass on 0.4.0)
- [x] Backward compatibility considered (upstream documents 0.4.0 as non-breaking; build + tests confirm)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)