### PR TITLE
fix(security): fail-close LLM resolver — remove env fallback from tenant path (EVE-511)

### DIFF
--- a/crates/server/src/services/llm_resolver.rs
+++ b/crates/server/src/services/llm_resolver.rs
@@ -772,7 +772,8 @@ mod tests {
     }
 
     /// EVE-511: resolver must not spend platform env keys for tenant execution.
-    /// A provider with no DB key must resolve to None (fail closed), never env.
+    /// Sets DEFAULT_OPENAI_API_KEY in the process env so the test would fail
+    /// against the old env-fallback implementation.
     #[tokio::test]
     async fn resolve_provider_api_key_env_key_set_does_not_leak() {
         let db = Arc::new(StorageBackend::in_memory());
@@ -791,12 +792,47 @@ mod tests {
             .await
             .unwrap();
 
-        // No DB key -> None, regardless of any env vars on the host.
-        // (The function no longer reads env vars at all — fail closed.)
+        // Safety: test-only, single-threaded assertion.
+        // set_var/remove_var are unsafe in Rust 2024 because they are not
+        // thread-safe; this test serialises the env mutation via the
+        // variable going out of scope before any assertion.
+        unsafe {
+            std::env::set_var("DEFAULT_OPENAI_API_KEY", "sk-platform-key-must-not-leak");
+        }
         let result = resolve_provider_api_key(&db, None, &provider).unwrap();
+        unsafe {
+            std::env::remove_var("DEFAULT_OPENAI_API_KEY");
+        }
+
         assert!(
             result.is_none(),
-            "resolve_provider_api_key must not fall back to env key — fail closed"
+            "resolve_provider_api_key must not fall back to DEFAULT_OPENAI_API_KEY"
+        );
+    }
+
+    /// EVE-511: resolve_provider_credentials must also fail closed.
+    /// Sets DEFAULT_OPENAI_API_KEY to verify it is never consulted.
+    #[tokio::test]
+    async fn resolve_provider_credentials_env_key_set_does_not_leak() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let resolver = LlmResolverService::new(db.clone(), None);
+
+        // No provider configured for this org at all.
+        // Safety: test-only env mutation, same rationale as above.
+        unsafe {
+            std::env::set_var("DEFAULT_OPENAI_API_KEY", "sk-platform-key-must-not-leak");
+        }
+        let result = resolver
+            .resolve_provider_credentials(DEFAULT_ORG_ID, "openai")
+            .await
+            .unwrap();
+        unsafe {
+            std::env::remove_var("DEFAULT_OPENAI_API_KEY");
+        }
+
+        assert!(
+            result.is_none(),
+            "resolve_provider_credentials must not fall back to DEFAULT_OPENAI_API_KEY"
         );
     }
 

--- a/crates/server/src/services/llm_resolver.rs
+++ b/crates/server/src/services/llm_resolver.rs
@@ -9,9 +9,11 @@
 //
 // API key resolution order (handled at service layer):
 // 1. Decrypted key from database (if set)
-// 2. Environment variable fallback (for development convenience):
-//    - openai: DEFAULT_OPENAI_API_KEY
-//    - anthropic: DEFAULT_ANTHROPIC_API_KEY
+// 2. None — fail closed; no environment variable fallback in the tenant path.
+//
+// The env-var helpers (get_default_api_key_from_env) remain available for
+// explicit standalone/dev entrypoints (CLI, InMemoryLlmProviderStore) but must
+// NOT be called from any org-scoped execution path.
 
 use crate::storage::{EncryptionService, StorageBackend, models::LlmProviderRow};
 use anyhow::Result;
@@ -56,16 +58,16 @@ where
     env_lookup(env_var).filter(|s| !s.is_empty())
 }
 
-/// Resolve API key for a provider.
+/// Resolve API key for a provider (fail-closed).
 ///
 /// Shared logic used by both LlmResolverService and ModelSyncService.
 ///
 /// Resolution order:
 /// 1. Decrypt from database if encryption is available and key is set
-/// 2. Fall back to environment variable (DEFAULT_OPENAI_API_KEY, DEFAULT_ANTHROPIC_API_KEY, etc.)
+/// 2. None — never falls back to environment variables
 ///
-/// If provider has an encrypted key but encryption service is not available,
-/// logs a warning and falls back to environment variable.
+/// Callers must treat None as "no provider configured" and surface an error.
+/// This prevents tenant execution from silently spending platform-level env keys.
 pub fn resolve_provider_api_key(
     db: &StorageBackend,
     encryption: Option<&EncryptionService>,
@@ -81,13 +83,12 @@ pub fn resolve_provider_api_key(
             tracing::warn!(
                 provider_id = %provider.id,
                 provider_type = %provider.provider_type,
-                "Provider has encrypted API key but encryption service is not configured. \
-                 Falling back to environment variable."
+                "Provider has encrypted API key but encryption service is not configured."
             );
         }
     }
 
-    Ok(get_default_api_key_from_env(&provider.provider_type))
+    Ok(None)
 }
 
 /// Resolved model with provider credentials (decrypted API key)
@@ -167,12 +168,15 @@ impl LlmResolverService {
         Ok(result)
     }
 
-    /// Resolve default credentials for a provider type.
+    /// Resolve default credentials for a provider type (fail-closed).
     ///
     /// Preference order:
     /// 1. Active providers matching the requested type, newest first
     /// 2. Other matching providers, newest first
-    /// 3. Environment fallback for the provider type with no base URL
+    ///
+    /// Returns None when no provider with a configured key is found.
+    /// Never falls back to environment variables — callers surface a
+    /// "no provider configured" error on None.
     pub async fn resolve_provider_credentials(
         &self,
         org_id: i64,
@@ -208,14 +212,7 @@ impl LlmResolverService {
             }
         }
 
-        Ok(
-            get_default_api_key_from_env(provider_type).map(|api_key| {
-                ResolvedProviderCredentials {
-                    api_key,
-                    base_url: None,
-                }
-            }),
-        )
+        Ok(None)
     }
 
     /// Invalidate all cached resolutions for an org.
@@ -752,7 +749,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn resolve_provider_api_key_no_key_falls_to_env() {
+    async fn resolve_provider_api_key_no_db_key_returns_none() {
         let db = Arc::new(StorageBackend::in_memory());
 
         let provider = db
@@ -769,9 +766,38 @@ mod tests {
             .await
             .unwrap();
 
-        // No encrypted key, no env var -> None
+        // No encrypted key in DB -> None, regardless of env
         let result = resolve_provider_api_key(&db, None, &provider).unwrap();
         assert!(result.is_none());
+    }
+
+    /// EVE-511: resolver must not spend platform env keys for tenant execution.
+    /// A provider with no DB key must resolve to None (fail closed), never env.
+    #[tokio::test]
+    async fn resolve_provider_api_key_env_key_set_does_not_leak() {
+        let db = Arc::new(StorageBackend::in_memory());
+
+        let provider = db
+            .create_llm_provider(
+                DEFAULT_ORG_ID,
+                CreateLlmProviderRow {
+                    name: "OpenAI".to_string(),
+                    provider_type: "openai".to_string(),
+                    base_url: None,
+                    api_key_encrypted: None,
+                    settings: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        // No DB key -> None, regardless of any env vars on the host.
+        // (The function no longer reads env vars at all — fail closed.)
+        let result = resolve_provider_api_key(&db, None, &provider).unwrap();
+        assert!(
+            result.is_none(),
+            "resolve_provider_api_key must not fall back to env key — fail closed"
+        );
     }
 
     // =========================================================================

--- a/crates/server/src/services/model_sync.rs
+++ b/crates/server/src/services/model_sync.rs
@@ -85,7 +85,7 @@ impl ModelSyncService {
             return Ok(SyncResult::NotSupported);
         }
 
-        // Get API key (decrypt from DB first, then env fallback)
+        // Get API key from DB (fail closed — no env fallback in tenant path).
         let api_key = self.resolve_api_key(&provider_row)?;
         let Some(api_key) = api_key else {
             return Ok(SyncResult::Failed {
@@ -393,12 +393,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_resolve_api_key_falls_back_to_env_without_encryption() {
+    async fn test_resolve_api_key_no_encryption_service_returns_none() {
         use everruns_core::DEFAULT_ORG_ID;
 
         let db = Arc::new(StorageBackend::in_memory());
         let registry = Arc::new(DriverRegistry::new());
-        // No encryption service
         let service = ModelSyncService::new(db.clone(), registry, None);
 
         let provider = db
@@ -415,13 +414,13 @@ mod tests {
             .await
             .unwrap();
 
-        // Should fall back to env (which won't be set in test) -> None
+        // Encrypted key but no decryption service -> None (fail closed)
         let resolved = service.resolve_api_key(&provider).unwrap();
         assert!(resolved.is_none());
     }
 
     #[tokio::test]
-    async fn test_resolve_api_key_no_encrypted_key_falls_to_env() {
+    async fn test_resolve_api_key_no_db_key_returns_none() {
         use everruns_core::DEFAULT_ORG_ID;
 
         let db = Arc::new(StorageBackend::in_memory());
@@ -442,7 +441,7 @@ mod tests {
             .await
             .unwrap();
 
-        // No encrypted key, no env var -> None
+        // No DB key -> None (fail closed, no env fallback)
         let resolved = service.resolve_api_key(&provider).unwrap();
         assert!(resolved.is_none());
     }

--- a/specs/llm-drivers.md
+++ b/specs/llm-drivers.md
@@ -368,6 +368,42 @@ The `LlmDriver` trait includes `supports_compact()` and `compact()` methods. See
 | Gemini | No |
 | LlmSim | No |
 
+## Key Resolution Contract (Fail-Closed)
+
+### Server-Side Tenant Path
+
+All API key resolution for tenant/org-scoped execution flows through
+`crates/server/src/services/llm_resolver.rs`. The contract is **fail-closed**:
+
+1. If the provider has an encrypted key in the database, decrypt and use it.
+2. If no database key is found (absent, decryption failed, or encryption service
+   unavailable), resolve to `None`.
+3. Callers receiving `None` MUST surface a "no provider configured" error to the
+   tenant — they must not fall through to environment variable reads.
+
+**Why**: With a platform-level `DEFAULT_*_API_KEY` present on the server host, an
+implicit env fallback silently funds tenant execution from platform credentials.
+Fail-closed prevents accidental cost-runaway under open signup.
+
+### Dev / CLI / Standalone Path
+
+Environment variable reads (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`,
+`DEFAULT_*_API_KEY`) remain valid only for explicit standalone/dev entrypoints:
+
+- `InMemoryLlmProviderStore::from_env()` — in-memory dev store used by `just start-dev`
+- `AnthropicLlmDriver::from_env()`, `OpenAIProtocolLlmDriver::from_env()`, etc. — CLI tools
+
+These constructors must **never** be called from org-scoped agent execution paths.
+
+### Invariant
+
+> A tenant turn or tenant-triggered embedding that resolves without a database key
+> must fail with a clear error, regardless of which environment variables are set
+> on the host process.
+
+This invariant is verified by the unit test `resolve_provider_api_key_env_key_set_does_not_leak`
+in `crates/server/src/services/llm_resolver.rs`.
+
 ## Testing
 
 1. **Unit Tests**: Each driver MUST have tests for error detection functions

--- a/specs/llm-drivers.md
+++ b/specs/llm-drivers.md
@@ -375,10 +375,13 @@ The `LlmDriver` trait includes `supports_compact()` and `compact()` methods. See
 All API key resolution for tenant/org-scoped execution flows through
 `crates/server/src/services/llm_resolver.rs`. The contract is **fail-closed**:
 
-1. If the provider has an encrypted key in the database, decrypt and use it.
-2. If no database key is found (absent, decryption failed, or encryption service
-   unavailable), resolve to `None`.
-3. Callers receiving `None` MUST surface a "no provider configured" error to the
+1. If the provider has an encrypted key in the database and the encryption service
+   is available, decrypt and return it. If decryption fails the call returns `Err`
+   (not `None`).
+2. If the provider has an encrypted key but the encryption service is unavailable,
+   log a warning and return `None` (not `Err`).
+3. If no database key is stored at all, return `None`.
+4. Callers receiving `None` MUST surface a "no provider configured" error to the
    tenant — they must not fall through to environment variable reads.
 
 **Why**: With a platform-level `DEFAULT_*_API_KEY` present on the server host, an

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -561,6 +561,7 @@ The shared validator blocks loopback, RFC1918, link-local, and cloud metadata ta
 | TM-LLM-008 | Cost runaway via agent loop | Medium | Max 10 iterations per agent turn; configurable | MITIGATED |
 | TM-LLM-020 | Client-supplied privileged message roles in AG-UI input | Medium | Anonymous AG-UI/CopilotKit clients could send `role: "system"` / `developer` / `tool` messages that flow into the LLM context alongside the agent's real system prompt. Mitigated in `crates/server/src/api/ag_ui.rs::validate_input_messages` by rejecting any non-{user,assistant} role at the runtime trust boundary with a generic 400 `invalid_request`, and by rejecting duplicate message ids. | MITIGATED |
 | TM-LLM-021 | Utility LLM key exposed through agent model configuration | High | The utility LLM uses deployment env secret `UTILITY_OPENAI_API_KEY`, is carried as a host service on `PlatformDefinition`, and is threaded only into capability `ToolContext`. It is not stored in provider records, exposed through model selection, or accepted from session/agent config. | MITIGATED |
+| TM-LLM-022 | Tenant execution silently spending platform env keys | High | `LlmResolverService::resolve_provider_api_key` and `resolve_provider_credentials` are fail-closed: they return `None` when no database key is found rather than falling back to `DEFAULT_*_API_KEY` env vars. Callers surface a "no provider configured" error. Env var helpers remain available only for explicit dev/CLI entrypoints. See `specs/llm-drivers.md` (Key Resolution Contract). | MITIGATED |
 
 ### Mitigation Details
 


### PR DESCRIPTION
## What
Make `LlmResolverService::resolve_provider_api_key` and `resolve_provider_credentials` fail-closed: they now return `None` instead of falling back to `DEFAULT_*_API_KEY` environment variables when no database key is found for a provider.

## Why
With a platform-level `DEFAULT_OPENAI_API_KEY` / `DEFAULT_ANTHROPIC_API_KEY` etc. present on the server host, a tenant with no org-configured provider could silently spend platform credentials. Under open signup this is a cost-runaway footgun and a billing trust boundary violation.

## How
- Remove the `get_default_api_key_from_env()` call at the end of `resolve_provider_api_key()` — return `Ok(None)` instead.
- Remove the env-fallback block at the end of `resolve_provider_credentials()` — return `Ok(None)` instead.
- All existing callers (`voice.rs`, `direct_worker_adapters.rs`, `grpc_service/worker_service_impl.rs`, `model_sync.rs`) already handle `None` correctly with "no provider configured" errors — no caller changes required.
- Update stale comments and test names in `model_sync.rs`.
- Add `Key Resolution Contract` section to `specs/llm-drivers.md` documenting the fail-closed invariant.
- Add TM-LLM-022 to `specs/threat-model.md`.
- Add regression test `resolve_provider_api_key_env_key_set_does_not_leak`.

Env-var helpers (`get_default_api_key_from_env`, driver `from_env()` methods) remain available for explicit dev/CLI entrypoints only (`InMemoryLlmProviderStore::from_env()`, standalone CLI commands).

## Risk
- Low. All four callers already handled `None` before this change — they just never received it when an env var was set. The behaviour change only affects deployments where a `DEFAULT_*_API_KEY` is set on the server host and a tenant has no org-configured provider. Those tenants will now get a "no provider configured" error rather than silently using the platform key.

## Security
- Threat categories reviewed: TM-LLM, TM-TENANT
- TM-LLM-022 added and marked MITIGATED: `resolve_provider_api_key` and `resolve_provider_credentials` no longer fall back to env vars during tenant execution.
- No new attack surface introduced.

## Follow-ups
No follow-ups.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JkQ7GTm9FqGEhREuV2siDA)_