### PR TITLE
feat: monitor session task kind

### DIFF
--- a/apps/ui/src/components/session/session-task-chips.tsx
+++ b/apps/ui/src/components/session/session-task-chips.tsx
@@ -7,7 +7,7 @@
 // matching the same gate used for the Tasks (resources route) nav tab.
 
 import Link from "next/link";
-import { Bot, Cpu, ListTodo, Loader2 } from "lucide-react";
+import { Bot, Cpu, ListTodo, Loader2, Radar } from "lucide-react";
 import { useSessionTasks } from "@/hooks/use-session-tasks";
 import { cn } from "@/lib/utils";
 import type { SessionTask, SessionTaskState } from "@/lib/api/types";
@@ -25,6 +25,9 @@ function taskKindIcon(kind: string) {
   }
   if (kind === "background_tool") {
     return <Cpu className="h-3 w-3 shrink-0" />;
+  }
+  if (kind === "monitor") {
+    return <Radar className="h-3 w-3 shrink-0" />;
   }
   return <ListTodo className="h-3 w-3 shrink-0" />;
 }

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -109,6 +109,7 @@ mod lua_code_mode;
 pub mod mcp;
 mod memory;
 mod message_metadata;
+mod monitors;
 mod noop;
 mod openai_tool_search;
 #[cfg(feature = "ui-capabilities")]

--- a/crates/core/src/capabilities/monitors.rs
+++ b/crates/core/src/capabilities/monitors.rs
@@ -1,0 +1,261 @@
+// Monitor task executor
+//
+// A monitor is a long-lived task (`running` until canceled) linked to a session
+// schedule. It is created by `spawn_background` when a `schedule` argument is
+// supplied, and its spec carries the `schedule_id` of the backing schedule.
+//
+// Canceling a monitor via `cancel_task` cancels the linked schedule (so it
+// stops firing) and transitions the task to `Canceled`.
+//
+// Decision: the executor is stateless — no in-process handle is needed because
+// the schedule poller fires externally and the task record is the durable link.
+
+use std::sync::Arc;
+
+use crate::session_task::{
+    SessionTaskState, SessionTaskUpdate, TASK_KIND_MONITOR, TaskExecutor, TaskExecutorPlugin,
+};
+
+/// Executor for `monitor` tasks. Lifecycle is driven by the schedule poller
+/// (server-side); the executor's only active role is cooperative cancellation.
+pub struct MonitorTaskExecutor;
+
+#[async_trait::async_trait]
+impl TaskExecutor for MonitorTaskExecutor {
+    fn kind(&self) -> &str {
+        TASK_KIND_MONITOR
+    }
+
+    /// Cancel the monitor: disable the linked schedule then mark the task Canceled.
+    ///
+    /// Both operations are best-effort. The task transitions to Canceled even if
+    /// the schedule store is unavailable or the cancel call fails — leaving a
+    /// dangling enabled schedule is less harmful than leaving the task stuck.
+    async fn cancel(
+        &self,
+        task: &crate::session_task::SessionTask,
+        context: &crate::traits::ToolContext,
+    ) -> crate::error::Result<()> {
+        // Attempt to cancel the linked schedule.
+        if let Some(schedule_id_str) = task.spec.get("schedule_id").and_then(|v| v.as_str()) {
+            match crate::typed_id::ScheduleId::parse(schedule_id_str) {
+                Ok(schedule_id) => {
+                    if let Some(ref store) = context.schedule_store
+                        && let Err(e) = store.cancel_schedule(task.session_id, schedule_id).await
+                    {
+                        tracing::warn!(
+                            task_id = %task.id,
+                            schedule_id = %schedule_id_str,
+                            error = %e,
+                            "MonitorTaskExecutor: cancel_schedule failed (best-effort)"
+                        );
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        task_id = %task.id,
+                        raw = %schedule_id_str,
+                        error = %e,
+                        "MonitorTaskExecutor: could not parse schedule_id from spec"
+                    );
+                }
+            }
+        }
+
+        // Transition the task to Canceled regardless of schedule outcome.
+        if let Some(ref registry) = context.session_task_registry
+            && let Err(e) = registry
+                .update(
+                    task.session_id,
+                    &task.id,
+                    SessionTaskUpdate {
+                        state: Some(SessionTaskState::Canceled),
+                        summary: Some("Monitor canceled".into()),
+                        ..Default::default()
+                    },
+                )
+                .await
+        {
+            tracing::warn!(
+                task_id = %task.id,
+                error = %e,
+                "MonitorTaskExecutor: failed to update task to Canceled"
+            );
+        }
+
+        Ok(())
+    }
+}
+
+inventory::submit! {
+    TaskExecutorPlugin {
+        executor: || Arc::new(MonitorTaskExecutor),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::capabilities::session_tasks::tests::InMemorySessionTaskRegistry;
+    use crate::session_schedule::SessionSchedule;
+    use crate::session_task::{
+        CreateSessionTask, SessionTaskRegistry, SessionTaskState, TaskLinks, TaskWakePolicy,
+    };
+    use crate::traits::{SessionScheduleStore, ToolContext};
+    use crate::typed_id::{ScheduleId, SessionId};
+    use std::sync::{Arc, Mutex};
+
+    // -------------------------------------------------------------------------
+    // Stub SessionScheduleStore
+    // -------------------------------------------------------------------------
+
+    #[derive(Default)]
+    struct StubScheduleStore {
+        canceled: Mutex<Vec<ScheduleId>>,
+    }
+
+    #[async_trait::async_trait]
+    impl SessionScheduleStore for StubScheduleStore {
+        async fn create_schedule(
+            &self,
+            session_id: SessionId,
+            description: String,
+            cron_expression: Option<String>,
+            scheduled_at: Option<chrono::DateTime<chrono::Utc>>,
+            timezone: String,
+        ) -> crate::error::Result<SessionSchedule> {
+            let _ = (
+                session_id,
+                description,
+                cron_expression,
+                scheduled_at,
+                timezone,
+            );
+            unimplemented!("not needed by cancel test")
+        }
+
+        async fn cancel_schedule(
+            &self,
+            session_id: SessionId,
+            schedule_id: ScheduleId,
+        ) -> crate::error::Result<SessionSchedule> {
+            self.canceled.lock().unwrap().push(schedule_id);
+            // Return a minimal schedule so the call succeeds.
+            Ok(SessionSchedule {
+                id: schedule_id,
+                session_id,
+                owner_principal_id: crate::typed_id::PrincipalId::new(),
+                resolved_owner_user_id: None,
+                owner: None,
+                effective_owner: None,
+                description: String::new(),
+                cron_expression: None,
+                scheduled_at: None,
+                timezone: "UTC".into(),
+                enabled: false,
+                schedule_type: crate::session_schedule::ScheduleType::OneShot,
+                next_trigger_at: None,
+                last_triggered_at: None,
+                trigger_count: 0,
+                created_at: chrono::Utc::now(),
+                updated_at: chrono::Utc::now(),
+            })
+        }
+
+        async fn count_active_schedules(
+            &self,
+            _session_id: SessionId,
+        ) -> crate::error::Result<u32> {
+            Ok(0)
+        }
+
+        async fn list_schedules(
+            &self,
+            _session_id: SessionId,
+        ) -> crate::error::Result<Vec<SessionSchedule>> {
+            Ok(vec![])
+        }
+    }
+
+    #[tokio::test]
+    async fn cancel_reads_schedule_id_and_transitions_to_canceled() {
+        let session_id = SessionId::new();
+        let schedule_id = ScheduleId::new();
+        let registry = Arc::new(InMemorySessionTaskRegistry::default());
+        let schedule_store = Arc::new(StubScheduleStore::default());
+
+        // Create a monitor task with a schedule_id in its spec.
+        let task = registry
+            .create(CreateSessionTask {
+                session_id,
+                id: None,
+                kind: TASK_KIND_MONITOR.to_string(),
+                display_name: "Test Monitor".to_string(),
+                spec: serde_json::json!({
+                    "schedule_id": schedule_id.to_string(),
+                }),
+                state: SessionTaskState::Running,
+                links: TaskLinks::default(),
+                wake_policy: TaskWakePolicy::Silent,
+            })
+            .await
+            .unwrap();
+
+        let context = ToolContext::new(session_id)
+            .with_session_task_registry(registry.clone())
+            .with_schedule_store(schedule_store.clone());
+
+        let executor = MonitorTaskExecutor;
+        executor.cancel(&task, &context).await.unwrap();
+
+        // cancel_schedule was called with the correct schedule_id.
+        // Drop the guard before any await.
+        {
+            let canceled = schedule_store.canceled.lock().unwrap();
+            assert_eq!(canceled.len(), 1);
+            assert_eq!(canceled[0], schedule_id);
+        }
+
+        // Task is now Canceled.
+        let updated = registry
+            .get(session_id, &task.id)
+            .await
+            .unwrap()
+            .expect("task should exist");
+        assert_eq!(updated.state, SessionTaskState::Canceled);
+        assert_eq!(updated.summary.as_deref(), Some("Monitor canceled"));
+    }
+
+    #[tokio::test]
+    async fn cancel_succeeds_without_schedule_store() {
+        let session_id = SessionId::new();
+        let schedule_id = ScheduleId::new();
+        let registry = Arc::new(InMemorySessionTaskRegistry::default());
+
+        let task = registry
+            .create(CreateSessionTask {
+                session_id,
+                id: None,
+                kind: TASK_KIND_MONITOR.to_string(),
+                display_name: "Test Monitor".to_string(),
+                spec: serde_json::json!({ "schedule_id": schedule_id.to_string() }),
+                state: SessionTaskState::Running,
+                links: TaskLinks::default(),
+                wake_policy: TaskWakePolicy::Silent,
+            })
+            .await
+            .unwrap();
+
+        // No schedule_store — cancel should still transition the task.
+        let context = ToolContext::new(session_id).with_session_task_registry(registry.clone());
+
+        MonitorTaskExecutor.cancel(&task, &context).await.unwrap();
+
+        let updated = registry
+            .get(session_id, &task.id)
+            .await
+            .unwrap()
+            .expect("task should exist");
+        assert_eq!(updated.state, SessionTaskState::Canceled);
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -428,9 +428,10 @@ pub use session_sqldb::{
 };
 pub use session_task::{
     CreateSessionTask, NewTaskMessage, SessionTask, SessionTaskFilter, SessionTaskRegistry,
-    SessionTaskState, SessionTaskUpdate, TaskArtifact, TaskError, TaskExecutor, TaskExecutorPlugin,
-    TaskInputRequest, TaskLinks, TaskMessage, TaskMessageDirection, TaskMessagePart, TaskProgress,
-    TaskSink, TaskWakePolicy, apply_task_update, find_task_executor,
+    SessionTaskState, SessionTaskUpdate, TASK_KIND_BACKGROUND_TOOL, TASK_KIND_EXTERNAL_AGENT,
+    TASK_KIND_MONITOR, TASK_KIND_SUBAGENT, TaskArtifact, TaskError, TaskExecutor,
+    TaskExecutorPlugin, TaskInputRequest, TaskLinks, TaskMessage, TaskMessageDirection,
+    TaskMessagePart, TaskProgress, TaskSink, TaskWakePolicy, apply_task_update, find_task_executor,
 };
 pub use skill::{
     ParsedSkillMd, Skill, SkillContent, SkillFileEntry, SkillSourceType, SkillStatus, SkillUsage,

--- a/crates/core/src/llmsim_driver.rs
+++ b/crates/core/src/llmsim_driver.rs
@@ -919,7 +919,7 @@ pub fn monitor_demo_script() -> LlmSimConfig {
             }],
         },
         SimTurn::Assistant(
-            "Monitor demo complete: a recurring monitor was scheduled and tracked              as a session task. Inspect it via GET /v1/sessions/{session_id}/tasks."
+            "Monitor demo complete: a recurring monitor was scheduled and tracked as a session task. Inspect it via GET /v1/sessions/{session_id}/tasks."
                 .to_string(),
         ),
     ];

--- a/crates/core/src/llmsim_driver.rs
+++ b/crates/core/src/llmsim_driver.rs
@@ -898,6 +898,34 @@ pub fn session_tasks_demo_script() -> LlmSimConfig {
     LlmSimConfig::scripted(turns)
 }
 
+/// Scripted scenario for the monitor task kind: spawns a recurring scheduled
+/// monitor (cron fires at second 0 every minute) so the session scheduler
+/// creates the schedule and a linked `monitor` task. Used by
+/// `LLMSIM_DEMO=monitor` for end-to-end verification without an LLM API key.
+pub fn monitor_demo_script() -> LlmSimConfig {
+    let turns = vec![
+        SimTurn::Mixed {
+            text: "Setting up a recurring monitor.".to_string(),
+            tool_calls: vec![SimToolCall {
+                name: "spawn_background".to_string(),
+                arguments: serde_json::json!({
+                    "tool": "bash",
+                    "args": { "commands": "echo monitor check" },
+                    "title": "Demo monitor",
+                    "signal_on_completion": false,
+                    "schedule": { "cron_expression": "0 * * * * * *", "timezone": "UTC" },
+                }),
+                id: Some("call_demo_monitor".to_string()),
+            }],
+        },
+        SimTurn::Assistant(
+            "Monitor demo complete: a recurring monitor was scheduled and tracked              as a session task. Inspect it via GET /v1/sessions/{session_id}/tasks."
+                .to_string(),
+        ),
+    ];
+    LlmSimConfig::scripted(turns)
+}
+
 // ============================================================================
 // Tests
 // ============================================================================

--- a/crates/core/src/session_task.rs
+++ b/crates/core/src/session_task.rs
@@ -31,6 +31,9 @@ pub type TaskProgress = crate::background::BackgroundProgress;
 pub const TASK_KIND_SUBAGENT: &str = "subagent";
 pub const TASK_KIND_EXTERNAL_AGENT: &str = "external_agent";
 pub const TASK_KIND_BACKGROUND_TOOL: &str = "background_tool";
+/// Long-lived monitor task linked to a session schedule. Stays `running`
+/// until the linked schedule is exhausted (one-shot) or `cancel_task` is called.
+pub const TASK_KIND_MONITOR: &str = "monitor";
 
 /// Generate a new task ID (`task_` prefix per specs/id-schema.md).
 pub fn generate_task_id() -> String {

--- a/crates/core/src/tools.rs
+++ b/crates/core/src/tools.rs
@@ -1097,20 +1097,66 @@ impl Tool for SpawnBackgroundTool {
                 )
                 .await
             {
-                Ok(schedule) => ToolExecutionResult::success(json!({
-                    "created": true,
-                    "status": "scheduled",
-                    "title": title,
-                    "tool": tool_name,
-                    "signal_on_completion": signal_on_completion,
-                    "schedule_id": schedule.id.to_string(),
-                    "schedule_type": schedule.schedule_type,
-                    "cron_expression": schedule.cron_expression,
-                    "scheduled_at": schedule.scheduled_at,
-                    "timezone": schedule.timezone,
-                    "next_trigger_at": schedule.next_trigger_at,
-                    "enabled": schedule.enabled
-                })),
+                Ok(schedule) => {
+                    // Best-effort: create a monitor task linked to this schedule.
+                    // The schedule is the source of truth; task creation failure
+                    // does not fail the spawn.
+                    let mut monitor_task_id: Option<String> = None;
+                    if let Some(ref task_registry) = context.session_task_registry {
+                        let spec = json!({
+                            "tool": tool_name,
+                            "arguments": &tool_args,
+                            "schedule_id": schedule.id.to_string(),
+                            "schedule_type": schedule.schedule_type,
+                            "cron_expression": schedule.cron_expression,
+                            "scheduled_at": schedule.scheduled_at,
+                            "timezone": schedule.timezone,
+                            "signal_on_completion": signal_on_completion,
+                        });
+                        match task_registry
+                            .create(crate::session_task::CreateSessionTask {
+                                session_id: context.session_id,
+                                id: None,
+                                kind: crate::session_task::TASK_KIND_MONITOR.to_string(),
+                                display_name: title.clone(),
+                                spec,
+                                state: crate::session_task::SessionTaskState::Running,
+                                links: crate::session_task::TaskLinks::default(),
+                                // Silent: the schedule's injected prompt message already
+                                // wakes the session; a second wake on every fire would be noise.
+                                wake_policy: crate::session_task::TaskWakePolicy::Silent,
+                            })
+                            .await
+                        {
+                            Ok(task) => {
+                                monitor_task_id = Some(task.id);
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    session_id = %context.session_id,
+                                    schedule_id = %schedule.id,
+                                    error = %e,
+                                    "Failed to create monitor task for schedule (best-effort)"
+                                );
+                            }
+                        }
+                    }
+                    ToolExecutionResult::success(json!({
+                        "created": true,
+                        "status": "scheduled",
+                        "title": title,
+                        "tool": tool_name,
+                        "signal_on_completion": signal_on_completion,
+                        "schedule_id": schedule.id.to_string(),
+                        "schedule_type": schedule.schedule_type,
+                        "cron_expression": schedule.cron_expression,
+                        "scheduled_at": schedule.scheduled_at,
+                        "timezone": schedule.timezone,
+                        "next_trigger_at": schedule.next_trigger_at,
+                        "enabled": schedule.enabled,
+                        "task_id": monitor_task_id,
+                    }))
+                }
                 Err(err) => ToolExecutionResult::internal_error(err),
             };
         }

--- a/crates/server/src/session_scheduler.rs
+++ b/crates/server/src/session_scheduler.rs
@@ -239,9 +239,11 @@ async fn fire_monitor_tasks(
     let tasks = match registry
         .list(
             session_id,
+            // Active monitors are `running`; terminal ones never re-fire, so
+            // filter at the DB to avoid scanning history as it grows.
             Some(&SessionTaskFilter {
                 kind: Some(TASK_KIND_MONITOR.to_string()),
-                state: None,
+                state: Some(SessionTaskState::Running),
             }),
         )
         .await
@@ -259,14 +261,14 @@ async fn fire_monitor_tasks(
     };
 
     // Filter to the task(s) whose spec["schedule_id"] matches this schedule.
+    // (The list above already restricts to running monitors.)
     let matched: Vec<_> = tasks
         .into_iter()
         .filter(|t| {
-            !t.state.is_terminal()
-                && t.spec
-                    .get("schedule_id")
-                    .and_then(|v| v.as_str())
-                    .is_some_and(|id| id == schedule_id_str)
+            t.spec
+                .get("schedule_id")
+                .and_then(|v| v.as_str())
+                .is_some_and(|id| id == schedule_id_str)
         })
         .collect();
 

--- a/crates/server/src/session_scheduler.rs
+++ b/crates/server/src/session_scheduler.rs
@@ -3,13 +3,24 @@
 // Background loop that claims due session schedules and triggers turns.
 // Each triggered schedule injects a user message into the session with
 // metadata.source = "schedule", then starts a turn workflow.
+//
+// Monitor task integration: when a schedule fires we find the linked monitor
+// task (matched by spec["schedule_id"]) and:
+//   - record an outbound message on its thread ("Monitor fired at …");
+//   - for one-shot schedules (cron_expression is None), transition the monitor
+//     to Succeeded ("Scheduled monitor completed").
+// Errors in this path are best-effort and never fail the fire loop.
 
 use crate::domains::session_schedules::SessionScheduleService;
 use crate::execution_metadata;
 use crate::services::EventService;
-use crate::storage::StorageBackend;
+use crate::storage::{DbSessionTaskRegistry, StorageBackend};
 use chrono::Utc;
 use everruns_core::events::{EventContext, EventRequest, InputMessageData};
+use everruns_core::session_task::{
+    NewTaskMessage, SessionTaskFilter, SessionTaskRegistry, SessionTaskState, SessionTaskUpdate,
+    TASK_KIND_MONITOR,
+};
 use everruns_core::typed_id::{MessageId, SessionId};
 use everruns_core::{ContentPart, Message, MessageRole, TextContentPart};
 use everruns_worker::AgentRunner;
@@ -56,6 +67,12 @@ async fn poll_and_trigger(
     event_service: &Arc<EventService>,
     runner: &Arc<dyn AgentRunner>,
 ) -> anyhow::Result<()> {
+    // Build the task registry once per poll iteration; reused for all fired schedules.
+    // EventService implements EventEmitter so task snapshot events piggyback on the
+    // same delivery path the worker uses.
+    let task_registry =
+        DbSessionTaskRegistry::new(db.clone()).with_event_emitter(event_service.clone());
+
     let due = db.claim_due_session_schedules(10).await?;
     if due.is_empty() {
         return Ok(());
@@ -70,6 +87,7 @@ async fn poll_and_trigger(
         let description = row.description.clone();
 
         // Mark triggered (updates next_trigger, disables one-shot, etc.)
+        let is_one_shot = row.cron_expression.is_none();
         if let Err(e) = schedule_service.mark_triggered(org_id, schedule_id).await {
             tracing::error!(
                 schedule_id = %schedule_id,
@@ -78,6 +96,9 @@ async fn poll_and_trigger(
             );
             continue;
         }
+
+        // Update linked monitor tasks (best-effort; never fail the fire loop).
+        fire_monitor_tasks(&task_registry, session_id, schedule_id, is_one_shot).await;
 
         // Look up session to get harness_id and agent_id for the runner.
         let session = match db.get_session(org_id, session_id).await {
@@ -199,4 +220,94 @@ async fn poll_and_trigger(
     }
 
     Ok(())
+}
+
+/// Record a fire event on linked monitor tasks and, for one-shot schedules,
+/// transition the monitor to `Succeeded`.
+///
+/// Best-effort: errors are logged; the caller never sees them.
+async fn fire_monitor_tasks(
+    registry: &DbSessionTaskRegistry,
+    session_id: SessionId,
+    schedule_id: everruns_core::typed_id::ScheduleId,
+    is_one_shot: bool,
+) {
+    let schedule_id_str = schedule_id.to_string();
+    let now = Utc::now();
+
+    // List monitor tasks for this session.
+    let tasks = match registry
+        .list(
+            session_id,
+            Some(&SessionTaskFilter {
+                kind: Some(TASK_KIND_MONITOR.to_string()),
+                state: None,
+            }),
+        )
+        .await
+    {
+        Ok(tasks) => tasks,
+        Err(e) => {
+            tracing::warn!(
+                session_id = %session_id,
+                schedule_id = %schedule_id_str,
+                error = %e,
+                "fire_monitor_tasks: failed to list monitor tasks"
+            );
+            return;
+        }
+    };
+
+    // Filter to the task(s) whose spec["schedule_id"] matches this schedule.
+    let matched: Vec<_> = tasks
+        .into_iter()
+        .filter(|t| {
+            !t.state.is_terminal()
+                && t.spec
+                    .get("schedule_id")
+                    .and_then(|v| v.as_str())
+                    .is_some_and(|id| id == schedule_id_str)
+        })
+        .collect();
+
+    for task in matched {
+        // Record an outbound message so the monitor's thread shows fire history.
+        let msg_text = format!("Monitor fired at {}.", now.to_rfc3339());
+        if let Err(e) = registry
+            .record_message(
+                session_id,
+                &task.id,
+                NewTaskMessage::outbound_text(msg_text),
+            )
+            .await
+        {
+            tracing::warn!(
+                task_id = %task.id,
+                error = %e,
+                "fire_monitor_tasks: record_message failed"
+            );
+        }
+
+        // One-shot: the schedule has been disabled; the monitor is done.
+        if is_one_shot
+            && let Err(e) = registry
+                .update(
+                    session_id,
+                    &task.id,
+                    SessionTaskUpdate {
+                        state: Some(SessionTaskState::Succeeded),
+                        summary: Some("Scheduled monitor completed".into()),
+                        ..Default::default()
+                    },
+                )
+                .await
+        {
+            tracing::warn!(
+                task_id = %task.id,
+                error = %e,
+                "fire_monitor_tasks: failed to transition one-shot monitor to Succeeded"
+            );
+        }
+        // Recurring monitors stay Running until cancel_task is called.
+    }
 }

--- a/crates/worker/src/adapters.rs
+++ b/crates/worker/src/adapters.rs
@@ -38,6 +38,9 @@ pub fn create_driver_registry() -> DriverRegistry {
     //   - `tasks` — starts a background bash run via `spawn_background` and
     //     lists it with `list_tasks`, exercising the session task registry
     //     end-to-end (specs/session-tasks.md) without an LLM API key.
+    //   - `monitor` — schedules a recurring monitor via `spawn_background`
+    //     with a `schedule`, exercising the `monitor` task kind and its
+    //     fire-history thread.
     //
     // Unknown values fall back to the default driver with a warning.
     match std::env::var("LLMSIM_DEMO").ok().as_deref() {
@@ -66,6 +69,15 @@ pub fn create_driver_registry() -> DriverRegistry {
             everruns_core::llmsim_driver::register_driver_with_config(
                 &mut registry,
                 everruns_core::llmsim_driver::session_tasks_demo_script(),
+            );
+        }
+        Some("monitor") => {
+            tracing::info!(
+                "LLMSIM_DEMO=monitor: registering scripted LlmSim driver for the monitor demo"
+            );
+            everruns_core::llmsim_driver::register_driver_with_config(
+                &mut registry,
+                everruns_core::llmsim_driver::monitor_demo_script(),
             );
         }
         Some(other) => {

--- a/specs/session-tasks.md
+++ b/specs/session-tasks.md
@@ -163,12 +163,12 @@ A monitor is a long-lived task (`running` until canceled or exhausted).
 `spawn_background` with a `schedule` argument creates a `monitor` task linked
 to the backing session schedule via `spec["schedule_id"]`. Each schedule fire
 appends an outbound message to the monitor's thread. One-shot monitors
-transition to `Succeeded` after their single fire; recurring monitors stay
-`Running` until `cancel_task` is called, which cancels the linked schedule and
-transitions the task to `Canceled`.
+transition to `succeeded` after their single fire; recurring monitors stay
+`running` until `cancel_task` is called, which cancels the linked schedule and
+transitions the task to `canceled`.
 
 Known limitation: canceling the underlying session schedule directly (not via
-`cancel_task`) currently leaves the monitor task in `Running` — prefer
+`cancel_task`) currently leaves the monitor task in `running` — prefer
 `cancel_task` to cancel both atomically; reconciling orphaned monitors is a
 follow-up (EVE-monitor-orphan).
 
@@ -294,7 +294,7 @@ No backward compatibility is required; data migrates forward once:
   to the session schedule via `spec["schedule_id"]`. The `session_scheduler`
   server loop finds matching monitors on each schedule fire, records an outbound
   message on their thread, and completes one-shot monitors (cron_expression
-  absent) to `Succeeded`. Recurring monitors stay `Running` until
+  absent) to `succeeded`. Recurring monitors stay `running` until
   `cancel_task`, which cancels the linked schedule via `MonitorTaskExecutor`.
   `TASK_KIND_MONITOR` and the other `TASK_KIND_*` constants are now re-exported
   from `everruns-core`.

--- a/specs/session-tasks.md
+++ b/specs/session-tasks.md
@@ -157,11 +157,20 @@ update); `post` and `output` are content (thread and stream). This keeps
 | `subagent` | create child session, send instructions | `send_message(child)` | child question → `request_input`; final message → `post` + terminal state |
 | `external_agent` | A2A `message/send` | `message/send` with `remote_task_id` | `reconcile` polls `tasks/get`; remote artifacts → `artifact` |
 | `background_tool` | run `execute_background` with the sink | rarely used | direct sink calls (existing `BackgroundEventSink` is a strict subset) |
-| `monitor` (future) | start watch loop | adjust what's watched | observation → `post`/`artifact`; triggered condition → `request_input` |
+| `monitor` | created by `spawn_background` with a `schedule` arg | n/a (schedule-driven) | schedule fire → outbound message on thread; one-shot → `succeeded`; recurring stays `running` |
 
-A monitor is a long-lived task (`running` until canceled). If recurrence or
-schedules are needed later, add a separate definition entity that spawns tasks
-(Temporal's definition/execution split) without touching the task model.
+A monitor is a long-lived task (`running` until canceled or exhausted).
+`spawn_background` with a `schedule` argument creates a `monitor` task linked
+to the backing session schedule via `spec["schedule_id"]`. Each schedule fire
+appends an outbound message to the monitor's thread. One-shot monitors
+transition to `Succeeded` after their single fire; recurring monitors stay
+`Running` until `cancel_task` is called, which cancels the linked schedule and
+transitions the task to `Canceled`.
+
+Known limitation: canceling the underlying session schedule directly (not via
+`cancel_task`) currently leaves the monitor task in `Running` — prefer
+`cancel_task` to cancel both atomically; reconciling orphaned monitors is a
+follow-up (EVE-monitor-orphan).
 
 ## Results and artifacts
 
@@ -279,6 +288,16 @@ No backward compatibility is required; data migrates forward once:
 - `GET /v1/sessions/{id}/resources` keeps serving infrastructure resources.
 
 ## Implementation notes (v1)
+
+- `monitor` kind is first-class as of this implementation. `spawn_background`
+  with a `schedule` argument creates a `monitor` task (kind = "monitor") linked
+  to the session schedule via `spec["schedule_id"]`. The `session_scheduler`
+  server loop finds matching monitors on each schedule fire, records an outbound
+  message on their thread, and completes one-shot monitors (cron_expression
+  absent) to `Succeeded`. Recurring monitors stay `Running` until
+  `cancel_task`, which cancels the linked schedule via `MonitorTaskExecutor`.
+  `TASK_KIND_MONITOR` and the other `TASK_KIND_*` constants are now re-exported
+  from `everruns-core`.
 
 - Storage: `session_tasks` + `session_task_messages` (migration 053);
   PostgreSQL and in-memory backends both route updates through


### PR DESCRIPTION
## What
Adds the **`monitor`** session-task kind — the first new task kind the registry abstraction (#2110, #2119) was built to support. A monitor is a long-lived task linked to a session schedule, making recurring/scheduled background work a first-class, visible, cancelable task.

- **Creation**: scheduled `spawn_background` (the `schedule` arg) now creates a `monitor` task in addition to the session schedule. The task's `spec.schedule_id` links it to the backing schedule. Returns `task_id` alongside `schedule_id`. Best-effort — the schedule remains the source of truth.
- **Fire history**: when the schedule fires, `session_scheduler` records an outbound "Monitor fired at …" message on the monitor's thread (so the UI shows fire history) and, for one-shot schedules, transitions the monitor to `Succeeded`. Recurring cron monitors stay `running` until canceled. Best-effort; never fails the fire loop.
- **Cancellation**: `MonitorTaskExecutor::cancel` cancels the linked schedule (so it stops firing) then transitions the task to `Canceled`. Wired through the existing `cancel_task` tool.
- **UI**: monitor chips get a `Radar` icon; otherwise reuse the existing task-chip/Tasks-tab rendering.
- **Wake policy** is `Silent` — the schedule already injects its own prompt message on each fire; a second wake would be noise.

## Why
The whole session-task abstraction was designed so new kinds plug in without touching the core model. Monitors were the spec's named future kind. Before this, scheduled background work existed only as opaque `session_schedules` rows — invisible in the task UI and not cancelable via the unified task tooling. Now monitors are first-class tasks.

## How
Built entirely on existing infrastructure: session schedules drive recurrence (no new scheduler), the task message channel provides fire history, the executor inventory provides `cancel`, and the task registry provides events/visibility. No new tables or migrations.

## Validation
- **Live dev-mode E2E** (new `LLMSIM_DEMO=monitor` script → scheduled `spawn_background` with a cron): verified the `monitor` task is created `running` and linked to its `schedule_id`; the cron fired within ~30s; `fire_monitor_tasks` recorded the "Monitor fired at …" message on the monitor's thread; the recurring monitor correctly stayed `running`.
- core 2,187 / server 1,459 lib tests green, including 2 new `MonitorTaskExecutor::cancel` unit tests (with and without a schedule store). clippy `--all-features -D warnings` clean; `just pre-push` green.
- No migrations.

## Risk
Low and additive. The only change to an existing path is a best-effort task creation inside the already-conditional `schedule` branch of `spawn_background`; if the task registry is absent or creation fails, behavior is exactly as before. Fire-history and one-shot completion are best-effort and never fail the schedule fire loop.

## Security
- Threat categories reviewed: **TM-TOOL** (monitor creation/cancel operate only on the calling session; `cancel` only touches the schedule_id stored in the task's own spec), **TM-DOS** (monitors are bounded by the existing per-session schedule cap `MAX_ACTIVE_SCHEDULES_PER_SESSION`; fire-history is one message per fire). No new endpoints, no schema changes, no new trust boundaries.

## Follow-ups
- **Autonomous observation streaming**: today a fire logs a generic "Monitor fired" message and the agent (prompted by the schedule's own message) runs the actual check. A v2 could run the wrapped tool directly in the fire path and post the real result/diff as the observation, with `request_input` on a triggering condition.
- **Reverse-sync**: canceling the underlying session schedule directly (via the schedule API, not `cancel_task`) currently leaves the monitor task `running`. Prefer `cancel_task`; reconciling the reverse direction is deferred.
- Remaining session-task follow-ups (dual-write retirement, `task`→`instructions` rename, gRPC orphan-listing RPC + attempt fencing, v2 spec items) are tracked in `specs/session-tasks.md`.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_011yqDiQ2GyoDdwFQTFTw12R)_