### PR TITLE
feat(core): transcript repair for dangling tool calls (EVE-533)

### DIFF
--- a/crates/core/src/atoms/act.rs
+++ b/crates/core/src/atoms/act.rs
@@ -2864,6 +2864,24 @@ mod tests {
             }
             Ok(false)
         }
+
+        async fn get_tool_call_status(
+            &self,
+            turn_id: &str,
+            tool_call_id: &str,
+        ) -> crate::error::Result<Option<crate::traits::DurableToolCallStatus>> {
+            let key = (turn_id.to_string(), tool_call_id.to_string());
+            let rows = self.rows.lock().unwrap();
+            Ok(rows.get(&key).map(|row| match row.status.as_str() {
+                "settled" => crate::traits::DurableToolCallStatus::Settled {
+                    result_json: row.result_json.clone(),
+                },
+                "interrupted" => crate::traits::DurableToolCallStatus::Interrupted {
+                    result_json: Some(row.result_json.clone()),
+                },
+                _ => crate::traits::DurableToolCallStatus::Running,
+            }))
+        }
     }
 
     fn make_act_input_with_store(

--- a/crates/core/src/atoms/reason.rs
+++ b/crates/core/src/atoms/reason.rs
@@ -34,7 +34,8 @@ use crate::events::{
     LlmToolSearchInfo, OutputMessageCompletedData, OutputMessageDeltaData,
     OutputMessageReplacedData, OutputMessageStartedData, ReasonCompletedData, ReasonItemData,
     ReasonStartedData, ReasonThinkingCompletedData, ReasonThinkingDeltaData,
-    ReasonThinkingStartedData, TokenUsage, ToolDefinitionSummary,
+    ReasonThinkingStartedData, TokenUsage, ToolDefinitionSummary, TranscriptRepairAction,
+    TranscriptRepairedData,
 };
 use crate::llm_driver_registry::{
     DriverRegistry, LlmCallConfigBuilder, LlmCompletionMetadata, LlmMessage, LlmMessageContent,
@@ -52,8 +53,8 @@ use crate::output_guardrail::{
 use crate::runtime_context::{AssembledTurnContext, assemble_turn_context};
 use crate::tool_types::{ToolCall, ToolDefinition};
 use crate::traits::{
-    AgentStore, EventEmitter, HarnessStore, ImageResolver, LlmProviderStore, ModelWithProvider,
-    ResolvedImage, SessionStore,
+    AgentStore, DurableToolCallStatus, DurableToolResultStore, EventEmitter, HarnessStore,
+    ImageResolver, LlmProviderStore, ModelWithProvider, ResolvedImage, SessionStore,
 };
 use crate::typed_id::{AgentId, HarnessId, MessageId, SessionId};
 use crate::{UserFacingErrorContext, user_facing_error_codes};
@@ -62,35 +63,139 @@ use crate::{UserFacingErrorContext, user_facing_error_codes};
 // Helper Functions
 // ============================================================================
 
-/// Patch dangling tool calls by adding synthetic "cancelled" results.
+/// Repair dangling tool calls (EVE-533): for every assistant tool_call with no matching
+/// ToolResult, synthesize a well-formed result so the next LLM call does not reject the
+/// transcript. Consults `durable_tool_results` (EVE-530) when available:
 ///
-/// This ensures every tool call has a corresponding tool result,
-/// preventing LLM API errors (e.g., OpenAI requires every tool_call to have a result).
-fn patch_dangling_tool_calls(messages: &[Message]) -> Vec<Message> {
+/// - `Settled` row found   → replay the stored result directly.
+/// - `Interrupted` row     → replay the stored interrupted error.
+/// - `Running` (stale)     → synthesize an "interrupted" placeholder.
+/// - Row not found         → synthesize a "cancelled" placeholder.
+///
+/// Emits `transcript.repaired` events via `event_emitter` for each repaired call.
+async fn repair_dangling_tool_calls(
+    messages: &[Message],
+    durable_store: Option<&dyn DurableToolResultStore>,
+    event_emitter: &dyn EventEmitter,
+    session_id: crate::typed_id::SessionId,
+    event_context: &EventContext,
+    turn_id: &str,
+) -> Vec<Message> {
     let mut result = Vec::new();
 
     for (i, msg) in messages.iter().enumerate() {
         result.push(msg.clone());
 
-        // After an assistant message with tool calls, add cancelled results for any missing ones
-        if msg.role == MessageRole::Agent && msg.has_tool_calls() {
-            for tc in msg.tool_calls() {
-                // Look for a matching tool result in ALL subsequent messages
-                let has_result = messages[(i + 1)..]
-                    .iter()
-                    .any(|m| m.role == MessageRole::ToolResult && m.tool_call_id() == Some(&tc.id));
+        if msg.role != MessageRole::Agent || !msg.has_tool_calls() {
+            continue;
+        }
 
-                if !has_result {
-                    result.push(Message::tool_result(
+        for tc in msg.tool_calls() {
+            let has_result = messages[(i + 1)..]
+                .iter()
+                .any(|m| m.role == MessageRole::ToolResult && m.tool_call_id() == Some(&tc.id));
+
+            if has_result {
+                continue;
+            }
+
+            // Consult durable_tool_results to determine the best repair strategy.
+            let (repair_msg, action) = if let Some(store) = durable_store {
+                match store.get_tool_call_status(turn_id, &tc.id).await {
+                    Ok(Some(DurableToolCallStatus::Settled { result_json })) => {
+                        // A settled result exists in durable storage; deserialize and replay it.
+                        let repair = match serde_json::from_value::<crate::tool_types::ToolResult>(
+                            result_json.clone(),
+                        ) {
+                            Ok(tr) => Message::tool_result(&tc.id, tr.result, tr.error),
+                            Err(_) => Message::tool_result(&tc.id, Some(result_json), None),
+                        };
+                        (repair, TranscriptRepairAction::Replay)
+                    }
+                    Ok(Some(DurableToolCallStatus::Interrupted { result_json })) => {
+                        // Settled as interrupted by a prior recovery.
+                        let err = result_json
+                            .as_ref()
+                            .and_then(|v| {
+                                serde_json::from_value::<crate::tool_types::ToolResult>(v.clone())
+                                    .ok()
+                            })
+                            .and_then(|tr| tr.error)
+                            .unwrap_or_else(|| {
+                                "tool execution did not complete before recovery; result unknown"
+                                    .to_string()
+                            });
+                        (
+                            Message::tool_result(&tc.id, None, Some(err)),
+                            TranscriptRepairAction::Replay,
+                        )
+                    }
+                    Ok(Some(DurableToolCallStatus::Running)) => {
+                        // Stale running claim from a dead worker; safe to synthesize.
+                        (
+                            Message::tool_result(
+                                &tc.id,
+                                None,
+                                Some(
+                                    "interrupted - tool execution was interrupted by worker \
+                                     failure and the result is uncertain; do not retry \
+                                     automatically"
+                                        .to_string(),
+                                ),
+                            ),
+                            TranscriptRepairAction::Synthesize,
+                        )
+                    }
+                    Ok(None) | Err(_) => {
+                        // No durable record: tool was never dispatched or store is unavailable.
+                        (
+                            Message::tool_result(
+                                &tc.id,
+                                None,
+                                Some(
+                                    "interrupted - tool was not executed before recovery; \
+                                     safe to retry"
+                                        .to_string(),
+                                ),
+                            ),
+                            TranscriptRepairAction::Synthesize,
+                        )
+                    }
+                }
+            } else {
+                // No durable store; fall back to generic cancelled.
+                (
+                    Message::tool_result(
                         &tc.id,
                         None,
                         Some(
                             "cancelled - another message came in before it could be completed"
                                 .to_string(),
                         ),
-                    ));
-                }
+                    ),
+                    TranscriptRepairAction::Synthesize,
+                )
+            };
+
+            // Emit transcript.repaired event for observability.
+            let repair_event = EventRequest::new(
+                session_id,
+                event_context.clone(),
+                TranscriptRepairedData {
+                    tool_call_id: tc.id.clone(),
+                    tool_name: Some(tc.name.clone()),
+                    action,
+                },
+            );
+            if let Err(e) = event_emitter.emit(repair_event).await {
+                tracing::warn!(
+                    tool_call_id = %tc.id,
+                    error = %e,
+                    "transcript repair: failed to emit transcript.repaired event"
+                );
             }
+
+            result.push(repair_msg);
         }
     }
 
@@ -405,6 +510,8 @@ pub struct ReasonAtom {
     stream_heartbeater: Option<Arc<dyn crate::traits::StreamHeartbeater>>,
     /// Optional provider stall timeout (EVE-531). Default: 120s.
     provider_stall_timeout: Option<std::time::Duration>,
+    /// Optional durable tool result store for transcript repair (EVE-533).
+    durable_tool_result_store: Option<Arc<dyn DurableToolResultStore>>,
 }
 
 impl ReasonAtom {
@@ -433,6 +540,7 @@ impl ReasonAtom {
             file_store: None,
             stream_heartbeater: None,
             provider_stall_timeout: None,
+            durable_tool_result_store: None,
         }
     }
 
@@ -480,6 +588,19 @@ impl ReasonAtom {
     /// the stream is aborted and the activity fails with a retryable error.
     pub fn with_provider_stall_timeout(mut self, timeout: std::time::Duration) -> Self {
         self.provider_stall_timeout = Some(timeout);
+        self
+    }
+
+    /// Set the durable tool result store for transcript repair (EVE-533).
+    ///
+    /// When provided, transcript repair consults this store to replay settled tool
+    /// results or synthesize appropriate interrupted placeholders rather than always
+    /// emitting a generic "cancelled" message.
+    pub fn with_durable_tool_result_store(
+        mut self,
+        store: Arc<dyn DurableToolResultStore>,
+    ) -> Self {
+        self.durable_tool_result_store = Some(store);
         self
     }
 }
@@ -889,8 +1010,19 @@ impl ReasonAtom {
                 }
             });
 
-        // 9. Patch dangling tool calls (add cancelled results for tool calls without responses)
-        let patched_messages = patch_dangling_tool_calls(&messages);
+        // 9. Repair dangling tool calls (EVE-533): ensure every assistant tool_call
+        // has a matching ToolResult before the LLM call. Consults durable_tool_results
+        // when available to replay settled results or synthesize interrupted placeholders.
+        let repair_event_context = EventContext::from_atom_context(context);
+        let patched_messages = repair_dangling_tool_calls(
+            &messages,
+            self.durable_tool_result_store.as_deref(),
+            self.event_emitter.as_ref(),
+            session_id,
+            &repair_event_context,
+            &context.turn_id.to_string(),
+        )
+        .await;
 
         // 9b. Let enabled capabilities build a prompt-facing model view from
         // lossless stored messages. Storage remains unchanged.
@@ -2453,15 +2585,24 @@ mod tests {
         }));
     }
 
-    #[test]
-    fn test_patch_dangling_tool_calls_no_tool_calls() {
+    #[tokio::test]
+    async fn test_repair_dangling_tool_calls_no_tool_calls() {
+        use crate::events::EventContext;
+        use crate::typed_id::SessionId;
         let messages = vec![Message::user("Hello"), Message::assistant("Hi there!")];
-        let patched = patch_dangling_tool_calls(&messages);
+        let emitter = crate::traits::NoopEventEmitter;
+        let session_id = SessionId::new();
+        let ctx = EventContext::empty();
+        let patched =
+            repair_dangling_tool_calls(&messages, None, &emitter, session_id, &ctx, "turn_01")
+                .await;
         assert_eq!(patched.len(), 2);
     }
 
-    #[test]
-    fn test_patch_dangling_tool_calls_with_result() {
+    #[tokio::test]
+    async fn test_repair_dangling_tool_calls_with_result() {
+        use crate::events::EventContext;
+        use crate::typed_id::SessionId;
         let tool_call = ToolCall {
             id: "call_123".to_string(),
             name: "get_weather".to_string(),
@@ -2474,12 +2615,19 @@ mod tests {
             Message::tool_result("call_123", Some(serde_json::json!({"temp": 72})), None),
         ];
 
-        let patched = patch_dangling_tool_calls(&messages);
+        let emitter = crate::traits::NoopEventEmitter;
+        let session_id = SessionId::new();
+        let ctx = EventContext::empty();
+        let patched =
+            repair_dangling_tool_calls(&messages, None, &emitter, session_id, &ctx, "turn_01")
+                .await;
         assert_eq!(patched.len(), 3);
     }
 
-    #[test]
-    fn test_patch_dangling_tool_calls_missing_result() {
+    #[tokio::test]
+    async fn test_repair_dangling_tool_calls_missing_result_no_store() {
+        use crate::events::EventContext;
+        use crate::typed_id::SessionId;
         let tool_call = ToolCall {
             id: "call_456".to_string(),
             name: "search_web".to_string(),
@@ -2492,11 +2640,94 @@ mod tests {
             Message::user("Actually, never mind"),
         ];
 
-        let patched = patch_dangling_tool_calls(&messages);
+        let emitter = crate::traits::NoopEventEmitter;
+        let session_id = SessionId::new();
+        let ctx = EventContext::empty();
+        let patched =
+            repair_dangling_tool_calls(&messages, None, &emitter, session_id, &ctx, "turn_01")
+                .await;
         // Should have added a cancelled result
         assert_eq!(patched.len(), 4);
         assert_eq!(patched[2].role, MessageRole::ToolResult);
         assert_eq!(patched[2].tool_call_id(), Some("call_456"));
+    }
+
+    #[tokio::test]
+    async fn test_repair_dangling_tool_calls_settled_result_replayed() {
+        use crate::events::EventContext;
+        use crate::traits::{DurableToolCallStatus, DurableToolResultStore, ToolCallClaimResult};
+        use crate::typed_id::SessionId;
+
+        struct MockSettledStore;
+        #[async_trait::async_trait]
+        impl DurableToolResultStore for MockSettledStore {
+            async fn try_claim_tool_call(
+                &self,
+                _: &str,
+                _: &str,
+                _: &str,
+                _: &str,
+            ) -> crate::error::Result<ToolCallClaimResult> {
+                Ok(ToolCallClaimResult::Claimed {
+                    claim_token: uuid::Uuid::new_v4(),
+                })
+            }
+            async fn settle_tool_call(
+                &self,
+                _: &str,
+                _: &str,
+                _: serde_json::Value,
+                _: &str,
+                _: uuid::Uuid,
+            ) -> crate::error::Result<bool> {
+                Ok(true)
+            }
+            async fn get_tool_call_status(
+                &self,
+                _turn_id: &str,
+                _tool_call_id: &str,
+            ) -> crate::error::Result<Option<DurableToolCallStatus>> {
+                Ok(Some(DurableToolCallStatus::Settled {
+                    result_json: serde_json::json!({
+                        "tool_call_id": "call_789",
+                        "result": {"answer": 42},
+                        "error": null,
+                        "images": null,
+                        "connection_required": null,
+                        "raw_output": null
+                    }),
+                }))
+            }
+        }
+
+        let tool_call = ToolCall {
+            id: "call_789".to_string(),
+            name: "compute".to_string(),
+            arguments: serde_json::json!({"x": 21}),
+        };
+        let messages = vec![
+            Message::user("Compute"),
+            Message::assistant_with_tools("Computing...", vec![tool_call]),
+        ];
+
+        let store = MockSettledStore;
+        let emitter = crate::traits::NoopEventEmitter;
+        let session_id = SessionId::new();
+        let ctx = EventContext::empty();
+        let patched = repair_dangling_tool_calls(
+            &messages,
+            Some(&store as &dyn DurableToolResultStore),
+            &emitter,
+            session_id,
+            &ctx,
+            "turn_01",
+        )
+        .await;
+
+        // Settled result should be replayed (not cancelled message)
+        assert_eq!(patched.len(), 3);
+        assert_eq!(patched[2].role, MessageRole::ToolResult);
+        assert_eq!(patched[2].tool_call_id(), Some("call_789"));
     }
 
     #[test]

--- a/crates/core/src/atoms/reason.rs
+++ b/crates/core/src/atoms/reason.rs
@@ -69,8 +69,9 @@ use crate::{UserFacingErrorContext, user_facing_error_codes};
 ///
 /// - `Settled` row found   → replay the stored result directly.
 /// - `Interrupted` row     → replay the stored interrupted error.
-/// - `Running` (stale)     → synthesize an "interrupted" placeholder.
-/// - Row not found         → synthesize a "cancelled" placeholder.
+/// - `Running` (stale)     → synthesize an "interrupted – uncertain – do not retry" placeholder.
+/// - Row not found         → synthesize an "interrupted – not executed – safe to retry" placeholder.
+/// - Store error           → synthesize an "interrupted – status unknown – do not retry" placeholder.
 ///
 /// Emits `transcript.repaired` events via `event_emitter` for each repaired call.
 async fn repair_dangling_tool_calls(
@@ -146,8 +147,8 @@ async fn repair_dangling_tool_calls(
                             TranscriptRepairAction::Synthesize,
                         )
                     }
-                    Ok(None) | Err(_) => {
-                        // No durable record: tool was never dispatched or store is unavailable.
+                    Ok(None) => {
+                        // No durable record: tool was never dispatched before recovery.
                         (
                             Message::tool_result(
                                 &tc.id,
@@ -155,6 +156,26 @@ async fn repair_dangling_tool_calls(
                                 Some(
                                     "interrupted - tool was not executed before recovery; \
                                      safe to retry"
+                                        .to_string(),
+                                ),
+                            ),
+                            TranscriptRepairAction::Synthesize,
+                        )
+                    }
+                    Err(e) => {
+                        // Store temporarily unavailable: we cannot know whether the tool ran.
+                        tracing::warn!(
+                            tool_call_id = %tc.id,
+                            error = %e,
+                            "transcript repair: durable store error; status unknown"
+                        );
+                        (
+                            Message::tool_result(
+                                &tc.id,
+                                None,
+                                Some(
+                                    "interrupted - tool execution status unknown due to \
+                                     store error; do not retry automatically"
                                         .to_string(),
                                 ),
                             ),
@@ -2728,6 +2749,238 @@ mod tests {
         assert_eq!(patched.len(), 3);
         assert_eq!(patched[2].role, MessageRole::ToolResult);
         assert_eq!(patched[2].tool_call_id(), Some("call_789"));
+    }
+
+    #[tokio::test]
+    async fn test_repair_dangling_tool_calls_interrupted_result_replayed() {
+        use crate::events::EventContext;
+        use crate::traits::{DurableToolCallStatus, DurableToolResultStore, ToolCallClaimResult};
+        use crate::typed_id::SessionId;
+
+        struct MockInterruptedStore;
+        #[async_trait::async_trait]
+        impl DurableToolResultStore for MockInterruptedStore {
+            async fn try_claim_tool_call(
+                &self,
+                _: &str,
+                _: &str,
+                _: &str,
+                _: &str,
+            ) -> crate::error::Result<ToolCallClaimResult> {
+                Ok(ToolCallClaimResult::Claimed {
+                    claim_token: uuid::Uuid::new_v4(),
+                })
+            }
+            async fn settle_tool_call(
+                &self,
+                _: &str,
+                _: &str,
+                _: serde_json::Value,
+                _: &str,
+                _: uuid::Uuid,
+            ) -> crate::error::Result<bool> {
+                Ok(true)
+            }
+            async fn get_tool_call_status(
+                &self,
+                _turn_id: &str,
+                _tool_call_id: &str,
+            ) -> crate::error::Result<Option<DurableToolCallStatus>> {
+                Ok(Some(DurableToolCallStatus::Interrupted {
+                    result_json: None,
+                }))
+            }
+        }
+
+        let tool_call = ToolCall {
+            id: "call_int".to_string(),
+            name: "slow_op".to_string(),
+            arguments: serde_json::json!({}),
+        };
+        let messages = vec![
+            Message::user("Do it"),
+            Message::assistant_with_tools("Doing...", vec![tool_call]),
+        ];
+
+        let store = MockInterruptedStore;
+        let emitter = crate::traits::NoopEventEmitter;
+        let session_id = SessionId::new();
+        let ctx = EventContext::empty();
+        let patched = repair_dangling_tool_calls(
+            &messages,
+            Some(&store as &dyn DurableToolResultStore),
+            &emitter,
+            session_id,
+            &ctx,
+            "turn_01",
+        )
+        .await;
+
+        assert_eq!(patched.len(), 3);
+        let repair = &patched[2];
+        assert_eq!(repair.role, MessageRole::ToolResult);
+        assert_eq!(repair.tool_call_id(), Some("call_int"));
+        // Interrupted replay uses the stored error or fallback text; must contain "interrupted"
+        let content = format!("{:?}", repair);
+        assert!(
+            content.contains("interrupted") || content.contains("not complete"),
+            "expected interrupted message, got: {content}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_repair_dangling_tool_calls_running_synthesized() {
+        use crate::events::EventContext;
+        use crate::traits::{DurableToolCallStatus, DurableToolResultStore, ToolCallClaimResult};
+        use crate::typed_id::SessionId;
+
+        struct MockRunningStore;
+        #[async_trait::async_trait]
+        impl DurableToolResultStore for MockRunningStore {
+            async fn try_claim_tool_call(
+                &self,
+                _: &str,
+                _: &str,
+                _: &str,
+                _: &str,
+            ) -> crate::error::Result<ToolCallClaimResult> {
+                Ok(ToolCallClaimResult::Claimed {
+                    claim_token: uuid::Uuid::new_v4(),
+                })
+            }
+            async fn settle_tool_call(
+                &self,
+                _: &str,
+                _: &str,
+                _: serde_json::Value,
+                _: &str,
+                _: uuid::Uuid,
+            ) -> crate::error::Result<bool> {
+                Ok(true)
+            }
+            async fn get_tool_call_status(
+                &self,
+                _turn_id: &str,
+                _tool_call_id: &str,
+            ) -> crate::error::Result<Option<DurableToolCallStatus>> {
+                Ok(Some(DurableToolCallStatus::Running))
+            }
+        }
+
+        let tool_call = ToolCall {
+            id: "call_run".to_string(),
+            name: "long_job".to_string(),
+            arguments: serde_json::json!({}),
+        };
+        let messages = vec![
+            Message::user("Start job"),
+            Message::assistant_with_tools("Starting...", vec![tool_call]),
+        ];
+
+        let store = MockRunningStore;
+        let emitter = crate::traits::NoopEventEmitter;
+        let session_id = SessionId::new();
+        let ctx = EventContext::empty();
+        let patched = repair_dangling_tool_calls(
+            &messages,
+            Some(&store as &dyn DurableToolResultStore),
+            &emitter,
+            session_id,
+            &ctx,
+            "turn_01",
+        )
+        .await;
+
+        assert_eq!(patched.len(), 3);
+        let repair = &patched[2];
+        assert_eq!(repair.role, MessageRole::ToolResult);
+        assert_eq!(repair.tool_call_id(), Some("call_run"));
+        // Running stale claim must warn "uncertain; do not retry automatically"
+        let content = format!("{:?}", repair);
+        assert!(
+            content.contains("uncertain") || content.contains("do not retry"),
+            "expected uncertain/do-not-retry message, got: {content}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_repair_dangling_tool_calls_store_error_unknown() {
+        use crate::error::AgentLoopError;
+        use crate::events::EventContext;
+        use crate::traits::{DurableToolResultStore, ToolCallClaimResult};
+        use crate::typed_id::SessionId;
+
+        struct MockErrorStore;
+        #[async_trait::async_trait]
+        impl DurableToolResultStore for MockErrorStore {
+            async fn try_claim_tool_call(
+                &self,
+                _: &str,
+                _: &str,
+                _: &str,
+                _: &str,
+            ) -> crate::error::Result<ToolCallClaimResult> {
+                Ok(ToolCallClaimResult::Claimed {
+                    claim_token: uuid::Uuid::new_v4(),
+                })
+            }
+            async fn settle_tool_call(
+                &self,
+                _: &str,
+                _: &str,
+                _: serde_json::Value,
+                _: &str,
+                _: uuid::Uuid,
+            ) -> crate::error::Result<bool> {
+                Ok(true)
+            }
+            async fn get_tool_call_status(
+                &self,
+                _turn_id: &str,
+                _tool_call_id: &str,
+            ) -> crate::error::Result<Option<crate::traits::DurableToolCallStatus>> {
+                Err(AgentLoopError::tool("simulated store failure"))
+            }
+        }
+
+        let tool_call = ToolCall {
+            id: "call_err".to_string(),
+            name: "risky_op".to_string(),
+            arguments: serde_json::json!({}),
+        };
+        let messages = vec![
+            Message::user("Do risky op"),
+            Message::assistant_with_tools("On it...", vec![tool_call]),
+        ];
+
+        let store = MockErrorStore;
+        let emitter = crate::traits::NoopEventEmitter;
+        let session_id = SessionId::new();
+        let ctx = EventContext::empty();
+        let patched = repair_dangling_tool_calls(
+            &messages,
+            Some(&store as &dyn DurableToolResultStore),
+            &emitter,
+            session_id,
+            &ctx,
+            "turn_01",
+        )
+        .await;
+
+        assert_eq!(patched.len(), 3);
+        let repair = &patched[2];
+        assert_eq!(repair.role, MessageRole::ToolResult);
+        assert_eq!(repair.tool_call_id(), Some("call_err"));
+        // Store error must NOT say "safe to retry"
+        let content = format!("{:?}", repair);
+        assert!(
+            !content.contains("safe to retry"),
+            "store error must not say 'safe to retry', got: {content}"
+        );
+        assert!(
+            content.contains("do not retry") || content.contains("status unknown"),
+            "expected do-not-retry/status-unknown message, got: {content}"
+        );
     }
 
     #[test]

--- a/crates/core/src/events.rs
+++ b/crates/core/src/events.rs
@@ -65,6 +65,7 @@ pub const TOOL_COMPLETED: &str = "tool.completed";
 pub const TOOL_PROGRESS: &str = "tool.progress";
 pub const TOOL_OUTPUT_DELTA: &str = "tool.output.delta";
 pub const TOOL_CALL_REQUESTED: &str = "tool.call_requested";
+pub const TRANSCRIPT_REPAIRED: &str = "transcript.repaired";
 
 // LLM events
 pub const LLM_GENERATION: &str = "llm.generation";
@@ -464,6 +465,7 @@ impl Event {
                 | TOOL_COMPLETED
                 | TOOL_PROGRESS
                 | TOOL_CALL_REQUESTED
+                | TRANSCRIPT_REPAIRED
         )
     }
 
@@ -1242,6 +1244,36 @@ pub struct ToolOutputDeltaData {
 
     /// Output stream identifier (e.g., "stdout", "stderr")
     pub stream: String,
+}
+
+/// Action taken during transcript repair for a dangling tool call.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum TranscriptRepairAction {
+    /// A settled result was found in durable storage and replayed into the transcript.
+    Replay,
+    /// A synthetic interrupted result was synthesized to make the transcript well-formed.
+    Synthesize,
+}
+
+/// Data for transcript.repaired event (EVE-533).
+///
+/// Emitted once per dangling tool call when transcript repair runs before a `reason` call.
+/// A dangling call is an assistant `tool_call` with no matching `ToolResult` in the
+/// message history. Repair makes the transcript well-formed so the next LLM call succeeds.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct TranscriptRepairedData {
+    /// The tool call ID that was repaired.
+    pub tool_call_id: String,
+
+    /// The tool name, if known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_name: Option<String>,
+
+    /// Action taken: `replay` (settled result reused) or `synthesize` (interrupted placeholder added).
+    pub action: TranscriptRepairAction,
 }
 
 /// Data for tool.call_requested event
@@ -2264,6 +2296,9 @@ pub enum EventData {
     ToolOutputDelta(ToolOutputDeltaData),
     ToolCallRequested(ToolCallRequestedData),
 
+    // Recovery / repair events
+    TranscriptRepaired(TranscriptRepairedData),
+
     // LLM events
     LlmGeneration(LlmGenerationData),
 
@@ -2357,6 +2392,7 @@ impl EventData {
             EventData::ToolProgress(_) => TOOL_PROGRESS,
             EventData::ToolOutputDelta(_) => TOOL_OUTPUT_DELTA,
             EventData::ToolCallRequested(_) => TOOL_CALL_REQUESTED,
+            EventData::TranscriptRepaired(_) => TRANSCRIPT_REPAIRED,
             EventData::LlmGeneration(_) => LLM_GENERATION,
             EventData::ReasonThinkingDelta(_) => REASON_THINKING_DELTA,
             EventData::ReasonThinkingStarted(_) => REASON_THINKING_STARTED,
@@ -2468,6 +2504,8 @@ pub fn deserialize_event_data(event_type: &str, data: serde_json::Value) -> Even
                 .map(EventData::ToolOutputDelta),
             TOOL_CALL_REQUESTED => serde_json::from_value::<ToolCallRequestedData>(data.clone())
                 .map(EventData::ToolCallRequested),
+            TRANSCRIPT_REPAIRED => serde_json::from_value::<TranscriptRepairedData>(data.clone())
+                .map(EventData::TranscriptRepaired),
             LLM_GENERATION => serde_json::from_value::<LlmGenerationData>(data.clone())
                 .map(EventData::LlmGeneration),
             REASON_THINKING_STARTED => {
@@ -2595,6 +2633,7 @@ impl_from_event_data! {
     ToolProgressData => ToolProgress,
     ToolOutputDeltaData => ToolOutputDelta,
     ToolCallRequestedData => ToolCallRequested,
+    TranscriptRepairedData => TranscriptRepaired,
     LlmGenerationData => LlmGeneration,
     ReasonThinkingStartedData => ReasonThinkingStarted,
     ReasonThinkingDeltaData => ReasonThinkingDelta,

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -903,6 +903,19 @@ pub enum ToolCallClaimResult {
     },
 }
 
+/// Read-only status of a tool call in durable storage (EVE-533).
+#[derive(Debug, Clone)]
+pub enum DurableToolCallStatus {
+    /// Tool completed successfully or with an error; result is stored.
+    Settled { result_json: serde_json::Value },
+    /// Tool was settled with `interrupted` status; result may contain error details.
+    Interrupted {
+        result_json: Option<serde_json::Value>,
+    },
+    /// A claim exists but the tool never finished.
+    Running,
+}
+
 /// Durable per-tool-call idempotency store (EVE-530).
 ///
 /// Implements the claim/settle CAS that prevents double-execution of
@@ -937,6 +950,16 @@ pub trait DurableToolResultStore: Send + Sync + 'static {
         status: &str,
         claim_token: uuid::Uuid,
     ) -> Result<bool>;
+
+    /// Read-only lookup of a tool call's current status in durable storage (EVE-533).
+    ///
+    /// Used by transcript repair to decide whether to replay a stored result or
+    /// synthesize an interrupted placeholder. Returns `None` if no row exists.
+    async fn get_tool_call_status(
+        &self,
+        turn_id: &str,
+        tool_call_id: &str,
+    ) -> Result<Option<DurableToolCallStatus>>;
 }
 
 /// No-op implementation — used when no durable store is configured (dev/test).
@@ -966,6 +989,14 @@ impl DurableToolResultStore for NoopDurableToolResultStore {
         _claim_token: uuid::Uuid,
     ) -> Result<bool> {
         Ok(true)
+    }
+
+    async fn get_tool_call_status(
+        &self,
+        _turn_id: &str,
+        _tool_call_id: &str,
+    ) -> Result<Option<DurableToolCallStatus>> {
+        Ok(None)
     }
 }
 

--- a/crates/internal-protocol/src/lib.rs
+++ b/crates/internal-protocol/src/lib.rs
@@ -256,6 +256,7 @@ fn serialize_event_data(data: &everruns_core::EventData) -> serde_json::Value {
         EventData::VoiceOutputTranscriptCompleted(d) => serde_json::to_value(d).unwrap_or_default(),
         EventData::VoiceSessionEnded(d) => serde_json::to_value(d).unwrap_or_default(),
         EventData::VoiceSessionFailed(d) => serde_json::to_value(d).unwrap_or_default(),
+        EventData::TranscriptRepaired(d) => serde_json::to_value(d).unwrap_or_default(),
         EventData::Unsupported { data, .. } => {
             // Should not happen in production - unsupported events are filtered before reaching here
             data.clone()

--- a/crates/runtime/src/host.rs
+++ b/crates/runtime/src/host.rs
@@ -975,6 +975,9 @@ pub async fn execute_reason_activity<A: RuntimeHostAdapter>(
     if let Some(timeout) = adapter.provider_stall_timeout() {
         atom = atom.with_provider_stall_timeout(timeout);
     }
+    if let Some(store) = adapter.durable_tool_result_store() {
+        atom = atom.with_durable_tool_result_store(store);
+    }
 
     let input = ReasonInput {
         mcp_tool_definitions: turn_context.mcp_tool_definitions,

--- a/crates/server/src/storage/durable_tool_results.rs
+++ b/crates/server/src/storage/durable_tool_results.rs
@@ -1,8 +1,8 @@
-// PostgreSQL implementation of DurableToolResultStore (EVE-530).
+// PostgreSQL implementation of DurableToolResultStore (EVE-530, EVE-533).
 
 use async_trait::async_trait;
 use everruns_core::error::AgentLoopError;
-use everruns_core::traits::{DurableToolResultStore, ToolCallClaimResult};
+use everruns_core::traits::{DurableToolCallStatus, DurableToolResultStore, ToolCallClaimResult};
 use sqlx::PgPool;
 use uuid::Uuid;
 
@@ -147,5 +147,32 @@ impl DurableToolResultStore for PgDurableToolResultStore {
         };
 
         Ok(rows > 0)
+    }
+
+    async fn get_tool_call_status(
+        &self,
+        turn_id: &str,
+        tool_call_id: &str,
+    ) -> Result<Option<DurableToolCallStatus>, AgentLoopError> {
+        let row = sqlx::query_as::<_, (String, Option<serde_json::Value>)>(
+            r#"
+            SELECT status, result_json
+            FROM durable_tool_results
+            WHERE turn_id = $1 AND tool_call_id = $2
+            "#,
+        )
+        .bind(turn_id)
+        .bind(tool_call_id)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| AgentLoopError::tool(format!("durable_tool_results status lookup: {e}")))?;
+
+        Ok(row.map(|(status, result_json)| match status.as_str() {
+            "settled" => DurableToolCallStatus::Settled {
+                result_json: result_json.unwrap_or(serde_json::Value::Null),
+            },
+            "interrupted" => DurableToolCallStatus::Interrupted { result_json },
+            _ => DurableToolCallStatus::Running,
+        }))
     }
 }

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -15690,6 +15690,9 @@
             "$ref": "#/components/schemas/ToolCallRequestedData"
           },
           {
+            "$ref": "#/components/schemas/TranscriptRepairedData"
+          },
+          {
             "$ref": "#/components/schemas/LlmGenerationData"
           },
           {
@@ -27790,6 +27793,39 @@
               "null"
             ],
             "description": "Stable fingerprint of tool name + normalized arguments."
+          }
+        }
+      },
+      "TranscriptRepairAction": {
+        "type": "string",
+        "description": "Action taken during transcript repair for a dangling tool call.",
+        "enum": [
+          "replay",
+          "synthesize"
+        ]
+      },
+      "TranscriptRepairedData": {
+        "type": "object",
+        "description": "Data for transcript.repaired event (EVE-533).\n\nEmitted once per dangling tool call when transcript repair runs before a `reason` call.\nA dangling call is an assistant `tool_call` with no matching `ToolResult` in the\nmessage history. Repair makes the transcript well-formed so the next LLM call succeeds.",
+        "required": [
+          "tool_call_id",
+          "action"
+        ],
+        "properties": {
+          "action": {
+            "$ref": "#/components/schemas/TranscriptRepairAction",
+            "description": "Action taken: `replay` (settled result reused) or `synthesize` (interrupted placeholder added)."
+          },
+          "tool_call_id": {
+            "type": "string",
+            "description": "The tool call ID that was repaired."
+          },
+          "tool_name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The tool name, if known."
           }
         }
       },


### PR DESCRIPTION
## What
Upgrades the transcript-repair pass that runs before every LLM call in `ReasonAtom`. Previously `patch_dangling_tool_calls` always synthesized a generic "cancelled" result for any assistant `tool_call` missing a matching `ToolResult` in the message history. Now `repair_dangling_tool_calls`:

- Consults `durable_tool_results` (EVE-530) when available: replays the actual stored result for settled calls, uses the stored interrupted error for interrupted calls, and synthesizes appropriate deterministic messages for stale running claims or missing rows.
- Emits a `transcript.repaired` event per repaired call for observability.
- All synthetic results are deterministic (same input → same message) so event-sourced history stays consistent.

## Why
EVE-533: when a worker dies mid-`act`, some tool calls can be left with no matching `ToolResult` in the message store. The old repair always emitted a generic "cancelled" message regardless of what actually happened. With `durable_tool_results` (EVE-530) now in place, repair can distinguish:
- **Settled**: replay the actual stored result so the model sees the real outcome.
- **Interrupted** (settled with status=interrupted): replay the stored interrupted error.
- **Running** (stale claim from dead worker): synthesize "interrupted — result uncertain".
- **Not found** (never dispatched): synthesize "interrupted — safe to retry".

## How
- Added `DurableToolResultStore::get_tool_call_status()` read-only SELECT method to the trait; implemented in `NoopDurableToolResultStore`, `InMemoryDurableStore` (test), and `PgDurableToolResultStore`.
- Replaced sync `patch_dangling_tool_calls` with async `repair_dangling_tool_calls` that accepts the store and event emitter.
- Added `TRANSCRIPT_REPAIRED` event constant, `TranscriptRepairedData` struct, and `TranscriptRepairAction` enum to `events.rs`. Wired into `EventData` enum, `deserialize_event_data`, `is_atom_event`, `impl_from_event_data!`, and `internal-protocol::serialize_event_data`.
- Added `durable_tool_result_store: Option<Arc<dyn DurableToolResultStore>>` to `ReasonAtom` with `with_durable_tool_result_store()` builder. Wired in `execute_reason_activity` in `host.rs`.
- Updated 3 existing tests → 4 async tests covering: no tool calls, result already present, missing result (no store), settled result replayed from durable storage.

## Risk
- Low: repair logic is a context-preparation step before the LLM call. Worst case is a well-formed but suboptimal synthetic result — same as before. The store query is read-only with no side effects.
- Behavior change: when `durable_tool_results` has a settled result for a dangling call, repair now replays the actual result instead of emitting "cancelled". This is strictly better; the LLM sees the real outcome.

## Security
- Threat categories reviewed: TM-TOOL, TM-SQL, TM-LLM
- TM-SQL: `get_tool_call_status` is a fully parameterized SELECT (`$1`/`$2`) — no injection risk.
- TM-TOOL: `result_json` from durable storage is deserialized via `serde_json::from_value::<ToolResult>` with only `result` and `error` fields extracted into `Message`. No eval path, no new execution surface.
- TM-LLM: synthetic results are deterministic constant strings; no user-controlled content enters LLM context through this path.
- TM-TENANT: `get_tool_call_status` scopes by `turn_id` which is already inherently tenant-scoped (unique per session/org).

## Follow-ups
- **Re-dispatch path for Pure/Idempotent tools**: the spec calls for routing `running` + `Pure`/`Idempotent` tool calls back through `act` rather than synthesizing. This requires passing tool definitions into `ReasonAtom` or a separate recovery classifier step. Deferred: `ReasonAtom` does not currently have tool definitions; implementing this correctly requires a larger architectural change. A follow-up issue will cover the recovery classifier (turn-recovery.md).
- **turn-recovery.md spec**: no `specs/turn-recovery.md` exists yet. The recovery decision logic (detect → classify → repair) should be documented there. Deferred to a spec-writing follow-up.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)


---
_Generated by [Claude Code](https://claude.ai/code/session_01HZc73sZ4NJ9M3q2BvGs5ae)_