### PR TITLE
feat(models): enrich OpenRouter model sync

### DIFF
--- a/apps/ui/src/app/(main)/settings/providers/provider-card.tsx
+++ b/apps/ui/src/app/(main)/settings/providers/provider-card.tsx
@@ -32,8 +32,8 @@ export function ProviderCard({
   modelCounts: ProviderModelCounts;
   modelsLoading: boolean;
 }) {
-  // Only show sync button for providers without custom base URL (standard providers)
-  const canSync = !provider.base_url && provider.api_key_set;
+  const canSync =
+    provider.api_key_set && (!provider.base_url || isOpenRouterUrl(provider.base_url));
   const modelsHref = `/models?provider=${encodeURIComponent(provider.id)}`;
 
   return (
@@ -124,6 +124,15 @@ export function ProviderCard({
       </CardContent>
     </Card>
   );
+}
+
+function isOpenRouterUrl(baseUrl: string): boolean {
+  try {
+    const host = new URL(baseUrl).hostname.toLowerCase();
+    return host === "openrouter.ai";
+  } catch {
+    return false;
+  }
 }
 
 export function ProviderCardSkeleton() {

--- a/apps/ui/src/components/models/model-row.tsx
+++ b/apps/ui/src/components/models/model-row.tsx
@@ -296,8 +296,23 @@ export function ModelRow({
               {profile.modalities && <div>Input: {profile.modalities.input.join(", ")}</div>}
             </div>
           </div>
+          {profile.supported_parameters && profile.supported_parameters.length > 0 && (
+            <div className="border-t pt-3 mt-3">
+              <div className="font-medium text-muted-foreground mb-2 flex items-center gap-1 text-sm">
+                <Wrench className="h-3.5 w-3.5" />
+                Supported Parameters
+              </div>
+              <div className="flex flex-wrap gap-1">
+                {profile.supported_parameters.map((parameter) => (
+                  <Badge key={parameter} variant="outline" className="text-xs font-normal">
+                    {parameter}
+                  </Badge>
+                ))}
+              </div>
+            </div>
+          )}
           <div className="text-xs text-muted-foreground border-t pt-2 mt-2">
-            Profile data from{" "}
+            Profile data from provider discovery and{" "}
             <a
               href="https://models.dev"
               target="_blank"

--- a/apps/ui/src/lib/api/types/llm-types.ts
+++ b/apps/ui/src/lib/api/types/llm-types.ts
@@ -171,6 +171,12 @@ export interface LlmModelProfile {
   modalities?: LlmModelModalities;
   /** Reasoning effort configuration (for reasoning models) */
   reasoning_effort?: ReasoningEffortConfig;
+  /** Provider-advertised request parameters supported by this model */
+  supported_parameters?: string[];
+  /** Whether the model supports tool_search (deferred tool loading) */
+  tool_search?: boolean;
+  /** Whether the model supports native execution phases */
+  supports_phases?: boolean;
 }
 
 export interface CreateLlmProviderRequest {

--- a/crates/anthropic/src/driver.rs
+++ b/crates/anthropic/src/driver.rs
@@ -1373,6 +1373,7 @@ impl AnthropicModelInfo {
             modalities,
             reasoning_effort,
             tool_search: false,
+            supported_parameters: Vec::new(),
             supports_phases: false,
         }
     }

--- a/crates/core/src/llm_model_profiles.rs
+++ b/crates/core/src/llm_model_profiles.rs
@@ -423,6 +423,7 @@ fn openai_profile_data(model_id: &str) -> Option<LlmModelProfile> {
             }),
             reasoning_effort: Some(reasoning_effort_realtime()),
             tool_search: false,
+            supported_parameters: Vec::new(),
             supports_phases: true,
         }),
 
@@ -457,6 +458,7 @@ fn openai_profile_data(model_id: &str) -> Option<LlmModelProfile> {
             }),
             reasoning_effort: None,
             tool_search: false,
+            supported_parameters: Vec::new(),
             supports_phases: false,
         }),
 
@@ -491,6 +493,7 @@ fn openai_profile_data(model_id: &str) -> Option<LlmModelProfile> {
             }),
             reasoning_effort: None,
             tool_search: false,
+            supported_parameters: Vec::new(),
             supports_phases: false,
         }),
 
@@ -525,6 +528,7 @@ fn openai_profile_data(model_id: &str) -> Option<LlmModelProfile> {
             }),
             reasoning_effort: Some(reasoning_effort_standard()),
             tool_search: false,
+            supported_parameters: Vec::new(),
             supports_phases: false,
         }),
 
@@ -559,6 +563,7 @@ fn openai_profile_data(model_id: &str) -> Option<LlmModelProfile> {
             }),
             reasoning_effort: Some(reasoning_effort_standard()),
             tool_search: false,
+            supported_parameters: Vec::new(),
             supports_phases: false,
         }),
 
@@ -593,6 +598,7 @@ fn openai_profile_data(model_id: &str) -> Option<LlmModelProfile> {
             }),
             reasoning_effort: Some(reasoning_effort_high_only()),
             tool_search: false,
+            supported_parameters: Vec::new(),
             supports_phases: false,
         }),
 
@@ -627,6 +633,7 @@ fn openai_profile_data(model_id: &str) -> Option<LlmModelProfile> {
             }),
             reasoning_effort: Some(reasoning_effort_standard()),
             tool_search: false,
+            supported_parameters: Vec::new(),
             supports_phases: false,
         }),
 
@@ -661,6 +668,7 @@ fn openai_profile_data(model_id: &str) -> Option<LlmModelProfile> {
             }),
             reasoning_effort: Some(reasoning_effort_standard()),
             tool_search: false,
+            supported_parameters: Vec::new(),
             supports_phases: false,
         }),
 
@@ -695,6 +703,7 @@ fn openai_profile_data(model_id: &str) -> Option<LlmModelProfile> {
             }),
             reasoning_effort: Some(reasoning_effort_high_only()),
             tool_search: false,
+            supported_parameters: Vec::new(),
             supports_phases: false,
         }),
 
@@ -729,6 +738,7 @@ fn openai_profile_data(model_id: &str) -> Option<LlmModelProfile> {
             }),
             reasoning_effort: Some(reasoning_effort_standard()),
             tool_search: false,
+            supported_parameters: Vec::new(),
             supports_phases: false,
         }),
 
@@ -764,6 +774,7 @@ fn openai_profile_data(model_id: &str) -> Option<LlmModelProfile> {
             }),
             reasoning_effort: None,
             tool_search: false,
+            supported_parameters: Vec::new(),
             supports_phases: false,
         }),
 
@@ -798,6 +809,7 @@ fn openai_profile_data(model_id: &str) -> Option<LlmModelProfile> {
             }),
             reasoning_effort: None,
             tool_search: false,
+            supported_parameters: Vec::new(),
             supports_phases: false,
         }),
 
@@ -832,6 +844,7 @@ fn openai_profile_data(model_id: &str) -> Option<LlmModelProfile> {
             }),
             reasoning_effort: None,
             tool_search: false,
+            supported_parameters: Vec::new(),
             supports_phases: false,
         }),
 
@@ -868,6 +881,7 @@ fn openai_profile_data(model_id: &str) -> Option<LlmModelProfile> {
             }),
             reasoning_effort: Some(reasoning_effort_gpt5_pre51()),
             tool_search: false,
+            supported_parameters: Vec::new(),
             supports_phases: false,
         }),
 
@@ -902,6 +916,7 @@ fn openai_profile_data(model_id: &str) -> Option<LlmModelProfile> {
             }),
             reasoning_effort: Some(reasoning_effort_gpt5_pre51()),
             tool_search: false,
+            supported_parameters: Vec::new(),
             supports_phases: false,
         }),
 
@@ -936,6 +951,7 @@ fn openai_profile_data(model_id: &str) -> Option<LlmModelProfile> {
             }),
             reasoning_effort: Some(reasoning_effort_gpt5_pre51()),
             tool_search: false,
+            supported_parameters: Vec::new(),
             supports_phases: false,
         }),
 
@@ -970,6 +986,7 @@ fn openai_profile_data(model_id: &str) -> Option<LlmModelProfile> {
             }),
             reasoning_effort: Some(reasoning_effort_high_only()),
             tool_search: false,
+            supported_parameters: Vec::new(),
             supports_phases: false,
         }),
 
@@ -1004,6 +1021,7 @@ fn openai_profile_data(model_id: &str) -> Option<LlmModelProfile> {
             }),
             reasoning_effort: Some(reasoning_effort_gpt5_pre51()),
             tool_search: false,
+            supported_parameters: Vec::new(),
             supports_phases: false,
         }),
 
@@ -1039,6 +1057,7 @@ fn openai_profile_data(model_id: &str) -> Option<LlmModelProfile> {
             }),
             reasoning_effort: Some(reasoning_effort_gpt51()),
             tool_search: false,
+            supported_parameters: Vec::new(),
             supports_phases: false,
         }),
 
@@ -1073,6 +1092,7 @@ fn openai_profile_data(model_id: &str) -> Option<LlmModelProfile> {
             }),
             reasoning_effort: Some(reasoning_effort_gpt51()),
             tool_search: false,
+            supported_parameters: Vec::new(),
             supports_phases: false,
         }),
 
@@ -1107,6 +1127,7 @@ fn openai_profile_data(model_id: &str) -> Option<LlmModelProfile> {
             }),
             reasoning_effort: Some(reasoning_effort_gpt51()),
             tool_search: false,
+            supported_parameters: Vec::new(),
             supports_phases: false,
         }),
 
@@ -1142,6 +1163,7 @@ fn openai_profile_data(model_id: &str) -> Option<LlmModelProfile> {
             }),
             reasoning_effort: Some(reasoning_effort_gpt52()),
             tool_search: false,
+            supported_parameters: Vec::new(),
             supports_phases: false,
         }),
 
@@ -1177,6 +1199,7 @@ fn openai_profile_data(model_id: &str) -> Option<LlmModelProfile> {
             }),
             reasoning_effort: Some(reasoning_effort_gpt52()),
             tool_search: false,
+            supported_parameters: Vec::new(),
             supports_phases: false,
         }),
 
@@ -1211,6 +1234,7 @@ fn openai_profile_data(model_id: &str) -> Option<LlmModelProfile> {
             }),
             reasoning_effort: Some(reasoning_effort_gpt52_pro()),
             tool_search: false,
+            supported_parameters: Vec::new(),
             supports_phases: false,
         }),
 
@@ -1245,6 +1269,7 @@ fn openai_profile_data(model_id: &str) -> Option<LlmModelProfile> {
             }),
             reasoning_effort: Some(reasoning_effort_gpt52()),
             tool_search: false,
+            supported_parameters: Vec::new(),
             supports_phases: false,
         }),
 
@@ -1280,6 +1305,7 @@ fn openai_profile_data(model_id: &str) -> Option<LlmModelProfile> {
             }),
             reasoning_effort: Some(reasoning_effort_gpt52()),
             tool_search: false,
+            supported_parameters: Vec::new(),
             supports_phases: false,
         }),
 
@@ -1319,6 +1345,7 @@ fn openai_profile_data(model_id: &str) -> Option<LlmModelProfile> {
             }),
             reasoning_effort: Some(reasoning_effort_gpt55()),
             tool_search: true,
+            supported_parameters: Vec::new(),
             supports_phases: true,
         }),
 
@@ -1353,6 +1380,7 @@ fn openai_profile_data(model_id: &str) -> Option<LlmModelProfile> {
             }),
             reasoning_effort: Some(reasoning_effort_gpt52_pro()),
             tool_search: true,
+            supported_parameters: Vec::new(),
             supports_phases: true,
         }),
 
@@ -1395,6 +1423,7 @@ fn openai_profile_data(model_id: &str) -> Option<LlmModelProfile> {
             }),
             reasoning_effort: Some(reasoning_effort_gpt52()),
             tool_search: true,
+            supported_parameters: Vec::new(),
             supports_phases: true,
         }),
 
@@ -1429,6 +1458,7 @@ fn openai_profile_data(model_id: &str) -> Option<LlmModelProfile> {
             }),
             reasoning_effort: Some(reasoning_effort_gpt52()),
             tool_search: true,
+            supported_parameters: Vec::new(),
             supports_phases: true,
         }),
 
@@ -1463,6 +1493,7 @@ fn openai_profile_data(model_id: &str) -> Option<LlmModelProfile> {
             }),
             reasoning_effort: Some(reasoning_effort_gpt52()),
             tool_search: true,
+            supported_parameters: Vec::new(),
             supports_phases: true,
         }),
 
@@ -1502,6 +1533,7 @@ fn openai_profile_data(model_id: &str) -> Option<LlmModelProfile> {
             }),
             reasoning_effort: Some(reasoning_effort_gpt52_pro()),
             tool_search: true,
+            supported_parameters: Vec::new(),
             supports_phases: true,
         }),
 
@@ -1537,6 +1569,7 @@ fn openai_profile_data(model_id: &str) -> Option<LlmModelProfile> {
             }),
             reasoning_effort: Some(reasoning_effort_gpt5_pre51()),
             tool_search: false,
+            supported_parameters: Vec::new(),
             supports_phases: false,
         }),
 
@@ -1571,6 +1604,7 @@ fn openai_profile_data(model_id: &str) -> Option<LlmModelProfile> {
             }),
             reasoning_effort: Some(reasoning_effort_gpt51()),
             tool_search: false,
+            supported_parameters: Vec::new(),
             supports_phases: false,
         }),
 
@@ -1605,6 +1639,7 @@ fn openai_profile_data(model_id: &str) -> Option<LlmModelProfile> {
             }),
             reasoning_effort: Some(reasoning_effort_gpt52()),
             tool_search: false,
+            supported_parameters: Vec::new(),
             supports_phases: false,
         }),
 
@@ -1640,6 +1675,7 @@ fn openai_profile_data(model_id: &str) -> Option<LlmModelProfile> {
             }),
             reasoning_effort: Some(reasoning_effort_standard()),
             tool_search: false,
+            supported_parameters: Vec::new(),
             supports_phases: false,
         }),
 
@@ -1674,6 +1710,7 @@ fn openai_profile_data(model_id: &str) -> Option<LlmModelProfile> {
             }),
             reasoning_effort: Some(reasoning_effort_standard()),
             tool_search: false,
+            supported_parameters: Vec::new(),
             supports_phases: false,
         }),
 
@@ -1708,6 +1745,7 @@ fn openai_profile_data(model_id: &str) -> Option<LlmModelProfile> {
             }),
             reasoning_effort: Some(reasoning_effort_standard()),
             tool_search: false,
+            supported_parameters: Vec::new(),
             supports_phases: false,
         }),
 
@@ -1763,6 +1801,7 @@ fn third_party_profile_data(model_id: &str) -> Option<LlmModelProfile> {
                 }),
                 reasoning_effort: None,
                 tool_search: false,
+                supported_parameters: Vec::new(),
                 supports_phases: false,
             })
         }
@@ -1800,6 +1839,7 @@ fn third_party_profile_data(model_id: &str) -> Option<LlmModelProfile> {
             }),
             reasoning_effort: None,
             tool_search: false,
+            supported_parameters: Vec::new(),
             supports_phases: false,
         }),
 
@@ -1830,6 +1870,7 @@ fn third_party_profile_data(model_id: &str) -> Option<LlmModelProfile> {
             }),
             reasoning_effort: None,
             tool_search: false,
+            supported_parameters: Vec::new(),
             supports_phases: false,
         }),
 
@@ -1866,6 +1907,7 @@ fn third_party_profile_data(model_id: &str) -> Option<LlmModelProfile> {
             }),
             reasoning_effort: None,
             tool_search: false,
+            supported_parameters: Vec::new(),
             supports_phases: false,
         }),
 
@@ -1902,6 +1944,7 @@ fn third_party_profile_data(model_id: &str) -> Option<LlmModelProfile> {
             }),
             reasoning_effort: None,
             tool_search: false,
+            supported_parameters: Vec::new(),
             supports_phases: false,
         }),
 
@@ -1943,6 +1986,7 @@ fn third_party_profile_data(model_id: &str) -> Option<LlmModelProfile> {
             }),
             reasoning_effort: None,
             tool_search: false,
+            supported_parameters: Vec::new(),
             supports_phases: false,
         }),
 
@@ -1989,6 +2033,7 @@ fn anthropic_profile_data(model_id: &str) -> Option<LlmModelProfile> {
             }),
             reasoning_effort: Some(reasoning_effort_anthropic_adaptive_thinking()),
             tool_search: false,
+            supported_parameters: Vec::new(),
             supports_phases: false,
         }),
 
@@ -2024,6 +2069,7 @@ fn anthropic_profile_data(model_id: &str) -> Option<LlmModelProfile> {
             }),
             reasoning_effort: Some(reasoning_effort_anthropic_adaptive_thinking()),
             tool_search: false,
+            supported_parameters: Vec::new(),
             supports_phases: false,
         }),
 
@@ -2059,6 +2105,7 @@ fn anthropic_profile_data(model_id: &str) -> Option<LlmModelProfile> {
             }),
             reasoning_effort: Some(reasoning_effort_anthropic_adaptive_thinking()),
             tool_search: false,
+            supported_parameters: Vec::new(),
             supports_phases: false,
         }),
 
@@ -2093,6 +2140,7 @@ fn anthropic_profile_data(model_id: &str) -> Option<LlmModelProfile> {
             }),
             reasoning_effort: Some(reasoning_effort_anthropic_adaptive_thinking()),
             tool_search: false,
+            supported_parameters: Vec::new(),
             supports_phases: false,
         }),
 
@@ -2128,6 +2176,7 @@ fn anthropic_profile_data(model_id: &str) -> Option<LlmModelProfile> {
             }),
             reasoning_effort: Some(reasoning_effort_anthropic_extended_thinking()),
             tool_search: false,
+            supported_parameters: Vec::new(),
             supports_phases: false,
         }),
 
@@ -2162,6 +2211,7 @@ fn anthropic_profile_data(model_id: &str) -> Option<LlmModelProfile> {
             }),
             reasoning_effort: Some(reasoning_effort_anthropic_extended_thinking()),
             tool_search: false,
+            supported_parameters: Vec::new(),
             supports_phases: false,
         }),
 
@@ -2196,6 +2246,7 @@ fn anthropic_profile_data(model_id: &str) -> Option<LlmModelProfile> {
             }),
             reasoning_effort: Some(reasoning_effort_anthropic_extended_thinking()),
             tool_search: false,
+            supported_parameters: Vec::new(),
             supports_phases: false,
         }),
 
@@ -2231,6 +2282,7 @@ fn anthropic_profile_data(model_id: &str) -> Option<LlmModelProfile> {
             }),
             reasoning_effort: Some(reasoning_effort_anthropic_extended_thinking()),
             tool_search: false,
+            supported_parameters: Vec::new(),
             supports_phases: false,
         }),
 
@@ -2266,6 +2318,7 @@ fn anthropic_profile_data(model_id: &str) -> Option<LlmModelProfile> {
             }),
             reasoning_effort: Some(reasoning_effort_anthropic_extended_thinking()),
             tool_search: false,
+            supported_parameters: Vec::new(),
             supports_phases: false,
         }),
 
@@ -2300,6 +2353,7 @@ fn anthropic_profile_data(model_id: &str) -> Option<LlmModelProfile> {
             }),
             reasoning_effort: Some(reasoning_effort_anthropic_extended_thinking()),
             tool_search: false,
+            supported_parameters: Vec::new(),
             supports_phases: false,
         }),
 
@@ -2335,6 +2389,7 @@ fn anthropic_profile_data(model_id: &str) -> Option<LlmModelProfile> {
             }),
             reasoning_effort: Some(reasoning_effort_anthropic_extended_thinking()),
             tool_search: false,
+            supported_parameters: Vec::new(),
             supports_phases: false,
         }),
 
@@ -2370,6 +2425,7 @@ fn anthropic_profile_data(model_id: &str) -> Option<LlmModelProfile> {
             }),
             reasoning_effort: None,
             tool_search: false,
+            supported_parameters: Vec::new(),
             supports_phases: false,
         }),
 
@@ -2404,6 +2460,7 @@ fn anthropic_profile_data(model_id: &str) -> Option<LlmModelProfile> {
             }),
             reasoning_effort: None,
             tool_search: false,
+            supported_parameters: Vec::new(),
             supports_phases: false,
         }),
 
@@ -2438,6 +2495,7 @@ fn anthropic_profile_data(model_id: &str) -> Option<LlmModelProfile> {
             }),
             reasoning_effort: None,
             tool_search: false,
+            supported_parameters: Vec::new(),
             supports_phases: false,
         }),
 
@@ -2472,6 +2530,7 @@ fn anthropic_profile_data(model_id: &str) -> Option<LlmModelProfile> {
             }),
             reasoning_effort: None,
             tool_search: false,
+            supported_parameters: Vec::new(),
             supports_phases: false,
         }),
 
@@ -2506,6 +2565,7 @@ fn anthropic_profile_data(model_id: &str) -> Option<LlmModelProfile> {
             }),
             reasoning_effort: None,
             tool_search: false,
+            supported_parameters: Vec::new(),
             supports_phases: false,
         }),
 
@@ -2562,6 +2622,7 @@ fn gemini_profile_data(model_id: &str) -> Option<LlmModelProfile> {
             }),
             reasoning_effort: None,
             tool_search: false,
+            supported_parameters: Vec::new(),
             supports_phases: false,
         }),
 
@@ -2601,6 +2662,7 @@ fn gemini_profile_data(model_id: &str) -> Option<LlmModelProfile> {
             }),
             reasoning_effort: None,
             tool_search: false,
+            supported_parameters: Vec::new(),
             supports_phases: false,
         }),
 
@@ -2640,6 +2702,7 @@ fn gemini_profile_data(model_id: &str) -> Option<LlmModelProfile> {
             }),
             reasoning_effort: None,
             tool_search: false,
+            supported_parameters: Vec::new(),
             supports_phases: false,
         }),
 
@@ -2679,6 +2742,7 @@ fn gemini_profile_data(model_id: &str) -> Option<LlmModelProfile> {
             }),
             reasoning_effort: None,
             tool_search: false,
+            supported_parameters: Vec::new(),
             supports_phases: false,
         }),
 
@@ -2718,6 +2782,7 @@ fn gemini_profile_data(model_id: &str) -> Option<LlmModelProfile> {
             }),
             reasoning_effort: None,
             tool_search: false,
+            supported_parameters: Vec::new(),
             supports_phases: false,
         }),
 
@@ -2757,6 +2822,7 @@ fn gemini_profile_data(model_id: &str) -> Option<LlmModelProfile> {
             }),
             reasoning_effort: None,
             tool_search: false,
+            supported_parameters: Vec::new(),
             supports_phases: false,
         }),
 
@@ -2799,6 +2865,7 @@ fn llmsim_profile_data(model_id: &str) -> Option<LlmModelProfile> {
             }),
             reasoning_effort: Some(reasoning_effort_gpt52()), // Same as GPT-5.2
             tool_search: false,
+            supported_parameters: Vec::new(),
             supports_phases: false,
         }),
         _ => None,

--- a/crates/core/src/llm_models.rs
+++ b/crates/core/src/llm_models.rs
@@ -410,6 +410,9 @@ pub struct LlmModelProfile {
     /// token usage for large tool sets. Currently supported by GPT-5.4 and newer.
     #[serde(default)]
     pub tool_search: bool,
+    /// Provider-advertised request parameters supported by this model.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub supported_parameters: Vec<String>,
     /// Whether the model supports native execution phases ("commentary" / "final_answer").
     /// When true, the driver sends the `phase` field on assistant messages in the wire format.
     /// Currently supported by GPT-5.4 and newer via OpenAI Responses API.

--- a/crates/openai/src/types.rs
+++ b/crates/openai/src/types.rs
@@ -274,9 +274,15 @@ pub struct OpenRouterModelsResponse {
 pub struct OpenRouterModelInfo {
     /// Fully qualified model id (e.g. `nvidia/nemotron-3-super-120b-a12b`).
     pub id: String,
+    /// Canonical model slug, when OpenRouter aliases the public id.
+    #[serde(default)]
+    pub canonical_slug: Option<String>,
     /// Human-readable display name (e.g. "NVIDIA: Nemotron 3 Super").
     #[serde(default)]
     pub name: Option<String>,
+    /// Human-readable model description.
+    #[serde(default)]
+    pub description: Option<String>,
     /// Unix timestamp of when the model was added.
     #[serde(default)]
     pub created: Option<i64>,
@@ -286,6 +292,9 @@ pub struct OpenRouterModelInfo {
     /// Modality metadata (input/output modalities).
     #[serde(default)]
     pub architecture: Option<OpenRouterArchitecture>,
+    /// Per-token pricing reported by OpenRouter.
+    #[serde(default)]
+    pub pricing: Option<OpenRouterPricing>,
     /// Top-provider limits (max completion tokens, effective context).
     #[serde(default)]
     pub top_provider: Option<OpenRouterTopProvider>,
@@ -293,6 +302,9 @@ pub struct OpenRouterModelInfo {
     /// (or `reasoning_effort`) is what tells us reasoning is supported.
     #[serde(default)]
     pub supported_parameters: Vec<String>,
+    /// Provider-reported knowledge cutoff, when available.
+    #[serde(default)]
+    pub knowledge_cutoff: Option<String>,
 }
 
 /// Modality metadata from OpenRouter's `architecture` object.
@@ -302,6 +314,19 @@ pub struct OpenRouterArchitecture {
     pub input_modalities: Vec<String>,
     #[serde(default)]
     pub output_modalities: Vec<String>,
+}
+
+/// Per-token pricing reported by OpenRouter's `pricing` object.
+#[derive(Debug, Clone, Deserialize)]
+pub struct OpenRouterPricing {
+    #[serde(default)]
+    pub prompt: Option<String>,
+    #[serde(default)]
+    pub completion: Option<String>,
+    #[serde(default)]
+    pub input_cache_read: Option<String>,
+    #[serde(default)]
+    pub cache_read: Option<String>,
 }
 
 /// Per-request limits reported by the routed upstream provider.
@@ -336,9 +361,6 @@ impl OpenRouterModelInfo {
     }
 
     /// Build an [`LlmModelProfile`] from OpenRouter's advertised metadata.
-    ///
-    /// Cost is intentionally left `None`: pricing is available but the hardcoded
-    /// profiles own cost data, and merging is keyed on the hardcoded entry.
     pub fn to_discovered_profile(&self) -> everruns_core::llm_models::LlmModelProfile {
         use everruns_core::llm_models::*;
 
@@ -401,25 +423,48 @@ impl OpenRouterModelInfo {
 
         LlmModelProfile {
             name: self.name.clone().unwrap_or_else(|| self.id.clone()),
-            family: self.id.clone(),
-            description: None,
+            family: self
+                .canonical_slug
+                .clone()
+                .unwrap_or_else(|| self.id.clone()),
+            description: self.description.clone(),
             release_date: None,
             last_updated: None,
             attachment: image_input || pdf_input,
             reasoning,
             temperature: self.supports("temperature"),
-            knowledge: None,
+            knowledge: self.knowledge_cutoff.clone(),
             tool_call: self.supports("tools") || self.supports("tool_choice"),
             structured_output: self.supports("structured_outputs")
                 || self.supports("response_format"),
             open_weights: false,
-            cost: None,
+            cost: self.pricing.as_ref().and_then(OpenRouterPricing::to_cost),
             limits,
             modalities,
             reasoning_effort,
             tool_search: false,
+            supported_parameters: self.supported_parameters.clone(),
             supports_phases: false,
         }
+    }
+}
+
+impl OpenRouterPricing {
+    fn to_cost(&self) -> Option<everruns_core::llm_models::LlmModelCost> {
+        let input = openrouter_price_per_million(self.prompt.as_deref()?)?;
+        let output = openrouter_price_per_million(self.completion.as_deref()?)?;
+        let cache_read = self
+            .input_cache_read
+            .as_deref()
+            .or(self.cache_read.as_deref())
+            .and_then(openrouter_price_per_million);
+
+        Some(everruns_core::llm_models::LlmModelCost {
+            input,
+            output,
+            cache_read,
+            cost_tiers: Vec::new(),
+        })
     }
 }
 
@@ -430,6 +475,10 @@ impl OpenRouterModelInfo {
 /// clamps into range instead. Negative inputs clamp to `0`.
 fn clamp_i64_to_i32(value: i64) -> i32 {
     value.clamp(0, i32::MAX as i64) as i32
+}
+
+fn openrouter_price_per_million(value: &str) -> Option<f64> {
+    value.parse::<f64>().ok().map(|price| price * 1_000_000.0)
 }
 
 /// Standard low/medium/high effort config for OpenRouter reasoning models.
@@ -466,18 +515,26 @@ mod openrouter_tests {
     // OpenRouter's /api/v1/models response.
     const NEMOTRON_JSON: &str = r#"{
         "id": "nvidia/nemotron-3-super-120b-a12b",
+        "canonical_slug": "nvidia/nemotron-3-super-120b-a12b",
         "name": "NVIDIA: Nemotron 3 Super",
+        "description": "A reasoning-capable chat model.",
         "created": 1773245239,
         "context_length": 1000000,
         "architecture": {
             "input_modalities": ["text"],
             "output_modalities": ["text"]
         },
+        "pricing": {
+            "prompt": "0.00000010",
+            "completion": "0.00000040",
+            "input_cache_read": "0.00000002"
+        },
         "top_provider": { "context_length": 262144, "max_completion_tokens": null },
         "supported_parameters": [
             "include_reasoning", "max_tokens", "reasoning", "response_format",
             "structured_outputs", "temperature", "tool_choice", "tools", "top_p"
-        ]
+        ],
+        "knowledge_cutoff": "2025-01"
     }"#;
 
     fn parse(json: &str) -> OpenRouterModelInfo {
@@ -512,6 +569,35 @@ mod openrouter_tests {
         assert!(profile.temperature);
         assert_eq!(profile.name, "NVIDIA: Nemotron 3 Super");
         assert_eq!(profile.family, "nvidia/nemotron-3-super-120b-a12b");
+        assert_eq!(
+            profile.description.as_deref(),
+            Some("A reasoning-capable chat model.")
+        );
+        assert_eq!(profile.release_date, None);
+        assert_eq!(profile.knowledge.as_deref(), Some("2025-01"));
+        let supported: Vec<_> = profile
+            .supported_parameters
+            .iter()
+            .map(String::as_str)
+            .collect();
+        assert_eq!(
+            supported,
+            vec![
+                "include_reasoning",
+                "max_tokens",
+                "reasoning",
+                "response_format",
+                "structured_outputs",
+                "temperature",
+                "tool_choice",
+                "tools",
+                "top_p"
+            ]
+        );
+        let cost = profile.cost.expect("cost");
+        assert!((cost.input - 0.1).abs() < 1e-9);
+        assert!((cost.output - 0.4).abs() < 1e-9);
+        assert!((cost.cache_read.expect("cache read") - 0.02).abs() < 1e-9);
         // Prefer the routed provider's effective context window.
         let limits = profile.limits.expect("limits");
         assert_eq!(limits.context, 262144);

--- a/crates/server/src/domains/llm_models/service.rs
+++ b/crates/server/src/domains/llm_models/service.rs
@@ -366,8 +366,7 @@ impl LlmModelService {
             row.provider_type.parse().unwrap_or(LlmProviderType::Openai);
 
         // Look up hardcoded profile, then try discovered profile from provider_metadata.
-        // Hardcoded profiles take precedence (they have cost data), but discovered
-        // profiles fill gaps for models without hardcoded entries.
+        // Hardcoded profiles take precedence; discovered provider catalog data fills gaps.
         let hardcoded = get_model_profile(&provider_type, &row.model_id);
         let profile = if hardcoded.is_some() {
             // Merge: hardcoded base with discovered limits/capabilities as fallback
@@ -430,16 +429,21 @@ impl LlmModelService {
             attachment: hardcoded.attachment,
             reasoning: hardcoded.reasoning,
             temperature: hardcoded.temperature,
-            knowledge: hardcoded.knowledge, // Not available from API
+            knowledge: hardcoded.knowledge.or(discovered.knowledge),
             tool_call: hardcoded.tool_call,
             structured_output: hardcoded.structured_output,
             open_weights: hardcoded.open_weights,
-            cost: hardcoded.cost, // Never from API
+            cost: hardcoded.cost.or(discovered.cost),
             // Limits: hardcoded values are authoritative; use discovered values only as fallback
             limits: hardcoded.limits.or(discovered.limits),
             modalities: hardcoded.modalities.or(discovered.modalities),
             reasoning_effort: hardcoded.reasoning_effort.or(discovered.reasoning_effort),
             tool_search: hardcoded.tool_search,
+            supported_parameters: if hardcoded.supported_parameters.is_empty() {
+                discovered.supported_parameters
+            } else {
+                hardcoded.supported_parameters
+            },
             supports_phases: hardcoded.supports_phases,
         }
     }
@@ -595,6 +599,7 @@ mod tests {
             modalities: None,
             reasoning_effort: None,
             tool_search: false,
+            supported_parameters: Vec::new(),
             supports_phases: false,
         }
     }
@@ -615,14 +620,21 @@ mod tests {
         let discovered = LlmModelProfile {
             name: "Discovered Name".into(),
             family: "discovered-family".into(),
-            cost: None,
+            knowledge: Some("2025-01-01".into()),
+            cost: Some(everruns_core::LlmModelCost {
+                input: 0.5,
+                output: 1.0,
+                cache_read: Some(0.1),
+                cost_tiers: vec![],
+            }),
             ..base_profile()
         };
 
         let merged = LlmModelService::merge_profiles(hardcoded, discovered);
         assert_eq!(merged.name, "Hardcoded Name");
         assert_eq!(merged.family, "hardcoded-family");
-        assert!(merged.cost.is_some());
+        assert_eq!(merged.knowledge.as_deref(), Some("2025-01-01"));
+        assert_eq!(merged.cost.unwrap().input, 5.0);
     }
 
     #[test]
@@ -640,12 +652,26 @@ mod tests {
                 output: 64_000,
                 max_media: None,
             }),
+            knowledge: Some("2025-02-01".into()),
+            cost: Some(everruns_core::LlmModelCost {
+                input: 0.5,
+                output: 1.0,
+                cache_read: Some(0.1),
+                cost_tiers: vec![],
+            }),
+            supported_parameters: vec!["tools".into(), "temperature".into()],
             ..base_profile()
         };
 
         let merged = LlmModelService::merge_profiles(hardcoded, discovered);
         assert!(merged.limits.is_some());
         assert_eq!(merged.limits.unwrap().context, 200_000);
+        assert_eq!(merged.knowledge.as_deref(), Some("2025-02-01"));
+        assert_eq!(merged.cost.unwrap().output, 1.0);
+        assert_eq!(
+            merged.supported_parameters,
+            vec!["tools".to_string(), "temperature".to_string()]
+        );
     }
 
     #[test]

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -21352,6 +21352,13 @@
             "type": "boolean",
             "description": "Whether the model supports structured output (JSON mode)"
           },
+          "supported_parameters": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Provider-advertised request parameters supported by this model."
+          },
           "supports_phases": {
             "type": "boolean",
             "description": "Whether the model supports native execution phases (\"commentary\" / \"final_answer\").\nWhen true, the driver sends the `phase` field on assistant messages in the wire format.\nCurrently supported by GPT-5.4 and newer via OpenAI Responses API."

--- a/specs/apis.md
+++ b/specs/apis.md
@@ -386,7 +386,7 @@ When `limit` is provided:
 
 #### Model Sync
 
-The sync endpoint discovers available models from a provider's API. Returns `"status": "success"` with created/updated/stale counts, or `"status": "not_supported"` for providers with custom base URLs or providers that don't support model listing.
+The sync endpoint discovers available models from a provider's API. Returns `"status": "success"` with created/updated/stale counts, or `"status": "not_supported"` for providers with unsupported custom base URLs or providers that don't support model listing.
 
 #### List Models Query Parameters
 

--- a/specs/models.md
+++ b/specs/models.md
@@ -259,11 +259,11 @@ Profiles matched by provider_type + model_id with version normalization (e.g., "
 
 ### Model Discovery
 
-Automatic discovery of available models from provider APIs (OpenAI, Anthropic).
+Automatic discovery of available models from provider APIs (OpenAI, OpenRouter via the OpenAI-compatible driver, Anthropic).
 
 - **Background Sync** — Every 24 hours (configurable via `MODEL_SYNC_INTERVAL_HOURS`, 0 to disable)
 - **Manual Sync** — `POST /v1/llm-providers/:id/sync-models`
-- Only providers with standard base URLs synced (custom URLs skipped)
+- Only providers with standard base URLs or driver-recognized model-listing URLs synced (for example OpenRouter's OpenAI-compatible endpoint); unsupported custom URLs are skipped
 - New models added as `discovered`; existing models have `last_seen_at` updated
 
 ### UserConnection


### PR DESCRIPTION
## What
Add richer OpenRouter model-discovery metadata to the synced model profile and expose it in the models UI.

## Why
OpenRouter exposes useful catalog metadata beyond the generic OpenAI `/models` shape. Syncing that data lets admins inspect model limits, pricing, capabilities, and supported request parameters instead of creating models manually or guessing from model ids.

## How
- Parse OpenRouter catalog fields for canonical slug, description, pricing, knowledge cutoff, and supported parameters.
- Store supported parameters on `LlmModelProfile` and preserve discovered parameters when merging profiles.
- Render supported parameters in expanded model rows and allow sync for OpenRouter custom base URLs.
- Regenerate OpenAPI and update model-sync specs.

## Risk
- Low / Medium
- Main risk is stale or unexpected OpenRouter catalog fields producing incomplete metadata. Parsing uses optional fields and existing defaults; unknown fields are ignored.
- UI risk is long supported-parameter lists. They render as wrapped badges inside the expanded model details panel.

## Security
- Threat categories reviewed: TM-LLM, TM-API, TM-WEB, TM-DOS.
- Findings and resolutions: no provider API keys are logged or exposed; model sync continues to use existing HTTPS provider flow. OpenRouter catalog values are parsed as optional data and rendered through React text nodes, so no raw HTML injection path was added. No new network destination class was introduced beyond the already-recognized OpenRouter model-listing host. No unbounded user-controlled API request body or DB query was added.

## Validation
- `just pre-push`
- `cargo test -p everruns-openai`
- `cargo test -p everruns-server llm_models`
- `OPENROUTER_API_KEY=smoke-test cargo test -p everruns-openai --test openrouter_discovery_live -- --ignored --nocapture`
- `cd apps/ui && pnpm lint`
- `cd apps/ui && pnpm format:check`
- `cd apps/ui && pnpm build`
- `./scripts/export-openapi.sh`
- `curl -fsSL -H "Authorization: Bearer smoke-test" https://openrouter.ai/api/v1/models | jq ".data[0] | {id, name, pricing, supported_parameters}"`

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

