### PR TITLE
chore(deps): bump bashkit 0.7.2 -> 0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -559,9 +559,9 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bashkit"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7892a1440c479f5b70dfddf760fe9671c5436d4c7b5ba39bb05216e2e3f301"
+checksum = "5e20c182deb47b8ce2c8ba724f602cf73bdd6a566971f0f3525b6af60ea2a4c6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -69,7 +69,7 @@ fetchkit = { version = "=0.2.0", features = ["bot-auth"] }
 ed25519-dalek = { version = "2", features = ["rand_core"] }
 
 # Virtual bash interpreter
-bashkit = { version = "0.7.2", features = ["jq"] }
+bashkit = { version = "0.8.0", features = ["jq"] }
 
 # Tree-sitter for structural outlines (EVE-248)
 tree-sitter = { version = "0.24", optional = true }

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -71,7 +71,7 @@ mime_guess = "2"
 tokio-tungstenite.workspace = true
 futures-util.workspace = true
 
-bashkit = { version = "0.7.2", features = ["scripted_tool", "jq"] }
+bashkit = { version = "0.8.0", features = ["scripted_tool", "jq"] }
 
 everruns-config = { path = "../config" }
 everruns-core = { path = "../core", features = ["embedded-platform-docs", "openapi", "sqlx", "tree-sitter-outlines", "ui-capabilities"] }


### PR DESCRIPTION
## What
Bump the `bashkit` virtual-bash dependency from `0.7.2` to `0.8.0` in `crates/core` and `crates/server`, and update `Cargo.lock`.

## Why
Keep the sandboxed bash interpreter current. 0.8.0 brings additive improvements: Python `open()` bridged to the virtual filesystem, ripgrep display/default-filetype refinements, and bash interpreter state serialization for `declare -n`/readonly/integer attributes (with backward-compatible migration of legacy snapshots).

## How
- Updated the version constraint in `crates/core/Cargo.toml` and `crates/server/Cargo.toml` (features unchanged: `jq`, and `scripted_tool` on server).
- `cargo update -p bashkit --precise 0.8.0`.

## Risk
- **Low.** A 0.x minor bump of a first-party dependency (`github.com/everruns/bashkit`).
- The full workspace builds cleanly with no API breakage. The most behavior-relevant 0.8.0 change (interpreter variable-state serde) is **not** on a path everruns depends on — we construct a fresh `Bash` per execution via `Bash::builder()` and persist files through our own `SessionFileSystemAdapter` VFS rather than serializing bashkit interpreter state.

## Validation
- `cargo build -p everruns-core -p everruns-server --all-features` — clean.
- `cargo clippy -p everruns-core -p everruns-server --all-targets --all-features -- -D warnings` — clean.
- `cargo fmt --check` — clean.
- `cargo fetch --locked` — lockfile consistent.
- Tests: `capabilities::virtual_bash` (77 passed), all `capabilities::` (764 passed), server `mcp_endpoint` (61 passed).
- **Smoke:** the affected flow (virtual bash execution against the session VFS) is exercised end-to-end by in-tree tests running *real* bashkit 0.8.0 against the *real* `SessionFileSystemAdapter` — write/read/append/copy/rename/grep/script execution plus sandbox-boundary enforcement (`read_outside_workspace_fails`, `write_outside_workspace_fails`) all pass. Booting the HTTP server would only add transport layers unaffected by a bash-library bump.

## Security
- Threat categories reviewed: **TM-BASH** (sandbox) + dependency/supply-chain risk.
- Findings and resolutions:
  - Source unchanged (first-party `everruns/bashkit`, crates.io). No new features enabled in our manifests; the `http_client` feature remains off, so **TM-BASH-003** (no network builtins) is preserved.
  - New Python `open()` is bridged to the VFS only — bashkit holds no host/native file handles — so it does not widen the sandbox or VFS boundary.
  - Sandbox-boundary tests confirm reads/writes outside the workspace still fail under 0.8.0. No `THREAT[TM-BASH]` mitigation logic in our code changed.

## Follow-ups
- `examples/weekend-concierge-host` (excluded from the root workspace, `publish = false`) has a stale separate `Cargo.lock` pinning bashkit `0.6.0`. This predates this change and is out of scope; it should be regenerated separately if that example is revived.

## Checklist
- [x] Tests added or updated (existing virtual_bash/capabilities/mcp_endpoint suites cover the surface)
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)


---
_Generated by [Claude Code](https://claude.ai/code/session_019phNevYRaiJuXTdT9Y1SJZ)_