### PR TITLE
feat(durable): per-tool-call idempotency in Act activity (EVE-530)

### DIFF
--- a/crates/core/src/atoms/act.rs
+++ b/crates/core/src/atoms/act.rs
@@ -51,10 +51,10 @@ use crate::tool_fingerprint::{
 use crate::tool_narration::{
     ToolNarrationPhase, render_group_headline_with_locale, render_tool_narration_with_locale,
 };
-use crate::tool_types::{ToolCall, ToolDefinition, ToolResult};
+use crate::tool_types::{SideEffectClass, ToolCall, ToolDefinition, ToolResult};
 use crate::traits::{
-    AgentStore, EventEmitter, SessionFileSystem, SessionMutator, SessionStore, ToolContext,
-    ToolExecutor,
+    AgentStore, DurableToolResultStore, EventEmitter, SessionFileSystem, SessionMutator,
+    SessionStore, ToolCallClaimResult, ToolContext, ToolExecutor,
 };
 use crate::typed_id::{AgentId, HarnessId};
 use uuid::Uuid;
@@ -250,6 +250,11 @@ where
     /// When present, each tool call increments the org counter; calls that
     /// exceed the per-org window return a tool error rather than a hard failure.
     outbound_tool_rate_limiter: Option<Arc<dyn crate::traits::OutboundToolRateLimiter>>,
+    /// Per-tool-call idempotency store (EVE-530). When present, each tool call
+    /// is claimed before dispatch and settled after completion so that reclaiming
+    /// workers can skip already-settled calls and avoid double side-effects for
+    /// `AtMostOnce` tools.
+    durable_tool_result_store: Option<Arc<dyn DurableToolResultStore>>,
     /// Post-act hooks that run after tool execution completes.
     /// Hooks inspect the result and may emit events (e.g. tool.call_requested).
     hooks: Vec<Box<dyn PostActHook>>,
@@ -303,6 +308,7 @@ where
             budget_checker: None,
             payment_authority: None,
             outbound_tool_rate_limiter: None,
+            durable_tool_result_store: None,
             hooks: Self::default_hooks(),
             post_tool_hooks: Vec::new(),
             pre_tool_hooks: Vec::new(),
@@ -343,6 +349,7 @@ where
             budget_checker: None,
             payment_authority: None,
             outbound_tool_rate_limiter: None,
+            durable_tool_result_store: None,
             hooks: Self::default_hooks(),
             post_tool_hooks: Vec::new(),
             pre_tool_hooks: Vec::new(),
@@ -566,6 +573,15 @@ where
         limiter: Arc<dyn crate::traits::OutboundToolRateLimiter>,
     ) -> Self {
         self.outbound_tool_rate_limiter = Some(limiter);
+        self
+    }
+
+    /// Set the durable per-tool-call idempotency store (EVE-530).
+    pub fn with_durable_tool_result_store(
+        mut self,
+        store: Arc<dyn DurableToolResultStore>,
+    ) -> Self {
+        self.durable_tool_result_store = Some(store);
         self
     }
 }
@@ -990,6 +1006,218 @@ where
             };
         }
 
+        // Per-tool-call idempotency (EVE-530): claim before dispatch, replay if
+        // already settled, refuse AtMostOnce re-execution on stale running claims.
+        let claim_token = if let Some(ref store) = self.durable_tool_result_store {
+            let turn_id = context.turn_id.to_string();
+            match store
+                .try_claim_tool_call(
+                    &turn_id,
+                    &tool_call.id,
+                    &tool_call.name,
+                    &tool_call_fingerprint,
+                )
+                .await
+            {
+                Ok(ToolCallClaimResult::Claimed { claim_token }) => Some(claim_token),
+
+                Ok(ToolCallClaimResult::AlreadySettled {
+                    result_json,
+                    args_fingerprint: stored_fp,
+                }) => {
+                    // Determinism guard: stored args fingerprint must match current call.
+                    if stored_fp != tool_call_fingerprint {
+                        tracing::error!(
+                            session_id = %context.session_id,
+                            turn_id = %context.turn_id,
+                            tool_call_id = %tool_call.id,
+                            stored_fp = %stored_fp,
+                            current_fp = %tool_call_fingerprint,
+                            "ActAtom: determinism violation — replay args fingerprint mismatch"
+                        );
+                        return ToolCallResult {
+                            tool_call: tool_call.clone(),
+                            result: ToolResult {
+                                tool_call_id: tool_call.id.clone(),
+                                result: None,
+                                images: None,
+                                error: Some(format!(
+                                    "determinism violation: tool '{}' replay args fingerprint \
+                                     does not match prior execution (stored={stored_fp}, \
+                                     current={})",
+                                    tool_call.name, tool_call_fingerprint
+                                )),
+                                connection_required: None,
+                                raw_output: None,
+                            },
+                            success: false,
+                            status: "error".to_string(),
+                            connection_required: None,
+                        };
+                    }
+                    tracing::debug!(
+                        session_id = %context.session_id,
+                        turn_id = %context.turn_id,
+                        tool_call_id = %tool_call.id,
+                        "ActAtom: replaying already-settled tool call"
+                    );
+                    // Emit a replayed tool.completed without re-emitting tool.started.
+                    let replayed_result: ToolResult = serde_json::from_value(result_json.clone())
+                        .unwrap_or(ToolResult {
+                            tool_call_id: tool_call.id.clone(),
+                            result: Some(result_json),
+                            images: None,
+                            error: None,
+                            connection_required: None,
+                            raw_output: None,
+                        });
+                    let success = replayed_result.error.is_none();
+                    let status = if success { "success" } else { "error" };
+                    let result_fp = tool_result_fingerprint(&tool_call.name, &replayed_result);
+                    let completed_data = if success {
+                        let content = replayed_result
+                            .result
+                            .as_ref()
+                            .map(|r| vec![ContentPart::text(r.to_string())])
+                            .unwrap_or_default();
+                        ToolCompletedData::success(
+                            tool_call.id.clone(),
+                            tool_call.name.clone(),
+                            content,
+                            None,
+                        )
+                        .with_fingerprints(tool_call_fingerprint.clone(), result_fp)
+                        .with_display_name(display_name.clone())
+                    } else {
+                        ToolCompletedData::failure(
+                            tool_call.id.clone(),
+                            tool_call.name.clone(),
+                            status.to_string(),
+                            replayed_result.error.clone().unwrap_or_default(),
+                            None,
+                        )
+                        .with_fingerprints(tool_call_fingerprint.clone(), result_fp)
+                        .with_display_name(display_name.clone())
+                    };
+                    let _ = self
+                        .event_emitter
+                        .emit(EventRequest::new(
+                            context.session_id,
+                            event_context,
+                            completed_data,
+                        ))
+                        .await;
+                    let conn_req = replayed_result.connection_required.clone();
+                    return ToolCallResult {
+                        tool_call,
+                        result: replayed_result,
+                        success,
+                        status: status.to_string(),
+                        connection_required: conn_req,
+                    };
+                }
+
+                Ok(ToolCallClaimResult::AlreadyRunning { .. }) => {
+                    let sec = tool_def
+                        .map(|d| d.side_effect_class())
+                        .unwrap_or(SideEffectClass::AtMostOnce);
+                    match sec {
+                        SideEffectClass::Pure | SideEffectClass::Idempotent => {
+                            // Safe to re-execute; proceed as normal (no claim token).
+                            tracing::debug!(
+                                session_id = %context.session_id,
+                                tool_call_id = %tool_call.id,
+                                "ActAtom: stale running claim for idempotent tool, re-executing"
+                            );
+                            None
+                        }
+                        SideEffectClass::AtMostOnce => {
+                            tracing::warn!(
+                                session_id = %context.session_id,
+                                turn_id = %context.turn_id,
+                                tool_call_id = %tool_call.id,
+                                "ActAtom: AtMostOnce tool has stale running claim; returning interrupted result"
+                            );
+                            // Settle the stale claim as interrupted, then return an error.
+                            let _ = store
+                                .settle_tool_call(
+                                    &turn_id,
+                                    &tool_call.id,
+                                    serde_json::Value::Null,
+                                    "interrupted",
+                                    Uuid::nil(), // sentinel — settle accepts any token for interrupted
+                                )
+                                .await;
+                            return ToolCallResult {
+                                tool_call: tool_call.clone(),
+                                result: ToolResult {
+                                    tool_call_id: tool_call.id.clone(),
+                                    result: None,
+                                    images: None,
+                                    error: Some(format!(
+                                        "tool '{}' was interrupted mid-execution during a prior \
+                                         worker failure; result is uncertain and was not re-run \
+                                         (AtMostOnce safety)",
+                                        tool_call.name
+                                    )),
+                                    connection_required: None,
+                                    raw_output: None,
+                                },
+                                success: false,
+                                status: "error".to_string(),
+                                connection_required: None,
+                            };
+                        }
+                    }
+                }
+
+                Ok(ToolCallClaimResult::DeterminismViolation {
+                    stored_fingerprint,
+                    current_fingerprint,
+                }) => {
+                    tracing::error!(
+                        session_id = %context.session_id,
+                        turn_id = %context.turn_id,
+                        tool_call_id = %tool_call.id,
+                        stored = %stored_fingerprint,
+                        current = %current_fingerprint,
+                        "ActAtom: determinism violation on claim"
+                    );
+                    return ToolCallResult {
+                        tool_call: tool_call.clone(),
+                        result: ToolResult {
+                            tool_call_id: tool_call.id.clone(),
+                            result: None,
+                            images: None,
+                            error: Some(format!(
+                                "determinism violation: tool '{}' args fingerprint changed \
+                                 on replay (stored={stored_fingerprint}, \
+                                 current={current_fingerprint})",
+                                tool_call.name
+                            )),
+                            connection_required: None,
+                            raw_output: None,
+                        },
+                        success: false,
+                        status: "error".to_string(),
+                        connection_required: None,
+                    };
+                }
+
+                Err(e) => {
+                    tracing::warn!(
+                        session_id = %context.session_id,
+                        tool_call_id = %tool_call.id,
+                        error = %e,
+                        "ActAtom: durable claim failed; proceeding without idempotency"
+                    );
+                    None
+                }
+            }
+        } else {
+            None
+        };
+
         // Emit tool.started event (child of act.started)
         if let Err(e) = self
             .event_emitter
@@ -1321,6 +1549,39 @@ where
                     success = %success,
                     "ActAtom: tool execution completed"
                 );
+
+                // Settle the durable claim (EVE-530).
+                if let (Some(store), Some(token)) = (&self.durable_tool_result_store, claim_token) {
+                    let result_snapshot =
+                        serde_json::to_value(&tool_result).unwrap_or(serde_json::Value::Null);
+                    match store
+                        .settle_tool_call(
+                            &context.turn_id.to_string(),
+                            &tool_call.id,
+                            result_snapshot,
+                            "settled",
+                            token,
+                        )
+                        .await
+                    {
+                        Ok(false) => {
+                            tracing::warn!(
+                                session_id = %context.session_id,
+                                tool_call_id = %tool_call.id,
+                                "ActAtom: settle ownership check failed (task reclaimed)"
+                            );
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                session_id = %context.session_id,
+                                tool_call_id = %tool_call.id,
+                                error = %e,
+                                "ActAtom: settle_tool_call failed"
+                            );
+                        }
+                        Ok(true) => {}
+                    }
+                }
 
                 let conn_req = tool_result.connection_required.clone();
                 ToolCallResult {
@@ -2370,6 +2631,326 @@ mod tests {
         let result = atom.execute(input).await.unwrap();
 
         assert_eq!(result.success_count, 1);
+        assert_eq!(result.error_count, 0);
+    }
+
+    // -----------------------------------------------------------------------
+    // DurableToolResultStore idempotency tests (EVE-530)
+    // -----------------------------------------------------------------------
+
+    use crate::tool_types::{SideEffectClass, ToolHints};
+    use crate::traits::{DurableToolResultStore, ToolCallClaimResult};
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    #[derive(Default)]
+    struct InMemoryDurableStore {
+        rows: Mutex<HashMap<(String, String), StoreRow>>,
+    }
+
+    #[derive(Clone)]
+    struct StoreRow {
+        status: String,
+        result_json: serde_json::Value,
+        args_fingerprint: String,
+        #[allow(dead_code)]
+        claim_token: Uuid,
+    }
+
+    #[async_trait]
+    impl DurableToolResultStore for InMemoryDurableStore {
+        async fn try_claim_tool_call(
+            &self,
+            turn_id: &str,
+            tool_call_id: &str,
+            _tool_name: &str,
+            args_fingerprint: &str,
+        ) -> crate::error::Result<ToolCallClaimResult> {
+            let key = (turn_id.to_string(), tool_call_id.to_string());
+            let mut rows = self.rows.lock().unwrap();
+            if let Some(row) = rows.get(&key) {
+                match row.status.as_str() {
+                    "settled" => {
+                        if row.args_fingerprint != args_fingerprint {
+                            return Ok(ToolCallClaimResult::DeterminismViolation {
+                                stored_fingerprint: row.args_fingerprint.clone(),
+                                current_fingerprint: args_fingerprint.to_string(),
+                            });
+                        }
+                        return Ok(ToolCallClaimResult::AlreadySettled {
+                            result_json: row.result_json.clone(),
+                            args_fingerprint: row.args_fingerprint.clone(),
+                        });
+                    }
+                    _ => {
+                        return Ok(ToolCallClaimResult::AlreadyRunning {
+                            args_fingerprint: row.args_fingerprint.clone(),
+                        });
+                    }
+                }
+            }
+            let token = Uuid::new_v4();
+            rows.insert(
+                key,
+                StoreRow {
+                    status: "running".to_string(),
+                    result_json: serde_json::Value::Null,
+                    args_fingerprint: args_fingerprint.to_string(),
+                    claim_token: token,
+                },
+            );
+            Ok(ToolCallClaimResult::Claimed { claim_token: token })
+        }
+
+        async fn settle_tool_call(
+            &self,
+            turn_id: &str,
+            tool_call_id: &str,
+            result_json: serde_json::Value,
+            status: &str,
+            _claim_token: Uuid,
+        ) -> crate::error::Result<bool> {
+            let key = (turn_id.to_string(), tool_call_id.to_string());
+            let mut rows = self.rows.lock().unwrap();
+            if let Some(row) = rows.get_mut(&key) {
+                row.status = status.to_string();
+                row.result_json = result_json;
+                return Ok(true);
+            }
+            Ok(false)
+        }
+    }
+
+    fn make_act_input_with_store(
+        tool_call: ToolCall,
+        tool_defs: Vec<ToolDefinition>,
+        context: AtomContext,
+    ) -> ActInput {
+        ActInput {
+            org_id: None,
+            context,
+            harness_id: HarnessId::from_seed(1),
+            agent_id: Some(AgentId::new()),
+            tool_calls: vec![tool_call],
+            tool_definitions: tool_defs,
+            locale: None,
+            blueprint_id: None,
+            network_access: None,
+            parallel_tool_calls: None,
+        }
+    }
+
+    fn arg_echo_tool_def(side_effect: SideEffectClass) -> ToolDefinition {
+        ToolDefinition::Builtin(crate::BuiltinTool {
+            name: "argument_echo".to_string(),
+            display_name: None,
+            description: "echo".to_string(),
+            parameters: json!({"type": "object"}),
+            policy: Default::default(),
+            category: None,
+            deferrable: Default::default(),
+            hints: ToolHints::default().with_side_effect_class(side_effect),
+            full_parameters: None,
+        })
+    }
+
+    /// First execution succeeds normally and the result is settled in the store.
+    #[tokio::test]
+    async fn test_idempotency_first_execution_claims_and_settles() {
+        let store = Arc::new(InMemoryDurableStore::default());
+        let mut executor = ToolRegistry::with_defaults();
+        executor.register(ArgumentEchoTool);
+        let atom =
+            ActAtom::new(executor, NoopEventEmitter).with_durable_tool_result_store(store.clone());
+
+        let context = AtomContext::new(SessionId::new(), TurnId::new(), MessageId::new());
+        let tc = ToolCall {
+            id: "c1".to_string(),
+            name: "argument_echo".to_string(),
+            arguments: json!({"value": "hello"}),
+        };
+        let input = make_act_input_with_store(
+            tc,
+            vec![arg_echo_tool_def(SideEffectClass::AtMostOnce)],
+            context,
+        );
+
+        let result = atom.execute(input).await.unwrap();
+        assert_eq!(result.success_count, 1);
+        assert_eq!(result.error_count, 0);
+
+        // Row should be settled now.
+        let rows = store.rows.lock().unwrap();
+        let row = rows.values().next().unwrap();
+        assert_eq!(row.status, "settled");
+    }
+
+    /// Second execution replays the stored result without re-running the tool.
+    #[tokio::test]
+    async fn test_idempotency_replay_already_settled() {
+        use crate::tool_fingerprint::tool_call_fingerprint;
+
+        let store = Arc::new(InMemoryDurableStore::default());
+        let tc = ToolCall {
+            id: "c1".to_string(),
+            name: "argument_echo".to_string(),
+            arguments: json!({"value": "hello"}),
+        };
+        let fp = tool_call_fingerprint(&tc);
+
+        // Pre-populate as settled.
+        {
+            let stored_result = serde_json::to_value(crate::ToolResult {
+                tool_call_id: "c1".to_string(),
+                result: Some(json!({"value": "hello"})),
+                images: None,
+                error: None,
+                connection_required: None,
+                raw_output: None,
+            })
+            .unwrap();
+            store.rows.lock().unwrap().insert(
+                (
+                    "turn_00000000000000000000000000000000".to_string(),
+                    "c1".to_string(),
+                ),
+                StoreRow {
+                    status: "settled".to_string(),
+                    result_json: stored_result,
+                    args_fingerprint: fp,
+                    claim_token: Uuid::new_v4(),
+                },
+            );
+        }
+
+        let mut executor = ToolRegistry::with_defaults();
+        executor.register(ArgumentEchoTool);
+        let atom =
+            ActAtom::new(executor, NoopEventEmitter).with_durable_tool_result_store(store.clone());
+
+        let context = AtomContext::new(
+            SessionId::new(),
+            TurnId::from_uuid(Uuid::nil()),
+            MessageId::new(),
+        );
+        let input = make_act_input_with_store(
+            tc,
+            vec![arg_echo_tool_def(SideEffectClass::AtMostOnce)],
+            context,
+        );
+
+        let result = atom.execute(input).await.unwrap();
+        assert_eq!(result.success_count, 1, "replay should count as success");
+        assert_eq!(result.error_count, 0);
+    }
+
+    /// AtMostOnce tool with a stale running claim returns an interrupted error.
+    #[tokio::test]
+    async fn test_idempotency_at_most_once_stale_running_returns_interrupted() {
+        use crate::tool_fingerprint::tool_call_fingerprint;
+
+        let store = Arc::new(InMemoryDurableStore::default());
+        let tc = ToolCall {
+            id: "c1".to_string(),
+            name: "argument_echo".to_string(),
+            arguments: json!({"value": "x"}),
+        };
+        let fp = tool_call_fingerprint(&tc);
+
+        // Pre-populate as running (stale from dead worker).
+        store.rows.lock().unwrap().insert(
+            (
+                "turn_00000000000000000000000000000000".to_string(),
+                "c1".to_string(),
+            ),
+            StoreRow {
+                status: "running".to_string(),
+                result_json: serde_json::Value::Null,
+                args_fingerprint: fp,
+                claim_token: Uuid::new_v4(),
+            },
+        );
+
+        let mut executor = ToolRegistry::with_defaults();
+        executor.register(ArgumentEchoTool);
+        let atom =
+            ActAtom::new(executor, NoopEventEmitter).with_durable_tool_result_store(store.clone());
+
+        let context = AtomContext::new(
+            SessionId::new(),
+            TurnId::from_uuid(Uuid::nil()),
+            MessageId::new(),
+        );
+        let input = make_act_input_with_store(
+            tc,
+            vec![arg_echo_tool_def(SideEffectClass::AtMostOnce)],
+            context,
+        );
+
+        let result = atom.execute(input).await.unwrap();
+        assert_eq!(
+            result.error_count, 1,
+            "AtMostOnce stale running should error"
+        );
+        let err = result.results[0].result.error.as_deref().unwrap_or("");
+        assert!(
+            err.contains("interrupted"),
+            "error should mention interrupted: {err}"
+        );
+
+        // Row should be settled as interrupted.
+        let rows = store.rows.lock().unwrap();
+        let row = rows.values().next().unwrap();
+        assert_eq!(row.status, "interrupted");
+    }
+
+    /// Pure/Idempotent tool with a stale running claim proceeds to execution normally.
+    #[tokio::test]
+    async fn test_idempotency_idempotent_tool_stale_running_reexecutes() {
+        use crate::tool_fingerprint::tool_call_fingerprint;
+
+        let store = Arc::new(InMemoryDurableStore::default());
+        let tc = ToolCall {
+            id: "c1".to_string(),
+            name: "argument_echo".to_string(),
+            arguments: json!({"value": "x"}),
+        };
+        let fp = tool_call_fingerprint(&tc);
+
+        store.rows.lock().unwrap().insert(
+            (
+                "turn_00000000000000000000000000000000".to_string(),
+                "c1".to_string(),
+            ),
+            StoreRow {
+                status: "running".to_string(),
+                result_json: serde_json::Value::Null,
+                args_fingerprint: fp,
+                claim_token: Uuid::new_v4(),
+            },
+        );
+
+        let mut executor = ToolRegistry::with_defaults();
+        executor.register(ArgumentEchoTool);
+        let atom =
+            ActAtom::new(executor, NoopEventEmitter).with_durable_tool_result_store(store.clone());
+
+        let context = AtomContext::new(
+            SessionId::new(),
+            TurnId::from_uuid(Uuid::nil()),
+            MessageId::new(),
+        );
+        let input = make_act_input_with_store(
+            tc,
+            vec![arg_echo_tool_def(SideEffectClass::Idempotent)],
+            context,
+        );
+
+        let result = atom.execute(input).await.unwrap();
+        assert_eq!(
+            result.success_count, 1,
+            "Idempotent should re-execute successfully"
+        );
         assert_eq!(result.error_count, 0);
     }
 }

--- a/crates/core/src/atoms/act.rs
+++ b/crates/core/src/atoms/act.rs
@@ -140,6 +140,10 @@ pub struct ToolCallResult {
     /// If set, the tool requires a user connection for this provider before it can execute.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub connection_required: Option<String>,
+    /// Determinism violation message. When Some, ActAtom::execute returns Err to fail the
+    /// durable workflow fast rather than continuing with a corrupted replay.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub determinism_fatal: Option<String>,
 }
 
 /// Result of the ActAtom
@@ -873,6 +877,14 @@ where
             "ActAtom: all tools completed"
         );
 
+        // Fail the durable workflow fast on any determinism violation (EVE-530).
+        // All tool.completed events have already been emitted above for affected calls.
+        if let Some(fatal_msg) = results.iter().find_map(|r| r.determinism_fatal.as_deref()) {
+            return Err(crate::error::AgentLoopError::tool(format!(
+                "act activity aborted due to determinism violation: {fatal_msg}"
+            )));
+        }
+
         let mut act_result = ActResult {
             results,
             completed: true,
@@ -1003,6 +1015,7 @@ where
                 success: false,
                 status: "error".to_string(),
                 connection_required: None,
+                determinism_fatal: None,
             };
         }
 
@@ -1027,6 +1040,12 @@ where
                 }) => {
                     // Determinism guard: stored args fingerprint must match current call.
                     if stored_fp != tool_call_fingerprint {
+                        let err_msg = format!(
+                            "determinism violation: tool '{}' replay args fingerprint \
+                             does not match prior execution (stored={stored_fp}, \
+                             current={})",
+                            tool_call.name, tool_call_fingerprint
+                        );
                         tracing::error!(
                             session_id = %context.session_id,
                             turn_id = %context.turn_id,
@@ -1035,24 +1054,38 @@ where
                             current_fp = %tool_call_fingerprint,
                             "ActAtom: determinism violation — replay args fingerprint mismatch"
                         );
+                        let result_fp =
+                            tool_result_fingerprint(&tool_call.name, &ToolResult::error(&err_msg));
+                        let _ = self
+                            .event_emitter
+                            .emit(EventRequest::new(
+                                context.session_id,
+                                event_context,
+                                ToolCompletedData::failure(
+                                    tool_call.id.clone(),
+                                    tool_call.name.clone(),
+                                    "error".to_string(),
+                                    err_msg.clone(),
+                                    None,
+                                )
+                                .with_fingerprints(tool_call_fingerprint.clone(), result_fp)
+                                .with_display_name(display_name.clone()),
+                            ))
+                            .await;
                         return ToolCallResult {
                             tool_call: tool_call.clone(),
                             result: ToolResult {
                                 tool_call_id: tool_call.id.clone(),
                                 result: None,
                                 images: None,
-                                error: Some(format!(
-                                    "determinism violation: tool '{}' replay args fingerprint \
-                                     does not match prior execution (stored={stored_fp}, \
-                                     current={})",
-                                    tool_call.name, tool_call_fingerprint
-                                )),
+                                error: Some(err_msg.clone()),
                                 connection_required: None,
                                 raw_output: None,
                             },
                             success: false,
                             status: "error".to_string(),
                             connection_required: None,
+                            determinism_fatal: Some(err_msg),
                         };
                     }
                     tracing::debug!(
@@ -1075,11 +1108,22 @@ where
                     let status = if success { "success" } else { "error" };
                     let result_fp = tool_result_fingerprint(&tool_call.name, &replayed_result);
                     let completed_data = if success {
-                        let content = replayed_result
+                        // Reconstruct content: text + images (preserves image-producing tools on replay)
+                        let mut content = replayed_result
                             .result
                             .as_ref()
                             .map(|r| vec![ContentPart::text(r.to_string())])
                             .unwrap_or_default();
+                        if let Some(ref images) = replayed_result.images {
+                            for img in images {
+                                content.push(ContentPart::Image(
+                                    crate::message::ImageContentPart::from_base64(
+                                        &img.base64,
+                                        &img.media_type,
+                                    ),
+                                ));
+                            }
+                        }
                         ToolCompletedData::success(
                             tool_call.id.clone(),
                             tool_call.name.clone(),
@@ -1114,10 +1158,65 @@ where
                         success,
                         status: status.to_string(),
                         connection_required: conn_req,
+                        determinism_fatal: None,
                     };
                 }
 
-                Ok(ToolCallClaimResult::AlreadyRunning { .. }) => {
+                Ok(ToolCallClaimResult::AlreadyRunning {
+                    args_fingerprint: stored_fp,
+                }) => {
+                    // Determinism guard: even in the running state, a fingerprint mismatch
+                    // means the workflow is replaying with different args — fail loudly.
+                    if stored_fp != tool_call_fingerprint {
+                        let err_msg = format!(
+                            "determinism violation: tool '{}' args fingerprint changed \
+                             while prior claim is still running (stored={stored_fp}, \
+                             current={tool_call_fingerprint})",
+                            tool_call.name
+                        );
+                        tracing::error!(
+                            session_id = %context.session_id,
+                            turn_id = %context.turn_id,
+                            tool_call_id = %tool_call.id,
+                            stored = %stored_fp,
+                            current = %tool_call_fingerprint,
+                            "ActAtom: determinism violation — running claim fingerprint mismatch"
+                        );
+                        let result_fp =
+                            tool_result_fingerprint(&tool_call.name, &ToolResult::error(&err_msg));
+                        let _ = self
+                            .event_emitter
+                            .emit(EventRequest::new(
+                                context.session_id,
+                                event_context,
+                                ToolCompletedData::failure(
+                                    tool_call.id.clone(),
+                                    tool_call.name.clone(),
+                                    "error".to_string(),
+                                    err_msg.clone(),
+                                    None,
+                                )
+                                .with_fingerprints(tool_call_fingerprint.clone(), result_fp)
+                                .with_display_name(display_name.clone()),
+                            ))
+                            .await;
+                        return ToolCallResult {
+                            tool_call: tool_call.clone(),
+                            result: ToolResult {
+                                tool_call_id: tool_call.id.clone(),
+                                result: None,
+                                images: None,
+                                error: Some(err_msg.clone()),
+                                connection_required: None,
+                                raw_output: None,
+                            },
+                            success: false,
+                            status: "error".to_string(),
+                            connection_required: None,
+                            determinism_fatal: Some(err_msg),
+                        };
+                    }
+
                     let sec = tool_def
                         .map(|d| d.side_effect_class())
                         .unwrap_or(SideEffectClass::AtMostOnce);
@@ -1145,8 +1244,34 @@ where
                                     &tool_call.id,
                                     serde_json::Value::Null,
                                     "interrupted",
-                                    Uuid::nil(), // sentinel — settle accepts any token for interrupted
+                                    Uuid::nil(), // sentinel — bypass token check for interrupt
                                 )
+                                .await;
+                            let err_msg = format!(
+                                "tool '{}' was interrupted mid-execution during a prior \
+                                 worker failure; result is uncertain and was not re-run \
+                                 (AtMostOnce safety)",
+                                tool_call.name
+                            );
+                            let result_fp = tool_result_fingerprint(
+                                &tool_call.name,
+                                &ToolResult::error(&err_msg),
+                            );
+                            let _ = self
+                                .event_emitter
+                                .emit(EventRequest::new(
+                                    context.session_id,
+                                    event_context,
+                                    ToolCompletedData::failure(
+                                        tool_call.id.clone(),
+                                        tool_call.name.clone(),
+                                        "interrupted".to_string(),
+                                        err_msg.clone(),
+                                        None,
+                                    )
+                                    .with_fingerprints(tool_call_fingerprint.clone(), result_fp)
+                                    .with_display_name(display_name.clone()),
+                                ))
                                 .await;
                             return ToolCallResult {
                                 tool_call: tool_call.clone(),
@@ -1154,18 +1279,14 @@ where
                                     tool_call_id: tool_call.id.clone(),
                                     result: None,
                                     images: None,
-                                    error: Some(format!(
-                                        "tool '{}' was interrupted mid-execution during a prior \
-                                         worker failure; result is uncertain and was not re-run \
-                                         (AtMostOnce safety)",
-                                        tool_call.name
-                                    )),
+                                    error: Some(err_msg),
                                     connection_required: None,
                                     raw_output: None,
                                 },
                                 success: false,
                                 status: "error".to_string(),
                                 connection_required: None,
+                                determinism_fatal: None,
                             };
                         }
                     }
@@ -1175,6 +1296,12 @@ where
                     stored_fingerprint,
                     current_fingerprint,
                 }) => {
+                    let err_msg = format!(
+                        "determinism violation: tool '{}' args fingerprint changed \
+                         on replay (stored={stored_fingerprint}, \
+                         current={current_fingerprint})",
+                        tool_call.name
+                    );
                     tracing::error!(
                         session_id = %context.session_id,
                         turn_id = %context.turn_id,
@@ -1183,24 +1310,38 @@ where
                         current = %current_fingerprint,
                         "ActAtom: determinism violation on claim"
                     );
+                    let result_fp =
+                        tool_result_fingerprint(&tool_call.name, &ToolResult::error(&err_msg));
+                    let _ = self
+                        .event_emitter
+                        .emit(EventRequest::new(
+                            context.session_id,
+                            event_context,
+                            ToolCompletedData::failure(
+                                tool_call.id.clone(),
+                                tool_call.name.clone(),
+                                "error".to_string(),
+                                err_msg.clone(),
+                                None,
+                            )
+                            .with_fingerprints(tool_call_fingerprint.clone(), result_fp)
+                            .with_display_name(display_name.clone()),
+                        ))
+                        .await;
                     return ToolCallResult {
                         tool_call: tool_call.clone(),
                         result: ToolResult {
                             tool_call_id: tool_call.id.clone(),
                             result: None,
                             images: None,
-                            error: Some(format!(
-                                "determinism violation: tool '{}' args fingerprint changed \
-                                 on replay (stored={stored_fingerprint}, \
-                                 current={current_fingerprint})",
-                                tool_call.name
-                            )),
+                            error: Some(err_msg.clone()),
                             connection_required: None,
                             raw_output: None,
                         },
                         success: false,
                         status: "error".to_string(),
                         connection_required: None,
+                        determinism_fatal: Some(err_msg),
                     };
                 }
 
@@ -1298,6 +1439,7 @@ where
                 success: false,
                 status: "error".to_string(),
                 connection_required: None,
+                determinism_fatal: None,
             };
         };
 
@@ -1590,6 +1732,7 @@ where
                     success,
                     status: status.to_string(),
                     connection_required: conn_req,
+                    determinism_fatal: None,
                 }
             }
             Err(e) => {
@@ -1658,6 +1801,7 @@ where
                     success: false,
                     status: "error".to_string(),
                     connection_required: None,
+                    determinism_fatal: None,
                 }
             }
         }
@@ -2480,6 +2624,7 @@ mod tests {
                 success: false,
                 status: "success".to_string(),
                 connection_required: Some("daytona".to_string()),
+                determinism_fatal: None,
             }],
             completed: true,
             success_count: 0,

--- a/crates/core/src/atoms/act_hooks.rs
+++ b/crates/core/src/atoms/act_hooks.rs
@@ -453,6 +453,7 @@ mod tests {
             success: true,
             status: "success".to_string(),
             connection_required: connection_required.map(|s| s.to_string()),
+            determinism_fatal: None,
         }
     }
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -187,12 +187,13 @@ pub use runtime_context::{
     resolve_runtime_capabilities,
 };
 pub use traits::{
-    DisabledSessionFileSystemFactory, EventEmitter, HarnessStore, ImageResolver, KeyInfo,
-    LeasedResourceStore, LlmProviderStore, ModelWithProvider, NoopEventEmitter,
-    OutboundToolRateLimiter, ResolvedImage, SecretInfo, SessionFileStore, SessionFileSystem,
-    SessionFileSystemFactory, SessionFileSystemFactoryContext, SessionMutator,
-    SessionResourceRegistry, SessionSqlDbStoreRef, SessionStorageStore, SessionStore, ToolContext,
-    ToolExecutor, UserConnectionResolver,
+    DisabledSessionFileSystemFactory, DurableToolResultStore, EventEmitter, HarnessStore,
+    ImageResolver, KeyInfo, LeasedResourceStore, LlmProviderStore, ModelWithProvider,
+    NoopDurableToolResultStore, NoopEventEmitter, OutboundToolRateLimiter, ResolvedImage,
+    SecretInfo, SessionFileStore, SessionFileSystem, SessionFileSystemFactory,
+    SessionFileSystemFactoryContext, SessionMutator, SessionResourceRegistry, SessionSqlDbStoreRef,
+    SessionStorageStore, SessionStore, ToolCallClaimResult, ToolContext, ToolExecutor,
+    UserConnectionResolver,
 };
 pub use user_facing_error::{
     UserFacingError, UserFacingErrorContext, UserFacingErrorFields, classify_runtime_error_message,
@@ -343,8 +344,8 @@ pub use atoms::{
 
 // Tool types (runtime types defined in this crate)
 pub use tool_types::{
-    BuiltinTool, ClientSideTool, DeferrablePolicy, ToolCall, ToolDefinition, ToolHints, ToolPolicy,
-    ToolResult,
+    BuiltinTool, ClientSideTool, DeferrablePolicy, SideEffectClass, ToolCall, ToolDefinition,
+    ToolHints, ToolPolicy, ToolResult,
 };
 
 // Note: CapabilityId and CapabilityStatus are re-exported via capabilities module

--- a/crates/core/src/tool_types.rs
+++ b/crates/core/src/tool_types.rs
@@ -630,6 +630,20 @@ pub struct ToolResult {
     pub raw_output: Option<String>,
 }
 
+impl ToolResult {
+    /// Construct a minimal error-only ToolResult (used for fingerprinting error paths).
+    pub fn error(msg: &str) -> Self {
+        Self {
+            tool_call_id: String::new(),
+            result: None,
+            images: None,
+            error: Some(msg.to_string()),
+            connection_required: None,
+            raw_output: None,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/core/src/tool_types.rs
+++ b/crates/core/src/tool_types.rs
@@ -224,6 +224,11 @@ impl ToolDefinition {
         self.hints().cpu_bound.unwrap_or(false)
     }
 
+    /// Effective side-effect class for this tool (defaults to `AtMostOnce`).
+    pub fn side_effect_class(&self) -> SideEffectClass {
+        self.hints().effective_side_effect_class()
+    }
+
     /// Get reporting attribution for the capability that contributed this tool.
     pub fn capability_attribution(&self) -> Option<(&str, Option<&str>)> {
         self.hints()
@@ -335,6 +340,30 @@ fn add_human_intent_to_schema(schema: &mut Value) {
     // useful, but old calls, provider quirks, and client-side calls remain valid.
 }
 
+/// How many times a tool call may safely be executed given the same inputs.
+///
+/// Used by the durable Act activity (EVE-530) to decide what to do when a
+/// prior execution attempt left a `running` claim in `durable_tool_results`:
+///
+/// * `Pure` / `Idempotent` — the running claim is stale; re-execute freely.
+/// * `AtMostOnce` — never re-execute from a stale running claim; settle it
+///   as `interrupted` and surface an uncertain result to the model instead.
+///
+/// When unset (`None`), the conservative default is `AtMostOnce`.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub enum SideEffectClass {
+    /// No external side effects; always safe to re-execute (e.g. read-only queries).
+    Pure,
+    /// Idempotent side effects; safe to re-execute with the same arguments
+    /// (e.g. create-or-update, PUT-style writes).
+    Idempotent,
+    /// Exactly-once semantics required; must not be re-executed from a stale
+    /// running claim (e.g. charge a card, send an email, open a PR).
+    #[default]
+    AtMostOnce,
+}
+
 /// Semantic hints describing a tool's behavioral properties.
 ///
 /// Follows the MCP tool annotations convention (readOnlyHint, destructiveHint,
@@ -432,6 +461,16 @@ pub struct ToolHints {
     /// instead of the generic "Ran Manage Agents".
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub narration_noun: Option<String>,
+
+    /// Replay-safety class used by the durable Act activity (EVE-530).
+    ///
+    /// Controls what happens when a worker reclaims a stale `running` claim:
+    /// `Pure`/`Idempotent` tools are re-executed; `AtMostOnce` tools are
+    /// settled as `interrupted` to prevent double side-effects.
+    ///
+    /// `None` is treated conservatively as `AtMostOnce`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub side_effect_class: Option<SideEffectClass>,
 }
 
 impl ToolHints {
@@ -515,6 +554,20 @@ impl ToolHints {
     pub fn with_narration_noun(mut self, noun: impl Into<String>) -> Self {
         self.narration_noun = Some(noun.into());
         self
+    }
+
+    /// Builder: set the replay-safety class (EVE-530).
+    pub fn with_side_effect_class(mut self, class: SideEffectClass) -> Self {
+        self.side_effect_class = Some(class);
+        self
+    }
+
+    /// Returns the effective side-effect class, defaulting to `AtMostOnce`
+    /// when unset (conservative default).
+    pub fn effective_side_effect_class(&self) -> SideEffectClass {
+        self.side_effect_class
+            .clone()
+            .unwrap_or(SideEffectClass::AtMostOnce)
     }
 }
 

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -874,6 +874,101 @@ pub trait OutboundToolRateLimiter: Send + Sync {
     async fn check_org(&self, org_id: &crate::typed_id::OrgId) -> bool;
 }
 
+// ============================================================================
+// DurableToolResultStore — per-tool-call idempotency (EVE-530)
+// ============================================================================
+
+/// Result of a claim attempt on the per-tool-call idempotency store.
+#[derive(Debug)]
+pub enum ToolCallClaimResult {
+    /// First claim for this (turn_id, tool_call_id); caller should execute the tool.
+    /// `claim_token` must be passed to `settle_tool_call` to verify ownership.
+    Claimed { claim_token: uuid::Uuid },
+    /// A prior run already settled this call; replay the stored result.
+    AlreadySettled {
+        result_json: serde_json::Value,
+        args_fingerprint: String,
+    },
+    /// A prior run started but never settled. For `AtMostOnce` tools the
+    /// caller should NOT re-execute; for `Pure`/`Idempotent` tools the caller
+    /// may re-execute and then try to settle (the settle CAS will be a no-op if
+    /// a different claimer wins first).
+    AlreadyRunning { args_fingerprint: String },
+    /// A settled row exists but its `args_fingerprint` does not match the
+    /// current call — this is a determinism violation (workflow replay with
+    /// different inputs). The workflow should be failed loudly.
+    DeterminismViolation {
+        stored_fingerprint: String,
+        current_fingerprint: String,
+    },
+}
+
+/// Durable per-tool-call idempotency store (EVE-530).
+///
+/// Implements the claim/settle CAS that prevents double-execution of
+/// `AtMostOnce` tools on worker reclaim/replay.
+#[async_trait]
+pub trait DurableToolResultStore: Send + Sync + 'static {
+    /// Atomically claim `(turn_id, tool_call_id)` before tool dispatch.
+    ///
+    /// - Inserts a `running` row if none exists → `Claimed`.
+    /// - Finds an existing `settled` row → `AlreadySettled`.
+    /// - Finds an existing `running` row → `AlreadyRunning`.
+    /// - Finds a `settled` row with a mismatched `args_fingerprint`
+    ///   (determinism violation) → `DeterminismViolation`.
+    async fn try_claim_tool_call(
+        &self,
+        turn_id: &str,
+        tool_call_id: &str,
+        tool_name: &str,
+        args_fingerprint: &str,
+    ) -> Result<ToolCallClaimResult>;
+
+    /// Settle a previously claimed tool call with its result.
+    ///
+    /// `claim_token` must match the token returned by `try_claim_tool_call`.
+    /// Returns `Ok(true)` if the row was updated, `Ok(false)` if the claim
+    /// token no longer matches (ownership lost — treat as a warning).
+    async fn settle_tool_call(
+        &self,
+        turn_id: &str,
+        tool_call_id: &str,
+        result_json: serde_json::Value,
+        status: &str,
+        claim_token: uuid::Uuid,
+    ) -> Result<bool>;
+}
+
+/// No-op implementation — used when no durable store is configured (dev/test).
+/// Every call is treated as a fresh first execution; no replay or ownership checks.
+pub struct NoopDurableToolResultStore;
+
+#[async_trait]
+impl DurableToolResultStore for NoopDurableToolResultStore {
+    async fn try_claim_tool_call(
+        &self,
+        _turn_id: &str,
+        _tool_call_id: &str,
+        _tool_name: &str,
+        _args_fingerprint: &str,
+    ) -> Result<ToolCallClaimResult> {
+        Ok(ToolCallClaimResult::Claimed {
+            claim_token: uuid::Uuid::new_v4(),
+        })
+    }
+
+    async fn settle_tool_call(
+        &self,
+        _turn_id: &str,
+        _tool_call_id: &str,
+        _result_json: serde_json::Value,
+        _status: &str,
+        _claim_token: uuid::Uuid,
+    ) -> Result<bool> {
+        Ok(true)
+    }
+}
+
 /// Runtime context provided to tools during execution.
 ///
 /// This context contains:

--- a/crates/runtime/src/host.rs
+++ b/crates/runtime/src/host.rs
@@ -180,6 +180,12 @@ pub trait RuntimeHostAdapter: Send + Sync + Clone + 'static {
         None
     }
 
+    /// Per-turn durable tool result store for act-activity idempotency (EVE-530).
+    /// Default: `None` (no durable claim/settle — every execution runs tools fresh).
+    fn durable_tool_result_store(&self) -> Option<Arc<dyn everruns_core::DurableToolResultStore>> {
+        None
+    }
+
     /// MCP executor routing `mcp_*` tool calls for this session, if the host
     /// configures MCP (specs/runtime-mcp.md D4). Default: `None`, so hosts
     /// without scoped MCP servers keep the plain tool registry unchanged.
@@ -1120,6 +1126,9 @@ pub async fn execute_act_activity<A: RuntimeHostAdapter>(
     }
     if let Some(limiter) = adapter.outbound_tool_rate_limiter(org_id) {
         atom = atom.with_outbound_tool_rate_limiter(limiter);
+    }
+    if let Some(store) = adapter.durable_tool_result_store() {
+        atom = atom.with_durable_tool_result_store(store);
     }
 
     atom.execute(input).await

--- a/crates/server/migrations/050_durable_tool_results.sql
+++ b/crates/server/migrations/050_durable_tool_results.sql
@@ -1,0 +1,33 @@
+-- Per-tool-call idempotency store for the Act activity (EVE-530).
+--
+-- Each row represents one tool call dispatch attempt within a durable turn.
+-- The UNIQUE constraint on (turn_id, tool_call_id) is the CAS primitive:
+-- the first INSERT wins (claim), subsequent ones conflict and reveal the
+-- existing status so callers can decide to replay or skip.
+--
+-- status values:
+--   'running'     – claimed but not yet settled
+--   'settled'     – completed; result_json holds the tool result
+--   'interrupted' – AtMostOnce tool whose running claim became stale; not re-run
+CREATE TABLE durable_tool_results (
+    id             UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+    turn_id        TEXT         NOT NULL,
+    tool_call_id   TEXT         NOT NULL,
+    tool_name      TEXT         NOT NULL,
+    args_fingerprint TEXT       NOT NULL,
+    status         TEXT         NOT NULL DEFAULT 'running'
+                   CHECK (status IN ('running', 'settled', 'interrupted')),
+    -- Opaque token generated at claim time; settle CAS verifies this matches.
+    claim_token    UUID         NOT NULL,
+    result_json    JSONB,
+    created_at     TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    settled_at     TIMESTAMPTZ,
+    CONSTRAINT durable_tool_results_turn_call_uq UNIQUE (turn_id, tool_call_id)
+);
+
+COMMENT ON TABLE durable_tool_results IS
+    'Per-tool-call idempotency records for the Act durable activity (EVE-530). '
+    'Prevents double-execution of AtMostOnce tools on worker reclaim/replay.';
+
+CREATE INDEX durable_tool_results_turn_idx
+    ON durable_tool_results (turn_id);

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -1550,6 +1550,13 @@ impl WorkerAdapters for DirectWorkerAdapters {
             .map(|l| l.clone() as Arc<dyn everruns_core::OutboundToolRateLimiter>)
     }
 
+    fn durable_tool_result_store(&self) -> Option<Arc<dyn everruns_core::DurableToolResultStore>> {
+        self.db.pool().map(|pool| {
+            Arc::new(crate::storage::PgDurableToolResultStore::new(pool.clone()))
+                as Arc<dyn everruns_core::DurableToolResultStore>
+        })
+    }
+
     async fn invoke_scheduled_app_channel(
         &self,
         org_id: i64,

--- a/crates/server/src/storage/durable_tool_results.rs
+++ b/crates/server/src/storage/durable_tool_results.rs
@@ -1,0 +1,145 @@
+// PostgreSQL implementation of DurableToolResultStore (EVE-530).
+
+use async_trait::async_trait;
+use everruns_core::error::AgentLoopError;
+use everruns_core::traits::{DurableToolResultStore, ToolCallClaimResult};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+/// PostgreSQL-backed durable tool result store.
+///
+/// Uses the `durable_tool_results` table (migration 050) to persist claim/settle
+/// records for per-tool-call idempotency in the durable Act activity (EVE-530).
+#[derive(Clone)]
+pub struct PgDurableToolResultStore {
+    pool: PgPool,
+}
+
+impl PgDurableToolResultStore {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl DurableToolResultStore for PgDurableToolResultStore {
+    async fn try_claim_tool_call(
+        &self,
+        turn_id: &str,
+        tool_call_id: &str,
+        tool_name: &str,
+        args_fingerprint: &str,
+    ) -> Result<ToolCallClaimResult, AgentLoopError> {
+        let claim_token = Uuid::new_v4();
+
+        // Try to INSERT a running claim. On unique conflict the row already exists.
+        let inserted = sqlx::query(
+            r#"
+            INSERT INTO durable_tool_results
+                (turn_id, tool_call_id, tool_name, args_fingerprint, status, claim_token)
+            VALUES ($1, $2, $3, $4, 'running', $5)
+            ON CONFLICT (turn_id, tool_call_id) DO NOTHING
+            "#,
+        )
+        .bind(turn_id)
+        .bind(tool_call_id)
+        .bind(tool_name)
+        .bind(args_fingerprint)
+        .bind(claim_token)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| AgentLoopError::tool(format!("durable_tool_results claim: {e}")))?
+        .rows_affected();
+
+        if inserted == 1 {
+            return Ok(ToolCallClaimResult::Claimed { claim_token });
+        }
+
+        // Row already exists; read its current state.
+        let row = sqlx::query_as::<_, (String, Option<serde_json::Value>, String)>(
+            r#"
+            SELECT status, result_json, args_fingerprint
+            FROM durable_tool_results
+            WHERE turn_id = $1 AND tool_call_id = $2
+            "#,
+        )
+        .bind(turn_id)
+        .bind(tool_call_id)
+        .fetch_one(&self.pool)
+        .await
+        .map_err(|e| AgentLoopError::tool(format!("durable_tool_results read: {e}")))?;
+
+        let (status, result_json, stored_fp) = row;
+
+        match status.as_str() {
+            "settled" => {
+                if stored_fp != args_fingerprint {
+                    return Ok(ToolCallClaimResult::DeterminismViolation {
+                        stored_fingerprint: stored_fp,
+                        current_fingerprint: args_fingerprint.to_string(),
+                    });
+                }
+                Ok(ToolCallClaimResult::AlreadySettled {
+                    result_json: result_json.unwrap_or(serde_json::Value::Null),
+                    args_fingerprint: stored_fp,
+                })
+            }
+            "running" | "interrupted" => Ok(ToolCallClaimResult::AlreadyRunning {
+                args_fingerprint: stored_fp,
+            }),
+            other => Err(AgentLoopError::tool(format!(
+                "durable_tool_results: unknown status '{other}'"
+            ))),
+        }
+    }
+
+    async fn settle_tool_call(
+        &self,
+        turn_id: &str,
+        tool_call_id: &str,
+        result_json: serde_json::Value,
+        status: &str,
+        claim_token: Uuid,
+    ) -> Result<bool, AgentLoopError> {
+        // CAS update: only transition from 'running' if the claim token matches.
+        // The nil UUID sentinel bypasses the token check for forced interrupts.
+        let rows = if claim_token == Uuid::nil() {
+            sqlx::query(
+                r#"
+                UPDATE durable_tool_results
+                SET status = $1, result_json = $2, settled_at = now()
+                WHERE turn_id = $3 AND tool_call_id = $4 AND status = 'running'
+                "#,
+            )
+            .bind(status)
+            .bind(&result_json)
+            .bind(turn_id)
+            .bind(tool_call_id)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| AgentLoopError::tool(format!("durable_tool_results settle: {e}")))?
+            .rows_affected()
+        } else {
+            sqlx::query(
+                r#"
+                UPDATE durable_tool_results
+                SET status = $1, result_json = $2, settled_at = now()
+                WHERE turn_id = $3 AND tool_call_id = $4
+                  AND status = 'running'
+                  AND claim_token = $5
+                "#,
+            )
+            .bind(status)
+            .bind(&result_json)
+            .bind(turn_id)
+            .bind(tool_call_id)
+            .bind(claim_token)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| AgentLoopError::tool(format!("durable_tool_results settle: {e}")))?
+            .rows_affected()
+        };
+
+        Ok(rows > 0)
+    }
+}

--- a/crates/server/src/storage/durable_tool_results.rs
+++ b/crates/server/src/storage/durable_tool_results.rs
@@ -102,7 +102,13 @@ impl DurableToolResultStore for PgDurableToolResultStore {
         claim_token: Uuid,
     ) -> Result<bool, AgentLoopError> {
         // CAS update: only transition from 'running' if the claim token matches.
-        // The nil UUID sentinel bypasses the token check for forced interrupts.
+        // The nil UUID sentinel bypasses the token check for forced interrupts only.
+        if claim_token == Uuid::nil() && status != "interrupted" {
+            return Err(AgentLoopError::tool(format!(
+                "durable_tool_results: nil claim token bypass is restricted to \
+                 status='interrupted', got '{status}'"
+            )));
+        }
         let rows = if claim_token == Uuid::nil() {
             sqlx::query(
                 r#"

--- a/crates/server/src/storage/mod.rs
+++ b/crates/server/src/storage/mod.rs
@@ -12,6 +12,7 @@
 pub mod agent_store;
 pub mod backend;
 pub mod connection_resolver;
+pub mod durable_tool_results;
 pub mod encryption;
 pub mod harness_store;
 pub mod leased_resource_store;
@@ -35,6 +36,7 @@ mod event_tests;
 pub use agent_store::{DbAgentStore, create_db_agent_store};
 pub use backend::StorageBackend;
 pub use connection_resolver::{DbConnectionResolver, GitHubAppTokenMinter, NoopConnectionResolver};
+pub use durable_tool_results::PgDurableToolResultStore;
 pub use encryption::{
     ENCRYPTED_COLUMNS, EncryptedColumn, EncryptedPayload, EncryptionService,
     generate_encryption_key,

--- a/crates/worker/src/activities.rs
+++ b/crates/worker/src/activities.rs
@@ -303,6 +303,7 @@ mod tests {
                 success: true,
                 status: "success".to_string(),
                 connection_required: None,
+                determinism_fatal: None,
             }],
             completed: true,
             success_count: 1,

--- a/crates/worker/src/runtime_host.rs
+++ b/crates/worker/src/runtime_host.rs
@@ -271,6 +271,10 @@ impl<A: WorkerAdapters> RuntimeHostAdapter for WorkerRuntimeHost<A> {
         self.adapters.outbound_tool_rate_limiter(org_id)
     }
 
+    fn durable_tool_result_store(&self) -> Option<Arc<dyn everruns_core::DurableToolResultStore>> {
+        self.adapters.durable_tool_result_store()
+    }
+
     /// Execute `mcp_*` tool calls by resolving server connections over gRPC and
     /// calling them through the shared MCP client over the platform egress
     /// boundary (SSRF-guarded). Returns `None` when no egress service is

--- a/crates/worker/src/worker_adapters.rs
+++ b/crates/worker/src/worker_adapters.rs
@@ -309,6 +309,12 @@ pub trait WorkerAdapters: Send + Sync + Clone + 'static {
         None
     }
 
+    /// Per-turn durable tool result store for act-activity idempotency (EVE-530).
+    /// Default: `None` (no durable idempotency — suitable for dev/test environments).
+    fn durable_tool_result_store(&self) -> Option<Arc<dyn everruns_core::DurableToolResultStore>> {
+        None
+    }
+
     /// Invoke an app schedule channel when a durable schedule fires.
     async fn invoke_scheduled_app_channel(
         &self,

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -26646,6 +26646,15 @@
           }
         }
       },
+      "SideEffectClass": {
+        "type": "string",
+        "description": "How many times a tool call may safely be executed given the same inputs.\n\nUsed by the durable Act activity (EVE-530) to decide what to do when a\nprior execution attempt left a `running` claim in `durable_tool_results`:\n\n* `Pure` / `Idempotent` — the running claim is stale; re-execute freely.\n* `AtMostOnce` — never re-execute from a stale running claim; settle it\n  as `interrupted` and surface an uncertain result to the model instead.\n\nWhen unset (`None`), the conservative default is `AtMostOnce`.",
+        "enum": [
+          "Pure",
+          "Idempotent",
+          "AtMostOnce"
+        ]
+      },
       "Skill": {
         "type": "object",
         "description": "Skill entity (API response type)",
@@ -27642,6 +27651,17 @@
               "null"
             ],
             "description": "Tool requires API keys, credentials, or other secrets to function.\nUseful for UI to show connection prompts and for LLMs to anticipate\nauthentication failures."
+          },
+          "side_effect_class": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/SideEffectClass",
+                "description": "Replay-safety class used by the durable Act activity (EVE-530).\n\nControls what happens when a worker reclaims a stale `running` claim:\n`Pure`/`Idempotent` tools are re-executed; `AtMostOnce` tools are\nsettled as `interrupted` to prevent double side-effects.\n\n`None` is treated conservatively as `AtMostOnce`."
+              }
+            ]
           },
           "supports_background": {
             "type": [


### PR DESCRIPTION
## What

Adds per-tool-call idempotency (PreserveResult) to the Act activity so worker reclaim/replay no longer double-executes side-effectful tools.

## Why

When a durable worker is reclaimed mid-turn and the turn is replayed, every tool call in the Act activity previously re-ran unconditionally. For tools with `AtMostOnce` semantics (file writes, payments, external API calls) this produces duplicate effects.

## How

**Migration 050** — `durable_tool_results` table with a `UNIQUE (turn_id, tool_call_id)` constraint as the CAS primitive. Columns: `status` (`running`/`settled`/`interrupted`), `claim_token` UUID, `result_json` JSONB, `args_fingerprint`.

**`SideEffectClass` enum** on `ToolHints`: `Pure` | `Idempotent` | `AtMostOnce` (default). Tools declare their replay safety; the Act layer uses it to decide what to do with stale running claims.

**`ActAtom` claim/settle protocol**:
- Before dispatching each tool call, `try_claim_tool_call` atomically inserts a `running` row (CAS insert-or-ignore).
- `Claimed` → proceed, store the claim token.
- `AlreadySettled` → emit a replayed `tool.completed` and return the stored result without re-executing. Fingerprint guard ensures args haven't changed.
- `AlreadyRunning` + `Pure`/`Idempotent` → proceed (no claim token; settle is a no-op).
- `AlreadyRunning` + `AtMostOnce` → settle the stale row as `interrupted` (nil-UUID sentinel), return an error result explaining the tool was mid-execution during a worker failure.
- `DeterminismViolation` → return a workflow error; mismatched args fingerprint on replay indicates a workflow bug.
- After successful execution, `settle_tool_call` CAS-updates from `running` → `settled` using the claim token (parallel to `TaskNotOwned`).

**Wiring**:
- `DurableToolResultStore` trait + `NoopDurableToolResultStore` (always claims fresh; dev/test).
- `PgDurableToolResultStore` PostgreSQL implementation.
- `RuntimeHostAdapter::durable_tool_result_store()` (default `None`); wired in `execute_act_activity`.
- `WorkerAdapters::durable_tool_result_store()` default `None`; server direct-worker adapter returns `PgDurableToolResultStore`.

## Risk

- **Low** for the normal path — when no store is configured (dev mode), `NoopDurableToolResultStore` always returns `Claimed` so behaviour is unchanged.
- **Medium** for the database path — the new `INSERT ON CONFLICT DO NOTHING` + conditional `UPDATE` runs inside every tool dispatch on durable workers. Latency impact is one extra round-trip per tool call; acceptable given the durable execution model.
- The `interrupted` error for `AtMostOnce` stale running claims is visible to the agent loop and may surface as a tool error in the conversation. This is intentional and preferable to double-execution.

## Security

- **TM-SQL**: All query parameters are positional binds (`$1`…`$5`). No string interpolation into SQL. The CAS `UPDATE` checks both `status = 'running'` and `claim_token = $5`, preventing a reclaimd task from settling another task's claim.
- **TM-TENANT**: `turn_id` encodes session scope (UUID-derived from the durable workflow); org isolation is enforced by the upstream call site (ActAtom is already scoped to org/session). No cross-tenant query paths introduced.
- **TM-DOS**: The unique constraint bounds the table to one row per `(turn_id, tool_call_id)` pair. No unbounded growth path from a single turn.
- No authentication, authorization, file system, or prompt injection surface touched.

## Follow-ups

- **Durable store GC**: rows for completed turns accumulate indefinitely. A background job or TTL policy to prune old `durable_tool_results` rows should be added. Deferred — safe because the table is append-only and the unique constraint prevents unbounded growth per turn.
- **OAuth MCP auth provider**: noted in `runtime_host.rs` comment — OAuth MCP servers resolved via the non-scoped path arrive without a token. Unrelated to this PR.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)


---
_Generated by [Claude Code](https://claude.ai/code/session_01WFZRpE41urNbQT9NQJSi7K)_