### PR TITLE
fix(tool-search): preserve deferred schemas across serde

### DIFF
--- a/crates/core/src/capabilities/tool_search.rs
+++ b/crates/core/src/capabilities/tool_search.rs
@@ -922,6 +922,38 @@ mod tests {
     }
 
     #[test]
+    fn test_search_returns_full_schema_after_serde_round_trip() {
+        // Durable execution serializes reason output before scheduling act. The
+        // saved full schema must survive that boundary for deferred MCP proxies.
+        let hook = hook(1);
+        let tools = vec![builtin(
+            "mcp_docs__search",
+            "Search MCP docs",
+            DeferrablePolicy::Automatic,
+        )];
+        let deferred = hook.transform(tools);
+        let round_tripped: Vec<ToolDefinition> =
+            serde_json::from_value(serde_json::to_value(&deferred).unwrap()).unwrap();
+
+        let mcp = round_tripped
+            .iter()
+            .find(|t| t.name() == "mcp_docs__search")
+            .unwrap();
+        assert!(
+            mcp.parameters().get("properties").is_none(),
+            "visible MCP schema remains deferred after serde"
+        );
+
+        let results = ToolSearchTool::search(&round_tripped, "docs search");
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0]["name"], "mcp_docs__search");
+        assert!(
+            results[0]["parameters"].get("properties").is_some(),
+            "tool_search must return the full MCP schema after durable serde"
+        );
+    }
+
+    #[test]
     fn test_hook_opts_out_of_native_tool_search() {
         // Generic (client-side) deferral is mutually exclusive with hosted
         // tool_search; build() uses this to skip the hook when native is active.

--- a/crates/core/src/tool_types.rs
+++ b/crates/core/src/tool_types.rs
@@ -96,10 +96,9 @@ pub struct BuiltinTool {
     #[serde(default, skip_serializing_if = "ToolHints::is_empty")]
     pub hints: ToolHints,
     /// Original full parameter schema saved by `DeferSchemaHook` before stripping.
-    /// Never serialized; used only within the worker process so `tool_search` can
-    /// return the real schema even after the hook has replaced `parameters` with
-    /// the deferred stub.
-    #[serde(skip)]
+    /// Serialized only when present so durable reason-to-act scheduling can
+    /// preserve deferred schemas for `tool_search` in the act phase.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub full_parameters: Option<serde_json::Value>,
 }
 
@@ -127,10 +126,9 @@ pub struct ClientSideTool {
     #[serde(default, skip_serializing_if = "ToolHints::is_empty")]
     pub hints: ToolHints,
     /// Original full parameter schema saved by `DeferSchemaHook` before stripping.
-    /// Never serialized; used only within the worker process so `tool_search` can
-    /// return the real schema even after the hook has replaced `parameters` with
-    /// the deferred stub.
-    #[serde(skip)]
+    /// Serialized only when present so durable reason-to-act scheduling can
+    /// preserve deferred schemas for `tool_search` in the act phase.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub full_parameters: Option<serde_json::Value>,
 }
 

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -13330,6 +13330,9 @@
             ],
             "description": "Human-readable display name for UI rendering (e.g., \"Get Current Time\" for `get_current_time`)"
           },
+          "full_parameters": {
+            "description": "Original full parameter schema saved by `DeferSchemaHook` before stripping.\nSerialized only when present so durable reason-to-act scheduling can\npreserve deferred schemas for `tool_search` in the act phase."
+          },
           "hints": {
             "$ref": "#/components/schemas/ToolHints",
             "description": "Semantic hints describing the tool's behavioral properties"
@@ -13795,6 +13798,9 @@
               "null"
             ],
             "description": "Human-readable display name for UI rendering"
+          },
+          "full_parameters": {
+            "description": "Original full parameter schema saved by `DeferSchemaHook` before stripping.\nSerialized only when present so durable reason-to-act scheduling can\npreserve deferred schemas for `tool_search` in the act phase."
           },
           "hints": {
             "$ref": "#/components/schemas/ToolHints",


### PR DESCRIPTION
### Motivation
- Durable reason→act scheduling serializes and deserializes `ToolDefinition` payloads, which lost MCP full parameter schemas because `full_parameters` was `#[serde(skip)]`, causing `tool_search` in the act phase to only see the deferred stub.
- The change restores the intended behavior where deferred schemas survive the durable JSON boundary so `tool_search` can return real MCP schemas on demand without reintroducing full schemas for all tools.

### Description
- Change `full_parameters` on both `BuiltinTool` and `ClientSideTool` to `#[serde(default, skip_serializing_if = "Option::is_none")]` so the saved schema is serialized only when present (`crates/core/src/tool_types.rs`).
- Add a regression test `test_search_returns_full_schema_after_serde_round_trip` that defers an MCP-style tool, round-trips it through `serde_json::to_value`/`from_value`, and asserts the visible schema stays deferred while `tool_search` returns the preserved full schema (`crates/core/src/capabilities/tool_search.rs`).
- Keep compact serialization for ordinary tool definitions by omitting `full_parameters` when it is `None`.

### Testing
- Ran `cargo fmt --check` which passed.
- Ran the focused tests via `cargo test -p everruns-core capabilities::tool_search` and all tests passed (13 passed, 0 failed), including the new serde round-trip regression test.
- Ran the repository pre-push checks (`just pre-push`); an initial run reported a missing `origin/main` in this checkout, and a subsequent run with `MIGRATION_IMMUTABILITY_BASE_REF=HEAD just pre-push` passed all checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2328448c08832b81615bc1e006b420)