### PR TITLE
feat(llm): add OpenRouter routing controls

### DIFF
--- a/crates/core/src/atoms/reason.rs
+++ b/crates/core/src/atoms/reason.rs
@@ -1712,6 +1712,7 @@ impl ReasonAtom {
                                 previous_response_id: None,
                                 tool_search: None,
                                 prompt_cache: None,
+                                openrouter_routing: None,
                             };
 
                             match llm_driver
@@ -3123,6 +3124,7 @@ mod tests {
                 strategy: PromptCacheStrategy::Auto,
                 gemini_cached_content: None,
             }),
+            openrouter_routing: None,
         };
 
         let request_options = build_request_options(&config, "openai").unwrap();
@@ -3154,6 +3156,7 @@ mod tests {
                 strategy: PromptCacheStrategy::Auto,
                 gemini_cached_content: Some("cachedContents/demo-cache".to_string()),
             }),
+            openrouter_routing: None,
         };
 
         let request_options = build_request_options(&config, "gemini").unwrap();
@@ -3185,6 +3188,7 @@ mod tests {
                 strategy: PromptCacheStrategy::Auto,
                 gemini_cached_content: Some("cachedContents/demo-cache".to_string()),
             }),
+            openrouter_routing: None,
         };
 
         assert!(build_request_options(&config, "gemini").is_none());

--- a/crates/core/src/llm_driver_registry.rs
+++ b/crates/core/src/llm_driver_registry.rs
@@ -495,6 +495,187 @@ pub struct PromptCacheConfig {
     pub gemini_cached_content: Option<String>,
 }
 
+/// OpenRouter model fallback and provider routing controls.
+///
+/// These fields mirror OpenRouter's request-level routing extensions. Drivers
+/// must only forward this config to OpenRouter-compatible endpoints.
+#[derive(Debug, Clone, Default, PartialEq, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct OpenRouterRoutingConfig {
+    /// Candidate models to try in OpenRouter's fallback order.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub models: Vec<String>,
+    /// OpenRouter route strategy. Currently `fallback` is the stable route
+    /// value used with `models`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub route: Option<OpenRouterRoute>,
+    /// Provider ordering, policy, and sorting preferences.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider: Option<OpenRouterProviderRouting>,
+}
+
+impl OpenRouterRoutingConfig {
+    pub fn is_empty(&self) -> bool {
+        self.models.is_empty() && self.route.is_none() && self.provider.is_none()
+    }
+
+    /// Build an ordered model-fallback routing config.
+    pub fn fallback_models(models: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        let models = models.into_iter().map(Into::into).collect::<Vec<_>>();
+        let route = (!models.is_empty()).then_some(OpenRouterRoute::Fallback);
+        Self {
+            models,
+            route,
+            provider: None,
+        }
+    }
+
+    pub fn validate_for_primary_model(
+        &self,
+        primary_model: &str,
+    ) -> std::result::Result<(), String> {
+        if self.route == Some(OpenRouterRoute::Fallback) && self.models.is_empty() {
+            return Err(
+                "OpenRouter fallback routing requires at least one model in `models`".to_string(),
+            );
+        }
+
+        if let Some(first_model) = self.models.first()
+            && first_model != primary_model
+        {
+            return Err(format!(
+                "OpenRouter routing models[0] ('{first_model}') must match primary model ('{primary_model}')"
+            ));
+        }
+
+        Ok(())
+    }
+}
+
+/// OpenRouter route strategy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum OpenRouterRoute {
+    Fallback,
+}
+
+/// OpenRouter provider routing preferences.
+#[derive(Debug, Clone, Default, PartialEq, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct OpenRouterProviderRouting {
+    /// Provider slugs to try first, in order.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub order: Vec<String>,
+    /// Restrict routing to these provider slugs.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub only: Vec<String>,
+    /// Provider slugs to skip.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub ignore: Vec<String>,
+    /// Whether OpenRouter may fall back outside the ordered/allowed providers.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub allow_fallbacks: Option<bool>,
+    /// Require routed providers to support all request parameters.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub require_parameters: Option<bool>,
+    /// Restrict routing by provider data-retention policy.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub data_collection: Option<OpenRouterDataCollection>,
+    /// Restrict routing to zero-data-retention endpoints.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub zdr: Option<bool>,
+    /// Restrict routing to distillable-text endpoints.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub enforce_distillable_text: Option<bool>,
+    /// Restrict routing to provider quantization levels.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub quantizations: Vec<String>,
+    /// Sort provider endpoints by price, throughput, or latency.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sort: Option<OpenRouterProviderSort>,
+    /// Maximum accepted per-unit provider price.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_price: Option<OpenRouterMaxPrice>,
+}
+
+impl OpenRouterProviderRouting {
+    pub fn is_empty(&self) -> bool {
+        self.order.is_empty()
+            && self.only.is_empty()
+            && self.ignore.is_empty()
+            && self.allow_fallbacks.is_none()
+            && self.require_parameters.is_none()
+            && self.data_collection.is_none()
+            && self.zdr.is_none()
+            && self.enforce_distillable_text.is_none()
+            && self.quantizations.is_empty()
+            && self.sort.is_none()
+            && self.max_price.is_none()
+    }
+}
+
+/// OpenRouter provider data-retention preference.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum OpenRouterDataCollection {
+    Allow,
+    Deny,
+}
+
+/// OpenRouter provider sort preference.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(untagged)]
+pub enum OpenRouterProviderSort {
+    Simple(OpenRouterProviderSortBy),
+    Advanced(OpenRouterProviderSortOptions),
+}
+
+/// OpenRouter provider sorting dimension.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum OpenRouterProviderSortBy {
+    Price,
+    Throughput,
+    Latency,
+}
+
+/// OpenRouter advanced provider sort options.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct OpenRouterProviderSortOptions {
+    pub by: OpenRouterProviderSortBy,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub partition: Option<OpenRouterSortPartition>,
+}
+
+/// How OpenRouter sorts endpoints when multiple fallback models are present.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum OpenRouterSortPartition {
+    Model,
+    None,
+}
+
+/// Maximum accepted OpenRouter provider pricing, expressed in dollars per
+/// million prompt/completion tokens or per request/image where supported.
+#[derive(Debug, Clone, Default, PartialEq, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct OpenRouterMaxPrice {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prompt: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub completion: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub request: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub image: Option<f64>,
+}
+
 /// Configuration for an LLM call
 #[derive(Debug, Clone)]
 pub struct LlmCallConfig {
@@ -515,6 +696,8 @@ pub struct LlmCallConfig {
     pub tool_search: Option<ToolSearchConfig>,
     /// Prompt caching configuration for provider-specific cache controls.
     pub prompt_cache: Option<PromptCacheConfig>,
+    /// OpenRouter-only model fallback and provider routing controls.
+    pub openrouter_routing: Option<OpenRouterRoutingConfig>,
 }
 
 impl From<&RuntimeAgent> for LlmCallConfig {
@@ -529,6 +712,7 @@ impl From<&RuntimeAgent> for LlmCallConfig {
             previous_response_id: None,
             tool_search: runtime_agent.tool_search.clone(),
             prompt_cache: runtime_agent.prompt_cache.clone(),
+            openrouter_routing: None,
         }
     }
 }
@@ -635,6 +819,12 @@ impl LlmCallConfigBuilder {
     /// Set prompt caching configuration
     pub fn prompt_cache(mut self, config: PromptCacheConfig) -> Self {
         self.config.prompt_cache = Some(config);
+        self
+    }
+
+    /// Set OpenRouter model fallback and provider routing controls.
+    pub fn openrouter_routing(mut self, config: OpenRouterRoutingConfig) -> Self {
+        self.config.openrouter_routing = (!config.is_empty()).then_some(config);
         self
     }
 
@@ -1149,6 +1339,118 @@ mod tests {
         assert_eq!(llm_config.reasoning_effort, Some("medium".to_string()));
         assert_eq!(llm_config.temperature, Some(0.7));
         assert_eq!(llm_config.max_tokens, Some(1000));
+    }
+
+    #[test]
+    fn test_llm_call_config_builder_with_openrouter_routing() {
+        let runtime_agent = RuntimeAgent::new("You are helpful", "openai/gpt-5-mini");
+        let routing = OpenRouterRoutingConfig::fallback_models([
+            "openai/gpt-5-mini",
+            "anthropic/claude-sonnet-4.5",
+        ]);
+
+        let llm_config = LlmCallConfigBuilder::from(&runtime_agent)
+            .openrouter_routing(routing.clone())
+            .build();
+
+        assert_eq!(llm_config.openrouter_routing, Some(routing));
+    }
+
+    #[test]
+    fn test_openrouter_fallback_models_empty_is_empty() {
+        let routing = OpenRouterRoutingConfig::fallback_models(std::iter::empty::<String>());
+
+        assert!(routing.is_empty());
+        assert_eq!(routing.route, None);
+    }
+
+    #[test]
+    fn test_openrouter_routing_validates_primary_model() {
+        let routing = OpenRouterRoutingConfig::fallback_models([
+            "openai/gpt-5-mini",
+            "anthropic/claude-sonnet-4.5",
+        ]);
+
+        assert!(
+            routing
+                .validate_for_primary_model("openai/gpt-5-mini")
+                .is_ok()
+        );
+        let err = routing
+            .validate_for_primary_model("anthropic/claude-sonnet-4.5")
+            .unwrap_err();
+        assert!(err.contains("models[0]"));
+    }
+
+    #[test]
+    fn test_openrouter_routing_rejects_fallback_without_models() {
+        let routing = OpenRouterRoutingConfig {
+            route: Some(OpenRouterRoute::Fallback),
+            ..Default::default()
+        };
+
+        let err = routing
+            .validate_for_primary_model("openai/gpt-5-mini")
+            .unwrap_err();
+        assert!(err.contains("requires at least one model"));
+    }
+
+    #[test]
+    fn test_openrouter_routing_serializes_request_fields() {
+        let routing = OpenRouterRoutingConfig {
+            models: vec![
+                "openai/gpt-5-mini".to_string(),
+                "anthropic/claude-sonnet-4.5".to_string(),
+            ],
+            route: Some(OpenRouterRoute::Fallback),
+            provider: Some(OpenRouterProviderRouting {
+                order: vec!["anthropic".to_string(), "openai".to_string()],
+                allow_fallbacks: Some(false),
+                require_parameters: Some(true),
+                data_collection: Some(OpenRouterDataCollection::Deny),
+                zdr: Some(true),
+                sort: Some(OpenRouterProviderSort::Advanced(
+                    OpenRouterProviderSortOptions {
+                        by: OpenRouterProviderSortBy::Throughput,
+                        partition: Some(OpenRouterSortPartition::None),
+                    },
+                )),
+                max_price: Some(OpenRouterMaxPrice {
+                    prompt: Some(1.0),
+                    completion: Some(2.0),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+        };
+
+        let json = serde_json::to_value(routing).unwrap();
+
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "models": [
+                    "openai/gpt-5-mini",
+                    "anthropic/claude-sonnet-4.5"
+                ],
+                "route": "fallback",
+                "provider": {
+                    "order": ["anthropic", "openai"],
+                    "allow_fallbacks": false,
+                    "require_parameters": true,
+                    "data_collection": "deny",
+                    "zdr": true,
+                    "sort": {
+                        "by": "throughput",
+                        "partition": "none"
+                    },
+                    "max_price": {
+                        "prompt": 1.0,
+                        "completion": 2.0
+                    }
+                }
+            })
+        );
     }
 
     #[test]

--- a/crates/core/src/llmsim_driver.rs
+++ b/crates/core/src/llmsim_driver.rs
@@ -951,6 +951,7 @@ mod tests {
             previous_response_id: None,
             tool_search: None,
             prompt_cache: None,
+            openrouter_routing: None,
         }
     }
 

--- a/crates/core/src/model_router.rs
+++ b/crates/core/src/model_router.rs
@@ -16,6 +16,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+use crate::llm_driver_registry::OpenRouterRoutingConfig;
 use crate::typed_id::{ModelId, ModelRouterId};
 
 #[cfg(feature = "openapi")]
@@ -274,6 +275,79 @@ pub fn validate_route_shape(route: &ModelRouterRoute) -> Result<(), String> {
     Ok(())
 }
 
+/// OpenRouter-ready routing plan compiled from a model-router route.
+#[derive(Debug, Clone, PartialEq)]
+pub struct OpenRouterRoutePlan {
+    /// The concrete model slug to place in the required `model` request field.
+    pub primary_model: String,
+    /// Optional OpenRouter fallback routing fields. `None` means the route is a
+    /// direct single-model invocation and no provider-specific fields are needed.
+    pub routing: Option<OpenRouterRoutingConfig>,
+}
+
+/// Compile the currently executable Model Router strategies into OpenRouter's
+/// request-level fallback routing fields.
+///
+/// `model_slug_for_candidate` resolves Everruns `ModelId` references to the
+/// OpenRouter model slugs used on the wire (for example
+/// `anthropic/claude-sonnet-4.5`). Storage-backed resolution lives outside this
+/// foundational router module, so the caller supplies the lookup.
+pub fn compile_openrouter_route_plan(
+    route: &ModelRouterRoute,
+    model_slug_for_candidate: impl Fn(&ModelRouterCandidate) -> Option<String>,
+) -> Result<OpenRouterRoutePlan, String> {
+    validate_route_shape(route)?;
+
+    match route.strategy {
+        ModelRouterStrategy::Single => {
+            let candidate = route
+                .candidates
+                .first()
+                .ok_or_else(|| format!("route '{}' has no candidates", route.key))?;
+            let primary_model = model_slug_for_candidate(candidate).ok_or_else(|| {
+                format!(
+                    "route '{}' candidate '{}' does not resolve to an OpenRouter model slug",
+                    route.key, candidate.id
+                )
+            })?;
+            Ok(OpenRouterRoutePlan {
+                primary_model,
+                routing: None,
+            })
+        }
+        ModelRouterStrategy::OrderedFallback => {
+            let mut candidates = route.candidates.iter().collect::<Vec<_>>();
+            candidates.sort_by_key(|candidate| candidate.position);
+
+            let mut models = Vec::with_capacity(candidates.len());
+            for candidate in candidates {
+                let slug = model_slug_for_candidate(candidate).ok_or_else(|| {
+                    format!(
+                        "route '{}' candidate '{}' does not resolve to an OpenRouter model slug",
+                        route.key, candidate.id
+                    )
+                })?;
+                models.push(slug);
+            }
+
+            let primary_model = models
+                .first()
+                .cloned()
+                .ok_or_else(|| format!("route '{}' has no candidates", route.key))?;
+            Ok(OpenRouterRoutePlan {
+                primary_model,
+                routing: Some(OpenRouterRoutingConfig::fallback_models(models)),
+            })
+        }
+        ModelRouterStrategy::Weighted
+        | ModelRouterStrategy::Rules
+        | ModelRouterStrategy::Custom => Err(format!(
+            "route '{}' strategy '{}' cannot be compiled directly to OpenRouter fallback routing",
+            route.key, route.strategy
+        )),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -283,13 +357,39 @@ mod tests {
     }
 
     fn candidate(weight: i32, rules: Option<serde_json::Value>) -> ModelRouterCandidate {
+        candidate_with(weight, rules, 0, 1)
+    }
+
+    fn candidate_with(
+        weight: i32,
+        rules: Option<serde_json::Value>,
+        position: i32,
+        model_seed: u128,
+    ) -> ModelRouterCandidate {
         ModelRouterCandidate {
-            id: Uuid::nil(),
-            model_id: ModelId::from_seed(1),
+            id: Uuid::from_u128(model_seed),
+            model_id: ModelId::from_seed(model_seed),
             request_overrides: serde_json::Value::Null,
             weight,
             rules,
+            position,
+            created_at: now(),
+            updated_at: now(),
+        }
+    }
+
+    fn route(
+        strategy: ModelRouterStrategy,
+        candidates: Vec<ModelRouterCandidate>,
+    ) -> ModelRouterRoute {
+        ModelRouterRoute {
+            id: Uuid::nil(),
+            key: "base".into(),
+            purpose: "default route".into(),
+            when_to_use: "use this when no specific route fits".into(),
+            strategy,
             position: 0,
+            candidates,
             created_at: now(),
             updated_at: now(),
         }
@@ -425,18 +525,80 @@ mod tests {
 
     #[test]
     fn route_shape_accepts_ordered_fallback_with_multiple_candidates() {
-        let route = ModelRouterRoute {
-            id: Uuid::nil(),
-            key: "base".into(),
-            purpose: "default route".into(),
-            when_to_use: "use this when no specific route fits".into(),
-            strategy: ModelRouterStrategy::OrderedFallback,
-            position: 0,
-            candidates: vec![candidate(1, None), candidate(1, None)],
-            created_at: now(),
-            updated_at: now(),
-        };
+        let route = route(
+            ModelRouterStrategy::OrderedFallback,
+            vec![candidate(1, None), candidate(1, None)],
+        );
         assert!(validate_route_shape(&route).is_ok());
+    }
+
+    #[test]
+    fn openrouter_plan_single_returns_primary_without_routing() {
+        let route = route(ModelRouterStrategy::Single, vec![candidate(1, None)]);
+
+        let plan = compile_openrouter_route_plan(&route, |candidate| {
+            assert_eq!(candidate.model_id, ModelId::from_seed(1));
+            Some("openai/gpt-5-mini".to_string())
+        })
+        .unwrap();
+
+        assert_eq!(plan.primary_model, "openai/gpt-5-mini");
+        assert_eq!(plan.routing, None);
+    }
+
+    #[test]
+    fn openrouter_plan_ordered_fallback_preserves_candidate_order() {
+        let route = route(
+            ModelRouterStrategy::OrderedFallback,
+            vec![
+                candidate_with(1, None, 10, 2),
+                candidate_with(1, None, 0, 1),
+            ],
+        );
+
+        let plan = compile_openrouter_route_plan(&route, |candidate| {
+            if candidate.model_id == ModelId::from_seed(1) {
+                Some("openai/gpt-5-mini".to_string())
+            } else if candidate.model_id == ModelId::from_seed(2) {
+                Some("anthropic/claude-sonnet-4.5".to_string())
+            } else {
+                None
+            }
+        })
+        .unwrap();
+
+        assert_eq!(plan.primary_model, "openai/gpt-5-mini");
+        let routing = plan.routing.unwrap();
+        assert_eq!(
+            routing.models,
+            vec![
+                "openai/gpt-5-mini".to_string(),
+                "anthropic/claude-sonnet-4.5".to_string(),
+            ]
+        );
+        assert_eq!(
+            routing.route,
+            Some(crate::llm_driver_registry::OpenRouterRoute::Fallback)
+        );
+    }
+
+    #[test]
+    fn openrouter_plan_rejects_uncompiled_strategies() {
+        let route = route(ModelRouterStrategy::Weighted, vec![candidate(1, None)]);
+
+        let err = compile_openrouter_route_plan(&route, |_| Some("openai/gpt-5-mini".to_string()))
+            .unwrap_err();
+
+        assert!(err.contains("cannot be compiled directly"));
+    }
+
+    #[test]
+    fn openrouter_plan_rejects_missing_model_slug() {
+        let route = route(ModelRouterStrategy::Single, vec![candidate(1, None)]);
+
+        let err = compile_openrouter_route_plan(&route, |_| None).unwrap_err();
+
+        assert!(err.contains("does not resolve to an OpenRouter model slug"));
     }
 
     #[test]

--- a/crates/core/src/openresponses_protocol.rs
+++ b/crates/core/src/openresponses_protocol.rs
@@ -32,7 +32,7 @@ use std::sync::{Arc, Mutex};
 use crate::error::{AgentLoopError, Result};
 use crate::llm_driver_registry::{
     LlmCallConfig, LlmCompletionMetadata, LlmContentPart, LlmDriver, LlmMessage, LlmMessageContent,
-    LlmMessageRole, LlmResponseStream, LlmStreamEvent,
+    LlmMessageRole, LlmResponseStream, LlmStreamEvent, OpenRouterProviderRouting,
 };
 use crate::llm_models::LlmProviderType;
 use crate::llm_retry::{
@@ -781,9 +781,30 @@ impl LlmDriver for OpenResponsesProtocolLlmDriver {
         };
         let prompt_cache_key =
             Self::build_prompt_cache_key(config, &input_items, &instructions, &tools);
+        let openrouter_routing = if self.provider_type == LlmProviderType::Openrouter {
+            config.openrouter_routing.as_ref()
+        } else {
+            None
+        };
+        if let Some(routing) = openrouter_routing {
+            routing
+                .validate_for_primary_model(&config.model)
+                .map_err(AgentLoopError::llm)?;
+        }
+        let openrouter_provider = openrouter_routing.and_then(|routing| {
+            routing
+                .provider
+                .as_ref()
+                .filter(|provider| !provider.is_empty())
+                .cloned()
+        });
 
         let request = ResponsesRequest {
             model: config.model.clone(),
+            models: openrouter_routing
+                .and_then(|routing| (!routing.models.is_empty()).then_some(routing.models.clone())),
+            route: openrouter_routing.and_then(|routing| routing.route),
+            provider: openrouter_provider,
             input: input_items,
             instructions,
             previous_response_id,
@@ -1787,6 +1808,12 @@ pub fn compact_output_to_messages(
 #[derive(Debug, Serialize)]
 struct ResponsesRequest {
     model: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    models: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    route: Option<crate::llm_driver_registry::OpenRouterRoute>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    provider: Option<OpenRouterProviderRouting>,
     input: Vec<ResponsesInputItem>,
     #[serde(skip_serializing_if = "Option::is_none")]
     instructions: Option<String>,
@@ -1942,6 +1969,9 @@ mod tests {
     fn test_request_serialization() {
         let request = ResponsesRequest {
             model: "gpt-4o".to_string(),
+            models: None,
+            route: None,
+            provider: None,
             input: vec![ResponsesInputItem::Message {
                 r#type: "message".to_string(),
                 role: "user".to_string(),
@@ -1970,6 +2000,9 @@ mod tests {
     fn test_request_with_reasoning() {
         let request = ResponsesRequest {
             model: "o3".to_string(),
+            models: None,
+            route: None,
+            provider: None,
             input: vec![ResponsesInputItem::Message {
                 r#type: "message".to_string(),
                 role: "user".to_string(),
@@ -2003,6 +2036,9 @@ mod tests {
 
         let request = ResponsesRequest {
             model: "gpt-4o".to_string(),
+            models: None,
+            route: None,
+            provider: None,
             input: vec![ResponsesInputItem::Message {
                 r#type: "message".to_string(),
                 role: "user".to_string(),
@@ -2043,6 +2079,7 @@ mod tests {
                 strategy: crate::llm_driver_registry::PromptCacheStrategy::Auto,
                 gemini_cached_content: None,
             }),
+            openrouter_routing: None,
         };
         let input = vec![ResponsesInputItem::Message {
             r#type: "message".to_string(),
@@ -2080,6 +2117,7 @@ mod tests {
                 strategy: crate::llm_driver_registry::PromptCacheStrategy::Auto,
                 gemini_cached_content: None,
             }),
+            openrouter_routing: None,
         };
         let first_input = vec![ResponsesInputItem::Message {
             r#type: "message".to_string(),
@@ -2130,6 +2168,7 @@ mod tests {
                 strategy: crate::llm_driver_registry::PromptCacheStrategy::Auto,
                 gemini_cached_content: None,
             }),
+            openrouter_routing: None,
         };
         let input = vec![ResponsesInputItem::Message {
             r#type: "message".to_string(),
@@ -2170,6 +2209,7 @@ mod tests {
                 strategy: crate::llm_driver_registry::PromptCacheStrategy::Auto,
                 gemini_cached_content: None,
             }),
+            openrouter_routing: None,
         };
         let input = vec![ResponsesInputItem::Message {
             r#type: "message".to_string(),
@@ -2895,6 +2935,7 @@ mod tests {
             previous_response_id: Some("gen-turn-1".to_string()),
             tool_search: None,
             prompt_cache: None,
+            openrouter_routing: None,
         };
 
         // Fire the request. The stream body is irrelevant for this assertion.
@@ -2978,6 +3019,7 @@ mod tests {
                 threshold: 15,
             }),
             prompt_cache: None,
+            openrouter_routing: None,
         };
 
         let messages = vec![LlmMessage::text(LlmMessageRole::User, "hello")];
@@ -3002,6 +3044,229 @@ mod tests {
         assert_eq!(
             body["input"],
             json!([{"type": "message", "role": "user", "content": "hello"}])
+        );
+    }
+
+    #[tokio::test]
+    async fn openrouter_provider_sends_routing_controls() {
+        use crate::llm_driver_registry::{
+            OpenRouterDataCollection, OpenRouterMaxPrice, OpenRouterProviderSort,
+            OpenRouterProviderSortBy, OpenRouterProviderSortOptions, OpenRouterRoute,
+            OpenRouterRoutingConfig, OpenRouterSortPartition,
+        };
+        use serde_json::json;
+        use wiremock::matchers::method;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(""))
+            .mount(&server)
+            .await;
+
+        let api_url = format!("{}/v1/responses", server.uri());
+        let driver = OpenResponsesProtocolLlmDriver::with_base_url("test-key", api_url)
+            .with_provider_type(LlmProviderType::Openrouter);
+
+        let config = LlmCallConfig {
+            model: "openai/gpt-5-mini".to_string(),
+            temperature: None,
+            max_tokens: None,
+            tools: vec![],
+            reasoning_effort: None,
+            metadata: std::collections::HashMap::new(),
+            previous_response_id: None,
+            tool_search: None,
+            prompt_cache: None,
+            openrouter_routing: Some(OpenRouterRoutingConfig {
+                models: vec![
+                    "openai/gpt-5-mini".to_string(),
+                    "anthropic/claude-sonnet-4.5".to_string(),
+                ],
+                route: Some(OpenRouterRoute::Fallback),
+                provider: Some(OpenRouterProviderRouting {
+                    order: vec!["openai".to_string()],
+                    allow_fallbacks: Some(false),
+                    require_parameters: Some(true),
+                    data_collection: Some(OpenRouterDataCollection::Deny),
+                    zdr: Some(true),
+                    sort: Some(OpenRouterProviderSort::Advanced(
+                        OpenRouterProviderSortOptions {
+                            by: OpenRouterProviderSortBy::Latency,
+                            partition: Some(OpenRouterSortPartition::None),
+                        },
+                    )),
+                    max_price: Some(OpenRouterMaxPrice {
+                        prompt: Some(1.0),
+                        completion: Some(2.0),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                }),
+            }),
+        };
+
+        let messages = vec![LlmMessage::text(LlmMessageRole::User, "hello")];
+        let _ = driver.chat_completion_stream(messages, &config).await;
+
+        let requests = server
+            .received_requests()
+            .await
+            .expect("mock server recorded requests");
+        assert_eq!(requests.len(), 1, "exactly one request should be sent");
+        let body: serde_json::Value = requests[0].body_json().expect("request body is JSON");
+
+        assert_eq!(
+            body["models"],
+            json!(["openai/gpt-5-mini", "anthropic/claude-sonnet-4.5"])
+        );
+        assert_eq!(body["route"], "fallback");
+        assert_eq!(
+            body["provider"],
+            json!({
+                "order": ["openai"],
+                "allow_fallbacks": false,
+                "require_parameters": true,
+                "data_collection": "deny",
+                "zdr": true,
+                "sort": {
+                    "by": "latency",
+                    "partition": "none"
+                },
+                "max_price": {
+                    "prompt": 1.0,
+                    "completion": 2.0
+                }
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn openai_provider_omits_openrouter_routing_controls() {
+        use crate::llm_driver_registry::{OpenRouterRoute, OpenRouterRoutingConfig};
+        use wiremock::matchers::method;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(""))
+            .mount(&server)
+            .await;
+
+        let api_url = format!("{}/v1/responses", server.uri());
+        let driver = OpenResponsesProtocolLlmDriver::with_base_url("test-key", api_url);
+
+        let config = LlmCallConfig {
+            model: "gpt-5-mini".to_string(),
+            temperature: None,
+            max_tokens: None,
+            tools: vec![],
+            reasoning_effort: None,
+            metadata: std::collections::HashMap::new(),
+            previous_response_id: None,
+            tool_search: None,
+            prompt_cache: None,
+            openrouter_routing: Some(OpenRouterRoutingConfig {
+                models: vec!["openai/gpt-5-mini".to_string()],
+                route: Some(OpenRouterRoute::Fallback),
+                provider: None,
+            }),
+        };
+
+        let messages = vec![LlmMessage::text(LlmMessageRole::User, "hello")];
+        let _ = driver.chat_completion_stream(messages, &config).await;
+
+        let requests = server
+            .received_requests()
+            .await
+            .expect("mock server recorded requests");
+        assert_eq!(requests.len(), 1, "exactly one request should be sent");
+        let body: serde_json::Value = requests[0].body_json().expect("request body is JSON");
+
+        assert!(body.get("models").is_none(), "body: {body}");
+        assert!(body.get("route").is_none(), "body: {body}");
+        assert!(body.get("provider").is_none(), "body: {body}");
+    }
+
+    #[tokio::test]
+    async fn openrouter_provider_rejects_invalid_routing_controls() {
+        use crate::llm_driver_registry::{OpenRouterRoute, OpenRouterRoutingConfig};
+        use wiremock::matchers::method;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(""))
+            .mount(&server)
+            .await;
+
+        let api_url = format!("{}/v1/responses", server.uri());
+        let driver = OpenResponsesProtocolLlmDriver::with_base_url("test-key", api_url)
+            .with_provider_type(LlmProviderType::Openrouter);
+
+        let mismatch_config = LlmCallConfig {
+            model: "openai/gpt-5-mini".to_string(),
+            temperature: None,
+            max_tokens: None,
+            tools: vec![],
+            reasoning_effort: None,
+            metadata: std::collections::HashMap::new(),
+            previous_response_id: None,
+            tool_search: None,
+            prompt_cache: None,
+            openrouter_routing: Some(OpenRouterRoutingConfig {
+                models: vec!["anthropic/claude-sonnet-4.5".to_string()],
+                route: Some(OpenRouterRoute::Fallback),
+                provider: None,
+            }),
+        };
+        let err = match driver
+            .chat_completion_stream(
+                vec![LlmMessage::text(LlmMessageRole::User, "hello")],
+                &mismatch_config,
+            )
+            .await
+        {
+            Ok(_) => panic!("invalid OpenRouter routing should fail before dispatch"),
+            Err(err) => err,
+        };
+        assert!(err.to_string().contains("models[0]"));
+
+        let empty_fallback_config = LlmCallConfig {
+            model: "openai/gpt-5-mini".to_string(),
+            temperature: None,
+            max_tokens: None,
+            tools: vec![],
+            reasoning_effort: None,
+            metadata: std::collections::HashMap::new(),
+            previous_response_id: None,
+            tool_search: None,
+            prompt_cache: None,
+            openrouter_routing: Some(OpenRouterRoutingConfig {
+                models: vec![],
+                route: Some(OpenRouterRoute::Fallback),
+                provider: None,
+            }),
+        };
+        let err = match driver
+            .chat_completion_stream(
+                vec![LlmMessage::text(LlmMessageRole::User, "hello")],
+                &empty_fallback_config,
+            )
+            .await
+        {
+            Ok(_) => panic!("empty OpenRouter fallback routing should fail before dispatch"),
+            Err(err) => err,
+        };
+        assert!(err.to_string().contains("requires at least one model"));
+
+        let requests = server
+            .received_requests()
+            .await
+            .expect("mock server recorded requests");
+        assert!(
+            requests.is_empty(),
+            "invalid routing must be rejected before request dispatch"
         );
     }
 
@@ -3574,6 +3839,7 @@ mod tests {
             previous_response_id: None,
             tool_search: None,
             prompt_cache: None,
+            openrouter_routing: None,
         };
 
         // Simulate the driver's filter logic
@@ -3605,6 +3871,7 @@ mod tests {
             previous_response_id: None,
             tool_search: None,
             prompt_cache: None,
+            openrouter_routing: None,
         };
 
         let reasoning = config

--- a/crates/core/src/utility_llm.rs
+++ b/crates/core/src/utility_llm.rs
@@ -98,6 +98,7 @@ impl UtilityLlmRequest {
             previous_response_id: None,
             tool_search: None,
             prompt_cache: None,
+            openrouter_routing: None,
         };
         Ok((self.messages, config))
     }

--- a/crates/core/tests/reason_atom_test.rs
+++ b/crates/core/tests/reason_atom_test.rs
@@ -1131,6 +1131,7 @@ async fn test_driver_registry_integration() {
         previous_response_id: None,
         tool_search: None,
         prompt_cache: None,
+        openrouter_routing: None,
     };
 
     let response = driver

--- a/specs/llm-drivers.md
+++ b/specs/llm-drivers.md
@@ -312,6 +312,12 @@ tell they support reasoning and hides the effort selector. The discovered profil
 is persisted via the model-sync pipeline and surfaces on existing rows on the next
 sync. Cost is left to hardcoded profiles.
 
+OpenRouter-specific routing controls (`models`, `route`, and `provider`) are
+represented as typed `LlmCallConfig` fields. The Open Responses protocol driver
+serializes them only when the resolved provider type is OpenRouter, so ordinary
+OpenAI-compatible requests do not receive non-standard OpenRouter routing
+extensions.
+
 ### Stateful Continuation Invariant
 
 When a request to the OpenAI Responses API sets `previous_response_id`, the provider already holds the prior transcript server-side. The request must NOT also carry the full reconstructed transcript in `input` — that double-counts context and inflates prompt-cache keys.

--- a/specs/model-router.md
+++ b/specs/model-router.md
@@ -129,6 +129,21 @@ The runtime resolver and the strategy implementations themselves ship in a
 follow-up vertical slice. This PR validates that strategy values are one of
 the five enum members and parses them into typed values.
 
+### OpenRouter Routing Bridge
+
+The foundational router types also define a pure OpenRouter bridge for the
+strategies that map directly to OpenRouter request-level routing extensions.
+When every candidate resolves to an OpenRouter model slug, `single` compiles to
+the primary `model` field with no provider-specific routing, and
+`ordered_fallback` compiles to the first candidate as `model` plus OpenRouter
+`models` and `route: "fallback"` fields in candidate `position` order.
+
+`weighted`, `rules`, and `custom` remain Everruns resolver responsibilities
+because OpenRouter's fallback router does not express local sampling,
+parameterized rules, or host-registered custom logic. Future storage-backed
+resolver slices can use this bridge after they have validated org scope,
+provider type, and concrete model availability.
+
 ## Resolution Contract
 
 At LLM-call time the resolver returns:


### PR DESCRIPTION
## What
Add typed OpenRouter request-routing controls to the core LLM call path and a pure model-router bridge for OpenRouter-compatible routes.

## Why
OpenRouter model routers need to express model fallback and provider routing without waiting for the full Everruns runtime router resolver/API/UI slices. This gives those future slices a typed request plan for OpenRouter `models`, `route: fallback`, and `provider` controls.

References:
- https://openrouter.ai/docs/guides/routing/model-fallbacks
- https://openrouter.ai/docs/guides/routing/provider-selection

## How
- Added `OpenRouterRoutingConfig` and provider routing types to `LlmCallConfig`.
- Serialized `models`, `route`, and `provider` only when the resolved provider type is OpenRouter.
- Added `compile_openrouter_route_plan` for `single` and `ordered_fallback` model-router routes.
- Documented the narrow bridge contract in `specs/model-router.md` and `specs/llm-drivers.md`.
- Added unit and wiremock request tests for serialization, OpenRouter provider gating, and router-plan compilation.

## Risk
- Low
- Risk is limited to LLM request serialization. The new fields are optional and OpenRouter-gated; default construction preserves existing provider behavior.

## Security
- Threat categories reviewed: TM-LLM
- Findings and resolutions: No new credentials, endpoints, persistence, tenant reads, or logging were added. OpenRouter-specific request fields are only emitted for `LlmProviderType::Openrouter`, and tests assert OpenAI-compatible non-OpenRouter calls omit them.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

Validation:
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p everruns-core model_router --all-features`
- `cargo test -p everruns-core openrouter --all-features`
- `cargo test -p everruns-core --all-features`
- `bash scripts/lib/check-migration-ordering.sh`
- `just pre-push`