### PR TITLE
feat(runtime): inject user connection resolver into in-process runtime

### DIFF
--- a/crates/runtime/src/backends.rs
+++ b/crates/runtime/src/backends.rs
@@ -19,7 +19,7 @@ use everruns_core::message_retriever::{InputMessage, MessageRetriever};
 use everruns_core::session::Session;
 use everruns_core::traits::{
     AgentStore, EventEmitter, HarnessStore, LlmProviderStore, ModelWithProvider, SessionMutator,
-    SessionStorageStore, SessionStore,
+    SessionStorageStore, SessionStore, UserConnectionResolver,
 };
 use everruns_core::typed_id::SessionId;
 use std::sync::Arc;
@@ -108,6 +108,14 @@ pub struct RuntimeBackends {
     pub event_bus: Arc<dyn EventBus>,
     /// Session key/value + secret storage backend.
     pub storage_store: Arc<dyn SessionStorageStore>,
+    /// Optional resolver for user connection tokens (e.g. GitHub, Daytona).
+    ///
+    /// When set, the runtime exposes it through `ToolContext.connection_resolver`
+    /// so connection-aware capabilities can resolve tokens lazily at tool time.
+    /// `None` (the default) leaves the resolver unset, matching prior behavior.
+    /// There is no in-memory default because a connection resolver implies a
+    /// real credential source the embedder must supply.
+    pub connection_resolver: Option<Arc<dyn UserConnectionResolver>>,
 }
 
 impl RuntimeBackends {
@@ -125,6 +133,7 @@ impl RuntimeBackends {
             provider_store: Arc::new(InMemoryLlmProviderStore::new()),
             event_bus,
             storage_store: Arc::new(InMemorySessionStorageStore::new()),
+            connection_resolver: None,
         }
     }
 
@@ -160,6 +169,15 @@ impl RuntimeBackends {
 
     pub fn with_storage_store(mut self, store: Arc<dyn SessionStorageStore>) -> Self {
         self.storage_store = store;
+        self
+    }
+
+    /// Supply a resolver for user connection tokens (e.g. GitHub, Daytona).
+    ///
+    /// The runtime forwards it into `ToolContext` so connection-aware
+    /// capabilities resolve tokens lazily at tool execution time.
+    pub fn with_connection_resolver(mut self, resolver: Arc<dyn UserConnectionResolver>) -> Self {
+        self.connection_resolver = Some(resolver);
         self
     }
 }

--- a/crates/runtime/src/runtime.rs
+++ b/crates/runtime/src/runtime.rs
@@ -34,7 +34,7 @@ use everruns_core::session_file::{InitialFile, SessionFile};
 use everruns_core::tools::ToolResultImage;
 use everruns_core::traits::{
     AgentStore, EventEmitter, HarnessStore, LlmProviderStore, ModelWithProvider, SessionMutator,
-    SessionStorageStore, SessionStore,
+    SessionStorageStore, SessionStore, UserConnectionResolver,
 };
 use everruns_core::turn::{TurnAction, TurnContext, TurnOutcome, TurnStateMachine};
 use everruns_core::typed_id::{AgentId, HarnessId, OrgId, SessionId};
@@ -403,6 +403,7 @@ impl InProcessRuntimeBuilder {
             persisting_emitter,
             file_store,
             storage_store: backends.storage_store,
+            connection_resolver: backends.connection_resolver,
             mcp_auth_provider: self
                 .mcp_auth_provider
                 .unwrap_or_else(|| Arc::new(everruns_mcp::NoAuthProvider)),
@@ -442,6 +443,7 @@ pub struct InProcessRuntime {
     persisting_emitter: PersistingEventEmitter,
     file_store: Arc<dyn SessionFileSystem>,
     storage_store: Arc<dyn SessionStorageStore>,
+    connection_resolver: Option<Arc<dyn UserConnectionResolver>>,
     mcp_auth_provider: Arc<dyn everruns_mcp::McpAuthProvider>,
 }
 
@@ -907,6 +909,10 @@ impl RuntimeHostAdapter for InProcessRuntime {
 
     fn storage_store(&self) -> Option<Arc<dyn SessionStorageStore>> {
         Some(self.storage_store.clone())
+    }
+
+    fn connection_resolver(&self) -> Option<Arc<dyn UserConnectionResolver>> {
+        self.connection_resolver.clone()
     }
 
     fn utility_llm_service(&self) -> Option<Arc<dyn everruns_core::UtilityLlmService>> {

--- a/crates/runtime/tests/in_process_runtime_test.rs
+++ b/crates/runtime/tests/in_process_runtime_test.rs
@@ -692,3 +692,231 @@ async fn execute_btw_command_returns_ephemeral_answer() {
             .contains("requires a question")
     );
 }
+
+// ---------------------------------------------------------------------------
+// Connection resolver injection
+//
+// Proves embedders can supply their own `UserConnectionResolver` through
+// `RuntimeBackends` and have it reach connection-aware tools via
+// `ToolContext.connection_resolver` (the seam used by integrations such as
+// Daytona). See specs/runtime.md and crates/server/specs/user-connections.md.
+// ---------------------------------------------------------------------------
+
+struct StaticTokenResolver {
+    provider: String,
+    token: String,
+}
+
+#[async_trait]
+impl everruns_core::traits::UserConnectionResolver for StaticTokenResolver {
+    async fn get_connection_token(
+        &self,
+        _session_id: everruns_core::SessionId,
+        provider: &str,
+    ) -> everruns_core::Result<Option<String>> {
+        Ok((provider == self.provider).then(|| self.token.clone()))
+    }
+}
+
+struct ConnectionEchoCapability;
+
+impl everruns_core::capabilities::Capability for ConnectionEchoCapability {
+    fn id(&self) -> &str {
+        "connection_echo"
+    }
+    fn name(&self) -> &str {
+        "Connection Echo"
+    }
+    fn description(&self) -> &str {
+        "Testing capability: echoes a resolved connection token via ToolContext."
+    }
+    fn status(&self) -> everruns_core::capabilities::CapabilityStatus {
+        everruns_core::capabilities::CapabilityStatus::Available
+    }
+    fn tools(&self) -> Vec<Box<dyn everruns_core::tools::Tool>> {
+        vec![Box::new(ConnectionEchoTool)]
+    }
+}
+
+struct ConnectionEchoTool;
+
+#[async_trait]
+impl everruns_core::tools::Tool for ConnectionEchoTool {
+    fn name(&self) -> &str {
+        "echo_connection_token"
+    }
+    fn description(&self) -> &str {
+        "Resolve the connection token for a provider and return it."
+    }
+    fn parameters_schema(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "provider": { "type": "string", "description": "Provider id, e.g. daytona" }
+            },
+            "required": ["provider"],
+            "additionalProperties": false
+        })
+    }
+    fn requires_context(&self) -> bool {
+        true
+    }
+    async fn execute(
+        &self,
+        _arguments: serde_json::Value,
+    ) -> everruns_core::tools::ToolExecutionResult {
+        everruns_core::tools::ToolExecutionResult::tool_error("requires context")
+    }
+    async fn execute_with_context(
+        &self,
+        arguments: serde_json::Value,
+        context: &everruns_core::traits::ToolContext,
+    ) -> everruns_core::tools::ToolExecutionResult {
+        let provider = arguments
+            .get("provider")
+            .and_then(|v| v.as_str())
+            .unwrap_or("daytona");
+        let token = match context.connection_resolver.as_ref() {
+            Some(resolver) => resolver
+                .get_connection_token(context.session_id, provider)
+                .await
+                .ok()
+                .flatten(),
+            None => None,
+        };
+        match token {
+            Some(token) => everruns_core::tools::ToolExecutionResult::success(serde_json::json!({
+                "token": token
+            })),
+            None => everruns_core::tools::ToolExecutionResult::tool_error("no connection"),
+        }
+    }
+}
+
+fn connection_platform() -> PlatformDefinition {
+    let mut capabilities = CapabilityRegistry::new();
+    capabilities.register(ConnectionEchoCapability);
+    PlatformDefinition::new(capabilities, DriverRegistry::new())
+}
+
+#[tokio::test]
+async fn runtime_exposes_injected_connection_resolver_to_host_adapter() {
+    use everruns_runtime::RuntimeHostAdapter;
+
+    let resolver = Arc::new(StaticTokenResolver {
+        provider: "daytona".to_string(),
+        token: "tok-host-adapter".to_string(),
+    });
+    let backends = RuntimeBackends::in_memory().with_connection_resolver(resolver);
+
+    let runtime = InProcessRuntimeBuilder::new()
+        .platform_definition(connection_platform())
+        .backends(backends)
+        .llm_sim(LlmSimConfig::fixed("ok"))
+        .single_session(|s| s.harness("h", "h").agent("a", "a"))
+        .build()
+        .await
+        .unwrap();
+
+    let session_id = runtime.default_session_id().expect("default session id");
+    let resolver = runtime
+        .connection_resolver()
+        .expect("connection resolver should be wired into the host adapter");
+    let token = resolver
+        .get_connection_token(session_id, "daytona")
+        .await
+        .unwrap();
+    assert_eq!(token.as_deref(), Some("tok-host-adapter"));
+
+    // Unknown providers resolve to None rather than erroring.
+    let missing = resolver
+        .get_connection_token(session_id, "github")
+        .await
+        .unwrap();
+    assert_eq!(missing, None);
+}
+
+#[tokio::test]
+async fn runtime_without_resolver_leaves_connection_resolver_unset() {
+    use everruns_runtime::RuntimeHostAdapter;
+
+    let runtime = InProcessRuntimeBuilder::new()
+        .platform_definition(connection_platform())
+        .llm_sim(LlmSimConfig::fixed("ok"))
+        .single_session(|s| s.harness("h", "h").agent("a", "a"))
+        .build()
+        .await
+        .unwrap();
+
+    assert!(
+        runtime.connection_resolver().is_none(),
+        "no resolver should be wired unless the embedder supplies one",
+    );
+}
+
+#[tokio::test]
+async fn injected_resolver_reaches_tool_context_during_a_turn() {
+    let harness_id = "harness_00000000000000000000000000000061".parse().unwrap();
+    let agent_id = "agent_00000000000000000000000000000061".parse().unwrap();
+    let session_id: everruns_core::SessionId =
+        "session_00000000000000000000000000000061".parse().unwrap();
+
+    let resolver = Arc::new(StaticTokenResolver {
+        provider: "daytona".to_string(),
+        token: "tok-tool-context".to_string(),
+    });
+    let backends = RuntimeBackends::in_memory().with_connection_resolver(resolver);
+
+    let runtime = InProcessRuntimeBuilder::new()
+        .platform_definition(connection_platform())
+        .backends(backends)
+        .llm_sim(
+            LlmSimConfig::fixed("resolving token").with_tool_call_sequence(vec![
+                vec![ToolCall {
+                    id: "call_echo_1".into(),
+                    name: "echo_connection_token".into(),
+                    arguments: serde_json::json!({ "provider": "daytona" }),
+                }],
+                vec![],
+            ]),
+        )
+        .default_model(ModelWithProvider {
+            model: "llmsim-model".into(),
+            provider_type: LlmProviderType::LlmSim,
+            api_key: Some("fake-key".into()),
+            base_url: None,
+        })
+        .harness(
+            HarnessBuilder::new("conn", "You resolve connection tokens.")
+                .id(harness_id)
+                .capability("connection_echo")
+                .build(),
+        )
+        .agent(
+            AgentBuilder::new("conn-agent", "Use the tool.")
+                .id(agent_id)
+                .max_iterations(8)
+                .build(),
+        )
+        .session(session(session_id, harness_id, Some(agent_id)))
+        .build()
+        .await
+        .unwrap();
+
+    let result = runtime
+        .run_text_turn(session_id, "Resolve the daytona token.")
+        .await
+        .unwrap();
+    assert!(result.success);
+
+    let messages = runtime.messages(session_id).await.unwrap();
+    let tool_result = messages
+        .iter()
+        .find(|m| m.role == MessageRole::ToolResult && m.tool_call_id() == Some("call_echo_1"))
+        .expect("tool result message");
+    let serialized = serde_json::to_string(tool_result).expect("serialize tool result");
+    assert!(
+        serialized.contains("tok-tool-context"),
+        "resolved token must reach the tool via ToolContext; got: {serialized}",
+    );
+}

--- a/crates/runtime/tests/in_process_runtime_test.rs
+++ b/crates/runtime/tests/in_process_runtime_test.rs
@@ -772,23 +772,37 @@ impl everruns_core::tools::Tool for ConnectionEchoTool {
         arguments: serde_json::Value,
         context: &everruns_core::traits::ToolContext,
     ) -> everruns_core::tools::ToolExecutionResult {
-        let provider = arguments
-            .get("provider")
-            .and_then(|v| v.as_str())
-            .unwrap_or("daytona");
-        let token = match context.connection_resolver.as_ref() {
-            Some(resolver) => resolver
-                .get_connection_token(context.session_id, provider)
-                .await
-                .ok()
-                .flatten(),
-            None => None,
+        // Fail fast on broken argument plumbing rather than defaulting — a
+        // missing/empty `provider` means the tool call did not arrive intact,
+        // which must surface as an error, not a "no connection" false pass.
+        let provider = match arguments.get("provider").and_then(|v| v.as_str()) {
+            Some(provider) if !provider.is_empty() => provider,
+            _ => {
+                return everruns_core::tools::ToolExecutionResult::internal_error_msg(
+                    "echo_connection_token: missing or empty `provider` argument",
+                );
+            }
         };
-        match token {
-            Some(token) => everruns_core::tools::ToolExecutionResult::success(serde_json::json!({
-                "token": token
-            })),
-            None => everruns_core::tools::ToolExecutionResult::tool_error("no connection"),
+        // A missing resolver is a distinct wiring failure from "user has no
+        // connection" — keep them separable so the test catches each.
+        let Some(resolver) = context.connection_resolver.as_ref() else {
+            return everruns_core::tools::ToolExecutionResult::internal_error_msg(
+                "echo_connection_token: no connection resolver in ToolContext",
+            );
+        };
+        // Surface resolver failures as internal errors instead of swallowing
+        // them; only a clean `Ok(None)` is the legitimate "not connected" case.
+        match resolver
+            .get_connection_token(context.session_id, provider)
+            .await
+        {
+            Ok(Some(token)) => everruns_core::tools::ToolExecutionResult::success(
+                serde_json::json!({ "token": token }),
+            ),
+            Ok(None) => everruns_core::tools::ToolExecutionResult::tool_error("no connection"),
+            Err(err) => everruns_core::tools::ToolExecutionResult::internal_error_msg(format!(
+                "echo_connection_token: resolver failed: {err}"
+            )),
         }
     }
 }

--- a/specs/runtime.md
+++ b/specs/runtime.md
@@ -202,6 +202,18 @@ Use `RuntimeBackends::in_memory()` for the all-in-memory default, then chain
 `.with_message_store(...)`, `.with_storage_store(...)`, etc. to override
 individual non-filesystem stores.
 
+`RuntimeBackends` also carries an optional
+`connection_resolver: Option<Arc<dyn UserConnectionResolver>>`
+(set via `.with_connection_resolver(...)`). When supplied, the runtime exposes
+it through `ToolContext.connection_resolver` so connection-aware capabilities
+(for example the Daytona integration) resolve user connection tokens lazily at
+tool execution time. There is no in-memory default: a resolver implies a real
+credential source the embedder owns. When unset, `ToolContext.connection_resolver`
+stays `None` and connection-aware tools fall back to their own guidance
+(session secret, then "connect the provider"). See
+`crates/server/specs/user-connections.md` for the connection model the resolver
+serves.
+
 Session files are a platform service: `PlatformDefinition` carries a
 `SessionFileSystemFactory`, and the runtime always resolves the concrete
 filesystem from that factory before seeding files or executing turns. Embedders


### PR DESCRIPTION
## What
Adds an optional `UserConnectionResolver` seam to the in-process runtime
(`everruns-runtime`). Embedders can now supply their own resolver through
`RuntimeBackends::with_connection_resolver(...)`, and the runtime forwards it
into `ToolContext.connection_resolver` so connection-aware capabilities (e.g.
the Daytona integration) resolve user connection tokens lazily at tool
execution time.

## Why
The "connections" concept (`UserConnectionResolver`, `ConnectionProvider`,
`ToolContext.connection_resolver`) already exists in `everruns-core`, and the
Daytona integration is already written against it. But the in-process runtime
had **no way to wire a resolver**: `RuntimeBackends` carried no field for it and
`InProcessRuntime` inherited the `RuntimeHostAdapter::connection_resolver()`
default of `None`. As a result, `ToolContext.connection_resolver` was always
`None` in embedded execution, so the connections concept could only be used on
the server/worker path.

This closes that gap, so an embedder (e.g. an external embedded host or the
`examples/coding-cli`) can bring its own `UserConnectionResolver` +
`ConnectionProvider`s and have Daytona consume them transparently — no changes
to the integration required.

## How
- `RuntimeBackends` gains `connection_resolver: Option<Arc<dyn UserConnectionResolver>>`
  (default `None`) and a chainable `with_connection_resolver(...)` setter. No
  in-memory default — a resolver implies a real credential source the embedder
  owns.
- `InProcessRuntime` stores the resolver and overrides
  `RuntimeHostAdapter::connection_resolver()`. The act-atom wiring already
  consumes that accessor to populate `ToolContext`, so no other plumbing was
  needed.
- `specs/runtime.md` documents the new optional backend.

## Risk
- Low. Purely additive: a new optional field defaulting to `None` preserves
  existing behavior for every current embedder. Server/worker hosts
  (`WorkerRuntimeHost`) are unaffected — they implement `RuntimeHostAdapter`
  separately and already wire their own resolver.

## Security
- Threat categories reviewed: **TM-TOOL** (tool execution / connection token
  resolution), **TM-LLM** (token handling).
- Findings and resolutions:
  - The resolver is opt-in and embedder-supplied; no token is injected into
    prompts, tool arguments, or message history by this change. The
    `UserConnectionResolver` contract (see `crates/server/specs/user-connections.md`)
    keeps tokens out of LLM-visible surfaces; this PR only forwards the existing
    trait object.
  - No new endpoints, auth, DB, or dependencies. No secrets logged.
  - The test-only `ConnectionEchoCapability` deliberately echoes a token into a
    tool result to prove reachability; it lives in the test binary and is not
    shipped.

## Follow-ups
- Server-path resolver override on `ServerAppBuilder` (currently hardcodes
  `DbConnectionResolver`) so embedders can swap it there too — safe to defer; it
  is a separate path from this in-process change and not required for embedded
  use.
- Optional `leased_resource_store` / `session_resource_registry` seams on the
  in-process runtime for full Daytona sandbox lifecycle cleanup — safe to defer;
  Daytona functions without them (lease tracking is optional), losing only
  automatic orphan cleanup.

## Validation
- `cargo test -p everruns-runtime` — all suites green, including three new tests:
  host-adapter exposure, the unset default, and a resolved token reaching a tool
  via `ToolContext` during a real `run_text_turn`.
- `cargo fmt -p everruns-runtime --check` clean; `cargo clippy -p everruns-runtime
  --all-targets --all-features -- -D warnings` clean.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

https://claude.ai/code/session_01Khu9zdmVNLJ6CZkCLuExWT

---
_Generated by [Claude Code](https://claude.ai/code/session_01Khu9zdmVNLJ6CZkCLuExWT)_