### PR TITLE
refactor(payments): move Parallel paid capability out of core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2341,6 +2341,7 @@ dependencies = [
  "everruns-core",
  "inventory",
  "reqwest 0.13.4",
+ "serde",
  "serde_json",
  "tokio",
 ]

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -108,7 +108,6 @@ mod noop;
 mod openai_tool_search;
 #[cfg(feature = "ui-capabilities")]
 mod openui;
-mod parallel;
 pub mod persistent_memory;
 mod platform_management;
 mod prompt_caching;
@@ -219,7 +218,6 @@ pub use openai_tool_search::{
 };
 #[cfg(feature = "ui-capabilities")]
 pub use openui::{OPENUI_CAPABILITY_ID, OpenUiCapability};
-pub use parallel::ParallelCapability;
 pub use persistent_memory::{
     ForgetTool, MEMORY_CAPABILITY_ID, MemoryCapability, MemoryConfig, RecallTool, RememberTool,
 };
@@ -888,7 +886,6 @@ impl CapabilityRegistry {
         registry.register(InfinityContextCapability);
         registry.register(budgeting::BudgetingCapability);
         registry.register(SelfBudgetCapability);
-        registry.register(ParallelCapability);
         registry.register(CompactionCapability);
         registry.register(MemoryCapability);
 
@@ -2017,7 +2014,6 @@ mod tests {
             "human_intent",
             "budgeting",
             "self_budget",
-            "parallel",
             "noop",
             "current_time",
             "research",

--- a/crates/core/src/feature_flags.rs
+++ b/crates/core/src/feature_flags.rs
@@ -202,6 +202,11 @@ pub struct InternalFeatureFlags {
     /// Managed session-owned sandbox capability and lifecycle orchestration.
     /// Experimental and disabled by default.
     pub session_sandbox: bool,
+    /// Machine-payment capabilities (e.g. the Parallel paid search/extract/task
+    /// capability). Gates registration of any capability that spends real money
+    /// through `PaymentAuthority`. Disabled by default on all envs, including dev,
+    /// because spend is irreversible. Enable via `FEATURE_MACHINE_PAYMENTS=true`.
+    pub machine_payments: bool,
 }
 
 impl InternalFeatureFlags {
@@ -213,6 +218,7 @@ impl InternalFeatureFlags {
             docker_capability,
             container_sandbox: standard_flag("FEATURE_CONTAINER_SANDBOX", docker_capability),
             session_sandbox: standard_flag("FEATURE_SESSION_SANDBOX", false),
+            machine_payments: standard_flag("FEATURE_MACHINE_PAYMENTS", false),
         }
     }
 
@@ -222,6 +228,7 @@ impl InternalFeatureFlags {
             "docker_capability" => self.docker_capability,
             "container_sandbox" => self.container_sandbox,
             "session_sandbox" => self.session_sandbox,
+            "machine_payments" => self.machine_payments,
             _ => false,
         }
     }
@@ -454,6 +461,7 @@ mod tests {
         assert!(!flags.docker_capability);
         assert!(!flags.container_sandbox);
         assert!(!flags.session_sandbox);
+        assert!(!flags.machine_payments);
     }
 
     #[test]
@@ -502,11 +510,33 @@ mod tests {
             docker_capability: true,
             container_sandbox: true,
             session_sandbox: true,
+            machine_payments: true,
         };
         assert!(flags.is_enabled("docker_capability"));
         assert!(flags.is_enabled("container_sandbox"));
         assert!(flags.is_enabled("session_sandbox"));
+        assert!(flags.is_enabled("machine_payments"));
         assert!(!flags.is_enabled("nonexistent"));
+    }
+
+    #[test]
+    fn test_machine_payments_disabled_by_default() {
+        let _lock = lock_env();
+        unsafe { std::env::remove_var("FEATURE_MACHINE_PAYMENTS") };
+        let flags = InternalFeatureFlags::from_env();
+        assert!(
+            !flags.machine_payments,
+            "machine_payments should be disabled by default on all envs"
+        );
+    }
+
+    #[test]
+    fn test_machine_payments_enabled_by_env_override() {
+        let _lock = lock_env();
+        unsafe { std::env::set_var("FEATURE_MACHINE_PAYMENTS", "true") };
+        let flags = InternalFeatureFlags::from_env();
+        assert!(flags.machine_payments);
+        unsafe { std::env::remove_var("FEATURE_MACHINE_PAYMENTS") };
     }
 
     #[test]

--- a/crates/core/src/feature_flags.rs
+++ b/crates/core/src/feature_flags.rs
@@ -264,6 +264,14 @@ mod tests {
         ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner())
     }
 
+    /// Restore an env var to a previously captured value, or remove it if it was unset.
+    fn restore_env(key: &str, prev: Option<String>) {
+        match prev {
+            Some(value) => unsafe { std::env::set_var(key, value) },
+            None => unsafe { std::env::remove_var(key) },
+        }
+    }
+
     #[test]
     fn test_default_flags() {
         let flags = FeatureFlags::default();
@@ -522,21 +530,24 @@ mod tests {
     #[test]
     fn test_machine_payments_disabled_by_default() {
         let _lock = lock_env();
+        let prev = std::env::var("FEATURE_MACHINE_PAYMENTS").ok();
         unsafe { std::env::remove_var("FEATURE_MACHINE_PAYMENTS") };
         let flags = InternalFeatureFlags::from_env();
         assert!(
             !flags.machine_payments,
             "machine_payments should be disabled by default on all envs"
         );
+        restore_env("FEATURE_MACHINE_PAYMENTS", prev);
     }
 
     #[test]
     fn test_machine_payments_enabled_by_env_override() {
         let _lock = lock_env();
+        let prev = std::env::var("FEATURE_MACHINE_PAYMENTS").ok();
         unsafe { std::env::set_var("FEATURE_MACHINE_PAYMENTS", "true") };
         let flags = InternalFeatureFlags::from_env();
         assert!(flags.machine_payments);
-        unsafe { std::env::remove_var("FEATURE_MACHINE_PAYMENTS") };
+        restore_env("FEATURE_MACHINE_PAYMENTS", prev);
     }
 
     #[test]

--- a/integrations/parallel/Cargo.toml
+++ b/integrations/parallel/Cargo.toml
@@ -14,6 +14,7 @@ description = "Parallel MCP integration for Everruns"
 everruns-core = { path = "../../crates/core" }
 inventory.workspace = true
 reqwest.workspace = true
+serde.workspace = true
 serde_json.workspace = true
 async-trait.workspace = true
 

--- a/integrations/parallel/SPEC.md
+++ b/integrations/parallel/SPEC.md
@@ -1,8 +1,18 @@
-# Parallel MCP Integration
+# Parallel Integration
 
-Parallel exposes hosted MCP tools for real-time web search and URL fetching.
+This crate hosts two independent Parallel capabilities. They share only the vendor:
 
-## Capability
+- `parallel_search` — **free**, connection-backed. Contributes Parallel's hosted MCP
+  server for web search/fetch. Experimental (dev-only).
+- `parallel` — **paid**, payment-backed. Implements in-process search/extract/task tools
+  that spend real money through the core `PaymentAuthority`. Gated by the
+  `machine_payments` internal feature flag (off by default everywhere).
+
+The two have opposite trust models and share no code. Core owns the payment trust
+boundary (`PaymentAuthority`, payment DTOs, `ToolContext`); this crate owns only the
+thin vendor adapters.
+
+## `parallel_search` capability (free MCP)
 
 The `parallel_search` capability contributes one scoped remote MCP server named `Parallel`.
 Tools are discovered from the contributed MCP server so agents see a single MCP-backed tool surface.
@@ -25,11 +35,34 @@ Parallel currently exposes:
 
 The Everruns-visible tool names use the normal MCP prefix: `mcp_parallel__web_search` and `mcp_parallel__web_fetch`.
 
+## `parallel` capability (paid, machine payments)
+
+The `parallel` capability contributes in-process tools that route paid calls through the
+core `PaymentAuthority`. See [`specs/machine-payments.md`](../../specs/machine-payments.md)
+for the trust boundary and rails.
+
+- `parallel_search` — paid web search. Up to `$0.01` per call.
+- `parallel_extract` — structured extraction. Up to `$0.01` per URL, minimum `$0.01`.
+- `parallel_task` — deep async task. Up to `$0.10` (`pro`) / `$0.30` (`ultra`).
+- `parallel_task_status` — free polling of a task run; no payment.
+
+The paid tools never sign or submit payments themselves: they build a typed
+`MachinePaymentRequest` and call `ToolContext.payment_authority`. With no authority wired
+(the default), they fail closed. The capability is registered only when the
+`machine_payments` internal feature flag is on (`FEATURE_MACHINE_PAYMENTS=true`), off by
+default on every grade including dev because spend is irreversible.
+
 ## Tests
 
-- `tests/plugin_registration.rs` verifies capability and connection-provider inventory registration.
+- `tests/plugin_registration.rs` verifies inventory registration for both capabilities and
+  the connection provider, and that the paid `parallel` capability is flag-gated
+  (registered only when `FEATURE_MACHINE_PAYMENTS` is set).
 - `tests/live_api_test.rs` runs live no-secret MCP smoke tests against the free endpoint with `--features integration`.
+- Unit tests in `src/payments.rs` cover paid-tool metadata and fail-closed behavior when no
+  payment authority is configured.
 
 ## Security
 
-The integration uses the shared MCP URL validation path before discovery and execution. API keys are user-scoped connections, encrypted by the existing connection storage, and only sent as bearer auth when capability config opts into authenticated mode or the OAuth-compatible endpoint.
+The free MCP path uses the shared MCP URL validation path before discovery and execution. API keys are user-scoped connections, encrypted by the existing connection storage, and only sent as bearer auth when capability config opts into authenticated mode or the OAuth-compatible endpoint.
+
+The paid capability inherits the machine-payments mitigations (`TM-AGENT-022`, `TM-CRYPTO-008`): no generic paid-HTTP tool, capability/host allowlists and per-request caps enforced server-side by `PaymentAuthority`, wallet custody and signing kept in the control plane, and the `machine_payments` flag gating registration so a money-spending capability is never offered by default.

--- a/integrations/parallel/src/lib.rs
+++ b/integrations/parallel/src/lib.rs
@@ -8,6 +8,7 @@
 //! OAuth-compatible MCP endpoint.
 
 pub mod connection;
+pub mod payments;
 
 use everruns_core::capabilities::{Capability, CapabilityStatus, IntegrationPlugin};
 use everruns_core::connection_provider::ConnectionProviderPlugin;
@@ -15,12 +16,25 @@ use everruns_core::{McpServerAuthMode, ScopedMcpServer, ScopedMcpServers};
 use serde_json::{Value, json};
 
 use connection::ParallelConnectionProvider;
+pub use payments::ParallelPaymentsCapability;
 
 inventory::submit! {
     IntegrationPlugin {
         experimental_only: true,
         feature_flag: None,
         factory: || Box::new(ParallelCapability),
+    }
+}
+
+// Paid Parallel tools route spend through the core `PaymentAuthority`. Gated by
+// the `machine_payments` internal feature flag (off by default on all envs,
+// including dev, because spend is irreversible) rather than the experimental
+// grade gate, so it can be enabled deliberately in any environment.
+inventory::submit! {
+    IntegrationPlugin {
+        experimental_only: false,
+        feature_flag: Some("machine_payments"),
+        factory: || Box::new(ParallelPaymentsCapability),
     }
 }
 

--- a/integrations/parallel/src/payments.rs
+++ b/integrations/parallel/src/payments.rs
@@ -2,28 +2,32 @@
 //!
 //! Decision: expose only Parallel-specific tools. Payment mechanics stay inside
 //! `PaymentAuthority`, so the model cannot initiate arbitrary paid HTTP calls.
+//! Decision: this lives in the Parallel integration crate, not core. Core owns the
+//! payment trust boundary (`PaymentAuthority`, payment DTOs, `ToolContext`); the
+//! vendor-specific paid adapter is a plugin gated by the `machine_payments`
+//! internal feature flag.
 
-use super::{Capability, CapabilityStatus, RiskLevel};
-use crate::payment::{MachinePaymentRequest, PaymentMethod, PaymentRail};
-use crate::tool_types::ToolHints;
-use crate::tools::{Tool, ToolExecutionResult};
-use crate::traits::ToolContext;
 use async_trait::async_trait;
+use everruns_core::ToolHints;
+use everruns_core::capabilities::{Capability, CapabilityStatus, RiskLevel};
+use everruns_core::payment::{MachinePaymentRequest, PaymentMethod, PaymentRail};
+use everruns_core::tools::{Tool, ToolExecutionResult};
+use everruns_core::traits::ToolContext;
 use serde::Deserialize;
 use serde_json::{Value, json};
 
 const PARALLEL_BASE_URL: &str = "https://parallelmpp.dev";
 
-pub struct ParallelCapability;
+pub struct ParallelPaymentsCapability;
 
 #[async_trait]
-impl Capability for ParallelCapability {
+impl Capability for ParallelPaymentsCapability {
     fn id(&self) -> &str {
         "parallel"
     }
 
     fn name(&self) -> &str {
-        "Parallel"
+        "Parallel (Machine Payments)"
     }
 
     fn description(&self) -> &str {
@@ -424,4 +428,28 @@ fn missing_payment_authority() -> ToolExecutionResult {
 
 fn invalid_args(error: serde_json::Error) -> ToolExecutionResult {
     ToolExecutionResult::tool_error(format!("Invalid arguments: {error}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn metadata() {
+        let cap = ParallelPaymentsCapability;
+        assert_eq!(cap.id(), "parallel");
+        assert_eq!(cap.category(), Some("Machine Payments"));
+        assert_eq!(cap.risk_level(), RiskLevel::High);
+        assert_eq!(cap.tools().len(), 4);
+        assert_eq!(cap.features(), vec!["machine_payments"]);
+    }
+
+    #[tokio::test]
+    async fn paid_tools_fail_closed_without_authority() {
+        // No payment authority wired -> the paid tools must refuse, not spend.
+        let result = ParallelSearchTool
+            .execute(json!({ "query": "hello" }))
+            .await;
+        assert!(result.is_error());
+    }
 }

--- a/integrations/parallel/tests/plugin_registration.rs
+++ b/integrations/parallel/tests/plugin_registration.rs
@@ -44,6 +44,42 @@ fn parallel_not_registered_in_prod_registry() {
     assert!(!registry.has("parallel_search"));
 }
 
+// Env-var-mutating tests must not run in parallel with each other.
+static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+#[test]
+fn payments_plugin_is_flag_gated_not_experimental() {
+    let plugins: Vec<&IntegrationPlugin> = inventory::iter::<IntegrationPlugin>().collect();
+    let plugin = plugins
+        .iter()
+        .find(|p| (p.factory)().id() == "parallel")
+        .expect("Parallel payments plugin not found");
+
+    // Gated by the machine_payments flag rather than the experimental grade, so it
+    // can be enabled deliberately in any environment but never registers by default.
+    assert!(!plugin.experimental_only);
+    assert_eq!(plugin.feature_flag, Some("machine_payments"));
+}
+
+#[test]
+fn payments_capability_disabled_by_default() {
+    let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    unsafe { std::env::remove_var("FEATURE_MACHINE_PAYMENTS") };
+    // Off by default even in dev: spend is irreversible.
+    let registry = CapabilityRegistry::with_builtins_for_grade(DeploymentGrade::Dev);
+    assert!(!registry.has("parallel"));
+}
+
+#[test]
+fn payments_capability_enabled_by_flag() {
+    let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    unsafe { std::env::set_var("FEATURE_MACHINE_PAYMENTS", "true") };
+    // Deliberate enablement works in any grade, including prod.
+    let registry = CapabilityRegistry::with_builtins_for_grade(DeploymentGrade::Prod);
+    assert!(registry.has("parallel"));
+    unsafe { std::env::remove_var("FEATURE_MACHINE_PAYMENTS") };
+}
+
 #[test]
 fn connection_provider_is_submitted() {
     let plugins: Vec<&ConnectionProviderPlugin> =

--- a/integrations/parallel/tests/plugin_registration.rs
+++ b/integrations/parallel/tests/plugin_registration.rs
@@ -47,6 +47,14 @@ fn parallel_not_registered_in_prod_registry() {
 // Env-var-mutating tests must not run in parallel with each other.
 static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
+/// Restore an env var to a previously captured value, or remove it if it was unset.
+fn restore_env(key: &str, prev: Option<String>) {
+    match prev {
+        Some(value) => unsafe { std::env::set_var(key, value) },
+        None => unsafe { std::env::remove_var(key) },
+    }
+}
+
 #[test]
 fn payments_plugin_is_flag_gated_not_experimental() {
     let plugins: Vec<&IntegrationPlugin> = inventory::iter::<IntegrationPlugin>().collect();
@@ -64,20 +72,23 @@ fn payments_plugin_is_flag_gated_not_experimental() {
 #[test]
 fn payments_capability_disabled_by_default() {
     let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let prev = std::env::var("FEATURE_MACHINE_PAYMENTS").ok();
     unsafe { std::env::remove_var("FEATURE_MACHINE_PAYMENTS") };
     // Off by default even in dev: spend is irreversible.
     let registry = CapabilityRegistry::with_builtins_for_grade(DeploymentGrade::Dev);
     assert!(!registry.has("parallel"));
+    restore_env("FEATURE_MACHINE_PAYMENTS", prev);
 }
 
 #[test]
 fn payments_capability_enabled_by_flag() {
     let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let prev = std::env::var("FEATURE_MACHINE_PAYMENTS").ok();
     unsafe { std::env::set_var("FEATURE_MACHINE_PAYMENTS", "true") };
     // Deliberate enablement works in any grade, including prod.
     let registry = CapabilityRegistry::with_builtins_for_grade(DeploymentGrade::Prod);
     assert!(registry.has("parallel"));
-    unsafe { std::env::remove_var("FEATURE_MACHINE_PAYMENTS") };
+    restore_env("FEATURE_MACHINE_PAYMENTS", prev);
 }
 
 #[test]

--- a/specs/integrations.md
+++ b/specs/integrations.md
@@ -23,6 +23,23 @@ Every sandbox/execution integration crate must ship with the following artifacts
 
 New integrations should check off every row before merging. Existing integrations that are missing items should be brought up to parity incrementally.
 
+### Auth shape: connection-backed vs payment-backed
+
+The parity table above assumes a **connection-backed** integration: per-user OAuth/API-key
+credentials via a connection provider, validated with live-API tests. A **payment-backed**
+integration instead spends through the core `PaymentAuthority` (see
+[`specs/machine-payments.md`](machine-payments.md)) under a server-side wallet and policy,
+and has no per-user connection. For those, substitute the auth-shaped rows:
+
+| Connection-backed row | Payment-backed equivalent |
+|---|---|
+| Connection provider (OAuth/API-key form) | Declared `machine_payments` feature-flag gating + wallet/policy requirements |
+| Live API tests (real credentials) | Fail-closed tests (no authority → refuse) + `PaymentAuthority`-mock flows |
+| Threat model: integration-specific | Threat model: spend / prompt-injection (`TM-AGENT-022`, `TM-CRYPTO-008`) |
+
+A single vendor crate may host both shapes (e.g. `integrations/parallel` ships the free
+connection-backed `parallel_search` and the paid payment-backed `parallel`).
+
 ## CI Trigger Policy
 
 Integration coverage is intentionally split by cost and blast radius:
@@ -40,7 +57,7 @@ Auto-registered via `inventory` plugin system. Each crate has a `SPEC.md`.
 | Integration | Spec | Summary |
 |---|---|---|
 | Brave Search | [`integrations/brave-search/SPEC.md`](../integrations/brave-search/SPEC.md) | Web search via Brave Search API. Experimental (Dev only). |
-| Parallel | [`integrations/parallel/SPEC.md`](../integrations/parallel/SPEC.md) | Web search and URL fetch through Parallel MCP. Experimental (Dev only). |
+| Parallel | [`integrations/parallel/SPEC.md`](../integrations/parallel/SPEC.md) | Two capabilities: free `parallel_search` (web search/fetch via Parallel MCP, Dev only) and paid `parallel` (machine-payment search/extract/task, gated by `FEATURE_MACHINE_PAYMENTS`). |
 | DuckDuckGo | [`integrations/duckduckgo/SPEC.md`](../integrations/duckduckgo/SPEC.md) | Instant answers via DuckDuckGo API. Experimental (Dev only). |
 | GitHub | [`integrations/github/SPEC.md`](../integrations/github/SPEC.md) | GitHub Scout blueprint capability for read-only repository exploration. |
 | Browserless | [`integrations/browserless/SPEC.md`](../integrations/browserless/SPEC.md) | Cloud browser automation — screenshots, DOM, scraping, multi-step interactions. REST and CDP modes. |

--- a/specs/machine-payments.md
+++ b/specs/machine-payments.md
@@ -95,7 +95,11 @@ Unattended work must not silently spend a human user's wallet.
 
 ## Parallel MVP
 
-The `parallel` capability contributes:
+The `parallel` capability is the first machine-payment consumer. Core owns only the
+trust-boundary primitive (`PaymentAuthority`, payment DTOs, `ToolContext`); the
+vendor-specific paid adapter lives in the `integrations/parallel` crate and is
+registered as an integration plugin gated by the `machine_payments` internal feature
+flag. It contributes:
 - `parallel_search`
 - `parallel_extract`
 - `parallel_task`
@@ -131,13 +135,18 @@ Threat model entries:
 
 Current mitigations include no generic paid HTTP tool, capability and host
 allowlists, per-request caps, encrypted wallet custody, control-plane-only
-signing, no worker key exposure, and durable attempt records. Budget
-reservations, per-turn/day enforcement, and idempotency-key settlement hardening
-remain follow-ups.
+signing, no worker key exposure, and durable attempt records. Registration of any
+money-spending capability is itself gated by the `machine_payments` feature flag, so
+spend tools are never offered by default. Budget reservations, per-turn/day
+enforcement, and idempotency-key settlement hardening remain follow-ups.
 
 ## Rollout
 
-Feature flag: `FEATURE_MACHINE_PAYMENTS`.
+Feature flag: `FEATURE_MACHINE_PAYMENTS` (the `machine_payments` `InternalFeatureFlags`
+field). It is a standard flag, off by default on every grade including dev because spend
+is irreversible; set `FEATURE_MACHINE_PAYMENTS=true` to deliberately enable. The flag
+gates registration of machine-payment capabilities (currently the `parallel` integration
+plugin).
 
 Recommended sequence:
 1. Payment DTOs, account/policy/attempt APIs, and UI.

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -836,7 +836,10 @@ no generic `paid_http_request` tool. The capability submits a typed payment requ
 `PaymentAuthority`; the server selects only active spend policies scoped to the current session,
 agent, agent identity, user, or organization and checks capability allowlist, host allowlist, rail
 preference, and per-request maximum before creating any rail-specific signature. Every attempt is
-persisted with status, amount, target URL, and receipt/error.
+persisted with status, amount, target URL, and receipt/error. Registration of any money-spending
+capability is additionally gated by the `machine_payments` feature flag
+(`FEATURE_MACHINE_PAYMENTS`), off by default on every grade, so spend tools are never offered
+unless deliberately enabled.
 
 ## 14. Voice Sessions (TM-VOICE)
 


### PR DESCRIPTION
## What
Moves the paid Parallel machine-payment capability out of `everruns-core` into the `integrations/parallel` crate, and gates its registration behind a new `machine_payments` feature flag.

- Core keeps only the trust-boundary primitive: `PaymentAuthority`, payment DTOs, and `ToolContext.payment_authority`. No vendor specifics remain in core.
- The paid capability (`parallel`, category "Machine Payments") now lives in `integrations/parallel/src/payments.rs` as `ParallelPaymentsCapability`, registered via the `inventory` plugin system alongside the existing free `parallel_search` MCP capability.
- Adds `machine_payments` to `InternalFeatureFlags` (`FEATURE_MACHINE_PAYMENTS`), off by default on **every** grade including dev because spend is irreversible. The plugin declares `feature_flag: Some("machine_payments")`, so it registers only when deliberately enabled.

## Why
A `RiskLevel::High`, money-spending capability was an **unconditional core builtin** — present in the catalog in every deployment grade including prod, while tamer features like `agent_delegation` sit behind grade/feature gates. The spec (`specs/machine-payments.md`) already promised a `FEATURE_MACHINE_PAYMENTS` flag that was never wired. This makes that flag real, gives the capability uniform gating, and gets vendor-specific paid code out of core so core owns only the payment trust boundary.

## How
- `feature_flags.rs`: new `machine_payments` field, `from_env` (`standard_flag`, default false), `is_enabled`, tests.
- Move capability (git rename) core → integration crate; imports rewired to `everruns_core::*`; struct renamed `ParallelPaymentsCapability`; tool logic unchanged.
- `integrations/parallel/src/lib.rs`: second `inventory::submit!` with `feature_flag: Some("machine_payments")`, `experimental_only: false` (so it can be enabled in any grade, never by default).
- Remove core `mod parallel` / `pub use` / unconditional `register(...)` and the `"parallel"` entry in the core-builtin test set.
- Specs: wire the previously spec-only `FEATURE_MACHINE_PAYMENTS`; add a payment-backed parity variant to `specs/integrations.md`; note the registration gate in `TM-AGENT-022`; update the integration `SPEC.md`.

## Risk
- **Low.** No migrations, no API schema change, no auth changes. The paid capability is no longer offered by default, but it was unusable without a configured wallet/policy and fails closed regardless. Runtime fail-closed (`missing_payment_authority`) is preserved.

## Security
- **Threat categories reviewed:** TM-TOOL (capability/tool registration), TM-AGENT-022 (agent-initiated machine-payment spend), TM-CRYPTO-008 (wallet key exposure).
- **Findings / resolutions:**
  - Net posture **improves**: a money-spending capability is now gated by `FEATURE_MACHINE_PAYMENTS` (off by default everywhere) instead of being an unconditional builtin — it is never offered unless deliberately enabled. `TM-AGENT-022` updated to record this gate.
  - No custody/signing/key-handling code moved. The capability only builds a typed `MachinePaymentRequest` and calls `PaymentAuthority`; signing and wallet custody stay server-side (`TM-CRYPTO-008` unchanged).
  - Tool input validation moved verbatim and preserved: search `mode` enum check, non-empty `urls`, and `run_id` path-traversal guard (`contains('/')`) on the free status endpoint.
  - Dependency: added `serde` (workspace dep, already used pervasively) to the integration crate. No new external dependencies.

## Validation
- `cargo fmt --check`, `cargo clippy --all-targets -D warnings` (core + integration): clean.
- `cargo check --workspace --all-targets`: clean (server + worker both link the integration crate, so the gated capability is reachable when enabled).
- `bash scripts/lib/pre-push.sh`: all 9 checks pass (incl. migration ordering, specs index, author attribution).
- Tests: `feature_flags` 25 pass (incl. new default-off + env-override); core registry dev/prod 2 pass (builtins no longer include `parallel`); integration crate 10 lib + 9 plugin tests incl. 3 new gating tests (`flag-gated/not-experimental`, `disabled-by-default`, `enabled-by-flag`) and a fail-closed unit test.
- **End-to-end smoke** (`start-dev`, `GET /api/v1/capabilities`):
  - Flag **off** (default): 56 capabilities; paid `parallel` **absent**; `parallel_search` present.
  - Flag **on** (`FEATURE_MACHINE_PAYMENTS=true`): 57 capabilities; `parallel` **present** (category "Machine Payments", risk "high"); server boots clean in both cases.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (internal code; no compat required per AGENTS.md — paid capability now opt-in)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)


---
_Generated by [Claude Code](https://claude.ai/code/session_01JCPtfrcBM2G75kA1sQ89YL)_