### PR TITLE
fix(mcp): parse SSE responses in tools discovery

### DIFF
--- a/crates/server/src/domains/mcp_servers/service.rs
+++ b/crates/server/src/domains/mcp_servers/service.rs
@@ -655,7 +655,10 @@ pub(crate) async fn fetch_mcp_tools(
         ));
     }
 
-    let mcp_response: McpToolsListResponse = serde_json::from_slice(&response.body)?;
+    let response_text = String::from_utf8(response.body)?;
+    let json_str = extract_json_from_response(&response_text)
+        .ok_or_else(|| anyhow!("SSE response missing data line"))?;
+    let mcp_response: McpToolsListResponse = serde_json::from_str(json_str)?;
 
     if let Some(error) = mcp_response.error {
         return Err(anyhow!(
@@ -670,6 +673,17 @@ pub(crate) async fn fetch_mcp_tools(
         .ok_or_else(|| anyhow!("MCP server returned empty result"))?;
 
     Ok(result.tools)
+}
+
+fn extract_json_from_response(response_text: &str) -> Option<&str> {
+    if response_text.starts_with("event:") || response_text.contains("\ndata:") {
+        response_text
+            .lines()
+            .find(|line| line.starts_with("data:"))
+            .map(|line| line.trim_start_matches("data:").trim())
+    } else {
+        Some(response_text.trim())
+    }
 }
 
 #[cfg(test)]
@@ -694,6 +708,24 @@ mod tests {
             EncryptionService::new("kek-v1:8B3uCQ4Znx45hl5nB+PKVriRrj/KtEVM+wBZ2VGa9vY=", &[])
                 .unwrap(),
         )
+    }
+
+    #[test]
+    fn extract_json_from_sse_response() {
+        let response =
+            "event: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"tools\":[]}}\n\n";
+        let extracted = super::extract_json_from_response(response).unwrap();
+        assert!(extracted.starts_with("{\"jsonrpc\""));
+    }
+
+    #[test]
+    fn extract_json_from_plain_json_response() {
+        let response = " {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"tools\":[]}} ";
+        let extracted = super::extract_json_from_response(response).unwrap();
+        assert_eq!(
+            extracted,
+            "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"tools\":[]}}"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Motivation
- `fetch_mcp_tools` advertised `Accept: application/json, text/event-stream` but deserialized the response body directly as JSON, causing discovery to fail for MCP servers that return SSE.
- The tool execution path already handles SSE, so discovery needed equivalent extraction to avoid breaking streamable MCP servers.

### Description
- `fetch_mcp_tools` now converts response bytes to text and extracts JSON from either plain JSON or an SSE `data:` line before deserializing into `McpToolsListResponse` in `crates/server/src/domains/mcp_servers/service.rs`.
- Added a small helper `extract_json_from_response(response_text: &str) -> Option<&str>` that returns the `data:` payload for SSE or the trimmed text for plain JSON.
- Added two focused unit tests `extract_json_from_sse_response` and `extract_json_from_plain_json_response` to exercise the extraction behavior.
- Kept SSRF re-validation and existing error handling and timeouts unchanged.

### Testing
- Added unit tests `extract_json_from_sse_response` and `extract_json_from_plain_json_response` in the MCP server service test module and they are included in the repository commit.
- Ran `cargo test -p everruns-server extract_json_from_` which started dependency download and compilation in this environment, but the run window did not capture a final pass/fail result; the test build progressed successfully up to long dependency compilation output.
- An earlier invocation with multiple positional test names failed due to incorrect `cargo test` argument usage, not a code failure, and full CI is expected to run downstream to verify all tests pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17c0af3248832ba86314876aa163df)