### PR TITLE
feat(ui): smooth chat streaming text

### DIFF
--- a/apps/ui/src/__tests__/streaming-message.test.tsx
+++ b/apps/ui/src/__tests__/streaming-message.test.tsx
@@ -1,0 +1,63 @@
+import { act, render, screen } from "@testing-library/react";
+import { StreamingMessage } from "@/components/streaming-message";
+
+jest.mock("@/components/chat/message-content", () => ({
+  MessageContent: ({ text }: { text: string }) => <div data-testid="message-content">{text}</div>,
+}));
+
+function advanceFrame() {
+  act(() => {
+    jest.advanceTimersByTime(16);
+  });
+}
+
+describe("StreamingMessage", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("reveals accepted text incrementally instead of rendering a full chunk immediately", () => {
+    render(<StreamingMessage text="Hello" />);
+
+    expect(screen.getByTestId("message-content")).toHaveTextContent("H");
+
+    advanceFrame();
+    expect(screen.getByTestId("message-content")).toHaveTextContent("He");
+
+    advanceFrame();
+    advanceFrame();
+    advanceFrame();
+    expect(screen.getByTestId("message-content")).toHaveTextContent("Hello");
+  });
+
+  it("keeps typing from the visible prefix when a larger accumulated delta arrives", () => {
+    const { rerender } = render(<StreamingMessage text="Hel" />);
+
+    advanceFrame();
+    advanceFrame();
+    expect(screen.getByTestId("message-content")).toHaveTextContent("Hel");
+
+    rerender(<StreamingMessage text="Hello world" />);
+
+    expect(screen.getByTestId("message-content")).toHaveTextContent("Hel");
+
+    advanceFrame();
+    expect(screen.getByTestId("message-content")).toHaveTextContent("Hell");
+  });
+
+  it("resets cleanly when the target text is replaced by a different turn", () => {
+    const { rerender } = render(<StreamingMessage text="Previous" />);
+
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+
+    rerender(<StreamingMessage text="New" />);
+
+    expect(screen.getByTestId("message-content")).toHaveTextContent("N");
+  });
+});

--- a/apps/ui/src/__tests__/streaming-message.test.tsx
+++ b/apps/ui/src/__tests__/streaming-message.test.tsx
@@ -34,6 +34,15 @@ describe("StreamingMessage", () => {
     expect(screen.getByTestId("message-content")).toHaveTextContent("Hello");
   });
 
+  it("reveals grapheme clusters without splitting combined glyphs", () => {
+    render(<StreamingMessage text="👩‍💻a" />);
+
+    expect(screen.getByTestId("message-content")).toHaveTextContent("👩‍💻");
+
+    advanceFrame();
+    expect(screen.getByTestId("message-content")).toHaveTextContent("👩‍💻a");
+  });
+
   it("keeps typing from the visible prefix when a larger accumulated delta arrives", () => {
     const { rerender } = render(<StreamingMessage text="Hel" />);
 

--- a/apps/ui/src/components/streaming-message.tsx
+++ b/apps/ui/src/components/streaming-message.tsx
@@ -14,7 +14,18 @@ import "./streaming-message.css";
 
 const FRAME_MS = 16;
 
+type GraphemeSegment = { segment: string };
+type SegmenterConstructor = new (
+  locales?: string | string[],
+  options?: { granularity: "grapheme" },
+) => { segment(input: string): Iterable<GraphemeSegment> };
+
 function splitCharacters(text: string): string[] {
+  const Segmenter = (Intl as typeof Intl & { Segmenter?: SegmenterConstructor }).Segmenter;
+  if (Segmenter) {
+    const segmenter = new Segmenter(undefined, { granularity: "grapheme" });
+    return Array.from(segmenter.segment(text), ({ segment }) => segment);
+  }
   return Array.from(text);
 }
 
@@ -56,9 +67,8 @@ function useSmoothedText(targetText: string): string {
     const timeout = window.setTimeout(() => {
       setVisibleCharacters((current) => {
         const sharedPrefix = countSharedPrefix(current, targetCharacters);
-        const baseLength = sharedPrefix === current.length ? current.length : sharedPrefix;
-        const remaining = targetCharacters.length - baseLength;
-        const nextLength = baseLength + charactersPerFrame(remaining);
+        const remaining = targetCharacters.length - sharedPrefix;
+        const nextLength = sharedPrefix + charactersPerFrame(remaining);
         return targetCharacters.slice(0, Math.min(nextLength, targetCharacters.length));
       });
     }, FRAME_MS);

--- a/apps/ui/src/components/streaming-message.tsx
+++ b/apps/ui/src/components/streaming-message.tsx
@@ -7,9 +7,67 @@
  * indicator and markdown rendering via Streamdown.
  */
 
+import { useEffect, useMemo, useState } from "react";
 import { cn } from "@/lib/utils";
 import { MessageContent } from "@/components/chat/message-content";
 import "./streaming-message.css";
+
+const FRAME_MS = 16;
+
+function splitCharacters(text: string): string[] {
+  return Array.from(text);
+}
+
+function countSharedPrefix(a: string[], b: string[]): number {
+  const max = Math.min(a.length, b.length);
+  for (let i = 0; i < max; i++) {
+    if (a[i] !== b[i]) return i;
+  }
+  return max;
+}
+
+function charactersPerFrame(remaining: number): number {
+  if (remaining > 240) return 10;
+  if (remaining > 120) return 6;
+  if (remaining > 48) return 3;
+  return 1;
+}
+
+function useSmoothedText(targetText: string): string {
+  const targetCharacters = useMemo(() => splitCharacters(targetText), [targetText]);
+  const [visibleCharacters, setVisibleCharacters] = useState<string[]>(() =>
+    targetCharacters.slice(0, Math.min(1, targetCharacters.length)),
+  );
+
+  useEffect(() => {
+    setVisibleCharacters((current) => {
+      if (targetCharacters.length === 0) return [];
+
+      const sharedPrefix = countSharedPrefix(current, targetCharacters);
+      if (sharedPrefix === current.length) return current;
+
+      return targetCharacters.slice(0, Math.max(sharedPrefix, 1));
+    });
+  }, [targetCharacters]);
+
+  useEffect(() => {
+    if (visibleCharacters.length >= targetCharacters.length) return;
+
+    const timeout = window.setTimeout(() => {
+      setVisibleCharacters((current) => {
+        const sharedPrefix = countSharedPrefix(current, targetCharacters);
+        const baseLength = sharedPrefix === current.length ? current.length : sharedPrefix;
+        const remaining = targetCharacters.length - baseLength;
+        const nextLength = baseLength + charactersPerFrame(remaining);
+        return targetCharacters.slice(0, Math.min(nextLength, targetCharacters.length));
+      });
+    }, FRAME_MS);
+
+    return () => window.clearTimeout(timeout);
+  }, [targetCharacters, visibleCharacters]);
+
+  return visibleCharacters.join("");
+}
 
 interface StreamingMessageProps {
   text: string;
@@ -17,6 +75,8 @@ interface StreamingMessageProps {
 }
 
 export function StreamingMessage({ text, className }: StreamingMessageProps) {
+  const visibleText = useSmoothedText(text);
+
   return (
     <div className={cn("relative", className)}>
       <div className="mb-2 inline-flex items-center gap-1.5 text-[10px] uppercase tracking-[0.18em] text-primary/75">
@@ -28,7 +88,7 @@ export function StreamingMessage({ text, className }: StreamingMessageProps) {
       </div>
 
       <div className="streaming-cursor">
-        <MessageContent text={text} isStreaming={true} />
+        <MessageContent text={visibleText} isStreaming={true} />
       </div>
     </div>
   );


### PR DESCRIPTION
## What
Smooths live chat response rendering so accumulated SSE deltas are revealed through a small character buffer instead of appearing as larger appended chunks.

## Why
Streaming responses could feel jumpy when the backend accepted and delivered multiple characters or words at once. Revealing the accepted text progressively makes the response look more like typing while preserving the existing SSE/event pipeline.

## How
Added a `useSmoothedText` buffer inside `StreamingMessage` that:
- keeps accepting the latest accumulated response text immediately
- reveals text frame-by-frame from the shared visible prefix
- speeds up catch-up when the hidden backlog is large
- resets cleanly when a different turn replaces the target text

Added focused Jest coverage for incremental reveal, larger accumulated deltas, and replacement/reset behavior.

## Risk
- Low
- The changed surface is limited to the transient streaming UI. Completed messages still render from the canonical completed event history.
- Main risk is perceived streaming speed being too slow or too fast for unusually large chunks; catch-up thresholds bound backlog growth.

## Security
- Threat categories reviewed: TM-WEB, TM-DOS.
- Findings and resolutions: No new trust boundary, raw HTML path, URL handling, auth/authz behavior, dependency, network request, or backend resource surface was introduced. React/Streamdown rendering remains the existing path. The smoothing loop is bounded to one timer per rendered streaming message and uses adaptive multi-character catch-up for large backlogs.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

Validation performed locally:
- `pnpm exec jest --runTestsByPath src/__tests__/streaming-message.test.tsx`
- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run build`
- Browser smoke test on `http://localhost:9120/dev/markdown`
- `bash scripts/lib/check-migration-ordering.sh`
- `just pre-push`
