### PR TITLE
feat(rate-limit): per-org outbound tool-call rate limiting (EVE-514)

### DIFF
--- a/crates/core/src/atoms/act.rs
+++ b/crates/core/src/atoms/act.rs
@@ -213,6 +213,10 @@ where
     budget_checker: Option<Arc<dyn crate::traits::BudgetChecker>>,
     /// Optional internal payment authority for paid capability tools.
     payment_authority: Option<Arc<dyn crate::traits::PaymentAuthority>>,
+    /// Optional per-org outbound tool-call rate limiter (TM-TOOL-009).
+    /// When present, each tool call increments the org counter; calls that
+    /// exceed the per-org window return a tool error rather than a hard failure.
+    outbound_tool_rate_limiter: Option<Arc<dyn crate::traits::OutboundToolRateLimiter>>,
     /// Post-act hooks that run after tool execution completes.
     /// Hooks inspect the result and may emit events (e.g. tool.call_requested).
     hooks: Vec<Box<dyn PostActHook>>,
@@ -265,6 +269,7 @@ where
             network_access: None,
             budget_checker: None,
             payment_authority: None,
+            outbound_tool_rate_limiter: None,
             hooks: Self::default_hooks(),
             post_tool_hooks: Vec::new(),
             pre_tool_hooks: Vec::new(),
@@ -304,6 +309,7 @@ where
             network_access: None,
             budget_checker: None,
             payment_authority: None,
+            outbound_tool_rate_limiter: None,
             hooks: Self::default_hooks(),
             post_tool_hooks: Vec::new(),
             pre_tool_hooks: Vec::new(),
@@ -518,6 +524,15 @@ where
         authority: Arc<dyn crate::traits::PaymentAuthority>,
     ) -> Self {
         self.payment_authority = Some(authority);
+        self
+    }
+
+    /// Set the per-org outbound tool-call rate limiter (TM-TOOL-009).
+    pub fn with_outbound_tool_rate_limiter(
+        mut self,
+        limiter: Arc<dyn crate::traits::OutboundToolRateLimiter>,
+    ) -> Self {
+        self.outbound_tool_rate_limiter = Some(limiter);
         self
     }
 }
@@ -1061,6 +1076,36 @@ where
         tool_context.tool_call_id = Some(tool_call.id.clone());
 
         let execution_tool_call = self.transform_tool_call_for_execution(tool_call.clone());
+
+        // Per-org outbound tool-call rate limiting (TM-TOOL-009).
+        // Checked before hooks so rate-limited calls never reach executors.
+        // Returns a tool error (not a hard turn failure) so the LLM can back off.
+        if let (Some(limiter), Some(ref org_id)) = (&self.outbound_tool_rate_limiter, self.org_id)
+            && !limiter.check_org(org_id).await
+        {
+            tracing::warn!(
+                session_id = %context.session_id,
+                tool_name = %execution_tool_call.name,
+                "ActAtom: outbound tool rate limit exceeded for org"
+            );
+            return ToolCallResult {
+                tool_call: tool_call.clone(),
+                result: ToolResult {
+                    tool_call_id: execution_tool_call.id.clone(),
+                    result: None,
+                    images: None,
+                    error: Some(
+                        "Outbound tool rate limit exceeded for this organization; back off and retry later.".to_string(),
+                    ),
+                    connection_required: None,
+                    raw_output: None,
+                },
+                success: false,
+                status: "error".to_string(),
+                connection_required: None,
+            };
+        }
+
         // Run pre-tool-use hooks (capability-contributed). They can mutate
         // the tool call or block execution entirely. First Block wins; the
         // tool is not invoked, and the synthetic error result flows through
@@ -2066,5 +2111,122 @@ mod tests {
 
         assert!(!parsed.waiting_for_tool_results);
         assert!(parsed.client_tool_calls.is_empty());
+    }
+
+    /// Verify that a denying `OutboundToolRateLimiter` short-circuits tool execution
+    /// and returns a rate-limit error result rather than calling the actual tool.
+    #[tokio::test]
+    async fn test_outbound_tool_rate_limiter_blocks_execution() {
+        use crate::typed_id::OrgId;
+
+        struct DenyAll;
+        #[async_trait]
+        impl crate::traits::OutboundToolRateLimiter for DenyAll {
+            async fn check_org(&self, _org_id: &OrgId) -> bool {
+                false
+            }
+        }
+
+        let mut executor = ToolRegistry::with_defaults();
+        executor.register(ArgumentEchoTool);
+        let atom = ActAtom::new(executor, NoopEventEmitter)
+            .with_org_id(OrgId::from_seed(1))
+            .with_outbound_tool_rate_limiter(Arc::new(DenyAll));
+
+        let context = AtomContext::new(SessionId::new(), TurnId::new(), MessageId::new());
+        let input = ActInput {
+            org_id: Some(1),
+            context,
+            harness_id: HarnessId::from_seed(1),
+            agent_id: Some(AgentId::new()),
+            tool_calls: vec![ToolCall {
+                id: "call_1".to_string(),
+                name: "argument_echo".to_string(),
+                arguments: json!({"value": "should_not_reach"}),
+            }],
+            tool_definitions: vec![ToolDefinition::Builtin(crate::BuiltinTool {
+                name: "argument_echo".to_string(),
+                display_name: None,
+                description: "echo".to_string(),
+                parameters: json!({"type": "object"}),
+                policy: Default::default(),
+                category: None,
+                deferrable: Default::default(),
+                hints: crate::tool_types::ToolHints::default(),
+            })],
+            locale: None,
+            blueprint_id: None,
+            network_access: None,
+            parallel_tool_calls: None,
+        };
+
+        let result = atom.execute(input).await.unwrap();
+
+        assert_eq!(result.success_count, 0);
+        assert_eq!(result.error_count, 1);
+        let tool_result = &result.results[0];
+        assert!(!tool_result.success);
+        assert_eq!(tool_result.status, "error");
+        assert!(
+            tool_result
+                .result
+                .error
+                .as_deref()
+                .unwrap_or("")
+                .contains("rate limit exceeded")
+        );
+        assert!(tool_result.result.result.is_none());
+    }
+
+    /// Verify that an allowing `OutboundToolRateLimiter` does not block execution.
+    #[tokio::test]
+    async fn test_outbound_tool_rate_limiter_allows_execution() {
+        use crate::typed_id::OrgId;
+
+        struct AllowAll;
+        #[async_trait]
+        impl crate::traits::OutboundToolRateLimiter for AllowAll {
+            async fn check_org(&self, _org_id: &OrgId) -> bool {
+                true
+            }
+        }
+
+        let mut executor = ToolRegistry::with_defaults();
+        executor.register(ArgumentEchoTool);
+        let atom = ActAtom::new(executor, NoopEventEmitter)
+            .with_org_id(OrgId::from_seed(1))
+            .with_outbound_tool_rate_limiter(Arc::new(AllowAll));
+
+        let context = AtomContext::new(SessionId::new(), TurnId::new(), MessageId::new());
+        let input = ActInput {
+            org_id: Some(1),
+            context,
+            harness_id: HarnessId::from_seed(1),
+            agent_id: Some(AgentId::new()),
+            tool_calls: vec![ToolCall {
+                id: "call_1".to_string(),
+                name: "argument_echo".to_string(),
+                arguments: json!({"value": "hello"}),
+            }],
+            tool_definitions: vec![ToolDefinition::Builtin(crate::BuiltinTool {
+                name: "argument_echo".to_string(),
+                display_name: None,
+                description: "echo".to_string(),
+                parameters: json!({"type": "object"}),
+                policy: Default::default(),
+                category: None,
+                deferrable: Default::default(),
+                hints: crate::tool_types::ToolHints::default(),
+            })],
+            locale: None,
+            blueprint_id: None,
+            network_access: None,
+            parallel_tool_calls: None,
+        };
+
+        let result = atom.execute(input).await.unwrap();
+
+        assert_eq!(result.success_count, 1);
+        assert_eq!(result.error_count, 0);
     }
 }

--- a/crates/core/src/atoms/act.rs
+++ b/crates/core/src/atoms/act.rs
@@ -919,6 +919,35 @@ where
                 .map(|(id, name)| (id.to_string(), name.map(str::to_string)))
         });
 
+        // Per-org outbound tool-call rate limiting (TM-TOOL-009).
+        // Checked before tool.started so a denied call emits no events and leaves
+        // no unmatched started/completed pair in UI or telemetry.
+        if let (Some(limiter), Some(ref org_id)) = (&self.outbound_tool_rate_limiter, self.org_id)
+            && !limiter.check_org(org_id).await
+        {
+            tracing::warn!(
+                session_id = %context.session_id,
+                tool_name = %tool_call.name,
+                "ActAtom: outbound tool rate limit exceeded for org"
+            );
+            return ToolCallResult {
+                tool_call: tool_call.clone(),
+                result: ToolResult {
+                    tool_call_id: tool_call.id.clone(),
+                    result: None,
+                    images: None,
+                    error: Some(
+                        "Outbound tool rate limit exceeded for this organization; back off and retry later.".to_string(),
+                    ),
+                    connection_required: None,
+                    raw_output: None,
+                },
+                success: false,
+                status: "error".to_string(),
+                connection_required: None,
+            };
+        }
+
         // Emit tool.started event (child of act.started)
         if let Err(e) = self
             .event_emitter
@@ -1076,35 +1105,6 @@ where
         tool_context.tool_call_id = Some(tool_call.id.clone());
 
         let execution_tool_call = self.transform_tool_call_for_execution(tool_call.clone());
-
-        // Per-org outbound tool-call rate limiting (TM-TOOL-009).
-        // Checked before hooks so rate-limited calls never reach executors.
-        // Returns a tool error (not a hard turn failure) so the LLM can back off.
-        if let (Some(limiter), Some(ref org_id)) = (&self.outbound_tool_rate_limiter, self.org_id)
-            && !limiter.check_org(org_id).await
-        {
-            tracing::warn!(
-                session_id = %context.session_id,
-                tool_name = %execution_tool_call.name,
-                "ActAtom: outbound tool rate limit exceeded for org"
-            );
-            return ToolCallResult {
-                tool_call: tool_call.clone(),
-                result: ToolResult {
-                    tool_call_id: execution_tool_call.id.clone(),
-                    result: None,
-                    images: None,
-                    error: Some(
-                        "Outbound tool rate limit exceeded for this organization; back off and retry later.".to_string(),
-                    ),
-                    connection_required: None,
-                    raw_output: None,
-                },
-                success: false,
-                status: "error".to_string(),
-                connection_required: None,
-            };
-        }
 
         // Run pre-tool-use hooks (capability-contributed). They can mutate
         // the tool call or block execution entirely. First Block wins; the

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -185,10 +185,11 @@ pub use runtime_context::{
 };
 pub use traits::{
     DisabledSessionFileSystemFactory, EventEmitter, HarnessStore, ImageResolver, KeyInfo,
-    LeasedResourceStore, LlmProviderStore, ModelWithProvider, NoopEventEmitter, ResolvedImage,
-    SecretInfo, SessionFileStore, SessionFileSystem, SessionFileSystemFactory,
-    SessionFileSystemFactoryContext, SessionMutator, SessionResourceRegistry, SessionSqlDbStoreRef,
-    SessionStorageStore, SessionStore, ToolContext, ToolExecutor, UserConnectionResolver,
+    LeasedResourceStore, LlmProviderStore, ModelWithProvider, NoopEventEmitter,
+    OutboundToolRateLimiter, ResolvedImage, SecretInfo, SessionFileStore, SessionFileSystem,
+    SessionFileSystemFactory, SessionFileSystemFactoryContext, SessionMutator,
+    SessionResourceRegistry, SessionSqlDbStoreRef, SessionStorageStore, SessionStore, ToolContext,
+    ToolExecutor, UserConnectionResolver,
 };
 pub use user_facing_error::{
     UserFacingError, UserFacingErrorContext, UserFacingErrorFields, classify_runtime_error_message,

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -830,6 +830,21 @@ pub trait PaymentAuthority: Send + Sync {
     ) -> Result<crate::payment::MachinePaymentResponse>;
 }
 
+// OutboundToolRateLimiter - Per-org outbound tool-call rate limiting (TM-TOOL-009)
+// ============================================================================
+
+/// Per-org gate on outbound tool execution.
+///
+/// Returns `true` if the call is within the per-org budget, `false` if the
+/// org has exceeded its outbound tool rate limit for this window.
+/// Implementations must be fail-open: Valkey/backend errors should return `true`
+/// rather than blocking legitimate tool calls.
+#[async_trait]
+pub trait OutboundToolRateLimiter: Send + Sync {
+    /// Key by the public org UUID (keyed string representation).
+    async fn check_org(&self, org_id: &crate::typed_id::OrgId) -> bool;
+}
+
 /// Runtime context provided to tools during execution.
 ///
 /// This context contains:

--- a/crates/runtime/src/host.rs
+++ b/crates/runtime/src/host.rs
@@ -170,6 +170,15 @@ pub trait RuntimeHostAdapter: Send + Sync + Clone + 'static {
     ) -> Option<Arc<dyn PaymentAuthority>> {
         None
     }
+
+    /// Per-org outbound tool-call rate limiter (TM-TOOL-009).
+    /// Default: `None` (no rate limiting — suitable for in-process / test environments).
+    fn outbound_tool_rate_limiter(
+        &self,
+        _org_id: i64,
+    ) -> Option<Arc<dyn everruns_core::OutboundToolRateLimiter>> {
+        None
+    }
 }
 
 struct RuntimeExecutionCapabilities {
@@ -763,6 +772,9 @@ pub async fn execute_act_activity<A: RuntimeHostAdapter>(
     }
     if let Some(payment_authority) = adapter.payment_authority(org_id, input.agent_id) {
         atom = atom.with_payment_authority(payment_authority);
+    }
+    if let Some(limiter) = adapter.outbound_tool_rate_limiter(org_id) {
+        atom = atom.with_outbound_tool_rate_limiter(limiter);
     }
 
     atom.execute(input).await

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -1694,7 +1694,8 @@ impl ServerAppBuilder {
                 .with_egress_service(platform_definition.egress_service())
                 .with_virtual_registry(virtual_registry.clone())
                 .with_storage_store(session_storage_store)
-                .with_runner(runner.clone());
+                .with_runner(runner.clone())
+                .with_org_rate_limiter(Arc::new(org_rate_limiter.clone()));
 
                 // Wire lazy connection resolver (requires encryption for token decryption).
                 // Without encryption (e.g. DEV_MODE without SECRETS_ENCRYPTION_KEY) we cannot

--- a/crates/server/src/auth/rate_limit.rs
+++ b/crates/server/src/auth/rate_limit.rs
@@ -463,7 +463,7 @@ impl OrgRateLimiter {
             .await
     }
 
-    /// Check per-org outbound tool call rate (keyed by org public UUID string).
+    /// Check per-org outbound tool call rate (keyed by the org's typed-ID string, e.g. `org_<uuid>`).
     /// Returns Err if the org has exceeded RATE_LIMIT_ORG_TOOL_CALLS_PER_MINUTE.
     pub async fn check_outbound_tool_call(&self, org_key: &str) -> Result<(), RateLimitError> {
         self.check_keyed(OrgOp::ToolCall, org_key.to_string(), ORG_WINDOW_SECS)
@@ -533,8 +533,9 @@ impl OrgRateLimiter {
 /// `everruns-core` trait implementation: lets `OrgRateLimiter` be injected into
 /// `ActAtom` as the per-org outbound tool-call gate (TM-TOOL-009).
 ///
-/// Keyed by the org's public UUID string so the limiter works with the
-/// public OrgId that ActAtom holds (internal i64 is not available there).
+/// Keyed by `OrgId::to_string()` (typed-ID form, e.g. `org_<uuid>`) — the
+/// same format used by `check_outbound_tool_call`. The internal i64 is not
+/// available in `ActAtom`, so `OrgId` is the natural key.
 #[async_trait::async_trait]
 impl everruns_core::OutboundToolRateLimiter for OrgRateLimiter {
     async fn check_org(&self, org_id: &everruns_core::typed_id::OrgId) -> bool {

--- a/crates/server/src/auth/rate_limit.rs
+++ b/crates/server/src/auth/rate_limit.rs
@@ -344,6 +344,9 @@ const ORG_HOUR_SECS: u64 = 3600;
 const DEFAULT_SESSION_CREATE_RPM: u32 = 60;
 const DEFAULT_SCHEDULE_CREATE_RPM: u32 = 20;
 const DEFAULT_ORG_CREATE_RPH: u32 = 10;
+/// Default per-org outbound tool calls per minute (TM-TOOL-009).
+/// Generous enough not to affect normal agentic workloads; stops flood abuse.
+const DEFAULT_ORG_TOOL_CALLS_RPM: u32 = 1000;
 
 /// Per-org and per-user rate limiter for expensive operations.
 ///
@@ -351,6 +354,7 @@ const DEFAULT_ORG_CREATE_RPH: u32 = 10;
 /// - `session_create`: keyed by org_id, 60/min default
 /// - `schedule_create`: keyed by user_id, 20/min default
 /// - `org_create`: keyed by user_id, 10/hr default
+/// - `tool_calls`: keyed by org public UUID, 1000/min default (TM-TOOL-009)
 #[derive(Clone)]
 pub struct OrgRateLimiter {
     backend: OrgBackend,
@@ -362,12 +366,14 @@ enum OrgBackend {
         session_create: Arc<StringKeyedLimiter>,
         schedule_create: Arc<StringKeyedLimiter>,
         org_create: Arc<StringKeyedLimiter>,
+        tool_calls: Arc<StringKeyedLimiter>,
     },
     Valkey {
         client: ValkeyClient,
         session_create_limit: u32,
         schedule_create_limit: u32,
         org_create_limit: u32,
+        tool_calls_limit: u32,
     },
 }
 
@@ -384,6 +390,7 @@ enum OrgOp {
     Session,
     Schedule,
     Org,
+    ToolCall,
 }
 
 impl OrgRateLimiter {
@@ -404,6 +411,10 @@ impl OrgRateLimiter {
             "RATE_LIMIT_USER_ORG_CREATE_PER_HOUR",
             DEFAULT_ORG_CREATE_RPH,
         );
+        let tool_rpm: u32 = everruns_config::env_or(
+            "RATE_LIMIT_ORG_TOOL_CALLS_PER_MINUTE",
+            DEFAULT_ORG_TOOL_CALLS_RPM,
+        );
 
         match client {
             Some(c) => Self {
@@ -412,6 +423,7 @@ impl OrgRateLimiter {
                     session_create_limit: session_rpm.max(1),
                     schedule_create_limit: schedule_rpm.max(1),
                     org_create_limit: org_rph.max(1),
+                    tool_calls_limit: tool_rpm.max(1),
                 },
             },
             None => Self {
@@ -424,6 +436,9 @@ impl OrgRateLimiter {
                     ))),
                     org_create: Arc::new(RateLimiter::keyed(Quota::per_hour(
                         NonZeroU32::new(org_rph.max(1)).unwrap(),
+                    ))),
+                    tool_calls: Arc::new(RateLimiter::keyed(Quota::per_minute(
+                        NonZeroU32::new(tool_rpm.max(1)).unwrap(),
                     ))),
                 },
             },
@@ -448,6 +463,13 @@ impl OrgRateLimiter {
             .await
     }
 
+    /// Check per-org outbound tool call rate (keyed by org public UUID string).
+    /// Returns Err if the org has exceeded RATE_LIMIT_ORG_TOOL_CALLS_PER_MINUTE.
+    pub async fn check_outbound_tool_call(&self, org_key: &str) -> Result<(), RateLimitError> {
+        self.check_keyed(OrgOp::ToolCall, org_key.to_string(), ORG_WINDOW_SECS)
+            .await
+    }
+
     async fn check_keyed(
         &self,
         op: OrgOp,
@@ -459,11 +481,13 @@ impl OrgRateLimiter {
                 session_create,
                 schedule_create,
                 org_create,
+                tool_calls,
             } => {
                 let limiter = match op {
                     OrgOp::Session => session_create,
                     OrgOp::Schedule => schedule_create,
                     OrgOp::Org => org_create,
+                    OrgOp::ToolCall => tool_calls,
                 };
                 match limiter.check_key(&id) {
                     Ok(_) => Ok(()),
@@ -478,6 +502,7 @@ impl OrgRateLimiter {
                 session_create_limit,
                 schedule_create_limit,
                 org_create_limit,
+                tool_calls_limit,
             } => {
                 let (key, limit) = match op {
                     OrgOp::Session => {
@@ -488,6 +513,7 @@ impl OrgRateLimiter {
                         *schedule_create_limit,
                     ),
                     OrgOp::Org => (format!("rl:user:org_create:{id}"), *org_create_limit),
+                    OrgOp::ToolCall => (format!("rl:org:tool_calls:{id}"), *tool_calls_limit),
                 };
                 match client.check_rate_limit(&key, limit, window_secs).await {
                     Ok(_) => Ok(()),
@@ -501,6 +527,22 @@ impl OrgRateLimiter {
                 }
             }
         }
+    }
+}
+
+/// `everruns-core` trait implementation: lets `OrgRateLimiter` be injected into
+/// `ActAtom` as the per-org outbound tool-call gate (TM-TOOL-009).
+///
+/// Keyed by the org's public UUID string so the limiter works with the
+/// public OrgId that ActAtom holds (internal i64 is not available there).
+#[async_trait::async_trait]
+impl everruns_core::OutboundToolRateLimiter for OrgRateLimiter {
+    async fn check_org(&self, org_id: &everruns_core::typed_id::OrgId) -> bool {
+        // Fail-open: rate limit exceeded → false; backend error → true (already
+        // handled inside check_keyed via Valkey BackendError path).
+        self.check_outbound_tool_call(&org_id.to_string())
+            .await
+            .is_ok()
     }
 }
 
@@ -651,39 +693,34 @@ mod tests {
     // OrgRateLimiter tests
     // ============================================
 
-    #[tokio::test]
-    async fn org_rate_limiter_session_create_allows_initial() {
-        let limiter = OrgRateLimiter {
+    fn make_test_limiter_rpm(session_rpm: u32, schedule_rpm: u32, org_rph: u32) -> OrgRateLimiter {
+        OrgRateLimiter {
             backend: OrgBackend::InMemory {
                 session_create: Arc::new(RateLimiter::keyed(Quota::per_minute(
-                    NonZeroU32::new(60).unwrap(),
+                    NonZeroU32::new(session_rpm).unwrap(),
                 ))),
                 schedule_create: Arc::new(RateLimiter::keyed(Quota::per_minute(
-                    NonZeroU32::new(20).unwrap(),
+                    NonZeroU32::new(schedule_rpm).unwrap(),
                 ))),
                 org_create: Arc::new(RateLimiter::keyed(Quota::per_hour(
-                    NonZeroU32::new(10).unwrap(),
+                    NonZeroU32::new(org_rph).unwrap(),
+                ))),
+                tool_calls: Arc::new(RateLimiter::keyed(Quota::per_minute(
+                    NonZeroU32::new(1000).unwrap(),
                 ))),
             },
-        };
+        }
+    }
+
+    #[tokio::test]
+    async fn org_rate_limiter_session_create_allows_initial() {
+        let limiter = make_test_limiter_rpm(60, 20, 10);
         assert!(limiter.check_session_create(1).await.is_ok());
     }
 
     #[tokio::test]
     async fn org_rate_limiter_session_create_blocks_after_burst() {
-        let limiter = OrgRateLimiter {
-            backend: OrgBackend::InMemory {
-                session_create: Arc::new(RateLimiter::keyed(Quota::per_minute(
-                    NonZeroU32::new(3).unwrap(),
-                ))),
-                schedule_create: Arc::new(RateLimiter::keyed(Quota::per_minute(
-                    NonZeroU32::new(3).unwrap(),
-                ))),
-                org_create: Arc::new(RateLimiter::keyed(Quota::per_hour(
-                    NonZeroU32::new(3).unwrap(),
-                ))),
-            },
-        };
+        let limiter = make_test_limiter_rpm(3, 3, 3);
         for _ in 0..3 {
             let _ = limiter.check_session_create(42).await;
         }
@@ -696,24 +733,63 @@ mod tests {
     async fn org_rate_limiter_org_create_blocks_after_burst() {
         let user1 = Uuid::new_v4();
         let user2 = Uuid::new_v4();
-        let limiter = OrgRateLimiter {
-            backend: OrgBackend::InMemory {
-                session_create: Arc::new(RateLimiter::keyed(Quota::per_minute(
-                    NonZeroU32::new(3).unwrap(),
-                ))),
-                schedule_create: Arc::new(RateLimiter::keyed(Quota::per_minute(
-                    NonZeroU32::new(3).unwrap(),
-                ))),
-                org_create: Arc::new(RateLimiter::keyed(Quota::per_hour(
-                    NonZeroU32::new(2).unwrap(),
-                ))),
-            },
-        };
+        let limiter = make_test_limiter_rpm(3, 3, 2);
         for _ in 0..2 {
             let _ = limiter.check_org_create(user1).await;
         }
         assert!(limiter.check_org_create(user1).await.is_err());
         // Different user_id is unaffected
         assert!(limiter.check_org_create(user2).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn org_rate_limiter_tool_calls_allows_initial() {
+        use everruns_core::typed_id::OrgId;
+        let limiter = make_test_limiter_rpm(60, 20, 10);
+        let org_id = OrgId::new();
+        assert!(
+            limiter
+                .check_outbound_tool_call(&org_id.to_string())
+                .await
+                .is_ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn org_rate_limiter_tool_calls_blocks_after_burst() {
+        use everruns_core::typed_id::OrgId;
+        let limiter = OrgRateLimiter {
+            backend: OrgBackend::InMemory {
+                session_create: Arc::new(RateLimiter::keyed(Quota::per_minute(
+                    NonZeroU32::new(100).unwrap(),
+                ))),
+                schedule_create: Arc::new(RateLimiter::keyed(Quota::per_minute(
+                    NonZeroU32::new(100).unwrap(),
+                ))),
+                org_create: Arc::new(RateLimiter::keyed(Quota::per_hour(
+                    NonZeroU32::new(100).unwrap(),
+                ))),
+                tool_calls: Arc::new(RateLimiter::keyed(Quota::per_minute(
+                    NonZeroU32::new(2).unwrap(),
+                ))),
+            },
+        };
+        let org1 = OrgId::new();
+        let org2 = OrgId::new();
+        for _ in 0..2 {
+            let _ = limiter.check_outbound_tool_call(&org1.to_string()).await;
+        }
+        assert!(
+            limiter
+                .check_outbound_tool_call(&org1.to_string())
+                .await
+                .is_err()
+        );
+        assert!(
+            limiter
+                .check_outbound_tool_call(&org2.to_string())
+                .await
+                .is_ok()
+        );
     }
 }

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -280,6 +280,7 @@ pub struct DirectWorkerAdapters {
     permission_resolver: Arc<dyn PermissionResolver>,
     virtual_registry:
         Option<Arc<crate::domains::session_files::virtual_mount_registry::VirtualMountRegistry>>,
+    org_rate_limiter: Option<Arc<crate::auth::rate_limit::OrgRateLimiter>>,
 }
 
 impl DirectWorkerAdapters {
@@ -311,6 +312,7 @@ impl DirectWorkerAdapters {
             workflow_store: None,
             permission_resolver: Arc::new(everruns_core::DefaultPermissionResolver),
             virtual_registry: None,
+            org_rate_limiter: None,
         }
     }
 
@@ -323,6 +325,15 @@ impl DirectWorkerAdapters {
     /// Set the budget service for in-process budget tool parity.
     pub fn with_budget_service(mut self, service: Arc<BudgetService>) -> Self {
         self.budget_service = Some(service);
+        self
+    }
+
+    /// Set the per-org outbound tool-call rate limiter (TM-TOOL-009).
+    pub fn with_org_rate_limiter(
+        mut self,
+        limiter: Arc<crate::auth::rate_limit::OrgRateLimiter>,
+    ) -> Self {
+        self.org_rate_limiter = Some(limiter);
         self
     }
 
@@ -1486,6 +1497,15 @@ impl WorkerAdapters for DirectWorkerAdapters {
                 agent_id,
             ),
         ))
+    }
+
+    fn outbound_tool_rate_limiter(
+        &self,
+        _org_id: i64,
+    ) -> Option<Arc<dyn everruns_core::OutboundToolRateLimiter>> {
+        self.org_rate_limiter
+            .as_ref()
+            .map(|l| l.clone() as Arc<dyn everruns_core::OutboundToolRateLimiter>)
     }
 
     async fn invoke_scheduled_app_channel(

--- a/crates/worker/src/runtime_host.rs
+++ b/crates/worker/src/runtime_host.rs
@@ -207,4 +207,11 @@ impl<A: WorkerAdapters> RuntimeHostAdapter for WorkerRuntimeHost<A> {
     ) -> Option<Arc<dyn PaymentAuthority>> {
         self.adapters.payment_authority(org_id, agent_id)
     }
+
+    fn outbound_tool_rate_limiter(
+        &self,
+        org_id: i64,
+    ) -> Option<Arc<dyn everruns_core::OutboundToolRateLimiter>> {
+        self.adapters.outbound_tool_rate_limiter(org_id)
+    }
 }

--- a/crates/worker/src/worker_adapters.rs
+++ b/crates/worker/src/worker_adapters.rs
@@ -299,6 +299,16 @@ pub trait WorkerAdapters: Send + Sync + Clone + 'static {
         None
     }
 
+    /// Per-org outbound tool-call rate limiter (TM-TOOL-009).
+    /// Default: `None` (no rate limiting — suitable for dev/worker environments
+    /// that do not need the production limit).
+    fn outbound_tool_rate_limiter(
+        &self,
+        _org_id: i64,
+    ) -> Option<Arc<dyn everruns_core::OutboundToolRateLimiter>> {
+        None
+    }
+
     /// Invoke an app schedule channel when a durable schedule fires.
     async fn invoke_scheduled_app_channel(
         &self,

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -430,7 +430,7 @@ fn authorizer(action: AuthAction) -> Authorization {
 | TM-TOOL-006 | Disabled MCP server still callable | Medium | Server `status` flag checked before execution; disabled servers rejected | MITIGATED |
 | TM-TOOL-007 | MCP API key exposure | High | API keys encrypted at rest via envelope encryption; decrypted only at runtime | MITIGATED |
 | TM-TOOL-008 | Tool policy bypass | Low | `requires_approval` policy planned but not yet enforced (all tools auto-execute) | **OPEN** |
-| TM-TOOL-009 | No per-agent tool rate limiting | Medium | All tools execute without rate limits | **OPEN** |
+| TM-TOOL-009 | No per-org tool rate limiting | Medium | `OutboundToolRateLimiter` trait wired into `ActAtom.execute_single_tool`; `OrgRateLimiter::check_outbound_tool_call` enforces 1000 RPM per org (in-memory governor or Valkey sliding window); limit tunable via `RATE_LIMIT_ORG_TOOL_CALLS_PER_MINUTE`; fail-open on Valkey errors to preserve availability | MITIGATED |
 | TM-TOOL-010 | Skill SKILL.md prompt injection | Medium | Skill instructions returned as `tool_result` role (not system prompt); `<skill>` XML wrapper provides clear boundary | MITIGATED |
 | TM-TOOL-011 | Skill archive path traversal | High | ZIP extraction validates all paths; rejects `../`, absolute paths, symlinks; max 100 files, 1 MB each, 10 MB total | MITIGATED |
 | TM-TOOL-012 | Skill archive zip bomb | High | Decompressed size capped at 10 MB; file count capped at 100; individual file size capped at 1 MB | MITIGATED |
@@ -1312,7 +1312,7 @@ Even with per-secret scoping, an attacker who controls a previously-approved for
 | ~~TM-AGENT-012~~ | ~~Tool result size amplification~~ | ~~Medium~~ | Mitigated: 64 KiB hard limit via `OutputHardLimitHook` (EVE-225) |
 | TM-FS-008 | No session storage quota | Medium | Enforce per-session file size limits |
 | TM-TOOL-008 | Tool approval not enforced | Low | Implement HITL approval for requires_approval policy |
-| TM-TOOL-009 | No tool rate limiting | Medium | Per-agent tool execution rate limits |
+| ~~TM-TOOL-009~~ | ~~No tool rate limiting~~ | ~~Medium~~ | Mitigated: per-org 1000 RPM via `OutboundToolRateLimiter` in `ActAtom` (EVE-514) |
 | TM-DOS-003 | SSE connection exhaustion | Medium | Global (10k), per-org (1k), per-session (5) limits enforced |
 | TM-AGENT-016 | Plaintext secrets in chat history | Medium | Prefer Settings UI; phase out in-chat secret collection |
 | TM-AGENT-017 | Agent-initiated entity management | High | Add RBAC for platform management; audit logging; recursion depth limits |


### PR DESCRIPTION
## Summary

- Adds `OutboundToolRateLimiter` trait to `everruns-core` and wires it into `ActAtom.execute_single_tool`, so every tool execution is gated by a per-org RPM check before pre-use hooks or the executor runs
- Implements the limiter in `OrgRateLimiter` (dual-backend: governor in-memory for dev, Valkey sliding window for production); default 1 000 RPM, tunable via `RATE_LIMIT_ORG_TOOL_CALLS_PER_MINUTE`; fail-open on Valkey errors to preserve availability
- Injects the limiter through the adapter chain: `app_builder` → `DirectWorkerAdapters` → `WorkerAdapters` → `WorkerRuntimeHost` → `RuntimeHostAdapter` → `ActAtom`
- Resolves TM-TOOL-009 in `specs/threat-model.md`

## Test plan

- [ ] `cargo test -p everruns-core` — `test_outbound_tool_rate_limiter_blocks_execution` and `test_outbound_tool_rate_limiter_allows_execution` pass
- [ ] `cargo test -p everruns-server` — `org_rate_limiter_tool_calls_allows_initial` and `org_rate_limiter_tool_calls_blocks_after_burst` pass; all existing rate limiter tests still pass
- [ ] CI green (Format Check, Clippy, Unit Tests, Integration Tests)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fszn8mHhG7EbyFQB6dGxys)_