### PR TITLE
fix(events): correct SSE id cursor and voice event docs

### DIFF
--- a/crates/server/src/api/events.rs
+++ b/crates/server/src/api/events.rs
@@ -277,11 +277,11 @@ pub fn routes(state: AppState) -> Router {
         (
             status = 200,
             description = "Server-Sent Events stream. Each SSE message has the wire \
-                shape `event: <type>\\nid: <sequence>\\ndata: <json>\\n\\n`, where \
+                shape `event: <type>\\nid: <event_id>\\ndata: <json>\\n\\n`, where \
                 `<type>` is one of the event types in the `EventData` catalog \
                 (`turn.started`, `tool.completed`, `reason.thinking.delta`, …), \
-                `<sequence>` is a monotonically increasing per-session sequence id \
-                (usable as `since_id` on reconnect), and `<json>` is the body \
+                `<event_id>` is the event cursor (`event_{32-hex}` format, \
+                usable as `since_id` on reconnect), and `<json>` is the body \
                 schema below — a serialized `Event` whose `data` field carries \
                 the event-type-specific payload defined in `EventData`. Lifecycle \
                 framing events (`connected`, `disconnecting`) use the same SSE \

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -10138,7 +10138,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Server-Sent Events stream. Each SSE message has the wire shape `event: <type>\\nid: <sequence>\\ndata: <json>\\n\\n`, where `<type>` is one of the event types in the `EventData` catalog (`turn.started`, `tool.completed`, `reason.thinking.delta`, …), `<sequence>` is a monotonically increasing per-session sequence id (usable as `since_id` on reconnect), and `<json>` is the body schema below — a serialized `Event` whose `data` field carries the event-type-specific payload defined in `EventData`. Lifecycle framing events (`connected`, `disconnecting`) use the same SSE shape but carry a minimal JSON object in `data` rather than a full `Event`. See `specs/api-streaming.md` for the SSE convention.",
+            "description": "Server-Sent Events stream. Each SSE message has the wire shape `event: <type>\\nid: <event_id>\\ndata: <json>\\n\\n`, where `<type>` is one of the event types in the `EventData` catalog (`turn.started`, `tool.completed`, `reason.thinking.delta`, …), `<event_id>` is the event cursor (`event_{32-hex}` format, usable as `since_id` on reconnect), and `<json>` is the body schema below — a serialized `Event` whose `data` field carries the event-type-specific payload defined in `EventData`. Lifecycle framing events (`connected`, `disconnecting`) use the same SSE shape but carry a minimal JSON object in `data` rather than a full `Event`. See `specs/api-streaming.md` for the SSE convention.",
             "content": {
               "text/event-stream": {
                 "schema": {

--- a/specs/api-streaming.md
+++ b/specs/api-streaming.md
@@ -14,12 +14,12 @@ follows the standard SSE framing
 
 ```
 event: <type>
-id: <sequence>
+id: <event_id>
 retry: <ms>
 data: <json>
 
 event: <type>
-id: <sequence>
+id: <event_id>
 data: <json>
 
 ```
@@ -30,9 +30,9 @@ data: <json>
   Lifecycle framing events (`connected`, `disconnecting`) use the
   same field but carry a minimal framing payload rather than an
   `Event`.
-* `id:` — monotonic per-session sequence id. Reconnecting clients
-  pass it back as the `since_id` query parameter to resume without
-  missing events.
+* `id:` — event id cursor (`event_{32-hex}` format). Reconnecting
+  clients pass it back as the `since_id` query parameter to resume
+  without missing events.
 * `retry:` — server-suggested reconnect delay in milliseconds; see
   the per-endpoint description for the cycling policy.
 * `data:` — the per-event JSON body. The shape depends on the
@@ -55,11 +55,55 @@ event-type-specific payload defined by the `EventData` enum.
 
 Closed `event:` vocabulary on this endpoint:
 
-* Two lifecycle frames — `connected` (`{"status": "connected"}`) and
-  `disconnecting` (`{"reason": "connection_cycle", "retry_ms": <ms>}`)
-  — bracket the stream. Neither wraps an `Event`.
-* Every other `event:` value is the discriminant of an `EventData`
-  variant; `data:` is the corresponding `Event<…Data>` envelope.
+| `event:` value                  | `data:` shape                                                              |
+| ------------------------------- | -------------------------------------------------------------------------- |
+| `connected`                     | `{"status": "connected"}` (lifecycle; no `Event` wrapper)                  |
+| `disconnecting`                 | `{"reason": "connection_cycle", "retry_ms": 100}` (lifecycle)              |
+| `input.message`                 | `Event` (`data` = `InputMessageData`)                                      |
+| `output.message.started`        | `Event` (`data` = `OutputMessageStartedData`)                              |
+| `output.message.delta`          | `Event` (`data` = `OutputMessageDeltaData`)                                |
+| `output.message.completed`      | `Event` (`data` = `OutputMessageCompletedData`)                            |
+| `output.message.replaced`       | `Event` (`data` = `OutputMessageReplacedData`)                             |
+| `turn.started`                  | `Event` (`data` = `TurnStartedData`)                                       |
+| `turn.completed`                | `Event` (`data` = `TurnCompletedData`)                                     |
+| `turn.failed`                   | `Event` (`data` = `TurnFailedData`)                                        |
+| `turn.cancelled`                | `Event` (`data` = `TurnCancelledData`)                                     |
+| `reason.started`                | `Event` (`data` = `ReasonStartedData`)                                     |
+| `reason.completed`              | `Event` (`data` = `ReasonCompletedData`)                                   |
+| `reason.thinking.started`       | `Event` (`data` = `ReasonThinkingStartedData`)                             |
+| `reason.thinking.delta`         | `Event` (`data` = `ReasonThinkingDeltaData`)                               |
+| `reason.thinking.completed`     | `Event` (`data` = `ReasonThinkingCompletedData`)                           |
+| `reason.item`                   | `Event` (`data` = `ReasonItemData`)                                        |
+| `act.started`                   | `Event` (`data` = `ActStartedData`)                                        |
+| `act.completed`                 | `Event` (`data` = `ActCompletedData`)                                      |
+| `tool.started`                  | `Event` (`data` = `ToolStartedData`)                                       |
+| `tool.progress`                 | `Event` (`data` = `ToolProgressData`)                                      |
+| `tool.completed`                | `Event` (`data` = `ToolCompletedData`)                                     |
+| `tool.output.delta`             | `Event` (`data` = `ToolOutputDeltaData`)                                   |
+| `tool.call_requested`           | `Event` (`data` = `ToolCallRequestedData`)                                 |
+| `llm.generation`                | `Event` (`data` = `LlmGenerationData`)                                     |
+| `capability.usage`              | `Event` (`data` = `CapabilityUsageData`)                                   |
+| `session.started`               | `Event` (`data` = `SessionStartedData`)                                    |
+| `session.activated`             | `Event` (`data` = `SessionActivatedData`)                                  |
+| `session.idled`                 | `Event` (`data` = `SessionIdledData`)                                      |
+| `subagent.spawned`              | `Event` (`data` = `SubagentEventData`)                                     |
+| `subagent.completed`            | `Event` (`data` = `SubagentEventData`)                                     |
+| `subagent.failed`               | `Event` (`data` = `SubagentEventData`)                                     |
+| `subagent.cancelled`            | `Event` (`data` = `SubagentEventData`)                                     |
+| `context.compacting`            | `Event` (`data` = `ContextCompactingData`)                                 |
+| `context.compacted`             | `Event` (`data` = `ContextCompactedData`)                                  |
+| `file.written`                  | `Event` (`data` = `FileWrittenData`)                                       |
+| `budget.warning`                | `Event` (`data` = `BudgetEventData`)                                       |
+| `budget.paused`                 | `Event` (`data` = `BudgetEventData`)                                       |
+| `budget.exhausted`              | `Event` (`data` = `BudgetEventData`)                                       |
+| `budget.resumed`                | `Event` (`data` = `BudgetEventData`)                                       |
+| `voice.session.started`         | `Event` (`data` = `VoiceSessionStartedData`)                               |
+| `voice.input_transcript.delta`  | `Event` (`data` = `VoiceTranscriptData`)                                   |
+| `voice.input_transcript.completed`  | `Event` (`data` = `VoiceTranscriptData`)                               |
+| `voice.output_transcript.delta` | `Event` (`data` = `VoiceTranscriptData`)                                   |
+| `voice.output_transcript.completed` | `Event` (`data` = `VoiceTranscriptData`)                               |
+| `voice.session.ended`           | `Event` (`data` = `VoiceSessionEndedData`)                                 |
+| `voice.session.failed`          | `Event` (`data` = `VoiceSessionFailedData`)                                |
 
 The authoritative event-type → payload mapping is the `EventData`
 enum in [`crates/core/src/events.rs`](../crates/core/src/events.rs)


### PR DESCRIPTION
### Motivation

- The SSE/OpenAPI docs described the SSE `id:` field as a numeric per-session sequence and suggested clients send that sequence as `since_id`, which contradicts the runtime which uses prefixed `EventId` values.
- The SSE event catalog documented voice transcript event names with dotted `input.transcript`/`output.transcript` forms while runtime constants use underscore forms, causing client filter/dispatch mismatches.

### Description

- Update `specs/api-streaming.md` to document `id: <event_id>` and describe the `event_{32-hex}` `EventId` cursor format instead of a numeric sequence.
- Correct the voice transcript event names in the SSE event catalog to the underscore variants (`voice.input_transcript.*`, `voice.output_transcript.*`).
- Update the `/v1/sessions/{session_id}/sse` OpenAPI response description in `crates/server/src/api/events.rs` to reference `<event_id>` and the `event_{32-hex}` format; no runtime behavior was changed.

### Testing

- Ran `cargo fmt --check -p everruns-server` which completed successfully.
- Started `cargo test -p everruns-server --test openapi_descriptions_test`; the test run compiled dependencies and began execution in this environment but did not fully complete within the interactive session; no test failures were observed up to the build/execution stages reached.
- Changes were limited to documentation/OpenAPI annotations and therefore did not require runtime code changes or additional unit tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17c0ae433c832bbcb9fe826853db37)