### PR TITLE
feat(apps): enforce schedule channel rate limits (EVE-507)

### DIFF
--- a/crates/server/src/domains/apps/commands.rs
+++ b/crates/server/src/domains/apps/commands.rs
@@ -181,6 +181,24 @@ fn durable_store(ctx: &Ctx) -> Result<&Arc<dyn WorkflowEventStore + Send + Sync>
     })
 }
 
+/// Minimum seconds between consecutive schedule-channel triggers.
+/// Configurable via `SCHEDULE_CHANNEL_MIN_INTERVAL_SECONDS`; default 300 (5 min).
+fn schedule_channel_min_interval_seconds() -> i64 {
+    std::env::var("SCHEDULE_CHANNEL_MIN_INTERVAL_SECONDS")
+        .ok()
+        .and_then(|v| v.parse::<i64>().ok())
+        .unwrap_or(300)
+}
+
+/// Maximum number of enabled schedule channels per org.
+/// Configurable via `SCHEDULE_CHANNEL_MAX_PER_ORG`; default 10.
+fn schedule_channel_max_per_org() -> i64 {
+    std::env::var("SCHEDULE_CHANNEL_MAX_PER_ORG")
+        .ok()
+        .and_then(|v| v.parse::<i64>().ok())
+        .unwrap_or(10)
+}
+
 fn normalize_cron_expression(cron_expression: &str) -> Result<String, CommandError> {
     let fields = cron_expression.split_whitespace().collect::<Vec<_>>();
     let normalized = match fields.len() {
@@ -198,6 +216,19 @@ fn normalize_cron_expression(cron_expression: &str) -> Result<String, CommandErr
         ))
     })?;
     Ok(normalized)
+}
+
+/// Returns the minimum interval in seconds between the next few consecutive
+/// triggers of `schedule`. Returns None when fewer than 2 upcoming times exist.
+fn cron_min_interval_seconds(schedule: &cron::Schedule) -> Option<i64> {
+    let upcoming: Vec<_> = schedule.upcoming(Utc).take(3).collect();
+    if upcoming.len() < 2 {
+        return None;
+    }
+    upcoming
+        .windows(2)
+        .map(|w| (w[1] - w[0]).num_seconds())
+        .min()
 }
 
 fn normalize_and_validate_channel_config(
@@ -282,6 +313,17 @@ fn normalize_and_validate_channel_config(
                 ));
             }
             let normalized = normalize_cron_expression(&config.cron_expression)?;
+            // Enforce minimum cron interval.
+            let schedule = cron::Schedule::from_str(&normalized).expect("already validated");
+            let min_limit = schedule_channel_min_interval_seconds();
+            if let Some(interval) = cron_min_interval_seconds(&schedule)
+                && interval < min_limit
+            {
+                return Err(CommandError::bad_request(format!(
+                    "Schedule channel cron must fire no more than once every {min_limit} seconds (≥ {} min); expression fires every {interval} seconds",
+                    min_limit / 60
+                )));
+            }
             if let Some(map) = channel_config.as_object_mut() {
                 map.insert("cron_expression".to_string(), Value::String(normalized));
             }
@@ -2638,6 +2680,20 @@ impl Command for AddChannel {
 
         if self.req.channel_type == ChannelType::Schedule {
             let _ = durable_store(ctx)?;
+            let enabled = self.req.enabled.unwrap_or(true);
+            if enabled {
+                let count = ctx
+                    .db
+                    .count_enabled_schedule_channels_for_org(ctx.org_id())
+                    .await
+                    .map_err(classify_anyhow)?;
+                let max = schedule_channel_max_per_org();
+                if count >= max {
+                    return Err(CommandError::bad_request(format!(
+                        "Organization may have at most {max} enabled schedule channel(s); currently has {count}"
+                    )));
+                }
+            }
         }
 
         let channel_config = normalize_and_validate_channel_config(
@@ -3180,6 +3236,20 @@ impl Command for UpdateChannelCmd {
         );
         if final_channel_type == ChannelType::Schedule {
             let _ = durable_store(ctx)?;
+            // Enforce max enabled schedule channels per org when enabling a previously-disabled channel.
+            if self.req.enabled == Some(true) && !channel_row.enabled {
+                let count = ctx
+                    .db
+                    .count_enabled_schedule_channels_for_org(ctx.org_id())
+                    .await
+                    .map_err(classify_anyhow)?;
+                let max = schedule_channel_max_per_org();
+                if count >= max {
+                    return Err(CommandError::bad_request(format!(
+                        "Organization may have at most {max} enabled schedule channel(s); currently has {count}"
+                    )));
+                }
+            }
         }
         let normalized_channel_config =
             normalize_and_validate_channel_config(final_channel_type, final_channel_config)?;
@@ -3371,6 +3441,67 @@ mod tests {
     fn parse_run_history_window_rejects_overflowing_amount() {
         let err = parse_run_history_window(Some("9223372036854775807d"))
             .expect_err("overflowing window should fail");
+        assert!(matches!(err.kind, CommandErrorKind::BadRequest(_)));
+    }
+
+    // ---- schedule channel validation -----------------------------------------
+
+    #[test]
+    fn schedule_min_interval_default_is_300() {
+        // Safety: single-threaded test; no concurrent env mutation.
+        unsafe { std::env::remove_var("SCHEDULE_CHANNEL_MIN_INTERVAL_SECONDS") };
+        assert_eq!(schedule_channel_min_interval_seconds(), 300);
+    }
+
+    #[test]
+    fn cron_min_interval_every_5_min() {
+        // "0 */5 * * * *" fires every 5 minutes = 300 s.
+        let schedule = cron::Schedule::from_str("0 */5 * * * *").expect("valid cron");
+        let interval = cron_min_interval_seconds(&schedule).expect("interval exists");
+        assert_eq!(interval, 300);
+    }
+
+    #[test]
+    fn cron_min_interval_every_minute() {
+        // "0 * * * * *" fires every 60 s.
+        let schedule = cron::Schedule::from_str("0 * * * * *").expect("valid cron");
+        let interval = cron_min_interval_seconds(&schedule).expect("interval exists");
+        assert_eq!(interval, 60);
+    }
+
+    #[test]
+    fn schedule_channel_rejects_too_frequent_cron() {
+        // "0 * * * * *" = every minute (60 s) < 300 s default limit.
+        let config = json!({
+            "cron_expression": "* * * * *",
+            "message": "tick"
+        });
+        let err = normalize_and_validate_channel_config(ChannelType::Schedule, config)
+            .expect_err("should reject sub-5-min cron");
+        assert!(matches!(err.kind, CommandErrorKind::BadRequest(_)));
+    }
+
+    #[test]
+    fn schedule_channel_accepts_5_min_cron() {
+        // "*/5 * * * *" = every 5 minutes (300 s) — at the default limit.
+        // Safety: single-threaded test; no concurrent env mutation.
+        unsafe { std::env::remove_var("SCHEDULE_CHANNEL_MIN_INTERVAL_SECONDS") };
+        let config = json!({
+            "cron_expression": "*/5 * * * *",
+            "message": "ping"
+        });
+        normalize_and_validate_channel_config(ChannelType::Schedule, config)
+            .expect("5-min cron should be accepted");
+    }
+
+    #[test]
+    fn schedule_channel_rejects_empty_message() {
+        let config = json!({
+            "cron_expression": "0 */5 * * * *",
+            "message": "   "
+        });
+        let err = normalize_and_validate_channel_config(ChannelType::Schedule, config)
+            .expect_err("empty message should fail");
         assert!(matches!(err.kind, CommandErrorKind::BadRequest(_)));
     }
 }

--- a/crates/server/src/domains/apps/commands.rs
+++ b/crates/server/src/domains/apps/commands.rs
@@ -184,19 +184,23 @@ fn durable_store(ctx: &Ctx) -> Result<&Arc<dyn WorkflowEventStore + Send + Sync>
 /// Minimum seconds between consecutive schedule-channel triggers.
 /// Configurable via `SCHEDULE_CHANNEL_MIN_INTERVAL_SECONDS`; default 300 (5 min).
 fn schedule_channel_min_interval_seconds() -> i64 {
+    const DEFAULT: i64 = 300;
     std::env::var("SCHEDULE_CHANNEL_MIN_INTERVAL_SECONDS")
         .ok()
         .and_then(|v| v.parse::<i64>().ok())
-        .unwrap_or(300)
+        .filter(|&v| v > 0)
+        .unwrap_or(DEFAULT)
 }
 
 /// Maximum number of enabled schedule channels per org.
 /// Configurable via `SCHEDULE_CHANNEL_MAX_PER_ORG`; default 10.
 fn schedule_channel_max_per_org() -> i64 {
+    const DEFAULT: i64 = 10;
     std::env::var("SCHEDULE_CHANNEL_MAX_PER_ORG")
         .ok()
         .and_then(|v| v.parse::<i64>().ok())
-        .unwrap_or(10)
+        .filter(|&v| v > 0)
+        .unwrap_or(DEFAULT)
 }
 
 fn normalize_cron_expression(cron_expression: &str) -> Result<String, CommandError> {
@@ -1636,6 +1640,20 @@ impl Command for CreateApp {
         if let Some(channel_type) = channel_type.clone() {
             if channel_type == ChannelType::Schedule {
                 let _ = durable_store(ctx)?;
+                // Soft cap: count then create (TOCTOU window is intentional — this is a
+                // noisy-neighbor limit, not a hard security boundary; strict serialization
+                // is not worth the complexity).
+                let count = ctx
+                    .db
+                    .count_enabled_schedule_channels_for_org(ctx.org_id())
+                    .await
+                    .map_err(classify_anyhow)?;
+                let max = schedule_channel_max_per_org();
+                if count >= max {
+                    return Err(CommandError::bad_request(format!(
+                        "Organization may have at most {max} enabled schedule channel(s); currently has {count}"
+                    )));
+                }
             }
             channel_config = normalize_and_validate_channel_config(channel_type, channel_config)?;
         }
@@ -2682,6 +2700,7 @@ impl Command for AddChannel {
             let _ = durable_store(ctx)?;
             let enabled = self.req.enabled.unwrap_or(true);
             if enabled {
+                // Soft cap — TOCTOU window acceptable for a noisy-neighbor limit.
                 let count = ctx
                     .db
                     .count_enabled_schedule_channels_for_org(ctx.org_id())
@@ -3216,7 +3235,7 @@ impl Command for UpdateChannelCmd {
             .req
             .channel_type
             .clone()
-            .unwrap_or(current_channel_type);
+            .unwrap_or(current_channel_type.clone());
         let existing_decrypted = q::decrypt_channel_config(
             encryption,
             channel_row.channel_config_encrypted.as_deref(),
@@ -3236,8 +3255,14 @@ impl Command for UpdateChannelCmd {
         );
         if final_channel_type == ChannelType::Schedule {
             let _ = durable_store(ctx)?;
-            // Enforce max enabled schedule channels per org when enabling a previously-disabled channel.
-            if self.req.enabled == Some(true) && !channel_row.enabled {
+            // Check cap whenever this PATCH would result in a new enabled schedule channel
+            // that wasn't already one — covers both disabled→enabled and
+            // non-schedule-type→schedule-type while remaining enabled.
+            // Soft cap — TOCTOU window acceptable for a noisy-neighbor limit.
+            let final_enabled = self.req.enabled.unwrap_or(channel_row.enabled);
+            let was_enabled_schedule =
+                current_channel_type == ChannelType::Schedule && channel_row.enabled;
+            if final_enabled && !was_enabled_schedule {
                 let count = ctx
                     .db
                     .count_enabled_schedule_channels_for_org(ctx.org_id())
@@ -3372,6 +3397,12 @@ mod tests {
     use super::*;
     use everruns_core::typed_id::{AppChannelId, HarnessId, PrincipalId};
 
+    // Serialize env-mutating tests to prevent concurrent remove_var / read_var races.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    fn lock_env() -> std::sync::MutexGuard<'static, ()> {
+        ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
     fn test_app_and_channel() -> (App, AppChannel) {
         let now = Utc::now();
         let channel = AppChannel {
@@ -3448,7 +3479,8 @@ mod tests {
 
     #[test]
     fn schedule_min_interval_default_is_300() {
-        // Safety: single-threaded test; no concurrent env mutation.
+        let _lock = lock_env();
+        // Safety: ENV_LOCK serializes all env-mutating tests in this module.
         unsafe { std::env::remove_var("SCHEDULE_CHANNEL_MIN_INTERVAL_SECONDS") };
         assert_eq!(schedule_channel_min_interval_seconds(), 300);
     }
@@ -3483,8 +3515,9 @@ mod tests {
 
     #[test]
     fn schedule_channel_accepts_5_min_cron() {
+        let _lock = lock_env();
         // "*/5 * * * *" = every 5 minutes (300 s) — at the default limit.
-        // Safety: single-threaded test; no concurrent env mutation.
+        // Safety: ENV_LOCK serializes all env-mutating tests in this module.
         unsafe { std::env::remove_var("SCHEDULE_CHANNEL_MIN_INTERVAL_SECONDS") };
         let config = json!({
             "cron_expression": "*/5 * * * *",
@@ -3503,5 +3536,31 @@ mod tests {
         let err = normalize_and_validate_channel_config(ChannelType::Schedule, config)
             .expect_err("empty message should fail");
         assert!(matches!(err.kind, CommandErrorKind::BadRequest(_)));
+    }
+
+    #[test]
+    fn schedule_min_interval_rejects_zero_env() {
+        let _lock = lock_env();
+        // Safety: ENV_LOCK serializes all env-mutating tests in this module.
+        unsafe { std::env::set_var("SCHEDULE_CHANNEL_MIN_INTERVAL_SECONDS", "0") };
+        assert_eq!(
+            schedule_channel_min_interval_seconds(),
+            300,
+            "zero should fall back to default"
+        );
+        unsafe { std::env::remove_var("SCHEDULE_CHANNEL_MIN_INTERVAL_SECONDS") };
+    }
+
+    #[test]
+    fn schedule_max_per_org_rejects_zero_env() {
+        let _lock = lock_env();
+        // Safety: ENV_LOCK serializes all env-mutating tests in this module.
+        unsafe { std::env::set_var("SCHEDULE_CHANNEL_MAX_PER_ORG", "0") };
+        assert_eq!(
+            schedule_channel_max_per_org(),
+            10,
+            "zero should fall back to default"
+        );
+        unsafe { std::env::remove_var("SCHEDULE_CHANNEL_MAX_PER_ORG") };
     }
 }

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -2720,6 +2720,10 @@ impl StorageBackend {
         dispatch!(self, delete_app_channel, id)
     }
 
+    pub async fn count_enabled_schedule_channels_for_org(&self, org_id: i64) -> Result<i64> {
+        dispatch!(self, count_enabled_schedule_channels_for_org, org_id)
+    }
+
     // ============================================
     // Eval CRUD
     // ============================================

--- a/crates/server/src/storage/memory/app_channels.rs
+++ b/crates/server/src/storage/memory/app_channels.rs
@@ -90,4 +90,21 @@ impl InMemoryDatabase {
         let mut channels = self.app_channels.write();
         Ok(channels.remove(&id).is_some())
     }
+
+    pub async fn count_enabled_schedule_channels_for_org(&self, org_id: i64) -> Result<i64> {
+        let apps = self.apps.read();
+        let channels = self.app_channels.read();
+        let org_app_ids: std::collections::HashSet<Uuid> = apps
+            .values()
+            .filter(|a| a.org_id == org_id)
+            .map(|a| a.id)
+            .collect();
+        let count = channels
+            .values()
+            .filter(|ch| {
+                org_app_ids.contains(&ch.app_id) && ch.channel_type == "schedule" && ch.enabled
+            })
+            .count();
+        Ok(count as i64)
+    }
 }

--- a/crates/server/src/storage/repositories/app_channels.rs
+++ b/crates/server/src/storage/repositories/app_channels.rs
@@ -126,4 +126,20 @@ impl Database {
 
         Ok(result.rows_affected() > 0)
     }
+
+    pub async fn count_enabled_schedule_channels_for_org(&self, org_id: i64) -> Result<i64> {
+        let count = sqlx::query_scalar::<_, i64>(
+            r#"
+            SELECT COUNT(*)
+            FROM app_channels ac
+            JOIN apps a ON ac.app_id = a.id
+            WHERE a.org_id = $1 AND ac.channel_type = 'schedule' AND ac.enabled = true
+            "#,
+        )
+        .bind(org_id)
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(count)
+    }
 }

--- a/specs/app-invocation-channels.md
+++ b/specs/app-invocation-channels.md
@@ -144,6 +144,16 @@ Behavior:
 
 The durable scheduler only knows how to fire `invoke_scheduled_app_channel`. All app-specific resolution happens in the app domain at execution time.
 
+Limits:
+
+- Minimum cron interval: 300 seconds (5 minutes) by default; configurable via
+  `SCHEDULE_CHANNEL_MIN_INTERVAL_SECONDS`. Create/update rejects expressions
+  that would fire more frequently.
+- Maximum enabled schedule channels per org: 10 by default; configurable via
+  `SCHEDULE_CHANNEL_MAX_PER_ORG`. Enabling a channel (create with
+  `enabled=true`, or update from disabled to enabled) is rejected when the
+  org is already at the cap.
+
 ## Webhook Channel
 
 Config fields:

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -639,7 +639,7 @@ All `/v1/durable/*` HTTP endpoints require explicit platform-user auth. The auth
 
 | ID | Threat | Severity | Mitigation | Status |
 |----|--------|----------|------------|--------|
-| TM-SCHED-001 | Malicious schedule creation | Medium | Only platform users can create or manage durable schedules | MITIGATED |
+| TM-SCHED-001 | Malicious schedule creation / resource abuse | Medium | Only platform users can create or manage durable schedules; schedule channels enforce a minimum cron interval (`SCHEDULE_CHANNEL_MIN_INTERVAL_SECONDS`, default 300 s) and an org-level cap on enabled schedule channels (`SCHEDULE_CHANNEL_MAX_PER_ORG`, default 10) | MITIGATED |
 | TM-SCHED-002 | Catch-up explosion on restart | High | `max_catch_up` limits catch-up runs (default: 1); prevents hundreds of executions on restart | MITIGATED |
 | TM-SCHED-003 | Concurrent execution overload | Medium | `max_concurrent` field enforced; trigger skipped if limit reached | MITIGATED |
 | TM-SCHED-004 | Invalid cron expression DoS | Low | Cron parser validates expression at creation time; invalid expressions rejected | MITIGATED |


### PR DESCRIPTION
## What
Enforce two safety limits on app schedule channels:
- **Minimum cron interval**: reject expressions that fire more than once every 5 minutes (configurable via `SCHEDULE_CHANNEL_MIN_INTERVAL_SECONDS`, default 300 s).
- **Max enabled schedule channels per org**: cap at 10 (configurable via `SCHEDULE_CHANNEL_MAX_PER_ORG`, default 10). Enforced on `AddChannel` (enabled=true) and on `UpdateChannel` when transitioning from disabled → enabled.

## Why
Without these limits, a single org can saturate the durable scheduler with a sub-minute cron, or with an arbitrary number of concurrent schedule channels, causing resource exhaustion and noisy-neighbor effects.

## How
- `normalize_and_validate_channel_config()` now validates the cron interval for `ChannelType::Schedule` using `cron::Schedule::upcoming()` to compute the minimum gap between the next 3 triggers.
- `AddChannel::execute()` and `UpdateChannelCmd::execute()` call the new `count_enabled_schedule_channels_for_org()` storage method before persisting an enabled schedule channel.
- Storage: new method added to both PostgreSQL (`repositories/app_channels.rs`) and in-memory (`memory/app_channels.rs`) backends, and dispatched via `backend.rs`.
- Specs updated: `specs/app-invocation-channels.md` documents the limits; `specs/threat-model.md` updates TM-SCHED-001.

## Risk
- Low
- Existing channels are unaffected; limits only fire on create/update. Both thresholds are configurable at deploy time so operations can tune them without a code change.

## Security
- Threat categories reviewed: TM-SCHED (Scheduled Tasks), TM-DOS
- Findings: TM-SCHED-001 (malicious schedule creation / resource abuse) — mitigated by min-interval and per-org cap. TM-DOS-016 (mass resource creation) — complementary; the existing rate limiter throttles request velocity while these limits bound total resource consumption.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Fszn8mHhG7EbyFQB6dGxys)_