### PR TITLE
feat(core): fetchkit 0.4 transport injection for web_fetch egress

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2431,6 +2431,7 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "bashkit",
+ "bytes",
  "chrono",
  "ed25519-dalek",
  "eventsource-stream",
@@ -3049,21 +3050,22 @@ dependencies = [
 
 [[package]]
 name = "fetchkit"
-version = "0.2.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e551cfcd0082a9acbe9be3dc068f368ef6b5ea6546c47fdd76eb3216ddbf686"
+checksum = "82150b89249abf4f7a6bce136567c795803faa601fcb041157b7a43f4c1e856b"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
  "bytes",
  "ed25519-dalek",
  "futures",
- "rand 0.8.6",
+ "libc",
+ "rand 0.10.1",
  "reqwest 0.13.4",
  "schemars",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
  "tower",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -65,7 +65,8 @@ similar = "2"
 url = "2"
 
 # Web fetching
-fetchkit = { version = "=0.2.0", features = ["bot-auth"] }
+bytes = "1"
+fetchkit = { version = "=0.4.0", features = ["bot-auth"] }
 
 # Ed25519 key derivation (bot-auth public key registration)
 ed25519-dalek = { version = "2", features = ["rand_core"] }

--- a/crates/core/src/capabilities/web_fetch.rs
+++ b/crates/core/src/capabilities/web_fetch.rs
@@ -355,16 +355,23 @@ impl FileSaver for SessionFileSaver {
 /// File download: when `save_to_file` is provided, content is saved through
 /// the session filesystem (SessionFileSystem) via the SessionFileSaver adapter.
 pub struct WebFetchTool {
+    /// Builder template for this tool's fetchkit configuration. Cloned per
+    /// execution to inject the egress transport when the context provides an
+    /// `EgressService` (see `super::web_fetch_egress`).
+    builder: fetchkit::ToolBuilder,
+    /// Direct (non-egress) tool built from `builder`: serves metadata
+    /// (schema/description) and execution for contexts without an egress
+    /// service (e.g. embedded hosts), where fetchkit owns the HTTP client.
     fetchkit_tool: fetchkit::Tool,
     enable_save_to_file: bool,
     /// Cached description from ToolBuilder (owned copy of fetchkit's &str for our Tool trait)
     description: String,
-    /// Host-wide system allowlist ("green list") for the legacy direct path
-    /// only. When `ToolContext.egress_service` is present, fetches route
-    /// through the egress boundary, which enforces the allowlist itself; this
-    /// pre-flight check covers contexts without an egress service, where
-    /// fetchkit still owns the HTTP client. `None` = no global enforcement.
-    /// See `crate::system_allowlist` and `specs/system-allowlist.md`.
+    /// Host-wide system allowlist ("green list"), pre-checked on the initial
+    /// URL for a clear, distinct system-policy error. On the egress path the
+    /// boundary independently re-enforces it (final enforcement point, every
+    /// hop); on the direct path this pre-flight is the only enforcement.
+    /// `None` = no global enforcement. See `crate::system_allowlist` and
+    /// `specs/system-allowlist.md`.
     system_allowlist: Option<Arc<crate::system_allowlist::SystemAllowlist>>,
 }
 
@@ -378,6 +385,7 @@ impl WebFetchTool {
         let fetchkit_tool = builder.build();
         let description = fetchkit_tool.description().to_string();
         Self {
+            builder,
             fetchkit_tool,
             enable_save_to_file,
             description,
@@ -559,18 +567,16 @@ impl Tool for WebFetchTool {
             );
         }
 
-        // Legacy direct path only: the host-wide system allowlist is enforced
-        // here, before the per-session access list, so the operator-level
-        // policy yields a clear, distinct error when both would deny. On the
-        // egress path the boundary owns this check instead.
-        if context.egress_service.is_none()
-            && let Some(blocked) = self.system_policy_block(&request.url)
-        {
+        // Host-wide system allowlist, pre-checked on the initial URL for a
+        // clear, distinct system-policy error. On the egress path the boundary
+        // independently re-enforces it on every hop.
+        if let Some(blocked) = self.system_policy_block(&request.url) {
             return blocked;
         }
 
         // THREAT[TM-AGENT-018]: Enforce network access list. This is the
-        // user-facing pre-check; on the egress path the boundary re-checks it.
+        // user-facing pre-check; on the egress path the boundary re-checks it
+        // on every hop.
         if let Some(ref acl) = context.network_access
             && !acl.is_url_allowed(&request.url)
         {
@@ -580,50 +586,32 @@ impl Tool for WebFetchTool {
             ));
         }
 
-        // Egress-backed path (specs/egress.md migration step 3): transport,
-        // SSRF pinning, the network access list, and the system allowlist are
-        // owned by the host egress boundary. fetchkit stays the adapter for
-        // schema and content conversion.
-        if let Some(egress) = &context.egress_service {
-            let saver = if request.save_to_file.is_some() {
-                match &context.file_store {
-                    Some(store) => Some(SessionFileSaver {
-                        file_store: store.clone(),
-                        session_id: context.session_id,
-                    }),
-                    None => {
-                        return ToolExecutionResult::tool_error(
-                            "File system not available in this context",
-                        );
-                    }
-                }
-            } else {
-                None
-            };
-            return match super::web_fetch_egress::fetch_via_egress(
-                &request,
-                egress.as_ref(),
-                context.network_access.as_ref(),
-                saver.as_ref().map(|s| s as &dyn FileSaver),
-            )
-            .await
-            {
-                Ok(response) => {
-                    ToolExecutionResult::success(serde_json::to_value(&response).unwrap_or_else(
-                        |_| serde_json::json!({"error": "Failed to serialize response"}),
-                    ))
-                }
-                Err(e) => Self::map_error(e),
-            };
-        }
-
-        // Legacy direct path (no egress service in context, e.g. embedded
-        // hosts): fetchkit owns transport; the system allowlist was already
-        // pre-checked above.
+        // Egress-backed path (specs/egress.md migration step 3): when the host
+        // provides an egress service, inject it as fetchkit's HTTP transport.
+        // fetchkit keeps the whole pipeline (specialized fetchers, DNS policy,
+        // per-hop redirect validation, bot-auth signing, body caps); every
+        // HTTP hop crosses the egress boundary, which enforces the network
+        // access list and the system allowlist. Without an egress service
+        // (e.g. embedded hosts) fetchkit owns the HTTP client directly.
+        let routed_tool;
+        let tool = match &context.egress_service {
+            Some(egress) => {
+                routed_tool = self
+                    .builder
+                    .clone()
+                    .transport(Arc::new(super::web_fetch_egress::EgressHttpTransport::new(
+                        egress.clone(),
+                        context.network_access.clone(),
+                    )))
+                    .build();
+                &routed_tool
+            }
+            None => &self.fetchkit_tool,
+        };
 
         // If no save_to_file, use the simple path (no saver needed)
         if request.save_to_file.is_none() {
-            return match self.fetchkit_tool.execute(request).await {
+            return match tool.execute(request).await {
                 Ok(response) => {
                     ToolExecutionResult::success(serde_json::to_value(&response).unwrap_or_else(
                         |_| serde_json::json!({"error": "Failed to serialize response"}),
@@ -648,11 +636,7 @@ impl Tool for WebFetchTool {
             session_id: context.session_id,
         };
 
-        match self
-            .fetchkit_tool
-            .execute_with_saver(request, Some(&saver))
-            .await
-        {
+        match tool.execute_with_saver(request, Some(&saver)).await {
             Ok(response) => {
                 ToolExecutionResult::success(serde_json::to_value(&response).unwrap_or_else(
                     |_| serde_json::json!({"error": "Failed to serialize response"}),
@@ -673,12 +657,13 @@ mod tests {
     /// Create a WebFetchTool with permissive DNS policy for wiremock tests
     /// (wiremock binds to 127.0.0.1 which is blocked by default).
     fn tool_for_wiremock() -> WebFetchTool {
-        let fetchkit_tool = fetchkit::Tool::builder()
+        let builder = fetchkit::Tool::builder()
             .enable_save_to_file(true)
-            .block_private_ips(false)
-            .build();
+            .block_private_ips(false);
+        let fetchkit_tool = builder.build();
         let description = fetchkit_tool.description().to_string();
         WebFetchTool {
+            builder,
             fetchkit_tool,
             enable_save_to_file: true,
             description,

--- a/crates/core/src/capabilities/web_fetch_egress.rs
+++ b/crates/core/src/capabilities/web_fetch_egress.rs
@@ -70,7 +70,9 @@ impl HttpTransport for EgressHttpTransport {
             egress_request = egress_request.header(name, value);
         }
         if let Some(timeout) = req.timeout {
-            egress_request = egress_request.timeout_ms(timeout.as_millis() as u64);
+            // Saturate instead of wrapping on absurdly large durations.
+            let timeout_ms = u64::try_from(timeout.as_millis()).unwrap_or(u64::MAX);
+            egress_request = egress_request.timeout_ms(timeout_ms);
         }
         // `respect_proxy_env` is intentionally not forwarded: outbound proxy
         // policy is host-owned at the egress boundary, not per-fetch config.

--- a/crates/core/src/capabilities/web_fetch_egress.rs
+++ b/crates/core/src/capabilities/web_fetch_egress.rs
@@ -1,583 +1,128 @@
-//! Egress-backed fetch path for the `web_fetch` capability.
+//! Egress-backed HTTP transport for the `web_fetch` capability.
 //!
-//! Implements `specs/egress.md` migration step 3: outbound web_fetch HTTP goes
-//! through the host `EgressService` instead of fetchkit's internal clients.
-//! fetchkit remains the request/response adapter — it still owns the tool
-//! schema, description, and HTML→markdown/text conversion — but transport,
-//! the per-session `NetworkAccessList`, and the deployment-wide system
-//! allowlist are enforced at the egress boundary (`specs/system-allowlist.md`).
+//! Implements `specs/egress.md` migration step 3 via fetchkit's transport
+//! injection (fetchkit >= 0.4): [`EgressHttpTransport`] implements
+//! `fetchkit::HttpTransport` over the host `EgressService`, so fetchkit keeps
+//! its entire pipeline — specialized fetchers (GitHub, Wikipedia, arXiv, ...),
+//! DNS policy (resolve-then-check producing pinned addresses, TM-API-008),
+//! manual per-hop redirect validation, body caps, bot-auth signing, HTML
+//! conversion, and file saving — while every HTTP hop crosses the egress
+//! boundary, where the per-request `NetworkAccessList` and the deployment-wide
+//! system allowlist are enforced (`specs/system-allowlist.md`).
 //!
-//! Behavior differences vs the legacy fetchkit direct path:
-//! - Specialized fetchers (GitHub, Wikipedia, arXiv, ...) do not apply; every
-//!   URL is fetched generically. They own private HTTP clients inside fetchkit
-//!   that cannot route through egress. Restoring them requires upstream
-//!   transport injection in fetchkit.
-//! - SSRF protection uses `crate::url_validation::validate_url_dns_pinned`
-//!   (resolve-then-check with DNS pinning, TM-TOOL-018) instead of fetchkit's
-//!   `DnsPolicy`, matching the MCP and Lua egress call sites.
-//! - Request signing is requested as `EgressSigning::PlatformDefault`; the
-//!   fetchkit-local bot-auth Ed25519 signer applies only to the legacy direct
-//!   path (`specs/fetchkit.md`).
-//!
-//! Redirects are followed manually (TM-SSRF-010): every hop is re-validated
-//! against the network access list and SSRF rules, and each hop is a separate
-//! egress request, so the system allowlist applies to redirect targets too.
+//! fetchkit issues one transport call per redirect hop, so egress policy
+//! applies to redirect targets too (TM-SSRF-010 stays in fetchkit; the egress
+//! boundary independently re-denies hops its policy forbids). `pinned_addrs`
+//! carries fetchkit's resolve-then-check result into
+//! `EgressRequest.pinned_addrs`, closing the TOCTOU window at the egress
+//! client (TM-TOOL-018).
 
-use crate::egress::{
-    EgressError, EgressRequest, EgressRequestKind, EgressService, EgressSigning,
-    EgressStreamResponse,
-};
+use crate::egress::{EgressError, EgressRequest, EgressRequestKind, EgressService, EgressSigning};
 use crate::network_access::NetworkAccessList;
-use fetchkit::file_saver::FileSaver;
+use async_trait::async_trait;
+use bytes::Bytes;
 use fetchkit::{
-    DEFAULT_USER_AGENT, FetchError, FetchRequest, FetchResponse, HttpMethod, extract_headings,
-    extract_metadata, html_to_markdown, html_to_text, strip_boilerplate,
+    HttpTransport, TransportError, TransportMethod, TransportRequest, TransportResponse,
 };
 use futures::StreamExt;
-use std::collections::BTreeMap;
-use std::time::Duration;
-use url::Url;
+use std::sync::Arc;
 
-// Limits mirror fetchkit's DefaultFetcher so tool behavior stays consistent
-// across the egress and legacy paths.
-const MAX_REDIRECTS: usize = 10;
-const BODY_TIMEOUT: Duration = Duration::from_secs(30);
-const REQUEST_TIMEOUT_MS: u64 = 30_000;
-const DEFAULT_MAX_BODY_SIZE: usize = 10 * 1024 * 1024;
-const TRUNCATION_MESSAGE: &str = "\n\n[..content truncated...]";
-
-/// Binary content type prefixes (mirrors fetchkit's DefaultFetcher).
-const BINARY_PREFIXES: &[&str] = &[
-    "image/",
-    "audio/",
-    "video/",
-    "application/octet-stream",
-    "application/pdf",
-    "application/zip",
-    "application/gzip",
-    "application/x-tar",
-    "application/x-rar",
-    "application/x-7z",
-    "application/vnd.ms-",
-    "application/vnd.openxmlformats",
-    "font/",
-];
-
-/// Fetch a URL through the host egress boundary.
-///
-/// `network_access` is the merged harness/agent/session list; it is checked
-/// per redirect hop here (for clear errors) and passed on the `EgressRequest`
-/// so the egress service remains the final enforcement point. When `saver` is
-/// set and the request has `save_to_file`, raw bytes (including binary) are
-/// written through it instead of being returned inline.
-pub(crate) async fn fetch_via_egress(
-    request: &FetchRequest,
-    egress: &dyn EgressService,
-    network_access: Option<&NetworkAccessList>,
-    saver: Option<&dyn FileSaver>,
-) -> Result<FetchResponse, FetchError> {
-    fetch_via_egress_with_limit(
-        request,
-        egress,
-        network_access,
-        saver,
-        DEFAULT_MAX_BODY_SIZE,
-    )
-    .await
+/// fetchkit transport that sends every HTTP hop through the host egress boundary.
+pub(crate) struct EgressHttpTransport {
+    egress: Arc<dyn EgressService>,
+    /// Merged harness/agent/session access list, enforced at the egress
+    /// boundary for every hop — the final enforcement point per
+    /// `specs/egress.md`. `web_fetch` pre-checks the initial URL itself for
+    /// clearer user-facing errors.
+    network_access: Option<NetworkAccessList>,
 }
 
-async fn fetch_via_egress_with_limit(
-    request: &FetchRequest,
-    egress: &dyn EgressService,
-    network_access: Option<&NetworkAccessList>,
-    saver: Option<&dyn FileSaver>,
-    max_body_size: usize,
-) -> Result<FetchResponse, FetchError> {
-    if request.url.is_empty() {
-        return Err(FetchError::MissingUrl);
+impl EgressHttpTransport {
+    pub(crate) fn new(
+        egress: Arc<dyn EgressService>,
+        network_access: Option<NetworkAccessList>,
+    ) -> Self {
+        Self {
+            egress,
+            network_access,
+        }
     }
-    let method = request.effective_method();
-    let saving = saver.is_some() && request.save_to_file.is_some();
+}
 
-    let accept = if saving {
-        "*/*"
-    } else if request.wants_markdown() {
-        "text/html, text/markdown, text/plain, */*;q=0.8"
-    } else if request.wants_text() {
-        "text/html, text/plain, */*;q=0.8"
-    } else {
-        "*/*"
-    };
-
-    let (response, final_url, redirect_chain) = send_following_redirects(
-        &request.url,
-        method,
-        accept,
-        request,
-        egress,
-        network_access,
-    )
-    .await?;
-
-    let status_code = response.status;
-    let meta = ResponseMeta::from_headers(&response.headers, &final_url);
-
-    // 304 Not Modified (conditional request response) — no body to process.
-    if status_code == 304 {
-        return Ok(FetchResponse {
-            url: final_url,
-            status_code,
-            content_type: meta.content_type,
-            last_modified: meta.last_modified,
-            etag: meta.etag,
-            redirect_chain,
-            ..Default::default()
-        });
-    }
-
-    if method == HttpMethod::Head {
-        return Ok(FetchResponse {
-            url: final_url,
-            status_code,
-            content_type: meta.content_type,
-            size: meta.content_length,
-            last_modified: meta.last_modified,
-            etag: meta.etag,
-            filename: meta.filename,
-            method: Some("HEAD".to_string()),
-            redirect_chain,
-            ..Default::default()
-        });
-    }
-
-    if saving {
-        // File saves accept binary content; raw bytes go through the saver.
-        let (body, truncated) = read_body_capped(response, max_body_size).await?;
-        let size = body.len() as u64;
-        let save_path = request.save_to_file.as_deref().unwrap_or_default();
-        let result = saver
-            .expect("saving implies saver")
-            .save(save_path, &body)
-            .await
-            .map_err(|e| FetchError::SaveError(e.to_string()))?;
-        return Ok(FetchResponse {
-            url: final_url,
-            status_code,
-            content_type: meta.content_type,
-            size: Some(size),
-            last_modified: meta.last_modified,
-            etag: meta.etag,
-            filename: meta.filename,
-            truncated: if truncated { Some(true) } else { None },
-            saved_path: Some(result.path),
-            bytes_written: Some(result.bytes_written),
-            redirect_chain,
-            ..Default::default()
-        });
-    }
-
-    // Inline responses reject binary content (metadata only).
-    if let Some(ref ct) = meta.content_type
-        && is_binary_content_type(ct)
-    {
-        return Ok(FetchResponse {
-            url: final_url,
-            status_code,
-            content_type: meta.content_type,
-            size: meta.content_length,
-            last_modified: meta.last_modified,
-            etag: meta.etag,
-            filename: meta.filename,
-            redirect_chain,
-            error: Some(
-                "Binary content is not supported. Only textual content (HTML, text, JSON, etc.) can be fetched."
-                    .to_string(),
-            ),
-            ..Default::default()
-        });
-    }
-
-    let (body, truncated) = read_body_capped(response, max_body_size).await?;
-    let size = body.len() as u64;
-    let content = String::from_utf8_lossy(&body).to_string();
-    let is_paywall = detect_paywall(&content);
-    let is_html_content = is_html(&meta.content_type, &content);
-
-    // Structured page metadata is extracted before boilerplate stripping.
-    let page_metadata = if is_html_content {
-        let mut pm = extract_metadata(&content);
-        pm.headings = extract_headings(&content);
-        if pm.is_empty() { None } else { Some(pm) }
-    } else {
-        None
-    };
-
-    let wants_markdown = request.wants_markdown();
-    let wants_text = request.wants_text();
-    let (format, final_content) = if is_markdown_content_type(&meta.content_type) && wants_markdown
-    {
-        ("markdown".to_string(), content)
-    } else if is_plain_text_content_type(&meta.content_type) && wants_text {
-        ("text".to_string(), content)
-    } else if is_html_content {
-        let html = if request.wants_main_content() {
-            strip_boilerplate(&content)
-        } else {
-            content
+#[async_trait]
+impl HttpTransport for EgressHttpTransport {
+    async fn execute(&self, req: TransportRequest) -> Result<TransportResponse, TransportError> {
+        let method = match req.method {
+            TransportMethod::Get => "GET",
+            TransportMethod::Head => "HEAD",
         };
-        if wants_markdown {
-            ("markdown".to_string(), html_to_markdown(&html))
-        } else if wants_text {
-            ("text".to_string(), html_to_text(&html))
-        } else {
-            ("raw".to_string(), html)
+        let host = req.url.host_str().unwrap_or_default().to_string();
+        let mut egress_request =
+            EgressRequest::new(method, req.url.as_str(), EgressRequestKind::Capability)
+                // fetchkit signs bot-auth headers before handing the hop to
+                // the transport (re-signed per hop); platform-default signing
+                // remains available for a future platform signer
+                // (specs/egress.md).
+                .signing(EgressSigning::PlatformDefault)
+                .network_access(self.network_access.clone())
+                .pinned_addrs(host, req.pinned_addrs);
+        for (name, value) in req.headers {
+            egress_request = egress_request.header(name, value);
         }
-    } else {
-        ("raw".to_string(), content)
-    };
-
-    let mut final_content = filter_excessive_newlines(&final_content);
-    if truncated {
-        final_content.push_str(TRUNCATION_MESSAGE);
-    }
-    let word_count = count_words(&final_content);
-
-    Ok(FetchResponse {
-        url: final_url,
-        status_code,
-        content_type: meta.content_type,
-        size: Some(size),
-        last_modified: meta.last_modified,
-        etag: meta.etag,
-        filename: meta.filename,
-        format: Some(format),
-        content: Some(final_content),
-        truncated: if truncated { Some(true) } else { None },
-        metadata: page_metadata,
-        word_count: Some(word_count),
-        redirect_chain,
-        is_paywall: if is_paywall { Some(true) } else { None },
-        ..Default::default()
-    })
-}
-
-/// Send one egress request per redirect hop, re-validating every hop.
-///
-/// Returns `(response, final_url, redirect_chain)` where `redirect_chain`
-/// lists intermediate URLs (empty when no redirects occurred).
-async fn send_following_redirects(
-    initial_url: &str,
-    method: HttpMethod,
-    accept: &str,
-    request: &FetchRequest,
-    egress: &dyn EgressService,
-    network_access: Option<&NetworkAccessList>,
-) -> Result<(EgressStreamResponse, String, Vec<String>), FetchError> {
-    let mut current_url = initial_url.to_string();
-    let mut redirect_chain: Vec<String> = Vec::new();
-
-    for _hop in 0..=MAX_REDIRECTS {
-        // Per-hop network access check for a clear error; the egress service
-        // re-checks via `EgressRequest.network_access` as the final gate.
-        if let Some(acl) = network_access
-            && !acl.is_url_allowed(&current_url)
-        {
-            return Err(FetchError::FetcherError(format!(
-                "URL blocked by network access policy: {current_url}"
-            )));
+        if let Some(timeout) = req.timeout {
+            egress_request = egress_request.timeout_ms(timeout.as_millis() as u64);
         }
+        // `respect_proxy_env` is intentionally not forwarded: outbound proxy
+        // policy is host-owned at the egress boundary, not per-fetch config.
 
-        // THREAT[TM-API-008]/[TM-TOOL-018]: SSRF resolve-then-check with DNS
-        // pinning; the pinned addresses are handed to the egress transport.
-        let (validated_url, resolved_addrs) =
-            crate::url_validation::validate_url_dns_pinned(&current_url)
-                .await
-                .map_err(map_url_validation_error)?;
-        let pin_host = validated_url.host_str().unwrap_or("").to_string();
-
-        let mut egress_request = EgressRequest::new(
-            method.to_string(),
-            &current_url,
-            EgressRequestKind::Capability,
-        )
-        .header("user-agent", DEFAULT_USER_AGENT)
-        .header("accept", accept)
-        .signing(EgressSigning::PlatformDefault)
-        .network_access(network_access.cloned())
-        .pinned_addrs(pin_host, resolved_addrs)
-        .timeout_ms(REQUEST_TIMEOUT_MS);
-        if let Some(ref etag) = request.if_none_match {
-            egress_request = egress_request.header("if-none-match", etag.clone());
-        }
-        if let Some(ref date) = request.if_modified_since {
-            egress_request = egress_request.header("if-modified-since", date.clone());
-        }
-
-        let response = egress
+        let url = req.url;
+        let response = self
+            .egress
             .send_stream(egress_request)
             .await
             .map_err(map_egress_error)?;
-
-        // 304 is in the 3xx range but is not a redirect.
-        if !(300..400).contains(&response.status) || response.status == 304 {
-            return Ok((response, current_url, redirect_chain));
-        }
-
-        let location = response
-            .headers
-            .get("location")
-            .ok_or_else(|| {
-                FetchError::RequestError("redirect response missing Location header".to_string())
-            })?
-            .clone();
-        let base = Url::parse(&current_url)
-            .map_err(|_| FetchError::RequestError("redirect base URL invalid".to_string()))?;
-        let next_url = base.join(&location).map_err(|_| {
-            FetchError::RequestError("redirect Location is not a valid URL".to_string())
-        })?;
-        // THREAT[TM-INPUT-001]: Validate scheme at each redirect hop.
-        if next_url.scheme() != "http" && next_url.scheme() != "https" {
-            return Err(FetchError::InvalidUrlScheme);
-        }
-
-        redirect_chain.push(current_url);
-        current_url = next_url.to_string();
-    }
-
-    Err(FetchError::RequestError(format!(
-        "too many redirects (more than {MAX_REDIRECTS})"
-    )))
-}
-
-/// Map URL validation failures to fetch errors, keeping parity with the
-/// legacy path: malformed URLs and bad schemes surface as "Invalid URL…"
-/// rather than a generic policy block, which is reserved for SSRF denials.
-fn map_url_validation_error(error: crate::url_validation::UrlValidationError) -> FetchError {
-    use crate::url_validation::UrlValidationError;
-    match error {
-        UrlValidationError::InvalidUrl(_) | UrlValidationError::DisallowedScheme(_) => {
-            FetchError::InvalidUrlScheme
-        }
-        UrlValidationError::MissingHostname | UrlValidationError::BlockedHost(_) => {
-            FetchError::BlockedUrl
-        }
+        Ok(TransportResponse {
+            status: response.status,
+            url,
+            headers: response.headers.into_iter().collect(),
+            body: Box::pin(
+                response
+                    .body
+                    .map(|chunk| chunk.map(Bytes::from).map_err(map_egress_error)),
+            ),
+        })
     }
 }
 
-/// Map egress failures to fetch errors.
+/// Map egress failures onto transport errors.
 ///
-/// The caller checks the session network access list itself before sending,
-/// so a `NetworkAccessDenied` from the egress boundary means the deployment's
-/// system allowlist denied the URL (`specs/system-allowlist.md`).
-fn map_egress_error(error: EgressError) -> FetchError {
+/// `web_fetch` pre-checks the session access list and the system allowlist on
+/// the initial URL with distinct messages, so a `NetworkAccessDenied` here
+/// usually means a redirect hop was denied (by either list); keep the message
+/// policy-explicit but list-neutral.
+fn map_egress_error(error: EgressError) -> TransportError {
     match error {
-        EgressError::NetworkAccessDenied { url } => FetchError::FetcherError(format!(
-            "Endpoint blocked by system policy: {url} is not on the deployment's \
-             system allowlist of permitted public resources."
-        )),
-        EgressError::InvalidRequest(message) => FetchError::RequestError(message),
+        EgressError::NetworkAccessDenied { url } => {
+            TransportError::Request(format!("Outbound request blocked by network policy: {url}"))
+        }
+        EgressError::InvalidRequest(message) => TransportError::Request(message),
         EgressError::SigningUnavailable => {
-            FetchError::RequestError("outbound request signing unavailable".to_string())
+            TransportError::Other("outbound request signing unavailable".to_string())
         }
-        EgressError::Transport(message) => FetchError::RequestError(message),
+        EgressError::Transport(message) => TransportError::Request(message),
     }
-}
-
-/// Read the streaming body with a deadline and size cap, returning partial
-/// content with `truncated = true` when either limit is hit (TM-DOS-001/003).
-async fn read_body_capped(
-    response: EgressStreamResponse,
-    max_size: usize,
-) -> Result<(Vec<u8>, bool), FetchError> {
-    let mut body: Vec<u8> = Vec::new();
-    let mut stream = response.body;
-    let deadline = tokio::time::Instant::now() + BODY_TIMEOUT;
-
-    loop {
-        tokio::select! {
-            chunk = stream.next() => {
-                match chunk {
-                    Some(Ok(bytes)) => {
-                        let remaining = max_size.saturating_sub(body.len());
-                        if remaining == 0 {
-                            return Ok((body, true));
-                        }
-                        if bytes.len() > remaining {
-                            body.extend_from_slice(&bytes[..remaining]);
-                            return Ok((body, true));
-                        }
-                        body.extend_from_slice(&bytes);
-                    }
-                    Some(Err(e)) => {
-                        if body.is_empty() {
-                            return Err(FetchError::RequestError(e.to_string()));
-                        }
-                        return Ok((body, true));
-                    }
-                    None => return Ok((body, false)),
-                }
-            }
-            _ = tokio::time::sleep_until(deadline) => {
-                return Ok((body, true));
-            }
-        }
-    }
-}
-
-/// Common response metadata pulled from egress headers (lowercase names).
-struct ResponseMeta {
-    content_type: Option<String>,
-    last_modified: Option<String>,
-    etag: Option<String>,
-    content_length: Option<u64>,
-    filename: Option<String>,
-}
-
-impl ResponseMeta {
-    fn from_headers(headers: &BTreeMap<String, String>, url: &str) -> Self {
-        Self {
-            content_type: headers.get("content-type").cloned(),
-            last_modified: headers.get("last-modified").cloned(),
-            etag: headers.get("etag").cloned(),
-            content_length: headers.get("content-length").and_then(|s| s.parse().ok()),
-            filename: extract_filename(headers, url),
-        }
-    }
-}
-
-// ----------------------------------------------------------------------------
-// Helpers mirrored from fetchkit's private internals (DefaultFetcher/convert),
-// kept in sync so egress-path output matches the legacy direct path.
-// ----------------------------------------------------------------------------
-
-fn is_binary_content_type(content_type: &str) -> bool {
-    let ct_lower = content_type.to_lowercase();
-    BINARY_PREFIXES
-        .iter()
-        .any(|prefix| ct_lower.starts_with(prefix))
-}
-
-fn is_markdown_content_type(content_type: &Option<String>) -> bool {
-    content_type
-        .as_deref()
-        .and_then(|ct| ct.split(';').next())
-        .map(|media_type| media_type.trim().eq_ignore_ascii_case("text/markdown"))
-        .unwrap_or(false)
-}
-
-fn is_plain_text_content_type(content_type: &Option<String>) -> bool {
-    content_type
-        .as_deref()
-        .and_then(|ct| ct.split(';').next())
-        .map(|media_type| media_type.trim().eq_ignore_ascii_case("text/plain"))
-        .unwrap_or(false)
-}
-
-fn is_html(content_type: &Option<String>, body: &str) -> bool {
-    if let Some(ct) = content_type {
-        let ct_lower = ct.to_lowercase();
-        if ct_lower.contains("text/html") || ct_lower.contains("application/xhtml") {
-            return true;
-        }
-    }
-    let trimmed = body.trim_start();
-    trimmed.starts_with("<!DOCTYPE") || trimmed.starts_with("<html")
-}
-
-fn filter_excessive_newlines(s: &str) -> String {
-    let mut result = String::new();
-    let mut newline_count = 0;
-    for c in s.chars() {
-        if c == '\n' {
-            newline_count += 1;
-            if newline_count <= 2 {
-                result.push(c);
-            }
-        } else {
-            newline_count = 0;
-            result.push(c);
-        }
-    }
-    result
-}
-
-fn count_words(text: &str) -> u64 {
-    text.split_whitespace().count() as u64
-}
-
-const PAYWALL_INDICATORS: &[&str] = &[
-    "paywall",
-    "subscribe to read",
-    "subscribe to continue",
-    "subscription required",
-    "premium content",
-    "members only",
-    "sign in to read",
-    "log in to read",
-    "create a free account",
-    "already a subscriber",
-    "unlock this article",
-    "get unlimited access",
-    "start your free trial",
-];
-
-fn detect_paywall(html: &str) -> bool {
-    let lower = html.to_lowercase();
-    PAYWALL_INDICATORS
-        .iter()
-        .any(|indicator| lower.contains(indicator))
-}
-
-fn extract_filename(headers: &BTreeMap<String, String>, url: &str) -> Option<String> {
-    if let Some(disposition) = headers.get("content-disposition")
-        && let Some(filename) = parse_content_disposition_filename(disposition)
-    {
-        return Some(filename);
-    }
-    if let Ok(parsed) = Url::parse(url)
-        && let Some(mut segments) = parsed.path_segments()
-        && let Some(last) = segments.next_back()
-        && last.contains('.')
-        && !last.is_empty()
-    {
-        return Some(last.to_string());
-    }
-    None
-}
-
-fn parse_content_disposition_filename(value: &str) -> Option<String> {
-    let patterns = ["filename=\"", "filename="];
-    for pattern in patterns {
-        if let Some(start) = value.find(pattern) {
-            let rest = &value[start + pattern.len()..];
-            if pattern.ends_with('"') {
-                if let Some(end) = rest.find('"') {
-                    return Some(rest[..end].to_string());
-                }
-            } else {
-                let end = rest
-                    .find(|c: char| c.is_whitespace() || c == ';')
-                    .unwrap_or(rest.len());
-                let filename = rest[..end].trim_matches('"');
-                if !filename.is_empty() {
-                    return Some(filename.to_string());
-                }
-            }
-        }
-    }
-    None
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::egress::{EgressResponse, EgressResult};
-    use async_trait::async_trait;
+    use crate::egress::{EgressResponse, EgressResult, EgressStreamResponse};
+    use fetchkit::FetchRequest;
     use std::sync::Mutex;
 
     /// Programmable egress mock: pops queued responses in order and records
     /// every request it receives. Test URLs use public IP literals so
-    /// `validate_url_dns_pinned` passes without DNS resolution.
+    /// fetchkit's DNS policy passes without resolution (pinned_addrs empty).
     struct MockEgress {
         responses: Mutex<Vec<EgressResult<EgressResponse>>>,
         requests: Mutex<Vec<EgressRequest>>,
@@ -631,360 +176,104 @@ mod tests {
         }
     }
 
-    fn allow_all() -> Option<NetworkAccessList> {
-        None
+    fn tool_with_egress(egress: Arc<MockEgress>) -> fetchkit::Tool {
+        fetchkit::Tool::builder()
+            .transport(Arc::new(EgressHttpTransport::new(egress, None)))
+            .build()
     }
 
     #[tokio::test]
     async fn fetches_html_and_converts_to_markdown() {
-        let egress = MockEgress::with_responses(vec![MockEgress::ok(
+        let egress = Arc::new(MockEgress::with_responses(vec![MockEgress::ok(
             200,
             &[("content-type", "text/html; charset=utf-8")],
             "<html><head><title>T</title></head><body><h1>Title</h1><p>Body</p></body></html>",
-        )]);
-        let request = FetchRequest::new("http://93.184.216.34/page").as_markdown();
+        )]));
+        let tool = tool_with_egress(egress.clone());
 
-        let response = fetch_via_egress(&request, &egress, allow_all().as_ref(), None)
+        let response = tool
+            .execute(FetchRequest::new("http://93.184.216.34/page").as_markdown())
             .await
             .unwrap();
 
         assert_eq!(response.status_code, 200);
         assert_eq!(response.format.as_deref(), Some("markdown"));
         assert!(response.content.unwrap().contains("# Title"));
-        assert!(response.word_count.unwrap() > 0);
-    }
-
-    #[tokio::test]
-    async fn html_without_conversion_request_returns_raw() {
-        let egress = MockEgress::with_responses(vec![MockEgress::ok(
-            200,
-            &[("content-type", "text/html")],
-            "<html><body><p>Raw</p></body></html>",
-        )]);
-        let request = FetchRequest::new("http://93.184.216.34/page");
-
-        let response = fetch_via_egress(&request, &egress, allow_all().as_ref(), None)
-            .await
-            .unwrap();
-
-        assert_eq!(response.format.as_deref(), Some("raw"));
-        assert!(response.content.unwrap().contains("<p>Raw</p>"));
+        assert_eq!(egress.requested_urls(), vec!["http://93.184.216.34/page"]);
     }
 
     #[tokio::test]
     async fn follows_redirects_re_sending_each_hop_through_egress() {
-        let egress = MockEgress::with_responses(vec![
+        let egress = Arc::new(MockEgress::with_responses(vec![
             MockEgress::ok(302, &[("location", "http://93.184.216.35/final")], ""),
             MockEgress::ok(200, &[("content-type", "text/plain")], "done"),
-        ]);
-        let request = FetchRequest::new("http://93.184.216.34/start");
+        ]));
+        let tool = tool_with_egress(egress.clone());
 
-        let response = fetch_via_egress(&request, &egress, allow_all().as_ref(), None)
+        let response = tool
+            .execute(FetchRequest::new("http://93.184.216.34/start"))
             .await
             .unwrap();
 
         assert_eq!(response.status_code, 200);
         assert_eq!(response.url, "http://93.184.216.35/final");
-        assert_eq!(response.redirect_chain, vec!["http://93.184.216.34/start"]);
         assert_eq!(
             egress.requested_urls(),
-            vec!["http://93.184.216.34/start", "http://93.184.216.35/final"]
+            vec!["http://93.184.216.34/start", "http://93.184.216.35/final"],
+            "every redirect hop must cross the egress boundary"
         );
     }
 
     #[tokio::test]
-    async fn relative_redirect_location_is_resolved_against_base() {
-        let egress = MockEgress::with_responses(vec![
-            MockEgress::ok(301, &[("location", "/moved/here")], ""),
-            MockEgress::ok(200, &[("content-type", "text/plain")], "moved"),
-        ]);
-        let request = FetchRequest::new("http://93.184.216.34/start");
-
-        let response = fetch_via_egress(&request, &egress, allow_all().as_ref(), None)
-            .await
-            .unwrap();
-
-        assert_eq!(response.url, "http://93.184.216.34/moved/here");
-        assert_eq!(
-            egress.requested_urls(),
-            vec![
-                "http://93.184.216.34/start",
-                "http://93.184.216.34/moved/here"
-            ]
-        );
-    }
-
-    #[tokio::test]
-    async fn redirect_to_non_http_scheme_is_rejected() {
-        let egress = MockEgress::with_responses(vec![MockEgress::ok(
-            302,
-            &[("location", "ftp://93.184.216.34/file")],
-            "",
-        )]);
-        let request = FetchRequest::new("http://93.184.216.34/start");
-
-        let error = fetch_via_egress(&request, &egress, allow_all().as_ref(), None)
-            .await
-            .unwrap_err();
-
-        assert!(
-            matches!(error, FetchError::InvalidUrlScheme),
-            "got: {error}"
-        );
-    }
-
-    #[tokio::test]
-    async fn redirect_loop_stops_after_max_redirects() {
-        // Every hop redirects back to itself; the loop must terminate.
-        let hop = || MockEgress::ok(302, &[("location", "http://93.184.216.34/loop")], "");
-        let egress = MockEgress::with_responses((0..=MAX_REDIRECTS + 1).map(|_| hop()).collect());
-        let request = FetchRequest::new("http://93.184.216.34/loop");
-
-        let error = fetch_via_egress(&request, &egress, allow_all().as_ref(), None)
-            .await
-            .unwrap_err();
-
-        assert!(
-            error.to_string().contains("too many redirects"),
-            "got: {error}"
-        );
-        assert_eq!(egress.requested_urls().len(), MAX_REDIRECTS + 1);
-    }
-
-    #[tokio::test]
-    async fn network_access_list_is_attached_to_every_egress_request() {
-        // The egress boundary is the final enforcement point, so the merged
-        // list must ride on each hop's EgressRequest, not just the first.
-        let egress = MockEgress::with_responses(vec![
-            MockEgress::ok(302, &[("location", "http://93.184.216.35/final")], ""),
-            MockEgress::ok(200, &[("content-type", "text/plain")], "done"),
-        ]);
-        let acl = NetworkAccessList::allow_only(["93.184.216.34", "93.184.216.35"]);
-        let request = FetchRequest::new("http://93.184.216.34/start");
-
-        fetch_via_egress(&request, &egress, Some(&acl), None)
-            .await
-            .unwrap();
-
-        let requests = egress.requests.lock().unwrap();
-        assert_eq!(requests.len(), 2);
-        for sent in requests.iter() {
-            assert_eq!(sent.network_access.as_ref(), Some(&acl));
-        }
-    }
-
-    #[tokio::test]
-    async fn redirect_to_host_outside_access_list_is_blocked() {
-        let egress = MockEgress::with_responses(vec![MockEgress::ok(
-            302,
-            &[("location", "http://93.184.216.35/elsewhere")],
-            "",
-        )]);
-        let acl = NetworkAccessList::allow_only(["93.184.216.34"]);
-        let request = FetchRequest::new("http://93.184.216.34/start");
-
-        let error = fetch_via_egress(&request, &egress, Some(&acl), None)
-            .await
-            .unwrap_err();
-
-        assert!(
-            error
-                .to_string()
-                .contains("blocked by network access policy"),
-            "got: {error}"
-        );
-        // Only the first hop reached egress.
-        assert_eq!(egress.requested_urls().len(), 1);
-    }
-
-    #[tokio::test]
-    async fn redirect_to_private_address_is_blocked_by_ssrf_validation() {
-        let egress = MockEgress::with_responses(vec![MockEgress::ok(
-            302,
-            &[("location", "http://169.254.169.254/latest/meta-data/")],
-            "",
-        )]);
-        let request = FetchRequest::new("http://93.184.216.34/start");
-
-        let error = fetch_via_egress(&request, &egress, allow_all().as_ref(), None)
-            .await
-            .unwrap_err();
-
-        assert!(matches!(error, FetchError::BlockedUrl), "got: {error}");
-    }
-
-    #[tokio::test]
-    async fn invalid_scheme_and_malformed_urls_report_invalid_url() {
-        let egress = MockEgress::with_responses(vec![]);
-
-        for url in ["ftp://93.184.216.34/file", "not a url"] {
-            let request = FetchRequest::new(url);
-            let error = fetch_via_egress(&request, &egress, allow_all().as_ref(), None)
-                .await
-                .unwrap_err();
-            assert!(
-                matches!(error, FetchError::InvalidUrlScheme),
-                "{url}: got {error}"
-            );
-        }
-    }
-
-    #[tokio::test]
-    async fn egress_denial_maps_to_system_policy_error() {
-        let egress = MockEgress::with_responses(vec![Err(EgressError::NetworkAccessDenied {
-            url: "http://93.184.216.34/x".to_string(),
-        })]);
-        let request = FetchRequest::new("http://93.184.216.34/x");
-
-        let error = fetch_via_egress(&request, &egress, allow_all().as_ref(), None)
-            .await
-            .unwrap_err();
-
-        assert!(
-            error.to_string().contains("blocked by system policy"),
-            "got: {error}"
-        );
-    }
-
-    #[tokio::test]
-    async fn head_request_returns_metadata_without_content() {
-        let egress = MockEgress::with_responses(vec![MockEgress::ok(
-            200,
-            &[("content-type", "text/html"), ("content-length", "1234")],
-            "",
-        )]);
-        let request = FetchRequest::new("http://93.184.216.34/page").method(HttpMethod::Head);
-
-        let response = fetch_via_egress(&request, &egress, allow_all().as_ref(), None)
-            .await
-            .unwrap();
-
-        assert_eq!(response.method.as_deref(), Some("HEAD"));
-        assert_eq!(response.size, Some(1234));
-        assert!(response.content.is_none());
-    }
-
-    #[tokio::test]
-    async fn binary_content_returns_metadata_with_error() {
-        let egress = MockEgress::with_responses(vec![MockEgress::ok(
-            200,
-            &[("content-type", "image/png")],
-            "\u{1}\u{2}",
-        )]);
-        let request = FetchRequest::new("http://93.184.216.34/image.png");
-
-        let response = fetch_via_egress(&request, &egress, allow_all().as_ref(), None)
-            .await
-            .unwrap();
-
-        assert!(response.error.unwrap().contains("Binary content"));
-        assert!(response.content.is_none());
-        assert_eq!(response.filename.as_deref(), Some("image.png"));
-    }
-
-    #[tokio::test]
-    async fn save_to_file_accepts_binary_and_writes_through_saver() {
-        use fetchkit::file_saver::{FileSaveError, SaveResult};
-
-        struct RecordingSaver {
-            saved: Mutex<Option<(String, Vec<u8>)>>,
-        }
-
-        #[async_trait]
-        impl FileSaver for RecordingSaver {
-            async fn save(&self, path: &str, bytes: &[u8]) -> Result<SaveResult, FileSaveError> {
-                *self.saved.lock().unwrap() = Some((path.to_string(), bytes.to_vec()));
-                Ok(SaveResult {
-                    path: path.to_string(),
-                    bytes_written: bytes.len() as u64,
-                })
-            }
-        }
-
-        let egress = MockEgress::with_responses(vec![MockEgress::ok(
-            200,
-            &[("content-type", "application/pdf")],
-            "%PDF-fake",
-        )]);
-        let saver = RecordingSaver {
-            saved: Mutex::new(None),
-        };
-        let request = FetchRequest::new("http://93.184.216.34/doc.pdf").save_to_file("doc.pdf");
-
-        let response = fetch_via_egress(&request, &egress, allow_all().as_ref(), Some(&saver))
-            .await
-            .unwrap();
-
-        assert_eq!(response.saved_path.as_deref(), Some("doc.pdf"));
-        assert_eq!(response.bytes_written, Some(9));
-        assert!(response.content.is_none());
-        let saved = saver.saved.lock().unwrap().clone().unwrap();
-        assert_eq!(saved.1, b"%PDF-fake");
-    }
-
-    #[tokio::test]
-    async fn body_is_truncated_at_size_limit() {
-        let egress = MockEgress::with_responses(vec![MockEgress::ok(
-            200,
-            &[("content-type", "text/plain")],
-            "0123456789",
-        )]);
-        let request = FetchRequest::new("http://93.184.216.34/big");
-
-        let response =
-            fetch_via_egress_with_limit(&request, &egress, allow_all().as_ref(), None, 4)
-                .await
-                .unwrap();
-
-        assert_eq!(response.truncated, Some(true));
-        let content = response.content.unwrap();
-        assert!(content.starts_with("0123"));
-        assert!(content.contains("truncated"));
-    }
-
-    #[tokio::test]
-    async fn not_modified_304_passes_through() {
-        let egress =
-            MockEgress::with_responses(vec![MockEgress::ok(304, &[("etag", "\"abc\"")], "")]);
-        let request = FetchRequest::new("http://93.184.216.34/page").if_none_match("\"abc\"");
-
-        let response = fetch_via_egress(&request, &egress, allow_all().as_ref(), None)
-            .await
-            .unwrap();
-
-        assert_eq!(response.status_code, 304);
-        assert_eq!(response.etag.as_deref(), Some("\"abc\""));
-        assert!(response.content.is_none());
-    }
-
-    #[tokio::test]
-    async fn conditional_headers_are_forwarded() {
-        let egress = MockEgress::with_responses(vec![MockEgress::ok(
+    async fn forwards_request_metadata_to_egress() {
+        let egress = Arc::new(MockEgress::with_responses(vec![MockEgress::ok(
             200,
             &[("content-type", "text/plain")],
             "ok",
-        )]);
-        let request = FetchRequest::new("http://93.184.216.34/page")
-            .if_none_match("\"etag1\"")
-            .if_modified_since("Wed, 21 Oct 2015 07:28:00 GMT");
+        )]));
+        let acl = NetworkAccessList::allow_only(["93.184.216.34"]);
+        let tool = fetchkit::Tool::builder()
+            .transport(Arc::new(EgressHttpTransport::new(
+                egress.clone(),
+                Some(acl.clone()),
+            )))
+            .build();
 
-        fetch_via_egress(&request, &egress, allow_all().as_ref(), None)
+        tool.execute(FetchRequest::new("http://93.184.216.34/meta"))
             .await
             .unwrap();
 
         let requests = egress.requests.lock().unwrap();
-        assert_eq!(
-            requests[0].headers.get("if-none-match").map(String::as_str),
-            Some("\"etag1\"")
+        let request = &requests[0];
+        assert_eq!(request.method, "GET");
+        assert_eq!(request.kind, EgressRequestKind::Capability);
+        assert_eq!(request.signing, EgressSigning::PlatformDefault);
+        assert_eq!(request.network_access, Some(acl));
+        assert!(
+            request.headers.contains_key("user-agent")
+                || request.headers.contains_key("User-Agent"),
+            "fetchkit headers must be forwarded, got: {:?}",
+            request.headers.keys().collect::<Vec<_>>()
         );
-        assert_eq!(
-            requests[0]
-                .headers
-                .get("if-modified-since")
-                .map(String::as_str),
-            Some("Wed, 21 Oct 2015 07:28:00 GMT")
+    }
+
+    #[tokio::test]
+    async fn egress_denial_surfaces_as_policy_error() {
+        let egress = Arc::new(MockEgress::with_responses(vec![Err(
+            EgressError::NetworkAccessDenied {
+                url: "http://93.184.216.34/blocked".to_string(),
+            },
+        )]));
+        let tool = tool_with_egress(egress);
+
+        let error = tool
+            .execute(FetchRequest::new("http://93.184.216.34/blocked"))
+            .await
+            .unwrap_err();
+
+        assert!(
+            error.to_string().contains("blocked by network policy"),
+            "expected policy denial, got: {error}"
         );
-        assert_eq!(requests[0].kind, EgressRequestKind::Capability);
-        assert_eq!(requests[0].signing, EgressSigning::PlatformDefault);
     }
 }

--- a/specs/fetchkit.md
+++ b/specs/fetchkit.md
@@ -8,18 +8,19 @@ External library ([github.com/everruns/fetchkit](https://github.com/everruns/fet
 - `WebFetchTool` wraps `fetchkit::Tool` — delegates schema, description, llmtxt, and execution
 - All metadata (description, system prompt, input schema) comes from `fetchkit::ToolBuilder`, not constants
 - **Egress path (default in the runtime)**: when `ToolContext.egress_service`
-  is present, transport goes through `EgressService`
-  (`crates/core/src/capabilities/web_fetch_egress.rs`). fetchkit acts as the
-  request/response adapter (schema + HTML→markdown/text conversion); SSRF uses
-  `validate_url_dns_pinned` with per-hop redirect re-validation; the network
-  access list and system allowlist are enforced at the egress boundary.
-  Specialized fetchers (GitHub, Wikipedia, arXiv, …) do not apply on this path
-  — they own private HTTP clients inside fetchkit. Restoring them requires
-  upstream transport injection in fetchkit.
-- **Legacy direct path** (no egress service in context, e.g. embedded hosts):
+  is present, fetchkit's `HttpTransport` (fetchkit >= 0.4) is injected via
+  `ToolBuilder::transport` with `EgressHttpTransport`
+  (`crates/core/src/capabilities/web_fetch_egress.rs`). fetchkit keeps the
+  whole pipeline — specialized fetchers (GitHub, Wikipedia, arXiv, …), SSRF
+  via `DnsPolicy` (resolve-then-check; pinned addresses forwarded to
+  `EgressRequest.pinned_addrs`), per-hop redirect validation, bot-auth
+  signing, body caps — while every HTTP hop crosses the egress boundary,
+  which enforces the network access list and system allowlist.
+- **Direct path** (no egress service in context, e.g. embedded hosts):
   fetchkit owns transport; SSRF via `DnsPolicy::block_private_ips()` (blocks
-  loopback, RFC1918, link-local, cloud metadata); system allowlist enforced as
-  a pre-flight check in the tool.
+  loopback, RFC1918, link-local, cloud metadata).
+- The system allowlist and network access list are pre-checked on the initial
+  URL in the tool for clear user-facing errors on both paths.
 - See `crates/core/src/capabilities/web_fetch.rs`
 
 ## File download (`FileSaver`)
@@ -52,7 +53,7 @@ Server-wide via environment variables:
 | `BOT_AUTH_AGENT_FQDN` | no | FQDN for `Signature-Agent` header (key discovery) |
 | `BOT_AUTH_VALIDITY_SECS` | no | signature validity window, default 300 |
 
-When `BOT_AUTH_SIGNING_KEY_SEED` is set, `web_fetch` requests on the **legacy direct path** are signed. The egress path requests `EgressSigning::PlatformDefault` instead; fetchkit's signer is not applied there because signing policy belongs behind `EgressService` so web_fetch, LLM drivers, and integrations share the same outbound signing path (a platform egress signer does not exist yet — see `specs/egress.md`).
+When `BOT_AUTH_SIGNING_KEY_SEED` is set, all `web_fetch` requests are signed by fetchkit on both paths: signing happens before each hop is handed to the transport (re-signed per redirect hop), so it applies equally when the hop crosses the egress boundary. Egress-routed hops additionally request `EgressSigning::PlatformDefault`, a no-op until a platform egress signer exists; when one lands, signing policy should consolidate behind `EgressService` so web_fetch, LLM drivers, and integrations share one outbound signing path (see `specs/egress.md`).
 
 Generate a seed: `python3 -c "import os, base64; print(base64.urlsafe_b64encode(os.urandom(32)).rstrip(b'=').decode())"`
 

--- a/specs/system-allowlist.md
+++ b/specs/system-allowlist.md
@@ -92,15 +92,16 @@ allowlist also lists it. The system allowlist always wins.
 ### fetchkit / web_fetch
 
 When `ToolContext.egress_service` is present (always true in the runtime),
-`web_fetch` routes through the egress boundary
-(`crates/core/src/capabilities/web_fetch_egress.rs`), which enforces the
-allowlist like any other egress traffic; an egress denial surfaces as the same
-"Endpoint blocked by system policy: …" tool error.
+`web_fetch` injects the egress boundary as fetchkit's HTTP transport
+(`crates/core/src/capabilities/web_fetch_egress.rs`), so the allowlist is
+enforced at the boundary for every hop like any other egress traffic.
 
-On the legacy direct path (contexts without an egress service, e.g. embedded
-hosts), fetchkit still owns the HTTP client and the allowlist is enforced as an
-explicit pre-flight check in `crates/core/src/capabilities/web_fetch.rs` before
-any request is made.
+On both paths the tool pre-checks the initial URL and returns the distinct
+"Endpoint blocked by system policy: …" error before any request is made
+(`crates/core/src/capabilities/web_fetch.rs`). A denial raised at the egress
+boundary itself (e.g. a redirect hop) surfaces as "Outbound request blocked by
+network policy: …". On the direct path (contexts without an egress service,
+e.g. embedded hosts) the pre-flight check is the only enforcement.
 
 ### Operator responsibility
 


### PR DESCRIPTION
## What
Replace the egress path's hand-rolled fetch pipeline with fetchkit 0.4's transport injection: `EgressHttpTransport` implements `fetchkit::HttpTransport` over `EgressService`, injected per execution via `ToolBuilder::transport` when `ToolContext.egress_service` is present. Bumps fetchkit `=0.2.0` → `=0.4.0`. Net **−721 lines**.

## Why
#2118 migrated web_fetch transport behind the egress boundary but had to bypass fetchkit's clients, reimplementing ~990 lines of redirect/binary/truncation logic and losing the specialized fetchers — its docs noted "Restoring them requires upstream transport injection in fetchkit." That upstream API shipped in fetchkit 0.4.0 (everruns/fetchkit#135). This PR adopts it: fetchkit keeps its whole pipeline (specialized fetchers GitHub/Wikipedia/arXiv/…, DNS policy, per-hop redirect validation, body caps, bot-auth signing) while every HTTP hop still crosses the egress boundary.

## How
- `web_fetch_egress.rs`: 990-line reimplementation → ~115-line `EgressHttpTransport` adapter (+ tests). Maps `TransportRequest` → `EgressRequest` (kind=Capability, signing=PlatformDefault, per-hop `network_access`, fetchkit's resolved `pinned_addrs` → `EgressRequest.pinned_addrs` for TM-TOOL-018 pinning) and streams the response body back.
- `web_fetch.rs`: stores the `ToolBuilder` template; per execution builds an egress-routed Tool when the context has an egress service, direct Tool otherwise. Both paths now share one execution flow (incl. `save_to_file`).
- System-allowlist + ACL pre-flight checks on the initial URL restored on **both** paths for distinct user-facing errors (`Endpoint blocked by system policy…` / `URL blocked by network access policy…`); the egress boundary remains the final enforcement point on every hop.
- Fixes a #2118 message regression: egress denials no longer use the pre-#2113 "deployment's system allowlist" wording (now: `Outbound request blocked by network policy: {url}`).
- Behavior changes vs #2118's egress path: specialized fetchers restored; bot-auth signing restored (fetchkit signs each hop before it crosses the boundary — #2118 had silently dropped signing on the egress path); SSRF resolve-then-check now via fetchkit `DnsPolicy` (same protections as `validate_url_dns_pinned`: loopback/RFC1918/link-local/metadata blocked, resolve-then-check with pinning).
- Specs updated: `specs/fetchkit.md`, `specs/system-allowlist.md`.

## Risk
- Medium: replaces the egress-path fetch pipeline. Mitigated by keeping all #2118 egress-path tests green unchanged (routing, ACL denial, SSRF block, save_to_file via egress) plus new adapter tests (markdown conversion, per-hop redirect crossing, request metadata mapping, policy-denial mapping).
- `respect_proxy_env` is intentionally not forwarded — outbound proxy policy is host-owned at the egress boundary.

## Security
- Threat categories reviewed: TM-API-008 (SSRF — fetchkit DnsPolicy resolve-then-check + pinned addrs forwarded to egress client), TM-AGENT-018 (outbound URL filtering — ACL + system allowlist enforced at egress per hop, pre-flight retained), TM-TOOL-018 (DNS pinning TOCTOU — pinned addrs cross the boundary), TM-DOS-001/003 (body caps — owned by fetchkit, unchanged), TM-AGENT-013 (exfiltration — egress remains the single boundary).
- Findings: none. Enforcement is strictly equal-or-stronger than #2118 (same boundary checks, plus restored per-hop bot-auth signing). THREAT comments updated at the new mediation points.

## Validation
- `cargo test -p everruns-core --all-features` — green (incl. all #2118 egress-path tests unchanged + 4 new adapter tests)
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `bash scripts/lib/pre-push.sh` — 9/9 pass
- Smoke justification: the egress path is covered end-to-end at the tool boundary by the existing #2118 tests (mock egress through `execute_with_context`, including redirects and file saving); no API/config/migration surface changed.

## Follow-ups
- Consolidate signing policy behind `EgressService` (platform egress signer) so web_fetch, LLM drivers, and integrations share one signing path — pre-existing direction, noted in `specs/fetchkit.md`/`specs/egress.md`; deferred because no platform signer exists yet.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (tool contract unchanged; direct path unchanged)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_019s8CCGt99LUYpALmH9iYFq)_