### PR TITLE
feat(harness): enable message_metadata on generic harness

### DIFF
--- a/crates/server/src/harnesses/generic.rs
+++ b/crates/server/src/harnesses/generic.rs
@@ -6,7 +6,7 @@ pub fn definition() -> BuiltInHarnessDefinition {
     BuiltInHarnessDefinition::new(
         "generic",
         "Generic",
-        "General-purpose harness with file system, bash, web fetch, secrets, session management, session schedules, long-context support, context compaction, budgeting, self-managed budget guidance, tool output persistence, loop detection, and agent skills. Recommended default for most use cases.",
+        "General-purpose harness with file system, bash, web fetch, secrets, session management, session schedules, long-context support, context compaction, budgeting, self-managed budget guidance, tool output persistence, loop detection, message timestamp annotations, and agent skills. Recommended default for most use cases.",
         SYSTEM_PROMPT,
     )
     .with_tags(["generic", "default", "built-in"])
@@ -30,6 +30,7 @@ pub fn definition() -> BuiltInHarnessDefinition {
         BuiltInCapabilityDefinition::new("budgeting"),
         BuiltInCapabilityDefinition::new("self_budget"),
         BuiltInCapabilityDefinition::new("loop_detection"),
+        BuiltInCapabilityDefinition::new("message_metadata"),
         BuiltInCapabilityDefinition::with_config(
             "compaction",
             serde_json::json!({

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -2934,7 +2934,7 @@ mod tests {
             .expect("Generic harness should exist");
 
         let cap_ids: Vec<&str> = generic.capabilities.iter().map(|c| c.id.as_str()).collect();
-        assert_eq!(cap_ids.len(), 17);
+        assert_eq!(cap_ids.len(), 18);
         assert!(cap_ids.contains(&"human_intent"));
         assert!(cap_ids.contains(&"session_file_system"));
         assert!(cap_ids.contains(&"virtual_bash"));
@@ -2950,6 +2950,7 @@ mod tests {
         assert!(cap_ids.contains(&"budgeting"));
         assert!(cap_ids.contains(&"self_budget"));
         assert!(cap_ids.contains(&"loop_detection"));
+        assert!(cap_ids.contains(&"message_metadata"));
         assert!(cap_ids.contains(&"compaction"));
         assert!(cap_ids.contains(&"tool_output_persistence"));
         // Verify compaction default config

--- a/crates/server/tests/api_integration_test.rs
+++ b/crates/server/tests/api_integration_test.rs
@@ -1961,8 +1961,8 @@ async fn test_get_generic_harness() {
         .collect();
     assert_eq!(
         cap_ids.len(),
-        17,
-        "Generic harness should have 17 capabilities"
+        18,
+        "Generic harness should have 18 capabilities"
     );
     assert!(
         cap_ids.contains(&"human_intent"),
@@ -2012,6 +2012,10 @@ async fn test_get_generic_harness() {
     assert!(
         cap_ids.contains(&"loop_detection"),
         "Should have loop detection"
+    );
+    assert!(
+        cap_ids.contains(&"message_metadata"),
+        "Should have message metadata annotations"
     );
 }
 
@@ -2500,8 +2504,8 @@ async fn test_copy_seed_generic_harness() {
     // Generic harness capabilities should be preserved on copy
     assert_eq!(
         copied.capabilities.len(),
-        17,
-        "Copied harness should have same 17 capabilities"
+        18,
+        "Copied harness should have same 18 capabilities"
     );
     assert!(
         copied

--- a/docs/capabilities/message-metadata.md
+++ b/docs/capabilities/message-metadata.md
@@ -20,6 +20,8 @@ For user messages the timestamp is when the message was received; for agent mess
 
 This lets agents reason about timing: how long ago something was said, gaps between messages, and whether earlier statements are stale.
 
+Enabled by default on the Generic (default) harness.
+
 Annotations are applied only to the prompt-facing view of the conversation. Stored messages are never modified, and timestamps are stable across turns so prompt caching is unaffected. A short system prompt addition explains the annotation format to the model and instructs it not to emit annotations in its replies.
 
 ## Tools


### PR DESCRIPTION
## What
Enables the `message_metadata` capability (shipped in #2116) by default on the **Generic** harness. Sessions on the default harness now annotate user/agent messages with `[time <RFC3339 UTC>]` in the LLM-facing view out of the box.

- `crates/server/src/harnesses/generic.rs`: adds `message_metadata` to the capability list (now 18) and mentions message timestamp annotations in the harness description.
- Updates tests pinning that list: seed unit test (`len == 18` + contains) and API integration tests (`test_get_generic_harness`, `test_copy_seed_generic_harness`).
- Docs note on the capability page that it is enabled by default on the Generic harness.

## Why
Timestamp awareness (gaps between messages, staleness of earlier statements) is broadly useful and cheap (~25 bytes per message + a ~300-byte system prompt addition), so it belongs in the batteries-included default rather than being discover-and-enable.

## How
Default capability set is declared in the built-in harness definition; existing deployments pick it up when built-in harnesses are re-seeded at startup.

Validated with:
- Seed unit tests green (including `test_generic_harness_capabilities_are_registered`, which verifies the ID resolves in the registry).
- Full `api_integration_test` suite (114 tests) green against real PostgreSQL: local infra started, all 53 migrations applied to a fresh test DB, suite run single-threaded end-to-end.
- The annotation behavior itself is covered by the e2e test landed in #2116 (in-memory loop + echo driver).
- `just pre-push` green.

Smoke testing: the impacted flow is harness seeding + session capability resolution, exercised end-to-end by `test_create_session_with_generic_harness` and `test_session_features_generic_harness` against PostgreSQL. The annotation path itself is unchanged from #2116.

## Risk
- Low
- Behavior change for all sessions on the Generic harness: prompts gain per-message timestamp prefixes. Deterministic, server-generated content only; opt-out is removing the capability from a copied harness or setting `{"fields": []}`.

## Security
- Threat categories reviewed: TM-LLM (prompt construction). No new surface: this only enables an already-reviewed capability (#2116) whose annotations are server-generated timestamps with fixed formatting. No config, auth, or query changes.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (existing custom/copied harnesses unaffected; only the built-in Generic definition changes)
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5pBCDK1io2CHoBpuRxdzB)_