### PR TITLE
fix(core): avoid unwrapping user _raw_output_scalar keys

### DIFF
--- a/crates/core/src/tools.rs
+++ b/crates/core/src/tools.rs
@@ -192,11 +192,20 @@ impl ToolExecutionResult {
                     .as_object_mut()
                     .and_then(|obj| obj.remove("_raw_output"))
                     .and_then(|v| v.as_str().map(|s| s.to_string()));
-                // Unwrap scalar carrier (set by success_with_raw_output for non-object inputs)
-                let result_value = value
-                    .as_object_mut()
-                    .and_then(|obj| obj.remove("_raw_output_scalar"))
-                    .unwrap_or(value);
+                // Unwrap scalar carrier only when it matches the exact wrapper shape
+                // set by success_with_raw_output for non-object inputs.
+                let result_value = if let Some(obj) = value.as_object_mut() {
+                    let is_scalar_carrier = raw_output.is_some()
+                        && obj.len() == 1
+                        && obj.contains_key("_raw_output_scalar");
+                    if is_scalar_carrier {
+                        obj.remove("_raw_output_scalar").unwrap_or(Value::Null)
+                    } else {
+                        value
+                    }
+                } else {
+                    value
+                };
                 ToolResult {
                     tool_call_id: tool_call_id.to_string(),
                     result: Some(result_value),
@@ -2397,6 +2406,32 @@ mod tests {
             Some(serde_json::Value::String("compact summary".into()))
         );
         assert_eq!(tr.raw_output.as_deref(), Some("full output bytes"));
+    }
+
+    #[test]
+    fn test_success_result_with_raw_output_scalar_key_is_not_unwrapped() {
+        let res = ToolExecutionResult::success(
+            serde_json::json!({"_raw_output_scalar": "user_value", "kept": true}),
+        );
+        let tr = res.into_tool_result("call_1", "demo");
+        assert_eq!(
+            tr.result,
+            Some(serde_json::json!({"_raw_output_scalar": "user_value", "kept": true}))
+        );
+        assert_eq!(tr.raw_output, None);
+    }
+
+    #[test]
+    fn test_success_result_with_only_raw_output_scalar_key_is_not_unwrapped() {
+        // Single-key object with _raw_output_scalar must not be mistaken for a
+        // success_with_raw_output carrier when raw_output is absent.
+        let res = ToolExecutionResult::success(serde_json::json!({"_raw_output_scalar": "v"}));
+        let tr = res.into_tool_result("call_1", "demo");
+        assert_eq!(
+            tr.result,
+            Some(serde_json::json!({"_raw_output_scalar": "v"}))
+        );
+        assert_eq!(tr.raw_output, None);
     }
 
     #[test]

--- a/examples/coding-cli/src/app.rs
+++ b/examples/coding-cli/src/app.rs
@@ -1764,7 +1764,6 @@ mod tests {
         }
     }
 
-
     #[test]
     fn clear_command_description_mentions_scrollback() {
         let clear = COMMANDS


### PR DESCRIPTION
### Motivation
- A recent change introduced a scalar-carrier sidecar using `_raw_output_scalar` which `into_tool_result()` then unwrapped unconditionally, causing legitimate successful JSON results that contained `_raw_output_scalar` to be replaced with the scalar and lose data.
- This is a data-integrity regression: normal `ToolExecutionResult::success(json!(...))` payloads could be corrupted when they legally contained the `_raw_output_scalar` key.

### Description
- Scope the scalar-carrier unwrap in `ToolExecutionResult::into_tool_result` so it only unwraps when the object exactly matches the expected wrapper shape produced by `success_with_raw_output` (object length == 1 and contains `_raw_output_scalar`).
- Preserve ordinary successful object payloads that legitimately include `_raw_output_scalar` by leaving them untouched and not exposing `raw_output`.
- Add a regression unit test `test_success_result_with_raw_output_scalar_key_is_not_unwrapped` that verifies a normal `success(json!({...}))` containing `_raw_output_scalar` is preserved and does not set `raw_output`.

### Testing
- Ran `cargo test -p everruns-core test_success_result_with_raw_output_scalar_key_is_not_unwrapped -- --nocapture`, and the new test passed.
- The focused test run completed with `1 passed; 0 failed` for the added test in the crate unit test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17c0adf050832bbec2b9731b0b7731)