### PR TITLE
fix(ui): hide work log for direct answers

### DIFF
--- a/apps/ui/src/__tests__/chat-work-log-events.test.ts
+++ b/apps/ui/src/__tests__/chat-work-log-events.test.ts
@@ -1,0 +1,90 @@
+import {
+  getReasoningMultiIterationTurnIds,
+  shouldRenderWorkLogEvent,
+  isStructuralWorkLogEvent,
+} from "@/components/chat/chat-work-log-events";
+import type { Event, EventContext } from "@/lib/api/types";
+
+let seqCounter = 0;
+
+function makeEvent(type: string, data: Record<string, unknown>, context: EventContext = {}): Event {
+  seqCounter++;
+  return {
+    id: `evt-${seqCounter}`,
+    type,
+    ts: `2026-03-11T12:00:${String(seqCounter).padStart(2, "0")}Z`,
+    session_id: "session-1",
+    context,
+    data,
+    sequence: seqCounter,
+  };
+}
+
+function reasonCompletedEvent(turnId: string): Event {
+  return makeEvent(
+    "reason.completed",
+    {
+      success: true,
+      text_preview: "A concise answer preview",
+      has_tool_calls: false,
+      tool_call_count: 0,
+    },
+    { turn_id: turnId },
+  );
+}
+
+function reasonItemEvent(turnId: string): Event {
+  return makeEvent("reason.item", { turn_id: turnId, summary: ["Checked the repository"] });
+}
+
+describe("chat work log event eligibility", () => {
+  beforeEach(() => {
+    seqCounter = 0;
+  });
+
+  it("does not render one-iteration reasoning summaries as work logs", () => {
+    const event = reasonCompletedEvent("turn-1");
+
+    expect(shouldRenderWorkLogEvent(event, new Map([["turn-1", 1]]), new Set(), new Set())).toBe(
+      false,
+    );
+  });
+
+  it("renders multi-iteration reasoning summaries as work logs", () => {
+    const event = reasonCompletedEvent("turn-1");
+
+    expect(shouldRenderWorkLogEvent(event, new Map([["turn-1", 2]]), new Set(), new Set())).toBe(
+      true,
+    );
+  });
+
+  it("keeps active tool and action turns eligible before completion arrives", () => {
+    const toolRequest = makeEvent(
+      "tool.call_requested",
+      {
+        tool_calls: [{ id: "tool-1", name: "bash", arguments: {} }],
+      },
+      { turn_id: "turn-1" },
+    );
+    const reasonItem = reasonItemEvent("turn-1");
+
+    expect(isStructuralWorkLogEvent(toolRequest)).toBe(true);
+    expect(shouldRenderWorkLogEvent(reasonItem, new Map(), new Set(["turn-1"]), new Set())).toBe(
+      true,
+    );
+  });
+
+  it("renders active multi-iteration reasoning before turn completion arrives", () => {
+    const firstIteration = reasonCompletedEvent("turn-1");
+    const secondIteration = reasonCompletedEvent("turn-1");
+    const multiIterationTurnIds = getReasoningMultiIterationTurnIds([
+      firstIteration,
+      secondIteration,
+    ]);
+
+    expect(multiIterationTurnIds.has("turn-1")).toBe(true);
+    expect(
+      shouldRenderWorkLogEvent(firstIteration, new Map(), new Set(), multiIterationTurnIds),
+    ).toBe(true);
+  });
+});

--- a/apps/ui/src/__tests__/turn-delimiter.test.ts
+++ b/apps/ui/src/__tests__/turn-delimiter.test.ts
@@ -120,10 +120,15 @@ function toolCallRequestedEvent(turnId: string, inputMessageId: string): Event {
   );
 }
 
-function turnCompletedEvent(turnId: string, inputMessageId: string, durationMs: number): Event {
+function turnCompletedEvent(
+  turnId: string,
+  inputMessageId: string,
+  durationMs: number,
+  iterations: number = 1,
+): Event {
   return makeEvent(
     "turn.completed",
-    { turn_id: turnId, iterations: 1, duration_ms: durationMs },
+    { turn_id: turnId, iterations, duration_ms: durationMs },
     turnContext(turnId, inputMessageId),
   );
 }
@@ -131,7 +136,7 @@ function turnCompletedEvent(turnId: string, inputMessageId: string, durationMs: 
 describe("turn-delimiter", () => {
   beforeEach(resetSeq);
 
-  it("attaches completed turn duration to the last visible assistant event", () => {
+  it("does not attach completed turn duration for one-iteration direct answers", () => {
     const events = [
       inputMessageEvent("msg-1", "Hello"),
       turnStartedEvent("turn-1", "msg-1"),
@@ -141,8 +146,7 @@ describe("turn-delimiter", () => {
 
     const durations = getCompletedTurnDurationsByEvent(events);
 
-    expect(durations.get("evt-3")).toBe(203000);
-    expect(durations.size).toBe(1);
+    expect(durations.size).toBe(0);
   });
 
   it("uses the client tool request row when embedded tool calls are hidden", () => {
@@ -151,7 +155,7 @@ describe("turn-delimiter", () => {
       turnStartedEvent("turn-1", "msg-1"),
       outputMessageWithClientToolCallEvent("turn-1", "msg-1"),
       toolCallRequestedEvent("turn-1", "msg-1"),
-      turnCompletedEvent("turn-1", "msg-1", 4500),
+      turnCompletedEvent("turn-1", "msg-1", 4500, 2),
     ];
 
     const durations = getCompletedTurnDurationsByEvent(events);

--- a/apps/ui/src/components/chat/chat-message-list.tsx
+++ b/apps/ui/src/components/chat/chat-message-list.tsx
@@ -7,7 +7,7 @@
 "use client";
 
 import { Bot, CalendarClock, Loader2, Sparkles } from "lucide-react";
-import { memo, useMemo } from "react";
+import { memo, useCallback, useMemo } from "react";
 import type { ReactNode } from "react";
 import type {
   ContentPart,
@@ -25,6 +25,12 @@ import { MessageInfoIcon } from "@/components/chat/message-info-icon";
 import { MessageImage } from "@/components/chat/image-attachments";
 import { MessageContent } from "@/components/chat/message-content";
 import { ChatErrorAlert } from "@/components/chat/chat-error-alert";
+import {
+  getReasoningMultiIterationTurnIds,
+  getKnownTurnId,
+  isStructuralWorkLogEvent,
+  shouldRenderWorkLogEvent,
+} from "@/components/chat/chat-work-log-events";
 import { ToolActivityGroup } from "@/components/chat/tool-activity-group";
 import { SetupConnectionToolCall } from "@/components/chat/setup-connection-tool-call";
 import {
@@ -33,6 +39,7 @@ import {
 } from "@/components/chat/tool-activity-timeline-group";
 import {
   formatWorkedDuration,
+  getCompletedTurnIterationsByTurn,
   getCompletedTurnDurationsByEvent,
   getCompletedTurnDurationsByTurn,
 } from "@/components/chat/turn-delimiter";
@@ -68,21 +75,6 @@ type ActGroup = {
   completedHeadline?: string;
   rows: TimelineToolRow[];
 };
-
-function getKnownTurnId(event: Event): string | undefined {
-  const reasonItemData = getEventData(event, "reason.item");
-  return reasonItemData?.turn_id ?? event.context?.turn_id;
-}
-
-function isWorkLogEvent(event: Event): boolean {
-  if (event.type === "act.started" || event.type === "tool.call_requested") return true;
-
-  const reasonItemData = getEventData(event, "reason.item");
-  if (reasonItemData?.summary?.some((item) => item.trim().length > 0)) return true;
-
-  const reasonCompletedData = getEventData(event, "reason.completed");
-  return !!reasonCompletedData?.text_preview;
-}
 
 function ReasoningLogRow({ text }: { text: string }) {
   return (
@@ -235,6 +227,34 @@ export const ChatMessageList = memo(function ChatMessageList({
     () => getCompletedTurnDurationsByTurn(events ?? []),
     [events],
   );
+  const turnIterationsByTurnId = useMemo(
+    () => getCompletedTurnIterationsByTurn(events ?? []),
+    [events],
+  );
+  const structuralWorkTurnIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const event of chatEvents) {
+      if (!isStructuralWorkLogEvent(event)) continue;
+      const turnId = getKnownTurnId(event);
+      if (turnId) ids.add(turnId);
+    }
+    return ids;
+  }, [chatEvents]);
+  const reasoningMultiIterationTurnIds = useMemo(
+    () => getReasoningMultiIterationTurnIds(chatEvents),
+    [chatEvents],
+  );
+  const isWorkLogEvent = useCallback(
+    (event: Event) => {
+      return shouldRenderWorkLogEvent(
+        event,
+        turnIterationsByTurnId,
+        structuralWorkTurnIds,
+        reasoningMultiIterationTurnIds,
+      );
+    },
+    [reasoningMultiIterationTurnIds, structuralWorkTurnIds, turnIterationsByTurnId],
+  );
   const workLogTurnIds = useMemo(() => {
     const ids = new Set<string>();
     for (const event of chatEvents) {
@@ -243,7 +263,7 @@ export const ChatMessageList = memo(function ChatMessageList({
       if (turnId) ids.add(turnId);
     }
     return ids;
-  }, [chatEvents]);
+  }, [chatEvents, isWorkLogEvent]);
   const workLogEventsByTurnId = useMemo(() => {
     const groups = new Map<string, Event[]>();
     for (const event of chatEvents) {
@@ -258,7 +278,7 @@ export const ChatMessageList = memo(function ChatMessageList({
       }
     }
     return groups;
-  }, [chatEvents]);
+  }, [chatEvents, isWorkLogEvent]);
   const hasNarratedActEvents = useMemo(
     () => chatEvents.some((event) => event.type === "act.started"),
     [chatEvents],

--- a/apps/ui/src/components/chat/chat-work-log-events.ts
+++ b/apps/ui/src/components/chat/chat-work-log-events.ts
@@ -1,0 +1,57 @@
+import type { Event } from "@/lib/api/types";
+import { getEventData } from "@/lib/api/types";
+
+export function getKnownTurnId(event: Event): string | undefined {
+  const reasonItemData = getEventData(event, "reason.item");
+  return reasonItemData?.turn_id ?? event.context?.turn_id;
+}
+
+export function isStructuralWorkLogEvent(event: Event): boolean {
+  return event.type === "act.started" || event.type === "tool.call_requested";
+}
+
+export function hasReasoningWorkLogSummary(event: Event): boolean {
+  const reasonItemData = getEventData(event, "reason.item");
+  if (reasonItemData?.summary?.some((item) => item.trim().length > 0)) return true;
+
+  const reasonCompletedData = getEventData(event, "reason.completed");
+  return !!reasonCompletedData?.text_preview;
+}
+
+export function shouldRenderWorkLogEvent(
+  event: Event,
+  turnIterationsByTurnId: Map<string, number>,
+  structuralWorkTurnIds: Set<string>,
+  reasoningMultiIterationTurnIds: Set<string>,
+): boolean {
+  if (isStructuralWorkLogEvent(event)) return true;
+  if (!hasReasoningWorkLogSummary(event)) return false;
+
+  const turnId = getKnownTurnId(event);
+  if (!turnId) return false;
+
+  return (
+    (turnIterationsByTurnId.get(turnId) ?? 0) > 1 ||
+    structuralWorkTurnIds.has(turnId) ||
+    reasoningMultiIterationTurnIds.has(turnId)
+  );
+}
+
+export function getReasoningMultiIterationTurnIds(events: Event[]): Set<string> {
+  const countsByTurnId = new Map<string, number>();
+  const multiIterationTurnIds = new Set<string>();
+
+  for (const event of events) {
+    const reasonCompletedData = getEventData(event, "reason.completed");
+    if (!reasonCompletedData) continue;
+
+    const turnId = getKnownTurnId(event);
+    if (!turnId) continue;
+
+    const count = (countsByTurnId.get(turnId) ?? 0) + 1;
+    countsByTurnId.set(turnId, count);
+    if (count > 1) multiIterationTurnIds.add(turnId);
+  }
+
+  return multiIterationTurnIds;
+}

--- a/apps/ui/src/components/chat/turn-delimiter.ts
+++ b/apps/ui/src/components/chat/turn-delimiter.ts
@@ -84,6 +84,7 @@ export function getCompletedTurnDurationsByEvent(events: Event[]): Map<string, n
   const inputMessageTurnIds = getInputMessageTurnIds(events);
   const lastVisibleEventIdByTurn = new Map<string, string>();
   const durationMsByTurn = getCompletedTurnDurationsByTurn(events);
+  const iterationsByTurn = getCompletedTurnIterationsByTurn(events);
 
   for (const event of events) {
     if (isVisibleChatEvent(event, clientRequestedToolCallIds)) {
@@ -97,6 +98,7 @@ export function getCompletedTurnDurationsByEvent(events: Event[]): Map<string, n
   const durationsByEvent = new Map<string, number>();
 
   for (const [turnId, durationMs] of durationMsByTurn) {
+    if ((iterationsByTurn.get(turnId) ?? 0) <= 1) continue;
     const eventId = lastVisibleEventIdByTurn.get(turnId);
     if (eventId) {
       durationsByEvent.set(eventId, durationMs);
@@ -117,6 +119,19 @@ export function getCompletedTurnDurationsByTurn(events: Event[]): Map<string, nu
   }
 
   return durationMsByTurn;
+}
+
+export function getCompletedTurnIterationsByTurn(events: Event[]): Map<string, number> {
+  const iterationsByTurn = new Map<string, number>();
+
+  for (const event of events) {
+    const tcData = getEventData(event, "turn.completed");
+    if (tcData) {
+      iterationsByTurn.set(tcData.turn_id, tcData.iterations);
+    }
+  }
+
+  return iterationsByTurn;
 }
 
 export function formatWorkedDuration(durationMs: number): string {

--- a/specs/markdown-messages.md
+++ b/specs/markdown-messages.md
@@ -85,7 +85,7 @@ components/
    - Message markdown, tool activity, and todo progress must read as one transcript system
    - Tool rows should stay inline with the surrounding message rhythm
    - Do not nest bordered tool/todo cards inside another transcript card unless the content requires a dedicated viewport
-   - Turn work logs should remain expanded while work is active and collapse to a compact "Worked for ..." affordance once the final answer is available
+   - Turn work logs are for multi-iteration or tool/action work, not direct one-iteration answers; they should remain expanded while work is active and collapse to a compact "Worked for ..." affordance once the final answer is available
    - Work logs may show safe narration from reason summaries and tool/act headlines, but must not expose raw hidden thinking content
 
 ## Usage


### PR DESCRIPTION
## What
Hide the completed work-log divider/fold for one-iteration direct chat answers while preserving the folded work log for multi-iteration and tool/action turns.

## Why
Direct answers were showing a `Worked for ...` splitter after the answer and duplicating the answer preview in the collapsed work log, which made ordinary chat responses look like agent work.

## How
- Gate completed-turn duration dividers on `turn.completed.iterations > 1`.
- Extract work-log event eligibility so reasoning summaries only render inside folds for multi-iteration turns, turns with structural tool/action work, or active reasoning-only turns once multiple iterations are observed.
- Add focused regression tests for direct answers, multi-iteration summaries, active tool/action work, and active multi-iteration reasoning before `turn.completed`.
- Update the markdown/transcript spec with the direct-answer rule.

## Risk
- Low
- Main risk is accidentally hiding work-log summaries for real multi-step turns; covered by unit tests, CI UI smoke, and a browser smoke check on the dev chat-components page.

## Security
- Threat categories reviewed: TM-WEB, TM-DOS.
- Findings and resolutions: No new security issue found. The change renders the same event text through React-escaped text nodes and adds only bounded per-turn maps over the existing transcript event array. No auth, API, storage, raw HTML, or secret-handling paths changed.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

## Validation
- `pnpm run format:check`
- `pnpm run lint`
- `pnpm test -- chat-work-log-events.test.ts turn-delimiter.test.ts --runInBand`
- `pnpm run build`
- `RUSTUP_TOOLCHAIN=1.94.1 just pre-push`
- Browser smoke: `/dev/chat-components` still renders existing multi-step `Worked for ...` work logs
- CI: UI Build, Lint & Test; UI Playwright Smoke; CodeQL; CI Opt-Out Policy; Migration Immutability all passed on `159df653`
- Copilot review thread replied to and resolved
