### PR TITLE
refactor(models): flat model registry with vendor tags and surface predicates

### DIFF
--- a/apps/ui/src/__tests__/model-icon.test.tsx
+++ b/apps/ui/src/__tests__/model-icon.test.tsx
@@ -1,45 +1,45 @@
 import { render } from "@testing-library/react";
 import { ModelIcon } from "@/components/models/model-icon";
-import type { LlmModelWithProvider } from "@/lib/api/types";
+import type { LlmModelWithProvider, ModelVendor } from "@/lib/api/types";
 
 function model(
-  model_id: string,
-  family: string | undefined,
+  model_vendor: ModelVendor | undefined,
   provider_type: LlmModelWithProvider["provider_type"] = "openai_completions",
 ) {
-  return { model_id, provider_type, profile: family ? { family } : null };
+  return { provider_type, model_vendor };
 }
 
 describe("ModelIcon vendor selection", () => {
-  it("renders a per-vendor icon for OpenAI-compatible third-party models", () => {
-    const cases: Array<[ReturnType<typeof model>, string]> = [
-      [model("nemotron-3-super-120b-a12b", "nemotron-3-super"), "NVIDIA"],
-      [model("nvidia/nemotron-3-super-120b-a12b", undefined), "NVIDIA"],
-      [model("qwen/qwen3.7-max", "qwen3.7-max"), "Qwen"],
-      [model("MiniMax-M3", "minimax-m3"), "MiniMax"],
-      [model("kimi-k2-thinking", "kimi-k2-thinking"), "Moonshot"],
-      [model("x-ai/grok-4.3", "grok-4.3"), "xAI"],
-      [model("microsoft/MAI-1-preview", "mai-1-preview"), "Microsoft"],
+  it("renders a per-vendor icon from the model_vendor tag", () => {
+    const cases: Array<[ModelVendor, string]> = [
+      ["nvidia", "NVIDIA"],
+      ["qwen", "Qwen"],
+      ["minimax", "MiniMax"],
+      ["moonshot", "Moonshot"],
+      ["xai", "xAI"],
+      ["microsoft", "Microsoft"],
     ];
-    for (const [m, label] of cases) {
-      const { getByTitle, unmount } = render(<ModelIcon model={m} />);
+    for (const [vendor, label] of cases) {
+      const { getByTitle, unmount } = render(<ModelIcon model={model(vendor)} />);
       expect(getByTitle(label)).toBeInTheDocument();
       unmount();
     }
   });
 
-  it("falls back to the provider icon when no vendor is recognized", () => {
-    // Claude Opus 4.8 and Gemini map to their first-party provider icons.
-    const opus = render(
-      <ModelIcon model={model("claude-opus-4-8", "claude-opus-4-8", "anthropic")} />,
-    );
+  it("falls back to the provider icon for first-party and unknown vendors", () => {
+    // Claude Opus 4.8 (vendor anthropic) and Gemini (vendor google) use their
+    // provider-type icons rather than a dedicated brand icon.
+    const opus = render(<ModelIcon model={model("anthropic", "anthropic")} />);
     expect(opus.getByTitle("Anthropic")).toBeInTheDocument();
     opus.unmount();
 
-    const gemini = render(
-      <ModelIcon model={model("gemini-3.1-pro-preview", "gemini-3.1-pro-preview", "gemini")} />,
-    );
+    const gemini = render(<ModelIcon model={model("google", "gemini")} />);
     expect(gemini.getByTitle("Google Gemini")).toBeInTheDocument();
     gemini.unmount();
+
+    // No vendor tag at all → provider icon.
+    const bare = render(<ModelIcon model={model(undefined, "openai")} />);
+    expect(bare.getByTitle("OpenAI (Responses)")).toBeInTheDocument();
+    bare.unmount();
   });
 });

--- a/apps/ui/src/components/models/model-icon.tsx
+++ b/apps/ui/src/components/models/model-icon.tsx
@@ -1,15 +1,16 @@
-import type { LlmModelWithProvider } from "@/lib/api/types";
+import type { LlmModelWithProvider, ModelVendor } from "@/lib/api/types";
 import { ProviderIcon } from "@/components/providers/provider-icon";
 import { cn } from "@/lib/utils";
 
 // Per-model vendor icons.
 //
 // Provider icons are keyed by provider *type*, but many notable models are
-// served over the generic OpenAI-compatible Completions API (NVIDIA Nemotron,
-// Qwen, MiniMax, Kimi, Grok, Microsoft MAI, ...). For those the provider icon
-// alone would render an OpenAI mark, so we additionally key an icon off the
-// model itself (profile family + wire id) and fall back to the provider icon
-// when no vendor is recognized.
+// served over OpenAI-compatible gateways (NVIDIA Nemotron, Qwen, MiniMax, Kimi,
+// Grok, Microsoft MAI, ...) where the provider type alone would render an
+// OpenAI mark. The backend model registry tags each model with a vendor
+// (`model_vendor`); we map that tag to a brand icon and fall back to the
+// provider-type icon for first-party vendors (OpenAI, Anthropic, Google) and
+// unknown models.
 
 function NvidiaIcon({ size }: { size: number }) {
   return (
@@ -103,31 +104,17 @@ interface VendorIcon {
   Component: React.ComponentType<{ size: number }>;
 }
 
-// Recognize a vendor from the model's family / wire id. Substrings are checked
-// against the lowercased "<family> <model_id>" so both `qwen3.7-max` and an
-// OpenRouter-style `qwen/qwen3.7-max` resolve.
-function vendorForModel(model: ModelLike): VendorIcon | null {
-  const key = `${model.profile?.family ?? ""} ${model.model_id}`.toLowerCase();
-  if (key.includes("nemotron") || key.includes("nvidia")) {
-    return { label: "NVIDIA", Component: NvidiaIcon };
-  }
-  if (key.includes("qwen")) {
-    return { label: "Qwen", Component: QwenIcon };
-  }
-  if (key.includes("minimax")) {
-    return { label: "MiniMax", Component: MiniMaxIcon };
-  }
-  if (key.includes("kimi") || key.includes("moonshot")) {
-    return { label: "Moonshot", Component: MoonshotIcon };
-  }
-  if (key.includes("grok") || key.includes("x-ai") || key.includes("xai")) {
-    return { label: "xAI", Component: XaiIcon };
-  }
-  if (key.includes("mai-1") || key.includes("microsoft")) {
-    return { label: "Microsoft", Component: MicrosoftIcon };
-  }
-  return null;
-}
+// Brand icons for vendors that lack a dedicated provider-type icon. First-party
+// vendors (openai, anthropic, google, llmsim) intentionally fall through to the
+// provider icon, which already renders their brand.
+const VENDOR_ICONS: Partial<Record<ModelVendor, VendorIcon>> = {
+  nvidia: { label: "NVIDIA", Component: NvidiaIcon },
+  qwen: { label: "Qwen", Component: QwenIcon },
+  microsoft: { label: "Microsoft", Component: MicrosoftIcon },
+  minimax: { label: "MiniMax", Component: MiniMaxIcon },
+  moonshot: { label: "Moonshot", Component: MoonshotIcon },
+  xai: { label: "xAI", Component: XaiIcon },
+};
 
 const sizeMap = {
   sm: { icon: 16, container: "p-1.5" },
@@ -135,8 +122,8 @@ const sizeMap = {
   lg: { icon: 24, container: "p-2.5" },
 };
 
-type ModelLike = Pick<LlmModelWithProvider, "provider_type" | "model_id"> & {
-  profile?: { family?: string } | null;
+type ModelLike = Pick<LlmModelWithProvider, "provider_type"> & {
+  model_vendor?: ModelVendor | null;
 };
 
 interface ModelIconProps {
@@ -147,9 +134,9 @@ interface ModelIconProps {
 }
 
 /**
- * Icon for a specific model. Prefers a per-vendor brand icon derived from the
- * model family/id (for OpenAI-compatible third-party models), falling back to
- * the provider-type icon (OpenAI, Anthropic, Gemini, ...).
+ * Icon for a specific model. Prefers a per-vendor brand icon from the model's
+ * registry `model_vendor` tag, falling back to the provider-type icon (OpenAI,
+ * Anthropic, Gemini, ...).
  */
 export function ModelIcon({
   model,
@@ -157,7 +144,7 @@ export function ModelIcon({
   className,
   showBackground = true,
 }: ModelIconProps) {
-  const vendor = vendorForModel(model);
+  const vendor = model.model_vendor ? VENDOR_ICONS[model.model_vendor] : undefined;
   if (!vendor) {
     return (
       <ProviderIcon

--- a/apps/ui/src/lib/api/types/llm-types.ts
+++ b/apps/ui/src/lib/api/types/llm-types.ts
@@ -13,6 +13,19 @@ export type LlmProviderType =
 
 export type LlmProviderStatus = "active" | "disabled";
 
+/** Vendor/brand of a model, derived from the backend model registry. */
+export type ModelVendor =
+  | "openai"
+  | "anthropic"
+  | "google"
+  | "nvidia"
+  | "qwen"
+  | "microsoft"
+  | "minimax"
+  | "moonshot"
+  | "xai"
+  | "llmsim";
+
 export interface LlmProvider {
   id: string;
   name: string;
@@ -46,6 +59,8 @@ export interface LlmModelWithProvider extends LlmModel {
   healthy: boolean;
   /** Readonly profile with model capabilities (not persisted to database) */
   profile?: LlmModelProfile;
+  /** Vendor/brand from the model registry; drives branding. Not persisted. */
+  model_vendor?: ModelVendor;
 }
 
 // ============================================

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -387,11 +387,11 @@ pub use harness::{Harness, HarnessStatus, merge_harness, merge_harness_chain};
 pub use leased_resource::{
     LEASED_RESOURCES_FEATURE, LeasedResource, LeasedResourceStatus, UpsertLeasedResource,
 };
-pub use llm_model_profiles::get_model_profile;
+pub use llm_model_profiles::{get_model_profile, get_model_vendor};
 pub use llm_models::{
     CostTier, LlmModel, LlmModelCost, LlmModelLimits, LlmModelModalities, LlmModelProfile,
     LlmModelSource, LlmModelWithProvider, LlmProviderStatus, LlmProviderType, Modality,
-    ReasoningEffort, ReasoningEffortConfig, ReasoningEffortValue,
+    ModelVendor, ReasoningEffort, ReasoningEffortConfig, ReasoningEffortValue,
 };
 pub use mcp_proxy::{McpProxyTool, McpToolInvoker, build_mcp_proxy_tools};
 pub use mcp_server::{

--- a/crates/core/src/llm_model_profiles.rs
+++ b/crates/core/src/llm_model_profiles.rs
@@ -16,7 +16,7 @@
 
 use crate::llm_models::{
     CostTier, LlmModelCost, LlmModelLimits, LlmModelModalities, LlmModelProfile, LlmProviderType,
-    Modality, ReasoningEffort, ReasoningEffortConfig, ReasoningEffortValue,
+    Modality, ModelVendor, ReasoningEffort, ReasoningEffortConfig, ReasoningEffortValue,
 };
 
 // Helper functions for creating reasoning effort configurations
@@ -163,25 +163,192 @@ fn reasoning_effort_anthropic_adaptive_thinking() -> ReasoningEffortConfig {
     }
 }
 
-/// Get a model profile by matching provider_type and model_id
-/// Returns None if no matching profile is found
+/// Flat registry of known models. Lookup is provider-agnostic: a model is
+/// resolved by id across this whole list, then filtered by the `surfaces`
+/// predicate. `vendor` is a branding tag; the profile payload lives in
+/// `profile_data`, keyed by the canonical id (`ids[0]`).
+struct ModelDescriptor {
+    /// Accepted wire ids. `ids[0]` is the canonical id used to fetch the
+    /// profile payload; the rest are aliases (e.g. vendor-prefixed gateway
+    /// ids). Matched case-insensitively, by exact match or `"<id>-"` prefix
+    /// (which covers dated and `-latest` suffixes).
+    ids: &'static [&'static str],
+    vendor: ModelVendor,
+    /// Provider types (API surfaces) this model is offered under.
+    surfaces: &'static [LlmProviderType],
+}
+
+const fn md(
+    ids: &'static [&'static str],
+    vendor: ModelVendor,
+    surfaces: &'static [LlmProviderType],
+) -> ModelDescriptor {
+    ModelDescriptor {
+        ids,
+        vendor,
+        surfaces,
+    }
+}
+
+// OpenAI's own models are served by the Responses API, Azure, and the generic
+// Chat Completions path. Third-party OpenAI-compatible models (NVIDIA, Qwen,
+// ...) are reachable via Responses-capable gateways (e.g. OpenRouter) and the
+// Chat Completions path, but never Azure.
+const OPENAI: &[LlmProviderType] = &[
+    LlmProviderType::Openai,
+    LlmProviderType::AzureOpenai,
+    LlmProviderType::OpenaiCompletions,
+];
+const OPENAI_COMPAT: &[LlmProviderType] =
+    &[LlmProviderType::Openai, LlmProviderType::OpenaiCompletions];
+const ANTHROPIC: &[LlmProviderType] = &[LlmProviderType::Anthropic];
+const GEMINI: &[LlmProviderType] = &[LlmProviderType::Gemini];
+const LLMSIM: &[LlmProviderType] = &[LlmProviderType::LlmSim];
+
+static REGISTRY: &[ModelDescriptor] = &[
+    // OpenAI
+    md(&["gpt-realtime-2"], ModelVendor::OpenAi, OPENAI),
+    md(&["gpt-4o"], ModelVendor::OpenAi, OPENAI),
+    md(&["gpt-4o-mini"], ModelVendor::OpenAi, OPENAI),
+    md(&["o1"], ModelVendor::OpenAi, OPENAI),
+    md(&["o1-mini"], ModelVendor::OpenAi, OPENAI),
+    md(&["o1-pro"], ModelVendor::OpenAi, OPENAI),
+    md(&["o1-preview"], ModelVendor::OpenAi, OPENAI),
+    md(&["o3"], ModelVendor::OpenAi, OPENAI),
+    md(&["o3-mini"], ModelVendor::OpenAi, OPENAI),
+    md(&["o3-pro"], ModelVendor::OpenAi, OPENAI),
+    md(&["o3-deep-research"], ModelVendor::OpenAi, OPENAI),
+    md(&["o4-mini"], ModelVendor::OpenAi, OPENAI),
+    md(&["o4-mini-deep-research"], ModelVendor::OpenAi, OPENAI),
+    md(&["gpt-4.1"], ModelVendor::OpenAi, OPENAI),
+    md(&["gpt-4.1-mini"], ModelVendor::OpenAi, OPENAI),
+    md(&["gpt-4.1-nano"], ModelVendor::OpenAi, OPENAI),
+    md(&["gpt-5"], ModelVendor::OpenAi, OPENAI),
+    md(&["gpt-5-mini"], ModelVendor::OpenAi, OPENAI),
+    md(&["gpt-5-nano"], ModelVendor::OpenAi, OPENAI),
+    md(&["gpt-5-pro"], ModelVendor::OpenAi, OPENAI),
+    md(&["gpt-5-codex"], ModelVendor::OpenAi, OPENAI),
+    md(&["gpt-5-chat-latest"], ModelVendor::OpenAi, OPENAI),
+    md(&["gpt-5.1"], ModelVendor::OpenAi, OPENAI),
+    md(&["gpt-5.1-codex"], ModelVendor::OpenAi, OPENAI),
+    md(&["gpt-5.1-codex-mini"], ModelVendor::OpenAi, OPENAI),
+    md(&["gpt-5.1-codex-max"], ModelVendor::OpenAi, OPENAI),
+    md(&["gpt-5.1-chat-latest"], ModelVendor::OpenAi, OPENAI),
+    md(&["gpt-5.2"], ModelVendor::OpenAi, OPENAI),
+    md(&["gpt-5.2-pro"], ModelVendor::OpenAi, OPENAI),
+    md(&["gpt-5.2-codex"], ModelVendor::OpenAi, OPENAI),
+    md(&["gpt-5.2-chat-latest"], ModelVendor::OpenAi, OPENAI),
+    md(&["gpt-5.3-codex"], ModelVendor::OpenAi, OPENAI),
+    md(&["gpt-5.4"], ModelVendor::OpenAi, OPENAI),
+    md(&["gpt-5.4-mini"], ModelVendor::OpenAi, OPENAI),
+    md(&["gpt-5.4-nano"], ModelVendor::OpenAi, OPENAI),
+    md(&["gpt-5.4-pro"], ModelVendor::OpenAi, OPENAI),
+    md(&["gpt-5.5"], ModelVendor::OpenAi, OPENAI),
+    md(&["gpt-5.5-pro"], ModelVendor::OpenAi, OPENAI),
+    // Anthropic
+    md(&["claude-opus-4-8"], ModelVendor::Anthropic, ANTHROPIC),
+    md(&["claude-opus-4-7"], ModelVendor::Anthropic, ANTHROPIC),
+    md(&["claude-opus-4-6"], ModelVendor::Anthropic, ANTHROPIC),
+    md(&["claude-sonnet-4-6"], ModelVendor::Anthropic, ANTHROPIC),
+    md(&["claude-opus-4-5"], ModelVendor::Anthropic, ANTHROPIC),
+    md(&["claude-sonnet-4-5"], ModelVendor::Anthropic, ANTHROPIC),
+    md(&["claude-haiku-4-5"], ModelVendor::Anthropic, ANTHROPIC),
+    md(&["claude-opus-4-1"], ModelVendor::Anthropic, ANTHROPIC),
+    md(&["claude-opus-4"], ModelVendor::Anthropic, ANTHROPIC),
+    md(&["claude-sonnet-4"], ModelVendor::Anthropic, ANTHROPIC),
+    md(&["claude-3-7-sonnet"], ModelVendor::Anthropic, ANTHROPIC),
+    md(&["claude-3-5-sonnet"], ModelVendor::Anthropic, ANTHROPIC),
+    md(&["claude-3-5-haiku"], ModelVendor::Anthropic, ANTHROPIC),
+    md(&["claude-3-opus"], ModelVendor::Anthropic, ANTHROPIC),
+    md(&["claude-3-sonnet"], ModelVendor::Anthropic, ANTHROPIC),
+    md(&["claude-3-haiku"], ModelVendor::Anthropic, ANTHROPIC),
+    // Google Gemini
+    md(&["gemini-3.1-pro-preview"], ModelVendor::Google, GEMINI),
+    md(&["gemini-2.5-pro"], ModelVendor::Google, GEMINI),
+    md(&["gemini-2.5-flash"], ModelVendor::Google, GEMINI),
+    md(&["gemini-2.0-flash"], ModelVendor::Google, GEMINI),
+    md(&["gemini-1.5-pro"], ModelVendor::Google, GEMINI),
+    md(&["gemini-1.5-flash"], ModelVendor::Google, GEMINI),
+    // Third-party, OpenAI-compatible
+    md(
+        &[
+            "nemotron-3-super-120b-a12b",
+            "nvidia/nemotron-3-super-120b-a12b",
+        ],
+        ModelVendor::Nvidia,
+        OPENAI_COMPAT,
+    ),
+    md(
+        &["qwen3.7-max", "qwen/qwen3.7-max"],
+        ModelVendor::Qwen,
+        OPENAI_COMPAT,
+    ),
+    md(
+        &["mai-1-preview", "microsoft/mai-1-preview"],
+        ModelVendor::Microsoft,
+        OPENAI_COMPAT,
+    ),
+    md(
+        &["minimax-m3", "minimax/minimax-m3"],
+        ModelVendor::MiniMax,
+        OPENAI_COMPAT,
+    ),
+    md(
+        &["kimi-k2-thinking", "moonshotai/kimi-k2-thinking"],
+        ModelVendor::Moonshot,
+        OPENAI_COMPAT,
+    ),
+    md(
+        &["grok-4.3", "x-ai/grok-4.3", "xai/grok-4.3"],
+        ModelVendor::XAi,
+        OPENAI_COMPAT,
+    ),
+    // Test simulator
+    md(&["llmsim-default", "llmsim"], ModelVendor::LlmSim, LLMSIM),
+];
+
+/// Resolve the registry descriptor for a model id under a provider type.
+/// Matching is provider-filtered (the `surfaces` predicate) and picks the
+/// longest matching id so specific variants win over their prefixes (e.g.
+/// `gpt-4o-mini` over `gpt-4o`).
+fn resolve_descriptor(
+    provider_type: &LlmProviderType,
+    model_id: &str,
+) -> Option<&'static ModelDescriptor> {
+    let id = model_id.to_ascii_lowercase();
+    let mut best: Option<(usize, &'static ModelDescriptor)> = None;
+    for descriptor in REGISTRY {
+        if !descriptor.surfaces.contains(provider_type) {
+            continue;
+        }
+        for alias in descriptor.ids {
+            let alias = alias.to_ascii_lowercase();
+            let id_matches = id == alias || id.starts_with(&format!("{alias}-"));
+            if id_matches && best.is_none_or(|(len, _)| alias.len() > len) {
+                best = Some((alias.len(), descriptor));
+            }
+        }
+    }
+    best.map(|(_, descriptor)| descriptor)
+}
+
+/// Get a model profile by matching provider_type and model_id.
+/// Returns None if the id is not in the registry or is not offered under the
+/// given provider type.
 pub fn get_model_profile(
     provider_type: &LlmProviderType,
     model_id: &str,
 ) -> Option<LlmModelProfile> {
-    match provider_type {
-        // Open Responses (`openai`) and Azure only serve genuine OpenAI models.
-        LlmProviderType::Openai | LlmProviderType::AzureOpenai => get_openai_profile(model_id),
-        // The generic Chat Completions path additionally hosts third-party,
-        // OpenAI-compatible models (NVIDIA NIM, Alibaba, MiniMax, Moonshot, xAI,
-        // ...), so fall back to their profiles only here.
-        LlmProviderType::OpenaiCompletions => {
-            get_openai_profile(model_id).or_else(|| get_openai_compatible_profile(model_id))
-        }
-        LlmProviderType::Anthropic => get_anthropic_profile(model_id),
-        LlmProviderType::Gemini => get_gemini_profile(model_id),
-        LlmProviderType::LlmSim => get_llmsim_profile(model_id),
+    let descriptor = resolve_descriptor(provider_type, model_id)?;
+    let mut profile = profile_data(descriptor.ids[0])?;
+    // Native execution phases and tool_search exist only on the OpenAI Responses
+    // surface; do not advertise them when the model is reached via another
+    // provider type (Azure, Chat Completions, gateways).
+    if !matches!(provider_type, LlmProviderType::Openai) {
+        profile.supports_phases = false;
+        profile.tool_search = false;
     }
+    Some(profile)
 }
 
 /// Estimate the USD cost of a generation from the model's static price-table
@@ -204,11 +371,25 @@ pub fn estimate_cost_usd(
     Some(input_cost + output_cost)
 }
 
-fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
-    // Normalize model ID by extracting base name
-    let base_id = normalize_model_id(model_id);
+/// Get the vendor/brand for a model id, or None if it is not in the registry
+/// (or not offered under the given provider type).
+pub fn get_model_vendor(provider_type: &LlmProviderType, model_id: &str) -> Option<ModelVendor> {
+    resolve_descriptor(provider_type, model_id).map(|descriptor| descriptor.vendor)
+}
 
-    match base_id {
+/// Profile payload keyed by canonical model id. Pure value store: provider
+/// availability and vendor tagging live in `REGISTRY`, not here. The segments
+/// are grouped by author for readability only — there is no provider dispatch.
+fn profile_data(canonical: &str) -> Option<LlmModelProfile> {
+    openai_profile_data(canonical)
+        .or_else(|| anthropic_profile_data(canonical))
+        .or_else(|| gemini_profile_data(canonical))
+        .or_else(|| third_party_profile_data(canonical))
+        .or_else(|| llmsim_profile_data(canonical))
+}
+
+fn openai_profile_data(model_id: &str) -> Option<LlmModelProfile> {
+    match model_id {
         "gpt-realtime-2" => Some(LlmModelProfile {
             name: "GPT Realtime 2".into(),
             family: "gpt-realtime".into(),
@@ -1522,20 +1703,19 @@ fn get_openai_profile(model_id: &str) -> Option<LlmModelProfile> {
     }
 }
 
-/// Profiles for non-OpenAI models exposed through the OpenAI-compatible
-/// Chat Completions API. Reached only for the `openai_completions` provider
-/// type (see `get_model_profile`) — Open Responses / Azure do not serve these
-/// models, so they must not resolve there. Sourced from models.dev unless
+/// Profile payloads for non-OpenAI models exposed through OpenAI-compatible
+/// APIs (NVIDIA NIM, Alibaba, MiniMax, Moonshot, xAI, Microsoft). Pure value
+/// store keyed by canonical id; which provider surfaces each model is offered
+/// under is decided by `REGISTRY`, not here. Sourced from models.dev unless
 /// noted otherwise.
 ///
-/// Matching is case-insensitive and each arm accepts both the bare provider id
-/// and common vendor-prefixed aliases (OpenRouter style), so the profile
-/// resolves regardless of how the user registered the model id.
+/// The id is lowercased so the cased canonical ids and aliases below resolve
+/// regardless of how the caller passed them.
 ///
 /// `structured_output` is set to `false` where the upstream models.dev entry
 /// does not assert it: absence of the field is not a claim of support, so we
 /// do not advertise a capability we cannot confirm.
-fn get_openai_compatible_profile(model_id: &str) -> Option<LlmModelProfile> {
+fn third_party_profile_data(model_id: &str) -> Option<LlmModelProfile> {
     match model_id.to_ascii_lowercase().as_str() {
         // NVIDIA Nemotron 3 Super — flagship Nemotron reasoning model.
         // Source: models.dev (nvidia provider).
@@ -1758,11 +1938,8 @@ fn get_openai_compatible_profile(model_id: &str) -> Option<LlmModelProfile> {
     }
 }
 
-fn get_anthropic_profile(model_id: &str) -> Option<LlmModelProfile> {
-    // Normalize model ID by extracting base name
-    let base_id = normalize_anthropic_model_id(model_id);
-
-    match base_id {
+fn anthropic_profile_data(model_id: &str) -> Option<LlmModelProfile> {
+    match model_id {
         // Claude 4.8 series (newest)
         // Source: Anthropic model card (claude-api skill `shared/models.md`) and
         // docs.claude.com — Opus 4.8 is not yet in models.dev. Same API surface as
@@ -2324,35 +2501,8 @@ fn get_anthropic_profile(model_id: &str) -> Option<LlmModelProfile> {
     }
 }
 
-/// Normalize Gemini model ID by extracting the base model name
-/// e.g., "gemini-2.5-pro-preview-05-06" -> "gemini-2.5-pro"
-fn normalize_gemini_model_id(model_id: &str) -> &str {
-    let patterns = [
-        "gemini-3.1-pro-preview",
-        "gemini-2.5-flash",
-        "gemini-2.5-pro",
-        "gemini-2.0-flash",
-        "gemini-1.5-pro",
-        "gemini-1.5-flash",
-    ];
-
-    for pattern in patterns {
-        if model_id == pattern
-            || model_id.starts_with(&format!("{}-", pattern))
-            || model_id == format!("{}-latest", pattern)
-        {
-            return pattern;
-        }
-    }
-
-    model_id
-}
-
-/// Get Gemini model profile
-fn get_gemini_profile(model_id: &str) -> Option<LlmModelProfile> {
-    let base_id = normalize_gemini_model_id(model_id);
-
-    match base_id {
+fn gemini_profile_data(model_id: &str) -> Option<LlmModelProfile> {
+    match model_id {
         // Gemini 3.x series (newest). Source: models.dev (google provider).
         // `gemini-3-pro-preview` is deprecated upstream; 3.1 Pro Preview is the
         // current flagship Pro. Pricing has a >200K-token tier. Reasoning effort
@@ -2604,7 +2754,7 @@ fn get_gemini_profile(model_id: &str) -> Option<LlmModelProfile> {
 
 /// Get LlmSim model profile (simulated LLM for testing)
 /// Profile is modeled close to GPT-5.2 for realistic testing
-fn get_llmsim_profile(model_id: &str) -> Option<LlmModelProfile> {
+fn llmsim_profile_data(model_id: &str) -> Option<LlmModelProfile> {
     match model_id {
         "llmsim-default" | "llmsim" => Some(LlmModelProfile {
             name: "LlmSim Default".into(),
@@ -2643,116 +2793,29 @@ fn get_llmsim_profile(model_id: &str) -> Option<LlmModelProfile> {
     }
 }
 
-/// Normalize OpenAI model ID to base name
-/// e.g., "gpt-4o-2024-11-20" -> "gpt-4o"
-fn normalize_model_id(model_id: &str) -> &str {
-    // Known base model patterns (order matters - more specific first)
-    let patterns = [
-        // Realtime models
-        "gpt-realtime-2",
-        // GPT-5.5 models
-        "gpt-5.5-pro",
-        "gpt-5.5",
-        // GPT-5.4 models
-        "gpt-5.4-pro",
-        "gpt-5.4-nano",
-        "gpt-5.4-mini",
-        "gpt-5.4",
-        // GPT-5.3 models
-        "gpt-5.3-codex",
-        // GPT-5.2 models
-        "gpt-5.2-chat-latest",
-        "gpt-5.2-codex",
-        "gpt-5.2-pro",
-        "gpt-5.2",
-        // GPT-5.1 models
-        "gpt-5.1-chat-latest",
-        "gpt-5.1-codex-max",
-        "gpt-5.1-codex-mini",
-        "gpt-5.1-codex",
-        "gpt-5.1",
-        // GPT-5 models
-        "gpt-5-chat-latest",
-        "gpt-5-codex",
-        "gpt-5-nano",
-        "gpt-5-mini",
-        "gpt-5-pro",
-        "gpt-5",
-        // GPT-4.1 models
-        "gpt-4.1-nano",
-        "gpt-4.1-mini",
-        "gpt-4.1",
-        // GPT-4 models
-        "gpt-4o-mini",
-        "gpt-4o",
-        // Reasoning models (o-series)
-        "o4-mini-deep-research",
-        "o4-mini",
-        "o3-deep-research",
-        "o3-pro",
-        "o3-mini",
-        "o3",
-        "o1-preview",
-        "o1-mini",
-        "o1-pro",
-        "o1",
-    ];
-
-    for pattern in patterns {
-        if model_id == pattern || model_id.starts_with(&format!("{}-", pattern)) {
-            return pattern;
-        }
-    }
-
-    model_id
-}
-
-/// Normalize Anthropic model ID to base name
-/// e.g., "claude-3-5-sonnet-20241022" -> "claude-3-5-sonnet"
-fn normalize_anthropic_model_id(model_id: &str) -> &str {
-    // Known base model patterns (order matters - more specific first)
-    let patterns = [
-        // Claude 4.8
-        "claude-opus-4-8",
-        // Claude 4.7 / 4.6
-        "claude-opus-4-7",
-        "claude-opus-4-6",
-        "claude-sonnet-4-6",
-        // Claude 4.5 series
-        "claude-opus-4-5",
-        "claude-sonnet-4-5",
-        "claude-haiku-4-5",
-        // Claude 4.1 series
-        "claude-opus-4-1",
-        // Claude 4 series
-        "claude-sonnet-4",
-        "claude-opus-4",
-        // Claude 3.7 series
-        "claude-3-7-sonnet",
-        // Claude 3.5 series
-        "claude-3-5-sonnet",
-        "claude-3-5-haiku",
-        // Claude 3 series
-        "claude-3-opus",
-        "claude-3-sonnet",
-        "claude-3-haiku",
-    ];
-
-    for pattern in patterns {
-        if model_id == pattern
-            || model_id.starts_with(&format!("{}-", pattern))
-            || model_id == format!("{}-latest", pattern)
-        {
-            return pattern;
-        }
-    }
-
-    model_id
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // The per-vendor `normalize_*` functions were folded into the flat registry
+    // (longest-prefix matching in `resolve_descriptor`). These shims preserve
+    // the original normalization assertions as regression coverage: each maps a
+    // wire id to its canonical registry id under the relevant provider surface.
+    fn normalize_model_id(id: &str) -> &'static str {
+        resolve_descriptor(&LlmProviderType::Openai, id)
+            .map(|d| d.ids[0])
+            .unwrap_or("")
+    }
+    fn normalize_anthropic_model_id(id: &str) -> &'static str {
+        resolve_descriptor(&LlmProviderType::Anthropic, id)
+            .map(|d| d.ids[0])
+            .unwrap_or("")
+    }
+    fn normalize_gemini_model_id(id: &str) -> &'static str {
+        resolve_descriptor(&LlmProviderType::Gemini, id)
+            .map(|d| d.ids[0])
+            .unwrap_or("")
+    }
 
     #[test]
     fn test_get_profile_openai_gpt4o() {
@@ -3727,10 +3790,10 @@ mod tests {
     }
 
     #[test]
-    fn test_third_party_models_not_resolved_under_openai_or_azure() {
-        // The Chat-Completions-only third-party models must not appear as
-        // supported under the Open Responses (`openai`) or Azure providers,
-        // which only serve genuine OpenAI models.
+    fn test_third_party_surfaces() {
+        // Third-party, OpenAI-compatible models are reachable via the Chat
+        // Completions path AND via Responses-capable gateways (e.g. OpenRouter
+        // configured as an `openai` provider) — but never Azure OpenAI.
         for id in [
             "qwen3.7-max",
             "MiniMax-M3",
@@ -3738,17 +3801,84 @@ mod tests {
             "nemotron-3-super-120b-a12b",
         ] {
             assert!(
-                get_model_profile(&LlmProviderType::Openai, id).is_none(),
-                "{id} should not resolve under openai (Open Responses)"
+                get_model_profile(&LlmProviderType::OpenaiCompletions, id).is_some(),
+                "{id} should resolve under openai_completions"
+            );
+            assert!(
+                get_model_profile(&LlmProviderType::Openai, id).is_some(),
+                "{id} should resolve under openai (Open Responses gateway)"
             );
             assert!(
                 get_model_profile(&LlmProviderType::AzureOpenai, id).is_none(),
-                "{id} should not resolve under azure_openai"
+                "{id} must not resolve under azure_openai"
+            );
+            assert!(
+                get_model_profile(&LlmProviderType::Anthropic, id).is_none(),
+                "{id} must not resolve under anthropic"
             );
         }
+        // Native phases / tool_search are advertised only on the Responses
+        // surface, never on Chat Completions.
+        let grok_completions =
+            get_model_profile(&LlmProviderType::OpenaiCompletions, "grok-4.3").unwrap();
+        assert!(!grok_completions.supports_phases);
+        assert!(!grok_completions.tool_search);
+
         // Genuine OpenAI models still resolve under all OpenAI-family types.
         assert!(get_model_profile(&LlmProviderType::Openai, "gpt-4o").is_some());
         assert!(get_model_profile(&LlmProviderType::AzureOpenai, "gpt-4o").is_some());
+    }
+
+    #[test]
+    fn test_phases_and_tool_search_gated_to_responses_surface() {
+        // GPT-5.4 advertises phases + tool_search on the Responses surface...
+        let responses = get_model_profile(&LlmProviderType::Openai, "gpt-5.4").unwrap();
+        assert!(responses.supports_phases);
+        assert!(responses.tool_search);
+        // ...but not when reached via Chat Completions or Azure.
+        let completions =
+            get_model_profile(&LlmProviderType::OpenaiCompletions, "gpt-5.4").unwrap();
+        assert!(!completions.supports_phases);
+        assert!(!completions.tool_search);
+    }
+
+    #[test]
+    fn test_model_vendor_lookup() {
+        assert_eq!(
+            get_model_vendor(&LlmProviderType::Anthropic, "claude-opus-4-8"),
+            Some(ModelVendor::Anthropic)
+        );
+        assert_eq!(
+            get_model_vendor(
+                &LlmProviderType::OpenaiCompletions,
+                "nvidia/nemotron-3-super-120b-a12b"
+            ),
+            Some(ModelVendor::Nvidia)
+        );
+        assert_eq!(
+            get_model_vendor(&LlmProviderType::Openai, "gpt-5.4"),
+            Some(ModelVendor::OpenAi)
+        );
+        assert_eq!(get_model_vendor(&LlmProviderType::Openai, "made-up"), None);
+    }
+
+    #[test]
+    fn test_registry_canonical_ids_have_profiles() {
+        // Every canonical id in the registry must have a profile payload, and
+        // every profile must be reachable through the registry under at least
+        // one of its surfaces (no orphans on either side).
+        for descriptor in REGISTRY {
+            let canonical = descriptor.ids[0];
+            assert!(
+                profile_data(canonical).is_some(),
+                "registry id {canonical} has no profile payload"
+            );
+            let surface = &descriptor.surfaces[0];
+            assert!(
+                get_model_profile(surface, canonical).is_some(),
+                "registry id {canonical} does not resolve under its own surface"
+            );
+        }
     }
 
     #[test]

--- a/crates/core/src/llm_model_profiles.rs
+++ b/crates/core/src/llm_model_profiles.rs
@@ -315,15 +315,24 @@ fn resolve_descriptor(
     provider_type: &LlmProviderType,
     model_id: &str,
 ) -> Option<&'static ModelDescriptor> {
-    let id = model_id.to_ascii_lowercase();
+    // Match without allocating: compare bytes case-insensitively. Ids are ASCII.
+    let id = model_id.as_bytes();
     let mut best: Option<(usize, &'static ModelDescriptor)> = None;
     for descriptor in REGISTRY {
         if !descriptor.surfaces.contains(provider_type) {
             continue;
         }
         for alias in descriptor.ids {
-            let alias = alias.to_ascii_lowercase();
-            let id_matches = id == alias || id.starts_with(&format!("{alias}-"));
+            let alias = alias.as_bytes();
+            // Exact (case-insensitive) match, or an `"<alias>-"` prefix (which
+            // covers dated and `-latest` suffixes).
+            let id_matches = if id.len() == alias.len() {
+                id.eq_ignore_ascii_case(alias)
+            } else {
+                id.len() > alias.len()
+                    && id[alias.len()] == b'-'
+                    && id[..alias.len()].eq_ignore_ascii_case(alias)
+            };
             if id_matches && best.is_none_or(|(len, _)| alias.len() > len) {
                 best = Some((alias.len(), descriptor));
             }
@@ -341,9 +350,12 @@ pub fn get_model_profile(
 ) -> Option<LlmModelProfile> {
     let descriptor = resolve_descriptor(provider_type, model_id)?;
     let mut profile = profile_data(descriptor.ids[0])?;
-    // Native execution phases and tool_search exist only on the OpenAI Responses
-    // surface; do not advertise them when the model is reached via another
-    // provider type (Azure, Chat Completions, gateways).
+    // Native execution phases and tool_search are advertised only for the
+    // `openai` (Open Responses) provider type — that is the only surface whose
+    // driver implements them. Every other provider type (Azure, Chat
+    // Completions) gets them masked off, regardless of which model it serves.
+    // A gateway that exposes a Responses-compatible endpoint is configured as
+    // `openai`, so it is intentionally treated as Responses-capable here.
     if !matches!(provider_type, LlmProviderType::Openai) {
         profile.supports_phases = false;
         profile.tool_search = false;

--- a/crates/core/src/llm_models.rs
+++ b/crates/core/src/llm_models.rs
@@ -219,6 +219,10 @@ pub struct LlmModelWithProvider {
     /// Readonly profile with model capabilities (limits, pricing, modalities). Not persisted.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub profile: Option<LlmModelProfile>,
+    /// Vendor/brand of the model, derived from the model registry. Drives UI
+    /// branding (icons). `None` when the model id is not in the registry. Not persisted.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model_vendor: Option<ModelVendor>,
 }
 
 // ============================================
@@ -329,6 +333,25 @@ pub struct ReasoningEffortConfig {
     pub values: Vec<ReasoningEffortValue>,
     /// Default reasoning effort for this model
     pub default: ReasoningEffort,
+}
+
+/// Vendor / brand that authored a model. Independent of the provider type
+/// that serves it (the same model may be offered by several providers or
+/// gateways). Primarily drives UI iconography.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+#[serde(rename_all = "lowercase")]
+pub enum ModelVendor {
+    OpenAi,
+    Anthropic,
+    Google,
+    Nvidia,
+    Qwen,
+    Microsoft,
+    MiniMax,
+    Moonshot,
+    XAi,
+    LlmSim,
 }
 
 /// LLM Model Profile describing model capabilities

--- a/crates/server/src/domains/llm_models/service.rs
+++ b/crates/server/src/domains/llm_models/service.rs
@@ -387,6 +387,10 @@ impl LlmModelService {
         // checks; keep the derivation in one place.
         let healthy = row.provider_status == "active" && row.provider_api_key_set;
 
+        // Vendor/brand tag from the model registry (drives UI branding),
+        // independent of the configured provider type.
+        let model_vendor = everruns_core::get_model_vendor(&provider_type, &row.model_id);
+
         LlmModelWithProvider {
             id: row.id,
             provider_id: row.provider_id,
@@ -402,6 +406,7 @@ impl LlmModelService {
             provider_type,
             healthy,
             profile,
+            model_vendor,
         }
     }
 

--- a/crates/server/src/openapi.rs
+++ b/crates/server/src/openapi.rs
@@ -201,6 +201,10 @@ use utoipa::OpenApi;
         api::organizations::list_organizations,
         api::organizations::get_organization,
         api::organizations::update_organization,
+        // Org feature flags
+        api::org_feature_flags::get_org_feature_flags,
+        api::org_feature_flags::get_org_feature_flag_settings,
+        api::org_feature_flags::update_org_feature_flags,
         // Workspace Volumes
         api::volumes::create_volume,
             api::volumes::list_volumes,

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -19861,6 +19861,17 @@
                       "description": "Provider-side model identifier as sent on the wire (e.g. `gpt-4o`).",
                       "example": "claude-sonnet-4-5"
                     },
+                    "model_vendor": {
+                      "oneOf": [
+                        {
+                          "type": "null"
+                        },
+                        {
+                          "$ref": "#/components/schemas/ModelVendor",
+                          "description": "Vendor/brand of the model, derived from the model registry. Drives UI\nbranding (icons). `None` when the model id is not in the registry. Not persisted."
+                        }
+                      ]
+                    },
                     "profile": {
                       "oneOf": [
                         {
@@ -21206,6 +21217,17 @@
             "description": "Provider-side model identifier as sent on the wire (e.g. `gpt-4o`).",
             "example": "claude-sonnet-4-5"
           },
+          "model_vendor": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ModelVendor",
+                "description": "Vendor/brand of the model, derived from the model registry. Drives UI\nbranding (icons). `None` when the model id is not in the registry. Not persisted."
+              }
+            ]
+          },
           "profile": {
             "oneOf": [
               {
@@ -22139,6 +22161,22 @@
             "description": "Provider ID (internal identifier)"
           }
         }
+      },
+      "ModelVendor": {
+        "type": "string",
+        "description": "Vendor / brand that authored a model. Independent of the provider type\nthat serves it (the same model may be offered by several providers or\ngateways). Primarily drives UI iconography.",
+        "enum": [
+          "openai",
+          "anthropic",
+          "google",
+          "nvidia",
+          "qwen",
+          "microsoft",
+          "minimax",
+          "moonshot",
+          "xai",
+          "llmsim"
+        ]
       },
       "MoveFileRequest": {
         "type": "object",
@@ -30495,6 +30533,17 @@
                 "type": "string",
                 "description": "Provider-side model identifier as sent on the wire (e.g. `gpt-4o`).",
                 "example": "claude-sonnet-4-5"
+              },
+              "model_vendor": {
+                "oneOf": [
+                  {
+                    "type": "null"
+                  },
+                  {
+                    "$ref": "#/components/schemas/ModelVendor",
+                    "description": "Vendor/brand of the model, derived from the model registry. Drives UI\nbranding (icons). `None` when the model id is not in the registry. Not persisted."
+                  }
+                ]
               },
               "profile": {
                 "oneOf": [

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -6799,6 +6799,184 @@
         ]
       }
     },
+    "/v1/orgs/{org}/feature-flags": {
+      "get": {
+        "tags": [
+          "Organizations"
+        ],
+        "summary": "GET /v1/orgs/{org}/feature-flags — effective flags for the organization.",
+        "operationId": "get_org_feature_flags",
+        "parameters": [
+          {
+            "name": "org",
+            "in": "path",
+            "description": "Organization public id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Effective feature flags",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FeatureFlags"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Organization not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "cookieAuth": []
+          }
+        ]
+      },
+      "patch": {
+        "tags": [
+          "Organizations"
+        ],
+        "summary": "PATCH /v1/orgs/{org}/feature-flags — update org opt-in (admin only).",
+        "operationId": "update_org_feature_flags",
+        "parameters": [
+          {
+            "name": "org",
+            "in": "path",
+            "description": "Organization public id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateOrgFeatureFlagsRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Updated effective flags",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FeatureFlags"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid flag",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Organization not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "cookieAuth": []
+          }
+        ]
+      }
+    },
+    "/v1/orgs/{org}/feature-flags/settings": {
+      "get": {
+        "tags": [
+          "Organizations"
+        ],
+        "summary": "GET /v1/orgs/{org}/feature-flags/settings — catalog with system/org/effective state.",
+        "operationId": "get_org_feature_flag_settings",
+        "parameters": [
+          {
+            "name": "org",
+            "in": "path",
+            "description": "Organization public id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Feature flag settings",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrgFeatureFlagsSettingsResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Organization not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "cookieAuth": []
+          }
+        ]
+      }
+    },
     "/v1/payments/accounts": {
       "get": {
         "tags": [
@@ -15988,6 +16166,59 @@
           }
         }
       },
+      "FeatureFlags": {
+        "type": "object",
+        "description": "Feature flags exposed via `GET /v1/feature-flags` and consumed by the frontend.\n\nCurrently backed by environment variables and deployment grade.\nFuture: per-org flags, per-user flags, external providers.",
+        "required": [
+          "global_chat",
+          "notifications",
+          "mcp_endpoint",
+          "evals",
+          "app_budgets",
+          "agent_versions",
+          "voice",
+          "apps.detailV2",
+          "agent_delegation"
+        ],
+        "properties": {
+          "agent_delegation": {
+            "type": "boolean",
+            "description": "Outbound agent delegation capabilities (`a2a_agent_delegation`, `agent_handoff`).\nExperimental: auto-enabled in dev, off in prod by default.\nWhen off, these capabilities are not registered and cannot be assigned to agents."
+          },
+          "agent_versions": {
+            "type": "boolean",
+            "description": "Immutable agent versions, snapshots, forks, and app version binding.\nExperimental."
+          },
+          "app_budgets": {
+            "type": "boolean",
+            "description": "App / channel scoped budgets and periodic budget resets (`5h`, `1d`, ...).\nExperimental."
+          },
+          "apps.detailV2": {
+            "type": "boolean",
+            "description": "Channels-first app detail page and full-page channel forms. Experimental."
+          },
+          "evals": {
+            "type": "boolean",
+            "description": "Evals (user-facing behavioral evals for agents). Experimental."
+          },
+          "global_chat": {
+            "type": "boolean",
+            "description": "Global chat (per-user singleton chat session). Experimental."
+          },
+          "mcp_endpoint": {
+            "type": "boolean",
+            "description": "MCP endpoint (POST /mcp — Everruns as an MCP server). Experimental."
+          },
+          "notifications": {
+            "type": "boolean",
+            "description": "In-app notifications (bell, toasts, notification SSE). Experimental."
+          },
+          "voice": {
+            "type": "boolean",
+            "description": "Realtime voice endpoints and microphone controls. Experimental."
+          }
+        }
+      },
       "FileInfo": {
         "type": "object",
         "description": "File metadata without content",
@@ -22227,6 +22458,58 @@
           ]
         }
       },
+      "OrgFeatureFlagSetting": {
+        "type": "object",
+        "required": [
+          "name",
+          "label",
+          "description",
+          "experimental",
+          "system_enabled",
+          "org_enabled",
+          "effective"
+        ],
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "effective": {
+            "type": "boolean",
+            "description": "Effective value (`system_enabled && org_enabled`)."
+          },
+          "experimental": {
+            "type": "boolean"
+          },
+          "label": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "org_enabled": {
+            "type": "boolean",
+            "description": "Whether the organization has opted in."
+          },
+          "system_enabled": {
+            "type": "boolean",
+            "description": "Whether the deployment allows this flag (env / grade)."
+          }
+        }
+      },
+      "OrgFeatureFlagsSettingsResponse": {
+        "type": "object",
+        "required": [
+          "flags"
+        ],
+        "properties": {
+          "flags": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OrgFeatureFlagSetting"
+            }
+          }
+        }
+      },
       "OrganizationResponse": {
         "type": "object",
         "description": "Response for organization operations",
@@ -28389,6 +28672,24 @@
             ],
             "description": "Human-readable name. Safe to render in user-facing messages.",
             "example": "customer-preferences-archive"
+          }
+        }
+      },
+      "UpdateOrgFeatureFlagsRequest": {
+        "type": "object",
+        "required": [
+          "flags"
+        ],
+        "properties": {
+          "flags": {
+            "type": "object",
+            "description": "Map of flag name -> enabled. Omitted flags are unchanged.",
+            "additionalProperties": {
+              "type": "boolean"
+            },
+            "propertyNames": {
+              "type": "string"
+            }
           }
         }
       },


### PR DESCRIPTION
## What
Refactor LLM model-profile lookup from provider-type-partitioned functions into a single **flat registry** with vendor tags and per-model surface predicates.

Before, `get_model_profile` dispatched on `provider_type` to one of `get_openai_profile` / `get_anthropic_profile` / `get_gemini_profile` / `get_openai_compatible_profile`, each a big match with its own id normalizer — so e.g. a function named `get_openai_compatible_profile` returned NVIDIA Nemotron, and availability was coupled to the provider type rather than the model.

Two commits:
1. `refactor(models)` — the flat registry.
2. `fix(openapi)` — registers the pre-existing-unregistered `org_feature_flags` handlers in `ApiDoc` so `openapi_coverage_test` (red on `main`) passes; required to get this PR's CI green.

## Why
- A model's capabilities are intrinsic to the **model**, not to the provider type serving it. The same model can be offered by several providers/gateways.
- The old gating broke gateways: a third-party model (Nemotron, Qwen, …) served via OpenRouter configured as an `openai` (Open Responses) provider would not resolve, even though OpenRouter exposes a Responses-compatible endpoint.

## How
- New `REGISTRY: &[ModelDescriptor]` — each entry has `ids` (canonical + aliases, e.g. vendor-prefixed gateway ids), a `vendor` tag, and the `surfaces` (provider types) it's offered under.
- `resolve_descriptor` does **provider-agnostic** lookup: longest-prefix id match across the whole list (this subsumes the old date/`-latest` normalizers, which are deleted), then a `surfaces` predicate filters by provider type.
- Third-party models now resolve under **Chat Completions and Responses-capable gateways**, but still **never Azure**.
- Surface-dependent flags (`supports_phases`, `tool_search`) are gated to the OpenAI Responses surface **in the resolver**, instead of being implied by hard-coded call sites.
- Profile payloads are unchanged values keyed by canonical id (`profile_data`). Vendor is surfaced as `LlmModelWithProvider.model_vendor` (new `ModelVendor` enum) so the UI `ModelIcon` keys off the registry tag instead of sniffing `family`/`model_id` strings.
- Regenerated `docs/api/openapi.json` for the new enum + field, and for the 3 feature-flag paths.

## Risk
- Medium-low. Touches a central lookup used by ~9 call sites, but the public `get_model_profile` signature and all profile values are preserved. Behavior changes are intentional and tested: (a) third-party models resolve on the Responses surface, (b) `supports_phases`/`tool_search` are now false when a model is reached via non-Responses surfaces (previously implied true via call sites that already hard-code `Openai`, so runtime behavior is unchanged — only metadata shown for non-Responses placements is now accurate).

## Security
- Threat categories reviewed: **No security-relevant code changes.** Static model metadata returned by pure functions; `model_vendor` is a derived enum tag. `ModelIcon` renders hardcoded SVGs and switches on a typed enum (no user-controlled strings, no `dangerouslySetInnerHTML`). The OpenAPI fix only registers existing handlers in the spec. No auth/tenant/SQL/API-surface changes.
- Findings: none.

## Validation
- `cargo test -p everruns-core` — 2069 pass (incl. new registry tests: surface predicates, phases/tool_search gating, vendor lookup, and a no-orphan invariant asserting every registry id has a profile and resolves under its own surface).
- `cargo test -p everruns-server --lib llm_models` — 18 pass; `openapi_coverage_test` + `openapi_descriptions_test` pass; `cargo clippy` (core + server) and `cargo fmt --check` clean.
- UI: `oxlint` + `oxfmt` clean, `ModelIcon` jest test updated to assert vendor-tag selection.
- Rebased onto latest `main`; carried forward main's `estimate_cost_usd` and the gpt-5.5 `tool_search` re-enable.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

https://claude.ai/code/session_01FpWSqnjiTYi4MRYHMDwf6d