### PR TITLE
fix(capabilities): honor auto tool search threshold

### DIFF
--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -632,6 +632,17 @@ pub trait Capability: Send + Sync {
         vec![]
     }
 
+    /// Returns tool definition hooks adapted to per-capability config.
+    ///
+    /// Default delegates to `tool_definition_hooks()`. Capabilities whose
+    /// schema transforms depend on config override this method.
+    fn tool_definition_hooks_with_config(
+        &self,
+        _config: &serde_json::Value,
+    ) -> Vec<Arc<dyn ToolDefinitionHook>> {
+        self.tool_definition_hooks()
+    }
+
     /// Returns tool call hooks provided by this capability.
     ///
     /// These hooks run after the model has produced a tool call. They can read
@@ -1833,9 +1844,10 @@ pub async fn collect_capabilities_with_configs(
                 system_prompt_parts.push(contribution);
             }
 
-            // Collect tools (config-aware: capabilities can adapt based on per-agent config)
+            // Collect tools and hooks (config-aware: capabilities can adapt based on per-agent config)
             tools.extend(effective.tools_with_config(&cap_config.config));
-            tool_definition_hooks.extend(effective.tool_definition_hooks());
+            tool_definition_hooks
+                .extend(effective.tool_definition_hooks_with_config(&cap_config.config));
             tool_call_hooks.extend(effective.tool_call_hooks());
             // Output guardrails are NOT collected here — see CollectedCapabilities
             // for rationale. ReasonAtom re-derives them at stream-arming time.
@@ -3970,10 +3982,16 @@ mod tests {
     async fn test_collect_capabilities_auto_tool_search_resolves_to_generic_off_native() {
         let registry = CapabilityRegistry::with_builtins();
 
-        let configs = vec![AgentCapabilityConfig {
-            capability_ref: CapabilityId::new("auto_tool_search"),
-            config: serde_json::json!({"threshold": 7}),
-        }];
+        let configs = vec![
+            AgentCapabilityConfig {
+                capability_ref: CapabilityId::new("auto_tool_search"),
+                config: serde_json::json!({"threshold": 2}),
+            },
+            AgentCapabilityConfig {
+                capability_ref: CapabilityId::new("test_math"),
+                config: serde_json::json!({}),
+            },
+        ];
 
         // No native support → resolves to the generic client-side mechanism: no
         // hosted config, but the tool_search tool + DeferSchemaHook are collected.
@@ -3994,6 +4012,17 @@ mod tests {
         assert!(
             !collected.tool_definition_hooks.is_empty(),
             "auto_tool_search must contribute a client-side deferral hook"
+        );
+
+        let transformed =
+            collected.tool_definition_hooks[0].transform(collected.tool_definitions.clone());
+        let add_tool = transformed
+            .iter()
+            .find(|tool| tool.name() == "add")
+            .expect("test_math contributes add");
+        assert!(
+            add_tool.parameters().get("properties").is_none(),
+            "generic auto_tool_search must honor the configured threshold"
         );
     }
 

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -4014,8 +4014,10 @@ mod tests {
             "auto_tool_search must contribute a client-side deferral hook"
         );
 
-        let transformed =
-            collected.tool_definition_hooks[0].transform(collected.tool_definitions.clone());
+        let mut transformed = collected.tool_definitions.clone();
+        for hook in &collected.tool_definition_hooks {
+            transformed = hook.transform(transformed);
+        }
         let add_tool = transformed
             .iter()
             .find(|tool| tool.name() == "add")

--- a/crates/core/src/capabilities/tool_search.rs
+++ b/crates/core/src/capabilities/tool_search.rs
@@ -115,6 +115,19 @@ impl Capability for ToolSearchCapability {
             threshold: self.threshold,
         })]
     }
+
+    fn tool_definition_hooks_with_config(
+        &self,
+        config: &Value,
+    ) -> Vec<Arc<dyn ToolDefinitionHook>> {
+        let threshold = config
+            .get("threshold")
+            .and_then(|v| v.as_u64())
+            .map(|v| v as usize)
+            .unwrap_or(self.threshold);
+
+        vec![Arc::new(DeferSchemaHook { threshold })]
+    }
 }
 
 // ============================================================================


### PR DESCRIPTION
### Motivation
- `auto_tool_search` should let per-agent `threshold` settings control when schemas are deferred for non-native models, but the generic (client-side) path used the embedded default threshold instead of the agent config. 
- Capability collection called `tool_definition_hooks()` without passing per-capability config, so config-aware hook construction never ran for the generic `ToolSearchCapability`.

### Description
- Add a config-aware hook path `tool_definition_hooks_with_config` to the `Capability` trait with a default delegating to `tool_definition_hooks` so existing capabilities remain unchanged (`crates/core/src/capabilities/mod.rs`).
- Use `tool_definition_hooks_with_config(&cap_config.config)` during capability collection so hook construction can see per-agent config (`crates/core/src/capabilities/mod.rs`).
- Override `tool_definition_hooks_with_config` in `ToolSearchCapability` to parse `threshold` from the capability config and construct `DeferSchemaHook { threshold }` accordingly (`crates/core/src/capabilities/tool_search.rs`).
- Strengthen the `auto_tool_search` regression test to verify that the generic fallback honors a configured low threshold and strips schemas as expected (`crates/core/src/capabilities/mod.rs` tests).

### Testing
- Ran `cargo test -p everruns-core capabilities::tests::test_collect_capabilities_auto_tool_search_resolves_to_generic_off_native -- --nocapture` and it passed. 
- Ran `cargo test -p everruns-core auto_tool_search -- --nocapture` (covers hosted and generic paths) and all tests passed. 
- Ran `cargo fmt --check` and `cargo clippy -p everruns-core --all-targets --all-features -- -D warnings`, both of which completed without failures. 
- Committed the fix (`fix(capabilities): honor auto tool search threshold`) and created the PR with the above changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2258cce930832ba704d025ebeb0993)