### PR TITLE
feat(ui): custom HTTP headers in Add MCP Server form (EVE-541)

### DIFF
--- a/apps/ui/src/app/(main)/mcp-servers/page.tsx
+++ b/apps/ui/src/app/(main)/mcp-servers/page.tsx
@@ -32,7 +32,7 @@ import {
 } from "@/hooks/use-mcp-servers";
 import { usePolicies } from "@/hooks/use-policies";
 import { usePageTitle } from "@/hooks";
-import { Plus, Plug, Trash2, Key, Globe } from "lucide-react";
+import { Plus, Plug, Trash2, Key, Globe, X } from "lucide-react";
 import type { McpServer, CreateMcpServerRequest, McpServerAuthMode } from "@/lib/api/types";
 import {
   apiKeySecretSchema,
@@ -138,6 +138,8 @@ function AddMcpServerDialog({
   const [url, setUrl] = useState("");
   const [apiKey, setApiKey] = useState("");
   const [authMode, setAuthMode] = useState<McpServerAuthMode>("none");
+  const [headers, setHeaders] = useState<Array<{ key: string; value: string }>>([]);
+  const [headerErrors, setHeaderErrors] = useState<string | null>(null);
   const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
 
   const createServer = useCreateMcpServer();
@@ -149,6 +151,8 @@ function AddMcpServerDialog({
     setUrl("");
     setApiKey("");
     setAuthMode("none");
+    setHeaders([]);
+    setHeaderErrors(null);
     setFieldErrors({});
   }, [open]);
 
@@ -166,6 +170,18 @@ function AddMcpServerDialog({
       return;
     }
 
+    const nonEmptyHeaders = headers.filter((h) => h.key || h.value);
+    const missingKey = nonEmptyHeaders.find((h) => !h.key);
+    if (missingKey) {
+      setHeaderErrors("All headers must have a name");
+      return;
+    }
+    setHeaderErrors(null);
+    const headersRecord =
+      nonEmptyHeaders.length > 0
+        ? Object.fromEntries(nonEmptyHeaders.map((h) => [h.key, h.value]))
+        : undefined;
+
     const data: CreateMcpServerRequest = {
       name: parsed.data.name,
       description: parsed.data.description,
@@ -173,6 +189,7 @@ function AddMcpServerDialog({
       transport_type: "http",
       auth_mode: parsed.data.auth_mode,
       api_key: parsed.data.auth_mode === "api_key" ? parsed.data.api_key : undefined,
+      headers: headersRecord,
     };
     await createServer.mutateAsync(data);
     onOpenChange(false);
@@ -181,6 +198,8 @@ function AddMcpServerDialog({
     setUrl("");
     setApiKey("");
     setAuthMode("none");
+    setHeaders([]);
+    setHeaderErrors(null);
     setFieldErrors({});
   };
 
@@ -281,6 +300,60 @@ function AddMcpServerDialog({
               )}
             </div>
           )}
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <Label>Custom Headers (optional)</Label>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-7 text-xs"
+                onClick={() => setHeaders((prev) => [...prev, { key: "", value: "" }])}
+              >
+                <Plus className="h-3 w-3 mr-1" />
+                Add header
+              </Button>
+            </div>
+            {headers.length > 0 && (
+              <div className="space-y-2">
+                {headers.map((header, index) => (
+                  <div key={index} className="flex items-center gap-2">
+                    <Input
+                      placeholder="Name"
+                      value={header.key}
+                      onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                        setHeaders((prev) =>
+                          prev.map((h, i) => (i === index ? { ...h, key: e.target.value } : h)),
+                        );
+                        setHeaderErrors(null);
+                      }}
+                      className="flex-1"
+                    />
+                    <Input
+                      placeholder="Value"
+                      value={header.value}
+                      onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                        setHeaders((prev) =>
+                          prev.map((h, i) => (i === index ? { ...h, value: e.target.value } : h)),
+                        );
+                      }}
+                      className="flex-1"
+                    />
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      className="h-9 w-9 p-0 shrink-0"
+                      onClick={() => setHeaders((prev) => prev.filter((_, i) => i !== index))}
+                    >
+                      <X className="h-4 w-4" />
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            )}
+            {headerErrors && <p className="text-xs text-destructive">{headerErrors}</p>}
+          </div>
           <DialogFooter>
             <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
               Cancel


### PR DESCRIPTION
## What
Adds a dynamic key-value header editor to the Add MCP Server dialog so operators can supply custom HTTP headers when registering a server.

## Why
Some MCP servers require non-standard authentication or routing headers (e.g. `X-Workspace-ID`, `X-Tenant`) that don't fit the existing auth-mode options. The API already accepted `headers` on `CreateMcpServerRequest`; the UI had no way to supply them.

## How
- Added `headers` state (`Array<{key, value}>`) and `headerErrors` to `AddMcpServerDialog`.
- New section below the auth fields: label + "Add header" ghost button; each row is Name / Value inputs with an X remove button.
- Validation: rows where both key and value are empty are ignored; a non-empty value with no key is an error.
- Non-empty rows are folded into a `Record<string, string>` and forwarded as `CreateMcpServerRequest.headers`.
- State is reset on dialog open and after successful create.

## Risk
- Low — purely additive UI change; empty headers map is omitted from the request so existing servers are unaffected.

## Security
- Threat categories reviewed: TM-API (input passed to backend), TM-AUTH (headers could carry credentials)
- Header names and values are free-form strings sent to the backend as-is; the backend already stores/uses them. No new attack surface beyond what the API already accepted.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated — UI-only; no unit tests for this component exist; manual verification path: add server with headers, confirm they appear in network request
- [x] Backward compatibility considered — no schema changes, `headers` was already optional
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed

---
_Generated by [Claude Code](https://claude.ai/code/session_01VFnKN16PE34PQNKKzgqAsq)_