### PR TITLE
chore(release): prepare v0.8.36

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- New changes go here. Use `/prepare-release X.Y.Z` to generate draft from commits. -->
 
+## [0.8.36] - 2026-05-29
+
+### Highlights
+
+- **Hypermedia entity actions across resources** - Foundation for entity-level HATEOAS actions ([#1986](https://github.com/everruns/everruns/pull/1986)), now rolled out to Agents, Harnesses, Apps, and Skills ([#1989](https://github.com/everruns/everruns/pull/1989)).
+- **MCP traffic governed by EgressService** - MCP client calls now route through the dedicated outbound egress service ([#1993](https://github.com/everruns/everruns/pull/1993)), and MCP execute returns a structured-error envelope ([#1987](https://github.com/everruns/everruns/pull/1987)).
+- **OpenAPI extensions and example coverage** - LLM-specific OpenAPI extension foundation (`x-llm-*`) ([#1991](https://github.com/everruns/everruns/pull/1991)), SSE event-type catalog for the session stream ([#1990](https://github.com/everruns/everruns/pull/1990)), per-operation request/response example pairs foundation ([#1992](https://github.com/everruns/everruns/pull/1992)), and field-example coverage 37% → 44% ([#1988](https://github.com/everruns/everruns/pull/1988)).
+- **background_execution capability surfaces spawn_background** - Capabilities can now expose `spawn_background` through `background_execution` ([#1996](https://github.com/everruns/everruns/pull/1996)).
+- **ERcode persists reasoning artifacts** - Reasoning artifacts are persisted and rendered on session restore ([#1985](https://github.com/everruns/everruns/pull/1985)).
+
+### What's Changed
+
+- fix(ui): route sidebar Profile menu to /settings/profile ([#2001](https://github.com/everruns/everruns/pull/2001)) by [@chaliy](https://github.com/chaliy)
+- chore(deps): bump bashkit 0.7.2 -> 0.8.0 ([#2000](https://github.com/everruns/everruns/pull/2000)) by [@chaliy](https://github.com/chaliy)
+- chore(deps): bump OTEL 0.32, async-nats 0.49, sqlx 0.9, rusqlite 0.39 ([#1998](https://github.com/everruns/everruns/pull/1998)) by [@chaliy](https://github.com/chaliy)
+- feat(core): add scripted llmsim responses by [@chaliy](https://github.com/chaliy)
+- fix(ui): interpolate duration in chat turn divider ([#1997](https://github.com/everruns/everruns/pull/1997)) by [@chaliy](https://github.com/chaliy)
+- feat(capabilities): expose spawn_background via background_execution ([#1996](https://github.com/everruns/everruns/pull/1996)) by [@chaliy](https://github.com/chaliy)
+- fix(coding-cli): confine output chmod walk to /outputs subtree ([#1994](https://github.com/everruns/everruns/pull/1994)) by [@chaliy](https://github.com/chaliy)
+- chore(deps): bump llmsim from 0.3.0 to 0.4.0 ([#1995](https://github.com/everruns/everruns/pull/1995)) by [@chaliy](https://github.com/chaliy)
+- docs(api): per-operation request/response example pairs (foundation) ([#1992](https://github.com/everruns/everruns/pull/1992)) by [@chaliy](https://github.com/chaliy)
+- feat(mcp): route MCP client traffic through EgressService ([#1993](https://github.com/everruns/everruns/pull/1993)) by [@chaliy](https://github.com/chaliy)
+- feat(api): LLM-specific OpenAPI extensions foundation (x-llm-*) ([#1991](https://github.com/everruns/everruns/pull/1991)) by [@chaliy](https://github.com/chaliy)
+- docs(api): SSE event-type catalog in OpenAPI (session stream) ([#1990](https://github.com/everruns/everruns/pull/1990)) by [@chaliy](https://github.com/chaliy)
+- feat(api): roll out hypermedia entity actions to Agents/Harnesses/Apps/Skills ([#1989](https://github.com/everruns/everruns/pull/1989)) by [@chaliy](https://github.com/chaliy)
+- feat(api): structured-error envelope for MCP execute (server-side) ([#1987](https://github.com/everruns/everruns/pull/1987)) by [@chaliy](https://github.com/chaliy)
+- docs(api): push field-example coverage 37% → 44% (operator + LLM model wave) ([#1988](https://github.com/everruns/everruns/pull/1988)) by [@chaliy](https://github.com/chaliy)
+- feat(api): hypermedia entity actions foundation, sessions pilot ([#1986](https://github.com/everruns/everruns/pull/1986)) by [@chaliy](https://github.com/chaliy)
+- feat(ercode): persist and render reasoning artifacts for session restore ([#1985](https://github.com/everruns/everruns/pull/1985)) by [@chaliy](https://github.com/chaliy)
+
 ## [0.8.35] - 2026-05-27
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
- "uuid 1.23.1",
+ "uuid 1.23.2",
  "webpki-roots 1.0.7",
 ]
 
@@ -39,7 +39,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
- "uuid 1.23.1",
+ "uuid 1.23.2",
 ]
 
 [[package]]
@@ -85,7 +85,7 @@ dependencies = [
  "tower",
  "tower-http",
  "tracing",
- "uuid 1.23.1",
+ "uuid 1.23.2",
 ]
 
 [[package]]
@@ -138,7 +138,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
- "uuid 1.23.1",
+ "uuid 1.23.2",
 ]
 
 [[package]]
@@ -705,9 +705,9 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "8.0.2"
+version = "8.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
+checksum = "8119e4516436f5708bbc474a9d395bf12f1b5395e93a92a56e647ac3388c8610"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -716,9 +716,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "5.0.0"
+version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+checksum = "5962523e1b92ce1b5e793d9169b9943eece10d39f62550bc04bb605d75b94924"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -834,9 +834,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -942,9 +942,9 @@ dependencies = [
 
 [[package]]
 name = "cmov"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "coins-bip32"
@@ -1977,11 +1977,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-a2ui"
-version = "0.8.35"
+version = "0.8.36"
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.8.35"
+version = "0.8.36"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1997,7 +1997,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-cli"
-version = "0.8.35"
+version = "0.8.36"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2050,14 +2050,14 @@ dependencies = [
 
 [[package]]
 name = "everruns-config"
-version = "0.8.35"
+version = "0.8.36"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "everruns-container-sandbox"
-version = "0.8.35"
+version = "0.8.36"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2077,7 +2077,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.8.35"
+version = "0.8.36"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -2123,13 +2123,13 @@ dependencies = [
  "tree-sitter-typescript",
  "url",
  "utoipa",
- "uuid 1.23.1",
+ "uuid 1.23.2",
  "wiremock",
 ]
 
 [[package]]
 name = "everruns-durable"
-version = "0.8.35"
+version = "0.8.36"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2149,12 +2149,12 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
- "uuid 1.23.1",
+ "uuid 1.23.2",
 ]
 
 [[package]]
 name = "everruns-gemini"
-version = "0.8.35"
+version = "0.8.36"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2168,7 +2168,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-brave-search"
-version = "0.8.35"
+version = "0.8.36"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2184,7 +2184,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-browserless"
-version = "0.8.35"
+version = "0.8.36"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2205,7 +2205,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-cursor"
-version = "0.8.35"
+version = "0.8.36"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2220,7 +2220,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.8.35"
+version = "0.8.36"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2237,7 +2237,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-deno"
-version = "0.8.35"
+version = "0.8.36"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2260,7 +2260,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-docker"
-version = "0.8.35"
+version = "0.8.36"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2270,12 +2270,12 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
- "uuid 1.23.1",
+ "uuid 1.23.2",
 ]
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.8.35"
+version = "0.8.36"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2290,7 +2290,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-e2b"
-version = "0.8.35"
+version = "0.8.36"
 dependencies = [
  "async-trait",
  "buffa",
@@ -2317,7 +2317,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-github"
-version = "0.8.35"
+version = "0.8.36"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2334,7 +2334,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-parallel"
-version = "0.8.35"
+version = "0.8.36"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2346,7 +2346,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-sprites"
-version = "0.8.35"
+version = "0.8.36"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2362,7 +2362,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-internal-protocol"
-version = "0.8.35"
+version = "0.8.36"
 dependencies = [
  "chrono",
  "everruns-core",
@@ -2374,12 +2374,12 @@ dependencies = [
  "tonic",
  "tonic-prost",
  "tonic-prost-build",
- "uuid 1.23.1",
+ "uuid 1.23.2",
 ]
 
 [[package]]
 name = "everruns-llm-tests"
-version = "0.8.35"
+version = "0.8.36"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2393,12 +2393,12 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "uuid 1.23.1",
+ "uuid 1.23.2",
 ]
 
 [[package]]
 name = "everruns-macros"
-version = "0.8.35"
+version = "0.8.36"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -2406,7 +2406,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.8.35"
+version = "0.8.36"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2426,11 +2426,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-openui"
-version = "0.8.35"
+version = "0.8.36"
 
 [[package]]
 name = "everruns-runtime"
-version = "0.8.35"
+version = "0.8.36"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2442,7 +2442,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
- "uuid 1.23.1",
+ "uuid 1.23.2",
 ]
 
 [[package]]
@@ -2467,7 +2467,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-server"
-version = "0.8.35"
+version = "0.8.36"
 dependencies = [
  "aes-gcm",
  "ag-ui-core",
@@ -2548,14 +2548,14 @@ dependencies = [
  "url",
  "urlencoding",
  "utoipa",
- "uuid 1.23.1",
+ "uuid 1.23.2",
  "wiremock",
  "zip",
 ]
 
 [[package]]
 name = "everruns-session-sqldb"
-version = "0.8.35"
+version = "0.8.36"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2567,12 +2567,12 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
- "uuid 1.23.1",
+ "uuid 1.23.2",
 ]
 
 [[package]]
 name = "everruns-worker"
-version = "0.8.35"
+version = "0.8.36"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2607,7 +2607,7 @@ dependencies = [
  "tonic",
  "tracing",
  "turmoil",
- "uuid 1.23.1",
+ "uuid 1.23.2",
 ]
 
 [[package]]
@@ -3397,9 +3397,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb92f162bf56536459fc83c79b974bb12837acfed43d6bc370a7916d0ae15ecc"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3479,7 +3479,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -3833,7 +3833,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
 dependencies = [
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "widestring",
  "windows-registry",
  "windows-result 0.4.1",
@@ -3919,9 +3919,9 @@ dependencies = [
 
 [[package]]
 name = "jiff"
-version = "0.2.27"
+version = "0.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "392c70591e8749fe235ddaf513e6f58b26bce3dcc16524cecc8936f75afa161e"
+checksum = "4603d3033e49e2b0e31229fcab20a5d40089c607d975cd9c80551dc69eed9102"
 dependencies = [
  "jiff-static",
  "jiff-tzdb-platform",
@@ -3934,9 +3934,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.27"
+version = "0.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b605b0c050d845fc355bb11eb3f9a8deddc218ea60c76e61aa1f2adfb2c96a"
+checksum = "782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4142,9 +4142,9 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.18.4+1.9.3"
+version = "0.18.5+1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b26f66f35e1871b22efcf7191564123d2a446ca0538cde63c23adfefa9b15b7"
+checksum = "005d6ae6eac1912906073e069f7db60b1fa98e052a68227824afe3e3a1c59ca2"
 dependencies = [
  "cc",
  "libc",
@@ -4520,9 +4520,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "log",
@@ -4547,7 +4547,7 @@ dependencies = [
  "portable-atomic",
  "smallvec",
  "tagptr",
- "uuid 1.23.1",
+ "uuid 1.23.2",
 ]
 
 [[package]]
@@ -5671,7 +5671,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5709,7 +5709,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -6814,9 +6814,9 @@ checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook"
@@ -6965,9 +6965,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -7060,7 +7060,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "url",
- "uuid 1.23.1",
+ "uuid 1.23.2",
  "webpki-roots 1.0.7",
 ]
 
@@ -7128,7 +7128,7 @@ dependencies = [
  "sqlx-core",
  "thiserror 2.0.18",
  "tracing",
- "uuid 1.23.1",
+ "uuid 1.23.2",
 ]
 
 [[package]]
@@ -7164,7 +7164,7 @@ dependencies = [
  "stringprep",
  "thiserror 2.0.18",
  "tracing",
- "uuid 1.23.1",
+ "uuid 1.23.2",
  "whoami",
 ]
 
@@ -7191,7 +7191,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tracing",
  "url",
- "uuid 1.23.1",
+ "uuid 1.23.2",
 ]
 
 [[package]]
@@ -7622,7 +7622,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -7831,7 +7831,7 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -8133,9 +8133,9 @@ checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ucd-trie"
@@ -8321,7 +8321,7 @@ dependencies = [
  "quote",
  "regex",
  "syn 2.0.117",
- "uuid 1.23.1",
+ "uuid 1.23.2",
 ]
 
 [[package]]
@@ -8336,9 +8336,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
 dependencies = [
  "atomic",
  "getrandom 0.4.2",
@@ -8622,7 +8622,7 @@ dependencies = [
  "mac_address",
  "sha2 0.10.9",
  "thiserror 1.0.69",
- "uuid 1.23.1",
+ "uuid 1.23.2",
 ]
 
 [[package]]
@@ -9241,18 +9241,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.49"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bce33a6288fa3f072a8c2c7d0f2fdbb90e28298f0135c1f99b96c3db2efcc60b"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.49"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd425244944f4ab65ccff928e7323354c5a018c75838362fdce749dfad2ee1e"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.8.35"
+version = "0.8.36"
 edition = "2024"
 license = "MIT"
 authors = ["Everruns Contributors"]
@@ -132,7 +132,7 @@ futures-util = "0.3"
 
 # Everruns SDK
 everruns-sdk = "0.1.9"
-everruns-core = { path = "crates/core", version = "0.8.35" }
+everruns-core = { path = "crates/core", version = "0.8.36" }
 
 # A2A protocol
 a2a = { package = "a2a-lf", version = "0.3" }

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "everruns-ui",
-  "version": "0.8.35",
+  "version": "0.8.36",
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "exports": {

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -19,7 +19,7 @@ readme = "README.md"
 
 [dependencies]
 # Core dependencies
-everruns-config = { path = "../config", version = "0.8.35" }
+everruns-config = { path = "../config", version = "0.8.36" }
 anyhow.workspace = true
 thiserror.workspace = true
 async-trait.workspace = true
@@ -101,10 +101,10 @@ inventory.workspace = true
 llmsim = "0.4.0"
 
 # OpenUI component definitions and prompt generator
-everruns-openui = { path = "../openui", version = "0.8.35", optional = true }
+everruns-openui = { path = "../openui", version = "0.8.36", optional = true }
 
 # A2UI component catalog and prompt generator
-everruns-a2ui = { path = "../a2ui", version = "0.8.35", optional = true }
+everruns-a2ui = { path = "../a2ui", version = "0.8.36", optional = true }
 
 # A2A outbound agent delegation
 a2a.workspace = true


### PR DESCRIPTION
## Release v0.8.36

Bumps workspace + UI to `0.8.36`, regenerates lockfiles, syncs sub-crate path-pin versions, and drafts CHANGELOG entries from the 17 commits since `v0.8.35`.

### Highlights

- Hypermedia entity actions foundation + rollout to Agents/Harnesses/Apps/Skills (#1986, #1989)
- MCP traffic routed through EgressService (#1993); structured-error envelope for MCP execute (#1987)
- OpenAPI extensions: `x-llm-*` foundation (#1991), SSE event-type catalog (#1990), per-operation example pairs (#1992), field-example coverage 37% → 44% (#1988)
- `background_execution` capability exposes `spawn_background` (#1996)
- ERcode persists/renders reasoning artifacts for session restore (#1985)

### Checklist
- [x] Review CHANGELOG.md entries
- [x] Verify version numbers updated (Cargo.toml, apps/ui/package.json, crates/core path-pins)
- [x] Lockfiles regenerated
- [x] Migrations sequential (001..044)
- [ ] CI passes

### Post-merge
After merging, the release workflow will automatically:
- Create git tag `v0.8.36`
- Create GitHub Release with notes from CHANGELOG.md
- Trigger Docker image build with version tag
- Publish CLI binaries + update Homebrew tap
- Publish crates.io packages

---
_Generated by [Claude Code](https://claude.ai/code/session_01LSBN1ZkpK5kS9JRPir16cm)_