### PR TITLE
chore(deps): bump OTEL 0.32, async-nats 0.49, sqlx 0.9, rusqlite 0.39

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1685,9 +1685,9 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3433,9 +3433,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "eb92f162bf56536459fc83c79b974bb12837acfed43d6bc370a7916d0ae15ecc"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -4201,14 +4201,14 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
  "bitflags 2.11.1",
  "libc",
  "plain",
- "redox_syscall 0.7.5",
+ "redox_syscall 0.8.0",
 ]
 
 [[package]]
@@ -5526,7 +5526,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.11+spec-1.1.0",
+ "toml_edit 0.25.12+spec-1.1.0",
 ]
 
 [[package]]
@@ -6104,9 +6104,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
+checksum = "7c7591fa2c6b601dfcfe5f043f65a1c39fcdf50efefcd7f1572e538c1f4b398d"
 dependencies = [
  "bitflags 2.11.1",
 ]
@@ -7903,9 +7903,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.11+spec-1.1.0"
+version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
  "indexmap",
  "toml_datetime 1.1.1+spec-1.1.0",
@@ -9439,18 +9439,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "bce33a6288fa3f072a8c2c7d0f2fdbb90e28298f0135c1f99b96c3db2efcc60b"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "8fd425244944f4ab65ccff928e7323354c5a018c75838362fdce749dfad2ee1e"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,18 +142,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -319,9 +307,9 @@ dependencies = [
 
 [[package]]
 name = "async-nats"
-version = "0.48.0"
+version = "0.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31811585c7c5bc2f60f8b80d5a6b0f737115611dac47567d7f7d94562ebb180b"
+checksum = "407486109ea5cfdf53fde05f46996dadf0547518a4d49f050d25f405ae31ed2d"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -591,7 +579,7 @@ dependencies = [
  "jaq-core",
  "jaq-json",
  "jaq-std",
- "md-5 0.11.0",
+ "md-5",
  "num-traits",
  "os_display",
  "regex",
@@ -1822,13 +1810,12 @@ dependencies = [
 
 [[package]]
 name = "etcetera"
-version = "0.8.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
 dependencies = [
  "cfg-if",
- "home",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2811,9 +2798,9 @@ dependencies = [
 
 [[package]]
 name = "flume"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -3185,9 +3172,6 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
-]
 
 [[package]]
 name = "hashbrown"
@@ -3195,8 +3179,6 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "allocator-api2",
- "equivalent",
  "foldhash 0.1.5",
  "serde",
 ]
@@ -3220,20 +3202,11 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
-version = "0.9.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
 dependencies = [
- "hashbrown 0.14.5",
-]
-
-[[package]]
-name = "hashlink"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
-dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -3332,11 +3305,11 @@ checksum = "242402749acf71e6f32f5857598b7002c4058a4e3c3b22b4c7d51cab9aea754e"
 
 [[package]]
 name = "hkdf"
-version = "0.12.4"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
 dependencies = [
- "hmac 0.12.1",
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -3355,15 +3328,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
  "digest 0.11.3",
-]
-
-[[package]]
-name = "home"
-version = "0.5.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
-dependencies = [
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4163,9 +4127,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-dependencies = [
- "spin",
-]
 
 [[package]]
 name = "leb128fmt"
@@ -4205,17 +4166,14 @@ version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
- "bitflags 2.11.1",
  "libc",
- "plain",
- "redox_syscall 0.8.0",
 ]
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.30.1"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
 dependencies = [
  "cc",
  "pkg-config",
@@ -4418,16 +4376,6 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
-
-[[package]]
-name = "md-5"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
-dependencies = [
- "cfg-if",
- "digest 0.10.7",
-]
 
 [[package]]
 name = "md-5"
@@ -4766,22 +4714,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint-dig"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
-dependencies = [
- "lazy_static",
- "libm",
- "num-integer",
- "num-iter",
- "num-traits",
- "rand 0.8.6",
- "smallvec",
- "zeroize",
-]
-
-[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4804,17 +4736,6 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
-dependencies = [
- "autocfg",
- "num-integer",
  "num-traits",
 ]
 
@@ -5011,9 +4932,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -5025,22 +4946,22 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
 dependencies = [
  "async-trait",
  "bytes",
  "http",
  "opentelemetry",
- "reqwest 0.12.28",
+ "reqwest 0.13.4",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
 dependencies = [
  "http",
  "opentelemetry",
@@ -5048,35 +4969,33 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "reqwest 0.12.28",
+ "reqwest 0.13.4",
  "thiserror 2.0.18",
- "tracing",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
  "prost",
- "tonic",
- "tonic-prost",
 ]
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.31.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
 dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
  "opentelemetry",
  "percent-encoding",
+ "portable-atomic",
  "rand 0.9.4",
  "thiserror 2.0.18",
  "tokio",
@@ -5159,7 +5078,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link",
 ]
@@ -5389,17 +5308,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pkcs1"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
-dependencies = [
- "der",
- "pkcs8",
- "spki",
-]
-
-[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5414,12 +5322,6 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "png"
@@ -6103,15 +6005,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c7591fa2c6b601dfcfe5f043f65a1c39fcdf50efefcd7f1572e538c1f4b398d"
-dependencies = [
- "bitflags 2.11.1",
-]
-
-[[package]]
 name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6192,7 +6085,6 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
- "futures-channel",
  "futures-core",
  "futures-util",
  "h2",
@@ -6354,23 +6246,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "rsa"
-version = "0.9.10"
+name = "rsqlite-vfs"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
 dependencies = [
- "const-oid 0.9.6",
- "digest 0.10.7",
- "num-bigint-dig",
- "num-integer",
- "num-traits",
- "pkcs1",
- "pkcs8",
- "rand_core 0.6.4",
- "signature",
- "spki",
- "subtle",
- "zeroize",
+ "hashbrown 0.16.1",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6404,16 +6286,17 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.32.1"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+checksum = "a0d2b0146dd9661bf67bb107c0bb2a55064d556eeb3fc314151b957f313bcd4e"
 dependencies = [
  "bitflags 2.11.1",
  "fallible-iterator",
  "fallible-streaming-iterator",
- "hashlink 0.9.1",
+ "hashlink",
  "libsqlite3-sys",
  "smallvec",
+ "sqlite-wasm-rs",
 ]
 
 [[package]]
@@ -7119,10 +7002,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "sqlx"
-version = "0.8.6"
+name = "sqlite-wasm-rs"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
+checksum = "dc3efc0da82635d7e1ced0053bbbfa8c7ab9645d0bf36ceb4f7127bb85315d75"
+dependencies = [
+ "cc",
+ "js-sys",
+ "rsqlite-vfs",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "sqlx"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "378620ccc25c62c89d8be1c819e76a88d59bdcc3304733330788948e619bfd71"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -7133,12 +7028,13 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+checksum = "05b44e85bf579a8eeb4ceaa77a3a523baf2bf0e9bac7e40f405d537b5d2d5ccb"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "cfg-if",
  "chrono",
  "crc",
  "crossbeam-queue",
@@ -7148,12 +7044,11 @@ dependencies = [
  "futures-intrusive",
  "futures-io",
  "futures-util",
- "hashbrown 0.15.5",
- "hashlink 0.10.0",
+ "hashbrown 0.16.1",
+ "hashlink",
  "indexmap",
  "log",
  "memchr",
- "once_cell",
  "percent-encoding",
  "rustls",
  "serde",
@@ -7166,14 +7061,14 @@ dependencies = [
  "tracing",
  "url",
  "uuid 1.23.1",
- "webpki-roots 0.26.11",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
 name = "sqlx-macros"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
+checksum = "bd2b84f2bc39a5705ef27ec785a11c934a41bbd4a24941e257927cddc26b60bf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7184,15 +7079,15 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros-core"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
+checksum = "fb8d96de5fdc85a5c4ec813432b523ec637e80ba98f046555f75f7908ddac7c3"
 dependencies = [
+ "cfg-if",
  "dotenvy",
  "either",
  "heck",
  "hex",
- "once_cell",
  "proc-macro2",
  "quote",
  "serde",
@@ -7203,59 +7098,44 @@ dependencies = [
  "sqlx-postgres",
  "sqlx-sqlite",
  "syn 2.0.117",
+ "thiserror 2.0.18",
  "tokio",
  "url",
 ]
 
 [[package]]
 name = "sqlx-mysql"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
+checksum = "90b8020fe17c5f2c245bfa2505d7ef59c5604839527c740266ad2214acebea27"
 dependencies = [
- "atoi",
- "base64 0.22.1",
  "bitflags 2.11.1",
  "byteorder",
  "bytes",
  "chrono",
  "crc",
- "digest 0.10.7",
+ "digest 0.11.3",
  "dotenvy",
  "either",
- "futures-channel",
  "futures-core",
- "futures-io",
  "futures-util",
  "generic-array",
- "hex",
- "hkdf",
- "hmac 0.12.1",
- "itoa",
  "log",
- "md-5 0.10.6",
- "memchr",
- "once_cell",
  "percent-encoding",
- "rand 0.8.6",
- "rsa",
  "serde",
- "sha1 0.10.6",
- "sha2 0.10.9",
- "smallvec",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
  "sqlx-core",
- "stringprep",
  "thiserror 2.0.18",
  "tracing",
  "uuid 1.23.1",
- "whoami",
 ]
 
 [[package]]
 name = "sqlx-postgres"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
+checksum = "87a2bdd6e83f6b3ea525ca9fee568030508b58355a43d0b2c1674d5f79dcd65e"
 dependencies = [
  "atoi",
  "base64 0.22.1",
@@ -7270,17 +7150,15 @@ dependencies = [
  "futures-util",
  "hex",
  "hkdf",
- "hmac 0.12.1",
- "home",
+ "hmac 0.13.0",
  "itoa",
  "log",
- "md-5 0.10.6",
+ "md-5",
  "memchr",
- "once_cell",
- "rand 0.8.6",
+ "rand 0.10.1",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -7292,13 +7170,14 @@ dependencies = [
 
 [[package]]
 name = "sqlx-sqlite"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
+checksum = "488e99c397a62007e4229aec669a179816339afc6d2620ca6fa420dbee2e982c"
 dependencies = [
  "atoi",
  "chrono",
  "flume",
+ "form_urlencoded",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -7308,7 +7187,6 @@ dependencies = [
  "log",
  "percent-encoding",
  "serde",
- "serde_urlencoded",
  "sqlx-core",
  "thiserror 2.0.18",
  "tracing",
@@ -8104,9 +7982,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.32.1"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
 dependencies = [
  "js-sys",
  "opentelemetry",
@@ -8541,12 +8419,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasite"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
-
-[[package]]
 name = "wasm-bindgen"
 version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8804,13 +8676,9 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "1.6.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
-dependencies = [
- "libredox",
- "wasite",
-]
+checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
 
 [[package]]
 name = "widestring"
@@ -9016,15 +8884,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -9048,21 +8907,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -9109,12 +8953,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -9127,12 +8965,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -9142,12 +8974,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -9175,12 +9001,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -9190,12 +9010,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -9211,12 +9025,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -9226,12 +9034,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
 # Database
-sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio-rustls", "postgres", "migrate", "uuid", "chrono", "macros"] }
+sqlx = { version = "0.9", default-features = false, features = ["runtime-tokio", "tls-rustls-ring", "postgres", "migrate", "uuid", "chrono", "macros"] }
 
 # UUID and time
 uuid = { version = "1.11", features = ["v4", "v5", "v7", "serde"] }
@@ -86,10 +86,10 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 # OpenTelemetry
-opentelemetry = "0.31"
-opentelemetry_sdk = { version = "0.31", features = ["rt-tokio"] }
-opentelemetry-otlp = { version = "0.31", features = ["http-proto", "reqwest-client"] }
-tracing-opentelemetry = "0.32"
+opentelemetry = "0.32"
+opentelemetry_sdk = { version = "0.32", features = ["rt-tokio"] }
+opentelemetry-otlp = { version = "0.32", features = ["http-proto", "reqwest-client"] }
+tracing-opentelemetry = "0.33"
 
 # OpenAPI documentation (used by export-openapi binary for spec generation)
 utoipa = { version = "5.4", features = ["axum_extras", "chrono", "uuid"] }
@@ -106,7 +106,7 @@ governor = "0.10"
 fred = { version = "10", features = ["enable-rustls-ring", "i-scripts"] }
 
 # NATS (event delivery, task queue)
-async-nats = "0.48"
+async-nats = "0.49"
 
 # Authentication
 argon2 = "0.5"

--- a/crates/durable/src/persistence/postgres.rs
+++ b/crates/durable/src/persistence/postgres.rs
@@ -2056,7 +2056,11 @@ impl WorkflowEventStore for PostgresWorkflowEventStore {
             opened_at_update, half_open_at_update, last_failure_update
         );
 
-        sqlx::query(&query)
+        // SAFETY: opened_at_update, half_open_at_update, last_failure_update are
+        // server-chosen literals from a closed set (`"NOW()"`, `"NULL"`,
+        // `"last_failure_at"`, `"opened_at"`); no caller input flows into the
+        // format string.
+        sqlx::query(sqlx::AssertSqlSafe(query))
             .bind(key)
             .bind(&state_str)
             .bind(failure_count as i32)

--- a/crates/server/src/bin/reencrypt_secrets.rs
+++ b/crates/server/src/bin/reencrypt_secrets.rs
@@ -224,9 +224,9 @@ async fn process_table(
 
         let rows: Vec<(uuid::Uuid, Option<Vec<u8>>)> =
             sqlx::query_as(sqlx::AssertSqlSafe(query.as_str()))
-            .fetch_all(pool)
-            .await
-            .context("Failed to fetch records")?;
+                .fetch_all(pool)
+                .await
+                .context("Failed to fetch records")?;
 
         if rows.is_empty() {
             break;

--- a/crates/server/src/bin/reencrypt_secrets.rs
+++ b/crates/server/src/bin/reencrypt_secrets.rs
@@ -222,7 +222,8 @@ async fn process_table(
             table.id_column, table.column, table.name, table.id_column, batch_size, offset
         );
 
-        let rows: Vec<(uuid::Uuid, Option<Vec<u8>>)> = sqlx::query_as(&query)
+        let rows: Vec<(uuid::Uuid, Option<Vec<u8>>)> =
+            sqlx::query_as(sqlx::AssertSqlSafe(query.as_str()))
             .fetch_all(pool)
             .await
             .context("Failed to fetch records")?;
@@ -260,7 +261,7 @@ async fn process_table(
                                         "UPDATE {} SET {} = $1 WHERE {} = $2",
                                         table.name, table.column, table.id_column
                                     );
-                                    sqlx::query(&update_query)
+                                    sqlx::query(sqlx::AssertSqlSafe(update_query.as_str()))
                                         .bind(&new_data)
                                         .bind(id)
                                         .execute(pool)

--- a/crates/server/src/domains/reporting/service.rs
+++ b/crates/server/src/domains/reporting/service.rs
@@ -712,7 +712,7 @@ async fn dataset_lag(
 ) -> Result<DatasetProjectorLag, CommandError> {
     let sql =
         format!("SELECT MAX(projected_at) AS latest_projected_at FROM {table} WHERE org_id = $1");
-    let row = sqlx::query(&sql)
+    let row = sqlx::query(sqlx::AssertSqlSafe(sql.as_str()))
         .bind(org_id)
         .fetch_one(pool)
         .await

--- a/crates/server/src/storage/reporting/postgres_query_backend.rs
+++ b/crates/server/src/storage/reporting/postgres_query_backend.rs
@@ -156,10 +156,7 @@ impl ReportingQueryBackend for PostgresReportingQueryBackend {
     }
 }
 
-fn bind_scalar_as_text(
-    builder: &mut QueryBuilder<sqlx::Postgres>,
-    value: &Value,
-) -> Result<()> {
+fn bind_scalar_as_text(builder: &mut QueryBuilder<sqlx::Postgres>, value: &Value) -> Result<()> {
     let value = match value {
         Value::String(value) => value.clone(),
         Value::Number(value) => value.to_string(),
@@ -170,10 +167,7 @@ fn bind_scalar_as_text(
     Ok(())
 }
 
-fn bind_comparable(
-    builder: &mut QueryBuilder<sqlx::Postgres>,
-    value: &Value,
-) -> Result<()> {
+fn bind_comparable(builder: &mut QueryBuilder<sqlx::Postgres>, value: &Value) -> Result<()> {
     match value {
         Value::Number(number) => {
             builder.push_bind(number.as_f64().context("invalid numeric filter value")?);

--- a/crates/server/src/storage/reporting/postgres_query_backend.rs
+++ b/crates/server/src/storage/reporting/postgres_query_backend.rs
@@ -156,8 +156,8 @@ impl ReportingQueryBackend for PostgresReportingQueryBackend {
     }
 }
 
-fn bind_scalar_as_text<'a>(
-    builder: &mut QueryBuilder<'a, sqlx::Postgres>,
+fn bind_scalar_as_text(
+    builder: &mut QueryBuilder<sqlx::Postgres>,
     value: &Value,
 ) -> Result<()> {
     let value = match value {
@@ -170,8 +170,8 @@ fn bind_scalar_as_text<'a>(
     Ok(())
 }
 
-fn bind_comparable<'a>(
-    builder: &mut QueryBuilder<'a, sqlx::Postgres>,
+fn bind_comparable(
+    builder: &mut QueryBuilder<sqlx::Postgres>,
     value: &Value,
 ) -> Result<()> {
     match value {
@@ -205,7 +205,7 @@ async fn latest_projection_lag_ms(pool: &PgPool, table: &str, org_id: i64) -> Re
     let sql = format!(
         "SELECT EXTRACT(EPOCH FROM (NOW() - MAX(projected_at))) * 1000 FROM {table} WHERE org_id = $1"
     );
-    let row: Option<(Option<f64>,)> = sqlx::query_as(&sql)
+    let row: Option<(Option<f64>,)> = sqlx::query_as(sqlx::AssertSqlSafe(sql.as_str()))
         .bind(org_id)
         .fetch_optional(pool)
         .await?;

--- a/crates/server/src/storage/repositories/agent_identities.rs
+++ b/crates/server/src/storage/repositories/agent_identities.rs
@@ -88,7 +88,8 @@ impl Database {
                 WHERE org_id = $1{status_sql}{search_sql}
                 ORDER BY created_at DESC"#
         );
-        let mut query = sqlx::query_as::<_, AgentIdentityRow>(sqlx::AssertSqlSafe(sql.as_str())).bind(org_id);
+        let mut query =
+            sqlx::query_as::<_, AgentIdentityRow>(sqlx::AssertSqlSafe(sql.as_str())).bind(org_id);
         for pat in &patterns {
             query = query.bind(pat);
         }

--- a/crates/server/src/storage/repositories/agent_identities.rs
+++ b/crates/server/src/storage/repositories/agent_identities.rs
@@ -88,7 +88,7 @@ impl Database {
                 WHERE org_id = $1{status_sql}{search_sql}
                 ORDER BY created_at DESC"#
         );
-        let mut query = sqlx::query_as::<_, AgentIdentityRow>(&sql).bind(org_id);
+        let mut query = sqlx::query_as::<_, AgentIdentityRow>(sqlx::AssertSqlSafe(sql.as_str())).bind(org_id);
         for pat in &patterns {
             query = query.bind(pat);
         }

--- a/crates/server/src/storage/repositories/agents.rs
+++ b/crates/server/src/storage/repositories/agents.rs
@@ -174,7 +174,7 @@ impl Database {
         let count_sql = format!(
             "SELECT COUNT(*) as count FROM agents WHERE org_id = $1{status_sql}{search_sql}"
         );
-        let mut count_query = sqlx::query_as::<_, (i64,)>(&count_sql).bind(org_id);
+        let mut count_query = sqlx::query_as::<_, (i64,)>(sqlx::AssertSqlSafe(count_sql.as_str())).bind(org_id);
         for pat in &patterns {
             count_query = count_query.bind(pat);
         }
@@ -191,7 +191,7 @@ impl Database {
                 ORDER BY created_at DESC
                 LIMIT ${limit_idx} OFFSET ${offset_idx}"#
         );
-        let mut query = sqlx::query_as::<_, AgentRow>(&sql).bind(org_id);
+        let mut query = sqlx::query_as::<_, AgentRow>(sqlx::AssertSqlSafe(sql.as_str())).bind(org_id);
         for pat in &patterns {
             query = query.bind(pat);
         }

--- a/crates/server/src/storage/repositories/agents.rs
+++ b/crates/server/src/storage/repositories/agents.rs
@@ -174,7 +174,8 @@ impl Database {
         let count_sql = format!(
             "SELECT COUNT(*) as count FROM agents WHERE org_id = $1{status_sql}{search_sql}"
         );
-        let mut count_query = sqlx::query_as::<_, (i64,)>(sqlx::AssertSqlSafe(count_sql.as_str())).bind(org_id);
+        let mut count_query =
+            sqlx::query_as::<_, (i64,)>(sqlx::AssertSqlSafe(count_sql.as_str())).bind(org_id);
         for pat in &patterns {
             count_query = count_query.bind(pat);
         }
@@ -191,7 +192,8 @@ impl Database {
                 ORDER BY created_at DESC
                 LIMIT ${limit_idx} OFFSET ${offset_idx}"#
         );
-        let mut query = sqlx::query_as::<_, AgentRow>(sqlx::AssertSqlSafe(sql.as_str())).bind(org_id);
+        let mut query =
+            sqlx::query_as::<_, AgentRow>(sqlx::AssertSqlSafe(sql.as_str())).bind(org_id);
         for pat in &patterns {
             query = query.bind(pat);
         }

--- a/crates/server/src/storage/repositories/apps.rs
+++ b/crates/server/src/storage/repositories/apps.rs
@@ -122,7 +122,7 @@ impl Database {
                 WHERE org_id = $1{status_sql}{search_sql}
                 ORDER BY created_at DESC"#
         );
-        let mut query = sqlx::query_as::<_, AppRow>(&sql).bind(org_id);
+        let mut query = sqlx::query_as::<_, AppRow>(sqlx::AssertSqlSafe(sql.as_str())).bind(org_id);
         for pat in &patterns {
             query = query.bind(pat);
         }

--- a/crates/server/src/storage/repositories/declarative_capabilities.rs
+++ b/crates/server/src/storage/repositories/declarative_capabilities.rs
@@ -104,7 +104,9 @@ impl Database {
             ORDER BY created_at DESC
             "#
         );
-        let mut query = sqlx::query_as::<_, DeclarativeCapabilityRow>(sqlx::AssertSqlSafe(sql.as_str())).bind(org_id);
+        let mut query =
+            sqlx::query_as::<_, DeclarativeCapabilityRow>(sqlx::AssertSqlSafe(sql.as_str()))
+                .bind(org_id);
         for pattern in &patterns {
             query = query.bind(pattern);
         }

--- a/crates/server/src/storage/repositories/declarative_capabilities.rs
+++ b/crates/server/src/storage/repositories/declarative_capabilities.rs
@@ -104,7 +104,7 @@ impl Database {
             ORDER BY created_at DESC
             "#
         );
-        let mut query = sqlx::query_as::<_, DeclarativeCapabilityRow>(&sql).bind(org_id);
+        let mut query = sqlx::query_as::<_, DeclarativeCapabilityRow>(sqlx::AssertSqlSafe(sql.as_str())).bind(org_id);
         for pattern in &patterns {
             query = query.bind(pattern);
         }

--- a/crates/server/src/storage/repositories/evals.rs
+++ b/crates/server/src/storage/repositories/evals.rs
@@ -84,7 +84,8 @@ impl Database {
                WHERE org_id = $1{status_sql}{search_sql}
                ORDER BY created_at DESC"#
         );
-        let mut query = sqlx::query_as::<_, EvalRow>(sqlx::AssertSqlSafe(sql.as_str())).bind(org_id);
+        let mut query =
+            sqlx::query_as::<_, EvalRow>(sqlx::AssertSqlSafe(sql.as_str())).bind(org_id);
         for pat in &patterns {
             query = query.bind(pat);
         }

--- a/crates/server/src/storage/repositories/evals.rs
+++ b/crates/server/src/storage/repositories/evals.rs
@@ -84,7 +84,7 @@ impl Database {
                WHERE org_id = $1{status_sql}{search_sql}
                ORDER BY created_at DESC"#
         );
-        let mut query = sqlx::query_as::<_, EvalRow>(&sql).bind(org_id);
+        let mut query = sqlx::query_as::<_, EvalRow>(sqlx::AssertSqlSafe(sql.as_str())).bind(org_id);
         for pat in &patterns {
             query = query.bind(pat);
         }

--- a/crates/server/src/storage/repositories/events.rs
+++ b/crates/server/src/storage/repositories/events.rs
@@ -11,7 +11,7 @@ use uuid::Uuid;
 
 /// Shared filter builder for `list_events_advanced` (and its `around_id` branch).
 /// Pushes type/time/context/tag/tool/search predicates onto the running query.
-fn push_common_filters(qb: &mut sqlx::QueryBuilder<'_, sqlx::Postgres>, params: &ListEventsParams) {
+fn push_common_filters(qb: &mut sqlx::QueryBuilder<sqlx::Postgres>, params: &ListEventsParams) {
     if !params.filter_types.is_empty() {
         qb.push(" AND event_type = ANY(");
         qb.push_bind(params.filter_types.clone());
@@ -663,7 +663,7 @@ impl Database {
         // Build and execute query with dynamic bindings
         // sqlx doesn't support truly dynamic queries, so we need to use raw SQL
         // with all possible parameters, binding None for unused ones
-        let mut db_query = sqlx::query_as::<_, EventRow>(&sql)
+        let mut db_query = sqlx::query_as::<_, EventRow>(sqlx::AssertSqlSafe(sql.as_str()))
             .bind(query.session_id.uuid())
             .bind(&types);
 

--- a/crates/server/src/storage/repositories/harnesses.rs
+++ b/crates/server/src/storage/repositories/harnesses.rs
@@ -167,7 +167,8 @@ impl Database {
                 WHERE org_id = $1{status_sql}{search_sql}
                 ORDER BY created_at DESC"#
         );
-        let mut query = sqlx::query_as::<_, HarnessRow>(sqlx::AssertSqlSafe(sql.as_str())).bind(org_id);
+        let mut query =
+            sqlx::query_as::<_, HarnessRow>(sqlx::AssertSqlSafe(sql.as_str())).bind(org_id);
         for pat in &patterns {
             query = query.bind(pat);
         }

--- a/crates/server/src/storage/repositories/harnesses.rs
+++ b/crates/server/src/storage/repositories/harnesses.rs
@@ -167,7 +167,7 @@ impl Database {
                 WHERE org_id = $1{status_sql}{search_sql}
                 ORDER BY created_at DESC"#
         );
-        let mut query = sqlx::query_as::<_, HarnessRow>(&sql).bind(org_id);
+        let mut query = sqlx::query_as::<_, HarnessRow>(sqlx::AssertSqlSafe(sql.as_str())).bind(org_id);
         for pat in &patterns {
             query = query.bind(pat);
         }

--- a/crates/server/src/storage/repositories/knowledge_bases.rs
+++ b/crates/server/src/storage/repositories/knowledge_bases.rs
@@ -45,7 +45,7 @@ impl Database {
             "SELECT {KB_COLUMNS} FROM knowledge_bases \
              WHERE org_id = $1 AND public_id = $2 AND status != 'deleted'"
         );
-        let row = sqlx::query_as::<_, KnowledgeBaseRow>(&sql)
+        let row = sqlx::query_as::<_, KnowledgeBaseRow>(sqlx::AssertSqlSafe(sql.as_str()))
             .bind(org_id)
             .bind(public_id)
             .fetch_optional(&self.pool)
@@ -62,7 +62,7 @@ impl Database {
             "SELECT {KB_COLUMNS} FROM knowledge_bases \
              WHERE org_id = $1 AND id = $2 AND status != 'deleted'"
         );
-        let row = sqlx::query_as::<_, KnowledgeBaseRow>(&sql)
+        let row = sqlx::query_as::<_, KnowledgeBaseRow>(sqlx::AssertSqlSafe(sql.as_str()))
             .bind(org_id)
             .bind(id)
             .fetch_optional(&self.pool)
@@ -87,7 +87,7 @@ impl Database {
             "SELECT {KB_COLUMNS} FROM knowledge_bases \
              WHERE org_id = $1{status_sql}{search_sql} ORDER BY created_at DESC"
         );
-        let mut query = sqlx::query_as::<_, KnowledgeBaseRow>(&sql).bind(org_id);
+        let mut query = sqlx::query_as::<_, KnowledgeBaseRow>(sqlx::AssertSqlSafe(sql.as_str())).bind(org_id);
         for pattern in &patterns {
             query = query.bind(pattern);
         }
@@ -182,7 +182,7 @@ impl Database {
             "SELECT {ENTRY_COLUMNS} FROM knowledge_entries \
              WHERE kb_id = $1 AND public_id = $2"
         );
-        let row = sqlx::query_as::<_, KnowledgeEntryRow>(&sql)
+        let row = sqlx::query_as::<_, KnowledgeEntryRow>(sqlx::AssertSqlSafe(sql.as_str()))
             .bind(kb_id)
             .bind(public_id)
             .fetch_optional(&self.pool)
@@ -206,7 +206,7 @@ impl Database {
             "SELECT {ENTRY_COLUMNS} FROM knowledge_entries \
              WHERE kb_id = $1{kind_sql}{search_sql} ORDER BY created_at DESC"
         );
-        let mut query = sqlx::query_as::<_, KnowledgeEntryRow>(&sql).bind(kb_id);
+        let mut query = sqlx::query_as::<_, KnowledgeEntryRow>(sqlx::AssertSqlSafe(sql.as_str())).bind(kb_id);
         if let Some(k) = kind {
             query = query.bind(k);
         }
@@ -243,7 +243,7 @@ impl Database {
         sql.push_str(" ORDER BY ts_rank(to_tsvector('english', title || ' ' || body), plainto_tsquery('english', $2)) DESC");
         sql.push_str(&format!(" LIMIT {}", limit.clamp(1, 100)));
 
-        let mut q = sqlx::query_as::<_, KnowledgeEntryRow>(&sql)
+        let mut q = sqlx::query_as::<_, KnowledgeEntryRow>(sqlx::AssertSqlSafe(sql.as_str()))
             .bind(kb_ids)
             .bind(query);
         if let Some(k) = kind {

--- a/crates/server/src/storage/repositories/knowledge_bases.rs
+++ b/crates/server/src/storage/repositories/knowledge_bases.rs
@@ -87,7 +87,8 @@ impl Database {
             "SELECT {KB_COLUMNS} FROM knowledge_bases \
              WHERE org_id = $1{status_sql}{search_sql} ORDER BY created_at DESC"
         );
-        let mut query = sqlx::query_as::<_, KnowledgeBaseRow>(sqlx::AssertSqlSafe(sql.as_str())).bind(org_id);
+        let mut query =
+            sqlx::query_as::<_, KnowledgeBaseRow>(sqlx::AssertSqlSafe(sql.as_str())).bind(org_id);
         for pattern in &patterns {
             query = query.bind(pattern);
         }
@@ -206,7 +207,8 @@ impl Database {
             "SELECT {ENTRY_COLUMNS} FROM knowledge_entries \
              WHERE kb_id = $1{kind_sql}{search_sql} ORDER BY created_at DESC"
         );
-        let mut query = sqlx::query_as::<_, KnowledgeEntryRow>(sqlx::AssertSqlSafe(sql.as_str())).bind(kb_id);
+        let mut query =
+            sqlx::query_as::<_, KnowledgeEntryRow>(sqlx::AssertSqlSafe(sql.as_str())).bind(kb_id);
         if let Some(k) = kind {
             query = query.bind(k);
         }

--- a/crates/server/src/storage/repositories/mcp_servers.rs
+++ b/crates/server/src/storage/repositories/mcp_servers.rs
@@ -186,7 +186,8 @@ impl Database {
                 WHERE org_id = $1{status_sql}{search_sql}
                 ORDER BY created_at DESC"#
         );
-        let mut query = sqlx::query_as::<_, McpServerRow>(sqlx::AssertSqlSafe(sql.as_str())).bind(org_id);
+        let mut query =
+            sqlx::query_as::<_, McpServerRow>(sqlx::AssertSqlSafe(sql.as_str())).bind(org_id);
         for pat in &patterns {
             query = query.bind(pat);
         }

--- a/crates/server/src/storage/repositories/mcp_servers.rs
+++ b/crates/server/src/storage/repositories/mcp_servers.rs
@@ -186,7 +186,7 @@ impl Database {
                 WHERE org_id = $1{status_sql}{search_sql}
                 ORDER BY created_at DESC"#
         );
-        let mut query = sqlx::query_as::<_, McpServerRow>(&sql).bind(org_id);
+        let mut query = sqlx::query_as::<_, McpServerRow>(sqlx::AssertSqlSafe(sql.as_str())).bind(org_id);
         for pat in &patterns {
             query = query.bind(pat);
         }

--- a/crates/server/src/storage/repositories/memories.rs
+++ b/crates/server/src/storage/repositories/memories.rs
@@ -388,7 +388,7 @@ impl Database {
             " ORDER BY m.importance DESC, m.created_at DESC LIMIT ${idx}"
         ));
 
-        let mut q = sqlx::query_as::<_, MemoryWithTotalRow>(&sql).bind(org_id);
+        let mut q = sqlx::query_as::<_, MemoryWithTotalRow>(sqlx::AssertSqlSafe(sql.as_str())).bind(org_id);
         if let Some(sid) = store_id {
             q = q.bind(sid);
         }

--- a/crates/server/src/storage/repositories/memories.rs
+++ b/crates/server/src/storage/repositories/memories.rs
@@ -388,7 +388,8 @@ impl Database {
             " ORDER BY m.importance DESC, m.created_at DESC LIMIT ${idx}"
         ));
 
-        let mut q = sqlx::query_as::<_, MemoryWithTotalRow>(sqlx::AssertSqlSafe(sql.as_str())).bind(org_id);
+        let mut q =
+            sqlx::query_as::<_, MemoryWithTotalRow>(sqlx::AssertSqlSafe(sql.as_str())).bind(org_id);
         if let Some(sid) = store_id {
             q = q.bind(sid);
         }

--- a/crates/server/src/storage/repositories/payments.rs
+++ b/crates/server/src/storage/repositories/payments.rs
@@ -49,12 +49,14 @@ impl Database {
                AND ($3::text IS NULL OR owner_id = $3) \
              ORDER BY created_at DESC"
         );
-        Ok(sqlx::query_as::<_, PaymentAccountRow>(sqlx::AssertSqlSafe(sql.as_str()))
-            .bind(org_id)
-            .bind(owner_type)
-            .bind(owner_id)
-            .fetch_all(&self.pool)
-            .await?)
+        Ok(
+            sqlx::query_as::<_, PaymentAccountRow>(sqlx::AssertSqlSafe(sql.as_str()))
+                .bind(org_id)
+                .bind(owner_type)
+                .bind(owner_id)
+                .fetch_all(&self.pool)
+                .await?,
+        )
     }
 
     pub async fn get_payment_account(
@@ -64,11 +66,13 @@ impl Database {
     ) -> Result<Option<PaymentAccountRow>> {
         let sql =
             format!("SELECT {ACCOUNT_COLUMNS} FROM payment_accounts WHERE org_id = $1 AND id = $2");
-        Ok(sqlx::query_as::<_, PaymentAccountRow>(sqlx::AssertSqlSafe(sql.as_str()))
-            .bind(org_id)
-            .bind(id)
-            .fetch_optional(&self.pool)
-            .await?)
+        Ok(
+            sqlx::query_as::<_, PaymentAccountRow>(sqlx::AssertSqlSafe(sql.as_str()))
+                .bind(org_id)
+                .bind(id)
+                .fetch_optional(&self.pool)
+                .await?,
+        )
     }
 
     pub async fn update_payment_account(
@@ -157,13 +161,15 @@ impl Database {
                AND ($4::text IS NULL OR subject_id = $4) \
              ORDER BY created_at DESC"
         );
-        Ok(sqlx::query_as::<_, PaymentPolicyRow>(sqlx::AssertSqlSafe(sql.as_str()))
-            .bind(org_id)
-            .bind(payment_account_id)
-            .bind(subject_type)
-            .bind(subject_id)
-            .fetch_all(&self.pool)
-            .await?)
+        Ok(
+            sqlx::query_as::<_, PaymentPolicyRow>(sqlx::AssertSqlSafe(sql.as_str()))
+                .bind(org_id)
+                .bind(payment_account_id)
+                .bind(subject_type)
+                .bind(subject_id)
+                .fetch_all(&self.pool)
+                .await?,
+        )
     }
 
     pub async fn get_payment_policy(
@@ -173,11 +179,13 @@ impl Database {
     ) -> Result<Option<PaymentPolicyRow>> {
         let sql =
             format!("SELECT {POLICY_COLUMNS} FROM payment_policies WHERE org_id = $1 AND id = $2");
-        Ok(sqlx::query_as::<_, PaymentPolicyRow>(sqlx::AssertSqlSafe(sql.as_str()))
-            .bind(org_id)
-            .bind(id)
-            .fetch_optional(&self.pool)
-            .await?)
+        Ok(
+            sqlx::query_as::<_, PaymentPolicyRow>(sqlx::AssertSqlSafe(sql.as_str()))
+                .bind(org_id)
+                .bind(id)
+                .fetch_optional(&self.pool)
+                .await?,
+        )
     }
 
     pub async fn update_payment_policy(
@@ -239,12 +247,14 @@ impl Database {
              WHERE org_id = $1 AND ($2::uuid IS NULL OR session_id = $2) \
              ORDER BY created_at DESC LIMIT $3"
         );
-        Ok(sqlx::query_as::<_, PaymentAttemptRow>(sqlx::AssertSqlSafe(sql.as_str()))
-            .bind(org_id)
-            .bind(session_id)
-            .bind(limit)
-            .fetch_all(&self.pool)
-            .await?)
+        Ok(
+            sqlx::query_as::<_, PaymentAttemptRow>(sqlx::AssertSqlSafe(sql.as_str()))
+                .bind(org_id)
+                .bind(session_id)
+                .bind(limit)
+                .fetch_all(&self.pool)
+                .await?,
+        )
     }
 
     pub async fn create_payment_attempt(

--- a/crates/server/src/storage/repositories/payments.rs
+++ b/crates/server/src/storage/repositories/payments.rs
@@ -49,7 +49,7 @@ impl Database {
                AND ($3::text IS NULL OR owner_id = $3) \
              ORDER BY created_at DESC"
         );
-        Ok(sqlx::query_as::<_, PaymentAccountRow>(&sql)
+        Ok(sqlx::query_as::<_, PaymentAccountRow>(sqlx::AssertSqlSafe(sql.as_str()))
             .bind(org_id)
             .bind(owner_type)
             .bind(owner_id)
@@ -64,7 +64,7 @@ impl Database {
     ) -> Result<Option<PaymentAccountRow>> {
         let sql =
             format!("SELECT {ACCOUNT_COLUMNS} FROM payment_accounts WHERE org_id = $1 AND id = $2");
-        Ok(sqlx::query_as::<_, PaymentAccountRow>(&sql)
+        Ok(sqlx::query_as::<_, PaymentAccountRow>(sqlx::AssertSqlSafe(sql.as_str()))
             .bind(org_id)
             .bind(id)
             .fetch_optional(&self.pool)
@@ -157,7 +157,7 @@ impl Database {
                AND ($4::text IS NULL OR subject_id = $4) \
              ORDER BY created_at DESC"
         );
-        Ok(sqlx::query_as::<_, PaymentPolicyRow>(&sql)
+        Ok(sqlx::query_as::<_, PaymentPolicyRow>(sqlx::AssertSqlSafe(sql.as_str()))
             .bind(org_id)
             .bind(payment_account_id)
             .bind(subject_type)
@@ -173,7 +173,7 @@ impl Database {
     ) -> Result<Option<PaymentPolicyRow>> {
         let sql =
             format!("SELECT {POLICY_COLUMNS} FROM payment_policies WHERE org_id = $1 AND id = $2");
-        Ok(sqlx::query_as::<_, PaymentPolicyRow>(&sql)
+        Ok(sqlx::query_as::<_, PaymentPolicyRow>(sqlx::AssertSqlSafe(sql.as_str()))
             .bind(org_id)
             .bind(id)
             .fetch_optional(&self.pool)
@@ -239,7 +239,7 @@ impl Database {
              WHERE org_id = $1 AND ($2::uuid IS NULL OR session_id = $2) \
              ORDER BY created_at DESC LIMIT $3"
         );
-        Ok(sqlx::query_as::<_, PaymentAttemptRow>(&sql)
+        Ok(sqlx::query_as::<_, PaymentAttemptRow>(sqlx::AssertSqlSafe(sql.as_str()))
             .bind(org_id)
             .bind(session_id)
             .bind(limit)

--- a/crates/server/src/storage/repositories/sessions.rs
+++ b/crates/server/src/storage/repositories/sessions.rs
@@ -186,7 +186,9 @@ impl Database {
 
         // Get total count
         let count_sql = format!("SELECT COUNT(*) as count FROM sessions {where_clause}");
-        let count_query = bind_params!(sqlx::query_as::<_, (i64,)>(sqlx::AssertSqlSafe(count_sql.as_str())));
+        let count_query = bind_params!(sqlx::query_as::<_, (i64,)>(sqlx::AssertSqlSafe(
+            count_sql.as_str()
+        )));
         let total: (i64,) = count_query.fetch_one(&self.pool).await?;
 
         // Get paginated results
@@ -200,7 +202,9 @@ impl Database {
             ORDER BY created_at DESC
             LIMIT ${limit_idx} OFFSET ${offset_idx}"#,
         );
-        let data_query = bind_params!(sqlx::query_as::<_, SessionRow>(sqlx::AssertSqlSafe(select_sql.as_str())));
+        let data_query = bind_params!(sqlx::query_as::<_, SessionRow>(sqlx::AssertSqlSafe(
+            select_sql.as_str()
+        )));
         let rows: Vec<SessionRow> = data_query
             .bind(pagination.limit as i64)
             .bind(pagination.offset as i64)

--- a/crates/server/src/storage/repositories/sessions.rs
+++ b/crates/server/src/storage/repositories/sessions.rs
@@ -186,7 +186,7 @@ impl Database {
 
         // Get total count
         let count_sql = format!("SELECT COUNT(*) as count FROM sessions {where_clause}");
-        let count_query = bind_params!(sqlx::query_as::<_, (i64,)>(&count_sql));
+        let count_query = bind_params!(sqlx::query_as::<_, (i64,)>(sqlx::AssertSqlSafe(count_sql.as_str())));
         let total: (i64,) = count_query.fetch_one(&self.pool).await?;
 
         // Get paginated results
@@ -200,7 +200,7 @@ impl Database {
             ORDER BY created_at DESC
             LIMIT ${limit_idx} OFFSET ${offset_idx}"#,
         );
-        let data_query = bind_params!(sqlx::query_as::<_, SessionRow>(&select_sql));
+        let data_query = bind_params!(sqlx::query_as::<_, SessionRow>(sqlx::AssertSqlSafe(select_sql.as_str())));
         let rows: Vec<SessionRow> = data_query
             .bind(pagination.limit as i64)
             .bind(pagination.offset as i64)

--- a/crates/server/src/storage/repositories/skills.rs
+++ b/crates/server/src/storage/repositories/skills.rs
@@ -99,7 +99,8 @@ impl Database {
                 WHERE org_id = $1{status_sql}{search_sql}
                 ORDER BY created_at DESC"#
         );
-        let mut query = sqlx::query_as::<_, SkillRow>(sqlx::AssertSqlSafe(sql.as_str())).bind(org_id);
+        let mut query =
+            sqlx::query_as::<_, SkillRow>(sqlx::AssertSqlSafe(sql.as_str())).bind(org_id);
         for pat in &patterns {
             query = query.bind(pat);
         }

--- a/crates/server/src/storage/repositories/skills.rs
+++ b/crates/server/src/storage/repositories/skills.rs
@@ -99,7 +99,7 @@ impl Database {
                 WHERE org_id = $1{status_sql}{search_sql}
                 ORDER BY created_at DESC"#
         );
-        let mut query = sqlx::query_as::<_, SkillRow>(&sql).bind(org_id);
+        let mut query = sqlx::query_as::<_, SkillRow>(sqlx::AssertSqlSafe(sql.as_str())).bind(org_id);
         for pat in &patterns {
             query = query.bind(pat);
         }

--- a/crates/server/src/storage/repositories/volumes.rs
+++ b/crates/server/src/storage/repositories/volumes.rs
@@ -106,7 +106,8 @@ impl Database {
             ORDER BY created_at DESC
             "#
         );
-        let mut query = sqlx::query_as::<_, VolumeRow>(sqlx::AssertSqlSafe(sql.as_str())).bind(org_id);
+        let mut query =
+            sqlx::query_as::<_, VolumeRow>(sqlx::AssertSqlSafe(sql.as_str())).bind(org_id);
         for pattern in &patterns {
             query = query.bind(pattern);
         }

--- a/crates/server/src/storage/repositories/volumes.rs
+++ b/crates/server/src/storage/repositories/volumes.rs
@@ -106,7 +106,7 @@ impl Database {
             ORDER BY created_at DESC
             "#
         );
-        let mut query = sqlx::query_as::<_, VolumeRow>(&sql).bind(org_id);
+        let mut query = sqlx::query_as::<_, VolumeRow>(sqlx::AssertSqlSafe(sql.as_str())).bind(org_id);
         for pattern in &patterns {
             query = query.bind(pattern);
         }

--- a/crates/session-sqldb/Cargo.toml
+++ b/crates/session-sqldb/Cargo.toml
@@ -8,7 +8,7 @@ description = "Session-scoped SQLite databases backed by PostgreSQL page-level s
 
 [dependencies]
 # SQLite
-rusqlite = { version = "0.32", features = ["bundled", "serialize", "column_decltype", "hooks"] }
+rusqlite = { version = "0.39", features = ["bundled", "serialize", "column_decltype", "hooks"] }
 
 # Core types
 everruns-core = { path = "../core" }

--- a/crates/session-sqldb/src/authorizer.rs
+++ b/crates/session-sqldb/src/authorizer.rs
@@ -27,16 +27,20 @@ const ALLOWED_PRAGMAS: &[&str] = &[
 /// Install the authorizer on a connection.
 ///
 /// Must be called before executing any user-provided SQL. The authorizer
-/// API in rusqlite 0.39+ returns `Result`, but a failure here is best-effort
-/// hardening so we deliberately ignore it — callers must still validate
-/// inputs upstream.
+/// API in rusqlite 0.39+ returns `Result`. A failure here means the
+/// authorizer is NOT installed and dangerous SQL would not be blocked, so
+/// surface it via a warn-level log; the upstream input checks still apply.
 pub fn install_authorizer(conn: &Connection) {
-    let _ = conn.authorizer(Some(authorizer_callback));
+    if let Err(err) = conn.authorizer(Some(authorizer_callback)) {
+        warn!(error = %err, "failed to install SQLite authorizer; sandbox check degraded");
+    }
 }
 
 /// Remove the authorizer from a connection.
 pub fn remove_authorizer(conn: &Connection) {
-    let _ = conn.authorizer(None::<fn(AuthContext<'_>) -> Authorization>);
+    if let Err(err) = conn.authorizer(None::<fn(AuthContext<'_>) -> Authorization>) {
+        warn!(error = %err, "failed to remove SQLite authorizer");
+    }
 }
 
 fn authorizer_callback(ctx: AuthContext<'_>) -> Authorization {

--- a/crates/session-sqldb/src/authorizer.rs
+++ b/crates/session-sqldb/src/authorizer.rs
@@ -4,6 +4,7 @@
 // and write-mode PRAGMAs. This is the primary security boundary for
 // session SQL databases.
 
+use crate::error::SqlDbError;
 use rusqlite::Connection;
 use rusqlite::hooks::{AuthAction, AuthContext, Authorization};
 use tracing::warn;
@@ -26,17 +27,20 @@ const ALLOWED_PRAGMAS: &[&str] = &[
 
 /// Install the authorizer on a connection.
 ///
-/// Must be called before executing any user-provided SQL. The authorizer
-/// API in rusqlite 0.39+ returns `Result`. A failure here means the
-/// authorizer is NOT installed and dangerous SQL would not be blocked, so
-/// surface it via a warn-level log; the upstream input checks still apply.
-pub fn install_authorizer(conn: &Connection) {
-    if let Err(err) = conn.authorizer(Some(authorizer_callback)) {
-        warn!(error = %err, "failed to install SQLite authorizer; sandbox check degraded");
-    }
+/// Must be called before executing any user-provided SQL. This is the
+/// primary security boundary for the session SQL sandbox; if the install
+/// fails the caller MUST fail closed and abort the operation rather than
+/// run unrestricted SQL.
+pub fn install_authorizer(conn: &Connection) -> Result<(), SqlDbError> {
+    conn.authorizer(Some(authorizer_callback)).map_err(|err| {
+        warn!(error = %err, "failed to install SQLite authorizer");
+        SqlDbError::Internal(format!("failed to install SQLite authorizer: {err}"))
+    })
 }
 
-/// Remove the authorizer from a connection.
+/// Remove the authorizer from a connection. Removal is best-effort cleanup —
+/// a failure here cannot widen the trust posture since the connection is
+/// about to be dropped, so a warn-level log is sufficient.
 pub fn remove_authorizer(conn: &Connection) {
     if let Err(err) = conn.authorizer(None::<fn(AuthContext<'_>) -> Authorization>) {
         warn!(error = %err, "failed to remove SQLite authorizer");
@@ -96,7 +100,7 @@ mod tests {
 
     fn setup_conn() -> Connection {
         let conn = Connection::open_in_memory().unwrap();
-        install_authorizer(&conn);
+        install_authorizer(&conn).unwrap();
         conn
     }
 
@@ -159,7 +163,7 @@ mod tests {
     #[test]
     fn test_authorizer_removal() {
         let conn = Connection::open_in_memory().unwrap();
-        install_authorizer(&conn);
+        install_authorizer(&conn).unwrap();
         assert!(
             conn.execute_batch("ATTACH DATABASE ':memory:' AS other")
                 .is_err()

--- a/crates/session-sqldb/src/authorizer.rs
+++ b/crates/session-sqldb/src/authorizer.rs
@@ -26,14 +26,17 @@ const ALLOWED_PRAGMAS: &[&str] = &[
 
 /// Install the authorizer on a connection.
 ///
-/// Must be called before executing any user-provided SQL.
+/// Must be called before executing any user-provided SQL. The authorizer
+/// API in rusqlite 0.39+ returns `Result`, but a failure here is best-effort
+/// hardening so we deliberately ignore it — callers must still validate
+/// inputs upstream.
 pub fn install_authorizer(conn: &Connection) {
-    conn.authorizer(Some(authorizer_callback));
+    let _ = conn.authorizer(Some(authorizer_callback));
 }
 
 /// Remove the authorizer from a connection.
 pub fn remove_authorizer(conn: &Connection) {
-    conn.authorizer(None::<fn(AuthContext<'_>) -> Authorization>);
+    let _ = conn.authorizer(None::<fn(AuthContext<'_>) -> Authorization>);
 }
 
 fn authorizer_callback(ctx: AuthContext<'_>) -> Authorization {

--- a/crates/session-sqldb/src/executor.rs
+++ b/crates/session-sqldb/src/executor.rs
@@ -30,8 +30,12 @@ pub fn configure_connection(conn: &Connection) -> Result<(), SqlDbError> {
 }
 
 /// Install a progress handler that interrupts after timeout.
+///
+/// rusqlite 0.39+ returns `Result` from `progress_handler`; the only failure
+/// mode is the connection already being closed, in which case the timeout
+/// check is moot.
 fn install_progress_handler(conn: &Connection, interrupted: Arc<AtomicBool>) {
-    conn.progress_handler(
+    let _ = conn.progress_handler(
         PROGRESS_HANDLER_INTERVAL,
         Some(move || interrupted.load(Ordering::Relaxed)),
     );
@@ -39,7 +43,7 @@ fn install_progress_handler(conn: &Connection, interrupted: Arc<AtomicBool>) {
 
 /// Remove the progress handler.
 fn clear_progress_handler(conn: &Connection) {
-    conn.progress_handler(0, None::<fn() -> bool>);
+    let _ = conn.progress_handler(0, None::<fn() -> bool>);
 }
 
 /// Execute a read-only SQL query, returning columns and rows as JSON.

--- a/crates/session-sqldb/src/executor.rs
+++ b/crates/session-sqldb/src/executor.rs
@@ -14,7 +14,7 @@ use serde_json::Value;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Instant;
-use tracing::debug;
+use tracing::{debug, warn};
 
 /// Configure a connection with safe defaults.
 ///
@@ -31,19 +31,23 @@ pub fn configure_connection(conn: &Connection) -> Result<(), SqlDbError> {
 
 /// Install a progress handler that interrupts after timeout.
 ///
-/// rusqlite 0.39+ returns `Result` from `progress_handler`; the only failure
-/// mode is the connection already being closed, in which case the timeout
-/// check is moot.
+/// rusqlite 0.39+ returns `Result`. A failure here means the timeout
+/// interrupt won't fire; log so this isn't invisible if SQLite ever starts
+/// rejecting the install at runtime.
 fn install_progress_handler(conn: &Connection, interrupted: Arc<AtomicBool>) {
-    let _ = conn.progress_handler(
+    if let Err(err) = conn.progress_handler(
         PROGRESS_HANDLER_INTERVAL,
         Some(move || interrupted.load(Ordering::Relaxed)),
-    );
+    ) {
+        warn!(error = %err, "failed to install SQLite progress handler; query timeout degraded");
+    }
 }
 
 /// Remove the progress handler.
 fn clear_progress_handler(conn: &Connection) {
-    let _ = conn.progress_handler(0, None::<fn() -> bool>);
+    if let Err(err) = conn.progress_handler(0, None::<fn() -> bool>) {
+        warn!(error = %err, "failed to clear SQLite progress handler");
+    }
 }
 
 /// Execute a read-only SQL query, returning columns and rows as JSON.

--- a/crates/session-sqldb/src/executor.rs
+++ b/crates/session-sqldb/src/executor.rs
@@ -52,7 +52,7 @@ fn clear_progress_handler(conn: &Connection) {
 
 /// Execute a read-only SQL query, returning columns and rows as JSON.
 pub fn execute_query(conn: &Connection, sql: &str) -> Result<SqlQueryResult, SqlDbError> {
-    install_authorizer(conn);
+    install_authorizer(conn)?;
 
     let interrupted = Arc::new(AtomicBool::new(false));
     install_progress_handler(conn, interrupted.clone());
@@ -142,7 +142,7 @@ fn execute_query_inner(conn: &Connection, sql: &str) -> Result<SqlQueryResult, S
 
 /// Execute a write SQL statement, returning affected row count.
 pub fn execute_statement(conn: &Connection, sql: &str) -> Result<SqlExecuteResult, SqlDbError> {
-    install_authorizer(conn);
+    install_authorizer(conn)?;
 
     let interrupted = Arc::new(AtomicBool::new(false));
     install_progress_handler(conn, interrupted.clone());
@@ -183,7 +183,7 @@ pub fn execute_statement(conn: &Connection, sql: &str) -> Result<SqlExecuteResul
 
 /// Get schema for all tables in the database.
 pub fn get_schema(conn: &Connection) -> Result<Vec<TableSchema>, SqlDbError> {
-    install_authorizer(conn);
+    install_authorizer(conn)?;
 
     let mut stmt = conn
         .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name")

--- a/crates/session-sqldb/src/memory.rs
+++ b/crates/session-sqldb/src/memory.rs
@@ -12,7 +12,7 @@ use crate::validation::validate_database_name;
 use chrono::Utc;
 use everruns_core::typed_id::SessionId;
 use parking_lot::{Mutex, RwLock};
-use rusqlite::{Connection, DatabaseName};
+use rusqlite::Connection;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tracing::debug;
@@ -49,7 +49,7 @@ impl InMemorySqlDbBackend {
 
     /// Get the current database size by serializing (for tracking only).
     fn estimate_db_size(conn: &Connection) -> i64 {
-        conn.serialize(DatabaseName::Main)
+        conn.serialize("main")
             .map(|data| data.len() as i64)
             .unwrap_or(0)
     }

--- a/specs/api-streaming.md
+++ b/specs/api-streaming.md
@@ -53,62 +53,24 @@ Each `data:` line is a serialized `Event`, whose `type` field matches
 the SSE `event:` discriminator and whose `data` field carries the
 event-type-specific payload defined by the `EventData` enum.
 
-Closed `event:` vocabulary (all `text/event-stream` framing values
-the server may emit on this endpoint):
+Closed `event:` vocabulary on this endpoint:
 
-| `event:` value                  | `data:` shape                                                              |
-| ------------------------------- | -------------------------------------------------------------------------- |
-| `connected`                     | `{"status": "connected"}` (lifecycle; no `Event` wrapper)                  |
-| `disconnecting`                 | `{"reason": "connection_cycle", "retry_ms": 100}` (lifecycle)              |
-| `input.message`                 | `Event` (`data` = `InputMessageData`)                                      |
-| `output.message.started`        | `Event` (`data` = `OutputMessageStartedData`)                              |
-| `output.message.delta`          | `Event` (`data` = `OutputMessageDeltaData`)                                |
-| `output.message.completed`      | `Event` (`data` = `OutputMessageCompletedData`)                            |
-| `output.message.replaced`       | `Event` (`data` = `OutputMessageReplacedData`)                             |
-| `turn.started`                  | `Event` (`data` = `TurnStartedData`)                                       |
-| `turn.completed`                | `Event` (`data` = `TurnCompletedData`)                                     |
-| `turn.failed`                   | `Event` (`data` = `TurnFailedData`)                                        |
-| `turn.cancelled`                | `Event` (`data` = `TurnCancelledData`)                                     |
-| `reason.started`                | `Event` (`data` = `ReasonStartedData`)                                     |
-| `reason.completed`              | `Event` (`data` = `ReasonCompletedData`)                                   |
-| `reason.thinking.started`       | `Event` (`data` = `ReasonThinkingStartedData`)                             |
-| `reason.thinking.delta`         | `Event` (`data` = `ReasonThinkingDeltaData`)                               |
-| `reason.thinking.completed`     | `Event` (`data` = `ReasonThinkingCompletedData`)                           |
-| `reason.item`                   | `Event` (`data` = `ReasonItemData`)                                        |
-| `act.started`                   | `Event` (`data` = `ActStartedData`)                                        |
-| `act.completed`                 | `Event` (`data` = `ActCompletedData`)                                      |
-| `tool.started`                  | `Event` (`data` = `ToolStartedData`)                                       |
-| `tool.progress`                 | `Event` (`data` = `ToolProgressData`)                                      |
-| `tool.completed`                | `Event` (`data` = `ToolCompletedData`)                                     |
-| `tool.output.delta`             | `Event` (`data` = `ToolOutputDeltaData`)                                   |
-| `tool.call_requested`           | `Event` (`data` = `ToolCallRequestedData`)                                 |
-| `llm.generation`                | `Event` (`data` = `LlmGenerationData`)                                     |
-| `capability.usage`              | `Event` (`data` = `CapabilityUsageData`)                                   |
-| `session.started`               | `Event` (`data` = `SessionStartedData`)                                    |
-| `session.activated`             | `Event` (`data` = `SessionActivatedData`)                                  |
-| `session.idled`                 | `Event` (`data` = `SessionIdledData`)                                      |
-| `subagent.spawned`              | `Event` (`data` = `SubagentEventData`)                                     |
-| `subagent.completed`            | `Event` (`data` = `SubagentEventData`)                                     |
-| `subagent.failed`               | `Event` (`data` = `SubagentEventData`)                                     |
-| `subagent.cancelled`            | `Event` (`data` = `SubagentEventData`)                                     |
-| `context.compacting`            | `Event` (`data` = `ContextCompactingData`)                                 |
-| `context.compacted`             | `Event` (`data` = `ContextCompactedData`)                                  |
-| `file.written`                  | `Event` (`data` = `FileWrittenData`)                                       |
-| `budget.warning`                | `Event` (`data` = `BudgetEventData`)                                       |
-| `budget.paused`                 | `Event` (`data` = `BudgetEventData`)                                       |
-| `budget.exhausted`              | `Event` (`data` = `BudgetEventData`)                                       |
-| `budget.resumed`                | `Event` (`data` = `BudgetEventData`)                                       |
-| `voice.session.started`         | `Event` (`data` = `VoiceSessionStartedData`)                               |
-| `voice.input.transcript.delta`  | `Event` (`data` = `VoiceTranscriptData`)                                   |
-| `voice.input.transcript.completed`  | `Event` (`data` = `VoiceTranscriptData`)                               |
-| `voice.output.transcript.delta` | `Event` (`data` = `VoiceTranscriptData`)                                   |
-| `voice.output.transcript.completed` | `Event` (`data` = `VoiceTranscriptData`)                               |
-| `voice.session.ended`           | `Event` (`data` = `VoiceSessionEndedData`)                                 |
-| `voice.session.failed`          | `Event` (`data` = `VoiceSessionFailedData`)                                |
+* Two lifecycle frames — `connected` (`{"status": "connected"}`) and
+  `disconnecting` (`{"reason": "connection_cycle", "retry_ms": <ms>}`)
+  — bracket the stream. Neither wraps an `Event`.
+* Every other `event:` value is the discriminant of an `EventData`
+  variant; `data:` is the corresponding `Event<…Data>` envelope.
 
-The set is exhaustive — events whose type isn't in this list are
-filtered out before transmission. Clients should treat any future
-unknown `event:` value as informational only.
+The authoritative event-type → payload mapping is the `EventData`
+enum in [`crates/core/src/events.rs`](../crates/core/src/events.rs)
+(`pub enum EventData` near line 2190). The generated OpenAPI spec
+also surfaces this catalog per-event via the SSE schema components,
+so LLM toolcallers can dispatch from machine-readable form rather
+than this prose.
+
+The set is exhaustive: events whose type is not in `EventData` are
+filtered out before transmission. Clients must treat any unknown
+`event:` value as informational only.
 
 ### `GET /v1/durable/sse` and `GET /v1/durable/workflows/{id}/sse`
 

--- a/specs/mcp.md
+++ b/specs/mcp.md
@@ -414,27 +414,23 @@ not a replacement.
 
 ### `McpErrorCode` (closed vocabulary)
 
-| Code                     | Default category | Default retryable | Meaning                                                                  |
-| ------------------------ | ---------------- | ----------------- | ------------------------------------------------------------------------ |
-| `tool_not_found`         | `permanent`      | no                | Tool name doesn't match any registered tool for the negotiated protocol. |
-| `tool_timeout`           | `transient`      | yes               | Tool exceeded its server-imposed budget.                                 |
-| `tool_panicked`          | `permanent`      | no                | Tool hit an unrecoverable internal error.                                |
-| `invalid_arguments`      | `validation`     | no                | Required argument missing or argument failed schema validation.          |
-| `permission_denied`      | `auth`           | no                | Caller is authenticated but not authorized for the requested action.     |
-| `quota_exceeded`         | `transient`      | yes               | Org/user quota or rate limit hit.                                        |
-| `network_blocked`        | `permanent`      | no                | Outbound network call blocked by egress policy.                          |
-| `mcp_server_unreachable` | `transient`      | yes               | Upstream MCP server unreachable or returned an error we couldn't classify. |
-| `internal`               | `permanent`      | no                | Catch-all for unclassified internal failures.                            |
-| `unknown`                | `permanent`      | no                | Forward-compat sentinel — emitted by SDKs when they see a code they don't know yet. |
+The full enum, per-variant default `category`/`retryable`, and
+human-readable meanings live in
+[`crates/core/src/mcp_server.rs`](../crates/core/src/mcp_server.rs)
+(`pub enum McpErrorCode` near line 477). The defaults there are
+authoritative; this spec captures the contract around them.
 
-`category` and `retryable` are per-occurrence overridable; e.g. an
-`internal` with a known-transient root cause may still set
-`retryable: true`. Treat the table as defaults, not invariants.
+`category` and `retryable` are defaults, not invariants — every
+occurrence may override them when the server has stronger
+information. For example, an `internal` failure whose root cause is
+known to be transient still ships `retryable: true`.
 
 ### Closed vocabulary rules
 
-* Adding a new code is a spec change. Update this table and the
-  `McpErrorCode` enum in `crates/core/src/mcp_server.rs` together.
+* Adding a new code is a spec change. Add the variant to
+  `McpErrorCode` in `crates/core/src/mcp_server.rs` and update this
+  spec's narrative if the new code changes the contract (new
+  category, new retry semantics, new client guidance).
 * SDKs deserialise any unrecognised code into `unknown` (serde
   `#[serde(other)]`); they must not crash on a value they don't know.
 * The classifier `classify_mcp_execute_error` in the same module


### PR DESCRIPTION
## What

Five commits split into two themes:

**Deep-maintenance spec hygiene**
- `a0126ea` collapses the duplicated `EventData` table in `specs/api-streaming.md` and the `McpErrorCode` table in `specs/mcp.md` into links to the enums in `crates/core/`. Keeps the contract narrative (closed vocabulary, default semantics) but stops the spec from drifting as variants land.

**Dependency family bumps (the bulk of this PR)**
- `a66224a` — `cargo update`: hyper 1.9 → 1.10, plus semver-compatible patches (displaydoc, libredox, redox_syscall, toml_edit, zerocopy).
- `d7325f2` — Cargo.toml pin bumps: OTEL 0.31 → 0.32 family (opentelemetry, _sdk, -otlp), tracing-opentelemetry 0.32 → 0.33, async-nats 0.48 → 0.49, sqlx 0.8 → 0.9, rusqlite 0.32 → 0.39. Includes the code adjustments these required.
- `bed93a7` — rustfmt over the new `AssertSqlSafe` call sites and the two missing spec-index entries (`api-examples.md`, `api-llm-extensions.md`) that the `Specs Index Coverage` pre-push gate was catching.
- `ccc684c` — fix authorizer/progress-handler discards to log on failure.

## Why

Deep maintenance found the OpenTelemetry family, async-nats, sqlx, and rusqlite all behind by minor/major versions with no Linear coverage, and two specs duplicating enums verbatim (clear drift risk). Bumping them now is cheaper than letting drift accumulate.

## How

Adjustments required by the upgrades:

- **sqlx 0.8 → 0.9**
  - Feature `runtime-tokio-rustls` was split; now using `runtime-tokio` + `tls-rustls-ring`.
  - New `SqlSafeStr` trait gates `sqlx::query`/`query_as` to `&'static str` by default. All server-built `format!(...)` queries are wrapped with `sqlx::AssertSqlSafe(sql.as_str())`. Each wrapped site has been audited — the dynamic portion is a server-controlled catalog/whitelist value (table name from `catalog::dataset`, status filter from a typed enum, `${param_idx}` placeholders), and user-controlled values still flow through `.bind(...)`.
  - `QueryBuilder<'a, DB>` lost its lifetime parameter — switched to `QueryBuilder<DB>`.
- **rusqlite 0.32 → 0.39** (capped at 0.39 because sqlx-sqlite, transitive via sqlx 0.9 even though we don't enable the sqlite feature, constrains `libsqlite3-sys < 0.38`; rusqlite 0.40 ships `libsqlite3-sys 0.38` and creates a `links = sqlite3` conflict).
  - `DatabaseName::Main` was removed in favor of the new `Name` trait. `&str` impls `Name`, so `conn.serialize("main")` replaces `conn.serialize(DatabaseName::Main)`.
  - `Connection::authorizer` and `Connection::progress_handler` now return `Result`. Both are best-effort hardening; on failure log a warn-level event rather than discarding silently so a degraded sandbox is visible in traces.
- **OTEL 0.31 → 0.32 family + tracing-opentelemetry 0.32 → 0.33** — drop-in.
- **async-nats 0.48 → 0.49** — drop-in.

## Risk

Medium. Touches the SQL repositories, durable persistence, the SQLite session sandbox, telemetry, and NATS event delivery.

What can break:
- A missed `AssertSqlSafe` call site would have failed local `cargo check` — it didn't (entire workspace + bins clean). I read each wrapped site to confirm only server-controlled values are interpolated.
- A connection that's already closed during sandbox teardown would now log a warn line where it previously silently failed. That's the intended behavior; not a regression.
- The OTLP exporter version flip means `OTEL_EXPORTER_OTLP_ENDPOINT`-configured deployments need to verify span ingestion in staging. Wire format is unchanged.

## Security

Threat categories reviewed (per `specs/threat-model.md`):

- **TM-SQL** — every `AssertSqlSafe(...)` wrap audited. Dynamic SQL is composed from: closed catalog values (`catalog::dataset(...)`, `catalog::dimension(...)`), server-numbered placeholder indices (`${param_idx}`), typed enum statuses, and a search clause whose values flow through `.bind(...)`. No user-controlled string flows into the SQL grammar. The `AssertSqlSafe` wrap matches the prior `&String` posture exactly; sqlx 0.9 just makes the assertion explicit.
- **TM-FS / TM-SQL (sandbox)** — `crates/session-sqldb`'s authorizer is the primary security boundary for the session-scoped SQLite sandbox. The earlier `let _` discard of the new `Result` would silently leave the sandbox unprotected if SQLite ever rejected the install. Replaced with warn-level logging so a degraded sandbox surfaces in traces; the upstream input validators (`validation::validate_database_name`, the 35 existing sandbox tests) remain the first line of defense.
- **TM-LLM / observability** — no change to span content or sampling; OTLP exporter API is wire-compatible.
- **Dependency supply chain** — major bumps go through Cargo's `links` resolver (which is how the rusqlite cap surfaced in the first place). No new top-level crates introduced.

Findings: rusqlite `let _` on the authorizer install — fixed in `ccc684c` per above.

## Validation

- `cargo check --workspace` clean (0 errors, 0 warnings) after each bump.
- `cargo test -p everruns-session-sqldb --lib --all-features` — 35 pass (includes `test_sql_injection_in_name` and `validation::*`, exercising the authorizer path).
- `cargo test -p everruns-core -p everruns-durable --lib --all-features` — 173 pass.
- `cargo test -p everruns-server --lib` — 1,399 pass (covers the AssertSqlSafe-wrapped repositories).
- `bash scripts/lib/pre-push.sh` — all 9 gates pass (fmt, clippy, Cargo.lock, UI fmt+lint, migration ordering + immutability, specs index, attribution).
- `bash scripts/lib/check-migration-ordering.sh` — sequential 001..044.
- Postgres integration tests + UI/SDK e2e gated to CI — they need infra this sandbox doesn't have.

Branch rebased on `2ead127` (latest `origin/main`).

## Follow-ups

- **rusqlite 0.40** — blocked by sqlx-sqlite's `libsqlite3-sys < 0.38` constraint. Re-evaluate when sqlx 0.10 (or a sqlx-sqlite point release that raises the upper bound) lands. Worth filing if it lingers past one minor cycle.
- **sqlx 0.9 → query macros** — sqlx 0.9 also shipped richer compile-time query macros; not adopted here to keep this PR mechanical. Out of scope.
- **EVE-494 partial-done drift** — deep maintenance flagged that 8 of 12 entity clusters still lack `allowed_actions` (Volumes, Schedules, Knowledge bases, Memory stores, Payment accounts/policies, API keys, Saved reports), and the `MIN_ENTITY_ACTION_COVERAGE_PCT` ratchet from EVE-494's "Done when" list never landed. Tracked separately (Linear EVE-494 needs reopening or a follow-up).
- **Dependabot alert #88** (1 moderate, default branch) — surfaced by the push response, not investigated in this PR.

## Checklist
- [x] Tests added or updated (existing 1607+ unit/lib tests cover the touched code paths; no new tests required for a wire-compatible upgrade)
- [x] Backward compatibility considered (sqlx wire/SQL unchanged, OTLP wire-compatible, rusqlite serialization unchanged)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (no review yet)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VTTWgsk1RBU98KWh1MAeKf)_