### PR TITLE
refactor: retire session_resources dual-write for work kinds

### DIFF
--- a/crates/core/src/capabilities/a2a_delegation.rs
+++ b/crates/core/src/capabilities/a2a_delegation.rs
@@ -1,14 +1,13 @@
 // Outbound A2A agent delegation.
 //
 // Decision: V1 is outbound-only and stores configured external agents in the
-// capability config. Run state is persisted as session resources of kind
-// `agent_run`, which gives agents and UI a unified local/remote delegation
-// handle without introducing inbound A2A app-channel exposure.
+// capability config. Run state is persisted as session storage KV entries
+// (key = "agent_run:{run_id}") so agents and UI have a unified local/remote
+// delegation handle. An index key "agent_run:index" (JSON array of run_ids)
+// enables listing. The session resource registry is no longer used for A2A
+// runs (retired as part of the session-tasks dual-write cleanup).
 
 use super::{Capability, CapabilityLocalization, CapabilityStatus, RiskLevel, SystemPromptContext};
-use crate::session_resource::{
-    RegisterSessionResource, SessionResourceFilter, SessionResourceStatus,
-};
 use crate::session_task::{
     CreateSessionTask, NewTaskMessage, SessionTask, SessionTaskState, SessionTaskUpdate,
     TASK_KIND_EXTERNAL_AGENT, TaskError, TaskExecutor, TaskExecutorPlugin, TaskInputRequest,
@@ -16,7 +15,7 @@ use crate::session_task::{
 };
 use crate::tool_types::ToolHints;
 use crate::tools::{Tool, ToolExecutionResult};
-use crate::traits::{SessionResourceRegistry, ToolContext};
+use crate::traits::{SessionStorageStore, ToolContext};
 use crate::{Result, validate_safe_url};
 use a2a::{
     AgentCard, CancelTaskRequest, GetTaskRequest, Message, Part, Role, SendMessageConfiguration,
@@ -36,7 +35,6 @@ use tokio::time::{Instant, sleep};
 use url::Url;
 
 pub const A2A_AGENT_DELEGATION_CAPABILITY_ID: &str = "a2a_agent_delegation";
-const AGENT_RUN_KIND: &str = "agent_run";
 const DEFAULT_WAIT_TIMEOUT_SECS: u64 = 300;
 const DEFAULT_POLL_INTERVAL_MS: u64 = 1_000;
 const MAX_RESULT_CHARS: usize = 8_192;
@@ -573,16 +571,6 @@ impl AgentRunRecord {
         }
     }
 
-    fn resource_status(&self) -> SessionResourceStatus {
-        match self.status {
-            AgentRunStatus::Completed => SessionResourceStatus::Completed,
-            AgentRunStatus::Failed | AgentRunStatus::Canceled | AgentRunStatus::Rejected => {
-                SessionResourceStatus::Failed
-            }
-            _ => SessionResourceStatus::Active,
-        }
-    }
-
     fn public_json(&self) -> Value {
         json!({
             "agent_run_id": self.run_id,
@@ -607,14 +595,51 @@ fn run_id() -> String {
     format!("agrun_{}", uuid::Uuid::now_v7().simple())
 }
 
-fn require_registry(
+fn require_storage(
     context: &ToolContext,
-) -> std::result::Result<&Arc<dyn SessionResourceRegistry>, ToolExecutionResult> {
-    context.session_resource_registry.as_ref().ok_or_else(|| {
-        ToolExecutionResult::tool_error(
-            "Agent delegation tools require session_resource_registry context",
-        )
+) -> std::result::Result<&Arc<dyn SessionStorageStore>, ToolExecutionResult> {
+    context.storage_store.as_ref().ok_or_else(|| {
+        ToolExecutionResult::tool_error("Agent delegation tools require storage_store context")
     })
+}
+
+/// KV key for a specific agent run record.
+fn run_key(run_id: &str) -> String {
+    format!("agent_run:{run_id}")
+}
+
+/// KV key for the agent run index (list of all run_ids for this session).
+const AGENT_RUN_INDEX_KEY: &str = "agent_run:index";
+
+/// Load the current index (list of run_ids). Returns empty vec on missing/error.
+async fn load_run_index(
+    storage: &dyn SessionStorageStore,
+    session_id: crate::typed_id::SessionId,
+) -> Vec<String> {
+    storage
+        .get_value(session_id, AGENT_RUN_INDEX_KEY)
+        .await
+        .ok()
+        .flatten()
+        .and_then(|s| serde_json::from_str::<Vec<String>>(&s).ok())
+        .unwrap_or_default()
+}
+
+/// Append a run_id to the index (idempotent).
+async fn append_run_to_index(
+    storage: &dyn SessionStorageStore,
+    session_id: crate::typed_id::SessionId,
+    run_id: &str,
+) {
+    let mut index = load_run_index(storage, session_id).await;
+    if !index.contains(&run_id.to_string()) {
+        index.push(run_id.to_string());
+        if let Ok(serialized) = serde_json::to_string(&index) {
+            let _ = storage
+                .set_value(session_id, AGENT_RUN_INDEX_KEY, &serialized)
+                .await;
+        }
+    }
 }
 
 fn require_str<'a>(
@@ -632,19 +657,16 @@ fn require_str<'a>(
 
 async fn save_run(context: &ToolContext, record: &AgentRunRecord) -> Result<()> {
     mirror_run_to_task(context, record).await;
-    let Some(registry) = &context.session_resource_registry else {
+    let Some(storage) = &context.storage_store else {
         return Ok(());
     };
-    registry
-        .register(RegisterSessionResource {
-            session_id: context.session_id,
-            resource_id: record.run_id.clone(),
-            kind: AGENT_RUN_KIND.to_string(),
-            display_name: record.external_agent_name.clone(),
-            status: record.resource_status(),
-            metadata: serde_json::to_value(record).unwrap_or_else(|_| json!({})),
-        })
+    let serialized = serde_json::to_string(record).map_err(|e| {
+        crate::error::AgentLoopError::store(format!("failed to serialize agent run: {e}"))
+    })?;
+    storage
+        .set_value(context.session_id, &run_key(&record.run_id), &serialized)
         .await?;
+    append_run_to_index(storage.as_ref(), context.session_id, &record.run_id).await;
     Ok(())
 }
 
@@ -768,9 +790,9 @@ async fn load_run(
     context: &ToolContext,
     run_id: &str,
 ) -> std::result::Result<AgentRunRecord, ToolExecutionResult> {
-    let registry = require_registry(context)?;
-    let Some(entry) = registry
-        .get(context.session_id, run_id)
+    let storage = require_storage(context)?;
+    let Some(serialized) = storage
+        .get_value(context.session_id, &run_key(run_id))
         .await
         .map_err(ToolExecutionResult::internal_error)?
     else {
@@ -778,13 +800,8 @@ async fn load_run(
             "No agent run found with id: {run_id}"
         )));
     };
-    if entry.kind != AGENT_RUN_KIND {
-        return Err(ToolExecutionResult::tool_error(format!(
-            "Resource is not an agent run: {run_id}"
-        )));
-    }
-    serde_json::from_value(entry.metadata).map_err(|e| {
-        ToolExecutionResult::internal_error_msg(format!("Invalid agent run metadata: {e}"))
+    serde_json::from_str(&serialized).map_err(|e| {
+        ToolExecutionResult::internal_error_msg(format!("Invalid agent run record: {e}"))
     })
 }
 
@@ -1181,7 +1198,7 @@ impl Tool for SpawnAgentTool {
         arguments: Value,
         context: &ToolContext,
     ) -> ToolExecutionResult {
-        if let Err(e) = require_registry(context) {
+        if let Err(e) = require_storage(context) {
             return e;
         }
         let task = match require_str(&arguments, "task") {
@@ -1233,6 +1250,7 @@ impl Tool for SpawnAgentTool {
             wake_on_completion,
         );
         // Create the session task tracking this run (specs/session-tasks.md).
+        // run_id is stored in spec so load_run_for_task can do a direct key lookup.
         if let Some(task_registry) = &context.session_task_registry
             && let Ok(created) = task_registry
                 .create(CreateSessionTask {
@@ -1241,6 +1259,7 @@ impl Tool for SpawnAgentTool {
                     kind: TASK_KIND_EXTERNAL_AGENT.to_string(),
                     display_name: agent.name.clone(),
                     spec: json!({
+                        "run_id": &run_id,
                         "external_agent_id": agent.id,
                         "instructions": &task,
                         "mode": &mode,
@@ -1343,36 +1362,30 @@ impl Tool for GetAgentRunsTool {
                 Err(e) => e,
             };
         }
-        let registry = match require_registry(context) {
-            Ok(registry) => registry,
+        let storage = match require_storage(context) {
+            Ok(s) => s,
             Err(e) => return e,
         };
-        let entries = match registry
-            .list(
-                context.session_id,
-                Some(&SessionResourceFilter {
-                    kind: Some(AGENT_RUN_KIND.to_string()),
-                    status: None,
-                }),
-            )
-            .await
-        {
-            Ok(entries) => entries,
-            Err(e) => return ToolExecutionResult::internal_error(e),
-        };
+        let run_ids = load_run_index(storage.as_ref(), context.session_id).await;
         let status_filter = arguments
             .get("status_filter")
             .and_then(Value::as_str)
             .unwrap_or("all");
-        let runs = entries
-            .into_iter()
-            .filter_map(|entry| serde_json::from_value::<AgentRunRecord>(entry.metadata).ok())
-            .filter(|record| status_filter == "all" || record.status.to_string() == status_filter)
-            .map(|record| record.public_json())
-            .collect::<Vec<_>>();
+        let mut runs = Vec::new();
+        for run_id in run_ids {
+            if let Ok(Some(serialized)) = storage
+                .get_value(context.session_id, &run_key(&run_id))
+                .await
+                && let Ok(record) = serde_json::from_str::<AgentRunRecord>(&serialized)
+                && (status_filter == "all" || record.status.to_string() == status_filter)
+            {
+                runs.push(record.public_json());
+            }
+        }
+        let count = runs.len();
         ToolExecutionResult::success(json!({
             "agent_runs": runs,
-            "count": runs.len()
+            "count": count
         }))
     }
 
@@ -1669,30 +1682,25 @@ impl Tool for CancelAgentTool {
 // Task executor: external_agent
 // ============================================================================
 
-/// Locate the agent run mirrored by a session task. Runs land in the session
-/// resource registry as `agent_run` resources with the task id in metadata.
+/// Locate the agent run mirrored by a session task.
+/// The run_id is stored in the task's spec so we can do a direct KV lookup.
 async fn load_run_for_task(
     context: &ToolContext,
     task: &SessionTask,
 ) -> std::result::Result<AgentRunRecord, String> {
-    let Some(registry) = &context.session_resource_registry else {
-        return Err("external agent tasks require session_resource_registry context".to_string());
+    let Some(storage) = &context.storage_store else {
+        return Err("external agent tasks require storage_store context".to_string());
     };
-    let entries = registry
-        .list(
-            context.session_id,
-            Some(&SessionResourceFilter {
-                kind: Some(AGENT_RUN_KIND.to_string()),
-                status: None,
-            }),
-        )
-        .await
-        .map_err(|e| e.to_string())?;
-    entries
-        .into_iter()
-        .filter_map(|entry| serde_json::from_value::<AgentRunRecord>(entry.metadata).ok())
-        .find(|record| record.task_id.as_deref() == Some(task.id.as_str()))
-        .ok_or_else(|| format!("No agent run found for task {}", task.id))
+    // Direct lookup via run_id stored in task spec (set at spawn time).
+    if let Some(run_id) = task.spec.get("run_id").and_then(Value::as_str)
+        && let Ok(Some(serialized)) = storage
+            .get_value(context.session_id, &run_key(run_id))
+            .await
+    {
+        return serde_json::from_str::<AgentRunRecord>(&serialized)
+            .map_err(|e| format!("invalid agent run record for task {}: {e}", task.id));
+    }
+    Err(format!("No agent run found for task {}", task.id))
 }
 
 /// Agent config snapshot stored on the run, required to rebuild the A2A
@@ -1836,74 +1844,51 @@ mod tests {
     use tokio::time::timeout;
 
     #[derive(Default)]
-    struct TestSessionResourceRegistry {
-        entries: Mutex<HashMap<String, crate::session_resource::SessionResourceEntry>>,
+    struct TestStorageStore {
+        values: Mutex<HashMap<String, String>>,
     }
 
     #[async_trait]
-    impl SessionResourceRegistry for TestSessionResourceRegistry {
-        async fn register(
-            &self,
-            entry: RegisterSessionResource,
-        ) -> Result<crate::session_resource::SessionResourceEntry> {
-            let now = chrono::Utc::now();
-            let mut entries = self.entries.lock().unwrap();
-            let existing = entries.get(&entry.resource_id).cloned();
-            let out = crate::session_resource::SessionResourceEntry {
-                resource_id: entry.resource_id.clone(),
-                session_id: entry.session_id,
-                kind: entry.kind,
-                display_name: entry.display_name,
-                status: entry.status,
-                metadata: entry.metadata,
-                created_at: existing.as_ref().map(|e| e.created_at).unwrap_or(now),
-                updated_at: now,
-            };
-            entries.insert(entry.resource_id, out.clone());
-            Ok(out)
+    impl crate::traits::SessionStorageStore for TestStorageStore {
+        async fn set_value(&self, _session_id: SessionId, key: &str, value: &str) -> Result<()> {
+            self.values
+                .lock()
+                .unwrap()
+                .insert(key.to_string(), value.to_string());
+            Ok(())
         }
 
-        async fn update_status(
+        async fn get_value(&self, _session_id: SessionId, key: &str) -> Result<Option<String>> {
+            Ok(self.values.lock().unwrap().get(key).cloned())
+        }
+
+        async fn delete_value(&self, _session_id: SessionId, key: &str) -> Result<bool> {
+            Ok(self.values.lock().unwrap().remove(key).is_some())
+        }
+
+        async fn list_keys(&self, _session_id: SessionId) -> Result<Vec<crate::KeyInfo>> {
+            Ok(Vec::new())
+        }
+
+        async fn set_secret(
             &self,
             _session_id: SessionId,
-            resource_id: &str,
-            status: SessionResourceStatus,
-        ) -> Result<Option<crate::session_resource::SessionResourceEntry>> {
-            let mut entries = self.entries.lock().unwrap();
-            if let Some(entry) = entries.get_mut(resource_id) {
-                entry.status = status;
-                return Ok(Some(entry.clone()));
-            }
+            _name: &str,
+            _value: &str,
+        ) -> Result<()> {
+            Ok(())
+        }
+
+        async fn get_secret(&self, _session_id: SessionId, _name: &str) -> Result<Option<String>> {
             Ok(None)
         }
 
-        async fn get(
-            &self,
-            _session_id: SessionId,
-            resource_id: &str,
-        ) -> Result<Option<crate::session_resource::SessionResourceEntry>> {
-            Ok(self.entries.lock().unwrap().get(resource_id).cloned())
+        async fn delete_secret(&self, _session_id: SessionId, _name: &str) -> Result<bool> {
+            Ok(false)
         }
 
-        async fn list(
-            &self,
-            _session_id: SessionId,
-            filter: Option<&SessionResourceFilter>,
-        ) -> Result<Vec<crate::session_resource::SessionResourceEntry>> {
-            let entries = self.entries.lock().unwrap();
-            Ok(entries
-                .values()
-                .filter(|entry| {
-                    filter
-                        .and_then(|f| f.kind.as_deref())
-                        .is_none_or(|kind| entry.kind == kind)
-                })
-                .cloned()
-                .collect())
-        }
-
-        async fn deregister(&self, _session_id: SessionId, resource_id: &str) -> Result<bool> {
-            Ok(self.entries.lock().unwrap().remove(resource_id).is_some())
+        async fn list_secrets(&self, _session_id: SessionId) -> Result<Vec<crate::SecretInfo>> {
+            Ok(Vec::new())
         }
     }
 
@@ -2138,11 +2123,10 @@ mod tests {
     }
 
     fn context(
-        registry: Arc<TestSessionResourceRegistry>,
+        storage_store: Arc<TestStorageStore>,
         file_store: Arc<TestFileStore>,
     ) -> ToolContext {
-        ToolContext::with_file_store(SessionId::new(), file_store)
-            .with_session_resource_registry(registry)
+        ToolContext::with_stores(SessionId::new(), file_store, storage_store)
     }
 
     #[tokio::test]
@@ -2150,9 +2134,9 @@ mod tests {
         let base_url = spawn_real_a2a_agent().await;
         let config = configured_capability(base_url);
         let tool = SpawnAgentTool::new(config);
-        let registry = Arc::new(TestSessionResourceRegistry::default());
+        let storage_store = Arc::new(TestStorageStore::default());
         let file_store = Arc::new(TestFileStore::default());
-        let ctx = context(registry, file_store);
+        let ctx = context(storage_store, file_store);
 
         let result = tool
             .execute_with_context(
@@ -2180,9 +2164,9 @@ mod tests {
         let config = configured_capability(base_url);
         let spawn = SpawnAgentTool::new(config.clone());
         let wait = WaitAgentTool::new(config);
-        let registry = Arc::new(TestSessionResourceRegistry::default());
+        let storage_store = Arc::new(TestStorageStore::default());
         let file_store = Arc::new(TestFileStore::default());
-        let ctx = context(registry, file_store);
+        let ctx = context(storage_store, file_store);
 
         let result = spawn
             .execute_with_context(
@@ -2423,5 +2407,81 @@ mod tests {
         config.agents[0].preferred_binding = Some("JSONRPC".to_string());
         config.agents[0].poll_interval_ms = Some(99);
         assert!(config.agents[0].validate().is_err());
+    }
+
+    /// Roundtrip: save_run → load_run → load_run_for_task all resolve consistently.
+    #[tokio::test]
+    async fn agent_run_storage_roundtrip() {
+        let storage_store = Arc::new(TestStorageStore::default());
+        let file_store = Arc::new(TestFileStore::default());
+        let ctx = context(storage_store, file_store);
+
+        let run_id = "test-run-roundtrip".to_string();
+        let task_id = "task-abc".to_string();
+        let config = ExternalA2aAgentConfig {
+            id: "echo".to_string(),
+            name: "Echo".to_string(),
+            description: None,
+            base_url: Some("http://localhost:1".to_string()),
+            agent_card: None,
+            headers: BTreeMap::new(),
+            preferred_binding: None,
+            poll_interval_ms: None,
+            allow_local_urls: true,
+        };
+        let mut record = AgentRunRecord::new(
+            run_id.clone(),
+            &config,
+            "do something".to_string(),
+            AgentRunMode::Wait,
+            false,
+        );
+        record.task_id = Some(task_id.clone());
+
+        // save_run then load_run should round-trip the record.
+        save_run(&ctx, &record).await.expect("save_run failed");
+        let loaded = load_run(&ctx, &run_id).await.expect("load_run failed");
+        assert_eq!(loaded.run_id, run_id);
+        assert_eq!(loaded.task_id.as_deref(), Some(task_id.as_str()));
+
+        // load_run_for_task with run_id in spec should resolve the same record.
+        let now = chrono::Utc::now();
+        let fake_task = SessionTask {
+            id: task_id.clone(),
+            session_id: ctx.session_id,
+            kind: TASK_KIND_EXTERNAL_AGENT.to_string(),
+            display_name: "Echo".to_string(),
+            spec: json!({ "run_id": &run_id }),
+            state: SessionTaskState::Running,
+            state_detail: None,
+            progress: None,
+            links: TaskLinks::default(),
+            wake_policy: TaskWakePolicy::Silent,
+            input_request: None,
+            cancel_requested_at: None,
+            summary: None,
+            result_path: None,
+            artifacts: vec![],
+            error: None,
+            attempt: 1,
+            worker_id: None,
+            heartbeat_at: None,
+            started_at: None,
+            finished_at: None,
+            created_at: now,
+            updated_at: now,
+        };
+        let from_task = load_run_for_task(&ctx, &fake_task)
+            .await
+            .expect("load_run_for_task failed");
+        assert_eq!(from_task.run_id, run_id);
+
+        // The index should list the run_id.
+        let storage = ctx.storage_store.as_ref().unwrap();
+        let index = load_run_index(storage.as_ref(), ctx.session_id).await;
+        assert!(
+            index.contains(&run_id),
+            "run_id not found in index: {index:?}"
+        );
     }
 }

--- a/crates/core/src/capabilities/a2a_delegation.rs
+++ b/crates/core/src/capabilities/a2a_delegation.rs
@@ -3,8 +3,8 @@
 // Decision: V1 is outbound-only and stores configured external agents in the
 // capability config. Run state is persisted as session storage KV entries
 // (key = "agent_run:{run_id}") so agents and UI have a unified local/remote
-// delegation handle. An index key "agent_run:index" (JSON array of run_ids)
-// enables listing. The session resource registry is no longer used for A2A
+// delegation handle. Listing derives from `list_keys` by prefix — no index
+// key, so concurrent spawns cannot race. The resource registry is unused for
 // runs (retired as part of the session-tasks dual-write cleanup).
 
 use super::{Capability, CapabilityLocalization, CapabilityStatus, RiskLevel, SystemPromptContext};
@@ -608,38 +608,27 @@ fn run_key(run_id: &str) -> String {
     format!("agent_run:{run_id}")
 }
 
-/// KV key for the agent run index (list of all run_ids for this session).
-const AGENT_RUN_INDEX_KEY: &str = "agent_run:index";
+/// Prefix shared by all agent run KV keys.
+const AGENT_RUN_KEY_PREFIX: &str = "agent_run:";
 
-/// Load the current index (list of run_ids). Returns empty vec on missing/error.
-async fn load_run_index(
+/// List run_ids by prefix-filtering the session's KV keys. Derived from
+/// `list_keys` rather than a maintained index key, so concurrent spawns
+/// cannot race a read-modify-write and drop runs.
+async fn list_run_ids(
     storage: &dyn SessionStorageStore,
     session_id: crate::typed_id::SessionId,
 ) -> Vec<String> {
     storage
-        .get_value(session_id, AGENT_RUN_INDEX_KEY)
+        .list_keys(session_id)
         .await
-        .ok()
-        .flatten()
-        .and_then(|s| serde_json::from_str::<Vec<String>>(&s).ok())
         .unwrap_or_default()
-}
-
-/// Append a run_id to the index (idempotent).
-async fn append_run_to_index(
-    storage: &dyn SessionStorageStore,
-    session_id: crate::typed_id::SessionId,
-    run_id: &str,
-) {
-    let mut index = load_run_index(storage, session_id).await;
-    if !index.contains(&run_id.to_string()) {
-        index.push(run_id.to_string());
-        if let Ok(serialized) = serde_json::to_string(&index) {
-            let _ = storage
-                .set_value(session_id, AGENT_RUN_INDEX_KEY, &serialized)
-                .await;
-        }
-    }
+        .into_iter()
+        .filter_map(|info| {
+            info.key
+                .strip_prefix(AGENT_RUN_KEY_PREFIX)
+                .map(ToString::to_string)
+        })
+        .collect()
 }
 
 fn require_str<'a>(
@@ -666,7 +655,6 @@ async fn save_run(context: &ToolContext, record: &AgentRunRecord) -> Result<()> 
     storage
         .set_value(context.session_id, &run_key(&record.run_id), &serialized)
         .await?;
-    append_run_to_index(storage.as_ref(), context.session_id, &record.run_id).await;
     Ok(())
 }
 
@@ -1366,7 +1354,7 @@ impl Tool for GetAgentRunsTool {
             Ok(s) => s,
             Err(e) => return e,
         };
-        let run_ids = load_run_index(storage.as_ref(), context.session_id).await;
+        let run_ids = list_run_ids(storage.as_ref(), context.session_id).await;
         let status_filter = arguments
             .get("status_filter")
             .and_then(Value::as_str)
@@ -1867,7 +1855,18 @@ mod tests {
         }
 
         async fn list_keys(&self, _session_id: SessionId) -> Result<Vec<crate::KeyInfo>> {
-            Ok(Vec::new())
+            let now = chrono::Utc::now();
+            Ok(self
+                .values
+                .lock()
+                .unwrap()
+                .keys()
+                .map(|key| crate::KeyInfo {
+                    key: key.clone(),
+                    created_at: now,
+                    updated_at: now,
+                })
+                .collect())
         }
 
         async fn set_secret(
@@ -2476,9 +2475,9 @@ mod tests {
             .expect("load_run_for_task failed");
         assert_eq!(from_task.run_id, run_id);
 
-        // The index should list the run_id.
+        // The prefix-derived listing should include the run_id.
         let storage = ctx.storage_store.as_ref().unwrap();
-        let index = load_run_index(storage.as_ref(), ctx.session_id).await;
+        let index = list_run_ids(storage.as_ref(), ctx.session_id).await;
         assert!(
             index.contains(&run_id),
             "run_id not found in index: {index:?}"

--- a/crates/core/src/capabilities/agent_handoff.rs
+++ b/crates/core/src/capabilities/agent_handoff.rs
@@ -9,30 +9,27 @@
 use super::{Capability, CapabilityLocalization, CapabilityStatus, RiskLevel, SystemPromptContext};
 use crate::platform_store::PlatformStore;
 use crate::session::SubagentStatus;
-use crate::session_resource::{
-    RegisterSessionResource, SessionResourceFilter, SessionResourceStatus,
+use crate::session_task::{
+    CreateSessionTask, SessionTaskState, SessionTaskUpdate, TASK_KIND_SUBAGENT, TaskError,
+    TaskLinks, TaskWakePolicy,
 };
 use crate::tool_types::ToolHints;
 use crate::tools::{Tool, ToolExecutionResult};
-use crate::traits::{SessionResourceRegistry, ToolContext};
+use crate::traits::ToolContext;
 use crate::typed_id::{AgentId, HarnessId};
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
 pub const AGENT_HANDOFF_CAPABILITY_ID: &str = "agent_handoff";
-const AGENT_HANDOFF_RESOURCE_KIND: &str = "agent_handoff";
 const DEFAULT_WAIT_TIMEOUT_SECS: u64 = 300;
 
-fn terminal_handoff_status(wait_status: &str) -> Option<(SessionResourceStatus, SubagentStatus)> {
+fn terminal_handoff_status(wait_status: &str) -> Option<SubagentStatus> {
     match wait_status {
-        "idle" | "completed" => Some((SessionResourceStatus::Completed, SubagentStatus::Completed)),
-        "error" | "failed" => Some((SessionResourceStatus::Failed, SubagentStatus::Failed)),
-        "cancelled" => Some((SessionResourceStatus::Failed, SubagentStatus::Cancelled)),
-        "max_iterations_reached" => Some((
-            SessionResourceStatus::Failed,
-            SubagentStatus::MaxIterationsReached,
-        )),
+        "idle" | "completed" => Some(SubagentStatus::Completed),
+        "error" | "failed" => Some(SubagentStatus::Failed),
+        "cancelled" => Some(SubagentStatus::Cancelled),
+        "max_iterations_reached" => Some(SubagentStatus::MaxIterationsReached),
         _ => None,
     }
 }
@@ -416,35 +413,6 @@ async fn require_connections(
     Ok(())
 }
 
-async fn register_handoff_resource(
-    registry: Option<&std::sync::Arc<dyn SessionResourceRegistry>>,
-    parent_session_id: crate::typed_id::SessionId,
-    child_session_id: crate::typed_id::SessionId,
-    target: &AgentHandoffTargetConfig,
-    mode: AgentHandoffMode,
-    status: SessionResourceStatus,
-) {
-    let Some(registry) = registry else {
-        return;
-    };
-    let _ = registry
-        .register(RegisterSessionResource {
-            session_id: parent_session_id,
-            resource_id: child_session_id.to_string(),
-            kind: AGENT_HANDOFF_RESOURCE_KIND.to_string(),
-            display_name: target.name.clone(),
-            status,
-            metadata: json!({
-                "target": target.id,
-                "target_agent_id": target.agent_id,
-                "required_connections": target.required_connections,
-                "required_scopes": target.required_scopes,
-                "mode": mode.as_str(),
-            }),
-        })
-        .await;
-}
-
 pub struct StartAgentHandoffTool {
     config: AgentHandoffConfig,
 }
@@ -576,15 +544,34 @@ impl Tool for StartAgentHandoffTool {
             Err(error) => return ToolExecutionResult::internal_error(error),
         };
 
-        register_handoff_resource(
-            context.session_resource_registry.as_ref(),
-            context.session_id,
-            child_session.id,
-            target,
-            mode,
-            SessionResourceStatus::Active,
-        )
-        .await;
+        // Register a subagent-kind session task so the handoff appears in the
+        // task registry alongside other work-shaped tasks (specs/session-tasks.md).
+        let handoff_task_id: Option<String> =
+            if let Some(task_registry) = &context.session_task_registry {
+                task_registry
+                    .create(CreateSessionTask {
+                        session_id: context.session_id,
+                        id: None,
+                        kind: TASK_KIND_SUBAGENT.to_string(),
+                        display_name: target.name.clone(),
+                        spec: json!({
+                            "target_id": &target.id,
+                            "external_agent_id": target.agent_id,
+                            "mode": mode.as_str(),
+                        }),
+                        state: SessionTaskState::Running,
+                        links: TaskLinks {
+                            child_session_id: Some(child_session.id),
+                            ..Default::default()
+                        },
+                        wake_policy: TaskWakePolicy::Silent,
+                    })
+                    .await
+                    .ok()
+                    .map(|t| t.id)
+            } else {
+                None
+            };
 
         if let Err(error) = store.send_message(child_session.id, &handoff_task).await {
             return ToolExecutionResult::internal_error(error);
@@ -596,15 +583,6 @@ impl Tool for StartAgentHandoffTool {
         {
             Ok(status) => status,
             Err(error) => {
-                if let Some(registry) = &context.session_resource_registry {
-                    let _ = registry
-                        .update_status(
-                            context.session_id,
-                            &child_session.id.to_string(),
-                            SessionResourceStatus::Failed,
-                        )
-                        .await;
-                }
                 return ToolExecutionResult::success(json!({
                     "handoff_id": child_session.id.to_string(),
                     "target": target.id,
@@ -624,24 +602,14 @@ impl Tool for StartAgentHandoffTool {
         let result = last_agent_message(&messages)
             .unwrap_or_else(|| format!("Handoff completed with status: {status}"));
 
-        if let Some((resource_status, subagent_status)) = terminal_handoff_status(&status) {
-            if let Some(registry) = &context.session_resource_registry {
-                let _ = registry
-                    .update_status(
-                        context.session_id,
-                        &child_session.id.to_string(),
-                        resource_status,
-                    )
-                    .await;
-            }
-
+        if let Some(subagent_status) = terminal_handoff_status(&status) {
             if let Err(error) = store
                 .set_subagent_metadata(
                     child_session.id,
                     context.session_id,
                     &target.name,
                     &handoff_task,
-                    subagent_status,
+                    subagent_status.clone(),
                 )
                 .await
             {
@@ -651,6 +619,40 @@ impl Tool for StartAgentHandoffTool {
                     error = %error,
                     "failed to persist terminal handoff metadata"
                 );
+            }
+
+            // Mirror terminal state into the session task (best-effort).
+            if let (Some(registry), Some(task_id)) =
+                (&context.session_task_registry, &handoff_task_id)
+            {
+                let task_state = match subagent_status {
+                    SubagentStatus::Completed => SessionTaskState::Succeeded,
+                    SubagentStatus::Failed | SubagentStatus::MaxIterationsReached => {
+                        SessionTaskState::Failed
+                    }
+                    SubagentStatus::Cancelled => SessionTaskState::Canceled,
+                    SubagentStatus::Running | SubagentStatus::Spawning => SessionTaskState::Running,
+                };
+                let error = if task_state == SessionTaskState::Failed {
+                    Some(TaskError {
+                        kind: "handoff_failed".to_string(),
+                        message: format!("Handoff ended with status: {status}"),
+                    })
+                } else {
+                    None
+                };
+                let _ = registry
+                    .update(
+                        context.session_id,
+                        task_id,
+                        SessionTaskUpdate {
+                            state: Some(task_state),
+                            summary: Some(result.clone()),
+                            error,
+                            ..Default::default()
+                        },
+                    )
+                    .await;
             }
         }
 
@@ -710,21 +712,6 @@ impl Tool for GetAgentHandoffsTool {
         arguments: Value,
         context: &ToolContext,
     ) -> ToolExecutionResult {
-        if let Some(registry) = &context.session_resource_registry {
-            let filter = SessionResourceFilter {
-                kind: Some(AGENT_HANDOFF_RESOURCE_KIND.to_string()),
-                status: None,
-            };
-            let mut entries = match registry.list(context.session_id, Some(&filter)).await {
-                Ok(entries) => entries,
-                Err(error) => return ToolExecutionResult::internal_error(error),
-            };
-            if let Some(handoff_id) = arguments.get("handoff_id").and_then(Value::as_str) {
-                entries.retain(|entry| entry.resource_id == handoff_id);
-            }
-            return ToolExecutionResult::success(json!({ "handoffs": entries }));
-        }
-
         let store = match get_platform_store(context) {
             Ok(store) => store,
             Err(error) => return error,
@@ -872,12 +859,11 @@ mod tests {
     use super::*;
     use crate::Result;
     use crate::platform_store::tests::MockPlatformStore;
-    use crate::session_resource::{SessionResourceEntry, SessionResourceFilter};
     use crate::tools::{Tool, ToolExecutionResult};
-    use crate::traits::{SessionResourceRegistry, UserConnectionResolver};
+    use crate::traits::UserConnectionResolver;
     use crate::typed_id::SessionId;
-    use std::collections::{HashMap, HashSet};
-    use std::sync::{Arc, Mutex};
+    use std::collections::HashSet;
+    use std::sync::Arc;
     use uuid::Uuid;
 
     fn target_config(
@@ -958,106 +944,13 @@ mod tests {
         }
     }
 
-    #[derive(Default)]
-    struct TestResourceRegistry {
-        entries: Mutex<HashMap<(SessionId, String), SessionResourceEntry>>,
-    }
-
-    #[async_trait]
-    impl SessionResourceRegistry for TestResourceRegistry {
-        async fn register(&self, entry: RegisterSessionResource) -> Result<SessionResourceEntry> {
-            let now = chrono::Utc::now();
-            let record = SessionResourceEntry {
-                resource_id: entry.resource_id,
-                session_id: entry.session_id,
-                kind: entry.kind,
-                display_name: entry.display_name,
-                status: entry.status,
-                metadata: entry.metadata,
-                created_at: now,
-                updated_at: now,
-            };
-            self.entries.lock().expect("registry mutex").insert(
-                (record.session_id, record.resource_id.clone()),
-                record.clone(),
-            );
-            Ok(record)
-        }
-
-        async fn update_status(
-            &self,
-            session_id: SessionId,
-            resource_id: &str,
-            status: SessionResourceStatus,
-        ) -> Result<Option<SessionResourceEntry>> {
-            let mut entries = self.entries.lock().expect("registry mutex");
-            let Some(entry) = entries.get_mut(&(session_id, resource_id.to_string())) else {
-                return Ok(None);
-            };
-            entry.status = status;
-            entry.updated_at = chrono::Utc::now();
-            Ok(Some(entry.clone()))
-        }
-
-        async fn get(
-            &self,
-            session_id: SessionId,
-            resource_id: &str,
-        ) -> Result<Option<SessionResourceEntry>> {
-            Ok(self
-                .entries
-                .lock()
-                .expect("registry mutex")
-                .get(&(session_id, resource_id.to_string()))
-                .cloned())
-        }
-
-        async fn list(
-            &self,
-            session_id: SessionId,
-            filter: Option<&SessionResourceFilter>,
-        ) -> Result<Vec<SessionResourceEntry>> {
-            let mut entries = self
-                .entries
-                .lock()
-                .expect("registry mutex")
-                .values()
-                .filter(|entry| entry.session_id == session_id)
-                .filter(|entry| {
-                    filter
-                        .and_then(|f| f.kind.as_ref())
-                        .is_none_or(|kind| &entry.kind == kind)
-                })
-                .filter(|entry| {
-                    filter
-                        .and_then(|f| f.status)
-                        .is_none_or(|status| entry.status == status)
-                })
-                .cloned()
-                .collect::<Vec<_>>();
-            entries.sort_by(|a, b| a.resource_id.cmp(&b.resource_id));
-            Ok(entries)
-        }
-
-        async fn deregister(&self, session_id: SessionId, resource_id: &str) -> Result<bool> {
-            Ok(self
-                .entries
-                .lock()
-                .expect("registry mutex")
-                .remove(&(session_id, resource_id.to_string()))
-                .is_some())
-        }
-    }
-
     fn context(
         store: Arc<MockPlatformStore>,
         resolver: Option<Arc<dyn UserConnectionResolver>>,
-        registry: Option<Arc<dyn SessionResourceRegistry>>,
     ) -> ToolContext {
         let mut context = ToolContext::new(store.session.id);
         context.platform_store = Some(store);
         context.connection_resolver = resolver;
-        context.session_resource_registry = registry;
         context
     }
 
@@ -1092,18 +985,15 @@ mod tests {
     fn terminal_handoff_status_maps_only_terminal_wait_states() {
         assert_eq!(
             terminal_handoff_status("idle"),
-            Some((SessionResourceStatus::Completed, SubagentStatus::Completed))
+            Some(SubagentStatus::Completed)
         );
         assert_eq!(
             terminal_handoff_status("error"),
-            Some((SessionResourceStatus::Failed, SubagentStatus::Failed))
+            Some(SubagentStatus::Failed)
         );
         assert_eq!(
             terminal_handoff_status("max_iterations_reached"),
-            Some((
-                SessionResourceStatus::Failed,
-                SubagentStatus::MaxIterationsReached,
-            ))
+            Some(SubagentStatus::MaxIterationsReached)
         );
         assert_eq!(terminal_handoff_status("waiting_for_tool_results"), None);
         assert_eq!(terminal_handoff_status("paused"), None);
@@ -1138,7 +1028,7 @@ mod tests {
         let resolver = Arc::new(TestConnectionResolver {
             providers: HashSet::new(),
         });
-        let context = context(store, Some(resolver), None);
+        let context = context(store, Some(resolver));
 
         let result = tool
             .execute_with_context(
@@ -1165,7 +1055,7 @@ mod tests {
             vec!["fake_aws"],
         );
         let tool = start_tool(config);
-        let context = context(store, None, None);
+        let context = context(store, None);
 
         let result = tool
             .execute_with_context(
@@ -1183,7 +1073,6 @@ mod tests {
     #[tokio::test]
     async fn start_handoff_creates_child_session_for_target_agent() {
         let store = Arc::new(MockPlatformStore::new());
-        let registry = Arc::new(TestResourceRegistry::default());
         let resolver = Arc::new(TestConnectionResolver {
             providers: HashSet::from(["fake_aws".to_string()]),
         });
@@ -1193,7 +1082,7 @@ mod tests {
             vec!["fake_aws"],
         );
         let tool = start_tool(config);
-        let context = context(store.clone(), Some(resolver), Some(registry.clone()));
+        let context = context(store.clone(), Some(resolver));
 
         let result = tool
             .execute_with_context(
@@ -1212,21 +1101,6 @@ mod tests {
         assert_eq!(value["target"], "aws_operator");
         assert_eq!(value["target_agent_id"], json!(store.agent.public_id));
         assert_eq!(value["result"], "Hi!");
-
-        let handoff_id = value["handoff_id"].as_str().expect("handoff_id");
-        let entry = registry
-            .get(context.session_id, handoff_id)
-            .await
-            .expect("registry get")
-            .expect("handoff resource");
-        assert_eq!(entry.kind, AGENT_HANDOFF_RESOURCE_KIND);
-        assert_eq!(entry.status, SessionResourceStatus::Completed);
-        assert_eq!(entry.metadata["target"], "aws_operator");
-        assert_eq!(entry.metadata["required_connections"], json!(["fake_aws"]));
-        assert_eq!(
-            entry.metadata["required_scopes"],
-            json!(["fake_aws:rds:create"])
-        );
     }
 
     /// Regression for the confused-deputy issue this PR fixes: the child
@@ -1237,7 +1111,6 @@ mod tests {
     #[tokio::test]
     async fn start_handoff_uses_target_harness_not_parent() {
         let store = Arc::new(MockPlatformStore::new());
-        let registry = Arc::new(TestResourceRegistry::default());
         let resolver = Arc::new(TestConnectionResolver {
             providers: HashSet::from(["fake_aws".to_string()]),
         });
@@ -1248,7 +1121,7 @@ mod tests {
 
         let config = target_config(store.agent.public_id, target_harness_id, vec!["fake_aws"]);
         let tool = start_tool(config);
-        let context = context(store.clone(), Some(resolver), Some(registry));
+        let context = context(store.clone(), Some(resolver));
 
         let result = tool
             .execute_with_context(
@@ -1282,39 +1155,37 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn get_handoffs_lists_registered_handoff_resources() {
-        let store = Arc::new(MockPlatformStore::new());
-        let registry = Arc::new(TestResourceRegistry::default());
+    async fn get_handoffs_lists_child_sessions_as_handoffs() {
+        // The get_agent_handoffs tool uses list_sessions filtered by parent_session_id.
+        // Set up a mock store whose session record already represents a child session
+        // so list_sessions returns it in the filtered results.
+        let parent_id = SessionId::new();
+        let mut store_value = MockPlatformStore::new();
+        store_value.session.parent_session_id = Some(parent_id);
+        store_value.session.subagent_name = Some("AWS Operator".to_string());
+        store_value.session.subagent_status = Some(SubagentStatus::Completed);
+        let store = Arc::new(store_value);
         let config = target_config(store.agent.public_id, store.session.harness_id, vec![]);
-        let start = start_tool(config.clone());
         let get = get_tool(config);
-        let context = context(store, None, Some(registry));
 
-        let start_result = start
-            .execute_with_context(
-                json!({
-                    "target": "aws_operator",
-                    "task": "Create an RDS database named app-db"
-                }),
-                &context,
-            )
-            .await;
-        assert!(start_result.is_success());
+        let mut ctx = ToolContext::new(parent_id);
+        ctx.platform_store = Some(store);
 
-        let result = get.execute_with_context(json!({}), &context).await;
+        let result = get.execute_with_context(json!({}), &ctx).await;
         let ToolExecutionResult::Success(value) = result else {
             panic!("expected success, got {result:?}");
         };
-        assert_eq!(value["handoffs"].as_array().expect("handoffs").len(), 1);
-        assert_eq!(value["handoffs"][0]["kind"], AGENT_HANDOFF_RESOURCE_KIND);
-        assert_eq!(value["handoffs"][0]["status"], "completed");
+        let handoffs = value["handoffs"].as_array().expect("handoffs");
+        assert_eq!(handoffs.len(), 1);
+        assert_eq!(handoffs[0]["name"], "AWS Operator");
+        assert_eq!(handoffs[0]["status"], "completed");
     }
 
     #[tokio::test]
     async fn message_handoff_rejects_invalid_handoff_id() {
         let store = Arc::new(MockPlatformStore::new());
         let tool = message_tool(json!({}));
-        let context = context(store, None, None);
+        let context = context(store, None);
 
         let result = tool
             .execute_with_context(

--- a/crates/core/src/capabilities/agent_handoff.rs
+++ b/crates/core/src/capabilities/agent_handoff.rs
@@ -583,6 +583,27 @@ impl Tool for StartAgentHandoffTool {
         {
             Ok(status) => status,
             Err(error) => {
+                // Mirror the failure into the session task (best-effort) so it
+                // is not left running indefinitely — handoff tasks do not
+                // heartbeat, so the orphan reaper would never reclaim them.
+                if let (Some(registry), Some(task_id)) =
+                    (&context.session_task_registry, &handoff_task_id)
+                {
+                    let _ = registry
+                        .update(
+                            context.session_id,
+                            task_id,
+                            SessionTaskUpdate {
+                                state: Some(SessionTaskState::Failed),
+                                error: Some(TaskError {
+                                    kind: "handoff_failed".to_string(),
+                                    message: error.to_string(),
+                                }),
+                                ..Default::default()
+                            },
+                        )
+                        .await;
+                }
                 return ToolExecutionResult::success(json!({
                     "handoff_id": child_session.id.to_string(),
                     "target": target.id,

--- a/crates/core/src/capabilities/subagents.rs
+++ b/crates/core/src/capabilities/subagents.rs
@@ -84,29 +84,12 @@ impl Capability for SubagentCapability {
 
 const SUBAGENT_SYSTEM_PROMPT: &str = "Spawn subagents only for independent workstreams that benefit from parallelism or a separate context window. Do not delegate immediate sequential steps you can complete directly. No nested subagents. Use blueprints for specialist agents with their own tools and model.";
 
-fn terminal_subagent_status(
-    wait_status: &str,
-) -> Option<(
-    crate::session_resource::SessionResourceStatus,
-    crate::session::SubagentStatus,
-)> {
+fn terminal_subagent_status(wait_status: &str) -> Option<crate::session::SubagentStatus> {
     match wait_status {
-        "idle" | "completed" => Some((
-            crate::session_resource::SessionResourceStatus::Completed,
-            crate::session::SubagentStatus::Completed,
-        )),
-        "error" | "failed" => Some((
-            crate::session_resource::SessionResourceStatus::Failed,
-            crate::session::SubagentStatus::Failed,
-        )),
-        "cancelled" => Some((
-            crate::session_resource::SessionResourceStatus::Failed,
-            crate::session::SubagentStatus::Cancelled,
-        )),
-        "max_iterations_reached" => Some((
-            crate::session_resource::SessionResourceStatus::Failed,
-            crate::session::SubagentStatus::MaxIterationsReached,
-        )),
+        "idle" | "completed" => Some(crate::session::SubagentStatus::Completed),
+        "error" | "failed" => Some(crate::session::SubagentStatus::Failed),
+        "cancelled" => Some(crate::session::SubagentStatus::Cancelled),
+        "max_iterations_reached" => Some(crate::session::SubagentStatus::MaxIterationsReached),
         _ => None,
     }
 }
@@ -579,23 +562,6 @@ async fn spawn_create_and_wait(
         Err(e) => return ToolExecutionResult::internal_error(e),
     };
 
-    // Register subagent in session resource registry.
-    if let Some(ref registry) = context.session_resource_registry {
-        let _ = registry
-            .register(crate::session_resource::RegisterSessionResource {
-                session_id: context.session_id,
-                resource_id: child_session.id.to_string(),
-                kind: "subagent".to_string(),
-                display_name: name.to_string(),
-                status: crate::session_resource::SessionResourceStatus::Active,
-                metadata: json!({
-                    "task": task,
-                    "blueprint_id": blueprint_param,
-                }),
-            })
-            .await;
-    }
-
     // Create the session task tracking this subagent (specs/session-tasks.md).
     let mut task_id: Option<String> = None;
     if let Some(ref task_registry) = context.session_task_registry
@@ -688,16 +654,6 @@ async fn run_subagent_wait_and_settle(
     let status = match store.wait_for_idle(child_id, Some(300)).await {
         Ok(s) => s,
         Err(e) => {
-            // Mark as failed in registry.
-            if let Some(ref registry) = context.session_resource_registry {
-                let _ = registry
-                    .update_status(
-                        context.session_id,
-                        &child_id.to_string(),
-                        crate::session_resource::SessionResourceStatus::Failed,
-                    )
-                    .await;
-            }
             finish_subagent_task(
                 context,
                 task_id.as_deref(),
@@ -753,16 +709,11 @@ async fn run_subagent_wait_and_settle(
         );
     }
 
-    // Update registry and persist metadata only when the child reached a
+    // Persist metadata and update the session task only when the child reached a
     // terminal state. Non-terminal results from wait_for_idle (paused,
     // waiting_for_tool_results, timeout) leave the child Active.
-    if let Some((resource_status, subagent_status)) = terminal_status {
+    if let Some(subagent_status) = terminal_status {
         let task_state = terminal_subagent_task_state(&subagent_status);
-        if let Some(ref registry) = context.session_resource_registry {
-            let _ = registry
-                .update_status(context.session_id, &child_id.to_string(), resource_status)
-                .await;
-        }
         if let Err(e) = store
             .set_subagent_metadata(child_id, context.session_id, name, task, subagent_status)
             .await
@@ -1190,24 +1141,15 @@ mod tests {
     fn terminal_subagent_status_maps_only_terminal_wait_states() {
         assert_eq!(
             terminal_subagent_status("idle"),
-            Some((
-                crate::session_resource::SessionResourceStatus::Completed,
-                crate::session::SubagentStatus::Completed,
-            ))
+            Some(crate::session::SubagentStatus::Completed)
         );
         assert_eq!(
             terminal_subagent_status("failed"),
-            Some((
-                crate::session_resource::SessionResourceStatus::Failed,
-                crate::session::SubagentStatus::Failed,
-            ))
+            Some(crate::session::SubagentStatus::Failed)
         );
         assert_eq!(
             terminal_subagent_status("cancelled"),
-            Some((
-                crate::session_resource::SessionResourceStatus::Failed,
-                crate::session::SubagentStatus::Cancelled,
-            ))
+            Some(crate::session::SubagentStatus::Cancelled)
         );
         assert_eq!(
             terminal_subagent_task_state(&crate::session::SubagentStatus::Completed),

--- a/crates/core/src/tools.rs
+++ b/crates/core/src/tools.rs
@@ -20,7 +20,6 @@ use tracing::error;
 use crate::background::{
     BackgroundEventSink, BackgroundExecutableTool, BackgroundOutcome, BackgroundProgress,
 };
-use crate::session_resource::{RegisterSessionResource, SessionResourceStatus};
 use crate::session_schedule::MAX_ACTIVE_SCHEDULES_PER_SESSION;
 use crate::tool_types::{
     BuiltinTool, DeferrablePolicy, ToolCall, ToolDefinition, ToolHints, ToolPolicy, ToolResult,
@@ -1161,9 +1160,9 @@ impl Tool for SpawnBackgroundTool {
             };
         }
 
-        let Some(resource_registry) = &context.session_resource_registry else {
+        let Some(task_registry) = &context.session_task_registry else {
             return ToolExecutionResult::tool_error(
-                "Session resource registry not available in this context",
+                "Session task registry not available in this context. Background runs require task tracking.",
             );
         };
         if context.file_store.is_none() {
@@ -1196,52 +1195,32 @@ impl Tool for SpawnBackgroundTool {
         let artifact_dir = format!("/.background/{run_id}");
         let log_path = format!("{artifact_dir}/output.log");
         let result_path = format!("{artifact_dir}/result.json");
-        let metadata = json!({
-            "tool": tool_name,
-            "status_text": "Queued",
-            "signal_on_completion": signal_on_completion,
-            "artifact_dir": artifact_dir,
-            "log_path": log_path,
-            "result_path": result_path,
-        });
 
-        if let Err(e) = resource_registry
-            .register(RegisterSessionResource {
+        // Create the session task tracking this run (specs/session-tasks.md).
+        // task_registry is guaranteed Some above.
+        let task_id: Option<String> = match task_registry
+            .create(crate::session_task::CreateSessionTask {
                 session_id: context.session_id,
-                resource_id: run_id.clone(),
-                kind: "background_run".to_string(),
+                id: None,
+                kind: crate::session_task::TASK_KIND_BACKGROUND_TOOL.to_string(),
                 display_name: title.clone(),
-                status: SessionResourceStatus::Active,
-                metadata,
+                spec: json!({
+                    "tool": tool_name,
+                    "arguments": &tool_args,
+                }),
+                state: crate::session_task::SessionTaskState::Running,
+                links: crate::session_task::TaskLinks::default(),
+                wake_policy: crate::session_task::TaskWakePolicy::Silent,
             })
             .await
         {
-            return ToolExecutionResult::internal_error_msg(format!(
-                "Failed to register background run: {e}"
-            ));
-        }
-
-        // Create the session task tracking this run (specs/session-tasks.md).
-        let mut task_id: Option<String> = None;
-        if let Some(ref task_registry) = context.session_task_registry
-            && let Ok(task) = task_registry
-                .create(crate::session_task::CreateSessionTask {
-                    session_id: context.session_id,
-                    id: None,
-                    kind: crate::session_task::TASK_KIND_BACKGROUND_TOOL.to_string(),
-                    display_name: title.clone(),
-                    spec: json!({
-                        "tool": tool_name,
-                        "arguments": &tool_args,
-                    }),
-                    state: crate::session_task::SessionTaskState::Running,
-                    links: crate::session_task::TaskLinks::default(),
-                    wake_policy: crate::session_task::TaskWakePolicy::Silent,
-                })
-                .await
-        {
-            task_id = Some(task.id);
-        }
+            Ok(task) => Some(task.id),
+            Err(e) => {
+                return ToolExecutionResult::internal_error_msg(format!(
+                    "Failed to create background run task: {e}"
+                ));
+            }
+        };
 
         let background_context = context.clone().with_tool_registry(tool_registry.clone());
         let sink = Arc::new(SessionBackgroundSink::new(
@@ -1465,8 +1444,6 @@ impl SessionBackgroundSink {
             ..Default::default()
         })
         .await;
-        self.update_resource(SessionResourceStatus::Failed, Some("Canceled by request."))
-            .await?;
         if self.signal_on_completion {
             self.signal_session("canceled", "Canceled by request.")
                 .await?;
@@ -1502,8 +1479,6 @@ impl SessionBackgroundSink {
                     ..Default::default()
                 })
                 .await;
-                self.update_resource(SessionResourceStatus::Completed, Some(&outcome.summary))
-                    .await?;
                 if self.signal_on_completion {
                     self.signal_session("completed", &outcome.summary).await?;
                 }
@@ -1551,8 +1526,6 @@ impl SessionBackgroundSink {
                     ..Default::default()
                 })
                 .await;
-                self.update_resource(SessionResourceStatus::Failed, Some(&message))
-                    .await?;
                 if self.signal_on_completion {
                     self.signal_session("failed", &message).await?;
                 }
@@ -1578,41 +1551,6 @@ impl SessionBackgroundSink {
         platform_store
             .send_message(self.context.session_id, &message)
             .await
-    }
-
-    async fn update_resource(
-        &self,
-        status: SessionResourceStatus,
-        summary: Option<&str>,
-    ) -> Result<()> {
-        let Some(registry) = &self.context.session_resource_registry else {
-            return Ok(());
-        };
-        let state = self.state.lock().await;
-        let status_text = state.status_text.clone();
-        let progress = state.progress.clone();
-        let output_tail = state.output_tail.clone();
-        drop(state);
-        registry
-            .register(RegisterSessionResource {
-                session_id: self.context.session_id,
-                resource_id: self.run_id.clone(),
-                kind: "background_run".to_string(),
-                display_name: self.display_name.clone(),
-                status,
-                metadata: json!({
-                    "tool": self.tool_name,
-                    "status_text": status_text,
-                    "progress": progress,
-                    "output_tail": output_tail,
-                    "log_path": self.log_path,
-                    "result_path": self.result_path,
-                    "summary": summary,
-                    "signal_on_completion": self.signal_on_completion,
-                }),
-            })
-            .await?;
-        Ok(())
     }
 
     async fn write_text_file(&self, path: &str, content: &str) -> Result<()> {
@@ -1645,8 +1583,7 @@ impl BackgroundEventSink for SessionBackgroundSink {
             ..Default::default()
         })
         .await;
-        self.update_resource(SessionResourceStatus::Active, None)
-            .await
+        Ok(())
     }
 
     async fn output(&self, stream: &str, delta: &str) -> Result<()> {
@@ -1668,9 +1605,7 @@ impl BackgroundEventSink for SessionBackgroundSink {
                     .collect();
             }
         }
-        drop(state);
-        self.update_resource(SessionResourceStatus::Active, None)
-            .await
+        Ok(())
     }
 
     async fn progress(&self, progress: BackgroundProgress) -> Result<()> {
@@ -1682,8 +1617,7 @@ impl BackgroundEventSink for SessionBackgroundSink {
             ..Default::default()
         })
         .await;
-        self.update_resource(SessionResourceStatus::Active, None)
-            .await
+        Ok(())
     }
 }
 
@@ -1828,9 +1762,8 @@ mod tests {
     use crate::capabilities::GetCurrentTimeTool;
     use crate::platform_store::PlatformStore;
     use crate::session_file::{FileInfo, FileStat, SessionFile};
-    use crate::session_resource::{SessionResourceEntry, SessionResourceFilter};
     use crate::session_task::SessionTaskRegistry;
-    use crate::traits::{SessionFileSystem, SessionResourceRegistry, SessionScheduleStore};
+    use crate::traits::{SessionFileSystem, SessionScheduleStore};
     use crate::typed_id::{HarnessId, SessionId};
     use crate::{AgentId, KeyInfo, PlatformMessage, SecretInfo};
     use async_trait::async_trait;
@@ -2078,87 +2011,6 @@ mod tests {
 
         fn as_background_executable(&self) -> Option<&dyn BackgroundExecutableTool> {
             Some(self)
-        }
-    }
-
-    #[derive(Default)]
-    struct TestSessionResourceRegistry {
-        entries: Mutex<HashMap<String, SessionResourceEntry>>,
-    }
-
-    #[async_trait]
-    impl crate::traits::SessionResourceRegistry for TestSessionResourceRegistry {
-        async fn register(
-            &self,
-            entry: RegisterSessionResource,
-        ) -> crate::Result<SessionResourceEntry> {
-            let stored = SessionResourceEntry {
-                resource_id: entry.resource_id.clone(),
-                session_id: entry.session_id,
-                kind: entry.kind,
-                display_name: entry.display_name,
-                status: entry.status,
-                metadata: entry.metadata,
-                created_at: chrono::Utc::now(),
-                updated_at: chrono::Utc::now(),
-            };
-            self.entries
-                .lock()
-                .unwrap()
-                .insert(entry.resource_id, stored.clone());
-            Ok(stored)
-        }
-
-        async fn update_status(
-            &self,
-            _session_id: SessionId,
-            resource_id: &str,
-            status: SessionResourceStatus,
-        ) -> crate::Result<Option<SessionResourceEntry>> {
-            let mut entries = self.entries.lock().unwrap();
-            if let Some(entry) = entries.get_mut(resource_id) {
-                entry.status = status;
-                entry.updated_at = chrono::Utc::now();
-                return Ok(Some(entry.clone()));
-            }
-            Ok(None)
-        }
-
-        async fn get(
-            &self,
-            _session_id: SessionId,
-            resource_id: &str,
-        ) -> crate::Result<Option<SessionResourceEntry>> {
-            Ok(self.entries.lock().unwrap().get(resource_id).cloned())
-        }
-
-        async fn list(
-            &self,
-            session_id: SessionId,
-            filter: Option<&SessionResourceFilter>,
-        ) -> crate::Result<Vec<SessionResourceEntry>> {
-            Ok(self
-                .entries
-                .lock()
-                .unwrap()
-                .values()
-                .filter(|entry| entry.session_id == session_id)
-                .filter(|entry| {
-                    filter.is_none_or(|filter| {
-                        filter.kind.as_ref().is_none_or(|kind| &entry.kind == kind)
-                            && filter.status.is_none_or(|status| entry.status == status)
-                    })
-                })
-                .cloned()
-                .collect())
-        }
-
-        async fn deregister(
-            &self,
-            _session_id: SessionId,
-            resource_id: &str,
-        ) -> crate::Result<bool> {
-            Ok(self.entries.lock().unwrap().remove(resource_id).is_some())
         }
     }
 
@@ -2975,10 +2827,10 @@ mod tests {
     #[tokio::test]
     async fn test_spawn_background_executes_and_signals_session() {
         let session_id = SessionId::new();
-        let resource_registry = Arc::new(TestSessionResourceRegistry::default());
         let file_store = Arc::new(TestFileStore::default());
         let platform_store = Arc::new(TestPlatformStore::default());
         let storage_store = Arc::new(NoopStorageStore);
+        let task_registry = Arc::new(InMemoryTaskRegistry::default());
         let tool_registry = ToolRegistry::builder()
             .tool(SpawnBackgroundTool)
             .tool(TestBackgroundTool)
@@ -2987,7 +2839,7 @@ mod tests {
         let context = ToolContext::with_stores(session_id, file_store.clone(), storage_store)
             .with_tool_registry(Arc::new(tool_registry))
             .with_platform_store(platform_store.clone())
-            .with_session_resource_registry(resource_registry.clone());
+            .with_session_task_registry(task_registry.clone());
 
         let tool = SpawnBackgroundTool;
         let result = tool
@@ -3004,27 +2856,25 @@ mod tests {
             panic!("spawn_background should succeed");
         };
         let run_id = value["run_id"].as_str().unwrap().to_string();
+        let task_id = value["task_id"].as_str().unwrap().to_string();
 
         tokio::time::timeout(std::time::Duration::from_secs(2), async {
             loop {
-                let entry = resource_registry
-                    .get(session_id, &run_id)
-                    .await
-                    .unwrap()
-                    .expect("resource exists");
-                if entry.status == SessionResourceStatus::Completed {
-                    break entry;
+                if let Ok(Some(task)) = task_registry.get(session_id, &task_id).await
+                    && task.state == crate::session_task::SessionTaskState::Succeeded
+                {
+                    break task;
                 }
                 tokio::time::sleep(std::time::Duration::from_millis(20)).await;
             }
         })
         .await
         .expect("background run should complete");
+        let _ = run_id; // still available in result json
 
         let messages = platform_store.sent_messages.lock().unwrap().clone();
         assert_eq!(messages.len(), 1);
         assert!(messages[0].contains("Background run completed"));
-        assert!(messages[0].contains(&run_id));
 
         let log_file = file_store
             .read_file(session_id, &format!("/.background/{run_id}/output.log"))
@@ -3043,9 +2893,9 @@ mod tests {
     #[tokio::test]
     async fn test_spawn_background_persists_failure_artifacts() {
         let session_id = SessionId::new();
-        let resource_registry = Arc::new(TestSessionResourceRegistry::default());
         let file_store = Arc::new(TestFileStore::default());
         let storage_store = Arc::new(NoopStorageStore);
+        let task_registry = Arc::new(InMemoryTaskRegistry::default());
         let tool_registry = ToolRegistry::builder()
             .tool(SpawnBackgroundTool)
             .tool(TestFailingBackgroundTool)
@@ -3053,7 +2903,7 @@ mod tests {
 
         let context = ToolContext::with_stores(session_id, file_store.clone(), storage_store)
             .with_tool_registry(Arc::new(tool_registry))
-            .with_session_resource_registry(resource_registry.clone());
+            .with_session_task_registry(task_registry.clone());
 
         let result = SpawnBackgroundTool
             .execute_with_context(
@@ -3069,22 +2919,21 @@ mod tests {
             panic!("spawn_background should succeed");
         };
         let run_id = value["run_id"].as_str().unwrap().to_string();
+        let task_id = value["task_id"].as_str().unwrap().to_string();
 
         tokio::time::timeout(std::time::Duration::from_secs(2), async {
             loop {
-                let entry = resource_registry
-                    .get(session_id, &run_id)
-                    .await
-                    .unwrap()
-                    .expect("resource exists");
-                if entry.status == SessionResourceStatus::Failed {
-                    break entry;
+                if let Ok(Some(task)) = task_registry.get(session_id, &task_id).await
+                    && task.state == crate::session_task::SessionTaskState::Failed
+                {
+                    break task;
                 }
                 tokio::time::sleep(std::time::Duration::from_millis(20)).await;
             }
         })
         .await
         .expect("background run should fail");
+        let _ = run_id;
 
         let log_file = file_store
             .read_file(session_id, &format!("/.background/{run_id}/output.log"))
@@ -3114,9 +2963,9 @@ mod tests {
     #[tokio::test]
     async fn test_spawn_background_rejects_when_session_active_run_limit_reached() {
         let session_id = SessionId::new();
-        let resource_registry = Arc::new(TestSessionResourceRegistry::default());
         let file_store = Arc::new(TestFileStore::default());
         let storage_store = Arc::new(NoopStorageStore);
+        let task_registry = Arc::new(InMemoryTaskRegistry::default());
         let release = StdArc::new(AtomicBool::new(false));
         let tool_registry = ToolRegistry::builder()
             .tool(SpawnBackgroundTool)
@@ -3127,9 +2976,9 @@ mod tests {
 
         let context = ToolContext::with_stores(session_id, file_store, storage_store)
             .with_tool_registry(Arc::new(tool_registry))
-            .with_session_resource_registry(resource_registry.clone());
+            .with_session_task_registry(task_registry.clone());
 
-        let mut run_ids = Vec::new();
+        let mut task_ids = Vec::new();
         for _ in 0..MAX_ACTIVE_BACKGROUND_RUNS_PER_SESSION {
             let result = SpawnBackgroundTool
                 .execute_with_context(
@@ -3144,29 +2993,30 @@ mod tests {
             let ToolExecutionResult::Success(value) = result else {
                 panic!("background run below the session limit should start");
             };
-            run_ids.push(value["run_id"].as_str().unwrap().to_string());
+            task_ids.push(value["task_id"].as_str().unwrap().to_string());
         }
 
+        // Wait for all tasks to be running (semaphore acquired).
         tokio::time::timeout(std::time::Duration::from_secs(2), async {
             loop {
-                let active_runs = resource_registry
+                let running = task_registry
                     .list(
                         session_id,
-                        Some(&SessionResourceFilter {
-                            kind: Some("background_run".to_string()),
-                            status: Some(SessionResourceStatus::Active),
+                        Some(&crate::session_task::SessionTaskFilter {
+                            kind: Some(crate::session_task::TASK_KIND_BACKGROUND_TOOL.to_string()),
+                            state: Some(crate::session_task::SessionTaskState::Running),
                         }),
                     )
                     .await
                     .unwrap();
-                if active_runs.len() == MAX_ACTIVE_BACKGROUND_RUNS_PER_SESSION {
+                if running.len() == MAX_ACTIVE_BACKGROUND_RUNS_PER_SESSION {
                     break;
                 }
                 tokio::time::sleep(std::time::Duration::from_millis(20)).await;
             }
         })
         .await
-        .expect("background runs should become active");
+        .expect("background runs should become running");
 
         let result = SpawnBackgroundTool
             .execute_with_context(
@@ -3186,14 +3036,11 @@ mod tests {
 
         release.store(true, Ordering::SeqCst);
         tokio::time::timeout(std::time::Duration::from_secs(2), async {
-            for run_id in run_ids {
+            for task_id in task_ids {
                 loop {
-                    let entry = resource_registry
-                        .get(session_id, &run_id)
-                        .await
-                        .unwrap()
-                        .expect("resource exists");
-                    if entry.status == SessionResourceStatus::Completed {
+                    if let Ok(Some(task)) = task_registry.get(session_id, &task_id).await
+                        && task.state == crate::session_task::SessionTaskState::Succeeded
+                    {
                         break;
                     }
                     tokio::time::sleep(std::time::Duration::from_millis(20)).await;
@@ -3205,18 +3052,49 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_spawn_background_requires_file_store() {
+    async fn test_spawn_background_requires_task_registry() {
         let session_id = SessionId::new();
-        let resource_registry = Arc::new(TestSessionResourceRegistry::default());
+        let file_store = Arc::new(TestFileStore::default());
         let storage_store = Arc::new(NoopStorageStore);
         let tool_registry = ToolRegistry::builder()
             .tool(SpawnBackgroundTool)
             .tool(TestBackgroundTool)
             .build();
 
+        // No task_registry wired — should fail.
+        let context = ToolContext::with_stores(session_id, file_store, storage_store)
+            .with_tool_registry(Arc::new(tool_registry));
+
+        let result = SpawnBackgroundTool
+            .execute_with_context(
+                json!({
+                    "tool": "test_background",
+                    "args": {}
+                }),
+                &context,
+            )
+            .await;
+
+        let ToolExecutionResult::ToolError(message) = result else {
+            panic!("spawn_background should reject missing task registry");
+        };
+        assert!(message.contains("Session task registry not available"));
+    }
+
+    #[tokio::test]
+    async fn test_spawn_background_requires_file_store() {
+        let session_id = SessionId::new();
+        let storage_store = Arc::new(NoopStorageStore);
+        let task_registry = Arc::new(InMemoryTaskRegistry::default());
+        let tool_registry = ToolRegistry::builder()
+            .tool(SpawnBackgroundTool)
+            .tool(TestBackgroundTool)
+            .build();
+
+        // No file_store wired — should fail.
         let context = ToolContext::with_storage_store(session_id, storage_store)
             .with_tool_registry(Arc::new(tool_registry))
-            .with_session_resource_registry(resource_registry);
+            .with_session_task_registry(task_registry);
 
         let result = SpawnBackgroundTool
             .execute_with_context(
@@ -3237,9 +3115,9 @@ mod tests {
     #[tokio::test]
     async fn test_spawn_background_caps_output_log_size() {
         let session_id = SessionId::new();
-        let resource_registry = Arc::new(TestSessionResourceRegistry::default());
         let file_store = Arc::new(TestFileStore::default());
         let storage_store = Arc::new(NoopStorageStore);
+        let task_registry = Arc::new(InMemoryTaskRegistry::default());
         let tool_registry = ToolRegistry::builder()
             .tool(SpawnBackgroundTool)
             .tool(TestLargeOutputBackgroundTool)
@@ -3247,7 +3125,7 @@ mod tests {
 
         let context = ToolContext::with_stores(session_id, file_store.clone(), storage_store)
             .with_tool_registry(Arc::new(tool_registry))
-            .with_session_resource_registry(resource_registry.clone());
+            .with_session_task_registry(task_registry.clone());
 
         let result = SpawnBackgroundTool
             .execute_with_context(
@@ -3263,15 +3141,13 @@ mod tests {
             panic!("spawn_background should succeed");
         };
         let run_id = value["run_id"].as_str().unwrap().to_string();
+        let task_id = value["task_id"].as_str().unwrap().to_string();
 
         tokio::time::timeout(std::time::Duration::from_secs(2), async {
             loop {
-                let entry = resource_registry
-                    .get(session_id, &run_id)
-                    .await
-                    .unwrap()
-                    .expect("resource exists");
-                if entry.status == SessionResourceStatus::Completed {
+                if let Ok(Some(task)) = task_registry.get(session_id, &task_id).await
+                    && task.state == crate::session_task::SessionTaskState::Succeeded
+                {
                     break;
                 }
                 tokio::time::sleep(std::time::Duration::from_millis(20)).await;
@@ -3279,6 +3155,7 @@ mod tests {
         })
         .await
         .expect("background run should complete");
+        let _ = run_id;
 
         let log_content = file_store
             .read_file(session_id, &format!("/.background/{run_id}/output.log"))
@@ -3608,7 +3485,6 @@ mod tests {
     #[tokio::test]
     async fn test_cancel_background_run_via_task_registry() {
         let session_id = SessionId::new();
-        let resource_registry = Arc::new(TestSessionResourceRegistry::default());
         let file_store = Arc::new(TestFileStore::default());
         let storage_store = Arc::new(NoopStorageStore);
         let task_registry = Arc::new(InMemoryTaskRegistry::default());
@@ -3620,7 +3496,6 @@ mod tests {
 
         let context = ToolContext::with_stores(session_id, file_store.clone(), storage_store)
             .with_tool_registry(Arc::new(tool_registry))
-            .with_session_resource_registry(resource_registry.clone())
             .with_session_task_registry(task_registry.clone());
 
         let result = SpawnBackgroundTool
@@ -3643,14 +3518,8 @@ mod tests {
         // Wait until the background task is Running (heartbeat loop started).
         tokio::time::timeout(std::time::Duration::from_secs(5), async {
             loop {
-                let entry = resource_registry
-                    .get(session_id, &run_id)
-                    .await
-                    .unwrap()
-                    .expect("resource exists");
-                // Also wait for a heartbeat to confirm the watcher is live.
-                if entry.status == SessionResourceStatus::Active
-                    && let Ok(Some(task)) = task_registry.get(session_id, &task_id).await
+                // Wait for a heartbeat to confirm the watcher is live.
+                if let Ok(Some(task)) = task_registry.get(session_id, &task_id).await
                     && task.heartbeat_at.is_some()
                 {
                     break;

--- a/crates/server/migrations/054_retire_work_kind_resources.sql
+++ b/crates/server/migrations/054_retire_work_kind_resources.sql
@@ -1,0 +1,6 @@
+-- Remove session_resources rows for work-shaped kinds that were dual-written
+-- during the transitional period (retired in the session-tasks dual-write cleanup).
+-- These kinds are now tracked exclusively via session_tasks (or platform store
+-- for agent_handoff). New entries will not be created after this migration.
+DELETE FROM session_resources
+WHERE kind IN ('subagent', 'agent_run', 'background_run', 'agent_handoff');

--- a/crates/server/src/grpc_service/tests.rs
+++ b/crates/server/src/grpc_service/tests.rs
@@ -467,7 +467,6 @@ async fn test_subagent_and_handoff_tools_complete_over_grpc_platform_adapter() {
     use everruns_core::capabilities::{AgentHandoffCapability, Capability, SubagentCapability};
     use everruns_core::platform_store::PlatformStore;
     use everruns_core::tools::ToolExecutionResult;
-    use everruns_core::traits::SessionResourceRegistry;
 
     let service = test_worker_service_with_completing_runner().await;
     let parent = create_grpc_test_session(&service).await;
@@ -524,12 +523,9 @@ async fn test_subagent_and_handoff_tools_complete_over_grpc_platform_adapter() {
             Some(parent_id),
         ),
     );
-    let session_adapter = Arc::new(everruns_worker::grpc_adapters::GrpcAdapter::new(client));
-
     let mut context = everruns_core::traits::ToolContext::new(parent_id);
     context.platform_store = Some(adapter.clone());
     context.session_store = Some(adapter.clone());
-    context.session_resource_registry = Some(session_adapter.clone());
 
     let spawn_tool = SubagentCapability
         .tools()
@@ -566,16 +562,6 @@ async fn test_subagent_and_handoff_tools_complete_over_grpc_platform_adapter() {
         subagent.subagent_status,
         Some(everruns_core::session::SubagentStatus::Completed)
     );
-
-    let resources = session_adapter
-        .list(parent_id, None)
-        .await
-        .expect("list session resources");
-    assert!(resources.iter().any(|entry| {
-        entry.kind == "subagent"
-            && entry.resource_id == subagent_id.to_string()
-            && entry.status == everruns_core::SessionResourceStatus::Completed
-    }));
 
     let target_agent = adapter
         .create_agent(
@@ -638,16 +624,6 @@ async fn test_subagent_and_handoff_tools_complete_over_grpc_platform_adapter() {
         handoff.subagent_status,
         Some(everruns_core::session::SubagentStatus::Completed)
     );
-
-    let resources = session_adapter
-        .list(parent_id, None)
-        .await
-        .expect("list session resources after handoff");
-    assert!(resources.iter().any(|entry| {
-        entry.kind == "agent_handoff"
-            && entry.resource_id == handoff_id.to_string()
-            && entry.status == everruns_core::SessionResourceStatus::Completed
-    }));
 
     let _ = shutdown_tx.send(());
     server.await.expect("grpc server task should join");

--- a/crates/server/tests/app_a2a_integration_test.rs
+++ b/crates/server/tests/app_a2a_integration_test.rs
@@ -15,11 +15,8 @@ use axum::{
 };
 use everruns_core::DEFAULT_ORG_ID;
 use everruns_core::capabilities::{A2aAgentDelegationCapability, Capability};
-use everruns_core::session_resource::{
-    RegisterSessionResource, SessionResourceEntry, SessionResourceFilter, SessionResourceStatus,
-};
 use everruns_core::tools::ToolExecutionResult;
-use everruns_core::traits::{SessionResourceRegistry, ToolContext};
+use everruns_core::traits::{KeyInfo, SecretInfo, SessionStorageStore, ToolContext};
 use everruns_core::typed_id::SessionId;
 use everruns_server::storage::models::{AuditLogQuery, AuditLogRow};
 use hmac::{Hmac, Mac};
@@ -154,94 +151,90 @@ async fn wait_for_app_invocation_audit_log(
 }
 
 #[derive(Default)]
-struct TestSessionResourceRegistry {
-    entries: Mutex<HashMap<String, SessionResourceEntry>>,
+struct TestStorageStore {
+    values: Mutex<HashMap<String, String>>,
 }
 
-impl TestSessionResourceRegistry {
-    fn metadata(&self, resource_id: &str) -> Option<Value> {
-        self.entries
+impl TestStorageStore {
+    /// Parse the stored agent-run record for a run_id, if present.
+    fn run_record(&self, run_id: &str) -> Option<Value> {
+        self.values
             .lock()
             .unwrap()
-            .get(resource_id)
-            .map(|entry| entry.metadata.clone())
+            .get(&format!("agent_run:{run_id}"))
+            .and_then(|raw| serde_json::from_str(raw).ok())
     }
 }
 
 #[async_trait]
-impl SessionResourceRegistry for TestSessionResourceRegistry {
-    async fn register(
+impl SessionStorageStore for TestStorageStore {
+    async fn set_value(
         &self,
-        entry: RegisterSessionResource,
-    ) -> everruns_core::Result<SessionResourceEntry> {
+        _session_id: SessionId,
+        key: &str,
+        value: &str,
+    ) -> everruns_core::Result<()> {
+        self.values
+            .lock()
+            .unwrap()
+            .insert(key.to_string(), value.to_string());
+        Ok(())
+    }
+
+    async fn get_value(
+        &self,
+        _session_id: SessionId,
+        key: &str,
+    ) -> everruns_core::Result<Option<String>> {
+        Ok(self.values.lock().unwrap().get(key).cloned())
+    }
+
+    async fn delete_value(&self, _session_id: SessionId, key: &str) -> everruns_core::Result<bool> {
+        Ok(self.values.lock().unwrap().remove(key).is_some())
+    }
+
+    async fn list_keys(&self, _session_id: SessionId) -> everruns_core::Result<Vec<KeyInfo>> {
         let now = chrono::Utc::now();
-        let mut entries = self.entries.lock().unwrap();
-        let existing = entries.get(&entry.resource_id).cloned();
-        let out = SessionResourceEntry {
-            resource_id: entry.resource_id.clone(),
-            session_id: entry.session_id,
-            kind: entry.kind,
-            display_name: entry.display_name,
-            status: entry.status,
-            metadata: entry.metadata,
-            created_at: existing.as_ref().map(|e| e.created_at).unwrap_or(now),
-            updated_at: now,
-        };
-        entries.insert(entry.resource_id, out.clone());
-        Ok(out)
-    }
-
-    async fn update_status(
-        &self,
-        _session_id: SessionId,
-        resource_id: &str,
-        status: SessionResourceStatus,
-    ) -> everruns_core::Result<Option<SessionResourceEntry>> {
-        let mut entries = self.entries.lock().unwrap();
-        if let Some(entry) = entries.get_mut(resource_id) {
-            entry.status = status;
-            entry.updated_at = chrono::Utc::now();
-            return Ok(Some(entry.clone()));
-        }
-        Ok(None)
-    }
-
-    async fn get(
-        &self,
-        _session_id: SessionId,
-        resource_id: &str,
-    ) -> everruns_core::Result<Option<SessionResourceEntry>> {
-        Ok(self.entries.lock().unwrap().get(resource_id).cloned())
-    }
-
-    async fn list(
-        &self,
-        _session_id: SessionId,
-        filter: Option<&SessionResourceFilter>,
-    ) -> everruns_core::Result<Vec<SessionResourceEntry>> {
-        let entries = self.entries.lock().unwrap();
-        Ok(entries
-            .values()
-            .filter(|entry| {
-                filter
-                    .and_then(|f| f.kind.as_deref())
-                    .is_none_or(|kind| entry.kind == kind)
+        Ok(self
+            .values
+            .lock()
+            .unwrap()
+            .keys()
+            .map(|key| KeyInfo {
+                key: key.clone(),
+                created_at: now,
+                updated_at: now,
             })
-            .filter(|entry| {
-                filter
-                    .and_then(|f| f.status)
-                    .is_none_or(|status| entry.status == status)
-            })
-            .cloned()
             .collect())
     }
 
-    async fn deregister(
+    async fn set_secret(
         &self,
         _session_id: SessionId,
-        resource_id: &str,
+        _name: &str,
+        _value: &str,
+    ) -> everruns_core::Result<()> {
+        Ok(())
+    }
+
+    async fn get_secret(
+        &self,
+        _session_id: SessionId,
+        _name: &str,
+    ) -> everruns_core::Result<Option<String>> {
+        Ok(None)
+    }
+
+    async fn delete_secret(
+        &self,
+        _session_id: SessionId,
+        _name: &str,
     ) -> everruns_core::Result<bool> {
-        Ok(self.entries.lock().unwrap().remove(resource_id).is_some())
+        Ok(false)
+    }
+
+    async fn list_secrets(&self, _session_id: SessionId) -> everruns_core::Result<Vec<SecretInfo>> {
+        Ok(Vec::new())
     }
 }
 
@@ -324,17 +317,15 @@ fn outbound_delegation_config(
     json!({ "agents": [agent] })
 }
 
-async fn spawn_background_against_local_a2a(
-    config: Value,
-) -> (Arc<TestSessionResourceRegistry>, Value) {
+async fn spawn_background_against_local_a2a(config: Value) -> (Arc<TestStorageStore>, Value) {
     let capability = A2aAgentDelegationCapability;
     let spawn_tool = capability
         .tools_with_config(&config)
         .into_iter()
         .find(|tool| tool.name() == "spawn_agent")
         .expect("spawn_agent tool");
-    let registry = Arc::new(TestSessionResourceRegistry::default());
-    let ctx = ToolContext::new(SessionId::new()).with_session_resource_registry(registry.clone());
+    let storage = Arc::new(TestStorageStore::default());
+    let ctx = ToolContext::with_storage_store(SessionId::new(), storage.clone());
 
     let result = spawn_tool
         .execute_with_context(
@@ -352,15 +343,12 @@ async fn spawn_background_against_local_a2a(
     let ToolExecutionResult::Success(value) = result else {
         panic!("expected successful spawn_agent result: {result:?}");
     };
-    (registry, value)
+    (storage, value)
 }
 
-async fn wait_for_remote_task_snapshot(
-    registry: &TestSessionResourceRegistry,
-    run_id: &str,
-) -> Value {
+async fn wait_for_remote_task_snapshot(storage: &TestStorageStore, run_id: &str) -> Value {
     for _ in 0..30 {
-        if let Some(metadata) = registry.metadata(run_id) {
+        if let Some(metadata) = storage.run_record(run_id) {
             assert_ne!(
                 metadata["status"], "failed",
                 "agent_run failed before remote task snapshot was observed: {metadata:?}",
@@ -1227,7 +1215,7 @@ async fn outbound_a2a_delegation_reaches_local_app_with_discovery_card() {
     let discovery_base_url = spawn_agent_card_server(a2a_agent_card(&endpoint)).await;
     let config = outbound_delegation_config(&endpoint, &api_key, Some(&discovery_base_url));
 
-    let (registry, spawn_result) = spawn_background_against_local_a2a(config).await;
+    let (storage, spawn_result) = spawn_background_against_local_a2a(config).await;
 
     assert_ne!(
         spawn_result["status"], "failed",
@@ -1240,7 +1228,7 @@ async fn outbound_a2a_delegation_reaches_local_app_with_discovery_card() {
         remote_task_id
     );
 
-    let metadata = wait_for_remote_task_snapshot(&registry, run_id).await;
+    let metadata = wait_for_remote_task_snapshot(&storage, run_id).await;
     assert_eq!(metadata["remote_task_id"], remote_task_id);
     assert_eq!(metadata["last_remote_task_snapshot"]["id"], remote_task_id);
     assert!(
@@ -1265,7 +1253,7 @@ async fn outbound_a2a_delegation_reaches_local_app_with_inline_card() {
         create_published_served_a2a_app().await;
     let config = outbound_delegation_config(&endpoint, &api_key, None);
 
-    let (registry, spawn_result) = spawn_background_against_local_a2a(config).await;
+    let (storage, spawn_result) = spawn_background_against_local_a2a(config).await;
 
     assert_ne!(
         spawn_result["status"], "failed",
@@ -1278,7 +1266,7 @@ async fn outbound_a2a_delegation_reaches_local_app_with_inline_card() {
         remote_task_id
     );
 
-    let metadata = wait_for_remote_task_snapshot(&registry, run_id).await;
+    let metadata = wait_for_remote_task_snapshot(&storage, run_id).await;
     assert_eq!(metadata["remote_task_id"], remote_task_id);
     assert_eq!(metadata["last_remote_task_snapshot"]["id"], remote_task_id);
     assert!(

--- a/specs/session-resources.md
+++ b/specs/session-resources.md
@@ -51,9 +51,9 @@ rather than duplicate.
 | *(future)*                   | Direct `registry.register()`          | *(any string)*    | Caller-defined             |
 
 Work-shaped kinds (`subagent`, `agent_run`, `background_run`, `agent_handoff`)
-were migrated to `session_tasks` (migration 053). Subagents, agent runs, and
-background runs still register here transitionally alongside their task
-records; retiring the duplicate registration is a session-tasks follow-up.
+were migrated to `session_tasks` (migration 053). The dual-write transitional
+registrations were retired in migration 054; these kinds are no longer written
+to `session_resources`.
 
 ### Storage
 

--- a/specs/session-tasks.md
+++ b/specs/session-tasks.md
@@ -304,10 +304,12 @@ No backward compatibility is required; data migrates forward once:
   `apply_task_update` in `crates/core/src/session_task.rs`. gRPC workers get
   the registry via task RPCs in the internal worker protocol (payloads travel
   as canonical core JSON).
-- Spawning capabilities currently dual-write: tasks plus their legacy
-  session-resource registrations and `subagent.*` events. Retiring the
-  duplicates (and the `sessions.subagent_*` columns and the
-  `task` → `instructions` parameter rename) is follow-up work.
+- Session-resource dual-write retired (migration 054): subagent, background_run,
+  and agent_handoff no longer register in `session_resources`. A2A agent runs
+  (`external_agent` tasks) now store their run records in session storage KV
+  (`agent_run:{run_id}` keys). Legacy `subagent.*` events are retained for CLI
+  compatibility. The `sessions.subagent_*` column retirement and the
+  `task` → `instructions` parameter rename remain follow-up work.
 - Durability: `attempt`/`worker_id`/`heartbeat_at` are stored. The orphan
   reconciler (`session_task_reaper` durable activity, every 60 s) finds tasks
   with stale heartbeats (`heartbeat_at IS NOT NULL AND heartbeat_at < now -


### PR DESCRIPTION
## What
Retires the transitional `session_resources` dual-write for work-shaped kinds (#2110's documented follow-up). Session tasks are now the **sole** tracking for work; the resource registry narrows to infrastructure (sandboxes, browser sessions, sprites, voice connections).

- **Subagents + background runs**: pure visibility dual-writes removed (`spawn_subagent`/handoff registration + status updates; `spawn_background` registration + per-update `update_resource` re-registrations). `spawn_background` now requires the **task registry** (hard tool error without it) so runs can never be untracked.
- **A2A agent runs — store migration**: investigation showed this was *not* a dual-write: the resource registry was the run record's primary storage (`save_run` wrote the full `AgentRunRecord` as resource metadata; `load_run`/`load_run_for_task` read it back). Records now live in session storage KV (`agent_run:{run_id}` + an `agent_run:index` key for listing), with `run_id` added to the task spec so task→run lookup is a direct key read instead of a scan.
- **Agent handoffs**: instead of going untracked, `start_agent_handoff` now creates a `subagent`-kind session task (`links.child_session_id`) and mirrors the terminal state — handoffs gain task visibility for the first time.
- **Migration 054**: deletes work-kind rows re-accumulated since the 053 backfill.
- **Kept deliberately**: `subagent.*` event emission — the CLI renders these events; retiring them requires migrating the CLI to `task.*` first (documented in specs as the remaining follow-up).

## Why
Two tracking systems for the same work meant double writes on every status change, drift risk, and a confusing story ("which one is true?"). Tasks have been canonical since #2110/#2119/#2129; this completes the consolidation.

## How
Mostly deletion (net −280 lines before tests). The one design decision: A2A records moved to the session storage KV rather than into the task record, because run records mutate on every poll and `SessionTaskUpdate` deliberately cannot mutate `spec`.

## Validation
- core 2,221 / server 1,463 lib tests green (includes a new A2A roundtrip test: `save_run → load_run → load_run_for_task` over the KV store, and reworked spawn_background/handoff tests); clippy `--all-features -D warnings` clean; `just pre-push` green; migrations sequential 001..054.
- **Dev-mode smoke**: `LLMSIM_DEMO=tasks` end-to-end — the background run is tracked solely as a task (`succeeded` with summary) and `GET /v1/sessions/{id}/resources` returns **zero** work-kind entries.

## Risk
- Medium-low. The A2A store migration is the riskiest piece: **in-flight A2A runs persisted before this change (in resource metadata) become unreadable** — `get_agent_runs`/`wait_agent` on them will report not-found. Acceptable per the no-backward-compat policy; new runs are unaffected. Everything else is deletion of write-only paths.
- Migration 054 deletes rows that are duplicates of task records by construction.

## Security
- Threat categories reviewed: **TM-TENANT** (KV records are session-scoped via `storage_store.set_value(session_id, …)`, same boundary as the kv_store capability; reads keyed by the caller's own session), **TM-TOOL** (no new tools; requirement errors replaced like-for-like), **TM-SQL** (migration is a fixed-literal DELETE). No new endpoints or trust boundaries; the change removes a storage surface rather than adding one.

## Follow-ups
- Migrate the CLI session renderer from `subagent.*` to `task.*` events, then retire `subagent.*` emission.
- `task` → `instructions` parameter rename + `sessions.subagent_*` column retirement (next PR in this series).
- gRPC orphan-listing RPC + attempt fencing (tracked in specs/session-tasks.md).

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_011yqDiQ2GyoDdwFQTFTw12R)_