### PR TITLE
feat(bedrock): add AWS Bedrock Runtime LLM provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2334,6 +2334,7 @@ dependencies = [
  "async-trait",
  "aws-sdk-bedrockruntime",
  "aws-smithy-types",
+ "base64 0.22.1",
  "everruns-core",
  "futures",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ dependencies = [
  "futures",
  "pin-project-lite",
  "reqwest 0.12.28",
- "rustls",
+ "rustls 0.23.40",
  "rustls-pemfile",
  "semver",
  "serde",
@@ -75,9 +75,9 @@ dependencies = [
  "axum",
  "chrono",
  "futures",
- "hyper",
+ "hyper 1.10.1",
  "reqwest 0.12.28",
- "rustls",
+ "rustls 0.23.40",
  "serde",
  "serde_json",
  "tokio",
@@ -333,7 +333,7 @@ dependencies = [
  "ring",
  "rustls-native-certs",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.13",
  "serde",
  "serde_json",
  "serde_nanos",
@@ -341,7 +341,7 @@ dependencies = [
  "thiserror 2.0.18",
  "time",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tokio-stream",
  "tokio-util",
  "tokio-websockets",
@@ -425,6 +425,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "aws-credential-types"
+version = "1.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f20799b373a1be121fe3005fba0c2090af9411573878f224df44b42727fcaf7"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "zeroize",
+]
+
+[[package]]
 name = "aws-lc-rs"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -448,6 +460,284 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-runtime"
+version = "1.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ed8e8c52d2dc2390ad9f15647fe663f71e9780b4262c190fbb823a32721566"
+dependencies = [
+ "aws-credential-types",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "bytes-utils",
+ "fastrand",
+ "http 1.4.1",
+ "http-body 1.0.1",
+ "percent-encoding",
+ "pin-project-lite",
+ "tracing",
+ "uuid 1.23.2",
+]
+
+[[package]]
+name = "aws-sdk-bedrockruntime"
+version = "1.133.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76314880945928a4ee3956e92af451ef29ef04b734d008bb94b11158a60a1034"
+dependencies = [
+ "arc-swap",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.1",
+ "http-body-util",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sigv4"
+version = "1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bae38512beae0ffee7010fc24e7a8a123c53efdfef42a61e80fda4882418dc71"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "form_urlencoded",
+ "hex",
+ "hmac 0.13.0",
+ "http 0.2.12",
+ "http 1.4.1",
+ "percent-encoding",
+ "sha2 0.11.0",
+ "time",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-async"
+version = "1.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ffcaf626bdda484571968400c326a244598634dc75fd451325a54ad1a59acfc"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "aws-smithy-eventstream"
+version = "0.60.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf09d74e5e32f76b8762da505a3cd59303e367a664ca67295387baa8c1d7548"
+dependencies = [
+ "aws-smithy-types",
+ "bytes",
+ "crc32fast",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.63.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba1ab2dc1c2c3749ead27180d333c42f11be8b0e934058fb4b2258ee8dbe5231"
+dependencies = [
+ "aws-smithy-eventstream",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "futures-util",
+ "http 1.4.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http-client"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3ef8931ad1c98aa6a55b4256f847f3116090819844e0dd41ea682cac5dd2d3"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "h2 0.3.27",
+ "h2 0.4.14",
+ "http 0.2.12",
+ "http 1.4.1",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "hyper 1.10.1",
+ "hyper-rustls 0.24.2",
+ "hyper-rustls 0.27.9",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls 0.21.12",
+ "rustls 0.23.40",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.62.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "701a947f4797e52a911e114a898667c746c39feea467bbd1abd7b3721f702ffa"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-observability"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06c2315d173edbf1920da8ba3a7189695827002e4c0fc961973ab1c54abca9c"
+dependencies = [
+ "aws-smithy-runtime-api",
+]
+
+[[package]]
+name = "aws-smithy-runtime"
+version = "1.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e6f5caf6fea86f8c2206541ab5857cfcda9013426cdbe8fa0098b9e2d32182"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-http-client",
+ "aws-smithy-observability",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.1",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "pin-project-lite",
+ "pin-utils",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9db177daa6ba8afb9ee1aefcf548c907abcf52065e394ee11a92780057fe0e8c"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api-macros",
+ "aws-smithy-types",
+ "bytes",
+ "http 0.2.12",
+ "http 1.4.1",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api-macros"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d7396fd9500589e62e460e987ecb671bad374934e55ec3b5f498cc7a8a8a7b7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "aws-smithy-schema"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7442cb268338f0eb8278140a107c046756aa01093d8ef5e99628d34ae09c94f5"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "http 1.4.1",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53f93074121a1be41317b9aa607143ae17900631f7f59a99f2b905d519d6783b"
+dependencies = [
+ "base64-simd",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http 1.4.1",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "num-integer",
+ "pin-project-lite",
+ "pin-utils",
+ "ryu",
+ "serde",
+ "time",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "aws-types"
+version = "1.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d16bf10b03a3c01e6b3b7d47cd964e873ffe9e7d4e80fad16bd4c077cb068531"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "rustc_version",
+ "tracing",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -459,10 +749,10 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.1",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.10.1",
  "hyper-util",
  "itoa",
  "matchit",
@@ -492,8 +782,8 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.1",
+ "http-body 1.0.1",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -517,8 +807,8 @@ dependencies = [
  "form_urlencoded",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.1",
+ "http-body 1.0.1",
  "http-body-util",
  "mime",
  "multer",
@@ -559,6 +849,16 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
 
 [[package]]
 name = "base64ct"
@@ -1090,21 +1390,21 @@ dependencies = [
  "bytes",
  "flate2",
  "futures",
- "http",
- "http-body",
+ "http 1.4.1",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
- "hyper-rustls",
+ "hyper 1.10.1",
+ "hyper-rustls 0.27.9",
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "rustls",
+ "rustls 0.23.40",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tokio-util",
  "tower",
  "tracing",
@@ -2028,6 +2328,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "everruns-bedrock"
+version = "0.9.0"
+dependencies = [
+ "async-trait",
+ "aws-sdk-bedrockruntime",
+ "aws-smithy-types",
+ "everruns-core",
+ "futures",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+]
+
+[[package]]
 name = "everruns-cli"
 version = "0.9.0"
 dependencies = [
@@ -2043,7 +2359,7 @@ dependencies = [
  "ignore",
  "notify",
  "reqwest 0.13.4",
- "rustls",
+ "rustls 0.23.40",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -2139,7 +2455,7 @@ dependencies = [
  "rand 0.9.4",
  "regex",
  "reqwest 0.13.4",
- "rustls",
+ "rustls 0.23.40",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -2227,7 +2543,7 @@ dependencies = [
  "futures-util",
  "inventory",
  "reqwest 0.13.4",
- "rustls",
+ "rustls 0.23.40",
  "rustls-native-certs",
  "serde",
  "serde_json",
@@ -2279,10 +2595,10 @@ dependencies = [
  "everruns-core",
  "futures-util",
  "hickory-resolver",
- "http",
+ "http 1.4.1",
  "inventory",
  "reqwest 0.13.4",
- "rustls",
+ "rustls 0.23.40",
  "rustls-native-certs",
  "serde",
  "serde_json",
@@ -2333,13 +2649,13 @@ dependencies = [
  "connectrpc-build",
  "everruns-core",
  "futures",
- "http",
- "http-body",
+ "http 1.4.1",
+ "http-body 1.0.1",
  "inventory",
  "prost",
  "protox",
  "reqwest 0.13.4",
- "rustls",
+ "rustls 0.23.40",
  "rustls-native-certs",
  "serde",
  "serde_json",
@@ -2420,6 +2736,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "everruns-anthropic",
+ "everruns-bedrock",
  "everruns-core",
  "everruns-gemini",
  "everruns-openai",
@@ -2563,7 +2880,7 @@ dependencies = [
  "hex",
  "hmac 0.12.1",
  "http-body-util",
- "hyper",
+ "hyper 1.10.1",
  "hyper-util",
  "image",
  "inventory",
@@ -2630,6 +2947,7 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "everruns-anthropic",
+ "everruns-bedrock",
  "everruns-config",
  "everruns-container-sandbox",
  "everruns-core",
@@ -2924,12 +3242,12 @@ dependencies = [
  "parking_lot",
  "rand 0.8.6",
  "redis-protocol",
- "rustls",
+ "rustls 0.23.40",
  "rustls-native-certs",
  "semver",
  "socket2 0.5.10",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tokio-stream",
  "tokio-util",
  "url",
@@ -3208,6 +3526,25 @@ dependencies = [
 
 [[package]]
 name = "h2"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.12",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
@@ -3217,7 +3554,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http",
+ "http 1.4.1",
  "indexmap",
  "slab",
  "tokio",
@@ -3406,6 +3743,17 @@ dependencies = [
 
 [[package]]
 name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
@@ -3416,12 +3764,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.4.1",
 ]
 
 [[package]]
@@ -3432,8 +3791,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.1",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -3460,6 +3819,30 @@ dependencies = [
 
 [[package]]
 name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
@@ -3468,9 +3851,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2",
- "http",
- "http-body",
+ "h2 0.4.14",
+ "http 1.4.1",
+ "http-body 1.0.1",
  "httparse",
  "httpdate",
  "itoa",
@@ -3482,16 +3865,32 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http 0.2.12",
+ "hyper 0.14.32",
+ "log",
+ "rustls 0.21.12",
+ "tokio",
+ "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-rustls"
 version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http",
- "hyper",
+ "http 1.4.1",
+ "hyper 1.10.1",
  "hyper-util",
- "rustls",
+ "rustls 0.23.40",
+ "rustls-native-certs",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tower-service",
  "webpki-roots 1.0.7",
 ]
@@ -3502,7 +3901,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper",
+ "hyper 1.10.1",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -3517,7 +3916,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper",
+ "hyper 1.10.1",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -3535,9 +3934,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 1.4.1",
+ "http-body 1.0.1",
+ "hyper 1.10.1",
  "ipnet",
  "libc",
  "percent-encoding",
@@ -4683,7 +5082,7 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-util",
- "http",
+ "http 1.4.1",
  "httparse",
  "memchr",
  "mime",
@@ -5066,7 +5465,7 @@ checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
 dependencies = [
  "async-trait",
  "bytes",
- "http",
+ "http 1.4.1",
  "opentelemetry",
  "reqwest 0.13.4",
 ]
@@ -5077,7 +5476,7 @@ version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
 dependencies = [
- "http",
+ "http 1.4.1",
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-proto",
@@ -5148,6 +5547,12 @@ checksum = "ad5fd71b79026fb918650dde6d125000a233764f1c2f1659a1c71118e33ea08f"
 dependencies = [
  "unicode-width 0.2.2",
 ]
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "palette"
@@ -5453,6 +5858,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs8"
@@ -5817,7 +6228,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.1.2",
- "rustls",
+ "rustls 0.23.40",
  "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
@@ -5838,7 +6249,7 @@ dependencies = [
  "rand 0.9.4",
  "ring",
  "rustc-hash 2.1.2",
- "rustls",
+ "rustls 0.23.40",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -6217,6 +6628,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6a15a2fa0bfda9361941c45550896ae87b15cc6c8c939ea350079670332e211"
 
 [[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6239,12 +6656,12 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "h2 0.4.14",
+ "http 1.4.1",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
- "hyper-rustls",
+ "hyper 1.10.1",
+ "hyper-rustls 0.27.9",
  "hyper-tls",
  "hyper-util",
  "js-sys",
@@ -6253,7 +6670,7 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
+ "rustls 0.23.40",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -6261,7 +6678,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tokio-util",
  "tower",
  "tower-http",
@@ -6286,12 +6703,12 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "h2 0.4.14",
+ "http 1.4.1",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
- "hyper-rustls",
+ "hyper 1.10.1",
+ "hyper-rustls 0.27.9",
  "hyper-util",
  "js-sys",
  "log",
@@ -6300,7 +6717,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls",
+ "rustls 0.23.40",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "serde",
@@ -6308,7 +6725,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tokio-util",
  "tower",
  "tower-http",
@@ -6493,6 +6910,18 @@ dependencies = [
 
 [[package]]
 name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki 0.101.7",
+ "sct",
+]
+
+[[package]]
+name = "rustls"
 version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
@@ -6502,7 +6931,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
 ]
@@ -6549,10 +6978,10 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls",
+ "rustls 0.23.40",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki",
+ "rustls-webpki 0.103.13",
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
@@ -6564,6 +6993,16 @@ name = "rustls-platform-verifier-android"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted 0.9.0",
+]
 
 [[package]]
 name = "rustls-webpki"
@@ -6687,6 +7126,16 @@ dependencies = [
  "pbkdf2 0.11.0",
  "salsa20",
  "sha2 0.10.9",
+]
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -7212,7 +7661,7 @@ dependencies = [
  "log",
  "memchr",
  "percent-encoding",
- "rustls",
+ "rustls 0.23.40",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -7812,11 +8261,21 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls 0.21.12",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls",
+ "rustls 0.23.40",
  "tokio",
 ]
 
@@ -7839,11 +8298,11 @@ checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
 dependencies = [
  "futures-util",
  "log",
- "rustls",
+ "rustls 0.23.40",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tungstenite",
 ]
 
@@ -7871,13 +8330,13 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
- "http",
+ "http 1.4.1",
  "httparse",
  "rand 0.8.6",
  "ring",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tokio-util",
  "webpki-roots 0.26.11",
 ]
@@ -7984,11 +8443,11 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "bytes",
- "h2",
- "http",
- "http-body",
+ "h2 0.4.14",
+ "http 1.4.1",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.10.1",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
@@ -7996,7 +8455,7 @@ dependencies = [
  "socket2 0.6.4",
  "sync_wrapper",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tokio-stream",
  "tower",
  "tower-layer",
@@ -8073,8 +8532,8 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.1",
+ "http-body 1.0.1",
  "http-body-util",
  "pin-project-lite",
  "tokio",
@@ -8262,11 +8721,11 @@ checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
 dependencies = [
  "bytes",
  "data-encoding",
- "http",
+ "http 1.4.1",
  "httparse",
  "log",
  "rand 0.9.4",
- "rustls",
+ "rustls 0.23.40",
  "rustls-pki-types",
  "sha1 0.10.6",
  "thiserror 2.0.18",
@@ -8533,6 +8992,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "vtparse"
@@ -9270,9 +9735,9 @@ dependencies = [
  "base64 0.22.1",
  "deadpool",
  "futures",
- "http",
+ "http 1.4.1",
  "http-body-util",
- "hyper",
+ "hyper 1.10.1",
  "hyper-util",
  "log",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/server",
     "crates/worker",
     "crates/core",
+    "crates/bedrock",
     "crates/mcp",
     "crates/llm-tests",
     "crates/runtime",

--- a/apps/ui/src/app/(main)/settings/providers/provider-dialogs.tsx
+++ b/apps/ui/src/app/(main)/settings/providers/provider-dialogs.tsx
@@ -23,6 +23,7 @@ const PROVIDER_TYPES: { value: LlmProviderType; label: string }[] = [
   { value: "openai_completions", label: "OpenAI (Completions API)" },
   { value: "anthropic", label: "Anthropic" },
   { value: "gemini", label: "Google Gemini" },
+  { value: "bedrock", label: "AWS Bedrock" },
 ];
 
 // Get API key placeholder based on provider type
@@ -35,6 +36,8 @@ function getApiKeyPlaceholder(providerType: LlmProviderType): string {
       return "Azure OpenAI resource key";
     case "anthropic":
       return "sk-ant-api03-...";
+    case "bedrock":
+      return '{"access_key_id":"...","secret_access_key":"...","region":"us-east-1"}';
     default:
       return "your-api-key";
   }

--- a/apps/ui/src/components/providers/provider-icon.tsx
+++ b/apps/ui/src/components/providers/provider-icon.tsx
@@ -67,12 +67,33 @@ function AzureOpenAiIcon({ size }: { size: number }) {
   );
 }
 
+function AwsBedrockIcon({ size }: { size: number }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+    >
+      <path
+        d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
 const PROVIDER_ICON_COMPONENTS: Record<LlmProviderType, React.ComponentType<{ size: number }>> = {
   openai: OpenAiIcon,
   azure_openai: AzureOpenAiIcon,
   openai_completions: OpenAiIcon,
   anthropic: AnthropicIcon,
   gemini: GeminiIcon,
+  bedrock: AwsBedrockIcon,
 };
 
 const PROVIDER_LABELS: Record<LlmProviderType, string> = {
@@ -81,6 +102,7 @@ const PROVIDER_LABELS: Record<LlmProviderType, string> = {
   openai_completions: "OpenAI (Completions)",
   anthropic: "Anthropic",
   gemini: "Google Gemini",
+  bedrock: "AWS Bedrock",
 };
 
 interface ProviderIconProps {

--- a/apps/ui/src/lib/api/types/llm-types.ts
+++ b/apps/ui/src/lib/api/types/llm-types.ts
@@ -9,7 +9,8 @@ export type LlmProviderType =
   | "azure_openai"
   | "openai_completions"
   | "anthropic"
-  | "gemini";
+  | "gemini"
+  | "bedrock";
 
 export type LlmProviderStatus = "active" | "disabled";
 

--- a/crates/bedrock/Cargo.toml
+++ b/crates/bedrock/Cargo.toml
@@ -14,7 +14,6 @@ homepage.workspace = true
 repository.workspace = true
 documentation = "https://docs.rs/everruns-bedrock"
 description = "AWS Bedrock Runtime provider implementation for Everruns"
-readme = "README.md"
 
 [dependencies]
 # Core dependencies
@@ -33,6 +32,7 @@ serde_json.workspace = true
 tracing.workspace = true
 
 # Internal dependencies
+base64.workspace = true
 everruns-core.workspace = true
 
 # AWS SDK for Bedrock Runtime

--- a/crates/bedrock/Cargo.toml
+++ b/crates/bedrock/Cargo.toml
@@ -1,0 +1,43 @@
+# AWS Bedrock Provider Implementation
+# Decision: Implements LlmDriver using the AWS Bedrock Runtime ConverseStream API.
+# Uses aws-sdk-bedrockruntime for event stream handling; credentials are carried
+# as JSON in the ProviderConfig.api_key field.
+
+[package]
+name = "everruns-bedrock"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+documentation = "https://docs.rs/everruns-bedrock"
+description = "AWS Bedrock Runtime provider implementation for Everruns"
+readme = "README.md"
+
+[dependencies]
+# Core dependencies
+async-trait.workspace = true
+
+# Async runtime
+tokio.workspace = true
+futures.workspace = true
+tokio-stream.workspace = true
+
+# Serialization
+serde.workspace = true
+serde_json.workspace = true
+
+# Tracing
+tracing.workspace = true
+
+# Internal dependencies
+everruns-core.workspace = true
+
+# AWS SDK for Bedrock Runtime
+aws-sdk-bedrockruntime = "1"
+aws-smithy-types = "1"
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/bedrock/src/credential.rs
+++ b/crates/bedrock/src/credential.rs
@@ -25,7 +25,7 @@ impl BedrockCredential {
     pub fn from_api_key(api_key: &str) -> Result<Self> {
         serde_json::from_str(api_key).map_err(|e| {
             AgentLoopError::llm(format!(
-                "Bedrock credentials must be JSON {{access_key_id,secret_access_key,region}}: {e}"
+                "Bedrock credentials must be JSON {{access_key_id,secret_access_key}} (region and session_token are optional): {e}"
             ))
         })
     }

--- a/crates/bedrock/src/credential.rs
+++ b/crates/bedrock/src/credential.rs
@@ -1,0 +1,61 @@
+// Bedrock credential parsing
+//
+// Credentials are encoded as a JSON object in ProviderConfig.api_key:
+//   {"access_key_id":"...","secret_access_key":"...","session_token":"...","region":"..."}
+// session_token is optional. region defaults to "us-east-1" when omitted.
+
+use everruns_core::error::{AgentLoopError, Result};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BedrockCredential {
+    pub access_key_id: String,
+    pub secret_access_key: String,
+    #[serde(default)]
+    pub session_token: Option<String>,
+    #[serde(default = "default_region")]
+    pub region: String,
+}
+
+fn default_region() -> String {
+    "us-east-1".to_string()
+}
+
+impl BedrockCredential {
+    pub fn from_api_key(api_key: &str) -> Result<Self> {
+        serde_json::from_str(api_key).map_err(|e| {
+            AgentLoopError::llm(format!(
+                "Bedrock credentials must be JSON {{access_key_id,secret_access_key,region}}: {e}"
+            ))
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_full_credential() {
+        let json = r#"{"access_key_id":"AKID","secret_access_key":"SECRET","session_token":"TOKEN","region":"eu-west-1"}"#;
+        let cred = BedrockCredential::from_api_key(json).unwrap();
+        assert_eq!(cred.access_key_id, "AKID");
+        assert_eq!(cred.secret_access_key, "SECRET");
+        assert_eq!(cred.session_token.as_deref(), Some("TOKEN"));
+        assert_eq!(cred.region, "eu-west-1");
+    }
+
+    #[test]
+    fn test_parse_minimal_credential_defaults_region() {
+        let json = r#"{"access_key_id":"AKID","secret_access_key":"SECRET"}"#;
+        let cred = BedrockCredential::from_api_key(json).unwrap();
+        assert_eq!(cred.region, "us-east-1");
+        assert!(cred.session_token.is_none());
+    }
+
+    #[test]
+    fn test_parse_invalid_json_returns_error() {
+        assert!(BedrockCredential::from_api_key("not-json").is_err());
+        assert!(BedrockCredential::from_api_key("{}").is_err()); // missing required fields
+    }
+}

--- a/crates/bedrock/src/driver.rs
+++ b/crates/bedrock/src/driver.rs
@@ -19,6 +19,7 @@ use aws_sdk_bedrockruntime::types::{
     ToolSpecification, ToolUseBlock,
 };
 use aws_smithy_types::Document;
+use base64::prelude::*;
 use everruns_core::error::{AgentLoopError, Result};
 use everruns_core::llm_driver_registry::{
     BoxedLlmDriver, DiscoveredModel, DriverRegistry, LlmCallConfig, LlmCompletionMetadata,
@@ -109,7 +110,7 @@ impl LlmDriver for BedrockLlmDriver {
         };
 
         let inference_cfg = InferenceConfiguration::builder()
-            .set_temperature(config.temperature.map(|t| t as f32))
+            .set_temperature(config.temperature)
             .set_max_tokens(config.max_tokens.map(|t| t as i32))
             .build();
 
@@ -182,16 +183,31 @@ impl LlmDriver for BedrockLlmDriver {
                                 let mut ordered: Vec<(usize, PartialToolCall)> =
                                     pending.drain().collect();
                                 ordered.sort_by_key(|(idx, _)| *idx);
-                                let calls: Vec<ToolCall> = ordered
+                                let result: Result<Vec<ToolCall>> = ordered
                                     .into_iter()
-                                    .map(|(_, ptc)| ToolCall {
-                                        id: ptc.id,
-                                        name: ptc.name,
-                                        arguments: serde_json::from_str(&ptc.input_json)
-                                            .unwrap_or(Value::Object(serde_json::Map::new())),
+                                    .map(|(_, ptc)| {
+                                        let arguments = serde_json::from_str(&ptc.input_json)
+                                            .map_err(|e| {
+                                                AgentLoopError::llm(format!(
+                                                    "invalid Bedrock tool arguments JSON: {e}"
+                                                ))
+                                            })?;
+                                        Ok(ToolCall {
+                                            id: ptc.id,
+                                            name: ptc.name,
+                                            arguments,
+                                        })
                                     })
                                     .collect();
-                                let _ = tx.send(Ok(LlmStreamEvent::ToolCalls(calls)));
+                                match result {
+                                    Ok(calls) => {
+                                        let _ = tx.send(Ok(LlmStreamEvent::ToolCalls(calls)));
+                                    }
+                                    Err(e) => {
+                                        let _ = tx.send(Err(e));
+                                        return;
+                                    }
+                                }
                             }
                         }
                         ConverseStreamOutput::Metadata(e) => {
@@ -259,10 +275,10 @@ fn build_messages(messages: &[LlmMessage]) -> Result<(Vec<SystemContentBlock>, V
                     }
                     LlmMessageContent::Parts(parts) => {
                         for part in parts {
-                            if let LlmContentPart::Text { text } = part {
-                                if !text.is_empty() {
-                                    system_blocks.push(SystemContentBlock::Text(text.clone()));
-                                }
+                            if let LlmContentPart::Text { text } = part
+                                && !text.is_empty()
+                            {
+                                system_blocks.push(SystemContentBlock::Text(text.clone()));
                             }
                         }
                     }
@@ -281,41 +297,41 @@ fn build_messages(messages: &[LlmMessage]) -> Result<(Vec<SystemContentBlock>, V
                     i += 1;
                 }
                 if !tool_blocks.is_empty() {
-                    match Message::builder()
+                    let m = Message::builder()
                         .role(ConversationRole::User)
                         .set_content(Some(tool_blocks))
                         .build()
-                    {
-                        Ok(m) => bedrock_messages.push(m),
-                        Err(e) => warn!("Failed to build tool result message: {e}"),
-                    }
+                        .map_err(|e| {
+                            AgentLoopError::llm(format!("Failed to build Bedrock message: {e}"))
+                        })?;
+                    bedrock_messages.push(m);
                 }
             }
             LlmMessageRole::User => {
                 let blocks = build_user_content(msg)?;
                 if !blocks.is_empty() {
-                    match Message::builder()
+                    let m = Message::builder()
                         .role(ConversationRole::User)
                         .set_content(Some(blocks))
                         .build()
-                    {
-                        Ok(m) => bedrock_messages.push(m),
-                        Err(e) => warn!("Failed to build user message: {e}"),
-                    }
+                        .map_err(|e| {
+                            AgentLoopError::llm(format!("Failed to build Bedrock message: {e}"))
+                        })?;
+                    bedrock_messages.push(m);
                 }
                 i += 1;
             }
             LlmMessageRole::Assistant => {
                 let blocks = build_assistant_content(msg);
                 if !blocks.is_empty() {
-                    match Message::builder()
+                    let m = Message::builder()
                         .role(ConversationRole::Assistant)
                         .set_content(Some(blocks))
                         .build()
-                    {
-                        Ok(m) => bedrock_messages.push(m),
-                        Err(e) => warn!("Failed to build assistant message: {e}"),
-                    }
+                        .map_err(|e| {
+                            AgentLoopError::llm(format!("Failed to build Bedrock message: {e}"))
+                        })?;
+                    bedrock_messages.push(m);
                 }
                 i += 1;
             }
@@ -366,10 +382,10 @@ fn build_assistant_content(msg: &LlmMessage) -> Vec<ContentBlock> {
         }
         LlmMessageContent::Parts(parts) => {
             for part in parts {
-                if let LlmContentPart::Text { text } = part {
-                    if !text.is_empty() {
-                        blocks.push(ContentBlock::Text(text.clone()));
-                    }
+                if let LlmContentPart::Text { text } = part
+                    && !text.is_empty()
+                {
+                    blocks.push(ContentBlock::Text(text.clone()));
                 }
             }
         }
@@ -396,6 +412,10 @@ fn build_assistant_content(msg: &LlmMessage) -> Vec<ContentBlock> {
 
 fn build_tool_result_block(msg: &LlmMessage) -> Option<ContentBlock> {
     let tool_call_id = msg.tool_call_id.as_deref().unwrap_or("");
+    if tool_call_id.is_empty() {
+        warn!("Tool message is missing tool_call_id; skipping tool result block");
+        return None;
+    }
     let text = msg.content.to_text();
 
     let result_content = ToolResultContentBlock::Text(text);
@@ -417,25 +437,25 @@ fn build_tool_result_block(msg: &LlmMessage) -> Option<ContentBlock> {
 fn merge_consecutive_same_role(messages: Vec<Message>) -> Vec<Message> {
     let mut result: Vec<Message> = Vec::new();
     for msg in messages {
-        if let Some(last) = result.last() {
-            if last.role == msg.role {
-                let last_idx = result.len() - 1;
-                let prev = result.swap_remove(last_idx);
-                let mut combined_content = prev.content.clone();
-                combined_content.extend(msg.content.clone());
-                match Message::builder()
-                    .role(prev.role.clone())
-                    .set_content(Some(combined_content))
-                    .build()
-                {
-                    Ok(merged) => {
-                        result.push(merged);
-                        continue;
-                    }
-                    Err(_) => {
-                        // Fall through: re-insert both
-                        result.push(prev);
-                    }
+        if let Some(last) = result.last()
+            && last.role == msg.role
+        {
+            let last_idx = result.len() - 1;
+            let prev = result.swap_remove(last_idx);
+            let mut combined_content = prev.content.clone();
+            combined_content.extend(msg.content.clone());
+            match Message::builder()
+                .role(prev.role.clone())
+                .set_content(Some(combined_content))
+                .build()
+            {
+                Ok(merged) => {
+                    result.push(merged);
+                    continue;
+                }
+                Err(_) => {
+                    // Fall through: re-insert both
+                    result.push(prev);
                 }
             }
         }
@@ -480,7 +500,7 @@ fn parse_image_url(url: &str) -> Option<ContentBlock> {
     let (mime_b64, data) = rest.split_once(',')?;
     let mime = mime_b64.split(';').next()?;
 
-    let bytes = base64_decode(data)?;
+    let bytes = BASE64_STANDARD.decode(data).ok()?;
     let format = match mime {
         "image/jpeg" | "image/jpg" => ImageFormat::Jpeg,
         "image/png" => ImageFormat::Png,
@@ -500,37 +520,6 @@ fn parse_image_url(url: &str) -> Option<ContentBlock> {
         .ok()?;
 
     Some(ContentBlock::Image(image_block))
-}
-
-fn base64_decode(s: &str) -> Option<Vec<u8>> {
-    const CHARS: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-    let mut table = [255u8; 256];
-    for (i, &c) in CHARS.iter().enumerate() {
-        table[c as usize] = i as u8;
-    }
-
-    let input: Vec<u8> = s
-        .bytes()
-        .filter(|&b| b != b'\n' && b != b'\r' && b != b' ' && b != b'=')
-        .collect();
-
-    let mut out = Vec::with_capacity(input.len() * 3 / 4);
-    let mut buf = 0u32;
-    let mut bits = 0u8;
-
-    for &c in &input {
-        let val = table[c as usize];
-        if val == 255 {
-            return None; // Invalid character
-        }
-        buf = (buf << 6) | val as u32;
-        bits += 6;
-        if bits >= 8 {
-            bits -= 8;
-            out.push((buf >> bits) as u8);
-        }
-    }
-    Some(out)
 }
 
 // ============================================================================
@@ -617,14 +606,85 @@ mod tests {
     }
 
     #[test]
-    fn test_base64_decode_valid() {
-        let encoded = "SGVsbG8gV29ybGQ=";
-        let decoded = base64_decode(encoded).unwrap();
-        assert_eq!(decoded, b"Hello World");
+    fn test_merge_consecutive_same_role_combines_same_role() {
+        let make_msg = |role: ConversationRole, text: &str| {
+            Message::builder()
+                .role(role)
+                .content(ContentBlock::Text(text.to_string()))
+                .build()
+                .unwrap()
+        };
+        let messages = vec![
+            make_msg(ConversationRole::User, "hello"),
+            make_msg(ConversationRole::User, "world"),
+            make_msg(ConversationRole::Assistant, "ok"),
+        ];
+        let merged = merge_consecutive_same_role(messages);
+        assert_eq!(merged.len(), 2);
+        assert_eq!(merged[0].role, ConversationRole::User);
+        assert_eq!(merged[0].content.len(), 2);
+        assert_eq!(merged[1].role, ConversationRole::Assistant);
     }
 
     #[test]
-    fn test_base64_decode_invalid_returns_none() {
-        assert!(base64_decode("!@#$").is_none());
+    fn test_merge_consecutive_same_role_preserves_alternating() {
+        let make_msg = |role: ConversationRole, text: &str| {
+            Message::builder()
+                .role(role)
+                .content(ContentBlock::Text(text.to_string()))
+                .build()
+                .unwrap()
+        };
+        let messages = vec![
+            make_msg(ConversationRole::User, "q"),
+            make_msg(ConversationRole::Assistant, "a"),
+            make_msg(ConversationRole::User, "q2"),
+        ];
+        let merged = merge_consecutive_same_role(messages);
+        assert_eq!(merged.len(), 3);
+    }
+
+    #[test]
+    fn test_build_messages_system_extracted() {
+        use everruns_core::llm_driver_registry::{LlmMessage, LlmMessageContent, LlmMessageRole};
+        let messages = vec![
+            LlmMessage {
+                role: LlmMessageRole::System,
+                content: LlmMessageContent::Text("be helpful".to_string()),
+                tool_calls: None,
+                tool_call_id: None,
+                phase: None,
+                thinking: None,
+                thinking_signature: None,
+            },
+            LlmMessage {
+                role: LlmMessageRole::User,
+                content: LlmMessageContent::Text("hi".to_string()),
+                tool_calls: None,
+                tool_call_id: None,
+                phase: None,
+                thinking: None,
+                thinking_signature: None,
+            },
+        ];
+        let (system_blocks, bedrock_msgs) = build_messages(&messages).unwrap();
+        assert_eq!(system_blocks.len(), 1);
+        assert_eq!(bedrock_msgs.len(), 1);
+        assert_eq!(bedrock_msgs[0].role, ConversationRole::User);
+    }
+
+    #[test]
+    fn test_build_tool_result_block_missing_id_returns_none() {
+        use everruns_core::llm_driver_registry::{LlmMessage, LlmMessageContent, LlmMessageRole};
+        let msg = LlmMessage {
+            role: LlmMessageRole::Tool,
+            content: LlmMessageContent::Text("result".to_string()),
+            tool_calls: None,
+            tool_call_id: None,
+            phase: None,
+            thinking: None,
+            thinking_signature: None,
+        };
+        assert!(build_tool_result_block(&msg).is_none());
     }
 }

--- a/crates/bedrock/src/driver.rs
+++ b/crates/bedrock/src/driver.rs
@@ -9,7 +9,9 @@
 
 use async_trait::async_trait;
 use aws_sdk_bedrockruntime::Client;
-use aws_sdk_bedrockruntime::config::{BehaviorVersion, Builder as BedrockConfigBuilder, Credentials, Region};
+use aws_sdk_bedrockruntime::config::{
+    BehaviorVersion, Builder as BedrockConfigBuilder, Credentials, Region,
+};
 use aws_sdk_bedrockruntime::types::{
     ContentBlock, ContentBlockDelta, ContentBlockStart, ConversationRole, ConverseStreamOutput,
     ImageBlock, ImageFormat, ImageSource, InferenceConfiguration, Message, SystemContentBlock,
@@ -65,12 +67,13 @@ impl BedrockLlmDriver {
 
 /// Register the Bedrock driver with the given registry.
 pub fn register_driver(registry: &mut DriverRegistry) {
-    registry.register(ProviderType::Bedrock, |api_key, _base_url| {
-        match BedrockLlmDriver::new(api_key) {
+    registry.register(
+        ProviderType::Bedrock,
+        |api_key, _base_url| match BedrockLlmDriver::new(api_key) {
             Ok(driver) => Box::new(driver) as BoxedLlmDriver,
             Err(e) => Box::new(FailDriver(e.to_string())) as BoxedLlmDriver,
-        }
-    });
+        },
+    );
 }
 
 /// Driver that immediately fails with a credential error.
@@ -149,8 +152,7 @@ impl LlmDriver for BedrockLlmDriver {
                             let idx = e.content_block_index() as usize;
                             match e.delta() {
                                 Some(ContentBlockDelta::Text(t)) => {
-                                    let _ =
-                                        tx.send(Ok(LlmStreamEvent::TextDelta(t.clone())));
+                                    let _ = tx.send(Ok(LlmStreamEvent::TextDelta(t.clone())));
                                 }
                                 Some(ContentBlockDelta::ToolUse(t)) => {
                                     if let Some(tc) = pending.get_mut(&idx) {
@@ -242,9 +244,7 @@ struct PartialToolCall {
     input_json: String,
 }
 
-fn build_messages(
-    messages: &[LlmMessage],
-) -> Result<(Vec<SystemContentBlock>, Vec<Message>)> {
+fn build_messages(messages: &[LlmMessage]) -> Result<(Vec<SystemContentBlock>, Vec<Message>)> {
     let mut system_blocks: Vec<SystemContentBlock> = Vec::new();
     let mut bedrock_messages: Vec<Message> = Vec::new();
 
@@ -556,9 +556,11 @@ fn json_to_document(value: Value) -> Document {
         }
         Value::String(s) => Document::String(s),
         Value::Array(arr) => Document::Array(arr.into_iter().map(json_to_document).collect()),
-        Value::Object(obj) => {
-            Document::Object(obj.into_iter().map(|(k, v)| (k, json_to_document(v))).collect())
-        }
+        Value::Object(obj) => Document::Object(
+            obj.into_iter()
+                .map(|(k, v)| (k, json_to_document(v)))
+                .collect(),
+        ),
     }
 }
 
@@ -596,7 +598,10 @@ mod tests {
     #[test]
     fn test_json_to_document_types() {
         assert!(matches!(json_to_document(Value::Null), Document::Null));
-        assert!(matches!(json_to_document(Value::Bool(true)), Document::Bool(true)));
+        assert!(matches!(
+            json_to_document(Value::Bool(true)),
+            Document::Bool(true)
+        ));
         assert!(matches!(
             json_to_document(serde_json::json!(42)),
             Document::Number(aws_smithy_types::Number::PosInt(42))

--- a/crates/bedrock/src/driver.rs
+++ b/crates/bedrock/src/driver.rs
@@ -1,0 +1,625 @@
+// AWS Bedrock Runtime LLM Driver
+//
+// Implements LlmDriver using the AWS Bedrock Runtime ConverseStream API.
+// Uses the aws-sdk-bedrockruntime crate for typed event stream handling,
+// which handles SigV4 signing and binary event stream framing internally.
+//
+// Credential shape: api_key is a JSON object (see credential.rs).
+// base_url is unused.
+
+use async_trait::async_trait;
+use aws_sdk_bedrockruntime::Client;
+use aws_sdk_bedrockruntime::config::{BehaviorVersion, Builder as BedrockConfigBuilder, Credentials, Region};
+use aws_sdk_bedrockruntime::types::{
+    ContentBlock, ContentBlockDelta, ContentBlockStart, ConversationRole, ConverseStreamOutput,
+    ImageBlock, ImageFormat, ImageSource, InferenceConfiguration, Message, SystemContentBlock,
+    Tool, ToolConfiguration, ToolInputSchema, ToolResultBlock, ToolResultContentBlock,
+    ToolSpecification, ToolUseBlock,
+};
+use aws_smithy_types::Document;
+use everruns_core::error::{AgentLoopError, Result};
+use everruns_core::llm_driver_registry::{
+    BoxedLlmDriver, DiscoveredModel, DriverRegistry, LlmCallConfig, LlmCompletionMetadata,
+    LlmContentPart, LlmDriver, LlmMessage, LlmMessageContent, LlmMessageRole, LlmResponseStream,
+    LlmStreamEvent, ProviderType,
+};
+use everruns_core::tool_types::{ToolCall, ToolDefinition};
+use serde_json::Value;
+use std::collections::HashMap;
+use tokio_stream::wrappers::UnboundedReceiverStream;
+use tracing::warn;
+
+use crate::credential::BedrockCredential;
+
+/// AWS Bedrock Runtime LLM Driver.
+///
+/// Implements `LlmDriver` using the `ConverseStream` API.
+/// Credentials are parsed from the JSON-encoded `api_key` field.
+#[derive(Clone, Debug)]
+pub struct BedrockLlmDriver {
+    credential: BedrockCredential,
+}
+
+impl BedrockLlmDriver {
+    pub fn new(api_key: &str) -> Result<Self> {
+        let credential = BedrockCredential::from_api_key(api_key)?;
+        Ok(Self { credential })
+    }
+
+    fn create_client(&self) -> Client {
+        let creds = Credentials::new(
+            self.credential.access_key_id.clone(),
+            self.credential.secret_access_key.clone(),
+            self.credential.session_token.clone(),
+            None,
+            "everruns-bedrock",
+        );
+        let config = BedrockConfigBuilder::new()
+            .behavior_version(BehaviorVersion::latest())
+            .credentials_provider(creds)
+            .region(Region::new(self.credential.region.clone()))
+            .build();
+        Client::from_conf(config)
+    }
+}
+
+/// Register the Bedrock driver with the given registry.
+pub fn register_driver(registry: &mut DriverRegistry) {
+    registry.register(ProviderType::Bedrock, |api_key, _base_url| {
+        match BedrockLlmDriver::new(api_key) {
+            Ok(driver) => Box::new(driver) as BoxedLlmDriver,
+            Err(e) => Box::new(FailDriver(e.to_string())) as BoxedLlmDriver,
+        }
+    });
+}
+
+/// Driver that immediately fails with a credential error.
+struct FailDriver(String);
+
+#[async_trait]
+impl LlmDriver for FailDriver {
+    async fn chat_completion_stream(
+        &self,
+        _messages: Vec<LlmMessage>,
+        _config: &LlmCallConfig,
+    ) -> Result<LlmResponseStream> {
+        Err(AgentLoopError::llm(self.0.clone()))
+    }
+}
+
+#[async_trait]
+impl LlmDriver for BedrockLlmDriver {
+    async fn chat_completion_stream(
+        &self,
+        messages: Vec<LlmMessage>,
+        config: &LlmCallConfig,
+    ) -> Result<LlmResponseStream> {
+        let client = self.create_client();
+        let model_id = config.model.clone();
+
+        let (system_blocks, bedrock_messages) = build_messages(&messages)?;
+
+        let tool_cfg = if !config.tools.is_empty() {
+            Some(build_tool_config(&config.tools)?)
+        } else {
+            None
+        };
+
+        let inference_cfg = InferenceConfiguration::builder()
+            .set_temperature(config.temperature.map(|t| t as f32))
+            .set_max_tokens(config.max_tokens.map(|t| t as i32))
+            .build();
+
+        let mut req = client.converse_stream().model_id(&model_id);
+
+        for msg in bedrock_messages {
+            req = req.messages(msg);
+        }
+
+        if !system_blocks.is_empty() {
+            req = req.set_system(Some(system_blocks));
+        }
+
+        if let Some(tc) = tool_cfg {
+            req = req.tool_config(tc);
+        }
+
+        req = req.inference_config(inference_cfg);
+
+        let response = req.send().await.map_err(|e| {
+            let msg = format!("{e}");
+            if is_too_large(&msg) {
+                AgentLoopError::request_too_large(msg)
+            } else {
+                AgentLoopError::llm(format!("Bedrock ConverseStream failed: {e}"))
+            }
+        })?;
+
+        let mut event_stream = response.stream;
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<Result<LlmStreamEvent>>();
+
+        tokio::spawn(async move {
+            let mut pending: HashMap<usize, PartialToolCall> = HashMap::new();
+            let mut meta = LlmCompletionMetadata::default();
+
+            loop {
+                match event_stream.recv().await {
+                    Ok(Some(event)) => match event {
+                        ConverseStreamOutput::ContentBlockDelta(e) => {
+                            let idx = e.content_block_index() as usize;
+                            match e.delta() {
+                                Some(ContentBlockDelta::Text(t)) => {
+                                    let _ =
+                                        tx.send(Ok(LlmStreamEvent::TextDelta(t.clone())));
+                                }
+                                Some(ContentBlockDelta::ToolUse(t)) => {
+                                    if let Some(tc) = pending.get_mut(&idx) {
+                                        tc.input_json.push_str(t.input());
+                                    }
+                                }
+                                _ => {}
+                            }
+                        }
+                        ConverseStreamOutput::ContentBlockStart(e) => {
+                            let idx = e.content_block_index() as usize;
+                            if let Some(ContentBlockStart::ToolUse(tu)) = e.start() {
+                                pending.insert(
+                                    idx,
+                                    PartialToolCall {
+                                        id: tu.tool_use_id().to_string(),
+                                        name: tu.name().to_string(),
+                                        input_json: String::new(),
+                                    },
+                                );
+                            }
+                        }
+                        ConverseStreamOutput::MessageStop(e) => {
+                            meta.finish_reason = Some(e.stop_reason().as_str().to_string());
+                            // Emit accumulated tool calls now; Done is emitted on stream end.
+                            if !pending.is_empty() {
+                                let mut ordered: Vec<(usize, PartialToolCall)> =
+                                    pending.drain().collect();
+                                ordered.sort_by_key(|(idx, _)| *idx);
+                                let calls: Vec<ToolCall> = ordered
+                                    .into_iter()
+                                    .map(|(_, ptc)| ToolCall {
+                                        id: ptc.id,
+                                        name: ptc.name,
+                                        arguments: serde_json::from_str(&ptc.input_json)
+                                            .unwrap_or(Value::Object(serde_json::Map::new())),
+                                    })
+                                    .collect();
+                                let _ = tx.send(Ok(LlmStreamEvent::ToolCalls(calls)));
+                            }
+                        }
+                        ConverseStreamOutput::Metadata(e) => {
+                            // Metadata arrives after MessageStop and carries token usage.
+                            if let Some(usage) = e.usage() {
+                                let prompt = usage.input_tokens() as u32;
+                                let completion = usage.output_tokens() as u32;
+                                meta.prompt_tokens = Some(prompt);
+                                meta.completion_tokens = Some(completion);
+                                meta.total_tokens = Some(prompt + completion);
+                            }
+                        }
+                        _ => {} // MessageStart, ContentBlockStop, Unknown — no action needed
+                    },
+                    Ok(None) => {
+                        // Stream ended — emit Done with accumulated metadata.
+                        let _ = tx.send(Ok(LlmStreamEvent::Done(Box::new(meta))));
+                        return;
+                    }
+                    Err(e) => {
+                        let msg = format!("{e}");
+                        let err = if is_too_large(&msg) {
+                            AgentLoopError::request_too_large(msg)
+                        } else {
+                            AgentLoopError::llm(format!("Bedrock stream error: {e}"))
+                        };
+                        let _ = tx.send(Err(err));
+                        return;
+                    }
+                }
+            }
+        });
+
+        Ok(Box::pin(UnboundedReceiverStream::new(rx)))
+    }
+
+    async fn list_models(&self) -> Result<Option<Vec<DiscoveredModel>>> {
+        // Converse-compatible model set is seeded statically; skip discovery.
+        Ok(None)
+    }
+}
+
+// ============================================================================
+// Message conversion
+// ============================================================================
+
+struct PartialToolCall {
+    id: String,
+    name: String,
+    input_json: String,
+}
+
+fn build_messages(
+    messages: &[LlmMessage],
+) -> Result<(Vec<SystemContentBlock>, Vec<Message>)> {
+    let mut system_blocks: Vec<SystemContentBlock> = Vec::new();
+    let mut bedrock_messages: Vec<Message> = Vec::new();
+
+    let mut i = 0;
+    while i < messages.len() {
+        let msg = &messages[i];
+        match msg.role {
+            LlmMessageRole::System => {
+                match &msg.content {
+                    LlmMessageContent::Text(text) if !text.is_empty() => {
+                        system_blocks.push(SystemContentBlock::Text(text.clone()));
+                    }
+                    LlmMessageContent::Parts(parts) => {
+                        for part in parts {
+                            if let LlmContentPart::Text { text } = part {
+                                if !text.is_empty() {
+                                    system_blocks.push(SystemContentBlock::Text(text.clone()));
+                                }
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+                i += 1;
+            }
+            LlmMessageRole::Tool => {
+                // Collect consecutive Tool messages into one User message.
+                let mut tool_blocks: Vec<ContentBlock> = Vec::new();
+                while i < messages.len() && messages[i].role == LlmMessageRole::Tool {
+                    let tm = &messages[i];
+                    if let Some(block) = build_tool_result_block(tm) {
+                        tool_blocks.push(block);
+                    }
+                    i += 1;
+                }
+                if !tool_blocks.is_empty() {
+                    match Message::builder()
+                        .role(ConversationRole::User)
+                        .set_content(Some(tool_blocks))
+                        .build()
+                    {
+                        Ok(m) => bedrock_messages.push(m),
+                        Err(e) => warn!("Failed to build tool result message: {e}"),
+                    }
+                }
+            }
+            LlmMessageRole::User => {
+                let blocks = build_user_content(msg)?;
+                if !blocks.is_empty() {
+                    match Message::builder()
+                        .role(ConversationRole::User)
+                        .set_content(Some(blocks))
+                        .build()
+                    {
+                        Ok(m) => bedrock_messages.push(m),
+                        Err(e) => warn!("Failed to build user message: {e}"),
+                    }
+                }
+                i += 1;
+            }
+            LlmMessageRole::Assistant => {
+                let blocks = build_assistant_content(msg);
+                if !blocks.is_empty() {
+                    match Message::builder()
+                        .role(ConversationRole::Assistant)
+                        .set_content(Some(blocks))
+                        .build()
+                    {
+                        Ok(m) => bedrock_messages.push(m),
+                        Err(e) => warn!("Failed to build assistant message: {e}"),
+                    }
+                }
+                i += 1;
+            }
+        }
+    }
+
+    let bedrock_messages = merge_consecutive_same_role(bedrock_messages);
+    Ok((system_blocks, bedrock_messages))
+}
+
+fn build_user_content(msg: &LlmMessage) -> Result<Vec<ContentBlock>> {
+    let mut blocks = Vec::new();
+    match &msg.content {
+        LlmMessageContent::Text(text) => {
+            if !text.is_empty() {
+                blocks.push(ContentBlock::Text(text.clone()));
+            }
+        }
+        LlmMessageContent::Parts(parts) => {
+            for part in parts {
+                match part {
+                    LlmContentPart::Text { text } => {
+                        if !text.is_empty() {
+                            blocks.push(ContentBlock::Text(text.clone()));
+                        }
+                    }
+                    LlmContentPart::Image { url } => {
+                        if let Some(block) = parse_image_url(url) {
+                            blocks.push(block);
+                        }
+                    }
+                    LlmContentPart::Audio { .. } => {
+                        warn!("Audio content is not supported by Bedrock ConverseStream; skipping");
+                    }
+                }
+            }
+        }
+    }
+    Ok(blocks)
+}
+
+fn build_assistant_content(msg: &LlmMessage) -> Vec<ContentBlock> {
+    let mut blocks = Vec::new();
+
+    match &msg.content {
+        LlmMessageContent::Text(text) if !text.is_empty() => {
+            blocks.push(ContentBlock::Text(text.clone()));
+        }
+        LlmMessageContent::Parts(parts) => {
+            for part in parts {
+                if let LlmContentPart::Text { text } = part {
+                    if !text.is_empty() {
+                        blocks.push(ContentBlock::Text(text.clone()));
+                    }
+                }
+            }
+        }
+        _ => {}
+    }
+
+    if let Some(calls) = &msg.tool_calls {
+        for call in calls {
+            let input_doc = json_to_document(call.arguments.clone());
+            match ToolUseBlock::builder()
+                .tool_use_id(&call.id)
+                .name(&call.name)
+                .input(input_doc)
+                .build()
+            {
+                Ok(tu) => blocks.push(ContentBlock::ToolUse(tu)),
+                Err(e) => warn!("Failed to build tool use block: {e}"),
+            }
+        }
+    }
+
+    blocks
+}
+
+fn build_tool_result_block(msg: &LlmMessage) -> Option<ContentBlock> {
+    let tool_call_id = msg.tool_call_id.as_deref().unwrap_or("");
+    let text = msg.content.to_text();
+
+    let result_content = ToolResultContentBlock::Text(text);
+    match ToolResultBlock::builder()
+        .tool_use_id(tool_call_id)
+        .content(result_content)
+        .build()
+    {
+        Ok(tr) => Some(ContentBlock::ToolResult(tr)),
+        Err(e) => {
+            warn!("Failed to build tool result block: {e}");
+            None
+        }
+    }
+}
+
+/// Merge consecutive messages with the same role.
+/// Bedrock requires strictly alternating User/Assistant messages.
+fn merge_consecutive_same_role(messages: Vec<Message>) -> Vec<Message> {
+    let mut result: Vec<Message> = Vec::new();
+    for msg in messages {
+        if let Some(last) = result.last() {
+            if last.role == msg.role {
+                let last_idx = result.len() - 1;
+                let prev = result.swap_remove(last_idx);
+                let mut combined_content = prev.content.clone();
+                combined_content.extend(msg.content.clone());
+                match Message::builder()
+                    .role(prev.role.clone())
+                    .set_content(Some(combined_content))
+                    .build()
+                {
+                    Ok(merged) => {
+                        result.push(merged);
+                        continue;
+                    }
+                    Err(_) => {
+                        // Fall through: re-insert both
+                        result.push(prev);
+                    }
+                }
+            }
+        }
+        result.push(msg);
+    }
+    result
+}
+
+// ============================================================================
+// Tool configuration
+// ============================================================================
+
+fn build_tool_config(tools: &[ToolDefinition]) -> Result<ToolConfiguration> {
+    let mut tool_list = Vec::new();
+    for tool in tools {
+        let schema_doc = json_to_document(tool.parameters().clone());
+        let spec = ToolSpecification::builder()
+            .name(tool.name())
+            .description(tool.description())
+            .input_schema(ToolInputSchema::Json(schema_doc))
+            .build()
+            .map_err(|e| AgentLoopError::llm(format!("Failed to build tool spec: {e}")))?;
+        tool_list.push(Tool::ToolSpec(spec));
+    }
+    ToolConfiguration::builder()
+        .set_tools(Some(tool_list))
+        .build()
+        .map_err(|e| AgentLoopError::llm(format!("Failed to build tool config: {e}")))
+}
+
+// ============================================================================
+// Image parsing
+// ============================================================================
+
+fn parse_image_url(url: &str) -> Option<ContentBlock> {
+    if !url.starts_with("data:") {
+        warn!("HTTP image URLs are not supported by Bedrock ConverseStream (use base64 data URLs)");
+        return None;
+    }
+
+    let rest = url.strip_prefix("data:")?;
+    let (mime_b64, data) = rest.split_once(',')?;
+    let mime = mime_b64.split(';').next()?;
+
+    let bytes = base64_decode(data)?;
+    let format = match mime {
+        "image/jpeg" | "image/jpg" => ImageFormat::Jpeg,
+        "image/png" => ImageFormat::Png,
+        "image/gif" => ImageFormat::Gif,
+        "image/webp" => ImageFormat::Webp,
+        other => {
+            warn!("Unsupported image MIME type for Bedrock: {other}; skipping");
+            return None;
+        }
+    };
+
+    let source = ImageSource::Bytes(aws_sdk_bedrockruntime::primitives::Blob::new(bytes));
+    let image_block = ImageBlock::builder()
+        .format(format)
+        .source(source)
+        .build()
+        .ok()?;
+
+    Some(ContentBlock::Image(image_block))
+}
+
+fn base64_decode(s: &str) -> Option<Vec<u8>> {
+    const CHARS: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut table = [255u8; 256];
+    for (i, &c) in CHARS.iter().enumerate() {
+        table[c as usize] = i as u8;
+    }
+
+    let input: Vec<u8> = s
+        .bytes()
+        .filter(|&b| b != b'\n' && b != b'\r' && b != b' ' && b != b'=')
+        .collect();
+
+    let mut out = Vec::with_capacity(input.len() * 3 / 4);
+    let mut buf = 0u32;
+    let mut bits = 0u8;
+
+    for &c in &input {
+        let val = table[c as usize];
+        if val == 255 {
+            return None; // Invalid character
+        }
+        buf = (buf << 6) | val as u32;
+        bits += 6;
+        if bits >= 8 {
+            bits -= 8;
+            out.push((buf >> bits) as u8);
+        }
+    }
+    Some(out)
+}
+
+// ============================================================================
+// JSON → aws_smithy_types::Document conversion
+// ============================================================================
+
+fn json_to_document(value: Value) -> Document {
+    match value {
+        Value::Null => Document::Null,
+        Value::Bool(b) => Document::Bool(b),
+        Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                if i >= 0 {
+                    Document::Number(aws_smithy_types::Number::PosInt(i as u64))
+                } else {
+                    Document::Number(aws_smithy_types::Number::NegInt(i))
+                }
+            } else if let Some(f) = n.as_f64() {
+                Document::Number(aws_smithy_types::Number::Float(f))
+            } else {
+                Document::Null
+            }
+        }
+        Value::String(s) => Document::String(s),
+        Value::Array(arr) => Document::Array(arr.into_iter().map(json_to_document).collect()),
+        Value::Object(obj) => {
+            Document::Object(obj.into_iter().map(|(k, v)| (k, json_to_document(v))).collect())
+        }
+    }
+}
+
+// ============================================================================
+// Error classification
+// ============================================================================
+
+fn is_too_large(msg: &str) -> bool {
+    let lower = msg.to_lowercase();
+    lower.contains("too long")
+        || lower.contains("too large")
+        || lower.contains("context length")
+        || lower.contains("maximum tokens")
+        || lower.contains("input is too long")
+        || lower.contains("prompt is too long")
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_too_large_detects_bedrock_messages() {
+        assert!(is_too_large("ValidationException: Input is too long"));
+        assert!(is_too_large("maximum tokens exceeded"));
+        assert!(is_too_large("prompt is too long for this model"));
+        assert!(!is_too_large("authentication failed"));
+        assert!(!is_too_large("model not found"));
+    }
+
+    #[test]
+    fn test_json_to_document_types() {
+        assert!(matches!(json_to_document(Value::Null), Document::Null));
+        assert!(matches!(json_to_document(Value::Bool(true)), Document::Bool(true)));
+        assert!(matches!(
+            json_to_document(serde_json::json!(42)),
+            Document::Number(aws_smithy_types::Number::PosInt(42))
+        ));
+        assert!(matches!(
+            json_to_document(serde_json::json!(-1)),
+            Document::Number(aws_smithy_types::Number::NegInt(-1))
+        ));
+        assert!(matches!(
+            json_to_document(Value::String("hello".to_string())),
+            Document::String(s) if s == "hello"
+        ));
+    }
+
+    #[test]
+    fn test_base64_decode_valid() {
+        let encoded = "SGVsbG8gV29ybGQ=";
+        let decoded = base64_decode(encoded).unwrap();
+        assert_eq!(decoded, b"Hello World");
+    }
+
+    #[test]
+    fn test_base64_decode_invalid_returns_none() {
+        assert!(base64_decode("!@#$").is_none());
+    }
+}

--- a/crates/bedrock/src/lib.rs
+++ b/crates/bedrock/src/lib.rs
@@ -1,0 +1,27 @@
+//! AWS Bedrock Runtime provider driver for Everruns.
+//!
+//! `everruns-bedrock` implements the [`LlmDriver`] contract from `everruns-core`
+//! using the AWS Bedrock Runtime `ConverseStream` API.
+//!
+//! Credentials are encoded as JSON in the `api_key` field:
+//! ```json
+//! {"access_key_id":"...","secret_access_key":"...","session_token":"...","region":"us-east-1"}
+//! ```
+//! `session_token` is optional. The `base_url` field is unused.
+//!
+//! # Example
+//!
+//! ```
+//! use everruns_bedrock::{BedrockLlmDriver, register_driver};
+//! use everruns_core::DriverRegistry;
+//!
+//! let mut registry = DriverRegistry::new();
+//! register_driver(&mut registry);
+//! ```
+
+mod credential;
+mod driver;
+
+pub use driver::{BedrockLlmDriver, register_driver};
+
+pub use everruns_core::llm_driver_registry::{DriverRegistry, LlmDriver};

--- a/crates/core/src/atoms/reason.rs
+++ b/crates/core/src/atoms/reason.rs
@@ -2116,6 +2116,7 @@ impl ReasonAtom {
             crate::llm_models::LlmProviderType::Anthropic => ProviderType::Anthropic,
             crate::llm_models::LlmProviderType::Gemini => ProviderType::Gemini,
             crate::llm_models::LlmProviderType::LlmSim => ProviderType::LlmSim,
+            crate::llm_models::LlmProviderType::Bedrock => ProviderType::Bedrock,
         };
 
         let mut config = ProviderConfig::new(provider_type);

--- a/crates/core/src/llm_driver_registry.rs
+++ b/crates/core/src/llm_driver_registry.rs
@@ -857,6 +857,8 @@ pub enum ProviderType {
     Gemini,
     /// LLM simulator for testing (uses llmsim crate)
     LlmSim,
+    /// AWS Bedrock Runtime (ConverseStream API)
+    Bedrock,
 }
 
 impl std::str::FromStr for ProviderType {
@@ -870,6 +872,7 @@ impl std::str::FromStr for ProviderType {
             "anthropic" => Ok(ProviderType::Anthropic),
             "gemini" => Ok(ProviderType::Gemini),
             "llmsim" => Ok(ProviderType::LlmSim),
+            "bedrock" => Ok(ProviderType::Bedrock),
             _ => Err(format!("Unknown provider type: {}", s)),
         }
     }
@@ -884,6 +887,7 @@ impl std::fmt::Display for ProviderType {
             ProviderType::Anthropic => write!(f, "anthropic"),
             ProviderType::Gemini => write!(f, "gemini"),
             ProviderType::LlmSim => write!(f, "llmsim"),
+            ProviderType::Bedrock => write!(f, "bedrock"),
         }
     }
 }

--- a/crates/core/src/llm_models.rs
+++ b/crates/core/src/llm_models.rs
@@ -31,6 +31,8 @@ pub enum LlmProviderType {
     /// LLM simulator for testing
     #[serde(rename = "llmsim")]
     LlmSim,
+    /// AWS Bedrock Runtime (ConverseStream API)
+    Bedrock,
 }
 
 impl std::fmt::Display for LlmProviderType {
@@ -42,6 +44,7 @@ impl std::fmt::Display for LlmProviderType {
             LlmProviderType::Anthropic => write!(f, "anthropic"),
             LlmProviderType::Gemini => write!(f, "gemini"),
             LlmProviderType::LlmSim => write!(f, "llmsim"),
+            LlmProviderType::Bedrock => write!(f, "bedrock"),
         }
     }
 }
@@ -57,6 +60,7 @@ impl std::str::FromStr for LlmProviderType {
             "anthropic" => Ok(LlmProviderType::Anthropic),
             "gemini" => Ok(LlmProviderType::Gemini),
             "llmsim" => Ok(LlmProviderType::LlmSim),
+            "bedrock" => Ok(LlmProviderType::Bedrock),
             _ => Err(format!("Unknown provider type: {}", s)),
         }
     }

--- a/crates/llm-tests/Cargo.toml
+++ b/crates/llm-tests/Cargo.toml
@@ -21,6 +21,7 @@ everruns-core = { path = "../core" }
 everruns-openai = { path = "../openai" }
 everruns-anthropic = { path = "../anthropic" }
 everruns-gemini = { path = "../gemini" }
+everruns-bedrock = { path = "../bedrock" }
 
 anyhow.workspace = true
 async-trait.workspace = true

--- a/crates/llm-tests/tests/llm_test_matrix/mod.rs
+++ b/crates/llm-tests/tests/llm_test_matrix/mod.rs
@@ -108,6 +108,20 @@ pub const GEMINI_FLASH: ProviderModelConfig = ProviderModelConfig::new(
     "GEMINI_API_KEY",
 );
 
+// Bedrock: credentials are JSON in the env var, not a plain API key.
+// Set AWS_BEDROCK_CREDENTIALS to the JSON credential object.
+pub const BEDROCK_HAIKU: ProviderModelConfig = ProviderModelConfig::new(
+    LlmProviderType::Bedrock,
+    "anthropic.claude-3-5-haiku-20241022-v1:0",
+    "AWS_BEDROCK_CREDENTIALS",
+);
+
+pub const BEDROCK_SONNET: ProviderModelConfig = ProviderModelConfig::new(
+    LlmProviderType::Bedrock,
+    "anthropic.claude-3-5-sonnet-20241022-v2:0",
+    "AWS_BEDROCK_CREDENTIALS",
+);
+
 // ============================================================================
 // Unified driver registry
 // ============================================================================
@@ -118,5 +132,6 @@ pub fn all_providers_registry() -> DriverRegistry {
     everruns_anthropic::register_driver(&mut registry);
     everruns_openai::register_driver(&mut registry);
     everruns_gemini::register_driver(&mut registry);
+    everruns_bedrock::register_driver(&mut registry);
     registry
 }

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -1901,6 +1901,7 @@ fn string_to_provider_type(s: &str) -> LlmProviderType {
         "anthropic" => LlmProviderType::Anthropic,
         "gemini" => LlmProviderType::Gemini,
         "llmsim" => LlmProviderType::LlmSim,
+        "bedrock" => LlmProviderType::Bedrock,
         _ => {
             tracing::warn!(provider_type = %s, "Unknown provider_type in database; falling back to llmsim");
             LlmProviderType::LlmSim

--- a/crates/server/src/domains/session_commands/service.rs
+++ b/crates/server/src/domains/session_commands/service.rs
@@ -389,6 +389,7 @@ fn provider_type_from_llm(provider_type: LlmProviderType) -> Result<ProviderType
         LlmProviderType::Anthropic => ProviderType::Anthropic,
         LlmProviderType::Gemini => ProviderType::Gemini,
         LlmProviderType::LlmSim => ProviderType::LlmSim,
+        LlmProviderType::Bedrock => ProviderType::Bedrock,
     })
 }
 

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -41,6 +41,7 @@ mod seed_ids {
     pub const ANTHROPIC_PROVIDER: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000002);
     pub const LLMSIM_PROVIDER: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000003);
     pub const GEMINI_PROVIDER: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000004);
+    pub const BEDROCK_PROVIDER: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000005);
 
     // Agents (0x100-0x1FF)
     pub const DAD_JOKES_AGENT: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000101);
@@ -134,6 +135,12 @@ mod seed_ids {
     pub const GEMINI_25_PRO: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000601);
     pub const GEMINI_25_FLASH: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000602);
     pub const GEMINI_20_FLASH: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000603);
+
+    // Bedrock Models (0x700-0x7FF)
+    pub const BEDROCK_CLAUDE_HAIKU_35: Uuid =
+        Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000701);
+    pub const BEDROCK_CLAUDE_SONNET_35: Uuid =
+        Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000702);
 }
 
 // ============================================
@@ -1386,6 +1393,11 @@ const SEED_PROVIDERS: &[SeedProvider] = &[
         name: "LlmSim",
         provider_type: "llmsim",
     },
+    SeedProvider {
+        id: seed_ids::BEDROCK_PROVIDER,
+        name: "AWS Bedrock",
+        provider_type: "bedrock",
+    },
 ];
 
 fn enabled_seed_provider_ids(platform_definition: &PlatformDefinition) -> HashSet<Uuid> {
@@ -1999,6 +2011,23 @@ const SEED_MODELS: &[SeedModel] = &[
         provider_id: seed_ids::GEMINI_PROVIDER,
         model_id: "gemini-2.0-flash",
         display_name: "Gemini 2.0 Flash",
+        enabled: false,
+        is_favorite: false,
+    },
+    // AWS Bedrock (ConverseStream API)
+    SeedModel {
+        id: seed_ids::BEDROCK_CLAUDE_HAIKU_35,
+        provider_id: seed_ids::BEDROCK_PROVIDER,
+        model_id: "anthropic.claude-3-5-haiku-20241022-v1:0",
+        display_name: "Claude 3.5 Haiku (Bedrock)",
+        enabled: false,
+        is_favorite: false,
+    },
+    SeedModel {
+        id: seed_ids::BEDROCK_CLAUDE_SONNET_35,
+        provider_id: seed_ids::BEDROCK_PROVIDER,
+        model_id: "anthropic.claude-3-5-sonnet-20241022-v2:0",
+        display_name: "Claude 3.5 Sonnet v2 (Bedrock)",
         enabled: false,
         is_favorite: false,
     },

--- a/crates/server/src/services/llm_resolver.rs
+++ b/crates/server/src/services/llm_resolver.rs
@@ -47,15 +47,39 @@ fn get_default_api_key_with_lookup<F>(provider_type: &str, env_lookup: F) -> Opt
 where
     F: Fn(&str) -> Option<String>,
 {
-    let env_var = match provider_type.to_lowercase().as_str() {
-        "openai" => "DEFAULT_OPENAI_API_KEY",
-        "azure_openai" => "DEFAULT_AZURE_OPENAI_API_KEY",
-        "anthropic" => "DEFAULT_ANTHROPIC_API_KEY",
-        "gemini" => "DEFAULT_GEMINI_API_KEY",
-        _ => return None,
-    };
+    match provider_type.to_lowercase().as_str() {
+        "openai" => env_lookup("DEFAULT_OPENAI_API_KEY").filter(|s| !s.is_empty()),
+        "azure_openai" => env_lookup("DEFAULT_AZURE_OPENAI_API_KEY").filter(|s| !s.is_empty()),
+        "anthropic" => env_lookup("DEFAULT_ANTHROPIC_API_KEY").filter(|s| !s.is_empty()),
+        "gemini" => env_lookup("DEFAULT_GEMINI_API_KEY").filter(|s| !s.is_empty()),
+        "bedrock" => {
+            // Construct JSON credentials from Bedrock-specific or generic AWS env vars.
+            let access_key_id = env_lookup("AWS_BEDROCK_ACCESS_KEY_ID")
+                .or_else(|| env_lookup("AWS_ACCESS_KEY_ID"))
+                .filter(|s| !s.is_empty())?;
+            let secret_access_key = env_lookup("AWS_BEDROCK_SECRET_ACCESS_KEY")
+                .or_else(|| env_lookup("AWS_SECRET_ACCESS_KEY"))
+                .filter(|s| !s.is_empty())?;
+            let region = env_lookup("AWS_BEDROCK_REGION")
+                .or_else(|| env_lookup("AWS_REGION"))
+                .filter(|s| !s.is_empty())
+                .unwrap_or_else(|| "us-east-1".to_string());
+            let session_token = env_lookup("AWS_BEDROCK_SESSION_TOKEN")
+                .or_else(|| env_lookup("AWS_SESSION_TOKEN"))
+                .filter(|s| !s.is_empty());
 
-    env_lookup(env_var).filter(|s| !s.is_empty())
+            let mut cred = serde_json::json!({
+                "access_key_id": access_key_id,
+                "secret_access_key": secret_access_key,
+                "region": region,
+            });
+            if let Some(token) = session_token {
+                cred["session_token"] = serde_json::Value::String(token);
+            }
+            Some(cred.to_string())
+        }
+        _ => None,
+    }
 }
 
 /// Resolve API key for a provider (fail-closed).

--- a/crates/server/src/services/model_sync.rs
+++ b/crates/server/src/services/model_sync.rs
@@ -101,9 +101,9 @@ impl ModelSyncService {
             LlmProviderType::Anthropic => ProviderType::Anthropic,
             LlmProviderType::Gemini => ProviderType::Gemini,
             LlmProviderType::LlmSim => {
-                // LlmSim doesn't support model discovery
                 return Ok(SyncResult::NotSupported);
             }
+            LlmProviderType::Bedrock => ProviderType::Bedrock,
         };
 
         let config = ProviderConfig {

--- a/crates/server/src/storage/llm_provider_store.rs
+++ b/crates/server/src/storage/llm_provider_store.rs
@@ -141,6 +141,7 @@ fn parse_provider_type(provider_type_str: &str) -> Result<LlmProviderType> {
         "anthropic" => Ok(LlmProviderType::Anthropic),
         "gemini" => Ok(LlmProviderType::Gemini),
         "llmsim" => Ok(LlmProviderType::LlmSim),
+        "bedrock" => Ok(LlmProviderType::Bedrock),
         _ => Err(AgentLoopError::Configuration(format!(
             "Unsupported provider_type in database: {}",
             provider_type_str

--- a/crates/worker/Cargo.toml
+++ b/crates/worker/Cargo.toml
@@ -35,6 +35,7 @@ everruns-container-sandbox = { path = "../container-sandbox" }
 everruns-openai = { path = "../openai" }
 everruns-anthropic = { path = "../anthropic" }
 everruns-gemini = { path = "../gemini" }
+everruns-bedrock = { path = "../bedrock" }
 everruns-internal-protocol = { path = "../internal-protocol" }
 everruns-mcp.workspace = true
 everruns-runtime = { path = "../runtime" }

--- a/crates/worker/src/adapters.rs
+++ b/crates/worker/src/adapters.rs
@@ -20,6 +20,7 @@ pub fn create_driver_registry() -> DriverRegistry {
     everruns_openai::register_driver(&mut registry);
     everruns_anthropic::register_driver(&mut registry);
     everruns_gemini::register_driver(&mut registry);
+    everruns_bedrock::register_driver(&mut registry);
 
     // LlmSim. The `LLMSIM_DEMO` env var lets operators opt the in-process
     // LlmSim driver into a pre-baked scripted scenario without changing

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -21606,7 +21606,8 @@
           "openai_completions",
           "anthropic",
           "gemini",
-          "llmsim"
+          "llmsim",
+          "bedrock"
         ],
         "example": "anthropic"
       },

--- a/specs/llm-drivers.md
+++ b/specs/llm-drivers.md
@@ -49,7 +49,7 @@ graph TD
 
 2. **Streaming Response**: Drivers return a stream of `LlmStreamEvent` (TextDelta, ToolCalls, ThinkingDelta, ThinkingSignature, Done, Error).
 
-3. **Provider Types**: `OpenAI` (Responses API), `OpenAICompletions` (Chat Completions), `Anthropic`, `Gemini`, `LlmSim` (testing).
+3. **Provider Types**: `OpenAI` (Responses API), `OpenAICompletions` (Chat Completions), `Anthropic`, `Gemini`, `Bedrock` (AWS Bedrock ConverseStream), `LlmSim` (testing).
 
 ### Error Types (Contract)
 
@@ -263,6 +263,7 @@ sequenceDiagram
 | Chat Completions protocol | `crates/core/src/openai_protocol.rs` |
 | Anthropic driver | `crates/anthropic/src/driver.rs` |
 | Gemini driver | `crates/gemini/src/driver.rs` |
+| Bedrock driver | `crates/bedrock/src/driver.rs` |
 | Error handling | `crates/core/src/atoms/reason.rs` |
 
 ## OpenAI Driver Variants
@@ -389,6 +390,7 @@ The `LlmDriver` trait includes `supports_compact()` and `compact()` methods. See
 | OpenAI (Completions API) | No |
 | Anthropic | No |
 | Gemini | No |
+| Bedrock | No |
 | LlmSim | No |
 
 ## Key Resolution Contract (Fail-Closed)


### PR DESCRIPTION
## What

Adds AWS Bedrock Runtime as a supported LLM provider (`bedrock`), using the ConverseStream API via the `aws-sdk-bedrockruntime` crate.

Closes EVE-526.

## Why

Operators who deploy on AWS and prefer to route model traffic through Bedrock (for compliance, IAM controls, or private model access) currently have no supported path. This adds first-class Bedrock support with the same interface as OpenAI/Anthropic/Gemini drivers.

## How

- New `crates/bedrock` crate implementing `LlmDriver` via `ConverseStream`
- Credentials encoded as JSON in the provider's `api_key` field: `{"access_key_id":"...","secret_access_key":"...","region":"us-east-1"}`; optional `session_token` field
- `LlmProviderType::Bedrock` / `ProviderType::Bedrock` added to core types
- Dev startup materialises `AWS_BEDROCK_ACCESS_KEY_ID` / `AWS_ACCESS_KEY_ID` env vars into the seed Bedrock provider (fail-closed path unchanged)
- Two seed models: `anthropic.claude-3-5-haiku-20241022-v1:0` and `anthropic.claude-3-5-sonnet-20241022-v2:0`
- UI: provider icon (AWS layers SVG), `PROVIDER_TYPES` entry, and JSON credential placeholder in the API key field
- Integration test matrix extended with `BEDROCK_HAIKU` and `BEDROCK_SONNET` configs; credentials from `AWS_BEDROCK_CREDENTIALS` env var

Key implementation details:
- Bedrock requires strictly alternating User/Assistant messages; consecutive same-role messages are merged
- Consecutive Tool-role messages are collected into a single User message with multiple `toolResult` blocks
- Token usage arrives in `Metadata` event (after `MessageStop`); `Done` is emitted on stream end (`Ok(None)`) to capture both stop reason and usage

## Risk

- **Low** for existing providers — Bedrock is additive; no existing paths modified except adding enum variants and registering the driver
- Bedrock driver uses `aws-sdk-bedrockruntime` which pulls in ~30 new transitive deps (all AWS/hyper ecosystem)
- `list_models` returns `None` so no model sync is attempted; model set is seed-only for now

## Security

- Threat categories reviewed: TM-AUTH (credential handling), TM-API (outbound calls)
- Bedrock credentials are JSON-encoded and stored encrypted in DB (same path as all other provider keys); the fail-closed invariant is unchanged
- Bedrock driver uses AWS SigV4 signing via the official SDK — credentials never appear in HTTP headers in plaintext
- `from_env()` fallback only applies to the dev seed materialization path, not the tenant execution path

## Follow-ups

- Add more Bedrock model IDs to seed data (Nova, Llama, Titan, etc.) — deferred until credential access is confirmed in prod
- `list_models()` currently returns `None`; Bedrock has a ListFoundationModels API that could be wired up later
- No extended-thinking (chain-of-thought) support for Bedrock Claude yet — requires separate `reasoningConfig` parameter

## Checklist

- [x] Tests added or updated (unit tests in `bedrock/src/driver.rs`; integration test matrix extended)
- [x] Backward compatibility considered (additive only; no existing behavior changed)
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)


---
_Generated by [Claude Code](https://claude.ai/code/session_01DWXVu2xBWp9hjqZtZA8PVg)_