### PR TITLE
feat(egress): system-wide outbound allowlist

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2459,6 +2459,7 @@ dependencies = [
  "sqlx",
  "thiserror 2.0.18",
  "tokio",
+ "toml 0.8.23",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -34,6 +34,7 @@ futures.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true
+toml = "0.8"
 
 # UUID and time
 uuid.workspace = true

--- a/crates/core/src/capabilities/web_fetch.rs
+++ b/crates/core/src/capabilities/web_fetch.rs
@@ -292,6 +292,12 @@ pub struct WebFetchTool {
     enable_save_to_file: bool,
     /// Cached description from ToolBuilder (owned copy of fetchkit's &str for our Tool trait)
     description: String,
+    /// Host-wide system allowlist ("green list"). fetchkit owns its own HTTP
+    /// client and does not (yet) route through `EgressService`, so the
+    /// deployment-wide allowlist is enforced here as a pre-flight check that
+    /// returns a clear system-policy error. `None` = no global enforcement.
+    /// See `crate::system_allowlist` and `specs/system-allowlist.md`.
+    system_allowlist: Option<Arc<crate::system_allowlist::SystemAllowlist>>,
 }
 
 impl WebFetchTool {
@@ -307,6 +313,22 @@ impl WebFetchTool {
             fetchkit_tool,
             enable_save_to_file,
             description,
+            system_allowlist: crate::system_allowlist::SystemAllowlist::from_env(),
+        }
+    }
+
+    /// Reject URLs not covered by the active system allowlist with an explicit
+    /// system-policy error. Returns `None` when the allowlist is disabled or the
+    /// URL is permitted.
+    fn system_policy_block(&self, url: &str) -> Option<ToolExecutionResult> {
+        match &self.system_allowlist {
+            Some(allowlist) if !allowlist.is_url_allowed(url) => {
+                Some(ToolExecutionResult::tool_error(format!(
+                    "Endpoint blocked by system policy: {url} is not on the deployment's \
+                     system allowlist of permitted public resources."
+                )))
+            }
+            _ => None,
         }
     }
 }
@@ -438,6 +460,11 @@ impl Tool for WebFetchTool {
             Err(e) => return e,
         };
 
+        // Host-wide system allowlist applies even without a session context.
+        if let Some(blocked) = self.system_policy_block(&request.url) {
+            return blocked;
+        }
+
         match self.fetchkit_tool.execute(request).await {
             Ok(response) => {
                 ToolExecutionResult::success(serde_json::to_value(&response).unwrap_or_else(
@@ -462,6 +489,13 @@ impl Tool for WebFetchTool {
             return ToolExecutionResult::tool_error(
                 "File download is disabled for this capability",
             );
+        }
+
+        // Host-wide system allowlist (green list). Enforced before the
+        // per-session access list so the operator-level policy yields a clear,
+        // distinct error.
+        if let Some(blocked) = self.system_policy_block(&request.url) {
+            return blocked;
         }
 
         // THREAT[TM-AGENT-018]: Enforce network access list
@@ -535,7 +569,37 @@ mod tests {
             fetchkit_tool,
             enable_save_to_file: true,
             description,
+            system_allowlist: None,
         }
+    }
+
+    #[tokio::test]
+    async fn system_allowlist_blocks_with_clear_system_policy_error() {
+        use crate::system_allowlist::SystemAllowlist;
+
+        let mut tool = tool_for_wiremock();
+        tool.system_allowlist = Some(
+            SystemAllowlist::from_toml("[groups.test]\nallowed = [\"allowed.example.com\"]\n")
+                .map(Arc::new)
+                .unwrap(),
+        );
+
+        let result = tool
+            .execute(serde_json::json!({ "url": "https://blocked.example.com/path" }))
+            .await;
+
+        let message = match result {
+            ToolExecutionResult::ToolError(message) => message,
+            other => panic!("blocked URL should be a tool error, got: {other:?}"),
+        };
+        assert!(
+            message.contains("blocked by system policy"),
+            "error should name the system policy, got: {message}"
+        );
+        assert!(
+            message.contains("blocked.example.com"),
+            "error should include the URL, got: {message}"
+        );
     }
 
     #[test]

--- a/crates/core/src/egress.rs
+++ b/crates/core/src/egress.rs
@@ -6,11 +6,13 @@
 //! transport clients directly.
 
 use crate::network_access::NetworkAccessList;
+use crate::system_allowlist::SystemAllowlist;
 use async_trait::async_trait;
 use futures::{Stream, StreamExt};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::pin::Pin;
+use std::sync::Arc;
 use std::time::Duration;
 use thiserror::Error;
 
@@ -195,6 +197,10 @@ impl EgressService for DisabledEgressService {
 #[derive(Clone)]
 pub struct DirectEgressService {
     client: reqwest::Client,
+    /// Optional host-wide allowlist applied to every outbound request,
+    /// independently of the per-request `network_access`. `None` means no
+    /// global enforcement. See `crate::system_allowlist`.
+    system_allowlist: Option<Arc<SystemAllowlist>>,
 }
 
 impl std::fmt::Debug for DirectEgressService {
@@ -219,14 +225,32 @@ impl DirectEgressService {
                 .redirect(reqwest::redirect::Policy::none())
                 .build()
                 .expect("build direct egress HTTP client"),
+            system_allowlist: None,
         }
     }
 
     pub fn with_client(client: reqwest::Client) -> Self {
-        Self { client }
+        Self {
+            client,
+            system_allowlist: None,
+        }
     }
 
-    fn validate_request(request: &EgressRequest) -> EgressResult<()> {
+    /// Construct with the global system allowlist resolved from the environment.
+    ///
+    /// Enforcement is active only when `EVERRUNS_SYSTEM_ALLOWLIST_ENABLED` is
+    /// set; otherwise this behaves exactly like [`DirectEgressService::new`].
+    pub fn from_env() -> Self {
+        Self::new().with_system_allowlist(SystemAllowlist::from_env())
+    }
+
+    /// Attach (or clear) the host-wide system allowlist.
+    pub fn with_system_allowlist(mut self, system_allowlist: Option<Arc<SystemAllowlist>>) -> Self {
+        self.system_allowlist = system_allowlist;
+        self
+    }
+
+    fn validate_request(&self, request: &EgressRequest) -> EgressResult<()> {
         if request.method.trim().is_empty() {
             return Err(EgressError::invalid("method is required"));
         }
@@ -247,11 +271,21 @@ impl DirectEgressService {
                 url: request.url.clone(),
             });
         }
+        // Host-wide allowlist: when enabled, every outbound request must match
+        // one of the curated public resources, regardless of request kind or the
+        // per-request network access list.
+        if let Some(allowlist) = &self.system_allowlist
+            && !allowlist.is_url_allowed(&request.url)
+        {
+            return Err(EgressError::NetworkAccessDenied {
+                url: request.url.clone(),
+            });
+        }
         Ok(())
     }
 
     fn build_request(&self, request: EgressRequest) -> EgressResult<reqwest::RequestBuilder> {
-        Self::validate_request(&request)?;
+        self.validate_request(&request)?;
         if request.signing == EgressSigning::Required {
             return Err(EgressError::SigningUnavailable);
         }
@@ -426,6 +460,64 @@ mod tests {
             .unwrap_err();
 
         assert!(matches!(error, EgressError::NetworkAccessDenied { .. }));
+    }
+
+    #[tokio::test]
+    async fn system_allowlist_blocks_unlisted_hosts() {
+        use crate::system_allowlist::SystemAllowlist;
+        let allowlist = SystemAllowlist::from_toml(
+            r#"
+            [groups.test]
+            allowed = ["allowed.example.com"]
+            "#,
+        )
+        .unwrap();
+
+        let service = DirectEgressService::new().with_system_allowlist(Some(Arc::new(allowlist)));
+        let error = service
+            .send(EgressRequest::new(
+                "GET",
+                "https://blocked.example.com/path",
+                // Even system-owned traffic (no per-request network_access) is
+                // subject to the host-wide allowlist.
+                EgressRequestKind::LlmProvider,
+            ))
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, EgressError::NetworkAccessDenied { .. }));
+    }
+
+    #[tokio::test]
+    async fn system_allowlist_permits_listed_hosts() {
+        use crate::system_allowlist::SystemAllowlist;
+        let server = MockServer::start().await;
+        let host = reqwest::Url::parse(&server.uri())
+            .unwrap()
+            .host_str()
+            .unwrap()
+            .to_string();
+        Mock::given(method("GET"))
+            .and(path("/ok"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let allowlist =
+            SystemAllowlist::from_toml(&format!("[groups.test]\nallowed = [\"{host}\"]\n"))
+                .unwrap();
+        let service = DirectEgressService::new().with_system_allowlist(Some(Arc::new(allowlist)));
+        let response = service
+            .send(EgressRequest::new(
+                "GET",
+                format!("{}/ok", server.uri()),
+                EgressRequestKind::Capability,
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status, 200);
     }
 
     #[tokio::test]

--- a/crates/core/src/egress.rs
+++ b/crates/core/src/egress.rs
@@ -273,7 +273,10 @@ impl DirectEgressService {
         }
         // Host-wide allowlist: when enabled, every outbound request must match
         // one of the curated public resources, regardless of request kind or the
-        // per-request network access list.
+        // per-request network access list. This is a separate, AND-ed gate — it
+        // is never merged into `request.network_access`, so harness/agent/session
+        // allowlists can only narrow within it and can never widen past it. The
+        // system allowlist is a hard ceiling with maximum priority.
         if let Some(allowlist) = &self.system_allowlist
             && !allowlist.is_url_allowed(&request.url)
         {
@@ -482,6 +485,37 @@ mod tests {
                 // subject to the host-wide allowlist.
                 EgressRequestKind::LlmProvider,
             ))
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, EgressError::NetworkAccessDenied { .. }));
+    }
+
+    #[tokio::test]
+    async fn system_allowlist_cannot_be_overridden_by_request_acl() {
+        use crate::system_allowlist::SystemAllowlist;
+        // The system allowlist is a hard ceiling: even a request whose own
+        // network_access explicitly permits the host must still be denied when
+        // the system allowlist does not list it. Sessions can narrow, never widen.
+        let allowlist = SystemAllowlist::from_toml(
+            r#"
+            [groups.test]
+            allowed = ["allowed.example.com"]
+            "#,
+        )
+        .unwrap();
+
+        let service = DirectEgressService::new().with_system_allowlist(Some(Arc::new(allowlist)));
+        let error = service
+            .send(
+                EgressRequest::new(
+                    "GET",
+                    "https://blocked.example.com/path",
+                    EgressRequestKind::Capability,
+                )
+                // A maximally-permissive per-request ACL that allows the host.
+                .network_access(Some(NetworkAccessList::allow_only(["blocked.example.com"]))),
+            )
             .await
             .unwrap_err();
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -107,6 +107,7 @@ pub mod session_sandbox;
 pub mod session_schedule;
 pub mod session_sqldb;
 pub mod skill;
+pub mod system_allowlist;
 pub mod volume;
 
 // Multi-platform channel abstractions (thread context, delivery, routing)
@@ -237,6 +238,7 @@ pub use egress::{
     EgressRequestKind, EgressResponse, EgressResult, EgressService, EgressSigning,
     EgressStreamResponse,
 };
+pub use system_allowlist::{AllowGroup, SYSTEM_ALLOWLIST_ENABLED_ENV, SystemAllowlist};
 
 // System email re-exports
 pub use email::{

--- a/crates/core/src/system_allowlist.rs
+++ b/crates/core/src/system_allowlist.rs
@@ -1,0 +1,182 @@
+//! System-wide outbound allowlist ("green list").
+//!
+//! An optional, host-owned global allowlist of well-known public resources
+//! (package registries, source hosting, AI/cloud provider APIs, ...). It is an
+//! internal, curated list — not agent/session/user configuration — shipped as
+//! an embedded TOML (`system_allowlist.toml`) and grouped by category so it
+//! stays manageable.
+//!
+//! When enabled via `EVERRUNS_SYSTEM_ALLOWLIST_ENABLED`, the egress boundary
+//! denies any outbound request whose URL does not match one of the groups, in
+//! addition to (and independently of) the per-agent/session
+//! [`NetworkAccessList`]. It is disabled by default, so the default behavior is
+//! unchanged. See `specs/system-allowlist.md`.
+
+use crate::network_access::NetworkAccessList;
+use serde::Deserialize;
+use std::collections::BTreeMap;
+use std::sync::{Arc, OnceLock};
+
+/// Environment variable that enables the global system allowlist.
+pub const SYSTEM_ALLOWLIST_ENABLED_ENV: &str = "EVERRUNS_SYSTEM_ALLOWLIST_ENABLED";
+
+/// Embedded TOML source of the curated allowlist.
+const EMBEDDED_TOML: &str = include_str!("system_allowlist.toml");
+
+#[derive(Debug, Clone, Deserialize)]
+struct AllowlistFile {
+    #[serde(default)]
+    groups: BTreeMap<String, GroupSpec>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct GroupSpec {
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    allowed: Vec<String>,
+}
+
+/// A named category of allowed host patterns.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AllowGroup {
+    pub name: String,
+    pub description: Option<String>,
+    pub allowed: Vec<String>,
+}
+
+/// Curated, system-wide outbound allowlist.
+///
+/// Matching reuses [`NetworkAccessList`] semantics: the flattened set of group
+/// patterns forms a single non-empty `allowed` list, so only URLs matching at
+/// least one pattern are permitted.
+#[derive(Debug, Clone)]
+pub struct SystemAllowlist {
+    groups: Vec<AllowGroup>,
+    acl: NetworkAccessList,
+}
+
+impl SystemAllowlist {
+    /// Parse a TOML document into a `SystemAllowlist`.
+    pub fn from_toml(source: &str) -> Result<Self, toml::de::Error> {
+        let file: AllowlistFile = toml::from_str(source)?;
+        let mut groups = Vec::with_capacity(file.groups.len());
+        let mut patterns = Vec::new();
+        for (name, spec) in file.groups {
+            patterns.extend(spec.allowed.iter().cloned());
+            groups.push(AllowGroup {
+                name,
+                description: spec.description,
+                allowed: spec.allowed,
+            });
+        }
+        Ok(Self {
+            groups,
+            acl: NetworkAccessList::allow_only(patterns),
+        })
+    }
+
+    /// The curated allowlist embedded in the binary (parsed once and cached).
+    pub fn embedded() -> Arc<SystemAllowlist> {
+        static EMBEDDED: OnceLock<Arc<SystemAllowlist>> = OnceLock::new();
+        EMBEDDED
+            .get_or_init(|| {
+                Arc::new(
+                    SystemAllowlist::from_toml(EMBEDDED_TOML)
+                        .expect("embedded system_allowlist.toml is valid"),
+                )
+            })
+            .clone()
+    }
+
+    /// Resolve the active allowlist from the environment.
+    ///
+    /// Returns `Some(embedded)` when `EVERRUNS_SYSTEM_ALLOWLIST_ENABLED` is
+    /// `true` or `1`, otherwise `None` (no global enforcement).
+    pub fn from_env() -> Option<Arc<SystemAllowlist>> {
+        let enabled = std::env::var(SYSTEM_ALLOWLIST_ENABLED_ENV)
+            .map(|value| value == "true" || value == "1")
+            .unwrap_or(false);
+        enabled.then(SystemAllowlist::embedded)
+    }
+
+    /// Categories in the allowlist.
+    pub fn groups(&self) -> &[AllowGroup] {
+        &self.groups
+    }
+
+    /// Whether the given URL matches any allowed pattern in any group.
+    pub fn is_url_allowed(&self, url: &str) -> bool {
+        self.acl.is_url_allowed(url)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn embedded_allowlist_parses_and_has_groups() {
+        let allowlist = SystemAllowlist::embedded();
+        assert!(
+            !allowlist.groups().is_empty(),
+            "embedded allowlist should define groups"
+        );
+        // Every group should contribute at least one pattern.
+        for group in allowlist.groups() {
+            assert!(
+                !group.allowed.is_empty(),
+                "group {} has no patterns",
+                group.name
+            );
+        }
+    }
+
+    #[test]
+    fn embedded_allowlist_permits_known_public_resources() {
+        let allowlist = SystemAllowlist::embedded();
+        for url in [
+            "https://registry.npmjs.org/left-pad",
+            "https://static.crates.io/crates/serde/serde-1.0.0.crate",
+            "https://files.pythonhosted.org/packages/abc.whl",
+            "https://api.openai.com/v1/responses",
+            "https://api.anthropic.com/v1/messages",
+            "https://codeload.github.com/owner/repo/tar.gz/main",
+            "https://ghcr.io/v2/owner/image/manifests/latest",
+        ] {
+            assert!(allowlist.is_url_allowed(url), "should allow {url}");
+        }
+    }
+
+    #[test]
+    fn embedded_allowlist_denies_unlisted_hosts() {
+        let allowlist = SystemAllowlist::embedded();
+        for url in [
+            "https://evil.example.com/payload",
+            "http://169.254.169.254/latest/meta-data/",
+            "https://random-blog.net/post",
+        ] {
+            assert!(!allowlist.is_url_allowed(url), "should deny {url}");
+        }
+    }
+
+    #[test]
+    fn from_toml_flattens_group_patterns() {
+        let allowlist = SystemAllowlist::from_toml(
+            r#"
+            [groups.alpha]
+            description = "first"
+            allowed = ["*.alpha.test"]
+
+            [groups.beta]
+            allowed = ["beta.test"]
+            "#,
+        )
+        .expect("valid toml");
+
+        assert_eq!(allowlist.groups().len(), 2);
+        assert!(allowlist.is_url_allowed("https://api.alpha.test/x"));
+        assert!(allowlist.is_url_allowed("https://beta.test/y"));
+        assert!(!allowlist.is_url_allowed("https://gamma.test/z"));
+    }
+}

--- a/crates/core/src/system_allowlist.rs
+++ b/crates/core/src/system_allowlist.rs
@@ -70,10 +70,17 @@ impl SystemAllowlist {
                 allowed: spec.allowed,
             });
         }
-        Ok(Self {
-            groups,
-            acl: NetworkAccessList::allow_only(patterns),
-        })
+        // Fail closed: an allowlist with no patterns must deny everything. An
+        // empty `allowed` list in `NetworkAccessList` means "no restriction"
+        // (allow all), so an empty/misconfigured allowlist would otherwise
+        // silently disable enforcement. Substitute a sentinel that can never
+        // match a real URL, mirroring `merge_network_access`'s `<none>` guard.
+        let acl = if patterns.is_empty() {
+            NetworkAccessList::allow_only(["<none>"])
+        } else {
+            NetworkAccessList::allow_only(patterns)
+        };
+        Ok(Self { groups, acl })
     }
 
     /// The curated allowlist embedded in the binary (parsed once and cached).
@@ -157,6 +164,19 @@ mod tests {
             "https://random-blog.net/post",
         ] {
             assert!(!allowlist.is_url_allowed(url), "should deny {url}");
+        }
+    }
+
+    #[test]
+    fn empty_allowlist_fails_closed() {
+        // No groups, empty groups, and groups with no patterns must all deny
+        // every URL rather than silently allowing all traffic.
+        for source in ["", "[groups.empty]\n", "[groups.empty]\nallowed = []\n"] {
+            let allowlist = SystemAllowlist::from_toml(source).expect("valid toml");
+            assert!(
+                !allowlist.is_url_allowed("https://example.com/"),
+                "empty allowlist (source: {source:?}) must deny all URLs"
+            );
         }
     }
 

--- a/crates/core/src/system_allowlist.toml
+++ b/crates/core/src/system_allowlist.toml
@@ -1,0 +1,134 @@
+# System-wide outbound allowlist ("green list").
+#
+# Curated, internal list of well-known public resources that the global egress
+# boundary permits when the allowlist is enabled
+# (EVERRUNS_SYSTEM_ALLOWLIST_ENABLED=true). This is NOT end-user configuration —
+# it ships with the binary and is reviewed by maintainers.
+#
+# Organized into named groups so it stays manageable. Pattern format matches the
+# NetworkAccessList rules (see specs/network-access.md):
+#   - example.com            exact domain (any port/path)
+#   - *.example.com          domain and all subdomains (apex included)
+#   - https://example.com/x/ URL prefix (scheme + host + path)
+
+[groups.package_registries]
+description = "Language and package manager registries (npm, crates, pypi, ...)."
+allowed = [
+    "*.npmjs.org",
+    "*.npmjs.com",
+    "*.yarnpkg.com",
+    "*.crates.io",
+    "*.pypi.org",
+    "*.pythonhosted.org",
+    "*.rubygems.org",
+    "*.nuget.org",
+    "*.packagist.org",
+    "*.cocoapods.org",
+    "*.golang.org",
+    "repo.maven.apache.org",
+    "repo1.maven.org",
+    "*.maven.org",
+    "*.gradle.org",
+    "plugins.gradle.org",
+    "*.conda.anaconda.org",
+    "repo.anaconda.com",
+]
+
+[groups.source_hosting]
+description = "Source code hosting and collaboration platforms."
+allowed = [
+    "*.github.com",
+    "*.githubusercontent.com",
+    "*.github.io",
+    "*.gitlab.com",
+    "*.bitbucket.org",
+    "*.codeberg.org",
+    "*.sourceforge.net",
+    "*.sr.ht",
+]
+
+[groups.container_registries]
+description = "OCI / container image registries."
+allowed = [
+    "*.docker.com",
+    "*.docker.io",
+    "registry-1.docker.io",
+    "auth.docker.io",
+    "ghcr.io",
+    "*.quay.io",
+    "quay.io",
+    "gcr.io",
+    "*.gcr.io",
+    "*.pkg.dev",
+    "mcr.microsoft.com",
+    "public.ecr.aws",
+]
+
+[groups.ai_providers]
+description = "LLM and AI provider APIs."
+allowed = [
+    "*.openai.com",
+    "*.anthropic.com",
+    "*.googleapis.com",
+    "generativelanguage.googleapis.com",
+    "*.cohere.ai",
+    "*.cohere.com",
+    "*.mistral.ai",
+    "*.huggingface.co",
+    "*.hf.co",
+    "*.groq.com",
+    "*.openrouter.ai",
+    "openrouter.ai",
+    "*.replicate.com",
+    "*.together.ai",
+    "*.together.xyz",
+    "*.perplexity.ai",
+    "*.x.ai",
+    "*.deepseek.com",
+]
+
+[groups.cloud_providers]
+description = "Major cloud provider APIs and service endpoints."
+allowed = [
+    "*.amazonaws.com",
+    "*.azure.com",
+    "*.azureedge.net",
+    "*.windows.net",
+    "*.microsoftonline.com",
+    "*.openai.azure.com",
+    "*.googleapis.com",
+    "*.cloud.google.com",
+    "*.cloudflare.com",
+    "*.digitaloceanspaces.com",
+    "api.digitalocean.com",
+]
+
+[groups.os_packages]
+description = "Operating-system package mirrors and distribution archives."
+allowed = [
+    "*.debian.org",
+    "*.ubuntu.com",
+    "*.archlinux.org",
+    "*.alpinelinux.org",
+    "dl-cdn.alpinelinux.org",
+    "*.fedoraproject.org",
+    "*.opensuse.org",
+    "*.brew.sh",
+    "*.homebrew.org",
+]
+
+[groups.developer_tools]
+description = "Language toolchains, runtimes, and developer infrastructure."
+allowed = [
+    "*.rust-lang.org",
+    "static.rust-lang.org",
+    "*.python.org",
+    "*.nodejs.org",
+    "nodejs.org",
+    "*.golang.org",
+    "go.dev",
+    "*.deno.land",
+    "deno.land",
+    "*.gnu.org",
+    "*.kernel.org",
+]

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -1368,7 +1368,7 @@ impl WorkerAdapters for DirectWorkerAdapters {
                 let egress = self
                     .egress_service
                     .clone()
-                    .unwrap_or_else(|| Arc::new(everruns_core::DirectEgressService::default()));
+                    .unwrap_or_else(|| Arc::new(everruns_core::DirectEgressService::from_env()));
                 build_scoped_mcp_tool_definitions(
                     &effective,
                     Some(session.id),

--- a/crates/server/src/domains/mcp_servers/service.rs
+++ b/crates/server/src/domains/mcp_servers/service.rs
@@ -66,7 +66,7 @@ pub struct McpServerOAuthSettings {
 
 impl McpServerService {
     pub fn new(db: Arc<StorageBackend>, encryption: Option<Arc<EncryptionService>>) -> Self {
-        Self::with_egress_service(db, encryption, Arc::new(DirectEgressService::default()))
+        Self::with_egress_service(db, encryption, Arc::new(DirectEgressService::from_env()))
     }
 
     pub fn with_egress_service(

--- a/crates/server/src/platform.rs
+++ b/crates/server/src/platform.rs
@@ -24,7 +24,9 @@ pub fn oss_platform_definition_for_grade(grade: DeploymentGrade) -> PlatformDefi
     let capability_registry = CapabilityRegistry::with_builtins_for_grade(grade);
     let driver_registry = everruns_worker::create_driver_registry();
     let connection_providers = oss_connection_provider_registry_for_grade(grade);
-    let egress_service = Arc::new(DirectEgressService::default());
+    // Resolve the optional host-wide system allowlist from the environment
+    // (EVERRUNS_SYSTEM_ALLOWLIST_ENABLED). Disabled by default.
+    let egress_service = Arc::new(DirectEgressService::from_env());
     let email_sender = SystemEmailConfig::from_env()
         .expect("Invalid system email configuration")
         .into_sender_with_egress(egress_service.clone());

--- a/crates/worker/src/platform.rs
+++ b/crates/worker/src/platform.rs
@@ -6,8 +6,10 @@
 //! connection providers and harness templates are server-owned by default.
 
 use everruns_core::{
-    CapabilityRegistry, DeploymentGrade, PlatformDefinition, SystemUtilityLlmConfig,
+    CapabilityRegistry, DeploymentGrade, DirectEgressService, PlatformDefinition,
+    SystemUtilityLlmConfig,
 };
+use std::sync::Arc;
 
 /// Build the default worker-side platform definition for the current deployment grade.
 pub fn default_platform_definition() -> PlatformDefinition {
@@ -19,6 +21,10 @@ pub fn default_platform_definition_for_grade(grade: DeploymentGrade) -> Platform
     PlatformDefinition::builder()
         .capability_registry(CapabilityRegistry::with_builtins_for_grade(grade))
         .driver_registry(crate::create_driver_registry())
+        // Honor the host-wide system allowlist in distributed workers too, so
+        // EVERRUNS_SYSTEM_ALLOWLIST_ENABLED applies to worker egress (LLM, MCP,
+        // capabilities) the same as the control plane. Disabled by default.
+        .egress_service(Arc::new(DirectEgressService::from_env()))
         .utility_llm_service(SystemUtilityLlmConfig::from_env().into_service())
         .build()
 }

--- a/specs/README.md
+++ b/specs/README.md
@@ -97,6 +97,7 @@ Specs capture the "why" and "what", not exhaustive source detail. Link to code f
 - `specs/correlation-ids.md` - Correlation IDs
 - `specs/load-testing.md` - End-to-end load testing framework
 - `specs/network-access.md` - Network access allowlist/blocklist
+- `specs/system-allowlist.md` - System-wide outbound allowlist ("green list")
 - `specs/localization.md` - Locale/timezone resolution and backend localization rules
 - `specs/notifications.md` - Generic user notifications
 - `specs/email.md` - Internal email delivery abstraction

--- a/specs/egress.md
+++ b/specs/egress.md
@@ -97,6 +97,11 @@ System-owned fixed endpoints, such as a configured email provider or model
 provider URL, do not use the agent/session network access list unless that
 endpoint is derived from agent/session/user input.
 
+An optional deployment-wide allowlist (`specs/system-allowlist.md`) sits at the
+same boundary. When enabled, it constrains *all* egress — every request kind,
+independent of `network_access` — to a curated set of public resources. It is
+the in-process precursor to the future gateway's outbound allowlist.
+
 ## Signing
 
 Requests can set:

--- a/specs/system-allowlist.md
+++ b/specs/system-allowlist.md
@@ -77,6 +77,17 @@ independent of the per-request `network_access`. Both the system allowlist
 (if active) and the per-request `NetworkAccessList` (if present) must permit a
 URL for the request to proceed.
 
+### fetchkit / web_fetch
+
+`web_fetch` (fetchkit) owns its own HTTP client and does not route through
+`EgressService`, so the allowlist is enforced there as an explicit pre-flight
+check in `crates/core/src/capabilities/web_fetch.rs`. When the allowlist is
+enabled and a fetched URL is not covered, the tool returns a clear, distinct
+error — "Endpoint blocked by system policy: …" — before any request is made,
+rather than a generic transport failure. When fetchkit is migrated onto
+`EgressService` (see `specs/egress.md` migration order), the egress boundary
+becomes a second enforcement point and this pre-flight check can be revisited.
+
 ### Operator responsibility
 
 Because enforcement covers provider traffic too, an operator enabling the

--- a/specs/system-allowlist.md
+++ b/specs/system-allowlist.md
@@ -80,6 +80,15 @@ independent of the per-request `network_access`. Both the system allowlist
 (if active) and the per-request `NetworkAccessList` (if present) must permit a
 URL for the request to proceed.
 
+### Maximum priority (hard ceiling)
+
+The system allowlist is a separate, AND-ed gate — it is **never merged into**
+the harness/agent/session `NetworkAccessList`. Those layers can only narrow
+within the system allowlist (intersection on `allowed`, union on `blocked`);
+they can **never widen past it or override it**. When the allowlist is enabled,
+a session that explicitly allows a host still cannot reach it unless the system
+allowlist also lists it. The system allowlist always wins.
+
 ### fetchkit / web_fetch
 
 `web_fetch` (fetchkit) owns its own HTTP client and does not route through

--- a/specs/system-allowlist.md
+++ b/specs/system-allowlist.md
@@ -39,7 +39,10 @@ Current groups: `package_registries`, `source_hosting`, `container_registries`,
 
 `SystemAllowlist` flattens all group patterns into a single non-empty `allowed`
 `NetworkAccessList`, so only URLs matching at least one pattern are permitted.
-See `crates/core/src/system_allowlist.rs`.
+An allowlist with no patterns (empty/misconfigured TOML) **fails closed** — it
+denies every URL rather than allowing all — via a sentinel pattern, since an
+empty `NetworkAccessList.allowed` otherwise means "no restriction". See
+`crates/core/src/system_allowlist.rs`.
 
 ## Enabling
 
@@ -50,7 +53,7 @@ EVERRUNS_SYSTEM_ALLOWLIST_ENABLED=true   # or 1
 ```
 
 `DirectEgressService::from_env()` resolves the allowlist at construction. When
-unset or falsey, egress behavior is unchanged.
+unset or falsy, egress behavior is unchanged.
 
 The env var is read by every process that builds an egress service, so it
 applies uniformly across the **control plane** and **workers**:

--- a/specs/system-allowlist.md
+++ b/specs/system-allowlist.md
@@ -49,9 +49,20 @@ Disabled by default. Controlled by a single environment variable:
 EVERRUNS_SYSTEM_ALLOWLIST_ENABLED=true   # or 1
 ```
 
-`DirectEgressService::from_env()` resolves the allowlist at construction; the
-default OSS platform (`crates/server/src/platform.rs`) wires it in. When unset
-or falsey, egress behavior is unchanged.
+`DirectEgressService::from_env()` resolves the allowlist at construction. When
+unset or falsey, egress behavior is unchanged.
+
+The env var is read by every process that builds an egress service, so it
+applies uniformly across the **control plane** and **workers**:
+
+- `crates/server/src/platform.rs` — control-plane / in-process platform.
+- `crates/worker/src/platform.rs` — distributed worker platform.
+- `crates/server/src/domains/mcp_servers/service.rs` — MCP server egress.
+
+Each must construct egress via `DirectEgressService::from_env()` (not
+`::default()`) so the toggle is honored everywhere. The list contents are *not*
+env-configurable — they are the curated embedded TOML; only the on/off toggle is
+environmental.
 
 ## Enforcement
 

--- a/specs/system-allowlist.md
+++ b/specs/system-allowlist.md
@@ -1,0 +1,95 @@
+# System-wide Outbound Allowlist
+
+## Intent
+
+An optional, host-owned global allowlist ("green list") of well-known public
+resources that the egress boundary permits. It is a deployment-wide safety net
+that constrains *all* outbound traffic to a curated set of trusted public
+services, independently of per-agent/session `NetworkAccessList`.
+
+Unlike `NetworkAccessList`, this is **not** end-user or agent configuration. It
+is an internal, maintainer-curated list shipped with the binary. Operators turn
+it on or off; they do not edit it per deployment.
+
+## Data Model
+
+Source of truth is an embedded TOML file, `crates/core/src/system_allowlist.toml`,
+organized into named groups so it stays manageable instead of one flat list:
+
+```toml
+[groups.package_registries]
+description = "Language and package manager registries (npm, crates, pypi, ...)."
+allowed = ["*.npmjs.org", "*.crates.io", "*.pypi.org", ...]
+
+[groups.ai_providers]
+description = "LLM and AI provider APIs."
+allowed = ["*.openai.com", "*.anthropic.com", "*.googleapis.com", ...]
+```
+
+Each group has an optional `description` and a list of `allowed` host patterns.
+Patterns use the same format and matching rules as `NetworkAccessList` (see
+`specs/network-access.md`):
+
+- `example.com` — exact domain
+- `*.example.com` — domain and all subdomains (apex included)
+- `https://example.com/api/` — URL prefix
+
+Current groups: `package_registries`, `source_hosting`, `container_registries`,
+`ai_providers`, `cloud_providers`, `os_packages`, `developer_tools`.
+
+`SystemAllowlist` flattens all group patterns into a single non-empty `allowed`
+`NetworkAccessList`, so only URLs matching at least one pattern are permitted.
+See `crates/core/src/system_allowlist.rs`.
+
+## Enabling
+
+Disabled by default. Controlled by a single environment variable:
+
+```
+EVERRUNS_SYSTEM_ALLOWLIST_ENABLED=true   # or 1
+```
+
+`DirectEgressService::from_env()` resolves the allowlist at construction; the
+default OSS platform (`crates/server/src/platform.rs`) wires it in. When unset
+or falsey, egress behavior is unchanged.
+
+## Enforcement
+
+The `EgressService` is the single host-owned outbound boundary (see
+`specs/egress.md`). When the system allowlist is active, `DirectEgressService`
+denies any request whose URL does not match the allowlist, with
+`EgressError::NetworkAccessDenied`.
+
+This check is **global**: it applies to every `EgressRequestKind` — LLM provider
+calls, capabilities, integrations, system email, utility LLM, and MCP — and is
+independent of the per-request `network_access`. Both the system allowlist
+(if active) and the per-request `NetworkAccessList` (if present) must permit a
+URL for the request to proceed.
+
+### Operator responsibility
+
+Because enforcement covers provider traffic too, an operator enabling the
+allowlist must ensure every endpoint their deployment depends on (LLM providers,
+email provider, model discovery, configured MCP servers) is covered by a group.
+Self-hosted or uncommon endpoints not present in the curated groups will be
+blocked while the allowlist is enabled. The curated list intentionally includes
+the major AI and cloud providers so the common case works out of the box.
+
+## Relationship to other controls
+
+| Control | Scope | Configured by |
+|---------|-------|---------------|
+| System allowlist | Whole deployment, all egress kinds | Maintainers (curated), operator toggles via env |
+| `NetworkAccessList` | Per harness/agent/session, agent-authored URLs | Users/agents |
+| Future Egress Gateway | Network component owning outbound policy | Deployment |
+
+The system allowlist is a precursor to the Egress Gateway's outbound allowlist
+described in `specs/egress.md`: it gives a single deployment-wide allowlist
+today, in-process, ahead of the remote gateway.
+
+## Threat Model
+
+Reinforces **TM-AGENT-018** (outbound URL filtering) with a deployment-wide
+backstop that does not depend on per-agent configuration being set correctly,
+and narrows the blast radius of SSRF or exfiltration attempts to a curated set
+of public services.


### PR DESCRIPTION
## What

Adds an optional, host-owned **system-wide outbound allowlist** ("green list") of well-known public resources, enforced at the egress boundary. When enabled, all outbound HTTP is constrained to a curated set of trusted public services (package registries, source hosting, container registries, AI/cloud providers, OS packages, developer tools).

- Curated as an embedded, grouped TOML (`crates/core/src/system_allowlist.toml`) — internal, maintainer-reviewed, not end-user config.
- Toggled by a single env var: `EVERRUNS_SYSTEM_ALLOWLIST_ENABLED=true|1`. **Disabled by default**, so existing behavior is unchanged.
- Enforced in `DirectEgressService` across **all** `EgressRequestKind`s (LLM provider, capability, integration, email, MCP), independently of the per-agent/session `NetworkAccessList`.
- Honored uniformly across **control plane and workers** (server platform, distributed worker platform, MCP server egress).
- `web_fetch`/fetchkit (which owns its own HTTP client and doesn't route through `EgressService`) gets a pre-flight check that returns a clear error — **"Endpoint blocked by system policy: …"** — naming the URL, before any request is made.

New spec: `specs/system-allowlist.md` (+ README index, egress.md cross-reference).

## Why

Today, outbound URL filtering depends entirely on per-agent/session `NetworkAccessList` being configured correctly. This adds a deployment-wide backstop that does not depend on per-agent config — narrowing the blast radius of SSRF/exfiltration to a curated set of public services — and gives operators a single on/off switch. It's the in-process precursor to the future Egress Gateway's outbound allowlist (`specs/egress.md`).

## How

- New `crate::system_allowlist` module: parses the grouped TOML, flattens patterns into a single non-empty `NetworkAccessList` (reusing existing pattern-matching semantics), and resolves enable/disable from the environment. Embedded list parsed once and cached.
- `DirectEgressService::from_env()` constructs the service with the allowlist resolved from env; `validate_request` denies non-matching URLs with `NetworkAccessDenied`. All egress construction sites switched from `::default()`/`::new()` to `::from_env()`.
- `WebFetchTool` carries the allowlist (from env) and rejects non-covered URLs with an explicit system-policy `tool_error`.

## Risk

- **Low.** Disabled by default; no behavior change unless the operator opts in.
- When enabled, enforcement covers provider traffic too. An operator turning it on must ensure their dependencies (LLM providers, email, MCP servers) are covered by a group; the curated list includes the major AI/cloud providers so the common case works out of the box. Documented in the spec under "Operator responsibility".

## Security

- **Threat categories reviewed:** TM-AGENT-018 (outbound URL filtering / SSRF), TM-API-008 (egress isolation), TM-TOOL (web_fetch / MCP egress paths). This change is defense-in-depth: it adds a deployment-wide outbound allowlist and strengthens, rather than weakens, the egress boundary.
- **Findings:** None adverse. Allowlist input is an embedded, compile-time-trusted TOML and a boolean env var — no untrusted input at parse time. Existing `THREAT[TM-AGENT-018]`/`THREAT[TM-API-008]` mitigations in `web_fetch` are preserved; the new pre-flight check sits adjacent to them.
- **Dependency:** adds `toml = "0.8"` to `everruns-core` — already used by `everruns-cli` and present in `Cargo.lock` (no new transitive fetch).

## Validation

- `everruns-core` unit tests: new coverage in `system_allowlist` (parse, embedded list permits known registries/AI hosts, denies unlisted hosts), `egress` (allowlist blocks unlisted, permits listed across request kinds), and `web_fetch` (blocked URL yields the clear "blocked by system policy" error). All pass.
- `bash scripts/lib/pre-push.sh`: green — `cargo fmt --check`, `cargo clippy --all-targets --all-features -D warnings`, `cargo fetch --locked`, migration ordering/immutability, specs-index coverage, attribution.
- Smoke test: booted `everruns-server` in dev (in-memory) mode with `EVERRUNS_SYSTEM_ALLOWLIST_ENABLED=true` → clean startup, `/health` 200, no errors; and with the flag off → `/health` 200 (no regression).

## Follow-ups

- Migrate `web_fetch`/fetchkit onto `EgressService` (egress spec migration step 3). Once done, the egress boundary becomes a second enforcement point and the web_fetch pre-flight check can be revisited. Deferred: it's a larger, independent migration; the pre-flight check delivers the required behavior today. Worth a Linear issue (EVE) if not already tracked.
- Optional: a runtime-overridable extra allowlist (env-supplied patterns merged on top of the embedded list) if operators later need per-deployment additions without a rebuild. Deferred: not requested; the embedded curated list is the intended model for now.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (disabled by default; no behavior change)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

https://claude.ai/code/session_019HMzeBvx2YL1FvCteEKTvo

---
_Generated by [Claude Code](https://claude.ai/code/session_019HMzeBvx2YL1FvCteEKTvo)_