### PR TITLE
docs(runtime): add Runtime feature page

### DIFF
--- a/docs/advanced/embedding-everruns.md
+++ b/docs/advanced/embedding-everruns.md
@@ -143,7 +143,7 @@ That means you can rename the harnesses freely. A platform can ship a base harne
 
 ## In-Process Runtime
 
-If you do not want PostgreSQL, the control-plane server, or the worker boundary, use the public `everruns-runtime` crate instead of embedding the full server/worker stack.
+If you do not want PostgreSQL, the control-plane server, or the worker boundary, use the public `everruns-runtime` crate instead of embedding the full server/worker stack. See the [Runtime](/features/runtime/) page for a quickstart; this section covers how it fits the embedding story.
 
 This path is for applications that want to:
 

--- a/docs/features/runtime.mdx
+++ b/docs/features/runtime.mdx
@@ -1,0 +1,145 @@
+---
+title: Runtime
+description: Embed Everruns harnesses directly in your Rust process with the everruns-runtime crate — in-memory by default, no PostgreSQL, server, or worker required.
+sidebar:
+  label: Runtime
+---
+
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+
+The `everruns-runtime` crate runs an Everruns harness **entirely inside your own Rust process**. There is no PostgreSQL, no control-plane server, and no worker boundary — just the harness, your capabilities, and your code.
+
+It is the Rust-native counterpart to the [SDKs](/features/sdk/): where the SDKs talk to a running Everruns server over HTTP, the runtime *is* the engine, linked straight into your binary.
+
+Use the runtime when you want to:
+
+- Run a harness in-process with no external services
+- Register your own capabilities, drivers, and tools
+- Provide your own backend stores (files, messages, sessions, …)
+- Inspect the assembled turn context before execution
+
+It ships **in-memory by default**, so the smallest useful host is a single `build().await?` away.
+
+## Install
+
+Requires Rust (edition 2024).
+
+```bash
+cargo add everruns-runtime
+```
+
+The crate also depends on `everruns-core` for shared types (capabilities, drivers, models):
+
+```bash
+cargo add everruns-core
+```
+
+## Quickstart
+
+Build an in-process runtime with an in-memory backend and a simulated LLM, then run a turn:
+
+```rust
+use everruns_core::{
+    CapabilityRegistry, DriverRegistry, LlmProviderType, ModelWithProvider, PlatformDefinition,
+};
+use everruns_core::llmsim_driver::LlmSimConfig;
+use everruns_runtime::InProcessRuntimeBuilder;
+
+let platform = PlatformDefinition::new(CapabilityRegistry::new(), DriverRegistry::new());
+
+let runtime = InProcessRuntimeBuilder::new()
+    .platform_definition(platform)
+    .llm_sim(LlmSimConfig::fixed("hello from everruns-runtime"))
+    .default_model(ModelWithProvider {
+        model: "llmsim-model".into(),
+        provider_type: LlmProviderType::LlmSim,
+        api_key: Some("fake-key".into()),
+        base_url: None,
+    })
+    // .capability(...)
+    // .backends(...)
+    // .harness(...)
+    // .session(...)
+    .build()
+    .await?;
+```
+
+Swap `llm_sim(...)` for a real `default_model` (OpenAI, Anthropic, OpenRouter, Ollama, …) to talk to a live provider.
+
+## Inspect the turn context
+
+`load_context(session_id)` returns the exact merged context the reason phase will use — before the first turn or after messages already exist:
+
+```rust
+let context = runtime.load_context(session_id).await?;
+println!("messages = {}", context.messages.len());
+println!("model    = {}", context.runtime_agent.model);
+println!("tools    = {}", context.runtime_agent.tools.len());
+```
+
+The context bundles the harness chain, optional agent, session, filtered message history, resolved model, and the assembled `RuntimeAgent`. With no messages yet, `context.messages` is empty and model/locale resolution falls back to merged harness, agent, session, and platform defaults.
+
+Execute-time hosts use `everruns_core::assemble_turn_context(...)` while inspection uses `everruns_core::inspect_turn_context(...)`; both share the same assembly logic, so in-process and worker-backed behavior stay aligned.
+
+## Custom backends
+
+The runtime ships in-memory defaults, but public extension traits let you supply your own stores:
+
+| Trait | Backs |
+|---|---|
+| `RuntimeHarnessStore` | Harness definitions |
+| `RuntimeAgentStore` | Agent configurations |
+| `RuntimeSessionStore` | Sessions |
+| `RuntimeMessageStore` | Message history |
+| `RuntimeFileStore` | Session files |
+| `RuntimeProviderStore` | LLM providers |
+| `EventBus` | Emitted events (extends `EventEmitter`) |
+
+Pass them through `RuntimeBackends` on the builder; any store you don't override stays in-memory:
+
+```rust
+use everruns_runtime::{InProcessRuntimeBuilder, RuntimeBackends};
+
+let runtime = InProcessRuntimeBuilder::new()
+    .backends(
+        RuntimeBackends::in_memory()
+            .with_file_store(my_file_store)
+            .with_message_store(my_message_store)
+            .with_event_bus(my_event_bus),
+    )
+    .build()
+    .await?;
+```
+
+The default in-memory `EventBus` retains emitted events for `InProcessRuntime::events()`; production buses inherit the default `collected_events` and return an empty `Vec`.
+
+## Local MCP servers
+
+MCP server tools are first-class runtime tools. Local-process (stdio) MCP servers are gated behind the `mcp-stdio` feature, off by default so the hosted server/worker never compile stdio in:
+
+```bash
+cargo add everruns-runtime --features mcp-stdio
+```
+
+## Built with the runtime
+
+- **yolop** — a coding agent built directly on `everruns-runtime`, no server in the loop.
+- **`examples/coding-cli`** — a minimal terminal coding agent (codex/claude-code in spirit): TUI chat, real-filesystem tools on `RealDiskFileStore`, a custom `bash` tool, skills, and infinity-context trimming. The example lives at the workspace edge and depends on the public crate exactly the way an external embedder would.
+- **`examples/weekend-concierge-host`** — a root-level host app that defines its own capability, private tool data, seeded files, and an in-process turn loop.
+
+Run the in-tree examples:
+
+```bash
+cargo run -p everruns-runtime --example in_process_runtime
+cargo run -p everruns-runtime --example inspect_context
+cargo run --manifest-path examples/coding-cli/Cargo.toml
+cargo run --manifest-path examples/weekend-concierge-host/Cargo.toml
+```
+
+## See also
+
+- [Embedding Everruns](/advanced/embedding-everruns/) — compose your own `PlatformDefinition`, server, and worker; the runtime is the in-process slice of that story.
+- [SDKs](/features/sdk/) — client libraries for talking to a running Everruns server over HTTP.
+- [Harnesses](/features/harnesses/) — the agent execution templates the runtime runs.
+- [Capabilities](/capabilities/) — the tools and behaviors you register on a harness.
+- [docs.rs/everruns-runtime](https://docs.rs/everruns-runtime) — full API reference.

--- a/docs/features/runtime.mdx
+++ b/docs/features/runtime.mdx
@@ -5,8 +5,6 @@ sidebar:
   label: Runtime
 ---
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
-
 The `everruns-runtime` crate runs an Everruns harness **entirely inside your own Rust process**. There is no PostgreSQL, no control-plane server, and no worker boundary — just the harness, your capabilities, and your code.
 
 It is the Rust-native counterpart to the [SDKs](/features/sdk/): where the SDKs talk to a running Everruns server over HTTP, the runtime *is* the engine, linked straight into your binary.
@@ -22,7 +20,7 @@ It ships **in-memory by default**, so the smallest useful host is a single `buil
 
 ## Install
 
-Requires Rust (edition 2024).
+Requires Rust 1.94+ (edition 2024).
 
 ```bash
 cargo add everruns-runtime

--- a/docs/features/runtime.mdx
+++ b/docs/features/runtime.mdx
@@ -123,8 +123,15 @@ cargo add everruns-runtime --features mcp-stdio
 
 ## Built with the runtime
 
-- **yolop** — a coding agent built directly on `everruns-runtime`, no server in the loop.
-- **`examples/coding-cli`** — a minimal terminal coding agent (codex/claude-code in spirit): TUI chat, real-filesystem tools on `RealDiskFileStore`, a custom `bash` tool, skills, and infinity-context trimming. The example lives at the workspace edge and depends on the public crate exactly the way an external embedder would.
+- **[yolop](https://github.com/everruns/yolop)** — a minimal terminal coding agent built on `everruns-runtime` (codex/claude-code in spirit). It's the `coding-cli` example below promoted into a standalone, installable project: interactive TUI, real-filesystem tools, a `bash` tool, multi-provider LLMs (OpenAI, Anthropic, Gemini, OpenRouter, Ollama), MCP servers, resumable sessions, and Zed editor integration over ACP.
+
+  ```bash
+  brew install everruns/tap/yolop
+  # or
+  cargo install yolop --locked
+  ```
+
+- **`examples/coding-cli`** — the in-tree version of yolop: a single-binary coding agent with a ratatui TUI, real-filesystem tools on `RealDiskFileStore`, a custom `bash` tool, skills, and infinity-context trimming. It lives at the workspace edge and depends on the public crate exactly the way an external embedder would.
 - **`examples/weekend-concierge-host`** — a root-level host app that defines its own capability, private tool data, seeded files, and an in-process turn loop.
 
 Run the in-tree examples:

--- a/docs/features/runtime.mdx
+++ b/docs/features/runtime.mdx
@@ -123,7 +123,7 @@ cargo add everruns-runtime --features mcp-stdio
 
 ## Built with the runtime
 
-- **[yolop](https://github.com/everruns/yolop)** — a minimal terminal coding agent built on `everruns-runtime` (codex/claude-code in spirit). It's the `coding-cli` example below promoted into a standalone, installable project: interactive TUI, real-filesystem tools, a `bash` tool, multi-provider LLMs (OpenAI, Anthropic, Gemini, OpenRouter, Ollama), MCP servers, resumable sessions, and Zed editor integration over ACP.
+- **[yolop](https://github.com/everruns/yolop)** — a minimal terminal coding agent built on `everruns-runtime` (codex/claude-code in spirit). It started as the `coding-cli` example below, promoted into a standalone, releasable project, and is where active development happens: interactive TUI, real-filesystem tools, a `bash` tool, multi-provider LLMs (OpenAI, Anthropic, Gemini, OpenRouter, Ollama), MCP servers (stdio + HTTP), resumable sessions, and Zed editor integration over ACP.
 
   ```bash
   brew install everruns/tap/yolop
@@ -131,7 +131,7 @@ cargo add everruns-runtime --features mcp-stdio
   cargo install yolop --locked
   ```
 
-- **`examples/coding-cli`** — the in-tree version of yolop: a single-binary coding agent with a ratatui TUI, real-filesystem tools on `RealDiskFileStore`, a custom `bash` tool, skills, and infinity-context trimming. It lives at the workspace edge and depends on the public crate exactly the way an external embedder would.
+- **`examples/coding-cli`** — the in-tree reference embedder for the public crate: a single-binary coding agent with a ratatui TUI, real-filesystem tools on `RealDiskFileStore`, a custom `bash` tool, skills, and infinity-context trimming. It lives at the workspace edge and depends on the public crate exactly the way an external embedder would.
 - **`examples/weekend-concierge-host`** — a root-level host app that defines its own capability, private tool data, seeded files, and an in-process turn loop.
 
 Run the in-tree examples:


### PR DESCRIPTION
## What
Adds a dedicated **Runtime** feature page at `docs/features/runtime.mdx` (renders at `/features/runtime/`, auto-listed in the Features sidebar), covering the public `everruns-runtime` crate: install, in-process quickstart, `load_context()` turn inspection, custom backend traits, the `mcp-stdio` feature, and the agents built on it (yolop + the in-tree examples). Also adds a cross-link from the Embedding Everruns advanced page's In-Process Runtime section so the two complement rather than duplicate.

## Why
The runtime is a public, build-on-everruns surface (the Rust-native counterpart to the SDKs) but had no landing page — its only coverage was a sub-section of the "Embedding Everruns" advanced guide, with no canonical URL to point people at. yolop and `examples/coding-cli` are real consumers that deserve a discoverable home.

## How
- New `docs/features/runtime.mdx` modeled on the existing `features/sdk.mdx` (frontmatter, install, quickstart, tables, "Built with the runtime", "See also"). Content cross-checked against `docs/advanced/embedding-everruns.md`, `crates/runtime/Cargo.toml`, `examples/coding-cli`, and the upstream `everruns/yolop` README/Cargo.toml.
- One-line pointer added to the embedding guide's In-Process Runtime section linking to the new page.

## Risk
- Low — docs-only. No runtime behavior changes.
- Worst case: a broken link or stale crate detail; mitigated by a full `apps/docs` build (below).

## Security
- Threat categories reviewed: No security-relevant code changes — documentation-only (two Markdown/MDX files under `docs/`). No code, config, or infrastructure touched.
- Findings and resolutions: None.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated (n/a — docs only; validated via docs build)
- [x] Backward compatibility considered (n/a — docs only)
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

## Validation
- `pnpm run build` in `apps/docs` → **BUILD OK**, 363 pages built, postbuild notebook verification passed.
- Confirmed `features/runtime/index.html` rendered and every internal link target resolves (`features/sdk`, `features/harnesses`, `capabilities`, `advanced/embedding-everruns`, `api`, `event-reference`).

---
_Generated by [Claude Code](https://claude.ai/code/session_013yx1ZtdaG12n4Lq8aXwhtc)_