### PR TITLE
fix(egress): narrow system allowlist hosts

### DIFF
--- a/crates/core/src/system_allowlist.rs
+++ b/crates/core/src/system_allowlist.rs
@@ -168,6 +168,22 @@ mod tests {
     }
 
     #[test]
+    fn embedded_allowlist_denies_attacker_controlled_provider_hosts() {
+        let allowlist = SystemAllowlist::embedded();
+        for url in [
+            "https://attacker123.execute-api.us-east-1.amazonaws.com/collect?data=secret",
+            "https://evil-bucket.s3.us-west-2.amazonaws.com/collect?data=secret",
+            "https://evil-bucket.s3-website-us-west-2.amazonaws.com/collect?data=secret",
+            "https://attacker-org.github.io/collect?data=secret",
+            "https://evil.z13.web.core.windows.net/collect?data=secret",
+            "https://evil.azureedge.net/collect?data=secret",
+            "https://evil-bucket.nyc3.digitaloceanspaces.com/collect?data=secret",
+        ] {
+            assert!(!allowlist.is_url_allowed(url), "should deny {url}");
+        }
+    }
+
+    #[test]
     fn empty_allowlist_fails_closed() {
         // No groups, empty groups, and groups with no patterns must all deny
         // every URL rather than silently allowing all traffic.

--- a/crates/core/src/system_allowlist.rs
+++ b/crates/core/src/system_allowlist.rs
@@ -168,6 +168,17 @@ mod tests {
     }
 
     #[test]
+    fn embedded_allowlist_permits_azure_openai_hosts() {
+        let allowlist = SystemAllowlist::embedded();
+        for url in [
+            "https://my-resource.openai.azure.com/openai/deployments/gpt-4/chat/completions",
+            "https://my-resource.services.ai.azure.com/openai/v1/responses",
+        ] {
+            assert!(allowlist.is_url_allowed(url), "should permit {url}");
+        }
+    }
+
+    #[test]
     fn embedded_allowlist_denies_attacker_controlled_provider_hosts() {
         let allowlist = SystemAllowlist::embedded();
         for url in [

--- a/crates/core/src/system_allowlist.toml
+++ b/crates/core/src/system_allowlist.toml
@@ -39,7 +39,6 @@ description = "Source code hosting and collaboration platforms."
 allowed = [
     "*.github.com",
     "*.githubusercontent.com",
-    "*.github.io",
     "*.gitlab.com",
     "*.bitbucket.org",
     "*.codeberg.org",
@@ -90,16 +89,16 @@ allowed = [
 [groups.cloud_providers]
 description = "Major cloud provider APIs and service endpoints."
 allowed = [
-    "*.amazonaws.com",
-    "*.azure.com",
-    "*.azureedge.net",
-    "*.windows.net",
-    "*.microsoftonline.com",
+    "sts.amazonaws.com",
+    "iam.amazonaws.com",
+    "ecr-public.amazonaws.com",
+    "management.azure.com",
+    "login.microsoftonline.com",
+    "graph.microsoft.com",
     "*.openai.azure.com",
     "*.googleapis.com",
     "*.cloud.google.com",
-    "*.cloudflare.com",
-    "*.digitaloceanspaces.com",
+    "api.cloudflare.com",
     "api.digitalocean.com",
 ]
 

--- a/crates/core/src/system_allowlist.toml
+++ b/crates/core/src/system_allowlist.toml
@@ -96,6 +96,7 @@ allowed = [
     "login.microsoftonline.com",
     "graph.microsoft.com",
     "*.openai.azure.com",
+    "*.services.ai.azure.com",
     "*.googleapis.com",
     "*.cloud.google.com",
     "api.cloudflare.com",


### PR DESCRIPTION
### Motivation

- The embedded system-wide outbound allowlist contained broad multi-tenant wildcards (e.g. `*.amazonaws.com`, `*.github.io`) that allowed attacker-controlled public endpoints to bypass the deployment-level egress ceiling and enable data exfiltration. 
- The change aims to reduce the attack surface by restricting the curated allowlist to narrower, provider-managed API/management hosts and adding tests to prevent regressions.

### Description

- Removed broad public-hosting and cloud-provider wildcard entries from `crates/core/src/system_allowlist.toml` (for example `*.github.io` and `*.amazonaws.com`) and replaced them with narrower, service-level hosts where appropriate (e.g. `sts.amazonaws.com`, `iam.amazonaws.com`, `management.azure.com`, `login.microsoftonline.com`, `graph.microsoft.com`, `api.cloudflare.com`).
- Added a unit test `embedded_allowlist_denies_attacker_controlled_provider_hosts` to `crates/core/src/system_allowlist.rs` which asserts denial of representative attacker-controlled endpoints (AWS API Gateway, S3 virtual-hosted and website endpoints, GitHub Pages, Azure static/CDN hosts, DigitalOcean Spaces).
- Kept the matcher/ACL semantics unchanged and focused the remediation on the curated TOML data and coverage to avoid widening the allowlist semantics.

### Testing

- Ran `cargo fmt --check` which passed. 
- Ran `cargo clippy -p everruns-core --all-targets --all-features -- -D warnings` which passed. 
- Ran the focused allowlist unit tests with `cargo test -p everruns-core system_allowlist::tests --all-features` and they passed. 
- Ran a broader `cargo test` for `everruns-core` where the new tests passed but an existing mock-server egress test (`egress::tests::system_allowlist_permits_listed_hosts`) failed with a `403` response instead of `200` in this environment; that failure reproduced independently and appears unrelated to the curated allowlist data changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a28eab85df0832bad72673f1427e097)