### PR TITLE
feat(security): enforce BYOK-only posture, remove DEFAULT_* env key paths (EVE-512)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -829,10 +829,9 @@ jobs:
           cat worker.log 2>/dev/null || echo "No worker log"
 
   # Gated to push events: this job launches the PR-built `everruns-server`
-  # binary with DEFAULT_*_API_KEY in env (which map to the same secrets as
-  # workflow-test), so running it on fork PRs would let attacker-controlled
-  # binary code exfil the keys. PR coverage of the CLI is still provided by
-  # the CLI integration tests under `unit-test` (which run without keys).
+  # binary. Running on fork PRs would let attacker-controlled binary code exfil
+  # secrets. PR coverage of the CLI is still provided by the CLI integration
+  # tests under `unit-test` (which run without keys).
   cli-e2e-test:
     name: CLI E2E Tests
     runs-on: ubuntu-latest
@@ -847,9 +846,6 @@ jobs:
       AUTH_MODE: none
       API_PREFIX: ""
       SECRETS_ENCRYPTION_KEY: kek-v1:8B3uCQ4Znx45hl5nB+PKVriRrj/KtEVM+wBZ2VGa9vY=
-      DEFAULT_OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-      DEFAULT_ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      DEFAULT_GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
       EVERRUNS_API_KEY: "cli-e2e-test-key"
       RATE_LIMIT_API_REQUESTS_PER_MINUTE: "0"
 

--- a/README.md
+++ b/README.md
@@ -65,9 +65,6 @@ python3 -c "import os, base64; print('kek-v1:' + base64.b64encode(os.urandom(32)
 cat > .env <<'EOF'
 SECRETS_ENCRYPTION_KEY=kek-v1:<your-generated-key>
 WORKER_GRPC_AUTH_TOKEN=<a-random-token>
-DEFAULT_OPENAI_API_KEY=sk-...            # optional
-DEFAULT_ANTHROPIC_API_KEY=sk-ant-...     # optional
-DEFAULT_GEMINI_API_KEY=...               # optional
 EOF
 
 docker compose up -d

--- a/crates/server/src/domains/llm_providers/service.rs
+++ b/crates/server/src/domains/llm_providers/service.rs
@@ -260,7 +260,7 @@ fn validate_azure_openai_base_url(url: &Url) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{validate_provider_base_url, LlmProviderService};
+    use super::{LlmProviderService, validate_provider_base_url};
     use crate::storage::models::LlmProviderRow;
     use everruns_core::LlmProviderType;
     use everruns_core::typed_id::ProviderId;

--- a/crates/server/src/domains/llm_providers/service.rs
+++ b/crates/server/src/domains/llm_providers/service.rs
@@ -193,10 +193,7 @@ impl LlmProviderService {
 
     fn row_to_provider(row: &LlmProviderRow) -> LlmProvider {
         let provider_type = row.provider_type.parse().unwrap_or(LlmProviderType::Openai);
-        // api_key_set is true if either:
-        // 1. The API key is set in the database, OR
-        // 2. A DEFAULT_ environment variable is available for this provider type
-        let api_key_set = row.api_key_set || has_default_api_key_from_env(&row.provider_type);
+        let api_key_set = row.api_key_set;
 
         LlmProvider {
             id: row.id,
@@ -259,26 +256,6 @@ fn validate_azure_openai_base_url(url: &Url) -> Result<()> {
     }
 
     Ok(())
-}
-
-/// Check if a default API key is available from environment variable.
-///
-/// Environment variables (for development convenience):
-/// - DEFAULT_OPENAI_API_KEY: Fallback API key for OpenAI providers
-/// - DEFAULT_ANTHROPIC_API_KEY: Fallback API key for Anthropic providers
-fn has_default_api_key_from_env(provider_type: &str) -> bool {
-    let env_var = match provider_type.to_lowercase().as_str() {
-        "openai" => "DEFAULT_OPENAI_API_KEY",
-        "azure_openai" => "DEFAULT_AZURE_OPENAI_API_KEY",
-        "anthropic" => "DEFAULT_ANTHROPIC_API_KEY",
-        "gemini" => "DEFAULT_GEMINI_API_KEY",
-        _ => return false,
-    };
-
-    std::env::var(env_var)
-        .ok()
-        .filter(|s| !s.is_empty())
-        .is_some()
 }
 
 #[cfg(test)]
@@ -377,81 +354,5 @@ mod tests {
             err.to_string()
                 .contains("/openai/v1 or /openai/v1/responses")
         );
-    }
-
-    /// Testable version with injectable env lookup (test-only).
-    fn has_default_api_key_with_lookup<F>(provider_type: &str, env_lookup: F) -> bool
-    where
-        F: Fn(&str) -> Option<String>,
-    {
-        let env_var = match provider_type.to_lowercase().as_str() {
-            "openai" => "DEFAULT_OPENAI_API_KEY",
-            "azure_openai" => "DEFAULT_AZURE_OPENAI_API_KEY",
-            "anthropic" => "DEFAULT_ANTHROPIC_API_KEY",
-            "gemini" => "DEFAULT_GEMINI_API_KEY",
-            _ => return false,
-        };
-
-        env_lookup(env_var).filter(|s| !s.is_empty()).is_some()
-    }
-
-    fn mock_env<'a>(vars: &'a [(&'a str, &'a str)]) -> impl Fn(&str) -> Option<String> + 'a {
-        move |name| {
-            vars.iter()
-                .find(|(k, _)| *k == name)
-                .map(|(_, v)| v.to_string())
-        }
-    }
-
-    #[test]
-    fn test_has_default_api_key_openai() {
-        // Not set
-        assert!(!has_default_api_key_with_lookup("openai", mock_env(&[])));
-        assert!(!has_default_api_key_with_lookup("OpenAI", mock_env(&[])));
-
-        // Set
-        let env = mock_env(&[("DEFAULT_OPENAI_API_KEY", "sk-test-key")]);
-        assert!(has_default_api_key_with_lookup("openai", &env));
-        assert!(has_default_api_key_with_lookup("OpenAI", &env));
-    }
-
-    #[test]
-    fn test_has_default_api_key_azure_openai() {
-        assert!(!has_default_api_key_with_lookup(
-            "azure_openai",
-            mock_env(&[])
-        ));
-
-        let env = mock_env(&[("DEFAULT_AZURE_OPENAI_API_KEY", "azure-test-key")]);
-        assert!(has_default_api_key_with_lookup("azure_openai", &env));
-        assert!(has_default_api_key_with_lookup("Azure_OpenAI", &env));
-    }
-
-    #[test]
-    fn test_has_default_api_key_anthropic() {
-        // Not set
-        assert!(!has_default_api_key_with_lookup("anthropic", mock_env(&[])));
-
-        // Set
-        let env = mock_env(&[("DEFAULT_ANTHROPIC_API_KEY", "sk-ant-test-key")]);
-        assert!(has_default_api_key_with_lookup("anthropic", &env));
-        assert!(has_default_api_key_with_lookup("Anthropic", &env));
-    }
-
-    #[test]
-    fn test_has_default_api_key_unknown_provider() {
-        let env = mock_env(&[
-            ("DEFAULT_OPENAI_API_KEY", "sk-test"),
-            ("DEFAULT_ANTHROPIC_API_KEY", "sk-ant-test"),
-        ]);
-        // Unknown providers and providers without defaults return false
-        assert!(!has_default_api_key_with_lookup("unknown", &env));
-        assert!(!has_default_api_key_with_lookup("openai_completions", &env));
-    }
-
-    #[test]
-    fn test_has_default_api_key_empty_value() {
-        let env = mock_env(&[("DEFAULT_OPENAI_API_KEY", "")]);
-        assert!(!has_default_api_key_with_lookup("openai", &env));
     }
 }

--- a/crates/server/src/domains/llm_providers/service.rs
+++ b/crates/server/src/domains/llm_providers/service.rs
@@ -260,9 +260,40 @@ fn validate_azure_openai_base_url(url: &Url) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::validate_provider_base_url;
+    use super::{validate_provider_base_url, LlmProviderService};
+    use crate::storage::models::LlmProviderRow;
     use everruns_core::LlmProviderType;
+    use everruns_core::typed_id::ProviderId;
     use everruns_core::url_validation::validate_safe_url;
+
+    // Regression test for EVE-512: api_key_set must reflect only the DB value,
+    // never env vars, to prevent misleading "configured" display in the provider list.
+    #[test]
+    fn api_key_set_is_db_only_ignores_env() {
+        // Simulate DEFAULT_OPENAI_API_KEY present in env (as if someone set it).
+        // row_to_provider must still return api_key_set=false when the DB has no key.
+        unsafe { std::env::set_var("DEFAULT_OPENAI_API_KEY", "sk-test-key") };
+        let row = LlmProviderRow {
+            id: ProviderId::from_uuid(uuid::Uuid::now_v7()),
+            org_id: 1,
+            name: "openai".to_string(),
+            provider_type: "openai".to_string(),
+            base_url: None,
+            api_key_encrypted: None,
+            api_key_set: false,
+            status: "active".to_string(),
+            settings: serde_json::json!({}),
+            last_synced_at: None,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        };
+        let provider = LlmProviderService::row_to_provider(&row);
+        unsafe { std::env::remove_var("DEFAULT_OPENAI_API_KEY") };
+        assert!(
+            !provider.api_key_set,
+            "api_key_set must be false when DB has no key, regardless of env vars"
+        );
+    }
 
     // ---- SSRF prevention tests (EVE-69) ----
 

--- a/docs/getting-started/docker-compose.md
+++ b/docs/getting-started/docker-compose.md
@@ -36,11 +36,6 @@ Create a `.env` file with your encryption key and optional LLM API keys:
 ```bash
 # .env
 SECRETS_ENCRYPTION_KEY=kek-v1:<your-generated-key>
-
-# Optional: Add API keys here to skip UI configuration
-DEFAULT_OPENAI_API_KEY=sk-...
-DEFAULT_ANTHROPIC_API_KEY=sk-ant-...
-DEFAULT_GEMINI_API_KEY=AIza...
 ```
 
 ### 4. Start Services
@@ -88,7 +83,7 @@ docker compose up -d
 
 ### Configure LLM Provider
 
-If you didn't set LLM API keys (`DEFAULT_OPENAI_API_KEY`, `DEFAULT_ANTHROPIC_API_KEY`, or `DEFAULT_GEMINI_API_KEY`) in your `.env` file, configure via UI:
+Configure LLM provider keys via UI:
 
 1. Open http://localhost:9300
 2. Navigate to **Settings** > **Providers**

--- a/docs/sre/environment-variables.md
+++ b/docs/sre/environment-variables.md
@@ -264,32 +264,11 @@ python3 -c "import os, base64; print('kek-v1:' + base64.b64encode(os.urandom(32)
 SECRETS_ENCRYPTION_KEY=kek-v1:your-generated-key-here
 ```
 
-### Default API Keys (Development Convenience)
+### LLM Provider Keys
 
-For development, you can set default API keys via environment variables on the **control-plane only**. These are used as fallbacks when providers don't have keys configured in the database.
+LLM provider API keys are stored encrypted in the database and configured through the UI (Settings → LLM Providers) or API. There is no environment-variable fallback for provider key resolution — this is intentional (BYOK-only posture, see `specs/saas-architecture.md`).
 
-| Variable | Description |
-|----------|-------------|
-| `DEFAULT_OPENAI_API_KEY` | Fallback API key for OpenAI providers |
-| `DEFAULT_ANTHROPIC_API_KEY` | Fallback API key for Anthropic providers |
-| `DEFAULT_GEMINI_API_KEY` | Fallback API key for Google Gemini providers |
-
-**Example:**
-
-```bash
-# Set in .env or environment (control-plane only)
-DEFAULT_OPENAI_API_KEY=sk-...
-DEFAULT_ANTHROPIC_API_KEY=sk-ant-...
-DEFAULT_GEMINI_API_KEY=AIza...
-```
-
-**Notes:**
-- These variables are only used by the control-plane, not workers
-- Workers receive API keys via gRPC from the control-plane
-- Database-stored keys always take priority over environment variables
-- These are intended for development convenience, not production use
-- The `just start-all` command automatically sets these from `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, and `GEMINI_API_KEY` if present
-- If no API key is configured for a provider, LLM calls will fail and users will see an error message in the chat: "I encountered an error while processing your request. Please try again later."
+If no API key is configured for a provider, LLM calls fail with a clear auth error.
 
 ## System Email Delivery
 

--- a/examples/docker-compose-full.yaml
+++ b/examples/docker-compose-full.yaml
@@ -17,9 +17,9 @@
 #   2. Create .env file with:
 #      SECRETS_ENCRYPTION_KEY=kek-v1:<your-generated-key>
 #      WORKER_GRPC_AUTH_TOKEN=<your-token>  # Required: worker gRPC auth token
-#      DEFAULT_OPENAI_API_KEY=sk-...        # Optional: OpenAI API key
-#      DEFAULT_ANTHROPIC_API_KEY=sk-ant-... # Optional: Anthropic API key
-#      DEFAULT_GEMINI_API_KEY=...           # Optional: Google Gemini API key
+#
+#      LLM provider API keys: configure after deployment via the Everruns UI
+#      (Settings → LLM Providers). Do not pass raw provider keys as env vars.
 #
 #   3. Start everything:
 #      docker compose -f docker-compose-full.yaml up -d
@@ -95,9 +95,6 @@ services:
       VALKEY_URL: redis://valkey:6379
       NATS_URL: nats://nats:4222
       SECRETS_ENCRYPTION_KEY: ${SECRETS_ENCRYPTION_KEY}
-      DEFAULT_OPENAI_API_KEY: ${DEFAULT_OPENAI_API_KEY:-}
-      DEFAULT_ANTHROPIC_API_KEY: ${DEFAULT_ANTHROPIC_API_KEY:-}
-      DEFAULT_GEMINI_API_KEY: ${DEFAULT_GEMINI_API_KEY:-}
       WORKER_GRPC_AUTH_TOKEN: ${WORKER_GRPC_AUTH_TOKEN:-}
       OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-}
     depends_on:

--- a/infra/railway/README.md
+++ b/infra/railway/README.md
@@ -43,8 +43,8 @@ AUTH_ADMIN_PASSWORD=<template input>
 ```
 
 Provider API keys are intentionally not template inputs. Configure provider
-keys in the Everruns UI after deployment, or add `DEFAULT_*` variables to the
-server service manually when a deployment should start with seeded defaults.
+keys in the Everruns UI after deployment (Settings → LLM Providers). Do not
+add raw provider keys as server environment variables.
 
 ## Caddy Service
 
@@ -99,16 +99,6 @@ WORKER_GRPC_AUTH_TOKEN=${{ secret(32) }}
 SECRETS_ENCRYPTION_KEY=kek-v1:${{ secret(43, "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789+/") }}=
 
 PUBLIC_APP_URL=https://${{ caddy.RAILWAY_PUBLIC_DOMAIN }}
-```
-
-Optional LLM defaults. Do not include these in the public template form; add
-them manually to the server service only when a deployment should start with
-seeded provider defaults:
-
-```env
-DEFAULT_OPENAI_API_KEY=<manual server variable>
-DEFAULT_ANTHROPIC_API_KEY=<manual server variable>
-DEFAULT_GEMINI_API_KEY=<manual server variable>
 ```
 
 ## Worker Variables

--- a/specs/README.md
+++ b/specs/README.md
@@ -87,6 +87,7 @@ Specs capture the "why" and "what", not exhaustive source detail. Link to code f
 ## Infrastructure and operations
 
 - `specs/production-deployment.md` - Production deployment aggregation and reverse proxy contract
+- `specs/saas-architecture.md` - SaaS-specific deployment posture: BYOK, fail-closed key resolution, pre-signup checklist
 - `specs/migrations.md` - Database migration naming, squashing, ordering, conflict resolution
 - `specs/durable-execution-engine.md` - PostgreSQL-backed durable workflow engine
 - `specs/scheduled-tasks.md` - Cron-based scheduled tasks

--- a/specs/README.md
+++ b/specs/README.md
@@ -100,6 +100,7 @@ Specs capture the "why" and "what", not exhaustive source detail. Link to code f
 - `specs/notifications.md` - Generic user notifications
 - `specs/email.md` - Internal email delivery abstraction
 - `specs/egress.md` - Host-owned outbound network boundary and future gateway
+- `specs/user-hooks.md` - Operator-injected shell commands at lifecycle points
 - `specs/utility-llm.md` - Internal utility LLM service for capability internals
 - `specs/voice.md` - Voice Sessions
 - `specs/volumes.md` - Workspace Volumes

--- a/specs/models.md
+++ b/specs/models.md
@@ -228,9 +228,8 @@ Key design points:
 - Supported types: `openai`, `azure_openai`, `openai_completions`, `anthropic`, `gemini`, `llmsim`
 - API keys encrypted with AES-256-GCM envelope encryption (see `specs/encryption.md`)
 
-**API Key Resolution Order:**
-1. **Database** (priority): Encrypted in `llm_providers.api_key_encrypted`
-2. **Environment Variable** (fallback): provider-specific `DEFAULT_*_API_KEY` (for example `DEFAULT_OPENAI_API_KEY`, `DEFAULT_AZURE_OPENAI_API_KEY`, `DEFAULT_ANTHROPIC_API_KEY`)
+**API Key Resolution:**
+Keys are resolved exclusively from the database (`llm_providers.api_key_encrypted`). The resolver is fail-closed: if no encrypted key is present, the call returns no credentials rather than falling back to environment variables. See `specs/saas-architecture.md` for the BYOK posture and why env fallbacks are not used.
 
 Default providers and models seeded on startup. See `crates/server/src/seed.rs` for default model configurations (idempotent, well-known UUIDs).
 
@@ -284,4 +283,4 @@ See `crates/server/src/storage/models.rs` for the `UserConnectionRow` type.
 | Where are capabilities defined? | In-memory registry in API layer |
 | How are capabilities applied? | Resolved at API/service layer, merged into RuntimeAgent |
 | Where are API keys stored? | Encrypted in database, decrypted at runtime |
-| Environment variables for API keys? | `DEFAULT_OPENAI_API_KEY` and `DEFAULT_ANTHROPIC_API_KEY` as fallbacks |
+| Environment variables for API keys? | Not used for execution. Keys are DB-only (fail-closed). |

--- a/specs/saas-architecture.md
+++ b/specs/saas-architecture.md
@@ -1,0 +1,48 @@
+# SaaS Architecture
+
+## Abstract
+
+This spec captures constraints and postures specific to multi-tenant SaaS deployments of Everruns. Self-hosted (OSS) and SaaS share the same codebase; the differences lie in deployment configuration and operational decisions that must be made intentionally at each boundary.
+
+## BYOK-Only Posture
+
+Everruns is **Bring-Your-Own-Key (BYOK)** for LLM provider credentials. Every tenant that wants to execute LLM-backed agents must configure their own provider credentials through the Everruns UI (Settings → LLM Providers) or API. Platform operator credentials must never be exposed to the tenant execution path.
+
+### What This Means in Practice
+
+1. **No raw provider keys in the server/worker process environment.** Do not set `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `OPENROUTER_API_KEY`, or any similar raw provider key as an environment variable on the request-serving server or worker processes in a multi-tenant deployment.
+
+2. **No `DEFAULT_*` env vars in production SaaS.** The `DEFAULT_OPENAI_API_KEY`, `DEFAULT_ANTHROPIC_API_KEY`, `DEFAULT_GEMINI_API_KEY`, and `DEFAULT_AZURE_OPENAI_API_KEY` env vars are removed from the execution path. Setting them on a multi-tenant server process creates a latent cost-runaway path where agent failures caused by missing tenant keys silently fall back to spending platform credentials.
+
+3. **Key resolution is fail-closed.** `LlmResolverService::resolve_provider_api_key` and `resolve_provider_credentials` return `None` when no encrypted key exists in the database. They never fall back to environment variables. See `crates/server/src/services/llm_resolver.rs` (TM-LLM-022).
+
+4. **New orgs start with no providers.** Default seeds create provider *configurations* (name, type, base URL) but no API keys. Agents for a new org fail with a clear auth error rather than silently spending platform credentials.
+
+### Utility LLM
+
+`UTILITY_OPENAI_API_KEY` is a separate platform-internal key used exclusively for platform features such as tool search and embeddings in the context of platform operations. It is not a fallback for tenant agent execution and must be scoped to a dedicated, non-tenant-serving process or service account.
+
+### Model Sync
+
+The background model-sync job (`ModelSyncService`) discovers available models from provider APIs. When a provider has no encrypted key in the database and no encryption service is available, sync is skipped for that provider (fail-closed). Model sync that requires dedicated platform credentials (for a platform-managed default provider catalog) must use a service account separate from the request-serving server process.
+
+## Pre-Signup Checklist
+
+Before enabling open signup on a production SaaS deployment, verify:
+
+- [ ] No `DEFAULT_OPENAI_API_KEY` in the server/worker env.
+- [ ] No `DEFAULT_ANTHROPIC_API_KEY` in the server/worker env.
+- [ ] No `DEFAULT_GEMINI_API_KEY` in the server/worker env.
+- [ ] No `DEFAULT_AZURE_OPENAI_API_KEY` in the server/worker env.
+- [ ] No `UTILITY_OPENAI_API_KEY` accessible to the tenant execution path.
+- [ ] No raw `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, or `OPENROUTER_API_KEY` in the server/worker env.
+- [ ] `E2B_API_KEY`, `DENO_DEPLOY_TOKEN`, and equivalent execution-harness keys are scoped to the execution harness process, not the control-plane server.
+- [ ] `SECRETS_ENCRYPTION_KEY` is set and backed by a KMS-managed key (not a manually generated secret).
+
+## References
+
+- `specs/threat-model.md` — TM-LLM-022 (env fallback removal), TM-TENANT-008 (org-scoped user list)
+- `specs/models.md` — LLM provider key resolution
+- `specs/encryption.md` — envelope encryption for provider keys
+- `specs/llm-drivers.md` — key resolution contract (fail-closed)
+- `crates/server/src/services/llm_resolver.rs` — resolver implementation

--- a/specs/saas-architecture.md
+++ b/specs/saas-architecture.md
@@ -12,7 +12,7 @@ Everruns is **Bring-Your-Own-Key (BYOK)** for LLM provider credentials. Every te
 
 1. **No raw provider keys in the server/worker process environment.** Do not set `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `OPENROUTER_API_KEY`, or any similar raw provider key as an environment variable on the request-serving server or worker processes in a multi-tenant deployment.
 
-2. **No `DEFAULT_*` env vars in production SaaS.** The `DEFAULT_OPENAI_API_KEY`, `DEFAULT_ANTHROPIC_API_KEY`, `DEFAULT_GEMINI_API_KEY`, and `DEFAULT_AZURE_OPENAI_API_KEY` env vars are removed from the execution path. Setting them on a multi-tenant server process creates a latent cost-runaway path where agent failures caused by missing tenant keys silently fall back to spending platform credentials.
+2. **No `DEFAULT_*` env vars in production SaaS.** The `DEFAULT_OPENAI_API_KEY`, `DEFAULT_ANTHROPIC_API_KEY`, `DEFAULT_GEMINI_API_KEY`, and `DEFAULT_AZURE_OPENAI_API_KEY` env vars are not consulted by the current key resolver (removed in EVE-511/512). They must not be reintroduced: setting them on a multi-tenant server process would create a cost-runaway path where agents for orgs without configured keys spend platform credentials instead of failing with a clear auth error.
 
 3. **Key resolution is fail-closed.** `LlmResolverService::resolve_provider_api_key` and `resolve_provider_credentials` return `None` when no encrypted key exists in the database. They never fall back to environment variables. See `crates/server/src/services/llm_resolver.rs` (TM-LLM-022).
 


### PR DESCRIPTION
## What

Remove the `DEFAULT_*` environment variable paths from LLM provider key resolution and display, and document the BYOK-only deployment posture.

## Why

EVE-511 made `LlmResolverService` fail-closed (no env fallback for execution). The provider list endpoint still showed `api_key_set: true` when a `DEFAULT_*` env var was set, creating a misleading UX where the UI says "configured" but agent execution would fail. This PR removes that inconsistency and documents the BYOK-only posture to prevent the pattern from being reintroduced.

## How

- **`crates/server/src/domains/llm_providers/service.rs`**: Remove `has_default_api_key_from_env()` and its call from `row_to_provider`. `api_key_set` now reflects only DB-backed encrypted keys, consistent with the fail-closed resolver.
- **`examples/docker-compose-full.yaml`**: Remove `DEFAULT_OPENAI/ANTHROPIC/GEMINI_API_KEY` from the server service env. Replace quick-start note with guidance to configure keys via the UI after deployment.
- **`infra/railway/README.md`**: Remove the `DEFAULT_*` optional variables section and update template guidance.
- **`specs/saas-architecture.md`** (new): Document the BYOK-only posture, what it prohibits in SaaS deployments, the utility LLM separation, model sync constraints, and a pre-signup checklist.
- **`specs/models.md`**: Correct the API key resolution description to match the fail-closed reality.
- **`specs/README.md`**: Index the new spec.

## Risk

Low. The code change is a one-line removal in the provider list path (`api_key_set` display only). Execution was already fail-closed after EVE-511.

**Breaking change for self-hosted users who relied on `DEFAULT_*` env vars:** These users must configure LLM provider keys through the UI (Settings → LLM Providers) after this change. The EVE-511 fix had already broken agent execution for these users; this PR makes the UI display consistent.

## Security

- TM-LLM-022: This PR removes the last code path that could suggest `DEFAULT_*` env vars are functional, eliminating the risk of operators setting them under the mistaken belief that execution will use them.
- `has_default_api_key_from_env()` is deleted entirely, reducing the surface for future regressions.
- No new threat surface introduced.

## Follow-ups

- Infra: Remove raw provider keys from the prod server/worker process env in Doppler (tracked outside this repo). The pre-signup checklist in `specs/saas-architecture.md` is the reference.
- EVE-513, EVE-514: Distributed and per-tool rate limiting — not related to this change.

## Validation

- `cargo test -p everruns-server` — provider tests pass
- `pre-push` clean
- Rebased onto latest main (2026-06-02)

---
_Generated by [Claude Code](https://claude.ai/code/session_01M5YGvP3NQuYVe3heh2wj5d)_