### PR TITLE
fix(session-files): enforce quotas on copy and CAS writes

### DIFF
--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -954,9 +954,11 @@ impl WorkerAdapters for DirectWorkerAdapters {
         let content_bytes = SessionFile::decode_content(content, encoding)
             .map_err(|e| store_error(format!("Invalid content encoding: {}", e)))?;
 
+        // Fetch metadata only (no content blob) — content equality is enforced
+        // atomically in SQL by update_session_file_if_content_matches below.
         let existing = self
             .db
-            .get_session_file(session_id, path)
+            .get_session_file_info(session_id, path)
             .await
             .map_err(|e| {
                 tracing::error!("Failed to check existing file: {}", e);
@@ -966,9 +968,6 @@ impl WorkerAdapters for DirectWorkerAdapters {
             return Ok(None);
         };
         if existing.is_directory || existing.is_readonly {
-            return Ok(None);
-        }
-        if existing.content.as_deref().unwrap_or_default() != expected_bytes.as_slice() {
             return Ok(None);
         }
 

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -954,6 +954,37 @@ impl WorkerAdapters for DirectWorkerAdapters {
         let content_bytes = SessionFile::decode_content(content, encoding)
             .map_err(|e| store_error(format!("Invalid content encoding: {}", e)))?;
 
+        let existing = self
+            .db
+            .get_session_file(session_id, path)
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to check existing file: {}", e);
+                store_error("Failed to write file")
+            })?;
+        let Some(existing) = existing else {
+            return Ok(None);
+        };
+        if existing.is_directory || existing.is_readonly {
+            return Ok(None);
+        }
+        if existing.content.as_deref().unwrap_or_default() != expected_bytes.as_slice() {
+            return Ok(None);
+        }
+
+        {
+            use crate::domains::session_files::limits::check_write_quota;
+            check_write_quota(
+                &self.db,
+                session_id,
+                content_bytes.len() as i64,
+                existing.size_bytes,
+                &self.quota,
+            )
+            .await
+            .map_err(|e| store_error(e.to_string()))?;
+        }
+
         let row = self
             .db
             .update_session_file_if_content_matches(

--- a/crates/server/src/domains/session_files/service.rs
+++ b/crates/server/src/domains/session_files/service.rs
@@ -580,14 +580,14 @@ impl SessionFileService {
         let expected_bytes = SessionFile::decode_content(expected_content, expected_encoding)?;
         let content = SessionFile::decode_content(content, encoding)?;
 
-        let existing = self.db.get_session_file(session_id, &path).await?;
+        // Fetch metadata only (no content) to avoid transferring large blobs
+        // just to check flags. Content equality is enforced atomically in SQL by
+        // update_session_file_if_content_matches below.
+        let existing = self.db.get_session_file_info(session_id, &path).await?;
         let Some(existing) = existing else {
             return Ok(None);
         };
         if existing.is_directory || existing.is_readonly {
-            return Ok(None);
-        }
-        if existing.content.as_deref().unwrap_or_default() != expected_bytes.as_slice() {
             return Ok(None);
         }
 

--- a/crates/server/src/domains/session_files/service.rs
+++ b/crates/server/src/domains/session_files/service.rs
@@ -580,6 +580,20 @@ impl SessionFileService {
         let expected_bytes = SessionFile::decode_content(expected_content, expected_encoding)?;
         let content = SessionFile::decode_content(content, encoding)?;
 
+        let existing = self.db.get_session_file(session_id, &path).await?;
+        let Some(existing) = existing else {
+            return Ok(None);
+        };
+        if existing.is_directory || existing.is_readonly {
+            return Ok(None);
+        }
+        if existing.content.as_deref().unwrap_or_default() != expected_bytes.as_slice() {
+            return Ok(None);
+        }
+
+        self.check_write_quota(session_id, content.len() as i64, existing.size_bytes)
+            .await?;
+
         let row = self
             .db
             .update_session_file_if_content_matches(
@@ -708,13 +722,16 @@ impl SessionFileService {
 
         // Check source exists and is not a directory
         let source = self.db.get_session_file(session_id, &src_path).await?;
-        match source {
+        let source_size = match source {
             None => return Err(anyhow!("Source not found: {}", src_path)),
             Some(ref s) if s.is_directory => {
                 return Err(anyhow!("Cannot copy directories: {}", src_path));
             }
-            _ => {}
-        }
+            Some(ref s) => s.size_bytes,
+        };
+
+        // Copying creates another stored file, so it must consume session quota.
+        self.check_write_quota(session_id, source_size, 0).await?;
 
         // Check destination doesn't exist
         if self.db.session_file_exists(session_id, &dst_path).await? {
@@ -2063,6 +2080,123 @@ mod tests {
         assert!(
             err.to_string().contains("per-file limit"),
             "Expected per-file limit error, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn copy_file_enforces_session_total_limit() {
+        let db = StorageBackend::in_memory();
+        let sid = Uuid::new_v4();
+        let svc = SessionFileService::new(Arc::new(db)).with_quota_limits(QuotaLimits {
+            per_file_bytes: 15,
+            per_session_bytes: 20,
+        });
+
+        svc.create_file(
+            sid,
+            CreateFileInput {
+                path: "/a.txt".to_string(),
+                content: Some("x".repeat(15)),
+                encoding: None,
+                is_readonly: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        let err = svc
+            .copy_file(
+                sid,
+                CopyFileInput {
+                    src_path: "/a.txt".to_string(),
+                    dst_path: "/b.txt".to_string(),
+                },
+            )
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("quota exceeded"),
+            "Expected quota exceeded error, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn update_file_if_content_matches_enforces_per_file_limit() {
+        let db = StorageBackend::in_memory();
+        let sid = Uuid::new_v4();
+        let svc = SessionFileService::new(Arc::new(db)).with_quota_limits(QuotaLimits {
+            per_file_bytes: 10,
+            per_session_bytes: 500 * 1024 * 1024,
+        });
+
+        svc.create_file(
+            sid,
+            CreateFileInput {
+                path: "/f.txt".to_string(),
+                content: Some("hello".to_string()),
+                encoding: None,
+                is_readonly: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        let err = svc
+            .update_file_if_content_matches(sid, "/f.txt", "hello", "text", &"x".repeat(11), "text")
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("per-file limit"),
+            "Expected per-file limit error, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn update_file_if_content_matches_enforces_session_total_limit() {
+        let db = StorageBackend::in_memory();
+        let sid = Uuid::new_v4();
+        let svc = SessionFileService::new(Arc::new(db)).with_quota_limits(QuotaLimits {
+            per_file_bytes: 15,
+            per_session_bytes: 20,
+        });
+
+        svc.create_file(
+            sid,
+            CreateFileInput {
+                path: "/a.txt".to_string(),
+                content: Some("x".repeat(10)),
+                encoding: None,
+                is_readonly: None,
+            },
+        )
+        .await
+        .unwrap();
+        svc.create_file(
+            sid,
+            CreateFileInput {
+                path: "/b.txt".to_string(),
+                content: Some("y".repeat(5)),
+                encoding: None,
+                is_readonly: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        let err = svc
+            .update_file_if_content_matches(
+                sid,
+                "/b.txt",
+                &"y".repeat(5),
+                "text",
+                &"z".repeat(15),
+                "text",
+            )
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("quota exceeded"),
+            "Expected quota exceeded error, got: {err}"
         );
     }
 }

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -1594,6 +1594,14 @@ impl StorageBackend {
         dispatch!(self, get_session_file_by_id, id)
     }
 
+    pub async fn get_session_file_info(
+        &self,
+        session_id: Uuid,
+        path: &str,
+    ) -> Result<Option<SessionFileInfoRow>> {
+        dispatch!(self, get_session_file_info, session_id, path)
+    }
+
     pub async fn list_session_files(
         &self,
         session_id: Uuid,

--- a/crates/server/src/storage/memory/session_files.rs
+++ b/crates/server/src/storage/memory/session_files.rs
@@ -44,6 +44,19 @@ impl InMemoryDatabase {
             .cloned())
     }
 
+    pub async fn get_session_file_info(
+        &self,
+        session_id: Uuid,
+        path: &str,
+    ) -> Result<Option<SessionFileInfoRow>> {
+        Ok(self
+            .session_files
+            .read()
+            .values()
+            .find(|f| f.session_id == session_id && f.path == path)
+            .map(Self::file_to_info))
+    }
+
     pub async fn get_session_file_by_id(&self, id: Uuid) -> Result<Option<SessionFileRow>> {
         Ok(self.session_files.read().get(&id).cloned())
     }

--- a/crates/server/src/storage/repositories/session_files.rs
+++ b/crates/server/src/storage/repositories/session_files.rs
@@ -54,6 +54,27 @@ impl Database {
         Ok(row)
     }
 
+    /// Get file metadata (no content) — for lightweight pre-checks before atomic updates.
+    pub async fn get_session_file_info(
+        &self,
+        session_id: Uuid,
+        path: &str,
+    ) -> Result<Option<SessionFileInfoRow>> {
+        let row = sqlx::query_as::<_, SessionFileInfoRow>(
+            r#"
+            SELECT id, session_id, path, is_directory, is_readonly, size_bytes, created_at, updated_at
+            FROM session_files
+            WHERE session_id = $1 AND path = $2
+            "#,
+        )
+        .bind(session_id)
+        .bind(path)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(row)
+    }
+
     /// Get a file by ID
     pub async fn get_session_file_by_id(&self, id: Uuid) -> Result<Option<SessionFileRow>> {
         let row = sqlx::query_as::<_, SessionFileRow>(


### PR DESCRIPTION
### Motivation
- A scanner found that copying files and compare-and-set (CAS) updates bypassed the new per-file and per-session byte quotas, allowing authenticated users or in-process workers to exhaust session storage (TM-FS-008 / TM-DOS-005).
- Quotas must be enforced on every storage-mutating path (HTTP, DB-backed copy, CAS, and in-process worker paths) to close this storage-exhaustion bypass.

### Description
- Added a pre-write load and quota check to `SessionFileService::update_file_if_content_matches` that preserves CAS semantics (returns `None` for stale/missing/readonly snapshots) and calls `check_write_quota` before attempting the DB conditional update.
- Added a quota check in `SessionFileService::copy_file` that charges the `source.size_bytes` against the session quota via `check_write_quota` before duplicating the row.
- Mirrored the CAS quota enforcement in `DirectWorkerAdapters::write_file_if_content_matches` so in-process worker conditional writes cannot bypass limits.
- Added focused regression tests exercising copy and CAS quota enforcement (`copy_file_enforces_session_total_limit`, `update_file_if_content_matches_enforces_per_file_limit`, and `update_file_if_content_matches_enforces_session_total_limit`).

### Testing
- Ran `cargo test -p everruns-server --lib enforces` and the targeted tests passed (9 tests passed, 0 failed). 
- Ran `cargo fmt --check` and it succeeded. 
- Ran `cargo clippy -p everruns-server --all-targets --all-features -- -D warnings` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a224a8a1fd8832bb6ff623d1cddda88)