### PR TITLE
feat(llm): split Opus/Fable into 200K and 1M context profiles

### DIFF
--- a/crates/anthropic/src/driver.rs
+++ b/crates/anthropic/src/driver.rs
@@ -385,9 +385,17 @@ impl LlmDriver for AnthropicLlmDriver {
             Some(Self::convert_tools(&config.tools, prompt_cache_enabled))
         };
 
+        // `[1m]` model ids (e.g. `claude-opus-4-8[1m]`) are the gateway's
+        // large-context twins of the 200K base models. Anthropic's wire `model`
+        // field only accepts the bare id; the 1M window is requested via the
+        // `context-1m` beta header (added in the retry loop below). Strip the
+        // suffix for everything that reasons about the canonical model, and
+        // keep the flag for the header.
+        let (wire_model, wants_million_context) = split_million_context(&config.model);
+
         let profile = everruns_core::get_model_profile(
             &everruns_core::LlmProviderType::Anthropic,
-            &config.model,
+            wire_model,
         );
 
         // Sampling parameters are removed on Fable 5 and Opus 4.8/4.7 —
@@ -413,7 +421,7 @@ impl LlmDriver for AnthropicLlmDriver {
         // `thinking: {type: "enabled", budget_tokens}` form is removed and
         // returns 400, so this split is load-bearing, not stylistic.
         let (thinking, output_config) = match config.reasoning_effort.as_deref() {
-            Some(effort) if uses_adaptive_thinking(&config.model) => {
+            Some(effort) if uses_adaptive_thinking(wire_model) => {
                 match adaptive_effort_level(effort) {
                     Some(level) => (
                         Some(AnthropicThinking::adaptive()),
@@ -466,7 +474,7 @@ impl LlmDriver for AnthropicLlmDriver {
             matches!(thinking, Some(AnthropicThinking::Enabled { .. })) && tools.is_some();
 
         let mut request = AnthropicRequest {
-            model: config.model.clone(),
+            model: wire_model.to_string(),
             messages: anthropic_messages,
             max_tokens,
             temperature,
@@ -491,16 +499,26 @@ impl LlmDriver for AnthropicLlmDriver {
                 .header("anthropic-version", ANTHROPIC_VERSION)
                 .header("Content-Type", "application/json");
 
-            // Add interleaved thinking beta header when thinking is enabled with tools
-            // Required for tool use with extended thinking per Anthropic docs
+            // Anthropic beta features, combined into a single comma-separated
+            // `anthropic-beta` header:
+            //  - interleaved-thinking: required for tool use with budget-based
+            //    extended thinking (adaptive thinking interleaves on its own).
+            //  - context-1m: opts the `[1m]` model ids into the 1M context
+            //    window. It is GA / silently ignored on Opus 4.6+ and Fable 5
+            //    (the only ids we attach it to), so always sending it is safe.
+            let mut beta_features: Vec<&str> = Vec::new();
             if needs_interleaved_thinking {
-                request_builder =
-                    request_builder.header("anthropic-beta", "interleaved-thinking-2025-05-14");
+                beta_features.push("interleaved-thinking-2025-05-14");
+            }
+            if wants_million_context {
+                beta_features.push("context-1m-2025-08-07");
+            }
+            if !beta_features.is_empty() {
+                let beta = beta_features.join(",");
                 if retry_metadata.attempts == 0 {
-                    tracing::info!(
-                        "AnthropicDriver: enabling interleaved thinking beta for tool use"
-                    );
+                    tracing::info!(beta = %beta, "AnthropicDriver: enabling anthropic-beta features");
                 }
+                request_builder = request_builder.header("anthropic-beta", beta);
             }
 
             let response = request_builder
@@ -1069,6 +1087,18 @@ const ADAPTIVE_THINKING_FAMILIES: &[&str] = &[
     "claude-opus-4-6",
     "claude-sonnet-4-6",
 ];
+
+/// Split a possibly `[1m]`-suffixed model id (e.g. `claude-opus-4-8[1m]`) into
+/// the bare wire id Anthropic accepts and a flag marking the 1M-context twin.
+/// The `[1m]` ids are gateway-exposed large-context variants that share the
+/// base model's wire id and opt into the larger window via the `context-1m`
+/// beta header.
+fn split_million_context(model_id: &str) -> (&str, bool) {
+    match model_id.strip_suffix("[1m]") {
+        Some(bare) => (bare, true),
+        None => (model_id, false),
+    }
+}
 
 /// Whether a model id (optionally date-suffixed) belongs to an
 /// adaptive-thinking family.
@@ -2167,6 +2197,23 @@ mod tests {
     // ========================================================================
     // Discovered profile construction tests
     // ========================================================================
+
+    #[test]
+    fn test_split_million_context() {
+        assert_eq!(
+            split_million_context("claude-opus-4-8[1m]"),
+            ("claude-opus-4-8", true)
+        );
+        assert_eq!(
+            split_million_context("claude-fable-5[1m]"),
+            ("claude-fable-5", true)
+        );
+        // Bare ids are unchanged and not flagged.
+        assert_eq!(
+            split_million_context("claude-opus-4-8"),
+            ("claude-opus-4-8", false)
+        );
+    }
 
     #[test]
     fn test_to_discovered_profile_basic() {

--- a/crates/anthropic/src/driver.rs
+++ b/crates/anthropic/src/driver.rs
@@ -1088,16 +1088,45 @@ const ADAPTIVE_THINKING_FAMILIES: &[&str] = &[
     "claude-sonnet-4-6",
 ];
 
-/// Split a possibly `[1m]`-suffixed model id (e.g. `claude-opus-4-8[1m]`) into
+/// Anthropic families that support the 1M context window (Anthropic docs:
+/// context-windows / long-context pricing). Gates `[1m]` suffix handling. These
+/// coincide with `ADAPTIVE_THINKING_FAMILIES` today but are a distinct
+/// capability — kept separate so a future divergence (1M without adaptive
+/// thinking, or vice versa) cannot silently mis-gate either path.
+const MILLION_CONTEXT_FAMILIES: &[&str] = &[
+    "claude-fable-5",
+    "claude-opus-4-8",
+    "claude-opus-4-7",
+    "claude-opus-4-6",
+    "claude-sonnet-4-6",
+];
+
+/// Split a `[1m]`-suffixed Anthropic model id (e.g. `claude-opus-4-8[1m]`) into
 /// the bare wire id Anthropic accepts and a flag marking the 1M-context twin.
-/// The `[1m]` ids are gateway-exposed large-context variants that share the
-/// base model's wire id and opt into the larger window via the `context-1m`
-/// beta header.
+///
+/// The suffix is honored only when the bare id belongs to a family that
+/// actually supports the 1M window (`MILLION_CONTEXT_FAMILIES`). A
+/// manually-configured id that merely ends in `[1m]` but is not 1M-capable —
+/// e.g. `claude-3-haiku[1m]` or `claude-sonnet-4-5[1m]` — is left untouched. We
+/// must never rewrite an arbitrary configured id or send the `context-1m` beta
+/// header to a model that does not support the 1M window (it can 400 or
+/// silently truncate on models where the header was retired). Date-suffixed 1M
+/// ids (`claude-opus-4-8-20260101[1m]`) are still honored via family
+/// normalization.
 fn split_million_context(model_id: &str) -> (&str, bool) {
     match model_id.strip_suffix("[1m]") {
-        Some(bare) => (bare, true),
-        None => (model_id, false),
+        Some(bare) if is_million_context_family(bare) => (bare, true),
+        _ => (model_id, false),
     }
+}
+
+/// Whether a bare (optionally date-suffixed) Anthropic model id belongs to a
+/// family that supports the 1M context window.
+fn is_million_context_family(model_id: &str) -> bool {
+    let family = normalize_anthropic_id(model_id);
+    MILLION_CONTEXT_FAMILIES
+        .iter()
+        .any(|f| family.eq_ignore_ascii_case(f))
 }
 
 /// Whether a model id (optionally date-suffixed) belongs to an
@@ -2200,6 +2229,7 @@ mod tests {
 
     #[test]
     fn test_split_million_context() {
+        // Registered `[1m]` twins: stripped to the wire id and flagged.
         assert_eq!(
             split_million_context("claude-opus-4-8[1m]"),
             ("claude-opus-4-8", true)
@@ -2208,11 +2238,34 @@ mod tests {
             split_million_context("claude-fable-5[1m]"),
             ("claude-fable-5", true)
         );
+        assert_eq!(
+            split_million_context("claude-opus-4-6[1m]"),
+            ("claude-opus-4-6", true)
+        );
+
+        // Date-suffixed 1M-capable id is still honored (family normalization).
+        assert_eq!(
+            split_million_context("claude-opus-4-8-20260101[1m]"),
+            ("claude-opus-4-8-20260101", true)
+        );
+
         // Bare ids are unchanged and not flagged.
         assert_eq!(
             split_million_context("claude-opus-4-8"),
             ("claude-opus-4-8", false)
         );
+
+        // Models that merely end in `[1m]` but are NOT 1M-capable must be left
+        // untouched — never strip them or send `context-1m` (it can 400 or
+        // silently truncate, e.g. on sonnet-4-5 where the header was retired).
+        for not_1m in [
+            "claude-3-haiku[1m]",
+            "claude-3-haiku-20240307[1m]",
+            "claude-sonnet-4-5[1m]",
+            "totally-made-up[1m]",
+        ] {
+            assert_eq!(split_million_context(not_1m), (not_1m, false), "{not_1m}");
+        }
     }
 
     #[test]

--- a/crates/core/src/llm_model_profiles.rs
+++ b/crates/core/src/llm_model_profiles.rs
@@ -250,6 +250,14 @@ static REGISTRY: &[ModelDescriptor] = &[
     md(&["claude-opus-4-8"], ModelVendor::Anthropic, ANTHROPIC),
     md(&["claude-opus-4-7"], ModelVendor::Anthropic, ANTHROPIC),
     md(&["claude-opus-4-6"], ModelVendor::Anthropic, ANTHROPIC),
+    // 1M-context twins. The gateway exposes these `[1m]` ids alongside the
+    // 200K base models (e.g. "Opus 4.8" vs "Opus 4.8 (1M)" in the picker); the
+    // driver sends the `context-1m` beta header for them. See
+    // `anthropic_1m_variant` for how their profiles are derived.
+    md(&["claude-fable-5[1m]"], ModelVendor::Anthropic, ANTHROPIC),
+    md(&["claude-opus-4-8[1m]"], ModelVendor::Anthropic, ANTHROPIC),
+    md(&["claude-opus-4-7[1m]"], ModelVendor::Anthropic, ANTHROPIC),
+    md(&["claude-opus-4-6[1m]"], ModelVendor::Anthropic, ANTHROPIC),
     md(&["claude-sonnet-4-6"], ModelVendor::Anthropic, ANTHROPIC),
     md(&["claude-opus-4-5"], ModelVendor::Anthropic, ANTHROPIC),
     md(&["claude-sonnet-4-5"], ModelVendor::Anthropic, ANTHROPIC),
@@ -1995,6 +2003,24 @@ fn third_party_profile_data(model_id: &str) -> Option<LlmModelProfile> {
     }
 }
 
+/// Derive the 1M-context variant of a base Anthropic profile.
+///
+/// The gateway exposes `[1m]` model ids (e.g. `claude-opus-4-8[1m]`) as
+/// large-context twins of the 200K base profiles. Anthropic serves the full 1M
+/// window at standard per-token rates — there is no long-context premium — so
+/// the variant keeps the base profile's cost verbatim (no `cost_tiers`) and
+/// only raises the context limit. The display name gains a "(1M)" suffix to
+/// disambiguate the two entries in the model picker; `family` is left unchanged
+/// so the pair groups together. The Anthropic driver additionally sends the
+/// `context-1m` beta header for these ids.
+fn anthropic_1m_variant(mut profile: LlmModelProfile) -> LlmModelProfile {
+    if let Some(limits) = profile.limits.as_mut() {
+        limits.context = 1_000_000;
+    }
+    profile.name = format!("{} (1M)", profile.name);
+    profile
+}
+
 fn anthropic_profile_data(model_id: &str) -> Option<LlmModelProfile> {
     match model_id {
         // Claude Fable 5 (newest — top tier above Opus)
@@ -2026,7 +2052,8 @@ fn anthropic_profile_data(model_id: &str) -> Option<LlmModelProfile> {
                 cost_tiers: vec![],
             }),
             limits: Some(LlmModelLimits {
-                context: 1_000_000,
+                // Bare id is the 200K profile; `claude-fable-5[1m]` is the 1M twin.
+                context: 200_000,
                 input: None,
                 output: 128_000,
                 max_media: None,
@@ -2067,7 +2094,8 @@ fn anthropic_profile_data(model_id: &str) -> Option<LlmModelProfile> {
                 cost_tiers: vec![],
             }),
             limits: Some(LlmModelLimits {
-                context: 1_000_000,
+                // Bare id is the 200K profile; `claude-opus-4-8[1m]` is the 1M twin.
+                context: 200_000,
                 input: None,
                 output: 128_000,
                 max_media: None,
@@ -2106,7 +2134,8 @@ fn anthropic_profile_data(model_id: &str) -> Option<LlmModelProfile> {
                 cost_tiers: vec![],
             }),
             limits: Some(LlmModelLimits {
-                context: 1_000_000,
+                // Bare id is the 200K profile; `claude-opus-4-7[1m]` is the 1M twin.
+                context: 200_000,
                 input: None,
                 output: 128_000,
                 max_media: None,
@@ -2142,7 +2171,8 @@ fn anthropic_profile_data(model_id: &str) -> Option<LlmModelProfile> {
                 cost_tiers: vec![],
             }),
             limits: Some(LlmModelLimits {
-                context: 1_000_000,
+                // Bare id is the 200K profile; `claude-opus-4-6[1m]` is the 1M twin.
+                context: 200_000,
                 input: None,
                 output: 128_000,
                 max_media: Some(600),
@@ -2156,6 +2186,19 @@ fn anthropic_profile_data(model_id: &str) -> Option<LlmModelProfile> {
             supported_parameters: Vec::new(),
             supports_phases: false,
         }),
+
+        // 1M-context twins of the base profiles above. Same pricing and
+        // capabilities; only the context limit and display name differ.
+        "claude-fable-5[1m]" => anthropic_profile_data("claude-fable-5").map(anthropic_1m_variant),
+        "claude-opus-4-8[1m]" => {
+            anthropic_profile_data("claude-opus-4-8").map(anthropic_1m_variant)
+        }
+        "claude-opus-4-7[1m]" => {
+            anthropic_profile_data("claude-opus-4-7").map(anthropic_1m_variant)
+        }
+        "claude-opus-4-6[1m]" => {
+            anthropic_profile_data("claude-opus-4-6").map(anthropic_1m_variant)
+        }
 
         "claude-sonnet-4-6" => Some(LlmModelProfile {
             name: "Claude Sonnet 4.6".into(),
@@ -3532,7 +3575,8 @@ mod tests {
         assert!(profile.structured_output);
 
         let limits = profile.limits.unwrap();
-        assert_eq!(limits.context, 1_000_000);
+        // Bare id is the 200K profile; the 1M window is `claude-opus-4-7[1m]`.
+        assert_eq!(limits.context, 200_000);
         assert_eq!(limits.output, 128_000);
         assert_eq!(limits.max_media, None);
 
@@ -3569,7 +3613,8 @@ mod tests {
         assert!(profile.structured_output);
 
         let limits = profile.limits.unwrap();
-        assert_eq!(limits.context, 1_000_000);
+        // Bare id is the 200K profile; the 1M window is `claude-opus-4-6[1m]`.
+        assert_eq!(limits.context, 200_000);
         assert_eq!(limits.output, 128_000);
         assert_eq!(limits.max_media, Some(600));
 
@@ -3853,7 +3898,9 @@ mod tests {
         assert_eq!(cost.input, 10.00);
         assert_eq!(cost.output, 50.00);
         let limits = profile.limits.as_ref().unwrap();
-        assert_eq!(limits.context, 1_000_000);
+        // Bare id is the 200K profile; the 1M window is `claude-fable-5[1m]`
+        // (see test_claude_fable_5_1m_variant).
+        assert_eq!(limits.context, 200_000);
         assert_eq!(limits.output, 128_000);
         assert!(profile.reasoning_effort.is_some());
     }
@@ -3866,8 +3913,52 @@ mod tests {
         assert!(profile.reasoning);
         // Opus 4.8 removed sampling parameters (temperature returns 400).
         assert!(!profile.temperature);
-        assert_eq!(profile.limits.as_ref().unwrap().context, 1_000_000);
+        // Bare id is the 200K profile; the 1M window is `claude-opus-4-8[1m]`.
+        assert_eq!(profile.limits.as_ref().unwrap().context, 200_000);
         assert!(profile.reasoning_effort.is_some());
+    }
+
+    #[test]
+    fn test_claude_opus_4_8_1m_variant() {
+        // `[1m]` is the large-context twin: same flat pricing, 1M context,
+        // "(1M)" display suffix, shared family for grouping.
+        let base = get_model_profile(&LlmProviderType::Anthropic, "claude-opus-4-8").unwrap();
+        assert_eq!(base.limits.as_ref().unwrap().context, 200_000);
+
+        let m1 = get_model_profile(&LlmProviderType::Anthropic, "claude-opus-4-8[1m]").unwrap();
+        assert_eq!(m1.name, "Claude Opus 4.8 (1M)");
+        assert_eq!(m1.family, "claude-opus-4-8");
+        assert_eq!(m1.limits.as_ref().unwrap().context, 1_000_000);
+        assert_eq!(m1.limits.as_ref().unwrap().output, 128_000);
+
+        // Flat standard pricing — Anthropic serves the 1M window with no
+        // long-context premium, so cost matches the 200K base exactly.
+        let (base_cost, m1_cost) = (base.cost.unwrap(), m1.cost.unwrap());
+        assert_eq!(m1_cost.input, base_cost.input);
+        assert_eq!(m1_cost.output, base_cost.output);
+        assert_eq!(m1_cost.cache_read, base_cost.cache_read);
+        assert!(m1_cost.cost_tiers.is_empty());
+    }
+
+    #[test]
+    fn test_claude_fable_5_1m_variant() {
+        let base = get_model_profile(&LlmProviderType::Anthropic, "claude-fable-5").unwrap();
+        assert_eq!(base.limits.as_ref().unwrap().context, 200_000);
+
+        let m1 = get_model_profile(&LlmProviderType::Anthropic, "claude-fable-5[1m]").unwrap();
+        assert_eq!(m1.name, "Claude Fable 5 (1M)");
+        assert_eq!(m1.family, "claude-fable-5");
+        assert_eq!(m1.limits.as_ref().unwrap().context, 1_000_000);
+        assert_eq!(m1.cost.unwrap().input, base.cost.unwrap().input);
+    }
+
+    #[test]
+    fn test_claude_opus_4_7_and_4_6_have_1m_variants() {
+        for id in ["claude-opus-4-7[1m]", "claude-opus-4-6[1m]"] {
+            let m1 = get_model_profile(&LlmProviderType::Anthropic, id).unwrap();
+            assert_eq!(m1.limits.as_ref().unwrap().context, 1_000_000);
+            assert!(m1.name.ends_with("(1M)"));
+        }
     }
 
     #[test]

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -126,6 +126,8 @@ mod seed_ids {
     pub const CLAUDE_3_7_SONNET: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000306);
     pub const CLAUDE_3_5_SONNET: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000307);
     pub const CLAUDE_3_5_HAIKU: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000308);
+    // 1M-context variants (`[1m]` model ids), 0x3a0+ sub-range.
+    pub const CLAUDE_OPUS_4_7_1M: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_0000000003a7);
 
     // LlmSim Models (0x400-0x4FF)
     pub const LLMSIM_DEFAULT: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000401);
@@ -1902,6 +1904,17 @@ const SEED_MODELS: &[SeedModel] = &[
         provider_id: seed_ids::ANTHROPIC_PROVIDER,
         model_id: "claude-opus-4-7",
         display_name: "Claude Opus 4.7",
+        enabled: true,     // Enabled by default
+        is_favorite: true, // Favorite model
+    },
+    SeedModel {
+        // 1M-context twin of the 200K base above (driver sends the `context-1m`
+        // beta header for `[1m]` ids). Keeps a 1M Opus in the default picker
+        // now that the bare `claude-opus-4-7` profile is the 200K variant.
+        id: seed_ids::CLAUDE_OPUS_4_7_1M,
+        provider_id: seed_ids::ANTHROPIC_PROVIDER,
+        model_id: "claude-opus-4-7[1m]",
+        display_name: "Claude Opus 4.7 (1M)",
         enabled: true,     // Enabled by default
         is_favorite: true, // Favorite model
     },


### PR DESCRIPTION
## What
Two distinct model profiles per Opus (4.8/4.7/4.6) and Fable 5: a 200K base (bare id) and a 1M-context twin (`[1m]` id, e.g. `claude-opus-4-8[1m]`), matching the picker's "Opus 4.8" / "Opus 4.8 (1M)" pairs. Adds the driver wiring and seeds `claude-opus-4-7[1m]`.

## Why
Each model previously had a single profile pinned at 1M. The gateway exposes both a 200K and a 1M variant per model; selecting the `[1m]` entry resolved no profile and sent an invalid `...[1m]` model id to Anthropic (404).

## How
- `anthropic_1m_variant` derives each `[1m]` profile from its base: identical pricing, context raised to 1M, a "(1M)" display suffix, shared `family`. Registry entries + match arms added; the bracket suffix matches in `resolve_descriptor` as-is.
- Base profiles for the four models reduced to 200K.
- Anthropic driver: `split_million_context` strips `[1m]` for the wire `model` field (Anthropic only accepts the bare id) and sends `context-1m-2025-08-07` — folded with interleaved-thinking into one comma-separated `anthropic-beta` header — only for `[1m]` ids.
- Seed `claude-opus-4-7[1m]` ("Claude Opus 4.7 (1M)", enabled + favorite).

**Pricing is flat standard, no `cost_tiers`.** Anthropic's official pricing page serves the full 1M window for exactly these models at standard per-token rates (no long-context premium). The tiered surcharge in models.dev/302AI is stale third-party reseller data and was deliberately not used.

## Validation
- Unit tests: profile resolution (`*_1m_variant`), registry-canonical-id coverage, `split_million_context`, plus updated base-context assertions. Core 2097 / anthropic 39 / server-seed 28 pass.
- `cargo fmt`, `clippy -D warnings`, full `pre-push` green.
- End-to-end smoke against the dev API (`AUTH_MODE=none`, in-memory): `claude-opus-4-7` → ctx 200000; `claude-opus-4-7[1m]` → "Claude Opus 4.7 (1M)", ctx 1000000, same $5/$25 pricing. Seeding completed cleanly (65 models).

## Risk
- **Low.** Pure profile-data additions + a localized driver suffix/header change + one seed row. No migrations, no API/auth surface, no new dependencies.
- Behavioral note: the seeded `claude-opus-4-7` default drops 1M→200K. Mitigated by seeding the `[1m]` twin so a 1M Opus stays in the default picker.

## Security
- Threat categories reviewed: **TM-LLM** (model parameters, request transport), **TM-TENANT** (seeding is org-scoped via existing machinery).
- Findings: none. `context-1m-2025-08-07` is a static constant sent only for `[1m]` ids (never to retired models, which would break). `split_million_context` strips a fixed `[1m]` suffix from already-trusted model config — no injection vector. No API key handling, response/log exposure, or auth/authz paths changed. Cost is unchanged per-token; the 1M limit is the real model capability and existing budget metering applies. No new/changed deps. No nearby `THREAT[...]` mitigations affected.

## Follow-ups
- Seed `claude-fable-5` / `claude-opus-4-8` base + `[1m]` into the default lineup — **deferred**: promoting newer models into the OSS default set (enabled/favorite defaults) is a product decision, and deployments that already configure these models work today via the new profiles.
- `max_media` per-tier accuracy — docs cap 200K models at 100 media vs 600 at 1M; `claude-opus-4-6` base retains its prior `Some(600)`. Minor; out of scope here.
- Sonnet 4.6 1M split — not requested; the same pattern drops in if wanted.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)