### PR TITLE
chore(rust): upgrade toolchain to 1.96

### DIFF
--- a/.github/workflows/brave-search-integration.yml
+++ b/.github/workflows/brave-search-integration.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,7 +225,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
         with:
           components: rustfmt
 
@@ -241,13 +241,38 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
 
       - name: Check Cargo.lock is up to date
         run: cargo fetch --locked
 
       - name: Check publish-pin versions match workspace
         run: python3 scripts/sync-publish-pin-versions.py --check
+
+  msrv:
+    name: Published Crate MSRV
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.rust == 'true'
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Rust MSRV toolchain
+        uses: dtolnay/rust-toolchain@1.94.0
+
+      - name: Check published crates against MSRV
+        run: |
+          cargo check --locked --all-features \
+            -p everruns-config \
+            -p everruns-openui \
+            -p everruns-a2ui \
+            -p everruns-core \
+            -p everruns-openai \
+            -p everruns-anthropic \
+            -p everruns-integrations-duckduckgo \
+            -p everruns-integrations-github \
+            -p everruns-runtime
 
   migration-immutability:
     name: Migration Immutability
@@ -273,7 +298,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
         with:
           components: clippy
 
@@ -297,7 +322,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
@@ -334,7 +359,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
@@ -396,7 +421,7 @@ jobs:
         uses: dopplerhq/cli-action@v3
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
@@ -423,7 +448,7 @@ jobs:
         uses: dopplerhq/cli-action@v3
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
@@ -450,7 +475,7 @@ jobs:
         uses: dopplerhq/cli-action@v3
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
@@ -478,7 +503,7 @@ jobs:
         uses: dopplerhq/cli-action@v3
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
@@ -524,7 +549,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
 
 
       - name: Cache Rust
@@ -632,7 +657,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
@@ -711,7 +736,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
 
 
       - name: Cache Rust
@@ -927,7 +952,7 @@ jobs:
 
       - name: Install Rust toolchain
         if: matrix.language == 'rust'
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
 
       - name: Download server binary
         uses: actions/download-artifact@v4
@@ -1136,7 +1161,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/cli-binaries.yml
+++ b/.github/workflows/cli-binaries.yml
@@ -37,7 +37,7 @@ jobs:
           ref: ${{ inputs.tag }}
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
         with:
           targets: ${{ matrix.target }}
 

--- a/.github/workflows/container-sandbox-integration.yml
+++ b/.github/workflows/container-sandbox-integration.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
@@ -67,7 +67,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/cursor-integration.yml
+++ b/.github/workflows/cursor-integration.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
@@ -64,7 +64,7 @@ jobs:
         uses: dopplerhq/cli-action@v3
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/duckduckgo-integration.yml
+++ b/.github/workflows/duckduckgo-integration.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/integration-live-sweep.yml
+++ b/.github/workflows/integration-live-sweep.yml
@@ -58,7 +58,7 @@ jobs:
         uses: dopplerhq/cli-action@v3
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
@@ -90,7 +90,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
@@ -121,7 +121,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/licenses.yml
+++ b/.github/workflows/licenses.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
 
       - name: Cache cargo registry
         uses: actions/cache@v4

--- a/.github/workflows/parallel-integration.yml
+++ b/.github/workflows/parallel-integration.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -107,7 +107,7 @@ jobs:
           git -c advice.detachedHead=false checkout --detach "$TRUSTED_SHA"
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
 
       - name: Verify workspace version matches tag
         run: |

--- a/.github/workflows/server-worker-binaries.yml
+++ b/.github/workflows/server-worker-binaries.yml
@@ -48,7 +48,7 @@ jobs:
           ref: ${{ inputs.tag }}
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
         with:
           targets: ${{ matrix.target }}
 

--- a/.github/workflows/sprites-integration.yml
+++ b/.github/workflows/sprites-integration.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
 
 
       - name: Cache Rust
@@ -69,7 +69,7 @@ jobs:
         uses: dopplerhq/cli-action@v3
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
 
 
       - name: Cache Rust

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,8 @@
 ### Prerequisites
 
 - Docker & Docker Compose (for PostgreSQL)
-- Rust stable toolchain
+- Rust 1.96.0 toolchain for repo development
+- Rust 1.94.0 minimum supported Rust version for published crates
 - Node.js 18+ (for UI)
 - [just](https://github.com/casey/just) command runner
 - OpenAI or Anthropic API key (for LLM calls)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,8 @@ exclude = [
 [workspace.package]
 version = "0.8.36"
 edition = "2024"
+# Published crate MSRV: Rust 2024 plus current published dependency floors.
+rust-version = "1.94.0"
 license = "MIT"
 authors = ["Everruns Contributors"]
 homepage = "https://everruns.com"

--- a/crates/a2ui/Cargo.toml
+++ b/crates/a2ui/Cargo.toml
@@ -10,6 +10,7 @@
 name = "everruns-a2ui"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 authors.workspace = true
 homepage.workspace = true

--- a/crates/anthropic/Cargo.toml
+++ b/crates/anthropic/Cargo.toml
@@ -6,6 +6,7 @@
 name = "everruns-anthropic"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 authors.workspace = true
 homepage.workspace = true

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -8,6 +8,7 @@
 name = "everruns-config"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 authors.workspace = true
 homepage.workspace = true

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -9,6 +9,7 @@
 name = "everruns-core"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 authors.workspace = true
 homepage.workspace = true

--- a/crates/openai/Cargo.toml
+++ b/crates/openai/Cargo.toml
@@ -6,6 +6,7 @@
 name = "everruns-openai"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 authors.workspace = true
 homepage.workspace = true

--- a/crates/openui/Cargo.toml
+++ b/crates/openui/Cargo.toml
@@ -9,6 +9,7 @@
 name = "everruns-openui"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 authors.workspace = true
 homepage.workspace = true

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -6,6 +6,7 @@
 name = "everruns-runtime"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 authors.workspace = true
 homepage.workspace = true

--- a/crates/server/Dockerfile
+++ b/crates/server/Dockerfile
@@ -3,7 +3,7 @@
 # ============================================================================
 # Stage 1: Chef - Prepare cargo-chef for dependency caching
 # ============================================================================
-FROM rust:1.95-slim AS chef
+FROM rust:1.96.0-slim AS chef
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     pkg-config \

--- a/crates/worker/Dockerfile
+++ b/crates/worker/Dockerfile
@@ -3,7 +3,7 @@
 # ============================================================================
 # Stage 1: Chef - Prepare cargo-chef for dependency caching
 # ============================================================================
-FROM rust:1.95-slim AS chef
+FROM rust:1.96.0-slim AS chef
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     pkg-config \

--- a/docker/Dockerfile.unified
+++ b/docker/Dockerfile.unified
@@ -12,7 +12,7 @@
 # Stage 1: Builder base - Set up cross-compilation environment
 # Uses BUILDPLATFORM to run on host architecture for cross-compilation
 # ============================================================================
-FROM --platform=$BUILDPLATFORM rust:1.95-slim-bookworm AS builder-base
+FROM --platform=$BUILDPLATFORM rust:1.96.0-slim-bookworm AS builder-base
 
 # Install xx for cross-compilation support
 # Pinned by digest so a mutated tag can't slip a compromised toolchain into

--- a/integrations/duckduckgo/Cargo.toml
+++ b/integrations/duckduckgo/Cargo.toml
@@ -7,6 +7,7 @@
 name = "everruns-integrations-duckduckgo"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 authors.workspace = true
 homepage.workspace = true

--- a/integrations/github/Cargo.toml
+++ b/integrations/github/Cargo.toml
@@ -7,6 +7,7 @@
 name = "everruns-integrations-github"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 authors.workspace = true
 homepage.workspace = true

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "stable"
+channel = "1.96.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## What
Upgrade the repo build toolchain to Rust 1.96.0 and keep published crates on an explicit lower MSRV.

## Why
The repo should build and test against the newly released Rust 1.96.0 while avoiding an accidental MSRV bump for crates we publish to crates.io.

## How
- Pin `rust-toolchain.toml`, CI Rust setup, and Docker Rust builder images to Rust 1.96.0.
- Add workspace `rust-version = "1.94.0"` for published crates.
- Inherit that MSRV in the crates currently published by `publish-crates.yml`.
- Add a CI job that checks the published crate set against Rust 1.94.0.
- Document the repo toolchain and published-crate MSRV in `CONTRIBUTING.md`.

## Risk
- Low / Medium: CI and release build configuration changes can fail if a pin is unavailable or if an existing dependency raises its Rust floor.
- Runtime code is unchanged.

## Security
- Threat categories reviewed: CI/supply-chain configuration; no runtime threat-model category is materially changed.
- Findings and resolutions: no new dependency or secret handling path was added. The PR pins toolchains more explicitly and adds an MSRV check for the published crates.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

## Validation
- `git diff --check`
- Workflow YAML parse with Ruby YAML
- Published-crate `rust-version` coverage script
- Registry manifest scan found no locked dependency with `rust-version > 1.94.0`
- `RUSTUP_TOOLCHAIN=stable cargo fmt --check`
- `RUSTUP_TOOLCHAIN=stable cargo check --ignore-rust-version --locked --all-features -p everruns-config -p everruns-openui -p everruns-a2ui -p everruns-core -p everruns-openai -p everruns-anthropic -p everruns-integrations-duckduckgo -p everruns-integrations-github -p everruns-runtime`
- GitHub Actions CI green, including Rust 1.96.0 format/clippy/tests/builds, Rust 1.94.0 Published Crate MSRV, Docker Build, and Build Rust Images

## Local Validation Gap
`just pre-push` was attempted, but local Rust 1.96.0 installation repeatedly timed out downloading from `static.rust-lang.org` before the check could complete. GitHub Actions completed the exact pinned toolchain checks successfully.

## Smoke Test
Skipped: this is a toolchain, CI, Docker builder, and crate metadata change with no runtime behavior or user-facing flow changes.
