### PR TITLE
fix(api): fail-close llm metadata defaults

### DIFF
--- a/crates/server/src/api/messages.rs
+++ b/crates/server/src/api/messages.rs
@@ -231,6 +231,9 @@ pub fn routes(state: AppState) -> Router {
 #[utoipa::path(
     post,
     path = "/v1/sessions/{session_id}/messages",
+    extensions(
+        ("x-cost-tier" = json!("paid")),
+    ),
     params(
         ("session_id" = String, Path, description = "Session ID (prefixed, e.g., sess_...)")
     ),

--- a/crates/server/src/api/users.rs
+++ b/crates/server/src/api/users.rs
@@ -390,6 +390,9 @@ pub async fn switch_org(
 #[utoipa::path(
     delete,
     path = "/v1/users/me",
+    extensions(
+        ("x-side-effect" = json!("irreversible")),
+    ),
     responses(
         (status = 200, description = "Account deleted", body = DeleteAccountResponse),
         (status = 401, description = "Unauthorized"),

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -9890,7 +9890,8 @@
           "500": {
             "description": "Internal server error"
           }
-        }
+        },
+        "x-cost-tier": "paid"
       }
     },
     "/v1/sessions/{session_id}/pin": {
@@ -10971,7 +10972,8 @@
           "500": {
             "description": "Internal server error"
           }
-        }
+        },
+        "x-side-effect": "irreversible"
       },
       "patch": {
         "tags": [

--- a/specs/api-llm-extensions.md
+++ b/specs/api-llm-extensions.md
@@ -13,8 +13,8 @@ consumers ignore them unchanged.
 
 | Field             | Type             | Closed values                            | Default if unset       | Purpose                                                                            |
 | ----------------- | ---------------- | ---------------------------------------- | ---------------------- | ---------------------------------------------------------------------------------- |
-| `x-side-effect`   | enum             | `none` / `reversible` / `irreversible`   | `reversible`           | Worst-case mutation surface of the operation.                                       |
-| `x-cost-tier`     | enum             | `free` / `paid`                          | `free`                 | Whether invoking the operation can incur LLM token spend or other billed services. |
+| `x-side-effect`   | enum             | `none` / `reversible` / `irreversible`   | `irreversible`         | Worst-case mutation surface of the operation.                                       |
+| `x-cost-tier`     | enum             | `free` / `paid`                          | `paid`                 | Whether invoking the operation can incur LLM token spend or other billed services. |
 | `x-llm-prefer`    | enum             | `prefer` / `neutral` / `avoid`           | `neutral`              | Routing hint when multiple operations achieve a similar outcome.                    |
 | `x-llm-rationale` | string           | free-form, one sentence                  | (omitted)              | Surfaces alongside `x-llm-prefer != neutral` to explain the recommendation.        |
 | `x-error-codes`   | array of strings | `ErrorResponse.code` values              | (omitted)              | Closed set of `code` values this operation can emit.                                |
@@ -29,10 +29,10 @@ fields that are present.
   `PUT`, `PATCH`, `DELETE`). Use `irreversible` on hard-delete /
   rotate-credentials / destructive bash; `reversible` on soft-delete,
   archive, pause, unarchive, undo-eligible writes.
-* **`x-cost-tier`** — set `paid` on any operation that drives LLM
-  inference (`agent_run`, `session_send_message`, voice sessions,
-  `discover`/`execute` when they invoke an agent). Default `free` is
-  fine for everything else.
+* **`x-cost-tier`** — default is `paid` (fail-closed). Tag `free`
+  explicitly on read-only or definitively non-billed operations.
+  Operations that drive LLM inference (`agent_run`, `session_send_message`,
+  voice sessions, `discover`/`execute`) can omit the tag.
 * **`x-llm-prefer`** — set `avoid` on hard-delete or other
   semantically-destructive operations that have a safer alternative
   (e.g. `delete_agent` → recommend `archive` instead). Set `prefer`
@@ -50,10 +50,10 @@ fields that are present.
 
 ## Where defaults stop and tags start
 
-Tagging is not exhaustive — only operations that **differ from the
-default** need a tag. An LLM client treats absent tags as the
-default value, so leaving "reversible / free / neutral" implicit is
-the convention.
+Tagging is not exhaustive for preference/error/supersession hints, but
+side-effect and cost defaults are intentionally fail-closed. An LLM
+client treats absent tags as "irreversible / paid / neutral" by
+default, then uses explicit tags to relax that classification when safe.
 
 ## utoipa wiring
 


### PR DESCRIPTION
### Motivation

- The `x-llm-*` extension vocabulary previously treated absent `x-side-effect` as `reversible` and absent `x-cost-tier` as `free`, which makes untagged mutating or paid endpoints appear safe to LLM tool-callers.
- This default semantics is security-sensitive because LLM-driven clients can prefer or call endpoints based on those hints, risking irreversible or billed operations when the server did not explicitly tag them.

### Description

- Updated `specs/api-llm-extensions.md` to make defaults conservative (fail-closed): `x-side-effect` now defaults to `irreversible` and `x-cost-tier` now defaults to `paid`, and guidance text was clarified to require explicit tags to relax those classifications.
- Added explicit `x-cost-tier: paid` extension to the `POST /v1/sessions/{session_id}/messages` handler via `#[utoipa::path(extensions(...))]` in `crates/server/src/api/messages.rs` so workflow-triggering messages are not misclassified.
- Added explicit `x-side-effect: irreversible` extension to the `DELETE /v1/users/me` handler in `crates/server/src/api/users.rs` so the hard-delete endpoint is not misclassified.
- Regenerated the OpenAPI spec so `docs/api/openapi.json` reflects the new defaults and the two explicit operation extensions.

### Testing

- Ran `cargo fmt --check` which completed successfully.
- Ran `bash scripts/export-openapi.sh` to regenerate the OpenAPI artifact which completed successfully and included the updated `x-*` fields.
- Verified the updated handlers compile-form annotations and the spec contains the new `x-cost-tier`/`x-side-effect` entries (manual spot checks during export).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17be39e714832ba7a611e8ca4920b1)