### PR TITLE
chore(specs): clarify llm side-effect defaults

### DIFF
--- a/specs/api-llm-extensions.md
+++ b/specs/api-llm-extensions.md
@@ -91,11 +91,11 @@ ordering breaks the freshness gate.
 
 Workaround until utoipa stabilises: **emit only one extension per
 operation**. Encode anything you'd want to convey as a second entry
-either as the value of a more general tag, or simply omit it when
-the value would match the default (e.g. `x-side-effect: reversible`
-is the default for non-DELETE operations and can be left off
-implicitly). Multi-entry extensions on the same operation are
-tracked as a follow-on once utoipa switches to a deterministic
+as the value of a more general tag, or omit only values that match
+the fail-closed defaults (for example, absent `x-side-effect` is
+interpreted as `irreversible` for every operation, including
+non-DELETE methods). Multi-entry extensions on the same operation
+are tracked as a follow-on once utoipa switches to a deterministic
 container.
 
 ## First-wave rollout


### PR DESCRIPTION
### Motivation
- Remove a contradictory sentence in `specs/api-llm-extensions.md` that said non-DELETE operations default to `x-side-effect: reversible`, which conflicted with the vocabulary fail-closed default (`irreversible`) and could lead LLM clients to misclassify untagged mutating endpoints.

### Description
- Updated the deterministic-ordering/utoipa workaround wording in `specs/api-llm-extensions.md` to remove the stale reversible-default guidance and explicitly state that absent `x-side-effect` is interpreted as `irreversible` for every operation; this is a spec-only change (file modified: `specs/api-llm-extensions.md`).

### Testing
- Ran automated checks: `cargo fmt --check` succeeded, `git diff --check` succeeded, and `bash scripts/test-specs-index.sh` succeeded; `just pre-push` was started but hung during the lint step and was interrupted, after which the focused checks listed above passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a23152063d0832bb5f3aed5c5729dba)