### PR TITLE
feat(models): Claude Fable 5 support with adaptive thinking

### DIFF
--- a/crates/anthropic/src/driver.rs
+++ b/crates/anthropic/src/driver.rs
@@ -385,6 +385,26 @@ impl LlmDriver for AnthropicLlmDriver {
             Some(Self::convert_tools(&config.tools, prompt_cache_enabled))
         };
 
+        let profile = everruns_core::get_model_profile(
+            &everruns_core::LlmProviderType::Anthropic,
+            &config.model,
+        );
+
+        // Sampling parameters are removed on Fable 5 and Opus 4.8/4.7 —
+        // sending `temperature` returns 400 ("`temperature` is deprecated for
+        // this model"). The model profile's `temperature` flag is the source
+        // of truth; drop the parameter for models that reject it.
+        let temperature = config.temperature.filter(|_| {
+            let supported = profile.as_ref().is_none_or(|p| p.temperature);
+            if !supported {
+                tracing::warn!(
+                    model = %config.model,
+                    "AnthropicDriver: dropping temperature — not supported by this model"
+                );
+            }
+            supported
+        });
+
         // Build thinking config from reasoning effort.
         //
         // Recent Claude models (Fable 5, Opus 4.8/4.7, and the 4.6 family) use
@@ -420,18 +440,16 @@ impl LlmDriver for AnthropicLlmDriver {
         // Anthropic requires max_tokens (can't omit), so we look up the model's native limit.
         let max_tokens_from_profile = config.max_tokens.is_none();
         let base_max_tokens = config.max_tokens.unwrap_or_else(|| {
-            everruns_core::get_model_profile(
-                &everruns_core::LlmProviderType::Anthropic,
-                &config.model,
-            )
-            .and_then(|p| {
-                p.limits.and_then(|l| {
-                    u32::try_from(l.output)
-                        .ok()
-                        .and_then(|v| if v > 0 { Some(v) } else { None })
+            profile
+                .as_ref()
+                .and_then(|p| {
+                    p.limits.as_ref().and_then(|l| {
+                        u32::try_from(l.output)
+                            .ok()
+                            .and_then(|v| if v > 0 { Some(v) } else { None })
+                    })
                 })
-            })
-            .unwrap_or(16_384)
+                .unwrap_or(16_384)
         });
         let max_tokens = if let Some(AnthropicThinking::Enabled { budget_tokens }) = thinking {
             // max_tokens must be > thinking.budget_tokens per Anthropic requirements
@@ -451,7 +469,7 @@ impl LlmDriver for AnthropicLlmDriver {
             model: config.model.clone(),
             messages: anthropic_messages,
             max_tokens,
-            temperature: config.temperature,
+            temperature,
             system,
             stream: true,
             tools,

--- a/crates/anthropic/src/driver.rs
+++ b/crates/anthropic/src/driver.rs
@@ -385,17 +385,34 @@ impl LlmDriver for AnthropicLlmDriver {
             Some(Self::convert_tools(&config.tools, prompt_cache_enabled))
         };
 
-        // Build thinking config from reasoning effort
-        let thinking = config
-            .reasoning_effort
-            .as_ref()
-            .and_then(|e| AnthropicThinking::from_effort(e));
+        // Build thinking config from reasoning effort.
+        //
+        // Recent Claude models (Fable 5, Opus 4.8/4.7, and the 4.6 family) use
+        // adaptive thinking: `thinking: {type: "adaptive"}` plus
+        // `output_config.effort`. On Fable 5 and Opus 4.8/4.7 the budget-based
+        // `thinking: {type: "enabled", budget_tokens}` form is removed and
+        // returns 400, so this split is load-bearing, not stylistic.
+        let (thinking, output_config) = match config.reasoning_effort.as_deref() {
+            Some(effort) if uses_adaptive_thinking(&config.model) => {
+                match adaptive_effort_level(effort) {
+                    Some(level) => (
+                        Some(AnthropicThinking::adaptive()),
+                        Some(AnthropicOutputConfig {
+                            effort: level.to_string(),
+                        }),
+                    ),
+                    None => (None, None),
+                }
+            }
+            Some(effort) => (AnthropicThinking::enabled_from_effort(effort), None),
+            None => (None, None),
+        };
 
         tracing::info!(
             model = %config.model,
             reasoning_effort = ?config.reasoning_effort,
-            thinking_enabled = thinking.is_some(),
-            thinking_budget = ?thinking.as_ref().map(|t| t.budget_tokens),
+            thinking = ?thinking,
+            adaptive_effort = ?output_config.as_ref().map(|c| c.effort.as_str()),
             "AnthropicDriver: building request with thinking config"
         );
 
@@ -416,17 +433,19 @@ impl LlmDriver for AnthropicLlmDriver {
             })
             .unwrap_or(16_384)
         });
-        let max_tokens = if let Some(ref thinking_config) = thinking {
+        let max_tokens = if let Some(AnthropicThinking::Enabled { budget_tokens }) = thinking {
             // max_tokens must be > thinking.budget_tokens per Anthropic requirements
             // Only increase if the caller's limit is too low for the thinking budget
-            let min_for_thinking = thinking_config.budget_tokens + 1024; // minimum headroom for response
+            let min_for_thinking = budget_tokens + 1024; // minimum headroom for response
             base_max_tokens.max(min_for_thinking)
         } else {
             base_max_tokens
         };
 
-        // Check if we need interleaved thinking beta header BEFORE moving values
-        let needs_interleaved_thinking = thinking.is_some() && tools.is_some();
+        // Budget-based thinking with tools needs the interleaved-thinking beta
+        // header; adaptive thinking interleaves automatically (no header).
+        let needs_interleaved_thinking =
+            matches!(thinking, Some(AnthropicThinking::Enabled { .. })) && tools.is_some();
 
         let mut request = AnthropicRequest {
             model: config.model.clone(),
@@ -437,6 +456,7 @@ impl LlmDriver for AnthropicLlmDriver {
             stream: true,
             tools,
             thinking,
+            output_config,
         };
 
         // Retry loop for rate limit (429) and transient errors
@@ -940,6 +960,9 @@ struct AnthropicRequest {
     /// Extended thinking configuration (for Claude models that support it)
     #[serde(skip_serializing_if = "Option::is_none")]
     thinking: Option<AnthropicThinking>,
+    /// Output configuration — carries `effort` for adaptive thinking
+    #[serde(skip_serializing_if = "Option::is_none")]
+    output_config: Option<AnthropicOutputConfig>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -973,21 +996,81 @@ enum AnthropicSystemBlock {
     },
 }
 
-/// Extended thinking configuration for Claude
-#[derive(Debug, Serialize)]
-struct AnthropicThinking {
-    r#type: String,
-    /// Budget tokens for thinking (varies by effort level)
-    budget_tokens: u32,
+/// Thinking configuration for Claude.
+///
+/// `Enabled` is the legacy budget-based form; `Adaptive` is required on
+/// Fable 5 and Opus 4.8/4.7 (where `budget_tokens` returns 400) and is the
+/// recommended form on the 4.6 family. "No thinking" is always expressed by
+/// omitting the field — an explicit `{type: "disabled"}` is rejected by
+/// Fable 5.
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(tag = "type", rename_all = "lowercase")]
+enum AnthropicThinking {
+    Enabled {
+        /// Budget tokens for thinking (varies by effort level)
+        budget_tokens: u32,
+    },
+    Adaptive {
+        /// Fable 5 and Opus 4.8/4.7 omit thinking text by default
+        /// (`display: "omitted"`); "summarized" restores it so assistant
+        /// messages keep their thinking content like on budget-based models.
+        display: &'static str,
+    },
 }
 
 impl AnthropicThinking {
-    /// Create thinking config from reasoning effort level
-    fn from_effort(effort: &str) -> Option<Self> {
-        llm_driver_helpers::thinking_budget::from_effort(effort).map(|budget| Self {
-            r#type: "enabled".to_string(),
-            budget_tokens: budget,
-        })
+    /// Create a budget-based thinking config from a reasoning effort level
+    fn enabled_from_effort(effort: &str) -> Option<Self> {
+        llm_driver_helpers::thinking_budget::from_effort(effort)
+            .map(|budget_tokens| Self::Enabled { budget_tokens })
+    }
+
+    /// Adaptive thinking with summarized (visible) thinking content
+    fn adaptive() -> Self {
+        Self::Adaptive {
+            display: "summarized",
+        }
+    }
+}
+
+/// `output_config` request field — carries the effort level that controls
+/// adaptive thinking depth.
+#[derive(Debug, Serialize)]
+struct AnthropicOutputConfig {
+    effort: String,
+}
+
+/// Claude families that use adaptive thinking. On Fable 5 and Opus 4.8/4.7
+/// budget-based thinking is removed (400); on Opus 4.6 / Sonnet 4.6 it is
+/// deprecated and adaptive is the recommended form. Keep in sync with the
+/// adaptive-thinking profiles in `everruns_core::llm_model_profiles`.
+const ADAPTIVE_THINKING_FAMILIES: &[&str] = &[
+    "claude-fable-5",
+    "claude-opus-4-8",
+    "claude-opus-4-7",
+    "claude-opus-4-6",
+    "claude-sonnet-4-6",
+];
+
+/// Whether a model id (optionally date-suffixed) belongs to an
+/// adaptive-thinking family.
+fn uses_adaptive_thinking(model_id: &str) -> bool {
+    let family = normalize_anthropic_id(model_id);
+    ADAPTIVE_THINKING_FAMILIES
+        .iter()
+        .any(|f| family.eq_ignore_ascii_case(f))
+}
+
+/// Map an everruns reasoning-effort level to the `output_config.effort` value
+/// used with adaptive thinking. `xhigh` is surfaced as "Max" in the model
+/// profiles and maps to the API's `max` level.
+fn adaptive_effort_level(effort: &str) -> Option<&'static str> {
+    match effort.to_ascii_lowercase().as_str() {
+        "low" => Some("low"),
+        "medium" => Some("medium"),
+        "high" => Some("high"),
+        "xhigh" => Some("max"),
+        _ => None,
     }
 }
 
@@ -1506,6 +1589,49 @@ mod tests {
         let content = LlmMessageContent::Text(String::new());
         let blocks = AnthropicLlmDriver::convert_content(&content);
         assert!(blocks.is_empty(), "Empty text should be filtered out");
+    }
+
+    #[test]
+    fn test_uses_adaptive_thinking_by_family() {
+        // Adaptive-only / adaptive-recommended families, with and without
+        // dated suffixes.
+        assert!(uses_adaptive_thinking("claude-fable-5"));
+        assert!(uses_adaptive_thinking("claude-fable-5-20260601"));
+        assert!(uses_adaptive_thinking("claude-opus-4-8"));
+        assert!(uses_adaptive_thinking("claude-opus-4-7-20260416"));
+        assert!(uses_adaptive_thinking("claude-opus-4-6"));
+        assert!(uses_adaptive_thinking("claude-sonnet-4-6"));
+        // Budget-based families stay on extended thinking.
+        assert!(!uses_adaptive_thinking("claude-opus-4-5"));
+        assert!(!uses_adaptive_thinking("claude-sonnet-4-5"));
+        assert!(!uses_adaptive_thinking("claude-haiku-4-5-20251001"));
+    }
+
+    #[test]
+    fn test_thinking_config_serialization() {
+        // Adaptive must not carry budget_tokens (400 on Fable 5 / Opus 4.8 /
+        // 4.7); display:"summarized" opts back into visible thinking text,
+        // which those models omit by default.
+        let adaptive = serde_json::to_value(AnthropicThinking::adaptive()).unwrap();
+        assert_eq!(
+            adaptive,
+            json!({"type": "adaptive", "display": "summarized"})
+        );
+
+        let enabled = serde_json::to_value(AnthropicThinking::Enabled {
+            budget_tokens: 4096,
+        })
+        .unwrap();
+        assert_eq!(enabled, json!({"type": "enabled", "budget_tokens": 4096}));
+    }
+
+    #[test]
+    fn test_adaptive_effort_level_mapping() {
+        assert_eq!(adaptive_effort_level("low"), Some("low"));
+        assert_eq!(adaptive_effort_level("medium"), Some("medium"));
+        assert_eq!(adaptive_effort_level("HIGH"), Some("high"));
+        assert_eq!(adaptive_effort_level("xhigh"), Some("max"));
+        assert_eq!(adaptive_effort_level("unknown"), None);
     }
 
     #[test]

--- a/crates/core/src/llm_model_profiles.rs
+++ b/crates/core/src/llm_model_profiles.rs
@@ -2083,6 +2083,9 @@ fn anthropic_profile_data(model_id: &str) -> Option<LlmModelProfile> {
         }),
 
         // Claude 4.7 series
+        // Sampling parameters were removed starting with Opus 4.7: the API
+        // rejects `temperature` with "`temperature` is deprecated for this
+        // model" (verified live), hence `temperature: false`.
         "claude-opus-4-7" => Some(LlmModelProfile {
             name: "Claude Opus 4.7".into(),
             family: "claude-opus-4-7".into(),
@@ -2091,7 +2094,7 @@ fn anthropic_profile_data(model_id: &str) -> Option<LlmModelProfile> {
             last_updated: Some("2026-04-16".into()),
             attachment: true,
             reasoning: true,
-            temperature: true,
+            temperature: false,
             knowledge: Some("2026-01-01".into()),
             tool_call: true,
             structured_output: true,
@@ -3524,7 +3527,8 @@ mod tests {
         assert_eq!(profile.family, "claude-opus-4-7");
         assert!(profile.reasoning);
         assert!(profile.tool_call);
-        assert!(profile.temperature);
+        // Sampling parameters removed from Opus 4.7 on (API rejects `temperature`).
+        assert!(!profile.temperature);
         assert!(profile.structured_output);
 
         let limits = profile.limits.unwrap();

--- a/crates/core/src/llm_model_profiles.rs
+++ b/crates/core/src/llm_model_profiles.rs
@@ -148,7 +148,7 @@ fn reasoning_effort_anthropic_extended_thinking() -> ReasoningEffortConfig {
 }
 
 /// Adaptive thinking config for recent Claude reasoning models
-/// (Opus 4.7, Opus 4.6, Sonnet 4.6)
+/// (Fable 5, Opus 4.8, Opus 4.7, Opus 4.6, Sonnet 4.6)
 /// Uses thinking.type="adaptive" with effort parameter instead of budget_tokens
 /// Default: high, supports: low, medium, high, max (mapped to xhigh)
 fn reasoning_effort_anthropic_adaptive_thinking() -> ReasoningEffortConfig {
@@ -246,6 +246,7 @@ static REGISTRY: &[ModelDescriptor] = &[
     md(&["gpt-5.5"], ModelVendor::OpenAi, OPENAI),
     md(&["gpt-5.5-pro"], ModelVendor::OpenAi, OPENAI),
     // Anthropic
+    md(&["claude-fable-5"], ModelVendor::Anthropic, ANTHROPIC),
     md(&["claude-opus-4-8"], ModelVendor::Anthropic, ANTHROPIC),
     md(&["claude-opus-4-7"], ModelVendor::Anthropic, ANTHROPIC),
     md(&["claude-opus-4-6"], ModelVendor::Anthropic, ANTHROPIC),
@@ -1996,7 +1997,51 @@ fn third_party_profile_data(model_id: &str) -> Option<LlmModelProfile> {
 
 fn anthropic_profile_data(model_id: &str) -> Option<LlmModelProfile> {
     match model_id {
-        // Claude 4.8 series (newest)
+        // Claude Fable 5 (newest — top tier above Opus)
+        // Source: Anthropic model card (claude-api skill `shared/models.md`) and
+        // docs.claude.com — Fable 5 is not yet in models.dev. Same API surface as
+        // Opus 4.8: adaptive thinking only, sampling parameters removed (temperature
+        // returns 400, hence `temperature: false`). One extra restriction vs Opus
+        // 4.8: an explicit `thinking: {type: "disabled"}` also returns 400 — the
+        // param must be omitted entirely (our driver already omits it when no
+        // reasoning effort is set). Release/knowledge dates are not published in
+        // the model card; the Models API exposes them at runtime.
+        "claude-fable-5" => Some(LlmModelProfile {
+            name: "Claude Fable 5".into(),
+            family: "claude-fable-5".into(),
+            description: None,
+            release_date: None,
+            last_updated: None,
+            attachment: true,
+            reasoning: true,
+            temperature: false,
+            knowledge: None,
+            tool_call: true,
+            structured_output: true,
+            open_weights: false,
+            cost: Some(LlmModelCost {
+                input: 10.00,
+                output: 50.00,
+                cache_read: Some(1.00),
+                cost_tiers: vec![],
+            }),
+            limits: Some(LlmModelLimits {
+                context: 1_000_000,
+                input: None,
+                output: 128_000,
+                max_media: None,
+            }),
+            modalities: Some(LlmModelModalities {
+                input: vec![Modality::Text, Modality::Image, Modality::Pdf],
+                output: vec![Modality::Text],
+            }),
+            reasoning_effort: Some(reasoning_effort_anthropic_adaptive_thinking()),
+            tool_search: false,
+            supported_parameters: Vec::new(),
+            supports_phases: false,
+        }),
+
+        // Claude 4.8 series
         // Source: Anthropic model card (claude-api skill `shared/models.md`) and
         // docs.claude.com — Opus 4.8 is not yet in models.dev. Same API surface as
         // Opus 4.7: adaptive thinking only, sampling parameters removed (temperature
@@ -3791,6 +3836,23 @@ mod tests {
     }
 
     // Newly added flagship model profiles
+
+    #[test]
+    fn test_claude_fable_5_profile() {
+        let profile = get_model_profile(&LlmProviderType::Anthropic, "claude-fable-5").unwrap();
+        assert_eq!(profile.name, "Claude Fable 5");
+        assert_eq!(profile.family, "claude-fable-5");
+        assert!(profile.reasoning);
+        // Fable 5 removed sampling parameters (temperature returns 400).
+        assert!(!profile.temperature);
+        let cost = profile.cost.as_ref().unwrap();
+        assert_eq!(cost.input, 10.00);
+        assert_eq!(cost.output, 50.00);
+        let limits = profile.limits.as_ref().unwrap();
+        assert_eq!(limits.context, 1_000_000);
+        assert_eq!(limits.output, 128_000);
+        assert!(profile.reasoning_effort.is_some());
+    }
 
     #[test]
     fn test_claude_opus_4_8_profile() {

--- a/crates/llm-tests/tests/agent_run_basic.rs
+++ b/crates/llm-tests/tests/agent_run_basic.rs
@@ -33,6 +33,7 @@ use everruns_core::traits::ModelWithProvider;
 
 #[rstest]
 #[case::anthropic_haiku(ANTHROPIC_HAIKU)]
+#[case::anthropic_fable(ANTHROPIC_FABLE)]
 #[case::openai_gpt4o_mini(OPENAI_GPT4O_MINI)]
 #[case::openai_gpt54(OPENAI_GPT54)]
 #[case::gemini_flash(GEMINI_FLASH)]
@@ -66,6 +67,7 @@ async fn test_basic_completion(#[case] config: ProviderModelConfig) {
 
 #[rstest]
 #[case::anthropic_haiku(ANTHROPIC_HAIKU)]
+#[case::anthropic_fable(ANTHROPIC_FABLE)]
 #[case::openai_gpt4o_mini(OPENAI_GPT4O_MINI)]
 #[case::openai_gpt54(OPENAI_GPT54)]
 #[case::gemini_flash(GEMINI_FLASH)]

--- a/crates/llm-tests/tests/agent_run_with_thinking.rs
+++ b/crates/llm-tests/tests/agent_run_with_thinking.rs
@@ -27,6 +27,7 @@ use everruns_core::message_retriever::InputMessage;
 // ============================================================================
 
 #[rstest]
+#[case::anthropic_fable(ANTHROPIC_FABLE)]
 #[case::anthropic_opus(ANTHROPIC_OPUS)]
 #[case::anthropic_sonnet(ANTHROPIC_SONNET)]
 #[case::openai_gpt52(OPENAI_GPT52)]
@@ -48,10 +49,15 @@ async fn test_extended_thinking(#[case] config: ProviderModelConfig) {
         .await
         .unwrap();
 
+    // The prompt must be genuinely hard: on adaptive-thinking models (Claude
+    // Fable 5 / Opus 4.8+, GPT-5.x reasoning) the model decides whether to
+    // think at all, and trivial riddles deterministically skip thinking.
+    // Trailing zeros of 2024! = floor(2024/5) + floor(2024/25) + floor(2024/125)
+    // + floor(2024/625) = 404 + 80 + 16 + 3 = 503.
     let input = InputMessage {
         role: MessageRole::User,
         content: vec![ContentPart::text(
-            "A farmer has 17 chickens. All but 9 die. How many are left? Explain step by step why this is tricky.",
+            "How many trailing zeros does 2024! (factorial) have? Work it out carefully, then state the final count as a plain number.",
         )],
         controls: Some(Controls {
             model_id: None,
@@ -69,8 +75,8 @@ async fn test_extended_thinking(#[case] config: ProviderModelConfig) {
 
     assert!(result.success, "Turn should succeed: {:?}", result.error);
     assert!(
-        result.response.contains("9"),
-        "Response should contain the answer 9, got: {}",
+        result.response.contains("503"),
+        "Response should contain the answer 503, got: {}",
         result.response
     );
 
@@ -107,6 +113,7 @@ async fn test_extended_thinking(#[case] config: ProviderModelConfig) {
 // ============================================================================
 
 #[rstest]
+#[case::anthropic_fable(ANTHROPIC_FABLE)]
 #[case::anthropic_opus(ANTHROPIC_OPUS)]
 #[case::anthropic_sonnet(ANTHROPIC_SONNET)]
 #[case::openai_gpt52(OPENAI_GPT52)]

--- a/crates/llm-tests/tests/llm_test_matrix/mod.rs
+++ b/crates/llm-tests/tests/llm_test_matrix/mod.rs
@@ -72,15 +72,22 @@ impl std::fmt::Display for ProviderModelConfig {
 // Provider catalogue — add new providers/models here
 // ============================================================================
 
+pub const ANTHROPIC_FABLE: ProviderModelConfig = ProviderModelConfig::new(
+    LlmProviderType::Anthropic,
+    "claude-fable-5",
+    "ANTHROPIC_API_KEY",
+);
+
 pub const ANTHROPIC_HAIKU: ProviderModelConfig = ProviderModelConfig::new(
     LlmProviderType::Anthropic,
     "claude-haiku-4-5-20251001",
     "ANTHROPIC_API_KEY",
 );
 
+// Bare alias — the API does not serve a dated id for Opus 4.7.
 pub const ANTHROPIC_OPUS: ProviderModelConfig = ProviderModelConfig::new(
     LlmProviderType::Anthropic,
-    "claude-opus-4-7-20260416",
+    "claude-opus-4-7",
     "ANTHROPIC_API_KEY",
 );
 

--- a/specs/llm-drivers.md
+++ b/specs/llm-drivers.md
@@ -143,6 +143,8 @@ Agents can override `max_tokens` via agent config. Cost guardrails should be con
 
 Extended thinking allows models to perform chain-of-thought reasoning before generating responses. Supported by both Anthropic Claude and OpenAI o-series/GPT-5 models.
 
+Anthropic has two thinking request forms, selected per model family by the driver. Recent Claude families (Fable 5, Opus 4.8/4.7, and the 4.6 family) take adaptive thinking (`thinking.type = "adaptive"` plus `output_config.effort`); the budget-based `budget_tokens` form is removed on Fable 5 and Opus 4.8/4.7 and returns 400 there. Older Claude models keep budget-based extended thinking. The family list lives in `crates/anthropic/src/driver.rs` and must stay in sync with the adaptive-thinking profiles in `crates/core/src/llm_model_profiles.rs`.
+
 #### Stream Events
 
 When `reasoning_effort` is configured, drivers emit additional stream events:
@@ -159,7 +161,7 @@ Both providers require preserved thinking context for multi-turn conversations. 
 | `thinking_signature` | Cryptographic signature | `encrypted_content` token |
 
 Provider-specific wire format details live in the driver implementations:
-- `crates/anthropic/src/driver.rs` -- beta headers, signature capture, message ordering, budget tokens
+- `crates/anthropic/src/driver.rs` -- thinking form selection (adaptive vs budget-based), beta headers, signature capture, message ordering
 - `crates/openai/src/driver.rs` -- reasoning config, encrypted content, reasoning item format
 
 #### Reasoning Guard Logic
@@ -174,6 +176,10 @@ Reasoning parameters are validated at two levels to prevent API errors from non-
 2. **Driver level**: Both OpenAI drivers filter out `effort: "none"` before sending:
    - Responses API: omits `reasoning` object entirely
    - Chat Completions API: omits `reasoning_effort` field
+
+   The Anthropic driver additionally drops `temperature` for models whose
+   profile marks it unsupported (sampling parameters are removed from Opus 4.7
+   on; the API rejects them with a 400).
 
 The UI also prevents setting reasoning on non-thinking models (checks `profile.reasoning` and `profile.reasoning_effort`).
 


### PR DESCRIPTION
## What
Adds Claude Fable 5 (`claude-fable-5`) support: model registry entry and full profile (pricing, limits, modalities, adaptive reasoning effort), and fixes the Anthropic driver so reasoning effort works on adaptive-only Claude models instead of returning 400.

- `crates/core/src/llm_model_profiles.rs` — Fable 5 registry entry + profile ($10/$50 per MTok, 1M context, 128K output, text/image/PDF, adaptive effort low/medium/high/max, `temperature: false`); corrected Opus 4.7 profile (`temperature` was wrongly `true`).
- `crates/anthropic/src/driver.rs` — thinking config is now an enum: adaptive families (Fable 5, Opus 4.8/4.7/4.6, Sonnet 4.6) get `thinking: {type: "adaptive", display: "summarized"}` + `output_config.effort`; older models keep budget-based thinking. The interleaved-thinking beta header and budget headroom apply only to the budget path. The driver also drops `temperature` for models whose profile marks it unsupported.
- `crates/llm-tests/` — Fable 5 added to the test matrix (thinking, thinking+tools, basic completion, tool call); fixed stale `claude-opus-4-7-20260416` id (API serves only the bare alias — those cases were failing with "Model not available"); extended-thinking prompt hardened so adaptive models reliably trigger thinking.
- `specs/llm-drivers.md` — documents the adaptive/budget split and the temperature guard.

Fable 5 is **not** made the default model and is not seeded (same approach as Opus 4.8: models arrive via provider discovery; the hardcoded profile supplies cost/limits).

## Why
Fable 5 needs a proper profile (pricing, limits, capabilities) to be usable. Separately, the driver sent `thinking: {type: "enabled", budget_tokens}` to every model — that form is removed on Fable 5 and Opus 4.8/4.7 and returns 400, so reasoning effort was broken on all recent Claude models. Same for `temperature`, which these models reject.

## How
Family-gated request construction in the Anthropic driver (`uses_adaptive_thinking`, kept in sync with the adaptive profiles in core), effort mapped to `output_config.effort` (`xhigh` → `max`), `display: "summarized"` to keep thinking content visible (these models omit it by default), and profile-driven temperature filtering.

## Risk
- Low / Medium
- Behavior change for Opus 4.6 / Sonnet 4.6: they move from budget-based to adaptive thinking (the recommended form; budget is deprecated there). Verified live on the real API.
- Models without a hardcoded profile keep current behavior (budget thinking, temperature passthrough).

## Validation
- Live integration tests against the real Anthropic API: 6/6 thinking cases (Fable 5 + Opus 4.7 adaptive, Sonnet 4 budget), 5/5 basic/tool cases, 4/4 OpenAI thinking cases with the new prompt.
- Live curl probes: adaptive+summarized accepted on Fable 5 / Sonnet 4.6 / Opus 4.6; `temperature` rejected on Fable 5 / Opus 4.7, accepted on Opus 4.6.
- Unit tests: 38 driver + 76 profile tests green; clippy and `just pre-push` green.
- Smoke test (`start-dev`, full end-to-end): Fable 5 model created via API serves the correct profile; two multi-turn agent runs on `claude-fable-5` through the server returned correct answers (trailing zeros of 2024! = 503; smallest n with 1000 trailing zeros = 4005) with the adaptive request shape confirmed in driver logs.

## Security
- Threat categories reviewed: TM-LLM (request construction, model parameters).
- Findings and resolutions: none. No API-key handling changes; the new warn log carries only the model id; no new dependencies; static const data only; family matching is case-insensitive comparison against a const list. No threat-model updates needed.

## Follow-ups
- On adaptive models, a thinking block can stream with an **empty summarized text** plus a signature; the existing both-or-neither storage/replay logic then drops the block. Harmless today (live multi-turn and thinking+tool-use runs pass), but worth revisiting if Anthropic starts enforcing strict thinking-block replay for empty-summary blocks.
- `to_discovered_profile()` in the Anthropic driver hardcodes `temperature: true` for runtime-discovered models because the Models API doesn't expose a sampling capability; the driver-side guard uses hardcoded profiles, so known models are safe. Worth revisiting if Anthropic exposes the capability.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR (all 41 checks green or change-skipped; no `ci:skip-*` labels used)
- [x] All review comments addressed (Copilot reviewed 6/6 files, generated no comments; no other review threads)
