### PR TITLE
fix(worker): support subagent metadata over grpc

### DIFF
--- a/crates/core/src/capabilities/subagents.rs
+++ b/crates/core/src/capabilities/subagents.rs
@@ -399,6 +399,20 @@ impl Tool for SpawnSubagentTool {
                 .await;
         }
 
+        let _ = store
+            .set_subagent_metadata(
+                child_session.id,
+                context.session_id,
+                &name,
+                &task,
+                if status == "error" {
+                    crate::session::SubagentStatus::Failed
+                } else {
+                    crate::session::SubagentStatus::Completed
+                },
+            )
+            .await;
+
         ToolExecutionResult::success(json!({
             "subagent_id": child_session.id.to_string(),
             "name": name,

--- a/crates/core/src/capabilities/subagents.rs
+++ b/crates/core/src/capabilities/subagents.rs
@@ -387,31 +387,37 @@ impl Tool for SpawnSubagentTool {
         let result_text = last_agent_message(&messages)
             .unwrap_or_else(|| format!("Subagent completed with status: {status}"));
 
-        // Update registry with terminal status.
-        if let Some(ref registry) = context.session_resource_registry {
-            let terminal = if status == "error" {
-                crate::session_resource::SessionResourceStatus::Failed
-            } else {
-                crate::session_resource::SessionResourceStatus::Completed
-            };
-            let _ = registry
-                .update_status(context.session_id, &child_session.id.to_string(), terminal)
-                .await;
+        // Update registry and persist metadata only when the child reached a
+        // terminal state.  Non-terminal results from wait_for_idle (paused,
+        // waiting_for_tool_results, timeout) leave the child Active.
+        if status == "idle" {
+            if let Some(ref registry) = context.session_resource_registry {
+                let _ = registry
+                    .update_status(
+                        context.session_id,
+                        &child_session.id.to_string(),
+                        crate::session_resource::SessionResourceStatus::Completed,
+                    )
+                    .await;
+            }
+            if let Err(e) = store
+                .set_subagent_metadata(
+                    child_session.id,
+                    context.session_id,
+                    &name,
+                    &task,
+                    crate::session::SubagentStatus::Completed,
+                )
+                .await
+            {
+                tracing::warn!(
+                    session_id = %context.session_id,
+                    child_session_id = %child_session.id,
+                    error = %e,
+                    "failed to persist subagent completed metadata"
+                );
+            }
         }
-
-        let _ = store
-            .set_subagent_metadata(
-                child_session.id,
-                context.session_id,
-                &name,
-                &task,
-                if status == "error" {
-                    crate::session::SubagentStatus::Failed
-                } else {
-                    crate::session::SubagentStatus::Completed
-                },
-            )
-            .await;
 
         ToolExecutionResult::success(json!({
             "subagent_id": child_session.id.to_string(),

--- a/crates/internal-protocol/proto/worker.proto
+++ b/crates/internal-protocol/proto/worker.proto
@@ -33,6 +33,7 @@ service WorkerService {
     rpc GetSession(GetSessionRequest) returns (GetSessionResponse);
     rpc SetSessionStatus(SetSessionStatusRequest) returns (SetSessionStatusResponse);
     rpc SetSessionTitle(SetSessionTitleRequest) returns (SetSessionTitleResponse);
+    rpc SetSubagentMetadata(SetSubagentMetadataRequest) returns (SetSubagentMetadataResponse);
 
     // Message operations
     rpc GetMessage(GetMessageRequest) returns (GetMessageResponse);
@@ -421,6 +422,13 @@ message Session {
     optional Uuid resolved_owner_user_id = 17;
     // Captured immutable agent version for runtime provenance
     optional Uuid agent_version_id = 18;
+    // Parent/child metadata for subagent and agent handoff sessions.
+    optional Uuid parent_session_id = 19;
+    optional string subagent_name = 20;
+    optional string subagent_task = 21;
+    optional string subagent_status = 22;
+    optional string blueprint_id = 23;
+    optional string blueprint_config_json = 24;
 }
 
 message GetSessionRequest {
@@ -452,6 +460,19 @@ message SetSessionTitleRequest {
 }
 
 message SetSessionTitleResponse {
+    Session session = 1;
+}
+
+message SetSubagentMetadataRequest {
+    int64 org_id = 1;
+    Uuid session_id = 2;
+    Uuid parent_session_id = 3;
+    string subagent_name = 4;
+    string subagent_task = 5;
+    string subagent_status = 6;
+}
+
+message SetSubagentMetadataResponse {
     Session session = 1;
 }
 

--- a/crates/internal-protocol/src/lib.rs
+++ b/crates/internal-protocol/src/lib.rs
@@ -436,6 +436,18 @@ pub fn proto_session_to_schema(
         .as_ref()
         .map(|u| format!("principal_{}", u.value.replace("-", "")))
         .ok_or(ConversionError::MissingField("owner_principal_id"))?;
+    let parent_session_id_str = value
+        .parent_session_id
+        .as_ref()
+        .map(|u| format!("session_{}", u.value.replace("-", "")));
+    let subagent_status = value
+        .subagent_status
+        .as_deref()
+        .map(everruns_core::session::SubagentStatus::from);
+    let blueprint_config = value
+        .blueprint_config_json
+        .as_deref()
+        .and_then(|json| serde_json::from_str::<serde_json::Value>(json).ok());
 
     let capabilities: Vec<serde_json::Value> = value
         .capabilities
@@ -467,6 +479,12 @@ pub fn proto_session_to_schema(
         "started_at": started_at,
         "finished_at": finished_at,
         "hints": value.hints.as_ref().map(proto_struct_to_json),
+        "parent_session_id": parent_session_id_str,
+        "subagent_name": value.subagent_name,
+        "subagent_task": value.subagent_task,
+        "subagent_status": subagent_status,
+        "blueprint_id": value.blueprint_id,
+        "blueprint_config": blueprint_config,
     });
     serde_json::from_value(json).map_err(ConversionError::from)
 }
@@ -495,6 +513,17 @@ pub fn schema_session_to_proto(value: &everruns_core::Session) -> proto::Session
         tags: value.tags.clone(),
         owner_principal_id: Some(uuid_to_proto_uuid(value.owner_principal_id.uuid())),
         resolved_owner_user_id: value.resolved_owner_user_id.map(uuid_to_proto_uuid),
+        parent_session_id: value
+            .parent_session_id
+            .map(|id| uuid_to_proto_uuid(id.uuid())),
+        subagent_name: value.subagent_name.clone(),
+        subagent_task: value.subagent_task.clone(),
+        subagent_status: value.subagent_status.as_ref().map(ToString::to_string),
+        blueprint_id: value.blueprint_id.clone(),
+        blueprint_config_json: value
+            .blueprint_config
+            .as_ref()
+            .and_then(|config| serde_json::to_string(config).ok()),
         hints: value.hints.as_ref().map(|h| {
             let json = serde_json::to_value(h).unwrap_or_default();
             json_to_proto_struct(&json)
@@ -1428,12 +1457,12 @@ mod tests {
             is_pinned: None,
             active_schedule_count: None,
             features: vec![],
-            parent_session_id: None,
-            subagent_name: None,
-            subagent_task: None,
-            subagent_status: None,
-            blueprint_id: None,
-            blueprint_config: None,
+            parent_session_id: Some(everruns_core::SessionId::new()),
+            subagent_name: Some("Test Runner".to_string()),
+            subagent_task: Some("Run focused tests".to_string()),
+            subagent_status: Some(everruns_core::session::SubagentStatus::Running),
+            blueprint_id: Some("oracle".to_string()),
+            blueprint_config: Some(serde_json::json!({ "depth": "focused" })),
         };
 
         // Convert to proto
@@ -1444,6 +1473,9 @@ mod tests {
         );
         assert_eq!(proto_session.capabilities.len(), 1);
         assert_eq!(proto_session.tags, vec!["slack:thread:123.456".to_string()]);
+        assert_eq!(proto_session.subagent_name.as_deref(), Some("Test Runner"));
+        assert_eq!(proto_session.subagent_status.as_deref(), Some("running"));
+        assert_eq!(proto_session.blueprint_id.as_deref(), Some("oracle"));
 
         // Convert back to schema
         let schema_session = proto_session_to_schema(proto_session).unwrap();
@@ -1463,6 +1495,12 @@ mod tests {
         );
         assert_eq!(schema_session.capabilities.len(), 1);
         assert_eq!(schema_session.capabilities[0].capability_id(), "session");
+        assert_eq!(schema_session.parent_session_id, session.parent_session_id);
+        assert_eq!(schema_session.subagent_name, session.subagent_name);
+        assert_eq!(schema_session.subagent_task, session.subagent_task);
+        assert_eq!(schema_session.subagent_status, session.subagent_status);
+        assert_eq!(schema_session.blueprint_id, session.blueprint_id);
+        assert_eq!(schema_session.blueprint_config, session.blueprint_config);
     }
 
     #[test]

--- a/crates/server/src/grpc_service/mod.rs
+++ b/crates/server/src/grpc_service/mod.rs
@@ -253,6 +253,8 @@ use everruns_internal_protocol::proto::{
     SetSessionStatusResponse,
     SetSessionTitleRequest,
     SetSessionTitleResponse,
+    SetSubagentMetadataRequest,
+    SetSubagentMetadataResponse,
     SubscribeTaskNotificationsRequest,
     TaskNotification,
     TaskNotificationType,

--- a/crates/server/src/grpc_service/tests.rs
+++ b/crates/server/src/grpc_service/tests.rs
@@ -5,6 +5,12 @@ use tonic::service::Interceptor;
 static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 async fn test_worker_service() -> WorkerServiceImpl {
+    test_worker_service_with_runner(None).await
+}
+
+async fn test_worker_service_with_runner(
+    runner: Option<Arc<dyn everruns_worker::AgentRunner>>,
+) -> WorkerServiceImpl {
     let db = Arc::new(StorageBackend::in_memory());
     let grade = everruns_core::DeploymentGrade::Dev;
     let platform_definition = crate::oss_platform_definition_for_grade(grade);
@@ -20,7 +26,124 @@ async fn test_worker_service() -> WorkerServiceImpl {
     let event_service =
         EventService::with_listeners(db.clone(), crate::EventDelivery::in_memory(), vec![]);
 
-    WorkerServiceImpl::new(event_service, db, encryption, None, platform_definition)
+    WorkerServiceImpl::new(event_service, db, encryption, runner, platform_definition)
+}
+
+#[derive(Clone)]
+struct CompletingTestRunner {
+    db: Arc<StorageBackend>,
+    event_service: EventService,
+}
+
+#[async_trait::async_trait]
+impl everruns_worker::AgentRunner for CompletingTestRunner {
+    async fn start_run(
+        &self,
+        org_id: i64,
+        session_id: everruns_core::SessionId,
+        _harness_id: everruns_core::HarnessId,
+        _agent_id: Option<everruns_core::typed_id::AgentId>,
+        _input_message_id: everruns_core::MessageId,
+        _request_id: Option<String>,
+    ) -> anyhow::Result<()> {
+        self.event_service
+            .emit(everruns_core::EventRequest::new(
+                session_id,
+                everruns_core::events::EventContext::empty(),
+                everruns_core::events::OutputMessageCompletedData::new(
+                    everruns_core::Message::assistant("Child completed through gRPC"),
+                ),
+            ))
+            .await?;
+        self.db
+            .update_session(
+                org_id,
+                session_id,
+                crate::storage::models::UpdateSession {
+                    status: Some("idle".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await?;
+        Ok(())
+    }
+
+    async fn resume_after_tool_results(
+        &self,
+        _session_id: everruns_core::SessionId,
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn cancel_run(&self, _run_id: everruns_core::SessionId) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn is_running(&self, _run_id: everruns_core::SessionId) -> bool {
+        false
+    }
+
+    async fn active_count(&self) -> usize {
+        0
+    }
+}
+
+async fn test_worker_service_with_completing_runner() -> WorkerServiceImpl {
+    let db = Arc::new(StorageBackend::in_memory());
+    let grade = everruns_core::DeploymentGrade::Dev;
+    let platform_definition = crate::oss_platform_definition_for_grade(grade);
+    let encryption = Some(Arc::new(
+        EncryptionService::new("kek-v1:8B3uCQ4Znx45hl5nB+PKVriRrj/KtEVM+wBZ2VGa9vY=", &[])
+            .expect("valid test encryption key"),
+    ));
+
+    crate::seed::seed_all(&db, grade, &crate::seed::SeedAuthContext::default())
+        .await
+        .expect("seed test data");
+
+    let event_service =
+        EventService::with_listeners(db.clone(), crate::EventDelivery::in_memory(), vec![]);
+    let runner = Arc::new(CompletingTestRunner {
+        db: db.clone(),
+        event_service: event_service.clone(),
+    });
+
+    WorkerServiceImpl::new(
+        event_service,
+        db,
+        encryption,
+        Some(runner),
+        platform_definition,
+    )
+}
+
+struct AllowingConnectionResolver;
+
+#[async_trait::async_trait]
+impl everruns_core::traits::UserConnectionResolver for AllowingConnectionResolver {
+    async fn get_connection_token(
+        &self,
+        _session_id: everruns_core::SessionId,
+        _provider: &str,
+    ) -> everruns_core::error::Result<Option<String>> {
+        Ok(Some("test-token".to_string()))
+    }
+
+    async fn get_connection_user(
+        &self,
+        _session_id: everruns_core::SessionId,
+        _provider: &str,
+    ) -> everruns_core::error::Result<Option<uuid::Uuid>> {
+        Ok(None)
+    }
+
+    async fn get_connection_token_for_user(
+        &self,
+        _user_id: uuid::Uuid,
+        _provider: &str,
+    ) -> everruns_core::error::Result<Option<String>> {
+        Ok(Some("test-token".to_string()))
+    }
 }
 
 #[test]
@@ -180,6 +303,354 @@ async fn test_execute_command_unknown_command_returns_bad_request_kind() {
 
     assert_eq!(error.kind, 1);
     assert!(error.message.contains("Unknown command"));
+}
+
+async fn create_grpc_test_session(service: &WorkerServiceImpl) -> proto::Session {
+    let harness = service
+        .platform_list_harnesses(Request::new(PlatformListHarnessesRequest {
+            org_id: everruns_core::DEFAULT_ORG_ID,
+        }))
+        .await
+        .expect("list harnesses should succeed")
+        .into_inner()
+        .harnesses
+        .into_iter()
+        .next()
+        .expect("seeded harness");
+
+    service
+        .platform_create_session(Request::new(PlatformCreateSessionRequest {
+            org_id: everruns_core::DEFAULT_ORG_ID,
+            harness_id: harness.id,
+            agent_id: None,
+            title: None,
+            locale: None,
+            blueprint_id: None,
+            blueprint_config_json: None,
+        }))
+        .await
+        .expect("create session should succeed")
+        .into_inner()
+        .session
+        .expect("session response")
+}
+
+fn proto_session_id(session: &proto::Session) -> everruns_core::SessionId {
+    let id = session.id.as_ref().expect("session id");
+    everruns_core::SessionId::from_uuid(id.value.parse().expect("uuid session id"))
+}
+
+async fn start_grpc_test_server(
+    service: WorkerServiceImpl,
+) -> (
+    String,
+    tokio::sync::oneshot::Sender<()>,
+    tokio::task::JoinHandle<()>,
+) {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind grpc listener");
+    let addr = listener.local_addr().expect("grpc listener address");
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+    let (incoming_tx, incoming_rx) = tokio::sync::mpsc::channel(8);
+    let server = tokio::spawn(async move {
+        let accept_task = tokio::spawn(async move {
+            let mut shutdown_rx = shutdown_rx;
+            loop {
+                tokio::select! {
+                    _ = &mut shutdown_rx => break,
+                    accepted = listener.accept() => {
+                        match accepted {
+                            Ok((stream, _)) => {
+                                if incoming_tx.send(Ok(stream)).await.is_err() {
+                                    break;
+                                }
+                            }
+                            Err(error) => {
+                                let _ = incoming_tx.send(Err(error)).await;
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        });
+        tonic::transport::Server::builder()
+            .add_service(service.into_server())
+            .serve_with_incoming(tokio_stream::wrappers::ReceiverStream::new(incoming_rx))
+            .await
+            .expect("grpc test server should run");
+        accept_task.await.expect("grpc accept task should join");
+    });
+
+    (addr.to_string(), shutdown_tx, server)
+}
+
+#[tokio::test]
+async fn test_set_subagent_metadata_rpc_persists_child_linkage() {
+    let service = test_worker_service().await;
+    let parent = create_grpc_test_session(&service).await;
+    let child = create_grpc_test_session(&service).await;
+    let parent_id = parent.id.clone().expect("parent id");
+    let child_id = child.id.clone().expect("child id");
+
+    let updated = service
+        .set_subagent_metadata(Request::new(SetSubagentMetadataRequest {
+            org_id: everruns_core::DEFAULT_ORG_ID,
+            session_id: Some(child_id),
+            parent_session_id: Some(parent_id.clone()),
+            subagent_name: "Test Runner".to_string(),
+            subagent_task: "Run the focused gRPC regression".to_string(),
+            subagent_status: "running".to_string(),
+        }))
+        .await
+        .expect("set_subagent_metadata should succeed")
+        .into_inner()
+        .session
+        .expect("updated session");
+
+    assert_eq!(updated.parent_session_id, Some(parent_id));
+    assert_eq!(updated.subagent_name.as_deref(), Some("Test Runner"));
+    assert_eq!(
+        updated.subagent_task.as_deref(),
+        Some("Run the focused gRPC regression")
+    );
+    assert_eq!(updated.subagent_status.as_deref(), Some("running"));
+}
+
+#[tokio::test]
+async fn test_worker_grpc_platform_store_sets_subagent_metadata() {
+    use everruns_core::platform_store::PlatformStore;
+
+    let service = test_worker_service().await;
+    let parent = create_grpc_test_session(&service).await;
+    let child = create_grpc_test_session(&service).await;
+    let parent_id = proto_session_id(&parent);
+    let child_id = proto_session_id(&child);
+
+    let (addr, shutdown_tx, server) = start_grpc_test_server(service).await;
+
+    let client = everruns_worker::GrpcClient::connect(&addr)
+        .await
+        .expect("worker grpc client should connect");
+    let platform_store =
+        everruns_worker::grpc_adapters::GrpcOrgAdapter::new(client, everruns_core::DEFAULT_ORG_ID);
+
+    let updated = platform_store
+        .set_subagent_metadata(
+            child_id,
+            parent_id,
+            "Handoff Worker",
+            "Complete a worker-path handoff",
+            everruns_core::session::SubagentStatus::Running,
+        )
+        .await
+        .expect("worker platform store should set metadata over grpc");
+
+    assert_eq!(updated.parent_session_id, Some(parent_id));
+    assert_eq!(updated.subagent_name.as_deref(), Some("Handoff Worker"));
+    assert_eq!(
+        updated.subagent_task.as_deref(),
+        Some("Complete a worker-path handoff")
+    );
+    assert_eq!(
+        updated.subagent_status,
+        Some(everruns_core::session::SubagentStatus::Running)
+    );
+
+    let _ = shutdown_tx.send(());
+    server.await.expect("grpc server task should join");
+}
+
+#[tokio::test]
+async fn test_subagent_and_handoff_tools_complete_over_grpc_platform_adapter() {
+    use everruns_core::capabilities::{AgentHandoffCapability, Capability, SubagentCapability};
+    use everruns_core::platform_store::PlatformStore;
+    use everruns_core::tools::ToolExecutionResult;
+    use everruns_core::traits::SessionResourceRegistry;
+
+    let service = test_worker_service_with_completing_runner().await;
+    let parent = create_grpc_test_session(&service).await;
+    let parent_id = proto_session_id(&parent);
+    let user = service
+        .db
+        .create_user(crate::storage::models::CreateUserRow {
+            email: format!("grpc-subagent-{}@example.com", uuid::Uuid::now_v7()),
+            name: "gRPC Subagent Test".to_string(),
+            avatar_url: None,
+            roles: vec!["admin".to_string()],
+            password_hash: None,
+            email_verified: true,
+            auth_provider: None,
+            auth_provider_id: None,
+            external_id: None,
+        })
+        .await
+        .expect("create test user");
+    service
+        .db
+        .add_organization_member(everruns_core::DEFAULT_ORG_ID, user.id, "owner")
+        .await
+        .expect("add test user to default org");
+    service
+        .db
+        .update_session(
+            everruns_core::DEFAULT_ORG_ID,
+            parent_id,
+            crate::storage::models::UpdateSession {
+                resolved_owner_user_id: everruns_durable::UpdateField::Set(user.id),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("mark parent session as user owned");
+    let parent_harness_id = parent
+        .harness_id
+        .as_ref()
+        .expect("parent harness id")
+        .value
+        .parse()
+        .map(everruns_core::HarnessId::from_uuid)
+        .expect("harness uuid");
+
+    let (addr, shutdown_tx, server) = start_grpc_test_server(service).await;
+    let client = everruns_worker::GrpcClient::connect(&addr)
+        .await
+        .expect("worker grpc client should connect");
+    let adapter = Arc::new(
+        everruns_worker::grpc_adapters::GrpcOrgAdapter::new_for_platform_session(
+            client.clone(),
+            everruns_core::DEFAULT_ORG_ID,
+            Some(parent_id),
+        ),
+    );
+    let session_adapter = Arc::new(everruns_worker::grpc_adapters::GrpcAdapter::new(client));
+
+    let mut context = everruns_core::traits::ToolContext::new(parent_id);
+    context.platform_store = Some(adapter.clone());
+    context.session_store = Some(adapter.clone());
+    context.session_resource_registry = Some(session_adapter.clone());
+
+    let spawn_tool = SubagentCapability
+        .tools()
+        .into_iter()
+        .find(|tool| tool.name() == "spawn_subagent")
+        .expect("spawn_subagent tool");
+    let spawn_result = spawn_tool
+        .execute_with_context(
+            serde_json::json!({
+                "name": "gRPC Subagent",
+                "task": "Exercise spawn_subagent through the gRPC platform adapter"
+            }),
+            &context,
+        )
+        .await;
+    let ToolExecutionResult::Success(spawn_value) = spawn_result else {
+        panic!("spawn_subagent should succeed over grpc, got {spawn_result:?}");
+    };
+    assert_eq!(spawn_value["status"], "idle");
+    assert_eq!(spawn_value["result"], "Child completed through gRPC");
+    let subagent_id: everruns_core::SessionId = spawn_value["subagent_id"]
+        .as_str()
+        .expect("subagent_id")
+        .parse()
+        .expect("subagent id parses");
+    let subagent = adapter
+        .get_session_by_id(subagent_id)
+        .await
+        .expect("get spawned subagent")
+        .expect("spawned subagent exists");
+    assert_eq!(subagent.parent_session_id, Some(parent_id));
+    assert_eq!(subagent.subagent_name.as_deref(), Some("gRPC Subagent"));
+    assert_eq!(
+        subagent.subagent_status,
+        Some(everruns_core::session::SubagentStatus::Completed)
+    );
+
+    let resources = session_adapter
+        .list(parent_id, None)
+        .await
+        .expect("list session resources");
+    assert!(resources.iter().any(|entry| {
+        entry.kind == "subagent"
+            && entry.resource_id == subagent_id.to_string()
+            && entry.status == everruns_core::SessionResourceStatus::Completed
+    }));
+
+    let target_agent = adapter
+        .create_agent(
+            "grpc-handoff-target",
+            Some("gRPC Handoff Target"),
+            None,
+            "You complete test handoffs.",
+            &[],
+        )
+        .await
+        .expect("create handoff target agent");
+    let handoff_config = serde_json::json!({
+        "targets": [{
+            "id": "target",
+            "name": "gRPC Handoff Target",
+            "agent_id": target_agent.public_id,
+            "harness_id": parent_harness_id,
+            "required_connections": ["fake_aws"],
+            "required_scopes": ["fake_aws:rds:create"]
+        }]
+    });
+    let handoff_tool = AgentHandoffCapability
+        .tools_with_config(&handoff_config)
+        .into_iter()
+        .find(|tool| tool.name() == "start_agent_handoff")
+        .expect("start_agent_handoff tool");
+
+    context.connection_resolver = Some(Arc::new(AllowingConnectionResolver));
+    let handoff_result = handoff_tool
+        .execute_with_context(
+            serde_json::json!({
+                "target": "target",
+                "task": "Exercise start_agent_handoff through the gRPC platform adapter",
+                "public_context": { "ticket": "EVE-538" }
+            }),
+            &context,
+        )
+        .await;
+    let ToolExecutionResult::Success(handoff_value) = handoff_result else {
+        panic!("start_agent_handoff should succeed over grpc, got {handoff_result:?}");
+    };
+    assert_eq!(handoff_value["status"], "idle");
+    assert_eq!(handoff_value["result"], "Child completed through gRPC");
+    let handoff_id: everruns_core::SessionId = handoff_value["handoff_id"]
+        .as_str()
+        .expect("handoff_id")
+        .parse()
+        .expect("handoff id parses");
+    let handoff = adapter
+        .get_session_by_id(handoff_id)
+        .await
+        .expect("get handoff child")
+        .expect("handoff child exists");
+    assert_eq!(handoff.parent_session_id, Some(parent_id));
+    assert_eq!(
+        handoff.subagent_name.as_deref(),
+        Some("gRPC Handoff Target")
+    );
+    assert_eq!(
+        handoff.subagent_status,
+        Some(everruns_core::session::SubagentStatus::Completed)
+    );
+
+    let resources = session_adapter
+        .list(parent_id, None)
+        .await
+        .expect("list session resources after handoff");
+    assert!(resources.iter().any(|entry| {
+        entry.kind == "agent_handoff"
+            && entry.resource_id == handoff_id.to_string()
+            && entry.status == everruns_core::SessionResourceStatus::Completed
+    }));
+
+    let _ = shutdown_tx.send(());
+    server.await.expect("grpc server task should join");
 }
 
 #[tokio::test]

--- a/crates/server/src/grpc_service/worker_service_impl.rs
+++ b/crates/server/src/grpc_service/worker_service_impl.rs
@@ -532,6 +532,72 @@ impl WorkerService for WorkerServiceImpl {
         }))
     }
 
+    async fn set_subagent_metadata(
+        &self,
+        request: Request<SetSubagentMetadataRequest>,
+    ) -> Result<Response<SetSubagentMetadataResponse>, Status> {
+        use everruns_internal_protocol::schema_session_to_proto;
+
+        let req = request.into_inner();
+        let session_id = parse_uuid(req.session_id.as_ref())?;
+        let parent_session_id = parse_uuid(req.parent_session_id.as_ref())?;
+        let valid_statuses = [
+            "spawning",
+            "running",
+            "completed",
+            "failed",
+            "cancelled",
+            "max_iterations_reached",
+        ];
+        if !valid_statuses.contains(&req.subagent_status.as_str()) {
+            return Err(Status::invalid_argument(format!(
+                "Invalid subagent_status '{}'. Must be one of: {}",
+                req.subagent_status,
+                valid_statuses.join(", ")
+            )));
+        }
+
+        let row = self
+            .db
+            .set_subagent_metadata(
+                req.org_id,
+                everruns_core::SessionId::from_uuid(session_id),
+                everruns_core::SessionId::from_uuid(parent_session_id),
+                &req.subagent_name,
+                &req.subagent_task,
+                &req.subagent_status,
+            )
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to set subagent metadata: {}", e);
+                Status::internal("Failed to set subagent metadata")
+            })?
+            .ok_or_else(|| Status::not_found("Session not found"))?;
+
+        let fallback_harness = if row.harness_id.is_none() {
+            Some(
+                crate::org_init::base_harness_id(&self.db, req.org_id)
+                    .await
+                    .map_err(|e| {
+                        tracing::error!("Failed to resolve base harness: {}", e);
+                        Status::internal("Failed to resolve base harness")
+                    })?,
+            )
+        } else {
+            None
+        };
+        let org_public_id = everruns_core::org_public_id_from_internal(req.org_id);
+        let session = crate::domains::sessions::SessionService::row_to_session(
+            row,
+            &org_public_id,
+            fallback_harness,
+        );
+
+        Ok(Response::new(SetSubagentMetadataResponse {
+            session: Some(schema_session_to_proto(&session)),
+        }))
+    }
+
     async fn get_message(
         &self,
         request: Request<GetMessageRequest>,

--- a/crates/worker/src/grpc_adapters.rs
+++ b/crates/worker/src/grpc_adapters.rs
@@ -257,6 +257,38 @@ impl GrpcClient {
         proto_session_to_session(proto_session)
     }
 
+    pub async fn set_subagent_metadata(
+        &self,
+        org_id: i64,
+        session_id: SessionId,
+        parent_session_id: SessionId,
+        subagent_name: &str,
+        subagent_task: &str,
+        subagent_status: everruns_core::session::SubagentStatus,
+    ) -> Result<Session> {
+        let request = proto::SetSubagentMetadataRequest {
+            org_id,
+            session_id: Some(uuid_to_proto(session_id.uuid())),
+            parent_session_id: Some(uuid_to_proto(parent_session_id.uuid())),
+            subagent_name: subagent_name.to_string(),
+            subagent_task: subagent_task.to_string(),
+            subagent_status: subagent_status.to_string(),
+        };
+
+        let mut client = self.inner.lock().await;
+        let response = client
+            .set_subagent_metadata(request)
+            .await
+            .map_err(grpc_status_to_error)?;
+
+        let proto_session = response
+            .into_inner()
+            .session
+            .ok_or_else(|| grpc_missing_field("No session in response"))?;
+
+        proto_session_to_session(proto_session)
+    }
+
     pub async fn create_image_artifact(
         &self,
         org_id: i64,
@@ -1411,6 +1443,19 @@ fn proto_session_to_session(proto_session: proto::Session) -> Result<Session> {
         .as_ref()
         .map(|u| proto_uuid_to_uuid(Some(u)))
         .transpose()?;
+    let parent_session_id = proto_session
+        .parent_session_id
+        .as_ref()
+        .map(|u| proto_uuid_to_uuid(Some(u)).map(SessionId::from_uuid))
+        .transpose()?;
+    let subagent_status = proto_session
+        .subagent_status
+        .as_deref()
+        .map(everruns_core::session::SubagentStatus::from);
+    let blueprint_config = proto_session
+        .blueprint_config_json
+        .as_deref()
+        .and_then(|json| serde_json::from_str(json).ok());
 
     let status = match proto_session.status.to_lowercase().as_str() {
         "started" => everruns_core::SessionStatus::Started,
@@ -1479,12 +1524,12 @@ fn proto_session_to_session(proto_session: proto::Session) -> Result<Session> {
         is_pinned: None,
         active_schedule_count: None,
         features: vec![], // Computed at API read time, not in worker
-        parent_session_id: None,
-        subagent_name: None,
-        subagent_task: None,
-        subagent_status: None,
-        blueprint_id: None,
-        blueprint_config: None,
+        parent_session_id,
+        subagent_name: proto_session.subagent_name,
+        subagent_task: proto_session.subagent_task,
+        subagent_status,
+        blueprint_id: proto_session.blueprint_id,
+        blueprint_config,
     })
 }
 
@@ -3347,15 +3392,22 @@ impl everruns_core::platform_store::PlatformStore for GrpcOrgAdapter {
 
     async fn set_subagent_metadata(
         &self,
-        _session_id: SessionId,
-        _parent_session_id: SessionId,
-        _subagent_name: &str,
-        _subagent_task: &str,
-        _subagent_status: everruns_core::session::SubagentStatus,
+        session_id: SessionId,
+        parent_session_id: SessionId,
+        subagent_name: &str,
+        subagent_task: &str,
+        subagent_status: everruns_core::session::SubagentStatus,
     ) -> Result<Session> {
-        Err(AgentLoopError::store(
-            "set_subagent_metadata is not supported over grpc platform adapter",
-        ))
+        self.client
+            .set_subagent_metadata(
+                self.org_id,
+                session_id,
+                parent_session_id,
+                subagent_name,
+                subagent_task,
+                subagent_status,
+            )
+            .await
     }
 
     async fn delete_session(&self, id: SessionId) -> Result<()> {


### PR DESCRIPTION
## What
Add durable subagent metadata support to the gRPC platform adapter path.

## Why
Worker-side `spawn_subagent` and `start_agent_handoff` were failing when they tried to persist child-session metadata through the gRPC platform adapter:

`Message store error: set_subagent_metadata is not supported over grpc platform adapter`

## How
- Extend the worker proto contract with `SetSubagentMetadata` and preserve subagent/blueprint fields in proto session conversion.
- Implement the server-side worker gRPC method by delegating to the existing database-backed metadata operation under the authenticated org scope.
- Implement `GrpcOrgAdapter::set_subagent_metadata` so worker tools can persist child session parent/name/task/status metadata over gRPC.
- Persist foreground `spawn_subagent` terminal status into session metadata after the child reaches idle.
- Add focused gRPC regression tests for direct metadata persistence plus real `spawn_subagent` and `start_agent_handoff` tool execution through the worker gRPC adapter.

## Risk
- Low / Medium / High: Medium
- What can break: Internal worker gRPC session metadata serialization or subagent/handoff child session status updates.

## Security
Reviewed against `specs/threat-model.md`:
- `TM-TENANT`: new RPC is scoped through the authenticated worker org context and delegates to existing org-scoped DB behavior.
- `TM-AUTHZ`: no external user-facing endpoint added; this is internal worker service plumbing.
- `TM-DURABLE`: child session linkage/status metadata is now preserved across the gRPC boundary.
- `TM-TOOL`: tests exercise tool-driven subagent and handoff flows without widening tool authorization.
- No secrets or secret handling changes.

## Validation
- `cargo test -p everruns-internal-protocol test_proto_session_roundtrip_includes_organization_id -- --nocapture`
- `cargo test -p everruns-core subagent -- --nocapture`
- `cargo test -p everruns-server grpc -- --nocapture`
- `just pre-push`

Note: the original shared worktree currently contains unrelated unstaged A2A edits from another worker. Full pre-push validation and push were run from a clean detached worktree at commit `c5ae69b3`.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
