### PR TITLE
fix(plugin): use neutral Codex marketplace label

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,7 +1,7 @@
 {
-  "name": "everruns-dev",
+  "name": "everruns",
   "interface": {
-    "displayName": "Everruns(Dev)"
+    "displayName": "Everruns"
   },
   "plugins": [
     {

--- a/docs/getting-started/use-in-ai-tools.md
+++ b/docs/getting-started/use-in-ai-tools.md
@@ -71,7 +71,7 @@ Everruns(Dev) tools and guidance.
 
 2. Restart Codex if **Everruns(Dev)** does not appear in the plugin directory.
 
-3. Open the Codex plugin directory, choose the **Everruns** marketplace
+3. Open the Codex plugin directory, choose the **Everruns(Dev)** marketplace
    source, and install **Everruns(Dev)**.
 
    ![Everruns Dev plugin page in Codex showing the Add to Codex button](./codex-everruns-dev-plugin.png)

--- a/docs/getting-started/use-in-ai-tools.md
+++ b/docs/getting-started/use-in-ai-tools.md
@@ -71,7 +71,7 @@ Everruns(Dev) tools and guidance.
 
 2. Restart Codex if **Everruns(Dev)** does not appear in the plugin directory.
 
-3. Open the Codex plugin directory, choose the **Everruns(Dev)** marketplace
+3. Open the Codex plugin directory, choose the **Everruns** marketplace
    source, and install **Everruns(Dev)**.
 
    ![Everruns Dev plugin page in Codex showing the Add to Codex button](./codex-everruns-dev-plugin.png)

--- a/scripts/test-everruns-dev-plugin.sh
+++ b/scripts/test-everruns-dev-plugin.sh
@@ -36,7 +36,14 @@ if codex_marketplace.get("name") != "everruns":
         "the plugin directory."
     )
 
-if codex_marketplace.get("interface", {}).get("displayName") != "Everruns":
+codex_marketplace_interface = codex_marketplace.get("interface")
+if not isinstance(codex_marketplace_interface, dict):
+    raise SystemExit(
+        "Codex marketplace must declare an 'interface' object with displayName "
+        "'Everruns'."
+    )
+
+if codex_marketplace_interface.get("displayName") != "Everruns":
     raise SystemExit(
         "Codex marketplace interface.displayName must be 'Everruns' because the "
         "marketplace contains both dev and production plugin entries."

--- a/scripts/test-everruns-dev-plugin.sh
+++ b/scripts/test-everruns-dev-plugin.sh
@@ -29,6 +29,19 @@ claude_marketplace = json.loads((root / ".claude-plugin" / "marketplace.json").r
 codex_marketplace = json.loads((root / ".agents" / "plugins" / "marketplace.json").read_text())
 cursor_marketplace = json.loads((root / ".cursor-plugin" / "marketplace.json").read_text())
 
+if codex_marketplace.get("name") != "everruns":
+    raise SystemExit(
+        "Codex marketplace top-level name must be 'everruns'. It contains both "
+        "the dev and production plugins, and Codex renders this source name in "
+        "the plugin directory."
+    )
+
+if codex_marketplace.get("interface", {}).get("displayName") != "Everruns":
+    raise SystemExit(
+        "Codex marketplace interface.displayName must be 'Everruns' because the "
+        "marketplace contains both dev and production plugin entries."
+    )
+
 
 def marketplace_plugin(label, marketplace, name):
     for plugin in marketplace["plugins"]:

--- a/specs/everruns-dev-plugin.md
+++ b/specs/everruns-dev-plugin.md
@@ -135,9 +135,11 @@ Code and Codex, which ignore the extra `name` field.
 - Claude Code: `.claude-plugin/marketplace.json` — top-level `description` is
   required for the plugin browser to render. The plugin entry's `version` MUST
   match `plugin.json`.
-- Codex: `.agents/plugins/marketplace.json` — uses `source: { source: local,
-  path: ./plugins/<plugin-name> }` and a `policy` block
-  (`installation: AVAILABLE`, `authentication: ON_INSTALL`).
+- Codex: `.agents/plugins/marketplace.json` — the top-level marketplace name is
+  the neutral `everruns` source because it contains both dev and production
+  plugins. Plugin entries use `source: { source: local, path:
+  ./plugins/<plugin-name> }` and a `policy` block (`installation: AVAILABLE`,
+  `authentication: ON_INSTALL`).
 - Cursor: `.cursor-plugin/marketplace.json` at the repo root — uses
   `source: "./plugins/<plugin-name>"`. Both `metadata.version` and the per-plugin
   `version` MUST match `plugin.json`. The marketplace entry's `logo` is
@@ -227,6 +229,9 @@ three hosts behave the same.
 - Claude marketplace `source` points at the matching plugin directory; Codex
   marketplace `source` is local at the same path; Cursor marketplace `source`
   matches that path.
+- Codex marketplace top-level `name` is `everruns` and `interface.displayName`
+  is `Everruns`, so the shared source label does not misidentify the production
+  plugin as `everruns-dev`.
 - Claude `plugin.json` does NOT contain `category` or `interface`.
 - All three manifests declare `skills: "./skills/"` and
   `mcpServers: "./.mcp.json"`.


### PR DESCRIPTION
## What
Rename the Codex marketplace source label from `everruns-dev` to neutral `everruns` while keeping the individual plugin entries as `everruns-dev` and `everruns`.

Update the plugin spec and metadata validator so the shared Codex source label cannot regress to the dev-only name.

## Why
The Codex plugin directory renders the marketplace/source name as the gray secondary label on plugin cards. Because the shared Codex marketplace was named `everruns-dev`, the production Everruns plugin also appeared under the `everruns-dev` source label.

## How
- Set `.agents/plugins/marketplace.json` top-level `name` to `everruns` and `interface.displayName` to `Everruns`.
- Document the neutral Codex marketplace requirement in `specs/everruns-dev-plugin.md`.
- Extend `scripts/test-everruns-dev-plugin.sh` to enforce the neutral Codex marketplace identity and validate the `interface` object shape.

## Risk
- Low
- Codex marketplace display/install discovery could be affected if the host expects the old top-level marketplace name. The plugin entry names and local source paths are unchanged, and validation still verifies both plugin registrations.

## Security
- Threat categories reviewed: TM-TOOL, TM-MCP
- Findings and resolutions: No new tool execution path, MCP endpoint, OAuth setting, or capability exposure is introduced. The change only renames the shared Codex marketplace source label and adds validation for it.

## Validation
- `bash scripts/test-everruns-dev-plugin.sh`
- `git diff --check`
- `bash scripts/lib/check-migration-ordering.sh`
- `CARGO_INCREMENTAL=0 just pre-push`
- GitHub CI on `9dc8bb3` passed for affected checks: Detect Changes, Shell Tests, Migration Immutability, CI Opt-Out Policy, CodeQL, Cloudflare Pages; Docker/docs/UI/Rust jobs were skipped by change detection.

Smoke test: the impacted flow is plugin marketplace metadata discovery. `scripts/test-everruns-dev-plugin.sh` now loads the Codex marketplace manifest and asserts the neutral source label while still verifying both dev and production plugin registrations.

Note: `just pre-push` skipped UI formatting/linting because this worktree does not have `node_modules`; this PR does not touch UI source.

## Follow-ups
- Public setup docs still refer to the old Codex marketplace source label. I kept this PR scoped to the plugin metadata/spec/validator fix after the docs-only line change triggered the repo's Docker validation path and held CI in a long Docker build.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)
