### PR TITLE
feat(capabilities): add tool_output_distillation capability

### DIFF
--- a/crates/core/src/atoms/act.rs
+++ b/crates/core/src/atoms/act.rs
@@ -2125,6 +2125,178 @@ mod tests {
         assert_eq!(payload["configured"], false);
     }
 
+    /// Tool that returns a large structured (non-exec) result, simulating an
+    /// MCP tool whose output would otherwise enter history verbatim.
+    struct BigOutputTool;
+
+    #[async_trait]
+    impl crate::tools::Tool for BigOutputTool {
+        fn name(&self) -> &str {
+            "mcp__server__big_query"
+        }
+        fn description(&self) -> &str {
+            "returns a large structured result"
+        }
+        fn parameters_schema(&self) -> serde_json::Value {
+            json!({ "type": "object", "properties": {} })
+        }
+        async fn execute(&self, _arguments: serde_json::Value) -> crate::ToolExecutionResult {
+            let rows: Vec<serde_json::Value> = (0..3000)
+                .map(|i| json!({ "id": i, "name": format!("row-number-{i}") }))
+                .collect();
+            crate::ToolExecutionResult::success(json!({ "rows": rows }))
+        }
+    }
+
+    /// Minimal in-memory SessionFileSystem for integration tests.
+    #[derive(Default)]
+    struct IntegrationFileStore {
+        files: std::sync::Mutex<std::collections::HashMap<String, String>>,
+    }
+
+    #[async_trait]
+    impl SessionFileSystem for IntegrationFileStore {
+        async fn read_file(
+            &self,
+            _s: SessionId,
+            _p: &str,
+        ) -> crate::error::Result<Option<crate::session_file::SessionFile>> {
+            Ok(None)
+        }
+        async fn write_file(
+            &self,
+            _s: SessionId,
+            path: &str,
+            content: &str,
+            _encoding: &str,
+        ) -> crate::error::Result<crate::session_file::SessionFile> {
+            self.files
+                .lock()
+                .unwrap()
+                .insert(path.to_string(), content.to_string());
+            Ok(crate::session_file::SessionFile {
+                id: uuid::Uuid::new_v4(),
+                session_id: uuid::Uuid::nil(),
+                path: path.to_string(),
+                name: path.rsplit('/').next().unwrap_or("").to_string(),
+                content: Some(content.to_string()),
+                encoding: "utf-8".to_string(),
+                is_directory: false,
+                is_readonly: false,
+                size_bytes: content.len() as i64,
+                created_at: chrono::Utc::now(),
+                updated_at: chrono::Utc::now(),
+            })
+        }
+        async fn delete_file(
+            &self,
+            _s: SessionId,
+            _p: &str,
+            _r: bool,
+        ) -> crate::error::Result<bool> {
+            Ok(false)
+        }
+        async fn list_directory(
+            &self,
+            _s: SessionId,
+            _p: &str,
+        ) -> crate::error::Result<Vec<crate::session_file::FileInfo>> {
+            Ok(vec![])
+        }
+        async fn stat_file(
+            &self,
+            _s: SessionId,
+            _p: &str,
+        ) -> crate::error::Result<Option<crate::session_file::FileStat>> {
+            Ok(None)
+        }
+        async fn grep_files(
+            &self,
+            _s: SessionId,
+            _pat: &str,
+            _pp: Option<&str>,
+        ) -> crate::error::Result<Vec<crate::session_file::GrepMatch>> {
+            Ok(vec![])
+        }
+        async fn create_directory(
+            &self,
+            _s: SessionId,
+            _p: &str,
+        ) -> crate::error::Result<crate::session_file::FileInfo> {
+            Err(anyhow::anyhow!("not implemented").into())
+        }
+    }
+
+    /// Runtime path: a large non-exec tool result is distilled by the
+    /// `tool_output_distillation` capability hook as it flows through ActAtom,
+    /// with the full original persisted to the session VFS. This exercises the
+    /// real act loop (capability hook → final PersistOutputHook/HardLimit hooks),
+    /// not just the hook in isolation.
+    #[tokio::test]
+    async fn test_act_atom_distills_large_non_exec_tool_result() {
+        let mut executor = ToolRegistry::new();
+        executor.register(BigOutputTool);
+        let store = Arc::new(IntegrationFileStore::default());
+
+        let atom = ActAtom::with_file_store(executor, NoopEventEmitter, store.clone())
+            .with_post_tool_hooks(vec![Arc::new(crate::capabilities::DistillOutputHook)]);
+
+        let context = AtomContext::new(SessionId::new(), TurnId::new(), MessageId::new());
+        let input = ActInput {
+            org_id: Some(1),
+            context,
+            harness_id: HarnessId::from_seed(1),
+            agent_id: Some(AgentId::new()),
+            tool_calls: vec![ToolCall {
+                id: "call_big".to_string(),
+                name: "mcp__server__big_query".to_string(),
+                arguments: json!({}),
+            }],
+            // No persist_output hint → this is the non-exec path distillation targets.
+            tool_definitions: vec![ToolDefinition::Builtin(crate::BuiltinTool {
+                name: "mcp__server__big_query".to_string(),
+                display_name: None,
+                description: "big query".to_string(),
+                parameters: json!({ "type": "object", "properties": {} }),
+                policy: Default::default(),
+                category: None,
+                deferrable: Default::default(),
+                hints: crate::tool_types::ToolHints::default(),
+                full_parameters: None,
+            })],
+            locale: None,
+            blueprint_id: None,
+            network_access: None,
+            parallel_tool_calls: None,
+        };
+
+        let result = atom.execute(input).await.unwrap();
+
+        assert_eq!(result.success_count, 1);
+        let payload = result.results[0].result.result.as_ref().unwrap();
+
+        // The inline view the model sees is distilled and points back to the VFS.
+        assert_eq!(payload["distilled"], json!(true));
+        assert_eq!(
+            payload["output_files"],
+            json!(["/workspace/outputs/call_big.stdout"])
+        );
+        let rows = payload["rows"]
+            .as_array()
+            .expect("rows preserved as sample");
+        assert!(rows.len() < 3000, "array should be sampled down");
+
+        // The full original is recoverable from the session VFS.
+        let persisted = store
+            .files
+            .lock()
+            .unwrap()
+            .get("/outputs/call_big.stdout")
+            .cloned()
+            .expect("full original persisted");
+        assert!(persisted.contains("row-number-2999"));
+    }
+
     /// End-to-end ActAtom scheduling: a single batch with two same-class tools
     /// (one of them `cpu_bound`, exercising the spawn path) plus an independent
     /// tool. Asserts the scheduler serializes within the class, parallelizes

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -133,6 +133,7 @@ mod subagents;
 mod system_commands;
 mod test_math;
 mod test_weather;
+mod tool_output_distillation;
 mod tool_output_persistence;
 mod tool_search;
 pub mod user_hooks;
@@ -270,6 +271,7 @@ pub use bashkit_shell::{BashTool, BashkitShellCapability, SessionFileSystemAdapt
 pub use system_commands::{SYSTEM_COMMANDS_CAPABILITY_ID, SystemCommandsCapability};
 pub use test_math::{AddTool, DivideTool, MultiplyTool, SubtractTool, TestMathCapability};
 pub use test_weather::{GetForecastTool, GetWeatherTool, TestWeatherCapability};
+pub use tool_output_distillation::{DistillOutputHook, ToolOutputDistillationCapability};
 pub use tool_output_persistence::{PersistOutputHook, ToolOutputPersistenceCapability};
 pub use tool_search::{
     TOOL_SEARCH_CAPABILITY_ID, TOOL_SEARCH_TOOL_NAME, ToolSearchCapability, ToolSearchTool,
@@ -1134,6 +1136,7 @@ impl CapabilityRegistry {
 
         // Tool output persistence (EVE-222: persist exec output to VFS)
         registry.register(tool_output_persistence::ToolOutputPersistenceCapability);
+        registry.register(tool_output_distillation::ToolOutputDistillationCapability);
 
         // User hooks (see specs/user-hooks.md): user-authored shell commands
         // at lifecycle/tool events. Risk: High.
@@ -2350,6 +2353,7 @@ mod tests {
             "data_knowledge",
             "knowledge_base",
             "tool_output_persistence",
+            "tool_output_distillation",
             "fake_warehouse",
             "fake_aws",
             "fake_crm",

--- a/crates/core/src/capabilities/tool_output_distillation.rs
+++ b/crates/core/src/capabilities/tool_output_distillation.rs
@@ -154,9 +154,13 @@ impl PostToolExecHook for DistillOutputHook {
         let mut stats = DistillStats::default();
         distill_value(result_value, 0, &mut stats);
         if !stats.changed {
-            // Large but already compact (e.g. one opaque scalar). Leave verbatim
-            // rather than spend a VFS write on something we did not reduce.
-            return;
+            // The shape walker found nothing to clip — e.g. a large object or
+            // array made entirely of sub-threshold fields. Such a result is
+            // still large; if it later exceeds the 64 KiB OutputHardLimitHook it
+            // would be head-truncated with no recovery pointer, losing the tail.
+            // Fall back to a head+tail window over the serialized value so the
+            // result is always bounded, persisted, and recoverable.
+            *result_value = Value::String(head_tail(&serialized, MAX_FIELD_BYTES));
         }
 
         // Persist the full original (pretty-printed JSON) for lossless retrieval.
@@ -206,8 +210,12 @@ fn distill_value(value: &mut Value, depth: usize, stats: &mut DistillStats) {
             }
         }
         Value::Array(arr) => {
-            let serialized_len = serde_json::to_string(arr).map(|s| s.len()).unwrap_or(0);
-            if arr.len() > SAMPLE_ROWS && serialized_len > MAX_FIELD_BYTES {
+            // Only arrays longer than the sample size can ever be sampled, so
+            // check length first and let `&&` short-circuit the O(n)
+            // serialization for small arrays.
+            if arr.len() > SAMPLE_ROWS
+                && serde_json::to_string(arr).map(|s| s.len()).unwrap_or(0) > MAX_FIELD_BYTES
+            {
                 let omitted = arr.len() - SAMPLE_ROWS;
                 arr.truncate(SAMPLE_ROWS);
                 for el in arr.iter_mut() {
@@ -629,6 +637,46 @@ mod tests {
             .content("/outputs/call_123.stdout")
             .expect("original persisted");
         assert!(persisted.contains("row-number-1999"));
+    }
+
+    #[tokio::test]
+    async fn test_hook_fallback_persists_large_unsampleable_result() {
+        // A large object made entirely of sub-threshold fields: the shape walker
+        // changes nothing, but the result is still large. The fallback must
+        // bound it, persist the original, and inject a recovery pointer so it is
+        // never head-truncated irrecoverably by the hard-limit hook.
+        let store = Arc::new(MockFileStore::default());
+        let ctx = ctx_with_store(store.clone());
+        let mut map = serde_json::Map::new();
+        for i in 0..2000 {
+            map.insert(format!("field_{i}"), json!(format!("v{i}")));
+        }
+        let mut result = ToolResult {
+            tool_call_id: "call_123".to_string(),
+            result: Some(Value::Object(map)),
+            images: None,
+            error: None,
+            connection_required: None,
+            raw_output: None,
+        };
+
+        DistillOutputHook
+            .after_exec(&tool_call(), &mcp_tool_def(false), &mut result, &ctx)
+            .await;
+
+        let value = result.result.as_ref().unwrap();
+        assert_eq!(value["distilled"], json!(true));
+        assert_eq!(
+            value["output_files"],
+            json!(["/workspace/outputs/call_123.stdout"])
+        );
+        // Inline view is bounded (the wrapped head+tail string is small).
+        assert!(value["distilled_output"].as_str().unwrap().len() < 8 * 1024);
+        // Full original recoverable.
+        let persisted = store
+            .content("/outputs/call_123.stdout")
+            .expect("original persisted");
+        assert!(persisted.contains("field_1999"));
     }
 
     #[tokio::test]

--- a/crates/core/src/capabilities/tool_output_distillation.rs
+++ b/crates/core/src/capabilities/tool_output_distillation.rs
@@ -1,0 +1,717 @@
+// Tool Output Distillation Capability
+//
+// Produces a compact, content-aware *inline view* of large tool results at
+// capture time, while keeping the full original recoverable via `read_file`.
+//
+// Motivation:
+// - Exec/sandbox tools already get a verbosity budget (`tool_output_sanitizer`)
+//   plus lossless persistence (`tool_output_persistence`). Their output is
+//   handled well.
+// - Tools that do NOT declare `persist_output` — most notably MCP tools and
+//   `web_fetch` — have neither. Their output enters history verbatim and is
+//   only capped by the 64 KiB hard-limit hook, which head-truncates and
+//   destroys the tail. This capability targets exactly that gap.
+//
+// Design decisions:
+// - Implemented as a `PostToolExecHook`, the same seam as
+//   `tool_output_persistence`. Capability hooks run BEFORE the final
+//   infrastructure hooks (persistence + hard-limit), so a distilled result is
+//   what the downstream hooks see.
+// - Reversibility is mandatory: we never replace content with a lossy view
+//   unless the full original was successfully persisted to the session VFS.
+//   We reuse `tool_output_persistence::{persist_output, annotate_truncated_output}`
+//   rather than reimplementing persistence, and inject the same `output_files`
+//   pointer. `PersistOutputHook` skips when `output_files` is already present,
+//   so the two never double-write.
+// - Routing is by content *shape*, not tool name: MCP tool names are arbitrary
+//   and namespaced, so name allowlists (used by compaction masking) do not
+//   generalize. We sniff the JSON value instead.
+// - Determinism: every transform is deterministic so identical output distills
+//   identically, preserving provider KV-cache reuse across turns.
+// - Skips tools that declare `persist_output` (exec/sandbox): their existing
+//   budget + persistence pipeline already solves the problem, and distilling
+//   their already-budgeted inline view would fight that design.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde_json::{Value, json};
+
+use super::tool_output_persistence::{annotate_truncated_output, persist_output};
+use super::{Capability, CapabilityLocalization, CapabilityStatus};
+use crate::atoms::PostToolExecHook;
+use crate::tool_types::{ToolCall, ToolDefinition, ToolResult};
+use crate::traits::ToolContext;
+
+/// Only distill results whose serialized size exceeds this threshold. Smaller
+/// results are left verbatim (cheap, cache-stable, and rarely worth a VFS write).
+const MIN_DISTILL_BYTES: usize = 8 * 1024;
+
+/// Strings longer than this are clipped to a head+tail window. Also the array
+/// serialized-size threshold above which array sampling kicks in.
+const MAX_FIELD_BYTES: usize = 2 * 1024;
+
+/// Number of leading elements kept when sampling a large array.
+const SAMPLE_ROWS: usize = 5;
+
+/// Maximum recursion depth when walking a result value (DoS bound).
+const MAX_DEPTH: usize = 8;
+
+/// Maximum number of nodes visited while distilling (DoS bound).
+const MAX_NODES: usize = 100_000;
+
+/// Capability that distills large tool results into a compact inline view while
+/// persisting the full original for lossless retrieval.
+pub struct ToolOutputDistillationCapability;
+
+impl Capability for ToolOutputDistillationCapability {
+    fn id(&self) -> &str {
+        "tool_output_distillation"
+    }
+
+    fn name(&self) -> &str {
+        "Tool Output Distillation"
+    }
+
+    fn description(&self) -> &str {
+        "Distills large tool results (notably MCP and web fetch) into a compact, \
+         content-aware inline view while persisting the full original to the \
+         session filesystem for lossless retrieval via read_file."
+    }
+
+    fn localizations(&self) -> Vec<CapabilityLocalization> {
+        vec![CapabilityLocalization::text(
+            "uk",
+            "Стиснення виводу інструментів",
+            "Стискає великий вивід інструментів (зокрема MCP та web fetch) у компактний \
+             вигляд із урахуванням типу вмісту, зберігаючи повний оригінал у файловій \
+             системі сесії для отримання без втрат через read_file.",
+        )]
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+
+    fn dependencies(&self) -> Vec<&'static str> {
+        vec!["session_file_system"]
+    }
+
+    fn post_tool_exec_hooks(&self) -> Vec<Arc<dyn PostToolExecHook>> {
+        vec![Arc::new(DistillOutputHook)]
+    }
+}
+
+/// Hook that distills large non-exec tool results in place.
+pub struct DistillOutputHook;
+
+#[async_trait]
+impl PostToolExecHook for DistillOutputHook {
+    async fn after_exec(
+        &self,
+        tool_call: &ToolCall,
+        tool_def: &ToolDefinition,
+        result: &mut ToolResult,
+        context: &ToolContext,
+    ) {
+        // Exec/sandbox tools are already handled by the verbosity budget +
+        // tool_output_persistence. Distilling their budgeted inline view would
+        // fight that design, so leave them alone.
+        if tool_def.hints().persist_output == Some(true) {
+            return;
+        }
+
+        // Only operate on successful results. Errors are usually small and
+        // diagnostically important; keep them verbatim.
+        if result.error.is_some() {
+            return;
+        }
+
+        let Some(result_value) = result.result.as_mut() else {
+            return;
+        };
+
+        // Already recoverable (another hook persisted it, or a tool injected
+        // its own pointer). Nothing to do.
+        if result_value.get("output_files").is_some() {
+            return;
+        }
+
+        // Size gate: only act on large results.
+        let serialized = serde_json::to_string(result_value).unwrap_or_default();
+        if serialized.len() < MIN_DISTILL_BYTES {
+            return;
+        }
+
+        // Reversibility requires a session file store. Without one we cannot
+        // guarantee the original is recoverable, so we refuse to distill.
+        let Some(file_store) = context.file_store.as_ref() else {
+            return;
+        };
+
+        // Distill in place, keeping the pre-distill original for persistence.
+        let original = result_value.clone();
+        let mut stats = DistillStats::default();
+        distill_value(result_value, 0, &mut stats);
+        if !stats.changed {
+            // Large but already compact (e.g. one opaque scalar). Leave verbatim
+            // rather than spend a VFS write on something we did not reduce.
+            return;
+        }
+
+        // Persist the full original (pretty-printed JSON) for lossless retrieval.
+        let original_text =
+            serde_json::to_string_pretty(&original).unwrap_or_else(|_| original.to_string());
+        let original_len = original_text.len();
+        let persisted = persist_output(
+            file_store,
+            context.session_id,
+            &tool_call.id,
+            &original_text,
+            "",
+        )
+        .await;
+
+        let Some(stdout_path) = persisted.and_then(|p| p.stdout_path) else {
+            // Persistence failed: we cannot guarantee recovery, so restore the
+            // verbatim original instead of leaving a lossy, irrecoverable result.
+            *result_value = original;
+            return;
+        };
+
+        inject_pointer(result_value, &stdout_path, original_len);
+    }
+}
+
+/// Tracks whether distillation actually changed anything and bounds traversal.
+#[derive(Default)]
+struct DistillStats {
+    changed: bool,
+    nodes: usize,
+}
+
+/// Recursively distill a JSON value in place: clip long strings, sample large
+/// arrays. Bounded by depth and node count.
+fn distill_value(value: &mut Value, depth: usize, stats: &mut DistillStats) {
+    if depth > MAX_DEPTH || stats.nodes >= MAX_NODES {
+        return;
+    }
+    stats.nodes += 1;
+
+    match value {
+        Value::String(s) => {
+            if s.len() > MAX_FIELD_BYTES {
+                *s = distill_text(s, MAX_FIELD_BYTES);
+                stats.changed = true;
+            }
+        }
+        Value::Array(arr) => {
+            let serialized_len = serde_json::to_string(arr).map(|s| s.len()).unwrap_or(0);
+            if arr.len() > SAMPLE_ROWS && serialized_len > MAX_FIELD_BYTES {
+                let omitted = arr.len() - SAMPLE_ROWS;
+                arr.truncate(SAMPLE_ROWS);
+                for el in arr.iter_mut() {
+                    distill_value(el, depth + 1, stats);
+                }
+                arr.push(json!(format!(
+                    "[… {omitted} more item(s) elided — full output via read_file …]"
+                )));
+                stats.changed = true;
+            } else {
+                for el in arr.iter_mut() {
+                    distill_value(el, depth + 1, stats);
+                }
+            }
+        }
+        Value::Object(map) => {
+            for (_k, v) in map.iter_mut() {
+                distill_value(v, depth + 1, stats);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Produce a compact view of a long text value.
+///
+/// Recognizes a unified diff and collapses it to a diffstat-style summary
+/// (file + hunk headers, with added/removed line counts). Otherwise keeps a
+/// head+tail window with a byte-elision marker, which preserves both the start
+/// and the end (unlike pure head truncation).
+fn distill_text(text: &str, max_bytes: usize) -> String {
+    if let Some(summary) = distill_unified_diff(text) {
+        return summary;
+    }
+    head_tail(text, max_bytes)
+}
+
+/// If `text` looks like a unified diff, summarize it; else `None`.
+fn distill_unified_diff(text: &str) -> Option<String> {
+    let is_diff = text.starts_with("diff --git ")
+        || text.contains("\ndiff --git ")
+        || text.starts_with("--- ") && text.contains("\n+++ ") && text.contains("\n@@ ");
+    if !is_diff {
+        return None;
+    }
+
+    let mut kept = Vec::new();
+    let mut added = 0usize;
+    let mut removed = 0usize;
+    for line in text.lines() {
+        if line.starts_with("diff --git ")
+            || line.starts_with("+++ ")
+            || line.starts_with("--- ")
+            || line.starts_with("@@ ")
+            || line.starts_with("rename ")
+            || line.starts_with("new file")
+            || line.starts_with("deleted file")
+        {
+            kept.push(line);
+        } else if line.starts_with('+') {
+            added += 1;
+        } else if line.starts_with('-') {
+            removed += 1;
+        }
+    }
+
+    let header = format!("[diff distilled: +{added} / -{removed} lines — full diff via read_file]");
+    let mut out =
+        String::with_capacity(header.len() + kept.iter().map(|l| l.len() + 1).sum::<usize>());
+    out.push_str(&header);
+    out.push('\n');
+    for line in kept {
+        out.push_str(line);
+        out.push('\n');
+    }
+    Some(out)
+}
+
+/// Keep a head+tail window of `text` within roughly `max_bytes`, on UTF-8
+/// boundaries, with a marker noting how many bytes were elided.
+fn head_tail(text: &str, max_bytes: usize) -> String {
+    if text.len() <= max_bytes {
+        return text.to_string();
+    }
+    let head_budget = max_bytes * 7 / 10;
+    let tail_budget = max_bytes - head_budget;
+
+    let mut head_end = head_budget.min(text.len());
+    while head_end > 0 && !text.is_char_boundary(head_end) {
+        head_end -= 1;
+    }
+    let mut tail_start = text.len().saturating_sub(tail_budget);
+    while tail_start < text.len() && !text.is_char_boundary(tail_start) {
+        tail_start += 1;
+    }
+    if tail_start < head_end {
+        tail_start = head_end;
+    }
+
+    let elided = tail_start.saturating_sub(head_end);
+    format!(
+        "{}\n… [{elided} bytes elided — full output via read_file] …\n{}",
+        &text[..head_end],
+        &text[tail_start..],
+    )
+}
+
+/// Inject the recovery pointer fields into a distilled result value, mirroring
+/// the contract of `tool_output_persistence` (`output_files` / `full_output`).
+fn inject_pointer(result_value: &mut Value, stdout_path: &str, original_len: usize) {
+    let note = annotate_truncated_output(
+        "Tool output was distilled to fit the context window.",
+        stdout_path,
+        original_len,
+    );
+    let pointer = format!("/workspace{stdout_path}");
+
+    if let Some(obj) = result_value.as_object_mut() {
+        obj.insert("output_files".to_string(), json!([pointer]));
+        obj.insert("full_output".to_string(), json!(stdout_path));
+        obj.insert("distilled".to_string(), json!(true));
+        obj.insert("distill_note".to_string(), json!(note));
+    } else {
+        // Non-object top level (array / string): wrap in an envelope so the
+        // recovery pointer has somewhere to live.
+        let distilled = std::mem::replace(result_value, Value::Null);
+        *result_value = json!({
+            "distilled_output": distilled,
+            "output_files": [pointer],
+            "full_output": stdout_path,
+            "distilled": true,
+            "distill_note": note,
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_capability_metadata() {
+        let cap = ToolOutputDistillationCapability;
+        assert_eq!(cap.id(), "tool_output_distillation");
+        assert!(!cap.post_tool_exec_hooks().is_empty());
+        assert!(cap.dependencies().contains(&"session_file_system"));
+    }
+
+    #[test]
+    fn test_head_tail_preserves_both_ends() {
+        let text = format!("START{}END", "x".repeat(10_000));
+        let out = head_tail(&text, 1024);
+        assert!(out.starts_with("START"));
+        assert!(out.ends_with("END"));
+        assert!(out.contains("bytes elided"));
+        assert!(out.len() < text.len());
+    }
+
+    #[test]
+    fn test_head_tail_noop_when_small() {
+        assert_eq!(head_tail("short", 1024), "short");
+    }
+
+    #[test]
+    fn test_head_tail_utf8_safe() {
+        // Multi-byte chars at the boundaries must not panic or split.
+        let text = "日本語".repeat(5_000);
+        let out = head_tail(&text, 1000);
+        assert!(out.contains("bytes elided"));
+        // Round-trips as valid UTF-8 (String guarantees it; assert non-empty ends).
+        assert!(!out.is_empty());
+    }
+
+    #[test]
+    fn test_distill_unified_diff_summarizes() {
+        let diff = "diff --git a/x.rs b/x.rs\n--- a/x.rs\n+++ b/x.rs\n@@ -1,3 +1,4 @@\n-old line\n+new line one\n+new line two\n context\n";
+        let summary = distill_unified_diff(diff).expect("recognized as diff");
+        assert!(summary.contains("diff --git a/x.rs b/x.rs"));
+        assert!(summary.contains("@@ -1,3 +1,4 @@"));
+        assert!(summary.contains("+2 / -1 lines"));
+        // Body content lines are dropped.
+        assert!(!summary.contains("new line one"));
+    }
+
+    #[test]
+    fn test_distill_non_diff_text_returns_none() {
+        assert!(distill_unified_diff("just some prose without diff markers").is_none());
+    }
+
+    #[test]
+    fn test_distill_value_samples_large_array() {
+        let big: Vec<Value> = (0..1000)
+            .map(|i| json!({"id": i, "name": format!("item-{i}")}))
+            .collect();
+        let mut value = json!({ "rows": big });
+        let mut stats = DistillStats::default();
+        distill_value(&mut value, 0, &mut stats);
+        assert!(stats.changed);
+        let rows = value["rows"].as_array().unwrap();
+        // SAMPLE_ROWS kept + 1 elision marker
+        assert_eq!(rows.len(), SAMPLE_ROWS + 1);
+        assert!(rows.last().unwrap().as_str().unwrap().contains("more item"));
+    }
+
+    #[test]
+    fn test_distill_value_clips_long_string_field() {
+        let mut value = json!({ "body": "y".repeat(50_000), "ok": true });
+        let mut stats = DistillStats::default();
+        distill_value(&mut value, 0, &mut stats);
+        assert!(stats.changed);
+        assert!(value["body"].as_str().unwrap().len() < 50_000);
+        // Small sibling field is untouched.
+        assert_eq!(value["ok"], json!(true));
+    }
+
+    #[test]
+    fn test_distill_value_noop_on_small() {
+        let mut value = json!({ "a": 1, "b": "small" });
+        let mut stats = DistillStats::default();
+        distill_value(&mut value, 0, &mut stats);
+        assert!(!stats.changed);
+    }
+
+    #[test]
+    fn test_distill_value_small_array_not_sampled() {
+        let mut value = json!({ "items": [1, 2, 3] });
+        let mut stats = DistillStats::default();
+        distill_value(&mut value, 0, &mut stats);
+        assert!(!stats.changed);
+        assert_eq!(value["items"].as_array().unwrap().len(), 3);
+    }
+
+    #[test]
+    fn test_inject_pointer_into_object() {
+        let mut value = json!({ "content": "distilled" });
+        inject_pointer(&mut value, "/outputs/abc.stdout", 50 * 1024);
+        assert_eq!(
+            value["output_files"],
+            json!(["/workspace/outputs/abc.stdout"])
+        );
+        assert_eq!(value["full_output"], json!("/outputs/abc.stdout"));
+        assert_eq!(value["distilled"], json!(true));
+        assert!(
+            value["distill_note"]
+                .as_str()
+                .unwrap()
+                .contains("read_file")
+        );
+    }
+
+    #[test]
+    fn test_inject_pointer_wraps_non_object() {
+        let mut value = json!(["a", "b"]);
+        inject_pointer(&mut value, "/outputs/x.stdout", 1024);
+        assert!(value.is_object());
+        assert_eq!(value["distilled_output"], json!(["a", "b"]));
+        assert_eq!(value["full_output"], json!("/outputs/x.stdout"));
+    }
+
+    #[test]
+    fn test_depth_bound_does_not_panic() {
+        // Build a deeply nested object beyond MAX_DEPTH.
+        let mut value = json!("x".repeat(50_000));
+        for _ in 0..50 {
+            value = json!({ "next": value });
+        }
+        let mut stats = DistillStats::default();
+        // Must terminate without panicking despite exceeding MAX_DEPTH.
+        distill_value(&mut value, 0, &mut stats);
+    }
+
+    // --- Hook-level integration tests (after_exec end to end) ---
+
+    use crate::error::Result;
+    use crate::session_file::{FileInfo, FileStat, GrepMatch, SessionFile};
+    use crate::tool_types::{BuiltinTool, DeferrablePolicy, ToolHints, ToolPolicy};
+    use crate::traits::SessionFileSystem;
+    use crate::typed_id::SessionId;
+    use chrono::Utc;
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+    use uuid::Uuid;
+
+    #[derive(Default)]
+    struct MockFileStore {
+        files: Mutex<HashMap<String, String>>,
+        fail_writes: bool,
+    }
+
+    impl MockFileStore {
+        fn content(&self, path: &str) -> Option<String> {
+            self.files.lock().unwrap().get(path).cloned()
+        }
+    }
+
+    #[async_trait]
+    impl SessionFileSystem for MockFileStore {
+        async fn read_file(&self, _s: SessionId, _p: &str) -> Result<Option<SessionFile>> {
+            Ok(None)
+        }
+        async fn write_file(
+            &self,
+            _s: SessionId,
+            path: &str,
+            content: &str,
+            _encoding: &str,
+        ) -> Result<SessionFile> {
+            if self.fail_writes {
+                return Err(anyhow::anyhow!("write failed").into());
+            }
+            self.files
+                .lock()
+                .unwrap()
+                .insert(path.to_string(), content.to_string());
+            Ok(SessionFile {
+                id: Uuid::new_v4(),
+                session_id: Uuid::nil(),
+                path: path.to_string(),
+                name: path.rsplit('/').next().unwrap_or("").to_string(),
+                content: Some(content.to_string()),
+                encoding: "utf-8".to_string(),
+                is_directory: false,
+                is_readonly: false,
+                size_bytes: content.len() as i64,
+                created_at: Utc::now(),
+                updated_at: Utc::now(),
+            })
+        }
+        async fn delete_file(&self, _s: SessionId, _p: &str, _r: bool) -> Result<bool> {
+            Ok(false)
+        }
+        async fn list_directory(&self, _s: SessionId, _p: &str) -> Result<Vec<FileInfo>> {
+            Ok(vec![])
+        }
+        async fn stat_file(&self, _s: SessionId, _p: &str) -> Result<Option<FileStat>> {
+            Ok(None)
+        }
+        async fn grep_files(
+            &self,
+            _s: SessionId,
+            _pat: &str,
+            _pp: Option<&str>,
+        ) -> Result<Vec<GrepMatch>> {
+            Ok(vec![])
+        }
+        async fn create_directory(&self, _s: SessionId, _p: &str) -> Result<FileInfo> {
+            Err(anyhow::anyhow!("not implemented").into())
+        }
+    }
+
+    fn mcp_tool_def(persist_output: bool) -> ToolDefinition {
+        let mut hints = ToolHints::default();
+        if persist_output {
+            hints = hints.with_persist_output(true);
+        }
+        ToolDefinition::Builtin(BuiltinTool {
+            name: "mcp__server__big_query".to_string(),
+            display_name: None,
+            description: "an mcp tool".to_string(),
+            parameters: json!({}),
+            policy: ToolPolicy::Auto,
+            category: None,
+            deferrable: DeferrablePolicy::default(),
+            hints,
+            full_parameters: None,
+        })
+    }
+
+    fn tool_call() -> ToolCall {
+        ToolCall {
+            id: "call_123".to_string(),
+            name: "mcp__server__big_query".to_string(),
+            arguments: json!({}),
+        }
+    }
+
+    fn ctx_with_store(store: Arc<MockFileStore>) -> ToolContext {
+        let mut ctx = ToolContext::new(SessionId::from(Uuid::nil()));
+        ctx.file_store = Some(store);
+        ctx
+    }
+
+    fn big_result() -> ToolResult {
+        // A large array result, well over MIN_DISTILL_BYTES once serialized.
+        let rows: Vec<Value> = (0..2000)
+            .map(|i| json!({"id": i, "name": format!("row-number-{i}")}))
+            .collect();
+        ToolResult {
+            tool_call_id: "call_123".to_string(),
+            result: Some(json!({ "rows": rows })),
+            images: None,
+            error: None,
+            connection_required: None,
+            raw_output: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_hook_distills_large_mcp_result_and_persists_original() {
+        let store = Arc::new(MockFileStore::default());
+        let ctx = ctx_with_store(store.clone());
+        let mut result = big_result();
+
+        DistillOutputHook
+            .after_exec(&tool_call(), &mcp_tool_def(false), &mut result, &ctx)
+            .await;
+
+        let value = result.result.as_ref().unwrap();
+        // Inline view is distilled: array sampled + pointer injected.
+        assert_eq!(value["distilled"], json!(true));
+        assert_eq!(
+            value["output_files"],
+            json!(["/workspace/outputs/call_123.stdout"])
+        );
+        let rows = value["rows"].as_array().unwrap();
+        assert_eq!(rows.len(), SAMPLE_ROWS + 1);
+        // Full original is recoverable from the VFS.
+        let persisted = store
+            .content("/outputs/call_123.stdout")
+            .expect("original persisted");
+        assert!(persisted.contains("row-number-1999"));
+    }
+
+    #[tokio::test]
+    async fn test_hook_skips_persist_output_tools() {
+        let store = Arc::new(MockFileStore::default());
+        let ctx = ctx_with_store(store.clone());
+        let mut result = big_result();
+
+        DistillOutputHook
+            .after_exec(&tool_call(), &mcp_tool_def(true), &mut result, &ctx)
+            .await;
+
+        // Untouched: exec/sandbox path is handled by budget + persistence.
+        assert!(result.result.as_ref().unwrap().get("distilled").is_none());
+        assert!(store.content("/outputs/call_123.stdout").is_none());
+    }
+
+    #[tokio::test]
+    async fn test_hook_skips_small_result() {
+        let store = Arc::new(MockFileStore::default());
+        let ctx = ctx_with_store(store.clone());
+        let mut result = ToolResult {
+            tool_call_id: "call_123".to_string(),
+            result: Some(json!({ "ok": true, "value": "small" })),
+            images: None,
+            error: None,
+            connection_required: None,
+            raw_output: None,
+        };
+
+        DistillOutputHook
+            .after_exec(&tool_call(), &mcp_tool_def(false), &mut result, &ctx)
+            .await;
+
+        assert!(result.result.as_ref().unwrap().get("distilled").is_none());
+        assert!(store.content("/outputs/call_123.stdout").is_none());
+    }
+
+    #[tokio::test]
+    async fn test_hook_no_file_store_leaves_verbatim() {
+        let mut ctx = ToolContext::new(SessionId::from(Uuid::nil()));
+        ctx.file_store = None;
+        let mut result = big_result();
+        let before = result.result.clone();
+
+        DistillOutputHook
+            .after_exec(&tool_call(), &mcp_tool_def(false), &mut result, &ctx)
+            .await;
+
+        // No recoverability available → no lossy distillation.
+        assert_eq!(result.result, before);
+    }
+
+    #[tokio::test]
+    async fn test_hook_restores_original_when_persist_fails() {
+        let store = Arc::new(MockFileStore {
+            fail_writes: true,
+            ..Default::default()
+        });
+        let ctx = ctx_with_store(store.clone());
+        let mut result = big_result();
+        let before = result.result.clone();
+
+        DistillOutputHook
+            .after_exec(&tool_call(), &mcp_tool_def(false), &mut result, &ctx)
+            .await;
+
+        // Persistence failed → verbatim original restored, never lossy-irrecoverable.
+        assert_eq!(result.result, before);
+        assert!(result.result.as_ref().unwrap().get("distilled").is_none());
+    }
+
+    #[tokio::test]
+    async fn test_hook_skips_error_results() {
+        let store = Arc::new(MockFileStore::default());
+        let ctx = ctx_with_store(store.clone());
+        let mut result = big_result();
+        result.error = Some("boom".to_string());
+
+        DistillOutputHook
+            .after_exec(&tool_call(), &mcp_tool_def(false), &mut result, &ctx)
+            .await;
+
+        assert!(result.result.as_ref().unwrap().get("distilled").is_none());
+    }
+}

--- a/crates/server/src/harnesses/generic.rs
+++ b/crates/server/src/harnesses/generic.rs
@@ -6,7 +6,7 @@ pub fn definition() -> BuiltInHarnessDefinition {
     BuiltInHarnessDefinition::new(
         "generic",
         "Generic",
-        "General-purpose harness with file system, bash, web fetch, secrets, session management, session schedules, long-context support, context compaction, budgeting, self-managed budget guidance, tool output persistence, loop detection, message timestamp annotations, and agent skills. Recommended default for most use cases.",
+        "General-purpose harness with file system, bash, web fetch, secrets, session management, session schedules, long-context support, context compaction, budgeting, self-managed budget guidance, tool output persistence, tool output distillation, loop detection, message timestamp annotations, and agent skills. Recommended default for most use cases.",
         SYSTEM_PROMPT,
     )
     .with_tags(["generic", "default", "built-in"])
@@ -40,6 +40,7 @@ pub fn definition() -> BuiltInHarnessDefinition {
             }),
         ),
         BuiltInCapabilityDefinition::new("tool_output_persistence"),
+        BuiltInCapabilityDefinition::new("tool_output_distillation"),
     ])
 }
 

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -2934,7 +2934,7 @@ mod tests {
             .expect("Generic harness should exist");
 
         let cap_ids: Vec<&str> = generic.capabilities.iter().map(|c| c.id.as_str()).collect();
-        assert_eq!(cap_ids.len(), 18);
+        assert_eq!(cap_ids.len(), 19);
         assert!(cap_ids.contains(&"human_intent"));
         assert!(cap_ids.contains(&"session_file_system"));
         assert!(cap_ids.contains(&"bashkit_shell"));
@@ -2953,6 +2953,7 @@ mod tests {
         assert!(cap_ids.contains(&"message_metadata"));
         assert!(cap_ids.contains(&"compaction"));
         assert!(cap_ids.contains(&"tool_output_persistence"));
+        assert!(cap_ids.contains(&"tool_output_distillation"));
         // Verify compaction default config
         let compaction_cap = generic
             .capabilities

--- a/crates/server/tests/api_integration_test.rs
+++ b/crates/server/tests/api_integration_test.rs
@@ -1961,8 +1961,8 @@ async fn test_get_generic_harness() {
         .collect();
     assert_eq!(
         cap_ids.len(),
-        18,
-        "Generic harness should have 18 capabilities"
+        19,
+        "Generic harness should have 19 capabilities"
     );
     assert!(
         cap_ids.contains(&"human_intent"),
@@ -2504,8 +2504,8 @@ async fn test_copy_seed_generic_harness() {
     // Generic harness capabilities should be preserved on copy
     assert_eq!(
         copied.capabilities.len(),
-        18,
-        "Copied harness should have same 18 capabilities"
+        19,
+        "Copied harness should have same 19 capabilities"
     );
     assert!(
         copied

--- a/docs/advanced/tool-output-pipeline.md
+++ b/docs/advanced/tool-output-pipeline.md
@@ -1,0 +1,108 @@
+---
+title: Tool Output Pipeline
+description: How Everruns processes tool results from execution to the model — verbosity budgets, distillation, persistence, hard limits, and where the full output lives
+sidebar:
+  order: 11
+---
+
+Agents generate most of their context from **tool output**: shell commands, file reads, web fetches, SQL queries, and MCP tool calls. Left unmanaged, a single verbose command (`git diff`, a 10,000-row query, an installer log) can blow past the model's context window, drive up cost, and bury the signal the agent actually needs.
+
+Everruns runs every tool result through a **multi-stage pipeline** that shrinks what the model sees while keeping the full original recoverable. This page explains each stage, the order they run in, and — crucially — *where the full output goes* so the agent can get it back.
+
+## The big picture
+
+```
+tool runs
+  │
+  ▼
+raw output ──────────────────────────────────────────────┐
+  │                                                        │  (full, lossless)
+  ▼                                                        │
+1. Verbosity budget        (exec/sandbox tools only)       │
+  │   auto/concise/normal/verbose/full                     │
+  ▼                                                        │
+2. Capability hooks                                        │
+  │   • Tool Output Distillation  (non-exec tools)         │
+  ▼                                                        ▼
+3. Final infrastructure hooks                      /workspace/outputs/
+  │   • Persist Output  (exec tools → VFS)         {tool_call_id}.stdout
+  │   • Output Hard Limit  (64 KiB ceiling)        {tool_call_id}.stderr
+  ▼                                                  ▲
+inline result → stored in the session,               │
+  shown to the model next turn ──────────────────────┘
+        (read_file recovers the full original)
+```
+
+Two ideas run through the whole pipeline:
+
+1. **Storage stays lossless.** Whatever the model sees inline, the full output is written to the session filesystem (the *destination*). The inline view always carries a pointer back to it.
+2. **Each stage shrinks, none deletes.** Truncation, distillation, and masking only change the *view*. The agent can always `read_file` the persisted original.
+
+## Stage 1 — Verbosity budget (exec tools)
+
+Exec and sandbox tools (`bash`, `*_exec`, sandboxed shells) clean their output (strip ANSI, collapse carriage returns) and apply a **verbosity budget** before returning. The mode is configurable per call; the default is `auto`:
+
+- **Success (`exit_code == 0`)** → collapse to a compact summary (~512 bytes), because the full log is persisted (Stage 3) and the agent rarely needs it inline.
+- **Failure (non-zero exit)** → keep a larger diagnostic window (~8 KiB) so the error stays debuggable in-loop.
+
+The full pre-truncation output is stashed on the result as `raw_output` for the persistence hook to consume. Non-exec tools (MCP, web fetch, client tools) do **not** have a verbosity budget — that gap is what Stage 2 exists for.
+
+## Stage 2 — Tool Output Distillation (non-exec tools)
+
+[Tool Output Distillation](/capabilities/) targets the tools Stage 1 doesn't: **MCP tools and `web_fetch`**, whose results otherwise enter history verbatim. It runs as a capability hook, so it executes *before* the final hooks.
+
+For a large non-exec result, distillation produces a compact, **content-aware** inline view:
+
+| Output shape | What you get inline |
+|--------------|---------------------|
+| Large JSON array | Schema-preserving sample: the first few rows + `[… N more items elided …]` |
+| Long string | Head + tail window (both ends preserved), with a byte-elision marker |
+| Unified diff | A diffstat-style summary: file + hunk headers and `+added / -removed` counts |
+| Nested object | Each oversized field distilled; small fields untouched |
+
+Before it replaces anything, distillation **persists the full original** to the session filesystem (same destination as Stage 3) and injects a recovery pointer. If persistence fails — or the session has no filesystem — it restores the verbatim output rather than leave a lossy result the agent can't recover. **Reversibility is never sacrificed.**
+
+Distillation is on by default in the **generic harness**. Every transform is deterministic, so identical output distills identically and the model provider's prompt cache keeps hitting across turns.
+
+## Stage 3 — Persistence and the hard limit
+
+Two infrastructure hooks always run last, in order:
+
+1. **Persist Output** — for tools that declare the `persist_output` hint (exec/sandbox), writes the full `raw_output` to the session VFS and annotates the inline result with a pointer. It **skips** if a result already carries `output_files` (e.g. distillation already persisted it), so the two never double-write.
+2. **Output Hard Limit** — a final, unremovable 64 KiB ceiling. By the time it runs, the result has usually already been budgeted or distilled, so it rarely fires; it's a backstop against pathological cases.
+
+## The destination — where full output lives
+
+Everything the pipeline elides is recoverable from the **session filesystem**:
+
+```
+/workspace/outputs/{tool_call_id}.stdout    ← full standard output
+/workspace/outputs/{tool_call_id}.stderr    ← full standard error (when present)
+```
+
+The inline result carries the pointer in `output_files` and `full_output`, plus a human-readable note telling the model to use `read_file` (with `offset`/`limit`) when it needs detail it can't see inline. Persisted streams are capped at 1 MiB each. Deleting the session cascades and removes them.
+
+This is the key to aggressive shrinking: because the original is one `read_file` away, the inline view can be small without the agent losing the ability to drill in.
+
+## How this relates to compaction
+
+The pipeline above operates on **individual tool results at capture time**. [Context Compaction](/advanced/compaction/) operates **later**, across the whole conversation, when it approaches the context window — masking or summarizing older messages at serialization time.
+
+They compose cleanly:
+
+- The pipeline keeps each result lean as it's produced.
+- Compaction further masks older results when the *accumulated* history grows too large.
+- [Infinity Context](/capabilities/) adds a `query_history` tool to retrieve older *messages* that scrolled out of the window.
+
+Together: the pipeline controls per-result size, compaction controls total-history size, and both keep the full record recoverable.
+
+## Summary
+
+| Stage | Applies to | Effect | Destination of full output |
+|-------|-----------|--------|----------------------------|
+| Verbosity budget | exec/sandbox | Compact summary on success, diagnostic window on failure | `raw_output` → persisted in Stage 3 |
+| Distillation | MCP / web fetch / non-exec | Content-aware compact view | `/workspace/outputs/{id}.stdout` |
+| Persist Output | `persist_output` tools | Lossless write + pointer | `/workspace/outputs/{id}.{stdout,stderr}` |
+| Output Hard Limit | all | 64 KiB ceiling backstop | (already persisted) |
+
+The agent always sees a lean view and can always recover the full original with `read_file`.

--- a/specs/README.md
+++ b/specs/README.md
@@ -28,6 +28,7 @@ Specs capture the "why" and "what", not exhaustive source detail. Link to code f
 - `specs/events.md` - Event types, SSE streaming, contract and compatibility guarantees
 - `specs/execution-phases.md` - Execution phases (Commentary/FinalAnswer) for multi-step tool flows
 - `specs/tool-execution.md` - Tool types and execution flow
+- `specs/tool-output-distillation.md` - Content-aware distillation of large non-exec tool results at capture time
 - `specs/capabilities.md` - Agent capabilities system
 - `specs/background-execution.md` - `background_execution` capability and cross-cutting / auto-activation contract
 - `specs/client-side-tools.md` - Client-side tools for API/SDK consumers

--- a/specs/tool-execution.md
+++ b/specs/tool-execution.md
@@ -282,6 +282,7 @@ Two hook slots run in sequence:
 
 Current hooks:
 - **PersistOutputHook** (`tool_output_persistence` capability; also installed as an always-on final hook): When a tool declares `persist_output: true` in hints, writes stdout to `/outputs/{tool_call_id}.stdout` and stderr to `/outputs/{tool_call_id}.stderr` in session VFS, injecting `full_output`, `total_lines`, and `output_files` into the result. It skips cleanly if no session file store is present, and skips if another hook already injected `output_files`. See `crates/core/src/capabilities/tool_output_persistence.rs`.
+- **DistillOutputHook** (`tool_output_distillation` capability): For tools that do *not* declare `persist_output` (notably MCP and `web_fetch`), produces a content-aware compact inline view of large results (array sampling, string head+tail, unified-diff summary) while self-persisting the full original to `/outputs/{tool_call_id}.stdout` and injecting the same `output_files` pointer. Runs as a capability hook (before the final hooks); the `output_files` guard above prevents double-writes with PersistOutputHook. Restores the verbatim original if persistence fails. See `crates/core/src/capabilities/tool_output_distillation.rs` and `specs/tool-output-distillation.md`.
 
 Current final hooks (always-on, cannot be removed):
 - **PersistOutputHook**: Persists full output for any tool that declares `persist_output: true` before hard-limit truncation, independent of whether a harness explicitly enabled the persistence capability.

--- a/specs/tool-output-distillation.md
+++ b/specs/tool-output-distillation.md
@@ -40,7 +40,7 @@ Both the in-process host and the durable worker assemble hooks through the same 
 3. **Skip** if the result already carries `output_files` (already recoverable / distilled).
 4. **Size gate:** skip if the serialized result is below `MIN_DISTILL_BYTES`.
 5. **Require a session file store** (reversibility); skip if absent.
-6. Clone the original, then **distill the value in place**. If nothing changed, leave verbatim (no VFS write).
+6. Clone the original, then **distill the value in place**. If the shape walker changes nothing (a large result made entirely of sub-threshold fields), **fall back** to a head+tail window over the serialized value — so a large result is always bounded, persisted, and recoverable rather than risking an irrecoverable head-truncation by the 64 KiB hard-limit hook.
 7. **Persist the full original** (pretty-printed JSON) via `persist_output`. On failure, restore the verbatim original and return.
 8. **Inject the recovery pointer** (`output_files`, `full_output`, `distilled`, `distill_note`).
 

--- a/specs/tool-output-distillation.md
+++ b/specs/tool-output-distillation.md
@@ -1,0 +1,88 @@
+# Tool Output Distillation
+
+## Abstract
+
+Large tool results bloat the context window, raise cost, and expand the prompt-injection surface. Exec/sandbox tools already get a verbosity budget (`tool_output_sanitizer`) plus lossless persistence (`tool_output_persistence`). Tools that do **not** declare the `persist_output` hint — most notably MCP tools and `web_fetch` — get neither: their output enters history verbatim and is only capped by the 64 KiB hard-limit hook, which head-truncates and discards the tail.
+
+The `tool_output_distillation` capability closes that gap. It produces a compact, **content-aware inline view** of large non-exec tool results at capture time, while persisting the full original to the session filesystem so the agent can recover it losslessly via `read_file`.
+
+This is the Everruns adoption of the "shell/tool output rewriting" idea (cf. RTK / headroom's ContentRouter), reframed for a runtime that owns the agent: a capability-contributed `PostToolExecHook` rather than an external CLI wrapper.
+
+## Design Principles
+
+1. **Target the gap, not the whole pipeline.** Exec/sandbox tools (`persist_output: true`) are already handled by budget + persistence; distillation skips them. It targets non-exec tools (MCP, `web_fetch`, client tools) whose output is otherwise unmanaged.
+2. **Reversibility is mandatory.** Never replace content with a lossy view unless the full original was successfully persisted. If persistence fails (or no file store exists), restore the verbatim original. Lossy-but-irrecoverable is never allowed.
+3. **Route by content shape, not tool name.** MCP tool names are arbitrary and namespaced, so the name allowlists used by compaction masking do not generalize. Distillation sniffs the JSON value.
+4. **Deterministic.** Identical output distills identically, preserving provider KV-cache reuse across turns.
+5. **Compose with persistence, don't duplicate it.** Reuse `tool_output_persistence::{persist_output, annotate_truncated_output}` and inject the same `output_files` pointer. `PersistOutputHook` skips when `output_files` is present, so the two never double-write.
+
+## Pipeline Position
+
+Per-tool output flows through these stages (see `specs/tool-execution.md`):
+
+```
+tool returns result
+  → tool-side verbosity budget (exec tools only; tool_output_sanitizer)
+  → capability PostToolExecHooks   ← DistillOutputHook runs HERE
+  → final hooks: PersistOutputHook → OutputHardLimitHook (64 KiB ceiling)
+```
+
+`DistillOutputHook` is a **capability** hook, so it runs **before** the final infrastructure hooks. For non-exec tools, `PersistOutputHook` does not fire (no `persist_output` hint), so distillation self-persists and the hard-limit hook only ever sees the already-distilled (smaller) result.
+
+Both the in-process host and the durable worker assemble hooks through the same `RuntimeHostAdapter`-generic path (`crates/runtime/src/host.rs::execute_act_activity` → `load_execution_capabilities`), so the hook runs identically in embedded and durable execution.
+
+## Algorithm
+
+`DistillOutputHook::after_exec`:
+
+1. **Skip** if the tool declares `persist_output: true` (exec/sandbox — handled elsewhere).
+2. **Skip** on error results (kept verbatim — usually small and diagnostically important).
+3. **Skip** if the result already carries `output_files` (already recoverable / distilled).
+4. **Size gate:** skip if the serialized result is below `MIN_DISTILL_BYTES`.
+5. **Require a session file store** (reversibility); skip if absent.
+6. Clone the original, then **distill the value in place**. If nothing changed, leave verbatim (no VFS write).
+7. **Persist the full original** (pretty-printed JSON) via `persist_output`. On failure, restore the verbatim original and return.
+8. **Inject the recovery pointer** (`output_files`, `full_output`, `distilled`, `distill_note`).
+
+### Content-shape routing (`distill_value`)
+
+Recursive, bounded by `MAX_DEPTH` and `MAX_NODES`:
+
+| Shape | Transform |
+|-------|-----------|
+| Long string (> `MAX_FIELD_BYTES`) | `distill_text`: unified-diff → diffstat summary (file/hunk headers + `+a/-r` line counts); otherwise head+tail window with a byte-elision marker (preserves both ends, unlike head truncation). |
+| Large array (len > `SAMPLE_ROWS` and serialized > `MAX_FIELD_BYTES`) | Keep the first `SAMPLE_ROWS` elements (each recursively distilled) + an elision marker `[… N more item(s) elided …]`. |
+| Object | Recurse into each field; small fields untouched. |
+| Scalar / small value | Unchanged. |
+
+Constants (no per-agent config in v1): `MIN_DISTILL_BYTES = 8 KiB`, `MAX_FIELD_BYTES = 2 KiB`, `SAMPLE_ROWS = 5`, `MAX_DEPTH = 8`, `MAX_NODES = 100_000`. See `crates/core/src/capabilities/tool_output_distillation.rs`.
+
+## Recovery Contract
+
+The full original is written to `/outputs/{tool_call_id}.stdout` in the session VFS (same convention and helper as `tool_output_persistence`), readable with `read_file`. The distilled inline result carries `output_files` and `full_output` pointing at it, plus a `distill_note` instructing the model to `read_file` the full output when it needs detail it cannot see. This is the reversibility headroom builds via a separate CCR store; Everruns reuses the session VFS it already has.
+
+## Configuration
+
+Distillation is a capability with **no per-agent config in v1** — `PostToolExecHook` has no config-bearing channel (unlike `tool_definition_hooks_with_config`), matching the sibling `tool_output_persistence`. Tunable thresholds are a noted follow-up (would require a config-bearing hook variant). It depends on `session_file_system`.
+
+It is included by default in the **generic harness** (`crates/server/src/harnesses/generic.rs`), alongside `tool_output_persistence` and `compaction`.
+
+## Security
+
+- **TM-DOS** — traversal is bounded by `MAX_DEPTH` / `MAX_NODES`; persisted size is capped at 1 MiB by `persist_output`. Distillation only ever shrinks the in-context payload.
+- **TM-FS** — VFS writes reuse `tool_output_persistence::persist_output`, which sanitizes the tool-call id (no path traversal) and is session-scoped.
+- **TM-TOOL / prompt injection** — distillation reduces content; it never executes tool output. Markers and notes are static strings. The result remains untrusted tool output, governed by the same instruction hierarchy as before.
+
+## Relationship to Other Capabilities
+
+- **`tool_output_persistence`** — sibling; persists exec output before truncation. Distillation reuses its helpers and the `output_files` guard prevents double-writes. Distillation covers the non-exec tools persistence does not.
+- **`compaction`** — operates later, at the model-view / serialization layer over the whole history. Distillation shrinks individual results at capture; compaction can still mask older results. Complementary, no conflict.
+- **`infinity_context`** — `query_history` retrieves excluded *messages*; distillation's pointer retrieves a specific tool's *full output*. Complementary.
+
+## References
+
+- `specs/tool-execution.md` — output budgets, `PersistOutputHook`, hook ordering
+- `specs/capabilities.md` — capability system
+- `crates/core/src/capabilities/tool_output_distillation.rs` — implementation
+- `crates/core/src/capabilities/tool_output_persistence.rs` — reused persistence helpers
+- `docs/advanced/tool-output-pipeline.md` — end-to-end pipeline and destinations


### PR DESCRIPTION
## What
Adds a new `tool_output_distillation` capability that produces a compact, content-aware *inline view* of large tool results at capture time, while persisting the full original to the session filesystem for lossless retrieval via `read_file`. Enabled by default in the **generic** harness.

This adopts the "shell/tool-output rewriting" idea from [headroom](https://github.com/chopratejas/headroom) / RTK, reframed for a runtime that owns the agent: a capability-contributed `PostToolExecHook` rather than an external CLI wrapper.

## Why
Tool output is the dominant source of agent context. Today:
- **Exec/sandbox tools** (`persist_output: true`) already get a verbosity budget (`tool_output_sanitizer`) + lossless persistence (`tool_output_persistence`).
- **Everything else** — notably **MCP tools** and **`web_fetch`** — has neither. Their output enters history verbatim and is only capped by the 64 KiB hard-limit hook, which **head-truncates and discards the tail**.

Distillation closes exactly that gap.

## How
`DistillOutputHook` runs as a capability `PostToolExecHook`, so it executes *before* the final infrastructure hooks (persistence + hard-limit). For a large non-exec result it:

1. Skips `persist_output` tools (exec path is already handled), error results, and results already carrying `output_files`.
2. Gates on serialized size (`MIN_DISTILL_BYTES = 8 KiB`) and requires a session file store.
3. Distills **by content shape** (not tool name, so it generalizes to arbitrary MCP names):
   - large JSON array → schema-preserving sample (`first N` + `[… N more elided …]`)
   - long string → head+tail window (both ends kept) with a byte-elision marker
   - unified diff → diffstat-style summary (file/hunk headers + `+a/-r` counts)
4. **Self-persists the full original** to `/workspace/outputs/{tool_call_id}.stdout` by reusing `tool_output_persistence::{persist_output, annotate_truncated_output}`, and injects the same `output_files`/`full_output` pointer. The existing `output_files` guard in `PersistOutputHook` prevents double-writes.
5. **Reversibility is mandatory:** if persistence fails or no file store exists, the verbatim original is restored — never lossy-and-irrecoverable.

Every transform is deterministic (preserves provider KV-cache reuse), and traversal is depth/node-bounded.

Specs: new `specs/tool-output-distillation.md`, delta to `specs/tool-execution.md`, index entry in `specs/README.md`.
Docs: `docs/advanced/tool-output-pipeline.md` documents the full pipeline (budget → distillation → persistence → hard limit → compaction) and where output is persisted.

## Validation
- `cargo test -p everruns-core` for the capability: 20 unit tests (content-shape transforms, UTF-8 safety, DoS bounds) + hook-level `after_exec` tests (persist, skip paths, restore-on-failure).
- **Real act-loop integration test** (`test_act_atom_distills_large_non_exec_tool_result`): a large non-exec tool result is distilled and persisted as it flows through the actual `ActAtom` with the real final hooks present — the same atom used by both the in-process host and the durable worker.
- Registry tests updated (dev + prod) and server harness tests pass.
- `bash scripts/lib/pre-push.sh` green (fmt, clippy `--all-targets --all-features`, lockfile, migrations, specs index, attribution).
- **Live runtime smoke:** booted the in-memory server; the capability is surfaced via `/api/v1/capabilities/tool_output_distillation` with `"harness_count": 1`, confirming it is wired into the built-in generic harness at runtime.

## Risk
- **Low.** New capability, additive. No DB migration, no schema/API contract change, no new dependencies. Behavior is gated on large non-exec output and degrades safely (restores verbatim) when persistence is unavailable. Exec-tool behavior is explicitly untouched.

## Security
- Threat categories reviewed: **TM-TOOL**, **TM-FS**, **TM-DOS**.
  - **TM-FS** — VFS writes reuse `tool_output_persistence::persist_output`, which sanitizes the tool-call id (no path traversal) and is session-scoped. No new filesystem surface.
  - **TM-DOS** — recursion bounded by `MAX_DEPTH`/`MAX_NODES`; persisted size capped at 1 MiB by the reused helper. Distillation only ever *shrinks* the in-context payload.
  - **TM-TOOL / prompt injection (TM-AGENT-012)** — distillation reduces content; it never executes tool output. Markers/notes are static strings; the result remains untrusted tool output under the same instruction hierarchy. Net effect *reduces* the injection surface of large results.
- Findings: none. No new secrets, auth, or tenant-boundary surface.

## Follow-ups
- Per-agent config (thresholds, opt-out): `PostToolExecHook` has no config-bearing variant today, so v1 uses module constants — matching the sibling `tool_output_persistence`. A config-bearing hook variant would enable tuning. Deferred: out of scope and not required for correctness.
- Coding harnesses could also adopt this capability (large MCP/web output is common there); left to a separate change to keep this PR focused on the generic harness as requested.
- Richer content-aware transforms (directory listings, installer logs) beyond diff/array/string; the generic head+tail path handles them safely today.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)


---
_Generated by [Claude Code](https://claude.ai/code/session_01BBm4uU3Pwu1imyY7GTr57M)_