### PR TITLE
refactor(capabilities): align tool search capability name

### DIFF
--- a/crates/core/src/capabilities/auto_tool_search.rs
+++ b/crates/core/src/capabilities/auto_tool_search.rs
@@ -10,7 +10,7 @@
 //     `tool_search` tool loads them back on demand.
 //
 // Unlike picking one of those capabilities by hand, this one chooses at runtime.
-// It OWNS an `OpenAiToolSearchCapability` and a `GenericToolSearchCapability` and
+// It OWNS an `OpenAiToolSearchCapability` and a `ToolSearchCapability` and
 // implements `Capability::resolve_for_model`: capability collection knows the
 // agent's model (via `SystemPromptContext::model`) and delegates to whichever
 // inner capability fits. Only that one capability's contributions are collected —
@@ -21,7 +21,7 @@
 // work well across providers.
 
 use super::openai_tool_search::{OpenAiToolSearchCapability, model_supports_native_tool_search};
-use super::tool_search::GenericToolSearchCapability;
+use super::tool_search::ToolSearchCapability;
 use super::{Capability, CapabilityStatus};
 
 pub use super::openai_tool_search::DEFAULT_TOOL_SEARCH_THRESHOLD;
@@ -36,7 +36,7 @@ pub const AUTO_TOOL_SEARCH_CAPABILITY_ID: &str = "auto_tool_search";
 /// deferral activates) is shared by both and forwarded at construction.
 pub struct AutoToolSearchCapability {
     openai: OpenAiToolSearchCapability,
-    generic: GenericToolSearchCapability,
+    generic: ToolSearchCapability,
 }
 
 impl AutoToolSearchCapability {
@@ -47,7 +47,7 @@ impl AutoToolSearchCapability {
     pub fn with_threshold(threshold: usize) -> Self {
         Self {
             openai: OpenAiToolSearchCapability::with_threshold(threshold),
-            generic: GenericToolSearchCapability::with_threshold(threshold),
+            generic: ToolSearchCapability::with_threshold(threshold),
         }
     }
 }

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -261,7 +261,7 @@ pub use test_math::{AddTool, DivideTool, MultiplyTool, SubtractTool, TestMathCap
 pub use test_weather::{GetForecastTool, GetWeatherTool, TestWeatherCapability};
 pub use tool_output_persistence::{PersistOutputHook, ToolOutputPersistenceCapability};
 pub use tool_search::{
-    GenericToolSearchCapability, TOOL_SEARCH_CAPABILITY_ID, TOOL_SEARCH_TOOL_NAME, ToolSearchTool,
+    TOOL_SEARCH_CAPABILITY_ID, TOOL_SEARCH_TOOL_NAME, ToolSearchCapability, ToolSearchTool,
 };
 pub use user_hooks::UserHooksCapability;
 pub use virtual_bash::{BashTool, SessionFileSystemAdapter, VirtualBashCapability};
@@ -948,7 +948,7 @@ impl CapabilityRegistry {
         // OpenAI tool_search (deferred tool loading, all environments)
         registry.register(OpenAiToolSearchCapability::new());
         // Generic, provider-agnostic tool_search (client-side deferred loading)
-        registry.register(GenericToolSearchCapability::new());
+        registry.register(ToolSearchCapability::new());
         // Model-adaptive tool_search (hosted on capable models, generic elsewhere)
         registry.register(AutoToolSearchCapability::new());
         registry.register(PromptCachingCapability::new());

--- a/crates/core/src/capabilities/tool_search.rs
+++ b/crates/core/src/capabilities/tool_search.rs
@@ -57,11 +57,11 @@ keep their full schemas and do not need to be searched for.";
 /// Adding this capability enables client-side deferred tool loading for any
 /// model. `threshold` controls the minimum number of tools before schemas are
 /// deferred (default: [`DEFAULT_TOOL_SEARCH_THRESHOLD`]).
-pub struct GenericToolSearchCapability {
+pub struct ToolSearchCapability {
     threshold: usize,
 }
 
-impl GenericToolSearchCapability {
+impl ToolSearchCapability {
     pub fn new() -> Self {
         Self {
             threshold: DEFAULT_TOOL_SEARCH_THRESHOLD,
@@ -73,13 +73,13 @@ impl GenericToolSearchCapability {
     }
 }
 
-impl Default for GenericToolSearchCapability {
+impl Default for ToolSearchCapability {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl Capability for GenericToolSearchCapability {
+impl Capability for ToolSearchCapability {
     fn id(&self) -> &str {
         TOOL_SEARCH_CAPABILITY_ID
     }
@@ -380,7 +380,7 @@ mod tests {
 
     #[test]
     fn test_capability_metadata() {
-        let cap = GenericToolSearchCapability::new();
+        let cap = ToolSearchCapability::new();
         assert_eq!(cap.id(), TOOL_SEARCH_CAPABILITY_ID);
         assert_eq!(cap.name(), "Tool Search");
         assert_eq!(cap.category(), Some("Optimization"));

--- a/crates/llm-tests/tests/tool_search_test.rs
+++ b/crates/llm-tests/tests/tool_search_test.rs
@@ -18,8 +18,8 @@ use llm_test_matrix::*;
 
 use everruns_core::capabilities::{
     AutoToolSearchCapability, CurrentTimeCapability, FileSystemCapability,
-    GenericToolSearchCapability, OpenAiToolSearchCapability, SessionCapability,
-    StatelessTodoListCapability, TOOL_SEARCH_TOOL_NAME, TestMathCapability, TestWeatherCapability,
+    OpenAiToolSearchCapability, SessionCapability, StatelessTodoListCapability,
+    TOOL_SEARCH_TOOL_NAME, TestMathCapability, TestWeatherCapability, ToolSearchCapability,
 };
 use everruns_core::events::{EventData, LLM_GENERATION};
 use everruns_core::in_memory_loop::InMemoryAgenticLoop;
@@ -222,7 +222,7 @@ async fn test_anthropic_generic_tool_search() {
         .capability(SessionCapability) // 2 tools
         .capability(StatelessTodoListCapability) // 1 tool
         // Generic, provider-agnostic deferred loading (works on Anthropic).
-        .capability(GenericToolSearchCapability::new())
+        .capability(ToolSearchCapability::new())
         .max_iterations(6)
         .build()
         .await
@@ -253,7 +253,7 @@ async fn test_anthropic_generic_tool_search_low_threshold() {
         .capability(TestMathCapability)
         .capability(CurrentTimeCapability)
         // Low threshold: deferral activates even with few tools (6 > 3).
-        .capability(GenericToolSearchCapability::with_threshold(3))
+        .capability(ToolSearchCapability::with_threshold(3))
         .max_iterations(6)
         .build()
         .await

--- a/specs/tool-search.md
+++ b/specs/tool-search.md
@@ -57,7 +57,7 @@ There are three capabilities, two mechanisms:
 
 ### Auto resolution
 
-`auto_tool_search` is a runtime dispatcher, not a third mechanism. `AutoToolSearchCapability` owns an `OpenAiToolSearchCapability` and a `GenericToolSearchCapability` and implements `Capability::resolve_for_model`. The agent's model is carried on `SystemPromptContext::model`, so capability collection knows it and delegates to exactly one inner capability — collecting *its* contributions in place of the dispatcher's:
+`auto_tool_search` is a runtime dispatcher, not a third mechanism. `AutoToolSearchCapability` owns an `OpenAiToolSearchCapability` and a `ToolSearchCapability` and implements `Capability::resolve_for_model`. The agent's model is carried on `SystemPromptContext::model`, so capability collection knows it and delegates to exactly one inner capability — collecting *its* contributions in place of the dispatcher's:
 
 - **Model supports native tool_search** (`model_supports_native_tool_search`, OpenAI GPT-5.4+): resolves to `openai_tool_search`. Collection sets the hosted `ToolSearchConfig` (keyed on the resolved `effective.id()`); no client-side tool or hook is contributed.
 - **Model lacks native support, or model is unknown:** resolves to the generic `tool_search`. Collection contributes its `DeferSchemaHook` + `tool_search` tool + system-prompt note and sets no hosted config.


### PR DESCRIPTION
## What
Rename the generic provider-agnostic tool-search Rust type from `GenericToolSearchCapability` to `ToolSearchCapability` while keeping the stable public capability id `tool_search` unchanged.

## Why
The old Rust type name did not align with the public capability id/name, which made the tool-search capability surface inconsistent with the rest of the capability registry.

## How
- Rename the core capability type and update registry wiring, auto-tool-search dispatch, and focused LLM test imports.
- Update `specs/tool-search.md` so the auto dispatcher description names `ToolSearchCapability`.
- Scan other capability ids vs names; apparent mismatches such as `session_file_system`, `subagents`, `openui`, and `a2ui` are documented stable product ids and were intentionally left unchanged.

## Risk
- Low
- Public capability ids and runtime behavior are unchanged; the main risk is a missed Rust reference, covered by compile/tests and repo pre-push checks.

## Security
- Threat categories reviewed: TM-TOOL and TM-LLM, because the touched code is capability/tool-search wiring adjacent to tool schema deferral and LLM tool exposure.
- Findings and resolutions: no security-relevant behavior, trust-boundary, input validation, auth, secret handling, or tool execution changes. No threat-model update needed.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

## Validation
- `cargo fmt --check && git diff --check`
- `cargo test -p everruns-core tool_search`
- `cargo test -p everruns-llm-tests --test tool_search_test --features llm-tests --no-run`
- `just pre-push`
