### PR TITLE
fix(ui): route sidebar Profile menu to /settings/profile

### DIFF
--- a/apps/ui/src/__tests__/sidebar.test.tsx
+++ b/apps/ui/src/__tests__/sidebar.test.tsx
@@ -156,6 +156,26 @@ describe("Sidebar", () => {
     expect(screen.getByText("Connect via MCP")).toBeInTheDocument();
   });
 
+  it("routes the Profile menu item to /settings/profile", () => {
+    mockUseAuth.mockReturnValue({
+      user: { name: "Test User", email: "test@example.com", avatar_url: null },
+      requiresAuth: true,
+      isAuthenticated: true,
+      config: { mode: "password" },
+      isLoading: false,
+      logout: jest.fn(),
+      logoutPending: false,
+      createOrganization: undefined,
+    });
+
+    render(<Sidebar />);
+
+    fireEvent.click(screen.getByRole("button", { name: /test user/i }));
+    fireEvent.click(screen.getByRole("menuitem", { name: /profile/i }));
+
+    expect(mockPush).toHaveBeenCalledWith("/settings/profile");
+  });
+
   it("renders all navigation items", () => {
     render(<Sidebar />);
 

--- a/apps/ui/src/components/layout/sidebar-user-menu.tsx
+++ b/apps/ui/src/components/layout/sidebar-user-menu.tsx
@@ -97,7 +97,7 @@ export function SidebarUserMenu({
             <DropdownMenuGroup>
               <DropdownMenuLabel>My Account</DropdownMenuLabel>
               <NotificationMenuSub />
-              <DropdownMenuItem onClick={() => navigate("/settings")}>
+              <DropdownMenuItem onClick={() => navigate("/settings/profile")}>
                 <User className="icon-sharp mr-2 h-4 w-4" />
                 Profile
               </DropdownMenuItem>


### PR DESCRIPTION
## What
Resolves [EVE-503](https://linear.app/everruns/issue/EVE-503/fixui-sidebar-user-menu-profile-lands-on-settings-root-not). The sidebar user-dropdown **Profile** item navigated to `/settings`, which on SaaS lands on `/settings/organization` (the default tab the settings layout chooses). It now targets `/settings/profile` directly so the menu matches its label.

## Why
On `dev.everruns.com` v0.8.35, clicking **Profile** in the sidebar user popover opened the Organizations tab. Root cause is in `apps/ui/src/components/layout/sidebar-user-menu.tsx`:

```tsx
<DropdownMenuItem onClick={() => navigate("/settings")}>
  <User className="icon-sharp mr-2 h-4 w-4" />
  Profile
</DropdownMenuItem>
```

`/settings` redirects to whatever the settings layout chooses as the default — Organization on SaaS, Profile on OSS — so the bug is invisible on OSS-only deploys and visible on SaaS. The sibling **API Keys** item already targets `/settings/api-keys`; making Profile follow the same explicit pattern fixes the surface and removes the layout-default dependency.

## How
- `apps/ui/src/components/layout/sidebar-user-menu.tsx`: `navigate("/settings")` → `navigate("/settings/profile")` on the Profile dropdown item.
- `apps/ui/src/__tests__/sidebar.test.tsx`: add a focused test that opens the user menu, clicks **Profile**, and asserts `router.push("/settings/profile")` is called.

## Risk
- **Low.** Single string-literal change in a click handler, covered by a new unit test. `/settings/profile` already renders correctly per the issue's manual reproduction (direct nav works on dev SaaS), so the destination is known-good.

## Security
- Threat categories reviewed: **none directly applicable**. Pure client-side route-target change with no input, no auth, no data, no new dependencies, and no changes to API/policy/sandbox surface. No `THREAT[*]` comment touched.
- Findings and resolutions: none.

## Validation
- `pnpm test -- --testPathPatterns sidebar.test.tsx` — 32/32 pass (includes the new Profile-route case).
- `pnpm run format:check` — clean.
- `pnpm run lint` — clean.
- `bash scripts/lib/pre-push.sh` — all 9 gates pass (fmt, clippy, Cargo.lock, UI fmt+lint, migrations ordering + immutability, specs index, attribution).
- Interactive smoke deferred: the only behavior change is the navigate target string, the new jest test exercises the exact wiring (open menu → click Profile → `router.push("/settings/profile")`), and the destination route is already confirmed working on `dev.everruns.com` per the issue's reproduction. A `just start-dev` walk would not produce more signal than the unit test for a one-line target change.

Branch rebased on `3b567c4` (latest `origin/main`).

## Follow-ups
No follow-ups. The OSS Profile route is already explicit on the target page; no SaaS test_cases (which live in a separate repo) are affected by this OSS change.

## Checklist
- [x] Tests added or updated (1 new sidebar test, 32/32 pass)
- [x] Backward compatibility considered (no API/contract change; menu still navigates inside `/settings`)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (no review yet)

---
_Generated by [Claude Code](https://claude.ai/code/session_0135VahpscBp1cMzFBchwWJ4)_