### PR TITLE
chore(release): prepare v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- New changes go here. Use `/prepare-release X.Y.Z` to generate draft from commits. -->
 
-- feat(capabilities): model-adaptive `auto_tool_search` capability that uses OpenAI's hosted tool_search on supported models and the generic client-side fallback everywhere else; now the default in the `generic` harness
+## [0.9.0] - 2026-06-05
+
+### Highlights
+
+- **Model-adaptive `auto_tool_search`** - Uses OpenAI's hosted `tool_search` on supported models and the generic client-side fallback everywhere else; now the default in the `generic` harness ([#2056](https://github.com/everruns/everruns/pull/2056)).
+- **Deferred MCP tool schemas** - `tool_search` now defers MCP tool schema loading for any generic MCP server, reducing context overhead on first turn (EVE-524).
+- **Per-generation cost tracking** - Actual and estimated cost captured per-generation with denormalized totals for accurate billing attribution ([#2060](https://github.com/everruns/everruns/pull/2060)).
+- **OpenRouter enhancements** - Reasoning capability discovery ([#2063](https://github.com/everruns/everruns/pull/2063)) and enriched model sync with profiles and vendor icons ([#2067](https://github.com/everruns/everruns/pull/2067)).
+- **Flat model registry** - Vendor tags and surface predicates for cleaner model resolution ([#2066](https://github.com/everruns/everruns/pull/2066)).
+
+### What's Changed
+
+- feat(capabilities): model-adaptive `auto_tool_search` dispatcher ([#2056](https://github.com/everruns/everruns/pull/2056)) by [@chaliy](https://github.com/chaliy)
+- test(llm): verify auto_tool_search hosted round-trip on GPT-5.4 ([#2058](https://github.com/everruns/everruns/pull/2058)) by [@chaliy](https://github.com/chaliy)
+- refactor(capabilities): align tool search capability name by [@chaliy](https://github.com/chaliy)
+- feat(models): add profiles and vendor icons for latest flagship models ([#2057](https://github.com/everruns/everruns/pull/2057)) by [@chaliy](https://github.com/chaliy)
+- feat(usage): per-generation actual/estimated cost + denormalized totals ([#2060](https://github.com/everruns/everruns/pull/2060)) by [@chaliy](https://github.com/chaliy)
+- fix(llm): support hosted OpenAI tool search by [@chaliy](https://github.com/chaliy)
+- fix(coding-cli): use is_local() instead of hard-coded Stdio check ([#2055](https://github.com/everruns/everruns/pull/2055)) by [@chaliy](https://github.com/chaliy)
+- fix(tools): atomic per-session background run cap via in-process semaphore ([#2061](https://github.com/everruns/everruns/pull/2061)) by [@chaliy](https://github.com/chaliy)
+- fix(capabilities): honor resolve_for_model in all collection paths ([#2064](https://github.com/everruns/everruns/pull/2064)) by [@chaliy](https://github.com/chaliy)
+- feat(openai): discover OpenRouter reasoning capability ([#2063](https://github.com/everruns/everruns/pull/2063)) by [@chaliy](https://github.com/chaliy)
+- feat(tool-search): defer MCP tool schemas under generic tool_search (EVE-524) by [@chaliy](https://github.com/chaliy)
+- refactor(models): flat model registry with vendor tags and surface predicates ([#2066](https://github.com/everruns/everruns/pull/2066)) by [@chaliy](https://github.com/chaliy)
+- feat(models): enrich OpenRouter model sync ([#2067](https://github.com/everruns/everruns/pull/2067)) by [@chaliy](https://github.com/chaliy)
+- fix(core): scope tool_search registry introspection by [@chaliy](https://github.com/chaliy)
+- fix(ci): enforce msrv in aggregate gate ([#2073](https://github.com/everruns/everruns/pull/2073)) by [@chaliy](https://github.com/chaliy)
+- fix(session-files): enforce quotas on copy and CAS writes ([#2068](https://github.com/everruns/everruns/pull/2068)) by [@chaliy](https://github.com/chaliy)
+- fix(runtime): preserve stateful OpenAI tool outputs ([#2072](https://github.com/everruns/everruns/pull/2072)) by [@chaliy](https://github.com/chaliy)
+- fix(core): abort cpu-bound tool tasks on cancellation ([#2069](https://github.com/everruns/everruns/pull/2069)) by [@chaliy](https://github.com/chaliy)
+- fix(capabilities): honor auto tool search threshold ([#2071](https://github.com/everruns/everruns/pull/2071)) by [@chaliy](https://github.com/chaliy)
 
 ## [0.8.38] - 2026-06-05
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,6 +237,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -779,6 +788,12 @@ name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "by_address"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
 
 [[package]]
 name = "byte-slice-cast"
@@ -1977,11 +1992,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-a2ui"
-version = "0.8.38"
+version = "0.9.0"
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.8.38"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1997,7 +2012,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-cli"
-version = "0.8.38"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2051,14 +2066,14 @@ dependencies = [
 
 [[package]]
 name = "everruns-config"
-version = "0.8.38"
+version = "0.9.0"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "everruns-container-sandbox"
-version = "0.8.38"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2078,7 +2093,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.8.38"
+version = "0.9.0"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -2130,7 +2145,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-durable"
-version = "0.8.38"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2155,7 +2170,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-gemini"
-version = "0.8.38"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2169,7 +2184,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-brave-search"
-version = "0.8.38"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2185,7 +2200,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-browserless"
-version = "0.8.38"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2206,7 +2221,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-cursor"
-version = "0.8.38"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2221,7 +2236,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.8.38"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2238,7 +2253,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-deno"
-version = "0.8.38"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2261,7 +2276,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-docker"
-version = "0.8.38"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2276,7 +2291,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.8.38"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2291,7 +2306,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-e2b"
-version = "0.8.38"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "buffa",
@@ -2318,7 +2333,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-github"
-version = "0.8.38"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2335,7 +2350,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-parallel"
-version = "0.8.38"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2348,7 +2363,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-sprites"
-version = "0.8.38"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2364,7 +2379,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-internal-protocol"
-version = "0.8.38"
+version = "0.9.0"
 dependencies = [
  "chrono",
  "everruns-core",
@@ -2381,7 +2396,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-llm-tests"
-version = "0.8.38"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2400,7 +2415,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-macros"
-version = "0.8.38"
+version = "0.9.0"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -2408,7 +2423,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-mcp"
-version = "0.8.38"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2422,7 +2437,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.8.38"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2442,11 +2457,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-openui"
-version = "0.8.38"
+version = "0.9.0"
 
 [[package]]
 name = "everruns-runtime"
-version = "0.8.38"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2484,7 +2499,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-server"
-version = "0.8.38"
+version = "0.9.0"
 dependencies = [
  "aes-gcm",
  "ag-ui-core",
@@ -2573,7 +2588,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-session-sqldb"
-version = "0.8.38"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2590,7 +2605,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-worker"
-version = "0.8.38"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2683,6 +2698,12 @@ dependencies = [
  "regex-automata",
  "regex-syntax",
 ]
+
+[[package]]
+name = "fast-srgb8"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
 
 [[package]]
 name = "fastrand"
@@ -3218,12 +3239,17 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
+checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
 dependencies = [
  "hashbrown 0.16.1",
 ]
@@ -3647,9 +3673,9 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.25"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
+checksum = "b915661dd01db3f05050265b2477bcc6527b3792388e2749b41623cc592be67d"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -4358,11 +4384,11 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.16.4"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -5043,6 +5069,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad5fd71b79026fb918650dde6d125000a233764f1c2f1659a1c71118e33ea08f"
 dependencies = [
  "unicode-width 0.2.2",
+]
+
+[[package]]
+name = "palette"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbf71184cc5ecc2e4e1baccdb21026c20e5fc3dcf63028a086131b3ab00b6e6"
+dependencies = [
+ "approx",
+ "fast-srgb8",
+ "libm",
+ "palette_derive",
+]
+
+[[package]]
+name = "palette_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5030daf005bface118c096f510ffb781fc28f9ab6a32ab224d8631be6851d30"
+dependencies = [
+ "by_address",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5875,9 +5925,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui"
-version = "0.30.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1ce67fb8ba4446454d1c8dbaeda0557ff5e94d39d5e5ed7f10a65eb4c8266bc"
+checksum = "1695748e3a735b34968c887ceea5a380b43545903868ae8f5b666593100f6b68"
 dependencies = [
  "instability",
  "ratatui-core",
@@ -5885,22 +5935,26 @@ dependencies = [
  "ratatui-macros",
  "ratatui-termwiz",
  "ratatui-widgets",
+ "serde",
 ]
 
 [[package]]
 name = "ratatui-core"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
+checksum = "42d3603f354bba8c595fa47860e60142d7372b7210c27044c6a7d0e1a4336b44"
 dependencies = [
  "bitflags 2.12.1",
  "compact_str",
- "hashbrown 0.16.1",
+ "critical-section",
+ "hashbrown 0.17.1",
  "indoc",
  "itertools",
  "kasuari",
  "lru",
- "strum 0.27.2",
+ "palette",
+ "serde",
+ "strum 0.28.0",
  "thiserror 2.0.18",
  "unicode-segmentation",
  "unicode-truncate",
@@ -5909,9 +5963,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui-crossterm"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "577c9b9f652b4c121fb25c6a391dd06406d3b092ba68827e6d2f09550edc54b3"
+checksum = "2b2867bedcbd6a690ca4f8672a687b730ec07660c79844517b084311b529980c"
 dependencies = [
  "cfg-if",
  "crossterm",
@@ -5921,9 +5975,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui-macros"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f1342a13e83e4bb9d0b793d0ea762be633f9582048c892ae9041ef39c936f4"
+checksum = "80fac59720679490d89d200df411faa249be728681adcabed3d047ae72c48f1d"
 dependencies = [
  "ratatui-core",
  "ratatui-widgets",
@@ -5931,9 +5985,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui-termwiz"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f76fe0bd0ed4295f0321b1676732e2454024c15a35d01904ddb315afd3d545c"
+checksum = "386b8ff8f74ed749509391c56d549761a2fcdb408e1f42e467286bcb7dac8967"
 dependencies = [
  "ratatui-core",
  "termwiz",
@@ -5954,18 +6008,19 @@ dependencies = [
 
 [[package]]
 name = "ratatui-widgets"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
+checksum = "7ef4f17dd7ac3abf5adc2b920a03c61eee4bfe6a88fa5191936895525371d79c"
 dependencies = [
  "bitflags 2.12.1",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "indoc",
  "instability",
  "itertools",
  "line-clipping",
  "ratatui-core",
- "strum 0.27.2",
+ "serde",
+ "strum 0.28.0",
  "time",
  "unicode-segmentation",
  "unicode-width 0.2.2",
@@ -7259,11 +7314,11 @@ dependencies = [
 
 [[package]]
 name = "strum"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
- "strum_macros 0.27.2",
+ "strum_macros 0.28.0",
 ]
 
 [[package]]
@@ -7281,9 +7336,9 @@ dependencies = [
 
 [[package]]
 name = "strum_macros"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.8.38"
+version = "0.9.0"
 edition = "2024"
 # Published crate MSRV: Rust 2024 plus current published dependency floors.
 rust-version = "1.94.0"
@@ -135,8 +135,8 @@ futures-util = "0.3"
 
 # Everruns SDK
 everruns-sdk = "0.1.9"
-everruns-core = { path = "crates/core", version = "0.8.38" }
-everruns-mcp = { path = "crates/mcp", version = "0.8.38" }
+everruns-core = { path = "crates/core", version = "0.9.0" }
+everruns-mcp = { path = "crates/mcp", version = "0.9.0" }
 
 # A2A protocol
 a2a = { package = "a2a-lf", version = "0.3" }

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "everruns-ui",
-  "version": "0.8.38",
+  "version": "0.9.0",
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "exports": {

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -20,7 +20,7 @@ readme = "README.md"
 
 [dependencies]
 # Core dependencies
-everruns-config = { path = "../config", version = "0.8.38" }
+everruns-config = { path = "../config", version = "0.9.0" }
 anyhow.workspace = true
 thiserror.workspace = true
 async-trait.workspace = true
@@ -102,10 +102,10 @@ inventory.workspace = true
 llmsim = "0.4.0"
 
 # OpenUI component definitions and prompt generator
-everruns-openui = { path = "../openui", version = "0.8.38", optional = true }
+everruns-openui = { path = "../openui", version = "0.9.0", optional = true }
 
 # A2UI component catalog and prompt generator
-everruns-a2ui = { path = "../a2ui", version = "0.8.38", optional = true }
+everruns-a2ui = { path = "../a2ui", version = "0.9.0", optional = true }
 
 # A2A outbound agent delegation
 a2a.workspace = true


### PR DESCRIPTION
## What

Release v0.9.0 — model-adaptive tool_search, deferred MCP schemas, per-generation cost tracking, OpenRouter enhancements, and flat model registry.

## Why

Batch of feature and fix commits since v0.8.38 warrants a minor version bump.

## How

- Bumped workspace version in `Cargo.toml`, `apps/ui/package.json`, and `crates/core/Cargo.toml` from `0.8.38` → `0.9.0`
- Updated `CHANGELOG.md` with `[0.9.0]` section (highlights + full What's Changed list)
- Regenerated `Cargo.lock` and `apps/ui/pnpm-lock.yaml`

On merge to `main`, the release workflow detects the `chore(release): prepare v0.9.0` commit message and automatically creates the GitHub Release, Docker images, CLI binaries, and crates.io publish.

## Risk

- Low — version bump and changelog only; no logic changes.

## Security

- No security-relevant code changes in this PR.

## Follow-ups

No follow-ups.

## Checklist

- [x] Tests added or updated — N/A (no code changes)
- [x] Backward compatibility considered — N/A
- [x] Security review performed — no security-relevant changes
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed

---
_Generated by [Claude Code](https://claude.ai/code/session_017MxgYKfVo2A1d7s83kpeEU)_