### PR TITLE
fix(security): DNS-pinned SSRF re-check at MCP execution time (EVE-516)

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -27,7 +27,7 @@ async-trait.workspace = true
 
 # Async runtime
 # Note: "rt" is needed for tokio::spawn in event listener isolation
-tokio = { workspace = true, features = ["sync", "rt", "process", "time"] }
+tokio = { workspace = true, features = ["sync", "rt", "process", "time", "net"] }
 futures.workspace = true
 
 # Serialization

--- a/crates/core/src/egress.rs
+++ b/crates/core/src/egress.rs
@@ -79,6 +79,14 @@ pub struct EgressRequest {
     pub network_access: Option<NetworkAccessList>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub timeout_ms: Option<u64>,
+    /// Pre-resolved socket addresses for DNS pinning (TM-TOOL-018).
+    ///
+    /// When set, `DirectEgressService` builds a per-request client pinned to
+    /// these addresses via `resolve_to_addrs`, closing the TOCTOU window
+    /// between URL validation and the actual TCP connect.  Obtained from
+    /// `validate_url_dns_pinned`.  Not serialized — runtime-only hint.
+    #[serde(skip)]
+    pub pinned_addrs: Option<(String, Vec<std::net::SocketAddr>)>,
 }
 
 impl EgressRequest {
@@ -92,7 +100,23 @@ impl EgressRequest {
             signing: EgressSigning::Disabled,
             network_access: None,
             timeout_ms: None,
+            pinned_addrs: None,
         }
+    }
+
+    /// Pin the outbound connection to pre-resolved addresses (TM-TOOL-018).
+    ///
+    /// No-op when `addrs` is empty (e.g. IP-literal URLs where the static
+    /// check already validated the address).
+    pub fn pinned_addrs(
+        mut self,
+        host: impl Into<String>,
+        addrs: Vec<std::net::SocketAddr>,
+    ) -> Self {
+        if !addrs.is_empty() {
+            self.pinned_addrs = Some((host.into(), addrs));
+        }
+        self
     }
 
     pub fn header(mut self, name: impl Into<String>, value: impl Into<String>) -> Self {
@@ -232,17 +256,42 @@ impl DirectEgressService {
             return Err(EgressError::SigningUnavailable);
         }
 
-        let method = reqwest::Method::from_bytes(request.method.as_bytes())
+        let EgressRequest {
+            method,
+            url,
+            headers,
+            body,
+            timeout_ms,
+            pinned_addrs,
+            ..
+        } = request;
+
+        let method = reqwest::Method::from_bytes(method.as_bytes())
             .map_err(|error| EgressError::invalid(format!("invalid HTTP method: {error}")))?;
-        let mut builder = self.client.request(method, &request.url);
-        for (name, value) in request.headers {
+
+        // When pre-resolved addresses are provided, build a per-request client
+        // pinned to those IPs.  This closes the TOCTOU window between
+        // validate_url_dns_pinned and the actual TCP connect (TM-TOOL-018).
+        let mut builder = if let Some((ref host, ref addrs)) = pinned_addrs {
+            reqwest::Client::builder()
+                .connect_timeout(DEFAULT_CONNECT_TIMEOUT)
+                .redirect(reqwest::redirect::Policy::none())
+                .resolve_to_addrs(host, addrs)
+                .build()
+                .map_err(|e| EgressError::invalid(format!("pinned client build failed: {e}")))?
+                .request(method, &url)
+        } else {
+            self.client.request(method, &url)
+        };
+
+        for (name, value) in headers {
             builder = builder.header(name, value);
         }
-        if let Some(timeout_ms) = request.timeout_ms {
+        if let Some(timeout_ms) = timeout_ms {
             builder = builder.timeout(Duration::from_millis(timeout_ms));
         }
-        if !request.body.is_empty() {
-            builder = builder.body(request.body);
+        if !body.is_empty() {
+            builder = builder.body(body);
         }
         Ok(builder)
     }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -449,7 +449,9 @@ pub use permissions::{
 pub use dependency_blocker::{DependencyBlocker, detect_dependency_blocker};
 
 // URL validation re-exports
-pub use url_validation::{UrlValidationError, is_blocked_ip, validate_safe_url};
+pub use url_validation::{
+    UrlValidationError, is_blocked_ip, validate_safe_url, validate_url_dns_pinned,
+};
 
 // Deployment configuration
 pub use deployment::DeploymentGrade;

--- a/crates/core/src/url_validation.rs
+++ b/crates/core/src/url_validation.rs
@@ -68,6 +68,51 @@ pub fn validate_safe_url(raw_url: &str) -> Result<Url, UrlValidationError> {
     Ok(url)
 }
 
+/// Validate a URL is safe for server-side requests, including DNS resolution
+/// to catch DNS-rebinding attacks (TM-TOOL-018).
+///
+/// Performs static checks first (`validate_safe_url`), then resolves the
+/// hostname and verifies that every returned IP is in an allowed range.
+/// Use this at execution time (e.g. before making an outbound HTTP call).
+/// For write-time registration checks, `validate_safe_url` is sufficient.
+pub async fn validate_url_dns_pinned(raw_url: &str) -> Result<Url, UrlValidationError> {
+    // Static checks first — fast path for obviously bad URLs / IP literals.
+    let url = validate_safe_url(raw_url)?;
+
+    let host = url.host_str().ok_or(UrlValidationError::MissingHostname)?;
+
+    // If the host is already an IP literal the static check already validated it.
+    let bare = host
+        .strip_prefix('[')
+        .and_then(|s| s.strip_suffix(']'))
+        .unwrap_or(host);
+    if bare.parse::<std::net::IpAddr>().is_ok() {
+        return Ok(url);
+    }
+
+    // Resolve the hostname and reject if any address is in a blocked range.
+    let port = url.port_or_known_default().unwrap_or(443);
+    let addrs = tokio::net::lookup_host(format!("{host}:{port}"))
+        .await
+        .map_err(|_| UrlValidationError::BlockedHost(host.to_string()))?;
+
+    for addr in addrs {
+        if is_blocked_ip(addr.ip()) {
+            tracing::warn!(
+                host = %host,
+                resolved_ip = %addr.ip(),
+                "DNS rebinding check blocked: hostname resolves to private address"
+            );
+            return Err(UrlValidationError::BlockedHost(format!(
+                "{host} resolves to blocked address {}",
+                addr.ip()
+            )));
+        }
+    }
+
+    Ok(url)
+}
+
 /// Check if a hostname string is blocked (localhost, private IPs, metadata endpoints).
 fn is_blocked_host(host: &str) -> bool {
     let host_lower = host.to_lowercase();
@@ -419,5 +464,41 @@ mod tests {
                 .to_string()
                 .contains("http or https")
         );
+    }
+
+    // --- validate_url_dns_pinned: IP literals are caught by static pre-check ---
+    // (No real DNS calls needed; IP literal hosts skip the lookup path.)
+
+    #[tokio::test]
+    async fn dns_pinned_rejects_private_ip_literal() {
+        let result = validate_url_dns_pinned("http://10.0.0.1/mcp").await;
+        assert!(matches!(result, Err(UrlValidationError::BlockedHost(_))));
+    }
+
+    #[tokio::test]
+    async fn dns_pinned_rejects_loopback_ip_literal() {
+        let result = validate_url_dns_pinned("http://127.0.0.1/mcp").await;
+        assert!(matches!(result, Err(UrlValidationError::BlockedHost(_))));
+    }
+
+    #[tokio::test]
+    async fn dns_pinned_rejects_metadata_ip_literal() {
+        let result = validate_url_dns_pinned("http://169.254.169.254/latest/meta-data/").await;
+        assert!(matches!(result, Err(UrlValidationError::BlockedHost(_))));
+    }
+
+    #[tokio::test]
+    async fn dns_pinned_rejects_localhost_hostname() {
+        let result = validate_url_dns_pinned("http://localhost:8080/mcp").await;
+        assert!(matches!(result, Err(UrlValidationError::BlockedHost(_))));
+    }
+
+    #[tokio::test]
+    async fn dns_pinned_rejects_bad_scheme() {
+        let result = validate_url_dns_pinned("ftp://example.com/mcp").await;
+        assert!(matches!(
+            result,
+            Err(UrlValidationError::DisallowedScheme(_))
+        ));
     }
 }

--- a/crates/core/src/url_validation.rs
+++ b/crates/core/src/url_validation.rs
@@ -560,7 +560,7 @@ mod tests {
         _host: String,
         _port: u16,
     ) -> Result<Vec<SocketAddr>, std::io::Error> {
-        Ok(vec!["203.0.113.1:443".parse().unwrap()])
+        Ok(vec!["1.1.1.1:443".parse().unwrap()])
     }
 
     // Simulates a DNS failure / timeout.

--- a/crates/core/src/url_validation.rs
+++ b/crates/core/src/url_validation.rs
@@ -10,8 +10,13 @@
 // - Blocks RFC1918 (10.x, 172.16-31.x, 192.168.x)
 // - Blocks IPv6 loopback (::1) and link-local (fe80::)
 
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::time::Duration;
 use url::Url;
+
+/// DNS resolution is capped at this duration to prevent a stuck resolver from
+/// stalling MCP tool execution/discovery past the outbound HTTP timeout.
+const DNS_LOOKUP_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Errors from URL safety validation.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -72,31 +77,57 @@ pub fn validate_safe_url(raw_url: &str) -> Result<Url, UrlValidationError> {
 /// to catch DNS-rebinding attacks (TM-TOOL-018).
 ///
 /// Performs static checks first (`validate_safe_url`), then resolves the
-/// hostname and verifies that every returned IP is in an allowed range.
-/// Use this at execution time (e.g. before making an outbound HTTP call).
-/// For write-time registration checks, `validate_safe_url` is sufficient.
-pub async fn validate_url_dns_pinned(raw_url: &str) -> Result<Url, UrlValidationError> {
+/// hostname (with a 5-second timeout) and verifies that every returned IP is
+/// in an allowed range.  Returns the parsed `Url` and the **resolved socket
+/// addresses** so callers can pin the subsequent connection to those exact IPs
+/// via `reqwest::ClientBuilder::resolve_to_addrs`, closing the TOCTOU window.
+///
+/// For IP-literal URLs the returned `Vec<SocketAddr>` is empty — the static
+/// check already validated the IP.  For write-time registration checks,
+/// `validate_safe_url` is sufficient; use this function at execution time
+/// (i.e. just before each outbound HTTP call).
+pub async fn validate_url_dns_pinned(
+    raw_url: &str,
+) -> Result<(Url, Vec<SocketAddr>), UrlValidationError> {
+    validate_url_with_resolver(raw_url, default_dns_resolve).await
+}
+
+/// Inner implementation with an injectable resolver for unit testing.
+async fn validate_url_with_resolver<R, F>(
+    raw_url: &str,
+    resolve: R,
+) -> Result<(Url, Vec<SocketAddr>), UrlValidationError>
+where
+    R: Fn(String, u16) -> F,
+    F: std::future::Future<Output = Result<Vec<SocketAddr>, std::io::Error>>,
+{
     // Static checks first — fast path for obviously bad URLs / IP literals.
     let url = validate_safe_url(raw_url)?;
+    let host = url
+        .host_str()
+        .ok_or(UrlValidationError::MissingHostname)?
+        .to_string();
 
-    let host = url.host_str().ok_or(UrlValidationError::MissingHostname)?;
-
-    // If the host is already an IP literal the static check already validated it.
+    // IP literals were already validated by the static check; no DNS needed.
     let bare = host
         .strip_prefix('[')
         .and_then(|s| s.strip_suffix(']'))
-        .unwrap_or(host);
-    if bare.parse::<std::net::IpAddr>().is_ok() {
-        return Ok(url);
+        .unwrap_or(&host);
+    if bare.parse::<IpAddr>().is_ok() {
+        return Ok((url, Vec::new()));
     }
 
-    // Resolve the hostname and reject if any address is in a blocked range.
+    // Resolve the hostname and reject if any address falls in a blocked range.
     let port = url.port_or_known_default().unwrap_or(443);
-    let addrs = tokio::net::lookup_host(format!("{host}:{port}"))
+    let addrs = resolve(host.clone(), port)
         .await
-        .map_err(|_| UrlValidationError::BlockedHost(host.to_string()))?;
+        .map_err(|_| UrlValidationError::BlockedHost(host.clone()))?;
 
-    for addr in addrs {
+    if addrs.is_empty() {
+        return Err(UrlValidationError::BlockedHost(host.clone()));
+    }
+
+    for addr in &addrs {
         if is_blocked_ip(addr.ip()) {
             tracing::warn!(
                 host = %host,
@@ -110,7 +141,19 @@ pub async fn validate_url_dns_pinned(raw_url: &str) -> Result<Url, UrlValidation
         }
     }
 
-    Ok(url)
+    Ok((url, addrs))
+}
+
+/// Default resolver used in production: `tokio::net::lookup_host` with a
+/// 5-second timeout so a stuck DNS server cannot stall MCP execution.
+async fn default_dns_resolve(host: String, port: u16) -> Result<Vec<SocketAddr>, std::io::Error> {
+    tokio::time::timeout(
+        DNS_LOOKUP_TIMEOUT,
+        tokio::net::lookup_host(format!("{host}:{port}")),
+    )
+    .await
+    .map_err(|_| std::io::Error::new(std::io::ErrorKind::TimedOut, "DNS lookup timed out"))?
+    .map(|iter| iter.collect())
 }
 
 /// Check if a hostname string is blocked (localhost, private IPs, metadata endpoints).
@@ -466,8 +509,7 @@ mod tests {
         );
     }
 
-    // --- validate_url_dns_pinned: IP literals are caught by static pre-check ---
-    // (No real DNS calls needed; IP literal hosts skip the lookup path.)
+    // --- validate_url_dns_pinned: static pre-check path (IP literals) ---
 
     #[tokio::test]
     async fn dns_pinned_rejects_private_ip_literal() {
@@ -489,6 +531,7 @@ mod tests {
 
     #[tokio::test]
     async fn dns_pinned_rejects_localhost_hostname() {
+        // "localhost" is caught by the static pre-check; resolver is never called.
         let result = validate_url_dns_pinned("http://localhost:8080/mcp").await;
         assert!(matches!(result, Err(UrlValidationError::BlockedHost(_))));
     }
@@ -500,5 +543,82 @@ mod tests {
             result,
             Err(UrlValidationError::DisallowedScheme(_))
         ));
+    }
+
+    // --- validate_url_with_resolver: DNS resolution path (injectable resolver) ---
+
+    // Simulates DNS rebinding: public URL resolves to a private IP.
+    async fn private_ip_resolver(
+        _host: String,
+        _port: u16,
+    ) -> Result<Vec<SocketAddr>, std::io::Error> {
+        Ok(vec!["10.0.0.1:80".parse().unwrap()])
+    }
+
+    // Simulates a well-behaved response: public URL resolves to a public IP.
+    async fn public_ip_resolver(
+        _host: String,
+        _port: u16,
+    ) -> Result<Vec<SocketAddr>, std::io::Error> {
+        Ok(vec!["203.0.113.1:443".parse().unwrap()])
+    }
+
+    // Simulates a DNS failure / timeout.
+    async fn failing_resolver(
+        _host: String,
+        _port: u16,
+    ) -> Result<Vec<SocketAddr>, std::io::Error> {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::TimedOut,
+            "DNS lookup timed out",
+        ))
+    }
+
+    // Simulates empty DNS response (NXDOMAIN / no records).
+    async fn empty_resolver(_host: String, _port: u16) -> Result<Vec<SocketAddr>, std::io::Error> {
+        Ok(vec![])
+    }
+
+    #[tokio::test]
+    async fn dns_resolver_blocks_hostname_resolving_to_private_ip() {
+        // Simulates the DNS rebinding attack: public URL resolves to private IP.
+        let result =
+            validate_url_with_resolver("http://evil.example.com/mcp", private_ip_resolver).await;
+        assert!(
+            matches!(result, Err(UrlValidationError::BlockedHost(_))),
+            "expected BlockedHost, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn dns_resolver_allows_hostname_resolving_to_public_ip() {
+        let (url, addrs) =
+            validate_url_with_resolver("https://mcp.example.com/v1/mcp", public_ip_resolver)
+                .await
+                .expect("should succeed");
+        assert_eq!(url.host_str(), Some("mcp.example.com"));
+        // Caller pins the connection to these addrs via resolve_to_addrs.
+        assert_eq!(addrs.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn dns_resolver_blocks_on_lookup_failure() {
+        let result = validate_url_with_resolver("http://example.com/mcp", failing_resolver).await;
+        assert!(matches!(result, Err(UrlValidationError::BlockedHost(_))));
+    }
+
+    #[tokio::test]
+    async fn dns_resolver_blocks_empty_response() {
+        let result = validate_url_with_resolver("http://example.com/mcp", empty_resolver).await;
+        assert!(matches!(result, Err(UrlValidationError::BlockedHost(_))));
+    }
+
+    #[tokio::test]
+    async fn dns_resolver_returns_addrs_for_connection_pinning() {
+        let (_url, addrs) =
+            validate_url_with_resolver("https://mcp.example.com/v1/mcp", public_ip_resolver)
+                .await
+                .unwrap();
+        assert!(!addrs.is_empty());
     }
 }

--- a/crates/server/src/domains/mcp_servers/service.rs
+++ b/crates/server/src/domains/mcp_servers/service.rs
@@ -28,7 +28,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use uuid::Uuid;
 
-use everruns_core::validate_safe_url;
+use everruns_core::{validate_safe_url, validate_url_dns_pinned};
 
 use crate::domains::mcp_servers::types::{CreateMcpServerRequest, UpdateMcpServerRequest};
 
@@ -624,9 +624,11 @@ pub(crate) async fn fetch_mcp_tools(
     api_key: Option<&str>,
     headers: &HashMap<String, String>,
 ) -> Result<Vec<McpToolDefinition>> {
-    // Re-validate URL at fetch time (SSRF defense-in-depth). This runs before
-    // the egress request is constructed so unsafe URLs never reach the boundary.
-    validate_safe_url(url).map_err(|e| anyhow!("MCP server URL blocked: {}", e))?;
+    // Re-validate URL at fetch time with DNS resolution to catch DNS-rebinding
+    // (TM-TOOL-018). Runs before the egress request is constructed.
+    validate_url_dns_pinned(url)
+        .await
+        .map_err(|e| anyhow!("MCP server URL blocked: {}", e))?;
 
     let request_body = serde_json::to_vec(&McpToolsListRequest::default())?;
 

--- a/crates/server/src/domains/mcp_servers/service.rs
+++ b/crates/server/src/domains/mcp_servers/service.rs
@@ -28,7 +28,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use uuid::Uuid;
 
-use everruns_core::{validate_safe_url, validate_url_dns_pinned};
+use everruns_core::validate_url_dns_pinned;
 
 use crate::domains::mcp_servers::types::{CreateMcpServerRequest, UpdateMcpServerRequest};
 
@@ -624,15 +624,18 @@ pub(crate) async fn fetch_mcp_tools(
     api_key: Option<&str>,
     headers: &HashMap<String, String>,
 ) -> Result<Vec<McpToolDefinition>> {
-    // Re-validate URL at fetch time with DNS resolution to catch DNS-rebinding
-    // (TM-TOOL-018). Runs before the egress request is constructed.
-    validate_url_dns_pinned(url)
+    // Re-validate URL with DNS resolution and return resolved addrs for pinning
+    // (TM-TOOL-018). The addrs are carried into the EgressRequest so
+    // DirectEgressService connects to the validated IPs, closing the TOCTOU gap.
+    let (validated_url, resolved_addrs) = validate_url_dns_pinned(url)
         .await
         .map_err(|e| anyhow!("MCP server URL blocked: {}", e))?;
+    let pin_host = validated_url.host_str().unwrap_or("").to_string();
 
     let request_body = serde_json::to_vec(&McpToolsListRequest::default())?;
 
     let mut egress_request = EgressRequest::new("POST", url, EgressRequestKind::Mcp)
+        .pinned_addrs(pin_host, resolved_addrs)
         .header("Content-Type", "application/json")
         .header("Accept", "application/json, text/event-stream")
         .timeout_ms(MCP_CLIENT_TIMEOUT.as_millis() as u64)

--- a/crates/worker/src/mcp_executor.rs
+++ b/crates/worker/src/mcp_executor.rs
@@ -12,7 +12,7 @@ use everruns_core::{
     DirectEgressService, EgressRequest, EgressRequestKind, EgressService, McpContent,
     McpServerAuthMode, McpToolCallRequest, McpToolCallResponse, ToolCall, ToolDefinition,
     ToolResult, ToolResultImage, is_mcp_tool, mcp_oauth_session_secret_name, parse_mcp_tool_name,
-    validate_safe_url,
+    validate_url_dns_pinned,
 };
 use serde_json::json;
 use std::collections::HashMap;
@@ -209,18 +209,19 @@ async fn call_mcp_tool(
     arguments: serde_json::Value,
     authorization_header: Option<&str>,
 ) -> Result<(serde_json::Value, Vec<ToolResultImage>)> {
-    // Re-validate URL at execution time to catch TOCTOU / post-registration
-    // changes. Runs before the egress request is built so unsafe URLs never
-    // reach the boundary.
-    validate_safe_url(&server_info.url).map_err(|e| {
-        tracing::warn!(
-            mcp_server = %server_info.name,
-            url = %server_info.url,
-            error = %e,
-            "Blocked MCP tool execution: URL failed SSRF validation"
-        );
-        anyhow!("MCP server URL blocked: {}", e)
-    })?;
+    // Re-validate URL at execution time with DNS resolution to catch DNS-rebinding
+    // (TM-TOOL-018). Resolves the hostname and rejects any private/internal IP.
+    validate_url_dns_pinned(&server_info.url)
+        .await
+        .map_err(|e| {
+            tracing::warn!(
+                mcp_server = %server_info.name,
+                url = %server_info.url,
+                error = %e,
+                "Blocked MCP tool execution: URL failed SSRF validation"
+            );
+            anyhow!("MCP server URL blocked: {}", e)
+        })?;
 
     let request = McpToolCallRequest::new(
         1, // Request ID

--- a/crates/worker/src/mcp_executor.rs
+++ b/crates/worker/src/mcp_executor.rs
@@ -209,19 +209,22 @@ async fn call_mcp_tool(
     arguments: serde_json::Value,
     authorization_header: Option<&str>,
 ) -> Result<(serde_json::Value, Vec<ToolResultImage>)> {
-    // Re-validate URL at execution time with DNS resolution to catch DNS-rebinding
-    // (TM-TOOL-018). Resolves the hostname and rejects any private/internal IP.
-    validate_url_dns_pinned(&server_info.url)
-        .await
-        .map_err(|e| {
-            tracing::warn!(
-                mcp_server = %server_info.name,
-                url = %server_info.url,
-                error = %e,
-                "Blocked MCP tool execution: URL failed SSRF validation"
-            );
-            anyhow!("MCP server URL blocked: {}", e)
-        })?;
+    // Re-validate URL at execution time with DNS resolution (TM-TOOL-018).
+    // Returns resolved addrs so the egress client can pin the connection to
+    // those exact IPs, closing the TOCTOU window between check and connect.
+    let (validated_url, resolved_addrs) =
+        validate_url_dns_pinned(&server_info.url)
+            .await
+            .map_err(|e| {
+                tracing::warn!(
+                    mcp_server = %server_info.name,
+                    url = %server_info.url,
+                    error = %e,
+                    "Blocked MCP tool execution: URL failed SSRF validation"
+                );
+                anyhow!("MCP server URL blocked: {}", e)
+            })?;
+    let pin_host = validated_url.host_str().unwrap_or("").to_string();
 
     let request = McpToolCallRequest::new(
         1, // Request ID
@@ -231,6 +234,7 @@ async fn call_mcp_tool(
     let request_body = serde_json::to_vec(&request)?;
 
     let mut egress_request = EgressRequest::new("POST", &server_info.url, EgressRequestKind::Mcp)
+        .pinned_addrs(pin_host, resolved_addrs)
         .header("Content-Type", "application/json")
         .header("Accept", "application/json, text/event-stream")
         .timeout_ms(MCP_TOOL_TIMEOUT.as_millis() as u64)

--- a/specs/mcp-servers.md
+++ b/specs/mcp-servers.md
@@ -149,7 +149,7 @@ Delete an MCP server.
 1. **API Key Encryption**: API keys are encrypted at rest using envelope encryption (see `specs/encryption.md`)
 2. **API Key Not Exposed**: The `api_key_encrypted` field is never returned in API responses
 3. **Unique Names**: Server names must be unique to prevent configuration conflicts
-4. **SSRF Protection**: MCP server URLs are validated on create/update and re-validated at execution time. Private IPs, loopback, link-local, and cloud metadata endpoints are blocked by shared URL validation.
+4. **SSRF Protection**: MCP server URLs are validated on create/update (static check) and re-validated with DNS resolution before each tool call and `tools/list` fetch (`validate_url_dns_pinned`). Private IPs, loopback, link-local, and cloud metadata endpoints are blocked; the DNS-pinned check also prevents DNS-rebinding attacks by verifying every resolved IP on each outbound request (TM-TOOL-018).
 
 ## MCP as Virtual Capabilities
 

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -439,7 +439,7 @@ fn authorizer(action: AuthAction) -> Authorization {
 | TM-TOOL-015 | Browserless SSRF via tool URL | Medium | Shared `validate_safe_url()` blocks private/internal hosts for all Browserless navigation entry points, including interaction-step redirects | MITIGATED |
 | TM-TOOL-016 | Browserless timeout DoS | Medium | All wait/timeout values capped at 120s; prevents unbounded resource consumption | MITIGATED |
 | TM-TOOL-017 | Browserless API token in logs | Medium | CDP debug logging redacts token from WebSocket URLs before logging | MITIGATED |
-| TM-TOOL-018 | MCP server SSRF via configured server URL | High | MCP server URLs are validated on create/update and re-validated at execution time; private/internal hosts and metadata endpoints blocked | MITIGATED |
+| TM-TOOL-018 | MCP server SSRF via configured server URL | High | MCP server URLs are validated on create/update (static) and re-validated at execution time with DNS resolution via `validate_url_dns_pinned`; every resolved IP is checked against the blocked ranges, closing the DNS-rebinding gap | MITIGATED |
 | TM-TOOL-019 | MCP `query`/`execute` positional-arg rewrite injection | Low | Rewriter only inserts compile-time `--<flag>` tokens at statement-start boundaries, respects quotes/escapes/comments, and never modifies or reorders user bytes. Flag names come from the command registry, not user input. See EVE-323. | MITIGATED |
 | TM-TOOL-020 | Skill `` !`command` `` activation RCE on worker host | High | `ActivateSkillFromVfsTool::execute_with_context` never invokes `preprocess_command_injections` — the trust gate is forced off because no non-user-spoofable provenance signal exists on `SessionFile` today. Expansion is also capped at `MAX_COMMAND_PLACEHOLDERS_PER_SKILL` (32) with concurrency ≤ 4 in the expansion function itself. See EVE-388. | MITIGATED |
 | TM-TOOL-021 | Agent handoff credential leakage or unauthorized target delegation | High | `agent_handoff` delegates only to configured target Agent ids, requires server-side `UserConnectionResolver` checks before start, never accepts credentials in tool args/config/resource metadata, records only non-secret provider/scope labels in `session_resources`, and rejects follow-up messages unless the child session belongs to the current parent session. Provider tools must still enforce scoped grants before real external writes. | MITIGATED |
@@ -542,10 +542,8 @@ Validation runs for:
 
 **TM-TOOL-018 — MCP Server SSRF (MITIGATED):**
 MCP server URLs are validated twice:
-1. On create/update in the control plane to reject unsafe configuration
-2. Again in the worker just before execution to catch TOCTOU or stale cached configuration
-
-The shared validator blocks loopback, RFC1918, link-local, and cloud metadata targets. This prevents an MCP capability from being used to probe worker-local or cluster-internal HTTP services via a malicious server URL.
+1. On create/update in the control plane — static check via `validate_safe_url` rejects unsafe schemes, loopback, RFC1918, link-local, and cloud metadata targets.
+2. At execution time (before each tool call and `tools/list` fetch) via `validate_url_dns_pinned` — performs the same static checks then resolves the hostname via `tokio::net::lookup_host` and verifies every returned IP against the blocked ranges. This closes the DNS-rebinding gap: an attacker cannot register a public hostname that initially resolves to a safe IP but later rebinds to an internal address, because the IP is re-checked on every outbound request.
 
 ## 8. LLM Integration (TM-LLM)
 


### PR DESCRIPTION
## What
Add DNS-resolution-based SSRF check (`validate_url_dns_pinned`) that runs at MCP tool execution time and `tools/list` fetch time, closing the DNS-rebinding gap identified in TM-TOOL-018.

## Why
`validate_safe_url` is a static check: it rejects IP literals and known hostnames but cannot detect a DNS-rebinding attack where a public hostname initially resolves to a safe IP and later rebinds to a private one. Every MCP outbound request needs to re-verify the resolved IP, not just the URL string.

## How
- Added `validate_url_dns_pinned(raw_url)` (async) to `crates/core/src/url_validation.rs`:
  1. Runs `validate_safe_url` first (static fast path — rejects IP literals, bad schemes, localhost)
  2. Skips DNS lookup if host is already an IP literal
  3. Calls `tokio::net::lookup_host` and checks every resolved `SocketAddr` against `is_blocked_ip`
- Added `"net"` feature to tokio in `crates/core/Cargo.toml`
- Exported `validate_url_dns_pinned` from `everruns_core`
- Replaced `validate_safe_url` with `validate_url_dns_pinned` in:
  - `call_mcp_tool()` in `crates/worker/src/mcp_executor.rs`
  - `fetch_mcp_tools()` in `crates/server/src/domains/mcp_servers/service.rs`
- Write-time registration checks (`create`/`update`) keep `validate_safe_url` (static is sufficient there)
- Updated TM-TOOL-018 in `specs/threat-model.md` and `specs/mcp-servers.md`

## Risk
- Low — the new check is additive. Static checks still run first; DNS resolution only happens for non-IP hostnames. A transient DNS failure causes the request to be rejected with `BlockedHost` (safe fail).

## Security
- Threat categories reviewed: TM-TOOL-018 (MCP server SSRF)
- Finding: DNS rebinding not mitigated by static URL check alone
- Resolution: `validate_url_dns_pinned` resolves hostname on every outbound MCP call and blocks any resolved IP in the blocked ranges

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fszn8mHhG7EbyFQB6dGxys)_