### PR TITLE
fix(core): scope tool_search registry introspection

### DIFF
--- a/crates/core/src/atoms/act.rs
+++ b/crates/core/src/atoms/act.rs
@@ -29,6 +29,7 @@
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -663,6 +664,13 @@ where
         // Track act phase timing for Braintrust observability
         let act_start = Instant::now();
 
+        let visible_tool_names = Arc::new(
+            tool_definitions
+                .iter()
+                .map(|def| def.name().to_string())
+                .collect::<HashSet<_>>(),
+        );
+
         // Build tool name to definition map
         let tool_map: std::collections::HashMap<&str, &ToolDefinition> = tool_definitions
             .iter()
@@ -743,6 +751,7 @@ where
                     &act_span_id,
                     locale.as_deref(),
                     network_access.as_ref(),
+                    visible_tool_names.clone(),
                 )
             })
             .await;
@@ -885,6 +894,7 @@ where
         act_span_id: &str,
         locale: Option<&str>,
         network_access: Option<&crate::network_access::NetworkAccessList>,
+        visible_tool_names: Arc<HashSet<String>>,
     ) -> ToolCallResult {
         tracing::debug!(
             session_id = %context.session_id,
@@ -1085,6 +1095,7 @@ where
         if let Some(ref registry) = self.tool_registry {
             tool_context.tool_registry = Some(registry.clone());
         }
+        tool_context.visible_tool_names = Some(visible_tool_names.clone());
         if let Some(ref store) = self.memory_store {
             tool_context.memory_store = Some(store.clone());
         }

--- a/crates/core/src/capabilities/tool_search.rs
+++ b/crates/core/src/capabilities/tool_search.rs
@@ -317,7 +317,17 @@ impl Tool for ToolSearchTool {
             );
         };
 
-        let defs = registry.tool_definitions();
+        let Some(visible_tool_names) = &context.visible_tool_names else {
+            return ToolExecutionResult::tool_error(
+                "Visible tool allowlist not available in this context. tool_search requires turn-scoped tool definitions.",
+            );
+        };
+
+        let defs: Vec<_> = registry
+            .tool_definitions()
+            .into_iter()
+            .filter(|d| visible_tool_names.contains(d.name()))
+            .collect();
         let matches = Self::search(&defs, query);
 
         if matches.is_empty() {
@@ -558,6 +568,11 @@ mod tests {
 
         let mut ctx = ToolContext::new(uuid::Uuid::new_v4().into());
         ctx.tool_registry = Some(Arc::new(registry));
+        ctx.visible_tool_names = Some(Arc::new(
+            ["read_file".to_string(), TOOL_SEARCH_TOOL_NAME.to_string()]
+                .into_iter()
+                .collect(),
+        ));
 
         let result = ToolSearchTool
             .execute_with_context(json!({ "query": "file" }), &ctx)
@@ -570,5 +585,65 @@ mod tests {
         let read = tools.iter().find(|t| t["name"] == "read_file").unwrap();
         // Full schema is returned (not the deferred stub).
         assert!(read["parameters"]["properties"]["path"].is_object());
+    }
+
+    struct HiddenTool;
+    #[async_trait]
+    impl Tool for HiddenTool {
+        fn name(&self) -> &str {
+            "write_file"
+        }
+        fn description(&self) -> &str {
+            "Write contents to a file"
+        }
+        fn parameters_schema(&self) -> Value {
+            json!({
+                "type": "object",
+                "properties": { "path": { "type": "string" } },
+                "required": ["path"]
+            })
+        }
+        async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+            ToolExecutionResult::success(json!({}))
+        }
+    }
+
+    #[tokio::test]
+    async fn test_execute_filters_registry_to_visible_tools() {
+        use crate::tools::ToolRegistry;
+
+        let mut registry = ToolRegistry::new();
+        registry.register(MiniTool);
+        registry.register(HiddenTool);
+        registry.register(ToolSearchTool);
+
+        let mut ctx = ToolContext::new(uuid::Uuid::new_v4().into());
+        ctx.tool_registry = Some(Arc::new(registry));
+        ctx.visible_tool_names = Some(Arc::new(
+            ["read_file".to_string(), TOOL_SEARCH_TOOL_NAME.to_string()]
+                .into_iter()
+                .collect(),
+        ));
+
+        let result = ToolSearchTool
+            .execute_with_context(json!({ "query": "file" }), &ctx)
+            .await;
+
+        let ToolExecutionResult::Success(value) = result else {
+            panic!("expected success");
+        };
+        let tools = value["tools"].as_array().unwrap();
+        assert!(tools.iter().any(|t| t["name"] == "read_file"));
+        assert!(tools.iter().all(|t| t["name"] != "write_file"));
+
+        let result = ToolSearchTool
+            .execute_with_context(json!({ "query": "missing" }), &ctx)
+            .await;
+        let ToolExecutionResult::Success(value) = result else {
+            panic!("expected success");
+        };
+        let available = value["available_tools"].as_array().unwrap();
+        assert!(available.iter().any(|name| name == "read_file"));
+        assert!(available.iter().all(|name| name != "write_file"));
     }
 }

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -14,7 +14,7 @@ use crate::typed_id::{AgentId, HarnessId, ImageId, ModelId, SessionId};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use std::any::{Any, TypeId};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use uuid::Uuid;
 
@@ -952,6 +952,11 @@ pub struct ToolContext {
     /// `spawn_background` that need to inspect or delegate to sibling tools.
     pub tool_registry: Option<Arc<crate::tools::ToolRegistry>>,
 
+    /// Optional allowlist of tools visible to the model for this turn.
+    /// Registry-introspecting tools must filter through this before returning
+    /// sibling tool metadata, because the execution registry can be a superset.
+    pub visible_tool_names: Option<Arc<HashSet<String>>>,
+
     /// Optional memory store backend for persistent cross-session memory.
     pub memory_store: Option<Arc<dyn crate::memory_store::MemoryStoreBackend>>,
 
@@ -1000,6 +1005,7 @@ impl ToolContext {
             tool_call_id: None,
             capability_registry: None,
             tool_registry: None,
+            visible_tool_names: None,
             memory_store: None,
             org_id: None,
             network_access: None,
@@ -1034,6 +1040,7 @@ impl ToolContext {
             tool_call_id: None,
             capability_registry: None,
             tool_registry: None,
+            visible_tool_names: None,
             memory_store: None,
             org_id: None,
             network_access: None,
@@ -1071,6 +1078,7 @@ impl ToolContext {
             tool_call_id: None,
             capability_registry: None,
             tool_registry: None,
+            visible_tool_names: None,
             memory_store: None,
             org_id: None,
             network_access: None,
@@ -1109,6 +1117,7 @@ impl ToolContext {
             tool_call_id: None,
             capability_registry: None,
             tool_registry: None,
+            visible_tool_names: None,
             memory_store: None,
             org_id: None,
             network_access: None,
@@ -1185,6 +1194,7 @@ impl ToolContext {
             tool_call_id: None,
             capability_registry: None,
             tool_registry: None,
+            visible_tool_names: None,
             memory_store: None,
             org_id: None,
             network_access: None,
@@ -1263,6 +1273,12 @@ impl ToolContext {
     /// Set the active built-in tool registry on this context.
     pub fn with_tool_registry(mut self, registry: Arc<crate::tools::ToolRegistry>) -> Self {
         self.tool_registry = Some(registry);
+        self
+    }
+
+    /// Set the tool names visible to the model in this turn.
+    pub fn with_visible_tool_names(mut self, names: Arc<HashSet<String>>) -> Self {
+        self.visible_tool_names = Some(names);
         self
     }
 


### PR DESCRIPTION
### Motivation
- `tool_search` read the full worker `ToolRegistry` and could return names and full JSON schemas for default tools that were not enabled for the current agent, causing metadata disclosure.
- The execution registry is intentionally a superset (defaults + collected tools), so registry-introspecting tools must see only the model-visible subset for the current turn.

### Description
- Add a turn-scoped allowlist to `ToolContext` as `visible_tool_names: Option<Arc<HashSet<String>>>` and a builder `with_visible_tool_names` to carry model-visible tool names. (`crates/core/src/traits.rs`)
- Populate the allowlist in `ActAtom` from the current turn's `tool_definitions` and pass it into each tool execution `ToolContext` before running the tool. (`crates/core/src/atoms/act.rs`)
- Update the generic `tool_search` (`ToolSearchTool::execute_with_context`) to require the visible-tool allowlist and filter `registry.tool_definitions()` through it before returning matches or the fallback `available_tools`, preventing hidden default tools from leaking. (`crates/core/src/capabilities/tool_search.rs`)
- Add unit tests that verify hidden registry entries are excluded from both matched results and the `available_tools` miss-path, and apply formatting.

### Testing
- Ran `cargo fmt --check` (formatting applied where needed) and ensured formatting is clean.
- Ran focused unit tests with `cargo test -p everruns-core tool_search --all-features`, and the test suite passed (focused tests: 36 passed; 0 failed).
- Existing `tool_search` unit tests and new regression tests exercised both matched-schema and no-match fallback paths and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2258ccddfc832bbc99c950fb3116f5)