### PR TITLE
feat(ui): full-page declarative capability editor with MCP, skills, files UI

### DIFF
--- a/apps/ui/src/__tests__/declarative-capability-editor.test.tsx
+++ b/apps/ui/src/__tests__/declarative-capability-editor.test.tsx
@@ -27,8 +27,8 @@ describe("declarative capability form conversions", () => {
       transportType: "http",
       url: " https://mcp.example.com/v1 ",
       headers: [
-        { key: "X-Env", value: "prod" },
-        { key: "", value: "ignored" },
+        { id: "h1", key: "X-Env", value: "prod" },
+        { id: "h2", key: "  ", value: "ignored" },
       ],
       authMode: "oauth",
       oauthProviderId: "atlassian",
@@ -54,7 +54,7 @@ describe("declarative capability form conversions", () => {
       transportType: "stdio",
       command: "npx",
       args: "-y\n@modelcontextprotocol/server-filesystem\n",
-      env: [{ key: "ROOT", value: "/tmp" }],
+      env: [{ id: "e1", key: "ROOT", value: "/tmp" }],
     };
 
     expect(entriesToMcpServers([entry])).toEqual({

--- a/apps/ui/src/__tests__/declarative-capability-editor.test.tsx
+++ b/apps/ui/src/__tests__/declarative-capability-editor.test.tsx
@@ -1,0 +1,197 @@
+import { useState } from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { McpServersEditor } from "@/components/capabilities/mcp-servers-editor";
+import { SkillsEditor } from "@/components/capabilities/skills-editor";
+import { FilesEditor } from "@/components/capabilities/files-editor";
+import {
+  definitionToFormState,
+  entriesToFiles,
+  entriesToMcpServers,
+  entriesToSkills,
+  formStateToDefinition,
+  mcpServersToEntries,
+  newFileEntry,
+  newMcpServerEntry,
+  newSkillEntry,
+  type FileEntry,
+  type McpServerEntry,
+  type SkillEntry,
+} from "@/components/capabilities/declarative-form-types";
+import type { DeclarativeCapabilityDefinition } from "@/lib/api/types";
+
+describe("declarative capability form conversions", () => {
+  it("serializes an HTTP MCP server with headers and drops empty fields", () => {
+    const entry: McpServerEntry = {
+      ...newMcpServerEntry(),
+      name: "atlassian",
+      transportType: "http",
+      url: " https://mcp.example.com/v1 ",
+      headers: [
+        { key: "X-Env", value: "prod" },
+        { key: "", value: "ignored" },
+      ],
+      authMode: "oauth",
+      oauthProviderId: "atlassian",
+      toolDiscovery: false,
+    };
+
+    expect(entriesToMcpServers([entry])).toEqual({
+      atlassian: {
+        type: "http",
+        url: "https://mcp.example.com/v1",
+        headers: { "X-Env": "prod" },
+        auth_mode: "oauth",
+        oauth_provider_id: "atlassian",
+        tool_discovery: false,
+      },
+    });
+  });
+
+  it("serializes a stdio MCP server with args and env", () => {
+    const entry: McpServerEntry = {
+      ...newMcpServerEntry(),
+      name: "fs",
+      transportType: "stdio",
+      command: "npx",
+      args: "-y\n@modelcontextprotocol/server-filesystem\n",
+      env: [{ key: "ROOT", value: "/tmp" }],
+    };
+
+    expect(entriesToMcpServers([entry])).toEqual({
+      fs: {
+        type: "stdio",
+        command: "npx",
+        args: ["-y", "@modelcontextprotocol/server-filesystem"],
+        env: { ROOT: "/tmp" },
+      },
+    });
+  });
+
+  it("omits unnamed MCP servers and returns undefined when none remain", () => {
+    expect(entriesToMcpServers([{ ...newMcpServerEntry() }])).toBeUndefined();
+  });
+
+  it("round-trips MCP servers through parse and serialize", () => {
+    const servers = {
+      remote: { type: "http", url: "https://a.example/mcp", headers: { Authorization: "x" } },
+      local: { type: "stdio", command: "run", args: ["--flag"], tool_discovery: false },
+    };
+    expect(entriesToMcpServers(mcpServersToEntries(servers))).toEqual(servers);
+  });
+
+  it("serializes skills and filters blank bundled files", () => {
+    const skill: SkillEntry = {
+      ...newSkillEntry(),
+      name: "research-helper",
+      description: "Use for research",
+      instructions: "Do the thing",
+      files: [
+        { id: "a", path: "ref.md", content: "body" },
+        { id: "b", path: "  ", content: "skipme" },
+      ],
+      userInvocable: true,
+      disableModelInvocation: true,
+    };
+
+    expect(entriesToSkills([skill])).toEqual([
+      {
+        name: "research-helper",
+        description: "Use for research",
+        instructions: "Do the thing",
+        files: [{ path: "ref.md", content: "body" }],
+        user_invocable: true,
+        disable_model_invocation: true,
+      },
+    ]);
+  });
+
+  it("serializes files and skips blank paths", () => {
+    const files: FileEntry[] = [
+      { ...newFileEntry(), path: "/docs/README.md", content: "hi", access: "readwrite" },
+      { ...newFileEntry(), path: "   ", content: "skip" },
+    ];
+    expect(entriesToFiles(files)).toEqual([
+      { path: "/docs/README.md", content: "hi", access: "readwrite" },
+    ]);
+  });
+
+  it("round-trips a full definition through form state", () => {
+    const definition: DeclarativeCapabilityDefinition = {
+      name: "research_pack",
+      display_name: "Research Pack",
+      description: "Research helpers",
+      category: "Declarative",
+      icon: "puzzle",
+      system_prompt: "You are helpful.",
+      mcp_servers: { remote: { type: "http", url: "https://a.example/mcp" } },
+      skills: [
+        {
+          name: "helper",
+          description: "d",
+          instructions: "i",
+          files: [],
+          user_invocable: true,
+          disable_model_invocation: false,
+        },
+      ],
+      files: [{ path: "/a.txt", content: "x", access: "readonly" }],
+      dependencies: ["session_file_system", "skills"],
+      risk_level: "medium",
+    };
+
+    expect(formStateToDefinition(definitionToFormState(definition))).toEqual(definition);
+  });
+});
+
+function McpHarness() {
+  const [servers, setServers] = useState<McpServerEntry[]>([]);
+  return (
+    <div>
+      <span data-testid="count">{servers.length}</span>
+      <McpServersEditor servers={servers} onChange={setServers} />
+    </div>
+  );
+}
+
+describe("declarative capability editor interactions", () => {
+  it("adds and removes an MCP server", () => {
+    render(<McpHarness />);
+    expect(screen.getByTestId("count").textContent).toBe("0");
+
+    fireEvent.click(screen.getByRole("button", { name: /add mcp server/i }));
+    expect(screen.getByTestId("count").textContent).toBe("1");
+
+    fireEvent.click(screen.getByRole("button", { name: /remove server/i }));
+    expect(screen.getByTestId("count").textContent).toBe("0");
+  });
+
+  it("adds a skill and a file row", () => {
+    function SkillHarness() {
+      const [skills, setSkills] = useState<SkillEntry[]>([]);
+      return (
+        <div>
+          <span data-testid="skill-count">{skills.length}</span>
+          <SkillsEditor skills={skills} onChange={setSkills} />
+        </div>
+      );
+    }
+    function FileHarness() {
+      const [files, setFiles] = useState<FileEntry[]>([]);
+      return (
+        <div>
+          <span data-testid="file-count">{files.length}</span>
+          <FilesEditor files={files} onChange={setFiles} />
+        </div>
+      );
+    }
+
+    const { unmount } = render(<SkillHarness />);
+    fireEvent.click(screen.getByRole("button", { name: /add skill/i }));
+    expect(screen.getByTestId("skill-count").textContent).toBe("1");
+    unmount();
+
+    render(<FileHarness />);
+    fireEvent.click(screen.getByRole("button", { name: /add file/i }));
+    expect(screen.getByTestId("file-count").textContent).toBe("1");
+  });
+});

--- a/apps/ui/src/app/(main)/capabilities/declarative/[declarativeId]/page.tsx
+++ b/apps/ui/src/app/(main)/capabilities/declarative/[declarativeId]/page.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { use } from "react";
+import { useDeclarativeCapability, usePageTitle } from "@/hooks";
+import { Skeleton } from "@/components/ui/skeleton";
+import { ResourceNotFound } from "@/components/resource-not-found";
+import { DeclarativeCapabilityForm } from "@/components/capabilities/declarative-capability-form";
+
+export default function EditDeclarativeCapabilityPage({
+  params,
+}: {
+  params: Promise<{ declarativeId: string }>;
+}) {
+  const { declarativeId } = use(params);
+  const { data: capability, isLoading, error } = useDeclarativeCapability(declarativeId);
+  usePageTitle(capability?.display_name ?? capability?.name ?? null, "Edit Capability");
+
+  if (isLoading) {
+    return (
+      <div className="container mx-auto p-6">
+        <Skeleton className="h-4 w-24 mb-6" />
+        <Skeleton className="h-8 w-1/3 mb-4" />
+        <Skeleton className="h-64 w-full" />
+      </div>
+    );
+  }
+
+  if (error || !capability) {
+    return (
+      <ResourceNotFound
+        title={error ? "Capability unavailable" : "Capability not found"}
+        description={
+          error
+            ? `The capability could not be loaded: ${error.message}`
+            : "This declarative capability may have been deleted or moved to another organization."
+        }
+        backHref="/capabilities"
+        backLabel="Back to capabilities"
+        resourceId={declarativeId}
+      />
+    );
+  }
+
+  return (
+    <DeclarativeCapabilityForm
+      mode="edit"
+      id={capability.id}
+      initialDefinition={capability.definition}
+    />
+  );
+}

--- a/apps/ui/src/app/(main)/capabilities/declarative/new/page.tsx
+++ b/apps/ui/src/app/(main)/capabilities/declarative/new/page.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import { usePageTitle } from "@/hooks";
+import { DeclarativeCapabilityForm } from "@/components/capabilities/declarative-capability-form";
+
+export default function NewDeclarativeCapabilityPage() {
+  usePageTitle("New Declarative Capability");
+  return <DeclarativeCapabilityForm mode="create" />;
+}

--- a/apps/ui/src/app/(main)/capabilities/page.tsx
+++ b/apps/ui/src/app/(main)/capabilities/page.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import { useMemo, useState, type FormEvent } from "react";
+import { useMemo, useState } from "react";
 import {
   useCapabilities,
-  useCreateDeclarativeCapability,
   useDeclarativeCapabilities,
   useDeleteDeclarativeCapability,
   usePageTitle,
@@ -12,18 +11,9 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Textarea } from "@/components/ui/textarea";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from "@/components/ui/dialog";
 import Link from "next/link";
-import { CircleOff, Search as SearchIcon, Bot, Layers, X, Plus } from "lucide-react";
+import { CircleOff, Search as SearchIcon, Bot, Layers, X, Plus, Pencil } from "lucide-react";
 import { CopyButton } from "@/components/ui/copy-button";
 import type { Capability, CapabilityStatus, DeclarativeCapability } from "@/lib/api/types";
 import { getCapabilityIcon } from "@/lib/capability-icons";
@@ -50,125 +40,14 @@ function getStatusLabel(status: CapabilityStatus): string {
   }
 }
 
-function DeclarativeCapabilityDialog() {
-  const createCapability = useCreateDeclarativeCapability();
-  const [open, setOpen] = useState(false);
-  const [name, setName] = useState("");
-  const [displayName, setDisplayName] = useState("");
-  const [description, setDescription] = useState("");
-  const [systemPrompt, setSystemPrompt] = useState("");
-  const [mcpServers, setMcpServers] = useState("{}");
-  const [error, setError] = useState<string | null>(null);
-
-  const handleSubmit = async (event: FormEvent) => {
-    event.preventDefault();
-    setError(null);
-
-    let parsedMcpServers: Record<string, unknown> | undefined;
-    try {
-      parsedMcpServers = mcpServers.trim() ? JSON.parse(mcpServers) : undefined;
-    } catch {
-      setError("MCP servers must be valid JSON.");
-      return;
-    }
-
-    await createCapability.mutateAsync({
-      definition: {
-        name,
-        display_name: displayName.trim() || undefined,
-        description,
-        category: "Declarative",
-        icon: "puzzle",
-        system_prompt: systemPrompt.trim() || undefined,
-        mcp_servers:
-          parsedMcpServers && Object.keys(parsedMcpServers).length > 0
-            ? parsedMcpServers
-            : undefined,
-        dependencies: ["session_file_system", "skills"],
-        risk_level: "low",
-      },
-    });
-
-    setOpen(false);
-    setName("");
-    setDisplayName("");
-    setDescription("");
-    setSystemPrompt("");
-    setMcpServers("{}");
-  };
-
+function NewDeclarativeButton() {
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
-      <DialogTrigger asChild>
-        <Button type="button" size="sm">
-          <Plus className="mr-1.5 h-4 w-4" />
-          New Declarative
-        </Button>
-      </DialogTrigger>
-      <DialogContent className="max-w-2xl">
-        <DialogHeader>
-          <DialogTitle>New Declarative Capability</DialogTitle>
-        </DialogHeader>
-        <form className="space-y-4" onSubmit={handleSubmit}>
-          <div className="grid gap-2">
-            <Label htmlFor="declarative-name">Unique name</Label>
-            <Input
-              id="declarative-name"
-              placeholder="research_pack"
-              value={name}
-              onChange={(event) => setName(event.target.value.toLowerCase())}
-              required
-            />
-          </div>
-          <div className="grid gap-2">
-            <Label htmlFor="declarative-display-name">Display name</Label>
-            <Input
-              id="declarative-display-name"
-              placeholder="Research Pack"
-              value={displayName}
-              onChange={(event) => setDisplayName(event.target.value)}
-            />
-          </div>
-          <div className="grid gap-2">
-            <Label htmlFor="declarative-description">Description</Label>
-            <Input
-              id="declarative-description"
-              value={description}
-              onChange={(event) => setDescription(event.target.value)}
-              required
-            />
-          </div>
-          <div className="grid gap-2">
-            <Label htmlFor="declarative-prompt">System Prompt</Label>
-            <Textarea
-              id="declarative-prompt"
-              value={systemPrompt}
-              onChange={(event) => setSystemPrompt(event.target.value)}
-              rows={6}
-            />
-          </div>
-          <div className="grid gap-2">
-            <Label htmlFor="declarative-mcp">MCP Servers JSON</Label>
-            <Textarea
-              id="declarative-mcp"
-              value={mcpServers}
-              onChange={(event) => setMcpServers(event.target.value)}
-              rows={5}
-              className="font-mono text-xs"
-            />
-          </div>
-          {error && <p className="text-sm text-destructive">{error}</p>}
-          <div className="flex justify-end gap-2">
-            <Button type="button" variant="outline" onClick={() => setOpen(false)}>
-              Cancel
-            </Button>
-            <Button type="submit" disabled={createCapability.isPending || !name || !description}>
-              {createCapability.isPending ? "Creating..." : "Create"}
-            </Button>
-          </div>
-        </form>
-      </DialogContent>
-    </Dialog>
+    <Link href="/capabilities/declarative/new">
+      <Button type="button" size="sm">
+        <Plus className="mr-1.5 h-4 w-4" />
+        New Declarative
+      </Button>
+    </Link>
   );
 }
 
@@ -177,26 +56,34 @@ function DeclarativeCapabilityRow({ capability }: { capability: DeclarativeCapab
   const deleteCapability = useDeleteDeclarativeCapability();
   return (
     <div className="flex items-center justify-between gap-3 border p-3">
-      <div className="min-w-0">
+      <Link href={`/capabilities/declarative/${capability.id}`} className="min-w-0 flex-1 group">
         <div className="flex items-center gap-2">
-          <p className="font-medium truncate">
+          <p className="font-medium truncate group-hover:underline">
             {capability.display_name ?? localizedCapabilityName(capability, locale)}
           </p>
-          <CopyButton value={capability.capability_id} />
         </div>
         <p className="text-sm text-muted-foreground line-clamp-1">
           {localizedCapabilityDescription(capability, locale)}
         </p>
+      </Link>
+      <div className="flex items-center gap-2 shrink-0">
+        <CopyButton value={capability.capability_id} />
+        <Link href={`/capabilities/declarative/${capability.id}`}>
+          <Button type="button" variant="outline" size="sm">
+            <Pencil className="mr-1.5 h-3.5 w-3.5" />
+            Edit
+          </Button>
+        </Link>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => deleteCapability.mutate(capability.id)}
+          disabled={deleteCapability.isPending}
+        >
+          Archive
+        </Button>
       </div>
-      <Button
-        type="button"
-        variant="outline"
-        size="sm"
-        onClick={() => deleteCapability.mutate(capability.id)}
-        disabled={deleteCapability.isPending}
-      >
-        Archive
-      </Button>
     </div>
   );
 }
@@ -427,7 +314,7 @@ export default function CapabilitiesPage() {
               : formatCountLabel(totalCount, "capability", "capabilities")}
           </span>
         </div>
-        <DeclarativeCapabilityDialog />
+        <NewDeclarativeButton />
       </div>
 
       {filteredDeclarative.length > 0 && (

--- a/apps/ui/src/components/capabilities/declarative-capability-form.tsx
+++ b/apps/ui/src/components/capabilities/declarative-capability-form.tsx
@@ -1,0 +1,234 @@
+"use client";
+
+import { useMemo, useState, type FormEvent } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Badge } from "@/components/ui/badge";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { ArrowLeft } from "lucide-react";
+import type { DeclarativeCapabilityDefinition } from "@/lib/api/types";
+import { useCreateDeclarativeCapability, useUpdateDeclarativeCapability } from "@/hooks";
+import { McpServersEditor } from "./mcp-servers-editor";
+import { SkillsEditor } from "./skills-editor";
+import { FilesEditor } from "./files-editor";
+import {
+  definitionToFormState,
+  formStateToDefinition,
+  type DeclarativeFormState,
+} from "./declarative-form-types";
+
+function TabCount({ count }: { count: number }) {
+  if (count === 0) return null;
+  return (
+    <Badge variant="secondary" className="ml-1.5 h-4 px-1.5 text-[10px]">
+      {count}
+    </Badge>
+  );
+}
+
+export function DeclarativeCapabilityForm({
+  mode,
+  id,
+  initialDefinition,
+}: {
+  mode: "create" | "edit";
+  id?: string;
+  initialDefinition?: DeclarativeCapabilityDefinition;
+}) {
+  const router = useRouter();
+  const createCapability = useCreateDeclarativeCapability();
+  const updateCapability = useUpdateDeclarativeCapability();
+
+  const [state, setState] = useState<DeclarativeFormState>(() =>
+    definitionToFormState(initialDefinition),
+  );
+  const [tab, setTab] = useState("general");
+  const [error, setError] = useState<string | null>(null);
+
+  const set = <K extends keyof DeclarativeFormState>(key: K, value: DeclarativeFormState[K]) =>
+    setState((prev) => ({ ...prev, [key]: value }));
+
+  const isPending = createCapability.isPending || updateCapability.isPending;
+  const canSubmit = state.name.trim().length > 0 && state.description.trim().length > 0;
+
+  const definition = useMemo(() => formStateToDefinition(state), [state]);
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    setError(null);
+    try {
+      if (mode === "create") {
+        await createCapability.mutateAsync({ definition });
+      } else if (id) {
+        await updateCapability.mutateAsync({ id, request: { definition } });
+      }
+      router.push("/capabilities");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save capability.");
+    }
+  };
+
+  return (
+    <div className="container mx-auto p-6">
+      <Link
+        href="/capabilities"
+        className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground mb-6"
+      >
+        <ArrowLeft className="w-4 h-4 mr-2" />
+        Back to Capabilities
+      </Link>
+
+      <form onSubmit={handleSubmit} className="space-y-6">
+        <div className="flex items-start justify-between gap-4 flex-wrap">
+          <h1 className="text-2xl font-bold">
+            {mode === "create" ? "New Declarative Capability" : "Edit Declarative Capability"}
+          </h1>
+          <div className="flex items-center gap-2">
+            <Button type="button" variant="outline" onClick={() => router.push("/capabilities")}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isPending || !canSubmit}>
+              {isPending ? "Saving..." : mode === "create" ? "Create" : "Save changes"}
+            </Button>
+          </div>
+        </div>
+
+        <Tabs value={tab} onValueChange={setTab}>
+          <TabsList>
+            <TabsTrigger value="general">General</TabsTrigger>
+            <TabsTrigger value="mcp">
+              MCP Servers
+              <TabCount count={state.mcpServers.length} />
+            </TabsTrigger>
+            <TabsTrigger value="skills">
+              Skills
+              <TabCount count={state.skills.length} />
+            </TabsTrigger>
+            <TabsTrigger value="files">
+              Files
+              <TabCount count={state.files.length} />
+            </TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="general">
+            <Card>
+              <CardContent className="space-y-4 pt-6">
+                <div className="grid gap-2">
+                  <Label htmlFor="declarative-name">Unique name</Label>
+                  <Input
+                    id="declarative-name"
+                    placeholder="research_pack"
+                    value={state.name}
+                    onChange={(e) => set("name", e.target.value.toLowerCase())}
+                    disabled={mode === "edit"}
+                    required
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Lowercase letters, digits, <code>_</code> and <code>-</code>. Referenced as{" "}
+                    <code>declarative:{state.name || "name"}</code>.
+                    {mode === "edit" && " The name cannot be changed after creation."}
+                  </p>
+                </div>
+                <div className="grid gap-2">
+                  <Label htmlFor="declarative-display-name">Display name</Label>
+                  <Input
+                    id="declarative-display-name"
+                    placeholder="Research Pack"
+                    value={state.displayName}
+                    onChange={(e) => set("displayName", e.target.value)}
+                  />
+                </div>
+                <div className="grid gap-2">
+                  <Label htmlFor="declarative-description">Description</Label>
+                  <Input
+                    id="declarative-description"
+                    value={state.description}
+                    onChange={(e) => set("description", e.target.value)}
+                    required
+                  />
+                </div>
+                <div className="grid gap-2">
+                  <Label htmlFor="declarative-prompt">System prompt addition</Label>
+                  <Textarea
+                    id="declarative-prompt"
+                    value={state.systemPrompt}
+                    onChange={(e) => set("systemPrompt", e.target.value)}
+                    rows={8}
+                  />
+                </div>
+                <div className="grid gap-2">
+                  <Label htmlFor="declarative-risk">Risk level</Label>
+                  <Select
+                    value={state.riskLevel}
+                    onValueChange={(value) =>
+                      set("riskLevel", value as DeclarativeFormState["riskLevel"])
+                    }
+                  >
+                    <SelectTrigger id="declarative-risk" className="w-48">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="low">Low</SelectItem>
+                      <SelectItem value="medium">Medium</SelectItem>
+                      <SelectItem value="high">High (admin only)</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+              </CardContent>
+            </Card>
+          </TabsContent>
+
+          <TabsContent value="mcp">
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">MCP Servers</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <McpServersEditor
+                  servers={state.mcpServers}
+                  onChange={(servers) => set("mcpServers", servers)}
+                />
+              </CardContent>
+            </Card>
+          </TabsContent>
+
+          <TabsContent value="skills">
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">Skills</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <SkillsEditor skills={state.skills} onChange={(skills) => set("skills", skills)} />
+              </CardContent>
+            </Card>
+          </TabsContent>
+
+          <TabsContent value="files">
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">Files</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <FilesEditor files={state.files} onChange={(files) => set("files", files)} />
+              </CardContent>
+            </Card>
+          </TabsContent>
+        </Tabs>
+
+        {error && <p className="text-sm text-destructive">{error}</p>}
+      </form>
+    </div>
+  );
+}

--- a/apps/ui/src/components/capabilities/declarative-form-types.ts
+++ b/apps/ui/src/components/capabilities/declarative-form-types.ts
@@ -79,12 +79,18 @@ export function newFileEntry(): FileEntry {
 }
 
 function pairsToRecord(pairs: KeyValuePair[]): Record<string, string> {
-  return Object.fromEntries(pairs.filter((p) => p.key).map((p) => [p.key, p.value]));
+  return Object.fromEntries(
+    pairs.map((p) => [p.key.trim(), p.value] as const).filter(([key]) => key),
+  );
 }
 
 function recordToPairs(record: Record<string, string> | undefined): KeyValuePair[] {
   if (!record) return [];
-  return Object.entries(record).map(([key, value]) => ({ key, value: String(value) }));
+  return Object.entries(record).map(([key, value]) => ({
+    id: localId(),
+    key,
+    value: String(value),
+  }));
 }
 
 // --- MCP conversions -------------------------------------------------------

--- a/apps/ui/src/components/capabilities/declarative-form-types.ts
+++ b/apps/ui/src/components/capabilities/declarative-form-types.ts
@@ -1,0 +1,239 @@
+// Local form state for the declarative capability editor and helpers to convert
+// between the form shape and the API `DeclarativeCapabilityDefinition`.
+
+import type {
+  DeclarativeCapabilityDefinition,
+  DeclarativeCapabilityFile,
+  DeclarativeCapabilitySkill,
+} from "@/lib/api/types";
+import type { KeyValuePair } from "./key-value-editor";
+
+let counter = 0;
+// Stable local key for list rendering; never persisted.
+function localId(): string {
+  counter += 1;
+  return `local-${counter}-${Date.now()}`;
+}
+
+export interface McpServerEntry {
+  id: string;
+  name: string;
+  transportType: "http" | "stdio";
+  url: string;
+  headers: KeyValuePair[];
+  command: string;
+  args: string; // one argument per line
+  env: KeyValuePair[];
+  authMode: "none" | "api_key" | "oauth";
+  oauthProviderId: string;
+  toolDiscovery: boolean;
+}
+
+export interface SkillEntry {
+  id: string;
+  name: string;
+  description: string;
+  instructions: string;
+  files: Array<{ id: string; path: string; content: string }>;
+  userInvocable: boolean;
+  disableModelInvocation: boolean;
+}
+
+export interface FileEntry {
+  id: string;
+  path: string;
+  content: string;
+  access: "readonly" | "readwrite";
+}
+
+export function newMcpServerEntry(): McpServerEntry {
+  return {
+    id: localId(),
+    name: "",
+    transportType: "http",
+    url: "",
+    headers: [],
+    command: "",
+    args: "",
+    env: [],
+    authMode: "none",
+    oauthProviderId: "",
+    toolDiscovery: true,
+  };
+}
+
+export function newSkillEntry(): SkillEntry {
+  return {
+    id: localId(),
+    name: "",
+    description: "",
+    instructions: "",
+    files: [],
+    userInvocable: true,
+    disableModelInvocation: false,
+  };
+}
+
+export function newFileEntry(): FileEntry {
+  return { id: localId(), path: "", content: "", access: "readonly" };
+}
+
+function pairsToRecord(pairs: KeyValuePair[]): Record<string, string> {
+  return Object.fromEntries(pairs.filter((p) => p.key).map((p) => [p.key, p.value]));
+}
+
+function recordToPairs(record: Record<string, string> | undefined): KeyValuePair[] {
+  if (!record) return [];
+  return Object.entries(record).map(([key, value]) => ({ key, value: String(value) }));
+}
+
+// --- MCP conversions -------------------------------------------------------
+
+export function mcpServersToEntries(
+  servers: Record<string, unknown> | undefined,
+): McpServerEntry[] {
+  if (!servers) return [];
+  return Object.entries(servers).map(([name, raw]) => {
+    const s = (raw ?? {}) as Record<string, unknown>;
+    const transport = (s.type ?? s.transport_type ?? "http") as string;
+    return {
+      id: localId(),
+      name,
+      transportType: transport === "stdio" ? "stdio" : "http",
+      url: typeof s.url === "string" ? s.url : "",
+      headers: recordToPairs(s.headers as Record<string, string> | undefined),
+      command: typeof s.command === "string" ? s.command : "",
+      args: Array.isArray(s.args) ? (s.args as string[]).join("\n") : "",
+      env: recordToPairs(s.env as Record<string, string> | undefined),
+      authMode: (s.auth_mode as McpServerEntry["authMode"]) ?? "none",
+      oauthProviderId: typeof s.oauth_provider_id === "string" ? s.oauth_provider_id : "",
+      toolDiscovery: s.tool_discovery !== false,
+    };
+  });
+}
+
+function mcpEntryToValue(entry: McpServerEntry): Record<string, unknown> {
+  const value: Record<string, unknown> = { type: entry.transportType };
+  if (entry.transportType === "http") {
+    if (entry.url.trim()) value.url = entry.url.trim();
+    const headers = pairsToRecord(entry.headers);
+    if (Object.keys(headers).length > 0) value.headers = headers;
+  } else {
+    if (entry.command.trim()) value.command = entry.command.trim();
+    const args = entry.args
+      .split("\n")
+      .map((a) => a.trim())
+      .filter(Boolean);
+    if (args.length > 0) value.args = args;
+    const env = pairsToRecord(entry.env);
+    if (Object.keys(env).length > 0) value.env = env;
+  }
+  if (entry.authMode !== "none") value.auth_mode = entry.authMode;
+  if (entry.authMode === "oauth" && entry.oauthProviderId.trim()) {
+    value.oauth_provider_id = entry.oauthProviderId.trim();
+  }
+  if (!entry.toolDiscovery) value.tool_discovery = false;
+  return value;
+}
+
+export function entriesToMcpServers(
+  entries: McpServerEntry[],
+): Record<string, unknown> | undefined {
+  const named = entries.filter((e) => e.name.trim());
+  if (named.length === 0) return undefined;
+  return Object.fromEntries(named.map((e) => [e.name.trim(), mcpEntryToValue(e)]));
+}
+
+// --- Skill conversions -----------------------------------------------------
+
+export function skillsToEntries(skills: DeclarativeCapabilitySkill[] | undefined): SkillEntry[] {
+  if (!skills) return [];
+  return skills.map((skill) => ({
+    id: localId(),
+    name: skill.name,
+    description: skill.description,
+    instructions: skill.instructions,
+    files: (skill.files ?? []).map((f) => ({ id: localId(), path: f.path, content: f.content })),
+    userInvocable: skill.user_invocable !== false,
+    disableModelInvocation: skill.disable_model_invocation === true,
+  }));
+}
+
+export function entriesToSkills(entries: SkillEntry[]): DeclarativeCapabilitySkill[] {
+  return entries
+    .filter((e) => e.name.trim())
+    .map((e) => ({
+      name: e.name.trim(),
+      description: e.description,
+      instructions: e.instructions,
+      files: e.files
+        .filter((f) => f.path.trim())
+        .map((f) => ({ path: f.path.trim(), content: f.content })),
+      user_invocable: e.userInvocable,
+      disable_model_invocation: e.disableModelInvocation,
+    }));
+}
+
+// --- File conversions ------------------------------------------------------
+
+export function filesToEntries(files: DeclarativeCapabilityFile[] | undefined): FileEntry[] {
+  if (!files) return [];
+  return files.map((f) => ({
+    id: localId(),
+    path: f.path,
+    content: f.content,
+    access: f.access ?? "readonly",
+  }));
+}
+
+export function entriesToFiles(entries: FileEntry[]): DeclarativeCapabilityFile[] {
+  return entries
+    .filter((e) => e.path.trim())
+    .map((e) => ({ path: e.path.trim(), content: e.content, access: e.access }));
+}
+
+// --- Top-level form state --------------------------------------------------
+
+export interface DeclarativeFormState {
+  name: string;
+  displayName: string;
+  description: string;
+  systemPrompt: string;
+  riskLevel: "low" | "medium" | "high";
+  mcpServers: McpServerEntry[];
+  skills: SkillEntry[];
+  files: FileEntry[];
+}
+
+export function definitionToFormState(
+  def: DeclarativeCapabilityDefinition | undefined,
+): DeclarativeFormState {
+  return {
+    name: def?.name ?? "",
+    displayName: def?.display_name ?? "",
+    description: def?.description ?? "",
+    systemPrompt: def?.system_prompt ?? "",
+    riskLevel: def?.risk_level ?? "low",
+    mcpServers: mcpServersToEntries(def?.mcp_servers),
+    skills: skillsToEntries(def?.skills),
+    files: filesToEntries(def?.files),
+  };
+}
+
+export function formStateToDefinition(
+  state: DeclarativeFormState,
+): DeclarativeCapabilityDefinition {
+  return {
+    name: state.name.trim(),
+    display_name: state.displayName.trim() || undefined,
+    description: state.description.trim(),
+    category: "Declarative",
+    icon: "puzzle",
+    system_prompt: state.systemPrompt.trim() || undefined,
+    mcp_servers: entriesToMcpServers(state.mcpServers),
+    skills: entriesToSkills(state.skills),
+    files: entriesToFiles(state.files),
+    dependencies: ["session_file_system", "skills"],
+    risk_level: state.riskLevel,
+  };
+}

--- a/apps/ui/src/components/capabilities/files-editor.tsx
+++ b/apps/ui/src/components/capabilities/files-editor.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { FileText, Plus, Trash2 } from "lucide-react";
+import type { FileEntry } from "./declarative-form-types";
+import { newFileEntry } from "./declarative-form-types";
+
+const MAX_FILES = 32;
+
+export function FilesEditor({
+  files,
+  onChange,
+}: {
+  files: FileEntry[];
+  onChange: (files: FileEntry[]) => void;
+}) {
+  const update = (id: string, patch: Partial<FileEntry>) =>
+    onChange(files.map((f) => (f.id === id ? { ...f, ...patch } : f)));
+
+  return (
+    <div className="space-y-4">
+      {files.length === 0 && (
+        <p className="text-sm text-muted-foreground">
+          No files. Text files are mounted into the session filesystem at the given absolute path.
+        </p>
+      )}
+      {files.map((file) => (
+        <div key={file.id} className="space-y-3 border p-4">
+          <div className="flex items-start justify-between gap-2">
+            <div className="flex flex-1 items-center gap-2">
+              <div className="flex h-8 w-8 items-center justify-center bg-primary/10 shrink-0">
+                <FileText className="h-4 w-4 text-primary" />
+              </div>
+              <div className="grid flex-1 gap-1.5">
+                <Label htmlFor={`file-path-${file.id}`}>Mount path</Label>
+                <Input
+                  id={`file-path-${file.id}`}
+                  placeholder="/docs/README.md"
+                  value={file.path}
+                  onChange={(e) => update(file.id, { path: e.target.value })}
+                  className="font-mono text-xs"
+                />
+              </div>
+            </div>
+            <div className="grid gap-1.5">
+              <Label>Access</Label>
+              <Select
+                value={file.access}
+                onValueChange={(value) => update(file.id, { access: value as FileEntry["access"] })}
+              >
+                <SelectTrigger className="w-36">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="readonly">Read-only</SelectItem>
+                  <SelectItem value="readwrite">Read-write</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-9 w-9 p-0 shrink-0 self-end"
+              onClick={() => onChange(files.filter((f) => f.id !== file.id))}
+              aria-label="Remove file"
+            >
+              <Trash2 className="h-4 w-4" />
+            </Button>
+          </div>
+          <Textarea
+            placeholder="File content"
+            value={file.content}
+            onChange={(e) => update(file.id, { content: e.target.value })}
+            rows={5}
+            className="font-mono text-xs"
+          />
+        </div>
+      ))}
+
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        disabled={files.length >= MAX_FILES}
+        onClick={() => onChange([...files, newFileEntry()])}
+      >
+        <Plus className="h-4 w-4 mr-1" />
+        Add file
+      </Button>
+    </div>
+  );
+}

--- a/apps/ui/src/components/capabilities/key-value-editor.tsx
+++ b/apps/ui/src/components/capabilities/key-value-editor.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Plus, X } from "lucide-react";
+
+export interface KeyValuePair {
+  key: string;
+  value: string;
+}
+
+export function KeyValueEditor({
+  label,
+  pairs,
+  onChange,
+  keyPlaceholder = "Name",
+  valuePlaceholder = "Value",
+  addLabel = "Add",
+}: {
+  label: string;
+  pairs: KeyValuePair[];
+  onChange: (pairs: KeyValuePair[]) => void;
+  keyPlaceholder?: string;
+  valuePlaceholder?: string;
+  addLabel?: string;
+}) {
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <Label>{label}</Label>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-7 text-xs"
+          onClick={() => onChange([...pairs, { key: "", value: "" }])}
+        >
+          <Plus className="h-3 w-3 mr-1" />
+          {addLabel}
+        </Button>
+      </div>
+      {pairs.length > 0 && (
+        <div className="space-y-2">
+          {pairs.map((pair, index) => (
+            <div key={index} className="flex items-center gap-2">
+              <Input
+                placeholder={keyPlaceholder}
+                value={pair.key}
+                onChange={(e) =>
+                  onChange(pairs.map((p, i) => (i === index ? { ...p, key: e.target.value } : p)))
+                }
+                className="flex-1"
+              />
+              <Input
+                placeholder={valuePlaceholder}
+                value={pair.value}
+                onChange={(e) =>
+                  onChange(pairs.map((p, i) => (i === index ? { ...p, value: e.target.value } : p)))
+                }
+                className="flex-1"
+              />
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-9 w-9 p-0 shrink-0"
+                onClick={() => onChange(pairs.filter((_, i) => i !== index))}
+              >
+                <X className="h-4 w-4" />
+              </Button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/ui/src/components/capabilities/key-value-editor.tsx
+++ b/apps/ui/src/components/capabilities/key-value-editor.tsx
@@ -6,8 +6,16 @@ import { Label } from "@/components/ui/label";
 import { Plus, X } from "lucide-react";
 
 export interface KeyValuePair {
+  id: string;
   key: string;
   value: string;
+}
+
+let pairCounter = 0;
+// Stable per-row id so React keys survive insertion/removal; never persisted.
+export function newKeyValuePair(): KeyValuePair {
+  pairCounter += 1;
+  return { id: `kv-${pairCounter}-${Date.now()}`, key: "", value: "" };
 }
 
 export function KeyValueEditor({
@@ -34,7 +42,7 @@ export function KeyValueEditor({
           variant="ghost"
           size="sm"
           className="h-7 text-xs"
-          onClick={() => onChange([...pairs, { key: "", value: "" }])}
+          onClick={() => onChange([...pairs, newKeyValuePair()])}
         >
           <Plus className="h-3 w-3 mr-1" />
           {addLabel}
@@ -43,7 +51,7 @@ export function KeyValueEditor({
       {pairs.length > 0 && (
         <div className="space-y-2">
           {pairs.map((pair, index) => (
-            <div key={index} className="flex items-center gap-2">
+            <div key={pair.id} className="flex items-center gap-2">
               <Input
                 placeholder={keyPlaceholder}
                 value={pair.key}
@@ -66,6 +74,7 @@ export function KeyValueEditor({
                 size="sm"
                 className="h-9 w-9 p-0 shrink-0"
                 onClick={() => onChange(pairs.filter((_, i) => i !== index))}
+                aria-label={`Remove ${keyPlaceholder.toLowerCase()}`}
               >
                 <X className="h-4 w-4" />
               </Button>

--- a/apps/ui/src/components/capabilities/mcp-servers-editor.tsx
+++ b/apps/ui/src/components/capabilities/mcp-servers-editor.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Switch } from "@/components/ui/switch";
+import { Separator } from "@/components/ui/separator";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Plug, Plus, Trash2 } from "lucide-react";
+import { KeyValueEditor } from "./key-value-editor";
+import type { McpServerEntry } from "./declarative-form-types";
+import { newMcpServerEntry } from "./declarative-form-types";
+
+const MAX_MCP_SERVERS = 16;
+
+export function McpServersEditor({
+  servers,
+  onChange,
+}: {
+  servers: McpServerEntry[];
+  onChange: (servers: McpServerEntry[]) => void;
+}) {
+  const update = (id: string, patch: Partial<McpServerEntry>) =>
+    onChange(servers.map((s) => (s.id === id ? { ...s, ...patch } : s)));
+
+  return (
+    <div className="space-y-4">
+      {servers.length === 0 && (
+        <p className="text-sm text-muted-foreground">
+          No MCP servers. Add one to expose its tools to agents using this capability.
+        </p>
+      )}
+      {servers.map((server) => (
+        <div key={server.id} className="space-y-4 border p-4">
+          <div className="flex items-start justify-between gap-2">
+            <div className="flex items-center gap-2">
+              <div className="flex h-8 w-8 items-center justify-center bg-primary/10">
+                <Plug className="h-4 w-4 text-primary" />
+              </div>
+              <div className="grid gap-1.5">
+                <Label htmlFor={`mcp-name-${server.id}`}>Server name</Label>
+                <Input
+                  id={`mcp-name-${server.id}`}
+                  placeholder="atlassian"
+                  value={server.name}
+                  onChange={(e) => update(server.id, { name: e.target.value })}
+                  className="w-64"
+                />
+              </div>
+            </div>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-9 w-9 p-0 shrink-0"
+              onClick={() => onChange(servers.filter((s) => s.id !== server.id))}
+              aria-label="Remove server"
+            >
+              <Trash2 className="h-4 w-4" />
+            </Button>
+          </div>
+
+          <div className="grid gap-1.5">
+            <Label>Transport</Label>
+            <Select
+              value={server.transportType}
+              onValueChange={(value) =>
+                update(server.id, { transportType: value as McpServerEntry["transportType"] })
+              }
+            >
+              <SelectTrigger className="w-48">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="http">HTTP (remote)</SelectItem>
+                <SelectItem value="stdio">stdio (local process)</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          {server.transportType === "http" ? (
+            <>
+              <div className="grid gap-1.5">
+                <Label htmlFor={`mcp-url-${server.id}`}>URL</Label>
+                <Input
+                  id={`mcp-url-${server.id}`}
+                  placeholder="https://mcp.example.com/v1/mcp"
+                  value={server.url}
+                  onChange={(e) => update(server.id, { url: e.target.value })}
+                />
+              </div>
+              <KeyValueEditor
+                label="Headers"
+                pairs={server.headers}
+                onChange={(headers) => update(server.id, { headers })}
+                addLabel="Add header"
+              />
+            </>
+          ) : (
+            <>
+              <div className="grid gap-1.5">
+                <Label htmlFor={`mcp-command-${server.id}`}>Command</Label>
+                <Input
+                  id={`mcp-command-${server.id}`}
+                  placeholder="npx"
+                  value={server.command}
+                  onChange={(e) => update(server.id, { command: e.target.value })}
+                />
+              </div>
+              <div className="grid gap-1.5">
+                <Label htmlFor={`mcp-args-${server.id}`}>Arguments (one per line)</Label>
+                <Textarea
+                  id={`mcp-args-${server.id}`}
+                  placeholder={"-y\n@modelcontextprotocol/server-filesystem"}
+                  value={server.args}
+                  onChange={(e) => update(server.id, { args: e.target.value })}
+                  rows={3}
+                  className="font-mono text-xs"
+                />
+              </div>
+              <KeyValueEditor
+                label="Environment variables"
+                pairs={server.env}
+                onChange={(env) => update(server.id, { env })}
+                addLabel="Add variable"
+              />
+            </>
+          )}
+
+          <Separator />
+
+          <div className="grid gap-1.5">
+            <Label>Authentication</Label>
+            <Select
+              value={server.authMode}
+              onValueChange={(value) =>
+                update(server.id, { authMode: value as McpServerEntry["authMode"] })
+              }
+            >
+              <SelectTrigger className="w-48">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="none">None</SelectItem>
+                <SelectItem value="api_key">API key</SelectItem>
+                <SelectItem value="oauth">OAuth per user</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          {server.authMode === "oauth" && (
+            <div className="grid gap-1.5">
+              <Label htmlFor={`mcp-oauth-${server.id}`}>OAuth provider ID</Label>
+              <Input
+                id={`mcp-oauth-${server.id}`}
+                placeholder="atlassian"
+                value={server.oauthProviderId}
+                onChange={(e) => update(server.id, { oauthProviderId: e.target.value })}
+              />
+            </div>
+          )}
+
+          <div className="flex items-center justify-between">
+            <div className="space-y-0.5">
+              <Label htmlFor={`mcp-discovery-${server.id}`}>Live tool discovery</Label>
+              <p className="text-xs text-muted-foreground">
+                Discover tool definitions from the server at runtime.
+              </p>
+            </div>
+            <Switch
+              id={`mcp-discovery-${server.id}`}
+              checked={server.toolDiscovery}
+              onCheckedChange={(checked) => update(server.id, { toolDiscovery: checked })}
+            />
+          </div>
+        </div>
+      ))}
+
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        disabled={servers.length >= MAX_MCP_SERVERS}
+        onClick={() => onChange([...servers, newMcpServerEntry()])}
+      >
+        <Plus className="h-4 w-4 mr-1" />
+        Add MCP server
+      </Button>
+    </div>
+  );
+}

--- a/apps/ui/src/components/capabilities/skills-editor.tsx
+++ b/apps/ui/src/components/capabilities/skills-editor.tsx
@@ -1,0 +1,196 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Switch } from "@/components/ui/switch";
+import { Separator } from "@/components/ui/separator";
+import { Plus, Sparkles, Trash2, X } from "lucide-react";
+import type { SkillEntry } from "./declarative-form-types";
+import { newSkillEntry } from "./declarative-form-types";
+
+const MAX_SKILLS = 16;
+
+let fileCounter = 0;
+function fileId(): string {
+  fileCounter += 1;
+  return `skill-file-${fileCounter}-${Date.now()}`;
+}
+
+export function SkillsEditor({
+  skills,
+  onChange,
+}: {
+  skills: SkillEntry[];
+  onChange: (skills: SkillEntry[]) => void;
+}) {
+  const update = (id: string, patch: Partial<SkillEntry>) =>
+    onChange(skills.map((s) => (s.id === id ? { ...s, ...patch } : s)));
+
+  return (
+    <div className="space-y-4">
+      {skills.length === 0 && (
+        <p className="text-sm text-muted-foreground">
+          No skills. Skills are mounted under <code>/.agents/skills/</code> and can be invoked as
+          slash commands.
+        </p>
+      )}
+      {skills.map((skill) => (
+        <div key={skill.id} className="space-y-4 border p-4">
+          <div className="flex items-start justify-between gap-2">
+            <div className="flex items-center gap-2">
+              <div className="flex h-8 w-8 items-center justify-center bg-primary/10">
+                <Sparkles className="h-4 w-4 text-primary" />
+              </div>
+              <div className="grid gap-1.5">
+                <Label htmlFor={`skill-name-${skill.id}`}>Skill name</Label>
+                <Input
+                  id={`skill-name-${skill.id}`}
+                  placeholder="research-helper"
+                  value={skill.name}
+                  onChange={(e) => update(skill.id, { name: e.target.value })}
+                  className="w-64"
+                />
+              </div>
+            </div>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-9 w-9 p-0 shrink-0"
+              onClick={() => onChange(skills.filter((s) => s.id !== skill.id))}
+              aria-label="Remove skill"
+            >
+              <Trash2 className="h-4 w-4" />
+            </Button>
+          </div>
+
+          <div className="grid gap-1.5">
+            <Label htmlFor={`skill-desc-${skill.id}`}>Description</Label>
+            <Input
+              id={`skill-desc-${skill.id}`}
+              placeholder="When to use this skill"
+              value={skill.description}
+              onChange={(e) => update(skill.id, { description: e.target.value })}
+            />
+          </div>
+
+          <div className="grid gap-1.5">
+            <Label htmlFor={`skill-instructions-${skill.id}`}>Instructions (SKILL.md body)</Label>
+            <Textarea
+              id={`skill-instructions-${skill.id}`}
+              placeholder="Markdown instructions the model follows when this skill is active."
+              value={skill.instructions}
+              onChange={(e) => update(skill.id, { instructions: e.target.value })}
+              rows={6}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <Label>Bundled files</Label>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-7 text-xs"
+                onClick={() =>
+                  update(skill.id, {
+                    files: [...skill.files, { id: fileId(), path: "", content: "" }],
+                  })
+                }
+              >
+                <Plus className="h-3 w-3 mr-1" />
+                Add file
+              </Button>
+            </div>
+            {skill.files.map((file) => (
+              <div key={file.id} className="space-y-2 border p-2">
+                <div className="flex items-center gap-2">
+                  <Input
+                    placeholder="reference.md"
+                    value={file.path}
+                    onChange={(e) =>
+                      update(skill.id, {
+                        files: skill.files.map((f) =>
+                          f.id === file.id ? { ...f, path: e.target.value } : f,
+                        ),
+                      })
+                    }
+                    className="font-mono text-xs"
+                  />
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="h-9 w-9 p-0 shrink-0"
+                    onClick={() =>
+                      update(skill.id, { files: skill.files.filter((f) => f.id !== file.id) })
+                    }
+                    aria-label="Remove file"
+                  >
+                    <X className="h-4 w-4" />
+                  </Button>
+                </div>
+                <Textarea
+                  placeholder="File content"
+                  value={file.content}
+                  onChange={(e) =>
+                    update(skill.id, {
+                      files: skill.files.map((f) =>
+                        f.id === file.id ? { ...f, content: e.target.value } : f,
+                      ),
+                    })
+                  }
+                  rows={3}
+                  className="font-mono text-xs"
+                />
+              </div>
+            ))}
+          </div>
+
+          <Separator />
+
+          <div className="flex items-center justify-between">
+            <div className="space-y-0.5">
+              <Label htmlFor={`skill-invocable-${skill.id}`}>User-invocable</Label>
+              <p className="text-xs text-muted-foreground">
+                Appears as a <code>/{skill.name || "name"}</code> slash command.
+              </p>
+            </div>
+            <Switch
+              id={`skill-invocable-${skill.id}`}
+              checked={skill.userInvocable}
+              onCheckedChange={(checked) => update(skill.id, { userInvocable: checked })}
+            />
+          </div>
+          <div className="flex items-center justify-between">
+            <div className="space-y-0.5">
+              <Label htmlFor={`skill-no-model-${skill.id}`}>Disable model invocation</Label>
+              <p className="text-xs text-muted-foreground">
+                Prevent the model from auto-activating this skill.
+              </p>
+            </div>
+            <Switch
+              id={`skill-no-model-${skill.id}`}
+              checked={skill.disableModelInvocation}
+              onCheckedChange={(checked) => update(skill.id, { disableModelInvocation: checked })}
+            />
+          </div>
+        </div>
+      ))}
+
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        disabled={skills.length >= MAX_SKILLS}
+        onClick={() => onChange([...skills, newSkillEntry()])}
+      >
+        <Plus className="h-4 w-4 mr-1" />
+        Add skill
+      </Button>
+    </div>
+  );
+}

--- a/apps/ui/src/hooks/use-capabilities.ts
+++ b/apps/ui/src/hooks/use-capabilities.ts
@@ -89,9 +89,15 @@ export function useDeclarativeCapability(id: string | undefined) {
     enabled: !!org && !!id,
   });
 
+  const fallback = useResourceOrgFallback({
+    resourceId: id,
+    error: query.error,
+    isLoading: orgLoading || query.isLoading,
+  });
+
   return {
     ...query,
-    isLoading: orgLoading || query.isLoading,
+    isLoading: orgLoading || query.isLoading || fallback.isCheckingOtherOrgs,
   };
 }
 

--- a/apps/ui/src/hooks/use-capabilities.ts
+++ b/apps/ui/src/hooks/use-capabilities.ts
@@ -9,6 +9,7 @@ import {
   createDeclarativeCapability,
   deleteDeclarativeCapability,
   getCapability,
+  getDeclarativeCapability,
   listCapabilities,
   listDeclarativeCapabilities,
   updateDeclarativeCapability,
@@ -70,6 +71,22 @@ export function useDeclarativeCapabilities() {
     queryKey: [...queryKeys.declarativeCapabilities.list(), org],
     queryFn: () => listDeclarativeCapabilities(),
     enabled: !!org,
+  });
+
+  return {
+    ...query,
+    isLoading: orgLoading || query.isLoading,
+  };
+}
+
+export function useDeclarativeCapability(id: string | undefined) {
+  const { currentOrg, isLoading: orgLoading } = useOrg();
+  const org = currentOrg?.public_id;
+
+  const query = useQuery({
+    queryKey: [...queryKeys.declarativeCapabilities.detail(id ?? ""), org],
+    queryFn: () => getDeclarativeCapability(id!),
+    enabled: !!org && !!id,
   });
 
   return {

--- a/apps/ui/src/lib/api/capabilities.ts
+++ b/apps/ui/src/lib/api/capabilities.ts
@@ -31,6 +31,11 @@ export async function listDeclarativeCapabilities(): Promise<DeclarativeCapabili
   return response.data.data;
 }
 
+export async function getDeclarativeCapability(id: string): Promise<DeclarativeCapability> {
+  const response = await api.get<DeclarativeCapability>(`/v1/capabilities/declarative/${id}`);
+  return response.data;
+}
+
 export async function createDeclarativeCapability(
   request: CreateDeclarativeCapabilityRequest,
 ): Promise<DeclarativeCapability> {


### PR DESCRIPTION
## What
Replaces the cramped, create-only declarative-capability modal (which exposed MCP servers only as a raw JSON textarea) with a dedicated full-page editor that supports creating **and** editing, plus structured UI for MCP servers, skills, and file mounts.

- New routes: `/capabilities/declarative/new` and `/capabilities/declarative/[id]`
- Tabbed editor (General / MCP Servers / Skills / Files) with per-tab count badges
- **MCP Servers**: structured form replacing the JSON textarea — per-server name, HTTP/stdio transport, URL + headers (HTTP) or command + args + env (stdio), auth mode (none/api_key/oauth + provider id), live tool-discovery toggle
- **Skills**: name, description, SKILL.md instructions, bundled files, `user-invocable` and `disable-model-invocation` toggles
- **Files**: path + content + read-only/read-write access
- Edit support wired through the previously-unused `PATCH` hook; the capabilities list page now links rows to the editor with Edit/Archive actions
- Adds `getDeclarativeCapability` API fn + `useDeclarativeCapability` hook for the edit page

## Why
The old modal was a single `max-w-2xl` dialog with plain inputs and a hand-edited MCP JSON blob. The data model already supported MCP servers, skills, and file mounts, but none had real UI, and there was no way to edit a saved capability (only create + archive). This makes the full declarative model usable without hand-writing JSON.

## How
- New composite editors live under `apps/ui/src/components/capabilities/` and compose existing `@/components/ui/*` primitives (Tabs, Card, Select, Switch, Input, etc.) for visual consistency with the rest of the app.
- `declarative-form-types.ts` owns the form-state ⇄ `DeclarativeCapabilityDefinition` conversion (map↔array for MCP servers, field mapping for skills/files), keeping the React components thin.
- Client-side caps (MCP 16, skills 16, files 32) mirror the backend `MAX_*` constants.

## Risk
- **Low.** Frontend-only, additive. Sends data to existing, unchanged API endpoints; all validation (SSRF/scoped-MCP, size limits, name rules) stays server-side and is unchanged.

## Security
- Threat categories reviewed: **TM-WEB**, **TM-TOOL**, **TM-API**.
  - TM-WEB: all new values render through React (auto-escaped); no `dangerouslySetInnerHTML`, no new markdown rendering of user input → no XSS introduced.
  - TM-TOOL/TM-API: the form only collects MCP/skill/file config and posts to existing endpoints (`POST /v1/capabilities`, `GET/PATCH /v1/capabilities/declarative/{id}`). Scoped-MCP SSRF validation and size/count limits remain server-enforced. No new endpoints, no auth/authz/SQL changes, no secret handling (scoped MCP has no api-key secret field).
- Findings and resolutions: none. No threat-model update needed — this is a UI surface over an existing, server-validated API.

## Validation
- `pnpm run build` (Turbopack) — passes; both new routes registered
- `pnpm run lint`, `pnpm run format:check` — clean
- Jest: full suite **895 passed / 103 suites**, including a new `declarative-capability-editor.test.tsx` covering form↔API round-trips (MCP http/stdio, skills, files) and editor add/remove interactions
- Interactive end-to-end click-through was not possible in this sandbox: the standalone UI's client auth bootstrap blocks protected routes without a running backend, and the full stack (caddy/just/doppler + Rust build) couldn't be brought up here. The new client logic is instead covered by the production build + the new RTL/Jest tests.

## Follow-ups
- **Promote `KeyValueEditor` to a shared component** and refactor the `/mcp-servers` page's inline headers editor to use it — the key/value (headers/env) editor pattern is now implemented twice. Deferred because it touches an unrelated page and is pure cleanup, not required for this feature.
- **Verify the edit flow end-to-end against a live backend** once a full stack is available — only the create-form shell and pure conversion logic could be exercised here. Low risk (edit reuses the same form + the existing PATCH endpoint), but worth a manual pass.
- `api_key` auth mode for scoped MCP servers has no secret input in this UI (the `ScopedMcpServer` shape carries no api-key field — auth is via headers/OAuth provider id). Noting in case a secret-backed scoped auth path is wanted later.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (additive; no API/contract changes)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JAGLR4zRx9AE4W44yWJG6d)_