### PR TITLE
refactor(core): rename task tool parameter to instructions

### DIFF
--- a/crates/core/src/capabilities/a2a_delegation.rs
+++ b/crates/core/src/capabilities/a2a_delegation.rs
@@ -514,7 +514,7 @@ struct AgentRunRecord {
     kind: String,
     external_agent_id: String,
     external_agent_name: String,
-    task: String,
+    instructions: String,
     mode: AgentRunMode,
     status: AgentRunStatus,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -547,7 +547,7 @@ impl AgentRunRecord {
     fn new(
         run_id: String,
         agent: &ExternalA2aAgentConfig,
-        task: String,
+        instructions: String,
         mode: AgentRunMode,
         wake_on_completion: bool,
     ) -> Self {
@@ -556,7 +556,7 @@ impl AgentRunRecord {
             kind: "external_a2a".to_string(),
             external_agent_id: agent.id.clone(),
             external_agent_name: agent.name.clone(),
-            task,
+            instructions,
             mode,
             status: AgentRunStatus::Submitted,
             remote_task_id: None,
@@ -577,7 +577,7 @@ impl AgentRunRecord {
             "kind": self.kind,
             "external_agent_id": self.external_agent_id,
             "external_agent_name": self.external_agent_name,
-            "task": self.task,
+            "instructions": self.instructions,
             "mode": self.mode,
             "status": self.status,
             "remote_task_id": self.remote_task_id,
@@ -1152,7 +1152,7 @@ impl Tool for SpawnAgentTool {
         json!({
             "type": "object",
             "properties": {
-                "task": {"type": "string", "description": "Task to send to the external agent."},
+                "instructions": {"type": "string", "description": "Instructions to send to the external agent."},
                 "target": {
                     "type": "object",
                     "properties": {
@@ -1166,7 +1166,7 @@ impl Tool for SpawnAgentTool {
                 "wait_timeout_secs": {"type": "integer", "minimum": 1, "maximum": 86400},
                 "wake_on_completion": {"type": "boolean", "default": true}
             },
-            "required": ["task", "target"],
+            "required": ["instructions", "target"],
             "additionalProperties": false
         })
     }
@@ -1189,8 +1189,8 @@ impl Tool for SpawnAgentTool {
         if let Err(e) = require_storage(context) {
             return e;
         }
-        let task = match require_str(&arguments, "task") {
-            Ok(task) => task.to_string(),
+        let instructions = match require_str(&arguments, "instructions") {
+            Ok(instructions) => instructions.to_string(),
             Err(e) => return e,
         };
         let target = arguments.get("target").unwrap_or(&Value::Null);
@@ -1233,7 +1233,7 @@ impl Tool for SpawnAgentTool {
         let mut record = AgentRunRecord::new(
             run_id.clone(),
             &agent,
-            task.clone(),
+            instructions.clone(),
             mode.clone(),
             wake_on_completion,
         );
@@ -1249,7 +1249,7 @@ impl Tool for SpawnAgentTool {
                     spec: json!({
                         "run_id": &run_id,
                         "external_agent_id": agent.id,
-                        "instructions": &task,
+                        "instructions": &instructions,
                         "mode": &mode,
                     }),
                     state: SessionTaskState::Queued,
@@ -1266,7 +1266,9 @@ impl Tool for SpawnAgentTool {
         if let Err(e) = save_run(context, &record).await {
             return ToolExecutionResult::internal_error(e);
         }
-        if let Err(error) = submit_run(context, &agent, &mut record, &task, None, None).await {
+        if let Err(error) =
+            submit_run(context, &agent, &mut record, &instructions, None, None).await
+        {
             record.status = AgentRunStatus::Failed;
             set_error(&mut record, error);
             let _ = save_run(context, &record).await;
@@ -2140,7 +2142,7 @@ mod tests {
         let result = tool
             .execute_with_context(
                 json!({
-                    "task": "hello",
+                    "instructions": "hello",
                     "target": {"type": "external_a2a", "external_agent_id": "echo"},
                     "mode": "wait",
                     "wait_timeout_secs": 5
@@ -2170,7 +2172,7 @@ mod tests {
         let result = spawn
             .execute_with_context(
                 json!({
-                    "task": "background",
+                    "instructions": "background",
                     "target": {"type": "external_a2a", "external_agent_id": "echo"},
                     "mode": "background",
                     "wait_timeout_secs": 5,

--- a/crates/core/src/capabilities/agent_handoff.rs
+++ b/crates/core/src/capabilities/agent_handoff.rs
@@ -445,16 +445,16 @@ impl Tool for StartAgentHandoffTool {
                     "type": "string",
                     "description": "Configured handoff target id."
                 },
-                "task": {
+                "instructions": {
                     "type": "string",
-                    "description": "Work request for the target agent. Do not include credentials or bearer tokens."
+                    "description": "Instructions for the target agent. Do not include credentials or bearer tokens."
                 },
                 "public_context": {
                     "type": "object",
                     "description": "Non-secret structured context to include with the task."
                 }
             },
-            "required": ["target", "task"],
+            "required": ["target", "instructions"],
             "additionalProperties": false
         })
     }
@@ -483,7 +483,7 @@ impl Tool for StartAgentHandoffTool {
             Ok(value) => value,
             Err(error) => return error,
         };
-        let task = match require_str(&arguments, "task") {
+        let instructions = match require_str(&arguments, "instructions") {
             Ok(value) => value,
             Err(error) => return error,
         };
@@ -529,7 +529,7 @@ impl Tool for StartAgentHandoffTool {
             Err(error) => return ToolExecutionResult::internal_error(error),
         };
 
-        let handoff_task = child_task(task, arguments.get("public_context"));
+        let handoff_task = child_task(instructions, arguments.get("public_context"));
         let child_session = match store
             .set_subagent_metadata(
                 child_session.id,
@@ -1055,7 +1055,7 @@ mod tests {
             .execute_with_context(
                 json!({
                     "target": "aws_operator",
-                    "task": "Create an RDS database named app-db"
+                    "instructions": "Create an RDS database named app-db"
                 }),
                 &context,
             )
@@ -1082,7 +1082,7 @@ mod tests {
             .execute_with_context(
                 json!({
                     "target": "aws_operator",
-                    "task": "Create an RDS database named app-db"
+                    "instructions": "Create an RDS database named app-db"
                 }),
                 &context,
             )
@@ -1109,7 +1109,7 @@ mod tests {
             .execute_with_context(
                 json!({
                     "target": "aws_operator",
-                    "task": "Create an RDS database named app-db",
+                    "instructions": "Create an RDS database named app-db",
                     "public_context": { "region": "us-east-1" }
                 }),
                 &context,
@@ -1148,7 +1148,7 @@ mod tests {
             .execute_with_context(
                 json!({
                     "target": "aws_operator",
-                    "task": "Create an RDS database named app-db"
+                    "instructions": "Create an RDS database named app-db"
                 }),
                 &context,
             )

--- a/crates/core/src/capabilities/agent_handoff.rs
+++ b/crates/core/src/capabilities/agent_handoff.rs
@@ -451,7 +451,7 @@ impl Tool for StartAgentHandoffTool {
                 },
                 "public_context": {
                     "type": "object",
-                    "description": "Non-secret structured context to include with the task."
+                    "description": "Non-secret structured context to include with the instructions."
                 }
             },
             "required": ["target", "instructions"],

--- a/crates/core/src/capabilities/subagents.rs
+++ b/crates/core/src/capabilities/subagents.rs
@@ -254,9 +254,9 @@ impl Tool for SpawnSubagentTool {
                     "type": "string",
                     "description": "Human-readable name for the subagent (e.g. 'Test Runner', 'Auth Explorer'). Must be unique within this session."
                 },
-                "task": {
+                "instructions": {
                     "type": "string",
-                    "description": "Task description — what the subagent should do."
+                    "description": "Instructions for the subagent — what it should do."
                 },
                 "blueprint": {
                     "type": "string",
@@ -267,7 +267,7 @@ impl Tool for SpawnSubagentTool {
                     "description": "Blueprint-specific configuration. Only valid when `blueprint` is set. Validated against the blueprint's config schema."
                 }
             },
-            "required": ["name", "task"],
+            "required": ["name", "instructions"],
             "additionalProperties": false
         })
     }
@@ -300,7 +300,7 @@ impl Tool for SpawnSubagentTool {
             Ok(s) => s.trim().to_string(),
             Err(e) => return e,
         };
-        let task = match require_str(&arguments, "task") {
+        let instructions = match require_str(&arguments, "instructions") {
             Ok(s) => s.to_string(),
             Err(e) => return e,
         };
@@ -404,7 +404,13 @@ impl Tool for SpawnSubagentTool {
             let claim_token = uuid::Uuid::new_v4();
 
             let claim = match spawn_store
-                .try_claim_spawn(context.session_id, tool_call_id, &name, &task, claim_token)
+                .try_claim_spawn(
+                    context.session_id,
+                    tool_call_id,
+                    &name,
+                    &instructions,
+                    claim_token,
+                )
                 .await
             {
                 Ok(c) => c,
@@ -444,7 +450,7 @@ impl Tool for SpawnSubagentTool {
                         context,
                         child_session_id,
                         &name,
-                        &task,
+                        &instructions,
                         &blueprint_param,
                         task_id,
                         Some((
@@ -470,7 +476,7 @@ impl Tool for SpawnSubagentTool {
                         context,
                         &parent_session,
                         &name,
-                        &task,
+                        &instructions,
                         &blueprint_param,
                         &config_param,
                         Some((
@@ -491,7 +497,7 @@ impl Tool for SpawnSubagentTool {
             context,
             &parent_session,
             &name,
-            &task,
+            &instructions,
             &blueprint_param,
             &config_param,
             None,
@@ -508,8 +514,8 @@ impl Tool for SpawnSubagentTool {
 // Helpers for SpawnSubagentTool
 // =============================================================================
 
-/// Create a new child session, send the task, wait for completion, and settle
-/// the spawn handle (if a settle context is supplied).
+/// Create a new child session, send the instructions, wait for completion, and
+/// settle the spawn handle (if a settle context is supplied).
 ///
 /// `settle_ctx` = (spawn_store, tool_call_id, spawn_handle_id, claim_token).
 /// `spawn_handle_id` is used to call `register_child_session` after child creation.
@@ -519,7 +525,7 @@ async fn spawn_create_and_wait(
     context: &ToolContext,
     parent_session: &crate::session::Session,
     name: &str,
-    task: &str,
+    instructions: &str,
     blueprint_param: &Option<String>,
     config_param: &Option<Value>,
     settle_ctx: Option<(
@@ -553,7 +559,7 @@ async fn spawn_create_and_wait(
             child_session.id,
             context.session_id,
             name,
-            task,
+            instructions,
             crate::session::SubagentStatus::Running,
         )
         .await
@@ -572,7 +578,7 @@ async fn spawn_create_and_wait(
                 kind: TASK_KIND_SUBAGENT.to_string(),
                 display_name: name.to_string(),
                 spec: json!({
-                    "instructions": task,
+                    "instructions": instructions,
                     "blueprint_id": blueprint_param,
                 }),
                 state: SessionTaskState::Running,
@@ -608,8 +614,8 @@ async fn spawn_create_and_wait(
         None
     };
 
-    // Send the task as the first message
-    if let Err(e) = store.send_message(child_session.id, task).await {
+    // Send the instructions as the first message
+    if let Err(e) = store.send_message(child_session.id, instructions).await {
         finish_subagent_task(
             context,
             task_id.as_deref(),
@@ -629,7 +635,7 @@ async fn spawn_create_and_wait(
         context,
         child_session.id,
         name,
-        task,
+        instructions,
         blueprint_param,
         task_id,
         wait_settle_ctx,
@@ -645,7 +651,7 @@ async fn run_subagent_wait_and_settle(
     context: &ToolContext,
     child_id: crate::typed_id::SessionId,
     name: &str,
-    task: &str,
+    instructions: &str,
     blueprint_param: &Option<String>,
     task_id: Option<String>,
     settle_ctx: Option<(&dyn crate::traits::SubagentSpawnStore, &str, uuid::Uuid)>,
@@ -715,7 +721,13 @@ async fn run_subagent_wait_and_settle(
     if let Some(subagent_status) = terminal_status {
         let task_state = terminal_subagent_task_state(&subagent_status);
         if let Err(e) = store
-            .set_subagent_metadata(child_id, context.session_id, name, task, subagent_status)
+            .set_subagent_metadata(
+                child_id,
+                context.session_id,
+                name,
+                instructions,
+                subagent_status,
+            )
             .await
         {
             tracing::warn!(
@@ -836,7 +848,7 @@ impl Tool for GetSubagentsTool {
                     ToolExecutionResult::success(json!({
                         "subagent_id": child.id.to_string(),
                         "name": child.subagent_name,
-                        "task": child.subagent_task,
+                        "instructions": child.subagent_task,
                         "status": child.subagent_status.as_ref().map(|s| s.to_string())
                             .unwrap_or_else(|| child.status.to_string()),
                         "session_status": child.status.to_string(),
@@ -872,7 +884,7 @@ impl Tool for GetSubagentsTool {
                     json!({
                         "subagent_id": s.id.to_string(),
                         "name": s.subagent_name,
-                        "task": s.subagent_task,
+                        "instructions": s.subagent_task,
                         "status": s.subagent_status.as_ref().map(|st| st.to_string())
                             .unwrap_or_else(|| s.status.to_string()),
                         "created_at": s.created_at.to_rfc3339(),
@@ -1173,7 +1185,7 @@ mod tests {
         let schema = tool.parameters_schema();
         let required = schema["required"].as_array().unwrap();
         assert!(required.contains(&json!("name")));
-        assert!(required.contains(&json!("task")));
+        assert!(required.contains(&json!("instructions")));
     }
 
     #[test]
@@ -1192,7 +1204,9 @@ mod tests {
     #[tokio::test]
     async fn spawn_subagent_without_context_returns_error() {
         let tool = SpawnSubagentTool;
-        let result = tool.execute(json!({"name": "Test", "task": "test"})).await;
+        let result = tool
+            .execute(json!({"name": "Test", "instructions": "test"}))
+            .await;
         assert!(matches!(result, ToolExecutionResult::ToolError(_)));
     }
 

--- a/crates/core/src/context_report.rs
+++ b/crates/core/src/context_report.rs
@@ -712,7 +712,7 @@ mod tests {
                     vec![crate::ToolCall {
                         id: "call_subagent".into(),
                         name: "spawn_subagent".into(),
-                        arguments: json!({"name": "Scout", "task": "look around"}),
+                        arguments: json!({"name": "Scout", "instructions": "look around"}),
                     }],
                 ),
                 crate::Message::tool_result(

--- a/crates/core/tests/subagent_test.rs
+++ b/crates/core/tests/subagent_test.rs
@@ -96,7 +96,7 @@ async fn test_spawn_subagent_missing_name() {
 // =============================================================================
 
 #[tokio::test]
-async fn test_spawn_subagent_missing_task() {
+async fn test_spawn_subagent_missing_instructions() {
     let tool = find_tool("spawn_subagent");
     let ctx = empty_context();
 

--- a/crates/core/tests/subagent_test.rs
+++ b/crates/core/tests/subagent_test.rs
@@ -69,7 +69,7 @@ async fn test_spawn_subagent_missing_name() {
     let tool = find_tool("spawn_subagent");
 
     // Call execute (no context) — should return ToolError about requiring context
-    let result = tool.execute(json!({"task": "do something"})).await;
+    let result = tool.execute(json!({"instructions": "do something"})).await;
     assert!(
         matches!(result, ToolExecutionResult::ToolError(_)),
         "Expected ToolError when calling execute without context, got: {result:?}"
@@ -78,7 +78,7 @@ async fn test_spawn_subagent_missing_name() {
     // Call execute_with_context with missing name — should return ToolError about missing param
     let ctx = empty_context();
     let result = tool
-        .execute_with_context(json!({"task": "do something"}), &ctx)
+        .execute_with_context(json!({"instructions": "do something"}), &ctx)
         .await;
     match &result {
         ToolExecutionResult::ToolError(msg) => {
@@ -92,7 +92,7 @@ async fn test_spawn_subagent_missing_name() {
 }
 
 // =============================================================================
-// 3. spawn_subagent — missing task
+// 3. spawn_subagent — missing instructions
 // =============================================================================
 
 #[tokio::test]
@@ -106,11 +106,13 @@ async fn test_spawn_subagent_missing_task() {
     match &result {
         ToolExecutionResult::ToolError(msg) => {
             assert!(
-                msg.contains("task") || msg.contains("parameter") || msg.contains("platform_store"),
-                "Error should mention 'task' or 'parameter', got: {msg}"
+                msg.contains("instructions")
+                    || msg.contains("parameter")
+                    || msg.contains("platform_store"),
+                "Error should mention 'instructions' or 'parameter', got: {msg}"
             );
         }
-        _ => panic!("Expected ToolError for missing task, got: {result:?}"),
+        _ => panic!("Expected ToolError for missing instructions, got: {result:?}"),
     }
 }
 
@@ -193,13 +195,13 @@ fn test_spawn_subagent_schema_validation() {
         .as_array()
         .expect("required should be array");
     assert!(required.contains(&json!("name")));
-    assert!(required.contains(&json!("task")));
+    assert!(required.contains(&json!("instructions")));
     assert_eq!(required.len(), 2);
 
     // Check property types
     let props = &schema["properties"];
     assert_eq!(props["name"]["type"], "string");
-    assert_eq!(props["task"]["type"], "string");
+    assert_eq!(props["instructions"]["type"], "string");
 
     // Check additionalProperties
     assert_eq!(schema["additionalProperties"], json!(false));
@@ -323,7 +325,7 @@ async fn test_spawn_subagent_no_platform_store() {
     let ctx = empty_context();
 
     let result = tool
-        .execute_with_context(json!({"name": "Runner", "task": "run tests"}), &ctx)
+        .execute_with_context(json!({"name": "Runner", "instructions": "run tests"}), &ctx)
         .await;
 
     match &result {

--- a/crates/server/src/grpc_service/tests.rs
+++ b/crates/server/src/grpc_service/tests.rs
@@ -536,7 +536,7 @@ async fn test_subagent_and_handoff_tools_complete_over_grpc_platform_adapter() {
         .execute_with_context(
             serde_json::json!({
                 "name": "gRPC Subagent",
-                "task": "Exercise spawn_subagent through the gRPC platform adapter"
+                "instructions": "Exercise spawn_subagent through the gRPC platform adapter"
             }),
             &context,
         )
@@ -594,7 +594,7 @@ async fn test_subagent_and_handoff_tools_complete_over_grpc_platform_adapter() {
         .execute_with_context(
             serde_json::json!({
                 "target": "target",
-                "task": "Exercise start_agent_handoff through the gRPC platform adapter",
+                "instructions": "Exercise start_agent_handoff through the gRPC platform adapter",
                 "public_context": { "ticket": "EVE-538" }
             }),
             &context,

--- a/crates/server/tests/app_a2a_integration_test.rs
+++ b/crates/server/tests/app_a2a_integration_test.rs
@@ -330,7 +330,7 @@ async fn spawn_background_against_local_a2a(config: Value) -> (Arc<TestStorageSt
     let result = spawn_tool
         .execute_with_context(
             json!({
-                "task": "hello from outbound delegation",
+                "instructions": "hello from outbound delegation",
                 "target": {"type": "external_a2a", "external_agent_id": "local_app"},
                 "mode": "background",
                 "wait_timeout_secs": 5,

--- a/docs/capabilities/github-scout.md
+++ b/docs/capabilities/github-scout.md
@@ -21,7 +21,7 @@ Enable the `github_scout` capability on an agent or harness. Then spawn the blue
   "name": "spawn_subagent",
   "arguments": {
     "name": "Scout",
-    "task": "Find where authentication middleware is implemented.",
+    "instructions": "Find where authentication middleware is implemented.",
     "blueprint": "github_scout",
     "config": {
       "repos": ["fastify/fastify"]

--- a/docs/capabilities/sub-agents.md
+++ b/docs/capabilities/sub-agents.md
@@ -21,7 +21,7 @@ Create and start a new subagent. The subagent begins executing immediately in th
 | Parameter | Type | Required | Description |
 |---|---|---|---|
 | `name` | string | yes | Human-readable name for the subagent. Must be unique within the session. |
-| `task` | string | yes | Description of what the subagent should do. This becomes the subagent's initial prompt. |
+| `instructions` | string | yes | Instructions for what the subagent should do. This becomes the subagent's initial prompt. |
 | `blueprint` | string | no | Optional specialist blueprint ID, such as `github_scout`, that supplies its own prompt, model, and private tools. |
 | `config` | object | no | Blueprint-specific configuration. Only valid when `blueprint` is set. |
 

--- a/specs/a2a-capability.md
+++ b/specs/a2a-capability.md
@@ -105,7 +105,7 @@ Creates an external A2A run.
 
 Parameters:
 
-- `task` required
+- `instructions` required
 - `target.type = external_a2a`
 - `target.external_agent_id`
 - `mode = wait | background`
@@ -137,7 +137,7 @@ Calls A2A task cancellation and updates the local run state from the returned ta
 | `agent_run_id` | local handle |
 | `remote_task_id` | A2A `Task.id` |
 | `remote_context_id` | A2A `Task.contextId` |
-| `task` / follow-up message | A2A `Message` with `ROLE_USER` |
+| `instructions` / follow-up message | A2A `Message` with `ROLE_USER` |
 | result summary | first text artifact, else status message text |
 | `input_required` | non-terminal interrupted run |
 | `auth_required` | non-terminal interrupted run |

--- a/specs/agent-blueprints.md
+++ b/specs/agent-blueprints.md
@@ -216,7 +216,7 @@ The `AgentBlueprint` definition is stateless (code template). The session instan
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `name` | string | Yes | Human-readable name (same as today) |
-| `task` | string | Yes | Task description (same as today) |
+| `instructions` | string | Yes | Instructions for the subagent (renamed from `task`) |
 | `blueprint` | string | No | Blueprint ID. When set, child uses blueprint's RuntimeAgent. |
 | `config` | object | No | Blueprint-specific config. Validated against `config_schema`. |
 
@@ -315,7 +315,7 @@ These use the GitHub token from User Connections. They are private to the bluepr
   "name": "spawn_subagent",
   "arguments": {
     "name": "Scout",
-    "task": "Find how authentication middleware is implemented in the fastify repo.",
+    "instructions": "Find how authentication middleware is implemented in the fastify repo.",
     "blueprint": "github_scout",
     "config": { "repos": ["fastify/fastify"] }
   }

--- a/specs/session-tasks.md
+++ b/specs/session-tasks.md
@@ -227,9 +227,11 @@ creates a task and returns its `task_id`. Blocking (foreground) spawns also
 create task records: same object, and the UI shows it live while the parent
 turn waits; background is a mode, not a different entity.
 
-Naming cleanup: today `task` parameters carry instruction text
-(`subagent_task`, `spawn_subagent(task:)`). These rename to `instructions` so
-"task" unambiguously means the lifecycle object.
+Naming cleanup: `task` parameters that carry instruction text
+(`subagent_task`, `spawn_subagent(task:)`) have been renamed to `instructions` so
+"task" unambiguously means the lifecycle object. This rename is done for the
+model-facing tool parameters (`spawn_subagent`, `spawn_agent`, `handoff`);
+the `sessions.subagent_task` DB column retirement remains follow-up work.
 
 ## Wake-ups
 
@@ -308,8 +310,9 @@ No backward compatibility is required; data migrates forward once:
   and agent_handoff no longer register in `session_resources`. A2A agent runs
   (`external_agent` tasks) now store their run records in session storage KV
   (`agent_run:{run_id}` keys). Legacy `subagent.*` events are retained for CLI
-  compatibility. The `sessions.subagent_*` column retirement and the
-  `task` → `instructions` parameter rename remain follow-up work.
+  compatibility. The `task` → `instructions` parameter rename is done (model-facing
+  tool parameters `spawn_subagent`, `spawn_agent`, `handoff`). The
+  `sessions.subagent_*` column retirement remains follow-up work.
 - Durability: `attempt`/`worker_id`/`heartbeat_at` are stored. The orphan
   reconciler (`session_task_reaper` durable activity, every 60 s) finds tasks
   with stale heartbeats (`heartbeat_at IS NOT NULL AND heartbeat_at < now -

--- a/specs/subagents.md
+++ b/specs/subagents.md
@@ -76,7 +76,7 @@ See `crates/server/migrations/009_subagents.sql` for schema changes.
 
 ### spawn_subagent
 
-Creates a child session and sends the task as the first user message. In foreground mode, blocks until the child idles.
+Creates a child session and sends the instructions as the first user message. In foreground mode, blocks until the child idles.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -141,7 +141,7 @@ Parent Agent                          System                           Child Ses
      │─────────────────────────────────>│                                  │
      │                                  │  create session(parent_id=...)   │
      │                                  │─────────────────────────────────>│
-     │                                  │  send task as user message       │
+     │                                  │  send instructions as message    │
      │                                  │─────────────────────────────────>│
      │                                  │  emit subagent.spawned           │
      │                                  │                                  │

--- a/specs/subagents.md
+++ b/specs/subagents.md
@@ -81,15 +81,15 @@ Creates a child session and sends the task as the first user message. In foregro
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `name` | string | Yes | Human-readable name for the subagent |
-| `task` | string | Yes | Task description sent as first user message |
+| `instructions` | string | Yes | Instructions sent as first user message |
 
-**Returns:** Last assistant message from the child session (the subagent's response to the task).
+**Returns:** Last assistant message from the child session (the subagent's response to the instructions).
 
 **Behavior:**
 1. Creates child session with `parent_session_id` set to current session
 2. Inherits the parent session locale when present
 3. Sets `subagent_name`, `subagent_task`, `subagent_status = Spawning`
-4. Sends `task` as first user message → status transitions to `Running`
+4. Sends `instructions` as first user message → status transitions to `Running`
 5. Blocks on `wait_for_idle` (foreground mode)
 6. On child idle: returns last assistant message, status → `Completed`
 7. On child failure: returns error, status → `Failed`
@@ -103,7 +103,7 @@ Lists or retrieves detail for subagents spawned by the current session.
 | `name_or_id` | string | No | Filter by name (case-insensitive) or session ID |
 | `status_filter` | string | No | Filter by SubagentStatus value |
 
-**Returns:** Array of subagent summaries (name, status, task, created_at), or single subagent detail when `name_or_id` matches exactly one.
+**Returns:** Array of subagent summaries (name, status, instructions, created_at), or single subagent detail when `name_or_id` matches exactly one.
 
 ### message_subagent
 
@@ -137,7 +137,7 @@ All subagent events are emitted on the **parent** session's event stream. Event 
 ```
 Parent Agent                          System                           Child Session
      │                                  │                                  │
-     │  spawn_subagent("Runner", task)  │                                  │
+     │  spawn_subagent("Runner", instructions)  │                          │
      │─────────────────────────────────>│                                  │
      │                                  │  create session(parent_id=...)   │
      │                                  │─────────────────────────────────>│

--- a/test_cases/api/subagents/TC001_spawn_subagent_basic.md
+++ b/test_cases/api/subagents/TC001_spawn_subagent_basic.md
@@ -71,7 +71,7 @@ Verify that an agent with the `subagents` capability can spawn a subagent via th
 |-------|----------|
 | spawn_subagent called | `tool.called` event with `tool_name: "spawn_subagent"` |
 | Tool args contain name | `arguments.name` is `"Greeter"` |
-| Tool args contain task | `arguments.task` is non-empty |
+| Tool args contain instructions | `arguments.instructions` is non-empty |
 
 ### Tool Result Assertions
 


### PR DESCRIPTION
## What
Renames the instruction-text parameter from `task` to `instructions` on the three model-facing tools that carry it: `spawn_subagent`, `spawn_agent` (A2A), and `handoff`. Also renames the `AgentRunRecord.task` field/JSON key, the `get_subagents` output key, and updates docs, specs, and test cases.

## Why
With the session-task registry in place (`specs/session-tasks.md`), "task" now unambiguously means the lifecycle object. The spec's "Naming cleanup" section mandates this rename so a tool parameter named `task` no longer collides with the Task domain concept.

## How
Mechanical rename of the JSON schema property, `required` array, parsing (`require_str`), local variables, doc comments, and all test fixtures across the three capabilities, plus call-site fixtures in `context_report.rs`, gRPC service tests, and the A2A integration test.

Explicitly unchanged:
- CLI-consumed `subagent.*` event payload fields (`task` stays — CLI compatibility).
- `sessions.subagent_*` DB columns, spawn-handle store, and gRPC worker proto fields (`subagent_task`) — retirement investigated and deferred, see Follow-ups.
- Session-task `spec` already used `"instructions"` as its key; verified consistent.

## Risk
- Low
- Model-facing tool schema change: agents mid-session with cached tool definitions could send `task` and get a validation error; resolved on next turn when schemas are re-emitted. `AgentRunRecord` serde key changes on disk, but these KV records were introduced in #2143 (merged today) — no meaningful legacy data.

## Security
- No security-relevant code changes: pure identifier/schema rename, no auth, I/O, or trust-boundary changes (reviewed against TM categories; none apply).

## Follow-ups
- `sessions.subagent_*` column retirement: deferred. The columns are load-bearing in the gRPC spawn-handle protocol (`subagent_task` proto field, `subagent_spawn_handles` dedup keying) and the `get_subagents`/OpenAPI session schema. Earliest safe window is after session tasks fully supersede `get_subagents` and the gRPC subagent status flow.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_011yqDiQ2GyoDdwFQTFTw12R)_