### PR TITLE
docs(user-hooks): add user_prompt_submit and turn_end examples

### DIFF
--- a/crates/core/src/hook_dispatch.rs
+++ b/crates/core/src/hook_dispatch.rs
@@ -810,6 +810,151 @@ mod tests {
         }
     }
 
+    // Pull the first hook's bash command out of an `examples/hook-bundles/*.json`
+    // config so the example-bundle tests exercise the exact shipped command.
+    fn bundle_command(file_name: &str) -> String {
+        let path = format!(
+            "{}/../../examples/hook-bundles/{}",
+            env!("CARGO_MANIFEST_DIR"),
+            file_name
+        );
+        let raw = std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {path}: {e}"));
+        let value: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        value["hooks"][0]["executor"]["command"]
+            .as_str()
+            .unwrap_or_else(|| panic!("{file_name}: hooks[0].executor.command missing"))
+            .to_string()
+    }
+
+    #[tokio::test]
+    async fn example_block_secret_prompt_blocks_private_key() {
+        let cmd = bundle_command("block-secret-prompt.json");
+        let store: Arc<dyn SessionFileSystem> = Arc::new(MockFileStore::default());
+
+        // A prompt that pastes a private key is blocked, with the user_message
+        // surfaced to the caller.
+        let blocked = run(
+            store.clone(),
+            &cmd,
+            Default::default(),
+            payload(
+                HookEvent::UserPromptSubmit,
+                json!({ "message": "please use this key:\n-----BEGIN RSA PRIVATE KEY-----\nMII...\n-----END RSA PRIVATE KEY-----" }),
+            ),
+        )
+        .await;
+        match blocked {
+            HookOutcome::Block {
+                reason,
+                user_message,
+            } => {
+                assert!(reason.contains("private key"), "reason: {reason}");
+                assert!(
+                    user_message
+                        .as_deref()
+                        .unwrap_or_default()
+                        .contains("blocked"),
+                    "user_message: {user_message:?}"
+                );
+            }
+            other => panic!("expected Block, got {other:?}"),
+        }
+
+        // A benign prompt is allowed through unchanged.
+        let allowed = run(
+            store,
+            &cmd,
+            Default::default(),
+            payload(
+                HookEvent::UserPromptSubmit,
+                json!({ "message": "summarize the README" }),
+            ),
+        )
+        .await;
+        assert!(matches!(allowed, HookOutcome::Allow), "got {allowed:?}");
+    }
+
+    #[tokio::test]
+    async fn example_turn_end_log_appends_line() {
+        let cmd = bundle_command("turn-end-log.json");
+        let mock = Arc::new(MockFileStore::default());
+        let store: Arc<dyn SessionFileSystem> = mock.clone();
+
+        let outcome = run(
+            store,
+            &cmd,
+            Default::default(),
+            payload(HookEvent::TurnEnd, json!({ "success": true })),
+        )
+        .await;
+        // turn_end is advisory; the command emits `{}` (allow).
+        assert!(matches!(outcome, HookOutcome::Allow), "got {outcome:?}");
+
+        // The hook wrote a summary line built from the payload (ts / turn_id /
+        // success) — proving jq field access and the `>>` append both work.
+        let line = mock
+            .read("/.turn-log")
+            .or_else(|| mock.read("/workspace/.turn-log"))
+            .map(|s| s.trim().to_string())
+            .expect("turn-end hook should have written /.turn-log");
+        assert_eq!(line, "2026-05-28T00:00:00Z turn trn_test success=true");
+    }
+
+    #[tokio::test]
+    async fn doc_mutate_prompt_rewrites_message() {
+        // Mirrors the `prepend_style_note` mutate snippet in
+        // docs/capabilities/user-hooks.md: build the rewritten message in jq so
+        // the `\n` is a real newline (a shell-quoted "\n" would be literal).
+        let cmd = r#"echo "$EVERRUNS_HOOK_PAYLOAD_JSON" | jq -c '{decision:"mutate",patch:{message:("[reminder: follow the house style guide]\n" + .data.message)}}'"#;
+        let store: Arc<dyn SessionFileSystem> = Arc::new(MockFileStore::default());
+
+        let outcome = run(
+            store,
+            cmd,
+            Default::default(),
+            payload(
+                HookEvent::UserPromptSubmit,
+                json!({ "message": "fix the bug" }),
+            ),
+        )
+        .await;
+        match outcome {
+            HookOutcome::Mutate { patch, .. } => {
+                assert_eq!(
+                    patch.get("message").and_then(|v| v.as_str()),
+                    Some("[reminder: follow the house style guide]\nfix the bug")
+                );
+            }
+            other => panic!("expected Mutate, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn all_example_bundles_validate_against_user_hooks_schema() {
+        use crate::capabilities::{Capability, UserHooksCapability};
+
+        let dir = format!("{}/../../examples/hook-bundles", env!("CARGO_MANIFEST_DIR"));
+        let cap = UserHooksCapability;
+        let mut checked = 0;
+        for entry in std::fs::read_dir(&dir).unwrap() {
+            let path = entry.unwrap().path();
+            if path.extension().and_then(|e| e.to_str()) != Some("json") {
+                continue;
+            }
+            let raw = std::fs::read_to_string(&path).unwrap();
+            let config: serde_json::Value = serde_json::from_str(&raw)
+                .unwrap_or_else(|e| panic!("{}: invalid JSON: {e}", path.display()));
+            cap.validate_config(&config).unwrap_or_else(|e| {
+                panic!("{}: failed user_hooks validation: {e}", path.display())
+            });
+            checked += 1;
+        }
+        assert!(
+            checked >= 6,
+            "expected to validate the shipped bundles, saw {checked}"
+        );
+    }
+
     #[tokio::test]
     async fn jq_can_read_payload_from_env_path() {
         // Smoke test for the documented `jq` workflow. We use a tiny

--- a/docs/capabilities/user-hooks.md
+++ b/docs/capabilities/user-hooks.md
@@ -346,6 +346,90 @@ for ready-to-paste user-config bundle JSON.
 }
 ```
 
+### Block a user prompt that pastes a secret
+
+`user_prompt_submit` is the only lifecycle event that can **block**: a
+`block` decision aborts the turn before the LLM runs. The original prompt
+text arrives in `data.message`. Here the hook reads it, and if it looks like
+a pasted private key, rejects the turn with a message shown to the user.
+`on_error: "block"` makes the hook fail closed.
+
+```json
+{
+  "capabilities": [
+    { "ref": "virtual_bash" },
+    {
+      "ref": "user_hooks",
+      "config": {
+        "hooks": [
+          {
+            "id": "block_secrets_in_prompt",
+            "event": "user_prompt_submit",
+            "executor": {
+              "type": "bash",
+              "command": "msg=$(echo \"$EVERRUNS_HOOK_PAYLOAD_JSON\" | jq -r '.data.message'); if printf '%s' \"$msg\" | grep -qiE 'BEGIN (RSA|OPENSSH|EC|DSA) PRIVATE KEY'; then echo '{\"decision\":\"block\",\"reason\":\"prompt contains a private key\",\"user_message\":\"Your message looks like it contains a private key and was blocked. Remove the secret and resend.\"}'; else echo '{}'; fi"
+            },
+            "timeout_ms": 5000,
+            "on_error": "block",
+            "description": "Reject prompts that paste a private key"
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
+`user_prompt_submit` can also **mutate** the prompt instead of blocking —
+emit `{"decision":"mutate","patch":{"message":"<rewritten text>"}}` and the
+turn proceeds with the rewritten text. For example, to prepend a house style
+reminder:
+
+```jsonc
+{
+  "id": "prepend_style_note",
+  "event": "user_prompt_submit",
+  "executor": {
+    "type": "bash",
+    "command": "echo \"$EVERRUNS_HOOK_PAYLOAD_JSON\" | jq -c '{decision:\"mutate\",patch:{message:(\"[reminder: follow the house style guide]\\n\" + .data.message)}}'"
+  },
+  "on_error": "warn"
+}
+```
+
+### Log every completed turn
+
+`turn_end` is advisory — its decision is ignored, so use it for side effects
+like metrics or audit trails. The payload's `data.success` reports whether the
+turn finished cleanly.
+
+```json
+{
+  "capabilities": [
+    { "ref": "session_file_system" },
+    { "ref": "virtual_bash" },
+    {
+      "ref": "user_hooks",
+      "config": {
+        "hooks": [
+          {
+            "id": "log_turn_end",
+            "event": "turn_end",
+            "executor": {
+              "type": "bash",
+              "command": "echo \"$EVERRUNS_HOOK_PAYLOAD_JSON\" | jq -r '.ts + \" turn \" + .turn_id + \" success=\" + (.data.success | tostring)' >> /workspace/.turn-log; echo '{}'"
+            },
+            "timeout_ms": 3000,
+            "on_error": "warn",
+            "description": "Append one line per completed turn to /workspace/.turn-log"
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
 ## Observability
 
 Today, hook decisions and errors are recorded in the server logs via

--- a/examples/hook-bundles/README.md
+++ b/examples/hook-bundles/README.md
@@ -10,6 +10,8 @@ capability.
 | [`format-on-edit.json`](./format-on-edit.json) | `user_hooks` config | Run `cargo fmt` and `prettier` after each `edit_file`. |
 | [`session-bootstrap.json`](./session-bootstrap.json) | `user_hooks` config | Drop a sentinel file at session start. |
 | [`audit-every-tool.json`](./audit-every-tool.json) | `user_hooks` config | Append every tool call to `/workspace/.audit.log`. |
+| [`block-secret-prompt.json`](./block-secret-prompt.json) | `user_hooks` config | Block a user prompt that pastes a private key (`user_prompt_submit`). |
+| [`turn-end-log.json`](./turn-end-log.json) | `user_hooks` config | Append one line per completed turn to `/workspace/.turn-log` (`turn_end`). |
 
 ## Using a hook config
 

--- a/examples/hook-bundles/block-secret-prompt.json
+++ b/examples/hook-bundles/block-secret-prompt.json
@@ -1,0 +1,15 @@
+{
+  "hooks": [
+    {
+      "id": "block_secrets_in_prompt",
+      "event": "user_prompt_submit",
+      "executor": {
+        "type": "bash",
+        "command": "msg=$(echo \"$EVERRUNS_HOOK_PAYLOAD_JSON\" | jq -r '.data.message'); if printf '%s' \"$msg\" | grep -qiE 'BEGIN (RSA|OPENSSH|EC|DSA) PRIVATE KEY'; then echo '{\"decision\":\"block\",\"reason\":\"prompt contains a private key\",\"user_message\":\"Your message looks like it contains a private key and was blocked. Remove the secret and resend.\"}'; else echo '{}'; fi"
+      },
+      "timeout_ms": 5000,
+      "on_error": "block",
+      "description": "Reject user prompts that paste a private key (user_prompt_submit; blocks the turn, fails closed on hook error)"
+    }
+  ]
+}

--- a/examples/hook-bundles/turn-end-log.json
+++ b/examples/hook-bundles/turn-end-log.json
@@ -1,0 +1,15 @@
+{
+  "hooks": [
+    {
+      "id": "log_turn_end",
+      "event": "turn_end",
+      "executor": {
+        "type": "bash",
+        "command": "echo \"$EVERRUNS_HOOK_PAYLOAD_JSON\" | jq -r '.ts + \" turn \" + .turn_id + \" success=\" + (.data.success | tostring)' >> /workspace/.turn-log; echo '{}'"
+      },
+      "timeout_ms": 3000,
+      "on_error": "warn",
+      "description": "Append one line per completed turn to /workspace/.turn-log (turn_end; advisory, never blocks)"
+    }
+  ]
+}


### PR DESCRIPTION
## What

Adds worked, copy-pasteable examples for the two newly-wired user-hook lifecycle events (`user_prompt_submit`, `turn_end`) — docs prose, runnable bundles, and tests that prove the example commands actually work.

- **`examples/hook-bundles/block-secret-prompt.json`** — a `user_prompt_submit` hook that **blocks** a turn when the prompt pastes a private key, surfacing a user-facing message. `on_error: "block"` (fails closed).
- **`examples/hook-bundles/turn-end-log.json`** — an advisory `turn_end` hook that appends a summary line (`ts` / `turn_id` / `success`) per completed turn to `/workspace/.turn-log`.
- **`docs/capabilities/user-hooks.md`** — adds both as worked examples, plus an inline **mutate** variant showing how `user_prompt_submit` can rewrite the prompt text (`{"decision":"mutate","patch":{"message":…}}`).
- **`examples/hook-bundles/README.md`** — lists the two new bundles.

## Why

The how-to doc and bundles previously only covered the session/tool events. The two runtime events I just shipped (#2032) had no examples, so users had no reference for the blockable prompt hook or the advisory turn hook.

## How

Examples use only sandbox-available builtins (`jq` — feature-enabled and smoke-tested — plus `grep`/`printf`/`>>`). The mutate example builds the rewritten string inside `jq` so `\n` is a real newline (a shell-quoted `"\n"` would be literal — caught and fixed during testing).

## Risk

- **Low / docs + examples + tests only.** No runtime/production code paths changed.

## Security

- **Threat categories reviewed:** TM-HOOK. **No security-relevant production code changes** — the diff is documentation, example config, and test code. The new `block-secret-prompt` example is itself a security-positive pattern (rejecting secret-bearing prompts). No new threat surface; the existing TM-HOOK mitigations (sandbox, timeout, output cap, admin gate) are unchanged.

## Follow-ups

No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (additive examples)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

## Validation

- New core tests run the real `virtual_bash` dispatcher:
  - `example_block_secret_prompt_blocks_private_key` — Block on a private-key prompt, Allow on a benign one.
  - `example_turn_end_log_appends_line` — asserts the exact written log line.
  - `doc_mutate_prompt_rewrites_message` — asserts the mutate patch rewrites the message (real newline).
  - `all_example_bundles_validate_against_user_hooks_schema` — every bundle validates against `UserHooksCapability::validate_config`.
- `pre-push` clean (fmt, clippy `-D warnings`, lockfile, migrations, specs index, attribution); full core lib suite green (1997).

---
_Generated by [Claude Code](https://claude.ai/code/session_01TtjDajqb7QA5QwJBmgek4j)_