### PR TITLE
feat(openai): discover OpenRouter reasoning capability

### DIFF
--- a/crates/core/src/openresponses_protocol.rs
+++ b/crates/core/src/openresponses_protocol.rs
@@ -1235,6 +1235,8 @@ fn handle_streaming_event(
 
         StreamingEvent::ReasoningDelta { delta, .. } => LlmStreamEvent::ThinkingDelta(delta),
 
+        StreamingEvent::ReasoningTextDelta { delta, .. } => LlmStreamEvent::ThinkingDelta(delta),
+
         StreamingEvent::ReasoningSummaryDelta { delta, .. } => LlmStreamEvent::ThinkingDelta(delta),
 
         StreamingEvent::FunctionCallArgumentsDelta { item_id, delta, .. } => {

--- a/crates/core/src/openresponses_types.rs
+++ b/crates/core/src/openresponses_types.rs
@@ -993,6 +993,24 @@ pub enum StreamingEvent {
         text: String,
     },
 
+    // Plaintext reasoning deltas as emitted by OpenAI-compatible gateways
+    // (e.g. OpenRouter) for open reasoning models like NVIDIA Nemotron. These
+    // carry the model's chain-of-thought directly (no encrypted artifact), so
+    // they map to streaming thinking. Fields beyond `delta` are optional to stay
+    // tolerant of gateway-to-gateway shape differences.
+    #[serde(rename = "response.reasoning_text.delta")]
+    ReasoningTextDelta {
+        #[serde(default)]
+        sequence_number: u32,
+        #[serde(default)]
+        item_id: String,
+        #[serde(default)]
+        output_index: u32,
+        #[serde(default)]
+        content_index: u32,
+        delta: String,
+    },
+
     // Reasoning summary events
     #[serde(rename = "response.reasoning_summary_part.added")]
     ReasoningSummaryPartAdded {
@@ -1221,6 +1239,17 @@ mod tests {
                 assert_eq!(call_id, "call_123");
             }
             other => panic!("expected function_call, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_reasoning_text_delta_deserialization() {
+        // Shape emitted by OpenRouter for open reasoning models (e.g. Nemotron).
+        let json = r#"{"type":"response.reasoning_text.delta","output_index":0,"item_id":"rs_tmp_5jrlmgo85gg","content_index":0,"delta":"User asks","sequence_number":3}"#;
+        let event: StreamingEvent = serde_json::from_str(json).unwrap();
+        match event {
+            StreamingEvent::ReasoningTextDelta { delta, .. } => assert_eq!(delta, "User asks"),
+            _ => panic!("Wrong event type"),
         }
     }
 

--- a/crates/openai/src/driver.rs
+++ b/crates/openai/src/driver.rs
@@ -23,7 +23,7 @@ use everruns_core::llm_driver_registry::{
 use everruns_core::openai_protocol::is_azure_openai_api_url;
 use everruns_core::{CompactRequest, CompactResponse};
 
-use crate::types::OpenAiModelsResponse;
+use crate::types::{OpenAiModelsResponse, OpenRouterModelsResponse};
 
 const OPENAI_MODELS_URL: &str = "https://api.openai.com/v1/models";
 
@@ -144,7 +144,7 @@ impl LlmDriver for OpenAILlmDriver {
         }
 
         let models_url = models_url_for_api_url(self.api_url());
-        list_openai_models(self.inner.client(), self.inner.api_key(), &models_url).await
+        list_models_for_url(self.inner.client(), self.inner.api_key(), &models_url).await
     }
 
     fn supports_compact(&self) -> bool {
@@ -253,7 +253,7 @@ impl LlmDriver for OpenAICompletionsLlmDriver {
         }
 
         let models_url = models_url_for_api_url(self.api_url());
-        list_openai_models(self.inner.client(), self.inner.api_key(), &models_url).await
+        list_models_for_url(self.inner.client(), self.inner.api_key(), &models_url).await
     }
 }
 
@@ -270,6 +270,70 @@ impl std::fmt::Debug for OpenAICompletionsLlmDriver {
 // ============================================================================
 // Shared Utilities
 // ============================================================================
+
+/// Fetch and filter models for a `/models` URL, dispatching on the provider host.
+///
+/// OpenRouter returns much richer metadata than OpenAI (a `supported_parameters`
+/// array), so we parse it separately to derive capability profiles — notably
+/// `reasoning` support, which gates the UI's effort selector.
+async fn list_models_for_url(
+    client: &reqwest::Client,
+    api_key: &str,
+    models_url: &str,
+) -> Result<Option<Vec<DiscoveredModel>>> {
+    if is_openrouter_api_url(models_url) {
+        list_openrouter_models(client, api_key, models_url).await
+    } else {
+        list_openai_models(client, api_key, models_url).await
+    }
+}
+
+/// Fetch and filter OpenRouter models, building capability profiles from the
+/// `supported_parameters` metadata OpenRouter advertises.
+async fn list_openrouter_models(
+    client: &reqwest::Client,
+    api_key: &str,
+    models_url: &str,
+) -> Result<Option<Vec<DiscoveredModel>>> {
+    let response = apply_models_auth(client.get(models_url), models_url, api_key)
+        .send()
+        .await
+        .map_err(|e| AgentLoopError::llm(format!("Failed to fetch models: {}", e)))?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        return Err(AgentLoopError::llm(format!(
+            "Models API returned {}: {}",
+            status, body
+        )));
+    }
+
+    let models_response: OpenRouterModelsResponse = response
+        .json()
+        .await
+        .map_err(|e| AgentLoopError::llm(format!("Failed to parse models response: {}", e)))?;
+
+    let discovered: Vec<DiscoveredModel> = models_response
+        .data
+        .into_iter()
+        .filter(|m| m.is_chat_model())
+        .map(|m| {
+            let profile = m.to_discovered_profile();
+            DiscoveredModel {
+                created_at: m
+                    .created
+                    .and_then(|ts| chrono::Utc.timestamp_opt(ts, 0).single()),
+                display_name: m.name.clone(),
+                owned_by: m.id.split('/').next().map(str::to_owned),
+                model_id: m.id,
+                discovered_profile: Some(profile),
+            }
+        })
+        .collect();
+
+    Ok(Some(discovered))
+}
 
 /// Fetch and filter OpenAI models (shared between both drivers)
 async fn list_openai_models(
@@ -342,14 +406,24 @@ fn models_url_for_api_url(api_url: &str) -> String {
 }
 
 fn supports_model_listing(api_url: &str) -> bool {
-    is_openai_api_url(api_url) || is_azure_openai_api_url(api_url)
+    is_openai_api_url(api_url) || is_azure_openai_api_url(api_url) || is_openrouter_api_url(api_url)
 }
 
 fn is_openai_api_url(api_url: &str) -> bool {
+    url_host_eq(api_url, "api.openai.com")
+}
+
+/// OpenRouter exposes an OpenAI-compatible `/models` endpoint with richer
+/// metadata; recognize its host so discovery (and capability profiling) runs.
+fn is_openrouter_api_url(api_url: &str) -> bool {
+    url_host_eq(api_url, "openrouter.ai")
+}
+
+fn url_host_eq(api_url: &str, host: &str) -> bool {
     Url::parse(api_url)
         .ok()
         .and_then(|url| url.host_str().map(str::to_owned))
-        .is_some_and(|host| host.eq_ignore_ascii_case("api.openai.com"))
+        .is_some_and(|h| h.eq_ignore_ascii_case(host))
 }
 
 fn apply_models_auth(request: RequestBuilder, api_url: &str, api_key: &str) -> RequestBuilder {
@@ -410,7 +484,9 @@ pub fn register_driver(registry: &mut DriverRegistry) {
 
 #[cfg(test)]
 mod tests {
-    use super::{is_openai_api_url, supports_model_listing};
+    use super::{
+        is_openai_api_url, is_openrouter_api_url, models_url_for_api_url, supports_model_listing,
+    };
 
     #[test]
     fn supports_model_listing_for_openai_host_with_port() {
@@ -422,5 +498,26 @@ mod tests {
     #[test]
     fn rejects_non_openai_hosts_for_model_listing() {
         assert!(!is_openai_api_url("https://example.com/v1/responses"));
+    }
+
+    #[test]
+    fn supports_model_listing_for_openrouter() {
+        // OpenRouter is reached via the Open Responses driver with a custom base
+        // URL; discovery must run so capability profiles (reasoning) are derived.
+        assert!(is_openrouter_api_url(
+            "https://openrouter.ai/api/v1/responses"
+        ));
+        assert!(supports_model_listing(
+            "https://openrouter.ai/api/v1/responses"
+        ));
+        assert!(!is_openrouter_api_url("https://example.com/v1/responses"));
+    }
+
+    #[test]
+    fn openrouter_models_url_is_derived_from_responses_url() {
+        assert_eq!(
+            models_url_for_api_url("https://openrouter.ai/api/v1/responses"),
+            "https://openrouter.ai/api/v1/models"
+        );
     }
 }

--- a/crates/openai/src/types.rs
+++ b/crates/openai/src/types.rs
@@ -247,3 +247,334 @@ impl OpenAiModelInfo {
             || id.starts_with("chatgpt-")
     }
 }
+
+// ============================================================================
+// OpenRouter Models API Types
+// ============================================================================
+//
+// OpenRouter exposes the same OpenAI-compatible surface (`/responses`,
+// `/chat/completions`) but its `/models` endpoint returns much richer metadata
+// than OpenAI's bare `{id, created, owned_by}`. In particular it advertises a
+// `supported_parameters` array (e.g. `reasoning`, `tools`, `response_format`)
+// that lets us derive a capability profile at discovery time — most OpenRouter
+// models (NVIDIA Nemotron, DeepSeek, etc.) have no hardcoded profile, so without
+// this the UI cannot tell they support reasoning and hides the effort selector.
+
+/// Response from OpenRouter's `/api/v1/models` endpoint.
+#[derive(Debug, Clone, Deserialize)]
+pub struct OpenRouterModelsResponse {
+    pub data: Vec<OpenRouterModelInfo>,
+}
+
+/// Individual model entry from OpenRouter's models API.
+///
+/// Only the fields we map are modeled; unknown fields are ignored so the parse
+/// is resilient to OpenRouter adding metadata over time.
+#[derive(Debug, Clone, Deserialize)]
+pub struct OpenRouterModelInfo {
+    /// Fully qualified model id (e.g. `nvidia/nemotron-3-super-120b-a12b`).
+    pub id: String,
+    /// Human-readable display name (e.g. "NVIDIA: Nemotron 3 Super").
+    #[serde(default)]
+    pub name: Option<String>,
+    /// Unix timestamp of when the model was added.
+    #[serde(default)]
+    pub created: Option<i64>,
+    /// Maximum context window in tokens.
+    #[serde(default)]
+    pub context_length: Option<i64>,
+    /// Modality metadata (input/output modalities).
+    #[serde(default)]
+    pub architecture: Option<OpenRouterArchitecture>,
+    /// Top-provider limits (max completion tokens, effective context).
+    #[serde(default)]
+    pub top_provider: Option<OpenRouterTopProvider>,
+    /// Parameters the model/router accepts. The presence of `reasoning`
+    /// (or `reasoning_effort`) is what tells us reasoning is supported.
+    #[serde(default)]
+    pub supported_parameters: Vec<String>,
+}
+
+/// Modality metadata from OpenRouter's `architecture` object.
+#[derive(Debug, Clone, Deserialize)]
+pub struct OpenRouterArchitecture {
+    #[serde(default)]
+    pub input_modalities: Vec<String>,
+    #[serde(default)]
+    pub output_modalities: Vec<String>,
+}
+
+/// Per-request limits reported by the routed upstream provider.
+#[derive(Debug, Clone, Deserialize)]
+pub struct OpenRouterTopProvider {
+    #[serde(default)]
+    pub context_length: Option<i64>,
+    #[serde(default)]
+    pub max_completion_tokens: Option<i64>,
+}
+
+impl OpenRouterModelInfo {
+    /// Whether the model supports a given parameter (case-insensitive).
+    fn supports(&self, param: &str) -> bool {
+        self.supported_parameters
+            .iter()
+            .any(|p| p.eq_ignore_ascii_case(param))
+    }
+
+    /// Whether this is a text-producing chat model. OpenRouter also lists
+    /// image-only / non-text-output models, which we exclude from discovery.
+    pub fn is_chat_model(&self) -> bool {
+        match self.architecture.as_ref() {
+            Some(arch) if !arch.output_modalities.is_empty() => arch
+                .output_modalities
+                .iter()
+                .any(|m| m.eq_ignore_ascii_case("text")),
+            // No modality metadata — assume chat (OpenRouter's catalog is
+            // overwhelmingly text-output chat models).
+            _ => true,
+        }
+    }
+
+    /// Build an [`LlmModelProfile`] from OpenRouter's advertised metadata.
+    ///
+    /// Cost is intentionally left `None`: pricing is available but the hardcoded
+    /// profiles own cost data, and merging is keyed on the hardcoded entry.
+    pub fn to_discovered_profile(&self) -> everruns_core::llm_models::LlmModelProfile {
+        use everruns_core::llm_models::*;
+
+        // Reasoning is advertised via the `reasoning` parameter (modern unified
+        // control) or the legacy `reasoning_effort` alias.
+        let reasoning = self.supports("reasoning") || self.supports("reasoning_effort");
+        let reasoning_effort = reasoning.then(openrouter_effort_config);
+
+        // Modalities → attachment support.
+        let input_modalities = self
+            .architecture
+            .as_ref()
+            .map(|a| a.input_modalities.as_slice())
+            .unwrap_or(&[]);
+        let has_modality = |name: &str| {
+            input_modalities
+                .iter()
+                .any(|m| m.eq_ignore_ascii_case(name))
+        };
+        let image_input = has_modality("image");
+        let pdf_input = has_modality("file") || has_modality("pdf");
+
+        let modalities = {
+            let mut input = vec![Modality::Text];
+            if image_input {
+                input.push(Modality::Image);
+            }
+            if pdf_input {
+                input.push(Modality::Pdf);
+            }
+            Some(LlmModelModalities {
+                input,
+                output: vec![Modality::Text],
+            })
+        };
+
+        // Prefer the routed provider's effective context window when present.
+        let context = self
+            .top_provider
+            .as_ref()
+            .and_then(|t| t.context_length)
+            .or(self.context_length);
+        let max_output = self
+            .top_provider
+            .as_ref()
+            .and_then(|t| t.max_completion_tokens);
+        let limits = context.map(|ctx| {
+            let context = clamp_i64_to_i32(ctx);
+            LlmModelLimits {
+                context,
+                input: None,
+                // OpenRouter commonly omits a separate output cap
+                // (`max_completion_tokens: null`). Fall back to the context
+                // window — the model's theoretical max output — rather than
+                // emitting a misleading `0` that renders as "Output: 0".
+                output: max_output.map(clamp_i64_to_i32).unwrap_or(context),
+                max_media: None,
+            }
+        });
+
+        LlmModelProfile {
+            name: self.name.clone().unwrap_or_else(|| self.id.clone()),
+            family: self.id.clone(),
+            description: None,
+            release_date: None,
+            last_updated: None,
+            attachment: image_input || pdf_input,
+            reasoning,
+            temperature: self.supports("temperature"),
+            knowledge: None,
+            tool_call: self.supports("tools") || self.supports("tool_choice"),
+            structured_output: self.supports("structured_outputs")
+                || self.supports("response_format"),
+            open_weights: false,
+            cost: None,
+            limits,
+            modalities,
+            reasoning_effort,
+            tool_search: false,
+            supports_phases: false,
+        }
+    }
+}
+
+/// Saturating `i64` → `i32` conversion.
+///
+/// OpenRouter reports token counts as `i64`, while `LlmModelLimits` stores
+/// `i32`. A raw `as` cast wraps on overflow (producing negative limits); this
+/// clamps into range instead. Negative inputs clamp to `0`.
+fn clamp_i64_to_i32(value: i64) -> i32 {
+    value.clamp(0, i32::MAX as i64) as i32
+}
+
+/// Standard low/medium/high effort config for OpenRouter reasoning models.
+///
+/// OpenRouter normalizes `reasoning.effort` ∈ {low, medium, high} across upstream
+/// providers, so we expose those three with `medium` as the default.
+fn openrouter_effort_config() -> everruns_core::llm_models::ReasoningEffortConfig {
+    use everruns_core::llm_models::*;
+    ReasoningEffortConfig {
+        values: vec![
+            ReasoningEffortValue {
+                value: ReasoningEffort::Low,
+                name: "Low".into(),
+            },
+            ReasoningEffortValue {
+                value: ReasoningEffort::Medium,
+                name: "Medium".into(),
+            },
+            ReasoningEffortValue {
+                value: ReasoningEffort::High,
+                name: "High".into(),
+            },
+        ],
+        default: ReasoningEffort::Medium,
+    }
+}
+
+#[cfg(test)]
+mod openrouter_tests {
+    use super::*;
+    use everruns_core::llm_models::ReasoningEffort;
+
+    // Trimmed copy of the live `nvidia/nemotron-3-super-120b-a12b` entry from
+    // OpenRouter's /api/v1/models response.
+    const NEMOTRON_JSON: &str = r#"{
+        "id": "nvidia/nemotron-3-super-120b-a12b",
+        "name": "NVIDIA: Nemotron 3 Super",
+        "created": 1773245239,
+        "context_length": 1000000,
+        "architecture": {
+            "input_modalities": ["text"],
+            "output_modalities": ["text"]
+        },
+        "top_provider": { "context_length": 262144, "max_completion_tokens": null },
+        "supported_parameters": [
+            "include_reasoning", "max_tokens", "reasoning", "response_format",
+            "structured_outputs", "temperature", "tool_choice", "tools", "top_p"
+        ]
+    }"#;
+
+    fn parse(json: &str) -> OpenRouterModelInfo {
+        serde_json::from_str(json).expect("parse model")
+    }
+
+    #[test]
+    fn nemotron_profile_advertises_reasoning_with_effort_levels() {
+        let model = parse(NEMOTRON_JSON);
+        assert!(model.is_chat_model());
+
+        let profile = model.to_discovered_profile();
+        assert!(profile.reasoning, "Nemotron must be reasoning-capable");
+
+        let effort = profile
+            .reasoning_effort
+            .expect("reasoning models expose an effort config");
+        assert_eq!(effort.default, ReasoningEffort::Medium);
+        let values: Vec<_> = effort.values.iter().map(|v| v.value.clone()).collect();
+        assert_eq!(
+            values,
+            vec![
+                ReasoningEffort::Low,
+                ReasoningEffort::Medium,
+                ReasoningEffort::High
+            ]
+        );
+
+        // Capabilities derived from supported_parameters.
+        assert!(profile.tool_call);
+        assert!(profile.structured_output);
+        assert!(profile.temperature);
+        assert_eq!(profile.name, "NVIDIA: Nemotron 3 Super");
+        assert_eq!(profile.family, "nvidia/nemotron-3-super-120b-a12b");
+        // Prefer the routed provider's effective context window.
+        let limits = profile.limits.expect("limits");
+        assert_eq!(limits.context, 262144);
+        // max_completion_tokens is null here, so output falls back to context
+        // rather than a misleading 0.
+        assert_eq!(limits.output, 262144);
+    }
+
+    #[test]
+    fn oversized_token_counts_saturate_instead_of_wrapping() {
+        // Values beyond i32::MAX must clamp, not wrap to a negative number.
+        let model = parse(
+            r#"{
+                "id": "vendor/huge-context",
+                "context_length": 5000000000,
+                "architecture": { "output_modalities": ["text"] },
+                "supported_parameters": ["max_tokens"]
+            }"#,
+        );
+        let limits = model.to_discovered_profile().limits.expect("limits");
+        assert_eq!(limits.context, i32::MAX);
+        assert_eq!(limits.output, i32::MAX);
+        assert!(limits.output > 0);
+    }
+
+    #[test]
+    fn non_reasoning_model_has_no_effort_config() {
+        let model = parse(
+            r#"{
+                "id": "openai/gpt-4o-mini",
+                "architecture": { "output_modalities": ["text"] },
+                "supported_parameters": ["max_tokens", "temperature", "tools"]
+            }"#,
+        );
+        let profile = model.to_discovered_profile();
+        assert!(!profile.reasoning);
+        assert!(profile.reasoning_effort.is_none());
+        assert!(profile.tool_call);
+    }
+
+    #[test]
+    fn image_only_output_models_are_excluded() {
+        let model = parse(
+            r#"{
+                "id": "some/image-generator",
+                "architecture": { "output_modalities": ["image"] },
+                "supported_parameters": []
+            }"#,
+        );
+        assert!(!model.is_chat_model());
+    }
+
+    #[test]
+    fn legacy_reasoning_effort_alias_is_detected() {
+        let model = parse(
+            r#"{
+                "id": "vendor/legacy-reasoner",
+                "architecture": { "output_modalities": ["text"] },
+                "supported_parameters": ["reasoning_effort", "temperature"]
+            }"#,
+        );
+        let profile = model.to_discovered_profile();
+        assert!(profile.reasoning);
+        assert!(profile.reasoning_effort.is_some());
+    }
+}

--- a/crates/openai/tests/openrouter_discovery_live.rs
+++ b/crates/openai/tests/openrouter_discovery_live.rs
@@ -1,0 +1,69 @@
+//! Live smoke test for OpenRouter model discovery.
+//!
+//! Exercises the real `OpenAILlmDriver::list_models` path against OpenRouter's
+//! `/models` endpoint: HTTP fetch, deserialization, and capability profiling.
+//!
+//! Ignored by default (requires network + `OPENROUTER_API_KEY`); run manually:
+//!   `doppler run -- cargo test -p everruns-openai --test openrouter_discovery_live -- --ignored --nocapture`
+
+use everruns_core::llm_driver_registry::LlmDriver;
+use everruns_openai::OpenAILlmDriver;
+
+#[tokio::test]
+#[ignore = "live network + OPENROUTER_API_KEY"]
+async fn openrouter_discovers_nemotron_reasoning_profile() {
+    let api_key = std::env::var("OPENROUTER_API_KEY")
+        .expect("OPENROUTER_API_KEY must be set for the live smoke test");
+
+    let driver = OpenAILlmDriver::with_base_url(api_key, "https://openrouter.ai/api/v1");
+
+    let models = driver
+        .list_models()
+        .await
+        .expect("list_models should succeed")
+        .expect("OpenRouter should support model listing");
+
+    assert!(!models.is_empty(), "expected a non-empty model catalog");
+
+    // The target model must be discovered with a reasoning-capable profile so
+    // the UI exposes the effort selector.
+    let nemotron = models
+        .iter()
+        .find(|m| m.model_id == "nvidia/nemotron-3-super-120b-a12b")
+        .expect("nemotron-3-super should be in the OpenRouter catalog");
+
+    let profile = nemotron
+        .discovered_profile
+        .as_ref()
+        .expect("discovered models should carry a capability profile");
+
+    assert!(
+        profile.reasoning,
+        "Nemotron must be flagged reasoning-capable"
+    );
+    let effort = profile
+        .reasoning_effort
+        .as_ref()
+        .expect("reasoning models expose an effort config");
+    assert!(
+        !effort.values.is_empty(),
+        "effort config should list selectable levels"
+    );
+
+    // At least some of the broader catalog should also be reasoning-capable —
+    // guards against a parsing regression that silently drops the field.
+    let reasoning_count = models
+        .iter()
+        .filter(|m| m.discovered_profile.as_ref().is_some_and(|p| p.reasoning))
+        .count();
+    assert!(
+        reasoning_count > 10,
+        "expected many reasoning models, got {reasoning_count}"
+    );
+
+    eprintln!(
+        "OpenRouter discovery: {} models, {} reasoning-capable",
+        models.len(),
+        reasoning_count
+    );
+}

--- a/specs/llm-drivers.md
+++ b/specs/llm-drivers.md
@@ -281,6 +281,23 @@ The OpenAI crate provides two driver implementations:
 
 Both drivers share the same base URL handling and can work with OpenAI-compatible endpoints.
 
+### Model Discovery and Capability Profiles
+
+`list_models` runs only for hosts known to expose a usable `/models` endpoint
+(`api.openai.com`, Azure OpenAI, and `openrouter.ai`); other custom base URLs
+(self-hosted proxies) return `None` and are not synced.
+
+OpenAI's `/models` response is bare (`id`, `created`, `owned_by`) and yields no
+profile. OpenRouter returns richer metadata — notably a `supported_parameters`
+array — which the driver parses into an `LlmModelProfile`: `reasoning` (or the
+legacy `reasoning_effort` alias) maps to `profile.reasoning` plus a low/medium/high
+`reasoning_effort` config, and `tools`/`response_format`/modalities map to the
+corresponding capability flags. This matters because most OpenRouter models
+(e.g. NVIDIA Nemotron) have no hardcoded profile; without discovery the UI cannot
+tell they support reasoning and hides the effort selector. The discovered profile
+is persisted via the model-sync pipeline and surfaces on existing rows on the next
+sync. Cost is left to hardcoded profiles.
+
 ### Stateful Continuation Invariant
 
 When a request to the OpenAI Responses API sets `previous_response_id`, the provider already holds the prior transcript server-side. The request must NOT also carry the full reconstructed transcript in `input` — that double-counts context and inflates prompt-cache keys.


### PR DESCRIPTION
## What
Enable reasoning-effort control for OpenRouter models (e.g. NVIDIA Nemotron) by discovering their capabilities and surfacing live reasoning during streaming.

- Recognize the `openrouter.ai` host for model listing and parse OpenRouter's richer `/models` response into capability profiles. `reasoning` (or the legacy `reasoning_effort` alias) → `profile.reasoning` + a low/medium/high effort config; `tools`/`response_format`/modalities → the corresponding capability flags.
- Map OpenRouter's `response.reasoning_text.delta` stream events to thinking deltas so open reasoning models surface live thinking.

## Why
OpenRouter is reached through the Open Responses driver with a custom base URL. The wire path already accepts `reasoning: { effort }` against OpenRouter (verified live — effort is honored and scales). But model discovery was skipped for the host, so models like Nemotron landed with **no profile**. The UI gates the effort selector on `profile.reasoning && profile.reasoning_effort` (`use-chat-model-selection.ts`), so without a profile the control is hidden even though the backend would honor the effort. Nemotron's OpenRouter metadata advertises `reasoning`/`include_reasoning` (never top-level `reasoning_effort`), which the nested Responses shape already matches.

Separately, OpenRouter streams reasoning as `response.reasoning_text.delta`, an event the parser didn't map, so live thinking was dropped (final answer + usage were already handled).

## How
- `crates/openai/src/types.rs`: `OpenRouterModelInfo` + `to_discovered_profile()` mapping `supported_parameters`/`architecture`/`top_provider` to an `LlmModelProfile`. Cost is left to hardcoded profiles.
- `crates/openai/src/driver.rs`: `is_openrouter_api_url`, include it in `supports_model_listing`, and dispatch `list_models` to an OpenRouter parser. The existing model-sync pipeline persists the discovered profile (and updates existing rows on the next sync), so no server-side changes were needed.
- `crates/core/src/openresponses_types.rs` + `openresponses_protocol.rs`: new `ReasoningTextDelta` stream variant → `ThinkingDelta` (consistent with the existing `ReasoningSummaryDelta` mapping).
- `specs/llm-drivers.md`: documented model discovery and capability profiling.

## Risk
- **Low.** Additive: new host recognition + parsing + one stream-event variant. No changes to existing OpenAI/Azure discovery or the request path.
- Note: OpenRouter lists ~346 models, so discovery will create that many disabled model rows per OpenRouter provider on sync (same mechanism as OpenAI discovery, larger catalog). Operators enable the ones they want.

## Security
- Threat categories reviewed: **TM-API** (parsing an external provider's `/models` response), **TM-LLM** (model parameters / API-key handling), **TM-DOS** (catalog size).
- Findings and resolutions:
  - No injection surface: provider metadata is deserialized into typed structs; `model_id` flows to the DB through the existing parameterized sync path. No SQL/command/path construction from model data.
  - Auth unchanged: discovery reuses the existing bearer-auth helper; no API key is logged and the discovered profile carries only capability metadata.
  - Input validation: all OpenRouter fields are `#[serde(default)]` / optional (only `id` required); the parse is resilient to schema drift. `context as i32` mirrors the existing Anthropic discovery cast; realistic OpenRouter values (≤1M) fit.
  - Resource use: discovery is bounded by the provider catalog and runs on the periodic sync, matching existing OpenAI behavior.
  - No `THREAT[...]` mitigations touched; no new trust boundary, so no `specs/threat-model.md` change.

## Validation
- New unit tests: OpenRouter profile mapping from the real Nemotron JSON, host detection, models-URL derivation, the new stream event, plus non-reasoning / image-only / legacy-alias cases.
- Live smoke test (`crates/openai/tests/openrouter_discovery_live.rs`, `#[ignore]`d — network + key) run via Doppler through the **real** `OpenAILlmDriver::list_models`: **346 models, 192 reasoning-capable, Nemotron profiled**. Also confirmed live that `/responses` honors `reasoning:{effort}` and effort scales.
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` (touched crates), full `everruns-core` + `everruns-openai` suites green; `everruns-server` builds. Rebased on latest `origin/main`; migrations sequential (001..049).

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_0194YtUdJcHBndLNBj5nHYNp)_