### PR TITLE
fix(coding-cli): ignore workspace stdio MCP config

### DIFF
--- a/examples/coding-cli/src/mcp_config.rs
+++ b/examples/coding-cli/src/mcp_config.rs
@@ -11,14 +11,14 @@
 //! }
 //! ```
 //!
-//! Missing file → no servers. Both remote HTTP and local stdio
-//! (`{ "type": "stdio", "command": ..., "args": [...] }`) servers are
-//! supported; the CLI builds with the runtime's `mcp-stdio` feature.
+//! Missing file → no servers. Workspace-controlled local stdio servers are
+//! ignored because discovering them would spawn repository-provided commands
+//! before the user can approve them.
 
 use std::path::Path;
 
 use anyhow::{Context, Result};
-use everruns_core::ScopedMcpServers;
+use everruns_core::{McpServerTransportType, ScopedMcpServers};
 use serde::Deserialize;
 
 /// File name read from the workspace root.
@@ -44,16 +44,29 @@ pub fn load_mcp_servers(workspace_root: &Path) -> Result<ScopedMcpServers> {
         }
     };
 
-    let config: McpConfigFile =
+    let mut config: McpConfigFile =
         serde_json::from_str(&raw).with_context(|| format!("parsing {}", path.display()))?;
+    // `.mcp.json` is workspace-controlled input. Stdio MCP discovery executes
+    // the configured command during turn-context loading, before the CLI can
+    // ask for approval, so only non-executing transports are accepted here.
+    config.mcp_servers.retain(|name, server| {
+        if server.transport_type == McpServerTransportType::Stdio {
+            tracing::warn!(
+                server = %name,
+                file = %path.display(),
+                "ignoring workspace stdio MCP server: local process execution from .mcp.json is not trusted"
+            );
+            false
+        } else {
+            true
+        }
+    });
     Ok(config.mcp_servers)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use everruns_core::McpServerTransportType;
-
     fn write(dir: &Path, contents: &str) {
         std::fs::write(dir.join(MCP_CONFIG_FILE), contents).unwrap();
     }
@@ -114,7 +127,7 @@ mod tests {
     }
 
     #[test]
-    fn parses_stdio_server() {
+    fn ignores_stdio_server() {
         let dir = tempfile::tempdir().unwrap();
         write(
             dir.path(),
@@ -129,10 +142,6 @@ mod tests {
         );
 
         let servers = load_mcp_servers(dir.path()).unwrap();
-        let fs = servers.get("fs").expect("fs server");
-        assert_eq!(fs.transport_type, McpServerTransportType::Stdio);
-        assert_eq!(fs.command.as_deref(), Some("mcp-server-filesystem"));
-        assert_eq!(fs.args, vec!["/work".to_string()]);
-        assert_eq!(fs.env.get("RUST_LOG").map(String::as_str), Some("info"));
+        assert!(servers.is_empty());
     }
 }

--- a/examples/coding-cli/src/mcp_config.rs
+++ b/examples/coding-cli/src/mcp_config.rs
@@ -18,7 +18,7 @@
 use std::path::Path;
 
 use anyhow::{Context, Result};
-use everruns_core::{McpServerTransportType, ScopedMcpServers};
+use everruns_core::ScopedMcpServers;
 use serde::Deserialize;
 
 /// File name read from the workspace root.
@@ -50,7 +50,7 @@ pub fn load_mcp_servers(workspace_root: &Path) -> Result<ScopedMcpServers> {
     // the configured command during turn-context loading, before the CLI can
     // ask for approval, so only non-executing transports are accepted here.
     config.mcp_servers.retain(|name, server| {
-        if server.transport_type == McpServerTransportType::Stdio {
+        if server.transport_type.is_local() {
             tracing::warn!(
                 server = %name,
                 file = %path.display(),
@@ -67,6 +67,8 @@ pub fn load_mcp_servers(workspace_root: &Path) -> Result<ScopedMcpServers> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use everruns_core::McpServerTransportType;
+
     fn write(dir: &Path, contents: &str) {
         std::fs::write(dir.join(MCP_CONFIG_FILE), contents).unwrap();
     }


### PR DESCRIPTION
### Motivation
- Prevent repository-controlled `.mcp.json` from causing local process execution during MCP discovery by treating workspace stdio MCP servers as untrusted input.

### Description
- Change `examples/coding-cli/src/mcp_config.rs` so `load_mcp_servers` retains only non-executing transports (filters out `McpServerTransportType::Stdio`), emits a warning when ignoring stdio entries, and keeps HTTP MCP loading unchanged; update tests to assert workspace stdio entries are ignored.

### Testing
- Ran `cargo fmt --check -p everruns-coding-cli` and `cargo test -p everruns-coding-cli mcp_config -- --nocapture`, and the targeted unit tests passed (`5 passed`); `just pre-push` was executed and all local checks passed except the migration immutability check which failed only because the local checkout has no configured `origin/main` base ref (no migrations were changed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a205f9ac1f4832b898bfc35ef0b1569)