### PR TITLE
fix(server): bound grep regex complexity and scan volume (EVE-517)

### DIFF
--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -1135,7 +1135,7 @@ impl WorkerAdapters for DirectWorkerAdapters {
                 .map(regex::Regex::new)
                 .transpose()
                 .unwrap_or(None);
-            let virtual_matches = registry.grep(&session_id, &regex, None);
+            let virtual_matches = registry.grep(&session_id, &regex, None, 512 * 1024);
             matches.extend(
                 virtual_matches
                     .into_iter()

--- a/crates/server/src/domains/session_files/service.rs
+++ b/crates/server/src/domains/session_files/service.rs
@@ -704,7 +704,7 @@ impl SessionFileService {
         )
         .await?;
 
-        // Also search virtual mounts
+        // Also search virtual mounts (same per-file and NFA caps, TM-DOS-008)
         if let Some(registry) = &self.virtual_registry {
             let regex = build_grep_regex(&req.pattern)?;
             let path_regex = req
@@ -713,7 +713,8 @@ impl SessionFileService {
                 .map(build_grep_regex)
                 .transpose()?;
             // Pass None for path filter — we apply regex filtering below to match DB semantics
-            let virtual_matches = registry.grep(&session_id, &regex, None);
+            let virtual_matches =
+                registry.grep(&session_id, &regex, None, MAX_GREP_FILE_BYTES as usize);
             for vm in virtual_matches
                 .into_iter()
                 .filter(|vm| path_regex.as_ref().is_none_or(|re| re.is_match(&vm.path)))
@@ -1293,18 +1294,26 @@ pub async fn grep_session_files(
     pattern: &str,
     path_pattern: Option<&str>,
 ) -> Result<Vec<GrepResult>> {
-    // TM-DOS-008: cap pattern length and compiled NFA size.
+    // TM-DOS-008: cap pattern and path_pattern length, then cap compiled NFA size.
     anyhow::ensure!(
         pattern.len() <= MAX_GREP_PATTERN_LEN,
         "Regex pattern too long (max {} characters)",
         MAX_GREP_PATTERN_LEN
     );
+    if let Some(pp) = path_pattern {
+        anyhow::ensure!(
+            pp.len() <= MAX_GREP_PATTERN_LEN,
+            "Path pattern too long (max {} characters)",
+            MAX_GREP_PATTERN_LEN
+        );
+    }
 
     let regex = build_grep_regex(pattern)?;
 
-    // Get matching files from database
+    // Get matching files from database. MAX_GREP_FILE_BYTES is passed so the
+    // storage backend never loads content from files that exceed the per-file cap.
     let files = db
-        .grep_session_files(session_id, pattern, path_pattern)
+        .grep_session_files(session_id, pattern, path_pattern, MAX_GREP_FILE_BYTES)
         .await?;
 
     let mut results = Vec::new();
@@ -1312,7 +1321,7 @@ pub async fn grep_session_files(
 
     // For each matching file, find the actual line matches
     for file_info in files {
-        // TM-DOS-008: skip files that exceed the per-file size limit.
+        // Defense-in-depth: skip oversized files even if the storage filter missed them.
         if file_info.size_bytes > MAX_GREP_FILE_BYTES {
             continue;
         }
@@ -1498,6 +1507,18 @@ mod tests {
 
         let long_pattern = "a".repeat(MAX_GREP_PATTERN_LEN + 1);
         let result = grep_session_files(&db, sid, &long_pattern, None).await;
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("too long"), "Expected 'too long' in: {err}");
+    }
+
+    #[tokio::test]
+    async fn grep_session_files_rejects_overlong_path_pattern() {
+        let db = StorageBackend::in_memory();
+        let sid = Uuid::new_v4();
+
+        let long_path = "a".repeat(MAX_GREP_PATTERN_LEN + 1);
+        let result = grep_session_files(&db, sid, "hello", Some(&long_path)).await;
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(err.contains("too long"), "Expected 'too long' in: {err}");

--- a/crates/server/src/domains/session_files/service.rs
+++ b/crates/server/src/domains/session_files/service.rs
@@ -16,7 +16,7 @@ use everruns_core::{
     MountSource, SessionFile, SessionFileSystem, SessionFileSystemFactory,
     SessionFileSystemFactoryContext, SessionId,
 };
-use regex::Regex;
+use regex::{Regex, RegexBuilder};
 use std::sync::Arc;
 use uuid::Uuid;
 
@@ -706,8 +706,12 @@ impl SessionFileService {
 
         // Also search virtual mounts
         if let Some(registry) = &self.virtual_registry {
-            let regex = Regex::new(&req.pattern)?;
-            let path_regex = req.path_pattern.as_deref().map(Regex::new).transpose()?;
+            let regex = build_grep_regex(&req.pattern)?;
+            let path_regex = req
+                .path_pattern
+                .as_deref()
+                .map(build_grep_regex)
+                .transpose()?;
             // Pass None for path filter — we apply regex filtering below to match DB semantics
             let virtual_matches = registry.grep(&session_id, &regex, None);
             for vm in virtual_matches
@@ -1257,30 +1261,46 @@ impl SessionFileSystem for SessionFileService {
     }
 }
 
-/// Max regex pattern length to prevent resource-intensive compilation (TM-DOS-008).
+/// Max regex pattern length (TM-DOS-008): bounds compilation cost even before NFA construction.
 const MAX_GREP_PATTERN_LEN: usize = 1000;
+/// Max NFA/DFA compiled size in bytes (TM-DOS-008): prevents short patterns that expand to
+/// enormous automata (e.g. deeply nested alternation).
+const MAX_GREP_REGEX_SIZE: usize = 512 * 1024;
+/// Max file size to search (TM-DOS-008): skip files larger than this to bound per-file scan time.
+const MAX_GREP_FILE_BYTES: i64 = 512 * 1024;
+/// Max total bytes scanned across all files in a single grep call (TM-DOS-008).
+const MAX_GREP_TOTAL_SCAN_BYTES: usize = 5 * 1024 * 1024;
+
+/// Build a regex with compile-time size limits applied (TM-DOS-008).
+///
+/// The `regex` crate uses a Thompson NFA and cannot catastrophically backtrack,
+/// but a short pattern can still compile to a very large automaton. `size_limit`
+/// caps that at `MAX_GREP_REGEX_SIZE` bytes.
+fn build_grep_regex(pattern: &str) -> Result<Regex> {
+    RegexBuilder::new(pattern)
+        .size_limit(MAX_GREP_REGEX_SIZE)
+        .build()
+        .map_err(|e| anyhow!("Invalid or too-complex regex pattern: {e}"))
+}
 
 /// Search session files using grep-like regex pattern matching.
 ///
 /// Shared logic used by both `SessionFileService::grep` and
-/// `DirectWorkerAdapters::grep_files`. Enforces TM-DOS-008 pattern length
-/// limit to prevent expensive regex compilation.
+/// `DirectWorkerAdapters::grep_files`. Enforces TM-DOS-008 bounds.
 pub async fn grep_session_files(
     db: &StorageBackend,
     session_id: Uuid,
     pattern: &str,
     path_pattern: Option<&str>,
 ) -> Result<Vec<GrepResult>> {
-    // TM-DOS-008: Limit pattern length to prevent expensive regex compilation.
-    // Note: Rust's `regex` crate already prevents catastrophic backtracking
-    // (uses Thompson NFA), but compilation cost is O(n) in pattern length.
+    // TM-DOS-008: cap pattern length and compiled NFA size.
     anyhow::ensure!(
         pattern.len() <= MAX_GREP_PATTERN_LEN,
         "Regex pattern too long (max {} characters)",
         MAX_GREP_PATTERN_LEN
     );
 
-    let regex = Regex::new(pattern)?;
+    let regex = build_grep_regex(pattern)?;
 
     // Get matching files from database
     let files = db
@@ -1288,9 +1308,24 @@ pub async fn grep_session_files(
         .await?;
 
     let mut results = Vec::new();
+    let mut total_scanned: usize = 0;
 
     // For each matching file, find the actual line matches
     for file_info in files {
+        // TM-DOS-008: skip files that exceed the per-file size limit.
+        if file_info.size_bytes > MAX_GREP_FILE_BYTES {
+            continue;
+        }
+
+        // TM-DOS-008: abort if total bytes scanned across all files exceeds the cap.
+        let file_size = file_info.size_bytes.max(0) as usize;
+        anyhow::ensure!(
+            total_scanned.saturating_add(file_size) <= MAX_GREP_TOTAL_SCAN_BYTES,
+            "Grep request exceeds maximum scan size ({} bytes); narrow the path filter or pattern",
+            MAX_GREP_TOTAL_SCAN_BYTES
+        );
+        total_scanned += file_size;
+
         // Read full file content
         let file = db.get_session_file(session_id, &file_info.path).await?;
         if let Some(f) = file
@@ -1466,6 +1501,65 @@ mod tests {
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(err.contains("too long"), "Expected 'too long' in: {err}");
+    }
+
+    #[tokio::test]
+    async fn grep_session_files_catastrophic_pattern_completes_quickly() {
+        // The regex crate uses a Thompson NFA and cannot backtrack catastrophically.
+        // This pattern would hang a PCRE/backtracking engine on "aaa...a!" but must
+        // complete in bounded time here.
+        let db = StorageBackend::in_memory();
+        let sid = Uuid::new_v4();
+        let content = "a".repeat(30);
+        seed_file(&db, sid, "/bomb.txt", &content).await;
+
+        let pattern = "(a+)+b";
+        let result = grep_session_files(&db, sid, pattern, None).await.unwrap();
+        // No match (no 'b'), result is empty — but importantly it finishes quickly.
+        assert!(result.is_empty());
+    }
+
+    #[tokio::test]
+    async fn grep_session_files_skips_oversized_file() {
+        let db = StorageBackend::in_memory();
+        let sid = Uuid::new_v4();
+        // Write a small file and one large file (simulated as exceeding the limit in the row).
+        // The in-memory store stores actual bytes so we use the size threshold from the constant.
+        let small = "match me";
+        seed_file(&db, sid, "/small.txt", small).await;
+        let big_content = "match me ".repeat((MAX_GREP_FILE_BYTES as usize / 9) + 2);
+        seed_file(&db, sid, "/big.txt", &big_content).await;
+
+        let results = grep_session_files(&db, sid, "match me", None)
+            .await
+            .unwrap();
+        // Only the small file should appear; big.txt is skipped.
+        assert_eq!(results.len(), 1, "big.txt should have been skipped");
+        assert_eq!(results[0].path, "/small.txt");
+    }
+
+    #[tokio::test]
+    async fn grep_session_files_enforces_total_scan_limit() {
+        let db = StorageBackend::in_memory();
+        let sid = Uuid::new_v4();
+        // Write enough files to exceed the total scan cap without any single file
+        // exceeding the per-file cap.
+        let chunk = "x".repeat(MAX_GREP_FILE_BYTES as usize);
+        let files_needed = (MAX_GREP_TOTAL_SCAN_BYTES / MAX_GREP_FILE_BYTES as usize) + 2;
+        for i in 0..files_needed {
+            seed_file(&db, sid, &format!("/f{i}.txt"), &chunk).await;
+        }
+
+        let result = grep_session_files(&db, sid, "x", None).await;
+        assert!(
+            result.is_err(),
+            "Should fail when total scan cap is exceeded"
+        );
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("maximum scan size"),
+            "Expected 'maximum scan size' in: {msg}"
+        );
     }
 
     #[tokio::test]

--- a/crates/server/src/domains/session_files/virtual_mount_registry.rs
+++ b/crates/server/src/domains/session_files/virtual_mount_registry.rs
@@ -121,11 +121,15 @@ impl VirtualMountRegistry {
     }
 
     /// Search virtual files for grep matches.
+    ///
+    /// `max_file_bytes` caps per-file scan cost (TM-DOS-008); files larger than
+    /// this limit are silently skipped.
     pub fn grep(
         &self,
         session_id: &Uuid,
         pattern: &regex::Regex,
         path_filter: Option<&str>,
+        max_file_bytes: usize,
     ) -> Vec<VirtualGrepMatch> {
         let mut results = Vec::new();
         let mounts = self.mounts.read();
@@ -134,6 +138,10 @@ impl VirtualMountRegistry {
         };
         for mount in session_mounts {
             for (file_path, file) in mount.tree.all_files() {
+                // TM-DOS-008: skip virtual files exceeding the per-file size cap.
+                if file.content.len() > max_file_bytes {
+                    continue;
+                }
                 if let Some(filter) = path_filter {
                     let filter_prefix = if filter.ends_with('/') {
                         filter.to_string()
@@ -330,7 +338,7 @@ mod tests {
         registry.register(sid, "/docs".into(), Arc::new(tree), "cap".into());
 
         let pattern = regex::Regex::new("find me").unwrap();
-        let results = registry.grep(&sid, &pattern, None);
+        let results = registry.grep(&sid, &pattern, None, usize::MAX);
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].line_number, 2);
         assert_eq!(results[0].line, "find me");

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -1634,8 +1634,16 @@ impl StorageBackend {
         session_id: Uuid,
         pattern: &str,
         path_prefix: Option<&str>,
+        max_file_bytes: i64,
     ) -> Result<Vec<SessionFileInfoRow>> {
-        dispatch!(self, grep_session_files, session_id, pattern, path_prefix)
+        dispatch!(
+            self,
+            grep_session_files,
+            session_id,
+            pattern,
+            path_prefix,
+            max_file_bytes
+        )
     }
 
     pub async fn session_file_exists(&self, session_id: Uuid, path: &str) -> Result<bool> {

--- a/crates/server/src/storage/memory/session_files.rs
+++ b/crates/server/src/storage/memory/session_files.rs
@@ -282,6 +282,7 @@ impl InMemoryDatabase {
         session_id: Uuid,
         pattern: &str,
         path_prefix: Option<&str>,
+        max_file_bytes: i64,
     ) -> Result<Vec<SessionFileInfoRow>> {
         let session_id = SessionId::from_uuid(session_id);
         let regex = regex::Regex::new(pattern)?;
@@ -291,6 +292,10 @@ impl InMemoryDatabase {
             .values()
             .filter(|f| {
                 if f.session_id != session_id || f.is_directory {
+                    return false;
+                }
+                // TM-DOS-008: skip files exceeding size cap before scanning content.
+                if f.size_bytes > max_file_bytes {
                     return false;
                 }
                 if let Some(prefix) = path_prefix

--- a/crates/server/src/storage/repositories/session_files.rs
+++ b/crates/server/src/storage/repositories/session_files.rs
@@ -315,8 +315,9 @@ impl Database {
         session_id: Uuid,
         pattern: &str,
         path_pattern: Option<&str>,
+        max_file_bytes: i64,
     ) -> Result<Vec<SessionFileInfoRow>> {
-        // Search text files for content matching the pattern
+        // TM-DOS-008: size_bytes filter keeps Postgres from scanning large files.
         let rows = if let Some(path_pat) = path_pattern {
             sqlx::query_as::<_, SessionFileInfoRow>(
                 r#"
@@ -324,12 +325,14 @@ impl Database {
                 FROM session_files
                 WHERE session_id = $1
                     AND is_directory = FALSE
-                    AND path ~ $2
-                    AND convert_from(content, 'UTF8') ~ $3
+                    AND size_bytes <= $2
+                    AND path ~ $3
+                    AND convert_from(content, 'UTF8') ~ $4
                 ORDER BY path ASC
                 "#,
             )
             .bind(session_id)
+            .bind(max_file_bytes)
             .bind(path_pat)
             .bind(pattern)
             .fetch_all(&self.pool)
@@ -341,11 +344,13 @@ impl Database {
                 FROM session_files
                 WHERE session_id = $1
                     AND is_directory = FALSE
-                    AND convert_from(content, 'UTF8') ~ $2
+                    AND size_bytes <= $2
+                    AND convert_from(content, 'UTF8') ~ $3
                 ORDER BY path ASC
                 "#,
             )
             .bind(session_id)
+            .bind(max_file_bytes)
             .bind(pattern)
             .fetch_all(&self.pool)
             .await?

--- a/crates/server/src/storage/session_file_store.rs
+++ b/crates/server/src/storage/session_file_store.rs
@@ -13,6 +13,9 @@ use regex::Regex;
 use super::models::{CreateSessionFileRow, UpdateSessionFile};
 use super::repositories::Database;
 
+/// TM-DOS-008: per-file scan cap; must match MAX_GREP_FILE_BYTES in session_files::service.
+const GREP_MAX_FILE_BYTES: i64 = 512 * 1024;
+
 // ============================================================================
 // DbSessionFileStore - Stores session files in database
 // ============================================================================
@@ -521,10 +524,15 @@ impl SessionFileSystem for DbSessionFileStore {
         let regex = Regex::new(pattern)
             .map_err(|e| AgentLoopError::store(format!("Invalid regex pattern: {}", e)))?;
 
-        // Get matching files from database
+        // Get matching files from database (size-capped at storage level, TM-DOS-008)
         let files = self
             .db
-            .grep_session_files(session_id.uuid(), pattern, path_pattern)
+            .grep_session_files(
+                session_id.uuid(),
+                pattern,
+                path_pattern,
+                GREP_MAX_FILE_BYTES,
+            )
             .await
             .store_err()?;
 

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -940,7 +940,7 @@ When a bash script calls `bash` or `sh` or uses `eval`, bashkit re-invokes its o
 | TM-DOS-005 | Session file storage abuse | Medium | No per-session storage quota; large files stored as PostgreSQL BYTEA | **OPEN** (see TM-FS-008) |
 | TM-DOS-006 | Durable task queue flooding | Medium | Per-workflow pending task limit (see TM-DURABLE-004) | MITIGATED |
 | TM-DOS-007 | Nested JSON depth in API input | Medium | Input validation rejects deeply nested structures | MITIGATED |
-| TM-DOS-008 | ReDoS via file grep endpoint | Medium | `POST /v1/sessions/:id/fs/_/grep` accepts user regex with no complexity limits | **OPEN** |
+| TM-DOS-008 | ReDoS via file grep endpoint | Medium | `POST /v1/sessions/:id/fs/_/grep` accepts user regex with no complexity limits | **MITIGATED** |
 | TM-DOS-009 | Valkey unauthenticated access | Medium | Valkey listens on localhost:6379 by default; no AUTH configured in local/example compose | **CALLER RISK** |
 | TM-DOS-010 | AG-UI SSE connection exhaustion | Medium | AG-UI app streams reuse the shared `SseConnectionTracker`, enforcing the same global/per-org/per-session limits as other SSE endpoints. App owners can also configure a per-app, per-IP request cap via `AgUiChannelConfig.rate_limit_per_minute`: in-memory backend is a per-minute governor quota; when `VALKEY_URL` is set it becomes a Valkey sliding-window counter shared across instances and fail-closed on Valkey errors | MITIGATED |
 | TM-DOS-010 | Rate limit bypass via Valkey failure | Low | Fail-open design: if Valkey is down, requests are allowed without rate limiting | **ACCEPTED** |
@@ -1307,7 +1307,7 @@ Even with per-secret scoping, an attacker who controls a previously-approved for
 | ~~TM-DURABLE-002~~ | ~~gRPC auth optional, no org scoping~~ | ~~High~~ | Mitigated: Bearer token required in production + optional mTLS; workers cross-org by design |
 | ~~TM-DURABLE-010~~ | ~~Durable API endpoints unauthenticated~~ | ~~High~~ | Mitigated: All endpoints require AuthUser extractor |
 | ~~TM-TENANT-008~~ | ~~User listing cross-org~~ | ~~High~~ | Mitigated: `GET /v1/users` uses `ResolvedOrg` and `list_users_by_org` |
-| TM-DOS-008 | ReDoS via file grep endpoint | Medium | Add regex complexity limits and timeout |
+| ~~TM-DOS-008~~ | ~~ReDoS via file grep endpoint~~ | ~~Medium~~ | Mitigated: pattern length capped at 1 000 chars; NFA compiled size capped at 512 KB via `RegexBuilder::size_limit`; per-file scan skipped above 512 KB; total scan aborted above 5 MB per request (`grep_session_files`, `service.rs`) |
 | TM-AGENT-007 | No per-iteration tool call limit | Medium | Cap tool calls per LLM response |
 | ~~TM-AGENT-012~~ | ~~Tool result size amplification~~ | ~~Medium~~ | Mitigated: 64 KiB hard limit via `OutputHardLimitHook` (EVE-225) |
 | TM-FS-008 | No session storage quota | Medium | Enforce per-session file size limits |

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -940,7 +940,7 @@ When a bash script calls `bash` or `sh` or uses `eval`, bashkit re-invokes its o
 | TM-DOS-005 | Session file storage abuse | Medium | No per-session storage quota; large files stored as PostgreSQL BYTEA | **OPEN** (see TM-FS-008) |
 | TM-DOS-006 | Durable task queue flooding | Medium | Per-workflow pending task limit (see TM-DURABLE-004) | MITIGATED |
 | TM-DOS-007 | Nested JSON depth in API input | Medium | Input validation rejects deeply nested structures | MITIGATED |
-| TM-DOS-008 | ReDoS via file grep endpoint | Medium | `POST /v1/sessions/:id/fs/_/grep` accepts user regex with no complexity limits | **MITIGATED** |
+| TM-DOS-008 | ReDoS via file grep endpoint | Medium | Regex pattern and path_pattern length capped (1 000 chars); NFA size capped via `RegexBuilder::size_limit` (512 KB); storage backends skip files > 512 KB before scanning; total request scan aborted above 5 MB | MITIGATED |
 | TM-DOS-009 | Valkey unauthenticated access | Medium | Valkey listens on localhost:6379 by default; no AUTH configured in local/example compose | **CALLER RISK** |
 | TM-DOS-010 | AG-UI SSE connection exhaustion | Medium | AG-UI app streams reuse the shared `SseConnectionTracker`, enforcing the same global/per-org/per-session limits as other SSE endpoints. App owners can also configure a per-app, per-IP request cap via `AgUiChannelConfig.rate_limit_per_minute`: in-memory backend is a per-minute governor quota; when `VALKEY_URL` is set it becomes a Valkey sliding-window counter shared across instances and fail-closed on Valkey errors | MITIGATED |
 | TM-DOS-010 | Rate limit bypass via Valkey failure | Low | Fail-open design: if Valkey is down, requests are allowed without rate limiting | **ACCEPTED** |


### PR DESCRIPTION
## What

Adds three layers of DoS protection on `POST /v1/sessions/:id/fs/_/grep` (TM-DOS-008).

## Why

`grep_session_files` accepted user-supplied regexes with no bounds on compiled automaton size, per-file scan cost, or total request scan volume. While Rust's `regex` crate uses a Thompson NFA (no catastrophic backtracking), a short pattern can still compile to a large NFA and scanning many large files in one request could pin CPU/IO unboundedly.

## How

1. **NFA size cap** — wraps `Regex::new` with `RegexBuilder::size_limit(512 KB)` in a shared `build_grep_regex()` helper used by both the REST path and virtual-mount grep path.
2. **Per-file skip** — files larger than 512 KB are silently skipped; the request still returns results from smaller files.
3. **Total scan cap** — if cumulative content across all matched files exceeds 5 MB the request fails with a clear error.
4. The existing 1 000-char pattern length limit is preserved.

## Risk

- Low
- Callers scanning many large files in one request will now receive an error. This is intentional; they should narrow path filters or patterns. No observable regression for normal use.

## Security

- Threat categories reviewed: TM-DOS-008
- Findings: TM-DOS-008 was OPEN — pattern length capped but no NFA size limit, no content scan limit.
- Resolution: Three bounds added; TM-DOS-008 marked MITIGATED in `specs/threat-model.md`.

## Follow-ups

No follow-ups.

## Checklist

- [x] Tests added or updated (4 new: catastrophic-pattern completes quickly, oversized file skipped, total scan cap enforced, overlong-pattern existing)
- [x] Backward compatibility considered (no behavior change for typical patterns/files)
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

Closes EVE-517

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fszn8mHhG7EbyFQB6dGxys)_