### PR TITLE
fix(llm): support hosted OpenAI tool search

### DIFF
--- a/crates/core/src/llm_model_profiles.rs
+++ b/crates/core/src/llm_model_profiles.rs
@@ -1100,13 +1100,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_gpt55()),
-            // tool_search gated off pending live verification of the Responses-API
-            // deferred-loading round-trip on gpt-5.5. The round-trip reproducibly
-            // fails with a server_error during the reasoning phase (EVE-521), making
-            // the agent loop unusable on the default model. gpt-5.4 keeps tool_search
-            // (it has live integration coverage); re-enable here once the gpt-5.5
-            // round-trip is verified end-to-end.
-            tool_search: false,
+            tool_search: true,
             supports_phases: true,
         }),
 
@@ -1140,9 +1134,7 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
                 output: vec![Modality::Text],
             }),
             reasoning_effort: Some(reasoning_effort_gpt52_pro()),
-            // Gated off with gpt-5.5: the deferred-loading round-trip fails during the
-            // reasoning phase on the gpt-5.5 family (EVE-521). Re-enable once verified.
-            tool_search: false,
+            tool_search: true,
             supports_phases: true,
         }),
 
@@ -2677,8 +2669,7 @@ mod tests {
         assert!(profile.reasoning);
         assert!(profile.tool_call);
         assert!(profile.structured_output);
-        // tool_search is gated off on gpt-5.5 pending live round-trip verification (EVE-521).
-        assert!(!profile.tool_search);
+        assert!(profile.tool_search);
         assert!(profile.supports_phases);
 
         let limits = profile.limits.unwrap();
@@ -2734,8 +2725,7 @@ mod tests {
         assert!(profile.reasoning);
         assert!(profile.tool_call);
         assert!(profile.structured_output);
-        // tool_search gated off with the rest of the gpt-5.5 family (EVE-521).
-        assert!(!profile.tool_search);
+        assert!(profile.tool_search);
         assert!(profile.supports_phases);
 
         let cost = profile.cost.unwrap();

--- a/crates/core/src/openresponses_protocol.rs
+++ b/crates/core/src/openresponses_protocol.rs
@@ -3842,6 +3842,94 @@ mod tests {
     }
 
     #[test]
+    fn test_hosted_tool_search_completed_event_preserves_response_id() {
+        let event_json = r#"{
+            "type": "response.completed",
+            "sequence_number": 8,
+            "response": {
+                "id": "resp_tool_search",
+                "object": "response",
+                "created_at": 1780000000,
+                "status": "completed",
+                "model": "gpt-5.5",
+                "output": [
+                    {
+                        "type": "tool_search_call",
+                        "execution": "server",
+                        "call_id": null,
+                        "status": "completed",
+                        "arguments": { "paths": ["Math"] }
+                    },
+                    {
+                        "type": "tool_search_output",
+                        "execution": "server",
+                        "call_id": null,
+                        "status": "completed",
+                        "tools": [
+                            {
+                                "type": "namespace",
+                                "name": "Math",
+                                "description": "Tools for Math",
+                                "tools": [
+                                    {
+                                        "type": "function",
+                                        "name": "add",
+                                        "description": "Add numbers.",
+                                        "defer_loading": true,
+                                        "parameters": {
+                                            "type": "object",
+                                            "properties": {
+                                                "a": { "type": "number" },
+                                                "b": { "type": "number" }
+                                            },
+                                            "required": ["a", "b"],
+                                            "additionalProperties": false
+                                        }
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "type": "function_call",
+                        "id": "fc_123",
+                        "call_id": "call_123",
+                        "name": "add",
+                        "namespace": "Math",
+                        "arguments": "{\"a\":7,\"b\":3}",
+                        "status": "completed"
+                    }
+                ],
+                "usage": {
+                    "input_tokens": 10,
+                    "output_tokens": 5,
+                    "total_tokens": 15
+                }
+            }
+        }"#;
+
+        let event: StreamingEvent = serde_json::from_str(event_json).unwrap();
+        let stream_event = handle_streaming_event(
+            event,
+            &Mutex::new(0),
+            &Mutex::new(0),
+            &Mutex::new(None),
+            &Mutex::new(Vec::new()),
+            &Mutex::new(Some("tool_calls".to_string())),
+            "gpt-5.5".to_string(),
+            None,
+        );
+
+        match stream_event {
+            LlmStreamEvent::Done(metadata) => {
+                assert_eq!(metadata.response_id.as_deref(), Some("resp_tool_search"));
+                assert_eq!(metadata.finish_reason.as_deref(), Some("tool_calls"));
+            }
+            other => panic!("expected Done event, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn test_sanitize_parameters_adds_missing_properties() {
         let params = json!({"type": "object", "additionalProperties": false});
         let sanitized = OpenResponsesProtocolLlmDriver::sanitize_parameters(&params);

--- a/crates/core/src/openresponses_types.rs
+++ b/crates/core/src/openresponses_types.rs
@@ -716,6 +716,8 @@ pub enum OutputItem {
         id: String,
         call_id: String,
         name: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        namespace: Option<String>,
         arguments: String,
         status: ItemStatus,
     },
@@ -734,6 +736,22 @@ pub enum OutputItem {
         content: Option<Vec<ContentPart>>,
         #[serde(skip_serializing_if = "Option::is_none")]
         encrypted_content: Option<String>,
+    },
+    #[serde(rename = "tool_search_call")]
+    ToolSearchCall {
+        execution: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        call_id: Option<String>,
+        status: ItemStatus,
+        arguments: Value,
+    },
+    #[serde(rename = "tool_search_output")]
+    ToolSearchOutput {
+        execution: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        call_id: Option<String>,
+        status: ItemStatus,
+        tools: Vec<Value>,
     },
 }
 
@@ -1118,6 +1136,91 @@ mod tests {
         match event {
             StreamingEvent::OutputTextDelta { delta, .. } => assert_eq!(delta, "Hello"),
             _ => panic!("Wrong event type"),
+        }
+    }
+
+    #[test]
+    fn test_hosted_tool_search_response_output_deserialization() {
+        let json = r#"{
+            "id": "resp_123",
+            "object": "response",
+            "created_at": 1780000000,
+            "status": "completed",
+            "model": "gpt-5.5",
+            "output": [
+                {
+                    "type": "tool_search_call",
+                    "execution": "server",
+                    "call_id": null,
+                    "status": "completed",
+                    "arguments": { "paths": ["Math"] }
+                },
+                {
+                    "type": "tool_search_output",
+                    "execution": "server",
+                    "call_id": null,
+                    "status": "completed",
+                    "tools": [
+                        {
+                            "type": "namespace",
+                            "name": "Math",
+                            "description": "Tools for Math",
+                            "tools": [
+                                {
+                                    "type": "function",
+                                    "name": "add",
+                                    "description": "Add numbers.",
+                                    "defer_loading": true,
+                                    "parameters": {
+                                        "type": "object",
+                                        "properties": {
+                                            "a": { "type": "number" },
+                                            "b": { "type": "number" }
+                                        },
+                                        "required": ["a", "b"],
+                                        "additionalProperties": false
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "function_call",
+                    "id": "fc_123",
+                    "call_id": "call_123",
+                    "name": "add",
+                    "namespace": "Math",
+                    "arguments": "{\"a\":7,\"b\":3}",
+                    "status": "completed"
+                }
+            ],
+            "usage": {
+                "input_tokens": 10,
+                "output_tokens": 5,
+                "total_tokens": 15
+            }
+        }"#;
+
+        let response: ResponseResource = serde_json::from_str(json).unwrap();
+        assert_eq!(response.id, "resp_123");
+        assert_eq!(response.output.len(), 3);
+        assert!(matches!(
+            response.output[0],
+            OutputItem::ToolSearchCall { .. }
+        ));
+        assert!(matches!(
+            response.output[1],
+            OutputItem::ToolSearchOutput { .. }
+        ));
+        match &response.output[2] {
+            OutputItem::FunctionCall {
+                namespace, call_id, ..
+            } => {
+                assert_eq!(namespace.as_deref(), Some("Math"));
+                assert_eq!(call_id, "call_123");
+            }
+            other => panic!("expected function_call, got {other:?}"),
         }
     }
 

--- a/crates/llm-tests/tests/tool_search_test.rs
+++ b/crates/llm-tests/tests/tool_search_test.rs
@@ -1,9 +1,10 @@
 // Integration tests for tool_search (deferred tool loading).
 //
-// Tests the full pipeline: OpenAiToolSearchCapability → RuntimeAgent → LlmCallConfig →
-// OpenResponses driver with tool_search enabled.
+// Tests the full pipeline for provider-backed and generic client-side tool_search
+// capability wiring through RuntimeAgent and LlmCallConfig.
 //
-// Includes a real GPT-5.4 integration test that exercises tool_search end-to-end.
+// Includes real GPT-5.4 and GPT-5.5 integration tests that exercise hosted
+// tool_search end-to-end against the OpenAI API.
 //
 // Run all:
 //   cargo test -p everruns-llm-tests --test tool_search_test --features llm-tests
@@ -24,8 +25,29 @@ use everruns_core::capabilities::{
 use everruns_core::events::{EventData, LLM_GENERATION};
 use everruns_core::in_memory_loop::InMemoryAgenticLoop;
 
+async fn assert_hosted_tool_search_was_enabled(runner: &InMemoryAgenticLoop) {
+    let generations = runner.events_by_type(LLM_GENERATION).await;
+    assert!(
+        !generations.is_empty(),
+        "expected at least one llm.generation event"
+    );
+    assert!(
+        generations.iter().any(|event| {
+            let EventData::LlmGeneration(data) = &event.data else {
+                return false;
+            };
+            data.metadata
+                .request_options
+                .as_ref()
+                .and_then(|options| options.tool_search.as_ref())
+                .is_some_and(|tool_search| tool_search.enabled)
+        }),
+        "expected an llm.generation event with hosted tool_search enabled"
+    );
+}
+
 // ============================================================================
-// Scenario: tool_search with GPT-5.4 (many tools → deferred loading)
+// Scenario: hosted OpenAI tool_search (deferred loading)
 // ============================================================================
 
 /// Tests tool_search end-to-end with GPT-5.4:
@@ -98,6 +120,43 @@ async fn test_gpt54_tool_search_low_threshold() {
         result.tool_calls_count > 0,
         "Model should call add tool even with deferred schemas"
     );
+    assert_hosted_tool_search_was_enabled(&runner).await;
+}
+
+/// Tests hosted tool_search with GPT-5.5 and a lower custom threshold.
+///
+/// This covers the current default OpenAI model family against the real API and
+/// verifies both halves of the contract: hosted tool_search is present on the
+/// request, and the deferred tool can still be called and completed by the loop.
+#[tokio::test]
+async fn test_gpt55_tool_search_low_threshold() {
+    let Some(model) = OPENAI_GPT55.model() else {
+        eprintln!("Skipping: {} not set", OPENAI_GPT55.label());
+        return;
+    };
+
+    let runner = InMemoryAgenticLoop::builder()
+        .agent_name("GPT-5.5 Tool Search Agent")
+        .system_prompt("When asked to add numbers, use the add tool.")
+        .model(model)
+        .driver_registry(all_providers_registry())
+        .capability(TestMathCapability)
+        .capability(CurrentTimeCapability)
+        // Low threshold: tool_search activates even with few tools (5 > 3).
+        .capability(OpenAiToolSearchCapability::with_threshold(3))
+        .max_iterations(5)
+        .build()
+        .await
+        .unwrap();
+
+    let result = runner.run_turn("What is 7 + 3?").await.unwrap();
+
+    assert!(result.success, "Turn should succeed: {:?}", result.error);
+    assert!(
+        result.tool_calls_count > 0,
+        "GPT-5.5 should call add tool even with deferred schemas"
+    );
+    assert_hosted_tool_search_was_enabled(&runner).await;
 }
 
 /// Tests the model-adaptive `auto_tool_search` capability end-to-end on GPT-5.4.
@@ -159,6 +218,7 @@ async fn test_gpt54_auto_tool_search_resolves_to_hosted() {
             !generations.is_empty(),
             "expected at least one llm.generation event"
         );
+        assert_hosted_tool_search_was_enabled(&runner).await;
         for event in &generations {
             let EventData::LlmGeneration(data) = &event.data else {
                 continue;
@@ -193,6 +253,49 @@ async fn test_gpt54_auto_tool_search_resolves_to_hosted() {
         "auto_tool_search → hosted deferred loading should drive a get_current_time \
          call within {MAX_ATTEMPTS} attempts"
     );
+}
+
+/// Tests model-adaptive hosted resolution on GPT-5.5.
+#[tokio::test]
+async fn test_gpt55_auto_tool_search_resolves_to_hosted() {
+    let Some(model) = OPENAI_GPT55.model() else {
+        eprintln!("Skipping: {} not set", OPENAI_GPT55.label());
+        return;
+    };
+
+    let runner = InMemoryAgenticLoop::builder()
+        .agent_name("GPT-5.5 Auto Tool Search Agent")
+        .system_prompt("When asked to add numbers, use the add tool.")
+        .model(model)
+        .driver_registry(all_providers_registry())
+        .capability(TestMathCapability)
+        .capability(CurrentTimeCapability)
+        .capability(AutoToolSearchCapability::with_threshold(3))
+        .max_iterations(5)
+        .build()
+        .await
+        .unwrap();
+
+    let result = runner.run_turn("What is 7 + 3?").await.unwrap();
+
+    assert!(result.success, "Turn should succeed: {:?}", result.error);
+    assert!(
+        result.tool_calls_count > 0,
+        "GPT-5.5 auto_tool_search should call add through hosted deferred loading"
+    );
+    assert_hosted_tool_search_was_enabled(&runner).await;
+
+    let generations = runner.events_by_type(LLM_GENERATION).await;
+    for event in &generations {
+        let EventData::LlmGeneration(data) = &event.data else {
+            continue;
+        };
+        assert!(
+            !data.tools.iter().any(|t| t.name == TOOL_SEARCH_TOOL_NAME),
+            "auto_tool_search on GPT-5.5 must resolve to hosted: the client-side \
+             `{TOOL_SEARCH_TOOL_NAME}` tool must not be offered to the model"
+        );
+    }
 }
 
 // ============================================================================

--- a/docs/capabilities/openai-tool-search.md
+++ b/docs/capabilities/openai-tool-search.md
@@ -45,12 +45,8 @@ Tool search requires model-level support. Currently supported:
 | Model family | Supported |
 |---|---|
 | `gpt-5.4*` | Yes |
-| `gpt-5.5*` | Not yet — temporarily gated while the deferred-loading round-trip is verified |
+| `gpt-5.5*` | Yes |
 | All other models | No (capability is silently ignored) |
-
-The `gpt-5.5` family is temporarily gated: the OpenAI Responses deferred-loading
-round-trip fails with a `server_error` during the reasoning phase on these models,
-so the capability is silently skipped there until the round-trip is verified.
 
 When the capability is enabled but the model doesn't support tool_search, the feature is silently skipped — no errors, no behavior change.
 

--- a/specs/tool-search.md
+++ b/specs/tool-search.md
@@ -195,11 +195,8 @@ Set `tool_search: true` for models that support it. Default `false` for all othe
 
 A model's `tool_search: true` flag must be backed by a verified end-to-end round-trip
 (deferred-load → schema fetch → tool call) against the live provider, not just the
-request-shaping unit tests. The `gpt-5.5` family is gated `false` because the live
-round-trip fails with a `server_error` during the reasoning phase (EVE-521), even
-though the unit tests pass. Keep the flag off until a live tool-using turn succeeds
-on that model; the `gpt-5.4*` family is the currently verified one (see
-`crates/llm-tests/tests/tool_search_test.rs`).
+request-shaping unit tests. The `gpt-5.4*` and `gpt-5.5*` families are covered by
+live OpenAI integration tests in `crates/llm-tests/tests/tool_search_test.rs`.
 
 ## OpenAI Driver Changes
 
@@ -231,7 +228,7 @@ Track tool_search effectiveness via existing metadata:
 ### Phase 1: Model Profile + Driver (Low Risk)
 
 1. Add `tool_search: bool` to `LlmModelProfile` (default false)
-2. Set `tool_search: true` for verified models (currently the GPT-5.4 family; the GPT-5.5 family is gated off pending live verification, see "Model Profile Updates")
+2. Set `tool_search: true` for verified models (currently the GPT-5.4 and GPT-5.5 families; see "Model Profile Updates")
 3. Add `category: Option<String>` to `BuiltinTool` / `ToolDefinition`
 4. Propagate capability category to tool definitions in `collect_capabilities()`
 5. Extend `ResponsesTool` enum with `Namespace` and `ToolSearch` variants


### PR DESCRIPTION
## What
Support hosted OpenAI tool_search response items in the Responses parser, re-enable GPT-5.5 native tool_search, and add GPT-5.4/GPT-5.5 live integration coverage.

## Why
Hosted tool_search can emit tool_search_call and tool_search_output items before the function_call. Without typed parsing for those output items, the driver can lose response_id and break the next tool-result continuation.

## How
- Model hosted tool_search output items in OpenResponses output parsing.
- Preserve typed response.completed parsing so response_id survives.
- Re-enable GPT-5.5 native tool_search.
- Add live OpenAI integration tests for GPT-5.4/GPT-5.5 direct and auto hosted paths.
- Update docs/spec support tables.

## Risk
- Medium
- What can break: OpenAI Responses parsing, hosted tool_search continuation, GPT-5.5 hosted deferral. Mitigated by focused parser tests and live LLM integration tests.

## Security
- Threat categories reviewed: TM-LLM, TM-TOOL.
- Findings and resolutions: No new secrets, no new tool execution authority, and no new public API surface. Parser changes accept provider bookkeeping items and keep loaded tool definitions as JSON values during response parsing; actual tool execution remains limited to registered tool calls.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)
