### PR TITLE
fix(core): simplify web_fetch system-policy block message

### DIFF
--- a/crates/core/src/capabilities/web_fetch.rs
+++ b/crates/core/src/capabilities/web_fetch.rs
@@ -324,8 +324,8 @@ impl WebFetchTool {
         match &self.system_allowlist {
             Some(allowlist) if !allowlist.is_url_allowed(url) => {
                 Some(ToolExecutionResult::tool_error(format!(
-                    "Endpoint blocked by system policy: {url} is not on the deployment's \
-                     system allowlist of permitted public resources."
+                    "Endpoint blocked by system policy: {url} is not on the allowlist \
+                     of permitted public resources."
                 )))
             }
             _ => None,


### PR DESCRIPTION
## What
Shorten the `web_fetch` system-allowlist block message from "…is not on the deployment's system allowlist of permitted public resources." to "…is not on the allowlist of permitted public resources."

## Why
The previous wording was wordy and exposed internal deployment terminology ("deployment's system allowlist") to the agent/user. The shorter message conveys the same policy decision.

## How
Two-line string change in `system_policy_block()` in `crates/core/src/capabilities/web_fetch.rs`. Enforcement logic, control flow, and the distinct "Endpoint blocked by system policy:" prefix (referenced by `specs/system-allowlist.md`) are unchanged.

## Risk
- Low
- Only the message text changes; no enforcement behavior changes. The existing unit test asserts on the stable prefix and the blocked URL, both preserved.

## Security
- Threat categories reviewed: TM-AGENT-018 (outbound URL filtering) — the change sits inside the system-allowlist pre-flight check for `web_fetch`.
- Findings and resolutions: none. Enforcement predicate (`is_url_allowed`) and fail-closed behavior untouched; the message still includes only the agent-supplied URL (no new data exposure); no injection surface (same `format!` interpolation as before). No threat-model update needed.

## Validation
- `cargo test -p everruns-core --lib web_fetch::tests::system_allowlist_blocks_with_clear_system_policy_error` — passes; exercises the exact changed path (allowlist configured, blocked URL fetched, error message asserted).
- `cargo fmt --check`, `cargo clippy -p everruns-core --all-features --lib -- -D warnings` — clean.
- Full-stack smoke skipped with justification: the only runtime-visible delta is a string literal in a tool error, directly asserted end-to-end at the tool boundary by the unit test above; no control flow, config, or API surface changed.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated (existing test covers the changed message's stable assertions)
- [x] Backward compatibility considered (internal message, no API contract; spec references only the unchanged prefix)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_019s8CCGt99LUYpALmH9iYFq)_