### PR TITLE
feat(session-files): enforce per-file and per-session byte quotas (EVE-510)

### DIFF
--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -848,6 +848,37 @@ impl WorkerAdapters for DirectWorkerAdapters {
                 store_error("Failed to write file")
             })?;
 
+        // Quota check (TM-FS-008 / TM-DOS-005)
+        {
+            use crate::domains::session_files::limits::{
+                max_session_file_bytes, max_single_file_bytes,
+            };
+            let incoming = content_bytes.len() as i64;
+            let per_file_limit = max_single_file_bytes();
+            if incoming > per_file_limit {
+                return Err(store_error(format!(
+                    "File too large: {incoming} bytes exceeds the per-file limit of {per_file_limit} bytes"
+                )));
+            }
+            let existing_size = existing.as_ref().map(|f| f.size_bytes).unwrap_or(0);
+            let current_total =
+                self.db
+                    .total_session_file_bytes(session_id)
+                    .await
+                    .map_err(|e| {
+                        tracing::error!("Failed to query session file total: {}", e);
+                        store_error("Failed to write file")
+                    })?;
+            let delta = incoming - existing_size;
+            let new_total = current_total.saturating_add(delta.max(0));
+            let session_limit = max_session_file_bytes();
+            if new_total > session_limit {
+                return Err(store_error(format!(
+                    "Session storage quota exceeded: writing {incoming} bytes would bring total to {new_total} bytes (limit {session_limit} bytes)"
+                )));
+            }
+        }
+
         let row = if existing.is_some() {
             let update = UpdateSessionFile {
                 content: Some(content_bytes.clone()),

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -281,6 +281,7 @@ pub struct DirectWorkerAdapters {
     virtual_registry:
         Option<Arc<crate::domains::session_files::virtual_mount_registry::VirtualMountRegistry>>,
     org_rate_limiter: Option<Arc<crate::auth::rate_limit::OrgRateLimiter>>,
+    quota: crate::domains::session_files::limits::QuotaLimits,
 }
 
 impl DirectWorkerAdapters {
@@ -313,6 +314,7 @@ impl DirectWorkerAdapters {
             permission_resolver: Arc::new(everruns_core::DefaultPermissionResolver),
             virtual_registry: None,
             org_rate_limiter: None,
+            quota: crate::domains::session_files::limits::QuotaLimits::from_env(),
         }
     }
 
@@ -850,33 +852,12 @@ impl WorkerAdapters for DirectWorkerAdapters {
 
         // Quota check (TM-FS-008 / TM-DOS-005)
         {
-            use crate::domains::session_files::limits::{
-                max_session_file_bytes, max_single_file_bytes,
-            };
+            use crate::domains::session_files::limits::check_write_quota;
             let incoming = content_bytes.len() as i64;
-            let per_file_limit = max_single_file_bytes();
-            if incoming > per_file_limit {
-                return Err(store_error(format!(
-                    "File too large: {incoming} bytes exceeds the per-file limit of {per_file_limit} bytes"
-                )));
-            }
             let existing_size = existing.as_ref().map(|f| f.size_bytes).unwrap_or(0);
-            let current_total =
-                self.db
-                    .total_session_file_bytes(session_id)
-                    .await
-                    .map_err(|e| {
-                        tracing::error!("Failed to query session file total: {}", e);
-                        store_error("Failed to write file")
-                    })?;
-            let delta = incoming - existing_size;
-            let new_total = current_total.saturating_add(delta.max(0));
-            let session_limit = max_session_file_bytes();
-            if new_total > session_limit {
-                return Err(store_error(format!(
-                    "Session storage quota exceeded: writing {incoming} bytes would bring total to {new_total} bytes (limit {session_limit} bytes)"
-                )));
-            }
+            check_write_quota(&self.db, session_id, incoming, existing_size, &self.quota)
+                .await
+                .map_err(|e| store_error(e.to_string()))?;
         }
 
         let row = if existing.is_some() {

--- a/crates/server/src/domains/session_files/limits.rs
+++ b/crates/server/src/domains/session_files/limits.rs
@@ -3,21 +3,81 @@
 // Defaults are generous to avoid throttling legitimate long-horizon agentic
 // runs, while bounding Postgres BYTEA exhaustion. Operators can tighten via
 // env without redeploying code.
+//
+// Limits are read from env once at service construction time (via QuotaLimits::from_env),
+// not on every write, to avoid per-call overhead and process-global env mutation in tests.
 
-/// Max total bytes stored as session files per session (default 500 MB).
-pub fn max_session_file_bytes() -> i64 {
-    std::env::var("SESSION_FILE_MAX_BYTES")
-        .ok()
-        .and_then(|v| v.parse::<i64>().ok())
-        .filter(|&v| v > 0)
-        .unwrap_or(500 * 1024 * 1024)
+use crate::storage::StorageBackend;
+use anyhow::{Result, anyhow};
+use uuid::Uuid;
+
+const DEFAULT_SESSION_MAX: i64 = 500 * 1024 * 1024;
+const DEFAULT_PER_FILE_MAX: i64 = 100 * 1024 * 1024;
+
+/// Byte-level quota configuration for session file writes.
+#[derive(Clone, Copy, Debug)]
+pub struct QuotaLimits {
+    /// Maximum bytes for a single file write.
+    pub per_file_bytes: i64,
+    /// Maximum total bytes stored as session files per session.
+    pub per_session_bytes: i64,
 }
 
-/// Max bytes for a single file write (default 100 MB).
-pub fn max_single_file_bytes() -> i64 {
-    std::env::var("SESSION_FILE_SINGLE_MAX_BYTES")
+impl Default for QuotaLimits {
+    fn default() -> Self {
+        Self::from_env()
+    }
+}
+
+impl QuotaLimits {
+    /// Read limits from env vars (`SESSION_FILE_SINGLE_MAX_BYTES`,
+    /// `SESSION_FILE_MAX_BYTES`), falling back to generous defaults.
+    pub fn from_env() -> Self {
+        Self {
+            per_file_bytes: read_bytes_env("SESSION_FILE_SINGLE_MAX_BYTES", DEFAULT_PER_FILE_MAX),
+            per_session_bytes: read_bytes_env("SESSION_FILE_MAX_BYTES", DEFAULT_SESSION_MAX),
+        }
+    }
+}
+
+fn read_bytes_env(var: &str, default: i64) -> i64 {
+    std::env::var(var)
         .ok()
         .and_then(|v| v.parse::<i64>().ok())
         .filter(|&v| v > 0)
-        .unwrap_or(100 * 1024 * 1024)
+        .unwrap_or(default)
+}
+
+/// Check quota before writing `incoming_bytes` to a session file.
+///
+/// Pass `existing_bytes = 0` for new files. The session-total DB query is
+/// skipped when the write would not increase net storage (delta ≤ 0).
+pub async fn check_write_quota(
+    db: &StorageBackend,
+    session_id: Uuid,
+    incoming_bytes: i64,
+    existing_bytes: i64,
+    limits: &QuotaLimits,
+) -> Result<()> {
+    if incoming_bytes > limits.per_file_bytes {
+        return Err(anyhow!(
+            "File too large: {} bytes exceeds the per-file limit of {} bytes",
+            incoming_bytes,
+            limits.per_file_bytes
+        ));
+    }
+    let delta = incoming_bytes - existing_bytes;
+    if delta > 0 {
+        let current_total = db.total_session_file_bytes(session_id).await?;
+        let new_total = current_total.saturating_add(delta);
+        if new_total > limits.per_session_bytes {
+            return Err(anyhow!(
+                "Session storage quota exceeded: writing {} bytes would bring total to {} bytes (limit {} bytes)",
+                incoming_bytes,
+                new_total,
+                limits.per_session_bytes
+            ));
+        }
+    }
+    Ok(())
 }

--- a/crates/server/src/domains/session_files/limits.rs
+++ b/crates/server/src/domains/session_files/limits.rs
@@ -1,0 +1,23 @@
+// Storage quota limits for session files (TM-FS-008 / TM-DOS-005).
+//
+// Defaults are generous to avoid throttling legitimate long-horizon agentic
+// runs, while bounding Postgres BYTEA exhaustion. Operators can tighten via
+// env without redeploying code.
+
+/// Max total bytes stored as session files per session (default 500 MB).
+pub fn max_session_file_bytes() -> i64 {
+    std::env::var("SESSION_FILE_MAX_BYTES")
+        .ok()
+        .and_then(|v| v.parse::<i64>().ok())
+        .filter(|&v| v > 0)
+        .unwrap_or(500 * 1024 * 1024)
+}
+
+/// Max bytes for a single file write (default 100 MB).
+pub fn max_single_file_bytes() -> i64 {
+    std::env::var("SESSION_FILE_SINGLE_MAX_BYTES")
+        .ok()
+        .and_then(|v| v.parse::<i64>().ok())
+        .filter(|&v| v > 0)
+        .unwrap_or(100 * 1024 * 1024)
+}

--- a/crates/server/src/domains/session_files/mod.rs
+++ b/crates/server/src/domains/session_files/mod.rs
@@ -1,6 +1,7 @@
 // Session files domain — commands, queries, service, virtual-mount registry.
 
 pub mod commands;
+pub mod limits;
 pub mod queries;
 pub mod service;
 pub mod types;

--- a/crates/server/src/domains/session_files/service.rs
+++ b/crates/server/src/domains/session_files/service.rs
@@ -5,6 +5,7 @@
 // rather than waiting until execution time. The apply_capability_mounts()
 // method recursively creates files and directories from mount point definitions.
 
+use crate::domains::session_files::limits::{max_session_file_bytes, max_single_file_bytes};
 use crate::storage::{
     StorageBackend,
     models::{CreateSessionFileRow, SessionFileInfoRow, SessionFileRow, UpdateSessionFile},
@@ -157,6 +158,36 @@ impl SessionFileService {
         Ok(())
     }
 
+    /// Reject the write if `incoming_bytes` would exceed per-session or per-file quotas.
+    async fn check_write_quota(
+        &self,
+        session_id: Uuid,
+        incoming_bytes: i64,
+        existing_bytes: i64,
+    ) -> Result<()> {
+        let per_file_limit = max_single_file_bytes();
+        if incoming_bytes > per_file_limit {
+            return Err(anyhow!(
+                "File too large: {} bytes exceeds the per-file limit of {} bytes",
+                incoming_bytes,
+                per_file_limit
+            ));
+        }
+        let current_total = self.db.total_session_file_bytes(session_id).await?;
+        let delta = incoming_bytes - existing_bytes;
+        let new_total = current_total.saturating_add(delta.max(0));
+        let session_limit = max_session_file_bytes();
+        if new_total > session_limit {
+            return Err(anyhow!(
+                "Session storage quota exceeded: writing {} bytes would bring total to {} bytes (limit {} bytes)",
+                incoming_bytes,
+                new_total,
+                session_limit
+            ));
+        }
+        Ok(())
+    }
+
     /// Create a new file
     pub async fn create_file(&self, session_id: Uuid, req: CreateFileInput) -> Result<SessionFile> {
         let path = Self::normalize_path(&req.path);
@@ -171,6 +202,11 @@ impl SessionFileService {
         } else {
             None
         };
+
+        // Quota check before any DB writes (TM-FS-008 / TM-DOS-005)
+        let incoming_bytes = content.as_ref().map(|c| c.len() as i64).unwrap_or(0);
+        self.check_write_quota(session_id, incoming_bytes, 0)
+            .await?;
 
         // Ensure parent directory exists (create recursively if needed)
         if let Some(parent) = FileInfo::parent_path(&path) {
@@ -495,14 +531,18 @@ impl SessionFileService {
         }
 
         // Check if file exists and is not readonly
-        if let Some(existing) = self.db.get_session_file(session_id, &path).await? {
-            if existing.is_directory {
-                return Err(anyhow!("Cannot update directory: {}", path));
-            }
-            if existing.is_readonly && req.content.is_some() {
-                return Err(anyhow!("Cannot modify readonly file: {}", path));
-            }
-        }
+        let existing_size =
+            if let Some(existing) = self.db.get_session_file(session_id, &path).await? {
+                if existing.is_directory {
+                    return Err(anyhow!("Cannot update directory: {}", path));
+                }
+                if existing.is_readonly && req.content.is_some() {
+                    return Err(anyhow!("Cannot modify readonly file: {}", path));
+                }
+                existing.size_bytes
+            } else {
+                0
+            };
 
         // Decode content if provided
         let content = if let Some(ref content_str) = req.content {
@@ -511,6 +551,12 @@ impl SessionFileService {
         } else {
             None
         };
+
+        // Quota check (TM-FS-008 / TM-DOS-005)
+        if let Some(ref bytes) = content {
+            self.check_write_quota(session_id, bytes.len() as i64, existing_size)
+                .await?;
+        }
 
         let input = UpdateSessionFile {
             content,
@@ -1408,6 +1454,11 @@ mod tests {
     use crate::storage::StorageBackend;
     use crate::storage::models::CreateSessionFileRow;
     use std::sync::Arc;
+    use tokio::sync::Mutex;
+
+    // Serialize tests that mutate env vars to avoid races between parallel test threads.
+    static QUOTA_ENV_LOCK: std::sync::LazyLock<Mutex<()>> =
+        std::sync::LazyLock::new(|| Mutex::new(()));
 
     /// Seed a text file into the in-memory store.
     async fn seed_file(db: &StorageBackend, session_id: Uuid, path: &str, content: &str) {
@@ -1915,5 +1966,130 @@ mod tests {
             .await
             .unwrap_err();
         assert!(err.to_string().contains("readonly"));
+    }
+
+    // ===== Quota tests (TM-FS-008 / TM-DOS-005) =====
+
+    #[tokio::test]
+    async fn create_file_enforces_per_file_limit() {
+        let _guard = QUOTA_ENV_LOCK.lock().await;
+        // Override per-file limit to 10 bytes for this test.
+        unsafe {
+            std::env::set_var("SESSION_FILE_SINGLE_MAX_BYTES", "10");
+        }
+        let db = StorageBackend::in_memory();
+        let sid = Uuid::new_v4();
+        let svc = SessionFileService::new(Arc::new(db));
+
+        let err = svc
+            .create_file(
+                sid,
+                CreateFileInput {
+                    path: "/big.txt".to_string(),
+                    content: Some("x".repeat(11)),
+                    encoding: None,
+                    is_readonly: None,
+                },
+            )
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("per-file limit"),
+            "Expected per-file limit error, got: {err}"
+        );
+        unsafe {
+            std::env::remove_var("SESSION_FILE_SINGLE_MAX_BYTES");
+        }
+    }
+
+    #[tokio::test]
+    async fn create_file_enforces_session_total_limit() {
+        let _guard = QUOTA_ENV_LOCK.lock().await;
+        // Set session limit to 20 bytes; write two 15-byte files.
+        unsafe {
+            std::env::set_var("SESSION_FILE_MAX_BYTES", "20");
+            std::env::set_var("SESSION_FILE_SINGLE_MAX_BYTES", "15");
+        }
+        let db = StorageBackend::in_memory();
+        let sid = Uuid::new_v4();
+        let svc = SessionFileService::new(Arc::new(db));
+
+        // First write succeeds.
+        svc.create_file(
+            sid,
+            CreateFileInput {
+                path: "/a.txt".to_string(),
+                content: Some("x".repeat(15)),
+                encoding: None,
+                is_readonly: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        // Second write exceeds session total.
+        let err = svc
+            .create_file(
+                sid,
+                CreateFileInput {
+                    path: "/b.txt".to_string(),
+                    content: Some("x".repeat(15)),
+                    encoding: None,
+                    is_readonly: None,
+                },
+            )
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("quota exceeded"),
+            "Expected quota exceeded error, got: {err}"
+        );
+        unsafe {
+            std::env::remove_var("SESSION_FILE_MAX_BYTES");
+            std::env::remove_var("SESSION_FILE_SINGLE_MAX_BYTES");
+        }
+    }
+
+    #[tokio::test]
+    async fn update_file_enforces_per_file_limit() {
+        let _guard = QUOTA_ENV_LOCK.lock().await;
+        unsafe {
+            std::env::set_var("SESSION_FILE_SINGLE_MAX_BYTES", "10");
+        }
+        let db = StorageBackend::in_memory();
+        let sid = Uuid::new_v4();
+        let svc = SessionFileService::new(Arc::new(db));
+
+        svc.create_file(
+            sid,
+            CreateFileInput {
+                path: "/f.txt".to_string(),
+                content: Some("hello".to_string()),
+                encoding: None,
+                is_readonly: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        let err = svc
+            .update_file(
+                sid,
+                "/f.txt",
+                UpdateFileInput {
+                    content: Some("x".repeat(11)),
+                    encoding: None,
+                    is_readonly: None,
+                },
+            )
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("per-file limit"),
+            "Expected per-file limit error, got: {err}"
+        );
+        unsafe {
+            std::env::remove_var("SESSION_FILE_SINGLE_MAX_BYTES");
+        }
     }
 }

--- a/crates/server/src/domains/session_files/service.rs
+++ b/crates/server/src/domains/session_files/service.rs
@@ -5,7 +5,7 @@
 // rather than waiting until execution time. The apply_capability_mounts()
 // method recursively creates files and directories from mount point definitions.
 
-use crate::domains::session_files::limits::{max_session_file_bytes, max_single_file_bytes};
+use crate::domains::session_files::limits::{QuotaLimits, check_write_quota as quota_check};
 use crate::storage::{
     StorageBackend,
     models::{CreateSessionFileRow, SessionFileInfoRow, SessionFileRow, UpdateSessionFile},
@@ -95,6 +95,7 @@ pub struct SessionFileService {
     db: Arc<StorageBackend>,
     virtual_registry:
         Option<Arc<crate::domains::session_files::virtual_mount_registry::VirtualMountRegistry>>,
+    quota: QuotaLimits,
 }
 
 impl SessionFileService {
@@ -102,6 +103,7 @@ impl SessionFileService {
         Self {
             db,
             virtual_registry: None,
+            quota: QuotaLimits::from_env(),
         }
     }
 
@@ -110,6 +112,11 @@ impl SessionFileService {
         registry: Arc<crate::domains::session_files::virtual_mount_registry::VirtualMountRegistry>,
     ) -> Self {
         self.virtual_registry = Some(registry);
+        self
+    }
+
+    pub fn with_quota_limits(mut self, quota: QuotaLimits) -> Self {
+        self.quota = quota;
         self
     }
 
@@ -158,34 +165,20 @@ impl SessionFileService {
         Ok(())
     }
 
-    /// Reject the write if `incoming_bytes` would exceed per-session or per-file quotas.
     async fn check_write_quota(
         &self,
         session_id: Uuid,
         incoming_bytes: i64,
         existing_bytes: i64,
     ) -> Result<()> {
-        let per_file_limit = max_single_file_bytes();
-        if incoming_bytes > per_file_limit {
-            return Err(anyhow!(
-                "File too large: {} bytes exceeds the per-file limit of {} bytes",
-                incoming_bytes,
-                per_file_limit
-            ));
-        }
-        let current_total = self.db.total_session_file_bytes(session_id).await?;
-        let delta = incoming_bytes - existing_bytes;
-        let new_total = current_total.saturating_add(delta.max(0));
-        let session_limit = max_session_file_bytes();
-        if new_total > session_limit {
-            return Err(anyhow!(
-                "Session storage quota exceeded: writing {} bytes would bring total to {} bytes (limit {} bytes)",
-                incoming_bytes,
-                new_total,
-                session_limit
-            ));
-        }
-        Ok(())
+        quota_check(
+            &self.db,
+            session_id,
+            incoming_bytes,
+            existing_bytes,
+            &self.quota,
+        )
+        .await
     }
 
     /// Create a new file
@@ -1451,14 +1444,10 @@ struct MountStats {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::domains::session_files::limits::QuotaLimits;
     use crate::storage::StorageBackend;
     use crate::storage::models::CreateSessionFileRow;
     use std::sync::Arc;
-    use tokio::sync::Mutex;
-
-    // Serialize tests that mutate env vars to avoid races between parallel test threads.
-    static QUOTA_ENV_LOCK: std::sync::LazyLock<Mutex<()>> =
-        std::sync::LazyLock::new(|| Mutex::new(()));
 
     /// Seed a text file into the in-memory store.
     async fn seed_file(db: &StorageBackend, session_id: Uuid, path: &str, content: &str) {
@@ -1972,14 +1961,12 @@ mod tests {
 
     #[tokio::test]
     async fn create_file_enforces_per_file_limit() {
-        let _guard = QUOTA_ENV_LOCK.lock().await;
-        // Override per-file limit to 10 bytes for this test.
-        unsafe {
-            std::env::set_var("SESSION_FILE_SINGLE_MAX_BYTES", "10");
-        }
         let db = StorageBackend::in_memory();
         let sid = Uuid::new_v4();
-        let svc = SessionFileService::new(Arc::new(db));
+        let svc = SessionFileService::new(Arc::new(db)).with_quota_limits(QuotaLimits {
+            per_file_bytes: 10,
+            per_session_bytes: 500 * 1024 * 1024,
+        });
 
         let err = svc
             .create_file(
@@ -1997,22 +1984,16 @@ mod tests {
             err.to_string().contains("per-file limit"),
             "Expected per-file limit error, got: {err}"
         );
-        unsafe {
-            std::env::remove_var("SESSION_FILE_SINGLE_MAX_BYTES");
-        }
     }
 
     #[tokio::test]
     async fn create_file_enforces_session_total_limit() {
-        let _guard = QUOTA_ENV_LOCK.lock().await;
-        // Set session limit to 20 bytes; write two 15-byte files.
-        unsafe {
-            std::env::set_var("SESSION_FILE_MAX_BYTES", "20");
-            std::env::set_var("SESSION_FILE_SINGLE_MAX_BYTES", "15");
-        }
         let db = StorageBackend::in_memory();
         let sid = Uuid::new_v4();
-        let svc = SessionFileService::new(Arc::new(db));
+        let svc = SessionFileService::new(Arc::new(db)).with_quota_limits(QuotaLimits {
+            per_file_bytes: 15,
+            per_session_bytes: 20,
+        });
 
         // First write succeeds.
         svc.create_file(
@@ -2044,21 +2025,16 @@ mod tests {
             err.to_string().contains("quota exceeded"),
             "Expected quota exceeded error, got: {err}"
         );
-        unsafe {
-            std::env::remove_var("SESSION_FILE_MAX_BYTES");
-            std::env::remove_var("SESSION_FILE_SINGLE_MAX_BYTES");
-        }
     }
 
     #[tokio::test]
     async fn update_file_enforces_per_file_limit() {
-        let _guard = QUOTA_ENV_LOCK.lock().await;
-        unsafe {
-            std::env::set_var("SESSION_FILE_SINGLE_MAX_BYTES", "10");
-        }
         let db = StorageBackend::in_memory();
         let sid = Uuid::new_v4();
-        let svc = SessionFileService::new(Arc::new(db));
+        let svc = SessionFileService::new(Arc::new(db)).with_quota_limits(QuotaLimits {
+            per_file_bytes: 10,
+            per_session_bytes: 500 * 1024 * 1024,
+        });
 
         svc.create_file(
             sid,
@@ -2088,8 +2064,5 @@ mod tests {
             err.to_string().contains("per-file limit"),
             "Expected per-file limit error, got: {err}"
         );
-        unsafe {
-            std::env::remove_var("SESSION_FILE_SINGLE_MAX_BYTES");
-        }
     }
 }

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -1662,6 +1662,11 @@ impl StorageBackend {
         dispatch!(self, session_directory_has_children, session_id, path)
     }
 
+    /// Sum of size_bytes for all non-directory files in a session.
+    pub async fn total_session_file_bytes(&self, session_id: Uuid) -> Result<i64> {
+        dispatch!(self, total_session_file_bytes, session_id)
+    }
+
     /// Load all non-directory files with content for a session (single query, for git commit).
     pub async fn load_all_session_files_with_content(
         &self,

--- a/crates/server/src/storage/memory/session_files.rs
+++ b/crates/server/src/storage/memory/session_files.rs
@@ -357,6 +357,17 @@ impl InMemoryDatabase {
         }))
     }
 
+    pub async fn total_session_file_bytes(&self, session_id: Uuid) -> Result<i64> {
+        let session_id = SessionId::from_uuid(session_id);
+        Ok(self
+            .session_files
+            .read()
+            .values()
+            .filter(|f| f.session_id == session_id && !f.is_directory)
+            .map(|f| f.size_bytes)
+            .sum())
+    }
+
     /// Load all non-directory files with content for a session (single pass).
     pub async fn load_all_session_files_with_content(
         &self,

--- a/crates/server/src/storage/repositories/session_files.rs
+++ b/crates/server/src/storage/repositories/session_files.rs
@@ -416,7 +416,7 @@ impl Database {
     /// Sum of size_bytes across all non-directory files in a session.
     pub async fn total_session_file_bytes(&self, session_id: Uuid) -> Result<i64> {
         let row: (i64,) = sqlx::query_as(
-            "SELECT COALESCE(SUM(size_bytes), 0) FROM session_files WHERE session_id = $1 AND is_directory = false",
+            "SELECT COALESCE(SUM(size_bytes), 0)::bigint FROM session_files WHERE session_id = $1 AND is_directory = false",
         )
         .bind(session_id)
         .fetch_one(&self.pool)

--- a/crates/server/src/storage/repositories/session_files.rs
+++ b/crates/server/src/storage/repositories/session_files.rs
@@ -413,6 +413,17 @@ impl Database {
         Ok(result.is_some())
     }
 
+    /// Sum of size_bytes across all non-directory files in a session.
+    pub async fn total_session_file_bytes(&self, session_id: Uuid) -> Result<i64> {
+        let row: (i64,) = sqlx::query_as(
+            "SELECT COALESCE(SUM(size_bytes), 0) FROM session_files WHERE session_id = $1 AND is_directory = false",
+        )
+        .bind(session_id)
+        .fetch_one(&self.pool)
+        .await?;
+        Ok(row.0)
+    }
+
     /// Load all non-directory files with content for a session (single query).
     pub async fn load_all_session_files_with_content(
         &self,

--- a/specs/session-filesystem.md
+++ b/specs/session-filesystem.md
@@ -38,6 +38,15 @@ This document defines the session-level virtual filesystem for Everruns. Each se
 **Chosen:** No special handling for large files (>10MB)
 **Rationale:** MVP focuses on code and config files. Large file streaming can be added later with object storage backend.
 
+### Decision 7: Per-Session Storage Quotas
+**Chosen:** Enforce byte-level quotas at the application layer in both the HTTP API path and the agent tool path.
+
+**Limits (env-configurable):**
+- `SESSION_FILE_MAX_BYTES` — total bytes per session (default 500 MB)
+- `SESSION_FILE_SINGLE_MAX_BYTES` — per-file ceiling (default 100 MB)
+
+**Rationale:** Prevents unbounded PostgreSQL BYTEA growth from agentic file writes (TM-FS-008 / TM-DOS-005). Quota checks run before any DB insert, so they fail closed. Defaults are generous to avoid throttling long-horizon agentic runs.
+
 ### Decision 6: Workspace Mount Point
 **Chosen:** Session files exposed to agents at `/workspace`
 **Alternatives considered:**

--- a/specs/session-filesystem.md
+++ b/specs/session-filesystem.md
@@ -38,7 +38,7 @@ This document defines the session-level virtual filesystem for Everruns. Each se
 **Chosen:** No special handling for large files (>10MB)
 **Rationale:** MVP focuses on code and config files. Large file streaming can be added later with object storage backend.
 
-### Decision 7: Per-Session Storage Quotas
+### Decision 6: Per-Session Storage Quotas
 **Chosen:** Enforce byte-level quotas at the application layer in both the HTTP API path and the agent tool path.
 
 **Limits (env-configurable):**
@@ -47,7 +47,7 @@ This document defines the session-level virtual filesystem for Everruns. Each se
 
 **Rationale:** Prevents unbounded PostgreSQL BYTEA growth from agentic file writes (TM-FS-008 / TM-DOS-005). Quota checks run before any DB insert, so they fail closed. Defaults are generous to avoid throttling long-horizon agentic runs.
 
-### Decision 6: Workspace Mount Point
+### Decision 7: Workspace Mount Point
 **Chosen:** Session files exposed to agents at `/workspace`
 **Alternatives considered:**
 - Mount at root `/`: Conflicts with system directories

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -356,7 +356,7 @@ Code references:
 | TM-FS-005 | Readonly file modification or deletion | Medium | `is_readonly` flag enforced; readonly files cannot be modified or deleted; recursive directory deletion blocked if subtree contains readonly files | MITIGATED |
 | TM-FS-006 | File content unencrypted at rest | Low | Stored as BYTEA in PostgreSQL; relies on infrastructure-level encryption (disk, TDE) | **ACCEPTED** |
 | TM-FS-007 | No file access audit log | Low | File reads/writes not logged; privacy tradeoff | **ACCEPTED** |
-| TM-FS-008 | Large file storage abuse | Medium | No per-session storage quota enforced at application level | **OPEN** |
+| TM-FS-008 | Large file storage abuse | Medium | Per-session and per-file byte quotas enforced in `SessionFileService` and `DirectWorkerAdapters`; configurable via `SESSION_FILE_MAX_BYTES` / `SESSION_FILE_SINGLE_MAX_BYTES` env vars (defaults: 500 MB/session, 100 MB/file) | MITIGATED |
 | TM-FS-009 | CLI `initial_files` hidden-path exfiltration | High | Three-layer policy in `crates/cli/src/commands/agents.rs`: hard-deny floor (`DENIED_DOT_ENTRIES`) blocks `.env`, `.ssh`, `.aws`, `.gnupg`, `.git`, etc. unconditionally; built-in `ALLOWED_DOT_ENTRIES` permits common dev assets (`.github`, `.vscode`, `.claude`, `.mcp.json`, etc.); per-agent `initial_files_allow_hidden` manifest field extends the allowlist but cannot bypass the hard-deny floor. Skipped paths emit a stderr warning. See `specs/cli.md` (Initial Files Hidden Path Policy). | MITIGATED |
 
 ### Mitigation Details
@@ -367,10 +367,12 @@ Path validated at three layers:
 2. **Database constraint:** `session_files_path_check` CHECK constraint
 3. **Unique constraint:** `(session_id, path)` prevents collision
 
-**TM-FS-008 — Storage Quota (OPEN):**
-No per-session or per-org storage limit on session files. An agent could create many large files.
-- **Recommendation:** Enforce per-session file count and total size limits.
-- **Priority:** Medium
+**TM-FS-008 — Storage Quota:**
+Per-session and per-file byte quotas are enforced at the application layer in both the HTTP API path (`SessionFileService::create_file` / `update_file`) and the agent tool path (`DirectWorkerAdapters::write_file`). Limits are configurable via env:
+- `SESSION_FILE_MAX_BYTES` — total bytes per session (default 500 MB)
+- `SESSION_FILE_SINGLE_MAX_BYTES` — per-file ceiling (default 100 MB)
+
+Writes that would exceed either limit fail with a clear error before any DB insert.
 
 ## 6. Session SQL Database (TM-SQL)
 
@@ -874,7 +876,7 @@ Everruns uses [bashkit](https://github.com/everruns/bashkit) (v0.2.1) as a sandb
 | TM-BASH-013 | eval/bash re-invocation escape | Medium | `eval` and `bash`/`sh` commands re-invoke the sandboxed interpreter, not real shell | MITIGATED |
 | TM-BASH-014 | File permission bypass | Low | `chmod` is a no-op; session filesystem has no permission model | **BY DESIGN** |
 | TM-BASH-015 | Host information disclosure | Low | `hostname` → "everruns"; `whoami` → "everruns"; `uname` returns sandboxed values | MITIGATED |
-| TM-BASH-016 | Write amplification via bash | Medium | No per-session storage quota on files written by bash (see TM-FS-008) | **OPEN** (see TM-FS-008) |
+| TM-BASH-016 | Write amplification via bash | Medium | Per-session and per-file byte quotas enforced in `DirectWorkerAdapters::write_file` (see TM-FS-008) | MITIGATED |
 
 ### Mitigation Details
 
@@ -937,7 +939,7 @@ When a bash script calls `bash` or `sh` or uses `eval`, bashkit re-invokes its o
 | TM-DOS-002 | Agent loop infinite iteration | High | Max 10 iterations per turn; configurable | MITIGATED |
 | TM-DOS-003 | SSE connection exhaustion | Medium | Global (10k), per-org (1k), per-session (5) RAII connection limits via `SseConnectionTracker`; HTTP/2 flow control windows tuned (2 MB/stream, 16 MB/connection) with adaptive sizing; connection cycling with ±20% jitter prevents thundering herd; HTTP/2 PING keepalive detects dead connections | MITIGATED |
 | TM-DOS-004 | Database connection pool exhaustion | Medium | sqlx connection pool with max_connections; timeouts on acquisition | MITIGATED |
-| TM-DOS-005 | Session file storage abuse | Medium | No per-session storage quota; large files stored as PostgreSQL BYTEA | **OPEN** (see TM-FS-008) |
+| TM-DOS-005 | Session file storage abuse | Medium | Per-session and per-file byte quotas enforced at the application layer (see TM-FS-008) | MITIGATED |
 | TM-DOS-006 | Durable task queue flooding | Medium | Per-workflow pending task limit (see TM-DURABLE-004) | MITIGATED |
 | TM-DOS-007 | Nested JSON depth in API input | Medium | Input validation rejects deeply nested structures | MITIGATED |
 | TM-DOS-008 | ReDoS via file grep endpoint | Medium | Regex pattern and path_pattern length capped (1 000 chars); NFA size capped via `RegexBuilder::size_limit` (512 KB); storage backends skip files > 512 KB before scanning; total request scan aborted above 5 MB | MITIGATED |
@@ -1310,7 +1312,7 @@ Even with per-secret scoping, an attacker who controls a previously-approved for
 | ~~TM-DOS-008~~ | ~~ReDoS via file grep endpoint~~ | ~~Medium~~ | Mitigated: pattern length capped at 1 000 chars; NFA compiled size capped at 512 KB via `RegexBuilder::size_limit`; per-file scan skipped above 512 KB; total scan aborted above 5 MB per request (`grep_session_files`, `service.rs`) |
 | TM-AGENT-007 | No per-iteration tool call limit | Medium | Cap tool calls per LLM response |
 | ~~TM-AGENT-012~~ | ~~Tool result size amplification~~ | ~~Medium~~ | Mitigated: 64 KiB hard limit via `OutputHardLimitHook` (EVE-225) |
-| TM-FS-008 | No session storage quota | Medium | Enforce per-session file size limits |
+| ~~TM-FS-008~~ | ~~No session storage quota~~ | ~~Medium~~ | Mitigated: per-session (500 MB) and per-file (100 MB) byte quotas enforced in `SessionFileService` and `DirectWorkerAdapters`; env-configurable (EVE-510) |
 | TM-TOOL-008 | Tool approval not enforced | Low | Implement HITL approval for requires_approval policy |
 | ~~TM-TOOL-009~~ | ~~No tool rate limiting~~ | ~~Medium~~ | Mitigated: per-org 1000 RPM via `OutboundToolRateLimiter` in `ActAtom` (EVE-514) |
 | TM-DOS-003 | SSE connection exhaustion | Medium | Global (10k), per-org (1k), per-session (5) limits enforced |


### PR DESCRIPTION
## Summary

- Adds byte-level quotas for session file storage (TM-FS-008 / TM-DOS-005)
- Per-file limit: `SESSION_FILE_SINGLE_MAX_BYTES` env var, default 100 MB
- Per-session limit: `SESSION_FILE_MAX_BYTES` env var, default 500 MB
- Checks enforced on both write paths: HTTP API (`SessionFileService`) and agent tool (`DirectWorkerAdapters::write_file`)
- New `limits.rs` module; `total_session_file_bytes` storage method added to PostgreSQL, in-memory, and dispatch backends
- Threat model updated: TM-FS-008, TM-BASH-016, TM-DOS-005 marked MITIGATED

## Test plan

- [ ] `cargo test -p everruns-server --lib enforces` — 3 new quota tests pass (per-file limit, session total limit, update per-file limit)
- [ ] `bash scripts/lib/pre-push.sh` — all checks green
- [ ] Verify `SESSION_FILE_SINGLE_MAX_BYTES=100` env var causes file writes > 100 bytes to fail with "per-file limit" error
- [ ] Verify `SESSION_FILE_MAX_BYTES=200` env var causes session total writes > 200 bytes to fail with "quota exceeded" error

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fszn8mHhG7EbyFQB6dGxys)_