### PR TITLE
fix(core): disclose generic tool search stubs

### DIFF
--- a/crates/core/src/capabilities/tool_search.rs
+++ b/crates/core/src/capabilities/tool_search.rs
@@ -9,10 +9,11 @@
 // How it works:
 //   1. A `tool_definition_hook` (`DeferSchemaHook`) runs at runtime-agent build
 //      time. When the agent carries at least `threshold` tools, it replaces the
-//      parameter schema of every deferrable tool with a minimal stub. Only the
-//      name + description survive, so the model still sees that the tool exists
-//      but pays no token cost for its parameters. Tools marked
-//      `DeferrablePolicy::Never` (e.g. high-frequency tools) keep full schemas.
+//      parameter schema of every deferrable tool with a minimal disclosure stub.
+//      The model still sees that the tool exists, but the stub points it back
+//      to `tool_search` for the full schema instead of exposing parameters
+//      upfront. Tools marked `DeferrablePolicy::Never` (e.g. high-frequency
+//      tools) keep full schemas.
 //   2. A real `tool_search` tool is added to the registry. When the model calls
 //      it, the tool inspects its sibling tools via `ToolContext::tool_registry`
 //      (the same mechanism `spawn_background` uses) and returns the full
@@ -138,10 +139,13 @@ impl Capability for ToolSearchCapability {
 /// An open object so the provider still accepts the tool definition; the
 /// description nudges the model toward `tool_search` if it somehow tries to
 /// call the tool before loading the schema.
-fn deferred_stub_schema() -> Value {
+fn deferred_stub_schema(tool_name: &str) -> Value {
     json!({
         "type": "object",
-        "description": "Parameters hidden to save context. Call tool_search to load the full schema before using this tool.",
+        "description": format!(
+            "Parameter schema hidden to save context. Call tool_search with query \"{tool_name}\" to load the full schema before using this tool."
+        ),
+        "additionalProperties": true,
     })
 }
 
@@ -175,8 +179,8 @@ impl ToolDefinitionHook for DeferSchemaHook {
     }
 }
 
-/// Replace a tool's parameter schema with the deferred stub, keeping name,
-/// description, policy, category, and hints intact. The original schema is
+/// Replace a tool's parameter schema with the deferred disclosure stub, keeping
+/// name, description, policy, category, and hints intact. The original schema is
 /// saved in `full_parameters` so `tool_search` can return it on demand.
 fn strip_parameters(tool: ToolDefinition) -> ToolDefinition {
     match tool {
@@ -184,14 +188,14 @@ fn strip_parameters(tool: ToolDefinition) -> ToolDefinition {
             if b.full_parameters.is_none() {
                 b.full_parameters = Some(b.parameters.clone());
             }
-            b.parameters = deferred_stub_schema();
+            b.parameters = deferred_stub_schema(&b.name);
             ToolDefinition::Builtin(b)
         }
         ToolDefinition::ClientSide(mut c) => {
             if c.full_parameters.is_none() {
                 c.full_parameters = Some(c.parameters.clone());
             }
-            c.parameters = deferred_stub_schema();
+            c.parameters = deferred_stub_schema(&c.name);
             ToolDefinition::ClientSide(c)
         }
     }
@@ -436,9 +440,22 @@ mod tests {
         let hook = DeferSchemaHook { threshold: 15 };
         let out = hook.transform(many_tools(20));
         for t in &out {
-            // Stub schema: no real properties, carries the deferral hint.
+            // Stub schema: no real properties, carries a progressive-disclosure hint.
             assert!(t.parameters().get("properties").is_none());
-            assert!(t.parameters().get("description").is_some());
+            assert_eq!(t.parameters()["additionalProperties"], json!(true));
+            let description = t.parameters()["description"].as_str().unwrap();
+            assert!(
+                description.contains("tool_search"),
+                "deferred stub should point the model to tool_search"
+            );
+            assert!(
+                description.contains(t.name()),
+                "deferred stub should include the search query that reveals this schema"
+            );
+            assert!(
+                t.full_parameters().get("properties").is_some(),
+                "full schema should remain available for progressive disclosure"
+            );
         }
     }
 

--- a/specs/tool-search.md
+++ b/specs/tool-search.md
@@ -70,7 +70,7 @@ The executor (act) path collects without a model and so resolves to the generic 
 
 Implemented entirely in core, with no driver or agent-loop changes:
 
-1. A `ToolDefinitionHook` (`DeferSchemaHook`) runs in `RuntimeAgentBuilder::build()`. When the agent carries `>= threshold` tools, it replaces each deferrable tool's parameter schema with a small stub (name + description survive). `DeferrablePolicy::Never` tools and the `tool_search` tool keep full schemas.
+1. A `ToolDefinitionHook` (`DeferSchemaHook`) runs in `RuntimeAgentBuilder::build()`. When the agent carries `>= threshold` tools, it replaces each deferrable tool's parameter schema with a small progressive-disclosure stub (name + description survive, and the stub description tells the model which `tool_search` query reveals the full schema). `DeferrablePolicy::Never` tools and the `tool_search` tool keep full schemas.
 2. A real `tool_search` tool is registered. On call it reads sibling tool schemas from `ToolContext::tool_registry` (the same mechanism `spawn_background` uses) and returns the full schemas of tools matching the query.
 3. A system-prompt note tells the model to call `tool_search` before using a tool whose parameters it has not yet loaded.
 


### PR DESCRIPTION
## What
Update generic `tool_search` deferral so each hidden parameter schema is replaced with a progressive-disclosure stub that names the exact `tool_search` query needed to reveal the full schema.

## Why
`DeferSchemaHook` hid parameter schemas but only left a generic hint. Deferred tools now point the model at the concrete search path for their full schema while preserving the real schema internally for `tool_search` results.

## How
- Make deferred stubs tool-specific and keep them as open JSON objects so provider-side calls remain compatible after schema lookup.
- Preserve full parameters in `full_parameters` as before.
- Extend focused tests to prove stubs expose the search hint and still retain the full schema for progressive disclosure.
- Sync `specs/tool-search.md` with the generic fallback behavior.

## Risk
- Low
- Affected surface is generic tool schema metadata sent to LLM providers. The stub remains a standard open JSON object and does not add provider-specific JSON Schema extension keys.

## Security
- Threat categories reviewed: TM-TOOL, TM-LLM.
- Findings and resolutions: no new execution authority, auth, tenant boundary, or secret handling. The change only adjusts model-facing schema descriptions for already-visible deferred tools. Full schemas remain process-local in `full_parameters` and are still returned through the existing `tool_search` path.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

Validation:
- `cargo fmt --check`
- `cargo test -p everruns-core capabilities::tool_search`
- `just pre-push`
- `bash scripts/lib/check-migration-ordering.sh`

