### PR TITLE
fix(core): classify 403 model_not_found as model_unavailable

### DIFF
--- a/crates/core/src/openai_protocol.rs
+++ b/crates/core/src/openai_protocol.rs
@@ -567,12 +567,17 @@ impl std::fmt::Debug for OpenAIProtocolLlmDriver {
 /// Check if the error indicates the model was not found.
 ///
 /// OpenAI returns 404 or 400 with `"model_not_found"` code or `"does not exist"` message.
+/// OpenAI can also return 403 with `"model_not_found"` for tier-gated models — these must
+/// be classified as model_unavailable rather than provider_misconfigured.
 /// Also handles Gemini/OpenAI-compatible endpoints with similar patterns.
 pub fn is_openai_model_not_found(status: reqwest::StatusCode, error_text: &str) -> bool {
     let error_lower = error_text.to_lowercase();
 
-    // OpenAI can return either 404 or 400 for nonexistent models
-    if status == reqwest::StatusCode::NOT_FOUND || status == reqwest::StatusCode::BAD_REQUEST {
+    // OpenAI can return 404, 400, or 403 (tier-gated access) for nonexistent/inaccessible models
+    if status == reqwest::StatusCode::NOT_FOUND
+        || status == reqwest::StatusCode::BAD_REQUEST
+        || status == reqwest::StatusCode::FORBIDDEN
+    {
         // OpenAI: {"error":{"code":"model_not_found","message":"The model 'x' does not exist"}}
         if error_lower.contains("model_not_found") {
             return true;
@@ -1221,6 +1226,28 @@ mod tests {
         let error = r#"{"error":{"message":"Endpoint not found"}}"#;
         assert!(!is_openai_model_not_found(
             reqwest::StatusCode::NOT_FOUND,
+            error
+        ));
+    }
+
+    #[test]
+    fn test_is_openai_model_not_found_403_tier_gated_model() {
+        // OpenAI returns 403 for models that exist but require a higher API tier;
+        // these must classify as model_unavailable, not provider_misconfigured.
+        let error = r#"{"error":{"code":"model_not_found","message":"The model 'gpt-5.4-mini' does not exist or you do not have access to it.","type":"invalid_request_error","param":null}}"#;
+        assert!(is_openai_model_not_found(
+            reqwest::StatusCode::FORBIDDEN,
+            error
+        ));
+    }
+
+    #[test]
+    fn test_is_openai_model_not_found_403_plain_auth_error_is_not_model_not_found() {
+        // A plain 403 without model_not_found code is a real auth error and must
+        // NOT be classified as model_unavailable.
+        let error = r#"{"error":{"message":"Invalid authentication credentials","type":"authentication_error"}}"#;
+        assert!(!is_openai_model_not_found(
+            reqwest::StatusCode::FORBIDDEN,
             error
         ));
     }


### PR DESCRIPTION
## What

Fix `is_openai_model_not_found` to also detect HTTP 403 responses that carry a `model_not_found` error code in the body, classifying them as `model_unavailable` rather than `provider_misconfigured`.

## Why

OpenAI returns HTTP 403 (FORBIDDEN) for tier-gated models — models that exist in the API but require a higher access level than the current key provides. The error body contains `"code":"model_not_found"`. Before this fix, those 403 responses bypassed the model-not-found check (which only covered 404 and 400) and fell through to the generic `(403)` branch, producing `provider_misconfigured` ("There is a misconfiguration with the AI provider. Please contact support.") instead of the correct `model_unavailable`.

This is the root cause of `support.everruns.com` returning `provider_misconfigured` for `gpt-5.4-mini` when the org's OpenAI key does not have access to that model tier. The fix surfaces the real cause to operators, enabling them to either upgrade their API tier or switch to an accessible model.

Closes EVE-528.

## How

- Added `reqwest::StatusCode::FORBIDDEN` to the status codes checked against `"model_not_found"` in `is_openai_model_not_found` (`crates/core/src/openai_protocol.rs`).
- Plain 403 auth errors that do not contain `model_not_found` in the body are unaffected — they continue to classify as `provider_misconfigured`.
- Both `OpenAIProtocolLlmDriver` (Chat Completions) and `OpenResponsesProtocolLlmDriver` (Responses API) share this function via `use`, so both are fixed.
- Added two new tests: one confirming 403+model_not_found → model_unavailable, one confirming 403+auth_error → NOT model_unavailable.

## Risk

- **Low** — the change is narrowly scoped: only 403 responses whose body explicitly contains `model_not_found` are reclassified. All other 403 responses continue to route to `provider_misconfigured`.

## Security

- **TM-API** reviewed: the change does not relax any auth check; it only improves error classification on already-rejected requests. No credentials are exposed or re-used.
- No other threat categories touched.

## Follow-ups

- The production fix for `support.everruns.com` still requires an operator action: either upgrade the OpenAI key tier to access `gpt-5.4-mini`, or update the agent's model record to an accessible model (e.g. `gpt-5-mini`). This PR makes the error message actionable; it does not auto-heal the production config.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered (additive check, unrelated 403s unaffected)
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_019CAmroqJKvUs3Yt7NpVCaQ)_