### PR TITLE
feat(capabilities): expose spawn_background via background_execution

### DIFF
--- a/crates/core/src/capabilities/background_execution.rs
+++ b/crates/core/src/capabilities/background_execution.rs
@@ -1,0 +1,101 @@
+//! BackgroundExecution Capability — exposes `spawn_background` to the model
+//! whenever the active tool set contains at least one built-in tool that opts
+//! into detached execution via `ToolHints::supports_background`.
+//!
+//! This capability is auto-activated by
+//! [`super::collect_capabilities_with_configs`] after the explicit-capability
+//! collection loop. It can also be selected explicitly by id
+//! (`"background_execution"`) — the auto-activator skips it in that case.
+//!
+//! See `specs/background-execution.md` for the cross-cutting / meta-tool
+//! capability contract this implements.
+
+use super::{Capability, CapabilityStatus};
+use crate::tools::{SpawnBackgroundTool, Tool};
+
+/// Capability id used by the auto-activator in
+/// `collect_capabilities_with_configs`.
+pub const BACKGROUND_EXECUTION_CAPABILITY_ID: &str = "background_execution";
+
+/// Cross-cutting capability that contributes `spawn_background`.
+///
+/// Auto-activation rule: any collected tool with
+/// `hints.supports_background == Some(true)` causes this capability to be
+/// added to the agent's tool set, exposing `spawn_background` to the model
+/// and registering it in the worker tool registry.
+pub struct BackgroundExecutionCapability;
+
+impl Capability for BackgroundExecutionCapability {
+    fn id(&self) -> &str {
+        BACKGROUND_EXECUTION_CAPABILITY_ID
+    }
+
+    fn name(&self) -> &str {
+        "Background Execution"
+    }
+
+    fn description(&self) -> &str {
+        "Run any background-capable built-in tool asynchronously via \
+         `spawn_background`. Auto-activated whenever the agent has a tool \
+         that declares `supports_background=true`."
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+
+    fn icon(&self) -> Option<&str> {
+        Some("zap")
+    }
+
+    fn category(&self) -> Option<&str> {
+        Some("Execution")
+    }
+
+    fn tools(&self) -> Vec<Box<dyn Tool>> {
+        vec![Box::new(SpawnBackgroundTool)]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::capabilities::CapabilityRegistry;
+
+    #[test]
+    fn capability_metadata() {
+        let cap = BackgroundExecutionCapability;
+        assert_eq!(cap.id(), BACKGROUND_EXECUTION_CAPABILITY_ID);
+        assert_eq!(cap.id(), "background_execution");
+        assert_eq!(cap.name(), "Background Execution");
+        assert_eq!(cap.category(), Some("Execution"));
+        assert_eq!(cap.icon(), Some("zap"));
+        assert_eq!(cap.status(), CapabilityStatus::Available);
+    }
+
+    #[test]
+    fn capability_contributes_spawn_background_tool() {
+        let cap = BackgroundExecutionCapability;
+        let tools = cap.tools();
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0].name(), "spawn_background");
+    }
+
+    #[test]
+    fn capability_tool_definition_carries_spawn_background() {
+        let cap = BackgroundExecutionCapability;
+        let defs = cap.tool_definitions();
+        assert_eq!(defs.len(), 1);
+        assert_eq!(defs[0].name(), "spawn_background");
+    }
+
+    #[test]
+    fn capability_registered_in_builtins() {
+        let registry = CapabilityRegistry::with_builtins();
+        let cap = registry
+            .get(BACKGROUND_EXECUTION_CAPABILITY_ID)
+            .expect("background_execution must be registered as a built-in capability");
+        assert_eq!(cap.id(), BACKGROUND_EXECUTION_CAPABILITY_ID);
+        assert_eq!(cap.tools().len(), 1);
+    }
+}

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -87,6 +87,7 @@ mod a2ui;
 mod agent_handoff;
 mod agent_instructions;
 pub mod attach_skill;
+mod background_execution;
 mod btw;
 mod budgeting;
 pub mod compaction;
@@ -152,6 +153,7 @@ pub use attach_skill::{
     SkillInstructions, SkillMeta, SkillSource, discover_skills_from_entries, is_skill_capability,
     parse_skill_capability_id, reconstruct_skill_md, skill_capability_id,
 };
+pub use background_execution::{BACKGROUND_EXECUTION_CAPABILITY_ID, BackgroundExecutionCapability};
 pub use btw::{BTW_CAPABILITY_ID, BtwCapability};
 pub use budgeting::BudgetingCapability;
 pub use compaction::{
@@ -846,6 +848,7 @@ impl CapabilityRegistry {
         registry.register(StatelessTodoListCapability);
         registry.register(WebFetchCapability::from_env());
         registry.register(VirtualBashCapability);
+        registry.register(BackgroundExecutionCapability);
         registry.register(SessionScheduleCapability);
         registry.register(BtwCapability);
         registry.register(InfinityContextCapability);
@@ -1790,6 +1793,39 @@ pub async fn collect_capabilities_with_configs(
         }
     }
 
+    // Auto-activate `background_execution` whenever any collected tool
+    // declares background support via `ToolHints::supports_background`.
+    //
+    // This is the generic cross-cutting capability contract — meta-tools that
+    // wrap other tools based on hints should hook in here, not attach to a
+    // single owner capability (e.g. `virtual_bash`).
+    //
+    // Lockstep: we extend both `tools` (execution registry) and
+    // `tool_definitions` (model-visible) so the model can see and the worker
+    // can dispatch `spawn_background` from the same activation event. See
+    // `specs/background-execution.md`.
+    if !applied_ids
+        .iter()
+        .any(|id| id == BACKGROUND_EXECUTION_CAPABILITY_ID)
+        && tool_definitions
+            .iter()
+            .any(|def| def.hints().supports_background == Some(true))
+        && let Some(bg_cap) = registry.get(BACKGROUND_EXECUTION_CAPABILITY_ID)
+        && bg_cap.status() == CapabilityStatus::Available
+    {
+        tools.extend(bg_cap.tools());
+        let cap_category = bg_cap.category();
+        for def in bg_cap.tool_definitions() {
+            let def = match (def.category(), cap_category) {
+                (None, Some(cat)) => def.with_category(cat),
+                _ => def,
+            }
+            .with_capability_attribution(BACKGROUND_EXECUTION_CAPABILITY_ID, Some(bg_cap.name()));
+            tool_definitions.push(def);
+        }
+        applied_ids.push(BACKGROUND_EXECUTION_CAPABILITY_ID.to_string());
+    }
+
     // Sort message filter providers by priority (lower = earlier)
     message_filter_providers.sort_by_key(|(p, _)| p.priority());
 
@@ -1944,6 +1980,7 @@ mod tests {
             "stateless_todo_list",
             "web_fetch",
             "virtual_bash",
+            "background_execution",
             "session_schedule",
             "btw",
             "infinity_context",
@@ -3366,6 +3403,133 @@ mod tests {
         assert!(
             !registry.has("bash"),
             "with_defaults() must not include 'bash' — it comes from virtual_bash capability"
+        );
+    }
+
+    // =========================================================================
+    // EVE-501: background_execution auto-activation
+    // =========================================================================
+
+    /// Auto-activation: any collected tool with `supports_background=true`
+    /// causes `spawn_background` to appear in both tool_definitions and tools.
+    #[tokio::test]
+    async fn test_background_execution_auto_activates_with_virtual_bash() {
+        let registry = CapabilityRegistry::with_builtins();
+        let collected =
+            collect_capabilities(&["virtual_bash".to_string()], &registry, &test_ctx()).await;
+
+        let tool_names: Vec<&str> = collected
+            .tool_definitions
+            .iter()
+            .map(|t| t.name())
+            .collect();
+        assert!(
+            tool_names.contains(&"spawn_background"),
+            "spawn_background must be auto-activated when virtual_bash (a \
+             background-capable tool) is in the agent's capability set; got: {:?}",
+            tool_names
+        );
+        assert!(
+            collected
+                .applied_ids
+                .iter()
+                .any(|id| id == BACKGROUND_EXECUTION_CAPABILITY_ID),
+            "background_execution must be in applied_ids when auto-activated; \
+             got: {:?}",
+            collected.applied_ids
+        );
+
+        // Lockstep: implementations match definitions (executable in the worker).
+        assert!(
+            collected
+                .tools
+                .iter()
+                .any(|t| t.name() == "spawn_background"),
+            "spawn_background tool implementation must be present alongside the \
+             definition (lockstep contract)"
+        );
+    }
+
+    /// Negative: when no collected tool declares background support, the
+    /// capability must NOT auto-activate.
+    #[tokio::test]
+    async fn test_background_execution_does_not_auto_activate_without_hint() {
+        let registry = CapabilityRegistry::with_builtins();
+        // current_time has no background-capable tool.
+        let collected =
+            collect_capabilities(&["current_time".to_string()], &registry, &test_ctx()).await;
+
+        let tool_names: Vec<&str> = collected
+            .tool_definitions
+            .iter()
+            .map(|t| t.name())
+            .collect();
+        assert!(
+            !tool_names.contains(&"spawn_background"),
+            "spawn_background must NOT be activated without a background-capable \
+             tool; got: {:?}",
+            tool_names
+        );
+        assert!(
+            !collected
+                .applied_ids
+                .iter()
+                .any(|id| id == BACKGROUND_EXECUTION_CAPABILITY_ID),
+            "background_execution must not appear in applied_ids when no \
+             background-capable tool is present; got: {:?}",
+            collected.applied_ids
+        );
+    }
+
+    /// Idempotence: explicitly selecting `background_execution` plus a
+    /// background-capable tool must not produce duplicate spawn_background
+    /// entries.
+    #[tokio::test]
+    async fn test_background_execution_explicit_selection_is_idempotent() {
+        let registry = CapabilityRegistry::with_builtins();
+        let collected = collect_capabilities(
+            &[
+                "virtual_bash".to_string(),
+                BACKGROUND_EXECUTION_CAPABILITY_ID.to_string(),
+            ],
+            &registry,
+            &test_ctx(),
+        )
+        .await;
+
+        let spawn_background_count = collected
+            .tool_definitions
+            .iter()
+            .filter(|t| t.name() == "spawn_background")
+            .count();
+        assert_eq!(
+            spawn_background_count, 1,
+            "spawn_background must appear exactly once even when \
+             background_execution is selected explicitly alongside a \
+             background-capable tool"
+        );
+        let applied_count = collected
+            .applied_ids
+            .iter()
+            .filter(|id| id.as_str() == BACKGROUND_EXECUTION_CAPABILITY_ID)
+            .count();
+        assert_eq!(
+            applied_count, 1,
+            "background_execution must appear exactly once in applied_ids"
+        );
+    }
+
+    /// Lockstep: with_defaults() must NOT include spawn_background — it only
+    /// reaches the worker registry through the auto-activated capability.
+    /// This proves the executor cannot dispatch spawn_background without the
+    /// model having seen it.
+    #[test]
+    fn test_defaults_do_not_include_spawn_background() {
+        let registry = crate::ToolRegistry::with_defaults();
+        assert!(
+            !registry.has("spawn_background"),
+            "with_defaults() must not include 'spawn_background' — it comes \
+             from the background_execution capability (EVE-501)"
         );
     }
 

--- a/crates/core/src/tools.rs
+++ b/crates/core/src/tools.rs
@@ -542,7 +542,15 @@ impl ToolRegistry {
         ToolRegistry::builder()
             .tool(GetCurrentTimeTool)
             .tool(EchoTool)
-            .tool(SpawnBackgroundTool)
+            // NOTE: `spawn_background` is intentionally NOT a default tool —
+            // it is contributed by the `background_execution` capability,
+            // which is auto-activated by
+            // `collect_capabilities_with_configs` whenever a collected tool
+            // declares `ToolHints::supports_background = Some(true)`. Keeping
+            // it out of defaults preserves the lockstep contract between
+            // model-visible tools and the worker execution registry: the
+            // executor only knows about `spawn_background` when the model
+            // can also see it.
             .tool(ReportProgressTool)
             // TestMath capability tools
             .tool(AddTool)
@@ -2454,9 +2462,12 @@ mod tests {
             "should have get_current_time"
         );
         assert!(registry.has("echo"), "should have echo");
+        // spawn_background is contributed by the background_execution
+        // capability (auto-activated) — it must NOT be in defaults.
         assert!(
-            registry.has("spawn_background"),
-            "should have spawn_background"
+            !registry.has("spawn_background"),
+            "spawn_background must NOT be in defaults — it comes from the \
+             background_execution capability"
         );
         assert!(
             registry.has("report_progress"),
@@ -2488,8 +2499,8 @@ mod tests {
         // WebFetch capability tools
         assert!(registry.has("web_fetch"), "should have web_fetch");
 
-        // Total count
-        assert_eq!(registry.len(), 19, "should have 19 default tools");
+        // Total count: 19 - 1 (spawn_background, moved to capability) = 18
+        assert_eq!(registry.len(), 18, "should have 18 default tools");
     }
 
     #[tokio::test]
@@ -2545,6 +2556,14 @@ mod tests {
         assert!(
             !registry.has("kv_store"),
             "kv_store must not be in defaults — it comes from session_storage capability"
+        );
+        // spawn_background comes from background_execution capability and is
+        // auto-activated by `collect_capabilities_with_configs` when a
+        // background-capable tool is present (see EVE-501).
+        assert!(
+            !registry.has("spawn_background"),
+            "spawn_background must not be in defaults — it comes from the \
+             background_execution capability (auto-activated by tool hints)"
         );
     }
 

--- a/crates/core/tests/background_execution_test.rs
+++ b/crates/core/tests/background_execution_test.rs
@@ -1,0 +1,174 @@
+// EVE-501: integration tests for the `background_execution` capability.
+//
+// These tests assemble the runtime tool set the same way the worker and the
+// in-process runtime do (`collect_capabilities_with_configs` -> merge into a
+// `ToolRegistry`), and assert the lockstep invariant between the model-visible
+// tool list and the worker's executor: when any collected tool declares
+// `supports_background = true`, both the executor registry and the model-facing
+// tool definitions must include `spawn_background`.
+//
+// LLM-driver-level scripted-session coverage (driving an agent through a full
+// `spawn_background` invocation using llmsim 0.4.0 scripted mode) is the
+// suggested next layer; this test pins the contract that path depends on.
+
+use everruns_core::capabilities::{
+    AgentCapabilityConfig, BACKGROUND_EXECUTION_CAPABILITY_ID, CapabilityId, CapabilityRegistry,
+    SystemPromptContext, collect_capabilities_with_configs,
+};
+use everruns_core::tools::ToolRegistry;
+use everruns_core::typed_id::SessionId;
+
+fn ctx() -> SystemPromptContext {
+    SystemPromptContext::without_file_store(SessionId::new())
+}
+
+fn cap(id: &str) -> AgentCapabilityConfig {
+    AgentCapabilityConfig {
+        capability_ref: CapabilityId::new(id),
+        config: serde_json::Value::Object(serde_json::Map::new()),
+    }
+}
+
+/// Assemble the executor registry the same way the worker does:
+/// `with_defaults()` + collected capability tools. The model-visible tool list
+/// comes from `tool_definitions`.
+async fn assemble(
+    cap_ids: &[&str],
+) -> (
+    ToolRegistry,
+    Vec<everruns_core::tool_types::ToolDefinition>,
+    Vec<String>,
+) {
+    let registry = CapabilityRegistry::with_builtins();
+    let configs: Vec<AgentCapabilityConfig> = cap_ids.iter().map(|id| cap(id)).collect();
+    let collected = collect_capabilities_with_configs(&configs, &registry, &ctx()).await;
+
+    let mut tool_registry = ToolRegistry::with_defaults();
+    for tool in collected.tools {
+        tool_registry.register_boxed(tool);
+    }
+    (
+        tool_registry,
+        collected.tool_definitions,
+        collected.applied_ids,
+    )
+}
+
+/// Auto-activation: a session that includes `virtual_bash` (which advertises
+/// `supports_background=true` on its `bash` tool) must end up with
+/// `spawn_background` in BOTH the worker tool registry AND the model-visible
+/// tool definitions, via the `background_execution` capability.
+#[tokio::test]
+async fn virtual_bash_session_auto_activates_spawn_background_in_lockstep() {
+    let (registry, defs, applied) = assemble(&["virtual_bash"]).await;
+
+    assert!(
+        registry.has("bash"),
+        "virtual_bash must contribute the bash tool to the executor"
+    );
+    assert!(
+        registry.has("spawn_background"),
+        "spawn_background must be in the worker executor registry when a \
+         background-capable tool is present (lockstep)"
+    );
+
+    let def_names: Vec<&str> = defs.iter().map(|d| d.name()).collect();
+    assert!(
+        def_names.contains(&"bash"),
+        "model-visible tool list must include bash; got: {:?}",
+        def_names
+    );
+    assert!(
+        def_names.contains(&"spawn_background"),
+        "model-visible tool list must include spawn_background when a \
+         background-capable tool is present; got: {:?}",
+        def_names
+    );
+
+    assert!(
+        applied
+            .iter()
+            .any(|id| id == BACKGROUND_EXECUTION_CAPABILITY_ID),
+        "background_execution must appear in applied_ids when auto-activated; \
+         got: {:?}",
+        applied
+    );
+}
+
+/// Negative path: a session with only `current_time` (no background-capable
+/// tools) must NOT advertise `spawn_background` to the model, and the worker
+/// registry must not silently include it either — `with_defaults()` is no
+/// longer a hidden source.
+#[tokio::test]
+async fn non_background_session_does_not_expose_spawn_background() {
+    let (registry, defs, applied) = assemble(&["current_time"]).await;
+
+    assert!(
+        !registry.has("spawn_background"),
+        "spawn_background must NOT be in the executor when no \
+         background-capable tool is collected (EVE-501 lockstep contract)"
+    );
+
+    let def_names: Vec<&str> = defs.iter().map(|d| d.name()).collect();
+    assert!(
+        !def_names.contains(&"spawn_background"),
+        "spawn_background must NOT be in tool_definitions without a \
+         background-capable tool; got: {:?}",
+        def_names
+    );
+
+    assert!(
+        !applied
+            .iter()
+            .any(|id| id == BACKGROUND_EXECUTION_CAPABILITY_ID),
+        "background_execution must NOT appear in applied_ids without a \
+         background-capable tool; got: {:?}",
+        applied
+    );
+}
+
+/// Explicit selection of `background_execution` alongside a background-capable
+/// tool must not duplicate `spawn_background` in either layer.
+#[tokio::test]
+async fn explicit_background_execution_plus_virtual_bash_is_idempotent() {
+    let (registry, defs, applied) =
+        assemble(&["virtual_bash", BACKGROUND_EXECUTION_CAPABILITY_ID]).await;
+
+    assert!(registry.has("spawn_background"));
+
+    let spawn_count = defs
+        .iter()
+        .filter(|d| d.name() == "spawn_background")
+        .count();
+    assert_eq!(
+        spawn_count, 1,
+        "spawn_background must appear exactly once in tool_definitions even \
+         under explicit + auto-activation overlap"
+    );
+
+    let applied_count = applied
+        .iter()
+        .filter(|id| id.as_str() == BACKGROUND_EXECUTION_CAPABILITY_ID)
+        .count();
+    assert_eq!(
+        applied_count, 1,
+        "background_execution must appear exactly once in applied_ids"
+    );
+}
+
+/// Hint discovery: `spawn_background`'s tool definition carries the
+/// `background_execution` capability attribution so reporting/usage tracking
+/// attributes the dispatch correctly.
+#[tokio::test]
+async fn spawn_background_definition_carries_capability_attribution() {
+    let (_registry, defs, _applied) = assemble(&["virtual_bash"]).await;
+    let spawn_def = defs
+        .iter()
+        .find(|d| d.name() == "spawn_background")
+        .expect("spawn_background must be in tool_definitions");
+    let (cap_id, cap_name) = spawn_def
+        .capability_attribution()
+        .expect("spawn_background must carry capability attribution");
+    assert_eq!(cap_id, BACKGROUND_EXECUTION_CAPABILITY_ID);
+    assert_eq!(cap_name, Some("Background Execution"));
+}

--- a/specs/README.md
+++ b/specs/README.md
@@ -22,11 +22,14 @@ Specs capture the "why" and "what", not exhaustive source detail. Link to code f
 - `specs/apis.md` - HTTP API endpoints, error handling
 - `specs/api-conventions.md` - Cross-cutting HTTP API conventions
 - `specs/api-streaming.md` - SSE streaming conventions for API endpoints
+- `specs/api-examples.md` - Per-operation request/response examples on `#[utoipa::path]` handlers
+- `specs/api-llm-extensions.md` - LLM-specific OpenAPI extensions (`x-llm-*`)
 - `specs/public-endpoints.md` - Public endpoints, error sanitization contract, stable public code set
 - `specs/events.md` - Event types, SSE streaming, contract and compatibility guarantees
 - `specs/execution-phases.md` - Execution phases (Commentary/FinalAnswer) for multi-step tool flows
 - `specs/tool-execution.md` - Tool types and execution flow
 - `specs/capabilities.md` - Agent capabilities system
+- `specs/background-execution.md` - `background_execution` capability and cross-cutting / auto-activation contract
 - `specs/client-side-tools.md` - Client-side tools for API/SDK consumers
 - `specs/tool-search.md` - OpenAI tool_search deferred tool loading capability
 - `specs/fetchkit.md` - fetchkit library powering the `web_fetch` capability

--- a/specs/background-execution.md
+++ b/specs/background-execution.md
@@ -1,0 +1,47 @@
+# Background Execution Capability
+
+The `background_execution` capability contributes the `spawn_background` meta-tool to the agent's tool set. It implements the **cross-cutting capability** pattern: a capability that activates automatically based on properties of the active tool set, rather than being explicitly requested by the agent author.
+
+This document captures the contract. Tool-side behavior of `spawn_background` (artifacts, schedules, run handles) lives in `specs/tool-execution.md` under "Background Tool Execution".
+
+## Goal
+
+`spawn_background` is the generic background runner. It wraps any registered built-in tool that opts in via hints. Before EVE-501 the meta-tool was registered into the worker's tool registry by default but was never advertised to the model — sessions had `bash` with `supports_background=true` but no visible `spawn_background`, so models fell back to raw shell detaching. The fix is to expose `spawn_background` through the same capability path that contributes all other model-visible tools.
+
+## Contract
+
+1. **Tool contributor.** `background_execution` contributes a single tool implementation: `SpawnBackgroundTool`. It does not own a target tool; it dispatches to whatever tool the model names in the `tool` argument.
+
+2. **Auto-activation rule.** `collect_capabilities_with_configs` activates `background_execution` automatically when **any** collected tool definition declares `ToolHints.supports_background == Some(true)`. The capability does not need to appear in the agent's configured capability list.
+
+3. **Idempotence.** Explicit selection (id `"background_execution"` in the agent's capabilities) and auto-activation must not produce duplicate `spawn_background` entries. The auto-activator no-ops when the capability is already in `applied_ids`.
+
+4. **Lockstep with the worker registry.** Both `tool_definitions` (model-visible) and `tools` (worker execution registry) gain `spawn_background` from the same activation event. `ToolRegistry::with_defaults()` does **not** include `SpawnBackgroundTool` — if the model cannot see the tool, the worker must not silently dispatch it from a hidden default.
+
+5. **No owner capability.** `virtual_bash` only advertises `supports_background=true` on the `bash` tool and implements `BackgroundExecutableTool`. It does not contribute `spawn_background`. The same rule applies to any future background-capable tool: declare the hint, implement the trait, and the meta-tool surfaces via the generic capability.
+
+## Cross-cutting capability pattern
+
+`background_execution` is the reference example of a capability that is contributed by hints on other capabilities rather than by explicit configuration. Future meta-tools that wrap or augment other tools (e.g. progress reporting, retries, schedulable wrappers) should follow this pattern instead of attaching to a single owner:
+
+- Declare a stable capability id and contribute the meta-tool from `tools()`.
+- Express activation as a property of the collected tool set (a specific hint, capability id, or tool name) and add the check to the auto-activator block in `collect_capabilities_with_configs`.
+- Keep the meta-tool out of `ToolRegistry::with_defaults()` to preserve the lockstep invariant.
+- Allow explicit selection by id for tests and overlays; the auto-activator must remain idempotent.
+
+When a new cross-cutting capability is added, extend the auto-activation block rather than introducing a parallel activation phase — keep all rules in one place.
+
+## Test policy
+
+The capability ships with three layers of tests:
+
+- **Capability unit tests** (`crates/core/src/capabilities/background_execution.rs`): metadata, single-tool contribution, presence in the built-in registry.
+- **Activation unit tests** (`crates/core/src/capabilities/mod.rs`): positive trigger via `virtual_bash`, negative trigger with `current_time`, idempotence under explicit + auto-activation.
+- **Lockstep regression** (`crates/core/src/tools.rs`, `crates/core/src/capabilities/mod.rs`): `ToolRegistry::with_defaults()` must not include `spawn_background`.
+
+End-to-end scripted-session coverage (using `llmsim` scripted mode to drive an agent through a real `spawn_background` call) is the suggested next layer; it belongs alongside the existing `crates/server/tests/workflow_test.rs` LlmSim scenarios.
+
+## Related specs
+
+- `specs/tool-execution.md` — `spawn_background` runtime contract (artifacts, schedules, signal-on-completion).
+- `specs/capabilities.md` — Capability system, registration, dependency resolution.

--- a/specs/tool-execution.md
+++ b/specs/tool-execution.md
@@ -214,6 +214,8 @@ This applies to built-in `bash` and provider-backed exec tools such as `daytona_
 
 `spawn_background` is a built-in meta-tool that schedules another built-in tool to run asynchronously and returns immediately with a run handle. It is generic: the caller passes `tool` plus `args`; the target tool determines whether background execution is supported.
 
+`spawn_background` is contributed by the `background_execution` capability, which auto-activates whenever the collected tool set contains a background-capable tool. See `specs/background-execution.md` for the cross-cutting capability contract.
+
 Background eligibility rules:
 - The target tool must set `ToolHints.supports_background = Some(true)`.
 - The target tool must implement `BackgroundExecutableTool`.


### PR DESCRIPTION
## What
Resolves [EVE-501](https://linear.app/everruns/issue/EVE-501/expose-spawn-background-via-a-generic-capability-contract). Introduces the `background_execution` capability and a generic **cross-cutting / auto-activation** contract so `spawn_background` is exposed to the model whenever the active tool set contains a tool that declares `ToolHints::supports_background = Some(true)`.

## Why
`spawn_background` existed as a default executor tool, but no capability advertised it — sessions with `virtual_bash` had `bash` with `supports_background=true` but no visible `spawn_background`, so models fell back to raw shell detaching. The fix is to push `spawn_background` through the same capability path as every other model-visible tool and auto-activate that capability based on a property of the active tool set, not by attaching it to a single owner capability.

## How
- **New capability** `crates/core/src/capabilities/background_execution.rs`: `BackgroundExecutionCapability` contributes a single tool (`SpawnBackgroundTool`) under id `background_execution`. Registered in `CapabilityRegistry::with_builtins_for_grade()`.
- **Auto-activation** in `collect_capabilities_with_configs`: after the explicit-capability loop, if any collected `ToolDefinition.hints().supports_background == Some(true)` and `background_execution` is not already applied, the capability's tools and tool definitions are merged into the result. Idempotent under explicit selection.
- **Lockstep with the worker registry**: `SpawnBackgroundTool` removed from `ToolRegistry::with_defaults()`. The defaults regression test and the new `test_defaults_do_not_include_spawn_background` document the invariant — if the model can't see the tool, the worker won't silently dispatch it.
- **Tests** (all green):
  - Capability unit tests (4) in `capabilities/background_execution.rs`.
  - Activation unit tests + lockstep regression (4) in `capabilities/mod.rs`.
  - Integration tests (4) in `crates/core/tests/background_execution_test.rs` covering positive activation, negative path, idempotence, and capability-attribution propagation.
  - Existing 1895 core-lib tests pass; runtime + server seed tests pass.
- **Specs**: new `specs/background-execution.md` documents the contract and the cross-cutting pattern; `specs/tool-execution.md` and `specs/README.md` link to it.

## Risk
- **Medium.** Touches the central capability collection path used by every session and the default executor registry. The auto-activator runs once per collection, is guarded by both an applied-id check and a hint scan, and is unit + integration tested for positive/negative/idempotent paths.
- Move of `SpawnBackgroundTool` out of `with_defaults()` is mirrored by activation in every session that has a background-capable tool; verified against the Generic Harness via the existing `test_generic_harness_capabilities_produce_bash_tool` test (still green) and a new integration test covering the same configuration.
- Repo-side bonus: `specs/api-examples.md` and `specs/api-llm-extensions.md` are added to `specs/README.md` so the specs-index pre-push check passes (they were merged unindexed in earlier PRs).

## Security
- Threat categories reviewed: **TM-TOOL** (tool surface exposed to the model), **TM-AUTHZ** (capability dispatch).
- Findings and resolutions:
  - TM-TOOL — `spawn_background` was already executable by sessions that had it in their tool registry; the change does not widen the executable surface, only aligns advertisement with execution. The auto-activator only triggers when a sibling capability has already opted into background execution via hints, so it cannot fire as a privilege escalation vector on its own.
  - TM-AUTHZ — Capability dispatch remains gated by the existing capability registry and harness/agent capability configs. Explicit selection by id is still honoured and idempotent.
- No new SQL, IO, or network surface; no migration; no public API change.

## Validation
- `cargo fmt --check` clean.
- `cargo clippy -p everruns-core --all-targets -- -D warnings` clean.
- `cargo test -p everruns-core --lib` — 1895 passed.
- `cargo test -p everruns-core --test background_execution_test` — 4 passed.
- `cargo test -p everruns-runtime` — 15 passed.
- `cargo test -p everruns-server --lib seed::` regressions — 6 passed (Generic Harness `bash` tool registration intact).
- `bash scripts/lib/pre-push.sh` — all 9 checks pass.
- CI on the PR is green (relevant Rust + Docker + CodeQL + SDK compat checks all pass; path-filtered jobs skipped as expected).

## Follow-ups
- LLM-driver-level scripted-session coverage (driving an agent through a full `spawn_background` call using `llmsim` 0.4.0 scripted mode) is the suggested next layer; it would sit alongside the existing `crates/server/tests/workflow_test.rs` LlmSim scenarios. The collection-layer invariants this PR establishes are what such a test would depend on.

## Checklist
- [x] Tests added or updated (capability unit + auto-activation unit + integration; lockstep regressions)
- [x] Backward compatibility considered (Generic Harness regression tests still pass; explicit selection still honoured and idempotent)
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (Copilot reviewed, no actionable findings)