### PR TITLE
fix(worker): handle non-terminal subagent waits

### DIFF
--- a/crates/core/src/capabilities/agent_handoff.rs
+++ b/crates/core/src/capabilities/agent_handoff.rs
@@ -24,6 +24,19 @@ pub const AGENT_HANDOFF_CAPABILITY_ID: &str = "agent_handoff";
 const AGENT_HANDOFF_RESOURCE_KIND: &str = "agent_handoff";
 const DEFAULT_WAIT_TIMEOUT_SECS: u64 = 300;
 
+fn terminal_handoff_status(wait_status: &str) -> Option<(SessionResourceStatus, SubagentStatus)> {
+    match wait_status {
+        "idle" | "completed" => Some((SessionResourceStatus::Completed, SubagentStatus::Completed)),
+        "error" | "failed" => Some((SessionResourceStatus::Failed, SubagentStatus::Failed)),
+        "cancelled" => Some((SessionResourceStatus::Failed, SubagentStatus::Cancelled)),
+        "max_iterations_reached" => Some((
+            SessionResourceStatus::Failed,
+            SubagentStatus::MaxIterationsReached,
+        )),
+        _ => None,
+    }
+}
+
 pub struct AgentHandoffCapability;
 
 #[async_trait]
@@ -611,30 +624,35 @@ impl Tool for StartAgentHandoffTool {
         let result = last_agent_message(&messages)
             .unwrap_or_else(|| format!("Handoff completed with status: {status}"));
 
-        if let Some(registry) = &context.session_resource_registry {
-            let terminal = if status == "error" {
-                SessionResourceStatus::Failed
-            } else {
-                SessionResourceStatus::Completed
-            };
-            let _ = registry
-                .update_status(context.session_id, &child_session.id.to_string(), terminal)
-                .await;
-        }
+        if let Some((resource_status, subagent_status)) = terminal_handoff_status(&status) {
+            if let Some(registry) = &context.session_resource_registry {
+                let _ = registry
+                    .update_status(
+                        context.session_id,
+                        &child_session.id.to_string(),
+                        resource_status,
+                    )
+                    .await;
+            }
 
-        let _ = store
-            .set_subagent_metadata(
-                child_session.id,
-                context.session_id,
-                &target.name,
-                &handoff_task,
-                if status == "error" {
-                    SubagentStatus::Failed
-                } else {
-                    SubagentStatus::Completed
-                },
-            )
-            .await;
+            if let Err(error) = store
+                .set_subagent_metadata(
+                    child_session.id,
+                    context.session_id,
+                    &target.name,
+                    &handoff_task,
+                    subagent_status,
+                )
+                .await
+            {
+                tracing::warn!(
+                    session_id = %context.session_id,
+                    child_session_id = %child_session.id,
+                    error = %error,
+                    "failed to persist terminal handoff metadata"
+                );
+            }
+        }
 
         ToolExecutionResult::success(json!({
             "handoff_id": child_session.id.to_string(),
@@ -1068,6 +1086,27 @@ mod tests {
         );
         assert!(cap.describe_schema(Some("uk")).is_some());
         assert!(cap.describe_schema(None).is_some());
+    }
+
+    #[test]
+    fn terminal_handoff_status_maps_only_terminal_wait_states() {
+        assert_eq!(
+            terminal_handoff_status("idle"),
+            Some((SessionResourceStatus::Completed, SubagentStatus::Completed))
+        );
+        assert_eq!(
+            terminal_handoff_status("error"),
+            Some((SessionResourceStatus::Failed, SubagentStatus::Failed))
+        );
+        assert_eq!(
+            terminal_handoff_status("max_iterations_reached"),
+            Some((
+                SessionResourceStatus::Failed,
+                SubagentStatus::MaxIterationsReached,
+            ))
+        );
+        assert_eq!(terminal_handoff_status("waiting_for_tool_results"), None);
+        assert_eq!(terminal_handoff_status("paused"), None);
     }
 
     #[test]

--- a/crates/core/src/capabilities/subagents.rs
+++ b/crates/core/src/capabilities/subagents.rs
@@ -84,6 +84,43 @@ impl Capability for SubagentCapability {
 
 const SUBAGENT_SYSTEM_PROMPT: &str = "Spawn subagents only for independent workstreams that benefit from parallelism or a separate context window. Do not delegate immediate sequential steps you can complete directly. No nested subagents. Use blueprints for specialist agents with their own tools and model.";
 
+fn terminal_subagent_status(
+    wait_status: &str,
+) -> Option<(
+    crate::session_resource::SessionResourceStatus,
+    crate::session::SubagentStatus,
+)> {
+    match wait_status {
+        "idle" | "completed" => Some((
+            crate::session_resource::SessionResourceStatus::Completed,
+            crate::session::SubagentStatus::Completed,
+        )),
+        "error" | "failed" => Some((
+            crate::session_resource::SessionResourceStatus::Failed,
+            crate::session::SubagentStatus::Failed,
+        )),
+        "cancelled" => Some((
+            crate::session_resource::SessionResourceStatus::Failed,
+            crate::session::SubagentStatus::Cancelled,
+        )),
+        "max_iterations_reached" => Some((
+            crate::session_resource::SessionResourceStatus::Failed,
+            crate::session::SubagentStatus::MaxIterationsReached,
+        )),
+        _ => None,
+    }
+}
+
+fn terminal_subagent_task_state(
+    subagent_status: &crate::session::SubagentStatus,
+) -> SessionTaskState {
+    match subagent_status {
+        crate::session::SubagentStatus::Completed => SessionTaskState::Succeeded,
+        crate::session::SubagentStatus::Cancelled => SessionTaskState::Canceled,
+        _ => SessionTaskState::Failed,
+    }
+}
+
 // =============================================================================
 // Helper: get platform store from context
 // =============================================================================
@@ -692,8 +729,12 @@ async fn run_subagent_wait_and_settle(
     let result_text = last_agent_message(&messages)
         .unwrap_or_else(|| format!("Subagent completed with status: {status}"));
 
-    // Settle the spawn handle if we have a durable store.
+    let terminal_status = terminal_subagent_status(&status);
+
+    // Settle the spawn handle only when the child reached a terminal state.
+    // Non-terminal waits must stay reattachable on replay.
     if let Some((spawn_store, tool_call_id, claim_token)) = settle_ctx
+        && terminal_status.is_some()
         && let Err(e) = spawn_store
             .settle_spawn(
                 context.session_id,
@@ -713,53 +754,40 @@ async fn run_subagent_wait_and_settle(
     }
 
     // Update registry and persist metadata only when the child reached a
-    // terminal state.  Non-terminal results from wait_for_idle (paused,
+    // terminal state. Non-terminal results from wait_for_idle (paused,
     // waiting_for_tool_results, timeout) leave the child Active.
-    if status == "idle" {
+    if let Some((resource_status, subagent_status)) = terminal_status {
+        let task_state = terminal_subagent_task_state(&subagent_status);
         if let Some(ref registry) = context.session_resource_registry {
             let _ = registry
-                .update_status(
-                    context.session_id,
-                    &child_id.to_string(),
-                    crate::session_resource::SessionResourceStatus::Completed,
-                )
+                .update_status(context.session_id, &child_id.to_string(), resource_status)
                 .await;
         }
         if let Err(e) = store
-            .set_subagent_metadata(
-                child_id,
-                context.session_id,
-                name,
-                task,
-                crate::session::SubagentStatus::Completed,
-            )
+            .set_subagent_metadata(child_id, context.session_id, name, task, subagent_status)
             .await
         {
             tracing::warn!(
                 session_id = %context.session_id,
                 child_session_id = %child_id,
                 error = %e,
-                "failed to persist subagent completed metadata"
+                "failed to persist terminal subagent metadata"
             );
         }
-        finish_subagent_task(
-            context,
-            task_id.as_deref(),
-            SessionTaskState::Succeeded,
-            Some(truncate_summary(&result_text)),
-            None,
-        )
-        .await;
-    } else if status == "error" {
-        finish_subagent_task(
-            context,
-            task_id.as_deref(),
-            SessionTaskState::Failed,
-            Some(truncate_summary(&result_text)),
+        let task_error = if task_state == SessionTaskState::Failed {
             Some(TaskError {
-                kind: "error".to_string(),
-                message: "Subagent session ended with an error".to_string(),
-            }),
+                kind: status.clone(),
+                message: format!("Subagent session ended with status: {status}"),
+            })
+        } else {
+            None
+        };
+        finish_subagent_task(
+            context,
+            task_id.as_deref(),
+            task_state,
+            Some(truncate_summary(&result_text)),
+            task_error,
         )
         .await;
     }
@@ -1156,6 +1184,45 @@ mod tests {
             names,
             vec!["spawn_subagent", "get_subagents", "message_subagent"]
         );
+    }
+
+    #[test]
+    fn terminal_subagent_status_maps_only_terminal_wait_states() {
+        assert_eq!(
+            terminal_subagent_status("idle"),
+            Some((
+                crate::session_resource::SessionResourceStatus::Completed,
+                crate::session::SubagentStatus::Completed,
+            ))
+        );
+        assert_eq!(
+            terminal_subagent_status("failed"),
+            Some((
+                crate::session_resource::SessionResourceStatus::Failed,
+                crate::session::SubagentStatus::Failed,
+            ))
+        );
+        assert_eq!(
+            terminal_subagent_status("cancelled"),
+            Some((
+                crate::session_resource::SessionResourceStatus::Failed,
+                crate::session::SubagentStatus::Cancelled,
+            ))
+        );
+        assert_eq!(
+            terminal_subagent_task_state(&crate::session::SubagentStatus::Completed),
+            SessionTaskState::Succeeded
+        );
+        assert_eq!(
+            terminal_subagent_task_state(&crate::session::SubagentStatus::Cancelled),
+            SessionTaskState::Canceled
+        );
+        assert_eq!(
+            terminal_subagent_task_state(&crate::session::SubagentStatus::MaxIterationsReached),
+            SessionTaskState::Failed
+        );
+        assert_eq!(terminal_subagent_status("waiting_for_tool_results"), None);
+        assert_eq!(terminal_subagent_status("paused"), None);
     }
 
     #[test]


### PR DESCRIPTION
## What

Handle non-terminal `wait_for_idle` statuses in subagent and agent handoff tools without marking resources or metadata as completed.

## Why

After the gRPC metadata fix landed on main, subagent and handoff foreground paths still treated every non-error wait result as completed. Statuses like `waiting_for_tool_results` or `paused` should leave the registered resource active and avoid persisting terminal subagent metadata.

## How

- Add explicit terminal status mapping for subagents and handoffs.
- Persist completed/failed/cancelled/max-iteration metadata only for terminal wait states.
- Leave non-terminal wait states active.
- Add focused unit coverage for terminal and non-terminal mappings.

## Risk

- Low / Medium / High: Low
- What can break: Subagent and handoff resource status transitions if an unrecognized terminal status is introduced without adding it to the mapping.

## Security

Reviewed `TM-TOOL` and `TM-DOS` surfaces. This change narrows status side effects after tool-driven child session waits; it does not add new tool entry points, auth paths, external I/O, or unbounded loops. No new threat-model entries needed.

## Validation

- `cargo fmt --check`
- `cargo test -p everruns-core capabilities::subagents::tests --all-features`
- `cargo test -p everruns-core capabilities::agent_handoff::tests --all-features`
- `cargo test -p everruns-server grpc_service::tests::test_subagent_and_handoff_tools_complete_over_grpc_platform_adapter --all-features`
- `cargo test -p everruns-server --test app_a2a_integration_test outbound_a2a_delegation_reaches_local_app --all-features`
- `just pre-push`

## Follow-ups

No follow-ups.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
