### PR TITLE
fix(openai): restrict OpenRouter model discovery

### DIFF
--- a/crates/openai/src/driver.rs
+++ b/crates/openai/src/driver.rs
@@ -176,6 +176,8 @@ impl std::fmt::Debug for OpenAILlmDriver {
 #[derive(Clone)]
 pub struct OpenRouterLlmDriver {
     inner: OpenResponsesProtocolLlmDriver,
+    /// Whether using a custom base URL (not OpenRouter's API).
+    uses_custom_url: bool,
 }
 
 impl OpenRouterLlmDriver {
@@ -184,6 +186,7 @@ impl OpenRouterLlmDriver {
         Self {
             inner: OpenResponsesProtocolLlmDriver::with_base_url(api_key, OPENROUTER_RESPONSES_URL)
                 .with_provider_type(LlmProviderType::Openrouter),
+            uses_custom_url: false,
         }
     }
 
@@ -193,6 +196,7 @@ impl OpenRouterLlmDriver {
         Self {
             inner: OpenResponsesProtocolLlmDriver::with_base_url(api_key, api_url)
                 .with_provider_type(LlmProviderType::Openrouter),
+            uses_custom_url: true,
         }
     }
 
@@ -204,6 +208,11 @@ impl OpenRouterLlmDriver {
     /// Get the provider type used for model profile lookup.
     pub fn provider_type(&self) -> &LlmProviderType {
         self.inner.provider_type()
+    }
+
+    /// Check if using a custom base URL.
+    pub fn uses_custom_url(&self) -> bool {
+        self.uses_custom_url
     }
 }
 
@@ -218,6 +227,12 @@ impl LlmDriver for OpenRouterLlmDriver {
     }
 
     async fn list_models(&self) -> Result<Option<Vec<DiscoveredModel>>> {
+        // OpenRouter discovery is only safe against OpenRouter's own host.
+        // Custom proxy URLs may resolve to private infrastructure at request time.
+        if self.uses_custom_url && !is_openrouter_api_url(self.api_url()) {
+            return Ok(None);
+        }
+
         let models_url = models_url_for_api_url(self.api_url());
         list_models_for_url(self.inner.client(), self.inner.api_key(), &models_url).await
     }
@@ -369,11 +384,7 @@ async fn list_openrouter_models(
 
     if !response.status().is_success() {
         let status = response.status();
-        let body = response.text().await.unwrap_or_default();
-        return Err(AgentLoopError::llm(format!(
-            "Models API returned {}: {}",
-            status, body
-        )));
+        return Err(models_api_status_error(status));
     }
 
     let models_response: OpenRouterModelsResponse = response
@@ -415,11 +426,7 @@ async fn list_openai_models(
 
     if !response.status().is_success() {
         let status = response.status();
-        let body = response.text().await.unwrap_or_default();
-        return Err(AgentLoopError::llm(format!(
-            "Models API returned {}: {}",
-            status, body
-        )));
+        return Err(models_api_status_error(status));
     }
 
     let models_response: OpenAiModelsResponse = response
@@ -442,6 +449,10 @@ async fn list_openai_models(
         .collect();
 
     Ok(Some(discovered))
+}
+
+fn models_api_status_error(status: reqwest::StatusCode) -> AgentLoopError {
+    AgentLoopError::llm(format!("Models API returned status {status}"))
 }
 
 fn normalize_api_url(base_url: &str, endpoint_suffix: &str) -> String {

--- a/crates/openai/src/driver.rs
+++ b/crates/openai/src/driver.rs
@@ -176,7 +176,7 @@ impl std::fmt::Debug for OpenAILlmDriver {
 #[derive(Clone)]
 pub struct OpenRouterLlmDriver {
     inner: OpenResponsesProtocolLlmDriver,
-    /// Whether using a custom base URL (not OpenRouter's API).
+    /// Whether constructed with an explicit base URL override via [`with_base_url`].
     uses_custom_url: bool,
 }
 
@@ -384,6 +384,7 @@ async fn list_openrouter_models(
 
     if !response.status().is_success() {
         let status = response.status();
+        let _ = response.bytes().await; // drain body to allow connection reuse
         return Err(models_api_status_error(status));
     }
 
@@ -426,6 +427,7 @@ async fn list_openai_models(
 
     if !response.status().is_success() {
         let status = response.status();
+        let _ = response.bytes().await; // drain body to allow connection reuse
         return Err(models_api_status_error(status));
     }
 

--- a/crates/openai/src/tests.rs
+++ b/crates/openai/src/tests.rs
@@ -6,7 +6,7 @@ mod driver_tests {
         DriverRegistry, OpenAICompletionsLlmDriver, OpenAILlmDriver, OpenRouterLlmDriver,
         register_driver,
     };
-    use everruns_core::llm_driver_registry::{ProviderConfig, ProviderType};
+    use everruns_core::llm_driver_registry::{LlmDriver, ProviderConfig, ProviderType};
     use everruns_core::llm_models::LlmProviderType;
 
     #[test]
@@ -61,6 +61,31 @@ mod driver_tests {
         assert!(format!("{:?}", driver).contains("OpenRouterLlmDriver"));
         assert_eq!(driver.api_url(), "https://openrouter.ai/api/v1/responses");
         assert_eq!(driver.provider_type(), &LlmProviderType::Openrouter);
+    }
+
+    #[test]
+    fn test_openrouter_driver_with_base_url_marks_custom_url() {
+        let driver = OpenRouterLlmDriver::with_base_url(
+            "test-key",
+            "https://openrouter.ai/api/v1/responses",
+        );
+        assert_eq!(driver.api_url(), "https://openrouter.ai/api/v1/responses");
+        assert!(driver.uses_custom_url());
+    }
+
+    #[tokio::test]
+    async fn test_openrouter_custom_non_openrouter_host_skips_model_listing() {
+        let driver = OpenRouterLlmDriver::with_base_url(
+            "test-key",
+            "https://custom.api.example/v1/responses",
+        );
+
+        let discovered = driver
+            .list_models()
+            .await
+            .expect("custom non-OpenRouter discovery should be skipped");
+
+        assert!(discovered.is_none());
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Prevent server-side SSRF and upstream-data leakage from OpenRouter provider model sync when an org-configured custom base URL resolves to internal addresses and model-listing errors included raw upstream bodies.

### Description
- Add a `uses_custom_url: bool` flag to `OpenRouterLlmDriver` and a `uses_custom_url()` accessor to track when a driver was created with `with_base_url`.
- Short-circuit `OpenRouterLlmDriver::list_models` to return `Ok(None)` when `uses_custom_url` is true and the configured host is not `openrouter.ai`, matching the existing custom-URL skip behavior used by other OpenAI drivers.
- Replace error paths that previously included raw upstream response bodies in `list_openrouter_models` and `list_openai_models` with a sanitized status-only `models_api_status_error` to avoid disclosing internal response content.
- Add regression tests in `crates/openai/src/tests.rs` to assert custom-URL tracking and that non-OpenRouter custom hosts skip discovery.

### Testing
- Ran the focused regression test `cargo test -p everruns-openai --lib openrouter_custom_non_openrouter_host_skips_model_listing`, which passed.
- Ran `cargo test -p everruns-openai --lib` where 42 tests passed and 4 existing image-related tests failed with pre-existing "Loopback targets forbidden" errors not introduced by these changes, so the failures are unrelated to the model-discovery fix.
- Ran `cargo clippy -p everruns-openai --all-targets --all-features -- -D warnings`, which completed with no lints reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2919233840832b8e73f0455894509a)