### PR TITLE
feat(llm): add OpenRouter provider

### DIFF
--- a/apps/ui/src/__tests__/provider-icon.test.tsx
+++ b/apps/ui/src/__tests__/provider-icon.test.tsx
@@ -9,12 +9,25 @@ describe("ProviderIcon", () => {
     "openai_completions",
     "anthropic",
     "gemini",
+    "openrouter",
   ];
+  const filledProviderTypes: LlmProviderType[] = [
+    "openai",
+    "azure_openai",
+    "openai_completions",
+    "anthropic",
+    "gemini",
+  ];
+  const customSvgProviderTypes = filledProviderTypes;
 
   it.each(providerTypes)("renders inline SVG for %s provider", (providerType) => {
     const { container } = render(<ProviderIcon providerType={providerType} />);
     const svg = container.querySelector("svg");
     expect(svg).toBeInTheDocument();
+  });
+
+  it.each(customSvgProviderTypes)("renders path data for %s custom logo", (providerType) => {
+    const { container } = render(<ProviderIcon providerType={providerType} />);
     // Verify it uses currentColor for theme-adaptive rendering
     const path = container.querySelector("path");
     expect(path).toBeInTheDocument();
@@ -26,7 +39,7 @@ describe("ProviderIcon", () => {
     expect(img).not.toBeInTheDocument();
   });
 
-  it.each(providerTypes)("uses currentColor fill for %s", (providerType) => {
+  it.each(filledProviderTypes)("uses currentColor fill for %s", (providerType) => {
     const { container } = render(<ProviderIcon providerType={providerType} />);
     const pathsAndSvgs = container.querySelectorAll("[fill='currentColor']");
     expect(pathsAndSvgs.length).toBeGreaterThan(0);
@@ -97,6 +110,10 @@ describe("getProviderLabel", () => {
 
   it("returns correct label for gemini", () => {
     expect(getProviderLabel("gemini")).toBe("Google Gemini");
+  });
+
+  it("returns correct label for openrouter", () => {
+    expect(getProviderLabel("openrouter")).toBe("OpenRouter");
   });
 
   it("returns type string for unknown provider", () => {

--- a/apps/ui/src/app/(main)/settings/providers/provider-dialogs.tsx
+++ b/apps/ui/src/app/(main)/settings/providers/provider-dialogs.tsx
@@ -19,6 +19,7 @@ import type { LlmProvider, LlmProviderType, CreateLlmProviderRequest } from "@/l
 
 const PROVIDER_TYPES: { value: LlmProviderType; label: string }[] = [
   { value: "openai", label: "OpenAI (Responses API)" },
+  { value: "openrouter", label: "OpenRouter" },
   { value: "azure_openai", label: "Azure OpenAI" },
   { value: "openai_completions", label: "OpenAI (Completions API)" },
   { value: "anthropic", label: "Anthropic" },
@@ -32,6 +33,8 @@ function getApiKeyPlaceholder(providerType: LlmProviderType): string {
     case "openai":
     case "openai_completions":
       return "sk-...";
+    case "openrouter":
+      return "sk-or-...";
     case "azure_openai":
       return "Azure OpenAI resource key";
     case "anthropic":
@@ -49,6 +52,8 @@ function getBaseUrlPlaceholder(providerType: LlmProviderType): string {
       return "https://your-resource.openai.azure.com/openai/v1";
     case "openai":
       return "https://api.openai.com/v1";
+    case "openrouter":
+      return "https://openrouter.ai/api/v1";
     case "openai_completions":
       return "https://api.openai.com/v1/chat/completions";
     case "anthropic":

--- a/apps/ui/src/components/providers/provider-icon.tsx
+++ b/apps/ui/src/components/providers/provider-icon.tsx
@@ -89,6 +89,7 @@ function AwsBedrockIcon({ size }: { size: number }) {
 
 const PROVIDER_ICON_COMPONENTS: Record<LlmProviderType, React.ComponentType<{ size: number }>> = {
   openai: OpenAiIcon,
+  openrouter: Server,
   azure_openai: AzureOpenAiIcon,
   openai_completions: OpenAiIcon,
   anthropic: AnthropicIcon,
@@ -98,6 +99,7 @@ const PROVIDER_ICON_COMPONENTS: Record<LlmProviderType, React.ComponentType<{ si
 
 const PROVIDER_LABELS: Record<LlmProviderType, string> = {
   openai: "OpenAI (Responses)",
+  openrouter: "OpenRouter",
   azure_openai: "Azure OpenAI",
   openai_completions: "OpenAI (Completions)",
   anthropic: "Anthropic",

--- a/apps/ui/src/lib/api/types/llm-types.ts
+++ b/apps/ui/src/lib/api/types/llm-types.ts
@@ -6,6 +6,7 @@
 
 export type LlmProviderType =
   | "openai"
+  | "openrouter"
   | "azure_openai"
   | "openai_completions"
   | "anthropic"

--- a/crates/core/src/atoms/reason.rs
+++ b/crates/core/src/atoms/reason.rs
@@ -2109,6 +2109,7 @@ impl ReasonAtom {
     ) -> Result<crate::llm_driver_registry::BoxedLlmDriver> {
         let provider_type = match model.provider_type {
             crate::llm_models::LlmProviderType::Openai => ProviderType::OpenAI,
+            crate::llm_models::LlmProviderType::Openrouter => ProviderType::OpenRouter,
             crate::llm_models::LlmProviderType::AzureOpenai => ProviderType::AzureOpenAI,
             crate::llm_models::LlmProviderType::OpenaiCompletions => {
                 ProviderType::OpenAICompletions

--- a/crates/core/src/llm_driver_registry.rs
+++ b/crates/core/src/llm_driver_registry.rs
@@ -847,6 +847,8 @@ pub enum ProviderType {
     /// OpenAI using Open Responses API (<https://www.openresponses.org/>)
     /// This is the recommended API for new projects.
     OpenAI,
+    /// OpenRouter using the OpenAI-compatible Responses API.
+    OpenRouter,
     /// Azure OpenAI using the Azure-hosted OpenAI v1 API.
     AzureOpenAI,
     /// OpenAI using Chat Completions API (for backward compatibility)
@@ -867,6 +869,7 @@ impl std::str::FromStr for ProviderType {
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
             "openai" => Ok(ProviderType::OpenAI),
+            "openrouter" => Ok(ProviderType::OpenRouter),
             "azure_openai" => Ok(ProviderType::AzureOpenAI),
             "openai_completions" => Ok(ProviderType::OpenAICompletions),
             "anthropic" => Ok(ProviderType::Anthropic),
@@ -882,6 +885,7 @@ impl std::fmt::Display for ProviderType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ProviderType::OpenAI => write!(f, "openai"),
+            ProviderType::OpenRouter => write!(f, "openrouter"),
             ProviderType::AzureOpenAI => write!(f, "azure_openai"),
             ProviderType::OpenAICompletions => write!(f, "openai_completions"),
             ProviderType::Anthropic => write!(f, "anthropic"),
@@ -1128,6 +1132,10 @@ mod tests {
             ProviderType::OpenAI
         );
         assert_eq!(
+            "openrouter".parse::<ProviderType>().unwrap(),
+            ProviderType::OpenRouter
+        );
+        assert_eq!(
             "openai_completions".parse::<ProviderType>().unwrap(),
             ProviderType::OpenAICompletions
         );
@@ -1151,6 +1159,7 @@ mod tests {
     #[test]
     fn test_provider_type_display() {
         assert_eq!(ProviderType::OpenAI.to_string(), "openai");
+        assert_eq!(ProviderType::OpenRouter.to_string(), "openrouter");
         assert_eq!(ProviderType::AzureOpenAI.to_string(), "azure_openai");
         assert_eq!(
             ProviderType::OpenAICompletions.to_string(),

--- a/crates/core/src/llm_model_profiles.rs
+++ b/crates/core/src/llm_model_profiles.rs
@@ -196,11 +196,15 @@ const fn md(
 // Chat Completions path, but never Azure.
 const OPENAI: &[LlmProviderType] = &[
     LlmProviderType::Openai,
+    LlmProviderType::Openrouter,
     LlmProviderType::AzureOpenai,
     LlmProviderType::OpenaiCompletions,
 ];
-const OPENAI_COMPAT: &[LlmProviderType] =
-    &[LlmProviderType::Openai, LlmProviderType::OpenaiCompletions];
+const OPENAI_COMPAT: &[LlmProviderType] = &[
+    LlmProviderType::Openai,
+    LlmProviderType::Openrouter,
+    LlmProviderType::OpenaiCompletions,
+];
 const ANTHROPIC: &[LlmProviderType] = &[LlmProviderType::Anthropic];
 const GEMINI: &[LlmProviderType] = &[LlmProviderType::Gemini];
 const LLMSIM: &[LlmProviderType] = &[LlmProviderType::LlmSim];
@@ -352,11 +356,9 @@ pub fn get_model_profile(
     let descriptor = resolve_descriptor(provider_type, model_id)?;
     let mut profile = profile_data(descriptor.ids[0])?;
     // Native execution phases and tool_search are advertised only for the
-    // `openai` (Open Responses) provider type — that is the only surface whose
-    // driver implements them. Every other provider type (Azure, Chat
-    // Completions) gets them masked off, regardless of which model it serves.
-    // A gateway that exposes a Responses-compatible endpoint is configured as
-    // `openai`, so it is intentionally treated as Responses-capable here.
+    // `openai` provider type. OpenRouter uses a compatible but stateless
+    // Responses endpoint, so it keeps the base model profile while masking
+    // native OpenAI-only request options.
     if !matches!(provider_type, LlmProviderType::Openai) {
         profile.supports_phases = false;
         profile.tool_search = false;

--- a/crates/core/src/llm_models.rs
+++ b/crates/core/src/llm_models.rs
@@ -19,6 +19,8 @@ use utoipa::ToSchema;
 pub enum LlmProviderType {
     /// OpenAI using Open Responses API (<https://www.openresponses.org/>)
     Openai,
+    /// OpenRouter using the OpenAI-compatible Responses API
+    Openrouter,
     /// Azure OpenAI using the Azure-hosted OpenAI v1 API
     #[serde(rename = "azure_openai")]
     AzureOpenai,
@@ -39,6 +41,7 @@ impl std::fmt::Display for LlmProviderType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             LlmProviderType::Openai => write!(f, "openai"),
+            LlmProviderType::Openrouter => write!(f, "openrouter"),
             LlmProviderType::AzureOpenai => write!(f, "azure_openai"),
             LlmProviderType::OpenaiCompletions => write!(f, "openai_completions"),
             LlmProviderType::Anthropic => write!(f, "anthropic"),
@@ -55,6 +58,7 @@ impl std::str::FromStr for LlmProviderType {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "openai" => Ok(LlmProviderType::Openai),
+            "openrouter" => Ok(LlmProviderType::Openrouter),
             "azure_openai" => Ok(LlmProviderType::AzureOpenai),
             "openai_completions" => Ok(LlmProviderType::OpenaiCompletions),
             "anthropic" => Ok(LlmProviderType::Anthropic),
@@ -436,6 +440,10 @@ mod tests {
             "\"openai\""
         );
         assert_eq!(
+            serde_json::to_string(&LlmProviderType::Openrouter).unwrap(),
+            "\"openrouter\""
+        );
+        assert_eq!(
             serde_json::to_string(&LlmProviderType::OpenaiCompletions).unwrap(),
             "\"openai_completions\""
         );
@@ -465,6 +473,10 @@ mod tests {
             LlmProviderType::Openai
         ));
         assert!(matches!(
+            serde_json::from_str::<LlmProviderType>("\"openrouter\"").unwrap(),
+            LlmProviderType::Openrouter
+        ));
+        assert!(matches!(
             serde_json::from_str::<LlmProviderType>("\"openai_completions\"").unwrap(),
             LlmProviderType::OpenaiCompletions
         ));
@@ -492,6 +504,10 @@ mod tests {
         assert!(matches!(
             "openai".parse::<LlmProviderType>().unwrap(),
             LlmProviderType::Openai
+        ));
+        assert!(matches!(
+            "openrouter".parse::<LlmProviderType>().unwrap(),
+            LlmProviderType::Openrouter
         ));
         assert!(matches!(
             "openai_completions".parse::<LlmProviderType>().unwrap(),
@@ -552,6 +568,7 @@ mod tests {
     fn test_llm_provider_type_display() {
         // Verify Display works correctly
         assert_eq!(LlmProviderType::Openai.to_string(), "openai");
+        assert_eq!(LlmProviderType::Openrouter.to_string(), "openrouter");
         assert_eq!(LlmProviderType::AzureOpenai.to_string(), "azure_openai");
         assert_eq!(
             LlmProviderType::OpenaiCompletions.to_string(),

--- a/crates/core/src/openresponses_protocol.rs
+++ b/crates/core/src/openresponses_protocol.rs
@@ -34,6 +34,7 @@ use crate::llm_driver_registry::{
     LlmCallConfig, LlmCompletionMetadata, LlmContentPart, LlmDriver, LlmMessage, LlmMessageContent,
     LlmMessageRole, LlmResponseStream, LlmStreamEvent,
 };
+use crate::llm_models::LlmProviderType;
 use crate::llm_retry::{
     LlmRetryConfig, RateLimitInfo, RetryMetadata, is_rate_limit_status, is_transient_error,
 };
@@ -80,6 +81,7 @@ pub struct OpenResponsesProtocolLlmDriver {
     client: Client,
     api_key: String,
     api_url: String,
+    provider_type: LlmProviderType,
     /// Retry configuration for rate limit errors
     retry_config: LlmRetryConfig,
 }
@@ -91,6 +93,7 @@ impl OpenResponsesProtocolLlmDriver {
             client: Client::new(),
             api_key: api_key.into(),
             api_url: DEFAULT_API_URL.to_string(),
+            provider_type: LlmProviderType::Openai,
             retry_config: LlmRetryConfig::default(),
         }
     }
@@ -108,8 +111,15 @@ impl OpenResponsesProtocolLlmDriver {
             client: Client::new(),
             api_key: api_key.into(),
             api_url: api_url.into(),
+            provider_type: LlmProviderType::Openai,
             retry_config: LlmRetryConfig::default(),
         }
+    }
+
+    /// Set the model provider used for provider-specific request features.
+    pub fn with_provider_type(mut self, provider_type: LlmProviderType) -> Self {
+        self.provider_type = provider_type;
+        self
     }
 
     /// Configure retry behavior for rate limit errors
@@ -131,6 +141,11 @@ impl OpenResponsesProtocolLlmDriver {
     /// Get the HTTP client (for subclass access)
     pub fn client(&self) -> &Client {
         &self.client
+    }
+
+    /// Get the provider type used for model profile lookup.
+    pub fn provider_type(&self) -> &LlmProviderType {
+        &self.provider_type
     }
 
     fn convert_role(role: &LlmMessageRole) -> &'static str {
@@ -698,13 +713,18 @@ impl LlmDriver for OpenResponsesProtocolLlmDriver {
         messages: Vec<LlmMessage>,
         config: &LlmCallConfig,
     ) -> Result<LlmResponseStream> {
-        // Check model profile to determine if phases should be sent in the wire format.
-        // GPT-5.4 and newer models support native execution phases.
-        let supports_phases = crate::llm_model_profiles::get_model_profile(
-            &crate::llm_models::LlmProviderType::Openai,
-            &config.model,
-        )
-        .is_some_and(|p| p.supports_phases);
+        // Check the provider-specific model profile before sending native
+        // Responses features. OpenAI-compatible gateways may share base model
+        // metadata without supporting OpenAI-only extensions such as phases or
+        // hosted tool_search.
+        let model_profile =
+            crate::llm_model_profiles::get_model_profile(&self.provider_type, &config.model);
+        let supports_phases = model_profile
+            .as_ref()
+            .is_some_and(|profile| profile.supports_phases);
+        let supports_tool_search = model_profile
+            .as_ref()
+            .is_some_and(|profile| profile.tool_search);
 
         let (instructions, input_items) = Self::build_input(&messages, supports_phases);
 
@@ -729,7 +749,7 @@ impl LlmDriver for OpenResponsesProtocolLlmDriver {
         let tools = if config.tools.is_empty() {
             None
         } else if let Some(ref ts_config) = config.tool_search {
-            if ts_config.enabled {
+            if ts_config.enabled && supports_tool_search {
                 Some(Self::convert_tools_with_search(
                     &config.tools,
                     ts_config.threshold,
@@ -1226,6 +1246,7 @@ impl std::fmt::Debug for OpenResponsesProtocolLlmDriver {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("OpenResponsesProtocolLlmDriver")
             .field("api_url", &self.api_url)
+            .field("provider_type", &self.provider_type)
             .field("api_key", &"[REDACTED]")
             .finish()
     }
@@ -2914,6 +2935,73 @@ mod tests {
         assert!(
             has_tool_output,
             "the latest tool result must still be present; got {input:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn openrouter_provider_does_not_send_hosted_tool_search() {
+        use crate::tool_types::DeferrablePolicy;
+        use serde_json::json;
+        use wiremock::matchers::method;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(""))
+            .mount(&server)
+            .await;
+
+        let api_url = format!("{}/v1/responses", server.uri());
+        let driver = OpenResponsesProtocolLlmDriver::with_base_url("test-key", api_url)
+            .with_provider_type(LlmProviderType::Openrouter);
+
+        let tools: Vec<ToolDefinition> = (0..16)
+            .map(|i| {
+                make_tool(
+                    &format!("tool_{i}"),
+                    Some("General"),
+                    DeferrablePolicy::Automatic,
+                )
+            })
+            .collect();
+
+        let config = LlmCallConfig {
+            model: "gpt-5.4".to_string(),
+            temperature: None,
+            max_tokens: None,
+            tools,
+            reasoning_effort: None,
+            metadata: std::collections::HashMap::new(),
+            previous_response_id: None,
+            tool_search: Some(crate::llm_driver_registry::ToolSearchConfig {
+                enabled: true,
+                threshold: 15,
+            }),
+            prompt_cache: None,
+        };
+
+        let messages = vec![LlmMessage::text(LlmMessageRole::User, "hello")];
+        let _ = driver.chat_completion_stream(messages, &config).await;
+
+        let requests = server
+            .received_requests()
+            .await
+            .expect("mock server recorded requests");
+        assert_eq!(requests.len(), 1, "exactly one request should be sent");
+        let body: serde_json::Value = requests[0].body_json().expect("request body is JSON");
+        let tools = body["tools"].as_array().expect("tools is an array");
+
+        assert!(
+            tools.iter().all(|tool| tool["type"] == "function"),
+            "OpenRouter should receive regular function tools, not hosted tool_search payloads: {tools:?}"
+        );
+        assert!(
+            tools.iter().all(|tool| tool.get("defer_loading").is_none()),
+            "OpenRouter tool schemas should not be deferred by hosted tool_search: {tools:?}"
+        );
+        assert_eq!(
+            body["input"],
+            json!([{"type": "message", "role": "user", "content": "hello"}])
         );
     }
 

--- a/crates/openai/src/driver.rs
+++ b/crates/openai/src/driver.rs
@@ -20,12 +20,14 @@ use everruns_core::llm_driver_registry::{
     BoxedLlmDriver, DiscoveredModel, DriverRegistry, LlmCallConfig, LlmDriver, LlmMessage,
     LlmResponseStream, ProviderType,
 };
+use everruns_core::llm_models::LlmProviderType;
 use everruns_core::openai_protocol::is_azure_openai_api_url;
 use everruns_core::{CompactRequest, CompactResponse};
 
 use crate::types::{OpenAiModelsResponse, OpenRouterModelsResponse};
 
 const OPENAI_MODELS_URL: &str = "https://api.openai.com/v1/models";
+const OPENROUTER_RESPONSES_URL: &str = "https://openrouter.ai/api/v1/responses";
 
 // ============================================================================
 // OpenAI LLM Driver (Open Responses API)
@@ -161,6 +163,71 @@ impl std::fmt::Debug for OpenAILlmDriver {
         f.debug_struct("OpenAILlmDriver")
             .field("api_url", &self.api_url())
             .field("api", &"Open Responses")
+            .field("api_key", &"[REDACTED]")
+            .finish()
+    }
+}
+
+// ============================================================================
+// OpenRouter LLM Driver (OpenAI-compatible Responses API)
+// ============================================================================
+
+/// OpenRouter driver using its OpenAI-compatible Responses API.
+#[derive(Clone)]
+pub struct OpenRouterLlmDriver {
+    inner: OpenResponsesProtocolLlmDriver,
+}
+
+impl OpenRouterLlmDriver {
+    /// Create a new OpenRouter driver with the default Responses API endpoint.
+    pub fn new(api_key: impl Into<String>) -> Self {
+        Self {
+            inner: OpenResponsesProtocolLlmDriver::with_base_url(api_key, OPENROUTER_RESPONSES_URL)
+                .with_provider_type(LlmProviderType::Openrouter),
+        }
+    }
+
+    /// Create a new OpenRouter driver with an explicit API URL override.
+    pub fn with_base_url(api_key: impl Into<String>, api_url: impl Into<String>) -> Self {
+        let api_url = normalize_api_url(&api_url.into(), "/responses");
+        Self {
+            inner: OpenResponsesProtocolLlmDriver::with_base_url(api_key, api_url)
+                .with_provider_type(LlmProviderType::Openrouter),
+        }
+    }
+
+    /// Get the API URL.
+    pub fn api_url(&self) -> &str {
+        self.inner.api_url()
+    }
+
+    /// Get the provider type used for model profile lookup.
+    pub fn provider_type(&self) -> &LlmProviderType {
+        self.inner.provider_type()
+    }
+}
+
+#[async_trait]
+impl LlmDriver for OpenRouterLlmDriver {
+    async fn chat_completion_stream(
+        &self,
+        messages: Vec<LlmMessage>,
+        config: &LlmCallConfig,
+    ) -> Result<LlmResponseStream> {
+        self.inner.chat_completion_stream(messages, config).await
+    }
+
+    async fn list_models(&self) -> Result<Option<Vec<DiscoveredModel>>> {
+        let models_url = models_url_for_api_url(self.api_url());
+        list_models_for_url(self.inner.client(), self.inner.api_key(), &models_url).await
+    }
+}
+
+impl std::fmt::Debug for OpenRouterLlmDriver {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OpenRouterLlmDriver")
+            .field("api_url", &self.api_url())
+            .field("api", &"OpenRouter Responses")
             .field("api_key", &"[REDACTED]")
             .finish()
     }
@@ -442,6 +509,7 @@ fn apply_models_auth(request: RequestBuilder, api_url: &str, api_key: &str) -> R
 ///
 /// This registers:
 /// - `ProviderType::OpenAI` - Open Responses API (recommended)
+/// - `ProviderType::OpenRouter` - OpenRouter Responses API
 /// - `ProviderType::AzureOpenAI` - Azure OpenAI Responses API
 /// - `ProviderType::OpenAICompletions` - Chat Completions API (backward compatibility)
 ///
@@ -460,6 +528,14 @@ pub fn register_driver(registry: &mut DriverRegistry) {
         let driver = match base_url {
             Some(url) => OpenAILlmDriver::with_base_url(api_key, url),
             None => OpenAILlmDriver::new(api_key),
+        };
+        Box::new(driver) as BoxedLlmDriver
+    });
+
+    registry.register(ProviderType::OpenRouter, |api_key, base_url| {
+        let driver = match base_url {
+            Some(url) => OpenRouterLlmDriver::with_base_url(api_key, url),
+            None => OpenRouterLlmDriver::new(api_key),
         };
         Box::new(driver) as BoxedLlmDriver
     });

--- a/crates/openai/src/lib.rs
+++ b/crates/openai/src/lib.rs
@@ -4,9 +4,10 @@
 //! ecosystem. It implements the [`LlmDriver`] contract from `everruns-core` and
 //! registers OpenAI providers into a [`DriverRegistry`].
 //!
-//! The crate exposes two drivers:
+//! The crate exposes three drivers:
 //!
 //! - [`OpenAILlmDriver`], the recommended Responses API driver.
+//! - [`OpenRouterLlmDriver`], the OpenRouter Responses API driver.
 //! - [`OpenAICompletionsLlmDriver`], a Chat Completions compatibility driver.
 //!
 //! # Registering the Driver
@@ -60,7 +61,9 @@ mod types;
 #[cfg(test)]
 mod tests;
 
-pub use driver::{OpenAICompletionsLlmDriver, OpenAILlmDriver, register_driver};
+pub use driver::{
+    OpenAICompletionsLlmDriver, OpenAILlmDriver, OpenRouterLlmDriver, register_driver,
+};
 pub use image_capability::{EditImageTool, GenerateImageTool, GptImageGenCapability};
 pub use types::{
     ChatMessage, ChatRequest, CompletionMetadata, LlmConfig, LlmStreamEvent, MessageRole,

--- a/crates/openai/src/tests.rs
+++ b/crates/openai/src/tests.rs
@@ -2,8 +2,12 @@
 
 #[cfg(test)]
 mod driver_tests {
-    use crate::{DriverRegistry, OpenAICompletionsLlmDriver, OpenAILlmDriver, register_driver};
+    use crate::{
+        DriverRegistry, OpenAICompletionsLlmDriver, OpenAILlmDriver, OpenRouterLlmDriver,
+        register_driver,
+    };
     use everruns_core::llm_driver_registry::{ProviderConfig, ProviderType};
+    use everruns_core::llm_models::LlmProviderType;
 
     #[test]
     fn test_driver_with_api_key() {
@@ -52,6 +56,14 @@ mod driver_tests {
     }
 
     #[test]
+    fn test_openrouter_driver_defaults_to_responses_api() {
+        let driver = OpenRouterLlmDriver::new("test-key");
+        assert!(format!("{:?}", driver).contains("OpenRouterLlmDriver"));
+        assert_eq!(driver.api_url(), "https://openrouter.ai/api/v1/responses");
+        assert_eq!(driver.provider_type(), &LlmProviderType::Openrouter);
+    }
+
+    #[test]
     fn test_completions_driver_with_base_url() {
         let driver = OpenAICompletionsLlmDriver::with_base_url(
             "test-key",
@@ -69,12 +81,14 @@ mod driver_tests {
     fn test_register_driver() {
         let mut registry = DriverRegistry::new();
         assert!(!registry.has_driver(&ProviderType::OpenAI));
+        assert!(!registry.has_driver(&ProviderType::OpenRouter));
         assert!(!registry.has_driver(&ProviderType::AzureOpenAI));
         assert!(!registry.has_driver(&ProviderType::OpenAICompletions));
 
         register_driver(&mut registry);
 
         assert!(registry.has_driver(&ProviderType::OpenAI));
+        assert!(registry.has_driver(&ProviderType::OpenRouter));
         assert!(registry.has_driver(&ProviderType::AzureOpenAI));
         assert!(registry.has_driver(&ProviderType::OpenAICompletions));
 
@@ -82,6 +96,11 @@ mod driver_tests {
         let config = ProviderConfig::new(ProviderType::OpenAI).with_api_key("test-key");
         let driver = registry.create_driver(&config);
         assert!(driver.is_ok());
+
+        let openrouter_config =
+            ProviderConfig::new(ProviderType::OpenRouter).with_api_key("test-key");
+        let openrouter_driver = registry.create_driver(&openrouter_config);
+        assert!(openrouter_driver.is_ok());
 
         let azure_config = ProviderConfig::new(ProviderType::AzureOpenAI)
             .with_api_key("test-key")

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -1896,6 +1896,7 @@ impl DirectWorkerAdapters {
 fn string_to_provider_type(s: &str) -> LlmProviderType {
     match s.to_lowercase().as_str() {
         "openai" => LlmProviderType::Openai,
+        "openrouter" => LlmProviderType::Openrouter,
         "azure_openai" => LlmProviderType::AzureOpenai,
         "openai_completions" => LlmProviderType::OpenaiCompletions,
         "anthropic" => LlmProviderType::Anthropic,

--- a/crates/server/src/domains/session_commands/service.rs
+++ b/crates/server/src/domains/session_commands/service.rs
@@ -384,6 +384,7 @@ fn reasoning_effort(controls: Option<&Controls>) -> Option<String> {
 fn provider_type_from_llm(provider_type: LlmProviderType) -> Result<ProviderType> {
     Ok(match provider_type {
         LlmProviderType::Openai => ProviderType::OpenAI,
+        LlmProviderType::Openrouter => ProviderType::OpenRouter,
         LlmProviderType::AzureOpenai => ProviderType::AzureOpenAI,
         LlmProviderType::OpenaiCompletions => ProviderType::OpenAICompletions,
         LlmProviderType::Anthropic => ProviderType::Anthropic,

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -42,6 +42,7 @@ mod seed_ids {
     pub const LLMSIM_PROVIDER: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000003);
     pub const GEMINI_PROVIDER: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000004);
     pub const BEDROCK_PROVIDER: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000005);
+    pub const OPENROUTER_PROVIDER: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000006);
 
     // Agents (0x100-0x1FF)
     pub const DAD_JOKES_AGENT: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000101);
@@ -1382,6 +1383,11 @@ const SEED_PROVIDERS: &[SeedProvider] = &[
         id: seed_ids::ANTHROPIC_PROVIDER,
         name: "Anthropic",
         provider_type: "anthropic",
+    },
+    SeedProvider {
+        id: seed_ids::OPENROUTER_PROVIDER,
+        name: "OpenRouter",
+        provider_type: "openrouter",
     },
     SeedProvider {
         id: seed_ids::GEMINI_PROVIDER,

--- a/crates/server/src/services/llm_resolver.rs
+++ b/crates/server/src/services/llm_resolver.rs
@@ -49,6 +49,7 @@ where
 {
     match provider_type.to_lowercase().as_str() {
         "openai" => env_lookup("DEFAULT_OPENAI_API_KEY").filter(|s| !s.is_empty()),
+        "openrouter" => env_lookup("DEFAULT_OPENROUTER_API_KEY").filter(|s| !s.is_empty()),
         "azure_openai" => env_lookup("DEFAULT_AZURE_OPENAI_API_KEY").filter(|s| !s.is_empty()),
         "anthropic" => env_lookup("DEFAULT_ANTHROPIC_API_KEY").filter(|s| !s.is_empty()),
         "gemini" => env_lookup("DEFAULT_GEMINI_API_KEY").filter(|s| !s.is_empty()),
@@ -387,6 +388,7 @@ mod tests {
     fn test_get_default_api_key_unknown_provider() {
         let env = mock_env(&[
             ("DEFAULT_OPENAI_API_KEY", "sk-test"),
+            ("DEFAULT_OPENROUTER_API_KEY", "sk-or-test"),
             ("DEFAULT_ANTHROPIC_API_KEY", "sk-ant-test"),
         ]);
         // Unknown providers and providers without defaults return None
@@ -394,6 +396,10 @@ mod tests {
         assert_eq!(
             get_default_api_key_with_lookup("openai_completions", &env),
             None
+        );
+        assert_eq!(
+            get_default_api_key_with_lookup("openrouter", &env),
+            Some("sk-or-test".to_string())
         );
     }
 

--- a/crates/server/src/services/model_sync.rs
+++ b/crates/server/src/services/model_sync.rs
@@ -96,6 +96,7 @@ impl ModelSyncService {
         // Create driver for the provider
         let driver_type = match provider_type {
             LlmProviderType::Openai => ProviderType::OpenAI,
+            LlmProviderType::Openrouter => ProviderType::OpenRouter,
             LlmProviderType::AzureOpenai => ProviderType::AzureOpenAI,
             LlmProviderType::OpenaiCompletions => ProviderType::OpenAICompletions,
             LlmProviderType::Anthropic => ProviderType::Anthropic,
@@ -278,7 +279,10 @@ impl ModelSyncService {
 fn supports_sync_with_base_url(provider_type: &LlmProviderType) -> bool {
     matches!(
         provider_type,
-        LlmProviderType::Openai | LlmProviderType::AzureOpenai | LlmProviderType::OpenaiCompletions
+        LlmProviderType::Openai
+            | LlmProviderType::Openrouter
+            | LlmProviderType::AzureOpenai
+            | LlmProviderType::OpenaiCompletions
     )
 }
 
@@ -331,6 +335,7 @@ mod tests {
     fn test_azure_openai_supports_sync_with_base_url() {
         assert!(supports_sync_with_base_url(&LlmProviderType::AzureOpenai));
         assert!(supports_sync_with_base_url(&LlmProviderType::Openai));
+        assert!(supports_sync_with_base_url(&LlmProviderType::Openrouter));
         assert!(supports_sync_with_base_url(
             &LlmProviderType::OpenaiCompletions
         ));

--- a/crates/server/src/storage/llm_provider_store.rs
+++ b/crates/server/src/storage/llm_provider_store.rs
@@ -136,6 +136,7 @@ impl LlmProviderStore for DbLlmProviderStore {
 fn parse_provider_type(provider_type_str: &str) -> Result<LlmProviderType> {
     match provider_type_str.to_lowercase().as_str() {
         "openai" => Ok(LlmProviderType::Openai),
+        "openrouter" => Ok(LlmProviderType::Openrouter),
         "azure_openai" => Ok(LlmProviderType::AzureOpenai),
         "openai_completions" => Ok(LlmProviderType::OpenaiCompletions),
         "anthropic" => Ok(LlmProviderType::Anthropic),

--- a/crates/worker/src/grpc_adapters.rs
+++ b/crates/worker/src/grpc_adapters.rs
@@ -1627,6 +1627,7 @@ fn proto_model_with_provider_to_model(
 ) -> Result<ModelWithProvider> {
     let provider_type = match proto.provider_type.to_lowercase().as_str() {
         "openai" => everruns_core::LlmProviderType::Openai,
+        "openrouter" => everruns_core::LlmProviderType::Openrouter,
         "azure_openai" => everruns_core::LlmProviderType::AzureOpenai,
         "openai_completions" => everruns_core::LlmProviderType::OpenaiCompletions,
         "anthropic" => everruns_core::LlmProviderType::Anthropic,

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -21602,6 +21602,7 @@
         "description": "LLM provider type",
         "enum": [
           "openai",
+          "openrouter",
           "azure_openai",
           "openai_completions",
           "anthropic",

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -167,7 +167,7 @@ System-wide configuration for LLM providers, models, and MCP servers.
 
 An LLM Provider is a configured API provider such as OpenAI or Anthropic. Providers store encrypted API keys and contain models.
 
-- Provider types: `openai`, `openai_completions`, `anthropic`
+- Provider types include `openai`, `openrouter`, `openai_completions`, `anthropic`, `gemini`, and `bedrock`
 - Each provider contains many models
 - Default providers (OpenAI, Anthropic) are seeded on startup
 

--- a/docs/how-to/migrate-providers.md
+++ b/docs/how-to/migrate-providers.md
@@ -9,7 +9,7 @@ Everruns abstracts the LLM behind a uniform interface, so the same agent can run
 
 Two pieces decide which model runs:
 
-- **LLM Provider** — a configured API provider with encrypted credentials (e.g., `openai`, `anthropic`, `gemini`, `openai_completions`).
+- **LLM Provider** — a configured API provider with encrypted credentials (e.g., `openai`, `openrouter`, `anthropic`, `gemini`, `openai_completions`).
 - **LLM Model** — a specific model on a provider (e.g., `gpt-4o`, `claude-sonnet-4`, `gemini-1.5-pro`).
 
 Model resolution priority on each turn:

--- a/specs/concepts.md
+++ b/specs/concepts.md
@@ -217,7 +217,7 @@ erDiagram
 
 A configured API provider such as OpenAI or Anthropic. Stores encrypted API keys.
 
-- Provider types: `openai`, `azure_openai`, `openai_completions`, `anthropic`, `gemini`, `llmsim`
+- Provider types: `openai`, `openrouter`, `azure_openai`, `openai_completions`, `anthropic`, `gemini`, `bedrock`, `llmsim`
 - Each provider contains many models
 - Default providers are seeded on startup
 

--- a/specs/llm-drivers.md
+++ b/specs/llm-drivers.md
@@ -274,7 +274,7 @@ sequenceDiagram
 
 ## OpenAI Driver Variants
 
-The OpenAI crate provides two driver implementations:
+The OpenAI crate provides three driver implementations:
 
 1. **OpenAILlmDriver** (`ProviderType::OpenAI`)
    - Uses Open Responses API (https://www.openresponses.org/)
@@ -286,7 +286,14 @@ The OpenAI crate provides two driver implementations:
    - For backward compatibility with legacy integrations
    - Wraps `OpenAIProtocolLlmDriver`
 
-Both drivers share the same base URL handling and can work with OpenAI-compatible endpoints.
+3. **OpenRouterLlmDriver** (`ProviderType::OpenRouter`)
+   - Uses OpenRouter's OpenAI-compatible Responses API
+   - Defaults to `https://openrouter.ai/api/v1/responses`
+   - Wraps `OpenResponsesProtocolLlmDriver` with the OpenRouter provider profile
+
+The Responses drivers share the same base URL handling and can work with
+OpenAI-compatible endpoints while keeping provider-specific request features
+gated by the resolved provider type.
 
 ### Model Discovery and Capability Profiles
 

--- a/specs/models.md
+++ b/specs/models.md
@@ -225,7 +225,7 @@ Configuration for LLM API providers. See `crates/core/src/llm_models.rs` for ful
 
 Key design points:
 - `provider_type` stored as plain string without CHECK constraint (forward compatibility)
-- Supported types: `openai`, `azure_openai`, `openai_completions`, `anthropic`, `gemini`, `llmsim`
+- Supported types: `openai`, `openrouter`, `azure_openai`, `openai_completions`, `anthropic`, `gemini`, `bedrock`, `llmsim`
 - API keys encrypted with AES-256-GCM envelope encryption (see `specs/encryption.md`)
 
 **API Key Resolution Order:**


### PR DESCRIPTION
## What
Adds OpenRouter as a first-class LLM provider type across backend, driver registry, model sync, default seeding, OpenAPI, docs, and settings UI.

## Why
OpenRouter should be selectable and syncable without pretending to be a custom OpenAI provider, while still using its OpenAI-compatible Responses API and richer model metadata path.

## How
- Adds `openrouter` provider enums/parsing/mappings and seeds an OpenRouter provider.
- Adds `OpenRouterLlmDriver` with the default `https://openrouter.ai/api/v1/responses` endpoint and model listing support.
- Makes the shared Responses driver provider-aware so OpenRouter does not emit OpenAI-only phases or hosted `tool_search` payloads.
- Adds OpenRouter to provider UI options, icons, API types, docs/specs, and regenerated OpenAPI.

## Risk
- Medium
- Provider selection, model sync, and Responses request construction are touched. Existing OpenAI behavior is protected by focused driver/registry tests and provider-specific feature gating.

## Security
- Threat categories reviewed: TM-LLM, TM-API, TM-TENANT, TM-WEB, TM-DOS.
- Findings and resolutions:
  - Provider API keys still use the existing encrypted provider storage path; no new logging of secrets was added.
  - Provider base URL handling continues through existing safe URL validation and driver URL normalization; no new arbitrary fetch surface was introduced.
  - Tenant scope remains on existing LLM provider APIs and seed/default-provider paths; no cross-org query changes.
  - UI changes add static provider labels/icons only; no user-controlled HTML or URL rendering.
  - Hosted OpenAI-only `tool_search` and phase fields are now gated by provider-specific model profiles, avoiding incompatible OpenRouter request payloads.
  - No new threat-model entry needed; existing mitigations cover this provider addition.

## Validation
- `cargo test -p everruns-core openrouter_provider_does_not_send_hosted_tool_search --all-features`
- `cargo test -p everruns-core provider_type --all-features`
- `cargo test -p everruns-openai --all-features`
- `cargo test -p everruns-server default_api_key`
- `cd apps/ui && pnpm test -- provider-icon.test.tsx`
- `cd apps/ui && pnpm run format:check`
- `cd apps/ui && pnpm run lint`
- `./scripts/export-openapi.sh`
- `git diff --check`
- `cargo fmt --check`
- `bash scripts/lib/check-migration-ordering.sh`
- `bash scripts/test-specs-index.sh`
- `just pre-push` (passed; UI steps skipped because `apps/ui/node_modules` was absent at final run, with direct UI commands run separately above)
- Smoke: started `everruns-server` in dev mode on `127.0.0.1:27101`; `POST /api/v1/llm-providers` with `provider_type: openrouter`; verified create/read/list responses.

## Follow-ups
No follow-ups for this PR. Subsequent OpenRouter routing/cost/policy work is separately scoped in the planned sequential PRs.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)