### PR TITLE
feat(lua): route non-essential tool calls through Lua code mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -333,6 +333,10 @@ jobs:
         run: |
           cargo test -p everruns-anthropic -p everruns-openai -p everruns-gemini -p everruns-internal-protocol -p everruns-core --lib --all-features
           cargo test -p everruns-runtime --test in_process_runtime_test --test runtime_host_test -- --test-threads=1
+          # Lua code-mode capability: compiles the mlua engine (`lua` feature) and
+          # exercises the end-to-end routing contract + runnable example.
+          cargo test -p everruns-runtime --features lua --test lua_code_mode_test -- --test-threads=1
+          cargo run -p everruns-runtime --features lua --example lua_code_mode_agent
           cargo test -p everruns-cli --test auth_integration_test --test chat_integration_test --test files_integration_test -- --test-threads=1
           # Do not pass --all-features to integration crates: it enables their *-live-tests
           # features, which fail closed without real credentials. Live tests run in their

--- a/crates/core/src/capabilities/lua.rs
+++ b/crates/core/src/capabilities/lua.rs
@@ -324,31 +324,47 @@ impl Tool for LuaTool {
     }
 }
 
-/// Sibling tools exposed to Lua "code mode" via the `tools` table.
+/// Whether a tool is eligible to be driven through Lua "code mode" (the
+/// `tools.<name>` table) rather than called directly.
+///
+/// This is the single source of truth shared by two call sites so they can
+/// never drift apart: the engine's code-mode exposure
+/// ([`gated_code_mode_tools`]) and the `lua_code_mode` capability's
+/// tool-definition filter (which *hides* exactly this set from the model). If
+/// the two used different predicates a tool could be hidden from the model yet
+/// not re-exposed in Lua — an unreachable tool.
 ///
 /// Conservative gate (TM-LUA-009): `Auto` policy only (never approval- or
-/// client-side tools), non-destructive, non-execution, and never the execution
-/// tools themselves (`lua`/`bash` are excluded so code mode cannot re-enter a
-/// shell or itself). Returns an empty list when no tool registry is present.
-fn gated_code_mode_tools(context: &ToolContext) -> Vec<String> {
+/// client-side tools), non-destructive, non-`cpu_bound`, and never the
+/// execution tools themselves (`lua`/`bash` are excluded so code mode cannot
+/// re-enter a shell or itself).
+pub fn is_code_mode_eligible(
+    name: &str,
+    policy: &crate::tool_types::ToolPolicy,
+    hints: &ToolHints,
+) -> bool {
     use crate::tool_types::ToolPolicy;
+    name != "lua"
+        && name != "bash"
+        && *policy == ToolPolicy::Auto
+        && hints.destructive != Some(true)
+        && hints.cpu_bound != Some(true)
+}
+
+/// Sibling tools exposed to Lua "code mode" via the `tools` table.
+///
+/// Filters the live tool registry through [`is_code_mode_eligible`]. Returns an
+/// empty list when no tool registry is present.
+fn gated_code_mode_tools(context: &ToolContext) -> Vec<String> {
     let Some(reg) = context.tool_registry.as_ref() else {
         return Vec::new();
     };
     let mut out = Vec::new();
     for name in reg.tool_names() {
-        if name == "lua" || name == "bash" {
-            continue;
-        }
         let Some(tool) = reg.get(name) else { continue };
-        if tool.policy() != ToolPolicy::Auto {
-            continue;
+        if is_code_mode_eligible(name, &tool.policy(), &tool.hints()) {
+            out.push(name.to_string());
         }
-        let hints = tool.hints();
-        if hints.destructive == Some(true) || hints.cpu_bound == Some(true) {
-            continue;
-        }
-        out.push(name.to_string());
     }
     out.sort();
     out

--- a/crates/core/src/capabilities/lua_code_mode.rs
+++ b/crates/core/src/capabilities/lua_code_mode.rs
@@ -1,0 +1,328 @@
+//! Lua Code-Mode Routing Capability (experimental)
+//!
+//! Turns the sandboxed `lua` tool into the agent's *primary* action surface by
+//! hiding "non-essential" tools from the model's direct tool list. Those tools
+//! are not removed from the running session — they stay in the executable
+//! registry — they are just no longer offered to the model as direct tool
+//! calls. The agent reaches them inside a Lua script through the existing
+//! code-mode `tools.<name>(args)` table, so one script can read inputs, call
+//! several sibling tools, and shape the result in a single turn instead of a
+//! chain of individual round-trips.
+//!
+//! ## How the non-functional requirements are met
+//!
+//! 1. **Capability-extensibility only (tool filtering).** The sole mechanism is
+//!    the existing [`ToolDefinitionHook`] seam (see `specs/capabilities.md` →
+//!    Tool definition hooks). No new agent-loop plumbing: the hook runs after
+//!    the runtime agent has merged its final tool list and simply drops the
+//!    eligible definitions before they reach the model. The *executable*
+//!    `ToolRegistry` is built separately from capability `tools()` and is left
+//!    untouched, which is what keeps the hidden tools callable from Lua.
+//! 2. **Relies on the existing `lua` capability.** `lua` is declared as a hard
+//!    [`dependencies`](Capability::dependencies) entry, and its code mode
+//!    (`tools.<name>`) is what makes the hidden tools invokable. The filter
+//!    mirrors [`is_code_mode_eligible`] exactly, so the set removed from the
+//!    model is precisely the set Lua re-exposes — no tool can become
+//!    unreachable.
+//! 3. **Capabilities export their functions to Lua.** Every eligible capability
+//!    tool is surfaced inside the VM as a `tools.<name>(args)` function by the
+//!    `lua` engine. This capability is what makes that export the agent's
+//!    default path rather than an occasional optimization.
+
+use std::sync::Arc;
+
+use serde_json::{Value, json};
+
+use super::lua::is_code_mode_eligible;
+use super::{Capability, CapabilityStatus, RiskLevel, ToolDefinitionHook};
+use crate::tool_types::ToolDefinition;
+
+pub const LUA_CODE_MODE_CAPABILITY_ID: &str = "lua_code_mode";
+
+/// Behavior contract only (no tool inventory — that lives in the tool schemas
+/// and the `lua` capability's own prompt). Kept to two dense sentences per the
+/// prompt-budget guidance in `specs/capabilities.md`.
+const SYSTEM_PROMPT: &str = "Most action tools are intentionally omitted from your direct tool list; \
+to use them, call them from inside the `lua` tool via the `tools.<name>(args)` table, where a single \
+script can chain several calls and process their results in one turn. Prefer one Lua script over a \
+sequence of separate tool calls.";
+
+/// Capability that routes non-essential tool calls through the Lua sandbox.
+pub struct LuaCodeModeCapability;
+
+impl Capability for LuaCodeModeCapability {
+    fn id(&self) -> &str {
+        LUA_CODE_MODE_CAPABILITY_ID
+    }
+
+    fn name(&self) -> &str {
+        "Lua Code Mode"
+    }
+
+    fn description(&self) -> &str {
+        r#"Route non-essential tool calls through the Lua sandbox.
+
+Hides auto, non-destructive tools from the model's direct tool list so the agent
+orchestrates them inside the `lua` tool via `tools.<name>(args)` — fewer
+round-trips, structured results.
+
+> [!NOTE]
+> Requires the `lua` capability. Execution, approval-gated, destructive, and
+> client-side tools stay directly callable."#
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+
+    fn risk_level(&self) -> RiskLevel {
+        // Inseparable from `lua` (scripted code execution) and reshapes how the
+        // agent acts. Admin-gated like its dependency.
+        RiskLevel::High
+    }
+
+    fn icon(&self) -> Option<&str> {
+        Some("code")
+    }
+
+    fn category(&self) -> Option<&str> {
+        Some("Execution")
+    }
+
+    fn system_prompt_addition(&self) -> Option<&str> {
+        Some(SYSTEM_PROMPT)
+    }
+
+    fn dependencies(&self) -> Vec<&'static str> {
+        vec!["lua"]
+    }
+
+    fn tool_definition_hooks(&self) -> Vec<Arc<dyn ToolDefinitionHook>> {
+        vec![Arc::new(HideCodeModeToolsHook {
+            keep_visible: Vec::new(),
+        })]
+    }
+
+    fn tool_definition_hooks_with_config(
+        &self,
+        config: &Value,
+    ) -> Vec<Arc<dyn ToolDefinitionHook>> {
+        vec![Arc::new(HideCodeModeToolsHook {
+            keep_visible: parse_keep_visible(config),
+        })]
+    }
+
+    fn config_schema(&self) -> Option<Value> {
+        Some(json!({
+            "type": "object",
+            "properties": {
+                "keep_visible": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Tool names to keep directly callable by the model even when they would otherwise be routed through Lua code mode."
+                }
+            },
+            "additionalProperties": false
+        }))
+    }
+
+    fn validate_config(&self, config: &Value) -> Result<(), String> {
+        if config.is_null() {
+            return Ok(());
+        }
+        let obj = config
+            .as_object()
+            .ok_or_else(|| "config must be a JSON object".to_string())?;
+        if let Some(keep) = obj.get("keep_visible") {
+            let arr = keep
+                .as_array()
+                .ok_or_else(|| "keep_visible must be an array of tool names".to_string())?;
+            if arr.iter().any(|v| !v.is_string()) {
+                return Err("keep_visible entries must be strings".to_string());
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Read the optional `keep_visible` allowlist from per-agent config.
+fn parse_keep_visible(config: &Value) -> Vec<String> {
+    config
+        .get("keep_visible")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Drops code-mode-eligible tool definitions from the model-facing tool list.
+///
+/// Tools listed in `keep_visible` are always retained. Everything that is *not*
+/// eligible (the `lua`/`bash` execution tools, destructive, approval-gated,
+/// client-side, and `cpu_bound` tools) is also retained — those stay direct
+/// tool calls.
+struct HideCodeModeToolsHook {
+    keep_visible: Vec<String>,
+}
+
+impl ToolDefinitionHook for HideCodeModeToolsHook {
+    fn transform(&self, tools: Vec<ToolDefinition>) -> Vec<ToolDefinition> {
+        tools
+            .into_iter()
+            .filter(|def| {
+                let name = def.name();
+                self.keep_visible.iter().any(|k| k == name)
+                    || !is_code_mode_eligible(name, def.policy(), def.hints())
+            })
+            .collect()
+    }
+
+    fn applies_with_native_tool_search(&self) -> bool {
+        // This is a hard routing policy (the model must go through Lua), not a
+        // schema-deferral optimization, so it applies regardless of whether the
+        // model uses hosted tool_search.
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tool_types::{BuiltinTool, ClientSideTool, DeferrablePolicy, ToolHints, ToolPolicy};
+
+    fn builtin(name: &str, policy: ToolPolicy, hints: ToolHints) -> ToolDefinition {
+        ToolDefinition::Builtin(BuiltinTool {
+            name: name.to_string(),
+            display_name: None,
+            description: format!("{name} tool"),
+            parameters: json!({ "type": "object" }),
+            policy,
+            category: None,
+            deferrable: DeferrablePolicy::default(),
+            hints,
+            full_parameters: None,
+        })
+    }
+
+    fn names(defs: &[ToolDefinition]) -> Vec<&str> {
+        defs.iter().map(|d| d.name()).collect()
+    }
+
+    #[test]
+    fn capability_metadata() {
+        let cap = LuaCodeModeCapability;
+        assert_eq!(cap.id(), "lua_code_mode");
+        assert_eq!(cap.risk_level(), RiskLevel::High);
+        assert_eq!(cap.dependencies(), vec!["lua"]);
+        assert_eq!(cap.category(), Some("Execution"));
+        assert!(cap.system_prompt_addition().is_some());
+    }
+
+    #[test]
+    fn hides_eligible_tools_keeps_lua_and_essential() {
+        let hook = HideCodeModeToolsHook {
+            keep_visible: Vec::new(),
+        };
+        let defs = vec![
+            builtin("lua", ToolPolicy::Auto, ToolHints::default()),
+            builtin("bash", ToolPolicy::Auto, ToolHints::default()),
+            builtin("add", ToolPolicy::Auto, ToolHints::default()),
+            builtin(
+                "delete_file",
+                ToolPolicy::Auto,
+                ToolHints::default().with_destructive(true),
+            ),
+            builtin(
+                "transfer_funds",
+                ToolPolicy::RequiresApproval,
+                ToolHints::default(),
+            ),
+            ToolDefinition::ClientSide(ClientSideTool {
+                name: "pick_file".to_string(),
+                display_name: None,
+                description: "client".to_string(),
+                parameters: json!({ "type": "object" }),
+                category: None,
+                deferrable: DeferrablePolicy::default(),
+                hints: ToolHints::default(),
+                full_parameters: None,
+            }),
+        ];
+
+        let transformed = hook.transform(defs);
+        let kept = names(&transformed);
+        // `add` is the only eligible tool → hidden. Everything else stays.
+        assert!(kept.contains(&"lua"));
+        assert!(kept.contains(&"bash"));
+        assert!(kept.contains(&"delete_file"));
+        assert!(kept.contains(&"transfer_funds"));
+        assert!(kept.contains(&"pick_file"));
+        assert!(!kept.contains(&"add"), "eligible tool must be hidden");
+    }
+
+    #[test]
+    fn keep_visible_overrides_hiding() {
+        let hook = HideCodeModeToolsHook {
+            keep_visible: vec!["add".to_string()],
+        };
+        let defs = vec![
+            builtin("add", ToolPolicy::Auto, ToolHints::default()),
+            builtin("multiply", ToolPolicy::Auto, ToolHints::default()),
+        ];
+        let transformed = hook.transform(defs);
+        let kept = names(&transformed);
+        assert!(kept.contains(&"add"), "keep_visible must retain the tool");
+        assert!(!kept.contains(&"multiply"));
+    }
+
+    #[test]
+    fn config_aware_hook_reads_keep_visible() {
+        let cap = LuaCodeModeCapability;
+        let hook = cap
+            .tool_definition_hooks_with_config(&json!({ "keep_visible": ["multiply"] }))
+            .pop()
+            .unwrap();
+        let defs = vec![
+            builtin("add", ToolPolicy::Auto, ToolHints::default()),
+            builtin("multiply", ToolPolicy::Auto, ToolHints::default()),
+        ];
+        let transformed = hook.transform(defs);
+        let kept = names(&transformed);
+        assert_eq!(kept, vec!["multiply"]);
+    }
+
+    #[test]
+    fn validate_config_rejects_bad_keep_visible() {
+        let cap = LuaCodeModeCapability;
+        assert!(
+            cap.validate_config(&json!({ "keep_visible": ["ok"] }))
+                .is_ok()
+        );
+        assert!(cap.validate_config(&json!({})).is_ok());
+        assert!(cap.validate_config(&Value::Null).is_ok());
+        assert!(
+            cap.validate_config(&json!({ "keep_visible": "nope" }))
+                .is_err()
+        );
+        assert!(
+            cap.validate_config(&json!({ "keep_visible": [1, 2] }))
+                .is_err()
+        );
+    }
+
+    // Prompt-budget ratchet (specs/capabilities.md → prompt size). Lowering is
+    // always fine; raising requires an explicit bump + justification.
+    #[test]
+    fn system_prompt_within_budget() {
+        let cap = LuaCodeModeCapability;
+        let prompt = cap.system_prompt_addition().unwrap();
+        assert!(
+            prompt.len() <= 500,
+            "lua_code_mode prompt grew to {} bytes (budget 500)",
+            prompt.len()
+        );
+    }
+}

--- a/crates/core/src/capabilities/lua_code_mode.rs
+++ b/crates/core/src/capabilities/lua_code_mode.rs
@@ -138,6 +138,13 @@ round-trips, structured results.
         let obj = config
             .as_object()
             .ok_or_else(|| "config must be a JSON object".to_string())?;
+        // Enforce the same closed contract as `config_schema`
+        // (`additionalProperties: false`) on every write path.
+        for key in obj.keys() {
+            if key != "keep_visible" && key != "full_schemas" {
+                return Err(format!("unknown config key: {key}"));
+            }
+        }
         if let Some(keep) = obj.get("keep_visible") {
             let arr = keep
                 .as_array()
@@ -563,6 +570,12 @@ mod tests {
         assert!(
             cap.validate_config(&json!({ "full_schemas": "yes" }))
                 .is_err()
+        );
+        // Closed contract: unknown keys are rejected (matches config_schema's
+        // additionalProperties: false).
+        assert!(
+            cap.validate_config(&json!({ "nope": 1 })).is_err(),
+            "unknown config keys must be rejected"
         );
     }
 

--- a/crates/core/src/capabilities/lua_code_mode.rs
+++ b/crates/core/src/capabilities/lua_code_mode.rs
@@ -98,17 +98,17 @@ round-trips, structured results.
     }
 
     fn tool_definition_hooks(&self) -> Vec<Arc<dyn ToolDefinitionHook>> {
-        vec![Arc::new(HideCodeModeToolsHook {
-            keep_visible: Vec::new(),
-        })]
+        vec![Arc::new(HideCodeModeToolsHook::default())]
     }
 
     fn tool_definition_hooks_with_config(
         &self,
         config: &Value,
     ) -> Vec<Arc<dyn ToolDefinitionHook>> {
+        let opts = parse_options(config);
         vec![Arc::new(HideCodeModeToolsHook {
-            keep_visible: parse_keep_visible(config),
+            keep_visible: opts.keep_visible,
+            full_schemas: opts.full_schemas,
         })]
     }
 
@@ -120,6 +120,11 @@ round-trips, structured results.
                     "type": "array",
                     "items": { "type": "string" },
                     "description": "Tool names to keep directly callable by the model even when they would otherwise be routed through Lua code mode."
+                },
+                "full_schemas": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Embed each hidden tool's full JSON Schema in the lua tool description (lossless discovery). Off by default: a compact typed signature is shown instead."
                 }
             },
             "additionalProperties": false
@@ -141,21 +146,38 @@ round-trips, structured results.
                 return Err("keep_visible entries must be strings".to_string());
             }
         }
+        if let Some(full) = obj.get("full_schemas")
+            && !full.is_boolean()
+        {
+            return Err("full_schemas must be a boolean".to_string());
+        }
         Ok(())
     }
 }
 
-/// Read the optional `keep_visible` allowlist from per-agent config.
-fn parse_keep_visible(config: &Value) -> Vec<String> {
-    config
-        .get("keep_visible")
-        .and_then(|v| v.as_array())
-        .map(|arr| {
-            arr.iter()
-                .filter_map(|v| v.as_str().map(str::to_string))
-                .collect()
-        })
-        .unwrap_or_default()
+/// Per-agent options parsed from capability config.
+#[derive(Default)]
+struct CodeModeOptions {
+    keep_visible: Vec<String>,
+    full_schemas: bool,
+}
+
+fn parse_options(config: &Value) -> CodeModeOptions {
+    CodeModeOptions {
+        keep_visible: config
+            .get("keep_visible")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(str::to_string))
+                    .collect()
+            })
+            .unwrap_or_default(),
+        full_schemas: config
+            .get("full_schemas")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false),
+    }
 }
 
 /// Drops code-mode-eligible tool definitions from the model-facing tool list
@@ -170,9 +192,12 @@ fn parse_keep_visible(config: &Value) -> Vec<String> {
 /// otherwise have no way to discover their names/arguments. So the eligible set
 /// is summarized into a `tools.<name>{ args }` catalog appended to the `lua`
 /// tool's own description — the discovery surface the model reads right before
-/// it decides to call `lua`.
+/// it decides to call `lua`. Each entry shows a typed signature; with
+/// `full_schemas` it also embeds the tool's complete JSON Schema (lossless).
+#[derive(Default)]
 struct HideCodeModeToolsHook {
     keep_visible: Vec<String>,
+    full_schemas: bool,
 }
 
 impl ToolDefinitionHook for HideCodeModeToolsHook {
@@ -184,7 +209,7 @@ impl ToolDefinitionHook for HideCodeModeToolsHook {
             let hidden = !self.keep_visible.iter().any(|k| k == name)
                 && is_code_mode_eligible(name, def.policy(), def.hints());
             if hidden {
-                catalog.push(format_catalog_entry(&def));
+                catalog.push(format_catalog_entry(&def, self.full_schemas));
             } else {
                 kept.push(def);
             }
@@ -205,21 +230,29 @@ impl ToolDefinitionHook for HideCodeModeToolsHook {
     }
 }
 
-/// One catalog line: `- name(arg1, arg2, opt?) — first sentence of description`.
-fn format_catalog_entry(def: &ToolDefinition) -> String {
-    let args = arg_summary(def.full_parameters());
+/// One catalog entry: `- name(a: number, b?: string) — first sentence`, with an
+/// optional indented `schema: { ... }` line when `full_schemas` is set.
+fn format_catalog_entry(def: &ToolDefinition, full_schemas: bool) -> String {
+    let sig = typed_signature(def.full_parameters());
     let desc = first_sentence(def.description());
-    if desc.is_empty() {
-        format!("- {}({args})", def.name())
+    let mut entry = if desc.is_empty() {
+        format!("- {}({sig})", def.name())
     } else {
-        format!("- {}({args}) — {desc}", def.name())
+        format!("- {}({sig}) — {desc}", def.name())
+    };
+    if full_schemas {
+        entry.push_str(&format!(
+            "\n    schema: {}",
+            compact_schema(def.full_parameters())
+        ));
     }
+    entry
 }
 
-/// Comma-separated argument names from a JSON Schema object: required first,
-/// optional suffixed with `?`. The synthetic `human_intent` narration argument
-/// (added by the `human_intent` capability) is omitted as noise.
-fn arg_summary(schema: &Value) -> String {
+/// Typed argument signature from a JSON Schema object: `name: type` for required
+/// args first, then `name?: type` for optional ones. The synthetic
+/// `human_intent` narration argument (added by `human_intent`) is omitted.
+fn typed_signature(schema: &Value) -> String {
     let Some(props) = schema.get("properties").and_then(|v| v.as_object()) else {
         return String::new();
     };
@@ -228,18 +261,50 @@ fn arg_summary(schema: &Value) -> String {
         .and_then(|v| v.as_array())
         .map(|a| a.iter().filter_map(|x| x.as_str()).collect())
         .unwrap_or_default();
-    let mut names: Vec<String> = Vec::new();
+    let mut parts: Vec<String> = Vec::new();
     for r in &required {
-        if *r != crate::tool_types::HUMAN_INTENT_ARGUMENT && props.contains_key(*r) {
-            names.push((*r).to_string());
+        if *r != crate::tool_types::HUMAN_INTENT_ARGUMENT
+            && let Some(prop) = props.get(*r)
+        {
+            parts.push(format!("{r}: {}", json_type(prop)));
         }
     }
-    for key in props.keys() {
+    for (key, prop) in props {
         if key != crate::tool_types::HUMAN_INTENT_ARGUMENT && !required.contains(&key.as_str()) {
-            names.push(format!("{key}?"));
+            parts.push(format!("{key}?: {}", json_type(prop)));
         }
     }
-    names.join(", ")
+    parts.join(", ")
+}
+
+/// Render a JSON Schema property's `type` as a short string (e.g. `number`,
+/// `string|null`, `enum`, `object`). Falls back to `any` when unspecified.
+fn json_type(prop: &Value) -> String {
+    match prop.get("type") {
+        Some(Value::String(s)) => s.clone(),
+        Some(Value::Array(types)) => types
+            .iter()
+            .filter_map(|v| v.as_str())
+            .collect::<Vec<_>>()
+            .join("|"),
+        _ if prop.get("enum").is_some() => "enum".to_string(),
+        _ => "any".to_string(),
+    }
+}
+
+/// Minified JSON Schema for full discovery, with the synthetic `human_intent`
+/// argument stripped (it is never passed to `tools.*`).
+fn compact_schema(schema: &Value) -> String {
+    let mut schema = schema.clone();
+    if let Some(obj) = schema.as_object_mut() {
+        if let Some(props) = obj.get_mut("properties").and_then(|v| v.as_object_mut()) {
+            props.remove(crate::tool_types::HUMAN_INTENT_ARGUMENT);
+        }
+        if let Some(req) = obj.get_mut("required").and_then(|v| v.as_array_mut()) {
+            req.retain(|v| v.as_str() != Some(crate::tool_types::HUMAN_INTENT_ARGUMENT));
+        }
+    }
+    serde_json::to_string(&schema).unwrap_or_else(|_| "{}".to_string())
 }
 
 /// First sentence (up to `.` or newline), trimmed and length-capped.
@@ -259,11 +324,12 @@ fn first_sentence(description: &str) -> String {
 }
 
 /// Append the catalog to the `lua` tool's description so the model can discover
-/// the in-script `tools.*` functions.
+/// the in-script `tools.*` functions and their arguments.
 fn graft_catalog_onto_lua(def: &mut ToolDefinition, catalog: &[String]) {
     let block = format!(
         "\n\nThese tools are available ONLY inside this script via the `tools` table — \
-call them as `tools.<name>{{ args }}` (e.g. `local r = tools.add{{ a = 1, b = 2 }}`):\n{}",
+call them as `tools.<name>{{ args }}` (e.g. `local r = tools.add{{ a = 1, b = 2 }}`). \
+Argument types follow each name:\n{}",
         catalog.join("\n")
     );
     match def {
@@ -309,6 +375,7 @@ mod tests {
     fn hides_eligible_tools_keeps_lua_and_essential() {
         let hook = HideCodeModeToolsHook {
             keep_visible: Vec::new(),
+            full_schemas: false,
         };
         let defs = vec![
             builtin("lua", ToolPolicy::Auto, ToolHints::default()),
@@ -351,6 +418,7 @@ mod tests {
     fn grafts_catalog_onto_lua_description() {
         let hook = HideCodeModeToolsHook {
             keep_visible: Vec::new(),
+            full_schemas: false,
         };
         let add = ToolDefinition::Builtin(BuiltinTool {
             name: "add".to_string(),
@@ -372,20 +440,78 @@ mod tests {
         let kept = hook.transform(defs);
         // `add` is gone from the model's tool list...
         assert_eq!(names(&kept), vec!["lua"]);
-        // ...but discoverable from the lua tool description with its arguments.
+        // ...but discoverable from the lua tool description with typed arguments.
         let lua_desc = kept[0].description();
         assert!(lua_desc.contains("tools.<name>"), "{lua_desc}");
-        assert!(lua_desc.contains("- add(a, b)"), "{lua_desc}");
+        assert!(
+            lua_desc.contains("- add(a: number, b: number)"),
+            "{lua_desc}"
+        );
         assert!(
             lua_desc.contains("Add two numbers together"),
             "catalog should carry the description: {lua_desc}",
         );
+        // Default mode does not embed the full JSON schema.
+        assert!(!lua_desc.contains("schema:"), "{lua_desc}");
+    }
+
+    #[test]
+    fn full_schemas_embeds_complete_schema() {
+        let hook = HideCodeModeToolsHook {
+            keep_visible: Vec::new(),
+            full_schemas: true,
+        };
+        let add = ToolDefinition::Builtin(BuiltinTool {
+            name: "add".to_string(),
+            display_name: None,
+            description: "Add.".to_string(),
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "a": { "type": "number" },
+                    "b": { "type": "number" },
+                    "human_intent": { "type": "string" }
+                },
+                "required": ["a", "b"],
+            }),
+            policy: ToolPolicy::Auto,
+            category: None,
+            deferrable: DeferrablePolicy::default(),
+            hints: ToolHints::default(),
+            full_parameters: None,
+        });
+        let kept = hook.transform(vec![
+            builtin("lua", ToolPolicy::Auto, ToolHints::default()),
+            add,
+        ]);
+        let lua_desc = kept[0].description();
+        assert!(lua_desc.contains("schema:"), "{lua_desc}");
+        assert!(lua_desc.contains("\"properties\""), "{lua_desc}");
+        // The synthetic human_intent arg is stripped from both signature & schema.
+        assert!(!lua_desc.contains("human_intent"), "{lua_desc}");
+    }
+
+    #[test]
+    fn typed_signature_handles_optional_and_union_types() {
+        let sig = typed_signature(&json!({
+            "type": "object",
+            "properties": {
+                "path": { "type": "string" },
+                "limit": { "type": ["integer", "null"] },
+                "mode": { "enum": ["a", "b"] }
+            },
+            "required": ["path"],
+        }));
+        assert!(sig.starts_with("path: string"), "{sig}");
+        assert!(sig.contains("limit?: integer|null"), "{sig}");
+        assert!(sig.contains("mode?: enum"), "{sig}");
     }
 
     #[test]
     fn keep_visible_overrides_hiding() {
         let hook = HideCodeModeToolsHook {
             keep_visible: vec!["add".to_string()],
+            full_schemas: false,
         };
         let defs = vec![
             builtin("add", ToolPolicy::Auto, ToolHints::default()),
@@ -428,6 +554,14 @@ mod tests {
         );
         assert!(
             cap.validate_config(&json!({ "keep_visible": [1, 2] }))
+                .is_err()
+        );
+        assert!(
+            cap.validate_config(&json!({ "full_schemas": true }))
+                .is_ok()
+        );
+        assert!(
+            cap.validate_config(&json!({ "full_schemas": "yes" }))
                 .is_err()
         );
     }

--- a/crates/core/src/capabilities/lua_code_mode.rs
+++ b/crates/core/src/capabilities/lua_code_mode.rs
@@ -158,26 +158,43 @@ fn parse_keep_visible(config: &Value) -> Vec<String> {
         .unwrap_or_default()
 }
 
-/// Drops code-mode-eligible tool definitions from the model-facing tool list.
+/// Drops code-mode-eligible tool definitions from the model-facing tool list
+/// and grafts a catalog of them onto the `lua` tool description.
 ///
 /// Tools listed in `keep_visible` are always retained. Everything that is *not*
 /// eligible (the `lua`/`bash` execution tools, destructive, approval-gated,
 /// client-side, and `cpu_bound` tools) is also retained — those stay direct
 /// tool calls.
+///
+/// Because the hidden tools' standalone schemas are removed, the model would
+/// otherwise have no way to discover their names/arguments. So the eligible set
+/// is summarized into a `tools.<name>{ args }` catalog appended to the `lua`
+/// tool's own description — the discovery surface the model reads right before
+/// it decides to call `lua`.
 struct HideCodeModeToolsHook {
     keep_visible: Vec<String>,
 }
 
 impl ToolDefinitionHook for HideCodeModeToolsHook {
     fn transform(&self, tools: Vec<ToolDefinition>) -> Vec<ToolDefinition> {
-        tools
-            .into_iter()
-            .filter(|def| {
-                let name = def.name();
-                self.keep_visible.iter().any(|k| k == name)
-                    || !is_code_mode_eligible(name, def.policy(), def.hints())
-            })
-            .collect()
+        let mut kept: Vec<ToolDefinition> = Vec::new();
+        let mut catalog: Vec<String> = Vec::new();
+        for def in tools {
+            let name = def.name();
+            let hidden = !self.keep_visible.iter().any(|k| k == name)
+                && is_code_mode_eligible(name, def.policy(), def.hints());
+            if hidden {
+                catalog.push(format_catalog_entry(&def));
+            } else {
+                kept.push(def);
+            }
+        }
+        if !catalog.is_empty()
+            && let Some(lua) = kept.iter_mut().find(|d| d.name() == "lua")
+        {
+            graft_catalog_onto_lua(lua, &catalog);
+        }
+        kept
     }
 
     fn applies_with_native_tool_search(&self) -> bool {
@@ -185,6 +202,73 @@ impl ToolDefinitionHook for HideCodeModeToolsHook {
         // schema-deferral optimization, so it applies regardless of whether the
         // model uses hosted tool_search.
         true
+    }
+}
+
+/// One catalog line: `- name(arg1, arg2, opt?) — first sentence of description`.
+fn format_catalog_entry(def: &ToolDefinition) -> String {
+    let args = arg_summary(def.full_parameters());
+    let desc = first_sentence(def.description());
+    if desc.is_empty() {
+        format!("- {}({args})", def.name())
+    } else {
+        format!("- {}({args}) — {desc}", def.name())
+    }
+}
+
+/// Comma-separated argument names from a JSON Schema object: required first,
+/// optional suffixed with `?`. The synthetic `human_intent` narration argument
+/// (added by the `human_intent` capability) is omitted as noise.
+fn arg_summary(schema: &Value) -> String {
+    let Some(props) = schema.get("properties").and_then(|v| v.as_object()) else {
+        return String::new();
+    };
+    let required: Vec<&str> = schema
+        .get("required")
+        .and_then(|v| v.as_array())
+        .map(|a| a.iter().filter_map(|x| x.as_str()).collect())
+        .unwrap_or_default();
+    let mut names: Vec<String> = Vec::new();
+    for r in &required {
+        if *r != crate::tool_types::HUMAN_INTENT_ARGUMENT && props.contains_key(*r) {
+            names.push((*r).to_string());
+        }
+    }
+    for key in props.keys() {
+        if key != crate::tool_types::HUMAN_INTENT_ARGUMENT && !required.contains(&key.as_str()) {
+            names.push(format!("{key}?"));
+        }
+    }
+    names.join(", ")
+}
+
+/// First sentence (up to `.` or newline), trimmed and length-capped.
+fn first_sentence(description: &str) -> String {
+    let trimmed = description.trim();
+    let end = trimmed
+        .find(['.', '\n'])
+        .map(|i| i + 1)
+        .unwrap_or(trimmed.len());
+    let mut s = trimmed[..end].trim().to_string();
+    const MAX: usize = 140;
+    if s.len() > MAX {
+        s.truncate(MAX);
+        s.push('…');
+    }
+    s
+}
+
+/// Append the catalog to the `lua` tool's description so the model can discover
+/// the in-script `tools.*` functions.
+fn graft_catalog_onto_lua(def: &mut ToolDefinition, catalog: &[String]) {
+    let block = format!(
+        "\n\nThese tools are available ONLY inside this script via the `tools` table — \
+call them as `tools.<name>{{ args }}` (e.g. `local r = tools.add{{ a = 1, b = 2 }}`):\n{}",
+        catalog.join("\n")
+    );
+    match def {
+        ToolDefinition::Builtin(b) => b.description.push_str(&block),
+        ToolDefinition::ClientSide(c) => c.description.push_str(&block),
     }
 }
 
@@ -261,6 +345,41 @@ mod tests {
         assert!(kept.contains(&"transfer_funds"));
         assert!(kept.contains(&"pick_file"));
         assert!(!kept.contains(&"add"), "eligible tool must be hidden");
+    }
+
+    #[test]
+    fn grafts_catalog_onto_lua_description() {
+        let hook = HideCodeModeToolsHook {
+            keep_visible: Vec::new(),
+        };
+        let add = ToolDefinition::Builtin(BuiltinTool {
+            name: "add".to_string(),
+            display_name: None,
+            description: "Add two numbers together and return the result.".to_string(),
+            parameters: json!({
+                "type": "object",
+                "properties": { "a": { "type": "number" }, "b": { "type": "number" } },
+                "required": ["a", "b"],
+            }),
+            policy: ToolPolicy::Auto,
+            category: None,
+            deferrable: DeferrablePolicy::default(),
+            hints: ToolHints::default(),
+            full_parameters: None,
+        });
+        let defs = vec![builtin("lua", ToolPolicy::Auto, ToolHints::default()), add];
+
+        let kept = hook.transform(defs);
+        // `add` is gone from the model's tool list...
+        assert_eq!(names(&kept), vec!["lua"]);
+        // ...but discoverable from the lua tool description with its arguments.
+        let lua_desc = kept[0].description();
+        assert!(lua_desc.contains("tools.<name>"), "{lua_desc}");
+        assert!(lua_desc.contains("- add(a, b)"), "{lua_desc}");
+        assert!(
+            lua_desc.contains("Add two numbers together"),
+            "catalog should carry the description: {lua_desc}",
+        );
     }
 
     #[test]

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -105,6 +105,7 @@ mod infinity_context;
 mod knowledge_base;
 mod loop_detection;
 mod lua;
+mod lua_code_mode;
 pub mod mcp;
 mod noop;
 mod openai_tool_search;
@@ -212,7 +213,8 @@ pub use knowledge_base::{
     validate_knowledge_base_config,
 };
 pub use loop_detection::LoopDetectionCapability;
-pub use lua::{LUA_CAPABILITY_ID, LuaCapability, LuaTool, LuaVfs};
+pub use lua::{LUA_CAPABILITY_ID, LuaCapability, LuaTool, LuaVfs, is_code_mode_eligible};
+pub use lua_code_mode::{LUA_CODE_MODE_CAPABILITY_ID, LuaCodeModeCapability};
 pub use mcp::{
     MCP_CAPABILITY_PREFIX, McpCapability, is_mcp_capability, mcp_capability_id,
     parse_mcp_capability_id,
@@ -1030,6 +1032,9 @@ impl CapabilityRegistry {
         // when the `lua` cargo feature is also compiled in.
         if internal_flags.lua {
             registry.register(LuaCapability);
+            // Routes non-essential tool calls through the Lua sandbox by hiding
+            // them from the model's direct tool list. Depends on `lua`.
+            registry.register(LuaCodeModeCapability);
         }
         for plugin in inventory::iter::<IntegrationPlugin>() {
             if (!plugin.experimental_only || grade.experimental_features_enabled())

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -21,6 +21,11 @@ default = []
 # server/worker (which depend on this crate transitively) never compile stdio
 # in — see specs/runtime-mcp.md (D2). Embedders like the coding CLI opt in.
 mcp-stdio = ["everruns-mcp/stdio"]
+# Compile the experimental sandboxed Lua execution engine (mlua) into core so
+# the `lua` / `lua_code_mode` capabilities actually run scripts. Off by default
+# so the standard runtime build pulls in no interpreter. Enables the
+# `lua_code_mode_agent` example and the `lua_code_mode_test` integration test.
+lua = ["everruns-core/lua"]
 
 [dependencies]
 async-trait.workspace = true

--- a/crates/runtime/examples/lua_code_mode_agent.rs
+++ b/crates/runtime/examples/lua_code_mode_agent.rs
@@ -50,9 +50,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     "#;
 
     // Build the platform: only the math + lua capabilities are registered.
-    // `session_file_system` is intentionally not registered — the in-memory
-    // runtime provides the file store, and `lua`'s dependency on it resolves to
-    // nothing extra, so the only directly visible tool ends up being `lua`.
+    // `FileSystemCapability` (`session_file_system`) is deliberately NOT
+    // registered. `lua` depends on it, but an unregistered dependency is
+    // silently skipped, so no file tools exist here and the only model-visible
+    // tool ends up being `lua`. (The in-memory runtime still supplies the file
+    // store that `fs.*` writes to.) In a full platform where
+    // `session_file_system` IS registered, its tools would appear too: the
+    // read-only ones routed into code mode, destructive ones like `delete_file`
+    // staying directly callable.
     let mut caps = CapabilityRegistry::new();
     caps.register(LuaCapability);
     caps.register(LuaCodeModeCapability);

--- a/crates/runtime/examples/lua_code_mode_agent.rs
+++ b/crates/runtime/examples/lua_code_mode_agent.rs
@@ -139,8 +139,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         println!("{}", &lua_desc[idx..]);
     }
     assert!(
-        lua_desc.contains("multiply(a, b)"),
-        "lua description should advertise the hidden tools and their args",
+        lua_desc.contains("multiply(a: number, b: number)"),
+        "lua description should advertise the hidden tools and their typed args",
     );
 
     // 2. Run the turn. The agent orchestrates the hidden tools inside Lua.

--- a/crates/runtime/examples/lua_code_mode_agent.rs
+++ b/crates/runtime/examples/lua_code_mode_agent.rs
@@ -125,6 +125,24 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         );
     }
 
+    // The hidden tools are still discoverable: their catalog is grafted onto the
+    // `lua` tool description so a real model knows what `tools.*` to call.
+    let lua_desc = ctx
+        .runtime_agent
+        .tools
+        .iter()
+        .find(|t| t.name() == "lua")
+        .map(|t| t.description().to_string())
+        .unwrap_or_default();
+    println!("\n--- lua tool description (tail) ---");
+    if let Some(idx) = lua_desc.find("These tools are available ONLY inside this script") {
+        println!("{}", &lua_desc[idx..]);
+    }
+    assert!(
+        lua_desc.contains("multiply(a, b)"),
+        "lua description should advertise the hidden tools and their args",
+    );
+
     // 2. Run the turn. The agent orchestrates the hidden tools inside Lua.
     let turn = runtime
         .run_text_turn(session_id, "Compute 6 * 7 + 8.")

--- a/crates/runtime/examples/lua_code_mode_agent.rs
+++ b/crates/runtime/examples/lua_code_mode_agent.rs
@@ -1,0 +1,159 @@
+//! Lua code-mode agent: non-essential tool calls routed through the Lua sandbox.
+//!
+//! This example builds an agent whose action tools (`add`, `subtract`,
+//! `multiply`, `divide` from `test_math`) are **hidden** from the model's direct
+//! tool list by the `lua_code_mode` capability. The agent therefore cannot call
+//! them as ordinary tool calls — instead it drives them from inside a single
+//! `lua` script via the code-mode `tools.<name>(args)` table.
+//!
+//! The model is simulated (`LlmSim`) so the example is deterministic and needs
+//! no API key — it doubles as a CI smoke test. The simulated model emits one
+//! `lua` tool call that orchestrates two hidden math tools and writes the result
+//! to the workspace, then a final answer.
+//!
+//! Run it:
+//!
+//! ```text
+//! cargo run -p everruns-runtime --example lua_code_mode_agent --features lua
+//! ```
+//!
+//! Without the `lua` feature the engine is not compiled in and the script would
+//! return a "not compiled" error, so the example is gated behind it.
+
+#[cfg(not(feature = "lua"))]
+fn main() {
+    eprintln!(
+        "This example requires the `lua` feature:\n  \
+         cargo run -p everruns-runtime --example lua_code_mode_agent --features lua"
+    );
+}
+
+#[cfg(feature = "lua")]
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    use everruns_core::capabilities::{LuaCapability, LuaCodeModeCapability, TestMathCapability};
+    use everruns_core::llm_driver_registry::DriverRegistry;
+    use everruns_core::llmsim_driver::{LlmSimConfig, SimToolCall, SimTurn};
+    use everruns_core::{
+        AgentId, CapabilityRegistry, HarnessId, LlmProviderType, ModelWithProvider,
+        PlatformDefinition, SessionId,
+    };
+    use everruns_runtime::{AgentBuilder, HarnessBuilder, InProcessRuntimeBuilder, SessionBuilder};
+
+    // The math tools the agent will orchestrate through Lua. `tools.multiply` /
+    // `tools.add` etc. become available inside the script.
+    const SCRIPT: &str = r#"
+        local product = tools.multiply({ a = 6, b = 7 })   -- 42
+        local total = tools.add({ a = product.result, b = 8 }) -- 50
+        fs.write("/workspace/out.txt", string.format("%d", total.result))
+        return total.result
+    "#;
+
+    // Build the platform: only the math + lua capabilities are registered.
+    // `session_file_system` is intentionally not registered — the in-memory
+    // runtime provides the file store, and `lua`'s dependency on it resolves to
+    // nothing extra, so the only directly visible tool ends up being `lua`.
+    let mut caps = CapabilityRegistry::new();
+    caps.register(LuaCapability);
+    caps.register(LuaCodeModeCapability);
+    caps.register(TestMathCapability);
+
+    let mut drivers = DriverRegistry::new();
+    everruns_core::llmsim_driver::register_driver(&mut drivers);
+    let platform = PlatformDefinition::new(caps, drivers);
+
+    // Simulated model: turn 1 calls `lua` with the orchestration script; turn 2
+    // returns the final answer. No real API call.
+    let sim = LlmSimConfig::scripted(vec![
+        SimTurn::ToolCalls(vec![SimToolCall {
+            name: "lua".to_string(),
+            arguments: serde_json::json!({ "script": SCRIPT }),
+            id: None,
+        }]),
+        SimTurn::Assistant("The result is 50 (6 * 7 + 8).".to_string()),
+    ]);
+
+    let harness_id = HarnessId::new();
+    let agent_id = AgentId::new();
+    let session_id = SessionId::new();
+
+    let harness = HarnessBuilder::new(
+        "code-mode",
+        "You are an automation agent. Use the `lua` tool to do work; other tools \
+         are available inside Lua via tools.<name>(args).",
+    )
+    .id(harness_id)
+    .capability("lua")
+    .capability("lua_code_mode")
+    .capability("test_math")
+    .build();
+
+    let agent = AgentBuilder::new("code-mode-agent", "Complete the task, then stop.")
+        .id(agent_id)
+        .max_iterations(6)
+        .build();
+
+    let session = SessionBuilder::new(harness_id)
+        .id(session_id)
+        .agent(agent_id)
+        .build();
+
+    let runtime = InProcessRuntimeBuilder::new()
+        .platform_definition(platform)
+        .llm_sim(sim)
+        .default_model(ModelWithProvider {
+            model: "llmsim-model".to_string(),
+            provider_type: LlmProviderType::LlmSim,
+            api_key: Some("fake-key".to_string()),
+            base_url: None,
+        })
+        .harness(harness)
+        .agent(agent)
+        .session(session)
+        .build()
+        .await?;
+
+    // 1. Inspect the model-facing tool list: the math tools are hidden.
+    let ctx = runtime.load_context(session_id).await?;
+    let visible: Vec<&str> = ctx.runtime_agent.tools.iter().map(|t| t.name()).collect();
+    println!("Model-visible tools: {visible:?}");
+    assert!(visible.contains(&"lua"), "lua must stay directly callable");
+    for hidden in ["add", "subtract", "multiply", "divide"] {
+        assert!(
+            !visible.contains(&hidden),
+            "`{hidden}` should be hidden from the model and only reachable via Lua",
+        );
+    }
+
+    // 2. Run the turn. The agent orchestrates the hidden tools inside Lua.
+    let turn = runtime
+        .run_text_turn(session_id, "Compute 6 * 7 + 8.")
+        .await?;
+    assert!(turn.success, "turn should succeed");
+
+    // 3. The model never called a math tool directly — only `lua`.
+    let messages = runtime.messages(session_id).await?;
+    let mut direct_tool_names = Vec::new();
+    for msg in &messages {
+        for call in msg.tool_calls() {
+            direct_tool_names.push(call.name.clone());
+        }
+    }
+    println!("Tools the model called directly: {direct_tool_names:?}");
+    assert!(
+        direct_tool_names.iter().all(|n| n == "lua"),
+        "the model must only call `lua` directly, got {direct_tool_names:?}",
+    );
+
+    // 4. The Lua script produced the answer in the workspace.
+    let out = runtime
+        .read_file(session_id, "/workspace/out.txt")
+        .await?
+        .and_then(|f| f.content)
+        .unwrap_or_default();
+    println!("/workspace/out.txt = {out:?}");
+    assert!(out.contains("50"), "expected 50 in out.txt, got {out:?}");
+
+    println!("\n✅ Lua code-mode agent: math tools hidden from the model, executed via Lua.");
+    Ok(())
+}

--- a/crates/runtime/tests/lua_code_mode_test.rs
+++ b/crates/runtime/tests/lua_code_mode_test.rs
@@ -112,8 +112,8 @@ async fn hides_math_tools_but_runs_them_via_lua() {
         .map(|t| t.description().to_string())
         .unwrap_or_default();
     assert!(
-        lua_desc.contains("multiply(a, b)") && lua_desc.contains("tools.<name>"),
-        "lua description should catalog the hidden tools: {lua_desc}",
+        lua_desc.contains("multiply(a: number, b: number)") && lua_desc.contains("tools.<name>"),
+        "lua description should catalog the hidden tools with typed args: {lua_desc}",
     );
 
     // Run the turn; the agent orchestrates the hidden tools inside Lua.

--- a/crates/runtime/tests/lua_code_mode_test.rs
+++ b/crates/runtime/tests/lua_code_mode_test.rs
@@ -1,0 +1,132 @@
+//! Integration smoke test for the `lua_code_mode` capability over the public
+//! in-process runtime.
+//!
+//! Verifies the end-to-end contract: tools eligible for code mode are removed
+//! from the model-facing tool list, yet remain executable from inside a `lua`
+//! script via `tools.<name>(args)`. The model is simulated, so the test is
+//! deterministic and runs without credentials.
+//!
+//! Requires the `lua` feature (compiles the mlua engine):
+//!   cargo test -p everruns-runtime --features lua --test lua_code_mode_test
+
+#![cfg(feature = "lua")]
+
+use everruns_core::capabilities::{LuaCapability, LuaCodeModeCapability, TestMathCapability};
+use everruns_core::llm_driver_registry::DriverRegistry;
+use everruns_core::llmsim_driver::{LlmSimConfig, SimToolCall, SimTurn};
+use everruns_core::{
+    AgentId, CapabilityRegistry, HarnessId, LlmProviderType, ModelWithProvider, PlatformDefinition,
+    SessionId,
+};
+use everruns_runtime::{AgentBuilder, HarnessBuilder, InProcessRuntimeBuilder, SessionBuilder};
+
+const ORCHESTRATION_SCRIPT: &str = r#"
+    local product = tools.multiply({ a = 6, b = 7 })       -- 42
+    local total = tools.add({ a = product.result, b = 8 }) -- 50
+    fs.write("/workspace/out.txt", string.format("%d", total.result))
+    return total.result
+"#;
+
+fn platform() -> PlatformDefinition {
+    let mut caps = CapabilityRegistry::new();
+    caps.register(LuaCapability);
+    caps.register(LuaCodeModeCapability);
+    caps.register(TestMathCapability);
+
+    let mut drivers = DriverRegistry::new();
+    everruns_core::llmsim_driver::register_driver(&mut drivers);
+
+    PlatformDefinition::new(caps, drivers)
+}
+
+#[tokio::test]
+async fn hides_math_tools_but_runs_them_via_lua() {
+    let harness_id = HarnessId::new();
+    let agent_id = AgentId::new();
+    let session_id = SessionId::new();
+
+    let sim = LlmSimConfig::scripted(vec![
+        SimTurn::ToolCalls(vec![SimToolCall {
+            name: "lua".to_string(),
+            arguments: serde_json::json!({ "script": ORCHESTRATION_SCRIPT }),
+            id: None,
+        }]),
+        SimTurn::Assistant("Done: 50.".to_string()),
+    ]);
+
+    let harness = HarnessBuilder::new("code-mode", "Use the lua tool to act.")
+        .id(harness_id)
+        .capability("lua")
+        .capability("lua_code_mode")
+        .capability("test_math")
+        .build();
+    let agent = AgentBuilder::new("agent", "Finish the task then stop.")
+        .id(agent_id)
+        .max_iterations(6)
+        .build();
+    let session = SessionBuilder::new(harness_id)
+        .id(session_id)
+        .agent(agent_id)
+        .build();
+
+    let runtime = InProcessRuntimeBuilder::new()
+        .platform_definition(platform())
+        .llm_sim(sim)
+        .default_model(ModelWithProvider {
+            model: "llmsim-model".to_string(),
+            provider_type: LlmProviderType::LlmSim,
+            api_key: Some("fake-key".to_string()),
+            base_url: None,
+        })
+        .harness(harness)
+        .agent(agent)
+        .session(session)
+        .build()
+        .await
+        .expect("build runtime");
+
+    // The math tools are hidden from the model; `lua` stays directly callable.
+    let ctx = runtime
+        .load_context(session_id)
+        .await
+        .expect("load context");
+    let visible: Vec<&str> = ctx.runtime_agent.tools.iter().map(|t| t.name()).collect();
+    assert!(
+        visible.contains(&"lua"),
+        "lua should be visible: {visible:?}"
+    );
+    for hidden in ["add", "subtract", "multiply", "divide"] {
+        assert!(
+            !visible.contains(&hidden),
+            "`{hidden}` should be hidden from the model: {visible:?}",
+        );
+    }
+
+    // Run the turn; the agent orchestrates the hidden tools inside Lua.
+    let turn = runtime
+        .run_text_turn(session_id, "Compute 6 * 7 + 8.")
+        .await
+        .expect("run turn");
+    assert!(turn.success, "turn should succeed");
+
+    // The model only ever called `lua` directly.
+    let messages = runtime.messages(session_id).await.expect("messages");
+    let direct: Vec<String> = messages
+        .iter()
+        .flat_map(|m| m.tool_calls().into_iter().map(|c| c.name.clone()))
+        .collect();
+    assert!(!direct.is_empty(), "expected at least one tool call");
+    assert!(
+        direct.iter().all(|n| n == "lua"),
+        "model must only call lua directly, got {direct:?}",
+    );
+
+    // Lua executed the hidden tools and wrote the result.
+    let out = runtime
+        .read_file(session_id, "/workspace/out.txt")
+        .await
+        .expect("read out.txt")
+        .and_then(|f| f.content)
+        .unwrap_or_default();
+    assert!(out.contains("50"), "expected 50 in out.txt, got {out:?}");
+}

--- a/crates/runtime/tests/lua_code_mode_test.rs
+++ b/crates/runtime/tests/lua_code_mode_test.rs
@@ -102,6 +102,20 @@ async fn hides_math_tools_but_runs_them_via_lua() {
         );
     }
 
+    // The hidden tools are advertised in the lua tool description so a real
+    // model can discover them (their standalone schemas are gone).
+    let lua_desc = ctx
+        .runtime_agent
+        .tools
+        .iter()
+        .find(|t| t.name() == "lua")
+        .map(|t| t.description().to_string())
+        .unwrap_or_default();
+    assert!(
+        lua_desc.contains("multiply(a, b)") && lua_desc.contains("tools.<name>"),
+        "lua description should catalog the hidden tools: {lua_desc}",
+    );
+
     // Run the turn; the agent orchestrates the hidden tools inside Lua.
     let turn = runtime
         .run_text_turn(session_id, "Compute 6 * 7 + 8.")

--- a/specs/capabilities.md
+++ b/specs/capabilities.md
@@ -904,6 +904,18 @@ The `PlatformStore` trait (in `everruns-core`) defines the org-scoped management
 
 Experimental capabilities are available in development environments only (`DeploymentGrade::Dev`). They may change significantly or be removed.
 
+#### Lua execution (`lua`) and code-mode routing (`lua_code_mode`)
+
+- `lua` — sandboxed Lua 5.4 interpreter over the session workspace. High risk,
+  admin-gated, `FEATURE_LUA` + `lua` cargo feature. See
+  [lua-execution.md](lua-execution.md).
+- `lua_code_mode` — depends on `lua`; hides code-mode-eligible tools from the
+  model's direct tool list (via a `ToolDefinitionHook`) so the agent
+  orchestrates them inside a `lua` script through `tools.<name>(args)`. This is
+  the canonical example of using the tool-filtering extension point to reshape
+  the agent's action surface. See
+  [lua-execution.md](lua-execution.md#code-mode-routing-capability-lua_code_mode).
+
 #### DockerContainer
 
 - **ID**: `docker_container` (Dev only, integration plugin)

--- a/specs/lua-execution.md
+++ b/specs/lua-execution.md
@@ -202,6 +202,16 @@ model). Essential tools (the `lua`/`bash` execution tools, destructive,
 approval-gated, client-side, `cpu_bound`) are never eligible and stay direct
 tool calls.
 
+**Discovery.** Hiding a tool removes its standalone schema, so the hook also
+grafts a catalog of the hidden tools onto the **`lua` tool's description** —
+one `- name(arg1, arg2, opt?) — first sentence` line per tool, built from the
+same `ToolDefinition` list it is filtering (the synthetic `human_intent`
+argument is omitted). This is what tells the model which `tools.<name>{ args }`
+functions exist and what they take; the policy sentence in the capability's
+system prompt tells it *to* route through Lua, and the catalog in the lua tool
+description tells it *what is callable*. Putting the catalog on the lua tool
+(not the always-on system prompt) means it is paid only when `lua` is present.
+
 - **Config:** `{ "keep_visible": ["tool_a", ...] }` force-keeps named tools as
   direct calls even when they would otherwise be routed through Lua. Default empty.
 - **Risk:** `High` — inseparable from `lua` (scripted execution) and admin-gated

--- a/specs/lua-execution.md
+++ b/specs/lua-execution.md
@@ -158,15 +158,59 @@ pathological synchronous C ops (out-of-process execution is the robust fix).
     by the allow-list + the central egress boundary (TM-LUA-005).
   - **Code mode (target 7) — DONE.** The agent's sibling tools are registered as
     `tools.<name>(args) -> result`, dispatched over the same channel bridge as
-    `fs.*`. Gated (`gated_code_mode_tools`): only `Auto`-policy, non-destructive,
-    non-`cpu_bound` tools; approval/client-side and the execution tools
-    (`lua`/`bash`) are excluded. The child `ToolContext` drops `tool_registry`, so
-    code mode cannot recurse (TM-LUA-009).
+    `fs.*`. Eligibility is decided by the shared `lua::is_code_mode_eligible`
+    predicate (`gated_code_mode_tools` filters the live registry through it):
+    only `Auto`-policy, non-destructive, non-`cpu_bound` tools; approval/client-side
+    and the execution tools (`lua`/`bash`) are excluded. The child `ToolContext`
+    drops `tool_registry`, so code mode cannot recurse (TM-LUA-009).
+  - **Code-mode routing capability (`lua_code_mode`) — DONE.** Makes Lua the
+    agent's *primary* action surface by hiding the code-mode-eligible tools from
+    the model's direct tool list, so the agent must orchestrate them inside a
+    `lua` script. See "Code-mode routing capability" below.
   - **User libraries (target 6) — deferred.** A controlled `require(path)`-style
     loader that reads a **text** Lua file from `/workspace` and returns its
     exports. Text-only loading stays within the script's trust level (no bytecode
     → TM-LUA-006 holds), but the loader must cap module count/recursion and
     resolve paths through `LuaVfs`. Not yet implemented.
+
+## Code-mode routing capability (`lua_code_mode`)
+
+A separate, composable capability (`crates/core/src/capabilities/lua_code_mode.rs`)
+that turns code mode from an occasional optimization into the agent's default
+action path. It exists to satisfy three constraints:
+
+1. **Capability-extensibility only.** The single mechanism is the existing
+   `ToolDefinitionHook` tool-filtering seam (`specs/capabilities.md`). The hook
+   runs after the runtime agent has merged its final tool list and drops every
+   code-mode-eligible `ToolDefinition` before the schemas reach the model. No
+   new agent-loop plumbing.
+2. **Relies on the `lua` capability.** `lua_code_mode` declares `lua` as a hard
+   dependency and reuses `lua::is_code_mode_eligible` as the *same* predicate the
+   engine uses to expose `tools.<name>`. Because both sides share one predicate,
+   the set hidden from the model is exactly the set Lua re-exposes — a tool can
+   never become unreachable.
+3. **Capabilities export their tools to Lua.** The export channel is the
+   engine's `tools.<name>(args)` table; this capability is what makes that the
+   agent's primary path rather than an opt-in.
+
+Key property that makes this safe: the *executable* `ToolRegistry`
+(`ToolContext::tool_registry`) is built from capability `tools()` independently
+of the model-facing `ToolDefinition` list. The hook only edits the latter, so
+hidden tools stay fully executable — the act atom passes the full registry into
+the Lua child context, and code mode calls them directly (not back through the
+model). Essential tools (the `lua`/`bash` execution tools, destructive,
+approval-gated, client-side, `cpu_bound`) are never eligible and stay direct
+tool calls.
+
+- **Config:** `{ "keep_visible": ["tool_a", ...] }` force-keeps named tools as
+  direct calls even when they would otherwise be routed through Lua. Default empty.
+- **Risk:** `High` — inseparable from `lua` (scripted execution) and admin-gated
+  like its dependency. Registered only when `FEATURE_LUA` is on, next to `lua`.
+- **Evidence:** runnable end-to-end smoke test
+  `crates/runtime/tests/lua_code_mode_test.rs` and the documented example
+  `crates/runtime/examples/lua_code_mode_agent.rs` (both behind the runtime
+  `lua` feature, run in CI) assert that the math tools are hidden from the model
+  yet executed through one `lua` script.
 
 ## Migration (supersede `virtual_bash`)
 

--- a/specs/lua-execution.md
+++ b/specs/lua-execution.md
@@ -203,14 +203,17 @@ approval-gated, client-side, `cpu_bound`) are never eligible and stay direct
 tool calls.
 
 **Discovery.** Hiding a tool removes its standalone schema, so the hook also
-grafts a catalog of the hidden tools onto the **`lua` tool's description** —
-one `- name(arg1, arg2, opt?) — first sentence` line per tool, built from the
-same `ToolDefinition` list it is filtering (the synthetic `human_intent`
-argument is omitted). This is what tells the model which `tools.<name>{ args }`
-functions exist and what they take; the policy sentence in the capability's
-system prompt tells it *to* route through Lua, and the catalog in the lua tool
-description tells it *what is callable*. Putting the catalog on the lua tool
-(not the always-on system prompt) means it is paid only when `lua` is present.
+grafts a catalog of the hidden tools onto the **`lua` tool's description**, built
+from the same `ToolDefinition` list it is filtering (the synthetic
+`human_intent` argument is omitted). By default each entry is a typed signature —
+`- name(a: number, b?: string) — first sentence` (required args first, optional
+suffixed with `?`, types from the JSON Schema). The `full_schemas` config option
+additionally embeds each tool's complete minified JSON Schema (`schema: {…}`) for
+lossless discovery of nested/complex parameters, at a token cost. Either way the
+policy sentence in the capability's system prompt tells the model *to* route
+through Lua, and the catalog tells it *what is callable and with which
+arguments*. Putting the catalog on the lua tool (not the always-on system
+prompt) means it is paid only when `lua` is present.
 
 - **Config:** `{ "keep_visible": ["tool_a", ...] }` force-keeps named tools as
   direct calls even when they would otherwise be routed through Lua. Default empty.


### PR DESCRIPTION
## What
Adds the `lua_code_mode` capability: it hides "non-essential" tools from the model's
direct tool list so the agent must orchestrate them inside a `lua` script via the
existing code-mode `tools.<name>(args)` table. The hidden tools stay fully executable —
only their model-facing definitions are removed — and they are advertised back to the
model through a typed catalog grafted onto the `lua` tool description.

Result: with `lua` + `lua_code_mode` enabled, the model sees only `lua` (plus essential
tools), yet can drive every hidden tool from one script — fewer round-trips, structured
results.

## Why
The Lua engine already had "code mode" (`tools.<name>` exposes sibling tools inside a
script), but nothing made it the agent's primary action path. The request was a
capability that exports non-essential tool calls to Lua and forces the agent to act
through the Lua environment, built on the existing capability-extensibility mechanism
(tool filtering) and the existing `lua` capability.

## How
- **New capability `lua_code_mode`** (`crates/core/src/capabilities/lua_code_mode.rs`):
  contributes a `ToolDefinitionHook` (the existing tool-filtering seam — no new
  agent-loop plumbing) that drops code-mode-eligible tool definitions from the
  model-facing list. Depends on `lua`; registered next to it under `FEATURE_LUA`.
- **Shared predicate.** Extracted `lua::is_code_mode_eligible`, reused by both the
  engine's `tools.<name>` exposure and the new filter, so the set hidden from the model
  is exactly the set Lua re-exposes — no tool can become unreachable.
- **Safe by construction.** The executable `ToolRegistry` is built from capability
  `tools()` independently of the model-facing `ToolDefinition` list. The hook edits only
  the latter, so the act atom still passes the full registry into the Lua child context
  and code mode executes the hidden tools directly (not back through the model).
- **Discovery.** Because hiding a tool removes its schema, the hook grafts a catalog onto
  the `lua` tool description: a typed signature per tool (`name(a: number, b?: string)`),
  with an opt-in `full_schemas` config that embeds each tool's complete JSON Schema for
  lossless discovery of nested params. The synthetic `human_intent` arg is stripped.
- **Config:** `{ "keep_visible": [..], "full_schemas": bool }` — force-keep named tools as
  direct calls; toggle lossless schema discovery.
- **Runtime exposure:** added a `lua` feature to `everruns-runtime`, a runnable example
  (`lua_code_mode_agent`), and an integration smoke test (`lua_code_mode_test`); both run
  in CI under the new feature. Documented in `specs/lua-execution.md` and
  `specs/capabilities.md`.

## Validation
- `cargo test -p everruns-core --lib lua_code_mode` — 9 unit tests (filter, keep_visible,
  config validation, typed signatures, full_schemas, union/enum/optional types, prompt
  budget). All pass.
- `cargo test -p everruns-core --features lua --lib capabilities::lua::` — 25 lua tests
  incl. code mode still green after the predicate refactor.
- `cargo test -p everruns-runtime --features lua --test lua_code_mode_test` — end-to-end
  smoke over the in-process runtime (mlua actually executes): math tools hidden from the
  model, executed via one `lua` script, result written to the workspace; the model only
  ever calls `lua` directly.
- `cargo run -p everruns-runtime --example lua_code_mode_agent --features lua` — prints
  `Model-visible tools: ["lua"]`, the typed catalog, and the computed result `50`.
- `cargo fmt --all --check`, `cargo clippy -p everruns-core -p everruns-runtime
  --all-targets --features lua -- -D warnings`, default-feature build of both crates — all
  clean.

**Smoke test note:** `just start-dev` does not compile the mlua engine (default features),
so the runnable example + integration test over `everruns-runtime` (which do execute Lua)
are the higher-signal end-to-end smoke for this feature.

## Risk
- **Low.** Experimental, `FEATURE_LUA`-gated, admin-gated (High risk, same as `lua`).
  Fully additive and reversible — remove the capability and tools revert to direct calls;
  nothing is removed from the executable registry. No schema/migration/API changes.

## Security
- **Threat categories reviewed:** TM-LUA (Lua execution), TM-TOOL (tool registration /
  execution paths).
- **Findings and resolutions:**
  - *No authorization bypass.* The filter reuses `is_code_mode_eligible`, which excludes
    `RequiresApproval` and client-side tools as well as destructive/`cpu_bound`/execution
    tools. So an approval-gated or destructive tool is never hidden and never routed
    through code mode — its HITL/approval flow is preserved. The capability cannot make an
    ineligible tool executable via Lua (the engine's gate is unchanged, TM-LUA-009 child
    context still drops `tool_registry`).
  - *No new data exposure.* The catalog embeds tool names, typed signatures, optional JSON
    schemas, and the first sentence of descriptions — all metadata the model would already
    see if the tool were directly visible. No secrets; `human_intent` stripped.
  - *Resource use bounded* by tool count; no unbounded loops or allocations.
  - No `THREAT[...]` comments touched; no new threat introduced, so `specs/threat-model.md`
    is unchanged (the change operates within the existing TM-LUA envelope).

## Follow-ups
- **NFR "capabilities export functions to Lua" interpretation.** Realized through the
  existing code-mode `tools.<name>` table rather than a new per-capability Lua host-function
  injection API (e.g. `Capability::lua_modules()`). That would thread capability-owned
  closures through the feature-gated engine — a much larger surface. Deferred unless a
  use case needs Lua host functions beyond tool calls.
- **Public docs.** Documented in `specs/` only, matching `lua` itself (experimental,
  feature-flagged). A `docs/capabilities/` page can land if/when `lua` graduates from
  experimental.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (additive, feature-gated, no schema/API change)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

https://claude.ai/code/session_01LibJcMGJnhA9JFFsw22Pcv

---
_Generated by [Claude Code](https://claude.ai/code/session_01LibJcMGJnhA9JFFsw22Pcv)_