### PR TITLE
feat: session task cancellation, wake policy, reaper, and chat chips

### DIFF
--- a/apps/ui/src/__tests__/chat-panel.test.tsx
+++ b/apps/ui/src/__tests__/chat-panel.test.tsx
@@ -53,6 +53,12 @@ jest.mock("@/app/(main)/sessions/[sessionId]/session-context", () => ({
   useSessionContext: () => mockSessionContext,
 }));
 
+// SessionTaskChips pulls in org context + an SSE subscription; this suite
+// tests chat behavior, not the task strip.
+jest.mock("@/components/session/session-task-chips", () => ({
+  SessionTaskChips: () => null,
+}));
+
 jest.mock("@/hooks", () => ({
   useLlmModels: () => ({ data: [] }),
   useImageAttachments: () => ({

--- a/apps/ui/src/app/(main)/sessions/[sessionId]/layout.tsx
+++ b/apps/ui/src/app/(main)/sessions/[sessionId]/layout.tsx
@@ -19,7 +19,7 @@ const SESSION_TAB_LABELS: Record<SessionNavKey, string> = {
   files: "Files",
   events: "Events",
   storage: "Storage",
-  resources: "Resources",
+  resources: "Tasks",
   schedules: "Schedules",
   context: "Context",
 };

--- a/apps/ui/src/app/(main)/sessions/[sessionId]/resources/page.tsx
+++ b/apps/ui/src/app/(main)/sessions/[sessionId]/resources/page.tsx
@@ -178,12 +178,27 @@ function TaskCard({ task, sessionId }: { task: SessionTask; sessionId: string | 
             {task.error.kind}: {task.error.message}
           </div>
         ) : null}
-        {task.result_path ? <div className="truncate">Result: {task.result_path}</div> : null}
+        {task.result_path ? (
+          <div className="truncate">
+            Result:{" "}
+            {sessionId ? (
+              // Link to the session Files tab; no query-param deep-link to a
+              // specific path exists yet — add ?path= support when available.
+              <Link
+                href={`/sessions/${sessionId}/files`}
+                className="text-primary underline-offset-4 hover:underline"
+              >
+                {task.result_path}
+              </Link>
+            ) : (
+              task.result_path
+            )}
+          </div>
+        ) : null}
         {artifacts.length > 0 ? (
           <div className="grid gap-1">
             {artifacts.map((artifact, index) => (
               <div key={`${artifact.name}-${index}`} className="truncate">
-                {/* No VFS deep-link route exists; paths render as plain text. */}
                 {artifact.url ? (
                   <a
                     href={artifact.url}
@@ -193,6 +208,17 @@ function TaskCard({ task, sessionId }: { task: SessionTask; sessionId: string | 
                   >
                     {artifact.name}
                   </a>
+                ) : artifact.type === "file" && artifact.path && sessionId ? (
+                  // File artifacts with a VFS path link to the session Files
+                  // tab. No query-param deep-link to a specific path exists
+                  // yet — add ?path= support when available.
+                  <Link
+                    href={`/sessions/${sessionId}/files`}
+                    className="text-primary underline-offset-4 hover:underline"
+                  >
+                    {artifact.name}
+                    {` (${artifact.path})`}
+                  </Link>
                 ) : (
                   <span>
                     {artifact.name}

--- a/apps/ui/src/components/chat/chat-panel.tsx
+++ b/apps/ui/src/components/chat/chat-panel.tsx
@@ -23,6 +23,7 @@ import { ChatErrorAlert } from "@/components/chat/chat-error-alert";
 import { ChatMessageList } from "@/components/chat/chat-message-list";
 import { ChatComposer } from "@/components/chat/chat-composer";
 import { MessageContent } from "@/components/chat/message-content";
+import { SessionTaskChips } from "@/components/session/session-task-chips";
 import { StreamingMessage } from "@/components/streaming-message";
 import { ThinkingIndicator } from "@/components/thinking-indicator";
 import { Button } from "@/components/ui/button";
@@ -101,6 +102,7 @@ export function ChatPanel() {
     agentId,
     events,
     sessionId,
+    session,
     llmModel,
     chatEvents,
     toolResultsMap,
@@ -188,6 +190,11 @@ export function ChatPanel() {
     typeof navigator !== "undefined" &&
     !!navigator.mediaDevices?.getUserMedia &&
     typeof RTCPeerConnection !== "undefined";
+
+  // Task chips: shown only when the leased_resources session feature is present
+  // (same gate as the Tasks / resources nav tab).
+  const hasTasksFeature = session?.features?.includes("leased_resources") ?? false;
+  const sessionBasePath = `/sessions/${sessionId}`;
 
   useEffect(() => {
     if (!eventsLoading) {
@@ -529,6 +536,12 @@ export function ChatPanel() {
           </button>
         )}
       </div>
+
+      <SessionTaskChips
+        sessionId={sessionId}
+        basePath={sessionBasePath}
+        hasTasksFeature={hasTasksFeature}
+      />
 
       <ChatComposer
         commands={commands}

--- a/apps/ui/src/components/session/session-header.tsx
+++ b/apps/ui/src/components/session/session-header.tsx
@@ -258,7 +258,8 @@ export function buildSessionNavigation({
       ? [
           {
             key: "resources" as const,
-            label: "Resources",
+            // Route stays /resources — renaming it would break existing links.
+            label: "Tasks",
             href: `${basePath}/resources`,
             icon: Wrench,
           },

--- a/apps/ui/src/components/session/session-task-chips.tsx
+++ b/apps/ui/src/components/session/session-task-chips.tsx
@@ -96,12 +96,22 @@ interface SessionTaskChipsProps {
 }
 
 export function SessionTaskChips({ sessionId, basePath, hasTasksFeature }: SessionTaskChipsProps) {
-  const { data: tasks } = useSessionTasks(hasTasksFeature ? sessionId : undefined);
+  // Gate before mounting the inner component: useSessionTasks requires org
+  // context and opens an SSE subscription, so it must not run at all when the
+  // feature is off or no session exists.
+  if (!hasTasksFeature || !sessionId) {
+    return null;
+  }
+  return <ActiveTaskChips sessionId={sessionId} basePath={basePath} />;
+}
+
+function ActiveTaskChips({ sessionId, basePath }: { sessionId: string; basePath: string }) {
+  const { data: tasks } = useSessionTasks(sessionId);
 
   const activeTasks = tasks ? tasks.filter((t) => isActiveState(t.state)) : [];
 
-  // Render nothing (zero vertical space) when gated or no active tasks.
-  if (!hasTasksFeature || activeTasks.length === 0) {
+  // Render nothing (zero vertical space) when there are no active tasks.
+  if (activeTasks.length === 0) {
     return null;
   }
 

--- a/apps/ui/src/components/session/session-task-chips.tsx
+++ b/apps/ui/src/components/session/session-task-chips.tsx
@@ -78,9 +78,7 @@ function TaskChip({ task, tasksHref }: TaskChipProps) {
       <TooltipProvider>
         <Tooltip>
           <TooltipTrigger asChild>{chip}</TooltipTrigger>
-          <TooltipContent className="max-w-xs text-xs">
-            {task.state_detail}
-          </TooltipContent>
+          <TooltipContent className="max-w-xs text-xs">{task.state_detail}</TooltipContent>
         </Tooltip>
       </TooltipProvider>
     );

--- a/apps/ui/src/components/session/session-task-chips.tsx
+++ b/apps/ui/src/components/session/session-task-chips.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+// SessionTaskChips — compact strip of active task chips shown above the message
+// input in the chat view. Renders nothing when there are no active tasks.
+//
+// Gating: rendered only when the "leased_resources" session feature is present,
+// matching the same gate used for the Tasks (resources route) nav tab.
+
+import Link from "next/link";
+import { Bot, Cpu, ListTodo, Loader2 } from "lucide-react";
+import { useSessionTasks } from "@/hooks/use-session-tasks";
+import { cn } from "@/lib/utils";
+import type { SessionTask, SessionTaskState } from "@/lib/api/types";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+
+const ACTIVE_STATES: SessionTaskState[] = ["queued", "running", "awaiting_input"];
+
+function isActiveState(state: SessionTaskState): boolean {
+  return ACTIVE_STATES.includes(state);
+}
+
+function taskKindIcon(kind: string) {
+  if (kind === "subagent" || kind === "external_agent") {
+    return <Bot className="h-3 w-3 shrink-0" />;
+  }
+  if (kind === "background_tool") {
+    return <Cpu className="h-3 w-3 shrink-0" />;
+  }
+  return <ListTodo className="h-3 w-3 shrink-0" />;
+}
+
+function chipClasses(state: SessionTaskState): string {
+  switch (state) {
+    case "running":
+      // primary — blue tint, matches Badge variant="default"
+      return "bg-primary text-primary-foreground border-transparent";
+    case "awaiting_input":
+      // amber — stands out, matches taskStateBadge in resources/page.tsx
+      return "bg-amber-500 text-white border-transparent";
+    case "queued":
+    default:
+      // outline — muted, matches Badge variant="outline"
+      return "bg-transparent text-foreground border-border";
+  }
+}
+
+interface TaskChipProps {
+  task: SessionTask;
+  tasksHref: string;
+}
+
+function TaskChip({ task, tasksHref }: TaskChipProps) {
+  const label = task.display_name || task.id;
+  // Truncate long names to keep the strip compact.
+  const truncated = label.length > 30 ? `${label.slice(0, 28)}…` : label;
+
+  const chip = (
+    <Link
+      href={tasksHref}
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-xs font-medium",
+        "transition-opacity hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        chipClasses(task.state),
+      )}
+      aria-label={`Task: ${label} — ${task.state}`}
+    >
+      {task.state === "running" && (
+        <Loader2 className="h-3 w-3 shrink-0 animate-spin" aria-hidden="true" />
+      )}
+      {task.state !== "running" && taskKindIcon(task.kind)}
+      <span className="max-w-[14ch] truncate">{truncated}</span>
+    </Link>
+  );
+
+  // Show state_detail as a tooltip when available.
+  if (task.state_detail) {
+    return (
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>{chip}</TooltipTrigger>
+          <TooltipContent className="max-w-xs text-xs">
+            {task.state_detail}
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    );
+  }
+
+  return chip;
+}
+
+interface SessionTaskChipsProps {
+  sessionId: string | undefined;
+  /** Base path for this session, e.g. "/sessions/sess_abc" */
+  basePath: string;
+  /** Whether the leased_resources feature is enabled for this session */
+  hasTasksFeature: boolean;
+}
+
+export function SessionTaskChips({ sessionId, basePath, hasTasksFeature }: SessionTaskChipsProps) {
+  const { data: tasks } = useSessionTasks(hasTasksFeature ? sessionId : undefined);
+
+  const activeTasks = tasks ? tasks.filter((t) => isActiveState(t.state)) : [];
+
+  // Render nothing (zero vertical space) when gated or no active tasks.
+  if (!hasTasksFeature || activeTasks.length === 0) {
+    return null;
+  }
+
+  const tasksHref = `${basePath}/resources`;
+
+  return (
+    <div
+      className="flex flex-wrap items-center gap-1.5 border-t border-border/60 bg-muted/30 px-3 py-1.5"
+      role="region"
+      aria-label="Active tasks"
+    >
+      {activeTasks.map((task) => (
+        <TaskChip key={task.id} task={task} tasksHref={tasksHref} />
+      ))}
+    </div>
+  );
+}

--- a/crates/core/src/capabilities/a2a_delegation.rs
+++ b/crates/core/src/capabilities/a2a_delegation.rs
@@ -1001,14 +1001,20 @@ async fn background_monitor(
             let _ = write_result_artifact(&context, &mut failed).await;
             let _ = save_run(&context, &failed).await;
             post_task_completion_message(&context, &failed).await;
-            if failed.wake_on_completion {
+            // Legacy wake: only when no registry is present (registry-level
+            // wake_policy handles it otherwise via post_task_completion_message).
+            if failed.wake_on_completion && context.session_task_registry.is_none() {
                 let _ = wake_parent(&context, &failed).await;
             }
             return;
         }
     };
     post_task_completion_message(&context, &record).await;
-    if record.wake_on_completion {
+    // Registry-level wake_policy handles the wake when a task registry is
+    // present (post_task_completion_message records an outbound message which
+    // triggers the waker). Fall back to the legacy synthetic session message
+    // only when no registry is wired (older execution contexts).
+    if record.wake_on_completion && context.session_task_registry.is_none() {
         let _ = wake_parent(&context, &record).await;
     }
     let _ = save_run(&context, &record).await;

--- a/crates/core/src/capabilities/background_execution.rs
+++ b/crates/core/src/capabilities/background_execution.rs
@@ -57,9 +57,7 @@ impl Capability for BackgroundExecutionCapability {
     }
 }
 
-/// Task executor for `background_tool` tasks. Background runs have no cancel
-/// token today, so cancellation reports unsupported; inbound messages keep
-/// the default unsupported error.
+/// Task executor for `background_tool` tasks.
 pub struct BackgroundToolTaskExecutor;
 
 #[async_trait::async_trait]
@@ -68,15 +66,16 @@ impl crate::session_task::TaskExecutor for BackgroundToolTaskExecutor {
         crate::session_task::TASK_KIND_BACKGROUND_TOOL
     }
 
+    /// Cooperative cancellation: `cancel_task` records `cancel_requested_at`
+    /// in the registry; the background run's heartbeat loop polls it every ~2 s
+    /// and winds down when set.  No in-process token is needed — the record-
+    /// polling design works even when this call executes on a different worker.
     async fn cancel(
         &self,
         _task: &crate::session_task::SessionTask,
         _context: &crate::traits::ToolContext,
     ) -> crate::error::Result<()> {
-        Err(crate::error::AgentLoopError::tool(
-            "background tool runs do not support cancellation yet; \
-             the run continues until it finishes",
-        ))
+        Ok(())
     }
 }
 

--- a/crates/core/src/session_task.rs
+++ b/crates/core/src/session_task.rs
@@ -310,6 +310,19 @@ pub struct SessionTaskFilter {
 pub fn apply_task_update(task: &mut SessionTask, update: SessionTaskUpdate, now: DateTime<Utc>) {
     let was_terminal = task.state.is_terminal();
 
+    // Terminal states are final. An update that asks for a *different* state
+    // on an already-terminal task lost a race (e.g. the reaper marking a task
+    // orphaned after it succeeded) — ignore it entirely so its content fields
+    // (error, summary) cannot corrupt the terminal record. Updates that carry
+    // the same terminal state (idempotent re-mirrors) or no state at all
+    // (content enrichment) still apply below.
+    if was_terminal
+        && let Some(state) = update.state
+        && state != task.state
+    {
+        return;
+    }
+
     let mut next_state = update.state;
     if update.input_request.is_some() && !was_terminal {
         next_state = Some(SessionTaskState::AwaitingInput);
@@ -834,18 +847,47 @@ mod tests {
         assert_eq!(t.state, SessionTaskState::Succeeded);
         assert_eq!(t.finished_at, Some(now));
 
-        // State changes after terminal are ignored; content still applies.
+        // An update carrying a *different* state lost a race against the
+        // terminal transition — it is ignored entirely, content included
+        // (e.g. the reaper must not stamp an orphaned error on a task that
+        // succeeded meanwhile).
         apply_task_update(
             &mut t,
             SessionTaskUpdate {
-                state: Some(SessionTaskState::Running),
-                result_path: Some("/.tasks/x/result.json".to_string()),
+                state: Some(SessionTaskState::Failed),
+                error: Some(TaskError {
+                    kind: "orphaned".to_string(),
+                    message: "stale".to_string(),
+                }),
                 ..Default::default()
             },
             Utc::now(),
         );
         assert_eq!(t.state, SessionTaskState::Succeeded);
+        assert!(t.error.is_none());
+
+        // Idempotent re-mirrors with the SAME terminal state still enrich.
+        apply_task_update(
+            &mut t,
+            SessionTaskUpdate {
+                state: Some(SessionTaskState::Succeeded),
+                result_path: Some("/.tasks/x/result.json".to_string()),
+                ..Default::default()
+            },
+            Utc::now(),
+        );
         assert_eq!(t.result_path.as_deref(), Some("/.tasks/x/result.json"));
+
+        // Content-only updates (no state) also still apply.
+        apply_task_update(
+            &mut t,
+            SessionTaskUpdate {
+                summary: Some("enriched".to_string()),
+                ..Default::default()
+            },
+            Utc::now(),
+        );
+        assert_eq!(t.summary.as_deref(), Some("enriched"));
     }
 
     #[test]

--- a/crates/core/src/tools.rs
+++ b/crates/core/src/tools.rs
@@ -1212,23 +1212,96 @@ impl Tool for SpawnBackgroundTool {
         let tool_for_task = tool.clone();
         let tool_name_for_task = tool_name.to_string();
 
+        // Clone registry/ids for the cancel-watcher inside the spawned task.
+        let cancel_registry = context.session_task_registry.clone();
+        let cancel_session_id = context.session_id;
+        let cancel_task_id = task_id.clone();
+
         tokio::spawn(async move {
             let _background_run_permit = background_run_permit;
             let _session_run_permit = session_run_permit;
             let _ = sink.status("Starting").await;
-            let outcome = match tool_for_task.as_background_executable() {
-                Some(background_tool) => {
-                    background_tool
-                        .execute_background(tool_args, background_context, sink.clone())
-                        .await
+
+            // Run the tool future inside a select! against a cancel-watch loop
+            // when a task registry and task_id are wired up.  The watcher sends
+            // a heartbeat every ~2 s and checks cancel_requested_at; when set,
+            // it wins the select and the tool future is dropped.
+            //
+            // Rationale: cancel intent is recorded in shared storage so this
+            // design works even when cancel_task executes on a different worker.
+            let outcome: std::result::Result<BackgroundOutcome, ToolExecutionResult> = match (
+                cancel_registry.as_ref(),
+                cancel_task_id.as_deref(),
+            ) {
+                (Some(registry), Some(task_id_str)) => {
+                    let registry = registry.clone();
+                    let task_id_str = task_id_str.to_string();
+                    let tool_fut = async {
+                        match tool_for_task.as_background_executable() {
+                            Some(background_tool) => {
+                                background_tool
+                                    .execute_background(tool_args, background_context, sink.clone())
+                                    .await
+                            }
+                            None => Err(ToolExecutionResult::tool_error(format!(
+                                "Tool declared background support but has no background executor: {}",
+                                tool_name_for_task
+                            ))),
+                        }
+                    };
+                    let watch_fut = async {
+                        loop {
+                            tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+                            // Send heartbeat.
+                            let _ = registry
+                                .update(
+                                    cancel_session_id,
+                                    &task_id_str,
+                                    crate::session_task::SessionTaskUpdate {
+                                        heartbeat_at: Some(chrono::Utc::now()),
+                                        ..Default::default()
+                                    },
+                                )
+                                .await;
+                            // Check for cooperative cancel intent.
+                            if let Ok(Some(task)) =
+                                registry.get(cancel_session_id, &task_id_str).await
+                                && task.cancel_requested_at.is_some()
+                            {
+                                break;
+                            }
+                        }
+                    };
+                    tokio::select! {
+                        result = tool_fut => result,
+                        () = watch_fut => {
+                            // Cancel was requested; the tool future is dropped.
+                            Err(ToolExecutionResult::ToolError("canceled".to_string()))
+                        }
+                    }
                 }
-                None => Err(ToolExecutionResult::tool_error(format!(
-                    "Tool declared background support but has no background executor: {}",
-                    tool_name_for_task
-                ))),
+                // No registry or no task_id: run without cancel watch (unchanged behaviour).
+                _ => match tool_for_task.as_background_executable() {
+                    Some(background_tool) => {
+                        background_tool
+                            .execute_background(tool_args, background_context, sink.clone())
+                            .await
+                    }
+                    None => Err(ToolExecutionResult::tool_error(format!(
+                        "Tool declared background support but has no background executor: {}",
+                        tool_name_for_task
+                    ))),
+                },
             };
 
-            if let Err(err) = sink.finalize(outcome).await {
+            // Route canceled outcome through finalize_canceled so file/resource
+            // cleanup is consistent with the success/fail paths.
+            let finalize_result = if is_canceled_outcome(&outcome) {
+                sink.finalize_canceled().await
+            } else {
+                sink.finalize(outcome).await
+            };
+            if let Err(err) = finalize_result {
                 tracing::warn!(
                     run_id = run_id_for_task,
                     error = %err,
@@ -1318,6 +1391,39 @@ impl SessionBackgroundSink {
         let _ = registry
             .update(self.context.session_id, task_id, update)
             .await;
+    }
+
+    async fn finalize_canceled(&self) -> Result<()> {
+        let output_log = {
+            let state = self.state.lock().await;
+            let mut log = Self::final_output_log(&state);
+            log.push_str("\nCanceled by request.\n");
+            log
+        };
+        self.write_text_file(&self.log_path, &output_log).await?;
+        let result_json = serde_json::to_string_pretty(&serde_json::json!({"status": "canceled"}))
+            .unwrap_or_else(|_| r#"{"status":"canceled"}"#.to_string());
+        self.write_text_file(&self.result_path, &result_json)
+            .await?;
+
+        let mut state = self.state.lock().await;
+        state.status_text = "Canceled".to_string();
+        drop(state);
+
+        self.mirror_task(crate::session_task::SessionTaskUpdate {
+            state: Some(crate::session_task::SessionTaskState::Canceled),
+            summary: Some("Canceled by request.".to_string()),
+            result_path: Some(self.result_path.clone()),
+            ..Default::default()
+        })
+        .await;
+        self.update_resource(SessionResourceStatus::Failed, Some("Canceled by request."))
+            .await?;
+        if self.signal_on_completion {
+            self.signal_session("canceled", "Canceled by request.")
+                .await?;
+        }
+        Ok(())
     }
 
     async fn finalize(
@@ -1568,6 +1674,15 @@ impl SessionBackgroundSink {
     }
 }
 
+/// Returns true when an outcome from the cancel-watch select is the sentinel
+/// cancel signal (Err(ToolError("canceled"))).  Factored out so the condition
+/// is testable without a running async runtime.
+fn is_canceled_outcome(
+    outcome: &std::result::Result<BackgroundOutcome, ToolExecutionResult>,
+) -> bool {
+    matches!(outcome, Err(ToolExecutionResult::ToolError(msg)) if msg == "canceled")
+}
+
 async fn ensure_directory(
     file_store: &dyn crate::traits::SessionFileSystem,
     session_id: crate::SessionId,
@@ -1661,6 +1776,7 @@ mod tests {
     use crate::platform_store::PlatformStore;
     use crate::session_file::{FileInfo, FileStat, SessionFile};
     use crate::session_resource::{SessionResourceEntry, SessionResourceFilter};
+    use crate::session_task::SessionTaskRegistry;
     use crate::traits::{SessionFileSystem, SessionResourceRegistry, SessionScheduleStore};
     use crate::typed_id::{HarnessId, SessionId};
     use crate::{AgentId, KeyInfo, PlatformMessage, SecretInfo};
@@ -3234,5 +3350,305 @@ mod tests {
             panic!("spawn_background should reject ambiguous schedule shape");
         };
         assert!(message.contains("must not include both cron_expression and scheduled_at"));
+    }
+
+    // =========================================================================
+    // Cooperative cancellation tests
+    // =========================================================================
+
+    #[test]
+    fn test_is_canceled_outcome_detects_sentinel() {
+        // The sentinel produced by the cancel-watcher branch.
+        let sentinel: std::result::Result<BackgroundOutcome, ToolExecutionResult> =
+            Err(ToolExecutionResult::ToolError("canceled".to_string()));
+        assert!(is_canceled_outcome(&sentinel));
+    }
+
+    #[test]
+    fn test_is_canceled_outcome_does_not_match_other_errors() {
+        let other_err: std::result::Result<BackgroundOutcome, ToolExecutionResult> =
+            Err(ToolExecutionResult::ToolError("boom".to_string()));
+        assert!(!is_canceled_outcome(&other_err));
+
+        let success: std::result::Result<BackgroundOutcome, ToolExecutionResult> =
+            Ok(BackgroundOutcome {
+                summary: "ok".to_string(),
+                result: json!({"ok": true}),
+                raw_output: None,
+            });
+        assert!(!is_canceled_outcome(&success));
+    }
+
+    /// A background tool that sleeps indefinitely, allowing the test to exercise
+    /// cancel via the cancel-watcher without actually waiting forever.
+    #[derive(Default)]
+    struct SleepingBackgroundTool;
+
+    #[async_trait]
+    impl BackgroundExecutableTool for SleepingBackgroundTool {
+        async fn execute_background(
+            &self,
+            _arguments: Value,
+            _context: ToolContext,
+            sink: Arc<dyn BackgroundEventSink>,
+        ) -> std::result::Result<BackgroundOutcome, ToolExecutionResult> {
+            sink.status("Sleeping forever")
+                .await
+                .map_err(ToolExecutionResult::internal_error)?;
+            // Sleep for a very long time; the cancel-watcher will win the select.
+            tokio::time::sleep(std::time::Duration::from_secs(3600)).await;
+            Ok(BackgroundOutcome {
+                summary: "should not reach here".to_string(),
+                result: json!({}),
+                raw_output: None,
+            })
+        }
+    }
+
+    #[async_trait]
+    impl Tool for SleepingBackgroundTool {
+        fn name(&self) -> &str {
+            "test_background_sleeping"
+        }
+
+        fn display_name(&self) -> Option<&str> {
+            Some("Test Background Sleeping")
+        }
+
+        fn description(&self) -> &str {
+            "background test tool that sleeps indefinitely"
+        }
+
+        fn parameters_schema(&self) -> Value {
+            json!({
+                "type": "object",
+                "properties": {}
+            })
+        }
+
+        async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+            ToolExecutionResult::tool_error("foreground unsupported")
+        }
+
+        fn hints(&self) -> ToolHints {
+            ToolHints::default().with_supports_background(true)
+        }
+
+        fn as_background_executable(&self) -> Option<&dyn BackgroundExecutableTool> {
+            Some(self)
+        }
+    }
+
+    // Minimal in-memory SessionTaskRegistry for cancel tests.
+    // (Mirrors the double in capabilities/session_tasks.rs — kept local because
+    //  that module is private.)
+    #[derive(Default)]
+    struct InMemoryTaskRegistry {
+        tasks: Mutex<HashMap<String, crate::session_task::SessionTask>>,
+    }
+
+    #[async_trait]
+    impl crate::session_task::SessionTaskRegistry for InMemoryTaskRegistry {
+        async fn create(
+            &self,
+            input: crate::session_task::CreateSessionTask,
+        ) -> crate::Result<crate::session_task::SessionTask> {
+            let mut tasks = self.tasks.lock().unwrap();
+            if let Some(id) = &input.id
+                && let Some(existing) = tasks.get(id)
+            {
+                return Ok(existing.clone());
+            }
+            let task = crate::session_task::new_session_task(input, chrono::Utc::now());
+            tasks.insert(task.id.clone(), task.clone());
+            Ok(task)
+        }
+
+        async fn update(
+            &self,
+            _session_id: SessionId,
+            task_id: &str,
+            update: crate::session_task::SessionTaskUpdate,
+        ) -> crate::Result<Option<crate::session_task::SessionTask>> {
+            let mut tasks = self.tasks.lock().unwrap();
+            let Some(task) = tasks.get_mut(task_id) else {
+                return Ok(None);
+            };
+            crate::session_task::apply_task_update(task, update, chrono::Utc::now());
+            Ok(Some(task.clone()))
+        }
+
+        async fn get(
+            &self,
+            _session_id: SessionId,
+            task_id: &str,
+        ) -> crate::Result<Option<crate::session_task::SessionTask>> {
+            Ok(self.tasks.lock().unwrap().get(task_id).cloned())
+        }
+
+        async fn list(
+            &self,
+            _session_id: SessionId,
+            filter: Option<&crate::session_task::SessionTaskFilter>,
+        ) -> crate::Result<Vec<crate::session_task::SessionTask>> {
+            let tasks = self.tasks.lock().unwrap();
+            Ok(tasks
+                .values()
+                .filter(|task| {
+                    filter.is_none_or(|f| {
+                        f.kind.as_deref().is_none_or(|kind| task.kind == kind)
+                            && f.state.is_none_or(|state| task.state == state)
+                    })
+                })
+                .cloned()
+                .collect())
+        }
+
+        async fn request_cancel(
+            &self,
+            _session_id: SessionId,
+            task_id: &str,
+        ) -> crate::Result<Option<crate::session_task::SessionTask>> {
+            let mut tasks = self.tasks.lock().unwrap();
+            let Some(task) = tasks.get_mut(task_id) else {
+                return Ok(None);
+            };
+            task.cancel_requested_at
+                .get_or_insert_with(chrono::Utc::now);
+            task.updated_at = chrono::Utc::now();
+            Ok(Some(task.clone()))
+        }
+
+        async fn record_message(
+            &self,
+            _session_id: SessionId,
+            task_id: &str,
+            message: crate::session_task::NewTaskMessage,
+        ) -> crate::Result<crate::session_task::TaskMessage> {
+            let tasks = self.tasks.lock().unwrap();
+            let _task = tasks
+                .get(task_id)
+                .ok_or_else(|| crate::AgentLoopError::tool(format!("no task {task_id}")))?;
+            Ok(crate::session_task::TaskMessage {
+                id: crate::session_task::generate_task_message_id(),
+                task_id: task_id.to_string(),
+                direction: message.direction,
+                content: message.content,
+                in_reply_to: message.in_reply_to,
+                created_at: chrono::Utc::now(),
+            })
+        }
+
+        async fn list_messages(
+            &self,
+            _session_id: SessionId,
+            _task_id: &str,
+            _limit: Option<u32>,
+        ) -> crate::Result<Vec<crate::session_task::TaskMessage>> {
+            Ok(Vec::new())
+        }
+    }
+
+    /// End-to-end cancel test: spawn a long-sleeping background tool, then call
+    /// `request_cancel` on the task registry, and assert the task ends Canceled.
+    #[tokio::test]
+    async fn test_cancel_background_run_via_task_registry() {
+        let session_id = SessionId::new();
+        let resource_registry = Arc::new(TestSessionResourceRegistry::default());
+        let file_store = Arc::new(TestFileStore::default());
+        let storage_store = Arc::new(NoopStorageStore);
+        let task_registry = Arc::new(InMemoryTaskRegistry::default());
+
+        let tool_registry = ToolRegistry::builder()
+            .tool(SpawnBackgroundTool)
+            .tool(SleepingBackgroundTool)
+            .build();
+
+        let context = ToolContext::with_stores(session_id, file_store.clone(), storage_store)
+            .with_tool_registry(Arc::new(tool_registry))
+            .with_session_resource_registry(resource_registry.clone())
+            .with_session_task_registry(task_registry.clone());
+
+        let result = SpawnBackgroundTool
+            .execute_with_context(
+                json!({
+                    "tool": "test_background_sleeping",
+                    "args": {},
+                    "signal_on_completion": false
+                }),
+                &context,
+            )
+            .await;
+
+        let ToolExecutionResult::Success(value) = result else {
+            panic!("spawn_background should succeed");
+        };
+        let run_id = value["run_id"].as_str().unwrap().to_string();
+        let task_id = value["task_id"].as_str().unwrap().to_string();
+
+        // Wait until the background task is Running (heartbeat loop started).
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            loop {
+                let entry = resource_registry
+                    .get(session_id, &run_id)
+                    .await
+                    .unwrap()
+                    .expect("resource exists");
+                // Also wait for a heartbeat to confirm the watcher is live.
+                if entry.status == SessionResourceStatus::Active
+                    && let Ok(Some(task)) = task_registry.get(session_id, &task_id).await
+                    && task.heartbeat_at.is_some()
+                {
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            }
+        })
+        .await
+        .expect("background run should start and send at least one heartbeat");
+
+        // Request cancel.
+        task_registry
+            .request_cancel(session_id, &task_id)
+            .await
+            .expect("request_cancel should succeed");
+
+        // Wait for the task to reach Canceled state.
+        tokio::time::timeout(std::time::Duration::from_secs(10), async {
+            loop {
+                if let Ok(Some(task)) = task_registry.get(session_id, &task_id).await
+                    && task.state == crate::session_task::SessionTaskState::Canceled
+                {
+                    break task;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            }
+        })
+        .await
+        .expect("background task should reach Canceled state");
+
+        // Verify result.json and output.log were written.
+        let result_file = file_store
+            .read_file(session_id, &format!("/.background/{run_id}/result.json"))
+            .await
+            .unwrap()
+            .expect("result.json should exist");
+        let result_json: Value =
+            serde_json::from_str(result_file.content.as_deref().unwrap_or_default())
+                .expect("valid json");
+        assert_eq!(result_json["status"], "canceled");
+
+        let log_file = file_store
+            .read_file(session_id, &format!("/.background/{run_id}/output.log"))
+            .await
+            .unwrap()
+            .expect("output.log should exist");
+        assert!(
+            log_file
+                .content
+                .as_deref()
+                .unwrap_or_default()
+                .contains("Canceled by request.")
+        );
     }
 }

--- a/crates/core/src/tools.rs
+++ b/crates/core/src/tools.rs
@@ -1276,7 +1276,9 @@ impl Tool for SpawnBackgroundTool {
                         result = tool_fut => result,
                         () = watch_fut => {
                             // Cancel was requested; the tool future is dropped.
-                            Err(ToolExecutionResult::ToolError("canceled".to_string()))
+                            Err(ToolExecutionResult::ToolError(
+                                BACKGROUND_CANCEL_SENTINEL.to_string(),
+                            ))
                         }
                     }
                 }
@@ -1674,13 +1676,18 @@ impl SessionBackgroundSink {
     }
 }
 
+/// Internal sentinel injected by the cancel-watch select branch. Namespaced
+/// so a background tool that legitimately fails with "canceled" is never
+/// misclassified as a cooperative cancel.
+const BACKGROUND_CANCEL_SENTINEL: &str = "__everruns_background_cancel__";
+
 /// Returns true when an outcome from the cancel-watch select is the sentinel
-/// cancel signal (Err(ToolError("canceled"))).  Factored out so the condition
-/// is testable without a running async runtime.
+/// cancel signal.  Factored out so the condition is testable without a
+/// running async runtime.
 fn is_canceled_outcome(
     outcome: &std::result::Result<BackgroundOutcome, ToolExecutionResult>,
 ) -> bool {
-    matches!(outcome, Err(ToolExecutionResult::ToolError(msg)) if msg == "canceled")
+    matches!(outcome, Err(ToolExecutionResult::ToolError(msg)) if msg == BACKGROUND_CANCEL_SENTINEL)
 }
 
 async fn ensure_directory(
@@ -3359,8 +3366,9 @@ mod tests {
     #[test]
     fn test_is_canceled_outcome_detects_sentinel() {
         // The sentinel produced by the cancel-watcher branch.
-        let sentinel: std::result::Result<BackgroundOutcome, ToolExecutionResult> =
-            Err(ToolExecutionResult::ToolError("canceled".to_string()));
+        let sentinel: std::result::Result<BackgroundOutcome, ToolExecutionResult> = Err(
+            ToolExecutionResult::ToolError(BACKGROUND_CANCEL_SENTINEL.to_string()),
+        );
         assert!(is_canceled_outcome(&sentinel));
     }
 

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -1780,6 +1780,14 @@ impl ServerAppBuilder {
             {
                 tracing::error!(error = %e, "Failed to bootstrap leased-resource cleanup schedule");
             }
+            if let Err(e) =
+                crate::session_task_reaper_scheduler::ensure_session_task_reaper_schedule(
+                    store.clone(),
+                )
+                .await
+            {
+                tracing::error!(error = %e, "Failed to bootstrap session-task reaper schedule");
+            }
             let scheduler = everruns_durable::DurableScheduler::with_defaults(
                 store,
                 format!("scheduler-{}", uuid::Uuid::now_v7()),

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -1498,9 +1498,15 @@ impl WorkerAdapters for DirectWorkerAdapters {
     fn session_task_registry(
         &self,
     ) -> Option<Arc<dyn everruns_core::session_task::SessionTaskRegistry>> {
+        let waker = Arc::new(DirectSessionTaskWaker {
+            db: self.db.clone(),
+            event_service: self.event_service.clone(),
+            runner: self.runner.clone(),
+        });
         Some(Arc::new(
             crate::storage::DbSessionTaskRegistry::new(self.db.clone())
-                .with_event_emitter(self.event_service.clone()),
+                .with_event_emitter(self.event_service.clone())
+                .with_waker(waker),
         ))
     }
 
@@ -1675,6 +1681,33 @@ impl WorkerAdapters for DirectWorkerAdapters {
                 ))
             })?
             .is_some())
+    }
+
+    async fn list_orphaned_session_task_ids(
+        &self,
+        stale_after: chrono::Duration,
+        limit: i64,
+    ) -> Result<Vec<(everruns_core::SessionId, String)>> {
+        self.db
+            .list_orphaned_session_task_ids(stale_after, limit)
+            .await
+            .map_err(|e| store_error(format!("Failed to list orphaned session tasks: {e}")))
+    }
+
+    fn reaper_session_task_registry(
+        &self,
+    ) -> Arc<dyn everruns_core::session_task::SessionTaskRegistry> {
+        // Attach waker so reaped tasks can wake sessions per wake_policy.
+        let waker = Arc::new(DirectSessionTaskWaker {
+            db: self.db.clone(),
+            event_service: self.event_service.clone(),
+            runner: self.runner.clone(),
+        });
+        Arc::new(
+            crate::storage::DbSessionTaskRegistry::new(self.db.clone())
+                .with_event_emitter(self.event_service.clone())
+                .with_waker(waker),
+        )
     }
 }
 
@@ -1952,6 +1985,84 @@ fn event_to_message(event: Event) -> Option<Message> {
             })
         }
         _ => None,
+    }
+}
+
+// =============================================================================
+// DirectSessionTaskWaker — inject wake messages into sessions from the worker
+// =============================================================================
+
+/// Wake the owning session by injecting a synthetic user message via the same
+/// path as `platform_send_message` in the gRPC service. Uses an internal
+/// caller so the message is created without a user context.
+struct DirectSessionTaskWaker {
+    db: Arc<crate::storage::StorageBackend>,
+    event_service: Arc<crate::services::EventService>,
+    runner: Option<Arc<dyn everruns_worker::AgentRunner>>,
+}
+
+#[async_trait::async_trait]
+impl crate::storage::session_task_store::SessionTaskWaker for DirectSessionTaskWaker {
+    async fn wake(&self, session_id: everruns_core::SessionId, text: &str) -> anyhow::Result<()> {
+        // Fetch session without org-scope to get harness_id and org_id.
+        let session = self
+            .db
+            .get_session_unscoped(session_id)
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to look up session for wake: {e}"))?;
+        let Some(session) = session else {
+            return Ok(());
+        };
+        let Some(harness_id) = session.harness_id else {
+            tracing::debug!(
+                session_id = %session_id,
+                "SessionTaskWaker: session has no harness_id; skipping wake"
+            );
+            return Ok(());
+        };
+
+        let message_id = everruns_core::MessageId::new();
+        let now = chrono::Utc::now();
+        let core_message = everruns_core::Message {
+            id: message_id,
+            role: everruns_core::MessageRole::User,
+            content: vec![everruns_core::ContentPart::text(text)],
+            phase: None,
+            thinking: None,
+            thinking_signature: None,
+            controls: None,
+            metadata: None,
+            external_actor: None,
+            created_at: now,
+        };
+
+        self.event_service
+            .emit(everruns_core::EventRequest::new(
+                session_id,
+                everruns_core::events::EventContext::empty(),
+                everruns_core::events::InputMessageData::new(core_message),
+            ))
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to emit wake message event: {e}"))?;
+
+        if let Some(runner) = &self.runner {
+            let runner = runner.clone();
+            let agent_id = session.agent_id;
+            let org_id = session.org_id;
+            tokio::spawn(async move {
+                if let Err(e) = runner
+                    .start_run(org_id, session_id, harness_id, agent_id, message_id, None)
+                    .await
+                {
+                    tracing::warn!(
+                        session_id = %session_id,
+                        "SessionTaskWaker: failed to start turn workflow: {e}"
+                    );
+                }
+            });
+        }
+
+        Ok(())
     }
 }
 

--- a/crates/server/src/grpc_service/mod.rs
+++ b/crates/server/src/grpc_service/mod.rs
@@ -367,6 +367,83 @@ impl tonic::service::Interceptor for GrpcAuthInterceptor {
     }
 }
 
+// =============================================================================
+// GrpcSessionTaskWaker — inject wake messages into sessions from gRPC path
+// =============================================================================
+
+/// Wake the owning session by injecting a synthetic user message, mirroring
+/// the `platform_send_message` gRPC handler. Used by the session task registry
+/// in the gRPC worker path.
+struct GrpcSessionTaskWaker {
+    db: Arc<StorageBackend>,
+    event_service: EventService,
+    runner: Option<Arc<dyn everruns_worker::AgentRunner>>,
+}
+
+#[async_trait::async_trait]
+impl crate::storage::session_task_store::SessionTaskWaker for GrpcSessionTaskWaker {
+    async fn wake(&self, session_id: everruns_core::SessionId, text: &str) -> anyhow::Result<()> {
+        let session = self
+            .db
+            .get_session_unscoped(session_id)
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to look up session for wake: {e}"))?;
+        let Some(session) = session else {
+            return Ok(());
+        };
+        let Some(harness_id) = session.harness_id else {
+            tracing::debug!(
+                session_id = %session_id,
+                "GrpcSessionTaskWaker: session has no harness_id; skipping wake"
+            );
+            return Ok(());
+        };
+
+        let message_id = everruns_core::MessageId::new();
+        let now = chrono::Utc::now();
+        let core_message = everruns_core::Message {
+            id: message_id,
+            role: everruns_core::MessageRole::User,
+            content: vec![everruns_core::ContentPart::text(text)],
+            phase: None,
+            thinking: None,
+            thinking_signature: None,
+            controls: None,
+            metadata: None,
+            external_actor: None,
+            created_at: now,
+        };
+
+        self.event_service
+            .emit(everruns_core::EventRequest::new(
+                session_id,
+                everruns_core::events::EventContext::empty(),
+                everruns_core::events::InputMessageData::new(core_message),
+            ))
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to emit wake message event: {e}"))?;
+
+        if let Some(runner) = &self.runner {
+            let runner = runner.clone();
+            let agent_id = session.agent_id;
+            let org_id = session.org_id;
+            tokio::spawn(async move {
+                if let Err(e) = runner
+                    .start_run(org_id, session_id, harness_id, agent_id, message_id, None)
+                    .await
+                {
+                    tracing::warn!(
+                        session_id = %session_id,
+                        "GrpcSessionTaskWaker: failed to start turn workflow: {e}"
+                    );
+                }
+            });
+        }
+
+        Ok(())
+    }
+}
+
 /// gRPC service implementation for worker communication
 ///
 /// Uses domain commands/queries for agents and harnesses, and services for
@@ -633,11 +710,18 @@ impl WorkerServiceImpl {
     }
 
     /// Create the session task registry used by tools over gRPC. Attaches the
-    /// event service so registry mutations emit task.* events.
+    /// event service and waker so registry mutations emit task.* events and
+    /// inject wake messages into sessions per wake_policy.
     fn session_task_registry(&self) -> Arc<dyn everruns_core::session_task::SessionTaskRegistry> {
+        let waker = Arc::new(GrpcSessionTaskWaker {
+            db: self.db.clone(),
+            event_service: self.event_service.clone(),
+            runner: self.runner.clone(),
+        });
         Arc::new(
             crate::storage::DbSessionTaskRegistry::new(self.db.clone())
-                .with_event_emitter(Arc::new(self.event_service.clone())),
+                .with_event_emitter(Arc::new(self.event_service.clone()))
+                .with_waker(waker),
         )
     }
 

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -99,6 +99,9 @@ pub mod seed;
 pub mod leased_resource_scheduler;
 pub mod session_scheduler;
 
+// Session-task orphan reconciler schedule seeder
+pub mod session_task_reaper_scheduler;
+
 // Background sweep: time out sessions stuck in waiting_for_tool_results
 pub mod tool_result_timeout;
 

--- a/crates/server/src/session_task_reaper_scheduler.rs
+++ b/crates/server/src/session_task_reaper_scheduler.rs
@@ -1,0 +1,194 @@
+// Durable session-task reaper schedule bootstrap.
+//
+// Mirrors leased_resource_scheduler.rs exactly in structure and cadence
+// (every 60 seconds). The schedule seeds the `session_task_reaper` activity
+// which fails tasks whose worker heartbeat has gone stale.
+
+use anyhow::{Context, Result};
+use chrono::Utc;
+use everruns_durable::{
+    CreateScheduleRow, Pagination, ScheduleFilter, ScheduleTargetType, UpdateField, UpdateSchedule,
+    WorkflowEventStore,
+};
+use std::str::FromStr;
+use std::sync::Arc;
+
+const SESSION_TASK_REAPER_SCHEDULE_NAME: &str = "session-task-reaper";
+pub const SESSION_TASK_REAPER_ACTIVITY: &str = "session_task_reaper";
+// Every 60 seconds — same cadence as the leased-resource cleanup.
+const SESSION_TASK_REAPER_CRON: &str = "0 * * * * * *";
+const SESSION_TASK_REAPER_TIMEZONE: &str = "UTC";
+const SESSION_TASK_REAPER_DESCRIPTION: &str =
+    "Fails session tasks whose worker heartbeat has gone stale (orphan reconciler).";
+
+/// Ensure the durable session-task reaper schedule exists with the expected definition.
+pub async fn ensure_session_task_reaper_schedule(
+    store: Arc<dyn WorkflowEventStore + Send + Sync>,
+) -> Result<()> {
+    let desired_input = serde_json::to_value(
+        everruns_worker::session_task_reaper::SessionTaskReaperInput::default(),
+    )?;
+    let desired_next_trigger = next_trigger()?;
+
+    let existing = store
+        .list_schedules(
+            ScheduleFilter::default(),
+            Pagination {
+                offset: 0,
+                limit: 1_000,
+            },
+        )
+        .await?
+        .into_iter()
+        .find(|schedule| schedule.name == SESSION_TASK_REAPER_SCHEDULE_NAME);
+
+    if let Some(schedule) = existing {
+        let needs_update = schedule.description.as_deref() != Some(SESSION_TASK_REAPER_DESCRIPTION)
+            || schedule.cron_expression != SESSION_TASK_REAPER_CRON
+            || schedule.timezone != SESSION_TASK_REAPER_TIMEZONE
+            || schedule.target_type != ScheduleTargetType::Activity
+            || schedule.target_name != SESSION_TASK_REAPER_ACTIVITY
+            || schedule.target_input != desired_input
+            || !schedule.enabled
+            || schedule.max_concurrent != Some(1)
+            || schedule.catch_up_missed;
+
+        if needs_update {
+            store
+                .update_schedule(
+                    schedule.id,
+                    UpdateSchedule {
+                        description: UpdateField::Set(SESSION_TASK_REAPER_DESCRIPTION.to_string()),
+                        cron_expression: Some(SESSION_TASK_REAPER_CRON.to_string()),
+                        timezone: Some(SESSION_TASK_REAPER_TIMEZONE.to_string()),
+                        target_type: Some(ScheduleTargetType::Activity),
+                        target_name: Some(SESSION_TASK_REAPER_ACTIVITY.to_string()),
+                        target_input: Some(desired_input),
+                        enabled: Some(true),
+                        max_concurrent: UpdateField::Set(1),
+                        catch_up_missed: Some(false),
+                        max_catch_up: UpdateField::Set(1),
+                        next_trigger_at: UpdateField::Set(desired_next_trigger),
+                        ..Default::default()
+                    },
+                )
+                .await?;
+
+            tracing::info!(
+                schedule_id = %schedule.id,
+                "Updated durable session-task reaper schedule"
+            );
+        } else {
+            tracing::info!(
+                schedule_id = %schedule.id,
+                "Durable session-task reaper schedule already configured"
+            );
+        }
+
+        return Ok(());
+    }
+
+    match store
+        .create_schedule(CreateScheduleRow {
+            name: SESSION_TASK_REAPER_SCHEDULE_NAME.to_string(),
+            description: Some(SESSION_TASK_REAPER_DESCRIPTION.to_string()),
+            cron_expression: SESSION_TASK_REAPER_CRON.to_string(),
+            timezone: SESSION_TASK_REAPER_TIMEZONE.to_string(),
+            target_type: ScheduleTargetType::Activity,
+            target_name: SESSION_TASK_REAPER_ACTIVITY.to_string(),
+            target_input: desired_input,
+            enabled: true,
+            max_concurrent: Some(1),
+            catch_up_missed: false,
+            max_catch_up: Some(1),
+            retry_policy: None,
+            next_trigger_at: Some(desired_next_trigger),
+        })
+        .await
+    {
+        Ok(schedule_id) => {
+            tracing::info!(
+                schedule_id = %schedule_id,
+                "Created durable session-task reaper schedule"
+            );
+            Ok(())
+        }
+        Err(everruns_durable::StoreError::Database(error))
+            if error.contains("duplicate") || error.contains("unique") =>
+        {
+            tracing::info!("Session-task reaper schedule already exists");
+            Ok(())
+        }
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn next_trigger() -> Result<chrono::DateTime<Utc>> {
+    let schedule = cron::Schedule::from_str(SESSION_TASK_REAPER_CRON)
+        .context("Invalid session-task reaper cron expression")?;
+    schedule
+        .upcoming(Utc)
+        .next()
+        .context("Session-task reaper cron produced no next trigger")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use everruns_durable::InMemoryWorkflowEventStore;
+
+    async fn list_reaper_schedules(
+        store: &InMemoryWorkflowEventStore,
+    ) -> Vec<everruns_durable::ScheduleRow> {
+        store
+            .list_schedules(
+                ScheduleFilter::default(),
+                Pagination {
+                    offset: 0,
+                    limit: 100,
+                },
+            )
+            .await
+            .expect("schedules should list")
+            .into_iter()
+            .filter(|schedule| schedule.name == SESSION_TASK_REAPER_SCHEDULE_NAME)
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn ensures_expected_reaper_schedule_once() {
+        let store = Arc::new(InMemoryWorkflowEventStore::new());
+
+        ensure_session_task_reaper_schedule(store.clone())
+            .await
+            .expect("reaper schedule should bootstrap");
+        ensure_session_task_reaper_schedule(store.clone())
+            .await
+            .expect("reaper schedule bootstrap should be idempotent");
+
+        let schedules = list_reaper_schedules(store.as_ref()).await;
+        assert_eq!(schedules.len(), 1);
+
+        let schedule = &schedules[0];
+        assert_eq!(
+            schedule.description.as_deref(),
+            Some(SESSION_TASK_REAPER_DESCRIPTION)
+        );
+        assert_eq!(schedule.cron_expression, SESSION_TASK_REAPER_CRON);
+        assert_eq!(schedule.timezone, SESSION_TASK_REAPER_TIMEZONE);
+        assert_eq!(schedule.target_type, ScheduleTargetType::Activity);
+        assert_eq!(schedule.target_name, SESSION_TASK_REAPER_ACTIVITY);
+        assert_eq!(
+            schedule.target_input,
+            serde_json::to_value(
+                everruns_worker::session_task_reaper::SessionTaskReaperInput::default()
+            )
+            .expect("default reaper input should serialize")
+        );
+        assert!(schedule.enabled);
+        assert_eq!(schedule.max_concurrent, Some(1));
+        assert!(!schedule.catch_up_missed);
+        assert_eq!(schedule.max_catch_up, Some(1));
+        assert!(schedule.next_trigger_at.is_some());
+    }
+}

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -2723,6 +2723,16 @@ impl StorageBackend {
         dispatch!(self, list_session_task_messages, session_id, task_id, limit)
     }
 
+    /// Return (session_id, task_id) pairs for tasks with a stale heartbeat.
+    /// See individual backend impls for locking semantics.
+    pub async fn list_orphaned_session_task_ids(
+        &self,
+        stale_after: chrono::Duration,
+        limit: i64,
+    ) -> Result<Vec<(SessionId, String)>> {
+        dispatch!(self, list_orphaned_session_task_ids, stale_after, limit)
+    }
+
     // ============================================
     // Audit Logs (TM-OBS-007, EVE-226)
     // ============================================

--- a/crates/server/src/storage/memory/session_tasks.rs
+++ b/crates/server/src/storage/memory/session_tasks.rs
@@ -126,6 +126,35 @@ impl InMemoryDatabase {
         Ok(row)
     }
 
+    /// Return IDs of tasks that have a stale heartbeat (orphaned workers).
+    ///
+    /// A task is stale when:
+    /// - state IN ('queued', 'running'), AND
+    /// - heartbeat_at IS NOT NULL, AND
+    /// - heartbeat_at < now - stale_after.
+    ///
+    /// Tasks with NULL heartbeat_at are foreground subagent tasks (EVE-535
+    /// spawn-handle coverage) and are never reaped.
+    pub async fn list_orphaned_session_task_ids(
+        &self,
+        stale_after: chrono::Duration,
+        limit: i64,
+    ) -> Result<Vec<(SessionId, String)>> {
+        let cutoff = Self::now() - stale_after;
+        let tasks = self.session_tasks.read();
+        let mut result: Vec<(SessionId, String)> = tasks
+            .values()
+            .filter(|row| {
+                (row.state == "queued" || row.state == "running")
+                    && row.heartbeat_at.is_some_and(|hb| hb < cutoff)
+            })
+            .map(|row| (row.session_id, row.id.clone()))
+            .collect();
+        result.sort_by(|(_, a), (_, b)| a.cmp(b));
+        result.truncate(limit as usize);
+        Ok(result)
+    }
+
     /// Last `limit` messages, returned oldest first.
     pub async fn list_session_task_messages(
         &self,

--- a/crates/server/src/storage/repositories/session_tasks.rs
+++ b/crates/server/src/storage/repositories/session_tasks.rs
@@ -244,18 +244,18 @@ impl Database {
     ///
     /// Tasks with NULL heartbeat_at are excluded (foreground tasks without
     /// liveness probes; EVE-535 spawn-handle coverage applies instead).
-    /// Runs inside a transaction with `FOR UPDATE SKIP LOCKED` so concurrent
-    /// reapers claim disjoint sets.
+    ///
+    /// This is a plain snapshot read — no transaction is held across the
+    /// reaper's subsequent per-task updates, so concurrent reapers may pick
+    /// overlapping sets. That is safe: failing a task is applied through
+    /// `apply_task_update`, where terminal states are final, so a second
+    /// reaper's update is an idempotent no-op.
     pub async fn list_orphaned_session_task_ids(
         &self,
         stale_after: chrono::Duration,
         limit: i64,
     ) -> Result<Vec<(SessionId, String)>> {
         let stale_secs = stale_after.num_seconds();
-        // Transaction is necessary for FOR UPDATE to take effect for the
-        // caller's subsequent updates; the reaper calls update_session_task
-        // for each row in its own transaction, so we open and commit here
-        // just to get a consistent, lock-free snapshot.
         let rows = sqlx::query_as::<_, (SessionId, String)>(
             r#"
             SELECT session_id, id
@@ -265,7 +265,6 @@ impl Database {
               AND heartbeat_at < NOW() - ($1::bigint * INTERVAL '1 second')
             ORDER BY id
             LIMIT $2
-            FOR UPDATE SKIP LOCKED
             "#,
         )
         .bind(stale_secs)

--- a/crates/server/src/storage/repositories/session_tasks.rs
+++ b/crates/server/src/storage/repositories/session_tasks.rs
@@ -240,6 +240,41 @@ impl Database {
         Ok(row)
     }
 
+    /// Return (session_id, task_id) pairs for tasks with a stale heartbeat.
+    ///
+    /// Tasks with NULL heartbeat_at are excluded (foreground tasks without
+    /// liveness probes; EVE-535 spawn-handle coverage applies instead).
+    /// Runs inside a transaction with `FOR UPDATE SKIP LOCKED` so concurrent
+    /// reapers claim disjoint sets.
+    pub async fn list_orphaned_session_task_ids(
+        &self,
+        stale_after: chrono::Duration,
+        limit: i64,
+    ) -> Result<Vec<(SessionId, String)>> {
+        let stale_secs = stale_after.num_seconds();
+        // Transaction is necessary for FOR UPDATE to take effect for the
+        // caller's subsequent updates; the reaper calls update_session_task
+        // for each row in its own transaction, so we open and commit here
+        // just to get a consistent, lock-free snapshot.
+        let rows = sqlx::query_as::<_, (SessionId, String)>(
+            r#"
+            SELECT session_id, id
+            FROM session_tasks
+            WHERE state IN ('queued', 'running')
+              AND heartbeat_at IS NOT NULL
+              AND heartbeat_at < NOW() - ($1::bigint * INTERVAL '1 second')
+            ORDER BY id
+            LIMIT $2
+            FOR UPDATE SKIP LOCKED
+            "#,
+        )
+        .bind(stale_secs)
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows)
+    }
+
     /// Last `limit` messages, returned oldest first.
     pub async fn list_session_task_messages(
         &self,

--- a/crates/server/src/storage/session_task_store.rs
+++ b/crates/server/src/storage/session_task_store.rs
@@ -199,9 +199,16 @@ impl SessionTaskRegistry for DbSessionTaskRegistry {
         task_id: &str,
         update: SessionTaskUpdate,
     ) -> Result<Option<SessionTask>> {
-        // Read prior state so we can decide whether to wake after the update.
+        // Only THIS update's intent can trigger a wake: an unrelated update
+        // (heartbeat/progress) racing with another worker's transition must
+        // not observe prior=non-terminal/new=terminal and wake on its behalf.
+        let wants_terminal_wake = update.state.is_some_and(|s| s.is_terminal());
+        let wants_awaiting_input_wake =
+            update.input_request.is_some() || update.state == Some(SessionTaskState::AwaitingInput);
+
+        // Read prior state so we can detect the transition this update makes.
         // Best-effort: if the read fails we still proceed with the update.
-        let prior = if self.waker.is_some() {
+        let prior = if self.waker.is_some() && (wants_terminal_wake || wants_awaiting_input_wake) {
             self.get(session_id, task_id).await.ok().flatten()
         } else {
             None
@@ -220,10 +227,15 @@ impl SessionTaskRegistry for DbSessionTaskRegistry {
         if let Some(task) = &task {
             self.emit_task_snapshot(task, false).await;
 
-            // Wake enforcement: fire at most one wake per transition.
+            // Wake enforcement: fire at most one wake per transition, gated
+            // on the intent of this specific update.
             if let Some(prior) = &prior {
-                self.maybe_wake_on_terminal(prior, task).await;
-                self.maybe_wake_on_awaiting_input(prior, task).await;
+                if wants_terminal_wake {
+                    self.maybe_wake_on_terminal(prior, task).await;
+                }
+                if wants_awaiting_input_wake {
+                    self.maybe_wake_on_awaiting_input(prior, task).await;
+                }
             }
         }
         Ok(task)

--- a/crates/server/src/storage/session_task_store.rs
+++ b/crates/server/src/storage/session_task_store.rs
@@ -4,6 +4,9 @@
 // PostgreSQL and in-memory) and emits snapshot-carrying task.* events on the
 // owning session's event stream. Event emission is best-effort: failures are
 // logged and never fail the storage operation.
+//
+// Wake policy: after a state transition the registry calls the optional waker
+// best-effort (log on error, never fail the operation).
 
 use async_trait::async_trait;
 use chrono::Utc;
@@ -13,7 +16,7 @@ use everruns_core::events::{
 use everruns_core::session_task::{
     CreateSessionTask, NewTaskMessage, SessionTask, SessionTaskFilter, SessionTaskRegistry,
     SessionTaskState, SessionTaskUpdate, TaskMessage, TaskMessageDirection,
-    generate_task_message_id, new_session_task,
+    generate_task_message_id, new_session_task, task_message_text,
 };
 use everruns_core::traits::EventEmitter;
 use everruns_core::{AgentLoopError, Result, SessionId};
@@ -22,20 +25,49 @@ use super::backend::StorageBackend;
 use super::models::NewSessionTaskMessageRow;
 use std::sync::Arc;
 
+// ============================================================================
+// SessionTaskWaker — server-side concern for injecting messages into sessions
+// ============================================================================
+
+/// Wake the owning session's agent by injecting a synthetic message. Errors
+/// are treated best-effort: the caller logs and continues.
+#[async_trait]
+pub trait SessionTaskWaker: Send + Sync {
+    async fn wake(&self, session_id: SessionId, text: &str) -> anyhow::Result<()>;
+}
+
+// ============================================================================
+// DbSessionTaskRegistry
+// ============================================================================
+
 /// Database-backed session task registry.
 #[derive(Clone)]
 pub struct DbSessionTaskRegistry {
     db: Arc<StorageBackend>,
     emitter: Option<Arc<dyn EventEmitter>>,
+    waker: Option<Arc<dyn SessionTaskWaker>>,
 }
 
 impl DbSessionTaskRegistry {
     pub fn new(db: Arc<StorageBackend>) -> Self {
-        Self { db, emitter: None }
+        Self {
+            db,
+            emitter: None,
+            waker: None,
+        }
     }
 
     pub fn with_event_emitter(mut self, emitter: Arc<dyn EventEmitter>) -> Self {
         self.emitter = Some(emitter);
+        self
+    }
+
+    /// Attach a waker so the registry can inject wake messages into sessions
+    /// on qualifying state transitions. Only registries constructed with an
+    /// event emitter should also have a waker (worker/gRPC paths); the API
+    /// path (user-initiated mutations) must not wake.
+    pub fn with_waker(mut self, waker: Arc<dyn SessionTaskWaker>) -> Self {
+        self.waker = Some(waker);
         self
     }
 
@@ -65,6 +97,83 @@ impl DbSessionTaskRegistry {
         };
         self.emit(task.session_id, data).await;
     }
+
+    /// Deliver a wake message to the owning session (best-effort, log on error).
+    async fn try_wake(&self, session_id: SessionId, text: &str) {
+        let Some(waker) = &self.waker else {
+            return;
+        };
+        if let Err(e) = waker.wake(session_id, text).await {
+            tracing::warn!(
+                session_id = %session_id,
+                "SessionTaskWaker failed (best-effort): {e}"
+            );
+        }
+    }
+
+    /// Compose the wake text for a terminal transition and wake if policy requires.
+    ///
+    /// Called after a successful `update` that moved a non-terminal task to a
+    /// terminal state. Never double-wakes: we only fire when `prior` was
+    /// non-terminal AND `task` is terminal.
+    async fn maybe_wake_on_terminal(&self, prior: &SessionTask, task: &SessionTask) {
+        use everruns_core::session_task::TaskWakePolicy;
+        if prior.state.is_terminal() || !task.state.is_terminal() {
+            return;
+        }
+        match task.wake_policy {
+            TaskWakePolicy::Silent => {}
+            TaskWakePolicy::OnTerminal | TaskWakePolicy::OnActivity => {
+                let mut parts = vec![format!(
+                    "Task \"{}\" ({}) finished: {}.",
+                    task.display_name, task.id, task.state
+                )];
+                if let Some(summary) = &task.summary {
+                    parts.push(format!("- summary: {summary}"));
+                }
+                if let Some(result_path) = &task.result_path {
+                    parts.push(format!("- result_path: {result_path}"));
+                }
+                self.try_wake(task.session_id, &parts.join("\n")).await;
+            }
+        }
+    }
+
+    /// Wake on a transition INTO `awaiting_input` (OnActivity only).
+    async fn maybe_wake_on_awaiting_input(&self, prior: &SessionTask, task: &SessionTask) {
+        use everruns_core::session_task::TaskWakePolicy;
+        if task.wake_policy != TaskWakePolicy::OnActivity {
+            return;
+        }
+        if prior.state == SessionTaskState::AwaitingInput
+            || task.state != SessionTaskState::AwaitingInput
+        {
+            return;
+        }
+        let prompt = task
+            .input_request
+            .as_ref()
+            .map(|r| r.prompt.as_str())
+            .unwrap_or("Task is awaiting input.");
+        let text = format!(
+            "Task \"{}\" ({}) is awaiting input: {}",
+            task.display_name, task.id, prompt
+        );
+        self.try_wake(task.session_id, &text).await;
+    }
+
+    /// Wake on an outbound message (OnActivity only).
+    async fn maybe_wake_on_outbound_message(&self, task: &SessionTask, message_text: &str) {
+        use everruns_core::session_task::TaskWakePolicy;
+        if task.wake_policy != TaskWakePolicy::OnActivity {
+            return;
+        }
+        let text = format!(
+            "Task \"{}\" ({}) sent a message: {}",
+            task.display_name, task.id, message_text
+        );
+        self.try_wake(task.session_id, &text).await;
+    }
 }
 
 #[async_trait]
@@ -90,6 +199,14 @@ impl SessionTaskRegistry for DbSessionTaskRegistry {
         task_id: &str,
         update: SessionTaskUpdate,
     ) -> Result<Option<SessionTask>> {
+        // Read prior state so we can decide whether to wake after the update.
+        // Best-effort: if the read fails we still proceed with the update.
+        let prior = if self.waker.is_some() {
+            self.get(session_id, task_id).await.ok().flatten()
+        } else {
+            None
+        };
+
         let row = self
             .db
             .update_session_task(session_id, task_id, update)
@@ -102,6 +219,12 @@ impl SessionTaskRegistry for DbSessionTaskRegistry {
             .map_err(|e| AgentLoopError::store(format!("Invalid session task row: {e}")))?;
         if let Some(task) = &task {
             self.emit_task_snapshot(task, false).await;
+
+            // Wake enforcement: fire at most one wake per transition.
+            if let Some(prior) = &prior {
+                self.maybe_wake_on_terminal(prior, task).await;
+                self.maybe_wake_on_awaiting_input(prior, task).await;
+            }
         }
         Ok(task)
     }
@@ -205,6 +328,12 @@ impl SessionTaskRegistry for DbSessionTaskRegistry {
         };
         self.emit(session_id, data).await;
 
+        // Wake on outbound messages for OnActivity tasks.
+        if stored.direction == TaskMessageDirection::Outbound {
+            let msg_text = task_message_text(&stored.content);
+            self.maybe_wake_on_outbound_message(&task, &msg_text).await;
+        }
+
         // An inbound answer to the pending input request resumes the task.
         if stored.direction == TaskMessageDirection::Inbound
             && let (Some(in_reply_to), Some(pending)) = (&stored.in_reply_to, &task.input_request)
@@ -248,6 +377,37 @@ impl SessionTaskRegistry for DbSessionTaskRegistry {
 mod tests {
     use super::*;
     use everruns_core::session_task::{TaskInputRequest, TaskLinks, TaskWakePolicy};
+    use std::sync::Mutex;
+
+    // -------------------------------------------------------------------------
+    // Recording test waker
+    // -------------------------------------------------------------------------
+
+    #[derive(Default, Clone)]
+    struct RecordingWaker {
+        calls: Arc<Mutex<Vec<(SessionId, String)>>>,
+    }
+
+    impl RecordingWaker {
+        fn recorded(&self) -> Vec<(SessionId, String)> {
+            self.calls.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl SessionTaskWaker for RecordingWaker {
+        async fn wake(&self, session_id: SessionId, text: &str) -> anyhow::Result<()> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push((session_id, text.to_string()));
+            Ok(())
+        }
+    }
+
+    fn registry_with_waker(waker: Arc<dyn SessionTaskWaker>) -> DbSessionTaskRegistry {
+        DbSessionTaskRegistry::new(Arc::new(StorageBackend::in_memory())).with_waker(waker)
+    }
 
     fn registry() -> DbSessionTaskRegistry {
         DbSessionTaskRegistry::new(Arc::new(StorageBackend::in_memory()))
@@ -474,5 +634,270 @@ mod tests {
             .map(|m| everruns_core::session_task::task_message_text(&m.content))
             .collect();
         assert_eq!(texts, vec!["m3", "m4"]);
+    }
+
+    // -------------------------------------------------------------------------
+    // Wake policy tests
+    // -------------------------------------------------------------------------
+
+    fn create_input_with_policy(
+        session_id: SessionId,
+        policy: TaskWakePolicy,
+    ) -> CreateSessionTask {
+        CreateSessionTask {
+            session_id,
+            id: None,
+            kind: "background_tool".to_string(),
+            display_name: "Test task".to_string(),
+            spec: serde_json::json!({}),
+            state: SessionTaskState::Queued,
+            links: TaskLinks::default(),
+            wake_policy: policy,
+        }
+    }
+
+    #[tokio::test]
+    async fn silent_policy_never_wakes() {
+        let waker = Arc::new(RecordingWaker::default());
+        let registry = registry_with_waker(waker.clone());
+        let session_id = SessionId::new();
+
+        let task = registry
+            .create(create_input_with_policy(session_id, TaskWakePolicy::Silent))
+            .await
+            .unwrap();
+        registry
+            .update(
+                session_id,
+                &task.id,
+                SessionTaskUpdate {
+                    state: Some(SessionTaskState::Running),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        registry
+            .update(
+                session_id,
+                &task.id,
+                SessionTaskUpdate {
+                    state: Some(SessionTaskState::Succeeded),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        // Record an outbound message to verify no wake fires.
+        registry
+            .record_message(session_id, &task.id, NewTaskMessage::outbound_text("hello"))
+            .await
+            .unwrap();
+
+        assert!(waker.recorded().is_empty(), "Silent should never wake");
+    }
+
+    #[tokio::test]
+    async fn on_terminal_wakes_exactly_once_on_terminal_transition() {
+        let waker = Arc::new(RecordingWaker::default());
+        let registry = registry_with_waker(waker.clone());
+        let session_id = SessionId::new();
+
+        let task = registry
+            .create(create_input_with_policy(
+                session_id,
+                TaskWakePolicy::OnTerminal,
+            ))
+            .await
+            .unwrap();
+
+        // Non-terminal transition: no wake.
+        registry
+            .update(
+                session_id,
+                &task.id,
+                SessionTaskUpdate {
+                    state: Some(SessionTaskState::Running),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        assert!(waker.recorded().is_empty(), "Should not wake on running");
+
+        // Terminal transition: one wake.
+        registry
+            .update(
+                session_id,
+                &task.id,
+                SessionTaskUpdate {
+                    state: Some(SessionTaskState::Succeeded),
+                    summary: Some("done".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        let calls = waker.recorded();
+        assert_eq!(calls.len(), 1, "Should wake exactly once on terminal");
+        assert!(
+            calls[0].1.contains("finished: succeeded"),
+            "Wake text should describe terminal state"
+        );
+        assert!(
+            calls[0].1.contains("summary: done"),
+            "Wake text should include summary"
+        );
+
+        // Second update on already-terminal task: no second wake.
+        registry
+            .update(
+                session_id,
+                &task.id,
+                SessionTaskUpdate {
+                    result_path: Some("/.tasks/x/result.json".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(waker.recorded().len(), 1, "No double-wake after terminal");
+    }
+
+    #[tokio::test]
+    async fn on_activity_wakes_on_awaiting_input_and_outbound_message() {
+        let waker = Arc::new(RecordingWaker::default());
+        let registry = registry_with_waker(waker.clone());
+        let session_id = SessionId::new();
+
+        let task = registry
+            .create(create_input_with_policy(
+                session_id,
+                TaskWakePolicy::OnActivity,
+            ))
+            .await
+            .unwrap();
+
+        // Running transition: no wake.
+        registry
+            .update(
+                session_id,
+                &task.id,
+                SessionTaskUpdate {
+                    state: Some(SessionTaskState::Running),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        assert!(waker.recorded().is_empty());
+
+        // Outbound message: one wake.
+        registry
+            .record_message(
+                session_id,
+                &task.id,
+                NewTaskMessage::outbound_text("task says hi"),
+            )
+            .await
+            .unwrap();
+        let calls = waker.recorded();
+        assert_eq!(calls.len(), 1, "Should wake on outbound message");
+        assert!(calls[0].1.contains("task says hi"));
+
+        // Awaiting input: another wake.
+        registry
+            .update(
+                session_id,
+                &task.id,
+                SessionTaskUpdate {
+                    input_request: Some(TaskInputRequest {
+                        id: "req_1".to_string(),
+                        prompt: "Approve?".to_string(),
+                        expected: None,
+                    }),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        let calls = waker.recorded();
+        assert_eq!(calls.len(), 2, "Should wake on awaiting_input transition");
+        assert!(calls[1].1.contains("Approve?"));
+
+        // Second awaiting_input update (idempotent input_request churn from
+        // polling): no extra wake because state is already awaiting_input.
+        registry
+            .update(
+                session_id,
+                &task.id,
+                SessionTaskUpdate {
+                    input_request: Some(TaskInputRequest {
+                        id: "req_1".to_string(),
+                        prompt: "Approve?".to_string(),
+                        expected: None,
+                    }),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            waker.recorded().len(),
+            2,
+            "No duplicate wake for repeated awaiting_input"
+        );
+
+        // Terminal transition also wakes.
+        let mut answer = NewTaskMessage::inbound_text("yes");
+        answer.in_reply_to = Some("req_1".to_string());
+        registry
+            .record_message(session_id, &task.id, answer)
+            .await
+            .unwrap();
+        registry
+            .update(
+                session_id,
+                &task.id,
+                SessionTaskUpdate {
+                    state: Some(SessionTaskState::Succeeded),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        let calls = waker.recorded();
+        assert_eq!(
+            calls.len(),
+            3,
+            "Should also wake on terminal for OnActivity"
+        );
+    }
+
+    #[tokio::test]
+    async fn inbound_messages_do_not_wake() {
+        let waker = Arc::new(RecordingWaker::default());
+        let registry = registry_with_waker(waker.clone());
+        let session_id = SessionId::new();
+
+        let task = registry
+            .create(create_input_with_policy(
+                session_id,
+                TaskWakePolicy::OnActivity,
+            ))
+            .await
+            .unwrap();
+        registry
+            .record_message(
+                session_id,
+                &task.id,
+                NewTaskMessage::inbound_text("steering"),
+            )
+            .await
+            .unwrap();
+        assert!(
+            waker.recorded().is_empty(),
+            "Inbound messages should not wake"
+        );
     }
 }

--- a/crates/worker/src/durable_worker.rs
+++ b/crates/worker/src/durable_worker.rs
@@ -224,6 +224,7 @@ impl Default for DurableWorkerConfig {
                 "reason".to_string(),
                 "act".to_string(),
                 "leased_resource_cleanup".to_string(),
+                "session_task_reaper".to_string(),
                 "invoke_scheduled_app_channel".to_string(),
             ],
             max_concurrent_tasks: 1000, // High default for massive workflow parallelism
@@ -980,6 +981,19 @@ impl DurableWorker {
                     &cleanup_input,
                 )
                 .await;
+                (res, None)
+            }
+            "session_task_reaper" => {
+                let reaper_input: crate::session_task_reaper::SessionTaskReaperInput =
+                    serde_json::from_value(task.input.clone())
+                        .map_err(|e| anyhow::anyhow!("Failed to parse reaper input: {}", e))?;
+                let adapters = crate::grpc_worker_adapters::GrpcWorkerAdapters::from_client_with_platform_definition(
+                    grpc_client.clone(),
+                    self.platform_definition.as_ref().clone(),
+                );
+                let res =
+                    crate::session_task_reaper::execute_reaper_activity(&adapters, &reaper_input)
+                        .await;
                 (res, None)
             }
             "invoke_scheduled_app_channel" => {

--- a/crates/worker/src/durable_worker.rs
+++ b/crates/worker/src/durable_worker.rs
@@ -224,7 +224,10 @@ impl Default for DurableWorkerConfig {
                 "reason".to_string(),
                 "act".to_string(),
                 "leased_resource_cleanup".to_string(),
-                "session_task_reaper".to_string(),
+                // session_task_reaper is intentionally NOT a default here:
+                // the gRPC adapters have no orphan-listing RPC yet, so remote
+                // workers must not claim reaper tasks (the in-process unified
+                // worker handles them). Opting in via config fails fast.
                 "invoke_scheduled_app_channel".to_string(),
             ],
             max_concurrent_tasks: 1000, // High default for massive workflow parallelism

--- a/crates/worker/src/grpc_worker_adapters.rs
+++ b/crates/worker/src/grpc_worker_adapters.rs
@@ -532,4 +532,88 @@ impl WorkerAdapters for GrpcWorkerAdapters {
             )
             .await
     }
+
+    // Session task reaper — not yet wired over gRPC (reaper runs from the
+    // in-process direct worker; gRPC support can be added once a proto RPC
+    // is defined).
+    async fn list_orphaned_session_task_ids(
+        &self,
+        _stale_after: chrono::Duration,
+        _limit: i64,
+    ) -> Result<Vec<(everruns_core::SessionId, String)>> {
+        Ok(vec![])
+    }
+
+    fn reaper_session_task_registry(
+        &self,
+    ) -> std::sync::Arc<dyn everruns_core::session_task::SessionTaskRegistry> {
+        // gRPC path: no direct storage access; return a no-op registry.
+        // The reaper activity is registered only on the in-process worker.
+        Arc::new(NoopSessionTaskRegistry)
+    }
+}
+
+// Minimal no-op registry for the gRPC stub path.
+#[derive(Default)]
+struct NoopSessionTaskRegistry;
+
+#[async_trait::async_trait]
+impl everruns_core::session_task::SessionTaskRegistry for NoopSessionTaskRegistry {
+    async fn create(
+        &self,
+        _input: everruns_core::session_task::CreateSessionTask,
+    ) -> everruns_core::error::Result<everruns_core::session_task::SessionTask> {
+        Err(everruns_core::AgentLoopError::store("noop registry"))
+    }
+
+    async fn update(
+        &self,
+        _session_id: everruns_core::SessionId,
+        _task_id: &str,
+        _update: everruns_core::session_task::SessionTaskUpdate,
+    ) -> everruns_core::error::Result<Option<everruns_core::session_task::SessionTask>> {
+        Ok(None)
+    }
+
+    async fn get(
+        &self,
+        _session_id: everruns_core::SessionId,
+        _task_id: &str,
+    ) -> everruns_core::error::Result<Option<everruns_core::session_task::SessionTask>> {
+        Ok(None)
+    }
+
+    async fn list(
+        &self,
+        _session_id: everruns_core::SessionId,
+        _filter: Option<&everruns_core::session_task::SessionTaskFilter>,
+    ) -> everruns_core::error::Result<Vec<everruns_core::session_task::SessionTask>> {
+        Ok(vec![])
+    }
+
+    async fn request_cancel(
+        &self,
+        _session_id: everruns_core::SessionId,
+        _task_id: &str,
+    ) -> everruns_core::error::Result<Option<everruns_core::session_task::SessionTask>> {
+        Ok(None)
+    }
+
+    async fn record_message(
+        &self,
+        _session_id: everruns_core::SessionId,
+        _task_id: &str,
+        _message: everruns_core::session_task::NewTaskMessage,
+    ) -> everruns_core::error::Result<everruns_core::session_task::TaskMessage> {
+        Err(everruns_core::AgentLoopError::store("noop registry"))
+    }
+
+    async fn list_messages(
+        &self,
+        _session_id: everruns_core::SessionId,
+        _task_id: &str,
+        _limit: Option<u32>,
+    ) -> everruns_core::error::Result<Vec<everruns_core::session_task::TaskMessage>> {
+        Ok(vec![])
+    }
 }

--- a/crates/worker/src/grpc_worker_adapters.rs
+++ b/crates/worker/src/grpc_worker_adapters.rs
@@ -541,7 +541,12 @@ impl WorkerAdapters for GrpcWorkerAdapters {
         _stale_after: chrono::Duration,
         _limit: i64,
     ) -> Result<Vec<(everruns_core::SessionId, String)>> {
-        Ok(vec![])
+        // Fail fast instead of silently masking orphans: remote workers have
+        // no orphan-listing RPC yet, and session_task_reaper is excluded from
+        // their default activity types. A misconfigured opt-in surfaces here.
+        Err(everruns_core::AgentLoopError::store(
+            "session_task_reaper is not supported on gRPC workers (no orphan-listing RPC);              run it on the in-process worker",
+        ))
     }
 
     fn reaper_session_task_registry(

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -26,6 +26,7 @@ pub mod platform;
 pub mod runner;
 pub mod runtime_host;
 pub mod session_lifecycle;
+pub mod session_task_reaper;
 mod stream_heartbeater;
 pub mod task_error;
 pub mod unified_worker;

--- a/crates/worker/src/session_task_reaper.rs
+++ b/crates/worker/src/session_task_reaper.rs
@@ -1,0 +1,360 @@
+// Orphaned session-task reconciler.
+//
+// Decision: mirrors the leased-resource-cleanup activity end-to-end: same
+// durable schedule seeding, same cadence, same activity registration pattern.
+// The reaper finds tasks whose worker heartbeat has gone stale and fails them
+// via the registry so lifecycle invariants, events, and wake_policy all fire
+// exactly as they do for any other terminal transition.
+//
+// Tasks with NULL heartbeat_at are never reaped (foreground subagent tasks
+// are covered by EVE-535 spawn handles, not by this reconciler).
+
+use anyhow::Result;
+use everruns_core::session_task::{SessionTaskState, SessionTaskUpdate, TaskError};
+use serde::{Deserialize, Serialize};
+use tracing::{info, warn};
+
+use crate::worker_adapters::WorkerAdapters;
+
+/// How long a heartbeat may be stale before a task is considered orphaned.
+const DEFAULT_STALE_AFTER_SECONDS: i64 = 5 * 60; // 5 minutes
+
+/// How many orphaned tasks to process per reaper pass.
+const DEFAULT_LIMIT: i64 = 50;
+
+/// Durable activity input for the session-task reaper.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionTaskReaperInput {
+    /// Age (in seconds) after which a stale heartbeat marks a task orphaned.
+    pub stale_after_seconds: i64,
+    /// Max tasks to reap per pass.
+    pub limit: i64,
+}
+
+impl Default for SessionTaskReaperInput {
+    fn default() -> Self {
+        Self {
+            stale_after_seconds: DEFAULT_STALE_AFTER_SECONDS,
+            limit: DEFAULT_LIMIT,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct ReapOutcome {
+    session_id: String,
+    task_id: String,
+    status: String,
+    detail: String,
+}
+
+#[derive(Debug, Serialize)]
+struct ReapSummary {
+    candidates: usize,
+    reaped: usize,
+    skipped: usize,
+    outcomes: Vec<ReapOutcome>,
+}
+
+/// Execute one orphaned-session-task reconciliation pass.
+///
+/// For each stale task the reaper calls `registry.update` with
+/// `state=Failed, error={kind:"orphaned"}` so lifecycle invariants hold and
+/// `task.updated` events + wake_policy fire via the registry.
+pub async fn execute_reaper_activity<A: WorkerAdapters>(
+    adapters: &A,
+    input: &SessionTaskReaperInput,
+) -> Result<serde_json::Value> {
+    let stale_after = chrono::Duration::seconds(input.stale_after_seconds);
+
+    let candidates = adapters
+        .list_orphaned_session_task_ids(stale_after, input.limit)
+        .await?;
+
+    let registry = adapters.reaper_session_task_registry();
+
+    let mut summary = ReapSummary {
+        candidates: candidates.len(),
+        reaped: 0,
+        skipped: 0,
+        outcomes: Vec::with_capacity(candidates.len()),
+    };
+
+    for (session_id, task_id) in candidates {
+        let update = SessionTaskUpdate {
+            state: Some(SessionTaskState::Failed),
+            error: Some(TaskError {
+                kind: "orphaned".to_string(),
+                message: "worker heartbeat stopped".to_string(),
+            }),
+            ..Default::default()
+        };
+
+        match registry.update(session_id, &task_id, update).await {
+            Ok(Some(task)) if task.state == SessionTaskState::Failed => {
+                info!(
+                    session_id = %session_id,
+                    task_id = %task_id,
+                    "Session task reaper: marked orphaned task failed"
+                );
+                summary.reaped += 1;
+                summary.outcomes.push(ReapOutcome {
+                    session_id: session_id.to_string(),
+                    task_id: task_id.clone(),
+                    status: "reaped".to_string(),
+                    detail: "marked failed: orphaned".to_string(),
+                });
+            }
+            Ok(_) => {
+                // Task was already terminal or not found — skip.
+                summary.skipped += 1;
+                summary.outcomes.push(ReapOutcome {
+                    session_id: session_id.to_string(),
+                    task_id: task_id.clone(),
+                    status: "skipped".to_string(),
+                    detail: "already terminal or missing".to_string(),
+                });
+            }
+            Err(e) => {
+                warn!(
+                    session_id = %session_id,
+                    task_id = %task_id,
+                    error = %e,
+                    "Session task reaper: failed to update task"
+                );
+                summary.skipped += 1;
+                summary.outcomes.push(ReapOutcome {
+                    session_id: session_id.to_string(),
+                    task_id: task_id.clone(),
+                    status: "error".to_string(),
+                    detail: e.to_string(),
+                });
+            }
+        }
+    }
+
+    info!(
+        candidates = summary.candidates,
+        reaped = summary.reaped,
+        skipped = summary.skipped,
+        "Session task reaper pass completed"
+    );
+
+    Ok(serde_json::to_value(summary)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use everruns_core::session_task::{
+        CreateSessionTask, NewTaskMessage, SessionTask, SessionTaskFilter, SessionTaskRegistry,
+        SessionTaskState, TaskLinks, TaskMessage, TaskWakePolicy, apply_task_update,
+        new_session_task,
+    };
+    use everruns_core::{Result as CoreResult, SessionId};
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
+
+    // -------------------------------------------------------------------------
+    // In-memory mock registry (no server crate dependency)
+    // -------------------------------------------------------------------------
+
+    #[derive(Default, Clone)]
+    struct MockRegistry {
+        tasks: Arc<Mutex<HashMap<String, SessionTask>>>,
+    }
+
+    #[async_trait]
+    impl SessionTaskRegistry for MockRegistry {
+        async fn create(&self, input: CreateSessionTask) -> CoreResult<SessionTask> {
+            let task = new_session_task(input, chrono::Utc::now());
+            self.tasks
+                .lock()
+                .unwrap()
+                .insert(task.id.clone(), task.clone());
+            Ok(task)
+        }
+
+        async fn get(
+            &self,
+            _session_id: SessionId,
+            task_id: &str,
+        ) -> CoreResult<Option<SessionTask>> {
+            Ok(self.tasks.lock().unwrap().get(task_id).cloned())
+        }
+
+        async fn list(
+            &self,
+            _session_id: SessionId,
+            _filter: Option<&SessionTaskFilter>,
+        ) -> CoreResult<Vec<SessionTask>> {
+            Ok(self.tasks.lock().unwrap().values().cloned().collect())
+        }
+
+        async fn update(
+            &self,
+            _session_id: SessionId,
+            task_id: &str,
+            update: SessionTaskUpdate,
+        ) -> CoreResult<Option<SessionTask>> {
+            let mut tasks = self.tasks.lock().unwrap();
+            let Some(task) = tasks.get_mut(task_id) else {
+                return Ok(None);
+            };
+            apply_task_update(task, update, chrono::Utc::now());
+            Ok(Some(task.clone()))
+        }
+
+        async fn request_cancel(
+            &self,
+            _session_id: SessionId,
+            _task_id: &str,
+        ) -> CoreResult<Option<SessionTask>> {
+            Ok(None)
+        }
+
+        async fn record_message(
+            &self,
+            _session_id: SessionId,
+            _task_id: &str,
+            _message: NewTaskMessage,
+        ) -> CoreResult<TaskMessage> {
+            Err(anyhow::anyhow!("not implemented").into())
+        }
+
+        async fn list_messages(
+            &self,
+            _session_id: SessionId,
+            _task_id: &str,
+            _limit: Option<u32>,
+        ) -> CoreResult<Vec<TaskMessage>> {
+            Ok(vec![])
+        }
+    }
+
+    // We only need list_orphaned_session_task_ids and reaper_session_task_registry.
+    // Inline the reaper logic in `run_reaper` rather than wiring a full WorkerAdapters
+    // stub (which would require many unrelated async methods).
+
+    async fn run_reaper(
+        orphans: Vec<(SessionId, String)>,
+        registry: Arc<MockRegistry>,
+        input: &SessionTaskReaperInput,
+    ) -> serde_json::Value {
+        // Inline the reaper logic using the mock data directly so we avoid
+        // needing a full WorkerAdapters impl (which drags in many unrelated
+        // async methods). This mirrors execute_reaper_activity exactly.
+        let stale_after = chrono::Duration::seconds(input.stale_after_seconds);
+        let _ = stale_after; // used only in the real adapters call
+
+        let mut reaped = 0usize;
+        let mut skipped = 0usize;
+
+        for (session_id, task_id) in &orphans {
+            let update = SessionTaskUpdate {
+                state: Some(SessionTaskState::Failed),
+                error: Some(TaskError {
+                    kind: "orphaned".to_string(),
+                    message: "worker heartbeat stopped".to_string(),
+                }),
+                ..Default::default()
+            };
+            match registry.update(*session_id, task_id, update).await {
+                Ok(Some(task)) if task.state == SessionTaskState::Failed => {
+                    reaped += 1;
+                }
+                _ => {
+                    skipped += 1;
+                }
+            }
+        }
+
+        serde_json::json!({
+            "candidates": orphans.len(),
+            "reaped": reaped,
+            "skipped": skipped,
+        })
+    }
+
+    // -------------------------------------------------------------------------
+    // Tests
+    // -------------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn reaper_fails_stale_heartbeat_tasks() {
+        let registry = Arc::new(MockRegistry::default());
+        let session_id = SessionId::new();
+
+        // Seed a running task.
+        let task = registry
+            .create(CreateSessionTask {
+                session_id,
+                id: None,
+                kind: "background_tool".to_string(),
+                display_name: "Orphaned task".to_string(),
+                spec: serde_json::json!({}),
+                state: SessionTaskState::Running,
+                links: TaskLinks::default(),
+                wake_policy: TaskWakePolicy::Silent,
+            })
+            .await
+            .unwrap();
+
+        // Simulate: list_orphaned returns this task (heartbeat logic tested in server crate).
+        let orphans = vec![(session_id, task.id.clone())];
+        let input = SessionTaskReaperInput::default();
+        let result = run_reaper(orphans, registry.clone(), &input).await;
+
+        assert_eq!(result["reaped"], 1);
+        assert_eq!(result["skipped"], 0);
+
+        let updated = registry.get(session_id, &task.id).await.unwrap().unwrap();
+        assert_eq!(updated.state, SessionTaskState::Failed);
+        assert_eq!(updated.error.as_ref().unwrap().kind, "orphaned");
+    }
+
+    #[tokio::test]
+    async fn reaper_skips_already_terminal_tasks() {
+        let registry = Arc::new(MockRegistry::default());
+        let session_id = SessionId::new();
+
+        // Seed a task that is already succeeded.
+        let task = registry
+            .create(CreateSessionTask {
+                session_id,
+                id: None,
+                kind: "background_tool".to_string(),
+                display_name: "Already done".to_string(),
+                spec: serde_json::json!({}),
+                state: SessionTaskState::Succeeded,
+                links: TaskLinks::default(),
+                wake_policy: TaskWakePolicy::Silent,
+            })
+            .await
+            .unwrap();
+
+        // Simulate orphan list still containing this task (race condition in real code).
+        let orphans = vec![(session_id, task.id.clone())];
+        let input = SessionTaskReaperInput::default();
+        let result = run_reaper(orphans, registry.clone(), &input).await;
+
+        // apply_task_update won't move Succeeded→Failed, so it stays succeeded.
+        // Our run_reaper counts it as skipped when state isn't Failed after update.
+        let updated = registry.get(session_id, &task.id).await.unwrap().unwrap();
+        // State should remain Succeeded (terminal→terminal transition is a no-op).
+        assert_eq!(updated.state, SessionTaskState::Succeeded);
+        assert_eq!(result["candidates"], 1);
+    }
+
+    #[tokio::test]
+    async fn empty_orphan_list_produces_zero_reap() {
+        let registry = Arc::new(MockRegistry::default());
+        let input = SessionTaskReaperInput::default();
+        let result = run_reaper(vec![], registry, &input).await;
+
+        assert_eq!(result["candidates"], 0);
+        assert_eq!(result["reaped"], 0);
+        assert_eq!(result["skipped"], 0);
+    }
+}

--- a/crates/worker/src/unified_worker.rs
+++ b/crates/worker/src/unified_worker.rs
@@ -67,6 +67,7 @@ impl Default for TaskWorkerConfig {
                 "reason".to_string(),
                 "act".to_string(),
                 "leased_resource_cleanup".to_string(),
+                "session_task_reaper".to_string(),
                 activity_types::INVOKE_SCHEDULED_APP_CHANNEL.to_string(),
             ],
             max_concurrent_tasks: 1000,
@@ -493,6 +494,14 @@ where
             let res =
                 crate::leased_resource_cleanup::execute_cleanup_activity(adapters, &cleanup_input)
                     .await;
+            (res, None)
+        }
+        "session_task_reaper" => {
+            let reaper_input: crate::session_task_reaper::SessionTaskReaperInput =
+                serde_json::from_value(task.input.clone())
+                    .map_err(|e| anyhow::anyhow!("Failed to parse reaper input: {}", e))?;
+            let res =
+                crate::session_task_reaper::execute_reaper_activity(adapters, &reaper_input).await;
             (res, None)
         }
         activity_types::INVOKE_SCHEDULED_APP_CHANNEL => {

--- a/crates/worker/src/worker_adapters.rs
+++ b/crates/worker/src/worker_adapters.rs
@@ -381,6 +381,25 @@ pub trait WorkerAdapters: Send + Sync + Clone + 'static {
         retry_after_seconds: u32,
         error: &str,
     ) -> Result<bool>;
+
+    // =========================================================================
+    // Session task reaper (orphan reconciler)
+    // =========================================================================
+
+    /// Return (session_id, task_id) pairs for tasks whose worker heartbeat has
+    /// gone stale. Tasks with NULL heartbeat_at are excluded (foreground tasks
+    /// with no liveness probe are covered by EVE-535 spawn handles).
+    async fn list_orphaned_session_task_ids(
+        &self,
+        stale_after: chrono::Duration,
+        limit: i64,
+    ) -> Result<Vec<(everruns_core::SessionId, String)>>;
+
+    /// Session task registry for the reaper to call `update` through.
+    /// Must include an event emitter so task.updated events fire on reap.
+    fn reaper_session_task_registry(
+        &self,
+    ) -> std::sync::Arc<dyn everruns_core::session_task::SessionTaskRegistry>;
 }
 
 // =============================================================================

--- a/specs/session-tasks.md
+++ b/specs/session-tasks.md
@@ -302,8 +302,9 @@ No backward compatibility is required; data migrates forward once:
   `awaiting_input` entry and outbound messages. `Silent` never wakes.
   A2A's legacy `wake_parent` call is gated on `session_task_registry.is_none()`
   (backward compat for sessions without a registry).
-- Background tool cancel reports unsupported (no cancel token exists for
-  background runs yet).
+- Background tool cancellation is cooperative: runs with a task record
+  heartbeat every ~2s and poll `cancel_requested_at`, winding down to
+  `canceled` when set (works across worker processes).
 - `LLMSIM_DEMO=tasks` drives the full lifecycle end-to-end without an LLM
   key (see `crates/core/src/llmsim_driver.rs`).
 

--- a/specs/session-tasks.md
+++ b/specs/session-tasks.md
@@ -289,11 +289,19 @@ No backward compatibility is required; data migrates forward once:
   session-resource registrations and `subagent.*` events. Retiring the
   duplicates (and the `sessions.subagent_*` columns and the
   `task` → `instructions` parameter rename) is follow-up work.
-- Durability is partial: `attempt`/`worker_id`/`heartbeat_at` exist on the
-  record, but the orphan reconciler and stale-attempt fencing are not built
-  yet.
-- Wake-ups: `wake_policy` is stored; registry-level wake delivery is not yet
-  enforced — A2A keeps its existing completion wake-up message.
+- Durability: `attempt`/`worker_id`/`heartbeat_at` are stored. The orphan
+  reconciler (`session_task_reaper` durable activity, every 60 s) finds tasks
+  with stale heartbeats (`heartbeat_at IS NOT NULL AND heartbeat_at < now -
+  5m`) and fails them via the registry using `FOR UPDATE SKIP LOCKED` on the
+  PG backend. Tasks with `NULL heartbeat_at` (foreground subagent tasks) are
+  excluded (covered by EVE-535 spawn handles). Stale-attempt fencing is not
+  yet built.
+- Wake-ups: `wake_policy` is enforced at the registry level
+  (`DbSessionTaskRegistry`). `OnTerminal` wakes on any transition into
+  `succeeded`/`failed`/`canceled`. `OnActivity` additionally wakes on
+  `awaiting_input` entry and outbound messages. `Silent` never wakes.
+  A2A's legacy `wake_parent` call is gated on `session_task_registry.is_none()`
+  (backward compat for sessions without a registry).
 - Background tool cancel reports unsupported (no cancel token exists for
   background runs yet).
 - `LLMSIM_DEMO=tasks` drives the full lifecycle end-to-end without an LLM


### PR DESCRIPTION
## What
Follow-ups to the session task registry (#2110), making tasks controllable and visible end to end:

- **Cooperative cancellation for background tool runs** — runs with a task record heartbeat every 2s and poll `cancel_requested_at`; on cancel intent the run winds down, the task finalizes as `canceled`, and canceled log/result artifacts are written. `cancel_task` on `background_tool` now succeeds instead of reporting unsupported. The record-polling design works across worker processes (no in-process token).
- **Registry-level wake policy** — the registry now enforces `wake_policy`: terminal transitions (and for `on_activity`, input requests and outbound messages) wake the owning session via a `SessionTaskWaker` that injects a synthetic message and starts a run. A2A's hand-rolled completion wake-up is retired (kept only when no task registry is wired). Never double-wakes (prior-state guard).
- **Orphan reaper** — a new `session-task-reaper` durable schedule (every 60s, mirroring leased-resource cleanup) fails `queued`/`running` tasks whose worker heartbeat went stale for 5+ minutes (`error.kind = "orphaned"`), emitting `task.updated` snapshots. Tasks that never heartbeat (e.g. foreground subagents, covered by EVE-535 spawn handles) are never reaped.
- **UI activity visibility** — active tasks (queued/running/awaiting_input) render as live status chips above the chat composer (state colors, spinner, `state_detail` tooltip, click-through to the tab); the session tab is renamed "Tasks" (route unchanged); `result_path` and file artifacts link to the session Files tab.

## Why
These were the explicitly-deferred follow-ups from #2110: cancel did nothing for background runs, `wake_policy` was stored but unenforced, orphaned tasks lingered as `running` forever, and task activity was invisible from the chat view.

## How
Cancellation rides the existing task record (intent flag + polling) so it is worker-topology-agnostic. Wake and reaping live in the registry/server layer so every kind gets them; the reaper reuses the durable-schedule + activity pattern from leased-resource cleanup and routes failures through `registry.update` so events and wake fire normally.

## Validation
- core 2,150 / server 1,459 / worker 91 lib tests green (includes new tests: cancel end-to-end with a sleeping background tool; four wake-policy tests incl. no-double-wake; orphan-listing storage test); clippy `--all-features -D warnings` clean on all three crates; `just pre-push` green.
- Dev-mode smoke: `session-task-reaper` schedule created and executing every minute; the `LLMSIM_DEMO=tasks` lifecycle E2E (spawn → events → succeeded) still green on the in-memory backend.
- UI: lint/format/tsc clean.
- No migrations in this PR (the reaper uses a durable schedule row, not new schema).

## Risk
- Medium-low: the cancel watcher adds a 2s poll per active background run (bounded by the existing 5-per-session/64-per-worker semaphores); wake injects messages only on explicit `wake_policy` opt-in (everything defaults Silent except A2A background runs, which previously sent an equivalent hand-rolled message); the reaper only touches tasks that have heartbeated at least once.

## Security
- Threat categories reviewed: **TM-TOOL/TM-LLM** (wake messages inject synthetic user messages into the owning session — same trust path as the pre-existing A2A wake-up and `signal_on_completion`; content is composed server-side from task fields, opt-in via wake_policy), **TM-DOS** (heartbeat/cancel polling bounded by background-run semaphores; reaper batch-limited to 50/pass), **TM-TENANT** (reaper and wake operate strictly per task row's own `session_id`; no cross-session reads).
- Findings: none requiring changes; no new endpoints, no schema changes, no new trust boundaries.

## Follow-ups
Deferred (Linear issue creation was blocked by a tool-approval gate in this session; these remain tracked here and in specs/session-tasks.md):
- Monitors — the `monitor` task kind (long-lived observing tasks); the registry now has everything it needs.
- Stale-attempt fencing and task re-attach (reaper currently fails orphans; no `attempt+1` recovery).
- Retire the transitional dual-write (work-kind `session_resources` rows + `subagent.*` events).
- `task` → `instructions` parameter rename and `sessions.subagent_*` column retirement (breaking; batch separately).
- API-side executor delivery for `POST .../tasks/{id}/messages`.
- Spec-deferred v2 items: webhooks on terminal transitions, result retention/TTL, task definitions/recurrence, `get_task` output cursor, `?path=` deep links on the Files page.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_011yqDiQ2GyoDdwFQTFTw12R)_