### PR TITLE
feat(capabilities): add pre_tool_use_hooks seam for tool gating

### DIFF
--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -561,6 +561,20 @@ pub trait Capability: Send + Sync {
         None
     }
 
+    /// Returns pre-tool execution hooks provided by this capability.
+    ///
+    /// These hooks run before each individual tool is executed — for *every*
+    /// tool the agent calls (built-in, MCP, or client-side), not just this
+    /// capability's own tools. A hook can mutate the tool call or block it
+    /// outright (returning [`crate::atoms::PreToolUseDecision::Block`]), which
+    /// makes this the seam for cross-cutting policy such as approval gating.
+    /// The first hook to block wins.
+    ///
+    /// By default, returns an empty vector (no hooks).
+    fn pre_tool_use_hooks(&self) -> Vec<Arc<dyn crate::atoms::PreToolUseHook>> {
+        vec![]
+    }
+
     /// Returns post-tool execution hooks provided by this capability.
     ///
     /// These hooks run after each individual tool completes execution.

--- a/crates/runtime/src/host.rs
+++ b/crates/runtime/src/host.rs
@@ -376,7 +376,18 @@ async fn load_execution_capabilities<A: RuntimeHostAdapter>(
     // every event finalizes specs identically.
     let user_hook_specs =
         finalize_specs_from_configs(&resolved.resolved_capability_configs, &capability_registry);
-    let mut pre_tool_hooks: Vec<Arc<dyn everruns_core::atoms::PreToolUseHook>> = Vec::new();
+    // Capability-contributed pre-tool hooks run first (e.g. approval gating),
+    // then user-hook (`PreToolUse`) specs. The first hook to block wins.
+    let mut pre_tool_hooks: Vec<Arc<dyn everruns_core::atoms::PreToolUseHook>> = resolved
+        .resolved_capability_configs
+        .iter()
+        .flat_map(|config| {
+            capability_registry
+                .get(config.capability_id())
+                .map(|capability| capability.pre_tool_use_hooks())
+                .unwrap_or_default()
+        })
+        .collect();
     if !user_hook_specs.is_empty() {
         let dispatcher: Arc<dyn everruns_core::hook_executor::BashHookDispatcher> = Arc::new(
             everruns_core::hook_dispatch::VirtualBashHookDispatcher::new(adapter.file_store()),

--- a/crates/runtime/src/host.rs
+++ b/crates/runtime/src/host.rs
@@ -25,8 +25,8 @@ use everruns_core::traits::{
 };
 use everruns_core::typed_id::{AgentId, HarnessId, MessageId, SessionId, TurnId};
 use everruns_core::{
-    Agent, CapabilityRegistry, DependencyBlocker, DriverRegistry, EgressService, Harness, Session,
-    TokenUsage, ToolDefinition, ToolRegistry, UserFacingError, UtilityLlmService,
+    Agent, CapabilityRegistry, CapabilityStatus, DependencyBlocker, DriverRegistry, EgressService,
+    Harness, Session, TokenUsage, ToolDefinition, ToolRegistry, UserFacingError, UtilityLlmService,
     org_public_id_from_internal, resolve_runtime_capabilities,
 };
 use std::sync::Arc;
@@ -357,12 +357,17 @@ async fn load_execution_capabilities<A: RuntimeHostAdapter>(
         registry.register_boxed(tool);
     }
 
+    // Only `Available` capabilities contribute hooks, matching
+    // `collect_capabilities_with_configs` (which skips non-available
+    // capabilities). This keeps a `ComingSoon`/unavailable capability from
+    // affecting execution via any of its hook seams.
     let mut post_tool_hooks: Vec<Arc<dyn everruns_core::PostToolExecHook>> = resolved
         .resolved_capability_configs
         .iter()
         .flat_map(|config| {
             capability_registry
                 .get(config.capability_id())
+                .filter(|capability| capability.status() == CapabilityStatus::Available)
                 .map(|capability| capability.post_tool_exec_hooks())
                 .unwrap_or_default()
         })
@@ -384,6 +389,7 @@ async fn load_execution_capabilities<A: RuntimeHostAdapter>(
         .flat_map(|config| {
             capability_registry
                 .get(config.capability_id())
+                .filter(|capability| capability.status() == CapabilityStatus::Available)
                 .map(|capability| capability.pre_tool_use_hooks())
                 .unwrap_or_default()
         })
@@ -408,6 +414,7 @@ async fn load_execution_capabilities<A: RuntimeHostAdapter>(
         .flat_map(|config| {
             capability_registry
                 .get(config.capability_id())
+                .filter(|capability| capability.status() == CapabilityStatus::Available)
                 .map(|capability| capability.tool_call_hooks())
                 .unwrap_or_default()
         })

--- a/crates/runtime/tests/runtime_host_test.rs
+++ b/crates/runtime/tests/runtime_host_test.rs
@@ -280,6 +280,33 @@ impl Capability for GateCapability {
     }
 }
 
+/// Same blocking pre-tool hook as `GateCapability`, but the capability reports
+/// a non-`Available` status. Used to assert hooks from unavailable capabilities
+/// are not collected (mirrors `collect_capabilities_with_configs`).
+struct ComingSoonGateCapability;
+
+impl Capability for ComingSoonGateCapability {
+    fn id(&self) -> &str {
+        "coming_soon_gate"
+    }
+
+    fn name(&self) -> &str {
+        "Coming Soon Gate"
+    }
+
+    fn description(&self) -> &str {
+        "Unavailable test capability contributing a blocking pre-tool hook."
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::ComingSoon
+    }
+
+    fn pre_tool_use_hooks(&self) -> Vec<Arc<dyn everruns_core::atoms::PreToolUseHook>> {
+        vec![Arc::new(BlockEchoHook)]
+    }
+}
+
 struct BlockEchoHook;
 
 #[async_trait]
@@ -911,6 +938,81 @@ async fn act_activity_runs_capability_pre_tool_hook_and_blocks() {
     assert!(
         error.contains("denied by test policy"),
         "error should carry the hook's reason: {error}"
+    );
+}
+
+#[tokio::test]
+async fn act_activity_skips_pre_tool_hooks_from_unavailable_capability() {
+    let mut adapter = mock_host();
+    adapter.capability_registry.register(OverlayEchoCapability);
+    adapter
+        .capability_registry
+        .register(ComingSoonGateCapability);
+    set_default_model(&adapter).await;
+
+    let harness_id = HarnessId::from_uuid(Uuid::now_v7());
+    let session_id = SessionId::from_uuid(Uuid::now_v7());
+    let agent_id = AgentId::from_uuid(Uuid::now_v7());
+    let input_message_id = MessageId::from_uuid(Uuid::now_v7());
+
+    adapter
+        .harness_store
+        .add_harness(Harness {
+            capabilities: vec![
+                AgentCapabilityConfig::new("overlay_echo"),
+                AgentCapabilityConfig::new("coming_soon_gate"),
+            ],
+            ..harness(harness_id)
+        })
+        .await;
+    adapter.agent_store.add_agent(agent(agent_id, vec![])).await;
+    adapter
+        .session_store
+        .insert(Session {
+            agent_id: Some(agent_id),
+            ..session(session_id, harness_id)
+        })
+        .await;
+
+    let result = execute_act_activity(
+        &adapter,
+        ActInput {
+            org_id: Some(1),
+            context: AtomContext::new(
+                session_id,
+                TurnId::from_uuid(Uuid::now_v7()),
+                input_message_id,
+            ),
+            harness_id,
+            agent_id: Some(agent_id),
+            tool_calls: vec![ToolCall {
+                id: "call_unavailable_gate".into(),
+                name: "overlay_echo".into(),
+                arguments: json!({"value": "hook"}),
+            }],
+            tool_definitions: reason_tool_definitions(
+                &adapter,
+                session_id,
+                harness_id,
+                Some(agent_id),
+            )
+            .await,
+            locale: None,
+            blueprint_id: None,
+            network_access: None,
+            parallel_tool_calls: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    // The gating capability is `ComingSoon`, so its pre-tool hook must not be
+    // collected: the tool executes normally instead of being blocked.
+    assert_eq!(result.success_count, 1);
+    assert_eq!(result.error_count, 0);
+    assert_eq!(
+        result.results[0].result.result.as_ref().unwrap()["hooked"],
+        true
     );
 }
 

--- a/crates/runtime/tests/runtime_host_test.rs
+++ b/crates/runtime/tests/runtime_host_test.rs
@@ -254,6 +254,54 @@ impl everruns_core::atoms::PostToolExecHook for OverlayHook {
     }
 }
 
+/// Test capability that contributes a pre-tool hook blocking `overlay_echo`.
+/// Exercises the `Capability::pre_tool_use_hooks` seam used for approval gating.
+struct GateCapability;
+
+impl Capability for GateCapability {
+    fn id(&self) -> &str {
+        "gate"
+    }
+
+    fn name(&self) -> &str {
+        "Gate"
+    }
+
+    fn description(&self) -> &str {
+        "Test capability contributing a blocking pre-tool hook."
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+
+    fn pre_tool_use_hooks(&self) -> Vec<Arc<dyn everruns_core::atoms::PreToolUseHook>> {
+        vec![Arc::new(BlockEchoHook)]
+    }
+}
+
+struct BlockEchoHook;
+
+#[async_trait]
+impl everruns_core::atoms::PreToolUseHook for BlockEchoHook {
+    async fn before_exec(
+        &self,
+        tool_call: ToolCall,
+        _tool_def: &everruns_core::ToolDefinition,
+        _context: &ToolContext,
+    ) -> everruns_core::atoms::PreToolUseDecision {
+        if tool_call.name == "overlay_echo" {
+            everruns_core::atoms::PreToolUseDecision::Block {
+                tool_call,
+                reason: "denied by test policy".into(),
+                user_message: None,
+            }
+        } else {
+            everruns_core::atoms::PreToolUseDecision::Continue(tool_call)
+        }
+    }
+}
+
 struct OverlayEchoCapability;
 
 impl Capability for OverlayEchoCapability {
@@ -781,6 +829,88 @@ async fn act_activity_agent_session_runs_post_tool_hooks_from_merged_overlay() {
     assert_eq!(
         result.results[0].result.result.as_ref().unwrap()["hooked"],
         true
+    );
+}
+
+#[tokio::test]
+async fn act_activity_runs_capability_pre_tool_hook_and_blocks() {
+    let mut adapter = mock_host();
+    adapter.capability_registry.register(OverlayEchoCapability);
+    adapter.capability_registry.register(GateCapability);
+    set_default_model(&adapter).await;
+
+    let harness_id = HarnessId::from_uuid(Uuid::now_v7());
+    let session_id = SessionId::from_uuid(Uuid::now_v7());
+    let agent_id = AgentId::from_uuid(Uuid::now_v7());
+    let input_message_id = MessageId::from_uuid(Uuid::now_v7());
+
+    adapter
+        .harness_store
+        .add_harness(Harness {
+            capabilities: vec![
+                AgentCapabilityConfig::new("overlay_echo"),
+                AgentCapabilityConfig::new("gate"),
+            ],
+            ..harness(harness_id)
+        })
+        .await;
+    adapter.agent_store.add_agent(agent(agent_id, vec![])).await;
+    adapter
+        .session_store
+        .insert(Session {
+            agent_id: Some(agent_id),
+            ..session(session_id, harness_id)
+        })
+        .await;
+
+    let result = execute_act_activity(
+        &adapter,
+        ActInput {
+            org_id: Some(1),
+            context: AtomContext::new(
+                session_id,
+                TurnId::from_uuid(Uuid::now_v7()),
+                input_message_id,
+            ),
+            harness_id,
+            agent_id: Some(agent_id),
+            tool_calls: vec![ToolCall {
+                id: "call_blocked".into(),
+                name: "overlay_echo".into(),
+                arguments: json!({"value": "hook"}),
+            }],
+            tool_definitions: reason_tool_definitions(
+                &adapter,
+                session_id,
+                harness_id,
+                Some(agent_id),
+            )
+            .await,
+            locale: None,
+            blueprint_id: None,
+            network_access: None,
+            parallel_tool_calls: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    // The capability-contributed pre-tool hook blocked execution: the tool
+    // never ran (no `value` payload) and the error names the block reason.
+    assert_eq!(result.success_count, 0);
+    assert_eq!(result.error_count, 1);
+    let blocked = &result.results[0].result;
+    assert!(
+        blocked.result.is_none(),
+        "blocked tool should not produce output"
+    );
+    let error = blocked
+        .error
+        .as_ref()
+        .expect("blocked tool yields an error");
+    assert!(
+        error.contains("denied by test policy"),
+        "error should carry the hook's reason: {error}"
     );
 }
 

--- a/specs/tool-execution.md
+++ b/specs/tool-execution.md
@@ -262,6 +262,16 @@ Current examples:
 
 This pattern is intended for tools that must call an external API directly while still relying on the control plane for secrets, org scoping, and durable storage.
 
+### PreToolUseHook (per-tool hooks)
+
+`PreToolUseHook` is an async hook that runs before each individual tool is executed — for *every* tool the agent calls (built-in, MCP, or client-side). A hook can mutate the `ToolCall` (returning `Continue`) or block it (returning `Block`, which skips execution and returns the hook's reason as the tool error). Hooks chain sequentially; the first `Block` wins.
+
+Two sources feed the chain, in this order:
+1. **Capability hooks** — from active capabilities via `Capability::pre_tool_use_hooks()`. This is the seam for in-process, cross-cutting policy such as approval gating (consult an approval gate, honoring each tool's `ToolHints`).
+2. **User-hook specs** — `pre_tool_use` hooks dispatched per `specs/user-hooks.md`.
+
+Because this runs uniformly for all tools, it is the right place to gate tools the host does not implement itself (e.g. MCP tools executed by the runtime). See `Capability::pre_tool_use_hooks` and `crates/runtime/src/host.rs` (`load_execution_capabilities`).
+
 ### PostToolExecHook (per-tool hooks)
 
 `PostToolExecHook` is an async hook that runs after each individual tool execution, before ActAtom emits events. Capabilities contribute hooks via `Capability::post_tool_exec_hooks()`.

--- a/specs/tool-execution.md
+++ b/specs/tool-execution.md
@@ -264,7 +264,7 @@ This pattern is intended for tools that must call an external API directly while
 
 ### PreToolUseHook (per-tool hooks)
 
-`PreToolUseHook` is an async hook that runs before each individual tool is executed — for *every* tool the agent calls (built-in, MCP, or client-side). A hook can mutate the `ToolCall` (returning `Continue`) or block it (returning `Block`, which skips execution and returns the hook's reason as the tool error). Hooks chain sequentially; the first `Block` wins.
+`PreToolUseHook` is an async hook that runs before an individual tool is executed. For sessions that load execution capabilities the same chain runs uniformly for every tool the agent calls (built-in, MCP, or client-side); blueprint sessions resolve their tools directly and do not run these hooks. A hook can mutate the `ToolCall` (returning `Continue`) or block it (returning `Block`, which skips execution and surfaces the hook's reason as the tool error, prefixed with `blocked by pre_tool_use hook:`). Hooks chain sequentially; the first `Block` wins.
 
 Two sources feed the chain, in this order:
 1. **Capability hooks** — from active capabilities via `Capability::pre_tool_use_hooks()`. This is the seam for in-process, cross-cutting policy such as approval gating (consult an approval gate, honoring each tool's `ToolHints`).


### PR DESCRIPTION
## What

Add `Capability::pre_tool_use_hooks()` so capabilities can contribute pre-tool execution hooks, and gather them in the runtime's `load_execution_capabilities` ahead of user-hook `PreToolUse` specs.

## Why

Capabilities can already contribute `post_tool_exec_hooks()` and `tool_call_hooks()`, but pre-tool hooks could only come from user-hook (bash-dispatched) specs. That left no in-process seam for cross-cutting policy that must run *before* a tool executes — most importantly approval gating for tools the host does not implement itself (e.g. MCP tools executed by the runtime via `everruns-mcp`).

Hooks fire uniformly for every tool call (built-in, MCP, client-side) in sessions that load execution capabilities; the first to return `Block` aborts that call. A single capability hook can therefore route any tool through an approval gate honoring its `ToolHints` (skip readonly, prompt on destructive) — closing the MCP approval gap noted as a follow-up in `specs/runtime-mcp.md`.

## Changes

- `crates/core/src/capabilities/mod.rs` — new `pre_tool_use_hooks()` trait method (default empty), alongside the existing post/tool-call seams.
- `crates/runtime/src/host.rs` — gather capability pre-tool hooks in `load_execution_capabilities`, before user-hook `PreToolUse` specs. Hook collection (pre/post/tool-call) now filters by `capability.status() == Available`, matching `collect_capabilities_with_configs` so non-available capabilities cannot contribute hooks.
- `crates/runtime/tests/runtime_host_test.rs` — test capability whose pre-tool hook blocks a tool (asserts it never executes and the block reason surfaces as the tool error), plus a test asserting an unavailable capability's pre-tool hook is skipped.
- `specs/tool-execution.md` — document the seam (including the blueprint-session exception and the `blocked by pre_tool_use hook:` error prefix).

## Compatibility

Backward compatible: the default returns no hooks, so existing capabilities are unaffected.

## Testing

- `cargo clippy -p everruns-core -p everruns-runtime --all-targets` — clean.
- `cargo test -p everruns-runtime --test runtime_host_test` — 20/20 pass, including `act_activity_runs_capability_pre_tool_hook_and_blocks` and `act_activity_skips_pre_tool_hooks_from_unavailable_capability`.
- `cargo fmt --check` — clean.

The runtime host tests drive the real `execute_act_activity` path end-to-end (registering capabilities, resolving them, executing tool calls through the hook chain), so they serve as the smoke test for this seam. There is no user-facing/HTTP surface to exercise: the trait method defaults to empty and no built-in capability uses it yet, so running stack behavior is unchanged.

## Security

Threat surface: `TM-TOOL` (tool execution / hook seam). The new seam runs in-process trait methods only — no new external input, network, or query path. The status-gating fix actually tightens the trust boundary: a `ComingSoon`/`Deprecated` capability can no longer inject pre/post/tool-call hooks into execution, closing a small inconsistency where unavailable capabilities could influence tool execution. No secrets, logging, or data-exposure changes. No new dependencies. THREAT comments unchanged; no new threat introduced, so `specs/threat-model.md` needs no update.

## Follow-ups

- Wire an actual approval-gating capability onto this seam (consume `ToolHints` to skip readonly / prompt on destructive) to close the MCP approval gap from `specs/runtime-mcp.md`. Deferred: that is a distinct feature; this PR only adds the seam and its tests.
