### PR TITLE
feat(capabilities): annotate LLM-facing messages with metadata

### DIFF
--- a/crates/core/src/capabilities/message_metadata.rs
+++ b/crates/core/src/capabilities/message_metadata.rs
@@ -16,6 +16,29 @@ use crate::message::{ContentPart, Message, MessageRole};
 
 pub const MESSAGE_METADATA_CAPABILITY_ID: &str = "message_metadata";
 
+/// A metadata field that can be annotated onto a message.
+///
+/// New fields (e.g. the LLM model that produced an agent message, once stored
+/// messages record it) are added as variants here; each variant renders its
+/// own bracketed segment and may return `None` when the message lacks the data.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MessageMetadataField {
+    /// Message creation time, rendered as `[sent <RFC3339 UTC>]`.
+    SentTime,
+}
+
+impl MessageMetadataField {
+    fn render(&self, msg: &Message) -> Option<String> {
+        match self {
+            Self::SentTime => Some(format!(
+                "[sent {}]",
+                msg.created_at.to_rfc3339_opts(SecondsFormat::Secs, true)
+            )),
+        }
+    }
+}
+
 /// Per-agent configuration for message metadata annotations.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -26,6 +49,9 @@ pub struct MessageMetadataConfig {
     /// Annotate agent messages with their sent time.
     #[serde(default = "default_true")]
     pub agent_messages: bool,
+    /// Which metadata fields to annotate, in render order.
+    #[serde(default = "default_fields")]
+    pub fields: Vec<MessageMetadataField>,
 }
 
 impl Default for MessageMetadataConfig {
@@ -33,12 +59,17 @@ impl Default for MessageMetadataConfig {
         Self {
             user_messages: default_true(),
             agent_messages: default_true(),
+            fields: default_fields(),
         }
     }
 }
 
 fn default_true() -> bool {
     true
+}
+
+fn default_fields() -> Vec<MessageMetadataField> {
+    vec![MessageMetadataField::SentTime]
 }
 
 impl MessageMetadataConfig {
@@ -92,6 +123,15 @@ impl Capability for MessageMetadataCapability {
                     "type": "boolean",
                     "default": true,
                     "title": "Annotate agent messages"
+                },
+                "fields": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "enum": ["sent_time"]
+                    },
+                    "default": ["sent_time"],
+                    "title": "Metadata fields to annotate"
                 }
             },
             "additionalProperties": false
@@ -129,7 +169,7 @@ impl ModelViewProvider for MessageMetadataModelViewProvider {
                 MessageRole::System | MessageRole::ToolResult => false,
             };
             if annotate {
-                annotate_message(msg);
+                annotate_message(msg, &config.fields);
             }
         }
         messages
@@ -141,16 +181,21 @@ impl ModelViewProvider for MessageMetadataModelViewProvider {
     }
 }
 
-/// Render the metadata annotation for a message.
-pub fn sent_annotation(msg: &Message) -> String {
-    format!(
-        "[sent {}]",
-        msg.created_at.to_rfc3339_opts(SecondsFormat::Secs, true)
-    )
+/// Render the combined metadata annotation for a message, e.g.
+/// `[sent 2026-06-11T09:15:42Z]`. Returns `None` when no field yields a value.
+pub fn render_annotation(msg: &Message, fields: &[MessageMetadataField]) -> Option<String> {
+    let segments: Vec<String> = fields.iter().filter_map(|f| f.render(msg)).collect();
+    if segments.is_empty() {
+        None
+    } else {
+        Some(segments.join(" "))
+    }
 }
 
-fn annotate_message(msg: &mut Message) {
-    let annotation = sent_annotation(msg);
+fn annotate_message(msg: &mut Message, fields: &[MessageMetadataField]) {
+    let Some(annotation) = render_annotation(msg, fields) else {
+        return;
+    };
     if let Some(ContentPart::Text(t)) = msg
         .content
         .iter_mut()
@@ -180,6 +225,10 @@ mod tests {
 
     fn apply(messages: Vec<Message>, config: serde_json::Value) -> Vec<Message> {
         MessageMetadataModelViewProvider.apply_model_view(messages, &config, &ctx())
+    }
+
+    fn sent_annotation(msg: &Message) -> String {
+        render_annotation(msg, &[MessageMetadataField::SentTime]).unwrap()
     }
 
     #[test]
@@ -225,6 +274,22 @@ mod tests {
 
         assert_eq!(out[0].text().unwrap(), "you are a bot");
         assert!(out[1].text().is_none());
+    }
+
+    #[test]
+    fn test_explicit_fields_config() {
+        let user = Message::user("hello");
+        let expected = sent_annotation(&user);
+        let out = apply(vec![user], serde_json::json!({"fields": ["sent_time"]}));
+        assert_eq!(out[0].text().unwrap(), format!("{expected} hello"));
+    }
+
+    #[test]
+    fn test_empty_fields_disable_annotations() {
+        let user = Message::user("hello");
+        let out = apply(vec![user], serde_json::json!({"fields": []}));
+        assert_eq!(out[0].text().unwrap(), "hello");
+        assert_eq!(out[0].content.len(), 1);
     }
 
     #[test]
@@ -280,6 +345,15 @@ mod tests {
         assert!(
             cap.validate_config(&serde_json::json!({"user_messages": "nope"}))
                 .is_err()
+        );
+        assert!(
+            cap.validate_config(&serde_json::json!({"fields": ["sent_time"]}))
+                .is_ok()
+        );
+        assert!(
+            cap.validate_config(&serde_json::json!({"fields": ["llm_model"]}))
+                .is_err(),
+            "unknown metadata fields are rejected until implemented"
         );
         assert!(
             cap.validate_config(&serde_json::json!({"unknown": true}))

--- a/crates/core/src/capabilities/message_metadata.rs
+++ b/crates/core/src/capabilities/message_metadata.rs
@@ -42,15 +42,12 @@ impl MessageMetadataField {
 }
 
 /// Per-agent configuration for message metadata annotations.
+///
+/// User and agent messages are always annotated; only the rendered fields are
+/// configurable.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct MessageMetadataConfig {
-    /// Annotate user messages.
-    #[serde(default = "default_true")]
-    pub user_messages: bool,
-    /// Annotate agent messages.
-    #[serde(default = "default_true")]
-    pub agent_messages: bool,
     /// Which metadata fields to annotate, in render order.
     #[serde(default = "default_fields")]
     pub fields: Vec<MessageMetadataField>,
@@ -59,15 +56,9 @@ pub struct MessageMetadataConfig {
 impl Default for MessageMetadataConfig {
     fn default() -> Self {
         Self {
-            user_messages: default_true(),
-            agent_messages: default_true(),
             fields: default_fields(),
         }
     }
-}
-
-fn default_true() -> bool {
-    true
 }
 
 fn default_fields() -> Vec<MessageMetadataField> {
@@ -116,16 +107,6 @@ impl Capability for MessageMetadataCapability {
         Some(serde_json::json!({
             "type": "object",
             "properties": {
-                "user_messages": {
-                    "type": "boolean",
-                    "default": true,
-                    "title": "Annotate user messages"
-                },
-                "agent_messages": {
-                    "type": "boolean",
-                    "default": true,
-                    "title": "Annotate agent messages"
-                },
                 "fields": {
                     "type": "array",
                     "items": {
@@ -165,12 +146,7 @@ impl ModelViewProvider for MessageMetadataModelViewProvider {
     ) -> Vec<Message> {
         let config = MessageMetadataConfig::from_json(config);
         for msg in &mut messages {
-            let annotate = match msg.role {
-                MessageRole::User => config.user_messages,
-                MessageRole::Agent => config.agent_messages,
-                MessageRole::System | MessageRole::ToolResult => false,
-            };
-            if annotate {
+            if matches!(msg.role, MessageRole::User | MessageRole::Agent) {
                 annotate_message(msg, &config.fields);
             }
         }
@@ -295,21 +271,6 @@ mod tests {
     }
 
     #[test]
-    fn test_config_disables_roles() {
-        let user = Message::user("hello");
-        let agent = Message::assistant("hi");
-        let expected_agent = time_annotation(&agent);
-
-        let out = apply(
-            vec![user, agent],
-            serde_json::json!({"user_messages": false}),
-        );
-
-        assert_eq!(out[0].text().unwrap(), "hello");
-        assert_eq!(out[1].text().unwrap(), format!("{expected_agent} hi"));
-    }
-
-    #[test]
     fn test_tool_call_only_agent_message_gets_text_part() {
         let mut agent = Message::assistant("");
         agent.content = vec![ContentPart::ToolCall(ToolCallContentPart::new(
@@ -341,15 +302,11 @@ mod tests {
         assert!(cap.validate_config(&serde_json::Value::Null).is_ok());
         assert!(cap.validate_config(&serde_json::json!({})).is_ok());
         assert!(
-            cap.validate_config(&serde_json::json!({"user_messages": false}))
+            cap.validate_config(&serde_json::json!({"fields": ["timestamp"]}))
                 .is_ok()
         );
         assert!(
-            cap.validate_config(&serde_json::json!({"user_messages": "nope"}))
-                .is_err()
-        );
-        assert!(
-            cap.validate_config(&serde_json::json!({"fields": ["timestamp"]}))
+            cap.validate_config(&serde_json::json!({"fields": []}))
                 .is_ok()
         );
         assert!(
@@ -358,8 +315,69 @@ mod tests {
             "unknown metadata fields are rejected until implemented"
         );
         assert!(
+            cap.validate_config(&serde_json::json!({"fields": "timestamp"}))
+                .is_err(),
+            "fields must be an array"
+        );
+        assert!(
+            cap.validate_config(&serde_json::json!({"user_messages": false}))
+                .is_err(),
+            "role toggles were removed; user/agent messages are always annotated"
+        );
+        assert!(
             cap.validate_config(&serde_json::json!({"unknown": true}))
                 .is_err()
         );
+    }
+
+    /// Keeps `config_schema()` honest against the serde config shape, since
+    /// there is no compile-time link between the two.
+    #[test]
+    fn test_config_schema_matches_config_shape() {
+        let cap = MessageMetadataCapability;
+        let schema = cap.config_schema().expect("capability exposes a schema");
+
+        assert_eq!(schema["type"], "object");
+        assert_eq!(
+            schema["additionalProperties"], false,
+            "schema must reject unknown keys like validate_config does"
+        );
+
+        // Schema properties == serde fields of the default config.
+        let schema_keys: std::collections::BTreeSet<&str> = schema["properties"]
+            .as_object()
+            .expect("properties object")
+            .keys()
+            .map(String::as_str)
+            .collect();
+        let config_value = serde_json::to_value(MessageMetadataConfig::default()).unwrap();
+        let config_keys: std::collections::BTreeSet<&str> = config_value
+            .as_object()
+            .expect("config serializes to object")
+            .keys()
+            .map(String::as_str)
+            .collect();
+        assert_eq!(schema_keys, config_keys);
+
+        // The schema's enum of field names matches MessageMetadataField's
+        // serde names, and its default parses as a valid config.
+        let enum_values = schema["properties"]["fields"]["items"]["enum"]
+            .as_array()
+            .expect("fields enum");
+        for value in enum_values {
+            assert!(
+                serde_json::from_value::<MessageMetadataField>(value.clone()).is_ok(),
+                "schema enum value {value} is not a known MessageMetadataField"
+            );
+        }
+        assert_eq!(
+            enum_values.len(),
+            1,
+            "add new MessageMetadataField variants to the schema enum"
+        );
+        let schema_default = serde_json::json!({
+            "fields": schema["properties"]["fields"]["default"]
+        });
+        assert!(cap.validate_config(&schema_default).is_ok());
     }
 }

--- a/crates/core/src/capabilities/message_metadata.rs
+++ b/crates/core/src/capabilities/message_metadata.rs
@@ -1,0 +1,289 @@
+//! MessageMetadata Capability — annotates user/agent messages with metadata
+//! (currently the message sent time) in the prompt-facing model view.
+//!
+//! Annotations are applied via [`ModelViewProvider`] at LLM message
+//! construction time; stored messages are never modified. Timestamps come from
+//! `Message::created_at`, which is immutable, so annotations are stable across
+//! turns and do not invalidate provider prompt caches.
+
+use std::sync::Arc;
+
+use chrono::SecondsFormat;
+use serde::{Deserialize, Serialize};
+
+use super::{Capability, ModelViewContext, ModelViewProvider};
+use crate::message::{ContentPart, Message, MessageRole};
+
+pub const MESSAGE_METADATA_CAPABILITY_ID: &str = "message_metadata";
+
+/// Per-agent configuration for message metadata annotations.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MessageMetadataConfig {
+    /// Annotate user messages with their sent time.
+    #[serde(default = "default_true")]
+    pub user_messages: bool,
+    /// Annotate agent messages with their sent time.
+    #[serde(default = "default_true")]
+    pub agent_messages: bool,
+}
+
+impl Default for MessageMetadataConfig {
+    fn default() -> Self {
+        Self {
+            user_messages: default_true(),
+            agent_messages: default_true(),
+        }
+    }
+}
+
+fn default_true() -> bool {
+    true
+}
+
+impl MessageMetadataConfig {
+    /// Parse from JSON value, falling back to defaults for invalid config.
+    pub fn from_json(value: &serde_json::Value) -> Self {
+        serde_json::from_value(value.clone()).unwrap_or_default()
+    }
+}
+
+/// MessageMetadata capability — annotates conversation messages with sent-time
+/// metadata when they are sent to the LLM.
+pub struct MessageMetadataCapability;
+
+impl Capability for MessageMetadataCapability {
+    fn id(&self) -> &str {
+        MESSAGE_METADATA_CAPABILITY_ID
+    }
+
+    fn name(&self) -> &str {
+        "Message Metadata"
+    }
+
+    fn description(&self) -> &str {
+        "Annotates user and agent messages with metadata (sent time, UTC) when building the LLM request, so the model can reason about timing and gaps between messages. Stored messages are unchanged."
+    }
+
+    fn icon(&self) -> Option<&str> {
+        Some("clock")
+    }
+
+    fn category(&self) -> Option<&str> {
+        Some("Utilities")
+    }
+
+    fn system_prompt_addition(&self) -> Option<&str> {
+        Some(
+            "Conversation messages carry a bracketed annotation added by the system, e.g. `[sent 2026-06-11T09:15:42Z]` (UTC). Use it to reason about timing and gaps between messages. It is not part of what the author wrote; never emit such annotations in your replies.",
+        )
+    }
+
+    fn config_schema(&self) -> Option<serde_json::Value> {
+        Some(serde_json::json!({
+            "type": "object",
+            "properties": {
+                "user_messages": {
+                    "type": "boolean",
+                    "default": true,
+                    "title": "Annotate user messages"
+                },
+                "agent_messages": {
+                    "type": "boolean",
+                    "default": true,
+                    "title": "Annotate agent messages"
+                }
+            },
+            "additionalProperties": false
+        }))
+    }
+
+    fn validate_config(&self, config: &serde_json::Value) -> Result<(), String> {
+        if config.is_null() {
+            return Ok(());
+        }
+        serde_json::from_value::<MessageMetadataConfig>(config.clone())
+            .map(|_| ())
+            .map_err(|e| format!("invalid message_metadata config: {e}"))
+    }
+
+    fn model_view_provider(&self) -> Option<Arc<dyn ModelViewProvider>> {
+        Some(Arc::new(MessageMetadataModelViewProvider))
+    }
+}
+
+struct MessageMetadataModelViewProvider;
+
+impl ModelViewProvider for MessageMetadataModelViewProvider {
+    fn apply_model_view(
+        &self,
+        mut messages: Vec<Message>,
+        config: &serde_json::Value,
+        _context: &ModelViewContext<'_>,
+    ) -> Vec<Message> {
+        let config = MessageMetadataConfig::from_json(config);
+        for msg in &mut messages {
+            let annotate = match msg.role {
+                MessageRole::User => config.user_messages,
+                MessageRole::Agent => config.agent_messages,
+                MessageRole::System | MessageRole::ToolResult => false,
+            };
+            if annotate {
+                annotate_message(msg);
+            }
+        }
+        messages
+    }
+
+    /// After compaction masking (50) so annotations land on the final view.
+    fn priority(&self) -> i32 {
+        100
+    }
+}
+
+/// Render the metadata annotation for a message.
+pub fn sent_annotation(msg: &Message) -> String {
+    format!(
+        "[sent {}]",
+        msg.created_at.to_rfc3339_opts(SecondsFormat::Secs, true)
+    )
+}
+
+fn annotate_message(msg: &mut Message) {
+    let annotation = sent_annotation(msg);
+    if let Some(ContentPart::Text(t)) = msg
+        .content
+        .iter_mut()
+        .find(|p| matches!(p, ContentPart::Text(_)))
+    {
+        t.text = format!("{annotation} {}", t.text);
+    } else {
+        // No text part (e.g. tool-call-only agent message): carry the
+        // annotation as its own leading text part.
+        msg.content.insert(0, ContentPart::text(annotation));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::capabilities::CapabilityRegistry;
+    use crate::message::ToolCallContentPart;
+    use crate::typed_id::SessionId;
+
+    fn ctx() -> ModelViewContext<'static> {
+        ModelViewContext {
+            session_id: SessionId::new(),
+            prior_usage: None,
+        }
+    }
+
+    fn apply(messages: Vec<Message>, config: serde_json::Value) -> Vec<Message> {
+        MessageMetadataModelViewProvider.apply_model_view(messages, &config, &ctx())
+    }
+
+    #[test]
+    fn test_capability_metadata() {
+        let cap = MessageMetadataCapability;
+        assert_eq!(cap.id(), "message_metadata");
+        assert_eq!(cap.name(), "Message Metadata");
+        assert_eq!(cap.category(), Some("Utilities"));
+        assert!(cap.system_prompt_addition().is_some());
+        assert!(cap.tools().is_empty());
+    }
+
+    #[test]
+    fn test_capability_in_registry() {
+        let registry = CapabilityRegistry::with_builtins();
+        let cap = registry.get(MESSAGE_METADATA_CAPABILITY_ID).unwrap();
+        assert!(cap.model_view_provider().is_some());
+    }
+
+    #[test]
+    fn test_annotates_user_and_agent_messages() {
+        let user = Message::user("hello");
+        let agent = Message::assistant("hi there");
+        let expected_user = sent_annotation(&user);
+        let expected_agent = sent_annotation(&agent);
+
+        let out = apply(vec![user, agent], serde_json::json!({}));
+
+        assert_eq!(
+            out[0].text().unwrap(),
+            format!("{expected_user} hello"),
+            "user message gets sent-time prefix"
+        );
+        assert_eq!(out[1].text().unwrap(), format!("{expected_agent} hi there"));
+    }
+
+    #[test]
+    fn test_skips_system_and_tool_result_messages() {
+        let system = Message::system("you are a bot");
+        let tool = Message::tool_result("call_1", Some(serde_json::json!({"ok": true})), None);
+
+        let out = apply(vec![system, tool], serde_json::json!({}));
+
+        assert_eq!(out[0].text().unwrap(), "you are a bot");
+        assert!(out[1].text().is_none());
+    }
+
+    #[test]
+    fn test_config_disables_roles() {
+        let user = Message::user("hello");
+        let agent = Message::assistant("hi");
+        let expected_agent = sent_annotation(&agent);
+
+        let out = apply(
+            vec![user, agent],
+            serde_json::json!({"user_messages": false}),
+        );
+
+        assert_eq!(out[0].text().unwrap(), "hello");
+        assert_eq!(out[1].text().unwrap(), format!("{expected_agent} hi"));
+    }
+
+    #[test]
+    fn test_tool_call_only_agent_message_gets_text_part() {
+        let mut agent = Message::assistant("");
+        agent.content = vec![ContentPart::ToolCall(ToolCallContentPart::new(
+            "call_1",
+            "get_weather",
+            serde_json::json!({}),
+        ))];
+        let expected = sent_annotation(&agent);
+
+        let out = apply(vec![agent], serde_json::json!({}));
+
+        assert_eq!(out[0].content.len(), 2);
+        assert_eq!(out[0].text().unwrap(), expected);
+        assert!(matches!(out[0].content[1], ContentPart::ToolCall(_)));
+    }
+
+    #[test]
+    fn test_annotation_format_is_rfc3339_utc() {
+        let user = Message::user("hello");
+        let out = apply(vec![user], serde_json::json!({}));
+        let text = out[0].text().unwrap();
+        assert!(text.starts_with("[sent 2"), "got: {text}");
+        assert!(text.contains("Z] hello"), "got: {text}");
+    }
+
+    #[test]
+    fn test_validate_config() {
+        let cap = MessageMetadataCapability;
+        assert!(cap.validate_config(&serde_json::Value::Null).is_ok());
+        assert!(cap.validate_config(&serde_json::json!({})).is_ok());
+        assert!(
+            cap.validate_config(&serde_json::json!({"user_messages": false}))
+                .is_ok()
+        );
+        assert!(
+            cap.validate_config(&serde_json::json!({"user_messages": "nope"}))
+                .is_err()
+        );
+        assert!(
+            cap.validate_config(&serde_json::json!({"unknown": true}))
+                .is_err()
+        );
+    }
+}

--- a/crates/core/src/capabilities/message_metadata.rs
+++ b/crates/core/src/capabilities/message_metadata.rs
@@ -1,5 +1,5 @@
 //! MessageMetadata Capability — annotates user/agent messages with metadata
-//! (currently the message sent time) in the prompt-facing model view.
+//! (currently the message timestamp) in the prompt-facing model view.
 //!
 //! Annotations are applied via [`ModelViewProvider`] at LLM message
 //! construction time; stored messages are never modified. Timestamps come from
@@ -24,15 +24,17 @@ pub const MESSAGE_METADATA_CAPABILITY_ID: &str = "message_metadata";
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum MessageMetadataField {
-    /// Message creation time, rendered as `[sent <RFC3339 UTC>]`.
-    SentTime,
+    /// Message timestamp (`Message::created_at`), rendered as
+    /// `[time <RFC3339 UTC>]`. For user messages this is when the message was
+    /// received; for agent messages, when the reply was generated.
+    Timestamp,
 }
 
 impl MessageMetadataField {
     fn render(&self, msg: &Message) -> Option<String> {
         match self {
-            Self::SentTime => Some(format!(
-                "[sent {}]",
+            Self::Timestamp => Some(format!(
+                "[time {}]",
                 msg.created_at.to_rfc3339_opts(SecondsFormat::Secs, true)
             )),
         }
@@ -43,10 +45,10 @@ impl MessageMetadataField {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct MessageMetadataConfig {
-    /// Annotate user messages with their sent time.
+    /// Annotate user messages.
     #[serde(default = "default_true")]
     pub user_messages: bool,
-    /// Annotate agent messages with their sent time.
+    /// Annotate agent messages.
     #[serde(default = "default_true")]
     pub agent_messages: bool,
     /// Which metadata fields to annotate, in render order.
@@ -69,7 +71,7 @@ fn default_true() -> bool {
 }
 
 fn default_fields() -> Vec<MessageMetadataField> {
-    vec![MessageMetadataField::SentTime]
+    vec![MessageMetadataField::Timestamp]
 }
 
 impl MessageMetadataConfig {
@@ -79,8 +81,8 @@ impl MessageMetadataConfig {
     }
 }
 
-/// MessageMetadata capability — annotates conversation messages with sent-time
-/// metadata when they are sent to the LLM.
+/// MessageMetadata capability — annotates conversation messages with metadata
+/// (e.g. their timestamp) when they are sent to the LLM.
 pub struct MessageMetadataCapability;
 
 impl Capability for MessageMetadataCapability {
@@ -93,7 +95,7 @@ impl Capability for MessageMetadataCapability {
     }
 
     fn description(&self) -> &str {
-        "Annotates user and agent messages with metadata (sent time, UTC) when building the LLM request, so the model can reason about timing and gaps between messages. Stored messages are unchanged."
+        "Annotates user and agent messages with metadata (message timestamp, UTC) when building the LLM request, so the model can reason about timing and gaps between messages. Stored messages are unchanged."
     }
 
     fn icon(&self) -> Option<&str> {
@@ -106,7 +108,7 @@ impl Capability for MessageMetadataCapability {
 
     fn system_prompt_addition(&self) -> Option<&str> {
         Some(
-            "Conversation messages carry a bracketed annotation added by the system, e.g. `[sent 2026-06-11T09:15:42Z]` (UTC). Use it to reason about timing and gaps between messages. It is not part of what the author wrote; never emit such annotations in your replies.",
+            "Conversation messages carry a bracketed annotation added by the system, e.g. `[time 2026-06-11T09:15:42Z]` — the message's timestamp (UTC). Use it to reason about timing and gaps between messages. It is not part of what the author wrote; never emit such annotations in your replies.",
         )
     }
 
@@ -128,9 +130,9 @@ impl Capability for MessageMetadataCapability {
                     "type": "array",
                     "items": {
                         "type": "string",
-                        "enum": ["sent_time"]
+                        "enum": ["timestamp"]
                     },
-                    "default": ["sent_time"],
+                    "default": ["timestamp"],
                     "title": "Metadata fields to annotate"
                 }
             },
@@ -182,7 +184,7 @@ impl ModelViewProvider for MessageMetadataModelViewProvider {
 }
 
 /// Render the combined metadata annotation for a message, e.g.
-/// `[sent 2026-06-11T09:15:42Z]`. Returns `None` when no field yields a value.
+/// `[time 2026-06-11T09:15:42Z]`. Returns `None` when no field yields a value.
 pub fn render_annotation(msg: &Message, fields: &[MessageMetadataField]) -> Option<String> {
     let segments: Vec<String> = fields.iter().filter_map(|f| f.render(msg)).collect();
     if segments.is_empty() {
@@ -227,8 +229,8 @@ mod tests {
         MessageMetadataModelViewProvider.apply_model_view(messages, &config, &ctx())
     }
 
-    fn sent_annotation(msg: &Message) -> String {
-        render_annotation(msg, &[MessageMetadataField::SentTime]).unwrap()
+    fn time_annotation(msg: &Message) -> String {
+        render_annotation(msg, &[MessageMetadataField::Timestamp]).unwrap()
     }
 
     #[test]
@@ -252,15 +254,15 @@ mod tests {
     fn test_annotates_user_and_agent_messages() {
         let user = Message::user("hello");
         let agent = Message::assistant("hi there");
-        let expected_user = sent_annotation(&user);
-        let expected_agent = sent_annotation(&agent);
+        let expected_user = time_annotation(&user);
+        let expected_agent = time_annotation(&agent);
 
         let out = apply(vec![user, agent], serde_json::json!({}));
 
         assert_eq!(
             out[0].text().unwrap(),
             format!("{expected_user} hello"),
-            "user message gets sent-time prefix"
+            "user message gets timestamp prefix"
         );
         assert_eq!(out[1].text().unwrap(), format!("{expected_agent} hi there"));
     }
@@ -279,8 +281,8 @@ mod tests {
     #[test]
     fn test_explicit_fields_config() {
         let user = Message::user("hello");
-        let expected = sent_annotation(&user);
-        let out = apply(vec![user], serde_json::json!({"fields": ["sent_time"]}));
+        let expected = time_annotation(&user);
+        let out = apply(vec![user], serde_json::json!({"fields": ["timestamp"]}));
         assert_eq!(out[0].text().unwrap(), format!("{expected} hello"));
     }
 
@@ -296,7 +298,7 @@ mod tests {
     fn test_config_disables_roles() {
         let user = Message::user("hello");
         let agent = Message::assistant("hi");
-        let expected_agent = sent_annotation(&agent);
+        let expected_agent = time_annotation(&agent);
 
         let out = apply(
             vec![user, agent],
@@ -315,7 +317,7 @@ mod tests {
             "get_weather",
             serde_json::json!({}),
         ))];
-        let expected = sent_annotation(&agent);
+        let expected = time_annotation(&agent);
 
         let out = apply(vec![agent], serde_json::json!({}));
 
@@ -329,7 +331,7 @@ mod tests {
         let user = Message::user("hello");
         let out = apply(vec![user], serde_json::json!({}));
         let text = out[0].text().unwrap();
-        assert!(text.starts_with("[sent 2"), "got: {text}");
+        assert!(text.starts_with("[time 2"), "got: {text}");
         assert!(text.contains("Z] hello"), "got: {text}");
     }
 
@@ -347,7 +349,7 @@ mod tests {
                 .is_err()
         );
         assert!(
-            cap.validate_config(&serde_json::json!({"fields": ["sent_time"]}))
+            cap.validate_config(&serde_json::json!({"fields": ["timestamp"]}))
                 .is_ok()
         );
         assert!(

--- a/crates/core/src/capabilities/message_metadata.rs
+++ b/crates/core/src/capabilities/message_metadata.rs
@@ -179,7 +179,11 @@ fn annotate_message(msg: &mut Message, fields: &[MessageMetadataField]) {
         .iter_mut()
         .find(|p| matches!(p, ContentPart::Text(_)))
     {
-        t.text = format!("{annotation} {}", t.text);
+        t.text = if t.text.is_empty() {
+            annotation
+        } else {
+            format!("{annotation} {}", t.text)
+        };
     } else {
         // No text part (e.g. tool-call-only agent message): carry the
         // annotation as its own leading text part.
@@ -285,6 +289,16 @@ mod tests {
         assert_eq!(out[0].content.len(), 2);
         assert_eq!(out[0].text().unwrap(), expected);
         assert!(matches!(out[0].content[1], ContentPart::ToolCall(_)));
+    }
+
+    #[test]
+    fn test_empty_text_part_gets_annotation_without_trailing_space() {
+        let agent = Message::assistant("");
+        let expected = time_annotation(&agent);
+
+        let out = apply(vec![agent], serde_json::json!({}));
+
+        assert_eq!(out[0].text().unwrap(), expected);
     }
 
     #[test]

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -108,6 +108,7 @@ mod lua;
 mod lua_code_mode;
 pub mod mcp;
 mod memory;
+mod message_metadata;
 mod noop;
 mod openai_tool_search;
 #[cfg(feature = "ui-capabilities")]
@@ -220,6 +221,9 @@ pub use mcp::{
     parse_mcp_capability_id,
 };
 pub use memory::{MEMORY_CAPABILITY_ID, MemoryCapability};
+pub use message_metadata::{
+    MESSAGE_METADATA_CAPABILITY_ID, MessageMetadataCapability, MessageMetadataConfig,
+};
 pub use noop::NoopCapability;
 pub use openai_tool_search::{
     DEFAULT_TOOL_SEARCH_THRESHOLD, OPENAI_TOOL_SEARCH_CAPABILITY_ID, OpenAiToolSearchCapability,
@@ -937,6 +941,7 @@ impl CapabilityRegistry {
         registry.register(HumanIntentCapability);
         registry.register(NoopCapability);
         registry.register(CurrentTimeCapability);
+        registry.register(MessageMetadataCapability);
         registry.register(ResearchCapability);
         registry.register(PlatformManagementCapability);
         registry.register(FileSystemCapability);
@@ -2154,6 +2159,7 @@ mod tests {
             "infinity_context",
             "compaction",
             "memory",
+            "message_metadata",
             "openai_tool_search",
             "tool_search",
             "auto_tool_search",

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -223,6 +223,7 @@ pub use mcp::{
 pub use memory::{MEMORY_CAPABILITY_ID, MemoryCapability};
 pub use message_metadata::{
     MESSAGE_METADATA_CAPABILITY_ID, MessageMetadataCapability, MessageMetadataConfig,
+    MessageMetadataField, render_annotation,
 };
 pub use noop::NoopCapability;
 pub use openai_tool_search::{

--- a/crates/core/tests/message_metadata_test.rs
+++ b/crates/core/tests/message_metadata_test.rs
@@ -1,0 +1,61 @@
+// End-to-end test for the message_metadata capability.
+//
+// Uses the in-memory agentic loop with the echo sim driver: the assistant
+// reply mirrors exactly what the LLM received for the last user message, so
+// the timestamp annotation must be visible in the reply while the stored
+// user message stays unannotated.
+//
+// Run with: cargo test -p everruns-core --test message_metadata_test
+
+use everruns_core::MessageRetriever;
+use everruns_core::capabilities::MessageMetadataCapability;
+use everruns_core::in_memory_loop::InMemoryAgenticLoop;
+use everruns_core::llmsim_driver::LlmSimConfig;
+use everruns_core::message::MessageRole;
+
+#[tokio::test]
+async fn message_metadata_annotates_llm_view_not_storage() {
+    let agent_loop = InMemoryAgenticLoop::builder()
+        .with_llm_sim(LlmSimConfig::echo())
+        .capability(MessageMetadataCapability)
+        .build()
+        .await
+        .expect("loop builds");
+
+    let result = agent_loop.run_turn("hello there").await.expect("turn runs");
+
+    assert!(
+        result.response.contains("[time 2") && result.response.contains("Z] hello there"),
+        "LLM should see the timestamp annotation, got: {}",
+        result.response
+    );
+
+    // The annotation is model-view only: the stored user message is unchanged.
+    let messages = agent_loop
+        .message_retriever()
+        .load(agent_loop.session_id())
+        .await
+        .expect("messages load");
+    let stored_user = messages
+        .iter()
+        .find(|m| m.role == MessageRole::User)
+        .expect("user message stored");
+    assert_eq!(stored_user.text(), Some("hello there"));
+}
+
+#[tokio::test]
+async fn without_capability_no_annotation() {
+    let agent_loop = InMemoryAgenticLoop::builder()
+        .with_llm_sim(LlmSimConfig::echo())
+        .build()
+        .await
+        .expect("loop builds");
+
+    let result = agent_loop.run_turn("hello there").await.expect("turn runs");
+
+    assert!(
+        !result.response.contains("[time "),
+        "annotation must be opt-in, got: {}",
+        result.response
+    );
+}

--- a/crates/core/tests/prompt_budget.rs
+++ b/crates/core/tests/prompt_budget.rs
@@ -13,9 +13,9 @@
 
 use everruns_core::capabilities::{
     BudgetingCapability, Capability, DataKnowledgeCapability, FileSystemCapability,
-    InfinityContextCapability, MemoryCapability, SampleDataCapability, SelfBudgetCapability,
-    SessionSandboxCapability, SkillsCapability, StatelessTodoListCapability, SubagentCapability,
-    SystemPromptContext, WebFetchCapability,
+    InfinityContextCapability, MemoryCapability, MessageMetadataCapability, SampleDataCapability,
+    SelfBudgetCapability, SessionSandboxCapability, SkillsCapability, StatelessTodoListCapability,
+    SubagentCapability, SystemPromptContext, WebFetchCapability,
 };
 use everruns_core::typed_id::SessionId;
 
@@ -72,6 +72,11 @@ async fn memory_prompt_is_empty() {
 #[tokio::test]
 async fn subagents_prompt_within_budget() {
     assert_contribution_under(&SubagentCapability, 350).await;
+}
+
+#[tokio::test]
+async fn message_metadata_prompt_within_budget() {
+    assert_contribution_under(&MessageMetadataCapability, 350).await;
 }
 
 #[tokio::test]

--- a/docs/capabilities/index.md
+++ b/docs/capabilities/index.md
@@ -36,6 +36,7 @@ Structured data, time awareness, task tracking, and scheduling.
 |---|---|---|
 | [SQL Database](/capabilities/sql-database/) | `session_sql_database` | 3 |
 | [Current Time](/capabilities/current-time/) | `current_time` | 1 |
+| [Message Metadata](/capabilities/message-metadata/) | `message_metadata` | 0 |
 | [Task Management](/capabilities/task-management/) | `stateless_todo_list` | 1 |
 | [Schedules](/capabilities/session-schedules/) | `session_schedule` | 3 |
 

--- a/docs/capabilities/message-metadata.md
+++ b/docs/capabilities/message-metadata.md
@@ -1,0 +1,37 @@
+---
+title: Message Metadata
+description: Annotate user and agent messages with metadata such as sent time when they are sent to the LLM, so agents can reason about timing and gaps between messages.
+---
+
+| | |
+|---|---|
+| **ID** | `message_metadata` |
+| **Category** | Utilities |
+| **Features** | None |
+| **Dependencies** | None |
+
+Annotates user and agent messages with metadata — currently the time each message was sent (UTC) — when building the LLM request. The model sees each message prefixed with an annotation like:
+
+```
+[sent 2026-06-11T09:15:42Z] What changed since yesterday?
+```
+
+This lets agents reason about timing: how long ago something was said, gaps between messages, and whether earlier statements are stale.
+
+Annotations are applied only to the prompt-facing view of the conversation. Stored messages are never modified, and timestamps are stable across turns so prompt caching is unaffected. A short system prompt addition explains the annotation format to the model and instructs it not to emit annotations in its replies.
+
+## Tools
+
+None.
+
+## Configuration
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `user_messages` | boolean | `true` | Annotate user messages with sent time |
+| `agent_messages` | boolean | `true` | Annotate agent messages with sent time |
+
+## See Also
+
+- [Current Time](/capabilities/current-time/) — tool to get the current wall-clock time
+- [Capabilities Overview](/capabilities/)

--- a/docs/capabilities/message-metadata.md
+++ b/docs/capabilities/message-metadata.md
@@ -30,9 +30,9 @@ None.
 
 | Field | Type | Default | Description |
 |---|---|---|---|
-| `user_messages` | boolean | `true` | Annotate user messages |
-| `agent_messages` | boolean | `true` | Annotate agent messages |
-| `fields` | array | `["timestamp"]` | Metadata fields to render, in order. Supported: `timestamp`. More fields (e.g. the LLM model) will be added over time. |
+| `fields` | array | `["timestamp"]` | Metadata fields to render, in order. Supported: `timestamp`. An empty array disables annotations. More fields (e.g. the LLM model) will be added over time. |
+
+User and agent messages are always annotated; system and tool-result messages never are.
 
 ## See Also
 

--- a/docs/capabilities/message-metadata.md
+++ b/docs/capabilities/message-metadata.md
@@ -1,6 +1,6 @@
 ---
 title: Message Metadata
-description: Annotate user and agent messages with metadata such as sent time when they are sent to the LLM, so agents can reason about timing and gaps between messages.
+description: Annotate user and agent messages with metadata such as their timestamp when they are sent to the LLM, so agents can reason about timing and gaps between messages.
 ---
 
 | | |
@@ -10,11 +10,13 @@ description: Annotate user and agent messages with metadata such as sent time wh
 | **Features** | None |
 | **Dependencies** | None |
 
-Annotates user and agent messages with metadata — currently the time each message was sent (UTC) — when building the LLM request. The model sees each message prefixed with an annotation like:
+Annotates user and agent messages with metadata — currently each message's timestamp (UTC) — when building the LLM request. The model sees each message prefixed with an annotation like:
 
 ```
-[sent 2026-06-11T09:15:42Z] What changed since yesterday?
+[time 2026-06-11T09:15:42Z] What changed since yesterday?
 ```
+
+For user messages the timestamp is when the message was received; for agent messages, when the reply was generated.
 
 This lets agents reason about timing: how long ago something was said, gaps between messages, and whether earlier statements are stale.
 
@@ -30,7 +32,7 @@ None.
 |---|---|---|---|
 | `user_messages` | boolean | `true` | Annotate user messages |
 | `agent_messages` | boolean | `true` | Annotate agent messages |
-| `fields` | array | `["sent_time"]` | Metadata fields to render, in order. Supported: `sent_time`. More fields (e.g. the LLM model) will be added over time. |
+| `fields` | array | `["timestamp"]` | Metadata fields to render, in order. Supported: `timestamp`. More fields (e.g. the LLM model) will be added over time. |
 
 ## See Also
 

--- a/docs/capabilities/message-metadata.md
+++ b/docs/capabilities/message-metadata.md
@@ -28,8 +28,9 @@ None.
 
 | Field | Type | Default | Description |
 |---|---|---|---|
-| `user_messages` | boolean | `true` | Annotate user messages with sent time |
-| `agent_messages` | boolean | `true` | Annotate agent messages with sent time |
+| `user_messages` | boolean | `true` | Annotate user messages |
+| `agent_messages` | boolean | `true` | Annotate agent messages |
+| `fields` | array | `["sent_time"]` | Metadata fields to render, in order. Supported: `sent_time`. More fields (e.g. the LLM model) will be added over time. |
 
 ## See Also
 

--- a/specs/capabilities.md
+++ b/specs/capabilities.md
@@ -660,7 +660,7 @@ Following the agentskills.io specification:
 - **ID**: `message_metadata`
 - **Purpose**: Annotates user and agent messages with metadata (message timestamp, UTC) in the prompt-facing model view so the model can reason about timing and gaps between messages
 - **Tools**: None (uses `ModelViewProvider` only; priority 100, after compaction masking)
-- **Config**: `{"user_messages": bool, "agent_messages": bool, "fields": ["timestamp"]}` — which roles to annotate (both default true) and which metadata fields to render (default `["timestamp"]`)
+- **Config**: `{"fields": ["timestamp"]}` — which metadata fields to render, in order (default `["timestamp"]`; `[]` disables annotations). User and agent messages are always annotated; system and tool-result messages never are.
 - **Source**: `crates/core/src/capabilities/message_metadata.rs`
 - **Behavior**: Prefixes the first text part of each user/agent message with one bracketed segment per configured field (e.g. `[time <RFC3339 UTC>]` from `Message::created_at`); tool-call-only agent messages get the annotation as a leading text part. Fields are an extensible enum (`MessageMetadataField`); future fields (e.g. the LLM model behind an agent message, once stored messages record it) render their own segment and may skip messages that lack the data. Stored messages are unchanged, and `created_at` is immutable, so annotations are deterministic across turns and do not invalidate provider prompt caches. A small system prompt addition explains the annotation and forbids the model from emitting it.
 

--- a/specs/capabilities.md
+++ b/specs/capabilities.md
@@ -655,6 +655,15 @@ Following the agentskills.io specification:
 - **Config**: `{"threshold": N}` — number of consecutive identical tool-call batches before warning (default 3)
 - **Source**: `crates/core/src/capabilities/loop_detection.rs`
 
+#### MessageMetadata
+
+- **ID**: `message_metadata`
+- **Purpose**: Annotates user and agent messages with metadata (sent time, UTC) in the prompt-facing model view so the model can reason about timing and gaps between messages
+- **Tools**: None (uses `ModelViewProvider` only; priority 100, after compaction masking)
+- **Config**: `{"user_messages": bool, "agent_messages": bool}` — which roles to annotate (both default true)
+- **Source**: `crates/core/src/capabilities/message_metadata.rs`
+- **Behavior**: Prefixes the first text part of each user/agent message with `[sent <RFC3339 UTC>]` derived from `Message::created_at`; tool-call-only agent messages get the annotation as a leading text part. Stored messages are unchanged, and `created_at` is immutable, so annotations are deterministic across turns and do not invalidate provider prompt caches. A small system prompt addition explains the annotation and forbids the model from emitting it.
+
 #### PromptCanaryGuardrail
 
 - **ID**: `prompt_canary_guardrail`

--- a/specs/capabilities.md
+++ b/specs/capabilities.md
@@ -658,11 +658,11 @@ Following the agentskills.io specification:
 #### MessageMetadata
 
 - **ID**: `message_metadata`
-- **Purpose**: Annotates user and agent messages with metadata (sent time, UTC) in the prompt-facing model view so the model can reason about timing and gaps between messages
+- **Purpose**: Annotates user and agent messages with metadata (message timestamp, UTC) in the prompt-facing model view so the model can reason about timing and gaps between messages
 - **Tools**: None (uses `ModelViewProvider` only; priority 100, after compaction masking)
-- **Config**: `{"user_messages": bool, "agent_messages": bool, "fields": ["sent_time"]}` — which roles to annotate (both default true) and which metadata fields to render (default `["sent_time"]`)
+- **Config**: `{"user_messages": bool, "agent_messages": bool, "fields": ["timestamp"]}` — which roles to annotate (both default true) and which metadata fields to render (default `["timestamp"]`)
 - **Source**: `crates/core/src/capabilities/message_metadata.rs`
-- **Behavior**: Prefixes the first text part of each user/agent message with one bracketed segment per configured field (e.g. `[sent <RFC3339 UTC>]` from `Message::created_at`); tool-call-only agent messages get the annotation as a leading text part. Fields are an extensible enum (`MessageMetadataField`); future fields (e.g. the LLM model behind an agent message, once stored messages record it) render their own segment and may skip messages that lack the data. Stored messages are unchanged, and `created_at` is immutable, so annotations are deterministic across turns and do not invalidate provider prompt caches. A small system prompt addition explains the annotation and forbids the model from emitting it.
+- **Behavior**: Prefixes the first text part of each user/agent message with one bracketed segment per configured field (e.g. `[time <RFC3339 UTC>]` from `Message::created_at`); tool-call-only agent messages get the annotation as a leading text part. Fields are an extensible enum (`MessageMetadataField`); future fields (e.g. the LLM model behind an agent message, once stored messages record it) render their own segment and may skip messages that lack the data. Stored messages are unchanged, and `created_at` is immutable, so annotations are deterministic across turns and do not invalidate provider prompt caches. A small system prompt addition explains the annotation and forbids the model from emitting it.
 
 #### PromptCanaryGuardrail
 

--- a/specs/capabilities.md
+++ b/specs/capabilities.md
@@ -660,9 +660,9 @@ Following the agentskills.io specification:
 - **ID**: `message_metadata`
 - **Purpose**: Annotates user and agent messages with metadata (sent time, UTC) in the prompt-facing model view so the model can reason about timing and gaps between messages
 - **Tools**: None (uses `ModelViewProvider` only; priority 100, after compaction masking)
-- **Config**: `{"user_messages": bool, "agent_messages": bool}` — which roles to annotate (both default true)
+- **Config**: `{"user_messages": bool, "agent_messages": bool, "fields": ["sent_time"]}` — which roles to annotate (both default true) and which metadata fields to render (default `["sent_time"]`)
 - **Source**: `crates/core/src/capabilities/message_metadata.rs`
-- **Behavior**: Prefixes the first text part of each user/agent message with `[sent <RFC3339 UTC>]` derived from `Message::created_at`; tool-call-only agent messages get the annotation as a leading text part. Stored messages are unchanged, and `created_at` is immutable, so annotations are deterministic across turns and do not invalidate provider prompt caches. A small system prompt addition explains the annotation and forbids the model from emitting it.
+- **Behavior**: Prefixes the first text part of each user/agent message with one bracketed segment per configured field (e.g. `[sent <RFC3339 UTC>]` from `Message::created_at`); tool-call-only agent messages get the annotation as a leading text part. Fields are an extensible enum (`MessageMetadataField`); future fields (e.g. the LLM model behind an agent message, once stored messages record it) render their own segment and may skip messages that lack the data. Stored messages are unchanged, and `created_at` is immutable, so annotations are deterministic across turns and do not invalidate provider prompt caches. A small system prompt addition explains the annotation and forbids the model from emitting it.
 
 #### PromptCanaryGuardrail
 


### PR DESCRIPTION
## What
New built-in `message_metadata` capability: annotates user and agent messages with metadata — currently the message timestamp — when they are sent to the LLM, e.g. `[time 2026-06-11T09:15:42Z] What changed since yesterday?`.

- Applied via the existing `ModelViewProvider` extension point (priority 100, after compaction masking). Stored messages are never modified; `created_at` is immutable, so annotations are deterministic across turns and do not invalidate provider prompt caches.
- Config is `{"fields": ["timestamp"]}` — an ordered list of `MessageMetadataField` enum values rendered as one bracketed segment each. `[]` disables annotations; unknown field names are rejected at write time by `validate_config`. User/agent messages are always annotated; system/tool-result never.
- A small system prompt addition explains the annotation format and forbids the model from echoing it.
- Spec catalog entry (`specs/capabilities.md`) and docs page (`docs/capabilities/message-metadata.md` + index row).

## Why
Agents currently have no way to reason about timing: how long ago something was said, gaps between messages, staleness of earlier statements. Timestamp is the first field; the enum is the extension point for future fields (e.g. the generating LLM model, once stored messages record it).

## How
`Capability::model_view_provider()` (same hook compaction uses) transforms the prompt-facing message view in `ReasonAtom`: prefixes the first text part of each user/agent message, or inserts a leading text part for tool-call-only agent messages.

Validated with:
- 10 unit tests, including a schema-consistency test that keeps `config_schema()` aligned with the serde config shape and the field enum.
- End-to-end test driving a full turn through the in-memory agentic loop with the echo sim driver: the reply mirrors exactly what the LLM received, proving the annotation reaches the model view while storage stays clean (`crates/core/tests/message_metadata_test.rs`).
- Prompt budget test for the system prompt addition.
- Full `everruns-core` suite green (2,276 tests), clippy `-D warnings` clean, `just pre-push` green, rebased on latest `origin/main` with migration ordering verified (no migrations touched by this PR).

Smoke testing: covered by the in-memory agentic loop end-to-end test above, which exercises the exact impacted flow (LLM message construction) through the real turn state machine. No server/API/UI surface is touched and the capability is opt-in, so a full `start-dev` run adds no additional signal.

## Risk
- Low
- Opt-in capability; no behavior change unless enabled on an agent. Worst case is a malformed annotation in the prompt, covered by unit + e2e tests. Annotating past agent messages changes the cached-prefix bytes only once (annotations are stable thereafter).

## Security
- Threat categories reviewed: TM-LLM (prompt construction), TM-API (capability config write path).
- Findings and resolutions: none. Annotation content is server-generated `created_at` rendered via fixed RFC3339 formatting — no user-controlled strings are introduced into the prompt. Config writes are validated (`deny_unknown_fields`, closed enum). No new dependencies. The model-view mechanism itself pre-exists (compaction); no threat-model update needed.

## Follow-ups
- `model` metadata field (annotate agent messages with the generating LLM): deferred because stored messages do not currently record the model; it needs ReasonAtom to stamp the model onto the persisted agent message first. Noted in `specs/capabilities.md`.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (new opt-in capability; no API changes)
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5pBCDK1io2CHoBpuRxdzB)_