### PR TITLE
fix(runtime): preserve stateful OpenAI tool outputs

### DIFF
--- a/crates/core/src/capabilities/infinity_context.rs
+++ b/crates/core/src/capabilities/infinity_context.rs
@@ -126,13 +126,7 @@ impl MessageFilterProvider for InfinityContextFilterProvider {
             serde_json::from_value(config.clone()).unwrap_or_default();
         let existing_notice_count = take_existing_excluded_notice(messages);
         let trimmed_count = trim_messages_to_token_budget(messages, &config);
-        // EVE-519: drop tool-result messages whose matching tool-call was trimmed away.
-        // OpenAI Responses API rejects payloads with a function_call_output whose
-        // function_call is absent from both the request and the server-side chain.
-        let orphaned_count = drop_orphaned_tool_results(messages);
-        let total_excluded_count = existing_notice_count
-            .saturating_add(trimmed_count)
-            .saturating_add(orphaned_count);
+        let total_excluded_count = existing_notice_count.saturating_add(trimmed_count);
         if total_excluded_count > 0 {
             messages.insert(
                 0,
@@ -238,36 +232,6 @@ fn parse_excluded_notice_count(message: &Message) -> Option<usize> {
         return None;
     }
     count.parse().ok()
-}
-
-/// Drop ToolResult messages whose tool_call_id has no matching ToolCall in the visible window.
-///
-/// History trimming can leave a tool-result message in the context window after its
-/// corresponding assistant tool-call message has been trimmed away. Sending such an
-/// orphaned tool result to OpenAI Responses API causes a 400 "No tool call found" error.
-fn drop_orphaned_tool_results(messages: &mut Vec<Message>) -> usize {
-    use std::collections::HashSet;
-
-    if !messages.iter().any(|m| m.role == MessageRole::ToolResult) {
-        return 0;
-    }
-
-    let visible_call_ids: HashSet<String> = messages
-        .iter()
-        .flat_map(|m| m.tool_calls())
-        .map(|tc| tc.id.clone())
-        .collect();
-
-    let before = messages.len();
-    messages.retain(|m| {
-        if m.role == MessageRole::ToolResult {
-            return m
-                .tool_call_id()
-                .is_none_or(|id| visible_call_ids.contains(id));
-        }
-        true
-    });
-    before - messages.len()
 }
 
 fn trim_messages_to_token_budget(
@@ -978,13 +942,15 @@ mod tests {
     }
 
     #[test]
-    fn trim_must_not_keep_orphaned_tool_result() {
+    fn trim_preserves_locally_unmatched_tool_result_for_stateful_responses() {
         use crate::tool_types::ToolCall;
 
         let provider = InfinityContextFilterProvider;
         // min_recent_messages=3 keeps the last 3 messages. With a 1-token budget the
-        // two older messages are dropped, but one of the kept messages is a tool result
-        // whose matching tool call was dropped — an orphan that causes OpenAI 400s.
+        // two older messages are dropped, including the assistant tool call. The
+        // OpenAI Responses path may still have that call in previous_response_id
+        // state, so InfinityContext must not drop the tool output before provider
+        // serialization decides whether stateful continuation is active.
         let mut messages = vec![
             Message::user("old question"),
             Message::assistant_with_tools(
@@ -1007,8 +973,8 @@ mod tests {
         );
 
         assert!(
-            !messages.iter().any(|m| m.role == MessageRole::ToolResult),
-            "orphaned tool result must be dropped when its tool call is not in the visible window"
+            messages.iter().any(|m| m.role == MessageRole::ToolResult),
+            "locally unmatched tool result must be preserved until provider serialization"
         );
     }
 

--- a/crates/core/src/openai_protocol.rs
+++ b/crates/core/src/openai_protocol.rs
@@ -1443,7 +1443,6 @@ mod tests {
     #[test]
     fn drop_orphaned_tool_messages_removes_unmatched_tool_results() {
         use crate::llm_driver_registry::LlmMessageContent;
-        use crate::tool_types::ToolCall;
 
         let messages = vec![
             LlmMessage::text(LlmMessageRole::User, "hello"),
@@ -1452,6 +1451,9 @@ mod tests {
                 content: LlmMessageContent::Text("result".to_string()),
                 tool_calls: None,
                 tool_call_id: Some("call_trimmed".to_string()),
+                phase: None,
+                thinking: None,
+                thinking_signature: None,
             },
         ];
         let filtered = drop_orphaned_tool_messages(&messages);
@@ -1474,12 +1476,18 @@ mod tests {
                     arguments: json!({}),
                 }]),
                 tool_call_id: None,
+                phase: None,
+                thinking: None,
+                thinking_signature: None,
             },
             LlmMessage {
                 role: LlmMessageRole::Tool,
                 content: LlmMessageContent::Text("file content".to_string()),
                 tool_calls: None,
                 tool_call_id: Some("call_1".to_string()),
+                phase: None,
+                thinking: None,
+                thinking_signature: None,
             },
         ];
         let filtered = drop_orphaned_tool_messages(&messages);

--- a/crates/core/src/openai_protocol.rs
+++ b/crates/core/src/openai_protocol.rs
@@ -227,6 +227,42 @@ impl OpenAIProtocolLlmDriver {
     }
 }
 
+/// Drop Tool-role messages whose tool_call_id has no matching assistant tool call in the
+/// visible window. Chat Completions rejects payloads where a `tool`-role message references
+/// a call that is absent from the conversation.
+fn drop_orphaned_tool_messages(messages: &[LlmMessage]) -> Vec<LlmMessage> {
+    use std::collections::HashSet;
+
+    let visible_call_ids: HashSet<&str> = messages
+        .iter()
+        .filter(|m| m.role == LlmMessageRole::Assistant)
+        .flat_map(|m| m.tool_calls.iter().flatten())
+        .map(|tc| tc.id.as_str())
+        .collect();
+
+    if visible_call_ids.is_empty() {
+        return messages
+            .iter()
+            .filter(|m| m.role != LlmMessageRole::Tool)
+            .cloned()
+            .collect();
+    }
+
+    messages
+        .iter()
+        .filter(|m| {
+            if m.role == LlmMessageRole::Tool {
+                return m
+                    .tool_call_id
+                    .as_deref()
+                    .is_none_or(|id| visible_call_ids.contains(id));
+            }
+            true
+        })
+        .cloned()
+        .collect()
+}
+
 #[async_trait]
 impl LlmDriver for OpenAIProtocolLlmDriver {
     async fn chat_completion_stream(
@@ -237,6 +273,7 @@ impl LlmDriver for OpenAIProtocolLlmDriver {
         // Note: OTel instrumentation is handled via event listeners.
         // ReasonAtom emits llm.generation events, and OtelEventListener
         // creates gen-ai spans from those events.
+        let messages = drop_orphaned_tool_messages(&messages);
         let openai_messages: Vec<OpenAiMessage> =
             messages.iter().map(Self::convert_message).collect();
 
@@ -1401,5 +1438,51 @@ mod tests {
         }];
         let finalized = finalize_tool_calls(calls);
         assert_eq!(finalized[0].arguments, json!({"path": "src/main.rs"}));
+    }
+
+    #[test]
+    fn drop_orphaned_tool_messages_removes_unmatched_tool_results() {
+        use crate::llm_driver_registry::LlmMessageContent;
+        use crate::tool_types::ToolCall;
+
+        let messages = vec![
+            LlmMessage::text(LlmMessageRole::User, "hello"),
+            LlmMessage {
+                role: LlmMessageRole::Tool,
+                content: LlmMessageContent::Text("result".to_string()),
+                tool_calls: None,
+                tool_call_id: Some("call_trimmed".to_string()),
+            },
+        ];
+        let filtered = drop_orphaned_tool_messages(&messages);
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].role, LlmMessageRole::User);
+    }
+
+    #[test]
+    fn drop_orphaned_tool_messages_keeps_matched_tool_results() {
+        use crate::llm_driver_registry::LlmMessageContent;
+        use crate::tool_types::ToolCall;
+
+        let messages = vec![
+            LlmMessage {
+                role: LlmMessageRole::Assistant,
+                content: LlmMessageContent::Text(String::new()),
+                tool_calls: Some(vec![ToolCall {
+                    id: "call_1".to_string(),
+                    name: "read_file".to_string(),
+                    arguments: json!({}),
+                }]),
+                tool_call_id: None,
+            },
+            LlmMessage {
+                role: LlmMessageRole::Tool,
+                content: LlmMessageContent::Text("file content".to_string()),
+                tool_calls: None,
+                tool_call_id: Some("call_1".to_string()),
+            },
+        ];
+        let filtered = drop_orphaned_tool_messages(&messages);
+        assert_eq!(filtered.len(), 2);
     }
 }

--- a/crates/core/src/openresponses_protocol.rs
+++ b/crates/core/src/openresponses_protocol.rs
@@ -26,6 +26,7 @@ use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
+use std::collections::HashSet;
 use std::sync::{Arc, Mutex};
 
 use crate::error::{AgentLoopError, Result};
@@ -643,8 +644,37 @@ fn finalize_input_for_request(
     if previous_response_id.is_some() {
         compute_delta_input_items(input_items)
     } else {
-        input_items
+        drop_locally_orphaned_function_call_outputs(input_items)
     }
+}
+
+fn drop_locally_orphaned_function_call_outputs(
+    input_items: Vec<ResponsesInputItem>,
+) -> Vec<ResponsesInputItem> {
+    let visible_call_ids: HashSet<String> = input_items
+        .iter()
+        .filter_map(|item| match item {
+            ResponsesInputItem::FunctionCall { call_id, .. } => Some(call_id.clone()),
+            _ => None,
+        })
+        .collect();
+
+    if visible_call_ids.is_empty() {
+        return input_items
+            .into_iter()
+            .filter(|item| !matches!(item, ResponsesInputItem::FunctionCallOutput { .. }))
+            .collect();
+    }
+
+    input_items
+        .into_iter()
+        .filter(|item| match item {
+            ResponsesInputItem::FunctionCallOutput { call_id, .. } => {
+                visible_call_ids.contains(call_id.as_str())
+            }
+            _ => true,
+        })
+        .collect()
 }
 
 /// Whether the endpoint at `api_url` persists responses server-side and honors
@@ -2614,6 +2644,53 @@ mod tests {
             original_len,
             "stateless mode keeps the full transcript so the model has context"
         );
+    }
+
+    #[test]
+    fn finalize_input_drops_locally_orphaned_tool_output_without_previous_response_id() {
+        let items = vec![
+            ResponsesInputItem::Message {
+                r#type: "message".to_string(),
+                role: "user".to_string(),
+                content: ResponsesContent::Text("fresh".to_string()),
+                phase: None,
+            },
+            ResponsesInputItem::FunctionCallOutput {
+                r#type: "function_call_output".to_string(),
+                call_id: "call_trimmed".to_string(),
+                output: "result".to_string(),
+            },
+        ];
+
+        let out = finalize_input_for_request(items, &None);
+
+        assert_eq!(out.len(), 1);
+        let json = serde_json::to_value(&out[0]).unwrap();
+        assert_eq!(json["type"], "message");
+    }
+
+    #[test]
+    fn finalize_input_keeps_tool_output_with_previous_response_id_even_without_local_call() {
+        let items = vec![
+            ResponsesInputItem::FunctionCallOutput {
+                r#type: "function_call_output".to_string(),
+                call_id: "call_server_side".to_string(),
+                output: "stateful result".to_string(),
+            },
+            ResponsesInputItem::Message {
+                r#type: "message".to_string(),
+                role: "user".to_string(),
+                content: ResponsesContent::Text("follow-up".to_string()),
+                phase: None,
+            },
+        ];
+
+        let out = finalize_input_for_request(items, &Some("resp_prev_42".to_string()));
+
+        assert_eq!(out.len(), 2);
+        let json = serde_json::to_value(&out[0]).unwrap();
+        assert_eq!(json["type"], "function_call_output");
+        assert_eq!(json["call_id"], "call_server_side");
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- InfinityContext was dropping `ToolResult` messages during post-load trimming when their matching `ToolCall` was not present locally, which removed valid stateful OpenAI Responses `function_call_output` items that rely on `previous_response_id` (server-side state).

### Description
- Remove the provider-agnostic orphan-dropping pass from `InfinityContext` so locally unmatched tool outputs survive context trimming (`crates/core/src/capabilities/infinity_context.rs`).
- Add provider-side logic in the OpenResponses serialization path to drop locally-orphaned `function_call_output` items only for stateless requests while preserving all delta items when an effective `previous_response_id` is present (`crates/core/src/openresponses_protocol.rs`).
- Add and update tests to assert that InfinityContext preserves locally-unmatched tool results and that OpenResponses drops stateless orphans but keeps stateful tool outputs.
- Minor import/order formatting fixes applied to satisfy `cargo fmt`/`clippy`.

### Testing
- Ran `cargo test -p everruns-core infinity_context --all-features` and the InfinityContext-focused tests passed (21 passed, 0 failed).
- Ran `cargo test -p everruns-core finalize_input --all-features` and the OpenResponses finalize-input tests passed (5 passed, 0 failed).
- Ran `cargo fmt` (formatting applied) and then `cargo fmt --check`, both succeeding after fixing import ordering.
- Ran `cargo clippy -p everruns-core --all-targets --all-features -- -D warnings` with no warnings (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2258ce8030832b8b24fcb14397f4da)