### PR TITLE
feat(worker): gRPC session task reaper and stale-attempt fencing

### DIFF
--- a/crates/core/src/capabilities/session_tasks.rs
+++ b/crates/core/src/capabilities/session_tasks.rs
@@ -746,6 +746,15 @@ pub(crate) mod tests {
                 };
                 task.clone()
             };
+            // Stale-attempt fence (mirrors DbSessionTaskRegistry).
+            if let Some(expected) = message.expected_attempt
+                && expected != stored.attempt
+            {
+                return Err(crate::error::AgentLoopError::store(format!(
+                    "Stale attempt {expected} for task {task_id} (current attempt {})",
+                    stored.attempt
+                )));
+            }
             let recorded = TaskMessage {
                 id: generate_task_message_id(),
                 task_id: task_id.to_string(),

--- a/crates/core/src/session_task.rs
+++ b/crates/core/src/session_task.rs
@@ -293,11 +293,18 @@ pub struct SessionTaskUpdate {
     pub heartbeat_at: Option<DateTime<Utc>>,
     /// Stale-attempt fence: when set, the update is silently ignored if
     /// `task.attempt != expected_attempt`. Executors and sinks set this to
-    /// the attempt they captured at start so writes from a superseded attempt
-    /// are rejected once the reaper increments `attempt`. Writers that do not
-    /// track attempts (e.g. `cancel_task` from the API) leave this None.
+    /// the attempt they captured at start; the reaper bumps `attempt` (via
+    /// `increment_attempt`) when it fails an orphan, so a zombie executor's
+    /// later writes are rejected. Writers that do not track attempts
+    /// (e.g. `cancel_task` from the API) leave this None.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub expected_attempt: Option<i32>,
+    /// Supersede the current attempt: bumps `task.attempt` so writes fenced
+    /// on the previous attempt are rejected from now on. Set by the reaper
+    /// when it fails an orphaned task. Ignored if the update itself is
+    /// dropped by the fence or the terminal-state invariant.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub increment_attempt: bool,
 }
 
 /// Optional filter for listing tasks.
@@ -340,6 +347,12 @@ pub fn apply_task_update(task: &mut SessionTask, update: SessionTaskUpdate, now:
         && state != task.state
     {
         return;
+    }
+
+    // Supersede the current attempt (reaper failing an orphan): writes fenced
+    // on the old attempt are rejected from here on.
+    if update.increment_attempt {
+        task.attempt += 1;
     }
 
     let mut next_state = update.state;
@@ -517,6 +530,12 @@ pub struct NewTaskMessage {
     pub content: Vec<TaskMessagePart>,
     #[serde(default)]
     pub in_reply_to: Option<String>,
+    /// Stale-attempt fence for message writes: when set, registries reject
+    /// the message if `task.attempt` no longer matches, so a superseded
+    /// executor cannot append to the thread or trigger wake-ups. Not stored
+    /// with the message.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expected_attempt: Option<i32>,
 }
 
 impl NewTaskMessage {
@@ -525,6 +544,7 @@ impl NewTaskMessage {
             direction: TaskMessageDirection::Inbound,
             content: vec![TaskMessagePart::text(text)],
             in_reply_to: None,
+            expected_attempt: None,
         }
     }
 
@@ -533,7 +553,14 @@ impl NewTaskMessage {
             direction: TaskMessageDirection::Outbound,
             content: vec![TaskMessagePart::text(text)],
             in_reply_to: None,
+            expected_attempt: None,
         }
+    }
+
+    /// Fence this message write on the given attempt (see `expected_attempt`).
+    pub fn with_expected_attempt(mut self, attempt: i32) -> Self {
+        self.expected_attempt = Some(attempt);
+        self
     }
 }
 
@@ -771,10 +798,14 @@ impl TaskSink for RegistryTaskSink {
     }
 
     async fn post(&self, message: NewTaskMessage) -> Result<()> {
-        // record_message does not mutate task fields, so no fencing needed here;
-        // the registry's update path guards state changes.
+        // Fence message writes too: record_message emits events and can wake
+        // the parent session, so a superseded executor must not post.
         self.registry
-            .record_message(self.session_id, &self.task_id, message)
+            .record_message(
+                self.session_id,
+                &self.task_id,
+                message.with_expected_attempt(self.attempt),
+            )
             .await?;
         Ok(())
     }
@@ -1076,5 +1107,74 @@ mod tests {
         );
         // Writers that don't track attempts (e.g. cancel_task from the API) still apply.
         assert_eq!(t.summary.as_deref(), Some("cancel from API"));
+    }
+
+    #[test]
+    fn reaper_update_increments_attempt_and_fences_old_executor() {
+        let mut t = task();
+        t.state = SessionTaskState::Running;
+        assert_eq!(t.attempt, 1);
+        let now = Utc::now();
+
+        // Reaper-style update: fail as orphaned and supersede the attempt.
+        apply_task_update(
+            &mut t,
+            SessionTaskUpdate {
+                state: Some(SessionTaskState::Failed),
+                error: Some(TaskError {
+                    kind: "orphaned".to_string(),
+                    message: "worker heartbeat stopped".to_string(),
+                }),
+                increment_attempt: true,
+                ..Default::default()
+            },
+            now,
+        );
+        assert_eq!(t.state, SessionTaskState::Failed);
+        assert_eq!(t.attempt, 2, "orphan reap must supersede the attempt");
+
+        // The zombie executor's content-only heartbeat (no state change, so the
+        // terminal invariant alone would let it through) is now fenced out.
+        let later = now + chrono::Duration::seconds(5);
+        apply_task_update(
+            &mut t,
+            SessionTaskUpdate {
+                heartbeat_at: Some(later),
+                expected_attempt: Some(1),
+                ..Default::default()
+            },
+            later,
+        );
+        assert_ne!(
+            t.heartbeat_at,
+            Some(later),
+            "stale heartbeat must be rejected"
+        );
+    }
+
+    #[test]
+    fn increment_attempt_is_inert_when_update_is_dropped() {
+        let mut t = task();
+        t.state = SessionTaskState::Succeeded;
+        assert_eq!(t.attempt, 1);
+        let now = Utc::now();
+
+        // Reaper losing the race against a clean finish: the terminal-state
+        // invariant drops the whole update, including the attempt bump.
+        apply_task_update(
+            &mut t,
+            SessionTaskUpdate {
+                state: Some(SessionTaskState::Failed),
+                error: Some(TaskError {
+                    kind: "orphaned".to_string(),
+                    message: "worker heartbeat stopped".to_string(),
+                }),
+                increment_attempt: true,
+                ..Default::default()
+            },
+            now,
+        );
+        assert_eq!(t.state, SessionTaskState::Succeeded);
+        assert_eq!(t.attempt, 1, "dropped update must not bump the attempt");
     }
 }

--- a/crates/core/src/session_task.rs
+++ b/crates/core/src/session_task.rs
@@ -291,6 +291,13 @@ pub struct SessionTaskUpdate {
     pub worker_id: Option<String>,
     /// Liveness heartbeat timestamp.
     pub heartbeat_at: Option<DateTime<Utc>>,
+    /// Stale-attempt fence: when set, the update is silently ignored if
+    /// `task.attempt != expected_attempt`. Executors and sinks set this to
+    /// the attempt they captured at start so writes from a superseded attempt
+    /// are rejected once the reaper increments `attempt`. Writers that do not
+    /// track attempts (e.g. `cancel_task` from the API) leave this None.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expected_attempt: Option<i32>,
 }
 
 /// Optional filter for listing tasks.
@@ -311,6 +318,15 @@ pub struct SessionTaskFilter {
 /// - setting `input_request` forces `awaiting_input`; leaving
 ///   `awaiting_input` clears it.
 pub fn apply_task_update(task: &mut SessionTask, update: SessionTaskUpdate, now: DateTime<Utc>) {
+    // Stale-attempt fence: if the update carries an attempt expectation and it
+    // does not match the current attempt, this write came from a superseded
+    // executor — ignore it entirely (heartbeats, state changes, everything).
+    if let Some(expected) = update.expected_attempt
+        && expected != task.attempt
+    {
+        return;
+    }
+
     let was_terminal = task.state.is_terminal();
 
     // Terminal states are final. An update that asks for a *different* state
@@ -683,10 +699,16 @@ pub trait TaskSink: Send + Sync {
 
 /// `TaskSink` backed by a `SessionTaskRegistry`. Output deltas are dropped
 /// here; kinds with live output keep their existing streaming path.
+///
+/// Carries `attempt` for stale-attempt fencing: every update includes
+/// `expected_attempt` so writes from a superseded executor are rejected once
+/// the reaper increments the attempt counter on the task record.
 pub struct RegistryTaskSink {
     registry: Arc<dyn SessionTaskRegistry>,
     session_id: SessionId,
     task_id: String,
+    /// The attempt number this sink was created for (captured at task start).
+    attempt: i32,
 }
 
 impl RegistryTaskSink {
@@ -699,7 +721,15 @@ impl RegistryTaskSink {
             registry,
             session_id,
             task_id,
+            attempt: 1,
         }
+    }
+
+    /// Set the attempt number for fencing. Call this after reading the task
+    /// record at start so the sink rejects writes once the attempt is bumped.
+    pub fn with_attempt(mut self, attempt: i32) -> Self {
+        self.attempt = attempt;
+        self
     }
 }
 
@@ -713,6 +743,7 @@ impl TaskSink for RegistryTaskSink {
                 SessionTaskUpdate {
                     state: Some(state),
                     state_detail: detail,
+                    expected_attempt: Some(self.attempt),
                     ..Default::default()
                 },
             )
@@ -727,6 +758,7 @@ impl TaskSink for RegistryTaskSink {
                 &self.task_id,
                 SessionTaskUpdate {
                     progress: Some(progress),
+                    expected_attempt: Some(self.attempt),
                     ..Default::default()
                 },
             )
@@ -739,6 +771,8 @@ impl TaskSink for RegistryTaskSink {
     }
 
     async fn post(&self, message: NewTaskMessage) -> Result<()> {
+        // record_message does not mutate task fields, so no fencing needed here;
+        // the registry's update path guards state changes.
         self.registry
             .record_message(self.session_id, &self.task_id, message)
             .await?;
@@ -752,6 +786,7 @@ impl TaskSink for RegistryTaskSink {
                 &self.task_id,
                 SessionTaskUpdate {
                     input_request: Some(request),
+                    expected_attempt: Some(self.attempt),
                     ..Default::default()
                 },
             )
@@ -763,6 +798,10 @@ impl TaskSink for RegistryTaskSink {
         let Some(task) = self.registry.get(self.session_id, &self.task_id).await? else {
             return Ok(());
         };
+        // Check attempt before fetching artifacts to avoid a stale write.
+        if task.attempt != self.attempt {
+            return Ok(());
+        }
         let mut artifacts = task.artifacts;
         artifacts.push(artifact);
         self.registry
@@ -771,6 +810,7 @@ impl TaskSink for RegistryTaskSink {
                 &self.task_id,
                 SessionTaskUpdate {
                     artifacts: Some(artifacts),
+                    expected_attempt: Some(self.attempt),
                     ..Default::default()
                 },
             )
@@ -960,5 +1000,81 @@ mod tests {
     fn message_text_rendering() {
         let msg = NewTaskMessage::outbound_text("hello");
         assert_eq!(task_message_text(&msg.content), "hello");
+    }
+
+    // -------------------------------------------------------------------------
+    // Stale-attempt fencing tests
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn update_with_matching_attempt_applies() {
+        let mut t = task();
+        // Task starts at attempt 1.
+        assert_eq!(t.attempt, 1);
+        let now = Utc::now();
+
+        // An update that carries expected_attempt == task.attempt applies normally.
+        apply_task_update(
+            &mut t,
+            SessionTaskUpdate {
+                state: Some(SessionTaskState::Running),
+                state_detail: Some("step 1".to_string()),
+                heartbeat_at: Some(now),
+                expected_attempt: Some(1),
+                ..Default::default()
+            },
+            now,
+        );
+        assert_eq!(t.state, SessionTaskState::Running);
+        assert_eq!(t.state_detail.as_deref(), Some("step 1"));
+        assert_eq!(t.heartbeat_at, Some(now));
+    }
+
+    #[test]
+    fn update_with_stale_attempt_is_fully_ignored() {
+        let mut t = task();
+        // Simulate the reaper bumping the attempt by directly setting it.
+        t.attempt = 2;
+
+        let now = Utc::now();
+        let before_updated = t.updated_at;
+
+        // A write from the old executor (attempt = 1) must be fully ignored —
+        // state, heartbeat, and updated_at must not change.
+        apply_task_update(
+            &mut t,
+            SessionTaskUpdate {
+                state: Some(SessionTaskState::Running),
+                state_detail: Some("superseded".to_string()),
+                heartbeat_at: Some(now),
+                expected_attempt: Some(1),
+                ..Default::default()
+            },
+            now,
+        );
+        assert_eq!(t.state, SessionTaskState::Queued, "state must be unchanged");
+        assert!(t.state_detail.is_none(), "state_detail must be unchanged");
+        assert!(t.heartbeat_at.is_none(), "heartbeat must be unchanged");
+        assert_eq!(t.updated_at, before_updated, "updated_at must be unchanged");
+    }
+
+    #[test]
+    fn update_with_none_expected_attempt_applies_regardless() {
+        let mut t = task();
+        // Even with attempt = 99 and no expected_attempt, the update applies.
+        t.attempt = 99;
+        let now = Utc::now();
+
+        apply_task_update(
+            &mut t,
+            SessionTaskUpdate {
+                summary: Some("cancel from API".to_string()),
+                expected_attempt: None,
+                ..Default::default()
+            },
+            now,
+        );
+        // Writers that don't track attempts (e.g. cancel_task from the API) still apply.
+        assert_eq!(t.summary.as_deref(), Some("cancel from API"));
     }
 }

--- a/crates/core/src/tools.rs
+++ b/crates/core/src/tools.rs
@@ -1198,7 +1198,7 @@ impl Tool for SpawnBackgroundTool {
 
         // Create the session task tracking this run (specs/session-tasks.md).
         // task_registry is guaranteed Some above.
-        let task_id: Option<String> = match task_registry
+        let (task_id, task_attempt): (Option<String>, i32) = match task_registry
             .create(crate::session_task::CreateSessionTask {
                 session_id: context.session_id,
                 id: None,
@@ -1214,7 +1214,7 @@ impl Tool for SpawnBackgroundTool {
             })
             .await
         {
-            Ok(task) => Some(task.id),
+            Ok(task) => (Some(task.id), task.attempt),
             Err(e) => {
                 return ToolExecutionResult::internal_error_msg(format!(
                     "Failed to create background run task: {e}"
@@ -1241,6 +1241,8 @@ impl Tool for SpawnBackgroundTool {
         let cancel_registry = context.session_task_registry.clone();
         let cancel_session_id = context.session_id;
         let cancel_task_id = task_id.clone();
+        // Attempt captured at task creation for stale-attempt fencing.
+        let cancel_task_attempt = task_attempt;
 
         tokio::spawn(async move {
             let _background_run_permit = background_run_permit;
@@ -1277,13 +1279,16 @@ impl Tool for SpawnBackgroundTool {
                     let watch_fut = async {
                         loop {
                             tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-                            // Send heartbeat.
+                            // Send heartbeat with stale-attempt fencing so a
+                            // superseded executor's heartbeats are rejected once
+                            // the reaper increments the attempt counter.
                             let _ = registry
                                 .update(
                                     cancel_session_id,
                                     &task_id_str,
                                     crate::session_task::SessionTaskUpdate {
                                         heartbeat_at: Some(chrono::Utc::now()),
+                                        expected_attempt: Some(cancel_task_attempt),
                                         ..Default::default()
                                     },
                                 )

--- a/crates/internal-protocol/proto/worker.proto
+++ b/crates/internal-protocol/proto/worker.proto
@@ -2015,7 +2015,8 @@ message ListOrphanedSessionTasksRequest {
 
 // One (session_id, task_id) pair from the orphan scan.
 message OrphanedSessionTaskEntry {
-    // session_id as a UUID string (no prefix; the prefix is added by the server).
+    // session_id as a raw UUID string. The typed-id prefix ("ses_") is
+    // applied client-side when parsing into a SessionId.
     string session_id = 1;
     string task_id = 2;
 }

--- a/crates/internal-protocol/proto/worker.proto
+++ b/crates/internal-protocol/proto/worker.proto
@@ -177,6 +177,10 @@ service WorkerService {
     rpc RecordSessionTaskMessage(RecordSessionTaskMessageRequest) returns (SessionTaskMessageResponse);
     rpc ListSessionTaskMessages(ListSessionTaskMessagesRequest) returns (ListSessionTaskMessagesResponse);
 
+    // List (session_id, task_id) pairs for tasks with a stale heartbeat, so
+    // gRPC workers can run the session_task_reaper durable activity.
+    rpc ListOrphanedSessionTasks(ListOrphanedSessionTasksRequest) returns (ListOrphanedSessionTasksResponse);
+
     // === Session schedule operations ===
     // CRUD for session-scoped scheduled tasks (one-shot and recurring cron)
     rpc CreateSessionSchedule(CreateSessionScheduleRequest) returns (CreateSessionScheduleResponse);
@@ -1998,4 +2002,24 @@ message ListSessionTaskMessagesRequest {
 
 message ListSessionTaskMessagesResponse {
     repeated bytes message_json = 1;
+}
+
+// === List orphaned session tasks ===
+
+message ListOrphanedSessionTasksRequest {
+    // Age in seconds after which a stale heartbeat marks a task orphaned.
+    int64 stale_after_seconds = 1;
+    // Maximum number of results to return.
+    int64 limit = 2;
+}
+
+// One (session_id, task_id) pair from the orphan scan.
+message OrphanedSessionTaskEntry {
+    // session_id as a UUID string (no prefix; the prefix is added by the server).
+    string session_id = 1;
+    string task_id = 2;
+}
+
+message ListOrphanedSessionTasksResponse {
+    repeated OrphanedSessionTaskEntry entries = 1;
 }

--- a/crates/server/src/domains/session_tasks/commands.rs
+++ b/crates/server/src/domains/session_tasks/commands.rs
@@ -163,6 +163,9 @@ impl Command for PostSessionTaskMessage {
             direction: everruns_core::session_task::TaskMessageDirection::Inbound,
             content,
             in_reply_to: self.in_reply_to,
+            // API writers are unfenced: user messages apply regardless of
+            // executor attempt.
+            expected_attempt: None,
         };
         message.in_reply_to = message.in_reply_to.filter(|s| !s.is_empty());
 

--- a/crates/server/src/grpc_service/mod.rs
+++ b/crates/server/src/grpc_service/mod.rs
@@ -124,6 +124,8 @@ use everruns_internal_protocol::proto::{
     InvokeScheduledAppChannelResponse,
     ListCommandsRequest,
     ListCommandsResponse,
+    ListOrphanedSessionTasksRequest,
+    ListOrphanedSessionTasksResponse,
     ListSessionLeasedResourcesRequest,
     ListSessionLeasedResourcesResponse,
     ListSessionResourcesRequest,
@@ -143,6 +145,7 @@ use everruns_internal_protocol::proto::{
     McpServerInfo,
     McpToolDef,
     OptionalSessionTaskResponse,
+    OrphanedSessionTaskEntry, // orphan-scan entry for ListOrphanedSessionTasks
     PlatformCapabilityInfo,
     // Platform management types
     PlatformCopyHarnessRequest,

--- a/crates/server/src/grpc_service/tests.rs
+++ b/crates/server/src/grpc_service/tests.rs
@@ -966,3 +966,169 @@ fn test_db_info_to_proto_roundtrip() {
     assert!(proto.created_at.is_some());
     assert!(proto.updated_at.is_some());
 }
+
+// ============================================================================
+// Session task RPC tests — ListOrphanedSessionTasks
+// ============================================================================
+
+/// Helper: create a session task via the storage backend directly.
+async fn create_test_session_task(
+    db: &crate::storage::StorageBackend,
+    session_id: everruns_core::SessionId,
+    kind: &str,
+    state: everruns_core::session_task::SessionTaskState,
+    wake_policy: everruns_core::session_task::TaskWakePolicy,
+) -> String {
+    use everruns_core::session_task::{CreateSessionTask, TaskLinks, new_session_task};
+    let task = new_session_task(
+        CreateSessionTask {
+            session_id,
+            id: None,
+            kind: kind.to_string(),
+            display_name: "Test task".to_string(),
+            spec: serde_json::json!({}),
+            state,
+            links: TaskLinks::default(),
+            wake_policy,
+        },
+        chrono::Utc::now(),
+    );
+    db.create_session_task(&task)
+        .await
+        .expect("create task")
+        .0
+        .id
+}
+
+#[tokio::test]
+async fn test_list_orphaned_session_tasks_returns_stale_task() {
+    let svc = test_worker_service().await;
+    let db = svc.db.clone();
+
+    let session_id = everruns_core::SessionId::new();
+
+    let task_id = create_test_session_task(
+        &db,
+        session_id,
+        everruns_core::session_task::TASK_KIND_BACKGROUND_TOOL,
+        everruns_core::session_task::SessionTaskState::Running,
+        everruns_core::session_task::TaskWakePolicy::Silent,
+    )
+    .await;
+
+    // Backdate the heartbeat to be older than the stale threshold (5 minutes).
+    let stale_heartbeat = chrono::Utc::now() - chrono::Duration::minutes(10);
+    db.update_session_task(
+        session_id,
+        &task_id,
+        everruns_core::session_task::SessionTaskUpdate {
+            heartbeat_at: Some(stale_heartbeat),
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("set stale heartbeat");
+
+    // Call the RPC with a 5-minute stale threshold.
+    let request = tonic::Request::new(ListOrphanedSessionTasksRequest {
+        stale_after_seconds: 300,
+        limit: 50,
+    });
+    let response = svc
+        .list_orphaned_session_tasks(request)
+        .await
+        .expect("rpc should succeed");
+
+    let entries = response.into_inner().entries;
+    let found = entries.iter().any(|e| e.task_id == task_id);
+    assert!(
+        found,
+        "Expected task {} in orphan list, got: {:?}",
+        task_id,
+        entries.iter().map(|e| &e.task_id).collect::<Vec<_>>()
+    );
+}
+
+#[tokio::test]
+async fn test_list_orphaned_session_tasks_excludes_fresh_heartbeat() {
+    let svc = test_worker_service().await;
+    let db = svc.db.clone();
+
+    let session_id = everruns_core::SessionId::new();
+
+    let task_id = create_test_session_task(
+        &db,
+        session_id,
+        everruns_core::session_task::TASK_KIND_BACKGROUND_TOOL,
+        everruns_core::session_task::SessionTaskState::Running,
+        everruns_core::session_task::TaskWakePolicy::Silent,
+    )
+    .await;
+
+    // Set a recent heartbeat (only 1 second ago).
+    let fresh_heartbeat = chrono::Utc::now() - chrono::Duration::seconds(1);
+    db.update_session_task(
+        session_id,
+        &task_id,
+        everruns_core::session_task::SessionTaskUpdate {
+            heartbeat_at: Some(fresh_heartbeat),
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("set fresh heartbeat");
+
+    // Call with a 5-minute stale threshold — fresh task must not appear.
+    let request = tonic::Request::new(ListOrphanedSessionTasksRequest {
+        stale_after_seconds: 300,
+        limit: 50,
+    });
+    let response = svc
+        .list_orphaned_session_tasks(request)
+        .await
+        .expect("rpc should succeed");
+
+    let entries = response.into_inner().entries;
+    let found = entries.iter().any(|e| e.task_id == task_id);
+    assert!(
+        !found,
+        "Fresh-heartbeat task {} must not be in orphan list",
+        task_id
+    );
+}
+
+#[tokio::test]
+async fn test_list_orphaned_session_tasks_excludes_null_heartbeat() {
+    let svc = test_worker_service().await;
+    let db = svc.db.clone();
+
+    let session_id = everruns_core::SessionId::new();
+
+    // Create a task with no heartbeat (foreground/subagent tasks).
+    let task_id = create_test_session_task(
+        &db,
+        session_id,
+        everruns_core::session_task::TASK_KIND_SUBAGENT,
+        everruns_core::session_task::SessionTaskState::Running,
+        everruns_core::session_task::TaskWakePolicy::OnTerminal,
+    )
+    .await;
+
+    // heartbeat_at is NULL — must never appear in orphan list.
+    let request = tonic::Request::new(ListOrphanedSessionTasksRequest {
+        stale_after_seconds: 1,
+        limit: 50,
+    });
+    let response = svc
+        .list_orphaned_session_tasks(request)
+        .await
+        .expect("rpc should succeed");
+
+    let entries = response.into_inner().entries;
+    let found = entries.iter().any(|e| e.task_id == task_id);
+    assert!(
+        !found,
+        "NULL-heartbeat task {} must not be in orphan list",
+        task_id
+    );
+}

--- a/crates/server/src/grpc_service/worker_service_impl.rs
+++ b/crates/server/src/grpc_service/worker_service_impl.rs
@@ -3038,11 +3038,21 @@ impl WorkerService for WorkerServiceImpl {
         request: Request<ListOrphanedSessionTasksRequest>,
     ) -> Result<Response<ListOrphanedSessionTasksResponse>, Status> {
         let req = request.into_inner();
+        if req.stale_after_seconds <= 0 {
+            return Err(Status::invalid_argument(
+                "stale_after_seconds must be positive",
+            ));
+        }
+        if req.limit <= 0 {
+            return Err(Status::invalid_argument("limit must be positive"));
+        }
         let stale_after = chrono::Duration::seconds(req.stale_after_seconds);
+        // Cap the response size regardless of what the caller asks for.
+        let limit = req.limit.min(1000);
 
         let pairs = self
             .db
-            .list_orphaned_session_task_ids(stale_after, req.limit)
+            .list_orphaned_session_task_ids(stale_after, limit)
             .await
             .map_err(|e| {
                 tracing::error!("Failed to list orphaned session tasks: {e}");

--- a/crates/server/src/grpc_service/worker_service_impl.rs
+++ b/crates/server/src/grpc_service/worker_service_impl.rs
@@ -3033,6 +3033,33 @@ impl WorkerService for WorkerServiceImpl {
         }))
     }
 
+    async fn list_orphaned_session_tasks(
+        &self,
+        request: Request<ListOrphanedSessionTasksRequest>,
+    ) -> Result<Response<ListOrphanedSessionTasksResponse>, Status> {
+        let req = request.into_inner();
+        let stale_after = chrono::Duration::seconds(req.stale_after_seconds);
+
+        let pairs = self
+            .db
+            .list_orphaned_session_task_ids(stale_after, req.limit)
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to list orphaned session tasks: {e}");
+                Status::internal("Failed to list orphaned session tasks")
+            })?;
+
+        let entries = pairs
+            .into_iter()
+            .map(|(session_id, task_id)| OrphanedSessionTaskEntry {
+                session_id: session_id.uuid().to_string(),
+                task_id,
+            })
+            .collect();
+
+        Ok(Response::new(ListOrphanedSessionTasksResponse { entries }))
+    }
+
     // ========================================================================
     // Session schedule operations
     // ========================================================================

--- a/crates/server/src/storage/session_task_store.rs
+++ b/crates/server/src/storage/session_task_store.rs
@@ -308,6 +308,17 @@ impl SessionTaskRegistry for DbSessionTaskRegistry {
             .await?
             .ok_or_else(|| AgentLoopError::store(format!("Session task not found: {task_id}")))?;
 
+        // Stale-attempt fence: a superseded executor must not append to the
+        // thread (record_message emits events and can wake the parent).
+        if let Some(expected) = message.expected_attempt
+            && expected != task.attempt
+        {
+            return Err(AgentLoopError::store(format!(
+                "Stale attempt {expected} for task {task_id} (current attempt {})",
+                task.attempt
+            )));
+        }
+
         let row = self
             .db
             .insert_session_task_message(NewSessionTaskMessageRow {
@@ -646,6 +657,47 @@ mod tests {
             .map(|m| everruns_core::session_task::task_message_text(&m.content))
             .collect();
         assert_eq!(texts, vec!["m3", "m4"]);
+    }
+
+    #[tokio::test]
+    async fn record_message_rejects_stale_attempt() {
+        let registry = registry();
+        let session_id = SessionId::new();
+        let task = registry
+            .create(create_input_with_policy(session_id, TaskWakePolicy::Silent))
+            .await
+            .unwrap();
+
+        // Reaper-style supersede: fail as orphaned and bump the attempt.
+        registry
+            .update(
+                session_id,
+                &task.id,
+                SessionTaskUpdate {
+                    state: Some(SessionTaskState::Failed),
+                    increment_attempt: true,
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+
+        // The zombie executor (attempt 1) must not append to the thread.
+        let err = registry
+            .record_message(
+                session_id,
+                &task.id,
+                NewTaskMessage::outbound_text("zombie").with_expected_attempt(1),
+            )
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("Stale attempt"), "got: {err}");
+
+        // Unfenced writers (API messages) still apply.
+        registry
+            .record_message(session_id, &task.id, NewTaskMessage::inbound_text("user"))
+            .await
+            .unwrap();
     }
 
     // -------------------------------------------------------------------------

--- a/crates/worker/src/durable_worker.rs
+++ b/crates/worker/src/durable_worker.rs
@@ -224,10 +224,9 @@ impl Default for DurableWorkerConfig {
                 "reason".to_string(),
                 "act".to_string(),
                 "leased_resource_cleanup".to_string(),
-                // session_task_reaper is intentionally NOT a default here:
-                // the gRPC adapters have no orphan-listing RPC yet, so remote
-                // workers must not claim reaper tasks (the in-process unified
-                // worker handles them). Opting in via config fails fast.
+                // session_task_reaper now runs on gRPC workers via the
+                // ListOrphanedSessionTasks RPC (added alongside this change).
+                "session_task_reaper".to_string(),
                 "invoke_scheduled_app_channel".to_string(),
             ],
             max_concurrent_tasks: 1000, // High default for massive workflow parallelism

--- a/crates/worker/src/grpc_adapters.rs
+++ b/crates/worker/src/grpc_adapters.rs
@@ -485,6 +485,34 @@ impl GrpcClient {
         Ok(response.into_inner().updated)
     }
 
+    /// List (session_id, task_id) pairs for tasks with stale heartbeats.
+    /// Used by the session_task_reaper durable activity on gRPC workers.
+    pub async fn list_orphaned_session_tasks(
+        &self,
+        stale_after_seconds: i64,
+        limit: i64,
+    ) -> Result<Vec<(everruns_core::SessionId, String)>> {
+        let mut client = self.inner.lock().await;
+        let response = client
+            .list_orphaned_session_tasks(proto::ListOrphanedSessionTasksRequest {
+                stale_after_seconds,
+                limit,
+            })
+            .await
+            .map_err(grpc_status_to_error)?;
+        response
+            .into_inner()
+            .entries
+            .into_iter()
+            .map(|e| {
+                let uuid = uuid::Uuid::parse_str(&e.session_id).map_err(|err| {
+                    AgentLoopError::store(format!("Invalid session_id in orphan entry: {err}"))
+                })?;
+                Ok((everruns_core::SessionId::from_uuid(uuid), e.task_id))
+            })
+            .collect()
+    }
+
     pub async fn invoke_scheduled_app_channel(
         &self,
         org_id: i64,

--- a/crates/worker/src/grpc_worker_adapters.rs
+++ b/crates/worker/src/grpc_worker_adapters.rs
@@ -533,92 +533,24 @@ impl WorkerAdapters for GrpcWorkerAdapters {
             .await
     }
 
-    // Session task reaper — not yet wired over gRPC (reaper runs from the
-    // in-process direct worker; gRPC support can be added once a proto RPC
-    // is defined).
     async fn list_orphaned_session_task_ids(
         &self,
-        _stale_after: chrono::Duration,
-        _limit: i64,
+        stale_after: chrono::Duration,
+        limit: i64,
     ) -> Result<Vec<(everruns_core::SessionId, String)>> {
-        // Fail fast instead of silently masking orphans: remote workers have
-        // no orphan-listing RPC yet, and session_task_reaper is excluded from
-        // their default activity types. A misconfigured opt-in surfaces here.
-        Err(everruns_core::AgentLoopError::store(
-            "session_task_reaper is not supported on gRPC workers (no orphan-listing RPC);              run it on the in-process worker",
-        ))
+        self.client
+            .list_orphaned_session_tasks(stale_after.num_seconds(), limit)
+            .await
     }
 
     fn reaper_session_task_registry(
         &self,
     ) -> std::sync::Arc<dyn everruns_core::session_task::SessionTaskRegistry> {
-        // gRPC path: no direct storage access; return a no-op registry.
-        // The reaper activity is registered only on the in-process worker.
-        Arc::new(NoopSessionTaskRegistry)
-    }
-}
-
-// Minimal no-op registry for the gRPC stub path.
-#[derive(Default)]
-struct NoopSessionTaskRegistry;
-
-#[async_trait::async_trait]
-impl everruns_core::session_task::SessionTaskRegistry for NoopSessionTaskRegistry {
-    async fn create(
-        &self,
-        _input: everruns_core::session_task::CreateSessionTask,
-    ) -> everruns_core::error::Result<everruns_core::session_task::SessionTask> {
-        Err(everruns_core::AgentLoopError::store("noop registry"))
-    }
-
-    async fn update(
-        &self,
-        _session_id: everruns_core::SessionId,
-        _task_id: &str,
-        _update: everruns_core::session_task::SessionTaskUpdate,
-    ) -> everruns_core::error::Result<Option<everruns_core::session_task::SessionTask>> {
-        Ok(None)
-    }
-
-    async fn get(
-        &self,
-        _session_id: everruns_core::SessionId,
-        _task_id: &str,
-    ) -> everruns_core::error::Result<Option<everruns_core::session_task::SessionTask>> {
-        Ok(None)
-    }
-
-    async fn list(
-        &self,
-        _session_id: everruns_core::SessionId,
-        _filter: Option<&everruns_core::session_task::SessionTaskFilter>,
-    ) -> everruns_core::error::Result<Vec<everruns_core::session_task::SessionTask>> {
-        Ok(vec![])
-    }
-
-    async fn request_cancel(
-        &self,
-        _session_id: everruns_core::SessionId,
-        _task_id: &str,
-    ) -> everruns_core::error::Result<Option<everruns_core::session_task::SessionTask>> {
-        Ok(None)
-    }
-
-    async fn record_message(
-        &self,
-        _session_id: everruns_core::SessionId,
-        _task_id: &str,
-        _message: everruns_core::session_task::NewTaskMessage,
-    ) -> everruns_core::error::Result<everruns_core::session_task::TaskMessage> {
-        Err(everruns_core::AgentLoopError::store("noop registry"))
-    }
-
-    async fn list_messages(
-        &self,
-        _session_id: everruns_core::SessionId,
-        _task_id: &str,
-        _limit: Option<u32>,
-    ) -> everruns_core::error::Result<Vec<everruns_core::session_task::TaskMessage>> {
-        Ok(vec![])
+        // Reuse the same gRPC-backed session-task registry the worker uses for
+        // executor RPCs — lifecycle invariants, events, and wake_policy all
+        // flow through the server's DbSessionTaskRegistry.
+        Arc::new(crate::grpc_adapters::GrpcSessionTaskRegistry::new(
+            self.client.clone(),
+        ))
     }
 }

--- a/crates/worker/src/session_task_reaper.rs
+++ b/crates/worker/src/session_task_reaper.rs
@@ -87,6 +87,9 @@ pub async fn execute_reaper_activity<A: WorkerAdapters>(
                 kind: "orphaned".to_string(),
                 message: "worker heartbeat stopped".to_string(),
             }),
+            // Supersede the executor's attempt so its fenced writes
+            // (heartbeats, progress, messages) are rejected from now on.
+            increment_attempt: true,
             ..Default::default()
         };
 
@@ -258,6 +261,7 @@ mod tests {
                     kind: "orphaned".to_string(),
                     message: "worker heartbeat stopped".to_string(),
                 }),
+                increment_attempt: true,
                 ..Default::default()
             };
             match registry.update(*session_id, task_id, update).await {
@@ -312,6 +316,10 @@ mod tests {
         let updated = registry.get(session_id, &task.id).await.unwrap().unwrap();
         assert_eq!(updated.state, SessionTaskState::Failed);
         assert_eq!(updated.error.as_ref().unwrap().kind, "orphaned");
+        assert_eq!(
+            updated.attempt, 2,
+            "orphan reap must supersede the executor's attempt"
+        );
     }
 
     #[tokio::test]

--- a/specs/session-tasks.md
+++ b/specs/session-tasks.md
@@ -318,8 +318,16 @@ No backward compatibility is required; data migrates forward once:
   with stale heartbeats (`heartbeat_at IS NOT NULL AND heartbeat_at < now -
   5m`) and fails them via the registry using `FOR UPDATE SKIP LOCKED` on the
   PG backend. Tasks with `NULL heartbeat_at` (foreground subagent tasks) are
-  excluded (covered by EVE-535 spawn handles). Stale-attempt fencing is not
-  yet built.
+  excluded (covered by EVE-535 spawn handles). The reconciler now runs on gRPC
+  workers via the `ListOrphanedSessionTasks` RPC (added to the internal worker
+  protocol); `session_task_reaper` is included in the gRPC DurableWorker's
+  default activity types. Stale-attempt fencing is built: `SessionTaskUpdate`
+  carries an optional `expected_attempt` field; `apply_task_update` silently
+  drops any update where `expected_attempt` is set but does not match
+  `task.attempt`, so heartbeats and state writes from a superseded executor are
+  rejected once the reaper has marked the task. Writers that do not track
+  attempts (e.g. `cancel_task` from the API) leave `expected_attempt: None` and
+  are unaffected. Re-attach (attempt+1 restart) remains deferred.
 - Wake-ups: `wake_policy` is enforced at the registry level
   (`DbSessionTaskRegistry`). `OnTerminal` wakes on any transition into
   `succeeded`/`failed`/`canceled`. `OnActivity` additionally wakes on

--- a/specs/session-tasks.md
+++ b/specs/session-tasks.md
@@ -324,10 +324,12 @@ No backward compatibility is required; data migrates forward once:
   default activity types. Stale-attempt fencing is built: `SessionTaskUpdate`
   carries an optional `expected_attempt` field; `apply_task_update` silently
   drops any update where `expected_attempt` is set but does not match
-  `task.attempt`, so heartbeats and state writes from a superseded executor are
-  rejected once the reaper has marked the task. Writers that do not track
-  attempts (e.g. `cancel_task` from the API) leave `expected_attempt: None` and
-  are unaffected. Re-attach (attempt+1 restart) remains deferred.
+  `task.attempt`. When the reaper fails an orphan it sets `increment_attempt`,
+  bumping `task.attempt` so the superseded executor's heartbeats, state writes,
+  and message posts (`NewTaskMessage.expected_attempt`, enforced in
+  `record_message`) are rejected. Writers that do not track attempts
+  (e.g. `cancel_task` from the API) leave `expected_attempt: None` and are
+  unaffected. Re-attach (attempt+1 restart) remains deferred.
 - Wake-ups: `wake_policy` is enforced at the registry level
   (`DbSessionTaskRegistry`). `OnTerminal` wakes on any transition into
   `succeeded`/`failed`/`canceled`. `OnActivity` additionally wakes on


### PR DESCRIPTION
## What
Two durability follow-ups from `specs/session-tasks.md`:

1. **Orphan reaping on gRPC workers.** New `ListOrphanedSessionTasks` RPC in the internal worker protocol; the gRPC worker adapter's fail-fast stub and `NoopSessionTaskRegistry` are replaced with the real RPC call and the same `GrpcSessionTaskRegistry` used by executors. `session_task_reaper` is now in remote workers' default activity types.
2. **Stale-attempt write fencing.** `SessionTaskUpdate.expected_attempt` (serde-defaulted for cross-version payload compat) is enforced at the top of the shared `apply_task_update`: when set and mismatching `task.attempt`, the whole update is silently dropped. `RegistryTaskSink` and background-run heartbeats carry the attempt captured at task start.

## Why
The reaper previously ran only on the in-process worker — remote-worker deployments had no orphan reconciliation. Fencing is the spec-mandated guard ("sink writes carry `attempt` and writes from a superseded attempt are rejected") and the prerequisite for future re-attach.

## How
Proto + client method + server handler follow the existing 7 session-task RPC patterns (JSON-bytes payloads). Fencing lives in the one shared update path both PG and in-memory backends route through, mirroring the terminal-state invariant. Unfenced writers (API `cancel_task`, the reaper itself) pass `None` and are unaffected.

Honest caveat: fencing is dormant until something bumps `attempt` — re-attach (attempt+1 restart on a new worker) remains deferred and the reaper keeps failing orphans as `error.kind="orphaned"`.

## Risk
- Low/Medium
- Remote workers now claim `session_task_reaper` activities by default; the reaper only fails tasks with non-NULL heartbeats stale >5 min, and terminal-state invariants make double-reaping a no-op. The new RPC is additive; `expected_attempt` defaults to `None` so old payloads deserialize and behave as before.

## Security
- Threat categories reviewed: TM-API (new internal RPC) — handler delegates to the existing storage method with caller-supplied `stale_after`/`limit` only; no new trust boundary (internal worker protocol, same auth as the other task RPCs). No secrets or user input paths touched.
- Findings and resolutions: none.

## Follow-ups
- Re-attach (`start` on a new worker, `attempt + 1`) — deferred; fencing in this PR is its prerequisite.
- Monitor-orphan reconciliation (EVE-monitor-orphan) — unchanged.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_011yqDiQ2GyoDdwFQTFTw12R)_