### PR TITLE
fix(deno): retry connect_sandbox on 404 DEPLOYMENT_NOT_FOUND

### DIFF
--- a/integrations/deno/src/client.rs
+++ b/integrations/deno/src/client.rs
@@ -270,6 +270,31 @@ pub struct ExecOutput {
     pub stderr: String,
 }
 
+/// Retry `connect_fn` up to 3 times when it returns an HTTP 404 handshake
+/// error, using exponential backoff (500 ms → 1 s). Non-404 errors propagate
+/// immediately. Extracted so the retry logic can be unit-tested without real
+/// network I/O.
+async fn retry_on_404<T, F, Fut>(mut connect_fn: F) -> Result<T, String>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = Result<T, String>>,
+{
+    let mut last_err = String::new();
+    let mut delay_ms = 500u64;
+    for attempt in 0..3u8 {
+        if attempt > 0 {
+            tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+            delay_ms *= 2;
+        }
+        match connect_fn().await {
+            Ok(val) => return Ok(val),
+            Err(e) if e.starts_with("Deno sandbox websocket HTTP error: 404") => last_err = e,
+            Err(e) => return Err(e),
+        }
+    }
+    Err(last_err)
+}
+
 pub struct DenoClient {
     http: reqwest::Client,
     token: String,
@@ -509,20 +534,7 @@ impl DenoClient {
         );
         // Retry on 404: Deno Deploy may not expose the sandbox immediately after
         // the creation websocket closes, returning DEPLOYMENT_NOT_FOUND transiently.
-        let mut last_err = String::new();
-        let mut delay_ms = 500u64;
-        for attempt in 0..3u8 {
-            if attempt > 0 {
-                tokio::time::sleep(Duration::from_millis(delay_ms)).await;
-                delay_ms *= 2;
-            }
-            match self.connect_websocket(url.clone(), None).await {
-                Ok(session) => return Ok(session),
-                Err(e) if e.contains("HTTP error: 404") => last_err = e,
-                Err(e) => return Err(e),
-            }
-        }
-        Err(last_err)
+        retry_on_404(|| self.connect_websocket(url.clone(), None)).await
     }
 
     async fn connect_websocket(
@@ -1210,6 +1222,118 @@ mod tests {
         assert!(
             !request.contains("Proxy-Authorization"),
             "should not contain Proxy-Authorization: {request}"
+        );
+    }
+
+    // --- retry_on_404 unit tests ---
+    // Time is paused so tokio::time::sleep advances instantly without real wall-clock delay.
+
+    #[tokio::test(start_paused = true)]
+    async fn retry_on_404_exhausts_three_attempts_on_all_404s() {
+        use std::sync::{
+            Arc,
+            atomic::{AtomicU8, Ordering},
+        };
+        let attempts = Arc::new(AtomicU8::new(0));
+        let c = attempts.clone();
+        let result: Result<u32, String> = retry_on_404(|| {
+            let c = c.clone();
+            async move {
+                c.fetch_add(1, Ordering::Relaxed);
+                Err(
+                    "Deno sandbox websocket HTTP error: 404 Not Found — DEPLOYMENT_NOT_FOUND"
+                        .to_string(),
+                )
+            }
+        })
+        .await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("404"));
+        assert_eq!(
+            attempts.load(Ordering::Relaxed),
+            3,
+            "should try exactly 3 times"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn retry_on_404_fails_fast_on_non_404_error() {
+        use std::sync::{
+            Arc,
+            atomic::{AtomicU8, Ordering},
+        };
+        let attempts = Arc::new(AtomicU8::new(0));
+        let c = attempts.clone();
+        let result: Result<u32, String> = retry_on_404(|| {
+            let c = c.clone();
+            async move {
+                c.fetch_add(1, Ordering::Relaxed);
+                Err("Deno sandbox websocket HTTP error: 503 Service Unavailable".to_string())
+            }
+        })
+        .await;
+        assert!(result.is_err());
+        assert_eq!(
+            attempts.load(Ordering::Relaxed),
+            1,
+            "non-404 should not be retried"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn retry_on_404_succeeds_after_one_404() {
+        use std::sync::{
+            Arc,
+            atomic::{AtomicU8, Ordering},
+        };
+        let attempts = Arc::new(AtomicU8::new(0));
+        let c = attempts.clone();
+        let result: Result<u32, String> = retry_on_404(|| {
+            let c = c.clone();
+            async move {
+                let n = c.fetch_add(1, Ordering::Relaxed);
+                if n == 0 {
+                    Err(
+                        "Deno sandbox websocket HTTP error: 404 Not Found — DEPLOYMENT_NOT_FOUND"
+                            .to_string(),
+                    )
+                } else {
+                    Ok(42u32)
+                }
+            }
+        })
+        .await;
+        assert_eq!(result, Ok(42));
+        assert_eq!(
+            attempts.load(Ordering::Relaxed),
+            2,
+            "should succeed on second attempt"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn retry_on_404_body_containing_404_string_does_not_trigger_retry() {
+        // A non-404 HTTP error whose body happens to contain "404" should not be retried.
+        use std::sync::{
+            Arc,
+            atomic::{AtomicU8, Ordering},
+        };
+        let attempts = Arc::new(AtomicU8::new(0));
+        let c = attempts.clone();
+        let result: Result<u32, String> = retry_on_404(|| {
+            let c = c.clone();
+            async move {
+                c.fetch_add(1, Ordering::Relaxed);
+                // 500 error whose body mentions "404" — must NOT be retried
+                Err("Deno sandbox websocket HTTP error: 500 Internal Server Error — error code 404 in upstream".to_string())
+            }
+        })
+        .await;
+        assert!(result.is_err());
+        assert_eq!(
+            attempts.load(Ordering::Relaxed),
+            1,
+            "500 with 404 in body must not retry"
         );
     }
 }

--- a/integrations/deno/src/client.rs
+++ b/integrations/deno/src/client.rs
@@ -507,7 +507,22 @@ impl DenoClient {
             "wss://{}.{}/api/v3/sandbox/{}/connect",
             region, self.sandbox_base_domain, sandbox_id
         );
-        self.connect_websocket(url, None).await
+        // Retry on 404: Deno Deploy may not expose the sandbox immediately after
+        // the creation websocket closes, returning DEPLOYMENT_NOT_FOUND transiently.
+        let mut last_err = String::new();
+        let mut delay_ms = 500u64;
+        for attempt in 0..3u8 {
+            if attempt > 0 {
+                tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+                delay_ms *= 2;
+            }
+            match self.connect_websocket(url.clone(), None).await {
+                Ok(session) => return Ok(session),
+                Err(e) if e.contains("HTTP error: 404") => last_err = e,
+                Err(e) => return Err(e),
+            }
+        }
+        Err(last_err)
     }
 
     async fn connect_websocket(


### PR DESCRIPTION
## What
Add retry-on-404 in `DenoClient::connect_sandbox` with exponential backoff (up to 3 attempts, 500ms → 1s delays).

## Why
The nightly Integration Live Sweep failed on 2026-06-01 with `DEPLOYMENT_NOT_FOUND` (HTTP 404) on the first `exec` call immediately after successful sandbox creation. Deno Deploy does not guarantee the sandbox is immediately accessible for new websocket connections once the creation websocket closes — there is a brief initialization window during which `/api/v3/sandbox/{id}/connect` returns 404. This is a transient race condition, not a code bug. Previous fix for `ord` region transport errors already pinned CI to `ams`; this adds robustness against initialization timing.

## How
`connect_sandbox` now retries up to 3 times on HTTP 404 responses with 500ms then 1s delays before propagating the error. Non-404 errors still fail immediately. The retry window adds at most 1.5s for genuine "not found" cases (wrong ID, expired sandbox) which is acceptable.

## Risk
- Low
- Existing unit tests pass; live tests unchanged in logic. Maximum 1.5s added latency if a sandbox truly doesn't exist.

## Security
- Threat categories reviewed: No security-relevant code changes. Retry logic does not change auth, credential handling, or sandbox isolation.
- Findings and resolutions: N/A

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ub1DRPyLt7Mj74LoKUme9u)_