### PR TITLE
fix(ci): enforce msrv in aggregate gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1319,6 +1319,7 @@ jobs:
       - changes
       - format
       - lockfile
+      - msrv
       - clippy
       - unit-test
       - worker-test


### PR DESCRIPTION
### Motivation
- The `msrv` job performs a Published Crate MSRV check against Rust `1.94.0` but was not included in the aggregate branch-protection gate, allowing MSRV failures or cancellations to be invisible to the `ci-success` status.

### Description
- Add `msrv` to the `ci-success.needs` list in `.github/workflows/ci.yml` so the existing aggregation script will evaluate MSRV job results.
- This is a CI configuration-only change and does not modify runtime code or tests.

### Testing
- Verified the `msrv` job block exists and that `ci-success` now contains `- msrv` by printing the relevant lines with `sed`/`nl`, which showed the insertion succeeded.
- Executed local Python assertions that check for `'  msrv:'`, `'  ci-success:'`, and `'      - msrv'` in ` .github/workflows/ci.yml`, and they passed.
- Attempted `git fetch origin main` but it failed because this checkout has no `origin` remote, so no upstream rebase was performed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a537c8144832bb6281efdecca83b1)