### PR TITLE
feat(e2b,deno): BYO-only sandbox credentials (EVE-505)

### DIFF
--- a/crates/worker/src/leased_resource_cleanup.rs
+++ b/crates/worker/src/leased_resource_cleanup.rs
@@ -194,7 +194,7 @@ async fn cleanup_resource(
     resolver: &dyn UserConnectionResolver,
     storage_store: &dyn SessionStorageStore,
 ) -> Result<String> {
-    let token = resolve_provider_token(resource, resolver, storage_store).await?;
+    let token = resolve_provider_token(resource, resolver).await?;
 
     match (resource.provider.as_str(), resource.resource_type.as_str()) {
         ("daytona", "sandbox") => cleanup_daytona(resource, storage_store, &token).await,
@@ -215,11 +215,7 @@ async fn cleanup_resource(
 async fn resolve_provider_token(
     resource: &LeasedResource,
     resolver: &dyn UserConnectionResolver,
-    storage_store: &dyn SessionStorageStore,
 ) -> Result<String> {
-    if resource.provider == "e2b" {
-        return resolve_e2b_api_key(resource, storage_store).await;
-    }
     if let Some(owner_user_id) = resource.owner_user_id
         && let Some(token) = resolver
             .get_connection_token_for_user(owner_user_id, &resource.provider)
@@ -236,42 +232,12 @@ async fn resolve_provider_token(
         return Ok(token);
     }
 
-    if resource.provider == "deno"
-        && let Ok(token) = std::env::var("DENO_DEPLOY_TOKEN")
-        && !token.is_empty()
-    {
-        return Ok(token);
-    }
-
     Err(anyhow!(
         "No provider token available for leased resource {} ({}/{})",
         resource.id,
         resource.provider,
         resource.resource_type
     ))
-}
-
-async fn resolve_e2b_api_key(
-    resource: &LeasedResource,
-    storage_store: &dyn SessionStorageStore,
-) -> Result<String> {
-    if let Some(session_id) = resource.session_id
-        && let Some(token) = storage_store.get_secret(session_id, "E2B_API_KEY").await?
-        && !token.trim().is_empty()
-    {
-        return Ok(token);
-    }
-
-    let env_token = std::env::var("E2B_API_KEY")
-        .map_err(|_| anyhow!("E2B_API_KEY not configured for leased resource cleanup"))?;
-
-    if env_token.trim().is_empty() {
-        return Err(anyhow!(
-            "E2B_API_KEY is set but empty/whitespace for leased resource cleanup"
-        ));
-    }
-
-    Ok(env_token)
 }
 
 async fn cleanup_daytona(
@@ -492,11 +458,6 @@ fn deno_cleanup_org(resource: &LeasedResource) -> Option<String> {
         .and_then(serde_json::Value::as_str)
         .filter(|org| !org.is_empty())
         .map(str::to_string)
-        .or_else(|| {
-            std::env::var("DENO_DEPLOY_ORG")
-                .ok()
-                .filter(|org| !org.is_empty())
-        })
 }
 
 fn is_deno_not_found(error: &str) -> bool {
@@ -514,113 +475,6 @@ fn is_browserless_already_gone(error: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::HashMap;
-    use std::sync::{Mutex, OnceLock};
-
-    use async_trait::async_trait;
-    use everruns_core::{KeyInfo, LeasedResourceStatus, SecretInfo};
-    use uuid::Uuid;
-
-    // Tests that mutate process-wide env vars (e.g. E2B_API_KEY) must not run
-    // in parallel; `cargo test` schedules them on separate threads by default.
-    // The async-aware tokio Mutex is required because the guard is held
-    // across `.await` points while env-var state has to remain stable.
-    fn env_mutex() -> &'static tokio::sync::Mutex<()> {
-        static LOCK: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
-    }
-
-    struct TestSessionStorageStore {
-        secrets: Mutex<HashMap<(String, String), String>>,
-    }
-
-    impl TestSessionStorageStore {
-        fn with_secret(session_id: SessionId, name: &str, value: &str) -> Self {
-            let mut secrets = HashMap::new();
-            secrets.insert(
-                (session_id.to_string(), name.to_string()),
-                value.to_string(),
-            );
-            Self {
-                secrets: Mutex::new(secrets),
-            }
-        }
-
-        fn empty() -> Self {
-            Self {
-                secrets: Mutex::new(HashMap::new()),
-            }
-        }
-    }
-
-    #[async_trait]
-    impl SessionStorageStore for TestSessionStorageStore {
-        async fn set_value(
-            &self,
-            _session_id: SessionId,
-            _key: &str,
-            _value: &str,
-        ) -> everruns_core::Result<()> {
-            unimplemented!()
-        }
-
-        async fn get_value(
-            &self,
-            _session_id: SessionId,
-            _key: &str,
-        ) -> everruns_core::Result<Option<String>> {
-            unimplemented!()
-        }
-
-        async fn delete_value(
-            &self,
-            _session_id: SessionId,
-            _key: &str,
-        ) -> everruns_core::Result<bool> {
-            unimplemented!()
-        }
-
-        async fn list_keys(&self, _session_id: SessionId) -> everruns_core::Result<Vec<KeyInfo>> {
-            unimplemented!()
-        }
-
-        async fn set_secret(
-            &self,
-            _session_id: SessionId,
-            _name: &str,
-            _value: &str,
-        ) -> everruns_core::Result<()> {
-            unimplemented!()
-        }
-
-        async fn get_secret(
-            &self,
-            session_id: SessionId,
-            name: &str,
-        ) -> everruns_core::Result<Option<String>> {
-            Ok(self
-                .secrets
-                .lock()
-                .expect("test secrets lock poisoned")
-                .get(&(session_id.to_string(), name.to_string()))
-                .cloned())
-        }
-
-        async fn delete_secret(
-            &self,
-            _session_id: SessionId,
-            _name: &str,
-        ) -> everruns_core::Result<bool> {
-            unimplemented!()
-        }
-
-        async fn list_secrets(
-            &self,
-            _session_id: SessionId,
-        ) -> everruns_core::Result<Vec<SecretInfo>> {
-            unimplemented!()
-        }
-    }
 
     #[test]
     fn browserless_external_id_drops_query_string() {
@@ -651,124 +505,6 @@ mod tests {
         assert!(!is_browserless_already_gone(
             "CDP WebSocket connection failed: dns error"
         ));
-    }
-
-    #[tokio::test]
-    async fn e2b_cleanup_prefers_session_secret_override() {
-        let _guard = env_mutex().lock().await;
-        let session_id = SessionId::from_uuid(Uuid::nil());
-        let storage =
-            TestSessionStorageStore::with_secret(session_id, "E2B_API_KEY", "session-key");
-        let resource = LeasedResource {
-            id: Uuid::new_v4().into(),
-            session_id: Some(session_id),
-            provider: "e2b".to_string(),
-            resource_type: "sandbox".to_string(),
-            external_id: "sb_test".to_string(),
-            display_name: None,
-            status: LeasedResourceStatus::Active,
-            owner_user_id: None,
-            lease_duration_seconds: 60,
-            last_touched_at: chrono::Utc::now(),
-            metadata: serde_json::json!({}),
-            lease_expires_at: chrono::Utc::now(),
-            cleanup_started_at: None,
-            cleanup_completed_at: None,
-            cleanup_attempts: 0,
-            last_cleanup_error: None,
-            created_at: chrono::Utc::now(),
-            updated_at: chrono::Utc::now(),
-        };
-
-        unsafe {
-            std::env::set_var("E2B_API_KEY", "env-key");
-        }
-        let token = resolve_e2b_api_key(&resource, &storage)
-            .await
-            .expect("session override should resolve");
-        unsafe {
-            std::env::remove_var("E2B_API_KEY");
-        }
-
-        assert_eq!(token, "session-key");
-    }
-
-    #[tokio::test]
-    async fn e2b_cleanup_falls_back_to_env_key() {
-        let _guard = env_mutex().lock().await;
-        let session_id = SessionId::from_uuid(Uuid::nil());
-        let storage = TestSessionStorageStore::empty();
-        let resource = LeasedResource {
-            id: Uuid::new_v4().into(),
-            session_id: Some(session_id),
-            provider: "e2b".to_string(),
-            resource_type: "sandbox".to_string(),
-            external_id: "sb_test".to_string(),
-            display_name: None,
-            status: LeasedResourceStatus::Active,
-            owner_user_id: None,
-            lease_duration_seconds: 60,
-            last_touched_at: chrono::Utc::now(),
-            metadata: serde_json::json!({}),
-            lease_expires_at: chrono::Utc::now(),
-            cleanup_started_at: None,
-            cleanup_completed_at: None,
-            cleanup_attempts: 0,
-            last_cleanup_error: None,
-            created_at: chrono::Utc::now(),
-            updated_at: chrono::Utc::now(),
-        };
-
-        unsafe {
-            std::env::set_var("E2B_API_KEY", "env-key");
-        }
-        let token = resolve_e2b_api_key(&resource, &storage)
-            .await
-            .expect("env fallback should resolve");
-        unsafe {
-            std::env::remove_var("E2B_API_KEY");
-        }
-
-        assert_eq!(token, "env-key");
-    }
-
-    #[tokio::test]
-    async fn e2b_cleanup_rejects_blank_env_key() {
-        let _guard = env_mutex().lock().await;
-        let session_id = SessionId::from_uuid(Uuid::nil());
-        let storage = TestSessionStorageStore::empty();
-        let resource = LeasedResource {
-            id: Uuid::new_v4().into(),
-            session_id: Some(session_id),
-            provider: "e2b".to_string(),
-            resource_type: "sandbox".to_string(),
-            external_id: "sb_test".to_string(),
-            display_name: None,
-            status: LeasedResourceStatus::Active,
-            owner_user_id: None,
-            lease_duration_seconds: 60,
-            last_touched_at: chrono::Utc::now(),
-            metadata: serde_json::json!({}),
-            lease_expires_at: chrono::Utc::now(),
-            cleanup_started_at: None,
-            cleanup_completed_at: None,
-            cleanup_attempts: 0,
-            last_cleanup_error: None,
-            created_at: chrono::Utc::now(),
-            updated_at: chrono::Utc::now(),
-        };
-
-        unsafe {
-            std::env::set_var("E2B_API_KEY", "   ");
-        }
-        let error = resolve_e2b_api_key(&resource, &storage)
-            .await
-            .expect_err("blank env token should fail");
-        unsafe {
-            std::env::remove_var("E2B_API_KEY");
-        }
-
-        assert!(error.to_string().contains("empty/whitespace"));
     }
 
     #[test]

--- a/integrations/deno/src/lib.rs
+++ b/integrations/deno/src/lib.rs
@@ -5,8 +5,8 @@
 //!
 //! Decision: model the public tool surface after Daytona so agents can switch
 //! between cloud sandboxes with minimal prompt changes.
-//! Decision: prefer user connections, but allow `DENO_DEPLOY_TOKEN` /
-//! `DENO_DEPLOY_ORG` env fallbacks for operator-managed deployments and live tests.
+//! Decision: BYO connection model — credentials resolve from user connection only;
+//!   no env-var fallback. Fail with ConnectionRequired if not configured.
 //! Decision: create sandboxes with a fixed timeout instead of Deno's default
 //! `session` lifetime because Everruns closes the creator websocket after each tool.
 

--- a/integrations/deno/src/state.rs
+++ b/integrations/deno/src/state.rs
@@ -65,20 +65,6 @@ pub async fn get_credentials(
         }
     }
 
-    if let Ok(token) = std::env::var("DENO_DEPLOY_TOKEN")
-        && !token.is_empty()
-    {
-        let org = std::env::var("DENO_DEPLOY_ORG")
-            .ok()
-            .filter(|s| !s.is_empty());
-        if token.starts_with("ddp_") && org.is_none() {
-            return Err(ToolExecutionResult::tool_error(
-                "DENO_DEPLOY_TOKEN is a personal token (ddp_...) but DENO_DEPLOY_ORG is not set. Set DENO_DEPLOY_ORG or use an organization token (ddo_...).",
-            ));
-        }
-        return Ok(DenoCredentials { token, org });
-    }
-
     // THREAT[TM-AGENT-016]: Asking for sandbox credentials in chat would store
     // them plaintext in events. Return ConnectionRequired so the UI can render
     // the inline connection flow instead of asking the user to paste secrets.

--- a/integrations/e2b/SPEC.md
+++ b/integrations/e2b/SPEC.md
@@ -2,7 +2,7 @@
 
 ## Abstract
 
-The E2B capability integrates [E2B](https://e2b.dev/docs) cloud sandboxes as an agent execution environment. Agents can create, pause, resume, delete, and interact with isolated Linux environments per session. The implementation intentionally uses a **platform-owned** `E2B_API_KEY` from the server/worker environment instead of per-user connections.
+The E2B capability integrates [E2B](https://e2b.dev/docs) cloud sandboxes as an agent execution environment. Agents can create, pause, resume, delete, and interact with isolated Linux environments per session. Users bring their own E2B API key via the connection provider; no platform-owned or environment-variable fallback is accepted.
 
 **Status**: Available (All environments)
 
@@ -19,15 +19,15 @@ The Everruns integration mirrors Daytona's session-scoped state model, but uses 
 
 ## Authentication Model
 
-### Why global env-backed auth
+### BYO API Key
 
-E2B sandboxes are treated as **platform infrastructure** rather than user-owned external accounts:
+Users connect their own E2B account via the connection provider (API key form). Credential resolution:
 
-1. The control plane and workers read `E2B_API_KEY` from environment (Doppler in cloud agents).
-2. A per-session secret named `E2B_API_KEY` may override the env var for testing or custom deployments.
-3. Agents never ask end users to paste E2B credentials in chat.
+1. The E2B tool calls resolve the API key from the session's `e2b` user connection.
+2. If no connection is configured, the tool returns `ConnectionRequired`, triggering the inline connection dialog.
+3. There is no env-var or platform-wide fallback. Every E2B operation requires a user-provided key.
 
-This keeps credentials out of message history and avoids adding user-connections UI for a platform-managed service.
+This keeps credentials out of message history and scopes sandbox costs and quotas to each user's E2B account.
 
 ## State Management
 
@@ -115,7 +115,7 @@ This supports dashboard traceability, orphan cleanup, and audit review.
 
 ## Security
 
-- **Global API key** stays in environment/session secrets and never appears in tool output.
+- **API key** resolves from the user connection; never stored in env vars or emitted in tool output.
 - **envd access tokens** are session-scoped and stored only in encrypted session secrets.
 - **Sandbox isolation** depends on E2B runtime boundaries plus Everruns session-scoped secret lookups.
 - **Resource leak mitigation** uses E2B timeout + auto-pause plus Everruns leased-resource cleanup.
@@ -125,7 +125,7 @@ This supports dashboard traceability, orphan cleanup, and audit review.
 | Scenario | Result Type | Message |
 |---|---|---|
 | Missing required param | `ToolError` | `Missing required parameter: {name}` |
-| Missing API key | `ToolError` | `E2B API key not configured...` |
+| No E2B connection | `ConnectionRequired` | triggers inline connection dialog |
 | Missing sandbox state | `ToolError` | `Sandbox '{id}' not found...` |
 | E2B lifecycle/file/process error | `ToolError` | `E2B API error (...)` or sandbox-specific error |
 | Missing storage context | `ToolError` | `Storage not available in this context` |
@@ -146,6 +146,6 @@ Covers capability metadata, plugin registration, state serialization, and HTTP r
 E2B_API_KEY=<key> cargo test -p everruns-integrations-e2b --features e2b-live-tests --test live_api_test
 ```
 
-Exercises sandbox create → file write/read → command exec → cleanup against the real E2B service. Missing-credential behavior is **fail-closed**: with the feature flag on but `E2B_API_KEY` unset, the test panics (see `specs/integrations.md`).
+Exercises sandbox create → file write/read → command exec → cleanup against the real E2B service. The live test reads `E2B_API_KEY` directly from the environment (bypassing the connection provider), so you set the env var when running tests locally. Missing-credential behavior is **fail-closed**: with the feature flag on but `E2B_API_KEY` unset, the test panics (see `specs/integrations.md`).
 
 CI keeps E2B live coverage off `pull_request`: `.github/workflows/ci.yml` runs the live test only on pushes to `main` when `integrations/e2b/**` changes. `.github/workflows/integration-live-sweep.yml` reruns the same live path weekly and on demand to catch shared regressions that path filters miss.

--- a/integrations/e2b/src/connection.rs
+++ b/integrations/e2b/src/connection.rs
@@ -1,0 +1,102 @@
+// E2B Connection Provider
+//
+// Decision: API-key-based connection. User obtains key from E2B dashboard.
+// Decision: Validate key by calling GET /sandboxes — 200 means valid, 401/403 means invalid.
+// Decision: All E2B-specific connection config lives in this crate, not in the server crate.
+
+use async_trait::async_trait;
+use everruns_core::connection_provider::{
+    ConnectionFormSchema, ConnectionProvider, ConnectionType, ConnectionValidation, FieldType,
+    FormField,
+};
+
+use crate::E2B_API_BASE;
+
+pub struct E2BConnectionProvider;
+
+#[async_trait]
+impl ConnectionProvider for E2BConnectionProvider {
+    fn provider_id(&self) -> &str {
+        "e2b"
+    }
+
+    fn display_name(&self) -> &str {
+        "E2B"
+    }
+
+    fn description(&self) -> &str {
+        "Cloud sandbox environments powered by E2B"
+    }
+
+    fn icon(&self) -> &str {
+        "cloud"
+    }
+
+    fn connection_type(&self) -> ConnectionType {
+        ConnectionType::ApiKey
+    }
+
+    fn form_schema(&self) -> Option<ConnectionFormSchema> {
+        Some(ConnectionFormSchema {
+            fields: vec![FormField {
+                name: "api_key".to_string(),
+                label: "API Key".to_string(),
+                field_type: FieldType::Password,
+                required: true,
+                placeholder: Some("e2b_...".to_string()),
+                help_text: None,
+            }],
+            instructions_markdown: "\
+1. Go to [E2B Dashboard](https://e2b.dev/dashboard)\n\
+2. Navigate to **API Keys** in your account settings\n\
+3. Click **Create API Key**\n\
+4. Copy the key and paste it below"
+                .to_string(),
+        })
+    }
+
+    async fn validate(&self, credential: &str) -> Result<ConnectionValidation, String> {
+        let client = reqwest::Client::new();
+        let response = client
+            .get(format!("{E2B_API_BASE}/sandboxes"))
+            .header("X-API-KEY", credential)
+            .send()
+            .await
+            .map_err(|e| format!("Failed to reach E2B API: {e}"))?;
+
+        match response.status().as_u16() {
+            200..=299 => Ok(ConnectionValidation {
+                provider_username: None,
+                provider_metadata: None,
+            }),
+            401 | 403 => {
+                Err("Invalid API key. Check that the key is correct and active.".to_string())
+            }
+            status => Err(format!("Unexpected response from E2B API (HTTP {status})")),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn provider_metadata() {
+        let p = E2BConnectionProvider;
+        assert_eq!(p.provider_id(), "e2b");
+        assert_eq!(p.display_name(), "E2B");
+        assert_eq!(p.connection_type(), ConnectionType::ApiKey);
+        assert_eq!(p.icon(), "cloud");
+    }
+
+    #[test]
+    fn form_schema_has_api_key_field() {
+        let p = E2BConnectionProvider;
+        let schema = p.form_schema().expect("should have form schema");
+        assert_eq!(schema.fields.len(), 1);
+        assert_eq!(schema.fields[0].name, "api_key");
+        assert!(schema.fields[0].required);
+        assert!(schema.instructions_markdown.contains("e2b.dev/dashboard"));
+    }
+}

--- a/integrations/e2b/src/lib.rs
+++ b/integrations/e2b/src/lib.rs
@@ -1,23 +1,25 @@
 //! E2B Integration
 //!
-//! Cloud sandboxes backed by E2B. This integration intentionally uses a
-//! platform-owned API key (`E2B_API_KEY`) from the server/worker environment
-//! instead of user connections because E2B sandboxes are provisioned as shared
-//! platform infrastructure, not per-user third-party accounts.
+//! Cloud sandboxes backed by E2B. Users bring their own E2B API key via the
+//! connection provider; no platform-owned or environment-variable fallback.
 //! Decision: external integration crate, auto-registered via inventory.
-//! Decision: global env-backed API key with optional per-session secret override.
+//! Decision: BYO API-key connection model — credentials resolve from user
+//!   connection only; fail with ConnectionRequired if not configured.
 //! Decision: session-scoped sandbox state + leased-resource cleanup, similar to Daytona.
 
 pub mod client;
+pub mod connection;
 pub mod state;
 mod tools;
 
 use everruns_core::LEASED_RESOURCES_FEATURE;
 use everruns_core::capabilities::{Capability, CapabilityStatus, IntegrationPlugin, RiskLevel};
+use everruns_core::connection_provider::ConnectionProviderPlugin;
 use everruns_core::tools::Tool;
 
 use std::sync::LazyLock;
 
+use connection::E2BConnectionProvider;
 use tools::{
     E2BCreateSandboxTool, E2BExecTool, E2BListSandboxesTool, E2BManageSandboxTool, E2BReadFileTool,
     E2BWriteFileTool,
@@ -31,8 +33,14 @@ inventory::submit! {
     }
 }
 
+inventory::submit! {
+    ConnectionProviderPlugin {
+        experimental_only: false,
+        factory: || Box::new(E2BConnectionProvider),
+    }
+}
+
 pub const E2B_API_BASE: &str = "https://api.e2b.app";
-pub const E2B_API_KEY_SECRET: &str = "E2B_API_KEY";
 pub const E2B_SANDBOX_SECRET_PREFIX: &str = "e2b_sandbox:";
 pub const E2B_DEFAULT_TEMPLATE: &str = "base";
 pub const E2B_DEFAULT_TIMEOUT_SECS: u64 = 60 * 60;

--- a/integrations/e2b/src/state.rs
+++ b/integrations/e2b/src/state.rs
@@ -1,7 +1,5 @@
 //! E2B API types and session state helpers.
 
-use std::env;
-
 use everruns_core::UpsertLeasedResource;
 use everruns_core::resource_ownership::verify_owned_external_resource_if_available;
 use everruns_core::tools::ToolExecutionResult;
@@ -10,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use tracing::{error, warn};
 
-use crate::{E2B_API_KEY_SECRET, E2B_DEFAULT_WORKSPACE_PATH, E2B_SANDBOX_SECRET_PREFIX};
+use crate::{E2B_DEFAULT_WORKSPACE_PATH, E2B_SANDBOX_SECRET_PREFIX};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -74,25 +72,23 @@ pub struct SandboxState {
 pub const E2B_SANDBOX_LEASE_DURATION_SECONDS: u32 = 20 * 60;
 
 pub async fn get_api_key(context: &ToolContext) -> Result<String, ToolExecutionResult> {
-    if let Some(storage) = context.storage_store.as_ref() {
-        match storage
-            .get_secret(context.session_id, E2B_API_KEY_SECRET)
+    if let Some(resolver) = context.connection_resolver.as_ref() {
+        match resolver
+            .get_connection_token(context.session_id, "e2b")
             .await
         {
             Ok(Some(key)) if !key.trim().is_empty() => return Ok(key),
             Ok(_) => {}
             Err(e) => {
-                error!("Failed to resolve E2B session secret: {e}");
+                error!("Failed to resolve E2B user connection: {e}");
             }
         }
     }
 
-    match env::var(E2B_API_KEY_SECRET) {
-        Ok(key) if !key.trim().is_empty() => Ok(key),
-        _ => Err(ToolExecutionResult::tool_error(
-            "E2B API key not configured. Set E2B_API_KEY in the server/worker environment or as a session secret.",
-        )),
-    }
+    // THREAT[TM-AGENT-016]: asking for sandbox credentials in chat would store
+    // them plaintext in events. Return ConnectionRequired so the UI renders the
+    // inline connection flow instead of asking the user to paste secrets.
+    Err(ToolExecutionResult::connection_required("e2b"))
 }
 
 pub async fn get_sandbox_state(

--- a/integrations/e2b/tests/plugin_registration.rs
+++ b/integrations/e2b/tests/plugin_registration.rs
@@ -1,6 +1,7 @@
 //! Integration tests for E2B plugin registration and capability.
 
 use everruns_core::capabilities::{CapabilityRegistry, IntegrationPlugin};
+use everruns_core::connection_provider::ConnectionProviderPlugin;
 use everruns_core::deployment::DeploymentGrade;
 
 // Force linker to include the integration crate's inventory submissions.
@@ -58,4 +59,17 @@ fn test_e2b_capability_metadata() {
     assert_eq!(cap.category(), Some("Execution"));
     assert_eq!(cap.dependencies(), vec!["session_storage"]);
     assert_eq!(cap.tools().len(), 6);
+}
+
+#[test]
+fn test_e2b_connection_provider_is_submitted() {
+    let plugins: Vec<&ConnectionProviderPlugin> =
+        inventory::iter::<ConnectionProviderPlugin>().collect();
+    assert!(
+        plugins.iter().any(|plugin| {
+            let provider = (plugin.factory)();
+            provider.provider_id() == "e2b"
+        }),
+        "E2B ConnectionProviderPlugin should be submitted via inventory"
+    );
 }

--- a/integrations/e2b/tests/tool_integration.rs
+++ b/integrations/e2b/tests/tool_integration.rs
@@ -14,6 +14,7 @@ use everruns_core::leased_resource::{LeasedResource, LeasedResourceStatus, Upser
 use everruns_core::tools::{Tool, ToolExecutionResult};
 use everruns_core::traits::{
     KeyInfo, LeasedResourceStore, SecretInfo, SessionStorageStore, ToolContext,
+    UserConnectionResolver,
 };
 use everruns_core::typed_id::{LeasedResourceId, SessionId};
 use serde_json::json;
@@ -26,10 +27,10 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 // Force linker to include the integration crate.
 use everruns_integrations_e2b as _;
 
+use everruns_integrations_e2b::E2B_SANDBOX_SECRET_PREFIX;
 use everruns_integrations_e2b::E2BCapability;
 use everruns_integrations_e2b::client::E2BClient;
 use everruns_integrations_e2b::state::SandboxState;
-use everruns_integrations_e2b::{E2B_API_KEY_SECRET, E2B_SANDBOX_SECRET_PREFIX};
 
 // ============================================================================
 // Mock SessionStorageStore
@@ -200,6 +201,31 @@ impl LeasedResourceStore for MockLeasedResourceStore {
 }
 
 // ============================================================================
+// Mock ConnectionResolver
+// ============================================================================
+
+struct MockConnectionResolver {
+    token: Option<String>,
+}
+
+#[async_trait]
+impl UserConnectionResolver for MockConnectionResolver {
+    async fn get_connection_token(
+        &self,
+        _session_id: SessionId,
+        _provider: &str,
+    ) -> Result<Option<String>> {
+        Ok(self.token.clone())
+    }
+}
+
+fn e2b_resolver() -> Arc<dyn UserConnectionResolver> {
+    Arc::new(MockConnectionResolver {
+        token: Some("test_api_key".to_string()),
+    })
+}
+
+// ============================================================================
 // Helpers
 // ============================================================================
 
@@ -211,7 +237,7 @@ fn get_tool(name: &str) -> Box<dyn Tool> {
         .unwrap_or_else(|| panic!("Tool {name} not found"))
 }
 
-/// Seed sandbox state into the store. API key comes via session secret.
+/// Seed sandbox state into the store.
 async fn setup_context_with_sandbox(
     session_id: SessionId,
     store: &Arc<MockStorageStore>,
@@ -232,12 +258,6 @@ async fn setup_context_with_sandbox(
             &format!("{E2B_SANDBOX_SECRET_PREFIX}{sandbox_id}"),
             &serde_json::to_string(&state).unwrap(),
         )
-        .await;
-}
-
-async fn setup_api_key(session_id: SessionId, store: &Arc<MockStorageStore>) {
-    store
-        .seed_secret(session_id, E2B_API_KEY_SECRET, "test_api_key")
         .await;
 }
 
@@ -445,10 +465,10 @@ async fn test_exec_tool_missing_api_key() {
         .await;
 
     match result {
-        ToolExecutionResult::ToolError(msg) => {
-            assert!(msg.contains("API key not configured"), "Got: {msg}");
+        ToolExecutionResult::ConnectionRequired { provider } => {
+            assert_eq!(provider, "e2b");
         }
-        other => panic!("Expected ToolError, got: {other:?}"),
+        other => panic!("Expected ConnectionRequired, got: {other:?}"),
     }
 }
 
@@ -457,8 +477,8 @@ async fn test_exec_tool_missing_sandbox_state() {
     let tool = get_tool("e2b_exec");
     let session_id = SessionId::new();
     let store = Arc::new(MockStorageStore::new());
-    setup_api_key(session_id, &store).await;
-    let context = ToolContext::with_storage_store(session_id, store);
+    let context =
+        ToolContext::with_storage_store(session_id, store).with_connection_resolver(e2b_resolver());
 
     let result = tool
         .execute_with_context(
@@ -482,12 +502,12 @@ async fn test_exec_tool_rejects_cross_session_sandbox_id() {
     let attacker_session = SessionId::new();
     let store = Arc::new(MockStorageStore::new());
     let leased_resources = Arc::new(MockLeasedResourceStore::new());
-    setup_api_key(attacker_session, &store).await;
     leased_resources
         .seed_active(owner_session, "e2b", "sandbox", "sb_foreign")
         .await;
 
     let context = ToolContext::with_storage_store(attacker_session, store)
+        .with_connection_resolver(e2b_resolver())
         .with_leased_resource_store(leased_resources);
 
     let result = tool
@@ -513,8 +533,8 @@ async fn test_exec_tool_missing_command_param() {
     let tool = get_tool("e2b_exec");
     let session_id = SessionId::new();
     let store = Arc::new(MockStorageStore::new());
-    setup_api_key(session_id, &store).await;
-    let context = ToolContext::with_storage_store(session_id, store);
+    let context =
+        ToolContext::with_storage_store(session_id, store).with_connection_resolver(e2b_resolver());
 
     let result = tool
         .execute_with_context(json!({"sandbox_id": "sb_test"}), &context)
@@ -533,8 +553,8 @@ async fn test_exec_tool_missing_sandbox_id() {
     let tool = get_tool("e2b_exec");
     let session_id = SessionId::new();
     let store = Arc::new(MockStorageStore::new());
-    setup_api_key(session_id, &store).await;
-    let context = ToolContext::with_storage_store(session_id, store);
+    let context =
+        ToolContext::with_storage_store(session_id, store).with_connection_resolver(e2b_resolver());
 
     let result = tool
         .execute_with_context(json!({"command": "ls"}), &context)
@@ -553,8 +573,8 @@ async fn test_read_file_tool_missing_path() {
     let tool = get_tool("e2b_read_file");
     let session_id = SessionId::new();
     let store = Arc::new(MockStorageStore::new());
-    setup_api_key(session_id, &store).await;
-    let context = ToolContext::with_storage_store(session_id, store);
+    let context =
+        ToolContext::with_storage_store(session_id, store).with_connection_resolver(e2b_resolver());
 
     let result = tool
         .execute_with_context(json!({"sandbox_id": "sb_test"}), &context)
@@ -573,8 +593,8 @@ async fn test_write_file_tool_missing_content() {
     let tool = get_tool("e2b_write_file");
     let session_id = SessionId::new();
     let store = Arc::new(MockStorageStore::new());
-    setup_api_key(session_id, &store).await;
-    let context = ToolContext::with_storage_store(session_id, store);
+    let context =
+        ToolContext::with_storage_store(session_id, store).with_connection_resolver(e2b_resolver());
 
     let result = tool
         .execute_with_context(
@@ -596,9 +616,9 @@ async fn test_manage_sandbox_invalid_action() {
     let tool = get_tool("e2b_manage_sandbox");
     let session_id = SessionId::new();
     let store = Arc::new(MockStorageStore::new());
-    setup_api_key(session_id, &store).await;
     setup_context_with_sandbox(session_id, &store, "sb_test").await;
-    let context = ToolContext::with_storage_store(session_id, store);
+    let context =
+        ToolContext::with_storage_store(session_id, store).with_connection_resolver(e2b_resolver());
 
     let result = tool
         .execute_with_context(
@@ -689,7 +709,8 @@ async fn test_sandbox_state_persistence_roundtrip() {
 }
 
 #[tokio::test]
-async fn test_create_sandbox_tool_no_storage_context() {
+async fn test_create_sandbox_tool_no_connection() {
+    // Without a connection resolver, the tool returns ConnectionRequired.
     let tool = get_tool("e2b_create_sandbox");
     let session_id = SessionId::new();
     let context = ToolContext::new(session_id);
@@ -697,24 +718,24 @@ async fn test_create_sandbox_tool_no_storage_context() {
     let result = tool.execute_with_context(json!({}), &context).await;
 
     match result {
-        ToolExecutionResult::ToolError(msg) => {
-            assert!(msg.contains("API key not configured"), "Got: {msg}");
+        ToolExecutionResult::ConnectionRequired { provider } => {
+            assert_eq!(provider, "e2b");
         }
-        other => panic!("Expected ToolError, got: {other:?}"),
+        other => panic!("Expected ConnectionRequired, got: {other:?}"),
     }
 }
 
 #[tokio::test]
-async fn test_api_key_resolved_from_session_secret() {
-    // Verify that session-secret API key resolution works by contrasting
-    // behavior with and without a seeded E2B_API_KEY secret.
-    // Uses read_file which requires API key + sandbox state — the error
-    // changes from "API key not configured" to "not found" when the key
-    // is present, proving the resolution path works without any network call.
+async fn test_api_key_resolved_from_connection_resolver() {
+    // Verify that connection-resolver API key resolution works by contrasting
+    // behavior with and without a resolver. Uses read_file which requires
+    // API key + sandbox state — the error changes from ConnectionRequired to
+    // "not found" when the resolver is present, proving the resolution path
+    // works without any network call.
     let tool = get_tool("e2b_read_file");
     let session_id = SessionId::new();
 
-    // Without API key — should fail on key resolution
+    // Without connection resolver — should return ConnectionRequired
     let store_no_key = Arc::new(MockStorageStore::new());
     let ctx_no_key = ToolContext::with_storage_store(session_id, store_no_key);
     let result = tool
@@ -724,17 +745,17 @@ async fn test_api_key_resolved_from_session_secret() {
         )
         .await;
     match &result {
-        ToolExecutionResult::ToolError(msg) => {
-            assert!(msg.contains("API key not configured"), "Got: {msg}");
+        ToolExecutionResult::ConnectionRequired { provider } => {
+            assert_eq!(provider, "e2b");
         }
-        other => panic!("Expected ToolError about API key, got: {other:?}"),
+        other => panic!("Expected ConnectionRequired, got: {other:?}"),
     }
 
-    // With API key seeded as session secret — should get past key check
-    // and fail on missing sandbox state instead
+    // With connection resolver — should get past key check and fail on
+    // missing sandbox state instead
     let store_with_key = Arc::new(MockStorageStore::new());
-    setup_api_key(session_id, &store_with_key).await;
-    let ctx_with_key = ToolContext::with_storage_store(session_id, store_with_key);
+    let ctx_with_key = ToolContext::with_storage_store(session_id, store_with_key)
+        .with_connection_resolver(e2b_resolver());
     let result = tool
         .execute_with_context(
             json!({"sandbox_id": "sb_secret", "path": "/tmp/x"}),

--- a/specs/integrations.md
+++ b/specs/integrations.md
@@ -44,7 +44,7 @@ Auto-registered via `inventory` plugin system. Each crate has a `SPEC.md`.
 | DuckDuckGo | [`integrations/duckduckgo/SPEC.md`](../integrations/duckduckgo/SPEC.md) | Instant answers via DuckDuckGo API. Experimental (Dev only). |
 | GitHub | [`integrations/github/SPEC.md`](../integrations/github/SPEC.md) | GitHub Scout blueprint capability for read-only repository exploration. |
 | Browserless | [`integrations/browserless/SPEC.md`](../integrations/browserless/SPEC.md) | Cloud browser automation — screenshots, DOM, scraping, multi-step interactions. REST and CDP modes. |
-| E2B | [`integrations/e2b/SPEC.md`](../integrations/e2b/SPEC.md) | Cloud sandbox environments via E2B management API + envd runtime endpoints. Platform-owned token, multiple sandboxes per session. |
+| E2B | [`integrations/e2b/SPEC.md`](../integrations/e2b/SPEC.md) | Cloud sandbox environments via E2B management API + envd runtime endpoints. BYO API key via connection provider, multiple sandboxes per session. |
 | Daytona | [`integrations/daytona/SPEC.md`](../integrations/daytona/SPEC.md) | Cloud sandbox environments via Daytona REST API. Multiple sandboxes per session. |
 | Deno | [`integrations/deno/SPEC.md`](../integrations/deno/SPEC.md) | Cloud sandbox environments via Deno websocket sandbox API. Multiple sandboxes per session. |
 | Sprites | [`integrations/sprites/SPEC.md`](../integrations/sprites/SPEC.md) | Persistent Firecracker microVMs via Sprites (Fly.io). Persistent filesystem, checkpoints, HTTP services. |

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -1010,7 +1010,7 @@ Deno sandboxes are remote Linux microVMs managed over a websocket + REST control
 
 | ID | Threat | Severity | Mitigation | Status |
 |----|--------|----------|------------|--------|
-| TM-DENO-001 | Service-wide token misuse via env fallback | High | Prefer user connections; env fallback is operator-controlled and intended for managed deployments/tests | **CALLER RISK** |
+| TM-DENO-001 | Service-wide token misuse via env fallback | High | Env fallback removed; credential resolves exclusively from user connection (`connection_resolver`); tools return `ConnectionRequired` when no connection is configured | MITIGATED |
 | TM-DENO-002 | Cross-session sandbox access | Critical | Deno tools require session-owned sandbox IDs via leased-resource/session-resource ownership checks; persisted sandbox state remains session-scoped in `deno_sandbox:{id}` | MITIGATED |
 | TM-DENO-003 | Sandbox leak from default `session` timeout | Medium | `deno_create_sandbox` forbids `timeout="session"`; Everruns always uses explicit TTLs plus leased-resource cleanup | MITIGATED |
 | TM-API-015 | Lease metadata exposure | Medium | Deno lease metadata stores only non-secret routing/debug fields (`region`, optional `org`, workspace path, timestamps); tokens still resolve from connections/env at cleanup time | MITIGATED |
@@ -1043,11 +1043,11 @@ GitHub Scout is a blueprint-only integration. It gives the child agent private r
 
 ## 18. E2B Cloud Sandbox (TM-E2B)
 
-E2B sandboxes are remote Linux environments managed through the E2B Management API plus per-sandbox envd runtime endpoints. Everruns uses a platform-owned `E2B_API_KEY` from environment or session secret override, and stores per-sandbox envd access tokens in session-scoped secrets.
+E2B sandboxes are remote Linux environments managed through the E2B Management API plus per-sandbox envd runtime endpoints. Users bring their own E2B API key via the connection provider; no platform-owned or environment-variable fallback exists. Per-sandbox envd access tokens are stored in session-scoped secrets.
 
 | ID | Threat | Severity | Mitigation | Status |
 |----|--------|----------|------------|--------|
-| TM-E2B-001 | Platform-owned E2B API key compromise | High | `E2B_API_KEY` stays in server/worker environment or encrypted session secret override; never emitted in tool output | MITIGATED |
+| TM-E2B-001 | E2B API key captured in chat history | High | Tools return `ConnectionRequired` when no connection is configured, triggering the inline connection dialog; user connection credentials are encrypted at rest; key never emitted in tool output | MITIGATED |
 | TM-E2B-002 | envd access token disclosure | Medium | envd access token stored only in encrypted session secrets and sent only to E2B runtime headers | MITIGATED |
 | TM-E2B-003 | Cross-session sandbox access | Critical | E2B tools require session-owned sandbox IDs via leased-resource/session-resource ownership checks; envd state remains session-scoped under `e2b_sandbox:{id}` | MITIGATED |
 | TM-E2B-004 | Sandbox not deleted or paused — resource leak | Low | E2B timeout + auto-pause on create/resume, plus Everruns leased-resource cleanup | MITIGATED |


### PR DESCRIPTION
## Summary

- **E2B**: Add `E2BConnectionProvider` (API-key form, validates via `GET /sandboxes`), register via inventory. Rewrite `get_api_key()` to resolve from `connection_resolver` only — returns `ConnectionRequired` when no connection is configured. Remove `E2B_API_KEY_SECRET` constant, session-secret fallback, and env-var fallback entirely.
- **Deno**: Remove `DENO_DEPLOY_TOKEN`/`DENO_DEPLOY_ORG` env-var fallback block from `get_credentials()`. Connection provider was already in place.
- **Specs**: Update `specs/integrations.md`, `integrations/e2b/SPEC.md`, and `specs/threat-model.md` — TM-DENO-001 moves from CALLER RISK → MITIGATED; TM-E2B-001 description updated from platform-owned key to BYO.
- **Tests**: Replace `setup_api_key()` session-secret approach with `MockConnectionResolver` in E2B tool integration tests; add `test_e2b_connection_provider_is_submitted` to plugin registration tests.

## Test plan

- [x] `cargo test -p everruns-integrations-e2b -p everruns-integrations-deno` — all 19 E2B + all Deno unit/integration tests pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `just pre-push` — passes
- [ ] E2B/Deno live API tests (skipped in CI without live secrets, pass in live environments via Doppler)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fszn8mHhG7EbyFQB6dGxys)_