### PR TITLE
fix(openapi): preserve enum refs for schema examples

### DIFF
--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -741,6 +741,7 @@ pub trait ToolCallHook: Send + Sync {
     Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
 )]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "openapi", schema(example = "low"))]
 #[serde(rename_all = "lowercase")]
 pub enum RiskLevel {
     /// No special approval needed

--- a/crates/core/src/capability_dto.rs
+++ b/crates/core/src/capability_dto.rs
@@ -108,7 +108,7 @@ pub struct CapabilityInfo {
     pub config_ui_schema: Option<serde_json::Value>,
     /// TM-AGENT-005: Risk level. High-risk capabilities require admin approval.
     #[serde(skip_serializing_if = "is_low_risk", default = "default_risk_level")]
-    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "low"))]
+    #[cfg_attr(feature = "openapi", schema(example = "low"))]
     pub risk_level: RiskLevel,
     /// Number of active agents referencing this capability in the org.
     #[serde(default, skip_serializing_if = "is_zero_u64")]

--- a/crates/core/src/llm_models.rs
+++ b/crates/core/src/llm_models.rs
@@ -14,6 +14,7 @@ use utoipa::ToSchema;
 /// LLM provider type
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
+#[cfg_attr(feature = "openapi", schema(example = "anthropic"))]
 #[serde(rename_all = "snake_case")]
 pub enum LlmProviderType {
     /// OpenAI using Open Responses API (<https://www.openresponses.org/>)
@@ -79,6 +80,7 @@ pub enum LlmProviderStatus {
 /// How the model was added to the system
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
+#[cfg_attr(feature = "openapi", schema(example = "predefined"))]
 #[serde(rename_all = "snake_case")]
 pub enum LlmModelSource {
     /// User-created via API or UI
@@ -195,7 +197,7 @@ pub struct LlmModelWithProvider {
     #[cfg_attr(feature = "openapi", schema(example = true))]
     pub enabled: bool,
     /// How this model entry was added (manually, discovered, or seeded as predefined).
-    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "predefined"))]
+    #[cfg_attr(feature = "openapi", schema(example = "predefined"))]
     pub source: LlmModelSource,
     /// Timestamp when this model was created (RFC 3339).
     #[cfg_attr(feature = "openapi", schema(example = "2026-01-04T11:23:00Z"))]
@@ -207,7 +209,7 @@ pub struct LlmModelWithProvider {
     #[cfg_attr(feature = "openapi", schema(example = "Anthropic"))]
     pub provider_name: String,
     /// Joined provider implementation type.
-    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "anthropic"))]
+    #[cfg_attr(feature = "openapi", schema(example = "anthropic"))]
     pub provider_type: LlmProviderType,
     /// Derived: model is configured and ready for use. Currently means the
     /// joined provider is active and has an API key set; over time this may

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -12810,9 +12810,8 @@
             "example": "Session File System"
           },
           "risk_level": {
-            "type": "string",
-            "description": "TM-AGENT-005: Risk level. High-risk capabilities require admin approval.",
-            "example": "low"
+            "$ref": "#/components/schemas/RiskLevel",
+            "description": "TM-AGENT-005: Risk level. High-risk capabilities require admin approval."
           },
           "status": {
             "type": "string",
@@ -18010,9 +18009,8 @@
                   "example": "Session File System"
                 },
                 "risk_level": {
-                  "type": "string",
-                  "description": "TM-AGENT-005: Risk level. High-risk capabilities require admin approval.",
-                  "example": "low"
+                  "$ref": "#/components/schemas/RiskLevel",
+                  "description": "TM-AGENT-005: Risk level. High-risk capabilities require admin approval."
                 },
                 "status": {
                   "type": "string",
@@ -19864,14 +19862,12 @@
                       "example": "Anthropic"
                     },
                     "provider_type": {
-                      "type": "string",
-                      "description": "Joined provider implementation type.",
-                      "example": "anthropic"
+                      "$ref": "#/components/schemas/LlmProviderType",
+                      "description": "Joined provider implementation type."
                     },
                     "source": {
-                      "type": "string",
-                      "description": "How this model entry was added (manually, discovered, or seeded as predefined).",
-                      "example": "predefined"
+                      "$ref": "#/components/schemas/LlmModelSource",
+                      "description": "How this model entry was added (manually, discovered, or seeded as predefined)."
                     },
                     "updated_at": {
                       "type": "string",
@@ -21118,7 +21114,8 @@
           "manual",
           "discovered",
           "predefined"
-        ]
+        ],
+        "example": "predefined"
       },
       "LlmModelWithProvider": {
         "type": "object",
@@ -21210,14 +21207,12 @@
             "example": "Anthropic"
           },
           "provider_type": {
-            "type": "string",
-            "description": "Joined provider implementation type.",
-            "example": "anthropic"
+            "$ref": "#/components/schemas/LlmProviderType",
+            "description": "Joined provider implementation type."
           },
           "source": {
-            "type": "string",
-            "description": "How this model entry was added (manually, discovered, or seeded as predefined).",
-            "example": "predefined"
+            "$ref": "#/components/schemas/LlmModelSource",
+            "description": "How this model entry was added (manually, discovered, or seeded as predefined)."
           },
           "updated_at": {
             "type": "string",
@@ -21331,7 +21326,8 @@
           "anthropic",
           "gemini",
           "llmsim"
-        ]
+        ],
+        "example": "anthropic"
       },
       "LlmRequestOptions": {
         "type": "object",
@@ -22851,9 +22847,8 @@
                       "example": "Session File System"
                     },
                     "risk_level": {
-                      "type": "string",
-                      "description": "TM-AGENT-005: Risk level. High-risk capabilities require admin approval.",
-                      "example": "low"
+                      "$ref": "#/components/schemas/RiskLevel",
+                      "description": "TM-AGENT-005: Risk level. High-risk capabilities require admin approval."
                     },
                     "status": {
                       "type": "string",
@@ -25053,6 +25048,16 @@
             "minimum": 0
           }
         }
+      },
+      "RiskLevel": {
+        "type": "string",
+        "description": "Risk classification for capabilities (TM-AGENT-005).\n\nUsed to enforce approval requirements when assigning capabilities.",
+        "enum": [
+          "low",
+          "medium",
+          "high"
+        ],
+        "example": "low"
       },
       "RollbackAgentVersionRequest": {
         "type": "object",
@@ -29909,9 +29914,8 @@
                 "example": "Session File System"
               },
               "risk_level": {
-                "type": "string",
-                "description": "TM-AGENT-005: Risk level. High-risk capabilities require admin approval.",
-                "example": "low"
+                "$ref": "#/components/schemas/RiskLevel",
+                "description": "TM-AGENT-005: Risk level. High-risk capabilities require admin approval."
               },
               "status": {
                 "type": "string",
@@ -30455,14 +30459,12 @@
                 "example": "Anthropic"
               },
               "provider_type": {
-                "type": "string",
-                "description": "Joined provider implementation type.",
-                "example": "anthropic"
+                "$ref": "#/components/schemas/LlmProviderType",
+                "description": "Joined provider implementation type."
               },
               "source": {
-                "type": "string",
-                "description": "How this model entry was added (manually, discovered, or seeded as predefined).",
-                "example": "predefined"
+                "$ref": "#/components/schemas/LlmModelSource",
+                "description": "How this model entry was added (manually, discovered, or seeded as predefined)."
               },
               "updated_at": {
                 "type": "string",


### PR DESCRIPTION
### Motivation
- Fix an OpenAPI documentation regression where `schema(value_type = String, example = …)` on enum-typed fields caused utoipa to emit unconstrained `string` types and drop `$ref`/enum allowed-values for those fields.

### Description
- Remove `value_type = String` while keeping `example = …` on `CapabilityInfo.risk_level`, `LlmModelWithProvider.source`, and `LlmModelWithProvider.provider_type` so utoipa can preserve enum `$ref`/allowed values while still providing examples.

### Testing
- Attempted to run `cargo test -p everruns-server --test openapi_descriptions_test field_example_coverage_does_not_regress -- --exact`, which began dependency resolution and compilation but the full test completion was not captured in this environment; CI should run the OpenAPI gate tests to validate the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17c0ae386c832bbd34dcf71a8c3798)