### PR TITLE
chore(release): prepare v0.8.38

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- New changes go here. Use `/prepare-release X.Y.Z` to generate draft from commits. -->
 
-- feat(capabilities): generic provider-agnostic `tool_search` capability for client-side deferred tool loading on any model (Anthropic, Gemini, ...)
-- feat(mcp): MCP server tools are now first-class `ToolRegistry` tools across all hosts (runtime + durable worker) via `McpProxyTool`/`McpToolInvoker`, so `tool_search`, `openai_tool_search`, and `spawn_background` work transparently with MCP tools; the per-host `CompositeToolExecutor` routing was removed
+## [0.8.38] - 2026-06-05
+
+### Highlights
+
+- **Generic `tool_search` capability** - Provider-agnostic deferred tool loading now works on any model (Anthropic, Gemini, and others); MCP server tools are first-class `ToolRegistry` tools across all hosts via `McpProxyTool`/`McpToolInvoker`, so `tool_search`, `openai_tool_search`, and `spawn_background` work transparently with MCP tools ([#2050](https://github.com/everruns/everruns/pull/2050)).
+- **Pre-tool-use hook seam** - New `pre_tool_use_hooks` capability seam enables fine-grained tool gating before execution ([#2048](https://github.com/everruns/everruns/pull/2048)).
+
+### What's Changed
+
+- fix(core): emit tool calls when finish chunk carries empty content (EVE-522) ([#2052](https://github.com/everruns/everruns/pull/2052)) by [@chaliy](https://github.com/chaliy)
+- fix(core): replay full transcript on stateless Responses gateways ([#2051](https://github.com/everruns/everruns/pull/2051)) by [@chaliy](https://github.com/chaliy)
+- feat: generic tool_search + first-class MCP tools across all hosts ([#2050](https://github.com/everruns/everruns/pull/2050)) by [@chaliy](https://github.com/chaliy)
+- fix(llm): gate tool_search off on gpt-5.5 family (EVE-521) ([#2049](https://github.com/everruns/everruns/pull/2049)) by [@chaliy](https://github.com/chaliy)
+- feat(capabilities): add pre_tool_use_hooks seam for tool gating ([#2048](https://github.com/everruns/everruns/pull/2048)) by [@chaliy](https://github.com/chaliy)
+- refactor(payments): move Parallel paid capability out of core ([#2047](https://github.com/everruns/everruns/pull/2047)) by [@chaliy](https://github.com/chaliy)
 
 ## [0.8.37] - 2026-06-03
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,9 +307,9 @@ dependencies = [
 
 [[package]]
 name = "async-nats"
-version = "0.49.0"
+version = "0.49.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "407486109ea5cfdf53fde05f46996dadf0547518a4d49f050d25f405ae31ed2d"
+checksum = "fad3cd6df81292728e2a8cb1f1dcb4d7e7a1ab59b80c14fbbcba2baf9d5cf86a"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -869,9 +869,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -1977,11 +1977,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-a2ui"
-version = "0.8.37"
+version = "0.8.38"
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.8.37"
+version = "0.8.38"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1997,7 +1997,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-cli"
-version = "0.8.37"
+version = "0.8.38"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2051,14 +2051,14 @@ dependencies = [
 
 [[package]]
 name = "everruns-config"
-version = "0.8.37"
+version = "0.8.38"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "everruns-container-sandbox"
-version = "0.8.37"
+version = "0.8.38"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2078,7 +2078,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.8.37"
+version = "0.8.38"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -2130,7 +2130,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-durable"
-version = "0.8.37"
+version = "0.8.38"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2155,7 +2155,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-gemini"
-version = "0.8.37"
+version = "0.8.38"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2169,7 +2169,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-brave-search"
-version = "0.8.37"
+version = "0.8.38"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2185,7 +2185,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-browserless"
-version = "0.8.37"
+version = "0.8.38"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2206,7 +2206,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-cursor"
-version = "0.8.37"
+version = "0.8.38"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2221,7 +2221,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.8.37"
+version = "0.8.38"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2238,7 +2238,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-deno"
-version = "0.8.37"
+version = "0.8.38"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2261,7 +2261,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-docker"
-version = "0.8.37"
+version = "0.8.38"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2276,7 +2276,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.8.37"
+version = "0.8.38"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2291,7 +2291,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-e2b"
-version = "0.8.37"
+version = "0.8.38"
 dependencies = [
  "async-trait",
  "buffa",
@@ -2318,7 +2318,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-github"
-version = "0.8.37"
+version = "0.8.38"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2335,7 +2335,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-parallel"
-version = "0.8.37"
+version = "0.8.38"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2348,7 +2348,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-sprites"
-version = "0.8.37"
+version = "0.8.38"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2364,7 +2364,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-internal-protocol"
-version = "0.8.37"
+version = "0.8.38"
 dependencies = [
  "chrono",
  "everruns-core",
@@ -2381,7 +2381,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-llm-tests"
-version = "0.8.37"
+version = "0.8.38"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2400,7 +2400,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-macros"
-version = "0.8.37"
+version = "0.8.38"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -2408,7 +2408,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-mcp"
-version = "0.8.37"
+version = "0.8.38"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2422,7 +2422,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.8.37"
+version = "0.8.38"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2442,11 +2442,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-openui"
-version = "0.8.37"
+version = "0.8.38"
 
 [[package]]
 name = "everruns-runtime"
-version = "0.8.37"
+version = "0.8.38"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2484,7 +2484,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-server"
-version = "0.8.37"
+version = "0.8.38"
 dependencies = [
  "aes-gcm",
  "ag-ui-core",
@@ -2573,7 +2573,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-session-sqldb"
-version = "0.8.37"
+version = "0.8.38"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2590,7 +2590,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-worker"
-version = "0.8.37"
+version = "0.8.38"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4286,9 +4286,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.31"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "113b30b4cd05f7c06868fdb2854f66a7b9fece9a48425351cd532e810d74024f"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "logos"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.8.37"
+version = "0.8.38"
 edition = "2024"
 # Published crate MSRV: Rust 2024 plus current published dependency floors.
 rust-version = "1.94.0"
@@ -135,8 +135,8 @@ futures-util = "0.3"
 
 # Everruns SDK
 everruns-sdk = "0.1.9"
-everruns-core = { path = "crates/core", version = "0.8.37" }
-everruns-mcp = { path = "crates/mcp", version = "0.8.37" }
+everruns-core = { path = "crates/core", version = "0.8.38" }
+everruns-mcp = { path = "crates/mcp", version = "0.8.38" }
 
 # A2A protocol
 a2a = { package = "a2a-lf", version = "0.3" }

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "everruns-ui",
-  "version": "0.8.37",
+  "version": "0.8.38",
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "exports": {

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -20,7 +20,7 @@ readme = "README.md"
 
 [dependencies]
 # Core dependencies
-everruns-config = { path = "../config", version = "0.8.37" }
+everruns-config = { path = "../config", version = "0.8.38" }
 anyhow.workspace = true
 thiserror.workspace = true
 async-trait.workspace = true
@@ -102,10 +102,10 @@ inventory.workspace = true
 llmsim = "0.4.0"
 
 # OpenUI component definitions and prompt generator
-everruns-openui = { path = "../openui", version = "0.8.37", optional = true }
+everruns-openui = { path = "../openui", version = "0.8.38", optional = true }
 
 # A2UI component catalog and prompt generator
-everruns-a2ui = { path = "../a2ui", version = "0.8.37", optional = true }
+everruns-a2ui = { path = "../a2ui", version = "0.8.38", optional = true }
 
 # A2A outbound agent delegation
 a2a.workspace = true


### PR DESCRIPTION
## What
Release preparation for v0.8.38.

## Why
Ship 6 commits accumulated since v0.8.37, including generic `tool_search` capability, first-class MCP tools across all hosts, pre-tool-use hook seam, and core fix/replay fixes.

## How
- Bumped `Cargo.toml` workspace version 0.8.37 → 0.8.38 (including `everruns-core` and `everruns-mcp` path deps)
- Bumped `apps/ui/package.json` version 0.8.37 → 0.8.38
- Updated `CHANGELOG.md`: moved Unreleased → [0.8.38] with full What's Changed list and Highlights
- Ran `scripts/sync-publish-pin-versions.py --write` to sync `crates/core/Cargo.toml` path-dep pins
- Regenerated `Cargo.lock` via `cargo generate-lockfile`
- Regenerated `apps/ui/pnpm-lock.yaml` and `apps/docs/pnpm-lock.yaml` via `pnpm install --lockfile-only`

Migration ordering check: sequential 001..047, no issues.

Integration live sweep last ran 2026-06-01 with success. Main CI green on `dabd1b5`.

## Risk
- Low — version bump and changelog only; no logic changes.

## Security
- No security-relevant code changes in this PR.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated — N/A (version bump only)
- [x] Backward compatibility considered — N/A
- [x] Security review performed — no code changes
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed

---
_Generated by [Claude Code](https://claude.ai/code/session_01GtP3oygDdPNxTCCj876aaS)_