### PR TITLE
fix(api): align session cancel action with command behavior

### DIFF
--- a/crates/server/src/api/common.rs
+++ b/crates/server/src/api/common.rs
@@ -1397,8 +1397,8 @@ impl ResourceUrlable for everruns_core::budget::Budget {
 /// `ResourceUrlable` impl below so unit tests can exercise the state →
 /// rel set mapping without constructing a full `Session`.
 ///
-/// Cancel is offered only while a turn is mid-flight (`Active` /
-/// `WaitingForToolResults`); pin/unpin flips on `is_pinned`; events
+/// Cancel is offered only while a turn is mid-flight (`Active`);
+/// pin/unpin flips on `is_pinned`; events
 /// streaming, metadata edits, and delete are unconditional because the
 /// API exposes them regardless of run state.
 pub fn session_allowed_actions(
@@ -1430,10 +1430,7 @@ pub fn session_allowed_actions(
             .with_href(format!("{api_base}/v1/sessions/{id}/sse"))
             .with_hint("Subscribe to session events live over Server-Sent Events."),
     );
-    if matches!(
-        status,
-        SessionStatus::Active | SessionStatus::WaitingForToolResults
-    ) {
+    if matches!(status, SessionStatus::Active) {
         actions.push(
             AllowedAction::new("cancel")
                 .with_method("POST")
@@ -2215,23 +2212,12 @@ mod tests {
     }
 
     #[test]
-    fn session_actions_include_cancel_when_waiting_for_tool_results() {
-        use everruns_core::session::SessionStatus;
-        let actions = session_allowed_actions(
-            "session_01",
-            &SessionStatus::WaitingForToolResults,
-            false,
-            "https://api.example",
-        );
-        assert!(actions.iter().any(|a| a.rel == "cancel"));
-    }
-
-    #[test]
     fn session_actions_omit_cancel_in_idle_or_paused_states() {
         use everruns_core::session::SessionStatus;
         for status in [
             SessionStatus::Started,
             SessionStatus::Idle,
+            SessionStatus::WaitingForToolResults,
             SessionStatus::Paused,
         ] {
             let actions =

--- a/specs/api-conventions.md
+++ b/specs/api-conventions.md
@@ -118,7 +118,7 @@ disagree about what's offered.
 | `started`                    | no                |
 | `active`                     | **yes**           |
 | `idle`                       | no                |
-| `waiting_for_tool_results`   | **yes**           |
+| `waiting_for_tool_results`   | no                |
 | `paused`                     | no                |
 
 `self`, `events`, `update`, `delete`, and `pin`/`unpin` (chosen by


### PR DESCRIPTION
### Motivation
- The session hypermedia advertised a `cancel` action for `waiting_for_tool_results` sessions while the `CancelSession` command only performs cancellation for `Active` sessions, creating a client-visible contract mismatch.
- The change aims to prevent clients or LLM toolcallers from following a link that the server will noop, preserving honest hypermedia affordances.

### Description
- Restrict `session_allowed_actions` so `cancel` is offered only when `SessionStatus::Active` (remove `WaitingForToolResults` from the predicate) in `crates/server/src/api/common.rs`.
- Update unit tests to remove the assertion that `cancel` appears for `WaitingForToolResults` and include `WaitingForToolResults` in the omission test that ensures `cancel` is absent for non-mid-flight states.
- Update `specs/api-conventions.md` to mark `waiting_for_tool_results` as not including `cancel` and adjust the surrounding docstring comment for accuracy.

### Testing
- Attempted a targeted unit test run: `cargo test -p everruns-server --lib api::common::tests::session_actions_omit_cancel_in_idle_or_paused_states -- --exact`, but the run was blocked by an existing Cargo artifact lock in this environment and did not complete.
- No other automated tests were executed in this environment after the change due to the concurrent Cargo state preventing a clean test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17c0aec204832bb502ce45eef5f52a)