### PR TITLE
feat(ui): fold completed chat work logs

### DIFF
--- a/apps/ui/src/__tests__/turn-work-log.test.tsx
+++ b/apps/ui/src/__tests__/turn-work-log.test.tsx
@@ -1,0 +1,52 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { TurnWorkLog } from "@/components/chat/turn-work-log";
+
+describe("TurnWorkLog", () => {
+  it("starts collapsed for completed work", () => {
+    render(
+      <TurnWorkLog label="Worked for 2m 4s" isActive={false}>
+        <div>Read files and ran tests</div>
+      </TurnWorkLog>,
+    );
+
+    const button = screen.getByRole("button", { name: /worked for 2m 4s/i });
+    expect(button).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("stays open while active and collapses after completion", () => {
+    const { rerender } = render(
+      <TurnWorkLog label="Working" isActive>
+        <div>Inspecting the repo</div>
+      </TurnWorkLog>,
+    );
+
+    expect(screen.getByRole("button", { name: /working/i })).toHaveAttribute(
+      "aria-expanded",
+      "true",
+    );
+
+    rerender(
+      <TurnWorkLog label="Worked for 18s" isActive={false}>
+        <div>Inspecting the repo</div>
+      </TurnWorkLog>,
+    );
+
+    expect(screen.getByRole("button", { name: /worked for 18s/i })).toHaveAttribute(
+      "aria-expanded",
+      "false",
+    );
+  });
+
+  it("can be reopened after auto-collapse", () => {
+    render(
+      <TurnWorkLog label="Worked for 18s" isActive={false}>
+        <div>Inspecting the repo</div>
+      </TurnWorkLog>,
+    );
+
+    const button = screen.getByRole("button", { name: /worked for 18s/i });
+    fireEvent.click(button);
+
+    expect(button).toHaveAttribute("aria-expanded", "true");
+  });
+});

--- a/apps/ui/src/app/(main)/sessions/[sessionId]/session-context.tsx
+++ b/apps/ui/src/app/(main)/sessions/[sessionId]/session-context.tsx
@@ -369,6 +369,8 @@ export function SessionProvider({ sessionId, children }: SessionProviderProps) {
             e.type === "input.message" ||
             e.type === "output.message.completed" ||
             e.type === "turn.failed" ||
+            e.type === "reason.completed" ||
+            e.type === "reason.item" ||
             e.type === "act.started" ||
             e.type === "act.completed" ||
             e.type === "tool.started" ||

--- a/apps/ui/src/app/dev/_fixtures/chat-runtime-fixtures.ts
+++ b/apps/ui/src/app/dev/_fixtures/chat-runtime-fixtures.ts
@@ -68,6 +68,7 @@ function makeOutputEvent({
   text,
   toolCalls,
   metadata,
+  context = {},
 }: {
   id: string;
   sequence: number;
@@ -80,13 +81,14 @@ function makeOutputEvent({
     arguments: Record<string, unknown>;
   }>;
   metadata?: Record<string, unknown>;
+  context?: Event["context"];
 }): Event {
   return {
     id,
     type: "output.message.completed",
     ts,
     session_id: sessionId,
-    context: {},
+    context,
     data: {
       message: {
         id: `msg-${id}`,
@@ -492,6 +494,7 @@ export function getDevChatFixture(kind: "tool-activity" | "chat-components"): De
   }
 
   const sessionId = "session-dev-chat-components";
+  const foldedTurnId = "turn-components-folded";
   const events: Event[] = [
     makeInputEvent({
       id: "components-user-1",
@@ -558,7 +561,7 @@ export function getDevChatFixture(kind: "tool-activity" | "chat-components"): De
       type: "tool.call_requested",
       ts: "2026-03-07T21:45:13Z",
       session_id: sessionId,
-      context: {},
+      context: { turn_id: foldedTurnId },
       data: {
         headline: "Waiting on tools",
         tool_calls: [
@@ -583,7 +586,7 @@ export function getDevChatFixture(kind: "tool-activity" | "chat-components"): De
       type: "act.started",
       ts: "2026-03-07T21:45:18Z",
       session_id: sessionId,
-      context: { exec_id: "exec-components" },
+      context: { turn_id: foldedTurnId, exec_id: "exec-components" },
       data: {
         headline: "Refining transcript chrome",
         tool_calls: [
@@ -601,7 +604,7 @@ export function getDevChatFixture(kind: "tool-activity" | "chat-components"): De
       type: "tool.completed",
       ts: "2026-03-07T21:45:20Z",
       session_id: sessionId,
-      context: { exec_id: "exec-components" },
+      context: { turn_id: foldedTurnId, exec_id: "exec-components" },
       data: {
         tool_call_id: "cc-shell",
         tool_name: "bash",
@@ -627,7 +630,7 @@ export function getDevChatFixture(kind: "tool-activity" | "chat-components"): De
       type: "tool.completed",
       ts: "2026-03-07T21:45:22Z",
       session_id: sessionId,
-      context: { exec_id: "exec-components" },
+      context: { turn_id: foldedTurnId, exec_id: "exec-components" },
       data: {
         tool_call_id: "cc-edit",
         tool_name: "edit_file",
@@ -643,7 +646,7 @@ export function getDevChatFixture(kind: "tool-activity" | "chat-components"): De
       type: "act.completed",
       ts: "2026-03-07T21:45:22Z",
       session_id: sessionId,
-      context: { exec_id: "exec-components" },
+      context: { turn_id: foldedTurnId, exec_id: "exec-components" },
       data: {
         completed: true,
         success_count: 2,
@@ -659,7 +662,19 @@ export function getDevChatFixture(kind: "tool-activity" | "chat-components"): De
       ts: "2026-03-07T21:45:26Z",
       text: "The preview now uses the same transcript list and composer components as the live session view.",
       metadata: { model: "kimi-k2.5", reasoning_effort: "medium" },
+      context: { turn_id: foldedTurnId },
     }),
+    {
+      id: "components-turn-done",
+      type: "turn.completed",
+      ts: "2026-03-07T21:45:27Z",
+      session_id: sessionId,
+      context: { turn_id: foldedTurnId },
+      data: {
+        turn_id: foldedTurnId,
+        duration_ms: 9000,
+      },
+    },
   ];
 
   return {

--- a/apps/ui/src/components/chat/chat-message-list.tsx
+++ b/apps/ui/src/components/chat/chat-message-list.tsx
@@ -6,8 +6,9 @@
  */
 "use client";
 
-import { Bot, CalendarClock, Loader2 } from "lucide-react";
+import { Bot, CalendarClock, Loader2, Sparkles } from "lucide-react";
 import { memo, useMemo } from "react";
+import type { ReactNode } from "react";
 import type {
   ContentPart,
   Event,
@@ -33,7 +34,9 @@ import {
 import {
   formatWorkedDuration,
   getCompletedTurnDurationsByEvent,
+  getCompletedTurnDurationsByTurn,
 } from "@/components/chat/turn-delimiter";
+import { TurnWorkLog } from "@/components/chat/turn-work-log";
 import { chatSurfaceStyles } from "@/components/chat/chat-surface";
 import { CompactionDivider } from "@/components/chat/compaction-divider";
 import type { ToolCallContent } from "@/components/chat/tool-call-utils";
@@ -65,6 +68,30 @@ type ActGroup = {
   completedHeadline?: string;
   rows: TimelineToolRow[];
 };
+
+function getKnownTurnId(event: Event): string | undefined {
+  const reasonItemData = getEventData(event, "reason.item");
+  return reasonItemData?.turn_id ?? event.context?.turn_id;
+}
+
+function isWorkLogEvent(event: Event): boolean {
+  if (event.type === "act.started" || event.type === "tool.call_requested") return true;
+
+  const reasonItemData = getEventData(event, "reason.item");
+  if (reasonItemData?.summary?.some((item) => item.trim().length > 0)) return true;
+
+  const reasonCompletedData = getEventData(event, "reason.completed");
+  return !!reasonCompletedData?.text_preview;
+}
+
+function ReasoningLogRow({ text }: { text: string }) {
+  return (
+    <div className="flex items-start gap-2 py-1 text-[15px] leading-6 text-muted-foreground">
+      <Sparkles className="mt-1 h-3.5 w-3.5 flex-shrink-0 text-primary/70" />
+      <p className="whitespace-pre-wrap">{text}</p>
+    </div>
+  );
+}
 
 function getMessageImages(content: ContentPart[]): Array<{ image_id: string; filename?: string }> {
   return content.filter(isImageFilePart).map((part) => ({
@@ -204,6 +231,34 @@ export const ChatMessageList = memo(function ChatMessageList({
     () => getCompletedTurnDurationsByEvent(events ?? []),
     [events],
   );
+  const turnDurationByTurnId = useMemo(
+    () => getCompletedTurnDurationsByTurn(events ?? []),
+    [events],
+  );
+  const workLogTurnIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const event of chatEvents) {
+      if (!isWorkLogEvent(event)) continue;
+      const turnId = getKnownTurnId(event);
+      if (turnId) ids.add(turnId);
+    }
+    return ids;
+  }, [chatEvents]);
+  const workLogEventsByTurnId = useMemo(() => {
+    const groups = new Map<string, Event[]>();
+    for (const event of chatEvents) {
+      if (!isWorkLogEvent(event)) continue;
+      const turnId = getKnownTurnId(event);
+      if (!turnId) continue;
+      const group = groups.get(turnId);
+      if (group) {
+        group.push(event);
+      } else {
+        groups.set(turnId, [event]);
+      }
+    }
+    return groups;
+  }, [chatEvents]);
   const hasNarratedActEvents = useMemo(
     () => chatEvents.some((event) => event.type === "act.started"),
     [chatEvents],
@@ -212,6 +267,105 @@ export const ChatMessageList = memo(function ChatMessageList({
     () => buildActGroups(chatEvents, t("working")),
     [chatEvents, t],
   );
+  const renderWorkLog = (event: Event, children: ReactNode) => {
+    const turnId = getKnownTurnId(event);
+    const durationMs = turnId ? turnDurationByTurnId.get(turnId) : undefined;
+    const label =
+      durationMs == null
+        ? t("working")
+        : t("worked_for", { duration: formatWorkedDuration(durationMs) });
+
+    return (
+      <TurnWorkLog key={event.id} label={label} isActive={durationMs == null}>
+        {children}
+      </TurnWorkLog>
+    );
+  };
+  const renderWorkLogEventContent = (event: Event) => {
+    const reasonItemData = getEventData(event, "reason.item");
+    if (reasonItemData) {
+      const summary = (reasonItemData.summary ?? [])
+        .map((item) => item.trim())
+        .filter(Boolean)
+        .join("\n");
+      return summary ? <ReasoningLogRow key={event.id} text={summary} /> : null;
+    }
+
+    const reasonCompletedData = getEventData(event, "reason.completed");
+    if (reasonCompletedData) {
+      return reasonCompletedData.text_preview ? (
+        <ReasoningLogRow key={event.id} text={reasonCompletedData.text_preview} />
+      ) : null;
+    }
+
+    if (event.type === "act.started") {
+      const group = actGroupsByStartEventId.get(event.id);
+      if (!group || group.rows.length === 0) return null;
+      return (
+        <div key={event.id} className="space-y-1">
+          <ToolActivityTimelineGroup
+            headline={group.headline}
+            completedHeadline={group.completedHeadline}
+            rows={group.rows}
+          />
+        </div>
+      );
+    }
+
+    if (event.type !== "tool.call_requested") return null;
+
+    const reqData = getEventData(event, "tool.call_requested");
+    if (!reqData?.tool_calls?.length) return null;
+
+    if (reqData.headline || reqData.tool_summaries?.length) {
+      const rows: TimelineToolRow[] = (reqData.tool_summaries ?? []).map((summary) => ({
+        id: summary.id,
+        label: summary.narration ?? summary.display_name ?? summary.name,
+        state: "waiting",
+      }));
+
+      if (rows.length > 0) {
+        return (
+          <div key={event.id} className="space-y-1">
+            <ToolActivityTimelineGroup
+              headline={reqData.headline ?? t("waiting_on_tools")}
+              rows={rows}
+            />
+          </div>
+        );
+      }
+    }
+
+    const connectionCalls = reqData.tool_calls.filter(
+      (toolCall) => toolCall.name === "setup_connection",
+    );
+    const otherCalls = reqData.tool_calls.filter(
+      (toolCall) => toolCall.name !== "setup_connection",
+    );
+
+    return (
+      <div key={event.id} className="space-y-1">
+        {connectionCalls.map((toolCall) => (
+          <SetupConnectionToolCall
+            key={toolCall.id}
+            sessionId={sessionId}
+            toolCallId={toolCall.id}
+            provider={(toolCall.arguments as { provider?: string })?.provider ?? "unknown"}
+            toolResultsMap={toolResultsMap}
+          />
+        ))}
+        {otherCalls.length > 0 && (
+          <ToolActivityGroup
+            toolCalls={otherCalls}
+            toolResultsMap={toolResultsMap}
+            toolProgressMap={toolProgressMap}
+            toolOutputMap={toolOutputMap}
+            mode="client"
+          />
+        )}
+      </div>
+    );
+  };
 
   if (eventsLoading) {
     return (
@@ -266,99 +420,20 @@ export const ChatMessageList = memo(function ChatMessageList({
           );
         }
 
-        if (event.type === "act.started") {
-          const group = actGroupsByStartEventId.get(event.id);
-          if (!group || group.rows.length === 0) return null;
-          return (
-            <div key={event.id} className="space-y-3">
-              <div className="ml-9 space-y-1">
-                <ToolActivityTimelineGroup
-                  headline={group.headline}
-                  completedHeadline={group.completedHeadline}
-                  rows={group.rows}
-                />
-              </div>
-              {renderTurnDivider(
-                event.id,
-                turnDurationByEventId,
-                t("worked_for", {
-                  duration: formatWorkedDuration(turnDurationByEventId.get(event.id) ?? 0),
-                }),
-              )}
-            </div>
-          );
-        }
-
-        if (event.type === "tool.call_requested") {
-          const reqData = getEventData(event, "tool.call_requested");
-          if (!reqData?.tool_calls?.length) return null;
-
-          if (reqData.headline || reqData.tool_summaries?.length) {
-            const rows: TimelineToolRow[] = (reqData.tool_summaries ?? []).map((summary) => ({
-              id: summary.id,
-              label: summary.narration ?? summary.display_name ?? summary.name,
-              state: "waiting",
-            }));
-
-            if (rows.length > 0) {
-              return (
-                <div key={event.id} className="space-y-3">
-                  <div className="ml-9 space-y-1">
-                    <ToolActivityTimelineGroup
-                      headline={reqData.headline ?? t("waiting_on_tools")}
-                      rows={rows}
-                    />
-                  </div>
-                  {renderTurnDivider(
-                    event.id,
-                    turnDurationByEventId,
-                    t("worked_for", {
-                      duration: formatWorkedDuration(turnDurationByEventId.get(event.id) ?? 0),
-                    }),
-                  )}
-                </div>
-              );
-            }
+        if (isWorkLogEvent(event)) {
+          const turnId = getKnownTurnId(event);
+          if (turnId) {
+            const group = workLogEventsByTurnId.get(turnId) ?? [];
+            if (group[0]?.id !== event.id) return null;
+            return renderWorkLog(
+              event,
+              <div className="space-y-3">
+                {group.map((groupEvent) => renderWorkLogEventContent(groupEvent))}
+              </div>,
+            );
           }
 
-          const connectionCalls = reqData.tool_calls.filter(
-            (toolCall) => toolCall.name === "setup_connection",
-          );
-          const otherCalls = reqData.tool_calls.filter(
-            (toolCall) => toolCall.name !== "setup_connection",
-          );
-
-          return (
-            <div key={event.id} className="space-y-3">
-              <div className="ml-9 space-y-1">
-                {connectionCalls.map((toolCall) => (
-                  <SetupConnectionToolCall
-                    key={toolCall.id}
-                    sessionId={sessionId}
-                    toolCallId={toolCall.id}
-                    provider={(toolCall.arguments as { provider?: string })?.provider ?? "unknown"}
-                    toolResultsMap={toolResultsMap}
-                  />
-                ))}
-                {otherCalls.length > 0 && (
-                  <ToolActivityGroup
-                    toolCalls={otherCalls}
-                    toolResultsMap={toolResultsMap}
-                    toolProgressMap={toolProgressMap}
-                    toolOutputMap={toolOutputMap}
-                    mode="client"
-                  />
-                )}
-              </div>
-              {renderTurnDivider(
-                event.id,
-                turnDurationByEventId,
-                t("worked_for", {
-                  duration: formatWorkedDuration(turnDurationByEventId.get(event.id) ?? 0),
-                }),
-              )}
-            </div>
-          );
+          return renderWorkLog(event, renderWorkLogEventContent(event));
         }
 
         const isUser = event.type === "input.message";
@@ -386,24 +461,16 @@ export const ChatMessageList = memo(function ChatMessageList({
 
         if (isToolOnlyMessage) {
           if (hasNarratedActEvents) return null;
-          return (
-            <div key={event.id} className="space-y-3">
-              <div className="ml-9 space-y-1">
-                <ToolActivityGroup
-                  toolCalls={toolCalls}
-                  toolResultsMap={toolResultsMap}
-                  toolProgressMap={toolProgressMap}
-                  toolOutputMap={toolOutputMap}
-                />
-              </div>
-              {renderTurnDivider(
-                event.id,
-                turnDurationByEventId,
-                t("worked_for", {
-                  duration: formatWorkedDuration(turnDurationByEventId.get(event.id) ?? 0),
-                }),
-              )}
-            </div>
+          return renderWorkLog(
+            event,
+            <div className="space-y-1">
+              <ToolActivityGroup
+                toolCalls={toolCalls}
+                toolResultsMap={toolResultsMap}
+                toolProgressMap={toolProgressMap}
+                toolOutputMap={toolOutputMap}
+              />
+            </div>,
           );
         }
 
@@ -475,13 +542,17 @@ export const ChatMessageList = memo(function ChatMessageList({
               </div>
             )}
 
-            {renderTurnDivider(
-              event.id,
-              turnDurationByEventId,
-              t("worked_for", {
-                duration: formatWorkedDuration(turnDurationByEventId.get(event.id) ?? 0),
-              }),
-            )}
+            {(() => {
+              const turnId = getKnownTurnId(event);
+              if (turnId && workLogTurnIds.has(turnId)) return null;
+              return renderTurnDivider(
+                event.id,
+                turnDurationByEventId,
+                t("worked_for", {
+                  duration: formatWorkedDuration(turnDurationByEventId.get(event.id) ?? 0),
+                }),
+              );
+            })()}
           </div>
         );
       })}

--- a/apps/ui/src/components/chat/turn-delimiter.ts
+++ b/apps/ui/src/components/chat/turn-delimiter.ts
@@ -83,7 +83,7 @@ export function getCompletedTurnDurationsByEvent(events: Event[]): Map<string, n
   const clientRequestedToolCallIds = getClientRequestedToolCallIds(events);
   const inputMessageTurnIds = getInputMessageTurnIds(events);
   const lastVisibleEventIdByTurn = new Map<string, string>();
-  const durationMsByTurn = new Map<string, number>();
+  const durationMsByTurn = getCompletedTurnDurationsByTurn(events);
 
   for (const event of events) {
     if (isVisibleChatEvent(event, clientRequestedToolCallIds)) {
@@ -91,11 +91,6 @@ export function getCompletedTurnDurationsByEvent(events: Event[]): Map<string, n
       if (turnId) {
         lastVisibleEventIdByTurn.set(turnId, event.id);
       }
-    }
-
-    const tcData = getEventData(event, "turn.completed");
-    if (tcData && tcData.duration_ms != null) {
-      durationMsByTurn.set(tcData.turn_id, tcData.duration_ms);
     }
   }
 
@@ -109,6 +104,19 @@ export function getCompletedTurnDurationsByEvent(events: Event[]): Map<string, n
   }
 
   return durationsByEvent;
+}
+
+export function getCompletedTurnDurationsByTurn(events: Event[]): Map<string, number> {
+  const durationMsByTurn = new Map<string, number>();
+
+  for (const event of events) {
+    const tcData = getEventData(event, "turn.completed");
+    if (tcData && tcData.duration_ms != null) {
+      durationMsByTurn.set(tcData.turn_id, tcData.duration_ms);
+    }
+  }
+
+  return durationMsByTurn;
 }
 
 export function formatWorkedDuration(durationMs: number): string {

--- a/apps/ui/src/components/chat/turn-work-log.tsx
+++ b/apps/ui/src/components/chat/turn-work-log.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useEffect, useRef, useState, type ReactNode } from "react";
+import { ChevronDown, ChevronRight, Loader2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface TurnWorkLogProps {
+  label: string;
+  isActive: boolean;
+  children: ReactNode;
+}
+
+export function TurnWorkLog({ label, isActive, children }: TurnWorkLogProps) {
+  const [expanded, setExpanded] = useState(isActive);
+  const wasActiveRef = useRef(isActive);
+
+  useEffect(() => {
+    if (isActive) {
+      setExpanded(true);
+    } else if (wasActiveRef.current) {
+      setExpanded(false);
+    }
+    wasActiveRef.current = isActive;
+  }, [isActive]);
+
+  return (
+    <div className="space-y-2">
+      <button
+        type="button"
+        aria-expanded={expanded}
+        onClick={() => setExpanded((current) => !current)}
+        className="group flex w-full items-center gap-2 pt-2 text-left text-sm text-muted-foreground transition-colors hover:text-foreground"
+      >
+        <span className="flex min-h-5 min-w-5 items-center justify-center">
+          {isActive ? (
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          ) : expanded ? (
+            <ChevronDown className="h-4 w-4" />
+          ) : (
+            <ChevronRight className="h-4 w-4" />
+          )}
+        </span>
+        <span className="whitespace-nowrap font-medium">{label}</span>
+        <span className="h-px flex-1 bg-border transition-colors group-hover:bg-border/80" />
+      </button>
+
+      <div
+        aria-hidden={!expanded}
+        className={cn(
+          "grid transition-all duration-200 ease-out",
+          expanded ? "grid-rows-[1fr] opacity-100" : "grid-rows-[0fr] opacity-0",
+        )}
+      >
+        <div className="min-h-0 overflow-hidden">
+          <div className="ml-7 space-y-3 pb-1">{children}</div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/specs/markdown-messages.md
+++ b/specs/markdown-messages.md
@@ -85,6 +85,8 @@ components/
    - Message markdown, tool activity, and todo progress must read as one transcript system
    - Tool rows should stay inline with the surrounding message rhythm
    - Do not nest bordered tool/todo cards inside another transcript card unless the content requires a dedicated viewport
+   - Turn work logs should remain expanded while work is active and collapse to a compact "Worked for ..." affordance once the final answer is available
+   - Work logs may show safe narration from reason summaries and tool/act headlines, but must not expose raw hidden thinking content
 
 ## Usage
 


### PR DESCRIPTION
## What
Adds a Codex-style collapsible work-log row to the session chat transcript.

Completed turn work now folds behind a compact `Worked for ...` disclosure while the final assistant answer stays visible. Active work remains expanded.

## Why
Long tool/reasoning traces can bury the final answer. The transcript should keep progress visible while work is happening, then collapse it into a quick, reopenable summary once the answer lands.

## How
- Adds `TurnWorkLog`, which auto-expands while active and auto-collapses after completion.
- Groups reason summaries, act timelines, and client tool request activity by `turn_id` into one work log.
- Uses `turn.completed.duration_ms` for the completed `Worked for ...` label.
- Keeps raw hidden thinking private; only safe reason summaries/previews render.
- Updates the dev chat fixture and markdown-message spec for the folded transcript contract.

## Risk
- Low
- Chat transcript ordering or activity visibility could regress if events are missing `turn_id`; those events still render as standalone active work logs.

## Security
- Threat categories reviewed: TM-WEB, TM-DOS
- Findings and resolutions: No new trust boundary or raw HTML rendering. React escapes summary/headline text, and the implementation only renders safe `reason.item.summary` / `reason.completed.text_preview` rather than hidden thinking content. The grouping is bounded to already-loaded transcript events, so it does not add new network or storage pressure.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

Validation:
- `pnpm test -- turn-work-log.test.tsx --runInBand`
- `pnpm run lint`
- `pnpm run build`
- `bash scripts/lib/check-migration-ordering.sh`
- `RUSTUP_TOOLCHAIN=1.94.1 just pre-push`
- CI: `UI Build, Lint & Test`, `UI Playwright Smoke`, `CodeQL`, `CI Opt-Out Policy`, `Migration Immutability`, `Build Check`
- Browser smoke at `http://localhost:9120/dev/chat-components`: exactly one completed `Worked for 9s` disclosure, collapsed before the final answer

Note: plain `just pre-push` fails in this worktree because local `stable` resolves to rustc 1.92.0 while `sqlx 0.9.0` requires rustc 1.94.0. The same check passes with the installed Rust 1.94.1 toolchain.
