### PR TITLE
test(llm): verify auto_tool_search hosted round-trip on GPT-5.4

### DIFF
--- a/crates/llm-tests/tests/tool_search_test.rs
+++ b/crates/llm-tests/tests/tool_search_test.rs
@@ -17,9 +17,9 @@ mod llm_test_matrix;
 use llm_test_matrix::*;
 
 use everruns_core::capabilities::{
-    CurrentTimeCapability, FileSystemCapability, GenericToolSearchCapability,
-    OpenAiToolSearchCapability, SessionCapability, StatelessTodoListCapability, TestMathCapability,
-    TestWeatherCapability,
+    AutoToolSearchCapability, CurrentTimeCapability, FileSystemCapability,
+    GenericToolSearchCapability, OpenAiToolSearchCapability, SessionCapability,
+    StatelessTodoListCapability, TestMathCapability, TestWeatherCapability,
 };
 use everruns_core::in_memory_loop::InMemoryAgenticLoop;
 
@@ -96,6 +96,75 @@ async fn test_gpt54_tool_search_low_threshold() {
     assert!(
         result.tool_calls_count > 0,
         "Model should call add tool even with deferred schemas"
+    );
+}
+
+/// Tests the model-adaptive `auto_tool_search` capability end-to-end on GPT-5.4.
+///
+/// On a native model, `auto_tool_search` must resolve (at capability-collection
+/// time, via `Capability::resolve_for_model`) to the hosted OpenAI mechanism —
+/// not the client-side fallback. This exercises the real hosted round-trip
+/// (deferred load → server-side search → tool call) through `auto_tool_search`,
+/// confirming the dispatch picks hosted when the reason path knows the model.
+///
+/// Note: the hosted path adds no client-side `tool_search` tool, so this works
+/// with the in-memory loop's executor registry (which is built from
+/// `capability.tools()`); the deferred underlying tools come from the other
+/// capabilities and execute normally. If dispatch wrongly fell back to the
+/// generic mechanism here, the model would emit a `tool_search` call that the
+/// executor cannot satisfy and the turn would fail — so a passing turn is
+/// positive evidence the hosted path was selected.
+#[tokio::test]
+async fn test_gpt54_auto_tool_search_resolves_to_hosted() {
+    if OPENAI_GPT54.model().is_none() {
+        eprintln!("Skipping: {} not set", OPENAI_GPT54.label());
+        return;
+    }
+
+    // GPT-5.4 occasionally answers "what time is it" from priors without calling
+    // a tool, so retry a few times and require that at least one turn drives a
+    // real hosted round-trip. The hosted-vs-client-side resolution itself is
+    // deterministic (a pure function of the model) and covered by unit/collection
+    // tests; this guards only the live model's tool-calling, not the dispatch.
+    const MAX_ATTEMPTS: usize = 5;
+    let mut made_tool_call = false;
+
+    for attempt in 1..=MAX_ATTEMPTS {
+        let model = OPENAI_GPT54.model().expect("checked above");
+        let runner = InMemoryAgenticLoop::builder()
+            .agent_name("Auto Tool Search Agent")
+            .system_prompt(
+                "You are a helpful assistant. When asked about time, use the get_current_time tool.",
+            )
+            .model(model)
+            .driver_registry(all_providers_registry())
+            // Multiple capabilities to exceed the 15-tool threshold (16 total).
+            .capability(CurrentTimeCapability) // 1 tool
+            .capability(TestMathCapability) // 4 tools
+            .capability(TestWeatherCapability) // 2 tools
+            .capability(FileSystemCapability) // 6 tools
+            .capability(SessionCapability) // 2 tools
+            .capability(StatelessTodoListCapability) // 1 tool
+            // Model-adaptive: on GPT-5.4 this must resolve to the hosted mechanism.
+            .capability(AutoToolSearchCapability::new())
+            .max_iterations(5)
+            .build()
+            .await
+            .unwrap();
+
+        let result = runner.run_turn("What time is it right now?").await.unwrap();
+        assert!(result.success, "Turn should succeed: {:?}", result.error);
+        if result.tool_calls_count > 0 {
+            made_tool_call = true;
+            break;
+        }
+        eprintln!("attempt {attempt}/{MAX_ATTEMPTS}: model answered without a tool call; retrying");
+    }
+
+    assert!(
+        made_tool_call,
+        "auto_tool_search → hosted deferred loading should drive a get_current_time \
+         call within {MAX_ATTEMPTS} attempts"
     );
 }
 

--- a/crates/llm-tests/tests/tool_search_test.rs
+++ b/crates/llm-tests/tests/tool_search_test.rs
@@ -19,8 +19,9 @@ use llm_test_matrix::*;
 use everruns_core::capabilities::{
     AutoToolSearchCapability, CurrentTimeCapability, FileSystemCapability,
     GenericToolSearchCapability, OpenAiToolSearchCapability, SessionCapability,
-    StatelessTodoListCapability, TestMathCapability, TestWeatherCapability,
+    StatelessTodoListCapability, TOOL_SEARCH_TOOL_NAME, TestMathCapability, TestWeatherCapability,
 };
+use everruns_core::events::{EventData, LLM_GENERATION};
 use everruns_core::in_memory_loop::InMemoryAgenticLoop;
 
 // ============================================================================
@@ -103,17 +104,20 @@ async fn test_gpt54_tool_search_low_threshold() {
 ///
 /// On a native model, `auto_tool_search` must resolve (at capability-collection
 /// time, via `Capability::resolve_for_model`) to the hosted OpenAI mechanism —
-/// not the client-side fallback. This exercises the real hosted round-trip
-/// (deferred load → server-side search → tool call) through `auto_tool_search`,
-/// confirming the dispatch picks hosted when the reason path knows the model.
+/// not the client-side fallback. The test checks two things from the emitted
+/// `llm.generation` events:
 ///
-/// Note: the hosted path adds no client-side `tool_search` tool, so this works
-/// with the in-memory loop's executor registry (which is built from
-/// `capability.tools()`); the deferred underlying tools come from the other
-/// capabilities and execute normally. If dispatch wrongly fell back to the
-/// generic mechanism here, the model would emit a `tool_search` call that the
-/// executor cannot satisfy and the turn would fail — so a passing turn is
-/// positive evidence the hosted path was selected.
+/// 1. **Hosted was selected (deterministic).** The hosted mechanism offers the
+///    real (deferred) tools and adds *no* client-side `tool_search` tool, whereas
+///    the generic fallback *would* add one. So the absence of a `tool_search`
+///    tool in the model's tool list proves hosted resolution — independent of
+///    whether the model chose to call a tool on a given turn.
+/// 2. **The hosted round-trip executes (live).** The model actually calls
+///    `get_current_time` (deferred load → server-side search → tool call).
+///
+/// GPT-5.4 occasionally answers "what time is it" from priors without calling a
+/// tool, so the round-trip half is retried; the hosted-resolution half is
+/// asserted on every attempt's generation events.
 #[tokio::test]
 async fn test_gpt54_auto_tool_search_resolves_to_hosted() {
     if OPENAI_GPT54.model().is_none() {
@@ -121,13 +125,8 @@ async fn test_gpt54_auto_tool_search_resolves_to_hosted() {
         return;
     }
 
-    // GPT-5.4 occasionally answers "what time is it" from priors without calling
-    // a tool, so retry a few times and require that at least one turn drives a
-    // real hosted round-trip. The hosted-vs-client-side resolution itself is
-    // deterministic (a pure function of the model) and covered by unit/collection
-    // tests; this guards only the live model's tool-calling, not the dispatch.
     const MAX_ATTEMPTS: usize = 5;
-    let mut made_tool_call = false;
+    let mut called_get_current_time = false;
 
     for attempt in 1..=MAX_ATTEMPTS {
         let model = OPENAI_GPT54.model().expect("checked above");
@@ -154,15 +153,43 @@ async fn test_gpt54_auto_tool_search_resolves_to_hosted() {
 
         let result = runner.run_turn("What time is it right now?").await.unwrap();
         assert!(result.success, "Turn should succeed: {:?}", result.error);
-        if result.tool_calls_count > 0 {
-            made_tool_call = true;
+
+        let generations = runner.events_by_type(LLM_GENERATION).await;
+        assert!(
+            !generations.is_empty(),
+            "expected at least one llm.generation event"
+        );
+        for event in &generations {
+            let EventData::LlmGeneration(data) = &event.data else {
+                continue;
+            };
+            // (1) Hosted resolution: the client-side `tool_search` tool must not
+            // be offered to the model. Its presence would mean auto_tool_search
+            // fell back to the generic mechanism.
+            assert!(
+                !data.tools.iter().any(|t| t.name == TOOL_SEARCH_TOOL_NAME),
+                "auto_tool_search on GPT-5.4 must resolve to hosted: the client-side \
+                 `{TOOL_SEARCH_TOOL_NAME}` tool must not be offered to the model"
+            );
+            // (2) Round-trip: the model executed the deferred get_current_time tool.
+            if data
+                .output
+                .tool_calls
+                .iter()
+                .any(|call| call.name == "get_current_time")
+            {
+                called_get_current_time = true;
+            }
+        }
+
+        if called_get_current_time {
             break;
         }
-        eprintln!("attempt {attempt}/{MAX_ATTEMPTS}: model answered without a tool call; retrying");
+        eprintln!("attempt {attempt}/{MAX_ATTEMPTS}: no get_current_time call yet; retrying");
     }
 
     assert!(
-        made_tool_call,
+        called_get_current_time,
         "auto_tool_search → hosted deferred loading should drive a get_current_time \
          call within {MAX_ATTEMPTS} attempts"
     );


### PR DESCRIPTION
## What
Adds a live integration test (`test_gpt54_auto_tool_search_resolves_to_hosted`) that exercises the model-adaptive `auto_tool_search` capability against real GPT-5.4.

## Why
PR #2056 added `auto_tool_search` with unit/collection tests proving it *resolves* to the hosted `openai_tool_search` mechanism on native models. This adds the missing **live** evidence: that the resolved hosted path actually completes a real round-trip (deferred load → server-side search → tool call) end-to-end against the provider — closing the loop with observed behavior rather than inferred coverage.

## How
Mirrors the existing `test_gpt54_tool_search_with_many_capabilities` but uses `AutoToolSearchCapability` instead of `OpenAiToolSearchCapability`. 16 tools (6 capabilities) exceed the deferral threshold; on GPT-5.4 the dispatcher must pick hosted, and the model must still call `get_current_time` with deferred schemas.

The turn is retried up to 5 times: GPT-5.4 occasionally answers "what time is it" from priors without calling a tool (a property of the live model, observed ~1/3 of single runs). The hosted-vs-client-side resolution itself is deterministic (a pure function of the model string) and already covered by unit/collection tests, so the retry guards only the live model's tool-calling, not the dispatch. Like the sibling tests, it skips gracefully when `OPENAI_API_KEY` is unset.

## Risk
- **Very low.** Test-only addition in the gated `llm-tests` suite (skipped without API keys; runs in the live sweep).

## Validation
- `cargo fmt --check`: clean.
- `cargo clippy -p everruns-llm-tests --tests --features llm-tests`: clean.
- Ran live via Doppler against GPT-5.4 **4/4 green** with the retry (single-shot variant flaked ~1/3, confirming the retry is necessary and that the hosted round-trip does execute tool calls when the model cooperates).

## Security
- No security-relevant code changes (test-only; uses existing test capabilities and the provider key already used by the suite).

## Follow-ups
No follow-ups. (Related backlog from #2056: EVE-524 defer MCP schemas under generic tool_search; EVE-525 honor `resolve_for_model` in the model-less collection paths — both independent of this test.)

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (test-only)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

https://claude.ai/code/session_01UbcQZoUKid5sTwHVdYSFB1

---
_Generated by [Claude Code](https://claude.ai/code/session_01UbcQZoUKid5sTwHVdYSFB1)_