### PR TITLE
fix(ui): interpolate duration in chat turn divider

### DIFF
--- a/apps/ui/src/components/chat/chat-message-list.tsx
+++ b/apps/ui/src/components/chat/chat-message-list.tsx
@@ -475,7 +475,13 @@ export const ChatMessageList = memo(function ChatMessageList({
               </div>
             )}
 
-            {renderTurnDivider(event.id, turnDurationByEventId, t("worked_for"))}
+            {renderTurnDivider(
+              event.id,
+              turnDurationByEventId,
+              t("worked_for", {
+                duration: formatWorkedDuration(turnDurationByEventId.get(event.id) ?? 0),
+              }),
+            )}
           </div>
         );
       })}


### PR DESCRIPTION
## What
Resolves [EVE-500](https://linear.app/everruns/issue/EVE-500/fix-literal-duration-placeholder-in-session-chat-divider). The default message-render branch in `ChatMessageList` called `t("worked_for")` without the `duration` parameter, so the divider showed the literal `Worked for {duration}` placeholder instead of the actual elapsed time.

## Why
Four of the five `renderTurnDivider` call sites in `chat-message-list.tsx` already pass `{ duration: formatWorkedDuration(turnDurationByEventId.get(event.id) ?? 0) }`. The final one (the plain assistant/user message branch) was missed when the divider was added there, so the i18n fallback in `formatMessage` returned the raw `Worked for {duration}` template — the literal that users were seeing in Session > Chat.

## How
- Pass `{ duration: formatWorkedDuration(...) }` to `t("worked_for", ...)` on the message-render branch (one site).
- `renderTurnDivider` already skips rendering when no duration is recorded (`turnDurationByEventId.get(event.id) == null`), so messages without a known duration stay clean — no further fallback handling needed.

## Risk
- **Low.** Single-line UI fix scoped to one render branch in `ChatMessageList`. The other four divider paths already use this exact pattern.

## Security
- Threat categories reviewed: none directly applicable. Pure presentation fix; the interpolated string comes from the existing `formatWorkedDuration` helper (numeric input → `"950ms"` / `"5s"` / `"3m 23s"` formats).

## Validation
- `npm --prefix apps/ui run lint` — clean.
- `npm --prefix apps/ui run format:check` — clean.
- `npm --prefix apps/ui test -- --testPathPatterns turn-delimiter` — 3/3 pass.
- `bash scripts/lib/pre-push.sh` — all 9 checks pass.
- CI on the PR is green (UI Build/Lint/Test, UI Playwright Smoke, Build Check, CodeQL, Analyze actions/python/typescript; remaining jobs path-filtered as expected).
- Visual confirmation: with this fix, the message-only branch divider now reads e.g. `Worked for 2m 14s` instead of `Worked for {duration}` (matches the four other divider paths already in the file).

## Follow-ups
- No follow-ups. The duplicate `specs/README.md` indexing addition this branch carried originally was absorbed by #1996 on rebase.

## Checklist
- [x] Tests added or updated (existing `turn-delimiter` jest tests still pass; component-level snapshot test deferred — the fix is a one-line argument alignment matching four already-correct call sites in the same file)
- [x] Backward compatibility considered (no API/contract change)
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (Copilot reviewed, no actionable findings)