### PR TITLE
chore(release): prepare v0.8.37

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,59 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- New changes go here. Use `/prepare-release X.Y.Z` to generate draft from commits. -->
 
-### Changed
+## [0.8.37] - 2026-06-03
 
-- **API keys renamed to personal access tokens** - User-scoped auth credentials are now consistently called "personal access tokens" across the table (`personal_access_tokens`), API (`/v1/auth/personal-access-tokens`), UI (Settings > Personal access tokens), CLI, specs, and docs, making it explicit they are tied to a user (not an organization). Tokens are now prefixed `evr_pat_` instead of `evr_`; existing tokens are invalidated and must be re-created (re-run `everruns login`).
+### Highlights
+
+- **MCP client in the runtime** - New `everruns-mcp` crate ships a first-class MCP client with stdio transport, wired into the runtime and coding-CLI ([#2045](https://github.com/everruns/everruns/pull/2045)).
+- **API keys renamed to personal access tokens** - User-scoped auth credentials are now consistently called "personal access tokens" across the table (`personal_access_tokens`), API (`/v1/auth/personal-access-tokens`), UI (Settings > Personal access tokens), CLI, specs, and docs. Tokens are now prefixed `evr_pat_` instead of `evr_`; existing tokens are invalidated and must be re-created (re-run `everruns login`) ([#2043](https://github.com/everruns/everruns/pull/2043)).
+- **Security hardening** - SSRF DNS pinning for MCP server execution (EVE-516), ReDoS hardening for grep-based tool call regex (EVE-517), distributed + per-account rate limiting (EVE-513), and fail-closed LLM key resolution with env fallback removed (EVE-511).
+- **Org-level controls** - Feature flags with opt-in UI and API, per-org soft caps on concurrent sessions and active turns (EVE-508), per-org outbound tool-call rate limiting, and concurrency/volume caps for eval runs (EVE-509).
+- **User-defined hooks** - Composable bash executor for lifecycle hooks; `user_prompt_submit` and `turn_end` events now available ([#2022](https://github.com/everruns/everruns/pull/2022)).
+- **Session file quotas** - Per-file and per-session byte quotas enforced (EVE-510).
+
+### What's Changed
+
+- feat(mcp): MCP client in the runtime (everruns-mcp crate, stdio, coding-CLI) ([#2045](https://github.com/everruns/everruns/pull/2045)) by [@chaliy](https://github.com/chaliy)
+- fix(deno): retry connect_sandbox on 404 DEPLOYMENT_NOT_FOUND ([#2044](https://github.com/everruns/everruns/pull/2044)) by [@chaliy](https://github.com/chaliy)
+- refactor(auth): rename API keys to personal access tokens ([#2043](https://github.com/everruns/everruns/pull/2043)) by [@chaliy](https://github.com/chaliy)
+- feat(seed): materialize DEFAULT_*_API_KEY for single-tenant/dev ([#2042](https://github.com/everruns/everruns/pull/2042)) by [@chaliy](https://github.com/chaliy)
+- feat(feature-flags): org-level feature flag opt-in UI and API by [@chaliy](https://github.com/chaliy)
+- feat(sessions): add per-org soft cap on concurrent sessions and active turns (EVE-508) by [@chaliy](https://github.com/chaliy)
+- docs(user-hooks): add user_prompt_submit and turn_end examples by [@chaliy](https://github.com/chaliy)
+- fix(runtime): keep OpenAI tool call/result pairs during history trimming (EVE-519) by [@chaliy](https://github.com/chaliy)
+- feat(evals): concurrency and volume caps for eval runs (EVE-509) by [@chaliy](https://github.com/chaliy)
+- feat(session-files): enforce per-file and per-session byte quotas (EVE-510) by [@chaliy](https://github.com/chaliy)
+- feat(capabilities): wire the four remaining user-hook lifecycle events ([#2032](https://github.com/everruns/everruns/pull/2032)) by [@chaliy](https://github.com/chaliy)
+- feat(security): SSRF DNS pinning for MCP server execution (EVE-516) by [@chaliy](https://github.com/chaliy)
+- fix(security): harden grep-based tool call regex against ReDoS (EVE-517) by [@chaliy](https://github.com/chaliy)
+- feat(e2b,deno): BYO-only sandbox credentials (EVE-505) ([#2033](https://github.com/everruns/everruns/pull/2033)) by [@chaliy](https://github.com/chaliy)
+- feat(rate-limit): per-org outbound tool-call rate limiting (TM-TOOL-009) by [@chaliy](https://github.com/chaliy)
+- feat(apps): schedule channel rate limits (EVE-507) by [@chaliy](https://github.com/chaliy)
+- feat(feature-flags): agent_delegation feature flag (EVE-506) by [@chaliy](https://github.com/chaliy)
+- feat(security): distributed + per-account rate limiting (EVE-513) by [@chaliy](https://github.com/chaliy)
+- feat(llm): fail-closed key resolution, remove env fallback (EVE-511) by [@chaliy](https://github.com/chaliy)
+- feat(capabilities): user-defined hooks via composable bash executor ([#2022](https://github.com/everruns/everruns/pull/2022)) by [@chaliy](https://github.com/chaliy)
+- feat(plugin): add production everruns plugin by [@chaliy](https://github.com/chaliy)
+- feat(core): class-aware tool execution scheduler for ActAtom ([#2020](https://github.com/everruns/everruns/pull/2020)) by [@chaliy](https://github.com/chaliy)
+- feat(ui): smooth chat streaming text by [@chaliy](https://github.com/chaliy)
+- test(runtime): end-to-end ActAtom scheduler integration tests ([#2021](https://github.com/everruns/everruns/pull/2021)) by [@chaliy](https://github.com/chaliy)
+- fix(openapi): preserve enum refs for schema examples ([#2014](https://github.com/everruns/everruns/pull/2014)) by [@chaliy](https://github.com/chaliy)
+- fix(events): correct SSE id cursor and voice event docs ([#2012](https://github.com/everruns/everruns/pull/2012)) by [@chaliy](https://github.com/chaliy)
+- fix(api): fail-close llm metadata defaults ([#2008](https://github.com/everruns/everruns/pull/2008)) by [@chaliy](https://github.com/chaliy)
+- fix(voice): bridge realtime speech to durable chat by [@chaliy](https://github.com/chaliy)
+- fix(ui): hide work log for direct answers by [@chaliy](https://github.com/chaliy)
+- fix(mcp): extract JSON from SSE response body on tools fetch by [@chaliy](https://github.com/chaliy)
+- fix(core): disable direct egress redirect following by [@chaliy](https://github.com/chaliy)
+- fix(api): align session cancel action with command behavior by [@chaliy](https://github.com/chaliy)
+- fix(api): delegate allowed_actions from ResourceWithCounts by [@chaliy](https://github.com/chaliy)
+- fix(api): correct cancel turn OpenAPI success example by [@chaliy](https://github.com/chaliy)
+- fix(core): avoid unwrapping user _raw_output_scalar keys by [@chaliy](https://github.com/chaliy)
+- fix(coding-cli): replay reason.item signatures on resume by [@chaliy](https://github.com/chaliy)
+- fix(cli): clarify /clear command scope in description by [@chaliy](https://github.com/chaliy)
+- fix(plugin): use neutral Codex marketplace label by [@chaliy](https://github.com/chaliy)
+- chore(specs): resolve TM-TENANT-008 — GET /v1/users already org-scoped (EVE-515) by [@chaliy](https://github.com/chaliy)
+- chore(rust): upgrade toolchain to 1.96 by [@chaliy](https://github.com/chaliy)
 
 ## [0.8.36] - 2026-05-29
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -567,7 +567,7 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "bigdecimal",
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "chrono",
  "clap",
  "fancy-regex 0.18.0",
@@ -657,9 +657,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
 dependencies = [
  "serde_core",
 ]
@@ -1348,7 +1348,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "crossterm_winapi",
  "derive_more 2.1.1",
  "document-features",
@@ -1977,11 +1977,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-a2ui"
-version = "0.8.36"
+version = "0.8.37"
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.8.36"
+version = "0.8.37"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1997,7 +1997,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-cli"
-version = "0.8.36"
+version = "0.8.37"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2051,14 +2051,14 @@ dependencies = [
 
 [[package]]
 name = "everruns-config"
-version = "0.8.36"
+version = "0.8.37"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "everruns-container-sandbox"
-version = "0.8.36"
+version = "0.8.37"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2078,7 +2078,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.8.36"
+version = "0.8.37"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -2130,7 +2130,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-durable"
-version = "0.8.36"
+version = "0.8.37"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2155,7 +2155,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-gemini"
-version = "0.8.36"
+version = "0.8.37"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2169,7 +2169,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-brave-search"
-version = "0.8.36"
+version = "0.8.37"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2185,7 +2185,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-browserless"
-version = "0.8.36"
+version = "0.8.37"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2206,7 +2206,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-cursor"
-version = "0.8.36"
+version = "0.8.37"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2221,7 +2221,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.8.36"
+version = "0.8.37"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2238,7 +2238,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-deno"
-version = "0.8.36"
+version = "0.8.37"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2261,7 +2261,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-docker"
-version = "0.8.36"
+version = "0.8.37"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2276,7 +2276,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.8.36"
+version = "0.8.37"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2291,7 +2291,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-e2b"
-version = "0.8.36"
+version = "0.8.37"
 dependencies = [
  "async-trait",
  "buffa",
@@ -2318,7 +2318,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-github"
-version = "0.8.36"
+version = "0.8.37"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2335,7 +2335,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-parallel"
-version = "0.8.36"
+version = "0.8.37"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2347,7 +2347,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-sprites"
-version = "0.8.36"
+version = "0.8.37"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2363,7 +2363,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-internal-protocol"
-version = "0.8.36"
+version = "0.8.37"
 dependencies = [
  "chrono",
  "everruns-core",
@@ -2380,7 +2380,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-llm-tests"
-version = "0.8.36"
+version = "0.8.37"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2399,7 +2399,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-macros"
-version = "0.8.36"
+version = "0.8.37"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -2407,7 +2407,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-mcp"
-version = "0.8.36"
+version = "0.8.37"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2421,7 +2421,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.8.36"
+version = "0.8.37"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2441,11 +2441,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-openui"
-version = "0.8.36"
+version = "0.8.37"
 
 [[package]]
 name = "everruns-runtime"
-version = "0.8.36"
+version = "0.8.37"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2483,7 +2483,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-server"
-version = "0.8.36"
+version = "0.8.37"
 dependencies = [
  "aes-gcm",
  "ag-ui-core",
@@ -2572,7 +2572,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-session-sqldb"
-version = "0.8.36"
+version = "0.8.37"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2589,7 +2589,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-worker"
-version = "0.8.36"
+version = "0.8.37"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3103,7 +3103,7 @@ version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "libc",
  "libgit2-sys",
  "log",
@@ -3780,11 +3780,11 @@ dependencies = [
 
 [[package]]
 name = "inotify"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
+checksum = "533e68a5842e734946fe159fb03fc9bbbb254f590dd0d8ad321ae5ff7beca2c1"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "inotify-sys",
  "libc",
 ]
@@ -4115,9 +4115,9 @@ checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
 name = "kqueue"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
 dependencies = [
  "kqueue-sys",
  "libc",
@@ -4129,7 +4129,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "libc",
 ]
 
@@ -4213,9 +4213,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.28"
+version = "1.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc3a226e576f50782b3305c5ccf458698f92798987f551c6a02efe8276721e22"
+checksum = "85bc9657773828b90eeb625adff10eeac83cc21bbfd8e23a03eaa8a33c9e28d9"
 dependencies = [
  "cc",
  "libc",
@@ -4229,7 +4229,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
 ]
 
 [[package]]
@@ -4284,9 +4284,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.30"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+checksum = "113b30b4cd05f7c06868fdb2854f66a7b9fece9a48425351cd532e810d74024f"
 
 [[package]]
 name = "logos"
@@ -4629,7 +4629,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -4673,7 +4673,7 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "inotify",
  "kqueue",
  "libc",
@@ -4690,7 +4690,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
 ]
 
 [[package]]
@@ -4822,7 +4822,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
 ]
 
 [[package]]
@@ -4837,7 +4837,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "objc2",
 ]
 
@@ -4904,7 +4904,7 @@ version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -5346,7 +5346,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -5463,7 +5463,7 @@ version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "num-traits",
  "rand 0.9.4",
  "rand_chacha 0.9.0",
@@ -5634,7 +5634,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "memchr",
  "unicase",
 ]
@@ -5891,7 +5891,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "compact_str",
  "hashbrown 0.16.1",
  "indoc",
@@ -5956,7 +5956,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "hashbrown 0.16.1",
  "indoc",
  "instability",
@@ -5975,7 +5975,7 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
 ]
 
 [[package]]
@@ -6018,7 +6018,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
 ]
 
 [[package]]
@@ -6307,7 +6307,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0d2b0146dd9661bf67bb107c0bb2a55064d556eeb3fc314151b957f313bcd4e"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -6349,7 +6349,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -6374,9 +6374,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe 0.2.1",
  "rustls-pki-types",
@@ -6584,7 +6584,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -7126,7 +7126,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90b8020fe17c5f2c245bfa2505d7ef59c5604839527c740266ad2214acebea27"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "byteorder",
  "bytes",
  "chrono",
@@ -7156,7 +7156,7 @@ checksum = "87a2bdd6e83f6b3ea525ca9fee568030508b58355a43d0b2c1674d5f79dcd65e"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "byteorder",
  "chrono",
  "crc",
@@ -7371,7 +7371,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -7451,7 +7451,7 @@ checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "fancy-regex 0.11.0",
  "filedescriptor",
  "finl_unicode",
@@ -7924,7 +7924,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "async-compression",
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -8219,9 +8219,9 @@ checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-truncate"
@@ -8544,7 +8544,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -9178,7 +9178,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "indexmap",
  "log",
  "serde",
@@ -9235,9 +9235,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.8.36"
+version = "0.8.37"
 edition = "2024"
 # Published crate MSRV: Rust 2024 plus current published dependency floors.
 rust-version = "1.94.0"
@@ -135,8 +135,8 @@ futures-util = "0.3"
 
 # Everruns SDK
 everruns-sdk = "0.1.9"
-everruns-core = { path = "crates/core", version = "0.8.36" }
-everruns-mcp = { path = "crates/mcp", version = "0.8.36" }
+everruns-core = { path = "crates/core", version = "0.8.37" }
+everruns-mcp = { path = "crates/mcp", version = "0.8.37" }
 
 # A2A protocol
 a2a = { package = "a2a-lf", version = "0.3" }

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "everruns-ui",
-  "version": "0.8.36",
+  "version": "0.8.37",
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "exports": {

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -20,7 +20,7 @@ readme = "README.md"
 
 [dependencies]
 # Core dependencies
-everruns-config = { path = "../config", version = "0.8.36" }
+everruns-config = { path = "../config", version = "0.8.37" }
 anyhow.workspace = true
 thiserror.workspace = true
 async-trait.workspace = true
@@ -102,10 +102,10 @@ inventory.workspace = true
 llmsim = "0.4.0"
 
 # OpenUI component definitions and prompt generator
-everruns-openui = { path = "../openui", version = "0.8.36", optional = true }
+everruns-openui = { path = "../openui", version = "0.8.37", optional = true }
 
 # A2UI component catalog and prompt generator
-everruns-a2ui = { path = "../a2ui", version = "0.8.36", optional = true }
+everruns-a2ui = { path = "../a2ui", version = "0.8.37", optional = true }
 
 # A2A outbound agent delegation
 a2a.workspace = true


### PR DESCRIPTION
## What
Release preparation for v0.8.37.

## Why
Ship 40 commits accumulated since v0.8.36, including MCP client runtime, personal access tokens rename, security hardening, org-level controls, user-defined hooks, and session file quotas.

## How
- Bumped `Cargo.toml` workspace version 0.8.36 → 0.8.37 (including `everruns-core` and `everruns-mcp` path deps)
- Bumped `apps/ui/package.json` version 0.8.36 → 0.8.37
- Updated `CHANGELOG.md`: moved Unreleased → [0.8.37] with full What's Changed list and Highlights
- Regenerated `Cargo.lock` and `apps/ui/pnpm-lock.yaml`

Integration live sweep: Deno Live API Tests failed at `a9ea52f` (2026-06-01); resolved by commit `a924c3e` (`fix(deno): retry connect_sandbox on 404`, #2044) already on main. All other sweep jobs passed. Main CI is green.

## Risk
- Low — version bump and changelog only; no logic changes.

## Security
- No security-relevant code changes in this PR.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated — N/A (version bump only)
- [x] Backward compatibility considered — N/A
- [x] Security review performed — no code changes
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed

---
_Generated by [Claude Code](https://claude.ai/code/session_018dB85joqpGL4s6SrDszHEg)_