### PR TITLE
fix(core): disable direct egress redirect following

### DIFF
--- a/crates/core/src/egress.rs
+++ b/crates/core/src/egress.rs
@@ -192,6 +192,7 @@ impl DirectEgressService {
             client: reqwest::Client::builder()
                 .connect_timeout(DEFAULT_CONNECT_TIMEOUT)
                 .timeout(DEFAULT_REQUEST_TIMEOUT)
+                .redirect(reqwest::redirect::Policy::none())
                 .build()
                 .expect("build direct egress HTTP client"),
         }
@@ -389,6 +390,39 @@ mod tests {
             .unwrap_err();
 
         assert!(matches!(error, EgressError::SigningUnavailable));
+    }
+
+    #[tokio::test]
+    async fn direct_service_does_not_follow_redirects() {
+        let redirect_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/secret"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("secret"))
+            .expect(0)
+            .mount(&redirect_server)
+            .await;
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/start"))
+            .respond_with(
+                ResponseTemplate::new(302)
+                    .insert_header("Location", format!("{}/secret", redirect_server.uri())),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let response = DirectEgressService::new()
+            .send(EgressRequest::new(
+                "GET",
+                format!("{}/start", server.uri()),
+                EgressRequestKind::Capability,
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status, 302);
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Motivation
- Prevent an ACL bypass/SSRF where an allowed URL could return a 3xx redirect to a blocked or private destination because `DirectEgressService` used reqwest's default redirect-following client.

### Description
- Configure the `DirectEgressService` `reqwest::Client` with `.redirect(reqwest::redirect::Policy::none())` to disable automatic redirect following.
- Add a regression test `direct_service_does_not_follow_redirects` in `crates/core/src/egress.rs` that asserts a `302` is returned and the redirected target is not requested.

### Testing
- Ran the focused test `cargo test -p everruns-core direct_service_does_not_follow_redirects`; the test was exercised in this environment but the workspace compile is large and the full run did not finish within the session window, so CI should verify the test in a full run.
- Attempting `cargo test -p core ...` failed locally because the crate is named `everruns-core`, not `core`, so the correct focused test target is used above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17be3dcca8832b98fad9c4a70c45cf)