### PR TITLE
feat(models): add profiles and vendor icons for latest flagship models

### DIFF
--- a/apps/ui/src/__tests__/model-icon.test.tsx
+++ b/apps/ui/src/__tests__/model-icon.test.tsx
@@ -1,0 +1,45 @@
+import { render } from "@testing-library/react";
+import { ModelIcon } from "@/components/models/model-icon";
+import type { LlmModelWithProvider } from "@/lib/api/types";
+
+function model(
+  model_id: string,
+  family: string | undefined,
+  provider_type: LlmModelWithProvider["provider_type"] = "openai_completions",
+) {
+  return { model_id, provider_type, profile: family ? { family } : null };
+}
+
+describe("ModelIcon vendor selection", () => {
+  it("renders a per-vendor icon for OpenAI-compatible third-party models", () => {
+    const cases: Array<[ReturnType<typeof model>, string]> = [
+      [model("nemotron-3-super-120b-a12b", "nemotron-3-super"), "NVIDIA"],
+      [model("nvidia/nemotron-3-super-120b-a12b", undefined), "NVIDIA"],
+      [model("qwen/qwen3.7-max", "qwen3.7-max"), "Qwen"],
+      [model("MiniMax-M3", "minimax-m3"), "MiniMax"],
+      [model("kimi-k2-thinking", "kimi-k2-thinking"), "Moonshot"],
+      [model("x-ai/grok-4.3", "grok-4.3"), "xAI"],
+      [model("microsoft/MAI-1-preview", "mai-1-preview"), "Microsoft"],
+    ];
+    for (const [m, label] of cases) {
+      const { getByTitle, unmount } = render(<ModelIcon model={m} />);
+      expect(getByTitle(label)).toBeInTheDocument();
+      unmount();
+    }
+  });
+
+  it("falls back to the provider icon when no vendor is recognized", () => {
+    // Claude Opus 4.8 and Gemini map to their first-party provider icons.
+    const opus = render(
+      <ModelIcon model={model("claude-opus-4-8", "claude-opus-4-8", "anthropic")} />,
+    );
+    expect(opus.getByTitle("Anthropic")).toBeInTheDocument();
+    opus.unmount();
+
+    const gemini = render(
+      <ModelIcon model={model("gemini-3.1-pro-preview", "gemini-3.1-pro-preview", "gemini")} />,
+    );
+    expect(gemini.getByTitle("Google Gemini")).toBeInTheDocument();
+    gemini.unmount();
+  });
+});

--- a/apps/ui/src/components/models/model-icon.tsx
+++ b/apps/ui/src/components/models/model-icon.tsx
@@ -1,0 +1,179 @@
+import type { LlmModelWithProvider } from "@/lib/api/types";
+import { ProviderIcon } from "@/components/providers/provider-icon";
+import { cn } from "@/lib/utils";
+
+// Per-model vendor icons.
+//
+// Provider icons are keyed by provider *type*, but many notable models are
+// served over the generic OpenAI-compatible Completions API (NVIDIA Nemotron,
+// Qwen, MiniMax, Kimi, Grok, Microsoft MAI, ...). For those the provider icon
+// alone would render an OpenAI mark, so we additionally key an icon off the
+// model itself (profile family + wire id) and fall back to the provider icon
+// when no vendor is recognized.
+
+function NvidiaIcon({ size }: { size: number }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      width={size}
+      height={size}
+      fill="currentColor"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path d="M8.948 8.798v-1.43a6.7 6.7 0 0 1 .424-.018c3.922-.124 6.493 3.374 6.493 3.374s-2.774 3.851-5.75 3.851c-.398 0-.787-.062-1.158-.185v-4.346c1.528.185 1.837.857 2.747 2.385l2.04-1.714s-1.492-1.952-4-1.952a6.016 6.016 0 0 0-.796.035m0-4.735v2.138l.424-.027c5.45-.185 9.01 4.47 9.01 4.47s-4.08 4.964-8.33 4.964c-.37 0-.733-.035-1.095-.097v1.325c.3.035.61.062.91.062 3.957 0 6.82-2.023 9.593-4.408.459.371 2.34 1.263 2.73 1.652-2.633 2.208-8.772 3.984-12.253 3.984-.335 0-.653-.018-.971-.053v1.864H24V4.063zm0 10.326v1.131c-3.657-.654-4.673-4.46-4.673-4.46s1.758-1.944 4.673-2.262v1.237H8.94c-1.528-.186-2.73 1.245-2.73 1.245s.68 2.412 2.739 3.11M2.456 10.9s2.164-3.197 6.5-3.533V6.201C4.153 6.59 0 10.653 0 10.653s2.35 6.802 8.948 7.42v-1.237c-4.84-.6-6.492-5.936-6.492-5.936z" />
+    </svg>
+  );
+}
+
+function QwenIcon({ size }: { size: number }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      width={size}
+      height={size}
+      fill="currentColor"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path d="M23.919 14.545 20.817 9.17l1.47-2.544a.56.56 0 0 0 0-.566l-1.633-2.83a.57.57 0 0 0-.49-.283h-6.207L12.487.402a.57.57 0 0 0-.49-.284H8.732a.56.56 0 0 0-.49.284L5.139 5.775h-2.94a.56.56 0 0 0-.49.284L.077 8.887a.56.56 0 0 0 0 .567L3.18 14.83l-1.47 2.545a.56.56 0 0 0 0 .566l1.634 2.83a.57.57 0 0 0 .49.283h6.205l1.47 2.545a.57.57 0 0 0 .49.284h3.266a.57.57 0 0 0 .49-.284l3.104-5.375h2.94a.57.57 0 0 0 .49-.283l1.634-2.828a.55.55 0 0 0-.004-.568M8.733.686l1.634 2.828-1.634 2.828H21.8L20.164 9.17H7.425L5.63 6.06Zm1.306 19.801-6.205-.002 1.634-2.83h3.265L2.201 6.344h3.267q3.182 5.517 6.367 11.032zm10.124-5.66L18.53 12l-6.532 11.315-1.634-2.83c2.129-3.673 4.25-7.351 6.373-11.028h3.592l3.102 5.374z" />
+    </svg>
+  );
+}
+
+function XaiIcon({ size }: { size: number }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      width={size}
+      height={size}
+      fill="currentColor"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path d="M14.234 10.162 22.977 0h-2.072l-7.591 8.824L7.251 0H.258l9.168 13.343L.258 24H2.33l8.016-9.318L16.749 24h6.993zm-2.837 3.299-.929-1.329L3.076 1.56h3.182l5.965 8.532.929 1.329 7.754 11.09h-3.182z" />
+    </svg>
+  );
+}
+
+function MicrosoftIcon({ size }: { size: number }) {
+  // Microsoft's four-square mark, rendered monochrome with a gap.
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      width={size}
+      height={size}
+      fill="currentColor"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path d="M2 2h9.2v9.2H2zM12.8 2H22v9.2h-9.2zM2 12.8h9.2V22H2zM12.8 12.8H22V22h-9.2z" />
+    </svg>
+  );
+}
+
+function MiniMaxIcon({ size }: { size: number }) {
+  // Lettermark "M" — MiniMax has no published monochrome glyph icon.
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      width={size}
+      height={size}
+      fill="currentColor"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path d="M3 20V4h3.2l5.8 8 5.8-8H21v16h-3.3V9.4L12 17.2 6.3 9.4V20z" />
+    </svg>
+  );
+}
+
+function MoonshotIcon({ size }: { size: number }) {
+  // Crescent moon for Moonshot AI (Kimi).
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      width={size}
+      height={size}
+      fill="currentColor"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+    </svg>
+  );
+}
+
+interface VendorIcon {
+  label: string;
+  Component: React.ComponentType<{ size: number }>;
+}
+
+// Recognize a vendor from the model's family / wire id. Substrings are checked
+// against the lowercased "<family> <model_id>" so both `qwen3.7-max` and an
+// OpenRouter-style `qwen/qwen3.7-max` resolve.
+function vendorForModel(model: ModelLike): VendorIcon | null {
+  const key = `${model.profile?.family ?? ""} ${model.model_id}`.toLowerCase();
+  if (key.includes("nemotron") || key.includes("nvidia")) {
+    return { label: "NVIDIA", Component: NvidiaIcon };
+  }
+  if (key.includes("qwen")) {
+    return { label: "Qwen", Component: QwenIcon };
+  }
+  if (key.includes("minimax")) {
+    return { label: "MiniMax", Component: MiniMaxIcon };
+  }
+  if (key.includes("kimi") || key.includes("moonshot")) {
+    return { label: "Moonshot", Component: MoonshotIcon };
+  }
+  if (key.includes("grok") || key.includes("x-ai") || key.includes("xai")) {
+    return { label: "xAI", Component: XaiIcon };
+  }
+  if (key.includes("mai-1") || key.includes("microsoft")) {
+    return { label: "Microsoft", Component: MicrosoftIcon };
+  }
+  return null;
+}
+
+const sizeMap = {
+  sm: { icon: 16, container: "p-1.5" },
+  md: { icon: 20, container: "p-2" },
+  lg: { icon: 24, container: "p-2.5" },
+};
+
+type ModelLike = Pick<LlmModelWithProvider, "provider_type" | "model_id"> & {
+  profile?: { family?: string } | null;
+};
+
+interface ModelIconProps {
+  model: ModelLike;
+  size?: "sm" | "md" | "lg";
+  className?: string;
+  showBackground?: boolean;
+}
+
+/**
+ * Icon for a specific model. Prefers a per-vendor brand icon derived from the
+ * model family/id (for OpenAI-compatible third-party models), falling back to
+ * the provider-type icon (OpenAI, Anthropic, Gemini, ...).
+ */
+export function ModelIcon({
+  model,
+  size = "md",
+  className,
+  showBackground = true,
+}: ModelIconProps) {
+  const vendor = vendorForModel(model);
+  if (!vendor) {
+    return (
+      <ProviderIcon
+        providerType={model.provider_type}
+        size={size}
+        className={className}
+        showBackground={showBackground}
+      />
+    );
+  }
+
+  const { icon: iconSize, container } = sizeMap[size];
+  const { label, Component } = vendor;
+  return (
+    <div className={cn(showBackground && "bg-primary/10", container, className)} title={label}>
+      <Component size={iconSize} />
+    </div>
+  );
+}

--- a/apps/ui/src/components/models/model-picker.tsx
+++ b/apps/ui/src/components/models/model-picker.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Star } from "lucide-react";
-import { ProviderIcon } from "@/components/providers/provider-icon";
+import { ModelIcon } from "@/components/models/model-icon";
 import {
   Select,
   SelectContent,
@@ -80,11 +80,7 @@ export function ModelPicker({
             if (!selectedModel) return placeholder;
             return (
               <div className="flex items-center gap-2">
-                <ProviderIcon
-                  providerType={selectedModel.provider_type}
-                  size="sm"
-                  showBackground={false}
-                />
+                <ModelIcon model={selectedModel} size="sm" showBackground={false} />
                 <span>
                   {selectedModel.display_name} ({selectedModel.provider_name})
                 </span>
@@ -132,7 +128,7 @@ function ModelSelectItem({ model, showFavoriteToggle }: ModelSelectItemProps) {
   return (
     <SelectItem value={model.id}>
       <div className="flex items-center gap-2 w-full">
-        <ProviderIcon providerType={model.provider_type} size="sm" showBackground={false} />
+        <ModelIcon model={model} size="sm" showBackground={false} />
         <span className="flex-1">
           {model.display_name} ({model.provider_name})
         </span>

--- a/apps/ui/src/components/models/model-row.tsx
+++ b/apps/ui/src/components/models/model-row.tsx
@@ -18,7 +18,7 @@ import {
   ToggleRight,
   Trash2,
 } from "lucide-react";
-import { ProviderIcon } from "@/components/providers/provider-icon";
+import { ModelIcon } from "@/components/models/model-icon";
 import { EditModelDialog } from "@/components/models/edit-model-dialog";
 import { formatTokens } from "@/lib/formatting";
 import type { LlmModelWithProvider, LlmProvider, UpdateLlmModelRequest } from "@/lib/api/types";
@@ -81,8 +81,8 @@ export function ModelRow({
     <div className="border overflow-hidden">
       <div className="flex items-center justify-between p-3">
         <div className="flex items-center gap-3">
-          <ProviderIcon
-            providerType={model.provider_type}
+          <ModelIcon
+            model={model}
             size="sm"
             showBackground={false}
             className="text-muted-foreground"

--- a/crates/core/src/llm_model_profiles.rs
+++ b/crates/core/src/llm_model_profiles.rs
@@ -170,9 +170,14 @@ pub fn get_model_profile(
     model_id: &str,
 ) -> Option<LlmModelProfile> {
     match provider_type {
-        LlmProviderType::Openai
-        | LlmProviderType::AzureOpenai
-        | LlmProviderType::OpenaiCompletions => get_openai_profile(model_id),
+        // Open Responses (`openai`) and Azure only serve genuine OpenAI models.
+        LlmProviderType::Openai | LlmProviderType::AzureOpenai => get_openai_profile(model_id),
+        // The generic Chat Completions path additionally hosts third-party,
+        // OpenAI-compatible models (NVIDIA NIM, Alibaba, MiniMax, Moonshot, xAI,
+        // ...), so fall back to their profiles only here.
+        LlmProviderType::OpenaiCompletions => {
+            get_openai_profile(model_id).or_else(|| get_openai_compatible_profile(model_id))
+        }
         LlmProviderType::Anthropic => get_anthropic_profile(model_id),
         LlmProviderType::Gemini => get_gemini_profile(model_id),
         LlmProviderType::LlmSim => get_llmsim_profile(model_id),
@@ -1501,25 +1506,25 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
             supports_phases: false,
         }),
 
-        // Fall through to third-party models served over the OpenAI-compatible
-        // Chat Completions API (NVIDIA NIM, Alibaba, MiniMax, Moonshot, xAI, etc.).
-        _ => get_openai_compatible_profile(base_id),
+        _ => None,
     }
 }
 
 /// Profiles for non-OpenAI models exposed through the OpenAI-compatible
-/// Chat Completions API (`openai_completions` provider type). Sourced from
-/// models.dev unless noted otherwise.
+/// Chat Completions API. Reached only for the `openai_completions` provider
+/// type (see `get_model_profile`) — Open Responses / Azure do not serve these
+/// models, so they must not resolve there. Sourced from models.dev unless
+/// noted otherwise.
 ///
-/// Each arm accepts both the bare provider id and common vendor-prefixed
-/// aliases (OpenRouter style) so the profile resolves regardless of how the
-/// user registered the model id.
+/// Matching is case-insensitive and each arm accepts both the bare provider id
+/// and common vendor-prefixed aliases (OpenRouter style), so the profile
+/// resolves regardless of how the user registered the model id.
 ///
 /// `structured_output` is set to `false` where the upstream models.dev entry
 /// does not assert it: absence of the field is not a claim of support, so we
 /// do not advertise a capability we cannot confirm.
 fn get_openai_compatible_profile(model_id: &str) -> Option<LlmModelProfile> {
-    match model_id {
+    match model_id.to_ascii_lowercase().as_str() {
         // NVIDIA Nemotron 3 Super — flagship Nemotron reasoning model.
         // Source: models.dev (nvidia provider).
         "nemotron-3-super-120b-a12b" | "nvidia/nemotron-3-super-120b-a12b" => {
@@ -1600,7 +1605,7 @@ fn get_openai_compatible_profile(model_id: &str) -> Option<LlmModelProfile> {
         // text-only instruction model (not a reasoning model); context window,
         // pricing, and knowledge cutoff were never publicly disclosed, so cost
         // and limits are left unset rather than guessed.
-        "MAI-1-preview" | "mai-1-preview" | "microsoft/MAI-1-preview" => Some(LlmModelProfile {
+        "mai-1-preview" | "microsoft/mai-1-preview" => Some(LlmModelProfile {
             name: "MAI-1-preview".into(),
             family: "mai-1-preview".into(),
             description: None,
@@ -1626,7 +1631,7 @@ fn get_openai_compatible_profile(model_id: &str) -> Option<LlmModelProfile> {
 
         // MiniMax-M3 — flagship MiniMax model. Source: models.dev (minimax
         // provider). Reasoning is a toggle upstream (no graded effort).
-        "MiniMax-M3" | "minimax/MiniMax-M3" => Some(LlmModelProfile {
+        "minimax-m3" | "minimax/minimax-m3" => Some(LlmModelProfile {
             name: "MiniMax-M3".into(),
             family: "minimax-m3".into(),
             description: None,
@@ -3709,5 +3714,48 @@ mod tests {
     fn test_third_party_unknown_still_none() {
         let profile = get_model_profile(&LlmProviderType::OpenaiCompletions, "totally-made-up");
         assert!(profile.is_none());
+    }
+
+    #[test]
+    fn test_third_party_models_not_resolved_under_openai_or_azure() {
+        // The Chat-Completions-only third-party models must not appear as
+        // supported under the Open Responses (`openai`) or Azure providers,
+        // which only serve genuine OpenAI models.
+        for id in [
+            "qwen3.7-max",
+            "MiniMax-M3",
+            "grok-4.3",
+            "nemotron-3-super-120b-a12b",
+        ] {
+            assert!(
+                get_model_profile(&LlmProviderType::Openai, id).is_none(),
+                "{id} should not resolve under openai (Open Responses)"
+            );
+            assert!(
+                get_model_profile(&LlmProviderType::AzureOpenai, id).is_none(),
+                "{id} should not resolve under azure_openai"
+            );
+        }
+        // Genuine OpenAI models still resolve under all OpenAI-family types.
+        assert!(get_model_profile(&LlmProviderType::Openai, "gpt-4o").is_some());
+        assert!(get_model_profile(&LlmProviderType::AzureOpenai, "gpt-4o").is_some());
+    }
+
+    #[test]
+    fn test_third_party_alias_matching_is_case_insensitive() {
+        // Lowercased and vendor-prefixed variants all resolve to the same model.
+        let cases = [
+            ("minimax-m3", "MiniMax-M3"),
+            ("minimax/minimax-m3", "MiniMax-M3"),
+            ("MiniMax-M3", "MiniMax-M3"),
+            ("microsoft/mai-1-preview", "MAI-1-preview"),
+            ("MAI-1-PREVIEW", "MAI-1-preview"),
+            ("X-AI/Grok-4.3", "Grok 4.3"),
+        ];
+        for (id, name) in cases {
+            let profile = get_model_profile(&LlmProviderType::OpenaiCompletions, id)
+                .unwrap_or_else(|| panic!("missing profile for {id}"));
+            assert_eq!(profile.name, name, "wrong profile for {id}");
+        }
     }
 }

--- a/crates/core/src/llm_model_profiles.rs
+++ b/crates/core/src/llm_model_profiles.rs
@@ -1501,6 +1501,242 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
             supports_phases: false,
         }),
 
+        // Fall through to third-party models served over the OpenAI-compatible
+        // Chat Completions API (NVIDIA NIM, Alibaba, MiniMax, Moonshot, xAI, etc.).
+        _ => get_openai_compatible_profile(base_id),
+    }
+}
+
+/// Profiles for non-OpenAI models exposed through the OpenAI-compatible
+/// Chat Completions API (`openai_completions` provider type). Sourced from
+/// models.dev unless noted otherwise.
+///
+/// Each arm accepts both the bare provider id and common vendor-prefixed
+/// aliases (OpenRouter style) so the profile resolves regardless of how the
+/// user registered the model id.
+///
+/// `structured_output` is set to `false` where the upstream models.dev entry
+/// does not assert it: absence of the field is not a claim of support, so we
+/// do not advertise a capability we cannot confirm.
+fn get_openai_compatible_profile(model_id: &str) -> Option<LlmModelProfile> {
+    match model_id {
+        // NVIDIA Nemotron 3 Super — flagship Nemotron reasoning model.
+        // Source: models.dev (nvidia provider).
+        "nemotron-3-super-120b-a12b" | "nvidia/nemotron-3-super-120b-a12b" => {
+            Some(LlmModelProfile {
+                name: "Nemotron 3 Super".into(),
+                family: "nemotron-3-super".into(),
+                description: None,
+                release_date: Some("2026-03-11".into()),
+                last_updated: Some("2026-03-11".into()),
+                attachment: false,
+                reasoning: true,
+                temperature: true,
+                knowledge: Some("2024-04-01".into()),
+                tool_call: true,
+                structured_output: false,
+                open_weights: true,
+                cost: Some(LlmModelCost {
+                    input: 0.20,
+                    output: 0.80,
+                    cache_read: None,
+                    cost_tiers: vec![],
+                }),
+                limits: Some(LlmModelLimits {
+                    context: 262_144,
+                    input: None,
+                    output: 262_144,
+                    max_media: None,
+                }),
+                modalities: Some(LlmModelModalities {
+                    input: vec![Modality::Text],
+                    output: vec![Modality::Text],
+                }),
+                reasoning_effort: None,
+                tool_search: false,
+                supports_phases: false,
+            })
+        }
+
+        // Alibaba Qwen3.7 Max — flagship Qwen model.
+        // Source: models.dev (alibaba provider). Knowledge cutoff not published.
+        "qwen3.7-max" | "qwen/qwen3.7-max" => Some(LlmModelProfile {
+            name: "Qwen3.7 Max".into(),
+            family: "qwen3.7-max".into(),
+            description: None,
+            release_date: Some("2026-05-21".into()),
+            last_updated: Some("2026-05-21".into()),
+            attachment: false,
+            reasoning: true,
+            temperature: true,
+            knowledge: None,
+            tool_call: true,
+            structured_output: false,
+            open_weights: false,
+            cost: Some(LlmModelCost {
+                input: 2.50,
+                output: 7.50,
+                cache_read: Some(0.50),
+                cost_tiers: vec![],
+            }),
+            limits: Some(LlmModelLimits {
+                context: 1_000_000,
+                input: None,
+                output: 65_536,
+                max_media: None,
+            }),
+            modalities: Some(LlmModelModalities {
+                input: vec![Modality::Text],
+                output: vec![Modality::Text],
+            }),
+            reasoning_effort: None,
+            tool_search: false,
+            supports_phases: false,
+        }),
+
+        // Microsoft MAI-1-preview — Microsoft's first end-to-end in-house
+        // foundation model. Not on models.dev; sourced from Microsoft's official
+        // announcement (microsoft.ai/news/two-new-in-house-models). It is a
+        // text-only instruction model (not a reasoning model); context window,
+        // pricing, and knowledge cutoff were never publicly disclosed, so cost
+        // and limits are left unset rather than guessed.
+        "MAI-1-preview" | "mai-1-preview" | "microsoft/MAI-1-preview" => Some(LlmModelProfile {
+            name: "MAI-1-preview".into(),
+            family: "mai-1-preview".into(),
+            description: None,
+            release_date: Some("2025-08-28".into()),
+            last_updated: None,
+            attachment: false,
+            reasoning: false,
+            temperature: true,
+            knowledge: None,
+            tool_call: false,
+            structured_output: false,
+            open_weights: false,
+            cost: None,
+            limits: None,
+            modalities: Some(LlmModelModalities {
+                input: vec![Modality::Text],
+                output: vec![Modality::Text],
+            }),
+            reasoning_effort: None,
+            tool_search: false,
+            supports_phases: false,
+        }),
+
+        // MiniMax-M3 — flagship MiniMax model. Source: models.dev (minimax
+        // provider). Reasoning is a toggle upstream (no graded effort).
+        "MiniMax-M3" | "minimax/MiniMax-M3" => Some(LlmModelProfile {
+            name: "MiniMax-M3".into(),
+            family: "minimax-m3".into(),
+            description: None,
+            release_date: Some("2026-06-01".into()),
+            last_updated: Some("2026-06-01".into()),
+            attachment: true,
+            reasoning: true,
+            temperature: true,
+            knowledge: None,
+            tool_call: true,
+            structured_output: false,
+            open_weights: true,
+            cost: Some(LlmModelCost {
+                input: 0.60,
+                output: 2.40,
+                cache_read: Some(0.12),
+                cost_tiers: vec![],
+            }),
+            limits: Some(LlmModelLimits {
+                context: 512_000,
+                input: None,
+                output: 128_000,
+                max_media: None,
+            }),
+            modalities: Some(LlmModelModalities {
+                input: vec![Modality::Text, Modality::Image, Modality::Video],
+                output: vec![Modality::Text],
+            }),
+            reasoning_effort: None,
+            tool_search: false,
+            supports_phases: false,
+        }),
+
+        // Moonshot Kimi K2 Thinking — flagship Kimi reasoning model.
+        // Source: models.dev (moonshotai provider).
+        "kimi-k2-thinking" | "moonshotai/kimi-k2-thinking" => Some(LlmModelProfile {
+            name: "Kimi K2 Thinking".into(),
+            family: "kimi-k2-thinking".into(),
+            description: None,
+            release_date: Some("2025-11-06".into()),
+            last_updated: Some("2025-11-06".into()),
+            attachment: false,
+            reasoning: true,
+            temperature: true,
+            knowledge: Some("2024-08-01".into()),
+            tool_call: true,
+            structured_output: false,
+            open_weights: true,
+            cost: Some(LlmModelCost {
+                input: 0.60,
+                output: 2.50,
+                cache_read: Some(0.15),
+                cost_tiers: vec![],
+            }),
+            limits: Some(LlmModelLimits {
+                context: 262_144,
+                input: None,
+                output: 262_144,
+                max_media: None,
+            }),
+            modalities: Some(LlmModelModalities {
+                input: vec![Modality::Text],
+                output: vec![Modality::Text],
+            }),
+            reasoning_effort: None,
+            tool_search: false,
+            supports_phases: false,
+        }),
+
+        // xAI Grok 4.3 — flagship Grok model. Source: models.dev (xai provider).
+        // Pricing has a >200K-token tier. Knowledge cutoff not published.
+        "grok-4.3" | "x-ai/grok-4.3" | "xai/grok-4.3" => Some(LlmModelProfile {
+            name: "Grok 4.3".into(),
+            family: "grok-4.3".into(),
+            description: None,
+            release_date: Some("2026-04-17".into()),
+            last_updated: Some("2026-04-17".into()),
+            attachment: true,
+            reasoning: true,
+            temperature: true,
+            knowledge: None,
+            tool_call: true,
+            structured_output: false,
+            open_weights: false,
+            cost: Some(LlmModelCost {
+                input: 1.25,
+                output: 2.50,
+                cache_read: Some(0.20),
+                cost_tiers: vec![CostTier {
+                    above_tokens: 200_000,
+                    input: 2.50,
+                    output: 5.00,
+                    cache_read: Some(0.40),
+                }],
+            }),
+            limits: Some(LlmModelLimits {
+                context: 1_000_000,
+                input: None,
+                output: 30_000,
+                max_media: None,
+            }),
+            modalities: Some(LlmModelModalities {
+                input: vec![Modality::Text, Modality::Image, Modality::Pdf],
+                output: vec![Modality::Text],
+            }),
+            reasoning_effort: None,
+            tool_search: false,
+            supports_phases: false,
+        }),
+
         _ => None,
     }
 }
@@ -1510,7 +1746,47 @@ fn get_anthropic_profile(model_id: &str) -> Option<LlmModelProfile> {
     let base_id = normalize_anthropic_model_id(model_id);
 
     match base_id {
-        // Claude 4.7 series (newest)
+        // Claude 4.8 series (newest)
+        // Source: Anthropic model card (claude-api skill `shared/models.md`) and
+        // docs.claude.com — Opus 4.8 is not yet in models.dev. Same API surface as
+        // Opus 4.7: adaptive thinking only, sampling parameters removed (temperature
+        // returns 400, hence `temperature: false`). Release/knowledge dates are not
+        // published in the model card; the Models API exposes them at runtime.
+        "claude-opus-4-8" => Some(LlmModelProfile {
+            name: "Claude Opus 4.8".into(),
+            family: "claude-opus-4-8".into(),
+            description: None,
+            release_date: None,
+            last_updated: None,
+            attachment: true,
+            reasoning: true,
+            temperature: false,
+            knowledge: None,
+            tool_call: true,
+            structured_output: true,
+            open_weights: false,
+            cost: Some(LlmModelCost {
+                input: 5.00,
+                output: 25.00,
+                cache_read: Some(0.50),
+                cost_tiers: vec![],
+            }),
+            limits: Some(LlmModelLimits {
+                context: 1_000_000,
+                input: None,
+                output: 128_000,
+                max_media: None,
+            }),
+            modalities: Some(LlmModelModalities {
+                input: vec![Modality::Text, Modality::Image, Modality::Pdf],
+                output: vec![Modality::Text],
+            }),
+            reasoning_effort: Some(reasoning_effort_anthropic_adaptive_thinking()),
+            tool_search: false,
+            supports_phases: false,
+        }),
+
+        // Claude 4.7 series
         "claude-opus-4-7" => Some(LlmModelProfile {
             name: "Claude Opus 4.7".into(),
             family: "claude-opus-4-7".into(),
@@ -2035,6 +2311,7 @@ fn get_anthropic_profile(model_id: &str) -> Option<LlmModelProfile> {
 /// e.g., "gemini-2.5-pro-preview-05-06" -> "gemini-2.5-pro"
 fn normalize_gemini_model_id(model_id: &str) -> &str {
     let patterns = [
+        "gemini-3.1-pro-preview",
         "gemini-2.5-flash",
         "gemini-2.5-pro",
         "gemini-2.0-flash",
@@ -2059,6 +2336,56 @@ fn get_gemini_profile(model_id: &str) -> Option<LlmModelProfile> {
     let base_id = normalize_gemini_model_id(model_id);
 
     match base_id {
+        // Gemini 3.x series (newest). Source: models.dev (google provider).
+        // `gemini-3-pro-preview` is deprecated upstream; 3.1 Pro Preview is the
+        // current flagship Pro. Pricing has a >200K-token tier. Reasoning effort
+        // (low/medium/high) is offered upstream but, consistent with the other
+        // Gemini profiles here, effort selection is left unset.
+        "gemini-3.1-pro-preview" => Some(LlmModelProfile {
+            name: "Gemini 3.1 Pro Preview".into(),
+            family: "gemini-3.1-pro-preview".into(),
+            description: None,
+            release_date: Some("2026-02-19".into()),
+            last_updated: Some("2026-02-19".into()),
+            attachment: true,
+            reasoning: true,
+            temperature: true,
+            knowledge: Some("2025-01-01".into()),
+            tool_call: true,
+            structured_output: true,
+            open_weights: false,
+            cost: Some(LlmModelCost {
+                input: 2.00,
+                output: 12.00,
+                cache_read: Some(0.20),
+                cost_tiers: vec![CostTier {
+                    above_tokens: 200_000,
+                    input: 4.00,
+                    output: 18.00,
+                    cache_read: Some(0.40),
+                }],
+            }),
+            limits: Some(LlmModelLimits {
+                context: 1_048_576,
+                input: None,
+                output: 65_536,
+                max_media: None,
+            }),
+            modalities: Some(LlmModelModalities {
+                input: vec![
+                    Modality::Text,
+                    Modality::Image,
+                    Modality::Audio,
+                    Modality::Video,
+                    Modality::Pdf,
+                ],
+                output: vec![Modality::Text],
+            }),
+            reasoning_effort: None,
+            tool_search: false,
+            supports_phases: false,
+        }),
+
         "gemini-2.5-pro" => Some(LlmModelProfile {
             name: "Gemini 2.5 Pro".into(),
             family: "gemini-2.5-pro".into(),
@@ -2368,6 +2695,8 @@ fn normalize_model_id(model_id: &str) -> &str {
 fn normalize_anthropic_model_id(model_id: &str) -> &str {
     // Known base model patterns (order matters - more specific first)
     let patterns = [
+        // Claude 4.8
+        "claude-opus-4-8",
         // Claude 4.7 / 4.6
         "claude-opus-4-7",
         "claude-opus-4-6",
@@ -3301,6 +3630,84 @@ mod tests {
     #[test]
     fn test_gemini_unknown_model() {
         let profile = get_model_profile(&LlmProviderType::Gemini, "unknown-model");
+        assert!(profile.is_none());
+    }
+
+    // Newly added flagship model profiles
+
+    #[test]
+    fn test_claude_opus_4_8_profile() {
+        let profile = get_model_profile(&LlmProviderType::Anthropic, "claude-opus-4-8").unwrap();
+        assert_eq!(profile.name, "Claude Opus 4.8");
+        assert_eq!(profile.family, "claude-opus-4-8");
+        assert!(profile.reasoning);
+        // Opus 4.8 removed sampling parameters (temperature returns 400).
+        assert!(!profile.temperature);
+        assert_eq!(profile.limits.as_ref().unwrap().context, 1_000_000);
+        assert!(profile.reasoning_effort.is_some());
+    }
+
+    #[test]
+    fn test_gemini_3_1_pro_preview_profile() {
+        let profile =
+            get_model_profile(&LlmProviderType::Gemini, "gemini-3.1-pro-preview").unwrap();
+        assert_eq!(profile.name, "Gemini 3.1 Pro Preview");
+        assert!(profile.reasoning);
+        // >200K-token pricing tier.
+        let cost = profile.cost.as_ref().unwrap();
+        assert_eq!(cost.cost_tiers.len(), 1);
+        assert_eq!(cost.cost_tiers[0].above_tokens, 200_000);
+        assert_eq!(cost.cost_tiers[0].input, 4.00);
+    }
+
+    #[test]
+    fn test_gemini_3_1_pro_preview_normalizes_dated_suffix() {
+        let profile =
+            get_model_profile(&LlmProviderType::Gemini, "gemini-3.1-pro-preview-02-19").unwrap();
+        assert_eq!(profile.family, "gemini-3.1-pro-preview");
+    }
+
+    #[test]
+    fn test_third_party_profiles_via_openai_completions() {
+        // Bare ids and common vendor-prefixed aliases both resolve.
+        let cases = [
+            ("nemotron-3-super-120b-a12b", "Nemotron 3 Super"),
+            ("nvidia/nemotron-3-super-120b-a12b", "Nemotron 3 Super"),
+            ("qwen3.7-max", "Qwen3.7 Max"),
+            ("MAI-1-preview", "MAI-1-preview"),
+            ("MiniMax-M3", "MiniMax-M3"),
+            ("kimi-k2-thinking", "Kimi K2 Thinking"),
+            ("grok-4.3", "Grok 4.3"),
+            ("x-ai/grok-4.3", "Grok 4.3"),
+        ];
+        for (id, name) in cases {
+            let profile = get_model_profile(&LlmProviderType::OpenaiCompletions, id)
+                .unwrap_or_else(|| panic!("missing profile for {id}"));
+            assert_eq!(profile.name, name, "wrong profile for {id}");
+        }
+    }
+
+    #[test]
+    fn test_grok_4_3_has_context_tier() {
+        let profile = get_model_profile(&LlmProviderType::OpenaiCompletions, "grok-4.3").unwrap();
+        let cost = profile.cost.as_ref().unwrap();
+        assert_eq!(cost.cost_tiers.len(), 1);
+        assert_eq!(cost.cost_tiers[0].above_tokens, 200_000);
+    }
+
+    #[test]
+    fn test_mai_preview_has_no_cost_or_limits() {
+        // Microsoft never published pricing/limits for MAI-1-preview.
+        let profile =
+            get_model_profile(&LlmProviderType::OpenaiCompletions, "MAI-1-preview").unwrap();
+        assert!(profile.cost.is_none());
+        assert!(profile.limits.is_none());
+        assert!(!profile.reasoning);
+    }
+
+    #[test]
+    fn test_third_party_unknown_still_none() {
+        let profile = get_model_profile(&LlmProviderType::OpenaiCompletions, "totally-made-up");
         assert!(profile.is_none());
     }
 }


### PR DESCRIPTION
## What
Add `LlmModelProfile` entries for the current latest-flagship models, plus per-model vendor icons in the UI:

| Model | Wire id | Profile path |
|---|---|---|
| Claude Opus 4.8 | `claude-opus-4-8` | `get_anthropic_profile` |
| Gemini 3.1 Pro Preview | `gemini-3.1-pro-preview` | `get_gemini_profile` |
| NVIDIA Nemotron 3 Super | `nemotron-3-super-120b-a12b` | `openai_completions` fallback |
| Alibaba Qwen3.7 Max | `qwen3.7-max` | `openai_completions` fallback |
| Microsoft MAI-1-preview | `MAI-1-preview` | `openai_completions` fallback |
| MiniMax-M3 | `MiniMax-M3` | `openai_completions` fallback |
| Moonshot Kimi K2 Thinking | `kimi-k2-thinking` | `openai_completions` fallback |
| xAI Grok 4.3 | `grok-4.3` | `openai_completions` fallback |

One latest flagship per requested vendor — no older variants.

## Why
These models were requested as available profiles (capabilities, pricing, limits, modalities) so the model list/picker show accurate metadata and recognizable branding instead of a generic OpenAI mark.

## How
- **Profiles** (`crates/core/src/llm_model_profiles.rs`): Opus 4.8 added to the Anthropic match + normalizer; Gemini 3.1 Pro Preview added to the Gemini match + normalizer (incl. its >200K-token price tier). Third-party OpenAI-compatible models resolve through a new `get_openai_compatible_profile` fallback on the `openai_completions` path, accepting both bare ids and common vendor-prefixed aliases (e.g. `qwen/qwen3.7-max`, `x-ai/grok-4.3`).
- **Sourcing**: values taken from models.dev, or official provider docs where models.dev lacks the entry (Opus 4.8 from the Anthropic model card; MAI-1-preview from Microsoft's announcement) — noted in code comments. Unknown fields are left unset rather than guessed, per `specs/models.md`. Opus 4.8 sets `temperature: false` (sampling params removed, same surface as 4.7), matching the GPT-5.5 precedent.
- **Icons** (`apps/ui`): new `ModelIcon` picks a per-vendor brand icon (NVIDIA, Qwen, MiniMax, Moonshot, xAI, Microsoft) keyed off `profile.family`/`model_id`, falling back to the existing provider-type icon (so Opus → Anthropic, Gemini → Gemini). Wired into the model list and model picker.

## Risk
- Low. Additive, static model metadata + a pure presentational component. No API/schema/migration/auth changes. No seeding changes, so default behavior is unchanged until a matching model is configured.

## Security
- Threat categories reviewed: **No security-relevant code changes.** The profile additions are static hardcoded data returned by pure functions (no user input, no injection surface). `ModelIcon` renders hardcoded SVG constants (no `dangerouslySetInnerHTML`); `model_id`/`family` from the trusted backend are used only for substring matching, never rendered as HTML — no XSS (TM-WEB) surface.
- Findings and resolutions: none.

## Validation
- `cargo test -p everruns-core llm_model_profiles` — 68 pass (7 new: Opus 4.8, Gemini tier/normalization, all third-party ids+aliases, Grok tier, MAI sparse data, unknown-still-None).
- `cargo fmt --check` + `cargo clippy -p everruns-core` — clean.
- UI: `oxfmt --check`, `oxlint`, `tsc` (touched files), and a full `next build` — all clean.
- New `model-icon.test.tsx` (RTL) proves runtime vendor selection and provider fallback (2 pass). Smoke coverage is via unit/component tests + production build: these models are not seeded, so there is no default browser surface to exercise without manually configuring a provider.

## Follow-ups
- **MAI-1-preview**: Microsoft never published context/pricing, so `cost`/`limits` are unset; revisit when models.dev or Microsoft publish specs. Its successor `MAI-Thinking-1` also has no public specs yet.
- **Opus 4.8**: `release_date`/`knowledge` left unset — not published in the model card; the Anthropic Models API exposes them at runtime. Backfill when models.dev catches up.
- **Gemini 3.1 Pro Preview**: reasoning-effort selection left unset to match the existing Gemini profiles (the driver doesn't currently wire Gemini effort); enable alongside driver support.
- Third-party models are intentionally not seeded under any provider (per request scope); they resolve when added to a user-configured `openai_completions` provider.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

https://claude.ai/code/session_01FpWSqnjiTYi4MRYHMDwf6d

---
_Generated by [Claude Code](https://claude.ai/code/session_01FpWSqnjiTYi4MRYHMDwf6d)_