### PR TITLE
feat(lua): sandboxed Lua execution capability (experimental)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2013,7 +2013,7 @@ version = "0.9.0"
 
 [[package]]
 name = "everruns-agent-evals"
-version = "0.8.38"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "everruns-anthropic",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2010,6 +2010,19 @@ name = "everruns-a2ui"
 version = "0.8.38"
 
 [[package]]
+name = "everruns-agent-evals"
+version = "0.8.38"
+dependencies = [
+ "anyhow",
+ "everruns-anthropic",
+ "everruns-core",
+ "everruns-openai",
+ "everruns-runtime",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "everruns-anthropic"
 version = "0.8.38"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,6 +142,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2121,6 +2134,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
+ "piccolo",
  "rand 0.9.4",
  "regex",
  "reqwest 0.13.4",
@@ -3044,6 +3058,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "gc-arena"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cd70cf88a32937834aae9614ff2569b5d9467fa0c42c5d7762fd94a8de88266"
+dependencies = [
+ "allocator-api2",
+ "gc-arena-derive",
+ "hashbrown 0.14.5",
+ "sptr",
+]
+
+[[package]]
+name = "gc-arena-derive"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c612a69f5557a11046b77a7408d2836fe77077f842171cd211c5ef504bd3cddd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3209,6 +3247,10 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
 
 [[package]]
 name = "hashbrown"
@@ -5379,6 +5421,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "piccolo"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "003bf52de285e1ff1adcbc6572588db3849988ea660a2d55af3a2ffbc81f597f"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+ "anyhow",
+ "gc-arena",
+ "hashbrown 0.14.5",
+ "rand 0.8.6",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7107,6 +7164,12 @@ dependencies = [
  "base64ct",
  "der",
 ]
+
+[[package]]
+name = "sptr"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b9b39299b249ad65f3b7e96443bad61c02ca5cd3589f46cb6d610a0fd6c0d6a"
 
 [[package]]
 name = "sqlite-wasm-rs"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,19 +142,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "getrandom 0.3.4",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2147,7 +2134,6 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
- "piccolo",
  "rand 0.9.4",
  "regex",
  "reqwest 0.13.4",
@@ -3071,30 +3057,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gc-arena"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cd70cf88a32937834aae9614ff2569b5d9467fa0c42c5d7762fd94a8de88266"
-dependencies = [
- "allocator-api2",
- "gc-arena-derive",
- "hashbrown 0.14.5",
- "sptr",
-]
-
-[[package]]
-name = "gc-arena-derive"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c612a69f5557a11046b77a7408d2836fe77077f842171cd211c5ef504bd3cddd"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "synstructure",
-]
-
-[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3260,10 +3222,6 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
- "allocator-api2",
-]
 
 [[package]]
 name = "hashbrown"
@@ -5434,21 +5392,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "piccolo"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "003bf52de285e1ff1adcbc6572588db3849988ea660a2d55af3a2ffbc81f597f"
-dependencies = [
- "ahash",
- "allocator-api2",
- "anyhow",
- "gc-arena",
- "hashbrown 0.14.5",
- "rand 0.8.6",
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "pin-project"
 version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7177,12 +7120,6 @@ dependencies = [
  "base64ct",
  "der",
 ]
-
-[[package]]
-name = "sptr"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b9b39299b249ad65f3b7e96443bad61c02ca5cd3589f46cb6d610a0fd6c0d6a"
 
 [[package]]
 name = "sqlite-wasm-rs"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1793,10 +1793,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "erased-serde"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec"
+dependencies = [
+ "serde",
+ "serde_core",
+ "typeid",
+]
 
 [[package]]
 name = "errno"
@@ -2100,6 +2117,7 @@ dependencies = [
  "insta",
  "inventory",
  "llmsim",
+ "mlua",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
@@ -4372,6 +4390,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "lua-src"
+version = "547.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edaf29e3517b49b8b746701e5648ccb5785cde1c119062cbabbc5d5cd115e42"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "luajit-src"
+version = "210.5.12+a4f56a4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3a8e7962a5368d5f264d045a5a255e90f9aa3fc1941ae15a8d2940d42cac671"
+dependencies = [
+ "cc",
+ "which",
+]
+
+[[package]]
 name = "mac_address"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4547,6 +4584,38 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "mlua"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1f5f8fbebc7db5f671671134b9321c4b9aa9adeafccfd9a8c020ae45c6a35d0"
+dependencies = [
+ "bstr",
+ "either",
+ "erased-serde",
+ "futures-util",
+ "mlua-sys",
+ "num-traits",
+ "parking_lot",
+ "rustc-hash 2.1.2",
+ "rustversion",
+ "serde",
+ "serde-value",
+]
+
+[[package]]
+name = "mlua-sys"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "380c1f7e2099cafcf40e51d3a9f20a346977587aa4d012eae1f043149a728a93"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "lua-src",
+ "luajit-src",
+ "pkg-config",
 ]
 
 [[package]]
@@ -5026,6 +5095,15 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "ordered-float"
@@ -6626,6 +6704,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float 2.10.1",
+ "serde",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7466,7 +7554,7 @@ dependencies = [
  "nix",
  "num-derive",
  "num-traits",
- "ordered-float",
+ "ordered-float 4.6.0",
  "pest",
  "pest_derive",
  "phf",
@@ -8151,6 +8239,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8663,7 +8757,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
 dependencies = [
  "log",
- "ordered-float",
+ "ordered-float 4.6.0",
  "strsim",
  "thiserror 1.0.69",
  "wezterm-dynamic-derive",
@@ -8691,6 +8785,18 @@ dependencies = [
  "lazy_static",
  "serde",
  "wezterm-dynamic",
+]
+
+[[package]]
+name = "which"
+version = "7.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
+dependencies = [
+ "either",
+ "env_home",
+ "rustix",
+ "winsafe",
 ]
 
 [[package]]
@@ -9092,6 +9198,12 @@ checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wiremock"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ members = [
     "integrations/e2b",
     "integrations/sprites",
     "examples/coding-cli",
+    "crates/agent-evals",
 ]
 
 exclude = [

--- a/crates/agent-evals/Cargo.toml
+++ b/crates/agent-evals/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "everruns-agent-evals"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish = false
+description = "A/B evaluation harness comparing the lua vs virtual_bash execution capabilities"
+
+[[bin]]
+name = "lua-vs-bash"
+path = "src/main.rs"
+
+[dependencies]
+# Lua engine must be compiled into core for this harness (piccolo).
+everruns-core = { path = "../core", features = ["lua"] }
+everruns-runtime = { path = "../runtime" }
+everruns-anthropic = { path = "../anthropic" }
+everruns-openai = { path = "../openai" }
+tokio = { workspace = true, features = ["full"] }
+serde_json.workspace = true
+anyhow.workspace = true

--- a/crates/agent-evals/Cargo.toml
+++ b/crates/agent-evals/Cargo.toml
@@ -12,10 +12,8 @@ name = "lua-vs-bash"
 path = "src/main.rs"
 
 [dependencies]
-# Lua engine compiled into core for this harness.
-# `lua` = piccolo (native Rust); `lua-mlua` = mlua (full Lua 5.4 stdlib).
-# Switch this feature to pick the engine the eval exercises.
-everruns-core = { path = "../core", features = ["lua-mlua"] }
+# Compiles the experimental Lua execution capability (mlua engine) into core.
+everruns-core = { path = "../core", features = ["lua"] }
 everruns-runtime = { path = "../runtime" }
 everruns-anthropic = { path = "../anthropic" }
 everruns-openai = { path = "../openai" }

--- a/crates/agent-evals/Cargo.toml
+++ b/crates/agent-evals/Cargo.toml
@@ -12,8 +12,10 @@ name = "lua-vs-bash"
 path = "src/main.rs"
 
 [dependencies]
-# Lua engine must be compiled into core for this harness (piccolo).
-everruns-core = { path = "../core", features = ["lua"] }
+# Lua engine compiled into core for this harness.
+# `lua` = piccolo (native Rust); `lua-mlua` = mlua (full Lua 5.4 stdlib).
+# Switch this feature to pick the engine the eval exercises.
+everruns-core = { path = "../core", features = ["lua-mlua"] }
 everruns-runtime = { path = "../runtime" }
 everruns-anthropic = { path = "../anthropic" }
 everruns-openai = { path = "../openai" }

--- a/crates/agent-evals/src/main.rs
+++ b/crates/agent-evals/src/main.rs
@@ -193,10 +193,47 @@ async fn run_one(task: &Task, capability: &str, model: &ModelWithProvider, seed:
     m
 }
 
+/// Print the fully assembled system prompt each arm sends to the model (harness
+/// + agent + the execution capability's own contribution). No model call.
+async fn dump_prompts(model: &ModelWithProvider) -> anyhow::Result<()> {
+    for capability in ["virtual_bash", "lua"] {
+        let harness_id = HarnessId::from_seed(1);
+        let agent_id = AgentId::from_seed(1);
+        let session_id = SessionId::from_seed(1);
+        let harness = HarnessBuilder::new("eval", HARNESS_PROMPT)
+            .id(harness_id)
+            .capability(capability)
+            .build();
+        let agent = AgentBuilder::new("eval-agent", AGENT_PROMPT)
+            .id(agent_id)
+            .max_iterations(10)
+            .build();
+        let session = SessionBuilder::new(harness_id)
+            .id(session_id)
+            .agent(agent_id)
+            .build();
+        let runtime = InProcessRuntimeBuilder::new()
+            .platform_definition(platform())
+            .default_model(model.clone())
+            .harness(harness)
+            .agent(agent)
+            .session(session)
+            .build()
+            .await?;
+        let ctx = runtime.load_context(session_id).await?;
+        let tools: Vec<_> = ctx.runtime_agent.tools.iter().map(|t| t.name()).collect();
+        println!("\n========================================================");
+        println!("ARM: {capability}  | tools: {tools:?}");
+        println!("========== ASSEMBLED SYSTEM PROMPT ==========");
+        println!("{}", ctx.runtime_agent.system_prompt);
+        println!("========== END ==========");
+    }
+    Ok(())
+}
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let api_key = std::env::var("ANTHROPIC_API_KEY")
-        .map_err(|_| anyhow::anyhow!("set ANTHROPIC_API_KEY (Doppler) to run real-model evals"))?;
+    let api_key = std::env::var("ANTHROPIC_API_KEY").unwrap_or_else(|_| "dump-only".to_string());
     let model_name =
         std::env::var("EVAL_MODEL").unwrap_or_else(|_| "claude-haiku-4-5-20251001".to_string());
     let runs: u64 = std::env::var("EVAL_RUNS")
@@ -210,6 +247,14 @@ async fn main() -> anyhow::Result<()> {
         api_key: Some(api_key),
         base_url: None,
     };
+
+    // `--dump-prompts` prints the assembled prompts and exits (no model call).
+    if std::env::args().any(|a| a == "--dump-prompts") {
+        return dump_prompts(&model).await;
+    }
+    if std::env::var("ANTHROPIC_API_KEY").is_err() {
+        anyhow::bail!("set ANTHROPIC_API_KEY (Doppler) to run real-model evals");
+    }
 
     let arms = ["virtual_bash", "lua"];
     let tasks = tasks();

--- a/crates/agent-evals/src/main.rs
+++ b/crates/agent-evals/src/main.rs
@@ -1,0 +1,274 @@
+//! A/B evaluation harness: `lua` vs `virtual_bash` execution capability.
+//!
+//! Identical agent/model/prompt; the only difference between the two arms is
+//! which execution capability the harness grants. Each task seeds a workspace
+//! file, asks the agent to produce `/workspace/out.txt`, and a deterministic
+//! grader checks the result. We record success, tool-call count, tool errors,
+//! loop iterations, and latency per run.
+//!
+//! Run: `ANTHROPIC_API_KEY=… cargo run -p everruns-agent-evals --bin lua-vs-bash`
+//! Optional: `EVAL_MODEL=claude-… EVAL_RUNS=2`.
+
+use std::time::Instant;
+
+use everruns_core::capabilities::{LuaCapability, VirtualBashCapability};
+use everruns_core::llm_driver_registry::DriverRegistry;
+use everruns_core::session_file::InitialFile;
+use everruns_core::{
+    AgentId, CapabilityRegistry, HarnessId, LlmProviderType, MessageRole, ModelWithProvider,
+    PlatformDefinition, SessionId,
+};
+use everruns_runtime::{AgentBuilder, HarnessBuilder, InProcessRuntimeBuilder, SessionBuilder};
+
+const HARNESS_PROMPT: &str = "You are a data-processing assistant. You have exactly one \
+code-execution tool. To complete a task you MUST use that tool to read and write files in \
+/workspace — do not answer from your head. Always write the final answer to the file the task \
+names, then stop.";
+
+const AGENT_PROMPT: &str =
+    "Use your execution tool to read inputs and write outputs under /workspace. \
+Keep going until the requested output file exists, then stop.";
+
+struct Task {
+    id: &'static str,
+    slice: &'static str,
+    prompt: &'static str,
+    seed_path: Option<&'static str>,
+    seed_content: &'static str,
+    check_path: &'static str,
+    expect: &'static str,
+}
+
+fn tasks() -> Vec<Task> {
+    vec![
+        Task {
+            id: "math",
+            slice: "logic/math",
+            prompt: "Compute 17 * 23 + 5 and write only the number to /workspace/out.txt.",
+            seed_path: None,
+            seed_content: "",
+            check_path: "/workspace/out.txt",
+            expect: "396",
+        },
+        Task {
+            id: "json_sum",
+            slice: "data/json",
+            prompt: "Read the JSON array in /workspace/input.json. Sum the `amount` field of \
+every element and write only the total to /workspace/out.txt.",
+            seed_path: Some("/workspace/input.json"),
+            seed_content: r#"[{"amount": 10}, {"amount": 32}, {"amount": 100}]"#,
+            check_path: "/workspace/out.txt",
+            expect: "142",
+        },
+        Task {
+            id: "grep_count",
+            slice: "vfs/grep",
+            prompt: "Count how many lines in /workspace/log.txt contain the word ERROR and \
+write only that count to /workspace/out.txt.",
+            seed_path: Some("/workspace/log.txt"),
+            seed_content: "INFO ok\nERROR boom\nINFO fine\nERROR again\nWARN meh\nERROR third\n",
+            check_path: "/workspace/out.txt",
+            expect: "3",
+        },
+        Task {
+            id: "transform",
+            slice: "data/transform",
+            prompt: "Read /workspace/names.txt (one name per line). Write the same names to \
+/workspace/out.txt sorted alphabetically, one per line.",
+            seed_path: Some("/workspace/names.txt"),
+            seed_content: "charlie\nalice\nbob\n",
+            check_path: "/workspace/out.txt",
+            expect: "alice",
+        },
+    ]
+}
+
+#[derive(Default, Clone)]
+struct RunMetrics {
+    graded_ok: bool,
+    run_success: bool,
+    tool_calls: usize,
+    tool_errors: usize,
+    iterations: usize,
+    elapsed_ms: u128,
+    error: Option<String>,
+}
+
+fn platform() -> PlatformDefinition {
+    let mut caps = CapabilityRegistry::new();
+    caps.register(VirtualBashCapability);
+    caps.register(LuaCapability);
+
+    let mut drivers = DriverRegistry::new();
+    everruns_anthropic::register_driver(&mut drivers);
+    everruns_openai::register_driver(&mut drivers);
+    everruns_core::llmsim_driver::register_driver(&mut drivers);
+
+    PlatformDefinition::new(caps, drivers)
+}
+
+async fn run_one(task: &Task, capability: &str, model: &ModelWithProvider, seed: u64) -> RunMetrics {
+    let harness_id = HarnessId::from_seed(seed as u128);
+    let agent_id = AgentId::from_seed(seed as u128);
+    let session_id = SessionId::from_seed(seed as u128);
+
+    let mut harness = HarnessBuilder::new("eval", HARNESS_PROMPT)
+        .id(harness_id)
+        .capability(capability)
+        .build();
+    if let Some(path) = task.seed_path {
+        harness.initial_files.push(InitialFile {
+            path: path.to_string(),
+            content: task.seed_content.to_string(),
+            encoding: "text".to_string(),
+            is_readonly: false,
+        });
+    }
+
+    let agent = AgentBuilder::new("eval-agent", AGENT_PROMPT)
+        .id(agent_id)
+        .max_iterations(10)
+        .build();
+    let session = SessionBuilder::new(harness_id)
+        .id(session_id)
+        .agent(agent_id)
+        .build();
+
+    let runtime = match InProcessRuntimeBuilder::new()
+        .platform_definition(platform())
+        .default_model(model.clone())
+        .harness(harness)
+        .agent(agent)
+        .session(session)
+        .build()
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            return RunMetrics {
+                error: Some(format!("build: {e}")),
+                ..Default::default()
+            };
+        }
+    };
+
+    let start = Instant::now();
+    let turn = runtime.run_text_turn(session_id, task.prompt).await;
+    let elapsed_ms = start.elapsed().as_millis();
+
+    let mut m = RunMetrics {
+        elapsed_ms,
+        ..Default::default()
+    };
+    match turn {
+        Ok(t) => {
+            m.run_success = t.success;
+            m.iterations = t.iterations;
+        }
+        Err(e) => {
+            m.error = Some(format!("turn: {e}"));
+            return m;
+        }
+    }
+
+    // Tool-call / error accounting from the persisted message log.
+    if let Ok(messages) = runtime.messages(session_id).await {
+        for msg in &messages {
+            m.tool_calls += msg.tool_calls().len();
+            if msg.role == MessageRole::ToolResult {
+                let serialized = serde_json::to_string(msg).unwrap_or_default();
+                if serialized.contains("\"error\"") {
+                    m.tool_errors += 1;
+                }
+            }
+        }
+    }
+
+    // Deterministic grade against the workspace.
+    if let Ok(Some(file)) = runtime.read_file(session_id, task.check_path).await {
+        let content = file.content.unwrap_or_default();
+        m.graded_ok = content.contains(task.expect);
+    }
+
+    m
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let api_key = std::env::var("ANTHROPIC_API_KEY")
+        .map_err(|_| anyhow::anyhow!("set ANTHROPIC_API_KEY (Doppler) to run real-model evals"))?;
+    let model_name =
+        std::env::var("EVAL_MODEL").unwrap_or_else(|_| "claude-haiku-4-5-20251001".to_string());
+    let runs: u64 = std::env::var("EVAL_RUNS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(1);
+
+    let model = ModelWithProvider {
+        model: model_name.clone(),
+        provider_type: LlmProviderType::Anthropic,
+        api_key: Some(api_key),
+        base_url: None,
+    };
+
+    let arms = ["virtual_bash", "lua"];
+    let tasks = tasks();
+
+    println!("# lua vs virtual_bash — model={model_name}, runs/task={runs}\n");
+    println!("| task | slice | arm | graded | tool_calls | tool_errors | iters | ms | note |");
+    println!("|---|---|---|---|---|---|---|---|---|");
+
+    // arm -> (graded_ok, runs, tool_calls, tool_errors, iters, ms)
+    let mut agg: std::collections::HashMap<&str, (usize, usize, usize, usize, usize, u128)> =
+        std::collections::HashMap::new();
+    let mut seed: u64 = 1000;
+
+    for task in &tasks {
+        for arm in arms {
+            for _ in 0..runs {
+                seed += 1;
+                let m = run_one(task, arm, &model, seed).await;
+                let e = agg.entry(arm).or_default();
+                e.0 += m.graded_ok as usize;
+                e.1 += 1;
+                e.2 += m.tool_calls;
+                e.3 += m.tool_errors;
+                e.4 += m.iterations;
+                e.5 += m.elapsed_ms;
+                println!(
+                    "| {} | {} | {} | {} | {} | {} | {} | {} | {} |",
+                    task.id,
+                    task.slice,
+                    arm,
+                    if m.graded_ok { "✅" } else { "❌" },
+                    m.tool_calls,
+                    m.tool_errors,
+                    m.iterations,
+                    m.elapsed_ms,
+                    m.error.as_deref().unwrap_or(""),
+                );
+            }
+        }
+    }
+
+    println!("\n## Aggregate\n");
+    println!("| arm | success | tool_calls | tool_errors | avg_iters | avg_ms |");
+    println!("|---|---|---|---|---|---|");
+    for arm in arms {
+        if let Some(e) = agg.get(arm) {
+            let n = e.1.max(1);
+            println!(
+                "| {} | {}/{} | {} | {} | {:.1} | {} |",
+                arm,
+                e.0,
+                e.1,
+                e.2,
+                e.3,
+                e.4 as f64 / n as f64,
+                e.5 / n as u128,
+            );
+        }
+    }
+
+    Ok(())
+}

--- a/crates/agent-evals/src/main.rs
+++ b/crates/agent-evals/src/main.rs
@@ -25,8 +25,7 @@ code-execution tool. To complete a task you MUST use that tool to read and write
 /workspace — do not answer from your head. Always write the final answer to the file the task \
 names, then stop.";
 
-const AGENT_PROMPT: &str =
-    "Use your execution tool to read inputs and write outputs under /workspace. \
+const AGENT_PROMPT: &str = "Use your execution tool to read inputs and write outputs under /workspace. \
 Keep going until the requested output file exists, then stop.";
 
 struct Task {
@@ -107,7 +106,12 @@ fn platform() -> PlatformDefinition {
     PlatformDefinition::new(caps, drivers)
 }
 
-async fn run_one(task: &Task, capability: &str, model: &ModelWithProvider, seed: u64) -> RunMetrics {
+async fn run_one(
+    task: &Task,
+    capability: &str,
+    model: &ModelWithProvider,
+    seed: u64,
+) -> RunMetrics {
     let harness_id = HarnessId::from_seed(seed as u128);
     let agent_id = AgentId::from_seed(seed as u128);
     let session_id = SessionId::from_seed(seed as u128);

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -72,10 +72,9 @@ ed25519-dalek = { version = "2", features = ["rand_core"] }
 # Virtual bash interpreter
 bashkit = { version = "0.8.0", features = ["jq"] }
 
-# Sandboxed Lua interpreters (experimental `lua` capability, see specs/lua-execution.md).
-# Both optional + behind cargo features so the default build pulls in no interpreter.
-# Primary engine: native-Rust piccolo (no C/FFI, fuel-bounded). Reference: mlua.
-piccolo = { version = "0.3", optional = true }
+# Sandboxed Lua interpreter for the experimental `lua` capability (vendored Lua
+# 5.4, never LuaJIT). Optional + behind the `lua` cargo feature so the default
+# build does not compile the C sources. See specs/lua-execution.md.
 mlua = { version = "0.10", features = ["lua54", "vendored", "async", "send", "serialize"], optional = true }
 
 # Tree-sitter for structural outlines (EVE-248)
@@ -123,12 +122,9 @@ include_dir = { version = "0.7", optional = true }
 [features]
 default = ["llm-tests"]
 embedded-platform-docs = ["dep:include_dir"]
-# Experimental sandboxed Lua execution capability. Off by default. The engine is
-# chosen by feature: `lua` enables the native-Rust piccolo engine (primary);
-# `lua-mlua` enables the mlua reference engine (vendored Lua 5.4). See
-# specs/lua-execution.md.
-lua = ["dep:piccolo"]
-lua-mlua = ["dep:mlua"]
+# Experimental sandboxed Lua execution capability (mlua, vendored Lua 5.4).
+# Off by default; enabling compiles the C sources. See specs/lua-execution.md.
+lua = ["dep:mlua"]
 openapi = ["utoipa"]
 sqlx = ["dep:sqlx"]
 tree-sitter-outlines = ["dep:tree-sitter", "dep:tree-sitter-rust", "dep:tree-sitter-typescript", "dep:tree-sitter-python"]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -72,6 +72,11 @@ ed25519-dalek = { version = "2", features = ["rand_core"] }
 # Virtual bash interpreter
 bashkit = { version = "0.8.0", features = ["jq"] }
 
+# Sandboxed Lua interpreter (experimental `lua` capability, see specs/lua-execution.md).
+# Optional + behind the `lua` cargo feature so the default build does not compile
+# the vendored Lua 5.4 C sources. Never enable LuaJIT (FFI = sandbox escape).
+mlua = { version = "0.10", features = ["lua54", "vendored", "async", "send", "serialize"], optional = true }
+
 # Tree-sitter for structural outlines (EVE-248)
 tree-sitter = { version = "0.24", optional = true }
 tree-sitter-rust = { version = "0.23", optional = true }
@@ -117,6 +122,11 @@ include_dir = { version = "0.7", optional = true }
 [features]
 default = ["llm-tests"]
 embedded-platform-docs = ["dep:include_dir"]
+# Experimental sandboxed Lua execution capability. Off by default. The engine is
+# chosen by feature: `lua-mlua` enables the mlua reference engine (vendored Lua
+# 5.4); the native-Rust `piccolo` engine lands under `lua` in Phase 1. See
+# specs/lua-execution.md.
+lua-mlua = ["dep:mlua"]
 openapi = ["utoipa"]
 sqlx = ["dep:sqlx"]
 tree-sitter-outlines = ["dep:tree-sitter", "dep:tree-sitter-rust", "dep:tree-sitter-typescript", "dep:tree-sitter-python"]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -72,9 +72,10 @@ ed25519-dalek = { version = "2", features = ["rand_core"] }
 # Virtual bash interpreter
 bashkit = { version = "0.8.0", features = ["jq"] }
 
-# Sandboxed Lua interpreter (experimental `lua` capability, see specs/lua-execution.md).
-# Optional + behind the `lua` cargo feature so the default build does not compile
-# the vendored Lua 5.4 C sources. Never enable LuaJIT (FFI = sandbox escape).
+# Sandboxed Lua interpreters (experimental `lua` capability, see specs/lua-execution.md).
+# Both optional + behind cargo features so the default build pulls in no interpreter.
+# Primary engine: native-Rust piccolo (no C/FFI, fuel-bounded). Reference: mlua.
+piccolo = { version = "0.3", optional = true }
 mlua = { version = "0.10", features = ["lua54", "vendored", "async", "send", "serialize"], optional = true }
 
 # Tree-sitter for structural outlines (EVE-248)
@@ -123,9 +124,10 @@ include_dir = { version = "0.7", optional = true }
 default = ["llm-tests"]
 embedded-platform-docs = ["dep:include_dir"]
 # Experimental sandboxed Lua execution capability. Off by default. The engine is
-# chosen by feature: `lua-mlua` enables the mlua reference engine (vendored Lua
-# 5.4); the native-Rust `piccolo` engine lands under `lua` in Phase 1. See
+# chosen by feature: `lua` enables the native-Rust piccolo engine (primary);
+# `lua-mlua` enables the mlua reference engine (vendored Lua 5.4). See
 # specs/lua-execution.md.
+lua = ["dep:piccolo"]
 lua-mlua = ["dep:mlua"]
 openapi = ["utoipa"]
 sqlx = ["dep:sqlx"]

--- a/crates/core/src/capabilities/lua.rs
+++ b/crates/core/src/capabilities/lua.rs
@@ -1,0 +1,1294 @@
+//! Lua Execution Capability (experimental)
+//!
+//! Provides a sandboxed Lua interpreter over the session virtual filesystem.
+//! See `specs/lua-execution.md` for motivation, sandbox model, threat model
+//! (TM-LUA-*), and the phased roadmap (the goal is to supersede `virtual_bash`).
+//!
+//! Design (parallels `virtual_bash`):
+//! - `LuaCapability` is `High` risk and admin-gated, exactly like `virtual_bash`.
+//! - `LuaVfs` owns the `/workspace` <-> session-store path translation and is the
+//!   single seam to the (already session-scoped) `SessionFileSystem`. Tenant
+//!   isolation falls out of routing every path through that store.
+//! - `LuaLimits` is plain data; `engine::run` enforces it. The `mlua`
+//!   implementation lives behind `#[cfg(feature = "lua-mlua")]`, so the default
+//!   workspace build never fetches or compiles `mlua`. Swapping to a pure-Rust
+//!   VM (`piccolo`) later replaces only the engine module.
+//!
+//! Trust boundary (TM-LUA-001..008): `risk_level()` returns `High`; assigning
+//! this capability requires `OrgRole::Admin` via the same gates as
+//! `virtual_bash` (`check_high_risk_caps` / `require_admin_for_high_risk`).
+
+use super::{Capability, CapabilityStatus, RiskLevel};
+use crate::exec_tool_result::ExecToolResultPayload;
+use crate::session_file::SessionFile;
+use crate::tool_types::ToolHints;
+use crate::tools::{Tool, ToolExecutionResult};
+use crate::traits::{SessionFileSystem, ToolContext};
+use crate::typed_id::SessionId;
+use async_trait::async_trait;
+use serde_json::{Value, json};
+use std::sync::Arc;
+use std::time::Duration;
+
+pub const LUA_CAPABILITY_ID: &str = "lua";
+
+/// Workspace mount point in the virtual filesystem.
+const WORKSPACE_PREFIX: &str = "/workspace";
+
+const DEFAULT_TIMEOUT_MS: u64 = 30_000;
+const MAX_TIMEOUT_MS: u64 = 60_000;
+/// Hard memory cap for the VM (TM-LUA-003).
+const MEMORY_LIMIT_BYTES: usize = 32 * 1024 * 1024;
+/// Instruction budget before the VM is interrupted (TM-LUA-002).
+const MAX_INSTRUCTIONS: u64 = 50_000_000;
+/// Cap on captured `print` output before further writes are dropped (TM-LUA-008).
+const MAX_OUTPUT_BYTES: usize = 64 * 1024;
+
+const TOOL_DESCRIPTION: &str = r#"Execute a Lua 5.4 script in an isolated, sandboxed environment.
+
+The session filesystem is available through the `fs` table (rooted at /workspace),
+and `json.encode` / `json.decode` are available for structured data. Use `print(...)`
+for output and `return <value>` to send a JSON-serializable result back.
+
+No network, no host process access, no `io`/`os.execute`. CPU, memory, and runtime
+are bounded."#;
+
+const SYSTEM_PROMPT: &str = r#"You can run Lua 5.4 scripts via the `lua` tool for logic, math, and structured
+data processing over the session workspace.
+
+Host API:
+- `fs.read(path)`, `fs.write(path, s)`, `fs.append(path, s)`, `fs.exists(path)`
+- `fs.list(path)`, `fs.stat(path)`, `fs.remove(path[, recursive])`, `fs.mkdir(path)`
+- `fs.grep(pattern[, path])` (indexed search)
+- `json.encode(value)`, `json.decode(string)`
+- `print(...)` for output; `return value` to return a JSON-serializable result.
+
+Paths are rooted at /workspace. Negative space (do not use — these are nil):
+no `io`, no `os.execute`/`os.getenv`, no `require`/`package`, no `load`/`dofile`,
+and no network. Use the `fs` table for all file access."#;
+
+// ============================================================================
+// Capability
+// ============================================================================
+
+/// Lua execution capability — sandboxed scripting over the session VFS.
+pub struct LuaCapability;
+
+impl Capability for LuaCapability {
+    fn id(&self) -> &str {
+        LUA_CAPABILITY_ID
+    }
+
+    fn name(&self) -> &str {
+        "Lua"
+    }
+
+    fn description(&self) -> &str {
+        r#"Execute Lua scripts in an isolated, sandboxed environment.
+
+> [!NOTE]
+> Scripts run in a virtual environment with no host or network access. The
+> session filesystem is available via the `fs` table and `json` is available
+> for structured data."#
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+
+    fn risk_level(&self) -> RiskLevel {
+        // Scripted code execution + LLM-driven invocation: same trust elevation
+        // as virtual_bash. Admin-gated assignment (TM-LUA-001).
+        RiskLevel::High
+    }
+
+    fn icon(&self) -> Option<&str> {
+        Some("code")
+    }
+
+    fn category(&self) -> Option<&str> {
+        Some("Execution")
+    }
+
+    fn system_prompt_addition(&self) -> Option<&str> {
+        Some(SYSTEM_PROMPT)
+    }
+
+    fn tools(&self) -> Vec<Box<dyn Tool>> {
+        vec![Box::new(LuaTool)]
+    }
+
+    fn dependencies(&self) -> Vec<&'static str> {
+        vec!["session_file_system"]
+    }
+
+    fn features(&self) -> Vec<&'static str> {
+        vec!["file_system"]
+    }
+}
+
+// ============================================================================
+// Tool
+// ============================================================================
+
+/// Tool to execute a Lua script in the sandbox.
+pub struct LuaTool;
+
+#[async_trait]
+impl Tool for LuaTool {
+    fn name(&self) -> &str {
+        "lua"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("Lua")
+    }
+
+    fn description(&self) -> &str {
+        TOOL_DESCRIPTION
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "script": {
+                    "type": "string",
+                    "description": "Lua 5.4 source to execute."
+                },
+                "working_dir": {
+                    "type": "string",
+                    "default": WORKSPACE_PREFIX,
+                    "description": "Working directory (informational; paths in `fs.*` are /workspace-rooted)."
+                },
+                "timeout_ms": {
+                    "type": "integer",
+                    "default": DEFAULT_TIMEOUT_MS,
+                    "description": "Wall-clock timeout in milliseconds (capped at 60000)."
+                },
+                "output": crate::tool_output_sanitizer::output_verbosity_schema(),
+            },
+            "required": ["script"],
+        })
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_long_running(true)
+            .with_persist_output(true)
+            // Mutates the shared session workspace: serialize concurrent lua/bash
+            // calls in a batch so they don't race. Runs an in-process interpreter,
+            // so offload to its own task.
+            .with_concurrency_class("session_workspace")
+            .with_cpu_bound(true)
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error(
+            "lua requires context. This tool must be executed with session context.",
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        context: &ToolContext,
+    ) -> ToolExecutionResult {
+        let script = match arguments.get("script").and_then(|v| v.as_str()) {
+            Some(s) => s.to_string(),
+            None => return ToolExecutionResult::tool_error("Missing required parameter: script"),
+        };
+
+        let timeout_ms = arguments
+            .get("timeout_ms")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(DEFAULT_TIMEOUT_MS)
+            .min(MAX_TIMEOUT_MS);
+
+        let output_mode = arguments
+            .get("output")
+            .and_then(|v| v.as_str())
+            .unwrap_or("auto")
+            .to_string();
+
+        let file_store = match &context.file_store {
+            Some(store) => store.clone(),
+            None => {
+                return ToolExecutionResult::tool_error("File system not available in this context");
+            }
+        };
+
+        let vfs = Arc::new(LuaVfs::new(context.session_id, file_store));
+        let limits = LuaLimits {
+            memory_bytes: MEMORY_LIMIT_BYTES,
+            max_instructions: MAX_INSTRUCTIONS,
+            timeout: Duration::from_millis(timeout_ms),
+            max_output_bytes: MAX_OUTPUT_BYTES,
+        };
+
+        // Stream captured `print` output as tool.output.delta events.
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<String>();
+        let emit_context = context.clone();
+        let emit_task = tokio::spawn(async move {
+            while let Some(chunk) = rx.recv().await {
+                if !chunk.is_empty() {
+                    emit_context.emit_tool_output("lua", &chunk, "stdout").await;
+                }
+            }
+        });
+
+        // engine::run enforces its own deadline; the outer timeout is a backstop.
+        let outcome = tokio::time::timeout(
+            limits.timeout + Duration::from_secs(2),
+            engine::run(&script, vfs, &limits, tx),
+        )
+        .await;
+
+        let _ = emit_task.await;
+
+        let outcome = match outcome {
+            Ok(o) => o,
+            Err(_) => {
+                return ToolExecutionResult::tool_error(format!(
+                    "Lua execution timed out after {}ms",
+                    timeout_ms
+                ));
+            }
+        };
+
+        if let Some(err) = outcome.error {
+            let clean = crate::tool_output_sanitizer::clean_exec_output(&outcome.stdout);
+            return ToolExecutionResult::tool_error(if clean.is_empty() {
+                format!("Lua error: {err}")
+            } else {
+                format!("Lua error: {err}\n--- output ---\n{clean}")
+            });
+        }
+
+        // Shape stdout exactly like the exec tools so UI/persistence stay uniform.
+        let payload = ExecToolResultPayload::new(&outcome.stdout, "", 0, &output_mode);
+        let ExecToolResultPayload {
+            stdout,
+            truncated,
+            total_lines,
+            raw_output,
+            ..
+        } = payload;
+
+        ToolExecutionResult::success_with_raw_output(
+            json!({
+                "stdout": stdout,
+                "result": outcome.return_value,
+                "success": true,
+                "truncated": truncated,
+                "total_lines": total_lines,
+            }),
+            raw_output,
+        )
+    }
+}
+
+// ============================================================================
+// Limits & outcome (engine-agnostic)
+// ============================================================================
+
+/// Resource limits enforced by the engine (TM-LUA-002/003/008).
+///
+/// All fields but `timeout` are consumed only by the `mlua` engine, so they
+/// read as dead code in the default (feature-off) build.
+#[derive(Debug, Clone)]
+#[cfg_attr(not(feature = "lua-mlua"), allow(dead_code))]
+pub struct LuaLimits {
+    pub memory_bytes: usize,
+    pub max_instructions: u64,
+    pub timeout: Duration,
+    pub max_output_bytes: usize,
+}
+
+/// Result of one script execution.
+#[derive(Debug, Default)]
+pub struct LuaOutcome {
+    /// Captured `print` output.
+    pub stdout: String,
+    /// The script's `return` value, JSON-serialized (if any).
+    pub return_value: Option<Value>,
+    /// Set when the script raised an error or hit a limit.
+    pub error: Option<String>,
+}
+
+impl LuaOutcome {
+    fn engine_error(msg: impl Into<String>) -> Self {
+        Self {
+            error: Some(msg.into()),
+            ..Default::default()
+        }
+    }
+}
+
+// ============================================================================
+// LuaVfs — the only seam to the session filesystem (TM-LUA-004)
+// ============================================================================
+
+/// Entry returned by `fs.list` / `fs.stat`.
+#[derive(Debug, Clone)]
+pub struct VfsEntry {
+    pub name: String,
+    pub is_dir: bool,
+    pub size: i64,
+}
+
+/// A grep hit returned by `fs.grep`.
+#[derive(Debug, Clone)]
+pub struct VfsGrepHit {
+    pub path: String,
+    pub line_number: usize,
+    pub line: String,
+}
+
+/// Bridges the Lua `fs` table to `SessionFileSystem`, scoped to one session.
+pub struct LuaVfs {
+    session_id: SessionId,
+    store: Arc<dyn SessionFileSystem>,
+}
+
+impl LuaVfs {
+    pub fn new(session_id: SessionId, store: Arc<dyn SessionFileSystem>) -> Self {
+        Self { session_id, store }
+    }
+
+    /// Translate a Lua VFS path into a session-store path.
+    ///
+    /// Rules match `SessionFileSystemAdapter`: absolute, forward-slash,
+    /// `/workspace` stripped; anything outside `/workspace` is rejected so the
+    /// script can never reach another tenant or the host (TM-LUA-004).
+    fn to_session_path(path: &str) -> Option<String> {
+        let abs = if path.starts_with('/') {
+            path.to_string()
+        } else {
+            format!("/{path}")
+        };
+
+        if abs == WORKSPACE_PREFIX {
+            Some("/".to_string())
+        } else if let Some(stripped) = abs.strip_prefix(WORKSPACE_PREFIX) {
+            // Only `/workspace/...` is valid, not `/workspacefoo`.
+            if stripped.starts_with('/') {
+                Some(stripped.to_string())
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+    }
+
+    fn map_path(path: &str) -> Result<String, String> {
+        Self::to_session_path(path).ok_or_else(|| format!("path not in /workspace: {path}"))
+    }
+
+    pub async fn read(&self, path: &str) -> Result<String, String> {
+        let sp = Self::map_path(path)?;
+        match self.store.read_file(self.session_id, &sp).await {
+            Ok(Some(file)) => {
+                let content = file.content.unwrap_or_default();
+                let bytes = SessionFile::decode_content(&content, &file.encoding)
+                    .map_err(|e| e.to_string())?;
+                Ok(String::from_utf8_lossy(&bytes).into_owned())
+            }
+            Ok(None) => Err(format!("file not found: {path}")),
+            Err(e) => Err(e.to_string()),
+        }
+    }
+
+    pub async fn write(&self, path: &str, content: &str) -> Result<(), String> {
+        let sp = Self::map_path(path)?;
+        let (encoded, encoding) = SessionFile::encode_content(content.as_bytes());
+        self.store
+            .write_file(self.session_id, &sp, &encoded, &encoding)
+            .await
+            .map(|_| ())
+            .map_err(|e| e.to_string())
+    }
+
+    pub async fn append(&self, path: &str, content: &str) -> Result<(), String> {
+        // Append semantics: treat a missing file as empty.
+        let mut existing = self.read(path).await.unwrap_or_default();
+        existing.push_str(content);
+        self.write(path, &existing).await
+    }
+
+    pub async fn exists(&self, path: &str) -> Result<bool, String> {
+        let sp = Self::map_path(path)?;
+        if matches!(self.store.read_file(self.session_id, &sp).await, Ok(Some(_))) {
+            return Ok(true);
+        }
+        Ok(self
+            .store
+            .list_directory(self.session_id, &sp)
+            .await
+            .is_ok())
+    }
+
+    pub async fn stat(&self, path: &str) -> Result<Option<VfsEntry>, String> {
+        let sp = Self::map_path(path)?;
+        match self.store.stat_file(self.session_id, &sp).await {
+            Ok(Some(stat)) => Ok(Some(VfsEntry {
+                name: stat.name,
+                is_dir: stat.is_directory,
+                size: stat.size_bytes,
+            })),
+            Ok(None) => Ok(None),
+            Err(e) => Err(e.to_string()),
+        }
+    }
+
+    pub async fn list(&self, path: &str) -> Result<Vec<VfsEntry>, String> {
+        let sp = Self::map_path(path)?;
+        self.store
+            .list_directory(self.session_id, &sp)
+            .await
+            .map(|entries| {
+                entries
+                    .into_iter()
+                    .map(|e| VfsEntry {
+                        name: e.name,
+                        is_dir: e.is_directory,
+                        size: e.size_bytes,
+                    })
+                    .collect()
+            })
+            .map_err(|e| e.to_string())
+    }
+
+    pub async fn remove(&self, path: &str, recursive: bool) -> Result<bool, String> {
+        let sp = Self::map_path(path)?;
+        self.store
+            .delete_file(self.session_id, &sp, recursive)
+            .await
+            .map_err(|e| e.to_string())
+    }
+
+    pub async fn mkdir(&self, path: &str) -> Result<(), String> {
+        let sp = Self::map_path(path)?;
+        self.store
+            .create_directory(self.session_id, &sp)
+            .await
+            .map(|_| ())
+            .map_err(|e| e.to_string())
+    }
+
+    pub async fn grep(&self, pattern: &str, path: Option<&str>) -> Result<Vec<VfsGrepHit>, String> {
+        // None path => whole workspace; otherwise translate the scope.
+        let scope = match path {
+            Some(p) => {
+                let sp = Self::map_path(p)?;
+                if sp == "/" { None } else { Some(sp) }
+            }
+            None => None,
+        };
+        self.store
+            .grep_files(self.session_id, pattern, scope.as_deref())
+            .await
+            .map(|matches| {
+                matches
+                    .into_iter()
+                    .map(|m| VfsGrepHit {
+                        // Re-root to the Lua VFS namespace.
+                        path: format!("{WORKSPACE_PREFIX}{}", m.path),
+                        line_number: m.line_number,
+                        line: m.line,
+                    })
+                    .collect()
+            })
+            .map_err(|e| e.to_string())
+    }
+}
+
+// ============================================================================
+// Engine seam
+// ============================================================================
+
+#[cfg(not(feature = "lua-mlua"))]
+mod engine {
+    use super::{LuaLimits, LuaOutcome, LuaVfs};
+    use std::sync::Arc;
+
+    /// Stub used when the `lua` cargo feature is disabled (default). Keeps the
+    /// workspace buildable without pulling in `mlua`.
+    pub(super) async fn run(
+        _script: &str,
+        _vfs: Arc<LuaVfs>,
+        _limits: &LuaLimits,
+        _output: tokio::sync::mpsc::UnboundedSender<String>,
+    ) -> LuaOutcome {
+        LuaOutcome::engine_error(
+            "Lua engine is not compiled in this build (enable the `lua` cargo feature).",
+        )
+    }
+}
+
+// NOTE: The `mlua` engine below targets mlua 0.10 (Lua 5.4, vendored). It is
+// compiled only with `--features lua` and is wired end to end in Phase 2
+// (`specs/lua-execution.md`); exact API details may need to be pinned to the
+// resolved mlua version. The sandbox controls (stdlib whitelist, global
+// scrubbing, memory limit, instruction/deadline hook, no network) are the
+// contract that must hold regardless of API shape.
+#[cfg(feature = "lua-mlua")]
+mod engine {
+    use super::{LuaLimits, LuaOutcome, LuaVfs};
+    use mlua::{
+        HookTriggers, Lua, LuaOptions, LuaSerdeExt, StdLib, Value as LuaValue, Variadic, VmState,
+    };
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::{Arc, Mutex};
+    use std::time::Instant;
+
+    /// Granularity of the interrupt hook.
+    const HOOK_EVERY: u32 = 100_000;
+
+    pub(super) async fn run(
+        script: &str,
+        vfs: Arc<LuaVfs>,
+        limits: &LuaLimits,
+        output: tokio::sync::mpsc::UnboundedSender<String>,
+    ) -> LuaOutcome {
+        // Minimal safe stdlib: string/table/math/utf8 plus a scrubbed os. No
+        // io, package, debug, ffi (TM-LUA-001/006/007).
+        let libs = StdLib::STRING | StdLib::TABLE | StdLib::MATH | StdLib::OS | StdLib::UTF8;
+        let lua = match Lua::new_with(libs, LuaOptions::default()) {
+            Ok(l) => l,
+            Err(e) => return LuaOutcome::engine_error(format!("lua init failed: {e}")),
+        };
+
+        // Hard memory cap (TM-LUA-003).
+        let _ = lua.set_memory_limit(limits.memory_bytes);
+
+        if let Err(e) = scrub_globals(&lua) {
+            return LuaOutcome::engine_error(e);
+        }
+
+        // Deadline + instruction budget interrupt (TM-LUA-002).
+        let deadline = Instant::now() + limits.timeout;
+        let budget = limits.max_instructions;
+        let counted = Arc::new(AtomicU64::new(0));
+        {
+            let counted = counted.clone();
+            let _ = lua.set_hook(
+                HookTriggers::new().every_nth_instruction(HOOK_EVERY),
+                move |_lua, _debug| {
+                    if Instant::now() >= deadline {
+                        return Err(mlua::Error::runtime("lua: exceeded time limit"));
+                    }
+                    if counted.fetch_add(HOOK_EVERY as u64, Ordering::Relaxed) >= budget {
+                        return Err(mlua::Error::runtime("lua: exceeded instruction budget"));
+                    }
+                    Ok(VmState::Continue)
+                },
+            );
+        }
+
+        let stdout = Arc::new(Mutex::new(String::new()));
+        if let Err(e) = install_print(&lua, stdout.clone(), output, limits.max_output_bytes) {
+            return LuaOutcome::engine_error(format!("install print: {e}"));
+        }
+        if let Err(e) = install_fs(&lua, vfs) {
+            return LuaOutcome::engine_error(format!("install fs: {e}"));
+        }
+        if let Err(e) = install_json(&lua) {
+            return LuaOutcome::engine_error(format!("install json: {e}"));
+        }
+
+        let result: mlua::Result<LuaValue> =
+            lua.load(script).set_name("agent_script").eval_async().await;
+        let captured = stdout.lock().map(|s| s.clone()).unwrap_or_default();
+
+        match result {
+            Ok(value) => {
+                let return_value = match value {
+                    LuaValue::Nil => None,
+                    other => lua.from_value::<serde_json::Value>(other).ok(),
+                };
+                LuaOutcome {
+                    stdout: captured,
+                    return_value,
+                    error: None,
+                }
+            }
+            Err(e) => LuaOutcome {
+                stdout: captured,
+                return_value: None,
+                error: Some(e.to_string()),
+            },
+        }
+    }
+
+    /// Remove dangerous globals exposed by the loaded libraries
+    /// (TM-LUA-001/006). Anything not on the allow-list is set to nil.
+    fn scrub_globals(lua: &Lua) -> Result<(), String> {
+        let g = lua.globals();
+        for name in [
+            "io", "package", "require", "dofile", "loadfile", "load", "loadstring", "collectgarbage",
+        ] {
+            g.set(name, LuaValue::Nil).map_err(|e| e.to_string())?;
+        }
+        // Keep only the safe os subset.
+        if let Ok(os) = g.get::<mlua::Table>("os") {
+            for name in [
+                "execute", "getenv", "exit", "remove", "rename", "tmpname", "setlocale",
+            ] {
+                os.set(name, LuaValue::Nil).map_err(|e| e.to_string())?;
+            }
+        }
+        Ok(())
+    }
+
+    fn install_print(
+        lua: &Lua,
+        buf: Arc<Mutex<String>>,
+        sink: tokio::sync::mpsc::UnboundedSender<String>,
+        cap: usize,
+    ) -> mlua::Result<()> {
+        let print = lua.create_function(move |lua, args: Variadic<LuaValue>| {
+            let mut parts = Vec::with_capacity(args.len());
+            for a in args.iter() {
+                let s = lua
+                    .coerce_string(a.clone())?
+                    .map(|ls| ls.to_string_lossy())
+                    .unwrap_or_else(|| "nil".to_string());
+                parts.push(s);
+            }
+            let mut line = parts.join("\t");
+            line.push('\n');
+            if let Ok(mut g) = buf.lock() {
+                if g.len() < cap {
+                    g.push_str(&line);
+                }
+            }
+            let _ = sink.send(line);
+            Ok(())
+        })?;
+        lua.globals().set("print", print)?;
+        Ok(())
+    }
+
+    fn install_json(lua: &Lua) -> mlua::Result<()> {
+        let json = lua.create_table()?;
+        json.set(
+            "encode",
+            lua.create_function(|lua, value: LuaValue| {
+                let v: serde_json::Value = lua.from_value(value)?;
+                serde_json::to_string(&v).map_err(mlua::Error::external)
+            })?,
+        )?;
+        json.set(
+            "decode",
+            lua.create_function(|lua, s: String| {
+                let v: serde_json::Value =
+                    serde_json::from_str(&s).map_err(mlua::Error::external)?;
+                lua.to_value(&v)
+            })?,
+        )?;
+        lua.globals().set("json", json)?;
+        Ok(())
+    }
+
+    fn install_fs(lua: &Lua, vfs: Arc<LuaVfs>) -> mlua::Result<()> {
+        let fs = lua.create_table()?;
+
+        let v = vfs.clone();
+        fs.set(
+            "read",
+            lua.create_async_function(move |_, path: String| {
+                let v = v.clone();
+                async move { v.read(&path).await.map_err(mlua::Error::runtime) }
+            })?,
+        )?;
+
+        let v = vfs.clone();
+        fs.set(
+            "write",
+            lua.create_async_function(move |_, (path, content): (String, String)| {
+                let v = v.clone();
+                async move { v.write(&path, &content).await.map_err(mlua::Error::runtime) }
+            })?,
+        )?;
+
+        let v = vfs.clone();
+        fs.set(
+            "append",
+            lua.create_async_function(move |_, (path, content): (String, String)| {
+                let v = v.clone();
+                async move { v.append(&path, &content).await.map_err(mlua::Error::runtime) }
+            })?,
+        )?;
+
+        let v = vfs.clone();
+        fs.set(
+            "exists",
+            lua.create_async_function(move |_, path: String| {
+                let v = v.clone();
+                async move { v.exists(&path).await.map_err(mlua::Error::runtime) }
+            })?,
+        )?;
+
+        let v = vfs.clone();
+        fs.set(
+            "stat",
+            lua.create_async_function(move |lua, path: String| {
+                let v = v.clone();
+                async move {
+                    match v.stat(&path).await.map_err(mlua::Error::runtime)? {
+                        Some(e) => {
+                            let t = lua.create_table()?;
+                            t.set("name", e.name)?;
+                            t.set("is_dir", e.is_dir)?;
+                            t.set("size", e.size)?;
+                            Ok(LuaValue::Table(t))
+                        }
+                        None => Ok(LuaValue::Nil),
+                    }
+                }
+            })?,
+        )?;
+
+        let v = vfs.clone();
+        fs.set(
+            "list",
+            lua.create_async_function(move |lua, path: String| {
+                let v = v.clone();
+                async move {
+                    let entries = v.list(&path).await.map_err(mlua::Error::runtime)?;
+                    let arr = lua.create_table()?;
+                    for (i, e) in entries.into_iter().enumerate() {
+                        let t = lua.create_table()?;
+                        t.set("name", e.name)?;
+                        t.set("is_dir", e.is_dir)?;
+                        t.set("size", e.size)?;
+                        arr.set(i + 1, t)?;
+                    }
+                    Ok(arr)
+                }
+            })?,
+        )?;
+
+        let v = vfs.clone();
+        fs.set(
+            "remove",
+            lua.create_async_function(move |_, (path, recursive): (String, Option<bool>)| {
+                let v = v.clone();
+                async move {
+                    v.remove(&path, recursive.unwrap_or(false))
+                        .await
+                        .map_err(mlua::Error::runtime)
+                }
+            })?,
+        )?;
+
+        let v = vfs.clone();
+        fs.set(
+            "mkdir",
+            lua.create_async_function(move |_, path: String| {
+                let v = v.clone();
+                async move { v.mkdir(&path).await.map_err(mlua::Error::runtime) }
+            })?,
+        )?;
+
+        let v = vfs.clone();
+        fs.set(
+            "grep",
+            lua.create_async_function(move |lua, (pattern, path): (String, Option<String>)| {
+                let v = v.clone();
+                async move {
+                    let hits = v
+                        .grep(&pattern, path.as_deref())
+                        .await
+                        .map_err(mlua::Error::runtime)?;
+                    let arr = lua.create_table()?;
+                    for (i, h) in hits.into_iter().enumerate() {
+                        let t = lua.create_table()?;
+                        t.set("path", h.path)?;
+                        t.set("line_number", h.line_number)?;
+                        t.set("line", h.line)?;
+                        arr.set(i + 1, t)?;
+                    }
+                    Ok(arr)
+                }
+            })?,
+        )?;
+
+        lua.globals().set("fs", fs)?;
+        Ok(())
+    }
+}
+
+// ============================================================================
+// Tests (engine-agnostic)
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn capability_metadata() {
+        let cap = LuaCapability;
+        assert_eq!(cap.id(), "lua");
+        assert_eq!(cap.name(), "Lua");
+        assert_eq!(cap.status(), CapabilityStatus::Available);
+        assert_eq!(cap.risk_level(), RiskLevel::High);
+        assert_eq!(cap.category(), Some("Execution"));
+        assert_eq!(cap.dependencies(), vec!["session_file_system"]);
+        assert_eq!(cap.features(), vec!["file_system"]);
+    }
+
+    #[test]
+    fn capability_has_one_tool() {
+        let tools = LuaCapability.tools();
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0].name(), "lua");
+        assert!(tools[0].requires_context());
+    }
+
+    #[test]
+    fn schema_requires_script() {
+        let schema = LuaTool.parameters_schema();
+        let required = schema["required"].as_array().unwrap();
+        assert!(required.iter().any(|v| v == "script"));
+        assert!(schema["properties"].get("script").is_some());
+    }
+
+    // Path translation mirrors SessionFileSystemAdapter (TM-LUA-004).
+    #[test]
+    fn path_workspace_root_maps_to_root() {
+        assert_eq!(LuaVfs::to_session_path("/workspace"), Some("/".to_string()));
+    }
+
+    #[test]
+    fn path_workspace_file() {
+        assert_eq!(
+            LuaVfs::to_session_path("/workspace/a/b.txt"),
+            Some("/a/b.txt".to_string())
+        );
+    }
+
+    #[test]
+    fn path_relative_is_normalized() {
+        assert_eq!(
+            LuaVfs::to_session_path("workspace/x.txt"),
+            Some("/x.txt".to_string())
+        );
+    }
+
+    #[test]
+    fn path_outside_workspace_rejected() {
+        assert_eq!(LuaVfs::to_session_path("/etc/passwd"), None);
+        assert_eq!(LuaVfs::to_session_path("/home/agent/x"), None);
+        // /workspacefoo is not under /workspace
+        assert_eq!(LuaVfs::to_session_path("/workspacefoo"), None);
+    }
+
+    #[tokio::test]
+    async fn execute_without_context_errors() {
+        let result = LuaTool.execute(json!({"script": "return 1"})).await;
+        assert!(matches!(result, ToolExecutionResult::ToolError(msg) if msg.contains("requires context")));
+    }
+
+    #[tokio::test]
+    async fn execute_missing_script_errors() {
+        let ctx = ToolContext::new(SessionId::new());
+        let result = LuaTool.execute_with_context(json!({}), &ctx).await;
+        assert!(matches!(result, ToolExecutionResult::ToolError(msg) if msg.contains("Missing required parameter")));
+    }
+
+    #[tokio::test]
+    async fn execute_without_file_store_errors() {
+        let ctx = ToolContext::new(SessionId::new());
+        let result = LuaTool
+            .execute_with_context(json!({"script": "return 1"}), &ctx)
+            .await;
+        assert!(matches!(result, ToolExecutionResult::ToolError(msg) if msg.contains("not available")));
+    }
+
+    // When the engine is not compiled in (default build), the tool surfaces a
+    // clear error rather than silently succeeding.
+    #[cfg(not(feature = "lua-mlua"))]
+    #[tokio::test]
+    async fn engine_disabled_reports_not_compiled() {
+        let mut ctx = ToolContext::new(SessionId::new());
+        ctx.file_store = Some(Arc::new(EmptyFileStore));
+        let result = LuaTool
+            .execute_with_context(json!({"script": "return 1"}), &ctx)
+            .await;
+        assert!(matches!(result, ToolExecutionResult::ToolError(msg) if msg.contains("not compiled")));
+    }
+
+    /// Minimal file store: enough to populate `ToolContext::file_store` so the
+    /// tool reaches the engine seam. The engine-off path never touches it.
+    struct EmptyFileStore;
+
+    #[async_trait]
+    impl SessionFileSystem for EmptyFileStore {
+        async fn read_file(
+            &self,
+            _session_id: SessionId,
+            _path: &str,
+        ) -> crate::Result<Option<SessionFile>> {
+            Ok(None)
+        }
+
+        async fn write_file(
+            &self,
+            session_id: SessionId,
+            path: &str,
+            content: &str,
+            encoding: &str,
+        ) -> crate::Result<SessionFile> {
+            Ok(SessionFile {
+                id: uuid::Uuid::new_v4(),
+                session_id: session_id.into(),
+                path: path.to_string(),
+                name: path.rsplit('/').next().unwrap_or("").to_string(),
+                is_directory: false,
+                is_readonly: false,
+                content: Some(content.to_string()),
+                encoding: encoding.to_string(),
+                size_bytes: content.len() as i64,
+                created_at: chrono::Utc::now(),
+                updated_at: chrono::Utc::now(),
+            })
+        }
+
+        async fn delete_file(
+            &self,
+            _session_id: SessionId,
+            _path: &str,
+            _recursive: bool,
+        ) -> crate::Result<bool> {
+            Ok(false)
+        }
+
+        async fn list_directory(
+            &self,
+            _session_id: SessionId,
+            _path: &str,
+        ) -> crate::Result<Vec<crate::session_file::FileInfo>> {
+            Ok(vec![])
+        }
+
+        async fn stat_file(
+            &self,
+            _session_id: SessionId,
+            _path: &str,
+        ) -> crate::Result<Option<crate::FileStat>> {
+            Ok(None)
+        }
+
+        async fn grep_files(
+            &self,
+            _session_id: SessionId,
+            _pattern: &str,
+            _path_pattern: Option<&str>,
+        ) -> crate::Result<Vec<crate::GrepMatch>> {
+            Ok(vec![])
+        }
+
+        async fn create_directory(
+            &self,
+            session_id: SessionId,
+            path: &str,
+        ) -> crate::Result<crate::session_file::FileInfo> {
+            Ok(crate::session_file::FileInfo {
+                id: uuid::Uuid::new_v4(),
+                session_id: session_id.into(),
+                path: path.to_string(),
+                name: path.rsplit('/').next().unwrap_or("").to_string(),
+                is_directory: true,
+                is_readonly: false,
+                size_bytes: 0,
+                created_at: chrono::Utc::now(),
+                updated_at: chrono::Utc::now(),
+            })
+        }
+    }
+
+    // ========================================================================
+    // End-to-end engine tests (only when the `lua` feature is compiled in).
+    // ========================================================================
+
+    #[cfg(feature = "lua-mlua")]
+    mod engine_tests {
+        use super::*;
+        use std::collections::HashMap;
+        use std::sync::Mutex;
+
+        async fn run(script: &str, store: Arc<dyn SessionFileSystem>) -> Value {
+            let mut ctx = ToolContext::new(SessionId::new());
+            ctx.file_store = Some(store);
+            match LuaTool
+                .execute_with_context(json!({ "script": script }), &ctx)
+                .await
+            {
+                ToolExecutionResult::Success(v) => v,
+                other => panic!("expected success, got {other:?}"),
+            }
+        }
+
+        #[tokio::test]
+        async fn runs_logic_and_math() {
+            let v = run("return 2 + 3 * 4", Arc::new(EmptyFileStore)).await;
+            assert_eq!(v["result"], json!(14));
+            assert_eq!(v["success"], json!(true));
+        }
+
+        #[tokio::test]
+        async fn captures_print_output() {
+            let v = run("print('hello'); print('world')", Arc::new(EmptyFileStore)).await;
+            assert_eq!(v["stdout"], json!("hello\nworld\n"));
+        }
+
+        #[tokio::test]
+        async fn sandbox_blocks_dangerous_globals() {
+            // io/os.execute/load/require/dofile must be unavailable (TM-LUA-001/006).
+            let script = r#"
+                return {
+                    io = io == nil,
+                    exec = os.execute == nil,
+                    getenv = os.getenv == nil,
+                    load = load == nil,
+                    require = require == nil,
+                    dofile = dofile == nil,
+                }
+            "#;
+            let v = run(script, Arc::new(EmptyFileStore)).await;
+            for key in ["io", "exec", "getenv", "load", "require", "dofile"] {
+                assert_eq!(v["result"][key], json!(true), "{key} should be nil");
+            }
+        }
+
+        #[tokio::test]
+        async fn safe_os_subset_available() {
+            let v = run("return type(os.time())", Arc::new(EmptyFileStore)).await;
+            assert_eq!(v["result"], json!("number"));
+        }
+
+        #[tokio::test]
+        async fn fs_write_read_roundtrip() {
+            let store = Arc::new(MapFileStore::default());
+            let v = run(
+                r#"
+                fs.write("/workspace/a.txt", "hello")
+                return fs.read("/workspace/a.txt")
+                "#,
+                store,
+            )
+            .await;
+            assert_eq!(v["result"], json!("hello"));
+        }
+
+        #[tokio::test]
+        async fn json_roundtrip_through_vfs() {
+            let store = Arc::new(MapFileStore::default());
+            let v = run(
+                r#"
+                fs.write("/workspace/d.json", json.encode({ n = 42, name = "x" }))
+                local t = json.decode(fs.read("/workspace/d.json"))
+                return t.n
+                "#,
+                store,
+            )
+            .await;
+            assert_eq!(v["result"], json!(42));
+        }
+
+        #[tokio::test]
+        async fn fs_rejects_paths_outside_workspace() {
+            // Reaching outside /workspace raises a Lua error -> tool_error.
+            let mut ctx = ToolContext::new(SessionId::new());
+            ctx.file_store = Some(Arc::new(EmptyFileStore));
+            let result = LuaTool
+                .execute_with_context(
+                    json!({ "script": "return fs.read('/etc/passwd')" }),
+                    &ctx,
+                )
+                .await;
+            assert!(matches!(result, ToolExecutionResult::ToolError(msg) if msg.contains("workspace")));
+        }
+
+        #[tokio::test]
+        async fn instruction_budget_terminates_infinite_loop() {
+            // A tight infinite loop must be interrupted by the hook, not hang.
+            let result = LuaTool
+                .execute_with_context(
+                    json!({ "script": "while true do end", "timeout_ms": 1000 }),
+                    &{
+                        let mut ctx = ToolContext::new(SessionId::new());
+                        ctx.file_store = Some(Arc::new(EmptyFileStore));
+                        ctx
+                    },
+                )
+                .await;
+            assert!(matches!(result, ToolExecutionResult::ToolError(_)));
+        }
+
+        /// HashMap-backed store (normalized session paths) for fs round-trips.
+        #[derive(Default)]
+        struct MapFileStore {
+            files: Mutex<HashMap<String, String>>,
+        }
+
+        #[async_trait]
+        impl SessionFileSystem for MapFileStore {
+            async fn read_file(
+                &self,
+                session_id: SessionId,
+                path: &str,
+            ) -> crate::Result<Option<SessionFile>> {
+                let files = self.files.lock().unwrap();
+                Ok(files.get(path).map(|content| SessionFile {
+                    id: uuid::Uuid::new_v4(),
+                    session_id: session_id.into(),
+                    path: path.to_string(),
+                    name: path.rsplit('/').next().unwrap_or("").to_string(),
+                    is_directory: false,
+                    is_readonly: false,
+                    content: Some(content.clone()),
+                    encoding: "text".to_string(),
+                    size_bytes: content.len() as i64,
+                    created_at: chrono::Utc::now(),
+                    updated_at: chrono::Utc::now(),
+                }))
+            }
+
+            async fn write_file(
+                &self,
+                session_id: SessionId,
+                path: &str,
+                content: &str,
+                encoding: &str,
+            ) -> crate::Result<SessionFile> {
+                self.files
+                    .lock()
+                    .unwrap()
+                    .insert(path.to_string(), content.to_string());
+                Ok(SessionFile {
+                    id: uuid::Uuid::new_v4(),
+                    session_id: session_id.into(),
+                    path: path.to_string(),
+                    name: path.rsplit('/').next().unwrap_or("").to_string(),
+                    is_directory: false,
+                    is_readonly: false,
+                    content: Some(content.to_string()),
+                    encoding: encoding.to_string(),
+                    size_bytes: content.len() as i64,
+                    created_at: chrono::Utc::now(),
+                    updated_at: chrono::Utc::now(),
+                })
+            }
+
+            async fn delete_file(
+                &self,
+                _session_id: SessionId,
+                path: &str,
+                _recursive: bool,
+            ) -> crate::Result<bool> {
+                Ok(self.files.lock().unwrap().remove(path).is_some())
+            }
+
+            async fn list_directory(
+                &self,
+                session_id: SessionId,
+                path: &str,
+            ) -> crate::Result<Vec<crate::session_file::FileInfo>> {
+                let prefix = if path == "/" {
+                    "/".to_string()
+                } else {
+                    format!("{path}/")
+                };
+                let files = self.files.lock().unwrap();
+                Ok(files
+                    .iter()
+                    .filter(|(p, _)| p.starts_with(&prefix))
+                    .map(|(p, c)| crate::session_file::FileInfo {
+                        id: uuid::Uuid::new_v4(),
+                        session_id: session_id.into(),
+                        path: p.clone(),
+                        name: p.rsplit('/').next().unwrap_or("").to_string(),
+                        is_directory: false,
+                        is_readonly: false,
+                        size_bytes: c.len() as i64,
+                        created_at: chrono::Utc::now(),
+                        updated_at: chrono::Utc::now(),
+                    })
+                    .collect())
+            }
+
+            async fn stat_file(
+                &self,
+                _session_id: SessionId,
+                path: &str,
+            ) -> crate::Result<Option<crate::FileStat>> {
+                let files = self.files.lock().unwrap();
+                Ok(files.get(path).map(|c| crate::FileStat {
+                    path: path.to_string(),
+                    name: path.rsplit('/').next().unwrap_or("").to_string(),
+                    is_directory: false,
+                    is_readonly: false,
+                    size_bytes: c.len() as i64,
+                    created_at: chrono::Utc::now(),
+                    updated_at: chrono::Utc::now(),
+                }))
+            }
+
+            async fn grep_files(
+                &self,
+                _session_id: SessionId,
+                pattern: &str,
+                path_pattern: Option<&str>,
+            ) -> crate::Result<Vec<crate::GrepMatch>> {
+                let re = regex::Regex::new(pattern)
+                    .map_err(|e| crate::error::AgentLoopError::store(e.to_string()))?;
+                let files = self.files.lock().unwrap();
+                let mut out = Vec::new();
+                for (p, c) in files.iter() {
+                    if let Some(pp) = path_pattern {
+                        if !p.starts_with(pp) {
+                            continue;
+                        }
+                    }
+                    for (i, line) in c.lines().enumerate() {
+                        if re.is_match(line) {
+                            out.push(crate::GrepMatch {
+                                path: p.clone(),
+                                line_number: i + 1,
+                                line: line.to_string(),
+                            });
+                        }
+                    }
+                }
+                Ok(out)
+            }
+
+            async fn create_directory(
+                &self,
+                session_id: SessionId,
+                path: &str,
+            ) -> crate::Result<crate::session_file::FileInfo> {
+                Ok(crate::session_file::FileInfo {
+                    id: uuid::Uuid::new_v4(),
+                    session_id: session_id.into(),
+                    path: path.to_string(),
+                    name: path.rsplit('/').next().unwrap_or("").to_string(),
+                    is_directory: true,
+                    is_readonly: false,
+                    size_bytes: 0,
+                    created_at: chrono::Utc::now(),
+                    updated_at: chrono::Utc::now(),
+                })
+            }
+        }
+    }
+}

--- a/crates/core/src/capabilities/lua.rs
+++ b/crates/core/src/capabilities/lua.rs
@@ -62,11 +62,18 @@ Host API:
 - `fs.list(path)`, `fs.stat(path)`, `fs.remove(path[, recursive])`, `fs.mkdir(path)`
 - `fs.grep(pattern[, path])` (indexed search)
 - `json.encode(value)`, `json.decode(string)`
+- `base64.encode(string)`, `base64.decode(string)`
 - `print(...)` for output; `return value` to return a JSON-serializable result.
 
+Available base functions include `tonumber`, `tostring`, `type`, `pairs`,
+`ipairs`, `select`, `pcall`, `error`, `assert`, and `math.*`/`table.*`. NOTE:
+`string.format`, `string.find`, `string.match`, `string.gmatch`, and
+`string.gsub` are NOT available — build strings with concatenation and parse
+with `json.decode`/`fs.grep` instead.
+
 Paths are rooted at /workspace. Negative space (do not use — these are nil):
-no `io`, no `os.execute`/`os.getenv`, no `require`/`package`, no `load`/`dofile`,
-and no network. Use the `fs` table for all file access."#;
+no `io`, no `os`, no `require`/`package`, no `load`/`dofile`, and no network.
+Use the `fs` table for all file access."#;
 
 // ============================================================================
 // Capability
@@ -627,7 +634,9 @@ mod engine {
 
         let stash = lua.try_enter(|ctx| {
             install_print(ctx, stdout.clone(), output.clone(), limits.max_output_bytes);
+            install_stdlib_shims(ctx);
             install_json(ctx);
+            install_base64(ctx);
             install_fs(ctx, req_tx.clone());
             let closure = Closure::load(ctx, Some("agent_script"), script.as_bytes())?;
             Ok(ctx.stash(Executor::start(ctx, closure.into(), ())))
@@ -727,6 +736,57 @@ mod engine {
             Ok(CallbackReturn::Return)
         });
         ctx.set_global("print", print).ok();
+    }
+
+    /// Shims for base-library functions piccolo 0.3 does not provide but that
+    /// model-authored scripts commonly use. (piccolo's stdlib is partial; the
+    /// broader string.* gap is tracked in specs/lua-execution.md.)
+    fn install_stdlib_shims<'gc>(ctx: Context<'gc>) {
+        let tonumber = Callback::from_fn(&ctx, |ctx, _e, mut stack| {
+            let v = stack.get(0);
+            stack.clear();
+            let out = match v {
+                PValue::Integer(_) | PValue::Number(_) => v,
+                PValue::String(s) => {
+                    let raw = s.to_str_lossy();
+                    let t = raw.trim();
+                    if let Ok(i) = t.parse::<i64>() {
+                        PValue::Integer(i)
+                    } else if let Ok(f) = t.parse::<f64>() {
+                        PValue::Number(f)
+                    } else {
+                        PValue::Nil
+                    }
+                }
+                _ => PValue::Nil,
+            };
+            stack.replace(ctx, out);
+            Ok(CallbackReturn::Return)
+        });
+        ctx.set_global("tonumber", tonumber).ok();
+    }
+
+    /// `base64.encode(string) -> string` / `base64.decode(string) -> string`.
+    fn install_base64<'gc>(ctx: Context<'gc>) {
+        use base64::Engine as _;
+        let table = Table::new(&ctx);
+        let encode = Callback::from_fn(&ctx, |ctx, _e, mut stack| {
+            let s: piccolo::String = stack.consume(ctx)?;
+            let out = base64::engine::general_purpose::STANDARD.encode(s.as_bytes());
+            stack.replace(ctx, piccolo::String::from_slice(&ctx, out.as_bytes()));
+            Ok(CallbackReturn::Return)
+        });
+        let decode = Callback::from_fn(&ctx, |ctx, _e, mut stack| {
+            let s: piccolo::String = stack.consume(ctx)?;
+            let bytes = base64::engine::general_purpose::STANDARD
+                .decode(s.as_bytes())
+                .map_err(|e| lua_err(ctx, e.to_string()))?;
+            stack.replace(ctx, piccolo::String::from_slice(&ctx, &bytes));
+            Ok(CallbackReturn::Return)
+        });
+        table.set(ctx, "encode", encode).ok();
+        table.set(ctx, "decode", decode).ok();
+        ctx.set_global("base64", table).ok();
     }
 
     fn install_json<'gc>(ctx: Context<'gc>) {
@@ -1641,6 +1701,22 @@ mod tests {
             )
             .await;
             assert_eq!(v["result"], json!(42));
+        }
+
+        #[tokio::test]
+        async fn tonumber_shim_works() {
+            let v = run(r#"return tonumber("41") + 1"#, Arc::new(EmptyFileStore)).await;
+            assert_eq!(v["result"], json!(42));
+        }
+
+        #[tokio::test]
+        async fn base64_roundtrip() {
+            let v = run(
+                r#"return base64.decode(base64.encode("hello"))"#,
+                Arc::new(EmptyFileStore),
+            )
+            .await;
+            assert_eq!(v["result"], json!("hello"));
         }
 
         #[tokio::test]

--- a/crates/core/src/capabilities/lua.rs
+++ b/crates/core/src/capabilities/lua.rs
@@ -9,11 +9,10 @@
 //! - `LuaVfs` owns the `/workspace` <-> session-store path translation and is the
 //!   single seam to the (already session-scoped) `SessionFileSystem`. Tenant
 //!   isolation falls out of routing every path through that store.
-//! - `LuaLimits` is plain data; `engine::run` enforces it. The primary engine
-//!   is native-Rust `piccolo` (`feature = "lua"`); an `mlua` reference engine
-//!   (`feature = "lua-mlua"`) is kept as a fallback. With no engine feature the
-//!   default build pulls in no interpreter. The engine is the only swappable
-//!   module — capability, tool, VFS, and tests are engine-agnostic.
+//! - The engine is `mlua` (vendored Lua 5.4), behind the `lua` cargo feature so
+//!   the default build doesn't compile the C sources. `LuaLimits` is plain data;
+//!   `engine::run` enforces it (memory limit, instruction+deadline hook, scrubbed
+//!   stdlib). With the feature off the tool returns a "not compiled" error.
 //!
 //! Trust boundary (TM-LUA-001..008): `risk_level()` returns `High`; assigning
 //! this capability requires `OrgRole::Admin` via the same gates as
@@ -65,15 +64,12 @@ Host API:
 - `base64.encode(string)`, `base64.decode(string)`
 - `print(...)` for output; `return value` to return a JSON-serializable result.
 
-Available base functions include `tonumber`, `tostring`, `type`, `pairs`,
-`ipairs`, `select`, `pcall`, `error`, `assert`, and `math.*`/`table.*`. NOTE:
-`string.format`, `string.find`, `string.match`, `string.gmatch`, and
-`string.gsub` are NOT available — build strings with concatenation and parse
-with `json.decode`/`fs.grep` instead.
+The full Lua 5.4 standard library is available (`string.*` incl. `format`/
+`find`/`match`/`gsub`, `table.*` incl. `sort`, `math.*`, `os.time`/`os.date`).
 
-Paths are rooted at /workspace. Negative space (do not use — these are nil):
-no `io`, no `os`, no `require`/`package`, no `load`/`dofile`, and no network.
-Use the `fs` table for all file access."#;
+Disabled for sandboxing (do not use — nil): `io`, `os.execute`/`os.getenv`,
+`require`/`package`, `load`/`dofile`, and there is no network. Use the `fs`
+table for all file access."#;
 
 // ============================================================================
 // Capability
@@ -309,7 +305,7 @@ impl Tool for LuaTool {
 /// All fields but `timeout` are consumed only by the `mlua` engine, so they
 /// read as dead code in the default (feature-off) build.
 #[derive(Debug, Clone)]
-#[cfg_attr(not(any(feature = "lua", feature = "lua-mlua")), allow(dead_code))]
+#[cfg_attr(not(feature = "lua"), allow(dead_code))]
 pub struct LuaLimits {
     pub memory_bytes: usize,
     pub max_instructions: u64,
@@ -517,31 +513,53 @@ impl LuaVfs {
 }
 
 // ============================================================================
-// Engine seam
+// Engine (mlua)
 // ============================================================================
 
-// Primary engine: native-Rust piccolo 0.3 (no C/FFI). Sandbox is by
-// construction — `Lua::core()` loads only base/coroutine/math/string/table, so
-// there is no io/os/package/require/load to scrub (TM-LUA-001/006/007). CPU is
-// bounded by fuel per step + a wall-clock deadline (TM-LUA-002); memory by
-// `total_memory()` between steps (TM-LUA-003). piccolo is synchronous, so the
-// VM runs on a blocking thread and each async `fs.*` call is marshaled back to
-// the runtime over a channel (`blocking_recv`), which keeps tenant isolation in
-// the already session-scoped `LuaVfs`.
+#[cfg(not(feature = "lua"))]
+mod engine {
+    use super::{LuaLimits, LuaOutcome, LuaVfs};
+    use std::sync::Arc;
+
+    /// Stub used when the `lua` feature is off (default). Keeps the default
+    /// build from compiling the vendored Lua C sources.
+    pub(super) async fn run(
+        _script: &str,
+        _vfs: Arc<LuaVfs>,
+        _limits: &LuaLimits,
+        _output: tokio::sync::mpsc::UnboundedSender<String>,
+    ) -> LuaOutcome {
+        LuaOutcome::engine_error(
+            "Lua engine is not compiled in this build (enable the `lua` cargo feature).",
+        )
+    }
+}
+
+// The engine: mlua (vendored Lua 5.4, never LuaJIT). mlua loads the full stdlib,
+// so the sandbox works by *scrubbing* the dangerous surface
+// (io/os.execute/package/require/load/dofile/string.dump) rather than by
+// omission. Hardening (TM-LUA-001..008), all on by default, no configuration:
+// - memory: `set_memory_limit` hard cap;
+// - CPU/time: instruction-count hook + wall-clock deadline;
+// - isolation: the VM runs on a dedicated blocking thread and `fs.*` calls are
+//   marshaled to the async runtime over a channel. A pathological *synchronous*
+//   op (e.g. catastrophic Lua pattern in C, which the instruction hook cannot
+//   interrupt) therefore occupies one blocking-pool thread instead of stalling
+//   a shared runtime worker — multitenant containment. Residual: such an op is
+//   not force-killable in-process; the robust fix is out-of-process execution.
 #[cfg(feature = "lua")]
 mod engine {
     use super::{LuaLimits, LuaOutcome, LuaVfs, VfsEntry, VfsGrepHit};
-    use piccolo::{
-        Callback, CallbackReturn, Closure, Context, Executor, Fuel, Lua, Table, Value as PValue,
-        Variadic,
+    use mlua::{
+        HookTriggers, Lua, LuaOptions, LuaSerdeExt, StdLib, Value as LuaValue, Variadic, VmState,
     };
+    use std::sync::atomic::{AtomicU64, Ordering};
     use std::sync::{Arc, Mutex};
     use std::time::Instant;
     use tokio::sync::{mpsc, oneshot};
 
-    /// Fuel granted per executor step. Small enough that the deadline/budget are
-    /// checked frequently, large enough to amortize the enter() overhead.
-    const FUEL_PER_STEP: i32 = 8192;
+    /// Granularity of the interrupt hook (Lua instructions between checks).
+    const HOOK_EVERY: u32 = 100_000;
 
     // ---- VFS bridge: requests marshaled blocking-thread -> async runtime ----
 
@@ -581,13 +599,11 @@ mod engine {
             VfsOp::List(p) => vfs.list(&p).await.map(VfsReply::List),
             VfsOp::Remove(p, r) => vfs.remove(&p, r).await.map(VfsReply::Bool),
             VfsOp::Mkdir(p) => vfs.mkdir(&p).await.map(|_| VfsReply::Unit),
-            VfsOp::Grep(pat, scope) => {
-                vfs.grep(&pat, scope.as_deref()).await.map(VfsReply::Grep)
-            }
+            VfsOp::Grep(pat, scope) => vfs.grep(&pat, scope.as_deref()).await.map(VfsReply::Grep),
         }
     }
 
-    /// Synchronous VFS call from inside a piccolo callback (blocking thread).
+    /// Synchronous VFS call from inside a Lua host function (blocking thread).
     fn vfs_call(tx: &mpsc::UnboundedSender<VfsRequest>, op: VfsOp) -> Result<VfsReply, String> {
         let (reply_tx, reply_rx) = oneshot::channel();
         tx.send(VfsRequest { op, reply: reply_tx })
@@ -609,8 +625,8 @@ mod engine {
 
         let join = tokio::task::spawn_blocking(move || run_blocking(script, limits, req_tx, output));
 
-        // Service VFS requests until the blocking task drops every req_tx clone
-        // (which happens when the Lua VM and its callbacks are dropped).
+        // Service VFS requests on the runtime until the blocking task drops the
+        // sender (which happens when the Lua VM and its host functions are gone).
         while let Some(request) = req_rx.recv().await {
             let result = dispatch(&vfs, request.op).await;
             let _ = request.reply.send(result);
@@ -628,533 +644,7 @@ mod engine {
         req_tx: mpsc::UnboundedSender<VfsRequest>,
         output: mpsc::UnboundedSender<String>,
     ) -> LuaOutcome {
-        let stdout = Arc::new(Mutex::new(String::new()));
-        // core() = base/coroutine/math/string/table only. No io/os/package.
-        let mut lua = Lua::core();
-
-        let stash = lua.try_enter(|ctx| {
-            install_print(ctx, stdout.clone(), output.clone(), limits.max_output_bytes);
-            install_stdlib_shims(ctx);
-            install_json(ctx);
-            install_base64(ctx);
-            install_fs(ctx, req_tx.clone());
-            let closure = Closure::load(ctx, Some("agent_script"), script.as_bytes())?;
-            Ok(ctx.stash(Executor::start(ctx, closure.into(), ())))
-        });
-        let executor = match stash {
-            Ok(e) => e,
-            Err(e) => {
-                return LuaOutcome {
-                    stdout: take_stdout(&stdout),
-                    return_value: None,
-                    error: Some(e.to_string()),
-                };
-            }
-        };
-
-        let deadline = Instant::now() + limits.timeout;
-        let mut total_fuel: u64 = 0;
-        let finished: Result<(), String> = loop {
-            if Instant::now() >= deadline {
-                break Err("exceeded time limit".to_string());
-            }
-            if total_fuel >= limits.max_instructions {
-                break Err("exceeded instruction budget".to_string());
-            }
-            if lua.total_memory() > limits.memory_bytes {
-                break Err("exceeded memory limit".to_string());
-            }
-            total_fuel += FUEL_PER_STEP as u64;
-            let done = lua.enter(|ctx| {
-                let mut fuel = Fuel::with(FUEL_PER_STEP);
-                ctx.fetch(&executor).step(ctx, &mut fuel)
-            });
-            if done {
-                break Ok(());
-            }
-        };
-
-        let stdout_str = take_stdout(&stdout);
-        match finished {
-            Err(msg) => LuaOutcome {
-                stdout: stdout_str,
-                return_value: None,
-                error: Some(format!("lua: {msg}")),
-            },
-            Ok(()) => {
-                let ret = lua.try_enter(|ctx| {
-                    let values =
-                        ctx.fetch(&executor).take_result::<Variadic<Vec<PValue>>>(ctx)??;
-                    let first = values.0.into_iter().next().unwrap_or(PValue::Nil);
-                    Ok(pvalue_to_json_opt(ctx, first))
-                });
-                match ret {
-                    Ok(return_value) => LuaOutcome {
-                        stdout: stdout_str,
-                        return_value,
-                        error: None,
-                    },
-                    Err(e) => LuaOutcome {
-                        stdout: stdout_str,
-                        return_value: None,
-                        error: Some(e.to_string()),
-                    },
-                }
-            }
-        }
-    }
-
-    fn take_stdout(buf: &Arc<Mutex<String>>) -> String {
-        buf.lock().map(|s| s.clone()).unwrap_or_default()
-    }
-
-    /// Build a Lua error carrying a string message.
-    fn lua_err<'gc>(ctx: Context<'gc>, msg: String) -> piccolo::Error<'gc> {
-        PValue::String(piccolo::String::from_slice(&ctx, msg.as_bytes())).into()
-    }
-
-    fn install_print<'gc>(
-        ctx: Context<'gc>,
-        buf: Arc<Mutex<String>>,
-        sink: mpsc::UnboundedSender<String>,
-        cap: usize,
-    ) {
-        let print = Callback::from_fn(&ctx, move |ctx, _exec, mut stack| {
-            let mut parts = Vec::with_capacity(stack.len());
-            for i in 0..stack.len() {
-                parts.push(display_value(ctx, stack.get(i)));
-            }
-            stack.clear();
-            let mut line = parts.join("\t");
-            line.push('\n');
-            if let Ok(mut g) = buf.lock()
-                && g.len() < cap
-            {
-                g.push_str(&line);
-            }
-            let _ = sink.send(line);
-            Ok(CallbackReturn::Return)
-        });
-        ctx.set_global("print", print).ok();
-    }
-
-    /// Shims for base-library functions piccolo 0.3 does not provide but that
-    /// model-authored scripts commonly use. (piccolo's stdlib is partial; the
-    /// broader string.* gap is tracked in specs/lua-execution.md.)
-    fn install_stdlib_shims<'gc>(ctx: Context<'gc>) {
-        let tonumber = Callback::from_fn(&ctx, |ctx, _e, mut stack| {
-            let v = stack.get(0);
-            stack.clear();
-            let out = match v {
-                PValue::Integer(_) | PValue::Number(_) => v,
-                PValue::String(s) => {
-                    let raw = s.to_str_lossy();
-                    let t = raw.trim();
-                    if let Ok(i) = t.parse::<i64>() {
-                        PValue::Integer(i)
-                    } else if let Ok(f) = t.parse::<f64>() {
-                        PValue::Number(f)
-                    } else {
-                        PValue::Nil
-                    }
-                }
-                _ => PValue::Nil,
-            };
-            stack.replace(ctx, out);
-            Ok(CallbackReturn::Return)
-        });
-        ctx.set_global("tonumber", tonumber).ok();
-    }
-
-    /// `base64.encode(string) -> string` / `base64.decode(string) -> string`.
-    fn install_base64<'gc>(ctx: Context<'gc>) {
-        use base64::Engine as _;
-        let table = Table::new(&ctx);
-        let encode = Callback::from_fn(&ctx, |ctx, _e, mut stack| {
-            let s: piccolo::String = stack.consume(ctx)?;
-            let out = base64::engine::general_purpose::STANDARD.encode(s.as_bytes());
-            stack.replace(ctx, piccolo::String::from_slice(&ctx, out.as_bytes()));
-            Ok(CallbackReturn::Return)
-        });
-        let decode = Callback::from_fn(&ctx, |ctx, _e, mut stack| {
-            let s: piccolo::String = stack.consume(ctx)?;
-            let bytes = base64::engine::general_purpose::STANDARD
-                .decode(s.as_bytes())
-                .map_err(|e| lua_err(ctx, e.to_string()))?;
-            stack.replace(ctx, piccolo::String::from_slice(&ctx, &bytes));
-            Ok(CallbackReturn::Return)
-        });
-        table.set(ctx, "encode", encode).ok();
-        table.set(ctx, "decode", decode).ok();
-        ctx.set_global("base64", table).ok();
-    }
-
-    fn install_json<'gc>(ctx: Context<'gc>) {
-        let json = Table::new(&ctx);
-        let encode = Callback::from_fn(&ctx, |ctx, _exec, mut stack| {
-            let v = stack.get(0);
-            stack.clear();
-            let json = pvalue_to_json(ctx, v);
-            let s = serde_json::to_string(&json).map_err(|e| lua_err(ctx, e.to_string()))?;
-            stack.replace(ctx, piccolo::String::from_slice(&ctx, s.as_bytes()));
-            Ok(CallbackReturn::Return)
-        });
-        let decode = Callback::from_fn(&ctx, |ctx, _exec, mut stack| {
-            let s: piccolo::String = stack.consume(ctx)?;
-            let parsed: serde_json::Value = serde_json::from_slice(s.as_bytes())
-                .map_err(|e| lua_err(ctx, e.to_string()))?;
-            stack.replace(ctx, json_to_pvalue(ctx, &parsed));
-            Ok(CallbackReturn::Return)
-        });
-        json.set(ctx, "encode", encode).ok();
-        json.set(ctx, "decode", decode).ok();
-        ctx.set_global("json", json).ok();
-    }
-
-    fn install_fs<'gc>(ctx: Context<'gc>, tx: mpsc::UnboundedSender<VfsRequest>) {
-        let fs = Table::new(&ctx);
-
-        macro_rules! reply_str {
-            ($ctx:expr, $r:expr) => {
-                match $r {
-                    VfsReply::Str(s) => piccolo::String::from_slice(&$ctx, s.as_bytes()),
-                    _ => return Err(lua_err($ctx, "vfs: unexpected reply".to_string())),
-                }
-            };
-        }
-
-        let t = tx.clone();
-        fs.set(
-            ctx,
-            "read",
-            Callback::from_fn(&ctx, move |ctx, _e, mut stack| {
-                let path: piccolo::String = stack.consume(ctx)?;
-                let reply = vfs_call(&t, VfsOp::Read(path.to_str_lossy().into_owned()))
-                    .map_err(|e| lua_err(ctx, e))?;
-                stack.replace(ctx, reply_str!(ctx, reply));
-                Ok(CallbackReturn::Return)
-            }),
-        )
-        .ok();
-
-        let t = tx.clone();
-        fs.set(
-            ctx,
-            "write",
-            Callback::from_fn(&ctx, move |ctx, _e, mut stack| {
-                let (path, content): (piccolo::String, piccolo::String) = stack.consume(ctx)?;
-                vfs_call(
-                    &t,
-                    VfsOp::Write(
-                        path.to_str_lossy().into_owned(),
-                        content.to_str_lossy().into_owned(),
-                    ),
-                )
-                .map_err(|e| lua_err(ctx, e))?;
-                Ok(CallbackReturn::Return)
-            }),
-        )
-        .ok();
-
-        let t = tx.clone();
-        fs.set(
-            ctx,
-            "append",
-            Callback::from_fn(&ctx, move |ctx, _e, mut stack| {
-                let (path, content): (piccolo::String, piccolo::String) = stack.consume(ctx)?;
-                vfs_call(
-                    &t,
-                    VfsOp::Append(
-                        path.to_str_lossy().into_owned(),
-                        content.to_str_lossy().into_owned(),
-                    ),
-                )
-                .map_err(|e| lua_err(ctx, e))?;
-                Ok(CallbackReturn::Return)
-            }),
-        )
-        .ok();
-
-        let t = tx.clone();
-        fs.set(
-            ctx,
-            "exists",
-            Callback::from_fn(&ctx, move |ctx, _e, mut stack| {
-                let path: piccolo::String = stack.consume(ctx)?;
-                let reply = vfs_call(&t, VfsOp::Exists(path.to_str_lossy().into_owned()))
-                    .map_err(|e| lua_err(ctx, e))?;
-                let b = matches!(reply, VfsReply::Bool(true));
-                stack.replace(ctx, b);
-                Ok(CallbackReturn::Return)
-            }),
-        )
-        .ok();
-
-        let t = tx.clone();
-        fs.set(
-            ctx,
-            "stat",
-            Callback::from_fn(&ctx, move |ctx, _e, mut stack| {
-                let path: piccolo::String = stack.consume(ctx)?;
-                let reply = vfs_call(&t, VfsOp::Stat(path.to_str_lossy().into_owned()))
-                    .map_err(|e| lua_err(ctx, e))?;
-                match reply {
-                    VfsReply::Stat(Some(entry)) => stack.replace(ctx, entry_to_table(ctx, &entry)),
-                    VfsReply::Stat(None) => stack.replace(ctx, PValue::Nil),
-                    _ => return Err(lua_err(ctx, "vfs: unexpected reply".to_string())),
-                }
-                Ok(CallbackReturn::Return)
-            }),
-        )
-        .ok();
-
-        let t = tx.clone();
-        fs.set(
-            ctx,
-            "list",
-            Callback::from_fn(&ctx, move |ctx, _e, mut stack| {
-                let path: piccolo::String = stack.consume(ctx)?;
-                let reply = vfs_call(&t, VfsOp::List(path.to_str_lossy().into_owned()))
-                    .map_err(|e| lua_err(ctx, e))?;
-                let VfsReply::List(entries) = reply else {
-                    return Err(lua_err(ctx, "vfs: unexpected reply".to_string()));
-                };
-                let arr = Table::new(&ctx);
-                for (i, entry) in entries.iter().enumerate() {
-                    arr.set(ctx, (i + 1) as i64, entry_to_table(ctx, entry)).ok();
-                }
-                stack.replace(ctx, arr);
-                Ok(CallbackReturn::Return)
-            }),
-        )
-        .ok();
-
-        let t = tx.clone();
-        fs.set(
-            ctx,
-            "remove",
-            Callback::from_fn(&ctx, move |ctx, _e, mut stack| {
-                let (path, recursive): (piccolo::String, Option<bool>) = stack.consume(ctx)?;
-                let reply = vfs_call(
-                    &t,
-                    VfsOp::Remove(path.to_str_lossy().into_owned(), recursive.unwrap_or(false)),
-                )
-                .map_err(|e| lua_err(ctx, e))?;
-                stack.replace(ctx, matches!(reply, VfsReply::Bool(true)));
-                Ok(CallbackReturn::Return)
-            }),
-        )
-        .ok();
-
-        let t = tx.clone();
-        fs.set(
-            ctx,
-            "mkdir",
-            Callback::from_fn(&ctx, move |ctx, _e, mut stack| {
-                let path: piccolo::String = stack.consume(ctx)?;
-                vfs_call(&t, VfsOp::Mkdir(path.to_str_lossy().into_owned()))
-                    .map_err(|e| lua_err(ctx, e))?;
-                Ok(CallbackReturn::Return)
-            }),
-        )
-        .ok();
-
-        let t = tx.clone();
-        fs.set(
-            ctx,
-            "grep",
-            Callback::from_fn(&ctx, move |ctx, _e, mut stack| {
-                let (pattern, path): (piccolo::String, Option<piccolo::String>) =
-                    stack.consume(ctx)?;
-                let scope = path.map(|p| p.to_str_lossy().into_owned());
-                let reply = vfs_call(
-                    &t,
-                    VfsOp::Grep(pattern.to_str_lossy().into_owned(), scope),
-                )
-                .map_err(|e| lua_err(ctx, e))?;
-                let VfsReply::Grep(hits) = reply else {
-                    return Err(lua_err(ctx, "vfs: unexpected reply".to_string()));
-                };
-                let arr = Table::new(&ctx);
-                for (i, h) in hits.iter().enumerate() {
-                    let row = Table::new(&ctx);
-                    row.set(ctx, "path", piccolo::String::from_slice(&ctx, h.path.as_bytes()))
-                        .ok();
-                    row.set(ctx, "line_number", h.line_number as i64).ok();
-                    row.set(ctx, "line", piccolo::String::from_slice(&ctx, h.line.as_bytes()))
-                        .ok();
-                    arr.set(ctx, (i + 1) as i64, row).ok();
-                }
-                stack.replace(ctx, arr);
-                Ok(CallbackReturn::Return)
-            }),
-        )
-        .ok();
-
-        ctx.set_global("fs", fs).ok();
-    }
-
-    fn entry_to_table<'gc>(ctx: Context<'gc>, entry: &VfsEntry) -> Table<'gc> {
-        let t = Table::new(&ctx);
-        t.set(ctx, "name", piccolo::String::from_slice(&ctx, entry.name.as_bytes()))
-            .ok();
-        t.set(ctx, "is_dir", entry.is_dir).ok();
-        t.set(ctx, "size", entry.size).ok();
-        t
-    }
-
-    fn display_value<'gc>(ctx: Context<'gc>, v: PValue<'gc>) -> String {
-        match v {
-            PValue::Nil => "nil".to_string(),
-            PValue::Boolean(b) => b.to_string(),
-            PValue::Integer(i) => i.to_string(),
-            PValue::Number(n) => n.to_string(),
-            PValue::String(s) => s.to_str_lossy().into_owned(),
-            other => {
-                // Fall back to json for tables; opaque marker for the rest.
-                match pvalue_to_json(ctx, other) {
-                    serde_json::Value::Null => format!("{other:?}"),
-                    j => j.to_string(),
-                }
-            }
-        }
-    }
-
-    /// Top-level return conversion: a bare `nil` return means "no value".
-    fn pvalue_to_json_opt<'gc>(ctx: Context<'gc>, v: PValue<'gc>) -> Option<serde_json::Value> {
-        match v {
-            PValue::Nil => None,
-            other => Some(pvalue_to_json(ctx, other)),
-        }
-    }
-
-    fn pvalue_to_json<'gc>(ctx: Context<'gc>, v: PValue<'gc>) -> serde_json::Value {
-        use serde_json::Value as J;
-        match v {
-            PValue::Nil => J::Null,
-            PValue::Boolean(b) => J::Bool(b),
-            PValue::Integer(i) => J::Number(i.into()),
-            PValue::Number(n) => serde_json::Number::from_f64(n).map_or(J::Null, J::Number),
-            PValue::String(s) => J::String(s.to_str_lossy().into_owned()),
-            PValue::Table(t) => table_to_json(ctx, t),
-            // Functions/threads/userdata are not serializable.
-            _ => J::Null,
-        }
-    }
-
-    fn table_to_json<'gc>(ctx: Context<'gc>, t: Table<'gc>) -> serde_json::Value {
-        use serde_json::Value as J;
-        let len = t.length();
-        // Treat as an array iff keys are exactly 1..=len.
-        let mut is_array = len > 0;
-        let mut count = 0usize;
-        for (k, _) in t.iter() {
-            count += 1;
-            if !matches!(k, PValue::Integer(i) if i >= 1 && i <= len) {
-                is_array = false;
-            }
-        }
-        if is_array && count == len as usize {
-            let mut arr = Vec::with_capacity(len as usize);
-            for i in 1..=len {
-                arr.push(pvalue_to_json(ctx, t.get(ctx, i)));
-            }
-            J::Array(arr)
-        } else {
-            let mut map = serde_json::Map::new();
-            for (k, v) in t.iter() {
-                let key = match k {
-                    PValue::String(s) => s.to_str_lossy().into_owned(),
-                    PValue::Integer(i) => i.to_string(),
-                    PValue::Number(n) => n.to_string(),
-                    PValue::Boolean(b) => b.to_string(),
-                    _ => continue,
-                };
-                map.insert(key, pvalue_to_json(ctx, v));
-            }
-            J::Object(map)
-        }
-    }
-
-    fn json_to_pvalue<'gc>(ctx: Context<'gc>, v: &serde_json::Value) -> PValue<'gc> {
-        use serde_json::Value as J;
-        match v {
-            J::Null => PValue::Nil,
-            J::Bool(b) => PValue::Boolean(*b),
-            J::Number(n) => {
-                if let Some(i) = n.as_i64() {
-                    PValue::Integer(i)
-                } else {
-                    PValue::Number(n.as_f64().unwrap_or(0.0))
-                }
-            }
-            J::String(s) => PValue::String(piccolo::String::from_slice(&ctx, s.as_bytes())),
-            J::Array(items) => {
-                let t = Table::new(&ctx);
-                for (i, item) in items.iter().enumerate() {
-                    t.set(ctx, (i + 1) as i64, json_to_pvalue(ctx, item)).ok();
-                }
-                PValue::Table(t)
-            }
-            J::Object(obj) => {
-                let t = Table::new(&ctx);
-                for (k, val) in obj {
-                    t.set(
-                        ctx,
-                        piccolo::String::from_slice(&ctx, k.as_bytes()),
-                        json_to_pvalue(ctx, val),
-                    )
-                    .ok();
-                }
-                PValue::Table(t)
-            }
-        }
-    }
-}
-
-#[cfg(not(any(feature = "lua", feature = "lua-mlua")))]
-mod engine {
-    use super::{LuaLimits, LuaOutcome, LuaVfs};
-    use std::sync::Arc;
-
-    /// Stub used when no engine feature is enabled (default). Keeps the
-    /// workspace buildable without pulling in any interpreter.
-    pub(super) async fn run(
-        _script: &str,
-        _vfs: Arc<LuaVfs>,
-        _limits: &LuaLimits,
-        _output: tokio::sync::mpsc::UnboundedSender<String>,
-    ) -> LuaOutcome {
-        LuaOutcome::engine_error(
-            "Lua engine is not compiled in this build (enable the `lua` cargo feature).",
-        )
-    }
-}
-
-// Reference engine (mlua 0.10, vendored Lua 5.4). Compiled only with
-// `--features lua-mlua` and only when the primary piccolo engine is not also
-// enabled. Kept as a fallback per specs/lua-execution.md.
-#[cfg(all(feature = "lua-mlua", not(feature = "lua")))]
-mod engine {
-    use super::{LuaLimits, LuaOutcome, LuaVfs};
-    use mlua::{
-        HookTriggers, Lua, LuaOptions, LuaSerdeExt, StdLib, Value as LuaValue, Variadic, VmState,
-    };
-    use std::sync::atomic::{AtomicU64, Ordering};
-    use std::sync::{Arc, Mutex};
-    use std::time::Instant;
-
-    /// Granularity of the interrupt hook.
-    const HOOK_EVERY: u32 = 100_000;
-
-    pub(super) async fn run(
-        script: &str,
-        vfs: Arc<LuaVfs>,
-        limits: &LuaLimits,
-        output: tokio::sync::mpsc::UnboundedSender<String>,
-    ) -> LuaOutcome {
-        // Minimal safe stdlib: string/table/math/utf8 plus a scrubbed os. No
-        // io, package, debug, ffi (TM-LUA-001/006/007).
+        // Load only the libs we want; io/package/debug are never loaded.
         let libs = StdLib::STRING | StdLib::TABLE | StdLib::MATH | StdLib::OS | StdLib::UTF8;
         let lua = match Lua::new_with(libs, LuaOptions::default()) {
             Ok(l) => l,
@@ -1174,7 +664,7 @@ mod engine {
         let counted = Arc::new(AtomicU64::new(0));
         {
             let counted = counted.clone();
-            let _ = lua.set_hook(
+            lua.set_hook(
                 HookTriggers::new().every_nth_instruction(HOOK_EVERY),
                 move |_lua, _debug| {
                     if Instant::now() >= deadline {
@@ -1192,15 +682,17 @@ mod engine {
         if let Err(e) = install_print(&lua, stdout.clone(), output, limits.max_output_bytes) {
             return LuaOutcome::engine_error(format!("install print: {e}"));
         }
-        if let Err(e) = install_fs(&lua, vfs) {
-            return LuaOutcome::engine_error(format!("install fs: {e}"));
-        }
         if let Err(e) = install_json(&lua) {
             return LuaOutcome::engine_error(format!("install json: {e}"));
         }
+        if let Err(e) = install_base64(&lua) {
+            return LuaOutcome::engine_error(format!("install base64: {e}"));
+        }
+        if let Err(e) = install_fs(&lua, req_tx) {
+            return LuaOutcome::engine_error(format!("install fs: {e}"));
+        }
 
-        let result: mlua::Result<LuaValue> =
-            lua.load(script).set_name("agent_script").eval_async().await;
+        let result: mlua::Result<LuaValue> = lua.load(&script).set_name("agent_script").eval();
         let captured = stdout.lock().map(|s| s.clone()).unwrap_or_default();
 
         match result {
@@ -1224,7 +716,8 @@ mod engine {
     }
 
     /// Remove dangerous globals exposed by the loaded libraries
-    /// (TM-LUA-001/006). Anything not on the allow-list is set to nil.
+    /// (TM-LUA-001/006/007). No io/os.execute/package/require/load/dofile, and
+    /// `string.dump` (bytecode production) is removed defensively.
     fn scrub_globals(lua: &Lua) -> Result<(), String> {
         let g = lua.globals();
         for name in [
@@ -1232,7 +725,6 @@ mod engine {
         ] {
             g.set(name, LuaValue::Nil).map_err(|e| e.to_string())?;
         }
-        // Keep only the safe os subset.
         if let Ok(os) = g.get::<mlua::Table>("os") {
             for name in [
                 "execute", "getenv", "exit", "remove", "rename", "tmpname", "setlocale",
@@ -1240,13 +732,16 @@ mod engine {
                 os.set(name, LuaValue::Nil).map_err(|e| e.to_string())?;
             }
         }
+        if let Ok(string) = g.get::<mlua::Table>("string") {
+            string.set("dump", LuaValue::Nil).map_err(|e| e.to_string())?;
+        }
         Ok(())
     }
 
     fn install_print(
         lua: &Lua,
         buf: Arc<Mutex<String>>,
-        sink: tokio::sync::mpsc::UnboundedSender<String>,
+        sink: mpsc::UnboundedSender<String>,
         cap: usize,
     ) -> mlua::Result<()> {
         let print = lua.create_function(move |lua, args: Variadic<LuaValue>| {
@@ -1293,132 +788,151 @@ mod engine {
         Ok(())
     }
 
-    fn install_fs(lua: &Lua, vfs: Arc<LuaVfs>) -> mlua::Result<()> {
+    fn install_base64(lua: &Lua) -> mlua::Result<()> {
+        use base64::Engine as _;
+        let table = lua.create_table()?;
+        table.set(
+            "encode",
+            lua.create_function(|lua, s: mlua::String| {
+                let out = base64::engine::general_purpose::STANDARD.encode(s.as_bytes());
+                lua.create_string(out)
+            })?,
+        )?;
+        table.set(
+            "decode",
+            lua.create_function(|lua, s: mlua::String| {
+                let bytes = base64::engine::general_purpose::STANDARD
+                    .decode(s.as_bytes())
+                    .map_err(mlua::Error::external)?;
+                lua.create_string(bytes)
+            })?,
+        )?;
+        lua.globals().set("base64", table)?;
+        Ok(())
+    }
+
+    fn install_fs(lua: &Lua, tx: mpsc::UnboundedSender<VfsRequest>) -> mlua::Result<()> {
         let fs = lua.create_table()?;
 
-        let v = vfs.clone();
+        let t = tx.clone();
         fs.set(
             "read",
-            lua.create_async_function(move |_, path: String| {
-                let v = v.clone();
-                async move { v.read(&path).await.map_err(mlua::Error::runtime) }
+            lua.create_function(move |lua, path: String| {
+                match vfs_call(&t, VfsOp::Read(path)).map_err(mlua::Error::runtime)? {
+                    VfsReply::Str(s) => lua.create_string(s),
+                    _ => Err(mlua::Error::runtime("vfs: unexpected reply")),
+                }
             })?,
         )?;
 
-        let v = vfs.clone();
+        let t = tx.clone();
         fs.set(
             "write",
-            lua.create_async_function(move |_, (path, content): (String, String)| {
-                let v = v.clone();
-                async move { v.write(&path, &content).await.map_err(mlua::Error::runtime) }
+            lua.create_function(move |_lua, (path, content): (String, String)| {
+                vfs_call(&t, VfsOp::Write(path, content)).map_err(mlua::Error::runtime)?;
+                Ok(())
             })?,
         )?;
 
-        let v = vfs.clone();
+        let t = tx.clone();
         fs.set(
             "append",
-            lua.create_async_function(move |_, (path, content): (String, String)| {
-                let v = v.clone();
-                async move { v.append(&path, &content).await.map_err(mlua::Error::runtime) }
+            lua.create_function(move |_lua, (path, content): (String, String)| {
+                vfs_call(&t, VfsOp::Append(path, content)).map_err(mlua::Error::runtime)?;
+                Ok(())
             })?,
         )?;
 
-        let v = vfs.clone();
+        let t = tx.clone();
         fs.set(
             "exists",
-            lua.create_async_function(move |_, path: String| {
-                let v = v.clone();
-                async move { v.exists(&path).await.map_err(mlua::Error::runtime) }
+            lua.create_function(move |_lua, path: String| {
+                let reply = vfs_call(&t, VfsOp::Exists(path)).map_err(mlua::Error::runtime)?;
+                Ok(matches!(reply, VfsReply::Bool(true)))
             })?,
         )?;
 
-        let v = vfs.clone();
+        let t = tx.clone();
         fs.set(
             "stat",
-            lua.create_async_function(move |lua, path: String| {
-                let v = v.clone();
-                async move {
-                    match v.stat(&path).await.map_err(mlua::Error::runtime)? {
-                        Some(e) => {
-                            let t = lua.create_table()?;
-                            t.set("name", e.name)?;
-                            t.set("is_dir", e.is_dir)?;
-                            t.set("size", e.size)?;
-                            Ok(LuaValue::Table(t))
-                        }
-                        None => Ok(LuaValue::Nil),
+            lua.create_function(move |lua, path: String| {
+                match vfs_call(&t, VfsOp::Stat(path)).map_err(mlua::Error::runtime)? {
+                    VfsReply::Stat(Some(entry)) => {
+                        Ok(LuaValue::Table(entry_to_table(lua, &entry)?))
                     }
+                    VfsReply::Stat(None) => Ok(LuaValue::Nil),
+                    _ => Err(mlua::Error::runtime("vfs: unexpected reply")),
                 }
             })?,
         )?;
 
-        let v = vfs.clone();
+        let t = tx.clone();
         fs.set(
             "list",
-            lua.create_async_function(move |lua, path: String| {
-                let v = v.clone();
-                async move {
-                    let entries = v.list(&path).await.map_err(mlua::Error::runtime)?;
-                    let arr = lua.create_table()?;
-                    for (i, e) in entries.into_iter().enumerate() {
-                        let t = lua.create_table()?;
-                        t.set("name", e.name)?;
-                        t.set("is_dir", e.is_dir)?;
-                        t.set("size", e.size)?;
-                        arr.set(i + 1, t)?;
-                    }
-                    Ok(arr)
+            lua.create_function(move |lua, path: String| {
+                let VfsReply::List(entries) =
+                    vfs_call(&t, VfsOp::List(path)).map_err(mlua::Error::runtime)?
+                else {
+                    return Err(mlua::Error::runtime("vfs: unexpected reply"));
+                };
+                let arr = lua.create_table()?;
+                for (i, entry) in entries.iter().enumerate() {
+                    arr.set(i + 1, entry_to_table(lua, entry)?)?;
                 }
+                Ok(arr)
             })?,
         )?;
 
-        let v = vfs.clone();
+        let t = tx.clone();
         fs.set(
             "remove",
-            lua.create_async_function(move |_, (path, recursive): (String, Option<bool>)| {
-                let v = v.clone();
-                async move {
-                    v.remove(&path, recursive.unwrap_or(false))
-                        .await
-                        .map_err(mlua::Error::runtime)
-                }
+            lua.create_function(move |_lua, (path, recursive): (String, Option<bool>)| {
+                let reply = vfs_call(&t, VfsOp::Remove(path, recursive.unwrap_or(false)))
+                    .map_err(mlua::Error::runtime)?;
+                Ok(matches!(reply, VfsReply::Bool(true)))
             })?,
         )?;
 
-        let v = vfs.clone();
+        let t = tx.clone();
         fs.set(
             "mkdir",
-            lua.create_async_function(move |_, path: String| {
-                let v = v.clone();
-                async move { v.mkdir(&path).await.map_err(mlua::Error::runtime) }
+            lua.create_function(move |_lua, path: String| {
+                vfs_call(&t, VfsOp::Mkdir(path)).map_err(mlua::Error::runtime)?;
+                Ok(())
             })?,
         )?;
 
-        let v = vfs.clone();
+        let t = tx.clone();
         fs.set(
             "grep",
-            lua.create_async_function(move |lua, (pattern, path): (String, Option<String>)| {
-                let v = v.clone();
-                async move {
-                    let hits = v
-                        .grep(&pattern, path.as_deref())
-                        .await
-                        .map_err(mlua::Error::runtime)?;
-                    let arr = lua.create_table()?;
-                    for (i, h) in hits.into_iter().enumerate() {
-                        let t = lua.create_table()?;
-                        t.set("path", h.path)?;
-                        t.set("line_number", h.line_number)?;
-                        t.set("line", h.line)?;
-                        arr.set(i + 1, t)?;
-                    }
-                    Ok(arr)
+            lua.create_function(move |lua, (pattern, path): (String, Option<String>)| {
+                let VfsReply::Grep(hits) = vfs_call(&t, VfsOp::Grep(pattern, path))
+                    .map_err(mlua::Error::runtime)?
+                else {
+                    return Err(mlua::Error::runtime("vfs: unexpected reply"));
+                };
+                let arr = lua.create_table()?;
+                for (i, h) in hits.iter().enumerate() {
+                    let row = lua.create_table()?;
+                    row.set("path", h.path.clone())?;
+                    row.set("line_number", h.line_number)?;
+                    row.set("line", h.line.clone())?;
+                    arr.set(i + 1, row)?;
                 }
+                Ok(arr)
             })?,
         )?;
 
         lua.globals().set("fs", fs)?;
         Ok(())
+    }
+
+    fn entry_to_table(lua: &Lua, entry: &VfsEntry) -> mlua::Result<mlua::Table> {
+        let t = lua.create_table()?;
+        t.set("name", entry.name.clone())?;
+        t.set("is_dir", entry.is_dir)?;
+        t.set("size", entry.size)?;
+        Ok(t)
     }
 }
 
@@ -1512,7 +1026,7 @@ mod tests {
 
     // When the engine is not compiled in (default build), the tool surfaces a
     // clear error rather than silently succeeding.
-    #[cfg(not(any(feature = "lua", feature = "lua-mlua")))]
+    #[cfg(not(feature = "lua"))]
     #[tokio::test]
     async fn engine_disabled_reports_not_compiled() {
         let mut ctx = ToolContext::new(SessionId::new());
@@ -1616,7 +1130,7 @@ mod tests {
     // End-to-end engine tests (run for whichever engine feature is enabled).
     // ========================================================================
 
-    #[cfg(any(feature = "lua", feature = "lua-mlua"))]
+    #[cfg(feature = "lua")]
     mod engine_tests {
         use super::*;
         use std::collections::HashMap;
@@ -1667,7 +1181,7 @@ mod tests {
         }
 
         // os.* is a mlua-only safe subset; piccolo's core() loads no os library.
-        #[cfg(all(feature = "lua-mlua", not(feature = "lua")))]
+        #[cfg(feature = "lua")]
         #[tokio::test]
         async fn safe_os_subset_available() {
             let v = run("return type(os.time())", Arc::new(EmptyFileStore)).await;

--- a/crates/core/src/capabilities/lua.rs
+++ b/crates/core/src/capabilities/lua.rs
@@ -67,9 +67,14 @@ Host API:
 The full Lua 5.4 standard library is available (`string.*` incl. `format`/
 `find`/`match`/`gsub`, `table.*` incl. `sort`, `math.*`, `os.time`/`os.date`).
 
+When enabled by the environment (otherwise these globals are nil):
+- `http.get(url)` / `http.post(url, body)` -> `{ status, body }`, allow-listed
+  hosts only.
+- `tools.<name>(args_table)` -> result, to call other available tools.
+
 Disabled for sandboxing (do not use — nil): `io`, `os.execute`/`os.getenv`,
-`require`/`package`, `load`/`dofile`, and there is no network. Use the `fs`
-table for all file access."#;
+`require`/`package`, `load`/`dofile`. Use `fs` for files; raw sockets are not
+available (use `http` when present)."#;
 
 // ============================================================================
 // Capability
@@ -222,7 +227,9 @@ impl Tool for LuaTool {
         let file_store = match &context.file_store {
             Some(store) => store.clone(),
             None => {
-                return ToolExecutionResult::tool_error("File system not available in this context");
+                return ToolExecutionResult::tool_error(
+                    "File system not available in this context",
+                );
             }
         };
 
@@ -233,6 +240,19 @@ impl Tool for LuaTool {
             timeout: Duration::from_millis(timeout_ms),
             max_output_bytes: MAX_OUTPUT_BYTES,
         };
+
+        // Code mode (`tools.<name>`): expose only Auto, non-destructive,
+        // non-execution sibling tools. Excludes approval/client-side tools and
+        // the execution tools themselves (no `lua`/`bash` re-entry).
+        let allowed_tools = gated_code_mode_tools(context);
+
+        // HTTP (`http.*`) is fail-closed: needs a host egress service AND a
+        // non-empty network allow-list (the per-URL check happens at call time).
+        let http_enabled = context.egress_service.is_some()
+            && context
+                .network_access
+                .as_ref()
+                .is_some_and(|a| !a.allowed.is_empty());
 
         // Stream captured `print` output as tool.output.delta events.
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<String>();
@@ -248,7 +268,15 @@ impl Tool for LuaTool {
         // engine::run enforces its own deadline; the outer timeout is a backstop.
         let outcome = tokio::time::timeout(
             limits.timeout + Duration::from_secs(2),
-            engine::run(&script, vfs, &limits, tx),
+            engine::run(
+                &script,
+                vfs,
+                context.clone(),
+                allowed_tools,
+                http_enabled,
+                &limits,
+                tx,
+            ),
         )
         .await;
 
@@ -294,6 +322,36 @@ impl Tool for LuaTool {
             raw_output,
         )
     }
+}
+
+/// Sibling tools exposed to Lua "code mode" via the `tools` table.
+///
+/// Conservative gate (TM-LUA-009): `Auto` policy only (never approval- or
+/// client-side tools), non-destructive, non-execution, and never the execution
+/// tools themselves (`lua`/`bash` are excluded so code mode cannot re-enter a
+/// shell or itself). Returns an empty list when no tool registry is present.
+fn gated_code_mode_tools(context: &ToolContext) -> Vec<String> {
+    use crate::tool_types::ToolPolicy;
+    let Some(reg) = context.tool_registry.as_ref() else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for name in reg.tool_names() {
+        if name == "lua" || name == "bash" {
+            continue;
+        }
+        let Some(tool) = reg.get(name) else { continue };
+        if tool.policy() != ToolPolicy::Auto {
+            continue;
+        }
+        let hints = tool.hints();
+        if hints.destructive == Some(true) || hints.cpu_bound == Some(true) {
+            continue;
+        }
+        out.push(name.to_string());
+    }
+    out.sort();
+    out
 }
 
 // ============================================================================
@@ -427,7 +485,10 @@ impl LuaVfs {
 
     pub async fn exists(&self, path: &str) -> Result<bool, String> {
         let sp = Self::map_path(path)?;
-        if matches!(self.store.read_file(self.session_id, &sp).await, Ok(Some(_))) {
+        if matches!(
+            self.store.read_file(self.session_id, &sp).await,
+            Ok(Some(_))
+        ) {
             return Ok(true);
         }
         Ok(self
@@ -518,14 +579,18 @@ impl LuaVfs {
 
 #[cfg(not(feature = "lua"))]
 mod engine {
-    use super::{LuaLimits, LuaOutcome, LuaVfs};
+    use super::{LuaLimits, LuaOutcome, LuaVfs, ToolContext};
     use std::sync::Arc;
 
     /// Stub used when the `lua` feature is off (default). Keeps the default
     /// build from compiling the vendored Lua C sources.
+    #[allow(clippy::too_many_arguments)]
     pub(super) async fn run(
         _script: &str,
         _vfs: Arc<LuaVfs>,
+        _ctx: ToolContext,
+        _allowed_tools: Vec<String>,
+        _http_enabled: bool,
         _limits: &LuaLimits,
         _output: tokio::sync::mpsc::UnboundedSender<String>,
     ) -> LuaOutcome {
@@ -538,18 +603,24 @@ mod engine {
 // The engine: mlua (vendored Lua 5.4, never LuaJIT). mlua loads the full stdlib,
 // so the sandbox works by *scrubbing* the dangerous surface
 // (io/os.execute/package/require/load/dofile/string.dump) rather than by
-// omission. Hardening (TM-LUA-001..008), all on by default, no configuration:
+// omission. Hardening (TM-LUA-001..009), all on by default, no configuration:
 // - memory: `set_memory_limit` hard cap;
 // - CPU/time: instruction-count hook + wall-clock deadline;
-// - isolation: the VM runs on a dedicated blocking thread and `fs.*` calls are
-//   marshaled to the async runtime over a channel. A pathological *synchronous*
-//   op (e.g. catastrophic Lua pattern in C, which the instruction hook cannot
-//   interrupt) therefore occupies one blocking-pool thread instead of stalling
-//   a shared runtime worker — multitenant containment. Residual: such an op is
-//   not force-killable in-process; the robust fix is out-of-process execution.
+// - isolation: the VM runs on a dedicated blocking thread; `fs.*`, `http.*`, and
+//   `tools.*` calls are marshaled to the async runtime over a channel. A
+//   pathological *synchronous* op (e.g. catastrophic Lua pattern in C, which the
+//   instruction hook cannot interrupt) therefore occupies one blocking-pool
+//   thread instead of stalling a shared runtime worker — multitenant
+//   containment. Residual: such an op is not force-killable in-process; the
+//   robust fix is out-of-process execution.
+// - egress: `http.*` is fail-closed — it requires both a host `EgressService`
+//   and a non-empty network allow-list that permits the URL (TM-LUA-005).
+// - code mode: `tools.<name>(args)` re-enters only Auto, non-destructive,
+//   non-execution tools; the child context has no tool_registry, so code mode
+//   cannot recurse (TM-LUA-009).
 #[cfg(feature = "lua")]
 mod engine {
-    use super::{LuaLimits, LuaOutcome, LuaVfs, VfsEntry, VfsGrepHit};
+    use super::{LuaLimits, LuaOutcome, LuaVfs, ToolContext, VfsEntry, VfsGrepHit};
     use mlua::{
         HookTriggers, Lua, LuaOptions, LuaSerdeExt, StdLib, Value as LuaValue, Variadic, VmState,
     };
@@ -560,10 +631,12 @@ mod engine {
 
     /// Granularity of the interrupt hook (Lua instructions between checks).
     const HOOK_EVERY: u32 = 100_000;
+    /// Cap on an HTTP response body handed back to Lua.
+    const HTTP_BODY_CAP: usize = 1024 * 1024;
 
-    // ---- VFS bridge: requests marshaled blocking-thread -> async runtime ----
+    // ---- Host-call bridge: blocking VM thread -> async runtime ----
 
-    enum VfsOp {
+    enum Op {
         Read(String),
         Write(String, String),
         Append(String, String),
@@ -573,62 +646,155 @@ mod engine {
         Remove(String, bool),
         Mkdir(String),
         Grep(String, Option<String>),
+        Http {
+            method: &'static str,
+            url: String,
+            body: Option<String>,
+        },
+        Tool {
+            name: String,
+            args: serde_json::Value,
+        },
     }
 
-    enum VfsReply {
+    enum Reply {
         Str(String),
         Bool(bool),
         Unit,
         Stat(Option<VfsEntry>),
         List(Vec<VfsEntry>),
         Grep(Vec<VfsGrepHit>),
+        Http { status: u16, body: String },
+        Json(serde_json::Value),
     }
 
-    struct VfsRequest {
-        op: VfsOp,
-        reply: oneshot::Sender<Result<VfsReply, String>>,
+    struct Request {
+        op: Op,
+        reply: oneshot::Sender<Result<Reply, String>>,
     }
 
-    async fn dispatch(vfs: &LuaVfs, op: VfsOp) -> Result<VfsReply, String> {
+    async fn dispatch(vfs: &LuaVfs, ctx: &ToolContext, op: Op) -> Result<Reply, String> {
         match op {
-            VfsOp::Read(p) => vfs.read(&p).await.map(VfsReply::Str),
-            VfsOp::Write(p, c) => vfs.write(&p, &c).await.map(|_| VfsReply::Unit),
-            VfsOp::Append(p, c) => vfs.append(&p, &c).await.map(|_| VfsReply::Unit),
-            VfsOp::Exists(p) => vfs.exists(&p).await.map(VfsReply::Bool),
-            VfsOp::Stat(p) => vfs.stat(&p).await.map(VfsReply::Stat),
-            VfsOp::List(p) => vfs.list(&p).await.map(VfsReply::List),
-            VfsOp::Remove(p, r) => vfs.remove(&p, r).await.map(VfsReply::Bool),
-            VfsOp::Mkdir(p) => vfs.mkdir(&p).await.map(|_| VfsReply::Unit),
-            VfsOp::Grep(pat, scope) => vfs.grep(&pat, scope.as_deref()).await.map(VfsReply::Grep),
+            Op::Read(p) => vfs.read(&p).await.map(Reply::Str),
+            Op::Write(p, c) => vfs.write(&p, &c).await.map(|_| Reply::Unit),
+            Op::Append(p, c) => vfs.append(&p, &c).await.map(|_| Reply::Unit),
+            Op::Exists(p) => vfs.exists(&p).await.map(Reply::Bool),
+            Op::Stat(p) => vfs.stat(&p).await.map(Reply::Stat),
+            Op::List(p) => vfs.list(&p).await.map(Reply::List),
+            Op::Remove(p, r) => vfs.remove(&p, r).await.map(Reply::Bool),
+            Op::Mkdir(p) => vfs.mkdir(&p).await.map(|_| Reply::Unit),
+            Op::Grep(pat, scope) => vfs.grep(&pat, scope.as_deref()).await.map(Reply::Grep),
+            Op::Http { method, url, body } => do_http(ctx, method, url, body).await,
+            Op::Tool { name, args } => do_tool(ctx, &name, args).await.map(Reply::Json),
         }
     }
 
-    /// Synchronous VFS call from inside a Lua host function (blocking thread).
-    fn vfs_call(tx: &mpsc::UnboundedSender<VfsRequest>, op: VfsOp) -> Result<VfsReply, String> {
-        let (reply_tx, reply_rx) = oneshot::channel();
-        tx.send(VfsRequest { op, reply: reply_tx })
-            .map_err(|_| "vfs channel closed".to_string())?;
-        reply_rx
-            .blocking_recv()
-            .map_err(|_| "vfs reply dropped".to_string())?
+    /// HTTP via the host egress boundary. Fail-closed: requires both an
+    /// `EgressService` and an allow-list that explicitly permits the URL.
+    async fn do_http(
+        ctx: &ToolContext,
+        method: &'static str,
+        url: String,
+        body: Option<String>,
+    ) -> Result<Reply, String> {
+        use crate::egress::{EgressRequest, EgressRequestKind};
+        let acl = ctx.network_access.as_ref();
+        let permitted = acl
+            .map(|a| !a.allowed.is_empty() && a.is_url_allowed(&url))
+            .unwrap_or(false);
+        if !permitted {
+            return Err(format!(
+                "network egress denied: {url} is not in the allow-list"
+            ));
+        }
+        let egress = ctx
+            .egress_service
+            .as_ref()
+            .ok_or_else(|| "network egress unavailable in this environment".to_string())?;
+        let mut req =
+            EgressRequest::new(method, &url, EgressRequestKind::Capability).timeout_ms(15_000);
+        if let Some(a) = acl {
+            req = req.network_access(Some(a.clone()));
+        }
+        if let Some(b) = body {
+            req = req
+                .header("content-type", "application/json")
+                .body(b.into_bytes());
+        }
+        let resp = egress.send(req).await.map_err(|e| e.to_string())?;
+        let slice = if resp.body.len() > HTTP_BODY_CAP {
+            &resp.body[..HTTP_BODY_CAP]
+        } else {
+            &resp.body[..]
+        };
+        Ok(Reply::Http {
+            status: resp.status,
+            body: String::from_utf8_lossy(slice).into_owned(),
+        })
     }
 
+    /// Code mode: re-enter another tool. The child context drops `tool_registry`
+    /// so a code-mode tool cannot itself open code mode (no recursion).
+    async fn do_tool(
+        ctx: &ToolContext,
+        name: &str,
+        args: serde_json::Value,
+    ) -> Result<serde_json::Value, String> {
+        use crate::tools::ToolExecutionResult as R;
+        let reg = ctx
+            .tool_registry
+            .as_ref()
+            .ok_or_else(|| "tools unavailable in this environment".to_string())?;
+        let tool = reg
+            .get(name)
+            .ok_or_else(|| format!("unknown tool: {name}"))?;
+        let mut child = ctx.clone();
+        child.tool_registry = None;
+        child.tool_call_id = Some(format!("lua:{name}"));
+        match tool.execute_with_context(args, &child).await {
+            R::Success(v) => Ok(v),
+            R::SuccessWithImages { result, .. } => Ok(result),
+            R::ToolError(e) => Err(e),
+            R::InternalError(_) => Err("tool internal error".to_string()),
+            R::ConnectionRequired { provider } => {
+                Err(format!("tool requires a connection: {provider}"))
+            }
+        }
+    }
+
+    /// Synchronous host call from inside a Lua function (blocking thread).
+    fn call(tx: &mpsc::UnboundedSender<Request>, op: Op) -> Result<Reply, String> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        tx.send(Request {
+            op,
+            reply: reply_tx,
+        })
+        .map_err(|_| "host channel closed".to_string())?;
+        reply_rx
+            .blocking_recv()
+            .map_err(|_| "host reply dropped".to_string())?
+    }
+
+    #[allow(clippy::too_many_arguments)]
     pub(super) async fn run(
         script: &str,
         vfs: Arc<LuaVfs>,
+        ctx: ToolContext,
+        allowed_tools: Vec<String>,
+        http_enabled: bool,
         limits: &LuaLimits,
         output: mpsc::UnboundedSender<String>,
     ) -> LuaOutcome {
-        let (req_tx, mut req_rx) = mpsc::unbounded_channel::<VfsRequest>();
+        let (req_tx, mut req_rx) = mpsc::unbounded_channel::<Request>();
         let script = script.to_string();
         let limits = limits.clone();
 
-        let join = tokio::task::spawn_blocking(move || run_blocking(script, limits, req_tx, output));
+        let join = tokio::task::spawn_blocking(move || {
+            run_blocking(script, limits, req_tx, output, allowed_tools, http_enabled)
+        });
 
-        // Service VFS requests on the runtime until the blocking task drops the
-        // sender (which happens when the Lua VM and its host functions are gone).
         while let Some(request) = req_rx.recv().await {
-            let result = dispatch(&vfs, request.op).await;
+            let result = dispatch(&vfs, &ctx, request.op).await;
             let _ = request.reply.send(result);
         }
 
@@ -641,24 +807,23 @@ mod engine {
     fn run_blocking(
         script: String,
         limits: LuaLimits,
-        req_tx: mpsc::UnboundedSender<VfsRequest>,
+        req_tx: mpsc::UnboundedSender<Request>,
         output: mpsc::UnboundedSender<String>,
+        allowed_tools: Vec<String>,
+        http_enabled: bool,
     ) -> LuaOutcome {
-        // Load only the libs we want; io/package/debug are never loaded.
         let libs = StdLib::STRING | StdLib::TABLE | StdLib::MATH | StdLib::OS | StdLib::UTF8;
         let lua = match Lua::new_with(libs, LuaOptions::default()) {
             Ok(l) => l,
             Err(e) => return LuaOutcome::engine_error(format!("lua init failed: {e}")),
         };
 
-        // Hard memory cap (TM-LUA-003).
         let _ = lua.set_memory_limit(limits.memory_bytes);
 
         if let Err(e) = scrub_globals(&lua) {
             return LuaOutcome::engine_error(e);
         }
 
-        // Deadline + instruction budget interrupt (TM-LUA-002).
         let deadline = Instant::now() + limits.timeout;
         let budget = limits.max_instructions;
         let counted = Arc::new(AtomicU64::new(0));
@@ -688,8 +853,16 @@ mod engine {
         if let Err(e) = install_base64(&lua) {
             return LuaOutcome::engine_error(format!("install base64: {e}"));
         }
-        if let Err(e) = install_fs(&lua, req_tx) {
+        if let Err(e) = install_fs(&lua, req_tx.clone()) {
             return LuaOutcome::engine_error(format!("install fs: {e}"));
+        }
+        if http_enabled && let Err(e) = install_http(&lua, req_tx.clone()) {
+            return LuaOutcome::engine_error(format!("install http: {e}"));
+        }
+        if !allowed_tools.is_empty()
+            && let Err(e) = install_tools(&lua, req_tx, allowed_tools)
+        {
+            return LuaOutcome::engine_error(format!("install tools: {e}"));
         }
 
         let result: mlua::Result<LuaValue> = lua.load(&script).set_name("agent_script").eval();
@@ -716,24 +889,38 @@ mod engine {
     }
 
     /// Remove dangerous globals exposed by the loaded libraries
-    /// (TM-LUA-001/006/007). No io/os.execute/package/require/load/dofile, and
-    /// `string.dump` (bytecode production) is removed defensively.
+    /// (TM-LUA-001/006/007).
     fn scrub_globals(lua: &Lua) -> Result<(), String> {
         let g = lua.globals();
         for name in [
-            "io", "package", "require", "dofile", "loadfile", "load", "loadstring", "collectgarbage",
+            "io",
+            "package",
+            "require",
+            "dofile",
+            "loadfile",
+            "load",
+            "loadstring",
+            "collectgarbage",
         ] {
             g.set(name, LuaValue::Nil).map_err(|e| e.to_string())?;
         }
         if let Ok(os) = g.get::<mlua::Table>("os") {
             for name in [
-                "execute", "getenv", "exit", "remove", "rename", "tmpname", "setlocale",
+                "execute",
+                "getenv",
+                "exit",
+                "remove",
+                "rename",
+                "tmpname",
+                "setlocale",
             ] {
                 os.set(name, LuaValue::Nil).map_err(|e| e.to_string())?;
             }
         }
         if let Ok(string) = g.get::<mlua::Table>("string") {
-            string.set("dump", LuaValue::Nil).map_err(|e| e.to_string())?;
+            string
+                .set("dump", LuaValue::Nil)
+                .map_err(|e| e.to_string())?;
         }
         Ok(())
     }
@@ -811,15 +998,101 @@ mod engine {
         Ok(())
     }
 
-    fn install_fs(lua: &Lua, tx: mpsc::UnboundedSender<VfsRequest>) -> mlua::Result<()> {
+    fn install_http(lua: &Lua, tx: mpsc::UnboundedSender<Request>) -> mlua::Result<()> {
+        let http = lua.create_table()?;
+
+        let t = tx.clone();
+        http.set(
+            "get",
+            lua.create_function(move |lua, url: String| {
+                let reply = call(
+                    &t,
+                    Op::Http {
+                        method: "GET",
+                        url,
+                        body: None,
+                    },
+                )
+                .map_err(mlua::Error::runtime)?;
+                http_reply_to_table(lua, reply)
+            })?,
+        )?;
+
+        let t = tx.clone();
+        http.set(
+            "post",
+            lua.create_function(move |lua, (url, body): (String, Option<String>)| {
+                let reply = call(
+                    &t,
+                    Op::Http {
+                        method: "POST",
+                        url,
+                        body,
+                    },
+                )
+                .map_err(mlua::Error::runtime)?;
+                http_reply_to_table(lua, reply)
+            })?,
+        )?;
+
+        lua.globals().set("http", http)?;
+        Ok(())
+    }
+
+    fn http_reply_to_table(lua: &Lua, reply: Reply) -> mlua::Result<mlua::Table> {
+        let Reply::Http { status, body } = reply else {
+            return Err(mlua::Error::runtime("http: unexpected reply"));
+        };
+        let t = lua.create_table()?;
+        t.set("status", status)?;
+        t.set("body", body)?;
+        Ok(t)
+    }
+
+    fn install_tools(
+        lua: &Lua,
+        tx: mpsc::UnboundedSender<Request>,
+        names: Vec<String>,
+    ) -> mlua::Result<()> {
+        let tools = lua.create_table()?;
+        for name in names {
+            let t = tx.clone();
+            let n = name.clone();
+            tools.set(
+                name,
+                lua.create_function(move |lua, args: LuaValue| {
+                    let json: serde_json::Value = match args {
+                        LuaValue::Nil => serde_json::json!({}),
+                        other => lua.from_value(other)?,
+                    };
+                    let reply = call(
+                        &t,
+                        Op::Tool {
+                            name: n.clone(),
+                            args: json,
+                        },
+                    )
+                    .map_err(mlua::Error::runtime)?;
+                    let Reply::Json(v) = reply else {
+                        return Err(mlua::Error::runtime("tool: unexpected reply"));
+                    };
+                    lua.to_value(&v)
+                })?,
+            )?;
+        }
+        lua.globals().set("tools", tools)?;
+        Ok(())
+    }
+
+    fn install_fs(lua: &Lua, tx: mpsc::UnboundedSender<Request>) -> mlua::Result<()> {
         let fs = lua.create_table()?;
 
         let t = tx.clone();
         fs.set(
             "read",
             lua.create_function(move |lua, path: String| {
-                match vfs_call(&t, VfsOp::Read(path)).map_err(mlua::Error::runtime)? {
-                    VfsReply::Str(s) => lua.create_string(s),
+                match call(&t, Op::Read(path)).map_err(mlua::Error::runtime)? {
+                    Reply::Str(s) => lua.create_string(s),
                     _ => Err(mlua::Error::runtime("vfs: unexpected reply")),
                 }
             })?,
@@ -829,7 +1102,7 @@ mod engine {
         fs.set(
             "write",
             lua.create_function(move |_lua, (path, content): (String, String)| {
-                vfs_call(&t, VfsOp::Write(path, content)).map_err(mlua::Error::runtime)?;
+                call(&t, Op::Write(path, content)).map_err(mlua::Error::runtime)?;
                 Ok(())
             })?,
         )?;
@@ -838,7 +1111,7 @@ mod engine {
         fs.set(
             "append",
             lua.create_function(move |_lua, (path, content): (String, String)| {
-                vfs_call(&t, VfsOp::Append(path, content)).map_err(mlua::Error::runtime)?;
+                call(&t, Op::Append(path, content)).map_err(mlua::Error::runtime)?;
                 Ok(())
             })?,
         )?;
@@ -847,8 +1120,8 @@ mod engine {
         fs.set(
             "exists",
             lua.create_function(move |_lua, path: String| {
-                let reply = vfs_call(&t, VfsOp::Exists(path)).map_err(mlua::Error::runtime)?;
-                Ok(matches!(reply, VfsReply::Bool(true)))
+                let reply = call(&t, Op::Exists(path)).map_err(mlua::Error::runtime)?;
+                Ok(matches!(reply, Reply::Bool(true)))
             })?,
         )?;
 
@@ -856,11 +1129,9 @@ mod engine {
         fs.set(
             "stat",
             lua.create_function(move |lua, path: String| {
-                match vfs_call(&t, VfsOp::Stat(path)).map_err(mlua::Error::runtime)? {
-                    VfsReply::Stat(Some(entry)) => {
-                        Ok(LuaValue::Table(entry_to_table(lua, &entry)?))
-                    }
-                    VfsReply::Stat(None) => Ok(LuaValue::Nil),
+                match call(&t, Op::Stat(path)).map_err(mlua::Error::runtime)? {
+                    Reply::Stat(Some(entry)) => Ok(LuaValue::Table(entry_to_table(lua, &entry)?)),
+                    Reply::Stat(None) => Ok(LuaValue::Nil),
                     _ => Err(mlua::Error::runtime("vfs: unexpected reply")),
                 }
             })?,
@@ -870,8 +1141,8 @@ mod engine {
         fs.set(
             "list",
             lua.create_function(move |lua, path: String| {
-                let VfsReply::List(entries) =
-                    vfs_call(&t, VfsOp::List(path)).map_err(mlua::Error::runtime)?
+                let Reply::List(entries) =
+                    call(&t, Op::List(path)).map_err(mlua::Error::runtime)?
                 else {
                     return Err(mlua::Error::runtime("vfs: unexpected reply"));
                 };
@@ -887,9 +1158,9 @@ mod engine {
         fs.set(
             "remove",
             lua.create_function(move |_lua, (path, recursive): (String, Option<bool>)| {
-                let reply = vfs_call(&t, VfsOp::Remove(path, recursive.unwrap_or(false)))
+                let reply = call(&t, Op::Remove(path, recursive.unwrap_or(false)))
                     .map_err(mlua::Error::runtime)?;
-                Ok(matches!(reply, VfsReply::Bool(true)))
+                Ok(matches!(reply, Reply::Bool(true)))
             })?,
         )?;
 
@@ -897,7 +1168,7 @@ mod engine {
         fs.set(
             "mkdir",
             lua.create_function(move |_lua, path: String| {
-                vfs_call(&t, VfsOp::Mkdir(path)).map_err(mlua::Error::runtime)?;
+                call(&t, Op::Mkdir(path)).map_err(mlua::Error::runtime)?;
                 Ok(())
             })?,
         )?;
@@ -906,8 +1177,8 @@ mod engine {
         fs.set(
             "grep",
             lua.create_function(move |lua, (pattern, path): (String, Option<String>)| {
-                let VfsReply::Grep(hits) = vfs_call(&t, VfsOp::Grep(pattern, path))
-                    .map_err(mlua::Error::runtime)?
+                let Reply::Grep(hits) =
+                    call(&t, Op::Grep(pattern, path)).map_err(mlua::Error::runtime)?
                 else {
                     return Err(mlua::Error::runtime("vfs: unexpected reply"));
                 };
@@ -1005,14 +1276,18 @@ mod tests {
     #[tokio::test]
     async fn execute_without_context_errors() {
         let result = LuaTool.execute(json!({"script": "return 1"})).await;
-        assert!(matches!(result, ToolExecutionResult::ToolError(msg) if msg.contains("requires context")));
+        assert!(
+            matches!(result, ToolExecutionResult::ToolError(msg) if msg.contains("requires context"))
+        );
     }
 
     #[tokio::test]
     async fn execute_missing_script_errors() {
         let ctx = ToolContext::new(SessionId::new());
         let result = LuaTool.execute_with_context(json!({}), &ctx).await;
-        assert!(matches!(result, ToolExecutionResult::ToolError(msg) if msg.contains("Missing required parameter")));
+        assert!(
+            matches!(result, ToolExecutionResult::ToolError(msg) if msg.contains("Missing required parameter"))
+        );
     }
 
     #[tokio::test]
@@ -1021,7 +1296,9 @@ mod tests {
         let result = LuaTool
             .execute_with_context(json!({"script": "return 1"}), &ctx)
             .await;
-        assert!(matches!(result, ToolExecutionResult::ToolError(msg) if msg.contains("not available")));
+        assert!(
+            matches!(result, ToolExecutionResult::ToolError(msg) if msg.contains("not available"))
+        );
     }
 
     // When the engine is not compiled in (default build), the tool surfaces a
@@ -1034,7 +1311,9 @@ mod tests {
         let result = LuaTool
             .execute_with_context(json!({"script": "return 1"}), &ctx)
             .await;
-        assert!(matches!(result, ToolExecutionResult::ToolError(msg) if msg.contains("not compiled")));
+        assert!(
+            matches!(result, ToolExecutionResult::ToolError(msg) if msg.contains("not compiled"))
+        );
     }
 
     /// Minimal file store: enough to populate `ToolContext::file_store` so the
@@ -1233,18 +1512,169 @@ mod tests {
             assert_eq!(v["result"], json!("hello"));
         }
 
+        // ---- Phase 4: http (egress) + code mode (tools) ----
+
+        #[tokio::test]
+        async fn http_and_tools_disabled_by_default() {
+            // No egress service, no allow-list, no tool registry → both nil.
+            let v = run(
+                "return { http = http == nil, tools = tools == nil }",
+                Arc::new(EmptyFileStore),
+            )
+            .await;
+            assert_eq!(v["result"]["http"], json!(true));
+            assert_eq!(v["result"]["tools"], json!(true));
+        }
+
+        #[tokio::test]
+        async fn http_get_through_egress_allowlist() {
+            let mut ctx = ToolContext::new(SessionId::new());
+            ctx.file_store = Some(Arc::new(EmptyFileStore));
+            ctx.egress_service = Some(Arc::new(MockEgress));
+            ctx.network_access = Some(crate::network_access::NetworkAccessList::allow_only([
+                "example.com",
+            ]));
+            let v = match LuaTool
+                .execute_with_context(
+                    json!({ "script": r#"local r = http.get("https://example.com/x"); return { s = r.status, b = r.body }"# }),
+                    &ctx,
+                )
+                .await
+            {
+                ToolExecutionResult::Success(v) => v,
+                other => panic!("expected success, got {other:?}"),
+            };
+            assert_eq!(v["result"]["s"], json!(200));
+            assert_eq!(v["result"]["b"], json!("pong"));
+        }
+
+        #[tokio::test]
+        async fn http_denied_when_not_in_allowlist() {
+            let mut ctx = ToolContext::new(SessionId::new());
+            ctx.file_store = Some(Arc::new(EmptyFileStore));
+            ctx.egress_service = Some(Arc::new(MockEgress));
+            ctx.network_access = Some(crate::network_access::NetworkAccessList::allow_only([
+                "allowed.com",
+            ]));
+            let result = LuaTool
+                .execute_with_context(
+                    json!({ "script": r#"return http.get("https://evil.com/x").status"# }),
+                    &ctx,
+                )
+                .await;
+            assert!(
+                matches!(result, ToolExecutionResult::ToolError(msg) if msg.contains("egress denied"))
+            );
+        }
+
+        #[tokio::test]
+        async fn code_mode_calls_a_sibling_tool() {
+            let mut registry = crate::tools::ToolRegistry::new();
+            registry.register(EchoTool);
+            let mut ctx = ToolContext::new(SessionId::new());
+            ctx.file_store = Some(Arc::new(EmptyFileStore));
+            ctx.tool_registry = Some(Arc::new(registry));
+            let v = match LuaTool
+                .execute_with_context(
+                    json!({ "script": r#"return tools.echo({ n = 5 }).n"# }),
+                    &ctx,
+                )
+                .await
+            {
+                ToolExecutionResult::Success(v) => v,
+                other => panic!("expected success, got {other:?}"),
+            };
+            assert_eq!(v["result"], json!(5));
+        }
+
+        #[tokio::test]
+        async fn code_mode_excludes_execution_tools() {
+            // The `lua` tool itself must never be exposed via code mode.
+            let mut registry = crate::tools::ToolRegistry::new();
+            registry.register(EchoTool);
+            registry.register(LuaTool);
+            let mut ctx = ToolContext::new(SessionId::new());
+            ctx.file_store = Some(Arc::new(EmptyFileStore));
+            ctx.tool_registry = Some(Arc::new(registry));
+            let v = run_with_ctx(
+                "return { lua = tools.lua == nil, echo = tools.echo ~= nil }",
+                &ctx,
+            )
+            .await;
+            assert_eq!(
+                v["result"]["lua"],
+                json!(true),
+                "lua tool must not be exposed"
+            );
+            assert_eq!(v["result"]["echo"], json!(true));
+        }
+
+        async fn run_with_ctx(script: &str, ctx: &ToolContext) -> Value {
+            match LuaTool
+                .execute_with_context(json!({ "script": script }), ctx)
+                .await
+            {
+                ToolExecutionResult::Success(v) => v,
+                other => panic!("expected success, got {other:?}"),
+            }
+        }
+
+        /// Echoes its JSON argument back as the result.
+        struct EchoTool;
+
+        #[async_trait]
+        impl Tool for EchoTool {
+            fn name(&self) -> &str {
+                "echo"
+            }
+            fn description(&self) -> &str {
+                "Echo the argument."
+            }
+            fn parameters_schema(&self) -> Value {
+                json!({ "type": "object" })
+            }
+            async fn execute(&self, arguments: Value) -> ToolExecutionResult {
+                ToolExecutionResult::success(arguments)
+            }
+        }
+
+        /// Minimal egress service that returns a canned 200 response.
+        struct MockEgress;
+
+        #[async_trait]
+        impl crate::egress::EgressService for MockEgress {
+            async fn send(
+                &self,
+                _request: crate::egress::EgressRequest,
+            ) -> crate::egress::EgressResult<crate::egress::EgressResponse> {
+                Ok(crate::egress::EgressResponse {
+                    status: 200,
+                    headers: std::collections::BTreeMap::new(),
+                    body: b"pong".to_vec(),
+                })
+            }
+
+            async fn send_stream(
+                &self,
+                _request: crate::egress::EgressRequest,
+            ) -> crate::egress::EgressResult<crate::egress::EgressStreamResponse> {
+                Err(crate::egress::EgressError::Transport(
+                    "streaming not supported in mock".to_string(),
+                ))
+            }
+        }
+
         #[tokio::test]
         async fn fs_rejects_paths_outside_workspace() {
             // Reaching outside /workspace raises a Lua error -> tool_error.
             let mut ctx = ToolContext::new(SessionId::new());
             ctx.file_store = Some(Arc::new(EmptyFileStore));
             let result = LuaTool
-                .execute_with_context(
-                    json!({ "script": "return fs.read('/etc/passwd')" }),
-                    &ctx,
-                )
+                .execute_with_context(json!({ "script": "return fs.read('/etc/passwd')" }), &ctx)
                 .await;
-            assert!(matches!(result, ToolExecutionResult::ToolError(msg) if msg.contains("workspace")));
+            assert!(
+                matches!(result, ToolExecutionResult::ToolError(msg) if msg.contains("workspace"))
+            );
         }
 
         #[tokio::test]

--- a/crates/core/src/capabilities/lua.rs
+++ b/crates/core/src/capabilities/lua.rs
@@ -9,10 +9,11 @@
 //! - `LuaVfs` owns the `/workspace` <-> session-store path translation and is the
 //!   single seam to the (already session-scoped) `SessionFileSystem`. Tenant
 //!   isolation falls out of routing every path through that store.
-//! - `LuaLimits` is plain data; `engine::run` enforces it. The `mlua`
-//!   implementation lives behind `#[cfg(feature = "lua-mlua")]`, so the default
-//!   workspace build never fetches or compiles `mlua`. Swapping to a pure-Rust
-//!   VM (`piccolo`) later replaces only the engine module.
+//! - `LuaLimits` is plain data; `engine::run` enforces it. The primary engine
+//!   is native-Rust `piccolo` (`feature = "lua"`); an `mlua` reference engine
+//!   (`feature = "lua-mlua"`) is kept as a fallback. With no engine feature the
+//!   default build pulls in no interpreter. The engine is the only swappable
+//!   module — capability, tool, VFS, and tests are engine-agnostic.
 //!
 //! Trust boundary (TM-LUA-001..008): `risk_level()` returns `High`; assigning
 //! this capability requires `OrgRole::Admin` via the same gates as
@@ -301,7 +302,7 @@ impl Tool for LuaTool {
 /// All fields but `timeout` are consumed only by the `mlua` engine, so they
 /// read as dead code in the default (feature-off) build.
 #[derive(Debug, Clone)]
-#[cfg_attr(not(feature = "lua-mlua"), allow(dead_code))]
+#[cfg_attr(not(any(feature = "lua", feature = "lua-mlua")), allow(dead_code))]
 pub struct LuaLimits {
     pub memory_bytes: usize,
     pub max_instructions: u64,
@@ -512,13 +513,552 @@ impl LuaVfs {
 // Engine seam
 // ============================================================================
 
-#[cfg(not(feature = "lua-mlua"))]
+// Primary engine: native-Rust piccolo 0.3 (no C/FFI). Sandbox is by
+// construction — `Lua::core()` loads only base/coroutine/math/string/table, so
+// there is no io/os/package/require/load to scrub (TM-LUA-001/006/007). CPU is
+// bounded by fuel per step + a wall-clock deadline (TM-LUA-002); memory by
+// `total_memory()` between steps (TM-LUA-003). piccolo is synchronous, so the
+// VM runs on a blocking thread and each async `fs.*` call is marshaled back to
+// the runtime over a channel (`blocking_recv`), which keeps tenant isolation in
+// the already session-scoped `LuaVfs`.
+#[cfg(feature = "lua")]
+mod engine {
+    use super::{LuaLimits, LuaOutcome, LuaVfs, VfsEntry, VfsGrepHit};
+    use piccolo::{
+        Callback, CallbackReturn, Closure, Context, Executor, Fuel, Lua, Table, Value as PValue,
+        Variadic,
+    };
+    use std::sync::{Arc, Mutex};
+    use std::time::Instant;
+    use tokio::sync::{mpsc, oneshot};
+
+    /// Fuel granted per executor step. Small enough that the deadline/budget are
+    /// checked frequently, large enough to amortize the enter() overhead.
+    const FUEL_PER_STEP: i32 = 8192;
+
+    // ---- VFS bridge: requests marshaled blocking-thread -> async runtime ----
+
+    enum VfsOp {
+        Read(String),
+        Write(String, String),
+        Append(String, String),
+        Exists(String),
+        Stat(String),
+        List(String),
+        Remove(String, bool),
+        Mkdir(String),
+        Grep(String, Option<String>),
+    }
+
+    enum VfsReply {
+        Str(String),
+        Bool(bool),
+        Unit,
+        Stat(Option<VfsEntry>),
+        List(Vec<VfsEntry>),
+        Grep(Vec<VfsGrepHit>),
+    }
+
+    struct VfsRequest {
+        op: VfsOp,
+        reply: oneshot::Sender<Result<VfsReply, String>>,
+    }
+
+    async fn dispatch(vfs: &LuaVfs, op: VfsOp) -> Result<VfsReply, String> {
+        match op {
+            VfsOp::Read(p) => vfs.read(&p).await.map(VfsReply::Str),
+            VfsOp::Write(p, c) => vfs.write(&p, &c).await.map(|_| VfsReply::Unit),
+            VfsOp::Append(p, c) => vfs.append(&p, &c).await.map(|_| VfsReply::Unit),
+            VfsOp::Exists(p) => vfs.exists(&p).await.map(VfsReply::Bool),
+            VfsOp::Stat(p) => vfs.stat(&p).await.map(VfsReply::Stat),
+            VfsOp::List(p) => vfs.list(&p).await.map(VfsReply::List),
+            VfsOp::Remove(p, r) => vfs.remove(&p, r).await.map(VfsReply::Bool),
+            VfsOp::Mkdir(p) => vfs.mkdir(&p).await.map(|_| VfsReply::Unit),
+            VfsOp::Grep(pat, scope) => {
+                vfs.grep(&pat, scope.as_deref()).await.map(VfsReply::Grep)
+            }
+        }
+    }
+
+    /// Synchronous VFS call from inside a piccolo callback (blocking thread).
+    fn vfs_call(tx: &mpsc::UnboundedSender<VfsRequest>, op: VfsOp) -> Result<VfsReply, String> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        tx.send(VfsRequest { op, reply: reply_tx })
+            .map_err(|_| "vfs channel closed".to_string())?;
+        reply_rx
+            .blocking_recv()
+            .map_err(|_| "vfs reply dropped".to_string())?
+    }
+
+    pub(super) async fn run(
+        script: &str,
+        vfs: Arc<LuaVfs>,
+        limits: &LuaLimits,
+        output: mpsc::UnboundedSender<String>,
+    ) -> LuaOutcome {
+        let (req_tx, mut req_rx) = mpsc::unbounded_channel::<VfsRequest>();
+        let script = script.to_string();
+        let limits = limits.clone();
+
+        let join = tokio::task::spawn_blocking(move || run_blocking(script, limits, req_tx, output));
+
+        // Service VFS requests until the blocking task drops every req_tx clone
+        // (which happens when the Lua VM and its callbacks are dropped).
+        while let Some(request) = req_rx.recv().await {
+            let result = dispatch(&vfs, request.op).await;
+            let _ = request.reply.send(result);
+        }
+
+        match join.await {
+            Ok(outcome) => outcome,
+            Err(e) => LuaOutcome::engine_error(format!("lua task panicked: {e}")),
+        }
+    }
+
+    fn run_blocking(
+        script: String,
+        limits: LuaLimits,
+        req_tx: mpsc::UnboundedSender<VfsRequest>,
+        output: mpsc::UnboundedSender<String>,
+    ) -> LuaOutcome {
+        let stdout = Arc::new(Mutex::new(String::new()));
+        // core() = base/coroutine/math/string/table only. No io/os/package.
+        let mut lua = Lua::core();
+
+        let stash = lua.try_enter(|ctx| {
+            install_print(ctx, stdout.clone(), output.clone(), limits.max_output_bytes);
+            install_json(ctx);
+            install_fs(ctx, req_tx.clone());
+            let closure = Closure::load(ctx, Some("agent_script"), script.as_bytes())?;
+            Ok(ctx.stash(Executor::start(ctx, closure.into(), ())))
+        });
+        let executor = match stash {
+            Ok(e) => e,
+            Err(e) => {
+                return LuaOutcome {
+                    stdout: take_stdout(&stdout),
+                    return_value: None,
+                    error: Some(e.to_string()),
+                };
+            }
+        };
+
+        let deadline = Instant::now() + limits.timeout;
+        let mut total_fuel: u64 = 0;
+        let finished: Result<(), String> = loop {
+            if Instant::now() >= deadline {
+                break Err("exceeded time limit".to_string());
+            }
+            if total_fuel >= limits.max_instructions {
+                break Err("exceeded instruction budget".to_string());
+            }
+            if lua.total_memory() > limits.memory_bytes {
+                break Err("exceeded memory limit".to_string());
+            }
+            total_fuel += FUEL_PER_STEP as u64;
+            let done = lua.enter(|ctx| {
+                let mut fuel = Fuel::with(FUEL_PER_STEP);
+                ctx.fetch(&executor).step(ctx, &mut fuel)
+            });
+            if done {
+                break Ok(());
+            }
+        };
+
+        let stdout_str = take_stdout(&stdout);
+        match finished {
+            Err(msg) => LuaOutcome {
+                stdout: stdout_str,
+                return_value: None,
+                error: Some(format!("lua: {msg}")),
+            },
+            Ok(()) => {
+                let ret = lua.try_enter(|ctx| {
+                    let values =
+                        ctx.fetch(&executor).take_result::<Variadic<Vec<PValue>>>(ctx)??;
+                    let first = values.0.into_iter().next().unwrap_or(PValue::Nil);
+                    Ok(pvalue_to_json_opt(ctx, first))
+                });
+                match ret {
+                    Ok(return_value) => LuaOutcome {
+                        stdout: stdout_str,
+                        return_value,
+                        error: None,
+                    },
+                    Err(e) => LuaOutcome {
+                        stdout: stdout_str,
+                        return_value: None,
+                        error: Some(e.to_string()),
+                    },
+                }
+            }
+        }
+    }
+
+    fn take_stdout(buf: &Arc<Mutex<String>>) -> String {
+        buf.lock().map(|s| s.clone()).unwrap_or_default()
+    }
+
+    /// Build a Lua error carrying a string message.
+    fn lua_err<'gc>(ctx: Context<'gc>, msg: String) -> piccolo::Error<'gc> {
+        PValue::String(piccolo::String::from_slice(&ctx, msg.as_bytes())).into()
+    }
+
+    fn install_print<'gc>(
+        ctx: Context<'gc>,
+        buf: Arc<Mutex<String>>,
+        sink: mpsc::UnboundedSender<String>,
+        cap: usize,
+    ) {
+        let print = Callback::from_fn(&ctx, move |ctx, _exec, mut stack| {
+            let mut parts = Vec::with_capacity(stack.len());
+            for i in 0..stack.len() {
+                parts.push(display_value(ctx, stack.get(i)));
+            }
+            stack.clear();
+            let mut line = parts.join("\t");
+            line.push('\n');
+            if let Ok(mut g) = buf.lock()
+                && g.len() < cap
+            {
+                g.push_str(&line);
+            }
+            let _ = sink.send(line);
+            Ok(CallbackReturn::Return)
+        });
+        ctx.set_global("print", print).ok();
+    }
+
+    fn install_json<'gc>(ctx: Context<'gc>) {
+        let json = Table::new(&ctx);
+        let encode = Callback::from_fn(&ctx, |ctx, _exec, mut stack| {
+            let v = stack.get(0);
+            stack.clear();
+            let json = pvalue_to_json(ctx, v);
+            let s = serde_json::to_string(&json).map_err(|e| lua_err(ctx, e.to_string()))?;
+            stack.replace(ctx, piccolo::String::from_slice(&ctx, s.as_bytes()));
+            Ok(CallbackReturn::Return)
+        });
+        let decode = Callback::from_fn(&ctx, |ctx, _exec, mut stack| {
+            let s: piccolo::String = stack.consume(ctx)?;
+            let parsed: serde_json::Value = serde_json::from_slice(s.as_bytes())
+                .map_err(|e| lua_err(ctx, e.to_string()))?;
+            stack.replace(ctx, json_to_pvalue(ctx, &parsed));
+            Ok(CallbackReturn::Return)
+        });
+        json.set(ctx, "encode", encode).ok();
+        json.set(ctx, "decode", decode).ok();
+        ctx.set_global("json", json).ok();
+    }
+
+    fn install_fs<'gc>(ctx: Context<'gc>, tx: mpsc::UnboundedSender<VfsRequest>) {
+        let fs = Table::new(&ctx);
+
+        macro_rules! reply_str {
+            ($ctx:expr, $r:expr) => {
+                match $r {
+                    VfsReply::Str(s) => piccolo::String::from_slice(&$ctx, s.as_bytes()),
+                    _ => return Err(lua_err($ctx, "vfs: unexpected reply".to_string())),
+                }
+            };
+        }
+
+        let t = tx.clone();
+        fs.set(
+            ctx,
+            "read",
+            Callback::from_fn(&ctx, move |ctx, _e, mut stack| {
+                let path: piccolo::String = stack.consume(ctx)?;
+                let reply = vfs_call(&t, VfsOp::Read(path.to_str_lossy().into_owned()))
+                    .map_err(|e| lua_err(ctx, e))?;
+                stack.replace(ctx, reply_str!(ctx, reply));
+                Ok(CallbackReturn::Return)
+            }),
+        )
+        .ok();
+
+        let t = tx.clone();
+        fs.set(
+            ctx,
+            "write",
+            Callback::from_fn(&ctx, move |ctx, _e, mut stack| {
+                let (path, content): (piccolo::String, piccolo::String) = stack.consume(ctx)?;
+                vfs_call(
+                    &t,
+                    VfsOp::Write(
+                        path.to_str_lossy().into_owned(),
+                        content.to_str_lossy().into_owned(),
+                    ),
+                )
+                .map_err(|e| lua_err(ctx, e))?;
+                Ok(CallbackReturn::Return)
+            }),
+        )
+        .ok();
+
+        let t = tx.clone();
+        fs.set(
+            ctx,
+            "append",
+            Callback::from_fn(&ctx, move |ctx, _e, mut stack| {
+                let (path, content): (piccolo::String, piccolo::String) = stack.consume(ctx)?;
+                vfs_call(
+                    &t,
+                    VfsOp::Append(
+                        path.to_str_lossy().into_owned(),
+                        content.to_str_lossy().into_owned(),
+                    ),
+                )
+                .map_err(|e| lua_err(ctx, e))?;
+                Ok(CallbackReturn::Return)
+            }),
+        )
+        .ok();
+
+        let t = tx.clone();
+        fs.set(
+            ctx,
+            "exists",
+            Callback::from_fn(&ctx, move |ctx, _e, mut stack| {
+                let path: piccolo::String = stack.consume(ctx)?;
+                let reply = vfs_call(&t, VfsOp::Exists(path.to_str_lossy().into_owned()))
+                    .map_err(|e| lua_err(ctx, e))?;
+                let b = matches!(reply, VfsReply::Bool(true));
+                stack.replace(ctx, b);
+                Ok(CallbackReturn::Return)
+            }),
+        )
+        .ok();
+
+        let t = tx.clone();
+        fs.set(
+            ctx,
+            "stat",
+            Callback::from_fn(&ctx, move |ctx, _e, mut stack| {
+                let path: piccolo::String = stack.consume(ctx)?;
+                let reply = vfs_call(&t, VfsOp::Stat(path.to_str_lossy().into_owned()))
+                    .map_err(|e| lua_err(ctx, e))?;
+                match reply {
+                    VfsReply::Stat(Some(entry)) => stack.replace(ctx, entry_to_table(ctx, &entry)),
+                    VfsReply::Stat(None) => stack.replace(ctx, PValue::Nil),
+                    _ => return Err(lua_err(ctx, "vfs: unexpected reply".to_string())),
+                }
+                Ok(CallbackReturn::Return)
+            }),
+        )
+        .ok();
+
+        let t = tx.clone();
+        fs.set(
+            ctx,
+            "list",
+            Callback::from_fn(&ctx, move |ctx, _e, mut stack| {
+                let path: piccolo::String = stack.consume(ctx)?;
+                let reply = vfs_call(&t, VfsOp::List(path.to_str_lossy().into_owned()))
+                    .map_err(|e| lua_err(ctx, e))?;
+                let VfsReply::List(entries) = reply else {
+                    return Err(lua_err(ctx, "vfs: unexpected reply".to_string()));
+                };
+                let arr = Table::new(&ctx);
+                for (i, entry) in entries.iter().enumerate() {
+                    arr.set(ctx, (i + 1) as i64, entry_to_table(ctx, entry)).ok();
+                }
+                stack.replace(ctx, arr);
+                Ok(CallbackReturn::Return)
+            }),
+        )
+        .ok();
+
+        let t = tx.clone();
+        fs.set(
+            ctx,
+            "remove",
+            Callback::from_fn(&ctx, move |ctx, _e, mut stack| {
+                let (path, recursive): (piccolo::String, Option<bool>) = stack.consume(ctx)?;
+                let reply = vfs_call(
+                    &t,
+                    VfsOp::Remove(path.to_str_lossy().into_owned(), recursive.unwrap_or(false)),
+                )
+                .map_err(|e| lua_err(ctx, e))?;
+                stack.replace(ctx, matches!(reply, VfsReply::Bool(true)));
+                Ok(CallbackReturn::Return)
+            }),
+        )
+        .ok();
+
+        let t = tx.clone();
+        fs.set(
+            ctx,
+            "mkdir",
+            Callback::from_fn(&ctx, move |ctx, _e, mut stack| {
+                let path: piccolo::String = stack.consume(ctx)?;
+                vfs_call(&t, VfsOp::Mkdir(path.to_str_lossy().into_owned()))
+                    .map_err(|e| lua_err(ctx, e))?;
+                Ok(CallbackReturn::Return)
+            }),
+        )
+        .ok();
+
+        let t = tx.clone();
+        fs.set(
+            ctx,
+            "grep",
+            Callback::from_fn(&ctx, move |ctx, _e, mut stack| {
+                let (pattern, path): (piccolo::String, Option<piccolo::String>) =
+                    stack.consume(ctx)?;
+                let scope = path.map(|p| p.to_str_lossy().into_owned());
+                let reply = vfs_call(
+                    &t,
+                    VfsOp::Grep(pattern.to_str_lossy().into_owned(), scope),
+                )
+                .map_err(|e| lua_err(ctx, e))?;
+                let VfsReply::Grep(hits) = reply else {
+                    return Err(lua_err(ctx, "vfs: unexpected reply".to_string()));
+                };
+                let arr = Table::new(&ctx);
+                for (i, h) in hits.iter().enumerate() {
+                    let row = Table::new(&ctx);
+                    row.set(ctx, "path", piccolo::String::from_slice(&ctx, h.path.as_bytes()))
+                        .ok();
+                    row.set(ctx, "line_number", h.line_number as i64).ok();
+                    row.set(ctx, "line", piccolo::String::from_slice(&ctx, h.line.as_bytes()))
+                        .ok();
+                    arr.set(ctx, (i + 1) as i64, row).ok();
+                }
+                stack.replace(ctx, arr);
+                Ok(CallbackReturn::Return)
+            }),
+        )
+        .ok();
+
+        ctx.set_global("fs", fs).ok();
+    }
+
+    fn entry_to_table<'gc>(ctx: Context<'gc>, entry: &VfsEntry) -> Table<'gc> {
+        let t = Table::new(&ctx);
+        t.set(ctx, "name", piccolo::String::from_slice(&ctx, entry.name.as_bytes()))
+            .ok();
+        t.set(ctx, "is_dir", entry.is_dir).ok();
+        t.set(ctx, "size", entry.size).ok();
+        t
+    }
+
+    fn display_value<'gc>(ctx: Context<'gc>, v: PValue<'gc>) -> String {
+        match v {
+            PValue::Nil => "nil".to_string(),
+            PValue::Boolean(b) => b.to_string(),
+            PValue::Integer(i) => i.to_string(),
+            PValue::Number(n) => n.to_string(),
+            PValue::String(s) => s.to_str_lossy().into_owned(),
+            other => {
+                // Fall back to json for tables; opaque marker for the rest.
+                match pvalue_to_json(ctx, other) {
+                    serde_json::Value::Null => format!("{other:?}"),
+                    j => j.to_string(),
+                }
+            }
+        }
+    }
+
+    /// Top-level return conversion: a bare `nil` return means "no value".
+    fn pvalue_to_json_opt<'gc>(ctx: Context<'gc>, v: PValue<'gc>) -> Option<serde_json::Value> {
+        match v {
+            PValue::Nil => None,
+            other => Some(pvalue_to_json(ctx, other)),
+        }
+    }
+
+    fn pvalue_to_json<'gc>(ctx: Context<'gc>, v: PValue<'gc>) -> serde_json::Value {
+        use serde_json::Value as J;
+        match v {
+            PValue::Nil => J::Null,
+            PValue::Boolean(b) => J::Bool(b),
+            PValue::Integer(i) => J::Number(i.into()),
+            PValue::Number(n) => serde_json::Number::from_f64(n).map_or(J::Null, J::Number),
+            PValue::String(s) => J::String(s.to_str_lossy().into_owned()),
+            PValue::Table(t) => table_to_json(ctx, t),
+            // Functions/threads/userdata are not serializable.
+            _ => J::Null,
+        }
+    }
+
+    fn table_to_json<'gc>(ctx: Context<'gc>, t: Table<'gc>) -> serde_json::Value {
+        use serde_json::Value as J;
+        let len = t.length();
+        // Treat as an array iff keys are exactly 1..=len.
+        let mut is_array = len > 0;
+        let mut count = 0usize;
+        for (k, _) in t.iter() {
+            count += 1;
+            if !matches!(k, PValue::Integer(i) if i >= 1 && i <= len) {
+                is_array = false;
+            }
+        }
+        if is_array && count == len as usize {
+            let mut arr = Vec::with_capacity(len as usize);
+            for i in 1..=len {
+                arr.push(pvalue_to_json(ctx, t.get(ctx, i)));
+            }
+            J::Array(arr)
+        } else {
+            let mut map = serde_json::Map::new();
+            for (k, v) in t.iter() {
+                let key = match k {
+                    PValue::String(s) => s.to_str_lossy().into_owned(),
+                    PValue::Integer(i) => i.to_string(),
+                    PValue::Number(n) => n.to_string(),
+                    PValue::Boolean(b) => b.to_string(),
+                    _ => continue,
+                };
+                map.insert(key, pvalue_to_json(ctx, v));
+            }
+            J::Object(map)
+        }
+    }
+
+    fn json_to_pvalue<'gc>(ctx: Context<'gc>, v: &serde_json::Value) -> PValue<'gc> {
+        use serde_json::Value as J;
+        match v {
+            J::Null => PValue::Nil,
+            J::Bool(b) => PValue::Boolean(*b),
+            J::Number(n) => {
+                if let Some(i) = n.as_i64() {
+                    PValue::Integer(i)
+                } else {
+                    PValue::Number(n.as_f64().unwrap_or(0.0))
+                }
+            }
+            J::String(s) => PValue::String(piccolo::String::from_slice(&ctx, s.as_bytes())),
+            J::Array(items) => {
+                let t = Table::new(&ctx);
+                for (i, item) in items.iter().enumerate() {
+                    t.set(ctx, (i + 1) as i64, json_to_pvalue(ctx, item)).ok();
+                }
+                PValue::Table(t)
+            }
+            J::Object(obj) => {
+                let t = Table::new(&ctx);
+                for (k, val) in obj {
+                    t.set(
+                        ctx,
+                        piccolo::String::from_slice(&ctx, k.as_bytes()),
+                        json_to_pvalue(ctx, val),
+                    )
+                    .ok();
+                }
+                PValue::Table(t)
+            }
+        }
+    }
+}
+
+#[cfg(not(any(feature = "lua", feature = "lua-mlua")))]
 mod engine {
     use super::{LuaLimits, LuaOutcome, LuaVfs};
     use std::sync::Arc;
 
-    /// Stub used when the `lua` cargo feature is disabled (default). Keeps the
-    /// workspace buildable without pulling in `mlua`.
+    /// Stub used when no engine feature is enabled (default). Keeps the
+    /// workspace buildable without pulling in any interpreter.
     pub(super) async fn run(
         _script: &str,
         _vfs: Arc<LuaVfs>,
@@ -531,13 +1071,10 @@ mod engine {
     }
 }
 
-// NOTE: The `mlua` engine below targets mlua 0.10 (Lua 5.4, vendored). It is
-// compiled only with `--features lua` and is wired end to end in Phase 2
-// (`specs/lua-execution.md`); exact API details may need to be pinned to the
-// resolved mlua version. The sandbox controls (stdlib whitelist, global
-// scrubbing, memory limit, instruction/deadline hook, no network) are the
-// contract that must hold regardless of API shape.
-#[cfg(feature = "lua-mlua")]
+// Reference engine (mlua 0.10, vendored Lua 5.4). Compiled only with
+// `--features lua-mlua` and only when the primary piccolo engine is not also
+// enabled. Kept as a fallback per specs/lua-execution.md.
+#[cfg(all(feature = "lua-mlua", not(feature = "lua")))]
 mod engine {
     use super::{LuaLimits, LuaOutcome, LuaVfs};
     use mlua::{
@@ -663,10 +1200,10 @@ mod engine {
             }
             let mut line = parts.join("\t");
             line.push('\n');
-            if let Ok(mut g) = buf.lock() {
-                if g.len() < cap {
-                    g.push_str(&line);
-                }
+            if let Ok(mut g) = buf.lock()
+                && g.len() < cap
+            {
+                g.push_str(&line);
             }
             let _ = sink.send(line);
             Ok(())
@@ -915,7 +1452,7 @@ mod tests {
 
     // When the engine is not compiled in (default build), the tool surfaces a
     // clear error rather than silently succeeding.
-    #[cfg(not(feature = "lua-mlua"))]
+    #[cfg(not(any(feature = "lua", feature = "lua-mlua")))]
     #[tokio::test]
     async fn engine_disabled_reports_not_compiled() {
         let mut ctx = ToolContext::new(SessionId::new());
@@ -1016,10 +1553,10 @@ mod tests {
     }
 
     // ========================================================================
-    // End-to-end engine tests (only when the `lua` feature is compiled in).
+    // End-to-end engine tests (run for whichever engine feature is enabled).
     // ========================================================================
 
-    #[cfg(feature = "lua-mlua")]
+    #[cfg(any(feature = "lua", feature = "lua-mlua"))]
     mod engine_tests {
         use super::*;
         use std::collections::HashMap;
@@ -1052,23 +1589,25 @@ mod tests {
 
         #[tokio::test]
         async fn sandbox_blocks_dangerous_globals() {
-            // io/os.execute/load/require/dofile must be unavailable (TM-LUA-001/006).
+            // No filesystem/process/dynamic-code escape hatches (TM-LUA-001/006).
+            // Both engines guarantee these globals are nil.
             let script = r#"
                 return {
                     io = io == nil,
-                    exec = os.execute == nil,
-                    getenv = os.getenv == nil,
-                    load = load == nil,
+                    package = package == nil,
                     require = require == nil,
+                    load = load == nil,
                     dofile = dofile == nil,
                 }
             "#;
             let v = run(script, Arc::new(EmptyFileStore)).await;
-            for key in ["io", "exec", "getenv", "load", "require", "dofile"] {
+            for key in ["io", "package", "require", "load", "dofile"] {
                 assert_eq!(v["result"][key], json!(true), "{key} should be nil");
             }
         }
 
+        // os.* is a mlua-only safe subset; piccolo's core() loads no os library.
+        #[cfg(all(feature = "lua-mlua", not(feature = "lua")))]
         #[tokio::test]
         async fn safe_os_subset_available() {
             let v = run("return type(os.time())", Arc::new(EmptyFileStore)).await;
@@ -1254,10 +1793,10 @@ mod tests {
                 let files = self.files.lock().unwrap();
                 let mut out = Vec::new();
                 for (p, c) in files.iter() {
-                    if let Some(pp) = path_pattern {
-                        if !p.starts_with(pp) {
-                            continue;
-                        }
+                    if let Some(pp) = path_pattern
+                        && !p.starts_with(pp)
+                    {
+                        continue;
                     }
                     for (i, line) in c.lines().enumerate() {
                         if re.is_match(line) {

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -104,6 +104,7 @@ mod human_intent;
 mod infinity_context;
 mod knowledge_base;
 mod loop_detection;
+mod lua;
 pub mod mcp;
 mod noop;
 mod openai_tool_search;
@@ -211,6 +212,7 @@ pub use knowledge_base::{
     validate_knowledge_base_config,
 };
 pub use loop_detection::LoopDetectionCapability;
+pub use lua::{LUA_CAPABILITY_ID, LuaCapability, LuaTool, LuaVfs};
 pub use mcp::{
     MCP_CAPABILITY_PREFIX, McpCapability, is_mcp_capability, mcp_capability_id,
     parse_mcp_capability_id,
@@ -1010,6 +1012,13 @@ impl CapabilityRegistry {
         let internal_flags = crate::InternalFeatureFlags::from_env();
         if internal_flags.session_sandbox {
             registry.register(SessionSandboxCapability);
+        }
+
+        // Experimental sandboxed Lua execution (specs/lua-execution.md). High
+        // risk, admin-gated. Gated by FEATURE_LUA; scripts only actually run
+        // when the `lua` cargo feature is also compiled in.
+        if internal_flags.lua {
+            registry.register(LuaCapability);
         }
         for plugin in inventory::iter::<IntegrationPlugin>() {
             if (!plugin.experimental_only || grade.experimental_features_enabled())

--- a/crates/core/src/feature_flags.rs
+++ b/crates/core/src/feature_flags.rs
@@ -207,6 +207,10 @@ pub struct InternalFeatureFlags {
     /// through `PaymentAuthority`. Disabled by default on all envs, including dev,
     /// because spend is irreversible. Enable via `FEATURE_MACHINE_PAYMENTS=true`.
     pub machine_payments: bool,
+    /// Experimental sandboxed Lua execution capability (`specs/lua-execution.md`).
+    /// Disabled by default; requires the `lua` cargo feature to be compiled in to
+    /// actually run scripts. Enable via `FEATURE_LUA=true`.
+    pub lua: bool,
 }
 
 impl InternalFeatureFlags {
@@ -219,6 +223,7 @@ impl InternalFeatureFlags {
             container_sandbox: standard_flag("FEATURE_CONTAINER_SANDBOX", docker_capability),
             session_sandbox: standard_flag("FEATURE_SESSION_SANDBOX", false),
             machine_payments: standard_flag("FEATURE_MACHINE_PAYMENTS", false),
+            lua: standard_flag("FEATURE_LUA", false),
         }
     }
 
@@ -229,6 +234,7 @@ impl InternalFeatureFlags {
             "container_sandbox" => self.container_sandbox,
             "session_sandbox" => self.session_sandbox,
             "machine_payments" => self.machine_payments,
+            "lua" => self.lua,
             _ => false,
         }
     }
@@ -519,11 +525,13 @@ mod tests {
             container_sandbox: true,
             session_sandbox: true,
             machine_payments: true,
+            lua: true,
         };
         assert!(flags.is_enabled("docker_capability"));
         assert!(flags.is_enabled("container_sandbox"));
         assert!(flags.is_enabled("session_sandbox"));
         assert!(flags.is_enabled("machine_payments"));
+        assert!(flags.is_enabled("lua"));
         assert!(!flags.is_enabled("nonexistent"));
     }
 

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -19,10 +19,9 @@ path = "src/bin/export_openapi.rs"
 
 [features]
 # Experimental sandboxed Lua execution capability (specs/lua-execution.md).
-# Off by default; `lua` compiles the native-Rust piccolo engine into core,
-# `lua-mlua` the reference engine. Still also gated at runtime by FEATURE_LUA.
+# Off by default; `lua` compiles the mlua engine into core. Also runtime-gated
+# by FEATURE_LUA.
 lua = ["everruns-core/lua"]
-lua-mlua = ["everruns-core/lua-mlua"]
 
 [dependencies]
 axum.workspace = true

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -17,6 +17,13 @@ path = "src/bin/reencrypt_secrets.rs"
 name = "export-openapi"
 path = "src/bin/export_openapi.rs"
 
+[features]
+# Experimental sandboxed Lua execution capability (specs/lua-execution.md).
+# Off by default; `lua` compiles the native-Rust piccolo engine into core,
+# `lua-mlua` the reference engine. Still also gated at runtime by FEATURE_LUA.
+lua = ["everruns-core/lua"]
+lua-mlua = ["everruns-core/lua-mlua"]
+
 [dependencies]
 axum.workspace = true
 axum-extra.workspace = true

--- a/crates/worker/Cargo.toml
+++ b/crates/worker/Cargo.toml
@@ -4,6 +4,13 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[features]
+# Experimental sandboxed Lua execution capability (specs/lua-execution.md).
+# Off by default; `lua` compiles the native-Rust piccolo engine into core,
+# `lua-mlua` the reference engine. Still also gated at runtime by FEATURE_LUA.
+lua = ["everruns-core/lua"]
+lua-mlua = ["everruns-core/lua-mlua"]
+
 [dependencies]
 tokio.workspace = true
 serde.workspace = true

--- a/crates/worker/Cargo.toml
+++ b/crates/worker/Cargo.toml
@@ -6,10 +6,9 @@ license.workspace = true
 
 [features]
 # Experimental sandboxed Lua execution capability (specs/lua-execution.md).
-# Off by default; `lua` compiles the native-Rust piccolo engine into core,
-# `lua-mlua` the reference engine. Still also gated at runtime by FEATURE_LUA.
+# Off by default; `lua` compiles the mlua engine into core. Also runtime-gated
+# by FEATURE_LUA.
 lua = ["everruns-core/lua"]
-lua-mlua = ["everruns-core/lua-mlua"]
 
 [dependencies]
 tokio.workspace = true

--- a/specs/README.md
+++ b/specs/README.md
@@ -35,6 +35,7 @@ Specs capture the "why" and "what", not exhaustive source detail. Link to code f
 - `specs/fetchkit.md` - fetchkit library powering the `web_fetch` capability
 - `specs/toolkit-library-contract.md` - Convention for external toolkit libraries
 - `specs/bashkit-requirements.md` - Bash sandbox capabilities and requirements
+- `specs/lua-execution.md` - Experimental Lua execution capability (sandboxed VFS scripting; aims to supersede virtual_bash)
 
 ## Agents, sessions, and runtime resources
 

--- a/specs/lua-execution.md
+++ b/specs/lua-execution.md
@@ -246,27 +246,35 @@ Lives in a dedicated **`evals/`** tree (or a `crates/agent-evals` crate over
 The harness is implemented in `crates/agent-evals` (`lua-vs-bash` bin), runs both
 arms over `everruns-runtime`, and grades against the resulting workspace.
 
-### Empirical results (first run)
+### Empirical results
 
-Real Claude (`claude-haiku-4-5-20251001`), 4 tasks × 3 runs/arm:
+Real Claude (`claude-haiku-4-5-20251001`), 4 tasks × 3 runs/arm. Both Lua
+engines were measured against the same bash baseline:
 
 | arm | success | tool_calls | tool_errors | avg_iters | avg_ms |
 |---|---|---|---|---|---|
-| virtual_bash | 12/12 | 19 | 0 | 2.6 | 2607 |
-| lua | 9/12 | 46 | 27 | 4.6 | 7218 |
+| virtual_bash | 12/12 | 18 | 0 | 2.5 | 2597 |
+| lua — **mlua** | **12/12** | **12** | **0** | **2.0** | **2528** |
+| lua — piccolo | 9/12 | 46 | 27 | 4.6 | 7218 |
 
-Per-slice the thesis holds **and** the debt is now measured, not hypothesized:
+Findings:
 
-- **Structured tasks favor Lua.** On `math` and `json_sum` Lua used *fewer* tool
-  calls (1 vs 2) and was faster — it computes and returns a structured value in
-  one shot where bash needs a compute step plus a write step.
-- **The piccolo stdlib gap is a real blocker.** `transform` (sort lines) failed
-  3/3 on Lua with exactly 7 tool errors / 10 iterations each: the model reaches
-  for `table.sort`/`table.insert`/`string.format`, which piccolo 0.3.3 does not
-  define (its `table` lib exposes only `pack`/`unpack`). bash did it in one
-  `sort`. `grep_count` showed the same cause at lower severity.
-- **Conclusion.** The engine/VFS design is sound, but shimming the missing
-  stdlib (`table.sort/insert/remove/concat`, `string.format/find/match/gsub`) is
-  an **evidence-backed P0** for Phase 2 — without it Lua loses on exactly the
-  text/data munging bash is used for today, regardless of its structured-data
-  edge. Re-run the harness after the shims land.
+- **mlua matches bash on success and beats it on efficiency.** 12/12 with zero
+  tool errors, ~33% fewer tool calls (12 vs 18) and fewer iterations — the
+  structured-data edge materializes once the full stdlib is present (`json_sum`
+  and `math`: one Lua call computes and returns the value; bash needs compute +
+  write). This is the "replace bash" thesis confirmed with data.
+- **piccolo's stdlib gap is a hard blocker.** `transform` (sort lines) failed
+  3/3 on piccolo with 7 tool errors / 10 iterations each: the model reaches for
+  `table.sort`/`table.insert`/`string.format`, which piccolo 0.3.3 does not
+  define (its `table` lib exposes only `pack`/`unpack`). The same engine on mlua
+  passed it in one call. `grep_count` showed the same cause at lower severity.
+- **Decision.** Combined with piccolo being effectively unmaintained (no release
+  since 2024-06 vs mlua's monthly cadence) and the ~19-function-plus-pattern-
+  engine reimplementation cost, the evidence favors **mlua as the default
+  engine**. piccolo stays behind the seam for anyone wanting a pure-Rust VM and
+  willing to own the stdlib. License is a non-issue (both MIT; vendored Lua is
+  MIT).
+
+Re-run: `cargo run -p everruns-agent-evals --bin lua-vs-bash` (point the crate's
+`everruns-core` feature at `lua-mlua` or `lua` to pick the engine).

--- a/specs/lua-execution.md
+++ b/specs/lua-execution.md
@@ -155,14 +155,37 @@ follow-up; enumerated here for review:
 
 ## Phased roadmap
 
-- **Phase 1** *(this skeleton)* — capability + `lua` tool, `fs.*` + `json.*`,
-  sandbox limits as data, engine seam, path-translation + metadata tests.
-  Feature-flagged, admin-gated, dev grades only.
-- **Phase 2** — wire the `mlua` engine end to end, streaming `print`, background
-  execution parity, more data modules (csv/yaml/base64), bash-vs-lua eval harness.
-- **Phase 3** — `http.*` behind the egress allow-list.
-- **Phase 4** — user libraries (controlled loader) + code mode (tools as Lua
-  functions, per-tool policy enforced inside the script).
+- **Phase 1 — DONE.** Capability + `lua` tool, `fs.*` + `json.*`, sandbox limits,
+  engine seam, **native-Rust piccolo engine** with the async VFS bridge, full
+  e2e tests. Feature-flagged (`FEATURE_LUA` + `lua` cargo feature), admin-gated.
+- **Phase 2 — PARTIAL.** `tonumber` shim; `print` capture+stream; TM-LUA in the
+  threat model. **Open:** the `string.*` stdlib gap (format/find/match/gmatch/
+  gsub/rep), `os.*` subset, background-execution parity (`BackgroundExecutableTool`).
+- **Phase 3 — PARTIAL.** `base64` module done. **Open:** `csv`/`yaml` modules;
+  the bash-vs-lua eval harness (see Evaluation below).
+- **Phase 4 — DESIGNED, deferred to dedicated security-reviewed PRs.** Each item
+  expands the trust boundary and must clear `specs/threat-model.md` on its own:
+
+  - **`http.*` (target 5).** `http.get/post(url, opts)` routed through
+    `ToolContext::egress_service` and gated by `ToolContext::network_access`
+    (the merged harness∩agent∩session allow-list). No raw sockets. New threats:
+    SSRF to internal metadata endpoints, data exfiltration — this is the single
+    biggest surface and the reason bash omits network entirely. Must extend
+    TM-LUA-005 from "no network" to an allow-listed, audited egress.
+  - **User libraries (target 6).** A controlled `require(path)`-style loader that
+    reads a **text** Lua file from `/workspace`, compiles and runs it, and returns
+    its exports. Text-only loading does not exceed the inline script's trust level
+    (still no bytecode → TM-LUA-006 holds), but the loader must cap module count
+    and recursion depth and resolve paths through `LuaVfs`.
+  - **Code mode (target 7).** Register the agent's available tools as Lua
+    functions (`tools.<name>(args) -> result`) dispatched over the same channel
+    bridge as `fs.*`, so one script orchestrates many tool calls per turn. Gates:
+    honor each tool's `ToolPolicy` (approval-gated tools cannot be silently
+    called from a script), exclude other High-risk execution tools by default
+    (no `lua` calling `virtual_bash`/agent-spawn unless explicitly allow-listed),
+    bound total nested tool calls, and surface each call as a normal
+    `tool.started`/`tool.completed` event for audit. This is the flagship
+    "replace bash" capability and needs the most careful review.
 
 ## Migration (supersede `virtual_bash`)
 
@@ -182,4 +205,37 @@ follow-up; enumerated here for review:
 | Quoting / escaping footguns | None | Many |
 | Model fluency | Good | Excellent (larger prior) |
 | Compact shell idioms | Weaker | `grep | sed | awk` |
+| Stdlib completeness | Partial (piccolo gap, see above) | Full bashkit builtins |
 | Status | Experimental | Shipped |
+
+### Agent ergonomics (how well the model drives each)
+
+A separate axis from raw capability: which engine the model emits *correct,
+recoverable* calls in. Bash wins zero-shot fluency for throwaway text munging
+(huge training prior, compact pipelines). Lua wins reliability for stateful,
+structured, multi-step, or tool-orchestrating work: no shell-quoting footguns in
+JSON tool args, the host API surface exactly matches reality (no "command not
+found" dead ends), errors carry line numbers (tighter self-correction), and
+return values come back as structured JSON. Net: complementary today; Lua is the
+better substrate for code-mode (Phase 4), which is the workload that justifies
+superseding bash.
+
+### Evaluation harness
+
+Lives in a dedicated **`evals/`** tree (or a `crates/agent-evals` crate over
+`everruns-runtime`) — **not** `test_cases/`, which is for manual UI testing.
+
+- **A/B design.** Identical agent/model/prompt-scaffolding; swap only the
+  execution capability (`virtual_bash` ↔ `lua`). N runs per task for variance.
+- **Corpus, sliced by target** (logic/math, VFS munging, JSON/CSV transforms,
+  multi-file edits, grep-and-summarize, report generation, code-mode). Each task
+  = seeded workspace + goal + a deterministic Rust grader (LLM-judge, blinded to
+  arm, for open-ended tasks).
+- **Metrics** (most already emitted via `tool.started`/`tool.completed`, token
+  usage, durations): task success; tool-call validity rate (malformed/`not
+  found`/syntax); self-correction rate; round-trips; token cost + bytes returned;
+  latency; sandbox incidents.
+- **Decision gates** (wire to Migration above): parity on the munging slice
+  before defaulting agents to Lua; a material win on structured/code-mode slices;
+  no regression in sandbox incidents. The piccolo stdlib gap is expected to show
+  up here and must be weighed.

--- a/specs/lua-execution.md
+++ b/specs/lua-execution.md
@@ -1,0 +1,171 @@
+# Lua Execution Capability (experimental)
+
+> **Status: EXPERIMENTAL — Phase 1 skeleton.** Gated behind the `lua` cargo
+> feature in `everruns-core` and the `FEATURE_LUA` internal feature flag at
+> registry build time. Not registered in production grades yet.
+
+## Why
+
+`virtual_bash` (see `specs/bashkit-requirements.md`) gives agents scripted
+execution over the session workspace. It is excellent at shell-idiom file
+munging but weak at structured-data work: everything is text, piping is
+fragile, quoting is a footgun, and extending it with typed host functions
+(HTTP, MCP, tool-calling) means teaching an emulated POSIX shell new builtins.
+
+The `lua` capability provides a single sandboxed interpreter we fully own. It
+targets, in order:
+
+1. **Common logic** — control flow, conditionals (native Lua).
+2. **Math** — `math` stdlib (native Lua).
+3. **Virtual filesystem** — read / write / grep / traverse via a host `fs`
+   table backed by the session `SessionFileSystem`.
+4. **Data processing** — `json` host module (serde bridge); later csv/yaml/base64.
+5. **HTTP** *(later)* — a host `http` module behind the egress allow-list.
+6. **Functions** *(later)* — user-defined Lua libraries loaded from the VFS via
+   a controlled loader (not the real `package`/`require`).
+7. **Code mode** *(later)* — the agent's available tools registered as Lua
+   functions, so one script orchestrates many tool calls per turn.
+
+### Goal: supersede `virtual_bash`
+
+The intent is for `lua` to become the primary execution capability and for
+`virtual_bash` to be deprecated once `lua` reaches feature parity for the
+workflows bash is used for today. Until then the two ship side by side and are
+evaluated head to head (round-trips per task, token cost, success rate, sandbox
+incidents). No bash removal happens before that evidence exists. See
+"Migration" below.
+
+## Architecture
+
+Mirrors `virtual_bash` so the proven scaffolding is reused:
+
+- `LuaCapability` — `Capability` impl. `risk_level() = High`, admin-gated
+  exactly like `virtual_bash` (`check_high_risk_caps` /
+  `require_admin_for_high_risk`). Depends on `session_file_system`; contributes
+  the `file_system` feature.
+- `LuaTool` — single `lua` tool. `cpu_bound`, `concurrency_class =
+  "session_workspace"` (serialize concurrent workspace mutators in a batch),
+  `persist_output`, `long_running`.
+- `LuaVfs` — wraps `(SessionId, Arc<dyn SessionFileSystem>)`. Owns the
+  `/workspace` ↔ session-store path translation (identical rules to
+  `SessionFileSystemAdapter`: absolute, forward-slash, `/workspace` stripped,
+  traversal/outside-workspace rejected). This is what makes tenant isolation
+  free — every path resolves through the already session-scoped store.
+- **Engine seam** — `LuaLimits` (data) + `engine::run(...)`. The engine lives
+  behind a cargo feature; with it off, `engine::run` returns a "not compiled"
+  error so the default workspace build pulls in no interpreter. The capability,
+  tool, VFS, host-API surface, and tests are engine-agnostic, so the chosen
+  engine (`piccolo`, primary) and the reference engine (`mlua`, `lua-mlua`
+  feature) are interchangeable behind this one module.
+
+### Runtime choice
+
+**Decision: native-Rust `piccolo`.** No C/FFI surface to audit, fuel-based
+*true preemptive* CPU bounding, and sandbox-by-construction (the dangerous
+libraries simply do not exist — there is nothing to scrub). Trade-offs accepted:
+pre-1.0 maturity, a partial stdlib, and a manual async bridge for the VFS host
+calls (piccolo has no `create_async_function` equivalent).
+
+`mlua` (Lua 5.4, vendored) is retained only as a **reference engine** behind the
+`lua-mlua` cargo feature — it proved the engine seam end to end and is a fallback
+if the piccolo spike (below) shows it cannot run the scripts models actually
+write. **Never LuaJIT** under any engine (FFI = instant escape).
+
+**Spike gate (do first).** Before committing to piccolo, validate two unknowns
+with a short spike: (1) the async host-call bridge — a `fs.read` that round-trips
+to an async `SessionFileSystem`; (2) stdlib/language coverage against real
+model-authored snippets (`string.format`, `gmatch`, metatables, `pcall`). If
+either fails badly, fall back to `mlua` via the seam.
+
+## Sandbox model (multitenant safety)
+
+One **fresh VM per invocation**, never shared across sessions or tenants. No VM
+state outlives a single tool call. Enforced at construction:
+
+| Control | Mechanism |
+|---|---|
+| Stdlib whitelist | Load only `string`, `table`, `math`, `utf8`, and a safe `os` subset (`os.time`, `os.date`, `os.clock`). |
+| No ambient I/O | `io`, `package`/`require`, `debug`, `os.execute/getenv/exit/remove/rename/tmpname` scrubbed to `nil`. |
+| No dynamic code | `load`, `loadstring`, `dofile`, `loadfile` removed (bytecode loading is a classic escape vector). |
+| No FFI | Lua 5.4, not LuaJIT. |
+| Memory cap | `Lua::set_memory_limit` (default 32 MiB). |
+| CPU / wall-clock | Instruction-count hook checks a deadline + max-instruction budget and aborts; outer `tokio::time::timeout` as backstop. |
+| Egress | No network in Phase 1 (parallels TM-BASH-003). HTTP arrives in Phase 3 behind the egress allow-list. |
+| Output size | Reuse `tool_output_sanitizer` + `ExecToolResultPayload` (16 KiB window, 64 KiB hard cap). |
+| Runtime starvation | `cpu_bound` hint → ActAtom offloads to a dedicated task; instruction hook keeps a tight loop from pinning a worker thread. |
+
+The only way out of the VM is the injected host tables, all of which route
+through session-scoped stores.
+
+## Host API surface (Phase 1)
+
+```lua
+-- fs: backed by SessionFileSystem, /workspace-rooted
+fs.read(path)            -> string                 -- text (lossy for binary)
+fs.write(path, content)                            -- create/overwrite
+fs.append(path, content)
+fs.exists(path)          -> boolean
+fs.stat(path)            -> { name, is_dir, size } | nil
+fs.list(path)            -> { {name, is_dir, size}, ... }
+fs.remove(path[, recursive])
+fs.mkdir(path)
+fs.grep(pattern[, path]) -> { {path, line_number, line}, ... }  -- indexed grep_files
+
+-- json: serde bridge
+json.decode(s)           -> value
+json.encode(value)       -> string
+
+print(...)               -- captured, streamed as tool.output.delta, returned as stdout
+return value             -- serialized back to the model (json-encodable)
+```
+
+## Threat model (TM-LUA-\*)
+
+Parallels TM-BASH. Full integration into `specs/threat-model.md` is a Phase 1
+follow-up; enumerated here for review:
+
+- **TM-LUA-001 Arbitrary code execution.** Mitigated by the stdlib whitelist,
+  global scrubbing, and High risk-level (admin-gated assignment).
+- **TM-LUA-002 CPU exhaustion.** Instruction-count hook + deadline + outer
+  timeout.
+- **TM-LUA-003 Memory exhaustion.** `set_memory_limit` hard cap.
+- **TM-LUA-004 Filesystem escape / cross-tenant access.** All paths resolve
+  through `LuaVfs` → session-scoped `SessionFileSystem`; `/workspace`-rooted,
+  traversal rejected. No `io` library.
+- **TM-LUA-005 Network egress / exfiltration.** No network in Phase 1. Phase 3
+  HTTP gated by the egress allow-list (`ToolContext::network_access`).
+- **TM-LUA-006 Dynamic code / bytecode loading.** `load`/`loadstring`/`dofile`/
+  `loadfile` removed; no untrusted bytecode path.
+- **TM-LUA-007 Native escape (FFI).** Lua 5.4 only; LuaJIT forbidden.
+- **TM-LUA-008 Output-channel abuse.** Sanitizer + hard output cap.
+
+## Phased roadmap
+
+- **Phase 1** *(this skeleton)* — capability + `lua` tool, `fs.*` + `json.*`,
+  sandbox limits as data, engine seam, path-translation + metadata tests.
+  Feature-flagged, admin-gated, dev grades only.
+- **Phase 2** — wire the `mlua` engine end to end, streaming `print`, background
+  execution parity, more data modules (csv/yaml/base64), bash-vs-lua eval harness.
+- **Phase 3** — `http.*` behind the egress allow-list.
+- **Phase 4** — user libraries (controlled loader) + code mode (tools as Lua
+  functions, per-tool policy enforced inside the script).
+
+## Migration (supersede `virtual_bash`)
+
+1. Reach parity for the file-munging workflows bash covers (Phase 2 eval gate).
+2. Land code mode (Phase 4) — the capability bash cannot match.
+3. Default new agents to `lua`; mark `virtual_bash` deprecated in capability
+   metadata; keep existing bash-assigned agents running.
+4. Remove `virtual_bash` only after a deprecation window with no parity gaps.
+
+## Evaluation vs bash
+
+| | `lua` | `virtual_bash` |
+|---|---|---|
+| Structured data | Native tables + JSON | Text + fragile piping |
+| Sandbox ownership | Fully ours, extensible host fns | bashkit builtin set |
+| Path to HTTP / MCP / code-mode | First-class typed host functions | Awkward (emulated builtins) |
+| Quoting / escaping footguns | None | Many |
+| Model fluency | Good | Excellent (larger prior) |
+| Compact shell idioms | Weaker | `grep | sed | awk` |
+| Status | Experimental | Shipped |

--- a/specs/lua-execution.md
+++ b/specs/lua-execution.md
@@ -159,10 +159,13 @@ follow-up; enumerated here for review:
   engine seam, **native-Rust piccolo engine** with the async VFS bridge, full
   e2e tests. Feature-flagged (`FEATURE_LUA` + `lua` cargo feature), admin-gated.
 - **Phase 2 — PARTIAL.** `tonumber` shim; `print` capture+stream; TM-LUA in the
-  threat model. **Open:** the `string.*` stdlib gap (format/find/match/gmatch/
-  gsub/rep), `os.*` subset, background-execution parity (`BackgroundExecutableTool`).
-- **Phase 3 — PARTIAL.** `base64` module done. **Open:** `csv`/`yaml` modules;
-  the bash-vs-lua eval harness (see Evaluation below).
+  threat model. **Open (P0, evidence-backed by the eval below):** stdlib shims —
+  `table.sort/insert/remove/concat` and `string.format/find/match/gmatch/gsub/rep`
+  (their absence fails the sort task 3/3). Then `os.*` subset and
+  background-execution parity (`BackgroundExecutableTool`).
+- **Phase 3 — PARTIAL.** `base64` module + bash-vs-lua eval harness
+  (`crates/agent-evals`) done — see Evaluation results below. **Open:**
+  `csv`/`yaml` modules.
 - **Phase 4 — DESIGNED, deferred to dedicated security-reviewed PRs.** Each item
   expands the trust boundary and must clear `specs/threat-model.md` on its own:
 
@@ -239,3 +242,31 @@ Lives in a dedicated **`evals/`** tree (or a `crates/agent-evals` crate over
   before defaulting agents to Lua; a material win on structured/code-mode slices;
   no regression in sandbox incidents. The piccolo stdlib gap is expected to show
   up here and must be weighed.
+
+The harness is implemented in `crates/agent-evals` (`lua-vs-bash` bin), runs both
+arms over `everruns-runtime`, and grades against the resulting workspace.
+
+### Empirical results (first run)
+
+Real Claude (`claude-haiku-4-5-20251001`), 4 tasks × 3 runs/arm:
+
+| arm | success | tool_calls | tool_errors | avg_iters | avg_ms |
+|---|---|---|---|---|---|
+| virtual_bash | 12/12 | 19 | 0 | 2.6 | 2607 |
+| lua | 9/12 | 46 | 27 | 4.6 | 7218 |
+
+Per-slice the thesis holds **and** the debt is now measured, not hypothesized:
+
+- **Structured tasks favor Lua.** On `math` and `json_sum` Lua used *fewer* tool
+  calls (1 vs 2) and was faster — it computes and returns a structured value in
+  one shot where bash needs a compute step plus a write step.
+- **The piccolo stdlib gap is a real blocker.** `transform` (sort lines) failed
+  3/3 on Lua with exactly 7 tool errors / 10 iterations each: the model reaches
+  for `table.sort`/`table.insert`/`string.format`, which piccolo 0.3.3 does not
+  define (its `table` lib exposes only `pack`/`unpack`). bash did it in one
+  `sort`. `grep_count` showed the same cause at lower severity.
+- **Conclusion.** The engine/VFS design is sound, but shimming the missing
+  stdlib (`table.sort/insert/remove/concat`, `string.format/find/match/gsub`) is
+  an **evidence-backed P0** for Phase 2 — without it Lua loses on exactly the
+  text/data munging bash is used for today, regardless of its structured-data
+  edge. Re-run the harness after the shims land.

--- a/specs/lua-execution.md
+++ b/specs/lua-execution.md
@@ -51,57 +51,44 @@ Mirrors `virtual_bash` so the proven scaffolding is reused:
   `SessionFileSystemAdapter`: absolute, forward-slash, `/workspace` stripped,
   traversal/outside-workspace rejected). This is what makes tenant isolation
   free — every path resolves through the already session-scoped store.
-- **Engine seam** — `LuaLimits` (data) + `engine::run(...)`. The engine lives
-  behind a cargo feature; with it off, `engine::run` returns a "not compiled"
-  error so the default workspace build pulls in no interpreter. The capability,
-  tool, VFS, host-API surface, and tests are engine-agnostic, so the chosen
-  engine (`piccolo`, primary) and the reference engine (`mlua`, `lua-mlua`
-  feature) are interchangeable behind this one module.
+- **Engine** — `LuaLimits` (data) + `engine::run(...)`, behind the `lua` cargo
+  feature; with it off, `engine::run` returns a "not compiled" error so the
+  default workspace build pulls in no interpreter.
 
 ### Runtime choice
 
-**Decision: native-Rust `piccolo`.** No C/FFI surface to audit, fuel-based
-*true preemptive* CPU bounding, and sandbox-by-construction (the dangerous
-libraries simply do not exist — there is nothing to scrub). Trade-offs accepted:
-pre-1.0 maturity, a partial stdlib, and a manual async bridge for the VFS host
-calls (piccolo has no `create_async_function` equivalent).
+**Decision: `mlua` (vendored Lua 5.4, never LuaJIT) is the sole engine.** It is
+actively maintained, ships the complete Lua 5.4 stdlib, and exposes the
+memory/instruction controls the sandbox needs. `piccolo` (pure-Rust) was
+prototyped behind the same seam for its no-C appeal, but rejected: effectively
+unmaintained (no release since 2024-06) and a thin stdlib that would force us to
+reimplement ~19 functions plus a Lua-pattern engine on a dead base — and the eval
+below measured it failing tasks mlua passes. The pure-Rust safety win is moot
+when the dependency gets no security fixes. The engine seam was kept minimal (one
+`engine::run` + a not-compiled stub); there is no longer a second engine.
 
-`mlua` (Lua 5.4, vendored) is retained only as a **reference engine** behind the
-`lua-mlua` cargo feature — it proved the engine seam end to end and is a fallback
-if the piccolo spike (below) shows it cannot run the scripts models actually
-write. **Never LuaJIT** under any engine (FFI = instant escape).
-
-**Spike gate (done).** Two unknowns were validated empirically:
-1. **Async host-call bridge — PASS.** piccolo is synchronous, so the VM runs on
-   a `spawn_blocking` thread and each `fs.*` callback marshals its request to the
-   tokio runtime over an `mpsc` channel and `blocking_recv`s the reply. The async
-   `SessionFileSystem` round-trips cleanly; fs/json round-trip tests pass.
-2. **Stdlib/language coverage — PARTIAL (tracked debt).** piccolo 0.3.3 ships a
-   thin stdlib. Confirmed missing and relevant to model-authored scripts:
-   `tonumber` (base); `string.format`, `string.find`, `string.match`,
-   `string.gmatch`, `string.gsub`, `string.rep` (string lib); no `os` library.
-   `tonumber` is shimmed as a host function; the broader `string.*` gap is open
-   Phase 2 work. This is real "replace-bash" debt: until these are shimmed (or
-   piccolo gains them), some model-written Lua will fail where bash would not —
-   the bash-vs-lua eval (Phase 3) must weight this. If the gap proves too costly,
-   the `lua-mlua` engine (full Lua 5.4 stdlib) remains a seam-level fallback.
+The mlua trade-off vs piccolo is that the sandbox is **in-process native code**,
+not memory-isolated like wasm/process boundaries. That is accepted for an
+admin-gated experimental capability; see TM-LUA in `specs/threat-model.md` for
+the residual and the out-of-process path if hostile-CPU isolation is needed.
 
 ## Sandbox model (multitenant safety)
 
 One **fresh VM per invocation**, never shared across sessions or tenants. No VM
-state outlives a single tool call. Enforced at construction:
+state outlives a single tool call. All controls are on by default — **no
+configuration knobs**. Because mlua loads the full stdlib, the dangerous surface
+is **scrubbed** rather than absent:
 
 | Control | Mechanism |
 |---|---|
-| Stdlib whitelist | Load only `string`, `table`, `math`, `utf8`, and a safe `os` subset (`os.time`, `os.date`, `os.clock`). |
-| No ambient I/O | `io`, `package`/`require`, `debug`, `os.execute/getenv/exit/remove/rename/tmpname` scrubbed to `nil`. |
-| No dynamic code | `load`, `loadstring`, `dofile`, `loadfile` removed (bytecode loading is a classic escape vector). |
-| No FFI | Lua 5.4, not LuaJIT. |
-| Memory cap | `Lua::set_memory_limit` (default 32 MiB). |
-| CPU / wall-clock | Instruction-count hook checks a deadline + max-instruction budget and aborts; outer `tokio::time::timeout` as backstop. |
-| Egress | No network in Phase 1 (parallels TM-BASH-003). HTTP arrives in Phase 3 behind the egress allow-list. |
-| Output size | Reuse `tool_output_sanitizer` + `ExecToolResultPayload` (16 KiB window, 64 KiB hard cap). |
-| Runtime starvation | `cpu_bound` hint → ActAtom offloads to a dedicated task; instruction hook keeps a tight loop from pinning a worker thread. |
+| Stdlib loaded | Only `string`, `table`, `math`, `os`, `utf8` (`io`/`package`/`debug` never loaded). |
+| Scrub dangerous globals | `io`, `package`, `require`, `load`, `loadstring`, `dofile`, `loadfile`, `collectgarbage` → `nil`; `os.execute/getenv/exit/remove/rename/tmpname/setlocale` → `nil`; `string.dump` → `nil`. Safe `os.time/date/clock` kept. |
+| No native escape | Lua 5.4 (no FFI); `package`/`require` scrubbed so `package.loadlib` cannot `dlopen`; `debug` not loaded. |
+| Memory cap | `Lua::set_memory_limit` (32 MiB); over-budget alloc → Lua error. Host-side reads bounded by `SessionFileSystem` quotas. |
+| CPU / wall-clock | Instruction-count hook (every 100k ops) enforces an instruction budget + wall-clock deadline; outer `tokio::time::timeout` backstop. |
+| Runtime containment | The VM runs on a `spawn_blocking` thread; `fs.*` calls marshal to the runtime over a channel. A pathological *synchronous* op (e.g. catastrophic Lua pattern in C, which the hook cannot interrupt) occupies one blocking-pool thread instead of stalling a runtime worker. Residual: not force-killable in-process (out-of-process is the robust fix). |
+| Egress | No network host functions and no socket library. HTTP (Phase 4) will be gated by the egress allow-list. |
+| Output size | `print` capture capped at 64 KiB in-engine; result further shaped via `tool_output_sanitizer` / `ExecToolResultPayload`. |
 
 The only way out of the VM is the injected host tables, all of which route
 through session-scoped stores.
@@ -124,14 +111,14 @@ fs.grep(pattern[, path]) -> { {path, line_number, line}, ... }  -- indexed grep_
 json.decode(s)           -> value
 json.encode(value)       -> string
 base64.encode(s) / base64.decode(s)
-tonumber(s)              -- shimmed (piccolo base lacks it)
 
 print(...)               -- captured, streamed as tool.output.delta, returned as stdout
 return value             -- serialized back to the model (json-encodable)
 ```
 
-Not yet available on the piccolo engine (Phase 2 stdlib work): `string.format`,
-`string.find`/`match`/`gmatch`/`gsub`/`rep`, `os.*`, `csv`/`yaml` modules.
+The full Lua 5.4 stdlib (`string.*` incl. `format`/`find`/`match`/`gsub`,
+`table.*` incl. `sort`, `math.*`, `os.time`/`os.date`) is available — no shims
+needed. Open host modules (future): `csv`/`yaml`.
 
 ## Threat model (TM-LUA-\*)
 

--- a/specs/lua-execution.md
+++ b/specs/lua-execution.md
@@ -71,11 +71,20 @@ calls (piccolo has no `create_async_function` equivalent).
 if the piccolo spike (below) shows it cannot run the scripts models actually
 write. **Never LuaJIT** under any engine (FFI = instant escape).
 
-**Spike gate (do first).** Before committing to piccolo, validate two unknowns
-with a short spike: (1) the async host-call bridge — a `fs.read` that round-trips
-to an async `SessionFileSystem`; (2) stdlib/language coverage against real
-model-authored snippets (`string.format`, `gmatch`, metatables, `pcall`). If
-either fails badly, fall back to `mlua` via the seam.
+**Spike gate (done).** Two unknowns were validated empirically:
+1. **Async host-call bridge — PASS.** piccolo is synchronous, so the VM runs on
+   a `spawn_blocking` thread and each `fs.*` callback marshals its request to the
+   tokio runtime over an `mpsc` channel and `blocking_recv`s the reply. The async
+   `SessionFileSystem` round-trips cleanly; fs/json round-trip tests pass.
+2. **Stdlib/language coverage — PARTIAL (tracked debt).** piccolo 0.3.3 ships a
+   thin stdlib. Confirmed missing and relevant to model-authored scripts:
+   `tonumber` (base); `string.format`, `string.find`, `string.match`,
+   `string.gmatch`, `string.gsub`, `string.rep` (string lib); no `os` library.
+   `tonumber` is shimmed as a host function; the broader `string.*` gap is open
+   Phase 2 work. This is real "replace-bash" debt: until these are shimmed (or
+   piccolo gains them), some model-written Lua will fail where bash would not —
+   the bash-vs-lua eval (Phase 3) must weight this. If the gap proves too costly,
+   the `lua-mlua` engine (full Lua 5.4 stdlib) remains a seam-level fallback.
 
 ## Sandbox model (multitenant safety)
 
@@ -97,7 +106,7 @@ state outlives a single tool call. Enforced at construction:
 The only way out of the VM is the injected host tables, all of which route
 through session-scoped stores.
 
-## Host API surface (Phase 1)
+## Host API surface (implemented)
 
 ```lua
 -- fs: backed by SessionFileSystem, /workspace-rooted
@@ -111,13 +120,18 @@ fs.remove(path[, recursive])
 fs.mkdir(path)
 fs.grep(pattern[, path]) -> { {path, line_number, line}, ... }  -- indexed grep_files
 
--- json: serde bridge
+-- data processing
 json.decode(s)           -> value
 json.encode(value)       -> string
+base64.encode(s) / base64.decode(s)
+tonumber(s)              -- shimmed (piccolo base lacks it)
 
 print(...)               -- captured, streamed as tool.output.delta, returned as stdout
 return value             -- serialized back to the model (json-encodable)
 ```
+
+Not yet available on the piccolo engine (Phase 2 stdlib work): `string.format`,
+`string.find`/`match`/`gmatch`/`gsub`/`rep`, `os.*`, `csv`/`yaml` modules.
 
 ## Threat model (TM-LUA-\*)
 

--- a/specs/lua-execution.md
+++ b/specs/lua-execution.md
@@ -87,7 +87,8 @@ is **scrubbed** rather than absent:
 | Memory cap | `Lua::set_memory_limit` (32 MiB); over-budget alloc → Lua error. Host-side reads bounded by `SessionFileSystem` quotas. |
 | CPU / wall-clock | Instruction-count hook (every 100k ops) enforces an instruction budget + wall-clock deadline; outer `tokio::time::timeout` backstop. |
 | Runtime containment | The VM runs on a `spawn_blocking` thread; `fs.*` calls marshal to the runtime over a channel. A pathological *synchronous* op (e.g. catastrophic Lua pattern in C, which the hook cannot interrupt) occupies one blocking-pool thread instead of stalling a runtime worker. Residual: not force-killable in-process (out-of-process is the robust fix). |
-| Egress | No network host functions and no socket library. HTTP (Phase 4) will be gated by the egress allow-list. |
+| Egress | No raw sockets. `http.*` is fail-closed: routed only through the host `EgressService` and requires a non-empty allow-list that permits the URL, else it is not defined. |
+| Code mode | `tools.<name>` exposes only Auto/non-destructive/non-execution sibling tools; child context drops the registry (no recursion). |
 | Output size | `print` capture capped at 64 KiB in-engine; result further shaped via `tool_output_sanitizer` / `ExecToolResultPayload`. |
 
 The only way out of the VM is the injected host tables, all of which route
@@ -112,6 +113,11 @@ json.decode(s)           -> value
 json.encode(value)       -> string
 base64.encode(s) / base64.decode(s)
 
+-- when enabled by the environment (else the global is nil):
+http.get(url)            -> { status, body }   -- allow-listed hosts only
+http.post(url, body)     -> { status, body }
+tools.<name>(args_table) -> result             -- call a sibling tool (code mode)
+
 print(...)               -- captured, streamed as tool.output.delta, returned as stdout
 return value             -- serialized back to the model (json-encodable)
 ```
@@ -122,23 +128,12 @@ needed. Open host modules (future): `csv`/`yaml`.
 
 ## Threat model (TM-LUA-\*)
 
-Parallels TM-BASH. Full integration into `specs/threat-model.md` is a Phase 1
-follow-up; enumerated here for review:
-
-- **TM-LUA-001 Arbitrary code execution.** Mitigated by the stdlib whitelist,
-  global scrubbing, and High risk-level (admin-gated assignment).
-- **TM-LUA-002 CPU exhaustion.** Instruction-count hook + deadline + outer
-  timeout.
-- **TM-LUA-003 Memory exhaustion.** `set_memory_limit` hard cap.
-- **TM-LUA-004 Filesystem escape / cross-tenant access.** All paths resolve
-  through `LuaVfs` → session-scoped `SessionFileSystem`; `/workspace`-rooted,
-  traversal rejected. No `io` library.
-- **TM-LUA-005 Network egress / exfiltration.** No network in Phase 1. Phase 3
-  HTTP gated by the egress allow-list (`ToolContext::network_access`).
-- **TM-LUA-006 Dynamic code / bytecode loading.** `load`/`loadstring`/`dofile`/
-  `loadfile` removed; no untrusted bytecode path.
-- **TM-LUA-007 Native escape (FFI).** Lua 5.4 only; LuaJIT forbidden.
-- **TM-LUA-008 Output-channel abuse.** Sanitizer + hard output cap.
+The authoritative table lives in `specs/threat-model.md` (§15A), covering
+TM-LUA-001..009: arbitrary code execution, CPU/time, memory, filesystem/tenant
+isolation, network egress/SSRF (fail-closed `http.*`), dynamic-code/bytecode
+loading, native/FFI escape, output-channel abuse, and code-mode tool re-entry.
+The one stated residual is TM-LUA-002: in-process timeout is best-effort against
+pathological synchronous C ops (out-of-process execution is the robust fix).
 
 ## Phased roadmap
 
@@ -153,29 +148,25 @@ follow-up; enumerated here for review:
 - **Phase 3 — PARTIAL.** `base64` module + bash-vs-lua eval harness
   (`crates/agent-evals`) done — see Evaluation results below. **Open:**
   `csv`/`yaml` modules.
-- **Phase 4 — DESIGNED, deferred to dedicated security-reviewed PRs.** Each item
-  expands the trust boundary and must clear `specs/threat-model.md` on its own:
+- **Phase 4 — IMPLEMENTED (http + code mode); user libraries deferred.**
 
-  - **`http.*` (target 5).** `http.get/post(url, opts)` routed through
-    `ToolContext::egress_service` and gated by `ToolContext::network_access`
-    (the merged harness∩agent∩session allow-list). No raw sockets. New threats:
-    SSRF to internal metadata endpoints, data exfiltration — this is the single
-    biggest surface and the reason bash omits network entirely. Must extend
-    TM-LUA-005 from "no network" to an allow-listed, audited egress.
-  - **User libraries (target 6).** A controlled `require(path)`-style loader that
-    reads a **text** Lua file from `/workspace`, compiles and runs it, and returns
-    its exports. Text-only loading does not exceed the inline script's trust level
-    (still no bytecode → TM-LUA-006 holds), but the loader must cap module count
-    and recursion depth and resolve paths through `LuaVfs`.
-  - **Code mode (target 7).** Register the agent's available tools as Lua
-    functions (`tools.<name>(args) -> result`) dispatched over the same channel
-    bridge as `fs.*`, so one script orchestrates many tool calls per turn. Gates:
-    honor each tool's `ToolPolicy` (approval-gated tools cannot be silently
-    called from a script), exclude other High-risk execution tools by default
-    (no `lua` calling `virtual_bash`/agent-spawn unless explicitly allow-listed),
-    bound total nested tool calls, and surface each call as a normal
-    `tool.started`/`tool.completed` event for audit. This is the flagship
-    "replace bash" capability and needs the most careful review.
+  - **`http.*` (target 5) — DONE.** `http.get(url)` / `http.post(url, body)`
+    routed **only** through `ToolContext::egress_service` (the host egress
+    boundary) and **fail-closed**: a request runs only if `network_access` has a
+    non-empty allow-list that permits the URL; otherwise `http.*` is not even
+    defined. No raw sockets; response bodies capped at 1 MiB. SSRF/exfil mitigated
+    by the allow-list + the central egress boundary (TM-LUA-005).
+  - **Code mode (target 7) — DONE.** The agent's sibling tools are registered as
+    `tools.<name>(args) -> result`, dispatched over the same channel bridge as
+    `fs.*`. Gated (`gated_code_mode_tools`): only `Auto`-policy, non-destructive,
+    non-`cpu_bound` tools; approval/client-side and the execution tools
+    (`lua`/`bash`) are excluded. The child `ToolContext` drops `tool_registry`, so
+    code mode cannot recurse (TM-LUA-009).
+  - **User libraries (target 6) — deferred.** A controlled `require(path)`-style
+    loader that reads a **text** Lua file from `/workspace` and returns its
+    exports. Text-only loading stays within the script's trust level (no bytecode
+    → TM-LUA-006 holds), but the loader must cap module count/recursion and
+    resolve paths through `LuaVfs`. Not yet implemented.
 
 ## Migration (supersede `virtual_bash`)
 

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -947,10 +947,11 @@ configuration knobs.
 | TM-LUA-002 | CPU / wall-clock exhaustion | High | Instruction-count hook (every 100k ops) enforces an instruction budget + wall-clock deadline; outer tokio timeout backstop. The VM runs on a dedicated blocking thread, so a pathological *synchronous* op (e.g. catastrophic Lua pattern in C, which the hook cannot interrupt) occupies one blocking-pool thread instead of stalling a shared runtime worker. **Residual:** such an op is not force-killable in-process — robust fix is out-of-process execution. | MITIGATED (best-effort for synchronous C ops) |
 | TM-LUA-003 | Memory exhaustion | High | `Lua::set_memory_limit` hard 32 MiB cap (over-budget alloc → Lua error). Host-side reads bounded by `SessionFileSystem` quotas (TM-FS-008). | MITIGATED |
 | TM-LUA-004 | Filesystem escape / cross-tenant access | High | All paths route through `LuaVfs` → session-scoped `SessionFileSystem`; `/workspace`-rooted, traversal/outside-workspace rejected; `io` library not loaded | MITIGATED |
-| TM-LUA-005 | Network egress / exfiltration | High | No network host functions and no socket library; no way to open a connection. HTTP (Phase 4) will require the egress allow-list (`ToolContext::network_access`). | MITIGATED (no network) |
+| TM-LUA-005 | Network egress / SSRF / exfiltration | High | No socket library. `http.get/post` is **fail-closed**: routed only through the host `EgressService` (the central egress boundary) AND requires a non-empty `network_access` allow-list that permits the URL — checked before the request. Absent either, `http.*` is not even defined. Response bodies capped at 1 MiB. | MITIGATED (allow-listed egress) |
 | TM-LUA-006 | Dynamic code / bytecode loading | Medium | `load`/`loadstring`/`dofile`/`loadfile`/`require`/`package` scrubbed to nil; `string.dump` removed; no untrusted-bytecode path | MITIGATED |
 | TM-LUA-007 | Native escape (FFI / C modules) | High | Lua 5.4, never LuaJIT (no FFI); `package`/`require` scrubbed so `package.loadlib` cannot `dlopen` a shared object; `debug` library not loaded | MITIGATED |
 | TM-LUA-008 | Output-channel abuse | Medium | Captured `print` output capped (64 KiB) in-engine; tool result further shaped via `tool_output_sanitizer` | MITIGATED |
+| TM-LUA-009 | Code-mode tool re-entry / privilege escalation | High | `tools.<name>` exposes only `Auto`-policy, non-destructive, non-`cpu_bound` sibling tools; approval/client-side tools and the execution tools (`lua`/`bash`) are excluded. The child `ToolContext` has `tool_registry = None`, so a code-mode tool cannot itself open code mode (no recursion). Each call runs under the same session/org scope. | MITIGATED |
 
 ### Lua Isolation Summary
 
@@ -959,7 +960,8 @@ configuration knobs.
 | Real filesystem access | Blocked (LuaVfs → session store only; no `io`) |
 | Real process execution | Blocked (`os.execute`/`os.exit` scrubbed) |
 | Environment variables | Blocked (`os.getenv` scrubbed) |
-| Network / sockets | Blocked (no host functions, no socket lib) |
+| Network / sockets | No raw sockets; `http.*` fail-closed via host EgressService + allow-list |
+| Code mode (tools) | `tools.<name>` limited to Auto/non-destructive/non-exec tools; no recursion |
 | Dynamic code / bytecode | Blocked (`load`/`require`/`string.dump` scrubbed) |
 | Native / FFI / C modules | Blocked (no LuaJIT, no `package.loadlib`, no `debug`) |
 | Memory exhaustion | Bounded (`set_memory_limit` 32 MiB) |

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -932,6 +932,38 @@ When a bash script calls `bash` or `sh` or uses `eval`, bashkit re-invokes its o
 | Privilege escalation | Blocked (no sudo/su) |
 | Resource exhaustion | Limited (commands, loops, depth, timeout) |
 
+## 15A. Lua Sandbox (TM-LUA)
+
+Experimental sandboxed Lua execution capability (`crates/core/src/capabilities/lua.rs`,
+`specs/lua-execution.md`). High risk, admin-gated (same gates as `virtual_bash`),
+behind the `FEATURE_LUA` flag; scripts run only when the `lua` cargo feature
+(native-Rust piccolo engine) or `lua-mlua` (reference engine) is compiled in. One
+fresh VM per invocation, never shared across sessions/tenants.
+
+| ID | Threat | Severity | Mitigation | Status |
+|----|--------|----------|------------|--------|
+| TM-LUA-001 | Arbitrary code execution | High | Admin-gated assignment (High risk tier); piccolo `core()` loads only base/coroutine/math/string/table — no io/os/package | MITIGATED |
+| TM-LUA-002 | CPU exhaustion | High | Fuel budget per executor step + wall-clock deadline checked between steps; outer tokio timeout backstop | MITIGATED |
+| TM-LUA-003 | Memory exhaustion | High | `Lua::total_memory()` checked between steps against a 32 MiB cap | MITIGATED |
+| TM-LUA-004 | Filesystem escape / cross-tenant access | High | All paths route through `LuaVfs` → session-scoped `SessionFileSystem`; `/workspace`-rooted, traversal/outside-workspace rejected; no `io` library | MITIGATED |
+| TM-LUA-005 | Network egress / exfiltration | High | No network host functions in Phase 1; HTTP (Phase 3) will require the egress allow-list (`ToolContext::network_access`) | MITIGATED (no network) |
+| TM-LUA-006 | Dynamic code / bytecode loading | Medium | piccolo defines no `load`/`loadstring`/`dofile`/`loadfile`/`require`; mlua engine scrubs them | MITIGATED |
+| TM-LUA-007 | Native escape (FFI) | High | Pure-Rust piccolo has no FFI; mlua engine uses Lua 5.4 (never LuaJIT) | MITIGATED |
+| TM-LUA-008 | Output-channel abuse | Medium | Captured `print` output capped (64 KiB) in-engine; tool result further shaped via `tool_output_sanitizer` | MITIGATED |
+
+### Lua Isolation Summary
+
+| Property | Status |
+|----------|--------|
+| Real filesystem access | Blocked (LuaVfs → session store only) |
+| Real process execution | Blocked (no os/io) |
+| Network access | Blocked (no host functions) |
+| Dynamic code loading | Blocked (no load/require) |
+| Native/FFI escape | Blocked (pure-Rust piccolo) |
+| CPU exhaustion | Bounded (fuel + deadline) |
+| Memory exhaustion | Bounded (total_memory cap) |
+| Cross-tenant state | Blocked (fresh VM per invocation) |
+
 ## 16. Denial of Service (TM-DOS)
 
 | ID | Threat | Severity | Mitigation | Status |

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -935,33 +935,35 @@ When a bash script calls `bash` or `sh` or uses `eval`, bashkit re-invokes its o
 ## 15A. Lua Sandbox (TM-LUA)
 
 Experimental sandboxed Lua execution capability (`crates/core/src/capabilities/lua.rs`,
-`specs/lua-execution.md`). High risk, admin-gated (same gates as `virtual_bash`),
-behind the `FEATURE_LUA` flag; scripts run only when the `lua` cargo feature
-(native-Rust piccolo engine) or `lua-mlua` (reference engine) is compiled in. One
-fresh VM per invocation, never shared across sessions/tenants.
+`specs/lua-execution.md`). Engine: **mlua** (vendored Lua 5.4, never LuaJIT),
+behind the `lua` cargo feature. High risk, admin-gated (same gates as
+`virtual_bash`), and runtime-gated by `FEATURE_LUA`. One fresh VM per invocation,
+never shared across sessions/tenants. All hardening is on by default — no
+configuration knobs.
 
 | ID | Threat | Severity | Mitigation | Status |
 |----|--------|----------|------------|--------|
-| TM-LUA-001 | Arbitrary code execution | High | Admin-gated assignment (High risk tier); piccolo `core()` loads only base/coroutine/math/string/table — no io/os/package | MITIGATED |
-| TM-LUA-002 | CPU exhaustion | High | Fuel budget per executor step + wall-clock deadline checked between steps; outer tokio timeout backstop | MITIGATED |
-| TM-LUA-003 | Memory exhaustion | High | `Lua::total_memory()` checked between steps against a 32 MiB cap | MITIGATED |
-| TM-LUA-004 | Filesystem escape / cross-tenant access | High | All paths route through `LuaVfs` → session-scoped `SessionFileSystem`; `/workspace`-rooted, traversal/outside-workspace rejected; no `io` library | MITIGATED |
-| TM-LUA-005 | Network egress / exfiltration | High | No network host functions in Phase 1; HTTP (Phase 3) will require the egress allow-list (`ToolContext::network_access`) | MITIGATED (no network) |
-| TM-LUA-006 | Dynamic code / bytecode loading | Medium | piccolo defines no `load`/`loadstring`/`dofile`/`loadfile`/`require`; mlua engine scrubs them | MITIGATED |
-| TM-LUA-007 | Native escape (FFI) | High | Pure-Rust piccolo has no FFI; mlua engine uses Lua 5.4 (never LuaJIT) | MITIGATED |
+| TM-LUA-001 | Arbitrary code execution | High | Admin-gated assignment (High risk tier); only string/table/math/os/utf8 libs loaded; dangerous globals scrubbed | MITIGATED |
+| TM-LUA-002 | CPU / wall-clock exhaustion | High | Instruction-count hook (every 100k ops) enforces an instruction budget + wall-clock deadline; outer tokio timeout backstop. The VM runs on a dedicated blocking thread, so a pathological *synchronous* op (e.g. catastrophic Lua pattern in C, which the hook cannot interrupt) occupies one blocking-pool thread instead of stalling a shared runtime worker. **Residual:** such an op is not force-killable in-process — robust fix is out-of-process execution. | MITIGATED (best-effort for synchronous C ops) |
+| TM-LUA-003 | Memory exhaustion | High | `Lua::set_memory_limit` hard 32 MiB cap (over-budget alloc → Lua error). Host-side reads bounded by `SessionFileSystem` quotas (TM-FS-008). | MITIGATED |
+| TM-LUA-004 | Filesystem escape / cross-tenant access | High | All paths route through `LuaVfs` → session-scoped `SessionFileSystem`; `/workspace`-rooted, traversal/outside-workspace rejected; `io` library not loaded | MITIGATED |
+| TM-LUA-005 | Network egress / exfiltration | High | No network host functions and no socket library; no way to open a connection. HTTP (Phase 4) will require the egress allow-list (`ToolContext::network_access`). | MITIGATED (no network) |
+| TM-LUA-006 | Dynamic code / bytecode loading | Medium | `load`/`loadstring`/`dofile`/`loadfile`/`require`/`package` scrubbed to nil; `string.dump` removed; no untrusted-bytecode path | MITIGATED |
+| TM-LUA-007 | Native escape (FFI / C modules) | High | Lua 5.4, never LuaJIT (no FFI); `package`/`require` scrubbed so `package.loadlib` cannot `dlopen` a shared object; `debug` library not loaded | MITIGATED |
 | TM-LUA-008 | Output-channel abuse | Medium | Captured `print` output capped (64 KiB) in-engine; tool result further shaped via `tool_output_sanitizer` | MITIGATED |
 
 ### Lua Isolation Summary
 
 | Property | Status |
 |----------|--------|
-| Real filesystem access | Blocked (LuaVfs → session store only) |
-| Real process execution | Blocked (no os/io) |
-| Network access | Blocked (no host functions) |
-| Dynamic code loading | Blocked (no load/require) |
-| Native/FFI escape | Blocked (pure-Rust piccolo) |
-| CPU exhaustion | Bounded (fuel + deadline) |
-| Memory exhaustion | Bounded (total_memory cap) |
+| Real filesystem access | Blocked (LuaVfs → session store only; no `io`) |
+| Real process execution | Blocked (`os.execute`/`os.exit` scrubbed) |
+| Environment variables | Blocked (`os.getenv` scrubbed) |
+| Network / sockets | Blocked (no host functions, no socket lib) |
+| Dynamic code / bytecode | Blocked (`load`/`require`/`string.dump` scrubbed) |
+| Native / FFI / C modules | Blocked (no LuaJIT, no `package.loadlib`, no `debug`) |
+| Memory exhaustion | Bounded (`set_memory_limit` 32 MiB) |
+| CPU / wall-clock | Bounded for Lua code (hook + deadline); synchronous C ops contained to a blocking thread, best-effort timeout |
 | Cross-tenant state | Blocked (fresh VM per invocation) |
 
 ## 16. Denial of Service (TM-DOS)


### PR DESCRIPTION
## What
A new experimental `lua` capability: a sandboxed mlua (Lua 5.4) interpreter over the session virtual filesystem, with `fs.*`, `json.*`, `base64.*`, fail-closed `http.*`, and code-mode `tools.<name>(...)`. Plus an A/B eval harness (`crates/agent-evals`) comparing it to `virtual_bash`. Fully gated: `lua` cargo feature (off by default) **and** `FEATURE_LUA` (off by default), admin-gated assignment.

## Why
`virtual_bash` is weak at structured-data and tool-orchestration work (text-only, fragile quoting). A Lua engine gives a sandbox we fully own and can extend with typed host functions (HTTP, code-mode), aiming to eventually supersede bash. See `specs/lua-execution.md`.

## How
- `LuaCapability`/`LuaTool` mirror `virtual_bash` scaffolding; `LuaVfs` routes every path through the session-scoped `SessionFileSystem` (`/workspace`-rooted).
- Engine runs on a `spawn_blocking` thread; `fs`/`http`/`tools` calls marshal to the async runtime over one channel bridge.
- Engine evaluated empirically: piccolo (pure-Rust) prototyped but rejected (unmaintained ~2yrs + ~19-fn stdlib gap that failed tasks); mlua chosen. Real-Claude eval: mlua **12/12** vs bash 12/12 with ~33% fewer tool calls.

## Risk
- **Low for existing deployments** — the capability compiles only with `--features lua` and registers only with `FEATURE_LUA=true`; default builds/runtimes are unaffected.
- Medium for adopters who enable it: arbitrary scripted execution (admin-gated, sandboxed).

## Security
- Threat categories reviewed: **TM-LUA-001..009** (added to `specs/threat-model.md` §15A), plus TM-AGENT (admin gating) and TM-FS (quotas).
- Findings/resolutions:
  - Code exec / native escape: only string/table/math/os/utf8 loaded; `io`/`package`/`require`/`load`/`loadstring`/`dofile`/`string.dump`/`os.execute`/`os.getenv` scrubbed; no FFI/LuaJIT; no `debug`.
  - Memory: `set_memory_limit` 32 MiB. CPU/time: instruction hook + deadline + outer timeout.
  - **Egress (SSRF/exfil):** `http.*` fail-closed — only via host `EgressService` AND a non-empty allow-list permitting the URL; bodies capped 1 MiB.
  - **Code mode:** `tools.<name>` limited to Auto/non-destructive/non-exec tools; `lua`/`bash` excluded; child context drops the registry (no recursion).
  - **Residual (documented):** in-process wall-clock timeout is best-effort against pathological *synchronous* C ops (e.g. catastrophic patterns); contained to a blocking thread, not force-killable. Robust fix = out-of-process execution.

## Follow-ups
- User libraries (controlled `require` of workspace Lua text) — deferred (TM-LUA-006 rationale in spec).
- Out-of-process execution if hostile-CPU isolation becomes in-scope.
- `csv`/`yaml` host modules.

## Checklist
- [x] Tests added or updated (25 lua-feature tests: sandbox, limits, fs/json/base64 round-trips, http allow/deny, code-mode)
- [x] Backward compatibility considered (gated off by default; no impact on existing builds)
- [x] Security review performed against relevant threat model categories (TM-LUA-001..009)
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed

https://claude.ai/code/session_018PfJaeqBvvGZRdupYEGmt7

---
_Generated by [Claude Code](https://claude.ai/code/session_018PfJaeqBvvGZRdupYEGmt7)_