### PR TITLE
feat(flags): org-level feature flag opt-in

### DIFF
--- a/apps/ui/src/__tests__/settings-layout.test.tsx
+++ b/apps/ui/src/__tests__/settings-layout.test.tsx
@@ -123,7 +123,7 @@ describe("SettingsLayout", () => {
     expect(membersLink).toHaveClass("border-accent");
   });
 
-  it("has exactly 7 navigation items", () => {
+  it("has exactly 8 navigation items", () => {
     render(
       <SettingsLayout>
         <div>Test Content</div>
@@ -131,7 +131,7 @@ describe("SettingsLayout", () => {
     );
 
     const navLinks = screen.getAllByRole("link");
-    expect(navLinks).toHaveLength(7);
+    expect(navLinks).toHaveLength(8);
   });
 
   it("groups items under correct sections", () => {
@@ -152,6 +152,7 @@ describe("SettingsLayout", () => {
     expect(orgSection).toHaveTextContent("Organization");
     expect(orgSection).toHaveTextContent("LLM Providers");
     expect(orgSection).toHaveTextContent("Members");
+    expect(orgSection).toHaveTextContent("Features");
     expect(orgSection).toHaveTextContent("Payments");
     expect(orgSection).not.toHaveTextContent("Connections");
     expect(orgSection).not.toHaveTextContent("API Keys");

--- a/apps/ui/src/app/(main)/settings/features/page.tsx
+++ b/apps/ui/src/app/(main)/settings/features/page.tsx
@@ -5,10 +5,7 @@ import { Card } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Switch } from "@/components/ui/switch";
-import {
-  useOrgFeatureFlagSettings,
-  useUpdateOrgFeatureFlags,
-} from "@/hooks/use-org-feature-flags";
+import { useOrgFeatureFlagSettings, useUpdateOrgFeatureFlags } from "@/hooks/use-org-feature-flags";
 import { usePageTitle } from "@/hooks";
 import { useOrg } from "@/providers/org-provider";
 import type { OrgFeatureFlagSetting } from "@/lib/api/types";
@@ -34,7 +31,9 @@ export default function FeaturesSettingsPage() {
         <h2 className="text-lg font-semibold">Features</h2>
         <p className="mt-1 text-sm text-muted-foreground">
           Choose which experimental and optional capabilities are enabled for{" "}
-          <span className="font-medium text-foreground">{currentOrg?.name ?? "this organization"}</span>
+          <span className="font-medium text-foreground">
+            {currentOrg?.name ?? "this organization"}
+          </span>
           . Flags must be available on this deployment before your organization can opt in.
         </p>
       </div>
@@ -86,9 +85,11 @@ export default function FeaturesSettingsPage() {
               <p className="text-sm text-muted-foreground">{flag.description}</p>
             </div>
             <div className="flex shrink-0 items-center gap-2 pt-1">
-              {updateFlags.isPending && updateFlags.variables && flag.name in updateFlags.variables && (
-                <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
-              )}
+              {updateFlags.isPending &&
+                updateFlags.variables &&
+                flag.name in updateFlags.variables && (
+                  <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+                )}
               <Switch
                 id={`flag-${flag.name}`}
                 checked={flag.org_enabled}

--- a/apps/ui/src/app/(main)/settings/features/page.tsx
+++ b/apps/ui/src/app/(main)/settings/features/page.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { AlertCircle, FlaskConical, Loader2 } from "lucide-react";
+import { Card } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Switch } from "@/components/ui/switch";
+import {
+  useOrgFeatureFlagSettings,
+  useUpdateOrgFeatureFlags,
+} from "@/hooks/use-org-feature-flags";
+import { usePageTitle } from "@/hooks";
+import { useOrg } from "@/providers/org-provider";
+import type { OrgFeatureFlagSetting } from "@/lib/api/types";
+
+export default function FeaturesSettingsPage() {
+  usePageTitle("Features", "Settings");
+  const { currentOrg } = useOrg();
+  const canManage = currentOrg?.role === "owner" || currentOrg?.role === "admin";
+  const { data, isLoading, error } = useOrgFeatureFlagSettings();
+  const updateFlags = useUpdateOrgFeatureFlags();
+
+  const availableFlags = data?.flags.filter((f) => f.system_enabled) ?? [];
+  const unavailableCount = data?.flags.filter((f) => !f.system_enabled).length ?? 0;
+
+  const handleToggle = (flag: OrgFeatureFlagSetting, enabled: boolean) => {
+    if (!canManage) return;
+    updateFlags.mutate({ [flag.name]: enabled });
+  };
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-6 p-6">
+      <div>
+        <h2 className="text-lg font-semibold">Features</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Choose which experimental and optional capabilities are enabled for{" "}
+          <span className="font-medium text-foreground">{currentOrg?.name ?? "this organization"}</span>
+          . Flags must be available on this deployment before your organization can opt in.
+        </p>
+      </div>
+
+      {!canManage && (
+        <Card className="flex items-start gap-3 border-amber-500/30 bg-amber-500/5 p-4 text-sm">
+          <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600" />
+          <p>Only organization owners and admins can change feature settings.</p>
+        </Card>
+      )}
+
+      {error && (
+        <Card className="border-destructive/50 p-4 text-sm text-destructive">
+          Failed to load feature settings. Try refreshing the page.
+        </Card>
+      )}
+
+      {isLoading && (
+        <div className="space-y-3">
+          <Skeleton className="h-20 w-full" />
+          <Skeleton className="h-20 w-full" />
+          <Skeleton className="h-20 w-full" />
+        </div>
+      )}
+
+      {!isLoading && availableFlags.length === 0 && (
+        <Card className="p-6 text-sm text-muted-foreground">
+          No optional features are available to enable on this deployment.
+          {unavailableCount > 0 &&
+            ` (${unavailableCount} feature${unavailableCount === 1 ? "" : "s"} require operator configuration.)`}
+        </Card>
+      )}
+
+      <div className="space-y-3">
+        {availableFlags.map((flag) => (
+          <Card key={flag.name} className="flex items-start justify-between gap-4 p-4">
+            <div className="min-w-0 space-y-1">
+              <div className="flex flex-wrap items-center gap-2">
+                <Label htmlFor={`flag-${flag.name}`} className="text-base font-medium">
+                  {flag.label}
+                </Label>
+                {flag.experimental && (
+                  <span className="inline-flex items-center gap-1 text-xs text-amber-600">
+                    <FlaskConical className="h-3.5 w-3.5" />
+                    Experimental
+                  </span>
+                )}
+              </div>
+              <p className="text-sm text-muted-foreground">{flag.description}</p>
+            </div>
+            <div className="flex shrink-0 items-center gap-2 pt-1">
+              {updateFlags.isPending && updateFlags.variables && flag.name in updateFlags.variables && (
+                <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+              )}
+              <Switch
+                id={`flag-${flag.name}`}
+                checked={flag.org_enabled}
+                disabled={!canManage || updateFlags.isPending}
+                onCheckedChange={(checked) => handleToggle(flag, checked)}
+                aria-label={`Enable ${flag.label}`}
+              />
+            </div>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/ui/src/app/(main)/settings/layout.tsx
+++ b/apps/ui/src/app/(main)/settings/layout.tsx
@@ -3,7 +3,16 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
-import { Server, Key, Users, Building2, Cable, User, WalletCards, FlaskConical } from "lucide-react";
+import {
+  Server,
+  Key,
+  Users,
+  Building2,
+  Cable,
+  User,
+  WalletCards,
+  FlaskConical,
+} from "lucide-react";
 
 interface NavItem {
   name: string;

--- a/apps/ui/src/app/(main)/settings/layout.tsx
+++ b/apps/ui/src/app/(main)/settings/layout.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
-import { Server, Key, Users, Building2, Cable, User, WalletCards } from "lucide-react";
+import { Server, Key, Users, Building2, Cable, User, WalletCards, FlaskConical } from "lucide-react";
 
 interface NavItem {
   name: string;
@@ -38,6 +38,12 @@ const settingsSections: NavSection[] = [
         href: "/settings/members",
         icon: Users,
         description: "View and manage team members",
+      },
+      {
+        name: "Features",
+        href: "/settings/features",
+        icon: FlaskConical,
+        description: "Enable optional and experimental capabilities",
       },
       {
         name: "Payments",

--- a/apps/ui/src/app/layout.tsx
+++ b/apps/ui/src/app/layout.tsx
@@ -38,11 +38,11 @@ export default async function RootLayout({
       <body className="font-sans antialiased bg-brand-dots">
         <LocaleProvider>
           <QueryProvider>
-            <FeatureFlagsProvider>
-              <AuthProvider>
-                <OrgProvider initialOrgId={initialOrgId}>{children}</OrgProvider>
-              </AuthProvider>
-            </FeatureFlagsProvider>
+            <AuthProvider>
+              <OrgProvider initialOrgId={initialOrgId}>
+                <FeatureFlagsProvider>{children}</FeatureFlagsProvider>
+              </OrgProvider>
+            </AuthProvider>
           </QueryProvider>
         </LocaleProvider>
       </body>

--- a/apps/ui/src/hooks/use-global-search.ts
+++ b/apps/ui/src/hooks/use-global-search.ts
@@ -212,6 +212,12 @@ const NAVIGATION_PAGES: NavigationPage[] = [
     keywords: ["team", "invite"],
   },
   {
+    title: "Settings > Features",
+    href: "/settings/features",
+    icon: Settings,
+    keywords: ["feature", "flags", "experimental", "opt-in", "beta"],
+  },
+  {
     title: "Durable Execution",
     href: "/durable",
     icon: Cog,

--- a/apps/ui/src/hooks/use-org-feature-flags.ts
+++ b/apps/ui/src/hooks/use-org-feature-flags.ts
@@ -8,7 +8,7 @@ import { useOrg } from "@/providers/org-provider";
 
 export function useOrgFeatureFlags() {
   const { currentOrg } = useOrg();
-  const orgId = currentOrg?.id;
+  const orgId = currentOrg?.public_id;
 
   return useQuery({
     queryKey: ["org-feature-flags", orgId],
@@ -21,7 +21,7 @@ export function useOrgFeatureFlags() {
 
 export function useOrgFeatureFlagSettings() {
   const { currentOrg } = useOrg();
-  const orgId = currentOrg?.id;
+  const orgId = currentOrg?.public_id;
 
   return useQuery({
     queryKey: ["org-feature-flags-settings", orgId],
@@ -33,7 +33,7 @@ export function useOrgFeatureFlagSettings() {
 
 export function useUpdateOrgFeatureFlags() {
   const { currentOrg } = useOrg();
-  const orgId = currentOrg?.id;
+  const orgId = currentOrg?.public_id;
   const queryClient = useQueryClient();
 
   return useMutation({

--- a/apps/ui/src/hooks/use-org-feature-flags.ts
+++ b/apps/ui/src/hooks/use-org-feature-flags.ts
@@ -1,0 +1,47 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  getOrgFeatureFlagSettings,
+  getOrgFeatureFlags,
+  updateOrgFeatureFlags,
+} from "@/lib/api/feature-flags";
+import { useOrg } from "@/providers/org-provider";
+
+export function useOrgFeatureFlags() {
+  const { currentOrg } = useOrg();
+  const orgId = currentOrg?.id;
+
+  return useQuery({
+    queryKey: ["org-feature-flags", orgId],
+    queryFn: () => getOrgFeatureFlags(orgId!),
+    enabled: Boolean(orgId),
+    staleTime: 5 * 60 * 1000,
+    refetchOnWindowFocus: false,
+  });
+}
+
+export function useOrgFeatureFlagSettings() {
+  const { currentOrg } = useOrg();
+  const orgId = currentOrg?.id;
+
+  return useQuery({
+    queryKey: ["org-feature-flags-settings", orgId],
+    queryFn: () => getOrgFeatureFlagSettings(orgId!),
+    enabled: Boolean(orgId),
+    staleTime: 60 * 1000,
+  });
+}
+
+export function useUpdateOrgFeatureFlags() {
+  const { currentOrg } = useOrg();
+  const orgId = currentOrg?.id;
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (flags: Record<string, boolean>) => updateOrgFeatureFlags(orgId!, flags),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["org-feature-flags", orgId] });
+      queryClient.invalidateQueries({ queryKey: ["org-feature-flags-settings", orgId] });
+      queryClient.invalidateQueries({ queryKey: ["feature-flags"] });
+    },
+  });
+}

--- a/apps/ui/src/lib/api/feature-flags.ts
+++ b/apps/ui/src/lib/api/feature-flags.ts
@@ -1,8 +1,34 @@
 // Feature flags API client
 import { api } from "./client";
-import type { FeatureFlags } from "./types";
+import type { FeatureFlags, OrgFeatureFlagSetting, OrgFeatureFlagsSettingsResponse } from "./types";
 
+/** Deployment-level flags (pre-auth). Prefer org-scoped flags when an org is selected. */
 export async function getFeatureFlags(): Promise<FeatureFlags> {
   const { data } = await api.get<FeatureFlags>("/v1/feature-flags");
   return data;
 }
+
+/** Effective flags for an organization (system gate + org opt-in). */
+export async function getOrgFeatureFlags(orgId: string): Promise<FeatureFlags> {
+  const { data } = await api.get<FeatureFlags>(`/v1/orgs/${orgId}/feature-flags`);
+  return data;
+}
+
+export async function getOrgFeatureFlagSettings(
+  orgId: string,
+): Promise<OrgFeatureFlagsSettingsResponse> {
+  const { data } = await api.get<OrgFeatureFlagsSettingsResponse>(
+    `/v1/orgs/${orgId}/feature-flags/settings`,
+  );
+  return data;
+}
+
+export async function updateOrgFeatureFlags(
+  orgId: string,
+  flags: Record<string, boolean>,
+): Promise<FeatureFlags> {
+  const { data } = await api.patch<FeatureFlags>(`/v1/orgs/${orgId}/feature-flags`, { flags });
+  return data;
+}
+
+export type { OrgFeatureFlagSetting, OrgFeatureFlagsSettingsResponse };

--- a/apps/ui/src/lib/api/types/auth-types.ts
+++ b/apps/ui/src/lib/api/types/auth-types.ts
@@ -19,6 +19,20 @@ export interface FeatureFlags {
   agent_delegation: boolean;
 }
 
+export interface OrgFeatureFlagSetting {
+  name: string;
+  label: string;
+  description: string;
+  experimental: boolean;
+  system_enabled: boolean;
+  org_enabled: boolean;
+  effective: boolean;
+}
+
+export interface OrgFeatureFlagsSettingsResponse {
+  flags: OrgFeatureFlagSetting[];
+}
+
 export interface AuthConfigResponse {
   mode: AuthMode;
   password_auth_enabled: boolean;

--- a/apps/ui/src/providers/feature-flags-provider.tsx
+++ b/apps/ui/src/providers/feature-flags-provider.tsx
@@ -2,14 +2,15 @@
 
 // Feature flags provider
 //
-// Decision: Fetch flags once on mount via React Query (cached, no repeated queries).
+// Decision: When an org is selected, fetch org-effective flags (system + opt-in).
+// Decision: Fall back to deployment-level flags before org context is ready.
 // Decision: Default all flags to false while loading to avoid flash of gated content.
-// Decision: Provider sits above OrgProvider so flags are available everywhere.
 
 import { createContext, useContext, type ReactNode } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { getFeatureFlags } from "@/lib/api/feature-flags";
+import { getFeatureFlags, getOrgFeatureFlags } from "@/lib/api/feature-flags";
 import type { FeatureFlags } from "@/lib/api/types";
+import { useOrg } from "@/providers/org-provider";
 
 const DEFAULT_FLAGS: FeatureFlags = {
   global_chat: false,
@@ -30,20 +31,37 @@ export interface FeatureFlagsContextValue {
 
 const FeatureFlagsContext = createContext<FeatureFlagsContextValue | undefined>(undefined);
 
-export function FeatureFlagsProvider({ children }: { children: ReactNode }) {
-  const { data, isLoading } = useQuery({
-    queryKey: ["feature-flags"],
+function FeatureFlagsLoader({ children }: { children: ReactNode }) {
+  const { currentOrg } = useOrg();
+  const orgId = currentOrg?.id;
+
+  const systemQuery = useQuery({
+    queryKey: ["feature-flags", "system"],
     queryFn: getFeatureFlags,
-    staleTime: 5 * 60 * 1000, // 5 min
+    staleTime: 5 * 60 * 1000,
     refetchOnWindowFocus: false,
+    enabled: !orgId,
   });
 
+  const orgQuery = useQuery({
+    queryKey: ["feature-flags", "org", orgId],
+    queryFn: () => getOrgFeatureFlags(orgId!),
+    staleTime: 5 * 60 * 1000,
+    refetchOnWindowFocus: false,
+    enabled: Boolean(orgId),
+  });
+
+  const activeQuery = orgId ? orgQuery : systemQuery;
   const value: FeatureFlagsContextValue = {
-    flags: data ?? DEFAULT_FLAGS,
-    isLoading,
+    flags: activeQuery.data ?? DEFAULT_FLAGS,
+    isLoading: activeQuery.isLoading,
   };
 
   return <FeatureFlagsContext.Provider value={value}>{children}</FeatureFlagsContext.Provider>;
+}
+
+export function FeatureFlagsProvider({ children }: { children: ReactNode }) {
+  return <FeatureFlagsLoader>{children}</FeatureFlagsLoader>;
 }
 
 export function useFeatureFlags(): FeatureFlags {

--- a/apps/ui/src/providers/feature-flags-provider.tsx
+++ b/apps/ui/src/providers/feature-flags-provider.tsx
@@ -33,7 +33,7 @@ const FeatureFlagsContext = createContext<FeatureFlagsContextValue | undefined>(
 
 function FeatureFlagsLoader({ children }: { children: ReactNode }) {
   const { currentOrg } = useOrg();
-  const orgId = currentOrg?.id;
+  const orgId = currentOrg?.public_id;
 
   const systemQuery = useQuery({
     queryKey: ["feature-flags", "system"],

--- a/crates/core/src/feature_flags.rs
+++ b/crates/core/src/feature_flags.rs
@@ -127,6 +127,7 @@ impl FeatureFlags {
             agent_versions: opt_in("agent_versions", system.agent_versions),
             voice: opt_in("voice", system.voice),
             apps_detail_v2: opt_in("apps.detailV2", system.apps_detail_v2),
+            agent_delegation: opt_in("agent_delegation", system.agent_delegation),
         }
     }
 

--- a/crates/core/src/feature_flags.rs
+++ b/crates/core/src/feature_flags.rs
@@ -45,7 +45,7 @@ pub struct FeatureFlags {
 }
 
 /// Metadata for an API-visible feature flag (org opt-in UI + catalog).
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct FeatureFlagDefinition {
     /// Stable flag key (matches `FeatureFlags` field / `is_enabled` name).
     pub name: &'static str,
@@ -182,10 +182,6 @@ impl FeatureFlags {
             agent_delegation: true,
         }
     }
-}
-
-fn system_flag_enabled(system: &FeatureFlags, name: &str) -> bool {
-    system.is_enabled(name)
 }
 
 /// Backend-only feature flags. Not exposed via API or frontend.

--- a/crates/core/src/feature_flags.rs
+++ b/crates/core/src/feature_flags.rs
@@ -17,6 +17,7 @@ use crate::deployment::DeploymentGrade;
 /// Currently backed by environment variables and deployment grade.
 /// Future: per-org flags, per-user flags, external providers.
 #[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct FeatureFlags {
     /// Global chat (per-user singleton chat session). Experimental.
     pub global_chat: bool,
@@ -43,7 +44,92 @@ pub struct FeatureFlags {
     pub agent_delegation: bool,
 }
 
+/// Metadata for an API-visible feature flag (org opt-in UI + catalog).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FeatureFlagDefinition {
+    /// Stable flag key (matches `FeatureFlags` field / `is_enabled` name).
+    pub name: &'static str,
+    /// Human-readable title for settings UI.
+    pub label: &'static str,
+    /// Short description of what the flag gates.
+    pub description: &'static str,
+    /// When true, shown with experimental badges in the UI.
+    pub experimental: bool,
+}
+
+/// All API-visible flags that organizations may opt into when the deployment allows them.
+pub const API_FEATURE_FLAG_DEFINITIONS: &[FeatureFlagDefinition] = &[
+    FeatureFlagDefinition {
+        name: "global_chat",
+        label: "Global chat",
+        description: "Per-user singleton chat session in the sidebar.",
+        experimental: true,
+    },
+    FeatureFlagDefinition {
+        name: "notifications",
+        label: "Notifications",
+        description: "In-app notification bell, toasts, and notification SSE.",
+        experimental: true,
+    },
+    FeatureFlagDefinition {
+        name: "mcp_endpoint",
+        label: "MCP server endpoint",
+        description: "Expose Everruns as an MCP server (POST /mcp).",
+        experimental: true,
+    },
+    FeatureFlagDefinition {
+        name: "evals",
+        label: "Evals",
+        description: "Behavioral evals for agents.",
+        experimental: true,
+    },
+    FeatureFlagDefinition {
+        name: "app_budgets",
+        label: "App budgets",
+        description: "App and channel scoped budgets with periodic resets.",
+        experimental: true,
+    },
+    FeatureFlagDefinition {
+        name: "agent_versions",
+        label: "Agent versions",
+        description: "Immutable agent snapshots, forks, rollback, and app version binding.",
+        experimental: true,
+    },
+    FeatureFlagDefinition {
+        name: "voice",
+        label: "Voice",
+        description: "Realtime voice endpoints and microphone controls in chat.",
+        experimental: true,
+    },
+    FeatureFlagDefinition {
+        name: "apps.detailV2",
+        label: "Apps detail v2",
+        description: "Channels-first app detail page and full-page channel forms.",
+        experimental: true,
+    },
+];
+
 impl FeatureFlags {
+    /// Effective flags for an organization: deployment/system gates AND explicit org opt-in.
+    ///
+    /// Org overrides default to disabled; a flag is on only when the deployment allows it
+    /// and the org has opted in (`enabled: true` in storage).
+    pub fn for_org(system: &Self, org_enabled: &std::collections::HashMap<String, bool>) -> Self {
+        let opt_in = |name: &str, system_on: bool| -> bool {
+            system_on && org_enabled.get(name).copied().unwrap_or(false)
+        };
+        Self {
+            global_chat: opt_in("global_chat", system.global_chat),
+            notifications: opt_in("notifications", system.notifications),
+            mcp_endpoint: opt_in("mcp_endpoint", system.mcp_endpoint),
+            evals: opt_in("evals", system.evals),
+            app_budgets: opt_in("app_budgets", system.app_budgets),
+            agent_versions: opt_in("agent_versions", system.agent_versions),
+            voice: opt_in("voice", system.voice),
+            apps_detail_v2: opt_in("apps.detailV2", system.apps_detail_v2),
+        }
+    }
+
     /// Compute feature flags from environment variables and deployment grade.
     pub fn from_env(grade: &DeploymentGrade) -> Self {
         Self {
@@ -96,6 +182,10 @@ impl FeatureFlags {
             agent_delegation: true,
         }
     }
+}
+
+fn system_flag_enabled(system: &FeatureFlags, name: &str) -> bool {
+    system.is_enabled(name)
 }
 
 /// Backend-only feature flags. Not exposed via API or frontend.
@@ -320,6 +410,32 @@ mod tests {
         unsafe { std::env::remove_var("FEATURE_NOTIFICATIONS") };
         let flags = FeatureFlags::from_env(&DeploymentGrade::Prod);
         assert!(!flags.notifications);
+    }
+
+    #[test]
+    fn test_for_org_requires_system_and_opt_in() {
+        let system = FeatureFlags {
+            global_chat: true,
+            evals: true,
+            ..FeatureFlags::default()
+        };
+        let mut org = std::collections::HashMap::new();
+        org.insert("global_chat".to_string(), true);
+        let effective = FeatureFlags::for_org(&system, &org);
+        assert!(effective.global_chat);
+        assert!(!effective.evals);
+
+        let effective_none = FeatureFlags::for_org(&system, &std::collections::HashMap::new());
+        assert!(!effective_none.global_chat);
+    }
+
+    #[test]
+    fn test_for_org_cannot_enable_when_system_off() {
+        let system = FeatureFlags::default();
+        let mut org = std::collections::HashMap::new();
+        org.insert("global_chat".to_string(), true);
+        let effective = FeatureFlags::for_org(&system, &org);
+        assert!(!effective.global_chat);
     }
 
     #[test]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -458,7 +458,9 @@ pub use url_validation::{
 pub use deployment::DeploymentGrade;
 
 // Feature flags
-pub use feature_flags::{FeatureFlags, InternalFeatureFlags};
+pub use feature_flags::{
+    API_FEATURE_FLAG_DEFINITIONS, FeatureFlagDefinition, FeatureFlags, InternalFeatureFlags,
+};
 
 // Observation backends
 pub use observation::{BraintrustConfig, BraintrustListener, OtelEventListener};

--- a/crates/server/migrations/046_org_feature_flags.sql
+++ b/crates/server/migrations/046_org_feature_flags.sql
@@ -1,0 +1,11 @@
+-- Per-organization opt-in for API-visible feature flags.
+CREATE TABLE org_feature_flags (
+    org_id BIGINT NOT NULL REFERENCES organizations(org_id) ON DELETE CASCADE,
+    flag_name TEXT NOT NULL,
+    enabled BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (org_id, flag_name)
+);
+
+CREATE INDEX idx_org_feature_flags_org_id ON org_feature_flags (org_id);

--- a/crates/server/src/api/agents.rs
+++ b/crates/server/src/api/agents.rs
@@ -155,7 +155,7 @@ impl AppState {
             None,
             self.auth.permission_resolver.clone(),
         )
-        .with_feature_flags(FeatureFlags::from_env(&self.grade))
+        .with_feature_flags(org.feature_flags.clone())
     }
 }
 
@@ -1336,6 +1336,7 @@ mod high_risk_admin_gate_tests {
             user_id: None,
             role,
             is_platform_user: false,
+            feature_flags: FeatureFlags::default(),
         }
     }
 

--- a/crates/server/src/api/dispatch.rs
+++ b/crates/server/src/api/dispatch.rs
@@ -133,7 +133,12 @@ macro_rules! impl_dispatchable {
                 org: &crate::auth::ResolvedOrg,
             ) -> crate::api::dispatch::Dispatcher {
                 crate::api::dispatch::Dispatcher {
-                    ctx: self.ctx(org),
+                    ctx: {
+                        let mut ctx = self.ctx(org);
+                        // Org-scoped requests use effective flags (system + org opt-in).
+                        ctx.feature_flags = org.feature_flags.clone();
+                        ctx
+                    },
                     url_builder: crate::api::common::UrlBuilder::from_auth_config(
                         &self.auth.config,
                     ),

--- a/crates/server/src/api/mcp_endpoint/mod.rs
+++ b/crates/server/src/api/mcp_endpoint/mod.rs
@@ -851,6 +851,19 @@ async fn resolve_org_by_id(
 
     let role = org_row.role.parse::<OrgRole>().unwrap_or(OrgRole::Member);
 
+    let feature_flags = crate::services::org_feature_flags::resolve_org_feature_flags(
+        &state.db,
+        org_row.org_id,
+        &state.auth.system_feature_flags,
+    )
+    .await
+    .unwrap_or_else(|_| {
+        everruns_core::FeatureFlags::for_org(
+            &state.auth.system_feature_flags,
+            &std::collections::HashMap::new(),
+        )
+    });
+
     Ok(ResolvedOrg {
         org_id: org_row.org_id,
         public_id: org_row.public_id.clone(),
@@ -858,6 +871,7 @@ async fn resolve_org_by_id(
         user_id: Some(auth_user.id),
         role,
         is_platform_user: auth_user.is_platform_user,
+        feature_flags,
     })
 }
 
@@ -1473,6 +1487,7 @@ mod org_override_scope_tests {
             user_id: Some(Uuid::new_v4()),
             role: OrgRole::Member,
             is_platform_user: false,
+            feature_flags: everruns_core::FeatureFlags::default(),
         }
     }
 

--- a/crates/server/src/api/mod.rs
+++ b/crates/server/src/api/mod.rs
@@ -38,6 +38,7 @@ pub mod mcp_servers;
 pub mod memory_stores;
 pub mod messages;
 pub mod notifications;
+pub mod org_feature_flags;
 pub mod organizations;
 pub mod payments;
 pub mod prometheus;

--- a/crates/server/src/api/org_feature_flags.rs
+++ b/crates/server/src/api/org_feature_flags.rs
@@ -1,0 +1,186 @@
+// Organization feature flag opt-in API
+//
+// Decision: Effective flags = deployment/system gate AND org opt-in (default off).
+// Decision: GET settings exposes catalog for admin UI; PATCH requires OrgAdmin.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use axum::{
+    Json, Router,
+    extract::{Path, State},
+    routing::get,
+};
+use everruns_core::{FeatureFlags, validate_org_public_id};
+
+use crate::auth::middleware::{AuthState, OrgAdmin, ResolvedOrg};
+use crate::services::org_feature_flags::{
+    OrgFeatureFlagsSettingsResponse, build_org_feature_flag_settings,
+    validate_org_feature_flag_updates,
+};
+use crate::storage::StorageBackend;
+
+use super::common::{ApiOptionExt, ApiResult, ApiResultExt, ErrorResponse, impl_auth_state};
+use super::organizations::is_member_of_public_db;
+
+#[derive(Clone)]
+pub struct AppState {
+    pub db: Arc<StorageBackend>,
+    pub auth: AuthState,
+    pub system_feature_flags: FeatureFlags,
+}
+
+impl AppState {
+    pub fn new(
+        db: Arc<StorageBackend>,
+        auth: AuthState,
+        system_feature_flags: FeatureFlags,
+    ) -> Self {
+        Self {
+            db,
+            auth,
+            system_feature_flags,
+        }
+    }
+}
+
+impl_auth_state!(AppState);
+
+#[derive(Debug, Clone, serde::Deserialize, utoipa::ToSchema)]
+pub struct UpdateOrgFeatureFlagsRequest {
+    /// Map of flag name -> enabled. Omitted flags are unchanged.
+    pub flags: HashMap<String, bool>,
+}
+
+pub fn routes(state: AppState) -> Router {
+    Router::new()
+        .route(
+            "/v1/orgs/{org}/feature-flags",
+            get(get_org_feature_flags).patch(update_org_feature_flags),
+        )
+        .route(
+            "/v1/orgs/{org}/feature-flags/settings",
+            get(get_org_feature_flag_settings),
+        )
+        .with_state(state)
+}
+
+async fn resolve_path_org(
+    state: &AppState,
+    user_id: uuid::Uuid,
+    org_public_id: &str,
+) -> Result<i64, (axum::http::StatusCode, Json<ErrorResponse>)> {
+    if !validate_org_public_id(org_public_id) {
+        return Err(ErrorResponse::not_found("Organization").into());
+    }
+    if !is_member_of_public_db(&state.db, user_id, org_public_id).await? {
+        return Err(ErrorResponse::not_found("Organization").into());
+    }
+    let row = state
+        .db
+        .get_organization_by_public_id(org_public_id)
+        .await
+        .log_internal_error_json("get organization")?
+        .ok_or_not_found_json("Organization")?;
+    Ok(row.org_id)
+}
+
+/// GET /v1/orgs/{org}/feature-flags — effective flags for the organization.
+#[utoipa::path(
+    get,
+    path = "/v1/orgs/{org}/feature-flags",
+    tag = "Organizations",
+    params(("org" = String, Path, description = "Organization public id")),
+    responses(
+        (status = 200, description = "Effective feature flags", body = FeatureFlags),
+        (status = 404, description = "Organization not found", body = ErrorResponse),
+    ),
+    security(("bearerAuth" = []), ("cookieAuth" = []))
+)]
+pub async fn get_org_feature_flags(
+    State(state): State<AppState>,
+    Path(org_public_id): Path<String>,
+    user: crate::auth::AuthUser,
+) -> ApiResult<FeatureFlags> {
+    let org_id = resolve_path_org(&state, user.id, &org_public_id).await?;
+    let flags = crate::services::org_feature_flags::resolve_org_feature_flags(
+        &state.db,
+        org_id,
+        &state.system_feature_flags,
+    )
+    .await
+    .log_internal_error_json("resolve org feature flags")?;
+    Ok(Json(flags))
+}
+
+/// GET /v1/orgs/{org}/feature-flags/settings — catalog with system/org/effective state.
+#[utoipa::path(
+    get,
+    path = "/v1/orgs/{org}/feature-flags/settings",
+    tag = "Organizations",
+    params(("org" = String, Path, description = "Organization public id")),
+    responses(
+        (status = 200, description = "Feature flag settings", body = OrgFeatureFlagsSettingsResponse),
+        (status = 404, description = "Organization not found", body = ErrorResponse),
+    ),
+    security(("bearerAuth" = []), ("cookieAuth" = []))
+)]
+pub async fn get_org_feature_flag_settings(
+    State(state): State<AppState>,
+    Path(org_public_id): Path<String>,
+    user: crate::auth::AuthUser,
+) -> ApiResult<OrgFeatureFlagsSettingsResponse> {
+    let org_id = resolve_path_org(&state, user.id, &org_public_id).await?;
+    let org_enabled = state
+        .db
+        .list_org_feature_flags(org_id)
+        .await
+        .log_internal_error_json("list org feature flags")?;
+    Ok(Json(OrgFeatureFlagsSettingsResponse {
+        flags: build_org_feature_flag_settings(&state.system_feature_flags, &org_enabled),
+    }))
+}
+
+/// PATCH /v1/orgs/{org}/feature-flags — update org opt-in (admin only).
+#[utoipa::path(
+    patch,
+    path = "/v1/orgs/{org}/feature-flags",
+    tag = "Organizations",
+    params(("org" = String, Path, description = "Organization public id")),
+    request_body = UpdateOrgFeatureFlagsRequest,
+    responses(
+        (status = 200, description = "Updated effective flags", body = FeatureFlags),
+        (status = 400, description = "Invalid flag", body = ErrorResponse),
+        (status = 403, description = "Forbidden", body = ErrorResponse),
+        (status = 404, description = "Organization not found", body = ErrorResponse),
+    ),
+    security(("bearerAuth" = []), ("cookieAuth" = []))
+)]
+pub async fn update_org_feature_flags(
+    State(state): State<AppState>,
+    Path(org_public_id): Path<String>,
+    OrgAdmin(org): OrgAdmin,
+    Json(req): Json<UpdateOrgFeatureFlagsRequest>,
+) -> ApiResult<FeatureFlags> {
+    if org.public_id != org_public_id {
+        return Err(ErrorResponse::not_found("Organization").into());
+    }
+    if let Err(msg) = validate_org_feature_flag_updates(&state.system_feature_flags, &req.flags) {
+        return Err(ErrorResponse::new(msg).into_response(axum::http::StatusCode::BAD_REQUEST));
+    }
+
+    state
+        .db
+        .replace_org_feature_flags(org.org_id, &req.flags)
+        .await
+        .log_internal_error_json("update org feature flags")?;
+
+    let flags = crate::services::org_feature_flags::resolve_org_feature_flags(
+        &state.db,
+        org.org_id,
+        &state.system_feature_flags,
+    )
+    .await
+    .log_internal_error_json("resolve org feature flags")?;
+    Ok(Json(flags))
+}

--- a/crates/server/src/api/org_feature_flags.rs
+++ b/crates/server/src/api/org_feature_flags.rs
@@ -13,7 +13,7 @@ use axum::{
 };
 use everruns_core::{FeatureFlags, validate_org_public_id};
 
-use crate::auth::middleware::{AuthState, OrgAdmin, ResolvedOrg};
+use crate::auth::middleware::{AuthState, OrgAdmin};
 use crate::services::org_feature_flags::{
     OrgFeatureFlagsSettingsResponse, build_org_feature_flag_settings,
     validate_org_feature_flag_updates,
@@ -71,10 +71,10 @@ async fn resolve_path_org(
     org_public_id: &str,
 ) -> Result<i64, (axum::http::StatusCode, Json<ErrorResponse>)> {
     if !validate_org_public_id(org_public_id) {
-        return Err(ErrorResponse::not_found("Organization").into());
+        return Err(ErrorResponse::not_found("Organization"));
     }
     if !is_member_of_public_db(&state.db, user_id, org_public_id).await? {
-        return Err(ErrorResponse::not_found("Organization").into());
+        return Err(ErrorResponse::not_found("Organization"));
     }
     let row = state
         .db
@@ -163,7 +163,7 @@ pub async fn update_org_feature_flags(
     Json(req): Json<UpdateOrgFeatureFlagsRequest>,
 ) -> ApiResult<FeatureFlags> {
     if org.public_id != org_public_id {
-        return Err(ErrorResponse::not_found("Organization").into());
+        return Err(ErrorResponse::not_found("Organization"));
     }
     if let Err(msg) = validate_org_feature_flag_updates(&state.system_feature_flags, &req.flags) {
         return Err(ErrorResponse::new(msg).into_response(axum::http::StatusCode::BAD_REQUEST));

--- a/crates/server/src/api/organizations.rs
+++ b/crates/server/src/api/organizations.rs
@@ -531,7 +531,7 @@ pub async fn update_organization(
 }
 
 /// Check membership by querying the DB (avoids stale auth context).
-async fn is_member_of_public_db(
+pub(crate) async fn is_member_of_public_db(
     db: &StorageBackend,
     user_id: uuid::Uuid,
     org_public_id: &str,

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -477,10 +477,11 @@ impl ServerAppBuilder {
                 }
             }
         };
-        let auth_state =
-            auth::AuthState::new(auth_config.clone(), auth_backend.clone()).with_db(db.clone());
         let deployment_grade = everruns_core::DeploymentGrade::from_env();
         let feature_flags = everruns_core::FeatureFlags::from_env(&deployment_grade);
+        let auth_state = auth::AuthState::new(auth_config.clone(), auth_backend.clone())
+            .with_db(db.clone())
+            .with_system_feature_flags(feature_flags.clone());
         let internal_feature_flags = everruns_core::InternalFeatureFlags::from_env();
         let notifications_enabled = feature_flags.notifications;
         tracing::info!(?feature_flags, "Feature flags computed");
@@ -1161,6 +1162,13 @@ impl ServerAppBuilder {
             })
             .merge(api::skills::routes(skills_state))
             .merge(api::organizations::routes(organizations_state))
+            .merge(api::org_feature_flags::routes(
+                api::org_feature_flags::AppState::new(
+                    db.clone(),
+                    auth_state.clone(),
+                    feature_flags.clone(),
+                ),
+            ))
             .merge(api::volumes::routes(volumes_state))
             .merge(api::memory_stores::routes(memory_stores_state))
             .merge(api::knowledge_bases::routes(knowledge_bases_state))

--- a/crates/server/src/auth/middleware.rs
+++ b/crates/server/src/auth/middleware.rs
@@ -10,8 +10,8 @@ use axum::{
 use axum_extra::extract::CookieJar;
 use everruns_core::{
     ANONYMOUS_USER_EMAIL, ANONYMOUS_USER_ID, ANONYMOUS_USER_NAME, Caller, DEFAULT_ORG_ID,
-    DEFAULT_ORG_PUBLIC_ID, DefaultPermissionResolver, OrgMembership, OrgRole, PermissionResolver,
-    validate_org_public_id,
+    DEFAULT_ORG_PUBLIC_ID, DefaultPermissionResolver, FeatureFlags, OrgMembership, OrgRole,
+    PermissionResolver, validate_org_public_id,
 };
 use serde::Serialize;
 use std::sync::Arc;
@@ -163,6 +163,9 @@ pub struct AuthState {
     /// Used in AuthMethod::None (anonymous user only carries default org)
     /// and AuthMethod::Jwt (JWT may be stale after server-side org creation).
     pub db: Option<Arc<StorageBackend>>,
+    /// Deployment-level feature flags (env + grade). Combined with per-org opt-in
+    /// when building [`ResolvedOrg::feature_flags`].
+    pub system_feature_flags: FeatureFlags,
 }
 
 impl AuthState {
@@ -172,6 +175,7 @@ impl AuthState {
             backend,
             permission_resolver: Arc::new(DefaultPermissionResolver),
             db: None,
+            system_feature_flags: FeatureFlags::current(),
         }
     }
 
@@ -186,6 +190,7 @@ impl AuthState {
             backend,
             permission_resolver: resolver,
             db: None,
+            system_feature_flags: FeatureFlags::current(),
         }
     }
 
@@ -202,12 +207,18 @@ impl AuthState {
             backend,
             permission_resolver: Arc::new(DefaultPermissionResolver),
             db: Some(db),
+            system_feature_flags: FeatureFlags::current(),
         }
     }
 
     /// Set the storage backend (for org resolution in ResolvedOrg extraction).
     pub fn with_db(mut self, db: Arc<StorageBackend>) -> Self {
         self.db = Some(db);
+        self
+    }
+
+    pub fn with_system_feature_flags(mut self, flags: FeatureFlags) -> Self {
+        self.system_feature_flags = flags;
         self
     }
 }
@@ -500,6 +511,36 @@ pub struct ResolvedOrg {
     pub role: OrgRole,
     /// Whether the authenticated user may access global/platform surfaces.
     pub is_platform_user: bool,
+    /// Effective API-visible feature flags for this org (system gate + org opt-in).
+    pub feature_flags: FeatureFlags,
+}
+
+impl ResolvedOrg {
+    pub async fn with_effective_feature_flags(self, auth_state: &AuthState) -> Self {
+        let feature_flags = if let Some(db) = &auth_state.db {
+            crate::services::org_feature_flags::resolve_org_feature_flags(
+                db,
+                self.org_id,
+                &auth_state.system_feature_flags,
+            )
+            .await
+            .unwrap_or_else(|_| {
+                FeatureFlags::for_org(
+                    &auth_state.system_feature_flags,
+                    &std::collections::HashMap::new(),
+                )
+            })
+        } else {
+            FeatureFlags::for_org(
+                &auth_state.system_feature_flags,
+                &std::collections::HashMap::new(),
+            )
+        };
+        Self {
+            feature_flags,
+            ..self
+        }
+    }
 }
 
 impl From<&ResolvedOrg> for Caller {
@@ -525,6 +566,8 @@ where
     async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
         // First extract the authenticated user
         let user = AuthUser::from_request_parts(parts, state).await?;
+
+        let auth_state = AuthState::from_ref(state);
 
         match user.auth_method {
             AuthMethod::ApiKey => {
@@ -556,7 +599,10 @@ where
                         user_id: Some(user.id),
                         role: org.role,
                         is_platform_user: user.is_platform_user,
-                    });
+                        feature_flags: FeatureFlags::default(),
+                    }
+                    .with_effective_feature_flags(&auth_state)
+                    .await);
                 }
 
                 // No explicit org — convenience: if user has exactly one org, use it
@@ -569,7 +615,10 @@ where
                         user_id: Some(user.id),
                         role: org.role,
                         is_platform_user: user.is_platform_user,
-                    });
+                        feature_flags: FeatureFlags::default(),
+                    }
+                    .with_effective_feature_flags(&auth_state)
+                    .await);
                 }
 
                 // Multiple orgs, no explicit selection
@@ -585,7 +634,6 @@ where
                 // No-auth mode: anonymous user only carries the default org,
                 // but the user may have switched to a different org via cookie.
                 // Read the org cookie and resolve via DB if available.
-                let auth_state = AuthState::from_ref(state);
                 let jar = CookieJar::from_headers(&parts.headers);
                 let cookie_org_id = jar.get(ORG_COOKIE_NAME).map(|c| c.value().to_string());
 
@@ -600,7 +648,10 @@ where
                         user_id: None,
                         role: OrgRole::Owner, // Anonymous user is owner of all orgs
                         is_platform_user: user.is_platform_user,
-                    });
+                        feature_flags: FeatureFlags::default(),
+                    }
+                    .with_effective_feature_flags(&auth_state)
+                    .await);
                 }
 
                 // Fall back to default org
@@ -615,7 +666,10 @@ where
                     user_id: None,
                     role: org.role,
                     is_platform_user: user.is_platform_user,
-                })
+                    feature_flags: FeatureFlags::default(),
+                }
+                .with_effective_feature_flags(&auth_state)
+                .await)
             }
             AuthMethod::Jwt => {
                 // Session auth: get org from everruns_org cookie
@@ -638,7 +692,10 @@ where
                         user_id: Some(user.id),
                         role: org.role,
                         is_platform_user: user.is_platform_user,
-                    });
+                        feature_flags: FeatureFlags::default(),
+                    }
+                    .with_effective_feature_flags(&auth_state)
+                    .await);
                 }
 
                 let org_public_id = cookie_org.unwrap();
@@ -654,7 +711,6 @@ where
                 // the client JWT won't include it until PropelAuth refreshes the token).
                 // This mirrors the fix in the `switch_org` endpoint
                 // (`crates/server/src/api/users.rs`).
-                let auth_state = AuthState::from_ref(state);
                 if let Some(db) = &auth_state.db
                     && let Ok(user_orgs) = db.list_user_organizations(user.id).await
                 {
@@ -667,7 +723,10 @@ where
                             user_id: Some(user.id),
                             role,
                             is_platform_user: user.is_platform_user,
-                        });
+                            feature_flags: FeatureFlags::default(),
+                        }
+                        .with_effective_feature_flags(&auth_state)
+                        .await);
                     }
                     // DB available, user not a member → 404
                     return Err(AuthError {
@@ -692,7 +751,10 @@ where
                     user_id: Some(user.id),
                     role: org.role,
                     is_platform_user: user.is_platform_user,
-                })
+                    feature_flags: FeatureFlags::default(),
+                }
+                .with_effective_feature_flags(&auth_state)
+                .await)
             }
         }
     }
@@ -995,6 +1057,7 @@ mod tests {
             backend,
             permission_resolver: Arc::new(DefaultPermissionResolver),
             db: Some(db.clone()),
+            system_feature_flags: FeatureFlags::current(),
         };
         (state, db)
     }
@@ -1138,6 +1201,7 @@ mod tests {
             backend,
             permission_resolver: Arc::new(DefaultPermissionResolver),
             db: None, // No DB — forces JWT fallback
+            system_feature_flags: FeatureFlags::current(),
         };
 
         let (mut parts, _body) = Request::builder()
@@ -1207,6 +1271,7 @@ mod tests {
             backend,
             permission_resolver: Arc::new(DefaultPermissionResolver),
             db: None,
+            system_feature_flags: FeatureFlags::current(),
         }
     }
 

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -1932,6 +1932,42 @@ async fn seed_organization_settings(db: &StorageBackend) -> anyhow::Result<SeedR
     Ok(result)
 }
 
+/// Seed default-org feature flag opt-ins when none exist (dev-friendly bootstrap).
+async fn seed_default_org_feature_flags(db: &StorageBackend) -> anyhow::Result<SeedResult> {
+    use everruns_core::{
+        API_FEATURE_FLAG_DEFINITIONS, DEFAULT_ORG_ID, DeploymentGrade, FeatureFlags,
+    };
+    use std::collections::HashMap;
+
+    let mut result = SeedResult::default();
+    let existing = db.list_org_feature_flags(DEFAULT_ORG_ID).await?;
+    if !existing.is_empty() {
+        result.unchanged += 1;
+        return Ok(result);
+    }
+
+    let system = FeatureFlags::from_env(&DeploymentGrade::from_env());
+    let mut to_enable = HashMap::new();
+    for def in API_FEATURE_FLAG_DEFINITIONS {
+        if system.is_enabled(def.name) {
+            to_enable.insert(def.name.to_string(), true);
+        }
+    }
+    if to_enable.is_empty() {
+        result.unchanged += 1;
+        return Ok(result);
+    }
+
+    db.replace_org_feature_flags(DEFAULT_ORG_ID, &to_enable)
+        .await?;
+    tracing::info!(
+        count = to_enable.len(),
+        "Seeded default organization feature flag opt-ins"
+    );
+    result.created += 1;
+    Ok(result)
+}
+
 /// Seed LLM models into the database (upserts, only when changed)
 async fn seed_models_with_platform_definition(
     db: &StorageBackend,
@@ -2333,6 +2369,15 @@ pub async fn seed_all_with_platform_definition(
         "Organization settings seeded"
     );
     result.merge(org_settings_result);
+
+    let org_flags_result = seed_default_org_feature_flags(db).await?;
+    tracing::debug!(
+        created = org_flags_result.created,
+        updated = org_flags_result.updated,
+        unchanged = org_flags_result.unchanged,
+        "Organization feature flags seeded"
+    );
+    result.merge(org_flags_result);
 
     // Seed MCP servers (before agents that may use them)
     let mcp_result = seed_mcp_servers(db).await?;

--- a/crates/server/src/services/mod.rs
+++ b/crates/server/src/services/mod.rs
@@ -21,6 +21,7 @@ pub mod capability;
 pub mod event;
 pub mod llm_resolver;
 pub mod model_sync;
+pub mod org_feature_flags;
 pub mod principal;
 pub mod usage_tracking;
 

--- a/crates/server/src/services/org_feature_flags.rs
+++ b/crates/server/src/services/org_feature_flags.rs
@@ -1,0 +1,80 @@
+//! Resolve effective feature flags for an organization.
+
+use std::collections::HashMap;
+
+use everruns_core::FeatureFlags;
+
+use crate::storage::StorageBackend;
+
+pub async fn resolve_org_feature_flags(
+    db: &StorageBackend,
+    org_id: i64,
+    system: &FeatureFlags,
+) -> anyhow::Result<FeatureFlags> {
+    let org_enabled = db.list_org_feature_flags(org_id).await?;
+    Ok(FeatureFlags::for_org(system, &org_enabled))
+}
+
+pub fn build_org_feature_flag_settings(
+    system: &FeatureFlags,
+    org_enabled: &HashMap<String, bool>,
+) -> Vec<OrgFeatureFlagSetting> {
+    everruns_core::API_FEATURE_FLAG_DEFINITIONS
+        .iter()
+        .map(|def| {
+            let system_enabled = system.is_enabled(def.name);
+            let org_on = org_enabled.get(def.name).copied().unwrap_or(false);
+            let effective = system_enabled && org_on;
+            OrgFeatureFlagSetting {
+                name: def.name.to_string(),
+                label: def.label.to_string(),
+                description: def.description.to_string(),
+                experimental: def.experimental,
+                system_enabled,
+                org_enabled: org_on,
+                effective,
+            }
+        })
+        .collect()
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct OrgFeatureFlagSetting {
+    pub name: String,
+    pub label: String,
+    pub description: String,
+    pub experimental: bool,
+    /// Whether the deployment allows this flag (env / grade).
+    pub system_enabled: bool,
+    /// Whether the organization has opted in.
+    pub org_enabled: bool,
+    /// Effective value (`system_enabled && org_enabled`).
+    pub effective: bool,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
+pub struct OrgFeatureFlagsSettingsResponse {
+    pub flags: Vec<OrgFeatureFlagSetting>,
+}
+
+/// Validate PATCH payload: only known API-visible flags; cannot enable when system off.
+pub fn validate_org_feature_flag_updates(
+    system: &FeatureFlags,
+    updates: &HashMap<String, bool>,
+) -> Result<(), String> {
+    for (name, enabled) in updates {
+        let known = everruns_core::API_FEATURE_FLAG_DEFINITIONS
+            .iter()
+            .any(|d| d.name == name.as_str());
+        if !known {
+            return Err(format!("Unknown feature flag: {name}"));
+        }
+        if *enabled && !system.is_enabled(name) {
+            return Err(format!(
+                "Feature flag '{name}' is not available on this deployment"
+            ));
+        }
+    }
+    Ok(())
+}

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -1394,6 +1394,21 @@ impl StorageBackend {
         dispatch!(self, patch_organization_settings, org_id, input)
     }
 
+    pub async fn list_org_feature_flags(
+        &self,
+        org_id: i64,
+    ) -> Result<std::collections::HashMap<String, bool>> {
+        dispatch!(self, list_org_feature_flags, org_id)
+    }
+
+    pub async fn replace_org_feature_flags(
+        &self,
+        org_id: i64,
+        flags: &std::collections::HashMap<String, bool>,
+    ) -> Result<()> {
+        dispatch!(self, replace_org_feature_flags, org_id, flags)
+    }
+
     pub async fn create_llm_model(
         &self,
         org_id: i64,

--- a/crates/server/src/storage/memory/mod.rs
+++ b/crates/server/src/storage/memory/mod.rs
@@ -24,6 +24,7 @@ mod llm;
 mod mcp_servers;
 mod memories;
 mod notifications;
+mod org_feature_flags;
 mod organizations;
 mod payments;
 mod principals;
@@ -139,6 +140,7 @@ pub struct InMemoryDatabase {
     agent_identity_connections: RwLock<HashMap<Uuid, AgentIdentityConnectionRow>>,
     // Organization settings (default model, etc.)
     org_settings: RwLock<HashMap<i64, OrganizationSettingsRow>>,
+    org_feature_flags: RwLock<HashMap<i64, HashMap<String, bool>>>,
     // Evals (user-facing behavioral tests)
     evals: RwLock<HashMap<Uuid, EvalRow>>,
     eval_cases: RwLock<HashMap<Uuid, EvalCaseRow>>,
@@ -226,6 +228,7 @@ impl Default for InMemoryDatabase {
             principals: RwLock::new(HashMap::new()),
             agent_identity_connections: RwLock::new(HashMap::new()),
             org_settings: RwLock::new(HashMap::new()),
+            org_feature_flags: RwLock::new(HashMap::new()),
             evals: RwLock::new(HashMap::new()),
             eval_cases: RwLock::new(HashMap::new()),
             eval_runs: RwLock::new(HashMap::new()),

--- a/crates/server/src/storage/memory/org_feature_flags.rs
+++ b/crates/server/src/storage/memory/org_feature_flags.rs
@@ -1,0 +1,33 @@
+// In-memory storage: per-organization feature flag opt-ins
+
+use super::InMemoryDatabase;
+use anyhow::Result;
+use std::collections::HashMap;
+
+impl InMemoryDatabase {
+    pub async fn list_org_feature_flags(&self, org_id: i64) -> Result<HashMap<String, bool>> {
+        Ok(self
+            .org_feature_flags
+            .read()
+            .get(&org_id)
+            .cloned()
+            .unwrap_or_default())
+    }
+
+    pub async fn replace_org_feature_flags(
+        &self,
+        org_id: i64,
+        flags: &HashMap<String, bool>,
+    ) -> Result<()> {
+        let mut store = self.org_feature_flags.write();
+        let entry = store.entry(org_id).or_default();
+        for (flag_name, enabled) in flags {
+            if *enabled {
+                entry.insert(flag_name.clone(), true);
+            } else {
+                entry.remove(flag_name);
+            }
+        }
+        Ok(())
+    }
+}

--- a/crates/server/src/storage/repositories/mod.rs
+++ b/crates/server/src/storage/repositories/mod.rs
@@ -19,6 +19,7 @@ mod llm;
 mod mcp_servers;
 mod memories;
 mod notifications;
+mod org_feature_flags;
 mod organizations;
 mod payments;
 mod principals;

--- a/crates/server/src/storage/repositories/org_feature_flags.rs
+++ b/crates/server/src/storage/repositories/org_feature_flags.rs
@@ -1,0 +1,53 @@
+// PostgreSQL repository: per-organization feature flag opt-ins
+
+use super::Database;
+use anyhow::Result;
+use std::collections::HashMap;
+
+impl Database {
+    pub async fn list_org_feature_flags(&self, org_id: i64) -> Result<HashMap<String, bool>> {
+        let rows = sqlx::query_as::<_, (String, bool)>(
+            "SELECT flag_name, enabled FROM org_feature_flags WHERE org_id = $1",
+        )
+        .bind(org_id)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows.into_iter().collect())
+    }
+
+    pub async fn replace_org_feature_flags(
+        &self,
+        org_id: i64,
+        flags: &HashMap<String, bool>,
+    ) -> Result<()> {
+        let mut tx = self.pool.begin().await?;
+
+        for (flag_name, enabled) in flags {
+            if *enabled {
+                sqlx::query(
+                    r#"
+                    INSERT INTO org_feature_flags (org_id, flag_name, enabled)
+                    VALUES ($1, $2, TRUE)
+                    ON CONFLICT (org_id, flag_name) DO UPDATE SET
+                        enabled = TRUE,
+                        updated_at = NOW()
+                    "#,
+                )
+                .bind(org_id)
+                .bind(flag_name)
+                .execute(&mut *tx)
+                .await?;
+            } else {
+                sqlx::query("DELETE FROM org_feature_flags WHERE org_id = $1 AND flag_name = $2")
+                    .bind(org_id)
+                    .bind(flag_name)
+                    .execute(&mut *tx)
+                    .await?;
+            }
+        }
+
+        tx.commit().await?;
+        Ok(())
+    }
+}

--- a/crates/server/tests/api_integration_test.rs
+++ b/crates/server/tests/api_integration_test.rs
@@ -99,7 +99,7 @@ async fn test_org_feature_flags_opt_in() {
         .await
         .assert_status(StatusCode::BAD_REQUEST)
         .json();
-    assert!(patched.get("error").is_some());
+    assert!(patched.get("detail").is_some());
 
     let effective: serde_json::Value = server
         .get(&format!("/v1/orgs/{org_id}/feature-flags"))

--- a/crates/server/tests/api_integration_test.rs
+++ b/crates/server/tests/api_integration_test.rs
@@ -70,6 +70,46 @@ async fn test_feature_flags_endpoint() {
 }
 
 #[tokio::test]
+async fn test_org_feature_flags_opt_in() {
+    let server = TestServer::new().await;
+    let org_id = "org_00000000000000000000000000000001";
+
+    let settings: serde_json::Value = server
+        .get(&format!("/v1/orgs/{org_id}/feature-flags/settings"))
+        .await
+        .assert_status(StatusCode::OK)
+        .json();
+
+    let flags = settings["flags"].as_array().expect("flags array");
+    let notifications = flags
+        .iter()
+        .find(|f| f["name"] == "notifications")
+        .expect("notifications flag");
+    assert_eq!(
+        notifications["system_enabled"],
+        serde_json::Value::Bool(false)
+    );
+    assert_eq!(notifications["org_enabled"], serde_json::Value::Bool(false));
+
+    let patched: serde_json::Value = server
+        .patch(
+            &format!("/v1/orgs/{org_id}/feature-flags"),
+            serde_json::json!({ "flags": { "notifications": true } }),
+        )
+        .await
+        .assert_status(StatusCode::BAD_REQUEST)
+        .json();
+    assert!(patched.get("error").is_some());
+
+    let effective: serde_json::Value = server
+        .get(&format!("/v1/orgs/{org_id}/feature-flags"))
+        .await
+        .assert_status(StatusCode::OK)
+        .json();
+    assert_eq!(effective["notifications"], serde_json::Value::Bool(false));
+}
+
+#[tokio::test]
 async fn test_notifications_routes_disabled_by_default() {
     let server = TestServer::new().await;
 

--- a/crates/server/tests/test_harness.rs
+++ b/crates/server/tests/test_harness.rs
@@ -406,6 +406,11 @@ impl TestServer {
         let feature_flags_state = api::feature_flags::AppState {
             flags: feature_flags.clone(),
         };
+        let org_feature_flags_state = api::org_feature_flags::AppState::new(
+            db.clone(),
+            auth_state.clone(),
+            feature_flags.clone(),
+        );
         let user_connections_state = api::user_connections::AppState::new(
             db.clone(),
             encryption.clone(),
@@ -525,6 +530,7 @@ impl TestServer {
             .merge(api::organizations::routes(organizations_state))
             .merge(api::session_schedules::routes(session_schedules_state))
             .merge(api::feature_flags::routes(feature_flags_state))
+            .merge(api::org_feature_flags::routes(org_feature_flags_state))
             .merge(api::user_connections::routes(user_connections_state))
             .merge(api::reporting::routes(reporting_state))
             .merge(api::ag_ui::routes(ag_ui_state))

--- a/specs/feature-flags.md
+++ b/specs/feature-flags.md
@@ -11,13 +11,21 @@ System-level feature flags that control feature availability across the platform
 - **Explicit override wins**: `FEATURE_<NAME>=true/false` always takes priority over defaults
 - **Type-safe**: `FeatureFlags` struct with named boolean fields
 - **Fetch once**: UI fetches flags once on mount (React Query with 5min stale time)
-- **No DB needed (yet)**: Backed by env vars + deployment grade, no database table
+- **Org opt-in**: Organizations enable API-visible flags when the deployment allows them (stored in `org_feature_flags`)
 
 ### Flag Resolution Order
+
+**Deployment (system) flags:**
 
 1. Explicit env var `FEATURE_<NAME>=true|1` or `=false|0`
 2. For experimental flags: `DeploymentGrade::Dev` -> `true`
 3. Default: `false`
+
+**Effective flags for an organization:**
+
+1. System flag must be enabled on the deployment
+2. Organization must have opted in (`org_feature_flags.enabled = true`; default is off)
+3. `effective = system_enabled && org_enabled`
 
 ### Flag Types
 
@@ -52,16 +60,19 @@ Current API-visible experimental flags include:
 ### Backend
 
 - **Core**: `crates/core/src/feature_flags.rs` — `FeatureFlags` + `InternalFeatureFlags` structs, `from_env()`, resolution helpers
-- **API**: `GET /v1/feature-flags` — public endpoint, returns `FeatureFlags` as JSON
-- **Server**: `crates/server/src/api/feature_flags.rs` — route handler
+- **API**: `GET /v1/feature-flags` — public endpoint, returns deployment-level `FeatureFlags` as JSON
+- **Org API**: `GET/PATCH /v1/orgs/{org}/feature-flags`, `GET /v1/orgs/{org}/feature-flags/settings` — org opt-in (admin for PATCH)
+- **Server**: `crates/server/src/api/feature_flags.rs`, `crates/server/src/api/org_feature_flags.rs`
+- **Storage**: `org_feature_flags` table (migration `046_org_feature_flags.sql`)
 
-Flags are computed once at server startup and served from memory.
+Deployment flags are computed once at server startup. Org-effective flags are resolved per request from system flags + `org_feature_flags` rows (`ResolvedOrg::feature_flags`, `Ctx::feature_flags`).
 
 ### Frontend
 
 - **API client**: `apps/ui/src/lib/api/feature-flags.ts`
-- **Provider**: `apps/ui/src/providers/feature-flags-provider.tsx` — React context, fetches once
-- **Hooks**: `useFeatureFlags()` (all flags), `useFeatureFlag("flag_name")` (single flag)
+- **Provider**: `apps/ui/src/providers/feature-flags-provider.tsx` — fetches org-effective flags when an org is selected
+- **Settings**: `apps/ui/src/app/(main)/settings/features/page.tsx` — admin opt-in toggles
+- **Hooks**: `useFeatureFlags()` (effective flags), `useFeatureFlag("flag_name")` (single flag)
 - **Types**: `FeatureFlags` in `apps/ui/src/lib/api/types/auth-types.ts`
 
 ### Workers
@@ -99,8 +110,7 @@ Both are driven by `experimental: true` on the `NavItem` type in the sidebar, an
 
 ## Future Extensions
 
-- **Per-org flags**: Add `org_id` column to a `feature_flag_overrides` table
-- **Per-user flags**: Add `user_id` column
+- **Per-user flags**: Add `user_id` column for user-level overrides within an org
 - **External providers**: Implement a `FeatureFlagProvider` trait; plug in LaunchDarkly, Unleash, etc.
 - **Runtime toggle**: Admin API to update flag overrides without restart
 - **Worker propagation**: Include flags in gRPC `GetTurnContext` response


### PR DESCRIPTION
## What
Adds per-organization opt-in for API-visible feature flags, integrated with the existing deployment-level flag system.

## Why
Operators can expose capabilities on a deployment, but each organization should choose which experimental/optional features to enable for its users.

## How
- New `org_feature_flags` table and storage APIs
- Effective flags = `system_enabled && org_enabled` (default org opt-in off; default org seeded on first boot when system allows flags)
- Org API: `GET/PATCH /v1/orgs/{org}/feature-flags`, `GET /v1/orgs/{org}/feature-flags/settings`
- `ResolvedOrg` and `Dispatcher`/`Ctx` use org-effective flags
- UI: Settings → Features page; `FeatureFlagsProvider` fetches org flags when an org is selected

## Risk
- Medium: Changes flag resolution for all org-scoped requests; existing orgs start with flags off until opted in (default org auto-seeded when empty).
- Route registration still uses deployment-level flags at startup (unchanged).

## Security
- Threat categories reviewed: TM-AUTH, TM-AUTHZ, TM-API, TM-TENANT
- PATCH requires `OrgAdmin`; membership verified for GET; cannot enable flags unavailable on deployment
- Findings: No new exposure paths; org scoping enforced via existing membership checks

## Test plan
- [x] `cargo test -p everruns-core --lib feature_flags::tests`
- [x] Server compiles; integration test `test_org_feature_flags_opt_in` added (requires Postgres in CI)
- [ ] Manual: Settings → Features toggles for default org in dev

## Follow-ups
No follow-ups.