### PR TITLE
fix(coding-cli): clarify /clear scrollback behavior

### DIFF
--- a/examples/coding-cli/src/app.rs
+++ b/examples/coding-cli/src/app.rs
@@ -102,7 +102,7 @@ const COMMANDS: &[CommandSpec] = &[
     CommandSpec {
         name: "clear",
         usage: "/clear",
-        description: "clear transcript",
+        description: "clear in-memory transcript (not terminal scrollback)",
     },
     CommandSpec {
         name: "quit",
@@ -520,6 +520,10 @@ impl App {
                 self.lines.clear();
                 self.printed_lines = 0;
                 self.emit_system_banner();
+                self.push_system(
+                    "note: terminal scrollback is not purged; clear it with your terminal if needed"
+                        .into(),
+                );
             }
             "quit" | "exit" => self.should_quit = true,
             other => {
@@ -1760,6 +1764,15 @@ mod tests {
         }
     }
 
+
+    #[test]
+    fn clear_command_description_mentions_scrollback() {
+        let clear = COMMANDS
+            .iter()
+            .find(|cmd| cmd.name == "clear")
+            .expect("clear command present");
+        assert!(clear.description.contains("scrollback"));
+    }
     #[test]
     fn command_suggestions_list_commands_for_slash() {
         let caps = vec![model_capability_command()];


### PR DESCRIPTION
### Motivation
- The TUI was changed to render transcript lines into the native terminal scrollback, but the existing `/clear` command only cleared in-memory buffers and did not purge scrollback, creating a local confidentiality regression for users expecting `/clear` to remove previous transcript output.

### Description
- Update the `/clear` command help text to `clear in-memory transcript (not terminal scrollback)` to make semantics explicit in the UI.
- Add a runtime system notice after handling `/clear` that warns users `note: terminal scrollback is not purged; clear it with your terminal if needed` so users see an immediate warning after invoking the command.
- Add a unit test `clear_command_description_mentions_scrollback` that asserts the `COMMANDS` entry for `clear` contains the word `scrollback` to prevent regressions.
- Changes are confined to `examples/coding-cli/src/app.rs`.

### Testing
- Ran the focused unit test with `cargo test --manifest-path examples/coding-cli/Cargo.toml clear_command_description_mentions_scrollback`, which passed (1 test, 0 failures).
- Local test run of the example's test suite completed successfully for the added test case and did not introduce failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17c0af4dd0832b8d55bd00c2218b68)