### PR TITLE
fix(runtime): honor user prompt mutations

### DIFF
--- a/crates/runtime/src/host.rs
+++ b/crates/runtime/src/host.rs
@@ -973,16 +973,26 @@ pub async fn execute_reason_activity<A: RuntimeHostAdapter>(
         )
         .await?;
 
-        if let Some(message) = assembled
+        let message = assembled
             .messages
             .iter_mut()
             .find(|message| message.id == input.context.input_message_id)
-        {
-            // user_prompt_submit mutations are enforcement controls for the
-            // provider-bound prompt. Apply them to the assembled context only
-            // so persisted user history remains an audit record of the input.
-            message.content = vec![ContentPart::text(message_override)];
-        }
+            .ok_or_else(|| {
+                everruns_core::error::AgentLoopError::config(
+                    "user_prompt_submit mutation: input message not found in assembled context",
+                )
+            })?;
+
+        // user_prompt_submit mutations are enforcement controls for the
+        // provider-bound prompt. Apply them to the assembled context only
+        // so persisted user history remains an audit record of the input.
+        // Preserve non-text parts (images, files); replace only text parts.
+        message
+            .content
+            .retain(|part| !matches!(part, ContentPart::Text(_)));
+        message
+            .content
+            .insert(0, ContentPart::text(message_override));
 
         return atom.execute_with_assembled_context(input, assembled).await;
     }

--- a/crates/runtime/src/host.rs
+++ b/crates/runtime/src/host.rs
@@ -12,7 +12,7 @@ use everruns_core::events::{
     EventContext, EventRequest, OutputMessageCompletedData, SessionActivatedData, SessionIdledData,
     TurnCompletedData, TurnFailedData, TurnStartedData,
 };
-use everruns_core::message::Message;
+use everruns_core::message::{ContentPart, Message};
 use everruns_core::message_retriever::MessageRetriever;
 use everruns_core::platform_store::PlatformStore;
 use everruns_core::session::SessionStatus;
@@ -27,7 +27,7 @@ use everruns_core::typed_id::{AgentId, HarnessId, MessageId, SessionId, TurnId};
 use everruns_core::{
     Agent, CapabilityRegistry, CapabilityStatus, DependencyBlocker, DriverRegistry, EgressService,
     Harness, Session, TokenUsage, ToolDefinition, ToolRegistry, UserFacingError, UtilityLlmService,
-    org_public_id_from_internal, resolve_runtime_capabilities,
+    assemble_turn_context, org_public_id_from_internal, resolve_runtime_capabilities,
 };
 use std::sync::Arc;
 use tracing::warn;
@@ -790,11 +790,16 @@ pub async fn execute_input_activity<A: RuntimeHostAdapter>(
 /// skipped early). Errors loading specs are logged and treated as "no hooks"
 /// so a hook-collection failure never blocks a turn that wasn't asking to be
 /// hooked.
+struct UserPromptHookResult {
+    decision: everruns_core::lifecycle_hooks::UserPromptDecision,
+    original_message: String,
+}
+
 async fn run_user_prompt_submit_for_turn<A: RuntimeHostAdapter>(
     adapter: &A,
     org_id: i64,
     input: &ReasonInput,
-) -> everruns_core::error::Result<Option<everruns_core::lifecycle_hooks::UserPromptDecision>> {
+) -> everruns_core::error::Result<Option<UserPromptHookResult>> {
     let (specs, dispatcher) = match collect_lifecycle_hook_specs(
         adapter,
         org_id,
@@ -838,10 +843,14 @@ async fn run_user_prompt_submit_for_turn<A: RuntimeHostAdapter>(
         org_id: org_public_id_from_internal(org_id).parse().ok(),
         agent_id: input.agent_id.map(|a| a.to_string()),
     };
-    Ok(Some(
+    let original_message = message_text.clone();
+    let decision =
         everruns_core::lifecycle_hooks::run_user_prompt_submit_hooks(&hooks, &ctx, message_text)
-            .await,
-    ))
+            .await;
+    Ok(Some(UserPromptHookResult {
+        decision,
+        original_message,
+    }))
 }
 
 pub async fn execute_reason_activity<A: RuntimeHostAdapter>(
@@ -883,35 +892,45 @@ pub async fn execute_reason_activity<A: RuntimeHostAdapter>(
     // turn by reusing the same failure path as `dependency_blocked`: emit a
     // user-facing message + turn.failed, idle the session, and return a
     // non-success `ReasonResult` so no LLM/act work runs.
+    let mut user_prompt_message_override = None;
     if input.iteration <= 1
-        && let Some(everruns_core::lifecycle_hooks::UserPromptDecision::Block {
-            reason,
-            user_message,
-        }) = run_user_prompt_submit_for_turn(adapter, org_id, &input).await?
+        && let Some(hook_result) = run_user_prompt_submit_for_turn(adapter, org_id, &input).await?
     {
-        RuntimeSessionLifecycle::new(adapter.clone(), org_id, input.context.session_id)
-            .user_prompt_blocked(
-                input.context.turn_id,
-                input.context.input_message_id,
-                &reason,
-                user_message.as_deref(),
-            )
-            .await;
-        return Ok(ReasonResult {
-            success: false,
-            text: user_message.unwrap_or_else(|| reason.clone()),
-            tool_calls: vec![],
-            has_tool_calls: false,
-            tool_definitions: vec![],
-            max_iterations: everruns_core::runtime_agent::default_max_iterations(),
-            error: Some("blocked_by_user_prompt_hook".to_string()),
-            usage: None,
-            output_message_id: None,
-            time_to_first_token_ms: None,
-            response_id: None,
-            locale: None,
-            network_access: None,
-        });
+        match hook_result.decision {
+            everruns_core::lifecycle_hooks::UserPromptDecision::Block {
+                reason,
+                user_message,
+            } => {
+                RuntimeSessionLifecycle::new(adapter.clone(), org_id, input.context.session_id)
+                    .user_prompt_blocked(
+                        input.context.turn_id,
+                        input.context.input_message_id,
+                        &reason,
+                        user_message.as_deref(),
+                    )
+                    .await;
+                return Ok(ReasonResult {
+                    success: false,
+                    text: user_message.unwrap_or_else(|| reason.clone()),
+                    tool_calls: vec![],
+                    has_tool_calls: false,
+                    tool_definitions: vec![],
+                    max_iterations: everruns_core::runtime_agent::default_max_iterations(),
+                    error: Some("blocked_by_user_prompt_hook".to_string()),
+                    usage: None,
+                    output_message_id: None,
+                    time_to_first_token_ms: None,
+                    response_id: None,
+                    locale: None,
+                    network_access: None,
+                });
+            }
+            everruns_core::lifecycle_hooks::UserPromptDecision::Continue { message } => {
+                if message != hook_result.original_message {
+                    user_prompt_message_override = Some(message);
+                }
+            }
+        }
     }
 
     let turn_context = adapter
@@ -933,11 +952,42 @@ pub async fn execute_reason_activity<A: RuntimeHostAdapter>(
         atom = atom.with_image_resolver(image_resolver);
     }
 
-    atom.execute(ReasonInput {
+    let input = ReasonInput {
         mcp_tool_definitions: turn_context.mcp_tool_definitions,
         ..input
-    })
-    .await
+    };
+
+    if let Some(message_override) = user_prompt_message_override {
+        let mut assembled = assemble_turn_context(
+            adapter.harness_store(org_id).as_ref(),
+            adapter.agent_store(org_id).as_ref(),
+            adapter.session_store(org_id).as_ref(),
+            adapter.message_store().as_ref(),
+            adapter.provider_store(org_id).as_ref(),
+            &adapter.capability_registry(),
+            input.context.session_id,
+            input.harness_id,
+            input.agent_id,
+            &input.mcp_tool_definitions,
+            Some(adapter.file_store()),
+        )
+        .await?;
+
+        if let Some(message) = assembled
+            .messages
+            .iter_mut()
+            .find(|message| message.id == input.context.input_message_id)
+        {
+            // user_prompt_submit mutations are enforcement controls for the
+            // provider-bound prompt. Apply them to the assembled context only
+            // so persisted user history remains an audit record of the input.
+            message.content = vec![ContentPart::text(message_override)];
+        }
+
+        return atom.execute_with_assembled_context(input, assembled).await;
+    }
+
+    atom.execute(input).await
 }
 
 pub async fn execute_act_activity<A: RuntimeHostAdapter>(

--- a/crates/runtime/tests/runtime_host_test.rs
+++ b/crates/runtime/tests/runtime_host_test.rs
@@ -1683,6 +1683,74 @@ async fn user_prompt_submit_hook_allow_does_not_block() {
     );
 }
 
+/// A `user_prompt_submit` hook that emits `mutate` must rewrite the prompt
+/// before the provider-bound reason call, without changing persisted history.
+#[tokio::test]
+async fn user_prompt_submit_hook_mutate_rewrites_reason_context() {
+    use everruns_core::atoms::ReasonInput;
+    use everruns_core::llmsim_driver::{LlmSimConfig, register_driver_with_config};
+    use everruns_core::user_hook_types::HookEvent;
+    use everruns_runtime::execute_reason_activity;
+
+    let mut adapter = mock_host();
+    register_driver_with_config(&mut adapter.driver_registry, LlmSimConfig::echo());
+    set_default_model(&adapter).await;
+    adapter
+        .capability_registry
+        .register(LifecycleHookCapability {
+            event: HookEvent::UserPromptSubmit,
+            command: r#"echo '{"decision":"mutate","patch":{"message":"sanitized prompt"}}'"#
+                .into(),
+        });
+
+    let harness_id = HarnessId::from_uuid(Uuid::now_v7());
+    let session_id = SessionId::from_uuid(Uuid::now_v7());
+    adapter
+        .harness_store
+        .add_harness(Harness {
+            capabilities: vec![AgentCapabilityConfig::new("lifecycle_hook_test")],
+            ..harness(harness_id)
+        })
+        .await;
+    adapter
+        .session_store
+        .insert(session(session_id, harness_id))
+        .await;
+    let user_message = adapter
+        .message_store
+        .add(session_id, InputMessage::user("SECRET prompt"))
+        .await
+        .unwrap();
+
+    let turn_id = TurnId::from_uuid(Uuid::now_v7());
+    let result = execute_reason_activity(
+        &adapter,
+        1,
+        ReasonInput {
+            context: AtomContext::new(session_id, turn_id, user_message.id),
+            harness_id,
+            agent_id: None,
+            org_id: 1,
+            mcp_tool_definitions: vec![],
+            previous_response_id: None,
+            iteration: 1,
+        },
+    )
+    .await
+    .unwrap();
+
+    assert!(result.success, "mutated turn should reach the LLM");
+    assert_eq!(result.text, "Echo: sanitized prompt");
+
+    let stored_message = adapter
+        .message_store
+        .get(session_id, user_message.id)
+        .await
+        .unwrap()
+        .expect("stored user message");
+    assert_eq!(stored_message.content_to_llm_string(), "SECRET prompt");
+}
+
 /// A `turn_end` hook fires (advisory) when a turn completes. We drive a full
 /// in-process turn and assert the hook's side effect: a sentinel file written
 /// to the session VFS by the hook command.


### PR DESCRIPTION
### Motivation

- Fix a logic/security bypass where `user_prompt_submit` hooks that returned `Continue { message }` with a mutated prompt were ignored before the LLM call, causing original stored user text to reach providers and bypass mutation-based sanitation.

### Description

- Change `run_user_prompt_submit_for_turn` to return a `UserPromptHookResult` that carries both the `UserPromptDecision` and the original hook input so mutations can be detected. 
- Update `execute_reason_activity` to preserve existing `Block` behavior and to detect `Continue { message }` mutations, setting an in-memory `user_prompt_message_override` when the message differs from the original. 
- When a mutation is present, call `assemble_turn_context`, rewrite only the current input message in the assembled `AssembledTurnContext` (leaving persisted messages unchanged), and invoke `ReasonAtom::execute_with_assembled_context` so the provider-bound prompt reflects the hook mutation. 
- Add a regression test `user_prompt_submit_hook_mutate_rewrites_reason_context` that registers an `LlmSim` echo driver and asserts the LLM receives the mutated prompt while stored history remains the original text. 

### Testing

- Ran the focused runtime test `cargo test -p everruns-runtime user_prompt_submit_hook_mutate_rewrites_reason_context --test runtime_host_test` which passed. 
- Ran `cargo fmt --check` which passed. 
- Ran the repo pre-push checks (`just pre-push`); the checks completed but the migration immutability step failed due to the local checkout lacking an `origin/main` ref, not because of changed migrations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a23152170c0832b959a0c762841adb3)