### PR TITLE
chore(deps): bump bashkit 0.8.0 -> 0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -862,9 +862,9 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bashkit"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e20c182deb47b8ce2c8ba724f602cf73bdd6a566971f0f3525b6af60ea2a4c6"
+checksum = "868968c065151d2eec3aaba899f01540723dce112dcb8e23428a0f08aee3d7d6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -71,7 +71,7 @@ fetchkit = { version = "=0.2.0", features = ["bot-auth"] }
 ed25519-dalek = { version = "2", features = ["rand_core"] }
 
 # Virtual bash interpreter
-bashkit = { version = "0.8.0", features = ["jq"] }
+bashkit = { version = "0.10.0", features = ["jq"] }
 
 # Sandboxed Lua interpreter for the experimental `lua` capability (vendored Lua
 # 5.4, never LuaJIT). Optional + behind the `lua` cargo feature so the default

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -77,7 +77,7 @@ mime_guess = "2"
 tokio-tungstenite.workspace = true
 futures-util.workspace = true
 
-bashkit = { version = "0.8.0", features = ["scripted_tool", "jq"] }
+bashkit = { version = "0.10.0", features = ["scripted_tool", "jq"] }
 
 everruns-config = { path = "../config" }
 everruns-core = { path = "../core", features = ["embedded-platform-docs", "openapi", "sqlx", "tree-sitter-outlines", "ui-capabilities"] }


### PR DESCRIPTION
## What
Bump the `bashkit` virtual-bash interpreter from `0.8.0` to `0.10.0` in `crates/core` and `crates/server` (Cargo.toml + Cargo.lock).

## Why
Stay current with the upstream `bashkit` sandbox, picking up its latest builtins, fixes, and sandbox hardening. `0.10.0` is the latest published, non-yanked release.

## How
- Updated the `bashkit` requirement to `0.10.0` in `crates/core/Cargo.toml` (`jq`) and `crates/server/Cargo.toml` (`scripted_tool`, `jq`).
- Ran `cargo update -p bashkit --precise 0.10.0` to refresh the lockfile.
- No source changes were required: the workspace compiles cleanly against the new API (`--all-features`, all crates), so the bump is API-compatible with our usage.

### Validation
- `cargo build -p everruns-core -p everruns-server --all-features` — clean.
- `just pre-push` — green (fmt, clippy `--all-targets --all-features`, `cargo fetch --locked`, migration/specs/attribution checks).
- `cargo test -p everruns-core --all-features virtual_bash` — 82 passed. These exercise real bash execution through bashkit 0.10.0 end-to-end against `SessionFileSystemAdapter` (echo, pipes, redirection, file I/O, env vars, arithmetic, observability hooks).
- The `mcp_endpoint_test` integration suite is infra-gated (requires PostgreSQL/`DATABASE_URL`, unavailable in this sandbox — failures are `PoolTimedOut`, unrelated to this change). Covered by CI's postgres-integration job.

## Risk
- Low
- A `0.x` minor bump can carry breaking API changes, but the full-feature build and clippy across all crates and test targets compile cleanly, and the virtual-bash unit suite passes. Behavioral risk is limited to upstream bashkit changes within the bash sandbox runtime.

## Security
- Threat categories reviewed: **TM-BASH** (sandbox/command execution), **TM-TOOL** (MCP `scripted_tool` path).
- Findings and resolutions: No source changes — existing `THREAT[TM-BASH]` mitigations in `virtual_bash.rs` are untouched, and no execution limits, network allowlist, sandbox boundaries, or cargo features were widened (features unchanged: `jq`, `scripted_tool`). Supply chain: `bashkit` is a first-party crate (`everruns/bashkit`) pulled from crates.io with the checksum pinned in `Cargo.lock`; the lock diff changes only bashkit's version + checksum with no new transitive dependencies.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated (existing virtual_bash suite covers the bashkit integration; no new tests needed for a dep bump)
- [x] Backward compatibility considered (internal-only; compiles cleanly with no API changes)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01J6XgTUNYBDq32h4P6Gcujr)_