### PR TITLE
chore(release): prepare v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- New changes go here. Use `/prepare-release X.Y.Z` to generate draft from commits. -->
 
-### Added
+## [0.11.0] - 2026-06-12
 
-- **Generic `tool_search`: progressive disclosure + never-defer allowlist.** The provider-agnostic `ToolSearchCapability` now restores a revealed tool's full schema on its *registered* definition after a `tool_search` call (not just as result text), so structured tool callers can actually pass arguments to previously deferred tools. A new `with_never_defer([...])` constructor and a `never_defer` config array let an embedder keep hot-path tools (e.g. file/shell) fully loaded even when it does not own their `DeferrablePolicy`. Also exposed on `AutoToolSearchCapability`.
+### Highlights
+
+- **Declarative Capability Editor** - New full-page UI for managing MCP servers, skills, and files in one place ([#2141](https://github.com/everruns/everruns/pull/2141)).
+- **Web Fetch via Egress + Network Access UI** - `web_fetch` is now routed through the egress service with a network access controls panel in the UI ([#2118](https://github.com/everruns/everruns/pull/2118)).
+- **Session Tasks** - Background task registry with cancellation, wake policy, reaper, and chat chips for visibility ([#2119](https://github.com/everruns/everruns/pull/2119)).
+- **Memory API** - Memory file CRUD HTTP API; "Workspace Volume" renamed to "Memory" throughout ([#2111](https://github.com/everruns/everruns/pull/2111), [#2106](https://github.com/everruns/everruns/pull/2106)).
+- **Subagent Durable Reattach** - Durable spawn handles let long-running subagents reconnect after interruption (EVE-535).
+- **OpenRouter Routing Controls** - Fine-grained model routing configuration for OpenRouter ([#2123](https://github.com/everruns/everruns/pull/2123)).
+
+### What's Changed
+
+- feat(ui): full-page declarative capability editor with MCP, skills, files UI ([#2141](https://github.com/everruns/everruns/pull/2141)) by [@chaliy](https://github.com/chaliy)
+- feat(core): fetchkit 0.4 transport injection for web_fetch egress ([#2139](https://github.com/everruns/everruns/pull/2139)) by [@chaliy](https://github.com/chaliy)
+- perf(runtime-mcp): concurrent + cached per-session tool discovery ([#2138](https://github.com/everruns/everruns/pull/2138)) by [@chaliy](https://github.com/chaliy)
+- feat(core): progressive disclosure + never-defer for tool_search ([#2130](https://github.com/everruns/everruns/pull/2130)) by [@chaliy](https://github.com/chaliy)
+- feat(harness): enable message_metadata on generic harness ([#2136](https://github.com/everruns/everruns/pull/2136)) by [@chaliy](https://github.com/chaliy)
+- perf(mcp): stale-while-revalidate + single-flight tool cache ([#2131](https://github.com/everruns/everruns/pull/2131)) by [@chaliy](https://github.com/chaliy)
+- feat: monitor session task kind ([#2129](https://github.com/everruns/everruns/pull/2129)) by [@chaliy](https://github.com/chaliy)
+- feat(llm): add OpenRouter routing controls ([#2123](https://github.com/everruns/everruns/pull/2123)) by [@chaliy](https://github.com/chaliy)
+- fix(worker): handle non-terminal subagent waits ([#2124](https://github.com/everruns/everruns/pull/2124)) by [@chaliy](https://github.com/chaliy)
+- feat(capabilities): config schemas and localized metadata (uk) ([#2120](https://github.com/everruns/everruns/pull/2120)) by [@chaliy](https://github.com/chaliy)
+- feat(capabilities): rename virtual_bash to bashkit_shell ([#2122](https://github.com/everruns/everruns/pull/2122)) by [@chaliy](https://github.com/chaliy)
+- feat: session task cancellation, wake policy, reaper, and chat chips ([#2119](https://github.com/everruns/everruns/pull/2119)) by [@chaliy](https://github.com/chaliy)
+- feat(core): streaming session completions for command host (EVE-543) ([#2117](https://github.com/everruns/everruns/pull/2117)) by [@chaliy](https://github.com/chaliy)
+- feat: web_fetch via egress service + network access UI ([#2118](https://github.com/everruns/everruns/pull/2118)) by [@chaliy](https://github.com/chaliy)
+- feat(capabilities): annotate LLM-facing messages with metadata ([#2116](https://github.com/everruns/everruns/pull/2116)) by [@chaliy](https://github.com/chaliy)
+- feat(runtime): inject user connection resolver into in-process runtime ([#2115](https://github.com/everruns/everruns/pull/2115)) by [@chaliy](https://github.com/chaliy)
+- fix(core): simplify web_fetch system-policy block message ([#2113](https://github.com/everruns/everruns/pull/2113)) by [@chaliy](https://github.com/chaliy)
+- feat: session task registry for background work ([#2110](https://github.com/everruns/everruns/pull/2110)) by [@chaliy](https://github.com/chaliy)
+- feat(memory): Memory file CRUD HTTP API ([#2111](https://github.com/everruns/everruns/pull/2111)) by [@chaliy](https://github.com/chaliy)
+- feat(capabilities): /btw via extended command contract (EVE-543) ([#2109](https://github.com/everruns/everruns/pull/2109)) by [@chaliy](https://github.com/chaliy)
+- feat(core): durable spawn handles and subagent reattach (EVE-535) by [@chaliy](https://github.com/chaliy)
+- refactor: rename Workspace Volume to Memory; drop legacy memory_stores ([#2106](https://github.com/everruns/everruns/pull/2106)) by [@chaliy](https://github.com/chaliy)
+- feat(core): partial-stream finalize on replay (EVE-532) ([#2098](https://github.com/everruns/everruns/pull/2098)) by [@chaliy](https://github.com/chaliy)
+- fix(a2a): accept linked client JSON-RPC methods (EVE-540) by [@chaliy](https://github.com/chaliy)
+- feat(core): transcript repair for dangling tool calls (EVE-533) by [@chaliy](https://github.com/chaliy)
+- fix(worker): support subagent metadata over grpc (EVE-538) by [@chaliy](https://github.com/chaliy)
+- feat(ui): custom HTTP headers in Add MCP Server form (EVE-541) ([#2107](https://github.com/everruns/everruns/pull/2107)) by [@chaliy](https://github.com/chaliy)
+- fix(core): guard thinking stream output ([#2103](https://github.com/everruns/everruns/pull/2103)) by [@chaliy](https://github.com/chaliy)
+- fix(egress): narrow system allowlist hosts ([#2101](https://github.com/everruns/everruns/pull/2101)) by [@chaliy](https://github.com/chaliy)
+- fix(openai): restrict OpenRouter model discovery ([#2100](https://github.com/everruns/everruns/pull/2100)) by [@chaliy](https://github.com/chaliy)
+- fix(bedrock): bound stream event buffering by [@chaliy](https://github.com/chaliy)
+- refactor(brand): mathematically center the three-ring logo ([#2099](https://github.com/everruns/everruns/pull/2099)) by [@chaliy](https://github.com/chaliy)
 
 ## [0.10.0] - 2026-06-10
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -549,9 +549,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-eventstream"
-version = "0.60.20"
+version = "0.60.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faf09d74e5e32f76b8762da505a3cd59303e367a664ca67295387baa8c1d7548"
+checksum = "78d8391e65fcea47c586a22e1a41f173b38615b112b2c6b7a44e80cec3e6b706"
 dependencies = [
  "aws-smithy-types",
  "bytes",
@@ -692,9 +692,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.4.9"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53f93074121a1be41317b9aa607143ae17900631f7f59a99f2b905d519d6783b"
+checksum = "32b42fcf341259d85ca10fac9a2f6448a8ec691c6955a18e45bc3b71a85fab85"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -999,9 +999,9 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
  "hybrid-array",
 ]
@@ -1953,7 +1953,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer 0.12.0",
+ "block-buffer 0.12.1",
  "const-oid 0.10.2",
  "crypto-common 0.2.2",
  "ctutils",
@@ -2303,11 +2303,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-a2ui"
-version = "0.10.0"
+version = "0.11.0"
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2323,7 +2323,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-bedrock"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "aws-sdk-bedrockruntime",
@@ -2340,7 +2340,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-cli"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2394,14 +2394,14 @@ dependencies = [
 
 [[package]]
 name = "everruns-config"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "everruns-container-sandbox"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2421,7 +2421,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -2476,7 +2476,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-durable"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2501,7 +2501,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-gemini"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2515,7 +2515,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-brave-search"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2531,7 +2531,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-browserless"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2552,7 +2552,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-cursor"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2567,7 +2567,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2584,7 +2584,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-deno"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2607,7 +2607,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-docker"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2622,7 +2622,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2637,7 +2637,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-e2b"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "buffa",
@@ -2664,7 +2664,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-github"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2681,7 +2681,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-parallel"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2694,7 +2694,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-sprites"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2710,7 +2710,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-internal-protocol"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "chrono",
  "everruns-core",
@@ -2727,7 +2727,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-llm-tests"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2747,7 +2747,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-mcp"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2761,7 +2761,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2781,11 +2781,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-openui"
-version = "0.10.0"
+version = "0.11.0"
 
 [[package]]
 name = "everruns-runtime"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2824,7 +2824,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-server"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -2915,7 +2915,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-session-sqldb"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2932,7 +2932,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-worker"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4189,9 +4189,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.47.2"
+version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
+checksum = "86f0f8fee8c926415c58d6ae43a08523a26faccb2323f5e6b644fe7dd4ef6b82"
 dependencies = [
  "console",
  "once_cell",
@@ -4269,9 +4269,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jaq-core"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca0f164c8e9c55fc5aefe60b371df735c719b09930dac185878f2f8c7ab6b68"
+checksum = "7561783b20275a6c9cb576e39208b0c635f34ef14357f1f05a2927a774f3adec"
 dependencies = [
  "dyn-clone",
  "once_cell",
@@ -4280,9 +4280,9 @@ dependencies = [
 
 [[package]]
 name = "jaq-json"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5c5baabe63d1d72cde60ec7548a098036773e3541dbc65c6a44fb38e9cfb272"
+checksum = "d4ec9aaad7340e6990c6c1878ef3b46dbec624e535d7f786cc9ddcf94f773d33"
 dependencies = [
  "bstr",
  "bytes",
@@ -4299,9 +4299,9 @@ dependencies = [
 
 [[package]]
 name = "jaq-std"
-version = "3.0.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a11bb307027b20b3dc7b212ad687e7e410cbc43933eec5d498672ab2bc60666"
+checksum = "8bdc5a74b0feeb5e6a1dc2dd08c34280a61e37668d10a6a3b27ad69d0fb9ce2e"
 dependencies = [
  "aho-corasick",
  "base64 0.22.1",
@@ -4804,9 +4804,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.1"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memmem"
@@ -7453,9 +7453,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 dependencies = [
  "serde",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -549,9 +549,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-eventstream"
-version = "0.60.21"
+version = "0.60.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78d8391e65fcea47c586a22e1a41f173b38615b112b2c6b7a44e80cec3e6b706"
+checksum = "faf09d74e5e32f76b8762da505a3cd59303e367a664ca67295387baa8c1d7548"
 dependencies = [
  "aws-smithy-types",
  "bytes",
@@ -692,9 +692,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.5.0"
+version = "1.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b42fcf341259d85ca10fac9a2f6448a8ec691c6955a18e45bc3b71a85fab85"
+checksum = "53f93074121a1be41317b9aa607143ae17900631f7f59a99f2b905d519d6783b"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -999,9 +999,9 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.12.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
 dependencies = [
  "hybrid-array",
 ]
@@ -1953,7 +1953,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer 0.12.1",
+ "block-buffer 0.12.0",
  "const-oid 0.10.2",
  "crypto-common 0.2.2",
  "ctutils",
@@ -4189,9 +4189,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.48.0"
+version = "1.47.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f0f8fee8c926415c58d6ae43a08523a26faccb2323f5e6b644fe7dd4ef6b82"
+checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
 dependencies = [
  "console",
  "once_cell",
@@ -4269,9 +4269,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jaq-core"
-version = "3.1.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7561783b20275a6c9cb576e39208b0c635f34ef14357f1f05a2927a774f3adec"
+checksum = "dca0f164c8e9c55fc5aefe60b371df735c719b09930dac185878f2f8c7ab6b68"
 dependencies = [
  "dyn-clone",
  "once_cell",
@@ -4280,9 +4280,9 @@ dependencies = [
 
 [[package]]
 name = "jaq-json"
-version = "2.0.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4ec9aaad7340e6990c6c1878ef3b46dbec624e535d7f786cc9ddcf94f773d33"
+checksum = "f5c5baabe63d1d72cde60ec7548a098036773e3541dbc65c6a44fb38e9cfb272"
 dependencies = [
  "bstr",
  "bytes",
@@ -4299,9 +4299,9 @@ dependencies = [
 
 [[package]]
 name = "jaq-std"
-version = "3.0.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bdc5a74b0feeb5e6a1dc2dd08c34280a61e37668d10a6a3b27ad69d0fb9ce2e"
+checksum = "2a11bb307027b20b3dc7b212ad687e7e410cbc43933eec5d498672ab2bc60666"
 dependencies = [
  "aho-corasick",
  "base64 0.22.1",
@@ -4804,9 +4804,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "memmem"
@@ -7453,9 +7453,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.2"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.10.0"
+version = "0.11.0"
 edition = "2024"
 # Published crate MSRV: Rust 2024 plus current published dependency floors.
 rust-version = "1.94.0"
@@ -136,8 +136,8 @@ futures-util = "0.3"
 
 # Everruns SDK
 everruns-sdk = "0.1.9"
-everruns-core = { path = "crates/core", version = "0.10.0" }
-everruns-mcp = { path = "crates/mcp", version = "0.10.0" }
+everruns-core = { path = "crates/core", version = "0.11.0" }
+everruns-mcp = { path = "crates/mcp", version = "0.11.0" }
 
 # A2A protocol
 a2a = { package = "a2a-lf", version = "0.3" }

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "everruns-ui",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "exports": {

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -20,7 +20,7 @@ readme = "README.md"
 
 [dependencies]
 # Core dependencies
-everruns-config = { path = "../config", version = "0.10.0" }
+everruns-config = { path = "../config", version = "0.11.0" }
 anyhow.workspace = true
 thiserror.workspace = true
 async-trait.workspace = true
@@ -109,10 +109,10 @@ inventory.workspace = true
 llmsim = "0.4.0"
 
 # OpenUI component definitions and prompt generator
-everruns-openui = { path = "../openui", version = "0.10.0", optional = true }
+everruns-openui = { path = "../openui", version = "0.11.0", optional = true }
 
 # A2UI component catalog and prompt generator
-everruns-a2ui = { path = "../a2ui", version = "0.10.0", optional = true }
+everruns-a2ui = { path = "../a2ui", version = "0.11.0", optional = true }
 
 # A2A outbound agent delegation
 a2a.workspace = true

--- a/scripts/sync-publish-pin-versions.py
+++ b/scripts/sync-publish-pin-versions.py
@@ -52,7 +52,7 @@ INNER_PINS: dict[str, list[str]] = {
 }
 
 # Workspace.dependencies path pins (root Cargo.toml).
-WORKSPACE_PIN_DEPS: list[str] = ["everruns-core"]
+WORKSPACE_PIN_DEPS: list[str] = ["everruns-core", "everruns-mcp"]
 
 
 def workspace_version() -> str:


### PR DESCRIPTION
## Release v0.11.0

This PR prepares the v0.11.0 release.

### Highlights

- **Declarative Capability Editor** - New full-page UI for managing MCP servers, skills, and files in one place (#2141).
- **Web Fetch via Egress + Network Access UI** - `web_fetch` routed through egress service with network access controls panel (#2118).
- **Session Tasks** - Background task registry with cancellation, wake policy, reaper, and chat chips (#2119).
- **Memory API** - Memory file CRUD HTTP API; "Workspace Volume" renamed to "Memory" throughout (#2111, #2106).
- **Subagent Durable Reattach** - Durable spawn handles let long-running subagents reconnect after interruption (EVE-535).
- **OpenRouter Routing Controls** - Fine-grained model routing configuration (#2123).

### Changes

- `CHANGELOG.md` — v0.11.0 section with highlights and full What's Changed list
- `Cargo.toml` — workspace version bumped to 0.11.0; `everruns-mcp` pin updated
- `crates/core/Cargo.toml` — sibling pins updated to 0.11.0
- `apps/ui/package.json` — version bumped to 0.11.0
- `scripts/sync-publish-pin-versions.py` — added `everruns-mcp` to workspace pin map
- `Cargo.lock` — regenerated

### Checklist
- [x] Review CHANGELOG.md entries
- [x] Verify version numbers updated
- [x] Lock files regenerated
- [ ] CI passes

### Post-merge
After merging, the release workflow will automatically:
- Create git tag `v0.11.0`
- Create GitHub Release with notes from CHANGELOG.md
- Trigger Docker image build with version tag

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jz4XKXVKaMTih1ud8p3yB1)_