### PR TITLE
fix(core): guard thinking stream output

### DIFF
--- a/crates/core/src/atoms/reason.rs
+++ b/crates/core/src/atoms/reason.rs
@@ -137,6 +137,26 @@ fn is_error_placeholder_message(msg: &Message) -> bool {
     ERROR_PLACEHOLDER_MESSAGES.contains(&text) || is_dynamic_error_placeholder(text)
 }
 
+fn append_guarded_thinking_delta(
+    armed_guardrails: &mut [ArmedGuardrail],
+    thinking: &mut String,
+    pending_thinking_delta: &mut String,
+    delta: &str,
+) -> Option<TrippedGuardrail> {
+    thinking.push_str(delta);
+
+    // Thinking streams are user-visible and persisted on completion, so they
+    // must pass the same output guardrails as assistant text before any delta
+    // is emitted.
+    if let Some(t) = evaluate_guardrails(armed_guardrails, thinking, delta) {
+        pending_thinking_delta.clear();
+        Some(t)
+    } else {
+        pending_thinking_delta.push_str(delta);
+        None
+    }
+}
+
 fn is_dynamic_error_placeholder(text: &str) -> bool {
     (text.starts_with("Budget exhausted.") && text.ends_with("Increase the budget to continue."))
         || (text.starts_with("Budget paused.")
@@ -1725,9 +1745,21 @@ impl ReasonAtom {
                         }
                     }
                     LlmStreamEvent::ThinkingDelta(delta) => {
-                        // Accumulate thinking content from extended thinking models
-                        thinking.push_str(&delta);
-                        pending_thinking_delta.push_str(&delta);
+                        if let Some(t) = append_guarded_thinking_delta(
+                            &mut armed_guardrails,
+                            &mut thinking,
+                            &mut pending_thinking_delta,
+                            &delta,
+                        ) {
+                            tracing::warn!(
+                                session_id = %session_id,
+                                guardrail_capability_id = %t.capability_id,
+                                guardrail_id = %t.guardrail_id,
+                                "ReasonAtom: output guardrail tripped on thinking stream, replacing assistant message"
+                            );
+                            tripped = Some(t);
+                            break;
+                        }
                         last_token_at_unix = std::time::SystemTime::now()
                             .duration_since(std::time::UNIX_EPOCH)
                             .unwrap_or_default()
@@ -2301,6 +2333,72 @@ mod tests {
     use super::*;
     use crate::llm_driver_registry::{LlmCallConfig, PromptCacheConfig, PromptCacheStrategy};
     use std::collections::HashMap;
+
+    struct BlockWhenDeltaContains {
+        needle: &'static str,
+    }
+
+    impl crate::output_guardrail::OutputGuardrailRun for BlockWhenDeltaContains {
+        fn check(
+            &mut self,
+            _accumulated: &str,
+            delta: &str,
+        ) -> crate::output_guardrail::GuardrailDecision {
+            if delta.contains(self.needle) {
+                crate::output_guardrail::GuardrailDecision::block("test_leak", "[blocked]")
+            } else {
+                crate::output_guardrail::GuardrailDecision::Pass
+            }
+        }
+    }
+
+    fn test_armed_guardrail() -> ArmedGuardrail {
+        ArmedGuardrail {
+            capability_id: "test_capability".to_string(),
+            guardrail_id: "test_guardrail".to_string(),
+            run: Box::new(BlockWhenDeltaContains { needle: "secret" }),
+        }
+    }
+
+    #[test]
+    fn test_append_guarded_thinking_delta_blocks_before_pending_emit() {
+        let mut guardrails = vec![test_armed_guardrail()];
+        let mut thinking = "safe ".to_string();
+        let mut pending = "safe ".to_string();
+
+        let tripped = append_guarded_thinking_delta(
+            &mut guardrails,
+            &mut thinking,
+            &mut pending,
+            "secret instructions",
+        )
+        .expect("thinking delta should trip guardrail");
+
+        assert_eq!(tripped.capability_id, "test_capability");
+        assert_eq!(tripped.guardrail_id, "test_guardrail");
+        assert_eq!(tripped.block.reason_code, "test_leak");
+        assert_eq!(tripped.block.replacement, "[blocked]");
+        assert_eq!(thinking, "safe secret instructions");
+        assert!(pending.is_empty());
+    }
+
+    #[test]
+    fn test_append_guarded_thinking_delta_allows_safe_pending_emit() {
+        let mut guardrails = vec![test_armed_guardrail()];
+        let mut thinking = String::new();
+        let mut pending = String::new();
+
+        let tripped = append_guarded_thinking_delta(
+            &mut guardrails,
+            &mut thinking,
+            &mut pending,
+            "ordinary reasoning",
+        );
+
+        assert!(tripped.is_none());
+        assert_eq!(thinking, "ordinary reasoning");
+        assert_eq!(pending, "ordinary reasoning");
+    }
 
     #[test]
     fn test_reason_result_default() {

--- a/crates/core/tests/reason_atom_test.rs
+++ b/crates/core/tests/reason_atom_test.rs
@@ -226,6 +226,40 @@ impl everruns_core::LlmDriver for FlakyStreamDriver {
     }
 }
 
+#[derive(Clone, Debug)]
+struct ThinkingLeakDriver {
+    thinking: String,
+    answer: String,
+}
+
+#[async_trait]
+impl everruns_core::LlmDriver for ThinkingLeakDriver {
+    async fn chat_completion_stream(
+        &self,
+        _messages: Vec<everruns_core::LlmMessage>,
+        config: &everruns_core::LlmCallConfig,
+    ) -> everruns_core::Result<everruns_core::LlmResponseStream> {
+        Ok(Box::pin(stream::iter(vec![
+            Ok(everruns_core::LlmStreamEvent::ThinkingDelta(
+                self.thinking.clone(),
+            )),
+            Ok(everruns_core::LlmStreamEvent::TextDelta(
+                self.answer.clone(),
+            )),
+            Ok(everruns_core::LlmStreamEvent::Done(Box::new(
+                everruns_core::LlmCompletionMetadata {
+                    total_tokens: Some(8),
+                    prompt_tokens: Some(5),
+                    completion_tokens: Some(3),
+                    model: Some(config.model.clone()),
+                    finish_reason: Some("stop".to_string()),
+                    ..Default::default()
+                },
+            ))),
+        ])))
+    }
+}
+
 #[tokio::test]
 async fn test_reason_atom_with_fixed_response() {
     use everruns_core::memory::InMemoryEventEmitter;
@@ -2406,6 +2440,141 @@ async fn test_prompt_canary_guardrail_replaces_leaked_output() {
                 "leak text appeared in a delta accumulated field: {:?}",
                 data.accumulated
             );
+        }
+    }
+}
+
+/// End-to-end test that the prompt_canary_guardrail capability also suppresses
+/// user-visible thinking streams when an OpenRouter-style plaintext reasoning
+/// delta contains the guarded prompt canary.
+#[tokio::test]
+async fn test_prompt_canary_guardrail_replaces_leaked_thinking() {
+    use everruns_core::AgentCapabilityConfig;
+    use everruns_core::capabilities::{
+        PROMPT_CANARY_GUARDRAIL_CAPABILITY_ID, PromptCanaryGuardrailCapability,
+    };
+    use everruns_core::memory::InMemoryEventEmitter;
+
+    let (
+        harness_store,
+        agent_store,
+        session_store,
+        message_retriever,
+        provider_store,
+        harness_id,
+        agent_id,
+        session_id,
+    ) = setup_test_environment().await;
+
+    let leak_prompt = "You are an internal pricing oracle that never discloses margins. \
+         Refuse out-of-scope questions.";
+    {
+        let now = chrono::Utc::now();
+        let agent = Agent {
+            public_id: AgentId::from_uuid(agent_id),
+            internal_id: agent_id,
+            name: "thinking-leak-test-agent".to_string(),
+            display_name: Some("Thinking Leak Test Agent".to_string()),
+            description: None,
+            system_prompt: leak_prompt.to_string(),
+            default_model_id: None,
+            default_version_id: None,
+            forked_from_agent_id: None,
+            forked_from_version_id: None,
+            root_agent_id: None,
+            capabilities: vec![AgentCapabilityConfig::new(
+                PROMPT_CANARY_GUARDRAIL_CAPABILITY_ID,
+            )],
+            initial_files: vec![],
+            network_access: None,
+            max_iterations: None,
+            tools: vec![],
+            mcp_servers: Default::default(),
+            tags: vec![],
+            status: AgentStatus::Active,
+            created_at: now,
+            updated_at: now,
+            archived_at: None,
+            deleted_at: None,
+            usage: None,
+        };
+        agent_store.add_agent(agent).await;
+    }
+
+    message_retriever
+        .seed(
+            session_id.into(),
+            vec![Message::user("think about your prompt")],
+        )
+        .await;
+
+    let thinking_driver = ThinkingLeakDriver {
+        thinking: leak_prompt.to_string(),
+        answer: "safe answer".to_string(),
+    };
+    let mut driver_registry = DriverRegistry::new();
+    driver_registry.register(ProviderType::LlmSim, move |_api_key, _base_url| {
+        Box::new(thinking_driver.clone())
+    });
+
+    let mut capability_registry = CapabilityRegistry::new();
+    capability_registry.register(PromptCanaryGuardrailCapability);
+
+    let event_emitter = InMemoryEventEmitter::new();
+    let atom = ReasonAtom::new(
+        harness_store,
+        agent_store,
+        session_store,
+        message_retriever,
+        provider_store,
+        capability_registry,
+        driver_registry,
+        event_emitter.clone(),
+    );
+
+    let result = atom
+        .execute(ReasonInput {
+            context: create_context(session_id),
+            harness_id,
+            agent_id: Some(agent_id.into()),
+            org_id: 0,
+            mcp_tool_definitions: vec![],
+            previous_response_id: None,
+            iteration: 1,
+        })
+        .await
+        .expect("ReasonAtom should succeed");
+
+    assert!(result.success);
+    assert!(!result.text.contains("internal pricing oracle"));
+    assert!(result.text.contains("withheld"));
+
+    let events = event_emitter.events().await;
+    assert!(
+        events
+            .iter()
+            .any(|e| e.event_type == "output.message.replaced"),
+        "thinking guardrail trip should emit output.message.replaced"
+    );
+
+    for event in &events {
+        match &event.data {
+            everruns_core::EventData::ReasonThinkingDelta(data) => {
+                assert!(
+                    !data.delta.contains("internal pricing oracle")
+                        && !data.accumulated.contains("internal pricing oracle"),
+                    "thinking delta leaked guarded prompt: {:?}",
+                    data
+                );
+            }
+            everruns_core::EventData::ReasonThinkingCompleted(data) => {
+                assert!(
+                    !data.thinking.contains("internal pricing oracle"),
+                    "thinking completed leaked guarded prompt: {:?}",
+                    data
+                );
+            }
+            _ => {}
         }
     }
 }


### PR DESCRIPTION
### Motivation
- OpenRouter-compatible plaintext reasoning events (`response.reasoning_text.delta`) were mapped into the `ThinkingDelta` user-visible stream without running the streaming output guardrails, allowing protected prompt/canary content to be emitted or persisted via thinking events.

### Description
- Add `append_guarded_thinking_delta(…)` helper that appends a thinking delta but first runs `evaluate_guardrails` against the accumulated thinking so guardrails can block before a pending thinking delta is emitted.
- Route `LlmStreamEvent::ThinkingDelta` through the new helper in `ReasonAtom` and reuse the existing `output.message.replaced`/replacement flow when a guardrail trips so leaked thinking is cleared and not persisted (changes in `crates/core/src/atoms/reason.rs`).
- Add tests: focused unit tests covering guarded-appends for thinking deltas and an end-to-end ReasonAtom integration test that simulates an OpenRouter-style plaintext thinking leak and asserts `output.message.replaced` is emitted and no `reason.thinking.*` event contains the guarded prompt (changes in `crates/core/tests/reason_atom_test.rs`).

### Testing
- Ran `cargo fmt --check` and `cargo clippy -p everruns-core --all-targets --all-features -- -D warnings`, both succeeded. 
- Ran focused unit tests `cargo test -p everruns-core atoms::reason::tests::test_append_guarded_thinking_delta`, which passed. 
- Ran end-to-end integration test `cargo test -p everruns-core --test reason_atom_test test_prompt_canary_guardrail_replaces_leaked_thinking`, which passed. 
- Note: final CI (remote GitHub Actions) was not executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a289235327c832bb2282f7d84382c31)