### PR TITLE
feat(security): gate agent delegation behind feature flag (EVE-506)

### DIFF
--- a/apps/ui/src/lib/api/types/auth-types.ts
+++ b/apps/ui/src/lib/api/types/auth-types.ts
@@ -15,6 +15,8 @@ export interface FeatureFlags {
   agent_versions: boolean;
   voice: boolean;
   "apps.detailV2": boolean;
+  /** Outbound agent delegation (`a2a_agent_delegation`, `agent_handoff`). Experimental. */
+  agent_delegation: boolean;
 }
 
 export interface AuthConfigResponse {

--- a/apps/ui/src/providers/feature-flags-provider.tsx
+++ b/apps/ui/src/providers/feature-flags-provider.tsx
@@ -20,6 +20,7 @@ const DEFAULT_FLAGS: FeatureFlags = {
   agent_versions: false,
   voice: false,
   "apps.detailV2": false,
+  agent_delegation: false,
 };
 
 export interface FeatureFlagsContextValue {

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -905,10 +905,7 @@ impl CapabilityRegistry {
         // Outbound agent delegation — experimental (dev-only by default).
         // Risk: exfil, SSRF-adjacent reach, cost/recursion fan-out.
         // Gated by FEATURE_AGENT_DELEGATION; auto-enabled in dev, off in prod.
-        let agent_delegation_enabled = std::env::var("FEATURE_AGENT_DELEGATION")
-            .map(|v| v == "true" || v == "1")
-            .unwrap_or_else(|_| grade.experimental_features_enabled());
-        if agent_delegation_enabled {
+        if crate::FeatureFlags::from_env(&grade).agent_delegation {
             registry.register(AgentHandoffCapability);
             registry.register(A2aAgentDelegationCapability);
         }
@@ -2001,6 +1998,13 @@ mod tests {
     use std::collections::BTreeSet;
     use uuid::Uuid;
 
+    // Env-var-mutating tests must not run in parallel.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn lock_env() -> std::sync::MutexGuard<'static, ()> {
+        ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
     /// Test helper: dummy context with no file store
     fn test_ctx() -> SystemPromptContext {
         SystemPromptContext::without_file_store(SessionId::new())
@@ -2084,6 +2088,7 @@ mod tests {
     #[test]
     fn test_capability_registry_with_builtins_dev() {
         // Dev mode includes all built-in capabilities including experimental delegation
+        let _lock = lock_env();
         unsafe { std::env::remove_var("FEATURE_AGENT_DELEGATION") };
         let registry = CapabilityRegistry::with_builtins_for_grade(DeploymentGrade::Dev);
         assert_eq!(registry_ids(&registry), expected_dev_builtin_ids());
@@ -2094,6 +2099,7 @@ mod tests {
     #[test]
     fn test_capability_registry_with_builtins_prod() {
         // Prod mode excludes experimental capabilities including delegation
+        let _lock = lock_env();
         unsafe { std::env::remove_var("FEATURE_AGENT_DELEGATION") };
         let registry = CapabilityRegistry::with_builtins_for_grade(DeploymentGrade::Prod);
         assert_eq!(registry_ids(&registry), expected_core_builtin_ids());
@@ -2106,6 +2112,7 @@ mod tests {
     #[test]
     fn test_agent_delegation_enabled_by_env_in_prod() {
         // FEATURE_AGENT_DELEGATION=true enables delegation caps even in prod
+        let _lock = lock_env();
         unsafe { std::env::set_var("FEATURE_AGENT_DELEGATION", "true") };
         let registry = CapabilityRegistry::with_builtins_for_grade(DeploymentGrade::Prod);
         assert!(registry.has("agent_handoff"));
@@ -2116,6 +2123,7 @@ mod tests {
     #[test]
     fn test_agent_delegation_disabled_by_env_in_dev() {
         // FEATURE_AGENT_DELEGATION=false disables delegation caps even in dev
+        let _lock = lock_env();
         unsafe { std::env::set_var("FEATURE_AGENT_DELEGATION", "false") };
         let registry = CapabilityRegistry::with_builtins_for_grade(DeploymentGrade::Dev);
         assert!(!registry.has("agent_handoff"));

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -901,8 +901,17 @@ impl CapabilityRegistry {
 
         // Subagents (spawn child agent sessions, all environments)
         registry.register(SubagentCapability);
-        registry.register(AgentHandoffCapability);
-        registry.register(A2aAgentDelegationCapability);
+
+        // Outbound agent delegation — experimental (dev-only by default).
+        // Risk: exfil, SSRF-adjacent reach, cost/recursion fan-out.
+        // Gated by FEATURE_AGENT_DELEGATION; auto-enabled in dev, off in prod.
+        let agent_delegation_enabled = std::env::var("FEATURE_AGENT_DELEGATION")
+            .map(|v| v == "true" || v == "1")
+            .unwrap_or_else(|_| grade.experimental_features_enabled());
+        if agent_delegation_enabled {
+            registry.register(AgentHandoffCapability);
+            registry.register(A2aAgentDelegationCapability);
+        }
 
         // System commands (/clear, /status, /compact, /model)
         registry.register(SystemCommandsCapability);
@@ -1997,6 +2006,7 @@ mod tests {
         SystemPromptContext::without_file_store(SessionId::new())
     }
 
+    /// Base set of built-in capabilities present in all environments (no experimental delegation).
     fn expected_core_builtin_ids() -> BTreeSet<&'static str> {
         let mut ids = [
             "agent_instructions",
@@ -2028,8 +2038,6 @@ mod tests {
             "prompt_caching",
             "skills",
             "subagents",
-            "agent_handoff",
-            "a2a_agent_delegation",
             "system_commands",
             "sample_data",
             "data_knowledge",
@@ -2052,6 +2060,14 @@ mod tests {
         ids
     }
 
+    /// Full set for dev: base + experimental delegation capabilities.
+    fn expected_dev_builtin_ids() -> BTreeSet<&'static str> {
+        let mut ids = expected_core_builtin_ids();
+        ids.insert("agent_handoff");
+        ids.insert("a2a_agent_delegation");
+        ids
+    }
+
     fn registry_ids(registry: &CapabilityRegistry) -> BTreeSet<&str> {
         registry.capabilities.keys().map(String::as_str).collect()
     }
@@ -2067,19 +2083,44 @@ mod tests {
 
     #[test]
     fn test_capability_registry_with_builtins_dev() {
-        // Dev mode includes all built-in capabilities
+        // Dev mode includes all built-in capabilities including experimental delegation
+        unsafe { std::env::remove_var("FEATURE_AGENT_DELEGATION") };
         let registry = CapabilityRegistry::with_builtins_for_grade(DeploymentGrade::Dev);
-
-        assert_eq!(registry_ids(&registry), expected_core_builtin_ids());
+        assert_eq!(registry_ids(&registry), expected_dev_builtin_ids());
+        assert!(registry.has("agent_handoff"));
+        assert!(registry.has("a2a_agent_delegation"));
     }
 
     #[test]
     fn test_capability_registry_with_builtins_prod() {
-        // Prod mode excludes experimental capabilities
+        // Prod mode excludes experimental capabilities including delegation
+        unsafe { std::env::remove_var("FEATURE_AGENT_DELEGATION") };
         let registry = CapabilityRegistry::with_builtins_for_grade(DeploymentGrade::Prod);
         assert_eq!(registry_ids(&registry), expected_core_builtin_ids());
         // Experimental capabilities NOT included in prod
         assert!(!registry.has("docker_container"));
+        assert!(!registry.has("agent_handoff"));
+        assert!(!registry.has("a2a_agent_delegation"));
+    }
+
+    #[test]
+    fn test_agent_delegation_enabled_by_env_in_prod() {
+        // FEATURE_AGENT_DELEGATION=true enables delegation caps even in prod
+        unsafe { std::env::set_var("FEATURE_AGENT_DELEGATION", "true") };
+        let registry = CapabilityRegistry::with_builtins_for_grade(DeploymentGrade::Prod);
+        assert!(registry.has("agent_handoff"));
+        assert!(registry.has("a2a_agent_delegation"));
+        unsafe { std::env::remove_var("FEATURE_AGENT_DELEGATION") };
+    }
+
+    #[test]
+    fn test_agent_delegation_disabled_by_env_in_dev() {
+        // FEATURE_AGENT_DELEGATION=false disables delegation caps even in dev
+        unsafe { std::env::set_var("FEATURE_AGENT_DELEGATION", "false") };
+        let registry = CapabilityRegistry::with_builtins_for_grade(DeploymentGrade::Dev);
+        assert!(!registry.has("agent_handoff"));
+        assert!(!registry.has("a2a_agent_delegation"));
+        unsafe { std::env::remove_var("FEATURE_AGENT_DELEGATION") };
     }
 
     #[test]

--- a/crates/core/src/feature_flags.rs
+++ b/crates/core/src/feature_flags.rs
@@ -37,6 +37,10 @@ pub struct FeatureFlags {
     /// Channels-first app detail page and full-page channel forms. Experimental.
     #[serde(rename = "apps.detailV2")]
     pub apps_detail_v2: bool,
+    /// Outbound agent delegation capabilities (`a2a_agent_delegation`, `agent_handoff`).
+    /// Experimental: auto-enabled in dev, off in prod by default.
+    /// When off, these capabilities are not registered and cannot be assigned to agents.
+    pub agent_delegation: bool,
 }
 
 impl FeatureFlags {
@@ -51,6 +55,7 @@ impl FeatureFlags {
             agent_versions: experimental_flag("FEATURE_AGENT_VERSIONS", grade),
             voice: experimental_flag("FEATURE_VOICE", grade),
             apps_detail_v2: experimental_flag("FEATURE_APPS_DETAIL_V2", grade),
+            agent_delegation: experimental_flag("FEATURE_AGENT_DELEGATION", grade),
         }
     }
 
@@ -71,6 +76,7 @@ impl FeatureFlags {
             "agent_versions" => self.agent_versions,
             "voice" => self.voice,
             "apps.detailV2" => self.apps_detail_v2,
+            "agent_delegation" => self.agent_delegation,
             _ => false,
         }
     }
@@ -87,6 +93,7 @@ impl FeatureFlags {
             agent_versions: true,
             voice: true,
             apps_detail_v2: true,
+            agent_delegation: true,
         }
     }
 }
@@ -222,6 +229,7 @@ mod tests {
             agent_versions: true,
             voice: true,
             apps_detail_v2: true,
+            agent_delegation: true,
         };
         assert!(flags.is_enabled("global_chat"));
         assert!(flags.is_enabled("notifications"));
@@ -231,6 +239,7 @@ mod tests {
         assert!(flags.is_enabled("agent_versions"));
         assert!(flags.is_enabled("voice"));
         assert!(flags.is_enabled("apps.detailV2"));
+        assert!(flags.is_enabled("agent_delegation"));
         assert!(!flags.is_enabled("nonexistent"));
     }
 
@@ -245,6 +254,7 @@ mod tests {
             agent_versions: true,
             voice: true,
             apps_detail_v2: true,
+            agent_delegation: true,
         };
         let json = serde_json::to_string(&flags).unwrap();
         assert!(json.contains("\"global_chat\":true"));
@@ -253,9 +263,35 @@ mod tests {
         assert!(json.contains("\"agent_versions\":true"));
         assert!(json.contains("\"voice\":true"));
         assert!(json.contains("\"apps.detailV2\":true"));
+        assert!(json.contains("\"agent_delegation\":true"));
 
         let parsed: FeatureFlags = serde_json::from_str(&json).unwrap();
         assert_eq!(flags, parsed);
+    }
+
+    #[test]
+    fn test_agent_delegation_enabled_in_dev() {
+        let _lock = lock_env();
+        unsafe { std::env::remove_var("FEATURE_AGENT_DELEGATION") };
+        let flags = FeatureFlags::from_env(&DeploymentGrade::Dev);
+        assert!(flags.agent_delegation);
+    }
+
+    #[test]
+    fn test_agent_delegation_disabled_in_prod() {
+        let _lock = lock_env();
+        unsafe { std::env::remove_var("FEATURE_AGENT_DELEGATION") };
+        let flags = FeatureFlags::from_env(&DeploymentGrade::Prod);
+        assert!(!flags.agent_delegation);
+    }
+
+    #[test]
+    fn test_agent_delegation_env_override_in_prod() {
+        let _lock = lock_env();
+        unsafe { std::env::set_var("FEATURE_AGENT_DELEGATION", "true") };
+        let flags = FeatureFlags::from_env(&DeploymentGrade::Prod);
+        assert!(flags.agent_delegation);
+        unsafe { std::env::remove_var("FEATURE_AGENT_DELEGATION") };
     }
 
     #[test]

--- a/specs/capabilities.md
+++ b/specs/capabilities.md
@@ -88,6 +88,12 @@ gate. It is distinct from subagents and blueprints because the target is a
 normal Agent resource, not inherited runtime config and not a code-defined
 template. See [agent-handoff.md](agent-handoff.md).
 
+Both `agent_handoff` and `a2a_agent_delegation` are gated behind the
+`agent_delegation` feature flag (experimental, auto-enabled in dev, off in prod).
+When the flag is off, neither capability is registered and neither appears in the
+capability picker. Enable via `FEATURE_AGENT_DELEGATION=true` or use a
+`DeploymentGrade::Dev` environment. See `specs/feature-flags.md` and EVE-506.
+
 ### Architecture
 
 Capabilities are defined in **everruns-core** and resolved at the **API layer**:

--- a/specs/feature-flags.md
+++ b/specs/feature-flags.md
@@ -45,6 +45,7 @@ Current API-visible experimental flags include:
 
 - `agent_versions`: gates immutable Agent snapshots, forks, rollback, version diffs, and App version binding. See `specs/agent-versions.md`.
 - `apps.detailV2`: gates the channels-first App detail page and full-page channel New/Edit routes. Env var: `FEATURE_APPS_DETAIL_V2`.
+- `agent_delegation`: gates outbound agent delegation capabilities (`a2a_agent_delegation`, `agent_handoff`). When off, these capabilities are not registered in the backend and are absent from the capability picker. Env var: `FEATURE_AGENT_DELEGATION`. See EVE-506.
 
 ## Architecture
 


### PR DESCRIPTION
## What
Gate `a2a_agent_delegation` and `agent_handoff` behind a new `FEATURE_AGENT_DELEGATION` feature flag. Experimental: auto-enabled in `DeploymentGrade::Dev`, off in prod by default.

## Why
Under open signup the `OrgRole::Admin` gate is meaningless (every signup self-admins). These capabilities enable outbound calls to external agents (exfil, SSRF-adjacent reach, cost/recursion fan-out). EVE-506.

## How
- Add `agent_delegation: bool` to `FeatureFlags` (API-visible via `GET /v1/feature-flags`)
- Gate `AgentHandoffCapability` and `A2aAgentDelegationCapability` in `with_builtins_for_grade()` — when off, neither is registered
- Add `agent_delegation` to TypeScript `FeatureFlags` interface and `DEFAULT_FLAGS` (defaults to `false`)
- Update `specs/feature-flags.md` and `specs/capabilities.md`

## Risk
Low. Additive flag gate. Existing dev deployments continue working. Prod deployments no longer register these two capabilities by default.

## Security
- Threat categories reviewed: TM-AUTHZ, TM-TOOL, TM-TENANT
- Closes the open-signup bypass for high-risk outbound delegation tools

## Test plan
- [x] `test_agent_delegation_enabled_in_dev` — flag auto-on in dev
- [x] `test_agent_delegation_disabled_in_prod` — flag off in prod
- [x] `test_agent_delegation_env_override_in_prod` — `FEATURE_AGENT_DELEGATION=true` enables in prod
- [x] `test_agent_delegation_enabled_by_env_in_prod` — registry includes caps when flag is on
- [x] `test_agent_delegation_disabled_by_env_in_dev` — registry excludes caps when flag is off
- [x] Updated `test_capability_registry_with_builtins_dev` and `test_capability_registry_with_builtins_prod`
- [x] `cargo clippy` and `cargo fmt --check` clean

## Follow-ups
None.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fszn8mHhG7EbyFQB6dGxys)_