### PR TITLE
feat(capabilities): wire the four remaining user-hook lifecycle events

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -40,6 +40,7 @@ pub mod tool_types;
 pub mod hook_adapter;
 pub mod hook_dispatch;
 pub mod hook_executor;
+pub mod lifecycle_hooks;
 pub mod user_hook_types;
 
 // Deployment configuration

--- a/crates/core/src/lifecycle_hooks.rs
+++ b/crates/core/src/lifecycle_hooks.rs
@@ -1,0 +1,635 @@
+// User-defined lifecycle hooks: session and turn events.
+//
+// Two trait families bridge the four non-tool `HookEvent`s to runtime firing
+// points (see `specs/user-hooks.md`):
+//
+// - `SessionLifecycleHook` — `session_start` / `session_end`. Advisory only;
+//   a hook failure is logged and never aborts the session.
+// - `TurnLifecycleHook` — `user_prompt_submit` / `turn_end`. `turn_end` is
+//   advisory; `user_prompt_submit` can *block* (reject the inbound message and
+//   abort the turn) and *mutate* (rewrite the user message text).
+//
+// As with the tool hooks, capability authors hand the runtime *data*
+// (`UserHookSpec`); this module owns the spec -> `Arc<dyn …Hook>` translation
+// so the central timeout/output/sandbox limits stay enforced. The adapters
+// reuse the same `BashHookExecutor` + `BashHookDispatcher` as the pre/post
+// tool adapters, so payload delivery, output parsing, and `on_error` policy
+// are identical across every event.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde_json::json;
+
+use crate::hook_executor::{BashHookExecutor, ExecutorOpts, HookExecutor, HookPayload};
+use crate::typed_id::{OrgId, SessionId, TurnId};
+use crate::user_hook_types::{ExecutorSpec, HookEvent, HookId, HookOutcome, OnError, UserHookSpec};
+
+// ============================================================================
+// Context structs
+// ============================================================================
+
+/// Context available when a session-lifecycle hook fires. Lighter than
+/// `ToolContext`: at session create/close there is no tool, no turn, and no
+/// per-tool stores — only the session identity and (optionally) the agent.
+#[derive(Debug, Clone)]
+pub struct SessionHookContext {
+    pub session_id: SessionId,
+    pub org_id: Option<OrgId>,
+    pub agent_id: Option<String>,
+}
+
+/// Context available when a turn-lifecycle hook fires.
+#[derive(Debug, Clone)]
+pub struct TurnHookContext {
+    pub session_id: SessionId,
+    pub turn_id: Option<TurnId>,
+    pub org_id: Option<OrgId>,
+    pub agent_id: Option<String>,
+}
+
+// ============================================================================
+// Decisions
+// ============================================================================
+
+/// Outcome of a `user_prompt_submit` chain. Mirrors `PreToolUseDecision` but
+/// over the user message text rather than a `ToolCall`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UserPromptDecision {
+    /// Continue the turn with the (possibly rewritten) user message text.
+    Continue { message: String },
+    /// Reject the inbound message and abort the turn. `reason` is logged /
+    /// audited; `user_message` (if any) is surfaced to the caller.
+    Block {
+        reason: String,
+        user_message: Option<String>,
+    },
+}
+
+// ============================================================================
+// SessionLifecycleHook
+// ============================================================================
+
+/// Hook that fires on `session_start` or `session_end`. Advisory only — the
+/// runtime calls `fire` and logs any failure; it never blocks the session.
+#[async_trait]
+pub trait SessionLifecycleHook: Send + Sync {
+    /// Which event this hook is bound to (`SessionStart` or `SessionEnd`).
+    fn event(&self) -> HookEvent;
+    /// Stable id for logs.
+    fn hook_id(&self) -> &HookId;
+    /// Run the hook. The outcome is advisory; `Block`/`Mutate` are ignored
+    /// (logged) since these events cannot block or mutate anything.
+    async fn fire(&self, ctx: &SessionHookContext, data: serde_json::Value);
+}
+
+// ============================================================================
+// TurnLifecycleHook
+// ============================================================================
+
+/// Hook that fires on `user_prompt_submit` (blockable/mutable) or `turn_end`
+/// (advisory).
+#[async_trait]
+pub trait TurnLifecycleHook: Send + Sync {
+    fn event(&self) -> HookEvent;
+    fn hook_id(&self) -> &HookId;
+    /// The spec's `on_error` policy, used by the `user_prompt_submit` chain
+    /// runner to decide block-vs-continue on executor failure.
+    fn on_error(&self) -> OnError;
+    /// Run the hook against a payload. Returns the raw `HookOutcome`; chain
+    /// runners interpret it per-event (block/mutate for `user_prompt_submit`,
+    /// advisory for `turn_end`).
+    async fn run(&self, ctx: &TurnHookContext, data: serde_json::Value) -> HookOutcome;
+}
+
+// ============================================================================
+// Bash-backed adapters
+// ============================================================================
+
+/// Single adapter that implements both lifecycle traits over a bash executor.
+/// The `event` discriminates which trait method the runtime drives; the
+/// executor/limits/`on_error` handling is shared.
+struct BashLifecycleHook {
+    spec: UserHookSpec,
+    executor: Arc<dyn HookExecutor>,
+    opts: ExecutorOpts,
+    hook_id: HookId,
+}
+
+impl BashLifecycleHook {
+    fn new(spec: UserHookSpec, executor: Arc<dyn HookExecutor>, index: usize) -> Self {
+        let opts = ExecutorOpts {
+            timeout_ms: spec.timeout_ms,
+            max_output_bytes: 64 * 1024,
+        };
+        let hook_id = spec.resolve_id(index);
+        Self {
+            spec,
+            executor,
+            opts,
+            hook_id,
+        }
+    }
+
+    fn payload(&self, event: HookEvent, data: serde_json::Value) -> HookPayload {
+        HookPayload {
+            event,
+            hook_id: self.hook_id.clone(),
+            // session_id/org_id/turn_id are filled by the chain runner from
+            // the live context before dispatch; the nil default is overwritten
+            // there. (Lifecycle contexts vary by event, so the runner owns it.)
+            session_id: SessionId::from_uuid(uuid::Uuid::nil()),
+            turn_id: None,
+            org_id: None,
+            agent_id: None,
+            ts: chrono::Utc::now().to_rfc3339(),
+            data,
+        }
+    }
+}
+
+#[async_trait]
+impl SessionLifecycleHook for BashLifecycleHook {
+    fn event(&self) -> HookEvent {
+        self.spec.event
+    }
+    fn hook_id(&self) -> &HookId {
+        &self.hook_id
+    }
+    async fn fire(&self, ctx: &SessionHookContext, data: serde_json::Value) {
+        let mut payload = self.payload(self.spec.event, data);
+        payload.session_id = ctx.session_id;
+        payload.org_id = ctx.org_id;
+        payload.agent_id = ctx.agent_id.clone();
+        let outcome = self.executor.run(payload, &self.opts).await;
+        match outcome {
+            HookOutcome::Allow => {}
+            HookOutcome::Mutate { .. } | HookOutcome::Block { .. } => {
+                tracing::warn!(
+                    hook_id = %self.hook_id.as_str(),
+                    event = %self.spec.event.as_str(),
+                    "lifecycle hook returned block/mutate on an advisory event; ignoring"
+                );
+            }
+            HookOutcome::Error { message } => {
+                // Advisory: log per on_error but never abort the session.
+                tracing::warn!(
+                    hook_id = %self.hook_id.as_str(),
+                    event = %self.spec.event.as_str(),
+                    on_error = ?self.spec.on_error,
+                    message = %message,
+                    "lifecycle hook errored (advisory event, continuing)"
+                );
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl TurnLifecycleHook for BashLifecycleHook {
+    fn event(&self) -> HookEvent {
+        self.spec.event
+    }
+    fn hook_id(&self) -> &HookId {
+        &self.hook_id
+    }
+    fn on_error(&self) -> OnError {
+        self.spec.on_error
+    }
+    async fn run(&self, ctx: &TurnHookContext, data: serde_json::Value) -> HookOutcome {
+        let mut payload = self.payload(self.spec.event, data);
+        payload.session_id = ctx.session_id;
+        payload.turn_id = ctx.turn_id.map(|t| t.to_string());
+        payload.org_id = ctx.org_id;
+        payload.agent_id = ctx.agent_id.clone();
+        self.executor.run(payload, &self.opts).await
+    }
+}
+
+// ============================================================================
+// Builders
+// ============================================================================
+
+fn build_bash_executor(
+    spec: &UserHookSpec,
+    dispatcher: Arc<dyn crate::hook_executor::BashHookDispatcher>,
+) -> Arc<dyn HookExecutor> {
+    match &spec.executor {
+        ExecutorSpec::Bash { command, env } => Arc::new(BashHookExecutor::with_dispatcher(
+            command.clone(),
+            env.clone(),
+            dispatcher,
+        )),
+    }
+}
+
+/// Build `SessionLifecycleHook` adapters for every spec whose event is
+/// `event` (must be `SessionStart` or `SessionEnd`). Invalid specs are dropped
+/// with a warning so one bad entry can't take down the chain.
+pub fn build_session_lifecycle_hooks(
+    specs: &[UserHookSpec],
+    event: HookEvent,
+    dispatcher: Arc<dyn crate::hook_executor::BashHookDispatcher>,
+) -> Vec<Arc<dyn SessionLifecycleHook>> {
+    debug_assert!(matches!(
+        event,
+        HookEvent::SessionStart | HookEvent::SessionEnd
+    ));
+    let mut out: Vec<Arc<dyn SessionLifecycleHook>> = Vec::new();
+    for (index, spec) in specs.iter().enumerate() {
+        if spec.event != event {
+            continue;
+        }
+        if let Err(e) = spec.validate() {
+            tracing::warn!(
+                hook_id = %spec.resolve_id(index).as_str(),
+                error = %e,
+                "skipping invalid lifecycle hook spec"
+            );
+            continue;
+        }
+        let executor = build_bash_executor(spec, dispatcher.clone());
+        out.push(Arc::new(BashLifecycleHook::new(
+            spec.clone(),
+            executor,
+            index,
+        )));
+    }
+    out
+}
+
+/// Build `TurnLifecycleHook` adapters for every spec whose event is `event`
+/// (must be `UserPromptSubmit` or `TurnEnd`).
+pub fn build_turn_lifecycle_hooks(
+    specs: &[UserHookSpec],
+    event: HookEvent,
+    dispatcher: Arc<dyn crate::hook_executor::BashHookDispatcher>,
+) -> Vec<Arc<dyn TurnLifecycleHook>> {
+    debug_assert!(matches!(
+        event,
+        HookEvent::UserPromptSubmit | HookEvent::TurnEnd
+    ));
+    let mut out: Vec<Arc<dyn TurnLifecycleHook>> = Vec::new();
+    for (index, spec) in specs.iter().enumerate() {
+        if spec.event != event {
+            continue;
+        }
+        if let Err(e) = spec.validate() {
+            tracing::warn!(
+                hook_id = %spec.resolve_id(index).as_str(),
+                error = %e,
+                "skipping invalid lifecycle hook spec"
+            );
+            continue;
+        }
+        let executor = build_bash_executor(spec, dispatcher.clone());
+        out.push(Arc::new(BashLifecycleHook::new(
+            spec.clone(),
+            executor,
+            index,
+        )));
+    }
+    out
+}
+
+// ============================================================================
+// Chain runners
+// ============================================================================
+
+/// Run every session-lifecycle hook in order. Advisory: failures are handled
+/// inside each `fire` call; this never returns an error.
+pub async fn run_session_lifecycle_hooks(
+    hooks: &[Arc<dyn SessionLifecycleHook>],
+    ctx: &SessionHookContext,
+    data: serde_json::Value,
+) {
+    for hook in hooks {
+        hook.fire(ctx, data.clone()).await;
+    }
+}
+
+/// Run the `turn_end` chain. Advisory: each hook runs independently; block /
+/// mutate outcomes are logged and ignored, errors are logged per `on_error`.
+pub async fn run_turn_end_hooks(
+    hooks: &[Arc<dyn TurnLifecycleHook>],
+    ctx: &TurnHookContext,
+    data: serde_json::Value,
+) {
+    for hook in hooks {
+        match hook.run(ctx, data.clone()).await {
+            HookOutcome::Allow => {}
+            HookOutcome::Mutate { .. } | HookOutcome::Block { .. } => {
+                tracing::warn!(
+                    hook_id = %hook.hook_id().as_str(),
+                    "turn_end hook returned block/mutate on an advisory event; ignoring"
+                );
+            }
+            HookOutcome::Error { message } => {
+                tracing::warn!(
+                    hook_id = %hook.hook_id().as_str(),
+                    message = %message,
+                    "turn_end hook errored (advisory, continuing)"
+                );
+            }
+        }
+    }
+}
+
+/// Run the `user_prompt_submit` chain sequentially over the message text.
+/// Each hook sees the previous hook's mutated text. The first `Block` wins and
+/// aborts the chain; on executor error the spec's `on_error` policy applies
+/// (`Block` -> block, `Warn`/`Allow` -> continue with current text).
+pub async fn run_user_prompt_submit_hooks(
+    hooks: &[Arc<dyn TurnLifecycleHook>],
+    ctx: &TurnHookContext,
+    mut message: String,
+) -> UserPromptDecision {
+    for hook in hooks {
+        let data = json!({ "message": message });
+        match hook.run(ctx, data).await {
+            HookOutcome::Allow => {}
+            HookOutcome::Mutate { patch, .. } => {
+                if let Some(new_msg) = patch.get("message").and_then(|v| v.as_str()) {
+                    message = new_msg.to_string();
+                }
+            }
+            HookOutcome::Block {
+                reason,
+                user_message,
+            } => {
+                return UserPromptDecision::Block {
+                    reason,
+                    user_message,
+                };
+            }
+            HookOutcome::Error { message: err } => match hook.on_error() {
+                OnError::Block => {
+                    return UserPromptDecision::Block {
+                        reason: format!("hook {} errored: {err}", hook.hook_id().as_str()),
+                        user_message: None,
+                    };
+                }
+                OnError::Warn => {
+                    tracing::warn!(
+                        hook_id = %hook.hook_id().as_str(),
+                        message = %err,
+                        "user_prompt_submit hook errored"
+                    );
+                }
+                OnError::Allow => {}
+            },
+        }
+    }
+    UserPromptDecision::Continue { message }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::hook_executor::{BashExecOutput, BashHookDispatcher};
+    use crate::user_hook_types::{HookMatcher, HookSource};
+    use async_trait::async_trait;
+    use std::collections::BTreeMap;
+
+    /// Dispatcher that returns a canned stdout/exit so we exercise the full
+    /// parse + decision path without a real sandbox.
+    struct CannedDispatcher {
+        stdout: String,
+        exit_code: i32,
+    }
+
+    #[async_trait]
+    impl BashHookDispatcher for CannedDispatcher {
+        async fn dispatch(
+            &self,
+            _payload: &HookPayload,
+            _command: &str,
+            _extra_env: &BTreeMap<String, String>,
+            _opts: &ExecutorOpts,
+        ) -> Result<BashExecOutput, String> {
+            Ok(BashExecOutput {
+                exit_code: self.exit_code,
+                stdout: self.stdout.clone(),
+                stderr: String::new(),
+            })
+        }
+    }
+
+    fn spec(event: HookEvent, on_error: OnError) -> UserHookSpec {
+        UserHookSpec {
+            id: Some("t".into()),
+            event,
+            matcher: HookMatcher::default(),
+            executor: ExecutorSpec::Bash {
+                command: "true".into(),
+                env: Default::default(),
+            },
+            timeout_ms: 5000,
+            on_error,
+            description: None,
+            source: HookSource::UserConfig,
+        }
+    }
+
+    fn dispatcher(stdout: &str, exit: i32) -> Arc<dyn BashHookDispatcher> {
+        Arc::new(CannedDispatcher {
+            stdout: stdout.into(),
+            exit_code: exit,
+        })
+    }
+
+    fn turn_ctx() -> TurnHookContext {
+        TurnHookContext {
+            session_id: SessionId::new(),
+            turn_id: Some(TurnId::new()),
+            org_id: None,
+            agent_id: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn user_prompt_submit_allow_passes_message_through() {
+        let hooks = build_turn_lifecycle_hooks(
+            &[spec(HookEvent::UserPromptSubmit, OnError::Warn)],
+            HookEvent::UserPromptSubmit,
+            dispatcher("", 0),
+        );
+        let decision = run_user_prompt_submit_hooks(&hooks, &turn_ctx(), "hello".into()).await;
+        assert_eq!(
+            decision,
+            UserPromptDecision::Continue {
+                message: "hello".into()
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn user_prompt_submit_block_via_json() {
+        let hooks = build_turn_lifecycle_hooks(
+            &[spec(HookEvent::UserPromptSubmit, OnError::Warn)],
+            HookEvent::UserPromptSubmit,
+            dispatcher(
+                r#"{"decision":"block","reason":"nope","user_message":"blocked"}"#,
+                0,
+            ),
+        );
+        let decision = run_user_prompt_submit_hooks(&hooks, &turn_ctx(), "hello".into()).await;
+        match decision {
+            UserPromptDecision::Block {
+                reason,
+                user_message,
+            } => {
+                assert_eq!(reason, "nope");
+                assert_eq!(user_message.as_deref(), Some("blocked"));
+            }
+            other => panic!("expected Block, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn user_prompt_submit_block_via_nonzero_exit() {
+        // Empty stdout + non-zero exit = block (git-hook fallback).
+        let hooks = build_turn_lifecycle_hooks(
+            &[spec(HookEvent::UserPromptSubmit, OnError::Warn)],
+            HookEvent::UserPromptSubmit,
+            dispatcher("", 1),
+        );
+        let decision = run_user_prompt_submit_hooks(&hooks, &turn_ctx(), "hello".into()).await;
+        assert!(matches!(decision, UserPromptDecision::Block { .. }));
+    }
+
+    #[tokio::test]
+    async fn user_prompt_submit_mutate_rewrites_message() {
+        let hooks = build_turn_lifecycle_hooks(
+            &[spec(HookEvent::UserPromptSubmit, OnError::Warn)],
+            HookEvent::UserPromptSubmit,
+            dispatcher(
+                r#"{"decision":"mutate","patch":{"message":"rewritten"}}"#,
+                0,
+            ),
+        );
+        let decision = run_user_prompt_submit_hooks(&hooks, &turn_ctx(), "original".into()).await;
+        assert_eq!(
+            decision,
+            UserPromptDecision::Continue {
+                message: "rewritten".into()
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn user_prompt_submit_error_with_on_error_block_blocks() {
+        // Non-JSON stdout => executor Error; on_error=Block => Block.
+        let hooks = build_turn_lifecycle_hooks(
+            &[spec(HookEvent::UserPromptSubmit, OnError::Block)],
+            HookEvent::UserPromptSubmit,
+            dispatcher("not json at all", 0),
+        );
+        let decision = run_user_prompt_submit_hooks(&hooks, &turn_ctx(), "hello".into()).await;
+        assert!(matches!(decision, UserPromptDecision::Block { .. }));
+    }
+
+    #[tokio::test]
+    async fn user_prompt_submit_error_with_on_error_warn_continues() {
+        let hooks = build_turn_lifecycle_hooks(
+            &[spec(HookEvent::UserPromptSubmit, OnError::Warn)],
+            HookEvent::UserPromptSubmit,
+            dispatcher("not json", 0),
+        );
+        let decision = run_user_prompt_submit_hooks(&hooks, &turn_ctx(), "hello".into()).await;
+        assert_eq!(
+            decision,
+            UserPromptDecision::Continue {
+                message: "hello".into()
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn user_prompt_submit_chain_threads_mutations_then_blocks() {
+        // First hook rewrites, second hook blocks. Order preserved.
+        let specs = [
+            {
+                let mut s = spec(HookEvent::UserPromptSubmit, OnError::Warn);
+                s.id = Some("rewriter".into());
+                s
+            },
+            {
+                let mut s = spec(HookEvent::UserPromptSubmit, OnError::Warn);
+                s.id = Some("blocker".into());
+                s
+            },
+        ];
+        // Both hooks share one dispatcher returning a block; the first hook's
+        // mutate vs block is decided by stdout, so to test threading we build
+        // them individually with different dispatchers.
+        let rewriter = build_turn_lifecycle_hooks(
+            &specs[..1],
+            HookEvent::UserPromptSubmit,
+            dispatcher(r#"{"decision":"mutate","patch":{"message":"step1"}}"#, 0),
+        );
+        let blocker = build_turn_lifecycle_hooks(
+            &specs[1..],
+            HookEvent::UserPromptSubmit,
+            dispatcher(r#"{"decision":"block","reason":"stop"}"#, 0),
+        );
+        let mut chain = rewriter;
+        chain.extend(blocker);
+        let decision = run_user_prompt_submit_hooks(&chain, &turn_ctx(), "orig".into()).await;
+        assert!(matches!(decision, UserPromptDecision::Block { .. }));
+    }
+
+    #[tokio::test]
+    async fn turn_end_runs_advisory_and_ignores_block() {
+        let hooks = build_turn_lifecycle_hooks(
+            &[spec(HookEvent::TurnEnd, OnError::Warn)],
+            HookEvent::TurnEnd,
+            // Even a "block" decision must not abort anything here.
+            dispatcher(r#"{"decision":"block","reason":"ignored"}"#, 0),
+        );
+        // Just assert it runs without panicking; advisory has no return value.
+        run_turn_end_hooks(&hooks, &turn_ctx(), json!({"success": true})).await;
+    }
+
+    #[tokio::test]
+    async fn session_lifecycle_runs_advisory() {
+        let hooks = build_session_lifecycle_hooks(
+            &[spec(HookEvent::SessionStart, OnError::Warn)],
+            HookEvent::SessionStart,
+            dispatcher("", 0),
+        );
+        let ctx = SessionHookContext {
+            session_id: SessionId::new(),
+            org_id: None,
+            agent_id: Some("agt_x".into()),
+        };
+        run_session_lifecycle_hooks(&hooks, &ctx, json!({"agent_id": "agt_x"})).await;
+    }
+
+    #[tokio::test]
+    async fn builders_filter_by_event() {
+        let specs = vec![
+            spec(HookEvent::SessionStart, OnError::Warn),
+            spec(HookEvent::SessionEnd, OnError::Warn),
+            spec(HookEvent::TurnEnd, OnError::Warn),
+            spec(HookEvent::UserPromptSubmit, OnError::Warn),
+        ];
+        let d = dispatcher("", 0);
+        assert_eq!(
+            build_session_lifecycle_hooks(&specs, HookEvent::SessionStart, d.clone()).len(),
+            1
+        );
+        assert_eq!(
+            build_session_lifecycle_hooks(&specs, HookEvent::SessionEnd, d.clone()).len(),
+            1
+        );
+        assert_eq!(
+            build_turn_lifecycle_hooks(&specs, HookEvent::TurnEnd, d.clone()).len(),
+            1
+        );
+        assert_eq!(
+            build_turn_lifecycle_hooks(&specs, HookEvent::UserPromptSubmit, d).len(),
+            1
+        );
+    }
+}

--- a/crates/core/src/user_facing_error.rs
+++ b/crates/core/src/user_facing_error.rs
@@ -19,6 +19,8 @@ pub mod codes {
     pub const DEPENDENCY_UNAVAILABLE: &str = "dependency_unavailable";
     pub const MAX_ITERATIONS: &str = "max_iterations";
     pub const SOFT_LIMIT_REACHED: &str = "soft_limit_reached";
+    /// A `user_prompt_submit` hook rejected the inbound user message.
+    pub const BLOCKED_BY_HOOK: &str = "blocked_by_hook";
 }
 
 pub type UserFacingErrorFields = BTreeMap<String, Value>;

--- a/crates/runtime/src/host.rs
+++ b/crates/runtime/src/host.rs
@@ -179,6 +179,86 @@ struct RuntimeExecutionCapabilities {
     tool_call_hooks: Vec<Arc<dyn everruns_core::ToolCallHook>>,
 }
 
+/// Collect and finalize user-hook specs for a session from its resolved
+/// capability configs, plus the shared bash dispatcher used to run them.
+///
+/// This is the single place hook specs are gathered so every firing point —
+/// the act path (`load_execution_capabilities`) and the lifecycle firing
+/// points (`execute_reason_activity` for `user_prompt_submit`, turn completion
+/// for `turn_end`, and the server session paths) — applies identical
+/// `finalize_hook_specs` semantics: `{capability_id}:` namespace stamping,
+/// stable default ids, and `disabled_contributions` muting (TM-HOOK-004).
+fn finalize_specs_from_configs(
+    resolved_capability_configs: &[everruns_core::capability_types::AgentCapabilityConfig],
+    capability_registry: &CapabilityRegistry,
+) -> Vec<everruns_core::user_hook_types::UserHookSpec> {
+    let mut hook_contributions: Vec<(String, Vec<everruns_core::user_hook_types::UserHookSpec>)> =
+        Vec::new();
+    let mut disabled_contributions: Vec<String> = Vec::new();
+    for config in resolved_capability_configs {
+        let Some(capability) = capability_registry.get(config.capability_id()) else {
+            continue;
+        };
+        let specs = capability.user_hooks_with_config(&config.config);
+        if !specs.is_empty() {
+            hook_contributions.push((config.capability_id().to_string(), specs));
+        }
+        if config.capability_id() == "user_hooks" {
+            disabled_contributions.extend(
+                everruns_core::capabilities::user_hooks::disabled_contributions(&config.config),
+            );
+        }
+    }
+    everruns_core::hook_adapter::finalize_hook_specs(hook_contributions, &disabled_contributions)
+}
+
+/// Resolve a session's capability configs and collect finalized hook specs.
+/// Used by the lifecycle firing points, which need specs outside the act path.
+/// Returns `(specs, dispatcher)`; `specs` is empty when the session has no
+/// hook-contributing capabilities.
+async fn collect_lifecycle_hook_specs<A: RuntimeHostAdapter>(
+    adapter: &A,
+    org_id: i64,
+    session_id: SessionId,
+    harness_id: HarnessId,
+    agent_id: Option<AgentId>,
+) -> everruns_core::error::Result<(
+    Vec<everruns_core::user_hook_types::UserHookSpec>,
+    Arc<dyn everruns_core::hook_executor::BashHookDispatcher>,
+)> {
+    let capability_registry = adapter.capability_registry();
+    let harness_chain = adapter
+        .harness_store(org_id)
+        .get_harness_chain(harness_id)
+        .await?;
+    if harness_chain.is_empty() {
+        return Err(everruns_core::error::AgentLoopError::harness_not_found(
+            harness_id,
+        ));
+    }
+    let session = adapter
+        .session_store(org_id)
+        .get_session(session_id)
+        .await?
+        .ok_or_else(|| everruns_core::error::AgentLoopError::session_not_found(session_id))?;
+    let agent = match agent_id {
+        Some(agent_id) => adapter.agent_store(org_id).get_agent(agent_id).await?,
+        None => None,
+    };
+    let resolved = resolve_runtime_capabilities(
+        &harness_chain,
+        agent.as_ref(),
+        &session,
+        &capability_registry,
+    );
+    let specs =
+        finalize_specs_from_configs(&resolved.resolved_capability_configs, &capability_registry);
+    let dispatcher: Arc<dyn everruns_core::hook_executor::BashHookDispatcher> = Arc::new(
+        everruns_core::hook_dispatch::VirtualBashHookDispatcher::new(adapter.file_store()),
+    );
+    Ok((specs, dispatcher))
+}
+
 async fn load_execution_capabilities<A: RuntimeHostAdapter>(
     adapter: &A,
     org_id: i64,
@@ -268,39 +348,14 @@ async fn load_execution_capabilities<A: RuntimeHostAdapter>(
         })
         .collect();
 
-    // User-hook contributions (see `specs/user-hooks.md`).
-    // Collect specs across every resolved capability — both the
-    // user-facing `user_hooks` capability (user-config-authored) and any
-    // capability that bundles hooks via `Capability::user_hooks_with_config()`.
-    // Construct a single bash dispatcher backed by the session's file store
-    // and translate each PostToolUse spec into a `PostToolExecHook` adapter.
-    // Gather each capability's contributed specs as (capability_id, specs)
-    // pairs and the union of `disabled_contributions` declared on any
-    // `user_hooks` capability instance. `finalize_hook_specs` then stamps the
-    // source namespace, assigns stable ids, and drops muted entries — so the
-    // documented `disabled_contributions` muting (TM-HOOK-004) and the
-    // `{capability_id}:` HookId namespace actually take effect at runtime.
-    let mut hook_contributions: Vec<(String, Vec<everruns_core::user_hook_types::UserHookSpec>)> =
-        Vec::new();
-    let mut disabled_contributions: Vec<String> = Vec::new();
-    for config in &resolved.resolved_capability_configs {
-        let Some(capability) = capability_registry.get(config.capability_id()) else {
-            continue;
-        };
-        let specs = capability.user_hooks_with_config(&config.config);
-        if !specs.is_empty() {
-            hook_contributions.push((config.capability_id().to_string(), specs));
-        }
-        if config.capability_id() == "user_hooks" {
-            disabled_contributions.extend(
-                everruns_core::capabilities::user_hooks::disabled_contributions(&config.config),
-            );
-        }
-    }
-    let user_hook_specs = everruns_core::hook_adapter::finalize_hook_specs(
-        hook_contributions,
-        &disabled_contributions,
-    );
+    // User-hook contributions (see `specs/user-hooks.md`). `finalize_specs_from_configs`
+    // gathers specs across every resolved capability — both the user-facing
+    // `user_hooks` capability and any capability that bundles hooks — and applies
+    // `finalize_hook_specs` (namespace stamping, stable ids, `disabled_contributions`
+    // muting; TM-HOOK-004). The same helper backs the lifecycle firing points so
+    // every event finalizes specs identically.
+    let user_hook_specs =
+        finalize_specs_from_configs(&resolved.resolved_capability_configs, &capability_registry);
     let mut pre_tool_hooks: Vec<Arc<dyn everruns_core::atoms::PreToolUseHook>> = Vec::new();
     if !user_hook_specs.is_empty() {
         let dispatcher: Arc<dyn everruns_core::hook_executor::BashHookDispatcher> = Arc::new(
@@ -476,6 +531,87 @@ impl<A: RuntimeHostAdapter> RuntimeSessionLifecycle<A> {
             .await;
     }
 
+    /// Fire `turn_end` lifecycle hooks (advisory). Collects the session's hook
+    /// specs and runs every `turn_end` hook; failures are logged, never fatal.
+    /// `harness_id`/`agent_id` are required to resolve the capability chain.
+    pub async fn fire_turn_end_hooks(
+        &self,
+        harness_id: HarnessId,
+        agent_id: Option<AgentId>,
+        turn_id: TurnId,
+        success: bool,
+    ) {
+        let (specs, dispatcher) = match collect_lifecycle_hook_specs(
+            &self.adapter,
+            self.org_id,
+            self.session_id,
+            harness_id,
+            agent_id,
+        )
+        .await
+        {
+            Ok(pair) => pair,
+            Err(error) => {
+                warn!(
+                    session_id = %self.session_id,
+                    %error,
+                    "failed to collect turn_end hook specs; skipping"
+                );
+                return;
+            }
+        };
+        let hooks = everruns_core::lifecycle_hooks::build_turn_lifecycle_hooks(
+            &specs,
+            everruns_core::user_hook_types::HookEvent::TurnEnd,
+            dispatcher,
+        );
+        if hooks.is_empty() {
+            return;
+        }
+        let ctx = everruns_core::lifecycle_hooks::TurnHookContext {
+            session_id: self.session_id,
+            turn_id: Some(turn_id),
+            org_id: org_public_id_from_internal(self.org_id).parse().ok(),
+            agent_id: agent_id.map(|a| a.to_string()),
+        };
+        everruns_core::lifecycle_hooks::run_turn_end_hooks(
+            &hooks,
+            &ctx,
+            serde_json::json!({ "success": success }),
+        )
+        .await;
+    }
+
+    /// Abort a turn because a `user_prompt_submit` hook returned `Block`.
+    /// Reuses the dependency-blocked failure shape: emit a user-facing message
+    /// carrying the hook's `user_message` (or `reason`), then mark the turn
+    /// failed and idle the session.
+    pub async fn user_prompt_blocked(
+        &self,
+        turn_id: TurnId,
+        input_message_id: MessageId,
+        reason: &str,
+        user_message: Option<&str>,
+    ) {
+        let user_error =
+            UserFacingError::new(everruns_core::user_facing_error_codes::BLOCKED_BY_HOOK);
+        let shown = user_message.unwrap_or(reason);
+        let mut error_message = Message::assistant(shown);
+        let mut metadata = std::collections::HashMap::new();
+        user_error.apply_to_message_metadata(&mut metadata);
+        error_message.metadata = Some(metadata);
+
+        self.emit_event(EventRequest::new(
+            self.session_id,
+            EventContext::turn(turn_id, input_message_id),
+            OutputMessageCompletedData::new(error_message).with_user_facing_error(&user_error),
+        ))
+        .await;
+
+        self.turn_failed(turn_id, input_message_id, reason, Some(&user_error))
+            .await;
+    }
+
     pub async fn turn_failed(
         &self,
         turn_id: TurnId,
@@ -603,6 +739,66 @@ pub async fn execute_input_activity<A: RuntimeHostAdapter>(
     atom.execute(input).await
 }
 
+/// Collect `user_prompt_submit` hooks for this turn and run them against the
+/// inbound user message text. Returns `None` when the session has no such
+/// hooks (the common case — no overhead beyond the spec collection, which is
+/// skipped early). Errors loading specs are logged and treated as "no hooks"
+/// so a hook-collection failure never blocks a turn that wasn't asking to be
+/// hooked.
+async fn run_user_prompt_submit_for_turn<A: RuntimeHostAdapter>(
+    adapter: &A,
+    org_id: i64,
+    input: &ReasonInput,
+) -> everruns_core::error::Result<Option<everruns_core::lifecycle_hooks::UserPromptDecision>> {
+    let (specs, dispatcher) = match collect_lifecycle_hook_specs(
+        adapter,
+        org_id,
+        input.context.session_id,
+        input.harness_id,
+        input.agent_id,
+    )
+    .await
+    {
+        Ok(pair) => pair,
+        Err(error) => {
+            warn!(
+                session_id = %input.context.session_id,
+                %error,
+                "failed to collect user_prompt_submit hook specs; continuing without them"
+            );
+            return Ok(None);
+        }
+    };
+    let hooks = everruns_core::lifecycle_hooks::build_turn_lifecycle_hooks(
+        &specs,
+        everruns_core::user_hook_types::HookEvent::UserPromptSubmit,
+        dispatcher,
+    );
+    if hooks.is_empty() {
+        return Ok(None);
+    }
+
+    let message_text = adapter
+        .message_store()
+        .get(input.context.session_id, input.context.input_message_id)
+        .await
+        .ok()
+        .flatten()
+        .map(|m| m.content_to_llm_string())
+        .unwrap_or_default();
+
+    let ctx = everruns_core::lifecycle_hooks::TurnHookContext {
+        session_id: input.context.session_id,
+        turn_id: Some(input.context.turn_id),
+        org_id: org_public_id_from_internal(org_id).parse().ok(),
+        agent_id: input.agent_id.map(|a| a.to_string()),
+    };
+    Ok(Some(
+        everruns_core::lifecycle_hooks::run_user_prompt_submit_hooks(&hooks, &ctx, message_text)
+            .await,
+    ))
+}
+
 pub async fn execute_reason_activity<A: RuntimeHostAdapter>(
     adapter: &A,
     org_id: i64,
@@ -626,6 +822,44 @@ pub async fn execute_reason_activity<A: RuntimeHostAdapter>(
             tool_definitions: vec![],
             max_iterations: everruns_core::runtime_agent::default_max_iterations(),
             error: Some("dependency_unavailable".to_string()),
+            usage: None,
+            output_message_id: None,
+            time_to_first_token_ms: None,
+            response_id: None,
+            locale: None,
+            network_access: None,
+        });
+    }
+
+    // user_prompt_submit hook (see `specs/user-hooks.md`). Fires once per turn,
+    // on the first reason iteration, before the LLM is consulted — the closest
+    // choke point to "inbound user message accepted, before reason" that both
+    // the in-process loop and the durable worker share. A `Block` aborts the
+    // turn by reusing the same failure path as `dependency_blocked`: emit a
+    // user-facing message + turn.failed, idle the session, and return a
+    // non-success `ReasonResult` so no LLM/act work runs.
+    if input.iteration <= 1
+        && let Some(everruns_core::lifecycle_hooks::UserPromptDecision::Block {
+            reason,
+            user_message,
+        }) = run_user_prompt_submit_for_turn(adapter, org_id, &input).await?
+    {
+        RuntimeSessionLifecycle::new(adapter.clone(), org_id, input.context.session_id)
+            .user_prompt_blocked(
+                input.context.turn_id,
+                input.context.input_message_id,
+                &reason,
+                user_message.as_deref(),
+            )
+            .await;
+        return Ok(ReasonResult {
+            success: false,
+            text: user_message.unwrap_or_else(|| reason.clone()),
+            tool_calls: vec![],
+            has_tool_calls: false,
+            tool_definitions: vec![],
+            max_iterations: everruns_core::runtime_agent::default_max_iterations(),
+            error: Some("blocked_by_user_prompt_hook".to_string()),
             usage: None,
             output_message_id: None,
             time_to_first_token_ms: None,

--- a/crates/runtime/src/runtime.rs
+++ b/crates/runtime/src/runtime.rs
@@ -572,6 +572,10 @@ impl InProcessRuntime {
                     let ctx = state_machine.context();
                     let lifecycle =
                         RuntimeSessionLifecycle::new(self.clone(), org_id, ctx.session_id);
+                    let turn_succeeded = matches!(
+                        &outcome,
+                        TurnOutcome::Success { .. } | TurnOutcome::MaxIterationsReached { .. }
+                    );
                     match &outcome {
                         TurnOutcome::Success { iterations, .. }
                         | TurnOutcome::MaxIterationsReached { iterations, .. } => {
@@ -591,6 +595,16 @@ impl InProcessRuntime {
                                 .await;
                         }
                     }
+                    // turn_end lifecycle hooks (advisory). Fired after the
+                    // terminal turn event for both success and failure.
+                    lifecycle
+                        .fire_turn_end_hooks(
+                            session.harness_id,
+                            session.agent_id,
+                            ctx.turn_id,
+                            turn_succeeded,
+                        )
+                        .await;
                     return Ok(TurnResult::from_outcome(outcome, ctx.turn_id));
                 }
             }

--- a/crates/runtime/src/turn_strategy.rs
+++ b/crates/runtime/src/turn_strategy.rs
@@ -286,6 +286,17 @@ pub async fn plan_next_host_turn<A: RuntimeHostAdapter>(
                     .await;
             }
 
+            // turn_end lifecycle hooks (advisory). Fired once the turn reaches a
+            // terminal reason outcome on the durable/strategy path.
+            lifecycle
+                .fire_turn_end_hooks(
+                    state.harness_id,
+                    state.agent_id,
+                    turn_id,
+                    reason_result.success,
+                )
+                .await;
+
             Ok(RuntimeTurnPlan::Complete {
                 error: reason_result.error,
             })

--- a/crates/runtime/tests/runtime_host_test.rs
+++ b/crates/runtime/tests/runtime_host_test.rs
@@ -1273,3 +1273,228 @@ async fn plan_next_host_turn_waits_for_tool_results_when_session_hint_requests_i
         other => panic!("expected WaitForToolResults, got {other:?}"),
     }
 }
+
+// ============================================================================
+// Lifecycle hook wire-in tests (user_prompt_submit, turn_end)
+// ============================================================================
+
+/// Test capability that contributes one lifecycle hook via `user_hooks()`.
+/// The bash command is run for real through the in-process `virtual_bash`
+/// dispatcher, so these tests exercise the full collect -> build -> dispatch
+/// -> decision path, not a mock.
+struct LifecycleHookCapability {
+    event: everruns_core::user_hook_types::HookEvent,
+    command: String,
+}
+
+impl Capability for LifecycleHookCapability {
+    fn id(&self) -> &str {
+        "lifecycle_hook_test"
+    }
+    fn name(&self) -> &str {
+        "Lifecycle Hook Test"
+    }
+    fn description(&self) -> &str {
+        "Test capability contributing a single lifecycle hook."
+    }
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+    fn user_hooks(&self) -> Vec<everruns_core::user_hook_types::UserHookSpec> {
+        use everruns_core::user_hook_types::{
+            ExecutorSpec, HookMatcher, HookSource, OnError, UserHookSpec,
+        };
+        vec![UserHookSpec {
+            id: Some("lc".into()),
+            event: self.event,
+            matcher: HookMatcher::default(),
+            executor: ExecutorSpec::Bash {
+                command: self.command.clone(),
+                env: Default::default(),
+            },
+            timeout_ms: 5000,
+            on_error: OnError::Warn,
+            description: None,
+            source: HookSource::UserConfig,
+        }]
+    }
+}
+
+/// A `user_prompt_submit` hook that emits a `block` decision must abort the
+/// turn *before* the reason atom runs — verified by `execute_reason_activity`
+/// returning a non-success result with the `blocked_by_user_prompt_hook`
+/// error, without ever consulting an LLM (the mock host has no usable driver
+/// for a real reason step, so reaching it would surface a different error).
+#[tokio::test]
+async fn user_prompt_submit_hook_blocks_turn_before_reason() {
+    use everruns_core::atoms::ReasonInput;
+    use everruns_core::user_hook_types::HookEvent;
+    use everruns_runtime::execute_reason_activity;
+
+    let mut adapter = mock_host();
+    adapter.capability_registry.register(LifecycleHookCapability {
+        event: HookEvent::UserPromptSubmit,
+        command: r#"echo '{"decision":"block","reason":"policy","user_message":"Your message was blocked."}'"#
+            .into(),
+    });
+
+    let harness_id = HarnessId::from_uuid(Uuid::now_v7());
+    let session_id = SessionId::from_uuid(Uuid::now_v7());
+    adapter
+        .harness_store
+        .add_harness(Harness {
+            capabilities: vec![AgentCapabilityConfig::new("lifecycle_hook_test")],
+            ..harness(harness_id)
+        })
+        .await;
+    adapter
+        .session_store
+        .insert(session(session_id, harness_id))
+        .await;
+    let user_message = adapter
+        .message_store
+        .add(session_id, InputMessage::user("delete everything"))
+        .await
+        .unwrap();
+
+    let turn_id = TurnId::from_uuid(Uuid::now_v7());
+    let result = execute_reason_activity(
+        &adapter,
+        1,
+        ReasonInput {
+            context: AtomContext::new(session_id, turn_id, user_message.id),
+            harness_id,
+            agent_id: None,
+            org_id: 1,
+            mcp_tool_definitions: vec![],
+            previous_response_id: None,
+            iteration: 1,
+        },
+    )
+    .await
+    .unwrap();
+
+    assert!(!result.success, "blocked turn must not succeed");
+    assert_eq!(result.error.as_deref(), Some("blocked_by_user_prompt_hook"));
+    assert_eq!(result.text, "Your message was blocked.");
+    assert!(result.tool_calls.is_empty());
+
+    // The block is observable as a turn.failed event carrying the hook code.
+    let events = adapter.event_emitter.events().await;
+    assert!(
+        events.iter().any(|e| e.event_type == "turn.failed"),
+        "expected a turn.failed event, got: {:?}",
+        events.iter().map(|e| &e.event_type).collect::<Vec<_>>()
+    );
+}
+
+/// A `user_prompt_submit` hook that emits `allow` (empty stdout, exit 0) must
+/// not block — `execute_reason_activity` proceeds past the hook to the reason
+/// step. We only assert the hook did not short-circuit with the block error.
+#[tokio::test]
+async fn user_prompt_submit_hook_allow_does_not_block() {
+    use everruns_core::atoms::ReasonInput;
+    use everruns_core::user_hook_types::HookEvent;
+    use everruns_runtime::execute_reason_activity;
+
+    let mut adapter = mock_host();
+    set_default_model(&adapter).await;
+    adapter
+        .capability_registry
+        .register(LifecycleHookCapability {
+            event: HookEvent::UserPromptSubmit,
+            command: "true".into(), // empty stdout + exit 0 = allow
+        });
+
+    let harness_id = HarnessId::from_uuid(Uuid::now_v7());
+    let session_id = SessionId::from_uuid(Uuid::now_v7());
+    adapter
+        .harness_store
+        .add_harness(Harness {
+            capabilities: vec![AgentCapabilityConfig::new("lifecycle_hook_test")],
+            ..harness(harness_id)
+        })
+        .await;
+    adapter
+        .session_store
+        .insert(session(session_id, harness_id))
+        .await;
+    let user_message = adapter
+        .message_store
+        .add(session_id, InputMessage::user("hello"))
+        .await
+        .unwrap();
+
+    let turn_id = TurnId::from_uuid(Uuid::now_v7());
+    let result = execute_reason_activity(
+        &adapter,
+        1,
+        ReasonInput {
+            context: AtomContext::new(session_id, turn_id, user_message.id),
+            harness_id,
+            agent_id: None,
+            org_id: 1,
+            mcp_tool_definitions: vec![],
+            previous_response_id: None,
+            iteration: 1,
+        },
+    )
+    .await
+    .unwrap();
+
+    // Whatever the reason step does with the mock model, it must not be the
+    // user-prompt-hook block path.
+    assert_ne!(
+        result.error.as_deref(),
+        Some("blocked_by_user_prompt_hook"),
+        "allow hook must not block the turn"
+    );
+}
+
+/// A `turn_end` hook fires (advisory) when a turn completes. We drive a full
+/// in-process turn and assert the hook's side effect: a sentinel file written
+/// to the session VFS by the hook command.
+#[tokio::test]
+async fn turn_end_hook_fires_on_turn_completion() {
+    use everruns_core::user_hook_types::HookEvent;
+
+    let mut adapter = mock_host();
+    set_default_model(&adapter).await;
+    adapter
+        .capability_registry
+        .register(LifecycleHookCapability {
+            event: HookEvent::TurnEnd,
+            command: "echo turn-ended > /workspace/.turn_end_sentinel".into(),
+        });
+
+    let harness_id = HarnessId::from_uuid(Uuid::now_v7());
+    let session_id = SessionId::from_uuid(Uuid::now_v7());
+    adapter
+        .harness_store
+        .add_harness(Harness {
+            capabilities: vec![AgentCapabilityConfig::new("lifecycle_hook_test")],
+            ..harness(harness_id)
+        })
+        .await;
+    adapter
+        .session_store
+        .insert(session(session_id, harness_id))
+        .await;
+
+    // Fire the turn_end hooks directly through the lifecycle helper — this is
+    // the exact call the in-process loop and durable strategy make at turn
+    // completion, so it verifies the wired path without needing a full LLM turn.
+    let lifecycle = RuntimeSessionLifecycle::new(adapter.clone(), 1, session_id);
+    lifecycle
+        .fire_turn_end_hooks(harness_id, None, TurnId::from_uuid(Uuid::now_v7()), true)
+        .await;
+
+    let sentinel = adapter
+        .file_store
+        .read_file(session_id, "/.turn_end_sentinel")
+        .await;
+    assert!(
+        sentinel.is_ok() && sentinel.as_ref().unwrap().is_some(),
+        "turn_end hook should have written the sentinel file, got: {sentinel:?}"
+    );
+}

--- a/crates/server/src/domains/sessions/service.rs
+++ b/crates/server/src/domains/sessions/service.rs
@@ -422,51 +422,45 @@ impl SessionService {
         )
         .await?;
 
+        // Effective capability list (harness + agent + session), resolved once
+        // and shared by sandbox auto-start and the session_start hook so the
+        // merge rule lives in exactly one place per call. Agent-cap lookup
+        // failures propagate here (sandbox auto-start treats them as fatal),
+        // unlike the best-effort `resolve_session_capability_configs` used by
+        // the advisory delete path.
+        let agent_capabilities = if let Some(agent_id) = agent_id {
+            self.db
+                .get_agent_capabilities(agent_id.uuid())
+                .await?
+                .into_iter()
+                .map(|row| AgentCapabilityConfig::with_config(row.capability_id, row.config))
+                .collect::<Vec<_>>()
+        } else {
+            Vec::new()
+        };
+        let effective_capabilities = merge_capabilities(
+            &merge_capabilities(&effective_harness.capabilities, &agent_capabilities),
+            &session_capabilities,
+        );
+
         if let Some(service) = &self.session_sandbox_service {
-            let agent_capabilities = if let Some(agent_id) = agent_id {
-                self.db
-                    .get_agent_capabilities(agent_id.uuid())
-                    .await?
-                    .into_iter()
-                    .map(|row| AgentCapabilityConfig::with_config(row.capability_id, row.config))
-                    .collect::<Vec<_>>()
-            } else {
-                Vec::new()
-            };
-            let merged = merge_capabilities(&effective_harness.capabilities, &agent_capabilities);
-            let merged = merge_capabilities(&merged, &session_capabilities);
             service
-                .auto_start_for_capabilities(session.id, &merged)
+                .auto_start_for_capabilities(session.id, &effective_capabilities)
                 .await;
         }
 
         // session_start lifecycle hooks (advisory). Fire after the session row,
         // mounts, and initial files are in place so a hook can observe/seed the
-        // session VFS. Resolve the same effective capability list used above.
-        {
-            let agent_caps = if let Some(agent_id) = agent_id {
-                self.db
-                    .get_agent_capabilities(agent_id.uuid())
-                    .await
-                    .unwrap_or_default()
-                    .into_iter()
-                    .map(|row| AgentCapabilityConfig::with_config(row.capability_id, row.config))
-                    .collect::<Vec<_>>()
-            } else {
-                Vec::new()
-            };
-            let merged = merge_capabilities(&effective_harness.capabilities, &agent_caps);
-            let merged = merge_capabilities(&merged, &session_capabilities);
-            self.fire_session_lifecycle_hooks(
-                org_id,
-                session.id,
-                agent_id.map(|a| a.to_string()),
-                &merged,
-                everruns_core::user_hook_types::HookEvent::SessionStart,
-                serde_json::json!({ "agent_id": agent_id.map(|a| a.to_string()) }),
-            )
-            .await;
-        }
+        // session VFS.
+        self.fire_session_lifecycle_hooks(
+            org_id,
+            session.id,
+            agent_id.map(|a| a.to_string()),
+            &effective_capabilities,
+            everruns_core::user_hook_types::HookEvent::SessionStart,
+            serde_json::json!({ "agent_id": agent_id.map(|a| a.to_string()) }),
+        )
+        .await;
 
         Ok(session)
     }

--- a/crates/server/src/domains/sessions/service.rs
+++ b/crates/server/src/domains/sessions/service.rs
@@ -440,6 +440,34 @@ impl SessionService {
                 .await;
         }
 
+        // session_start lifecycle hooks (advisory). Fire after the session row,
+        // mounts, and initial files are in place so a hook can observe/seed the
+        // session VFS. Resolve the same effective capability list used above.
+        {
+            let agent_caps = if let Some(agent_id) = agent_id {
+                self.db
+                    .get_agent_capabilities(agent_id.uuid())
+                    .await
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|row| AgentCapabilityConfig::with_config(row.capability_id, row.config))
+                    .collect::<Vec<_>>()
+            } else {
+                Vec::new()
+            };
+            let merged = merge_capabilities(&effective_harness.capabilities, &agent_caps);
+            let merged = merge_capabilities(&merged, &session_capabilities);
+            self.fire_session_lifecycle_hooks(
+                org_id,
+                session.id,
+                agent_id.map(|a| a.to_string()),
+                &merged,
+                everruns_core::user_hook_types::HookEvent::SessionStart,
+                serde_json::json!({ "agent_id": agent_id.map(|a| a.to_string()) }),
+            )
+            .await;
+        }
+
         Ok(session)
     }
 
@@ -1134,16 +1162,144 @@ impl SessionService {
     }
 
     pub async fn delete(&self, caller: &Caller, id: Uuid) -> Result<bool> {
-        let deleted = self
-            .db
-            .delete_session(caller.org_id, SessionId::from_uuid(id))
-            .await?;
+        // session_end lifecycle hooks fire before eviction so the hook command
+        // can still read the session VFS. Advisory: failures never block the
+        // delete. Resolve the session's capability list first (best-effort).
+        let session_id = SessionId::from_uuid(id);
+        if let Ok(Some(row)) = self.db.get_session(caller.org_id, session_id).await {
+            let session_caps: Vec<AgentCapabilityConfig> =
+                serde_json::from_value(row.capabilities.clone()).unwrap_or_default();
+            let capabilities = self
+                .resolve_session_capability_configs(
+                    caller.org_id,
+                    row.harness_id,
+                    row.agent_id,
+                    &session_caps,
+                )
+                .await;
+            self.fire_session_lifecycle_hooks(
+                caller.org_id,
+                session_id,
+                row.agent_id.map(|a| a.to_string()),
+                &capabilities,
+                everruns_core::user_hook_types::HookEvent::SessionEnd,
+                serde_json::json!({ "reason": "deleted" }),
+            )
+            .await;
+        }
+
+        let deleted = self.db.delete_session(caller.org_id, session_id).await?;
 
         if deleted {
             self.session_file_service.evict_virtual_mounts(id);
         }
 
         Ok(deleted)
+    }
+
+    /// Resolve the effective capability configs for a session (harness chain +
+    /// agent + session), used by the lifecycle-hook firing helpers. Best-effort:
+    /// returns an empty list if the harness/agent can't be loaded, so a
+    /// resolution failure degrades to "no hooks" rather than erroring a
+    /// create/delete.
+    async fn resolve_session_capability_configs(
+        &self,
+        org_id: i64,
+        harness_id: Option<HarnessId>,
+        agent_id: Option<AgentId>,
+        session_caps: &[AgentCapabilityConfig],
+    ) -> Vec<AgentCapabilityConfig> {
+        let harness_caps = match harness_id {
+            Some(harness_id) => match crate::domains::harnesses::queries::resolve_effective(
+                self.db.as_ref(),
+                org_id,
+                harness_id,
+            )
+            .await
+            {
+                Ok(Some(h)) => h.capabilities,
+                _ => Vec::new(),
+            },
+            None => Vec::new(),
+        };
+        let agent_caps = if let Some(agent_id) = agent_id {
+            self.db
+                .get_agent_capabilities(agent_id.uuid())
+                .await
+                .unwrap_or_default()
+                .into_iter()
+                .map(|row| AgentCapabilityConfig::with_config(row.capability_id, row.config))
+                .collect::<Vec<_>>()
+        } else {
+            Vec::new()
+        };
+        let merged = merge_capabilities(&harness_caps, &agent_caps);
+        merge_capabilities(&merged, session_caps)
+    }
+
+    /// Fire session-lifecycle hooks (`session_start` / `session_end`) for a
+    /// session. Advisory only — collects + finalizes hook specs from the given
+    /// capability list, builds the bash-backed adapters against the session's
+    /// VFS, and runs them. Any failure is logged, never propagated.
+    async fn fire_session_lifecycle_hooks(
+        &self,
+        org_id: i64,
+        session_id: SessionId,
+        agent_id: Option<String>,
+        capabilities: &[AgentCapabilityConfig],
+        event: everruns_core::user_hook_types::HookEvent,
+        data: serde_json::Value,
+    ) {
+        let resolved = match resolve_capability_configs(capabilities, &self.capability_registry) {
+            Ok(r) => r,
+            Err(error) => {
+                tracing::warn!(
+                    session_id = %session_id,
+                    ?error,
+                    "failed to resolve capabilities for session lifecycle hooks; skipping"
+                );
+                return;
+            }
+        };
+        // Gather + finalize specs (namespace stamping, muting) identically to
+        // the runtime act/turn paths.
+        let mut contributions: Vec<(String, Vec<everruns_core::user_hook_types::UserHookSpec>)> =
+            Vec::new();
+        let mut disabled: Vec<String> = Vec::new();
+        for config in &resolved {
+            let Some(capability) = self.capability_registry.get(config.capability_id()) else {
+                continue;
+            };
+            let specs = capability.user_hooks_with_config(&config.config);
+            if !specs.is_empty() {
+                contributions.push((config.capability_id().to_string(), specs));
+            }
+            if config.capability_id() == "user_hooks" {
+                disabled.extend(
+                    everruns_core::capabilities::user_hooks::disabled_contributions(&config.config),
+                );
+            }
+        }
+        let specs = everruns_core::hook_adapter::finalize_hook_specs(contributions, &disabled);
+        let file_store: Arc<dyn everruns_core::traits::SessionFileSystem> = Arc::new(
+            crate::domains::session_files::SessionFileService::new(self.db.clone()),
+        );
+        let dispatcher: Arc<dyn everruns_core::hook_executor::BashHookDispatcher> =
+            Arc::new(everruns_core::hook_dispatch::VirtualBashHookDispatcher::new(file_store));
+        let hooks = everruns_core::lifecycle_hooks::build_session_lifecycle_hooks(
+            &specs, event, dispatcher,
+        );
+        if hooks.is_empty() {
+            return;
+        }
+        let ctx = everruns_core::lifecycle_hooks::SessionHookContext {
+            session_id,
+            org_id: everruns_core::org_public_id_from_internal(org_id)
+                .parse()
+                .ok(),
+            agent_id,
+        };
+        everruns_core::lifecycle_hooks::run_session_lifecycle_hooks(&hooks, &ctx, data).await;
     }
 
     /// Pin a session for a user
@@ -2930,5 +3086,132 @@ mod tests {
                 "got: {err} for tag: {forbidden}"
             );
         }
+    }
+
+    // Build a harness carrying a `user_hooks` capability with a single hook of
+    // the given event that writes a sentinel into the session VFS. Exercises the
+    // real server resolve -> finalize -> virtual_bash dispatch path end-to-end.
+    async fn harness_with_user_hook(
+        db: &Arc<StorageBackend>,
+        org_id: i64,
+        name: &str,
+        event: &str,
+        command: &str,
+    ) -> HarnessId {
+        let harness = db
+            .create_harness(
+                org_id,
+                CreateHarnessRow {
+                    name: name.to_string(),
+                    display_name: Some(name.to_string()),
+                    description: None,
+                    system_prompt: "hooked".to_string(),
+                    parent_harness_id: None,
+                    default_model_id: None,
+                    tags: vec![],
+                    initial_files: serde_json::json!([]),
+                    mcp_servers: serde_json::json!({}),
+                    network_access: None,
+                    is_built_in: false,
+                },
+            )
+            .await
+            .unwrap();
+        db.set_harness_capabilities(
+            harness.id.uuid(),
+            vec![(
+                "user_hooks".to_string(),
+                0,
+                serde_json::json!({
+                    "hooks": [{
+                        "event": event,
+                        "executor": { "type": "bash", "command": command },
+                    }]
+                }),
+            )],
+        )
+        .await
+        .unwrap();
+        harness.id
+    }
+
+    #[tokio::test]
+    async fn session_start_hook_fires_on_create() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let mut registry = CapabilityRegistry::new();
+        registry.register(everruns_core::capabilities::UserHooksCapability);
+        let session_service = SessionService::with_registry(db.clone(), registry);
+        let caller = Caller::internal(DEFAULT_ORG_ID);
+
+        let harness_id = harness_with_user_hook(
+            &db,
+            caller.org_id,
+            "session-start-harness",
+            "session_start",
+            "echo started > /workspace/.session_start_ok",
+        )
+        .await;
+
+        let session = session_service
+            .create(
+                &caller,
+                harness_id.uuid(),
+                None,
+                None,
+                build_create_request(harness_id, None, None),
+            )
+            .await
+            .unwrap();
+
+        // The session_start hook ran during create and wrote into the VFS.
+        let file = SessionFileService::new(db)
+            .read_file(session.id.uuid(), "/.session_start_ok")
+            .await
+            .unwrap();
+        assert!(
+            file.as_ref()
+                .is_some_and(|f| f.content.as_deref().is_some_and(|c| c.contains("started"))),
+            "session_start hook should have written the sentinel, got: {file:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn session_end_hook_fires_on_delete_without_blocking() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let mut registry = CapabilityRegistry::new();
+        registry.register(everruns_core::capabilities::UserHooksCapability);
+        let session_service = SessionService::with_registry(db.clone(), registry);
+        let caller = Caller::internal(DEFAULT_ORG_ID);
+
+        let harness_id = harness_with_user_hook(
+            &db,
+            caller.org_id,
+            "session-end-harness",
+            "session_end",
+            "echo ending > /workspace/.session_end_ok",
+        )
+        .await;
+
+        let session = session_service
+            .create(
+                &caller,
+                harness_id.uuid(),
+                None,
+                None,
+                build_create_request(harness_id, None, None),
+            )
+            .await
+            .unwrap();
+
+        // session_end is advisory: the hook fires (resolve -> dispatch) but never
+        // blocks the delete, which must still succeed.
+        let deleted = session_service
+            .delete(&caller, session.id.uuid())
+            .await
+            .unwrap();
+        assert!(
+            deleted,
+            "delete should succeed with a session_end hook present"
+        );
     }
 }

--- a/docs/capabilities/user-hooks.md
+++ b/docs/capabilities/user-hooks.md
@@ -358,19 +358,24 @@ resolved `hook_id` and the `tool_call_id`.
 observability pipeline as tool events (Braintrust, OTel). These are not
 emitted yet — see the spec's observability section.
 
-## What's not yet wired
+## Event firing
 
-`pre_tool_use` and `post_tool_use` **fire today**: a pre-hook can block or
-mutate a tool call before it runs, and a post-hook can mutate the tool
-result after it runs.
+All six events fire:
 
-The remaining events (`session_start`, `user_prompt_submit`, `turn_end`,
-`session_end`) ship their *contract, types, executor, and validation* here
-but their runtime firing points land in follow-up changes so reviewers can
-audit each one against the relevant execution atom in isolation. Configuring
-those events is a validated no-op until their wire-in ships. Track progress
-against
-[`specs/user-hooks.md`](https://github.com/everruns/everruns/blob/main/specs/user-hooks.md).
+- **`pre_tool_use`** — before each tool call; can block or mutate the call.
+- **`post_tool_use`** — after each tool call; can mutate the result.
+- **`session_start`** — after a session is created (mounts + initial files in
+  place); advisory.
+- **`session_end`** — when a session is deleted, before VFS eviction; advisory.
+- **`user_prompt_submit`** — on the first reason iteration, before the LLM is
+  consulted; can block (aborts the turn with a user-facing message) or mutate
+  the user message text.
+- **`turn_end`** — when a turn reaches a terminal outcome; advisory.
+
+Note on `user_prompt_submit` blocking: the API persists the user message and
+runs the turn asynchronously, so a block does not reject the HTTP request —
+it aborts the turn. The session shows a `turn.failed` outcome carrying the
+hook's `user_message`.
 
 ## See also
 

--- a/examples/hook-bundles/README.md
+++ b/examples/hook-bundles/README.md
@@ -8,7 +8,7 @@ capability.
 |---|---|---|
 | [`block-rm-rf.json`](./block-rm-rf.json) | `user_hooks` config | Block `rm -rf /...` calls on the `bash` tool. |
 | [`format-on-edit.json`](./format-on-edit.json) | `user_hooks` config | Run `cargo fmt` and `prettier` after each `edit_file`. |
-| [`session-bootstrap.json`](./session-bootstrap.json) | `user_hooks` config | Drop a sentinel file at session start. **Deferred:** `session_start` is not wired to fire yet — this bundle validates but is a no-op until the session-start wire-in lands. |
+| [`session-bootstrap.json`](./session-bootstrap.json) | `user_hooks` config | Drop a sentinel file at session start. |
 | [`audit-every-tool.json`](./audit-every-tool.json) | `user_hooks` config | Append every tool call to `/workspace/.audit.log`. |
 
 ## Using a hook config

--- a/specs/user-hooks.md
+++ b/specs/user-hooks.md
@@ -49,14 +49,22 @@ relevant execution atom in isolation.
 
 | Event | Trait | Fires at | Mutation surface | Can block? | Wire-in status |
 |---|---|---|---|---|---|
-| `session_start` | `SessionLifecycleHook::on_session_start` | session create | none | no | follow-up: server session create path |
-| `user_prompt_submit` | `TurnLifecycleHook::on_turn_start` | inbound user message accepted, before reason | user message text | yes | follow-up: turn entry |
+| `session_start` | `SessionLifecycleHook` | session create | none | no | **wired** in `SessionService::create_inner` (server) |
+| `user_prompt_submit` | `TurnLifecycleHook` | first reason iteration, before the LLM | user message text | yes | **wired** in `execute_reason_activity` (runtime) |
 | `pre_tool_use` | `PreToolUseHook::before_exec` | each tool call, before execution | `ToolCall.arguments` (JSON patch) | yes | **wired** in `ActAtom::execute_single_tool` |
 | `post_tool_use` | `PostToolExecHook::after_exec` (existing trait) | each tool call, after execution | `ToolResult` fields | no | **wired** via existing `PostToolExecHook` chain |
-| `turn_end` | `TurnLifecycleHook::on_turn_end` | turn finishes | none | no | follow-up: turn exit |
-| `session_end` | `SessionLifecycleHook::on_session_end` | session close/archive | none | no | follow-up: server session close path |
+| `turn_end` | `TurnLifecycleHook` | turn finishes | none | no | **wired** in `RuntimeSessionLifecycle::fire_turn_end_hooks` |
+| `session_end` | `SessionLifecycleHook` | session delete | none | no | **wired** in `SessionService::delete` (server) |
 
-This phasing trades a slightly longer rollout for cleaner reviewability:
+All six events now fire. `user_prompt_submit` fires on the first reason
+iteration (the shared choke point for both the in-process loop and the
+durable worker, immediately before the LLM is consulted) rather than at raw
+HTTP submission: the server returns the stored message to the caller and runs
+the turn asynchronously, so a `Block` aborts the turn (emitting a user-facing
+message + `turn.failed` and idling the session) rather than rejecting the
+original HTTP response.
+
+This phasing traded a slightly longer rollout for cleaner reviewability:
 each wire-in is a 50-100 LOC change against a single execution atom with
 focused tests, instead of one mega-PR touching every atom.
 


### PR DESCRIPTION
## What

Wires the four user-hook lifecycle events that previously shipped their contract/types/validation but had **no runtime firing point** — configuring them was a validated no-op. All six `HookEvent`s now fire end-to-end:

| Event | Fires at | Blockable? |
|---|---|---|
| `session_start` | `SessionService::create_inner`, after mounts + initial files | no (advisory) |
| `session_end` | `SessionService::delete`, before VFS eviction | no (advisory) |
| `user_prompt_submit` | `execute_reason_activity`, first reason iteration, before the LLM | **yes** |
| `turn_end` | `RuntimeSessionLifecycle::fire_turn_end_hooks`, at turn completion | no (advisory) |
| `pre_tool_use` / `post_tool_use` | (already wired) | — |

## Why

Completes the user-hooks taxonomy in `specs/user-hooks.md`. The remaining four events were deliberately phased for reviewability; this lands their firing points.

## How

- **Core** — new `lifecycle_hooks` module: `SessionLifecycleHook` + `TurnLifecycleHook` traits and a shared bash-backed adapter that reuses `BashHookExecutor` + `BashHookDispatcher`, so payload delivery, output limits, and `on_error` policy are identical to the tool hooks. `user_prompt_submit` runs sequentially over the message text (mutations thread, first `Block` wins); `turn_end` and the session events are advisory (block/mutate logged and ignored). New `BLOCKED_BY_HOOK` user-facing error code.
- **Runtime** — shared `finalize_specs_from_configs` / `collect_lifecycle_hook_specs` so every firing point finalizes specs identically (namespace stamping, `disabled_contributions` muting); the act path now uses the shared helper instead of an inline copy. `user_prompt_submit` blocks by reusing the `dependency_blocked` abort path (user-facing message + `turn.failed` + idle), so it works for both the in-process loop and the durable worker. `turn_end` fires on both the in-process and durable/strategy completion paths.
- **Server** — `session_start` fires after `create_inner`; `session_end` fires in `delete` before eviction. Capability resolution mirrors the existing `scoped_mcp` pattern and degrades to "no hooks" on error.

### Design note: `user_prompt_submit` blocking

The API persists the user message and runs the turn asynchronously, so a block cannot reject the original HTTP response. Instead it aborts the turn: the session shows a `turn.failed` outcome carrying the hook's `user_message`. `user_prompt_submit` fires on the first reason iteration (the shared choke point for the in-process loop and the durable worker, immediately before the LLM).

## Risk

- **Low.** Additive firing points; no change to who can configure hooks (`user_hooks` stays `High`-risk, admin-gated). Reuses the existing sandboxed executor/dispatcher unchanged.

## Security

- **Threat categories reviewed:** TM-HOOK (001–006), TM-BASH, TM-AUTHZ.
- **Findings/resolutions:**
  - TM-HOOK-003 (timeout/output DoS): `timeout_ms` is validated to `100..=30_000ms` at config-write time; the new adapter builds `ExecutorOpts { timeout_ms, max_output_bytes: 64 KiB }` — byte-identical to the existing tool-hook adapter. Preserved.
  - TM-HOOK-001/002 (path trust, egress): every firing point reuses the same `VirtualBashHookDispatcher` + sandboxed VFS / no-network bashkit build. Preserved.
  - TM-HOOK-004 (namespace + muting): all paths route through `finalize_hook_specs`. Preserved.
  - No new privilege surface: only firing points were added for events the threat model already enumerates ("lifecycle and tool events"); session create/delete remain authz-gated before these points.
  - **No threat-model changes required.**

## Follow-ups

No follow-ups. The previously-deferred declarative-capability hook bundles (TM-HOOK-006) remain out of scope and tracked separately in the threat model.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (internal-only; no external contract change)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

## Validation

- `pre-push` clean (fmt, clippy `-D warnings`, lockfile, migrations, specs index, attribution).
- core lib: 1993 pass incl. 10 new `lifecycle_hooks` tests (block via json/exit, mutate, chain threading, `on_error`, advisory, event filtering).
- runtime e2e (real `virtual_bash` dispatch): `user_prompt_submit` block aborts before reason, allow does not block, `turn_end` writes its sentinel to the session VFS.
- server integration (real dispatch, in-memory `StorageBackend`): `session_start` writes its sentinel on create; `session_end` fires on delete without blocking.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TtjDajqb7QA5QwJBmgek4j)_