### PR TITLE
fix(a2a): accept linked client JSON-RPC methods

### DIFF
--- a/crates/server/src/api/app_a2a.rs
+++ b/crates/server/src/api/app_a2a.rs
@@ -567,10 +567,10 @@ fn parse_message_params(params: &Value) -> Result<ParsedMessage, &'static str> {
             // without a discriminator, so accept missing kind/type only when
             // a string `text` field is present.
             let kind = part.get("kind").or_else(|| part.get("type"));
-            let is_text = kind
-                .and_then(Value::as_str)
-                .map(|kind| kind == "text")
-                .unwrap_or_else(|| part.get("text").and_then(Value::as_str).is_some());
+            let is_text = match kind {
+                Some(kind) => kind.as_str() == Some("text"),
+                None => part.get("text").and_then(Value::as_str).is_some(),
+            };
             if is_text {
                 part.get("text").and_then(Value::as_str).map(str::to_owned)
             } else {

--- a/crates/server/src/api/app_a2a.rs
+++ b/crates/server/src/api/app_a2a.rs
@@ -65,6 +65,14 @@ const METHOD_MESSAGE_SEND: &str = "message/send";
 const METHOD_MESSAGE_STREAM: &str = "message/stream";
 const METHOD_TASKS_GET: &str = "tasks/get";
 const METHOD_TASKS_CANCEL: &str = "tasks/cancel";
+// The linked Rust A2A client still emits legacy PascalCase JSON-RPC method
+// names while the current A2A endpoint contract uses slash-delimited names.
+// Keep the compatibility aliases at the method gate so they map to the same
+// audited handlers without widening the accepted method surface.
+const METHOD_MESSAGE_SEND_LEGACY: &str = "SendMessage";
+const METHOD_MESSAGE_STREAM_LEGACY: &str = "SendStreamingMessage";
+const METHOD_TASKS_GET_LEGACY: &str = "GetTask";
+const METHOD_TASKS_CANCEL_LEGACY: &str = "CancelTask";
 
 #[derive(Clone)]
 pub struct AppA2aState {
@@ -77,6 +85,12 @@ pub struct AppA2aState {
     pub rate_limiter: ChannelRateLimiter,
     pub auth_verifier: AppEndpointAuthVerifier,
     pub replay_store: A2aReplayStore,
+}
+
+struct MessageSendContext {
+    app_id: String,
+    channel_id: String,
+    req_id: Option<axum::Extension<RequestId>>,
 }
 
 impl AppA2aState {
@@ -167,6 +181,42 @@ fn rpc_error(id: Value, code: i32, message: impl Into<String>) -> Json<JsonRpcRe
     })
 }
 
+fn normalize_a2a_method(method: &str) -> &str {
+    match method {
+        METHOD_MESSAGE_SEND | METHOD_MESSAGE_SEND_LEGACY => METHOD_MESSAGE_SEND,
+        METHOD_MESSAGE_STREAM | METHOD_MESSAGE_STREAM_LEGACY => METHOD_MESSAGE_STREAM,
+        METHOD_TASKS_GET | METHOD_TASKS_GET_LEGACY => METHOD_TASKS_GET,
+        METHOD_TASKS_CANCEL | METHOD_TASKS_CANCEL_LEGACY => METHOD_TASKS_CANCEL,
+        other => other,
+    }
+}
+
+fn legacy_task_json(mut task: Value) -> Value {
+    if let Some(obj) = task.as_object_mut() {
+        obj.remove("kind");
+        if let Some(state) = obj
+            .get_mut("status")
+            .and_then(Value::as_object_mut)
+            .and_then(|status| status.get_mut("state"))
+            && let Some(state_label) = state.as_str()
+        {
+            let legacy = match state_label {
+                "submitted" => "TASK_STATE_SUBMITTED",
+                "working" => "TASK_STATE_WORKING",
+                "completed" => "TASK_STATE_COMPLETED",
+                "failed" => "TASK_STATE_FAILED",
+                "canceled" => "TASK_STATE_CANCELED",
+                "input_required" => "TASK_STATE_INPUT_REQUIRED",
+                "rejected" => "TASK_STATE_REJECTED",
+                "auth_required" => "TASK_STATE_AUTH_REQUIRED",
+                _ => "TASK_STATE_UNSPECIFIED",
+            };
+            *state = Value::String(legacy.to_string());
+        }
+    }
+    task
+}
+
 /// POST /v1/apps/{app_id}/a2a/{channel_id}
 #[utoipa::path(
     post,
@@ -230,15 +280,44 @@ pub async fn invoke_a2a(
 
     // Method gate. THREAT[TM-A2A-005]: only the audited methods reach the
     // session pipeline; everything else returns -32601 with no side effects.
-    match parsed.method.as_str() {
-        METHOD_MESSAGE_SEND => {
-            handle_message_send(&state, auth, parsed, rpc_id, app_id, channel_id, req_id).await
-        }
+    let requested_method = parsed.method.clone();
+    match normalize_a2a_method(&requested_method) {
+        METHOD_MESSAGE_SEND => handle_message_send(
+            &state,
+            auth,
+            parsed,
+            rpc_id,
+            MessageSendContext {
+                app_id,
+                channel_id,
+                req_id,
+            },
+            requested_method == METHOD_MESSAGE_SEND_LEGACY,
+        )
+        .await,
         METHOD_MESSAGE_STREAM => {
             handle_message_stream(&state, auth, parsed, rpc_id, app_id, channel_id, req_id).await
         }
-        METHOD_TASKS_GET => handle_tasks_get(&state, auth, parsed, rpc_id).await,
-        METHOD_TASKS_CANCEL => handle_tasks_cancel(&state, auth, parsed, rpc_id).await,
+        METHOD_TASKS_GET => {
+            handle_tasks_get(
+                &state,
+                auth,
+                parsed,
+                rpc_id,
+                requested_method == METHOD_TASKS_GET_LEGACY,
+            )
+            .await
+        }
+        METHOD_TASKS_CANCEL => {
+            handle_tasks_cancel(
+                &state,
+                auth,
+                parsed,
+                rpc_id,
+                requested_method == METHOD_TASKS_CANCEL_LEGACY,
+            )
+            .await
+        }
         other => (
             StatusCode::OK,
             rpc_error(
@@ -483,9 +562,16 @@ fn parse_message_params(params: &Value) -> Result<ParsedMessage, &'static str> {
     let text = parts
         .iter()
         .filter_map(|part| {
-            // Spec uses `kind: "text"`; older drafts used `type: "text"`. Accept both.
+            // Spec uses `kind: "text"`; older drafts used `type: "text"`.
+            // The linked Rust SDK serializes text parts as `{ "text": ... }`
+            // without a discriminator, so accept missing kind/type only when
+            // a string `text` field is present.
             let kind = part.get("kind").or_else(|| part.get("type"));
-            if kind.and_then(Value::as_str) == Some("text") {
+            let is_text = kind
+                .and_then(Value::as_str)
+                .map(|kind| kind == "text")
+                .unwrap_or_else(|| part.get("text").and_then(Value::as_str).is_some());
+            if is_text {
                 part.get("text").and_then(Value::as_str).map(str::to_owned)
             } else {
                 None
@@ -518,9 +604,8 @@ async fn handle_message_send(
     _auth: AuthorizedA2a,
     parsed: JsonRpcRequest,
     rpc_id: Value,
-    app_id: String,
-    channel_id: String,
-    req_id: Option<axum::Extension<RequestId>>,
+    ctx: MessageSendContext,
+    wrap_legacy_send_response: bool,
 ) -> Response {
     let parsed_msg = match parse_message_params(&parsed.params) {
         Ok(parsed) => parsed,
@@ -535,7 +620,7 @@ async fn handle_message_send(
     // from the session's turn lifecycle events, where the task corresponds
     // to the most recent turn for the underlying session.
     let task_id = Uuid::now_v7().to_string();
-    let request_id = req_id.map(|axum::Extension(id)| id.0);
+    let request_id = ctx.req_id.map(|axum::Extension(id)| id.0);
 
     let result = match invoke_a2a_app_channel(
         &state.db,
@@ -543,8 +628,8 @@ async fn handle_message_send(
         &state.session_service,
         &state.message_service,
         A2aInvocationRequest {
-            app_id,
-            channel_id,
+            app_id: ctx.app_id,
+            channel_id: ctx.channel_id,
             params: parsed.params,
             text: parsed_msg.text,
             message_id: parsed_msg.message_id,
@@ -561,7 +646,12 @@ async fn handle_message_send(
     };
 
     let task = build_task_json(result.session_id, "submitted", None);
-    (StatusCode::OK, rpc_success(rpc_id, task)).into_response()
+    let result = if wrap_legacy_send_response {
+        json!({ "task": legacy_task_json(task) })
+    } else {
+        task
+    };
+    (StatusCode::OK, rpc_success(rpc_id, result)).into_response()
 }
 
 /// Map a `tasks/get` / `tasks/cancel` JSON-RPC params object to an Everruns
@@ -590,6 +680,7 @@ async fn handle_tasks_get(
     auth: AuthorizedA2a,
     parsed: JsonRpcRequest,
     rpc_id: Value,
+    legacy_response: bool,
 ) -> Response {
     let session_id = match task_id_from_params(&parsed.params) {
         Ok(id) => id,
@@ -617,7 +708,10 @@ async fn handle_tasks_get(
         Err(err) => return internal_error(err).into_response(),
     };
 
-    let task = build_task_json(session.id, state_label, None);
+    let mut task = build_task_json(session.id, state_label, None);
+    if legacy_response {
+        task = legacy_task_json(task);
+    }
     (StatusCode::OK, rpc_success(rpc_id, task)).into_response()
 }
 
@@ -628,6 +722,7 @@ async fn handle_tasks_cancel(
     auth: AuthorizedA2a,
     parsed: JsonRpcRequest,
     rpc_id: Value,
+    legacy_response: bool,
 ) -> Response {
     let session_id = match task_id_from_params(&parsed.params) {
         Ok(id) => id,
@@ -656,7 +751,10 @@ async fn handle_tasks_cancel(
     };
 
     if matches!(current, "completed" | "canceled" | "failed") {
-        let task = build_task_json(session.id, current, None);
+        let mut task = build_task_json(session.id, current, None);
+        if legacy_response {
+            task = legacy_task_json(task);
+        }
         return (StatusCode::OK, rpc_success(rpc_id, task)).into_response();
     }
 
@@ -664,7 +762,10 @@ async fn handle_tasks_cancel(
         return internal_error(err).into_response();
     }
 
-    let task = build_task_json(session.id, "canceled", None);
+    let mut task = build_task_json(session.id, "canceled", None);
+    if legacy_response {
+        task = legacy_task_json(task);
+    }
     (StatusCode::OK, rpc_success(rpc_id, task)).into_response()
 }
 

--- a/crates/server/tests/app_a2a_integration_test.rs
+++ b/crates/server/tests/app_a2a_integration_test.rs
@@ -8,7 +8,11 @@ use std::{
 };
 
 use async_trait::async_trait;
-use axum::http::{Method, StatusCode};
+use axum::{
+    Json, Router,
+    http::{Method, StatusCode},
+    routing::get,
+};
 use everruns_core::DEFAULT_ORG_ID;
 use everruns_core::capabilities::{A2aAgentDelegationCapability, Capability};
 use everruns_core::session_resource::{
@@ -154,6 +158,17 @@ struct TestSessionResourceRegistry {
     entries: Mutex<HashMap<String, SessionResourceEntry>>,
 }
 
+impl TestSessionResourceRegistry {
+    fn metadata(&self, resource_id: &str) -> Option<Value> {
+        self.entries
+            .lock()
+            .unwrap()
+            .get(resource_id)
+            .map(|entry| entry.metadata.clone())
+    }
+}
+
+
 #[async_trait]
 impl SessionResourceRegistry for TestSessionResourceRegistry {
     async fn register(
@@ -231,34 +246,88 @@ impl SessionResourceRegistry for TestSessionResourceRegistry {
     }
 }
 
-async fn create_published_served_a2a_app() -> (TestServer, String, String) {
-    let (server, base_url) = TestServer::serving_in_memory().await;
-    let (app, api_key) = create_app_with_a2a(&server, "a2a-outbound-local", "{{a2a.text}}").await;
-    let app_id = app["id"].as_str().unwrap();
-    let channel_id = app["channels"][0]["id"].as_str().unwrap();
-    publish_app(&server, app_id).await;
-    let endpoint = format!("{base_url}/api/v1/apps/{app_id}/a2a/{channel_id}");
-    (server, endpoint, api_key)
-}
-
-fn outbound_delegation_config(discovery_base_url: &str, api_key: &str) -> Value {
+fn a2a_agent_card(endpoint: &str) -> Value {
     json!({
-        "agents": [{
-            "id": "local_app",
-            "name": "Local App",
-            "description": "Local Everruns A2A app endpoint",
-            "base_url": discovery_base_url,
-            "headers": {
-                "authorization": format!("Bearer {api_key}")
-            },
-            "preferred_binding": "JSONRPC",
-            "poll_interval_ms": 100,
-            "allow_local_urls": true
-        }]
+        "name": "Local Everruns A2A app",
+        "description": "Local A2A app endpoint used by outbound delegation tests",
+        "version": "0.1",
+        "protocolVersion": "0.3.0",
+        "preferredTransport": "JSONRPC",
+        "supportedInterfaces": [
+            {
+                "url": endpoint,
+                "protocolBinding": "JSONRPC",
+                "protocolVersion": "1.0"
+            }
+        ],
+        "capabilities": {
+            "streaming": false,
+            "pushNotifications": false,
+            "stateTransitionHistory": false
+        },
+        "defaultInputModes": ["text/plain"],
+        "defaultOutputModes": ["text/plain"],
+        "skills": []
     })
 }
 
-async fn spawn_background_against_local_a2a(config: Value) -> Value {
+async fn spawn_agent_card_server(card: Value) -> String {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind agent-card server");
+    let addr = listener.local_addr().expect("agent-card server addr");
+    let app = Router::new().route(
+        "/.well-known/agent-card.json",
+        get(move || {
+            let card = card.clone();
+            async move { Json(card) }
+        }),
+    );
+    tokio::spawn(async move {
+        axum::serve(listener, app)
+            .await
+            .expect("serve agent-card server");
+    });
+    format!("http://{addr}")
+}
+
+async fn create_published_served_a2a_app() -> (TestServer, String, String, String, String) {
+    let (server, base_url) = TestServer::serving_in_memory().await;
+    let (app, api_key) = create_app_with_a2a(&server, "a2a-outbound-local", "{{a2a.text}}").await;
+    let app_id = app["id"].as_str().unwrap().to_string();
+    let channel_id = app["channels"][0]["id"].as_str().unwrap().to_string();
+    publish_app(&server, &app_id).await;
+    let endpoint = format!("{base_url}/api/v1/apps/{app_id}/a2a/{channel_id}");
+    (server, endpoint, api_key, app_id, channel_id)
+}
+
+fn outbound_delegation_config(
+    endpoint: &str,
+    api_key: &str,
+    discovery_base_url: Option<&str>,
+) -> Value {
+    let mut agent = json!({
+        "id": "local_app",
+        "name": "Local App",
+        "description": "Local Everruns A2A app endpoint",
+        "headers": {
+            "authorization": format!("Bearer {api_key}")
+        },
+        "preferred_binding": "JSONRPC",
+        "poll_interval_ms": 100,
+        "allow_local_urls": true
+    });
+    if let Some(base_url) = discovery_base_url {
+        agent["base_url"] = json!(base_url);
+    } else {
+        agent["agent_card"] = a2a_agent_card(endpoint);
+    }
+    json!({ "agents": [agent] })
+}
+
+async fn spawn_background_against_local_a2a(
+    config: Value,
+) -> (Arc<TestSessionResourceRegistry>, Value) {
     let capability = A2aAgentDelegationCapability;
     let spawn_tool = capability
         .tools_with_config(&config)
@@ -266,7 +335,7 @@ async fn spawn_background_against_local_a2a(config: Value) -> Value {
         .find(|tool| tool.name() == "spawn_agent")
         .expect("spawn_agent tool");
     let registry = Arc::new(TestSessionResourceRegistry::default());
-    let ctx = ToolContext::new(SessionId::new()).with_session_resource_registry(registry);
+    let ctx = ToolContext::new(SessionId::new()).with_session_resource_registry(registry.clone());
 
     let result = spawn_tool
         .execute_with_context(
@@ -284,7 +353,26 @@ async fn spawn_background_against_local_a2a(config: Value) -> Value {
     let ToolExecutionResult::Success(value) = result else {
         panic!("expected successful spawn_agent result: {result:?}");
     };
-    value
+    (registry, value)
+}
+
+async fn wait_for_remote_task_snapshot(
+    registry: &TestSessionResourceRegistry,
+    run_id: &str,
+) -> Value {
+    for _ in 0..30 {
+        if let Some(metadata) = registry.metadata(run_id) {
+            assert_ne!(
+                metadata["status"], "failed",
+                "agent_run failed before remote task snapshot was observed: {metadata:?}",
+            );
+            if metadata["last_remote_task_snapshot"].is_object() {
+                return metadata;
+            }
+        }
+        sleep(Duration::from_millis(50)).await;
+    }
+    panic!("expected background monitor to record a remote task snapshot for {run_id}");
 }
 
 #[tokio::test]
@@ -1105,25 +1193,79 @@ async fn a2a_agent_card_published_only_when_live() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn outbound_a2a_delegation_resolves_local_app_discovery_card() {
-    let (_server, endpoint, api_key) = create_published_served_a2a_app().await;
-    let config = outbound_delegation_config(&endpoint, &api_key);
+async fn outbound_a2a_delegation_reaches_local_app_with_discovery_card() {
+    let (_server, endpoint, api_key, _app_id, _channel_id) =
+        create_published_served_a2a_app().await;
+    let discovery_base_url = spawn_agent_card_server(a2a_agent_card(&endpoint)).await;
+    let config = outbound_delegation_config(&endpoint, &api_key, Some(&discovery_base_url));
 
-    let spawn_result = spawn_background_against_local_a2a(config).await;
+    let (registry, spawn_result) = spawn_background_against_local_a2a(config).await;
 
-    assert_eq!(spawn_result["status"], "failed");
-    let error = spawn_result["error"].as_str().unwrap_or_default();
-    assert!(
-        !error.contains("Failed to resolve A2A AgentCard"),
-        "card discovery should parse before any send failure: {spawn_result:?}",
+    assert_ne!(
+        spawn_result["status"], "failed",
+        "spawn_agent failed: {spawn_result:?}",
     );
-    assert!(
-        !error.contains("failed to parse agent card"),
-        "served card must deserialize with the outbound A2A resolver: {spawn_result:?}",
+    let run_id = spawn_result["agent_run_id"].as_str().unwrap();
+    let remote_task_id = spawn_result["remote_task_id"].as_str().unwrap();
+    assert_eq!(
+        spawn_result["remote_context_id"].as_str().unwrap(),
+        remote_task_id
     );
+
+    let metadata = wait_for_remote_task_snapshot(&registry, run_id).await;
+    assert_eq!(metadata["remote_task_id"], remote_task_id);
+    assert_eq!(metadata["last_remote_task_snapshot"]["id"], remote_task_id);
     assert!(
-        error.contains("A2A send_message failed") || error.contains("Method not found"),
-        "expected remaining failure, if any, to be past AgentCard parsing and in EVE-540 scope: {spawn_result:?}",
+        matches!(
+            metadata["last_remote_task_snapshot"]["state"].as_str(),
+            Some(
+                "submitted"
+                    | "working"
+                    | "completed"
+                    | "TASK_STATE_SUBMITTED"
+                    | "TASK_STATE_WORKING"
+                    | "TASK_STATE_COMPLETED"
+            )
+        ),
+        "expected non-error remote task state, got {metadata:?}",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn outbound_a2a_delegation_reaches_local_app_with_inline_card() {
+    let (_server, endpoint, api_key, _app_id, _channel_id) =
+        create_published_served_a2a_app().await;
+    let config = outbound_delegation_config(&endpoint, &api_key, None);
+
+    let (registry, spawn_result) = spawn_background_against_local_a2a(config).await;
+
+    assert_ne!(
+        spawn_result["status"], "failed",
+        "spawn_agent failed: {spawn_result:?}",
+    );
+    let run_id = spawn_result["agent_run_id"].as_str().unwrap();
+    let remote_task_id = spawn_result["remote_task_id"].as_str().unwrap();
+    assert_eq!(
+        spawn_result["remote_context_id"].as_str().unwrap(),
+        remote_task_id
+    );
+
+    let metadata = wait_for_remote_task_snapshot(&registry, run_id).await;
+    assert_eq!(metadata["remote_task_id"], remote_task_id);
+    assert_eq!(metadata["last_remote_task_snapshot"]["id"], remote_task_id);
+    assert!(
+        matches!(
+            metadata["last_remote_task_snapshot"]["state"].as_str(),
+            Some(
+                "submitted"
+                    | "working"
+                    | "completed"
+                    | "TASK_STATE_SUBMITTED"
+                    | "TASK_STATE_WORKING"
+                    | "TASK_STATE_COMPLETED"
+            )
+        ),
+        "expected non-error remote task state, got {metadata:?}",
     );
 }
 

--- a/crates/server/tests/app_a2a_integration_test.rs
+++ b/crates/server/tests/app_a2a_integration_test.rs
@@ -168,7 +168,6 @@ impl TestSessionResourceRegistry {
     }
 }
 
-
 #[async_trait]
 impl SessionResourceRegistry for TestSessionResourceRegistry {
     async fn register(
@@ -666,6 +665,35 @@ async fn a2a_rejects_unsupported_methods_and_empty_text() {
         "method": "message/send",
         "params": {
             "message": { "role": "user", "parts": [] }
+        }
+    }))
+    .unwrap();
+    let response: Value = server
+        .request_raw(
+            Method::POST,
+            &format!("/v1/apps/{app_id}/a2a/{channel_id}"),
+            vec![
+                ("content-type", "application/json"),
+                ("authorization", &format!("Bearer {api_key}")),
+            ],
+            body,
+        )
+        .await
+        .assert_status(StatusCode::OK)
+        .json();
+    assert_eq!(response["error"]["code"], -32602);
+
+    // Present-but-malformed discriminators are invalid rather than treated as
+    // legacy discriminator-free text parts.
+    let body = serde_json::to_vec(&json!({
+        "jsonrpc": "2.0",
+        "id": "z",
+        "method": "message/send",
+        "params": {
+            "message": {
+                "role": "user",
+                "parts": [{ "kind": 123, "text": "malformed discriminator" }]
+            }
         }
     }))
     .unwrap();

--- a/specs/a2a-channel.md
+++ b/specs/a2a-channel.md
@@ -33,9 +33,10 @@ References:
 
 ## Non-Goals
 
-1. The full A2A method surface — this iteration supports `message/send`,
-   `message/stream`, `tasks/get`, and `tasks/cancel`. `tasks/resubscribe`,
-   push notifications, and authenticated extensions remain out of scope.
+1. The full A2A method surface — this iteration canonically supports
+   `message/send`, `message/stream`, `tasks/get`, and `tasks/cancel`.
+   `tasks/resubscribe`, push notifications, and authenticated extensions
+   remain out of scope.
 2. Persistent per-task identity beyond the session lifecycle. Tasks are
    identified by the underlying session id (`task_id == contextId`); a
    shared session reuses the same task id across follow-up messages.
@@ -105,7 +106,11 @@ API key generation:
   `google_oidc`, `oidc`, and `oauth2_introspection` use bearer tokens;
   `http_basic` uses HTTP Basic; `mtls` uses the configured trusted reverse
   proxy identity header.
-- Body: A2A JSON-RPC 2.0 envelope. Only `message/send` is honored:
+- Body: A2A JSON-RPC 2.0 envelope. Canonical methods are `message/send`,
+  `message/stream`, `tasks/get`, and `tasks/cancel`. For compatibility with
+  linked clients that still emit legacy method names, the endpoint accepts
+  `SendMessage`, `SendStreamingMessage`, `GetTask`, and `CancelTask` as aliases
+  for the canonical methods.
 
 ```json
 {
@@ -155,7 +160,7 @@ that key off the JSON-RPC `id` and `error.code` see a structured response:
 | 404  | —             | App or channel not found              |
 | 400  | —             | Invalid path-level input (e.g. malformed channel ID) |
 | 400  | `-32600`      | Invalid Request (malformed envelope, returned with HTTP 400) |
-| 200  | `-32601`      | Method not found (only `message/send`, `message/stream`, `tasks/get`, `tasks/cancel` are supported) |
+| 200  | `-32601`      | Method not found (only canonical `message/send`, `message/stream`, `tasks/get`, `tasks/cancel` and their legacy linked-client aliases are supported) |
 | 200  | `-32602`      | Invalid params (e.g. no non-empty text parts, malformed task id) |
 | 200  | `-32001`      | Task not found (`tasks/get` / `tasks/cancel` against an unknown task id) |
 


### PR DESCRIPTION
## What
Accept the linked A2A Rust client's legacy PascalCase JSON-RPC method names on Everruns app A2A endpoints while keeping the slash-delimited methods as the canonical contract.

## Why
EVE-540 showed outbound A2A delegation reaching a local Everruns A2A app endpoint but failing with `Method not found: SendMessage` because the linked client emits legacy names (`SendMessage`, `GetTask`, etc.) while the app endpoint accepted only `message/send`, `tasks/get`, and related names.

## How
- Normalize `SendMessage`, `SendStreamingMessage`, `GetTask`, and `CancelTask` into the existing audited A2A handlers.
- Shape legacy responses for the linked client where its SDK expects wrapped `SendMessage` responses and `TASK_STATE_*` state labels.
- Keep modern `message/send`, `message/stream`, `tasks/get`, and `tasks/cancel` responses unchanged.
- Add integration coverage for outbound `spawn_agent` background mode against a local Everruns A2A app using both discovery-card and inline-card config.
- Document canonical methods plus compatibility aliases in `specs/a2a-channel.md`.

## Risk
- Low / Medium: Low
- What can break: A2A JSON-RPC dispatch and task response shape. The alias path is gated to the same existing handlers after auth/channel checks, and canonical responses are preserved.

## Security
- Threat categories reviewed: TM-A2A-005, TM-A2A-006, TM-A2A-012, TM-API
- Findings and resolutions: No new auth, storage, or secret handling. Method aliases normalize at the existing method gate before reaching the same audited handlers. Text-part parsing remains text-only and requires string text. Task get/cancel still resolves through the authenticated channel binding.

## Follow-ups
Coordinate with EVE-539 if the published Agent Card schema changes while this PR is in review; this PR intentionally stays method-compatibility focused.

## Validation
- `cargo fmt --check`
- `cargo clippy -p everruns-server --all-targets --all-features -- -D warnings`
- `cargo test -p everruns-server --test app_a2a_integration_test -- --nocapture` (29 passed)
- `just pre-push`
- Smoke: `PORT_PREFIX=286 SECRETS_ENCRYPTION_KEY=... doppler run --project everruns --config dev -- just start-all --no-watch --no-ui`, then legacy `SendMessage` and `GetTask` against `/api/v1/apps/{app_id}/a2a/{channel_id}` returned task `session_019eaffe12d975b0ac123c69add2494d` with `TASK_STATE_SUBMITTED` then `TASK_STATE_WORKING`.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)
