### PR TITLE
feat(worker): stream-liveness heartbeat for Reason activity (EVE-531)

### DIFF
--- a/crates/core/src/atoms/reason.rs
+++ b/crates/core/src/atoms/reason.rs
@@ -1606,13 +1606,9 @@ impl ReasonAtom {
             let stall_timeout = self
                 .provider_stall_timeout
                 .unwrap_or(std::time::Duration::from_secs(120));
-            let mut stall_sleep =
-                Box::pin(tokio::time::sleep(stall_timeout));
-            let mut keepalive_ticker = tokio::time::interval(
-                std::time::Duration::from_secs(12),
-            );
-            keepalive_ticker
-                .set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            let mut stall_sleep = Box::pin(tokio::time::sleep(stall_timeout));
+            let mut keepalive_ticker = tokio::time::interval(std::time::Duration::from_secs(12));
+            keepalive_ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
             keepalive_ticker.tick().await; // consume immediate first tick
             let mut last_stream_heartbeat = Instant::now();
 
@@ -1656,19 +1652,19 @@ impl ReasonAtom {
                     .as_mut()
                     .reset(tokio::time::Instant::now() + stall_timeout);
                 // Per-event heartbeat (throttled to every 5s)
-                if last_stream_heartbeat.elapsed().as_millis() as u64 >= 5_000 {
-                    if let Some(ref hb) = self.stream_heartbeater {
-                        let now_secs = std::time::SystemTime::now()
-                            .duration_since(std::time::UNIX_EPOCH)
-                            .unwrap_or_default()
-                            .as_secs();
-                        hb.heartbeat(crate::traits::StreamProgress {
-                            accumulated_len: text.len() + thinking.len(),
-                            last_delta_at: now_secs,
-                        })
-                        .await;
-                        last_stream_heartbeat = Instant::now();
-                    }
+                if last_stream_heartbeat.elapsed().as_millis() as u64 >= 5_000
+                    && let Some(ref hb) = self.stream_heartbeater
+                {
+                    let now_secs = std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .unwrap_or_default()
+                        .as_secs();
+                    hb.heartbeat(crate::traits::StreamProgress {
+                        accumulated_len: text.len() + thinking.len(),
+                        last_delta_at: now_secs,
+                    })
+                    .await;
+                    last_stream_heartbeat = Instant::now();
                 }
                 match event? {
                     LlmStreamEvent::TextDelta(delta) => {

--- a/crates/core/src/atoms/reason.rs
+++ b/crates/core/src/atoms/reason.rs
@@ -381,6 +381,10 @@ pub struct ReasonAtom {
     /// Optional file store for capabilities that need filesystem access
     /// (e.g., agent_instructions reads AGENTS.md, skills_discovery scans for skills)
     file_store: Option<Arc<dyn crate::traits::SessionFileSystem>>,
+    /// Optional heartbeater for stream-liveness signalling (EVE-531).
+    stream_heartbeater: Option<Arc<dyn crate::traits::StreamHeartbeater>>,
+    /// Optional provider stall timeout (EVE-531). Default: 120s.
+    provider_stall_timeout: Option<std::time::Duration>,
 }
 
 impl ReasonAtom {
@@ -407,6 +411,8 @@ impl ReasonAtom {
             event_emitter: Arc::new(event_emitter),
             image_resolver: None,
             file_store: None,
+            stream_heartbeater: None,
+            provider_stall_timeout: None,
         }
     }
 
@@ -438,6 +444,22 @@ impl ReasonAtom {
     /// ```
     pub fn with_image_resolver(mut self, resolver: Arc<dyn ImageResolver>) -> Self {
         self.image_resolver = Some(resolver);
+        self
+    }
+
+    /// Set the stream heartbeater for liveness signalling during LLM streaming.
+    pub fn with_stream_heartbeater(
+        mut self,
+        heartbeater: Arc<dyn crate::traits::StreamHeartbeater>,
+    ) -> Self {
+        self.stream_heartbeater = Some(heartbeater);
+        self
+    }
+
+    /// Set the provider stall timeout. If no token arrives within this window,
+    /// the stream is aborted and the activity fails with a retryable error.
+    pub fn with_provider_stall_timeout(mut self, timeout: std::time::Duration) -> Self {
+        self.provider_stall_timeout = Some(timeout);
         self
     }
 }
@@ -1580,7 +1602,74 @@ impl ReasonAtom {
             let mut last_thinking_delta_emit = Instant::now();
             let mut time_to_first_token_ms: Option<u64> = None;
 
-            while let Some(event) = stream.next().await {
+            // EVE-531: stall timeout + keepalive heartbeat for stream-liveness
+            let stall_timeout = self
+                .provider_stall_timeout
+                .unwrap_or(std::time::Duration::from_secs(120));
+            let mut stall_sleep =
+                Box::pin(tokio::time::sleep(stall_timeout));
+            let mut keepalive_ticker = tokio::time::interval(
+                std::time::Duration::from_secs(12),
+            );
+            keepalive_ticker
+                .set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            keepalive_ticker.tick().await; // consume immediate first tick
+            let mut last_stream_heartbeat = Instant::now();
+
+            loop {
+                let event = tokio::select! {
+                    biased;
+                    next = stream.next() => match next {
+                        Some(e) => e,
+                        None => break,
+                    },
+                    _ = &mut stall_sleep => {
+                        tracing::warn!(
+                            session_id = %session_id,
+                            turn_id = %context.turn_id,
+                            stall_secs = stall_timeout.as_secs(),
+                            "ReasonAtom: provider stream stall timeout"
+                        );
+                        return Err(AgentLoopError::llm(format!(
+                            "provider stream stall: no tokens for {}s",
+                            stall_timeout.as_secs()
+                        )));
+                    },
+                    _ = keepalive_ticker.tick() => {
+                        if let Some(ref hb) = self.stream_heartbeater {
+                            let now_secs = std::time::SystemTime::now()
+                                .duration_since(std::time::UNIX_EPOCH)
+                                .unwrap_or_default()
+                                .as_secs();
+                            hb.heartbeat(crate::traits::StreamProgress {
+                                accumulated_len: text.len() + thinking.len(),
+                                last_delta_at: now_secs,
+                            })
+                            .await;
+                            last_stream_heartbeat = Instant::now();
+                        }
+                        continue;
+                    },
+                };
+                // Reset stall deadline on every received stream event
+                stall_sleep
+                    .as_mut()
+                    .reset(tokio::time::Instant::now() + stall_timeout);
+                // Per-event heartbeat (throttled to every 5s)
+                if last_stream_heartbeat.elapsed().as_millis() as u64 >= 5_000 {
+                    if let Some(ref hb) = self.stream_heartbeater {
+                        let now_secs = std::time::SystemTime::now()
+                            .duration_since(std::time::UNIX_EPOCH)
+                            .unwrap_or_default()
+                            .as_secs();
+                        hb.heartbeat(crate::traits::StreamProgress {
+                            accumulated_len: text.len() + thinking.len(),
+                            last_delta_at: now_secs,
+                        })
+                        .await;
+                        last_stream_heartbeat = Instant::now();
+                    }
+                }
                 match event? {
                     LlmStreamEvent::TextDelta(delta) => {
                         // Track time-to-first-token on first non-empty delta

--- a/crates/core/src/atoms/reason.rs
+++ b/crates/core/src/atoms/reason.rs
@@ -1611,6 +1611,14 @@ impl ReasonAtom {
             keepalive_ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
             keepalive_ticker.tick().await; // consume immediate first tick
             let mut last_stream_heartbeat = Instant::now();
+            // Tracks the wall-clock time of the last actual token received.
+            // Updated only on content events; keepalive heartbeats use this
+            // so the control plane can distinguish "alive/slow" from "making
+            // progress" without conflating keepalive pings with real tokens.
+            let mut last_token_at_unix: u64 = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs();
 
             loop {
                 let event = tokio::select! {
@@ -1633,13 +1641,9 @@ impl ReasonAtom {
                     },
                     _ = keepalive_ticker.tick() => {
                         if let Some(ref hb) = self.stream_heartbeater {
-                            let now_secs = std::time::SystemTime::now()
-                                .duration_since(std::time::UNIX_EPOCH)
-                                .unwrap_or_default()
-                                .as_secs();
                             hb.heartbeat(crate::traits::StreamProgress {
                                 accumulated_len: text.len() + thinking.len(),
-                                last_delta_at: now_secs,
+                                last_delta_at: last_token_at_unix,
                             })
                             .await;
                             last_stream_heartbeat = Instant::now();
@@ -1651,21 +1655,6 @@ impl ReasonAtom {
                 stall_sleep
                     .as_mut()
                     .reset(tokio::time::Instant::now() + stall_timeout);
-                // Per-event heartbeat (throttled to every 5s)
-                if last_stream_heartbeat.elapsed().as_millis() as u64 >= 5_000
-                    && let Some(ref hb) = self.stream_heartbeater
-                {
-                    let now_secs = std::time::SystemTime::now()
-                        .duration_since(std::time::UNIX_EPOCH)
-                        .unwrap_or_default()
-                        .as_secs();
-                    hb.heartbeat(crate::traits::StreamProgress {
-                        accumulated_len: text.len() + thinking.len(),
-                        last_delta_at: now_secs,
-                    })
-                    .await;
-                    last_stream_heartbeat = Instant::now();
-                }
                 match event? {
                     LlmStreamEvent::TextDelta(delta) => {
                         // Track time-to-first-token on first non-empty delta
@@ -1680,6 +1669,10 @@ impl ReasonAtom {
                         }
                         text.push_str(&delta);
                         pending_delta.push_str(&delta);
+                        last_token_at_unix = std::time::SystemTime::now()
+                            .duration_since(std::time::UNIX_EPOCH)
+                            .unwrap_or_default()
+                            .as_secs();
 
                         // Run output guardrails on the new accumulated text.
                         // Cheap by contract — runs in the streaming hot path.
@@ -1735,6 +1728,10 @@ impl ReasonAtom {
                         // Accumulate thinking content from extended thinking models
                         thinking.push_str(&delta);
                         pending_thinking_delta.push_str(&delta);
+                        last_token_at_unix = std::time::SystemTime::now()
+                            .duration_since(std::time::UNIX_EPOCH)
+                            .unwrap_or_default()
+                            .as_secs();
                         tracing::debug!(
                             session_id = %session_id,
                             delta_len = delta.len(),
@@ -1946,6 +1943,18 @@ impl ReasonAtom {
                             .await;
                         return Err(AgentLoopError::llm(err));
                     }
+                }
+                // Per-event heartbeat after processing the event, so accumulated_len
+                // reflects the just-received tokens. Throttled to every 5s.
+                if last_stream_heartbeat.elapsed().as_millis() as u64 >= 5_000
+                    && let Some(ref hb) = self.stream_heartbeater
+                {
+                    hb.heartbeat(crate::traits::StreamProgress {
+                        accumulated_len: text.len() + thinking.len(),
+                        last_delta_at: last_token_at_unix,
+                    })
+                    .await;
+                    last_stream_heartbeat = Instant::now();
                 }
             }
             (

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -190,11 +190,10 @@ pub use traits::{
     DisabledSessionFileSystemFactory, DurableToolResultStore, EventEmitter, HarnessStore,
     ImageResolver, KeyInfo, LeasedResourceStore, LlmProviderStore, ModelWithProvider,
     NoopDurableToolResultStore, NoopEventEmitter, NoopStreamHeartbeater, OutboundToolRateLimiter,
-    ResolvedImage, StreamHeartbeater, StreamProgress,
-    SecretInfo, SessionFileStore, SessionFileSystem, SessionFileSystemFactory,
+    ResolvedImage, SecretInfo, SessionFileStore, SessionFileSystem, SessionFileSystemFactory,
     SessionFileSystemFactoryContext, SessionMutator, SessionResourceRegistry, SessionSqlDbStoreRef,
-    SessionStorageStore, SessionStore, ToolCallClaimResult, ToolContext, ToolExecutor,
-    UserConnectionResolver,
+    SessionStorageStore, SessionStore, StreamHeartbeater, StreamProgress, ToolCallClaimResult,
+    ToolContext, ToolExecutor, UserConnectionResolver,
 };
 pub use user_facing_error::{
     UserFacingError, UserFacingErrorContext, UserFacingErrorFields, classify_runtime_error_message,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -189,7 +189,8 @@ pub use runtime_context::{
 pub use traits::{
     DisabledSessionFileSystemFactory, DurableToolResultStore, EventEmitter, HarnessStore,
     ImageResolver, KeyInfo, LeasedResourceStore, LlmProviderStore, ModelWithProvider,
-    NoopDurableToolResultStore, NoopEventEmitter, OutboundToolRateLimiter, ResolvedImage,
+    NoopDurableToolResultStore, NoopEventEmitter, NoopStreamHeartbeater, OutboundToolRateLimiter,
+    ResolvedImage, StreamHeartbeater, StreamProgress,
     SecretInfo, SessionFileStore, SessionFileSystem, SessionFileSystemFactory,
     SessionFileSystemFactoryContext, SessionMutator, SessionResourceRegistry, SessionSqlDbStoreRef,
     SessionStorageStore, SessionStore, ToolCallClaimResult, ToolContext, ToolExecutor,

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -969,6 +969,42 @@ impl DurableToolResultStore for NoopDurableToolResultStore {
     }
 }
 
+// ============================================================================
+// StreamHeartbeater — per-stream liveness signal for Reason activity (EVE-531)
+// ============================================================================
+
+/// Progress snapshot carried in each stream heartbeat.
+#[derive(Debug, Clone)]
+pub struct StreamProgress {
+    /// Accumulated text + thinking length (characters) at the time of heartbeat.
+    pub accumulated_len: usize,
+    /// Wall-clock time of the most recent received token (Unix seconds).
+    pub last_delta_at: u64,
+}
+
+/// Heartbeater the Reason streaming loop calls on delta batches and a keepalive
+/// timer, signalling that the provider connection is alive.
+///
+/// Implementations bridge to the durable-execution layer (e.g. gRPC).
+/// The no-op is used in dev/test where no durable store is present.
+#[async_trait]
+pub trait StreamHeartbeater: Send + Sync {
+    /// Signal stream liveness with current progress.
+    ///
+    /// Must be best-effort: errors must not propagate to the caller.
+    /// Cancel-safety is critical — if the worker dies the heartbeat stops
+    /// and the existing task-level reclaim takes over.
+    async fn heartbeat(&self, progress: StreamProgress);
+}
+
+/// No-op heartbeater — treats every stream as perpetually alive (dev/test).
+pub struct NoopStreamHeartbeater;
+
+#[async_trait]
+impl StreamHeartbeater for NoopStreamHeartbeater {
+    async fn heartbeat(&self, _progress: StreamProgress) {}
+}
+
 /// Runtime context provided to tools during execution.
 ///
 /// This context contains:

--- a/crates/runtime/src/host.rs
+++ b/crates/runtime/src/host.rs
@@ -186,6 +186,18 @@ pub trait RuntimeHostAdapter: Send + Sync + Clone + 'static {
         None
     }
 
+    /// Stream-liveness heartbeater for the Reason activity (EVE-531).
+    /// Default: `None` (no heartbeating — dev/in-memory environments use no-op).
+    fn stream_heartbeater(&self) -> Option<Arc<dyn everruns_core::StreamHeartbeater>> {
+        None
+    }
+
+    /// Provider stall timeout for the Reason activity (EVE-531).
+    /// Default: `None` (use built-in 120s default).
+    fn provider_stall_timeout(&self) -> Option<std::time::Duration> {
+        None
+    }
+
     /// MCP executor routing `mcp_*` tool calls for this session, if the host
     /// configures MCP (specs/runtime-mcp.md D4). Default: `None`, so hosts
     /// without scoped MCP servers keep the plain tool registry unchanged.
@@ -956,6 +968,12 @@ pub async fn execute_reason_activity<A: RuntimeHostAdapter>(
     .with_file_store(adapter.file_store());
     if let Some(image_resolver) = adapter.image_resolver(org_id) {
         atom = atom.with_image_resolver(image_resolver);
+    }
+    if let Some(hb) = adapter.stream_heartbeater() {
+        atom = atom.with_stream_heartbeater(hb);
+    }
+    if let Some(timeout) = adapter.provider_stall_timeout() {
+        atom = atom.with_provider_stall_timeout(timeout);
     }
 
     let input = ReasonInput {

--- a/crates/runtime/src/host.rs
+++ b/crates/runtime/src/host.rs
@@ -187,7 +187,7 @@ pub trait RuntimeHostAdapter: Send + Sync + Clone + 'static {
     }
 
     /// Stream-liveness heartbeater for the Reason activity (EVE-531).
-    /// Default: `None` (no heartbeating — dev/in-memory environments use no-op).
+    /// Default: `None` (no heartbeats sent — durable workers supply one).
     fn stream_heartbeater(&self) -> Option<Arc<dyn everruns_core::StreamHeartbeater>> {
         None
     }

--- a/crates/worker/src/activities.rs
+++ b/crates/worker/src/activities.rs
@@ -20,6 +20,7 @@ use everruns_runtime::{
     execute_reason_activity as runtime_execute_reason_activity,
 };
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 
 use crate::grpc_adapters::GrpcClient;
 use crate::grpc_worker_adapters::GrpcWorkerAdapters;
@@ -88,6 +89,7 @@ pub async fn reason_activity(
     org_id: i64,
     input: ReasonInput,
     platform_definition: &PlatformDefinition,
+    stream_heartbeater: Option<Arc<dyn everruns_core::traits::StreamHeartbeater>>,
 ) -> Result<ReasonResult> {
     tracing::info!(
         org_id = org_id,
@@ -97,16 +99,16 @@ pub async fn reason_activity(
         "Executing reason_activity"
     );
 
-    let result = runtime_execute_reason_activity(
-        &WorkerRuntimeHost::new(GrpcWorkerAdapters::from_client_with_platform_definition(
-            grpc_client,
-            platform_definition.clone(),
-        )),
-        org_id,
-        input,
-    )
-    .await
-    .context("ReasonAtom execution failed")?;
+    let mut adapters = GrpcWorkerAdapters::from_client_with_platform_definition(
+        grpc_client,
+        platform_definition.clone(),
+    );
+    if let Some(hb) = stream_heartbeater {
+        adapters = adapters.with_stream_heartbeater(hb);
+    }
+    let result = runtime_execute_reason_activity(&WorkerRuntimeHost::new(adapters), org_id, input)
+        .await
+        .context("ReasonAtom execution failed")?;
 
     // Turn lifecycle events (turn.completed, turn.failed, session.idled) are NOT
     // emitted here. They are deferred to the workflow scheduler which checks for

--- a/crates/worker/src/durable_worker.rs
+++ b/crates/worker/src/durable_worker.rs
@@ -911,6 +911,7 @@ impl DurableWorker {
                             grpc_client.clone(),
                             &turn_input,
                             self.store.clone(),
+                            task_id,
                         )
                         .await
                     }
@@ -1214,6 +1215,7 @@ impl DurableWorker {
         grpc_client: GrpcClient,
         input: &DurableTurnInput,
         store: Arc<Mutex<GrpcDurableStore>>,
+        task_id: Uuid,
     ) -> Result<serde_json::Value> {
         debug!(
             session_id = %input.session_id,
@@ -1279,12 +1281,21 @@ impl DurableWorker {
             iteration: input.iteration,
         };
 
+        // EVE-531: create stream heartbeater to signal provider liveness
+        let stream_heartbeater: Option<Arc<dyn everruns_core::traits::StreamHeartbeater>> =
+            Some(Arc::new(crate::stream_heartbeater::GrpcTaskHeartbeater {
+                store: store.clone(),
+                task_id,
+                worker_id: self.config.worker_id.clone(),
+            }));
+
         // Use the existing reason_activity function with gRPC adapters
         let result = reason_activity(
             grpc_client,
             input.org_id,
             reason_input,
             self.platform_definition.as_ref(),
+            stream_heartbeater,
         )
         .await;
 

--- a/crates/worker/src/grpc_worker_adapters.rs
+++ b/crates/worker/src/grpc_worker_adapters.rs
@@ -41,6 +41,7 @@ use crate::worker_adapters::{TurnContext, WorkerAdapters};
 pub struct GrpcWorkerAdapters {
     client: GrpcClient,
     platform_definition: PlatformDefinition,
+    stream_heartbeater: Option<Arc<dyn everruns_core::traits::StreamHeartbeater>>,
 }
 
 impl GrpcWorkerAdapters {
@@ -62,6 +63,7 @@ impl GrpcWorkerAdapters {
         Ok(Self {
             client,
             platform_definition,
+            stream_heartbeater: None,
         })
     }
 
@@ -81,7 +83,17 @@ impl GrpcWorkerAdapters {
         Self {
             client,
             platform_definition,
+            stream_heartbeater: None,
         }
+    }
+
+    /// Set the stream heartbeater for liveness signalling (EVE-531).
+    pub fn with_stream_heartbeater(
+        mut self,
+        heartbeater: Arc<dyn everruns_core::traits::StreamHeartbeater>,
+    ) -> Self {
+        self.stream_heartbeater = Some(heartbeater);
+        self
     }
 
     /// Get the underlying GrpcClient (for MCP executor)
@@ -463,6 +475,10 @@ impl WorkerAdapters for GrpcWorkerAdapters {
             GrpcPaymentAuthority::new(self.client.clone(), org_id)
                 .with_agent_id(agent_id.map(|id| id.to_string())),
         ))
+    }
+
+    fn stream_heartbeater(&self) -> Option<Arc<dyn everruns_core::StreamHeartbeater>> {
+        self.stream_heartbeater.clone()
     }
 
     async fn invoke_scheduled_app_channel(

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -26,6 +26,7 @@ pub mod platform;
 pub mod runner;
 pub mod runtime_host;
 pub mod session_lifecycle;
+mod stream_heartbeater;
 pub mod task_error;
 pub mod unified_worker;
 pub mod worker_adapters;
@@ -55,6 +56,7 @@ pub use grpc_adapters::{
 // Re-export task worker types
 pub use grpc_worker_adapters::GrpcWorkerAdapters;
 pub use runtime_host::WorkerRuntimeHost;
+pub use stream_heartbeater::GrpcTaskHeartbeater;
 pub use unified_worker::{TaskWorker, TaskWorkerConfig};
 pub use worker_adapters::{
     AdapterAgentStore, AdapterEventEmitter, AdapterLlmProviderStore, AdapterMessageRetriever,

--- a/crates/worker/src/runtime_host.rs
+++ b/crates/worker/src/runtime_host.rs
@@ -279,6 +279,10 @@ impl<A: WorkerAdapters> RuntimeHostAdapter for WorkerRuntimeHost<A> {
         self.adapters.stream_heartbeater()
     }
 
+    fn provider_stall_timeout(&self) -> Option<std::time::Duration> {
+        self.adapters.provider_stall_timeout()
+    }
+
     /// Execute `mcp_*` tool calls by resolving server connections over gRPC and
     /// calling them through the shared MCP client over the platform egress
     /// boundary (SSRF-guarded). Returns `None` when no egress service is

--- a/crates/worker/src/runtime_host.rs
+++ b/crates/worker/src/runtime_host.rs
@@ -275,6 +275,10 @@ impl<A: WorkerAdapters> RuntimeHostAdapter for WorkerRuntimeHost<A> {
         self.adapters.durable_tool_result_store()
     }
 
+    fn stream_heartbeater(&self) -> Option<Arc<dyn everruns_core::StreamHeartbeater>> {
+        self.adapters.stream_heartbeater()
+    }
+
     /// Execute `mcp_*` tool calls by resolving server connections over gRPC and
     /// calling them through the shared MCP client over the platform egress
     /// boundary (SSRF-guarded). Returns `None` when no egress service is

--- a/crates/worker/src/stream_heartbeater.rs
+++ b/crates/worker/src/stream_heartbeater.rs
@@ -1,0 +1,40 @@
+// Stream-liveness heartbeater bridging ReasonAtom to the durable task store (EVE-531).
+
+use async_trait::async_trait;
+use everruns_core::traits::{StreamHeartbeater, StreamProgress};
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use uuid::Uuid;
+
+use crate::grpc_durable_store::GrpcDurableStore;
+
+/// Heartbeater that calls `heartbeat_task` via the durable store gRPC client.
+///
+/// Created per-task in `execute_reason_activity` and wired into `GrpcWorkerAdapters`.
+/// Errors are logged but never propagated so they cannot disrupt the streaming loop.
+pub struct GrpcTaskHeartbeater {
+    pub store: Arc<Mutex<GrpcDurableStore>>,
+    pub task_id: Uuid,
+    pub worker_id: String,
+}
+
+#[async_trait]
+impl StreamHeartbeater for GrpcTaskHeartbeater {
+    async fn heartbeat(&self, progress: StreamProgress) {
+        let details = serde_json::json!({
+            "accumulated_len": progress.accumulated_len,
+            "last_delta_at": progress.last_delta_at,
+        });
+        let mut store = self.store.lock().await;
+        if let Err(e) = store
+            .heartbeat_task(self.task_id, &self.worker_id, Some(details))
+            .await
+        {
+            tracing::debug!(
+                task_id = %self.task_id,
+                error = %e,
+                "Stream heartbeat failed (non-fatal)"
+            );
+        }
+    }
+}

--- a/crates/worker/src/worker_adapters.rs
+++ b/crates/worker/src/worker_adapters.rs
@@ -316,7 +316,7 @@ pub trait WorkerAdapters: Send + Sync + Clone + 'static {
     }
 
     /// Stream-liveness heartbeater for the Reason activity (EVE-531).
-    /// Default: `None` (no heartbeating — dev/test environments use no-op).
+    /// Default: `None` (no heartbeats sent — durable workers supply one).
     fn stream_heartbeater(&self) -> Option<Arc<dyn everruns_core::StreamHeartbeater>> {
         None
     }

--- a/crates/worker/src/worker_adapters.rs
+++ b/crates/worker/src/worker_adapters.rs
@@ -315,6 +315,18 @@ pub trait WorkerAdapters: Send + Sync + Clone + 'static {
         None
     }
 
+    /// Stream-liveness heartbeater for the Reason activity (EVE-531).
+    /// Default: `None` (no heartbeating — dev/test environments use no-op).
+    fn stream_heartbeater(&self) -> Option<Arc<dyn everruns_core::StreamHeartbeater>> {
+        None
+    }
+
+    /// Provider stall timeout for the Reason activity (EVE-531).
+    /// Default: `None` (use built-in 120s default in ReasonAtom).
+    fn provider_stall_timeout(&self) -> Option<std::time::Duration> {
+        None
+    }
+
     /// Invoke an app schedule channel when a durable schedule fires.
     async fn invoke_scheduled_app_channel(
         &self,


### PR DESCRIPTION
## What

Implements EVE-531: stream-liveness heartbeating for the Reason (LLM) activity, preventing slow-but-alive provider streams from being spuriously reclaimed as dead workers (double-billing, duplicate calls).

## Changes

### `everruns-core`
- **`StreamHeartbeater` trait** (`traits.rs`): `async fn heartbeat(progress: StreamProgress)` — best-effort, cancel-safe. `StreamProgress` carries `accumulated_len` and `last_delta_at` (Unix seconds) so the control plane can distinguish "alive/slow" from "dead/silent".
- **`NoopStreamHeartbeater`**: no-op for dev/in-memory environments.
- **`ReasonAtom`** (`atoms/reason.rs`): replaced the `while let Some(event) = stream.next().await` polling loop with `loop { tokio::select! { ... } }` supporting:
  - **Stall timeout** (default 120s, configurable): if no token arrives within the window, the activity aborts with a retryable error rather than silently hanging.
  - **Keepalive ticker** (every 12s): fires heartbeat during token gaps so slow models (extended thinking, high latency) don't lose liveness signal.
  - **Per-event heartbeats** (throttled to 5s intervals): called after each delta batch for active streams.
- New builder methods: `with_stream_heartbeater()`, `with_provider_stall_timeout()`.

### `everruns-runtime`
- `RuntimeHostAdapter`: added optional `stream_heartbeater()` and `provider_stall_timeout()` methods (default `None`).
- `execute_reason_activity`: wires both into `ReasonAtom` construction.

### `everruns-worker`
- **`GrpcTaskHeartbeater`** (new `stream_heartbeater.rs`): calls `heartbeat_task(task_id, worker_id, details)` via the durable gRPC store, carrying `{accumulated_len, last_delta_at}` in the details JSON. Errors are logged at `debug` level and never propagated.
- `WorkerAdapters` trait: optional `stream_heartbeater()` / `provider_stall_timeout()` methods (default `None`).
- `GrpcWorkerAdapters`: `stream_heartbeater` field + `with_stream_heartbeater()` builder + `stream_heartbeater()` override.
- `WorkerRuntimeHost`: forwards `stream_heartbeater()` from adapters to `RuntimeHostAdapter`.
- `execute_reason_activity` (`durable_worker.rs`): creates `GrpcTaskHeartbeater` per-task and passes it through to `reason_activity`.
- `reason_activity` (`activities.rs`): accepts optional `stream_heartbeater` parameter and wires it into adapters.

## How it was validated

- `just pre-push` passes: fmt, clippy, lockfile, migration ordering, commit attribution all clean.
- All three crates compile: `everruns-core`, `everruns-runtime`, `everruns-worker`.
- Design invariants preserved:
  - **Worker-liveness** (existing 10s task heartbeat background task) and **stream-liveness** (this PR) are independent clocks answering different questions.
  - If the worker dies mid-stream, heartbeat calls stop and the existing 60s reclaim takes over — cancel-safety holds.
  - `GrpcTaskHeartbeater` errors are non-fatal; stream failures only propagate via the stall timeout.

## Security

- `TM-TOOL`: no new tool surface. `TM-LLM`: no changes to prompt construction or model params. `TM-DOS`: stall timeout bounds stream duration; no unbounded resources introduced. No other threat model categories touched.

## Follow-ups

- **EVE-532**: Partial-stream finalize on replay (ContinuePartial) — if a reason activity is legitimately reclaimed, decide whether to continue from accumulated text or restart. This PR provides the `accumulated_len` signal needed for that decision.
- Integration tests for the slow-stream / stall-timeout scenarios (scripted LlmSim) are tracked in the issue acceptance criteria and deferred to a follow-up test pass once EVE-532 lands.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WFZRpE41urNbQT9NQJSi7K)_