### PR TITLE
chore(release): publish everruns-integrations-parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,6 +272,7 @@ jobs:
             -p everruns-anthropic \
             -p everruns-integrations-duckduckgo \
             -p everruns-integrations-github \
+            -p everruns-integrations-parallel \
             -p everruns-runtime
 
   migration-immutability:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,6 +272,8 @@ jobs:
             -p everruns-anthropic \
             -p everruns-integrations-duckduckgo \
             -p everruns-integrations-github \
+            -p everruns-integrations-daytona \
+            -p everruns-integrations-e2b \
             -p everruns-integrations-parallel \
             -p everruns-runtime
 

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -160,6 +160,9 @@ jobs:
               "integrations/e2b/Cargo.toml": [
                   "everruns-core",
               ],
+              "integrations/parallel/Cargo.toml": [
+                  "everruns-core",
+              ],
           }
 
           for manifest_path, dependency_names in dependency_versions.items():
@@ -201,6 +204,7 @@ jobs:
             everruns-integrations-github
             everruns-integrations-daytona
             everruns-integrations-e2b
+            everruns-integrations-parallel
             everruns-runtime
           )
 

--- a/crates/core/src/capabilities/session_tasks.rs
+++ b/crates/core/src/capabilities/session_tasks.rs
@@ -646,7 +646,6 @@ pub(crate) mod tests {
     use chrono::Utc;
     use std::collections::HashMap;
     use std::sync::Mutex;
-    use std::sync::atomic::{AtomicUsize, Ordering};
 
     /// In-memory `SessionTaskRegistry` test double. Updates route through
     /// `apply_task_update` so lifecycle invariants match real backends.
@@ -790,10 +789,21 @@ pub(crate) mod tests {
         }
     }
 
-    /// Test executor kind. `deliver`/`cancel` succeed and count invocations.
+    /// Test executor kind. `deliver`/`cancel` succeed and log invocations.
+    /// The executor is process-global (inventory), so invocations are logged
+    /// per task id; task ids are unique per test, which keeps assertions
+    /// race-free under parallel test execution.
     const TEST_EXECUTOR_KIND: &str = "session_tasks_test";
-    static TEST_DELIVERED: AtomicUsize = AtomicUsize::new(0);
-    static TEST_CANCELED: AtomicUsize = AtomicUsize::new(0);
+    static TEST_DELIVERED: Mutex<Vec<String>> = Mutex::new(Vec::new());
+    static TEST_CANCELED: Mutex<Vec<String>> = Mutex::new(Vec::new());
+
+    fn executor_invocations(log: &Mutex<Vec<String>>, task_id: &str) -> usize {
+        log.lock()
+            .unwrap()
+            .iter()
+            .filter(|id| *id == task_id)
+            .count()
+    }
 
     struct TestTaskExecutor;
 
@@ -805,20 +815,20 @@ pub(crate) mod tests {
 
         async fn deliver(
             &self,
-            _task: &SessionTask,
+            task: &SessionTask,
             _message: &TaskMessage,
             _context: &ToolContext,
         ) -> crate::error::Result<()> {
-            TEST_DELIVERED.fetch_add(1, Ordering::SeqCst);
+            TEST_DELIVERED.lock().unwrap().push(task.id.clone());
             Ok(())
         }
 
         async fn cancel(
             &self,
-            _task: &SessionTask,
+            task: &SessionTask,
             _context: &ToolContext,
         ) -> crate::error::Result<()> {
-            TEST_CANCELED.fetch_add(1, Ordering::SeqCst);
+            TEST_CANCELED.lock().unwrap().push(task.id.clone());
             Ok(())
         }
     }
@@ -984,7 +994,6 @@ pub(crate) mod tests {
         )
         .await;
 
-        let before = TEST_DELIVERED.load(Ordering::SeqCst);
         let result = MessageTaskTool
             .execute_with_context(
                 json!({"task_id": task.id, "message": "keep going"}),
@@ -995,7 +1004,7 @@ pub(crate) mod tests {
             panic!("expected success: {result:?}");
         };
         assert_eq!(value["delivery"], "delivered");
-        assert_eq!(TEST_DELIVERED.load(Ordering::SeqCst), before + 1);
+        assert_eq!(executor_invocations(&TEST_DELIVERED, &task.id), 1);
 
         let messages = registry
             .list_messages(context.session_id, &task.id, None)
@@ -1093,7 +1102,6 @@ pub(crate) mod tests {
         )
         .await;
 
-        let before = TEST_CANCELED.load(Ordering::SeqCst);
         let result = CancelTaskTool
             .execute_with_context(json!({"task_id": task.id}), &context)
             .await;
@@ -1102,7 +1110,7 @@ pub(crate) mod tests {
         };
         assert_eq!(value["cancel_requested"], true);
         assert_eq!(value["executor"], "cancellation requested");
-        assert_eq!(TEST_CANCELED.load(Ordering::SeqCst), before + 1);
+        assert_eq!(executor_invocations(&TEST_CANCELED, &task.id), 1);
 
         let current = registry
             .get(context.session_id, &task.id)
@@ -1130,9 +1138,8 @@ pub(crate) mod tests {
         let ToolExecutionResult::Success(value) = result else {
             panic!("expected success: {result:?}");
         };
-        // The executor reply proves the skip; the shared TEST_CANCELED counter
-        // is not asserted here because parallel cancel tests also bump it.
         assert_eq!(value["executor"], "task already terminal");
+        assert_eq!(executor_invocations(&TEST_CANCELED, &task.id), 0);
     }
 
     #[tokio::test]

--- a/integrations/daytona/README.md
+++ b/integrations/daytona/README.md
@@ -7,6 +7,17 @@ cloud-based sandboxed code execution backed by the
 [Daytona](https://www.daytona.io) REST API, letting agents create sandboxes,
 run commands, and read or write files inside an isolated environment.
 
+## Quick Example
+
+```rust
+use everruns_core::capabilities::Capability;
+use everruns_integrations_daytona::DaytonaCapability;
+
+let capability = DaytonaCapability;
+
+assert_eq!(capability.id(), "daytona");
+```
+
 ## What It Provides
 
 - Per-session Daytona sandbox lifecycle (create, reuse, dispose)

--- a/integrations/e2b/README.md
+++ b/integrations/e2b/README.md
@@ -7,6 +7,17 @@ cloud sandboxes backed by [E2B](https://e2b.dev), letting agents create
 sandboxes, run processes, and read or write files inside an isolated
 environment.
 
+## Quick Example
+
+```rust
+use everruns_core::capabilities::Capability;
+use everruns_integrations_e2b::E2BCapability;
+
+let capability = E2BCapability;
+
+assert_eq!(capability.id(), "e2b");
+```
+
 ## What It Provides
 
 - Per-session E2B sandbox lifecycle with leased-resource cleanup

--- a/integrations/parallel/Cargo.toml
+++ b/integrations/parallel/Cargo.toml
@@ -6,12 +6,17 @@
 name = "everruns-integrations-parallel"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 authors.workspace = true
-description = "Parallel MCP integration for Everruns"
+homepage.workspace = true
+repository.workspace = true
+documentation = "https://docs.rs/everruns-integrations-parallel"
+description = "Parallel web search MCP integration for Everruns"
+readme = "README.md"
 
 [dependencies]
-everruns-core = { path = "../../crates/core" }
+everruns-core.workspace = true
 inventory.workspace = true
 reqwest.workspace = true
 serde.workspace = true

--- a/integrations/parallel/Cargo.toml
+++ b/integrations/parallel/Cargo.toml
@@ -14,6 +14,8 @@ repository.workspace = true
 documentation = "https://docs.rs/everruns-integrations-parallel"
 description = "Parallel web search MCP integration for Everruns"
 readme = "README.md"
+keywords = ["everruns", "parallel", "search", "agents"]
+categories = ["api-bindings", "development-tools"]
 
 [dependencies]
 everruns-core.workspace = true

--- a/integrations/parallel/README.md
+++ b/integrations/parallel/README.md
@@ -1,0 +1,34 @@
+# everruns-integrations-parallel
+
+Parallel web search integration for Everruns agents.
+
+This crate is part of the [Everruns](https://everruns.com) ecosystem. It
+contributes Parallel's hosted MCP server so agents get provider-owned
+`web_search` and `web_fetch` tools, free by default with an optional
+Parallel API-key connection for authenticated usage.
+
+## Quick Example
+
+```rust
+use everruns_core::capabilities::Capability;
+use everruns_integrations_parallel::ParallelCapability;
+
+let capability = ParallelCapability;
+
+assert_eq!(capability.id(), "parallel_search");
+```
+
+## What It Provides
+
+- `parallel_search` capability contributing the hosted Parallel MCP server
+  (`mcp_parallel__web_search`, `mcp_parallel__web_fetch`)
+- Optional user-scoped Parallel API-key connection with bearer auth and an
+  OAuth-compatible endpoint mode
+- A separate paid `parallel` capability (search/extract/task tools) that routes
+  spend through the core `PaymentAuthority`; gated behind the
+  `machine_payments` feature flag and off by default
+- Inventory-based Everruns integration registration
+
+## License
+
+MIT. See the repository-level `LICENSE` file.

--- a/scripts/sync-publish-pin-versions.py
+++ b/scripts/sync-publish-pin-versions.py
@@ -39,6 +39,7 @@ INNER_PINS: dict[str, list[str]] = {
     "integrations/github/Cargo.toml": ["everruns-core"],
     "integrations/daytona/Cargo.toml": ["everruns-core"],
     "integrations/e2b/Cargo.toml": ["everruns-core"],
+    "integrations/parallel/Cargo.toml": ["everruns-core"],
 }
 
 # Workspace.dependencies path pins (root Cargo.toml).


### PR DESCRIPTION
## What
Add the Parallel web search integration crate (`everruns-integrations-parallel`) to the published crates set on crates.io.

- `integrations/parallel/Cargo.toml`: add the publish metadata other published integrations carry (`rust-version`, `homepage`, `repository`, docs.rs `documentation`, `readme`, `keywords`, `categories`) and switch `everruns-core` from a bare path dependency to the version-pinned workspace dependency so `cargo publish` accepts the manifest.
- `integrations/parallel/README.md`: new crate README (required by the `readme` field, shown on crates.io), modeled on the duckduckgo integration README.
- `.github/workflows/publish-crates.yml`: add the crate to the `CRATES` publish list and to the `dependency_versions` pin verification map (after the daytona/e2b entries from #2112; conflicts resolved by keeping both).
- `scripts/sync-publish-pin-versions.py`: add the manifest to `INNER_PINS`, kept in lockstep with the workflow per `.agents/commands/prepare-release.md`.
- `.github/workflows/ci.yml`: add the crate to the `Published Crate MSRV` check, and also backfill `everruns-integrations-daytona` / `everruns-integrations-e2b` (published in #2112 but never added to that gate).

Two cleanups folded in while shipping:

- `integrations/daytona/README.md`, `integrations/e2b/README.md`: add a Quick Example block so they match the duckduckgo/parallel READMEs (they were the only published integrations missing it).
- `crates/core/src/capabilities/session_tasks.rs`: deflake. `message_task_records_and_delivers` failed in this PR's first CI run (`left: 2, right: 1`). The inventory-registered test executor counted deliver/cancel calls in process-global atomics and tests asserted an exact before/after delta, which races with parallel tests invoking the same executor. Invocations are now logged per task id (unique per test), making the asserts race-free; the terminal-skip cancel test now also asserts the executor was not called, which the old shared counter could not support (it carried a comment to that effect).

## Why
The Parallel search integration ships in-tree but is not on crates.io, unlike the other search integrations (`everruns-integrations-duckduckgo`, `everruns-integrations-github`). Publishing it lets external users of the published crates pull in Parallel web search.

## How
Mirror the existing duckduckgo/github (and now daytona/e2b, #2112) publish setup exactly; no runtime code changes. The crate publishes on the next release tag, after `everruns-core`, via the existing trusted-tag publish workflow.

## Risk
- Low
- Worst case for the publish change is a failed publish step at the next release; the workflow already skips already-published crates and retries on rate limits. Validated locally with the same `cargo package --locked -p everruns-integrations-parallel` command the workflow runs (full verify build passed against published `everruns-core 0.10.0`). The deflake is test-only; the README changes are docs-only. The MSRV-list additions were verified locally under the 1.94.0 toolchain.

## Security
- Threat categories reviewed: no security-relevant code changes — the diff is publish metadata, CI/workflow lists, READMEs, and a test-only deflake; no runtime code paths change. Supply-chain surface reviewed: publishing adds no new dependencies, and the publish workflow's trusted-tag validation (semver tag, expected SHA, reachable from `origin/main`) is unchanged.
- Findings and resolutions: none.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated — existing crate tests pass (`cargo test -p everruns-integrations-parallel`, 9 passed); session task tests deflaked and passing (13 passed)
- [x] Backward compatibility considered — first publish of this crate, nothing to break
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

## Validation
- `cargo package --locked -p everruns-integrations-parallel` — packages and verify-builds cleanly; README/SPEC/src/tests included
- `cargo +1.94.0 check --locked --all-features -p everruns-integrations-daytona -p everruns-integrations-e2b -p everruns-integrations-parallel` — clean under MSRV
- `cargo fmt --check`, `cargo clippy -p everruns-core --lib --tests`, `cargo clippy -p everruns-integrations-parallel --all-targets --all-features -- -D warnings` — clean
- `cargo test -p everruns-integrations-parallel` — 9 passed; `cargo test -p everruns-core --lib` — 2147 passed
- `python3 scripts/sync-publish-pin-versions.py --check` — all pins at 0.10.0
- `just pre-push` — all checks passed; rebased onto latest `origin/main` (post-#2110, #2112/#2113, #2115), migration ordering check clean
- Smoke test skipped: publish-config, docs, and test-only changes with no runtime behavior; the package verify build is the relevant end-to-end evidence.