### PR TITLE
fix(llm): gate tool_search off on gpt-5.5 family (EVE-521)

### DIFF
--- a/crates/core/src/llm_model_profiles.rs
+++ b/crates/core/src/llm_model_profiles.rs
@@ -1100,7 +1100,13 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_gpt55()),
-            tool_search: true,
+            // tool_search gated off pending live verification of the Responses-API
+            // deferred-loading round-trip on gpt-5.5. The round-trip reproducibly
+            // fails with a server_error during the reasoning phase (EVE-521), making
+            // the agent loop unusable on the default model. gpt-5.4 keeps tool_search
+            // (it has live integration coverage); re-enable here once the gpt-5.5
+            // round-trip is verified end-to-end.
+            tool_search: false,
             supports_phases: true,
         }),
 
@@ -1134,7 +1140,9 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_gpt52_pro()),
-            tool_search: true,
+            // Gated off with gpt-5.5: the deferred-loading round-trip fails during the
+            // reasoning phase on the gpt-5.5 family (EVE-521). Re-enable once verified.
+            tool_search: false,
             supports_phases: true,
         }),
 
@@ -2669,7 +2677,8 @@ mod tests {
         assert!(profile.reasoning);
         assert!(profile.tool_call);
         assert!(profile.structured_output);
-        assert!(profile.tool_search);
+        // tool_search is gated off on gpt-5.5 pending live round-trip verification (EVE-521).
+        assert!(!profile.tool_search);
         assert!(profile.supports_phases);
 
         let limits = profile.limits.unwrap();
@@ -2725,6 +2734,8 @@ mod tests {
         assert!(profile.reasoning);
         assert!(profile.tool_call);
         assert!(profile.structured_output);
+        // tool_search gated off with the rest of the gpt-5.5 family (EVE-521).
+        assert!(!profile.tool_search);
         assert!(profile.supports_phases);
 
         let cost = profile.cost.unwrap();

--- a/docs/capabilities/openai-tool-search.md
+++ b/docs/capabilities/openai-tool-search.md
@@ -46,7 +46,7 @@ Tool search requires model-level support. Currently supported:
 |---|---|
 | `gpt-5.4*` | Yes |
 | `gpt-5.5*` | Not yet — temporarily gated while the deferred-loading round-trip is verified |
-| Models outside the `gpt-5.4*` family | No (capability is silently ignored) |
+| All other models | No (capability is silently ignored) |
 
 The `gpt-5.5` family is temporarily gated: the OpenAI Responses deferred-loading
 round-trip fails with a `server_error` during the reasoning phase on these models,

--- a/docs/capabilities/openai-tool-search.md
+++ b/docs/capabilities/openai-tool-search.md
@@ -44,9 +44,13 @@ Tool search requires model-level support. Currently supported:
 
 | Model family | Supported |
 |---|---|
-| `gpt-5.5*` | Yes |
 | `gpt-5.4*` | Yes |
-| Models outside the `gpt-5.4*` and `gpt-5.5*` families | No (capability is silently ignored) |
+| `gpt-5.5*` | Not yet — temporarily gated while the deferred-loading round-trip is verified |
+| Models outside the `gpt-5.4*` family | No (capability is silently ignored) |
+
+The `gpt-5.5` family is temporarily gated: the OpenAI Responses deferred-loading
+round-trip fails with a `server_error` during the reasoning phase on these models,
+so the capability is silently skipped there until the round-trip is verified.
 
 When the capability is enabled but the model doesn't support tool_search, the feature is silently skipped — no errors, no behavior change.
 

--- a/specs/tool-search.md
+++ b/specs/tool-search.md
@@ -161,6 +161,14 @@ let use_tool_search = profile.tool_search && config.tools.len() >= TOOL_SEARCH_T
 
 Set `tool_search: true` for models that support it. Default `false` for all others. See `crates/core/src/llm_model_profiles.rs` for current profile definitions.
 
+A model's `tool_search: true` flag must be backed by a verified end-to-end round-trip
+(deferred-load → schema fetch → tool call) against the live provider, not just the
+request-shaping unit tests. The `gpt-5.5` family is gated `false` because the live
+round-trip fails with a `server_error` during the reasoning phase (EVE-521), even
+though the unit tests pass. Keep the flag off until a live tool-using turn succeeds
+on that model; `gpt-5.4` is the currently verified family (see
+`crates/llm-tests/tests/tool_search_test.rs`).
+
 ## OpenAI Driver Changes
 
 The OpenAI driver extends `ResponsesTool` with `Namespace` and `ToolSearch` variants and adds `convert_tools_with_search()` to handle namespace grouping and defer_loading. See `crates/core/src/openresponses_protocol.rs` for the implementation.
@@ -191,7 +199,7 @@ Track tool_search effectiveness via existing metadata:
 ### Phase 1: Model Profile + Driver (Low Risk)
 
 1. Add `tool_search: bool` to `LlmModelProfile` (default false)
-2. Set `tool_search: true` for supported GPT-5.4 and GPT-5.5 family models
+2. Set `tool_search: true` for verified models (currently the GPT-5.4 family; the GPT-5.5 family is gated off pending live verification, see "Model Profile Updates")
 3. Add `category: Option<String>` to `BuiltinTool` / `ToolDefinition`
 4. Propagate capability category to tool definitions in `collect_capabilities()`
 5. Extend `ResponsesTool` enum with `Namespace` and `ToolSearch` variants

--- a/specs/tool-search.md
+++ b/specs/tool-search.md
@@ -166,7 +166,7 @@ A model's `tool_search: true` flag must be backed by a verified end-to-end round
 request-shaping unit tests. The `gpt-5.5` family is gated `false` because the live
 round-trip fails with a `server_error` during the reasoning phase (EVE-521), even
 though the unit tests pass. Keep the flag off until a live tool-using turn succeeds
-on that model; `gpt-5.4` is the currently verified family (see
+on that model; the `gpt-5.4*` family is the currently verified one (see
 `crates/llm-tests/tests/tool_search_test.rs`).
 
 ## OpenAI Driver Changes


### PR DESCRIPTION
## What
Set `tool_search: false` for the `gpt-5.5` and `gpt-5.5-pro` model profiles, disabling OpenAI deferred tool loading on that family. `gpt-5.4*` keeps `tool_search: true`. Profile tests, capability docs, and the tool-search spec are updated to record the gate and the verification bar.

## Why
Enabling the `openai_tool_search` capability makes the agent loop fail on the default `gpt-5.5` model with a reproducible `server_error` during the reasoning phase (EVE-521). The model engages the deferred-schema-loading path and the request is rejected server-side. The same prompt succeeds with the capability disabled, so `openai_tool_search` is currently unusable on the default provider.

The failure only surfaces against a live `gpt-5.5` run — the existing request-shaping unit tests (`convert_tools_with_search`) and llmsim tests don't exercise the real Responses tool_search round-trip, so nothing caught this.

## How
- `crates/core/src/llm_model_profiles.rs`: flip `tool_search` to `false` for `gpt-5.5` and `gpt-5.5-pro`, with comments pointing at EVE-521. The existing `RuntimeAgentBuilder::build()` gate already clears `tool_search` for models whose profile reports `tool_search: false`, so no other code path changes.
- Keep `gpt-5.4*` enabled: it's the model with live end-to-end coverage in `crates/llm-tests/tests/tool_search_test.rs` and the canonical "supported" model in the `RuntimeAgentBuilder` gate tests — so the mechanism stays alive and testable.
- Update the `gpt-5.5`/`gpt-5.5-pro` profile unit tests to assert the gate (regression guard for EVE-521).
- Update `docs/capabilities/openai-tool-search.md` and `specs/tool-search.md` to record that a `tool_search: true` flag must be backed by a verified live round-trip, and that the 5.5 family is gated pending that verification.

## Risk
- Low. This only removes an API parameter (`tool_search` / namespaces / `defer_loading`) from requests to `gpt-5.5*`. Tool calls themselves are unchanged; the agent loop falls back to sending full tool schemas (the pre-tool_search behavior that already works). No migrations, no API surface changes.
- Worst case: marginally higher prompt-token usage on `gpt-5.5` agents with 15+ tools — which is strictly better than the current `server_error`.

## Security
- Threat categories reviewed: TM-LLM (model parameters / request shaping). The change only *removes* a request parameter from the OpenAI Responses call for `gpt-5.5`; it introduces no new input parsing, auth, or data-exposure surface. No `THREAT` comments are affected.
- Findings and resolutions: none.

## Follow-ups
- **Root-cause the round-trip on `gpt-5.5`.** The likely interaction is between `convert_tools_with_search` request shaping in `openresponses_protocol.rs` and gpt-5.5's native reasoning phases. Deferred — needs live `gpt-5.5` access to reproduce and verify; out of scope for restoring the default model.
- **Add a live (Doppler) integration test exercising a tool-using turn on a `tool_search: true` model**, mirroring the existing `gpt-5.4` tests, so the round-trip is verified before any model's flag is flipped on. Deferred — depends on the root-cause work above; re-enabling `gpt-5.5` should be gated on this test passing.
- **Re-evaluate `gpt-5.4*` once the round-trip is verified.** It shares the same code path and lacks a confirmed-failing repro, so it stays enabled (and has live coverage), but the same `server_error` risk theoretically applies. Tracked here for visibility.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

https://claude.ai/code/session_01TLySvYca1LwXAs8rmyWXkM

---
_Generated by [Claude Code](https://claude.ai/code/session_01TLySvYca1LwXAs8rmyWXkM)_