### PR TITLE
chore: publish daytona and e2b integrations to crates.io

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -154,6 +154,12 @@ jobs:
               "integrations/github/Cargo.toml": [
                   "everruns-core",
               ],
+              "integrations/daytona/Cargo.toml": [
+                  "everruns-core",
+              ],
+              "integrations/e2b/Cargo.toml": [
+                  "everruns-core",
+              ],
           }
 
           for manifest_path, dependency_names in dependency_versions.items():
@@ -193,6 +199,8 @@ jobs:
             everruns-anthropic
             everruns-integrations-duckduckgo
             everruns-integrations-github
+            everruns-integrations-daytona
+            everruns-integrations-e2b
             everruns-runtime
           )
 

--- a/integrations/daytona/Cargo.toml
+++ b/integrations/daytona/Cargo.toml
@@ -5,12 +5,19 @@
 name = "everruns-integrations-daytona"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+documentation = "https://docs.rs/everruns-integrations-daytona"
+readme = "README.md"
+keywords = ["everruns", "daytona", "sandbox", "agents"]
+categories = ["api-bindings", "development-tools"]
 description = "Daytona cloud sandbox integration for Everruns"
 
 [dependencies]
-everruns-core = { path = "../../crates/core" }
+everruns-core.workspace = true
 inventory.workspace = true
 
 # HTTP client for Daytona API

--- a/integrations/daytona/README.md
+++ b/integrations/daytona/README.md
@@ -1,0 +1,26 @@
+# everruns-integrations-daytona
+
+Daytona cloud sandbox integration for Everruns agents.
+
+This crate is part of the [Everruns](https://everruns.com) ecosystem. It adds
+cloud-based sandboxed code execution backed by the
+[Daytona](https://www.daytona.io) REST API, letting agents create sandboxes,
+run commands, and read or write files inside an isolated environment.
+
+## What It Provides
+
+- Per-session Daytona sandbox lifecycle (create, reuse, dispose)
+- In-sandbox command execution with streamed output
+- File read/write tools inside the sandbox
+- Bring-your-own Daytona API key via the user connection provider
+- Inventory-based Everruns integration registration
+
+## Configuration
+
+The Daytona API key is resolved from the user's `daytona` connection; there is
+no platform-owned or environment-variable fallback. Configure the connection
+before invoking sandbox tools.
+
+## License
+
+MIT. See the repository-level `LICENSE` file.

--- a/integrations/e2b/Cargo.toml
+++ b/integrations/e2b/Cargo.toml
@@ -2,7 +2,15 @@
 name = "everruns-integrations-e2b"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+documentation = "https://docs.rs/everruns-integrations-e2b"
+readme = "README.md"
+keywords = ["everruns", "e2b", "sandbox", "agents"]
+categories = ["api-bindings", "development-tools"]
 description = "E2B cloud sandbox integration for Everruns"
 build = "build.rs"
 
@@ -23,7 +31,7 @@ buffa = "0.2.0"
 rustls.workspace = true
 rustls-native-certs = "0.8"
 
-everruns-core = { path = "../../crates/core" }
+everruns-core.workspace = true
 
 [package.metadata.cargo-machete]
 ignored = ["connectrpc-build", "futures", "http-body", "prost", "protox"]

--- a/integrations/e2b/README.md
+++ b/integrations/e2b/README.md
@@ -1,0 +1,26 @@
+# everruns-integrations-e2b
+
+E2B cloud sandbox integration for Everruns agents.
+
+This crate is part of the [Everruns](https://everruns.com) ecosystem. It adds
+cloud sandboxes backed by [E2B](https://e2b.dev), letting agents create
+sandboxes, run processes, and read or write files inside an isolated
+environment.
+
+## What It Provides
+
+- Per-session E2B sandbox lifecycle with leased-resource cleanup
+- Process execution over the E2B Connect RPC API
+- File read/write tools inside the sandbox
+- Bring-your-own E2B API key via the user connection provider
+- Inventory-based Everruns integration registration
+
+## Configuration
+
+The E2B API key is resolved from the user's `e2b` connection only; there is no
+platform-owned or environment-variable fallback. Tools fail with
+`ConnectionRequired` until the connection is configured.
+
+## License
+
+MIT. See the repository-level `LICENSE` file.

--- a/scripts/sync-publish-pin-versions.py
+++ b/scripts/sync-publish-pin-versions.py
@@ -37,6 +37,8 @@ INNER_PINS: dict[str, list[str]] = {
     "crates/anthropic/Cargo.toml": ["everruns-core"],
     "integrations/duckduckgo/Cargo.toml": ["everruns-core"],
     "integrations/github/Cargo.toml": ["everruns-core"],
+    "integrations/daytona/Cargo.toml": ["everruns-core"],
+    "integrations/e2b/Cargo.toml": ["everruns-core"],
 }
 
 # Workspace.dependencies path pins (root Cargo.toml).


### PR DESCRIPTION
## What
Make the `everruns-integrations-daytona` and `everruns-integrations-e2b` crates
publishable to crates.io and wire them into the release pipeline.

- Switch both crates from a path-only `everruns-core` dependency to the
  versioned workspace dependency (`everruns-core.workspace = true`).
- Add the package metadata that crates.io requires / that the other published
  integrations carry: `rust-version`, `homepage`, `repository`, `documentation`,
  `readme`, `keywords`, `categories` (e2b also gains `authors`).
- Add a `README.md` for each crate (referenced by `readme = "README.md"`).
- Add both crates to the `CRATES` publish list and the `dependency_versions`
  verification map in `.github/workflows/publish-crates.yml`.
- Add both manifests to `INNER_PINS` in `scripts/sync-publish-pin-versions.py`
  to keep it in sync with the workflow.

## Why
Both integration crates were structurally complete but unpublishable: crates.io
rejects path-only dependencies, so `everruns-core = { path = ... }` (no version)
blocked publishing, and neither crate was listed in the publish workflow. This
brings them in line with the already-published integrations
(`everruns-integrations-duckduckgo`, `everruns-integrations-github`).

## How
Mirrored the existing published-integration pattern. The workflow publishes
`everruns-core` before the integration crates, so the dependency ordering for
the new entries is already correct (both are appended after `everruns-core`).
e2b's `build.rs` uses the pure-Rust `protox` compiler and its `proto/process.proto`
is committed, so it is included in the package and needs no `protoc` at build time.

## Risk
- Low
- Worst case is a failed crates.io publish step at release time, which is
  retried by the workflow and does not affect the product build or runtime. No
  runtime code changed.

## Security
- Threat categories reviewed: No security-relevant code changes. The diff is
  release/CI metadata, crate manifest fields, and READMEs. It does not touch
  secret handling, the workflow's trusted-ref verification, token usage, auth,
  APIs, or tool execution. No new dependencies are introduced — the crates were
  already built into the product; this only makes their source publishable.
- Findings and resolutions: None.

## Validation
- `cargo package -p everruns-integrations-daytona -p everruns-integrations-e2b`
  succeeds; the e2b package includes `build.rs` and `proto/process.proto`, and
  both include their README.
- `cargo check -p everruns-integrations-daytona -p everruns-integrations-e2b`
  passes; `cargo fmt --check` clean; `cargo fetch --locked` clean (dependency
  path unchanged, so `Cargo.lock` is unaffected).
- Ran the publish workflow's version-verification logic locally with the new
  map entries — passes at `0.10.0`.
- `python3 scripts/sync-publish-pin-versions.py --check` reports all pins at
  `0.10.0`; workflow YAML parses.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated (n/a — release metadata; verified via `cargo package` and the workflow verify logic locally)
- [x] Backward compatibility considered (no runtime/API change)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01L86JDqZQCiLJMymgMc7B1j)_