### PR TITLE
feat(worker): re-attach orphaned external_agent tasks

### DIFF
--- a/crates/core/src/capabilities/a2a_delegation.rs
+++ b/crates/core/src/capabilities/a2a_delegation.rs
@@ -1008,11 +1008,18 @@ async fn submit_run(
     save_run(context, record).await.map_err(|e| e.to_string())
 }
 
+/// Poll a remote A2A task until it reaches a terminal state or the deadline
+/// expires. Sends a registry heartbeat on every poll iteration when
+/// `heartbeat_attempt` is provided, so the reaper knows the worker is alive
+/// and stale writes from a superseded executor are rejected.
 async fn wait_for_run(
     context: &ToolContext,
     agent: &ExternalA2aAgentConfig,
     mut record: AgentRunRecord,
     timeout_secs: u64,
+    // When Some, write a heartbeat on every poll with this attempt fence so
+    // a superseded executor's stale writes are rejected.
+    heartbeat_attempt: Option<i32>,
 ) -> std::result::Result<AgentRunRecord, String> {
     if record.status.is_terminal() {
         write_result_artifact(context, &mut record)
@@ -1036,6 +1043,25 @@ async fn wait_for_run(
     );
 
     while Instant::now() < deadline {
+        // Heartbeat through the registry so the reaper sees a live worker.
+        if let (Some(attempt), Some(registry), Some(task_id)) = (
+            heartbeat_attempt,
+            &context.session_task_registry,
+            record.task_id.as_deref(),
+        ) {
+            let _ = registry
+                .update(
+                    context.session_id,
+                    task_id,
+                    SessionTaskUpdate {
+                        heartbeat_at: Some(chrono::Utc::now()),
+                        expected_attempt: Some(attempt),
+                        ..Default::default()
+                    },
+                )
+                .await;
+        }
+
         let task = client
             .get_task(&GetTaskRequest {
                 id: remote_task_id.clone(),
@@ -1087,15 +1113,20 @@ async fn timeout_or_error_result(
     ToolExecutionResult::tool_error(error)
 }
 
+/// Background poll loop for an A2A run. `heartbeat_attempt` is the task
+/// attempt number captured at spawn/re-attach time; heartbeats carry this so
+/// the fence rejects writes from a previously superseded attempt.
 async fn background_monitor(
     context: ToolContext,
     agent: ExternalA2aAgentConfig,
     record: AgentRunRecord,
     timeout_secs: u64,
+    heartbeat_attempt: Option<i32>,
 ) {
     let run_id = record.run_id.clone();
     let fallback_record = record.clone();
-    let record = match wait_for_run(&context, &agent, record, timeout_secs).await {
+    let record = match wait_for_run(&context, &agent, record, timeout_secs, heartbeat_attempt).await
+    {
         Ok(record) => record,
         Err(error) => {
             let mut failed = load_run(&context, &run_id).await.unwrap_or(fallback_record);
@@ -1277,16 +1308,31 @@ impl Tool for SpawnAgentTool {
         match mode {
             AgentRunMode::Background => {
                 let context = context.clone();
+                // Capture the attempt at spawn time (1 for a fresh spawn).
+                // The heartbeat loop uses this to fence stale writes from any
+                // future superseded attempt.
+                let heartbeat_attempt = record.task_id.is_some().then_some(1i32);
                 let background_record = record.clone();
                 tokio::spawn(async move {
-                    background_monitor(context, agent, background_record, timeout_secs).await;
+                    background_monitor(
+                        context,
+                        agent,
+                        background_record,
+                        timeout_secs,
+                        heartbeat_attempt,
+                    )
+                    .await;
                 });
                 ToolExecutionResult::success(record.public_json())
             }
-            AgentRunMode::Wait => match wait_for_run(context, &agent, record, timeout_secs).await {
-                Ok(record) => ToolExecutionResult::success(record.public_json()),
-                Err(error) => timeout_or_error_result(context, &run_id, error).await,
-            },
+            AgentRunMode::Wait => {
+                // Foreground wait: the tool executor owns the call stack so no
+                // separate heartbeat thread is needed; pass None.
+                match wait_for_run(context, &agent, record, timeout_secs, None).await {
+                    Ok(record) => ToolExecutionResult::success(record.public_json()),
+                    Err(error) => timeout_or_error_result(context, &run_id, error).await,
+                }
+            }
         }
     }
 
@@ -1454,7 +1500,8 @@ impl Tool for WaitAgentTool {
             .get("timeout_secs")
             .and_then(Value::as_u64)
             .unwrap_or(DEFAULT_WAIT_TIMEOUT_SECS);
-        match wait_for_run(context, &agent, record, timeout_secs).await {
+        // wait_agent is foreground; no separate heartbeat thread needed.
+        match wait_for_run(context, &agent, record, timeout_secs, None).await {
             Ok(record) => ToolExecutionResult::success(record.public_json()),
             Err(error) => timeout_or_error_result(context, run_id, error).await,
         }
@@ -1557,7 +1604,8 @@ impl Tool for MessageAgentTool {
             .get("wait_timeout_secs")
             .and_then(Value::as_u64)
             .unwrap_or(DEFAULT_WAIT_TIMEOUT_SECS);
-        match wait_for_run(context, &agent, record, timeout_secs).await {
+        // message_agent is foreground; no separate heartbeat thread needed.
+        match wait_for_run(context, &agent, record, timeout_secs, None).await {
             Ok(record) => ToolExecutionResult::success(record.public_json()),
             Err(error) => timeout_or_error_result(context, run_id, error).await,
         }
@@ -1714,6 +1762,61 @@ impl TaskExecutor for ExternalAgentTaskExecutor {
         TASK_KIND_EXTERNAL_AGENT
     }
 
+    fn can_reattach(&self) -> bool {
+        true
+    }
+
+    /// Re-attach to a running external A2A task after worker loss.
+    ///
+    /// Loads the persisted `AgentRunRecord` from session storage, then:
+    /// - If already terminal: mirrors the terminal state to the registry and
+    ///   returns (idempotent reconcile).
+    /// - If `remote_task_id` or `agent_config` is absent: returns an error so
+    ///   the reaper falls back to failing the task as orphaned.
+    /// - Otherwise: rebuilds the A2A client from the stored config snapshot and
+    ///   resumes the background poll loop with `heartbeat_attempt = task.attempt`
+    ///   (the NEW attempt number after the reaper bumped it) so stale writes from
+    ///   the superseded executor are rejected.
+    async fn start(&self, task: &SessionTask, context: &ToolContext) -> crate::error::Result<()> {
+        let record = load_run_for_task(context, task)
+            .await
+            .map_err(crate::error::AgentLoopError::tool)?;
+
+        // If the run is already terminal, just mirror and return.
+        if record.status.is_terminal() {
+            mirror_run_to_task(context, &record).await;
+            return Ok(());
+        }
+
+        // Missing remote_task_id means we never sent to the remote agent —
+        // there is nothing to poll; caller will fail this as orphaned.
+        if record.remote_task_id.is_none() {
+            return Err(crate::error::AgentLoopError::tool(format!(
+                "external_agent task {} has no remote_task_id; cannot re-attach",
+                task.id
+            )));
+        }
+
+        let agent = agent_snapshot(&record).map_err(crate::error::AgentLoopError::tool)?;
+
+        // Resume the background poll loop. Use the NEW attempt (bumped by the
+        // reaper) for heartbeating so the superseded executor's stale writes
+        // are rejected by the fence.
+        let heartbeat_attempt = Some(task.attempt);
+        let context = context.clone();
+        tokio::spawn(async move {
+            background_monitor(
+                context,
+                agent,
+                record,
+                DEFAULT_WAIT_TIMEOUT_SECS,
+                heartbeat_attempt,
+            )
+            .await;
+        });
+        Ok(())
+    }
+
     async fn deliver(
         &self,
         task: &SessionTask,
@@ -1818,6 +1921,7 @@ inventory::submit! {
 mod tests {
     use super::*;
     use crate::session_file::{FileInfo, FileStat, GrepMatch, SessionFile};
+    use crate::session_task::SessionTaskRegistry;
     use crate::traits::SessionFileSystem;
     use crate::typed_id::SessionId;
     use a2a::StreamResponse;
@@ -2408,6 +2512,249 @@ mod tests {
         config.agents[0].preferred_binding = Some("JSONRPC".to_string());
         config.agents[0].poll_interval_ms = Some(99);
         assert!(config.agents[0].validate().is_err());
+    }
+
+    // -------------------------------------------------------------------------
+    // ExternalAgentTaskExecutor::start() tests
+    // -------------------------------------------------------------------------
+
+    /// Minimal in-memory task registry for executor tests.
+    #[derive(Default, Clone)]
+    struct InMemRegistry {
+        tasks: Arc<Mutex<HashMap<String, crate::session_task::SessionTask>>>,
+    }
+
+    #[async_trait]
+    impl crate::session_task::SessionTaskRegistry for InMemRegistry {
+        async fn create(
+            &self,
+            input: crate::session_task::CreateSessionTask,
+        ) -> crate::error::Result<crate::session_task::SessionTask> {
+            let task = crate::session_task::new_session_task(input, chrono::Utc::now());
+            self.tasks
+                .lock()
+                .unwrap()
+                .insert(task.id.clone(), task.clone());
+            Ok(task)
+        }
+
+        async fn get(
+            &self,
+            _session_id: crate::typed_id::SessionId,
+            task_id: &str,
+        ) -> crate::error::Result<Option<crate::session_task::SessionTask>> {
+            Ok(self.tasks.lock().unwrap().get(task_id).cloned())
+        }
+
+        async fn list(
+            &self,
+            _session_id: crate::typed_id::SessionId,
+            _filter: Option<&crate::session_task::SessionTaskFilter>,
+        ) -> crate::error::Result<Vec<crate::session_task::SessionTask>> {
+            Ok(self.tasks.lock().unwrap().values().cloned().collect())
+        }
+
+        async fn update(
+            &self,
+            _session_id: crate::typed_id::SessionId,
+            task_id: &str,
+            update: crate::session_task::SessionTaskUpdate,
+        ) -> crate::error::Result<Option<crate::session_task::SessionTask>> {
+            let mut tasks = self.tasks.lock().unwrap();
+            let Some(task) = tasks.get_mut(task_id) else {
+                return Ok(None);
+            };
+            crate::session_task::apply_task_update(task, update, chrono::Utc::now());
+            Ok(Some(task.clone()))
+        }
+
+        async fn request_cancel(
+            &self,
+            _session_id: crate::typed_id::SessionId,
+            _task_id: &str,
+        ) -> crate::error::Result<Option<crate::session_task::SessionTask>> {
+            Ok(None)
+        }
+
+        async fn record_message(
+            &self,
+            _session_id: crate::typed_id::SessionId,
+            _task_id: &str,
+            _message: crate::session_task::NewTaskMessage,
+        ) -> crate::error::Result<crate::session_task::TaskMessage> {
+            Err(crate::error::AgentLoopError::tool("not implemented"))
+        }
+
+        async fn list_messages(
+            &self,
+            _session_id: crate::typed_id::SessionId,
+            _task_id: &str,
+            _limit: Option<u32>,
+        ) -> crate::error::Result<Vec<crate::session_task::TaskMessage>> {
+            Ok(vec![])
+        }
+    }
+
+    /// Build a SessionTask snapshot for testing (not persisted in any store).
+    fn fake_task_with_spec(
+        session_id: crate::typed_id::SessionId,
+        run_id: &str,
+        attempt: i32,
+    ) -> crate::session_task::SessionTask {
+        let now = chrono::Utc::now();
+        crate::session_task::SessionTask {
+            id: format!("task_{run_id}"),
+            session_id,
+            kind: TASK_KIND_EXTERNAL_AGENT.to_string(),
+            display_name: "Test external agent".to_string(),
+            spec: json!({ "run_id": run_id }),
+            state: SessionTaskState::Running,
+            state_detail: None,
+            progress: None,
+            links: TaskLinks::default(),
+            wake_policy: TaskWakePolicy::Silent,
+            input_request: None,
+            cancel_requested_at: None,
+            summary: None,
+            result_path: None,
+            artifacts: vec![],
+            error: None,
+            attempt,
+            worker_id: None,
+            heartbeat_at: None,
+            started_at: None,
+            finished_at: None,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    /// start() with a terminal run record should mirror state and return Ok.
+    #[tokio::test]
+    async fn external_agent_executor_start_mirrors_terminal_run() {
+        let storage = Arc::new(TestStorageStore::default());
+        let registry = Arc::new(InMemRegistry::default());
+        let session_id = crate::typed_id::SessionId::new();
+
+        let run_id = "run-terminal".to_string();
+        let config = ExternalA2aAgentConfig {
+            id: "echo".to_string(),
+            name: "Echo".to_string(),
+            description: None,
+            base_url: None,
+            agent_card: None,
+            headers: BTreeMap::new(),
+            preferred_binding: None,
+            poll_interval_ms: None,
+            allow_local_urls: false,
+        };
+        let task_id = format!("task_{run_id}");
+
+        // Create a completed run record.
+        let mut record = AgentRunRecord::new(
+            run_id.clone(),
+            &config,
+            "instructions".to_string(),
+            AgentRunMode::Background,
+            false,
+        );
+        record.status = AgentRunStatus::Completed;
+        record.result = Some("done".to_string());
+        record.remote_task_id = Some("remote-xyz".to_string());
+        record.task_id = Some(task_id.clone());
+
+        // Persist the run record.
+        let serialized = serde_json::to_string(&record).unwrap();
+        storage
+            .set_value(session_id, &run_key(&run_id), &serialized)
+            .await
+            .unwrap();
+
+        // Create the session task in the registry so mirror_run_to_task can update it.
+        registry
+            .create(crate::session_task::CreateSessionTask {
+                session_id,
+                id: Some(task_id.clone()),
+                kind: TASK_KIND_EXTERNAL_AGENT.to_string(),
+                display_name: "Echo".to_string(),
+                spec: json!({ "run_id": &run_id }),
+                state: SessionTaskState::Running,
+                links: TaskLinks::default(),
+                wake_policy: TaskWakePolicy::Silent,
+            })
+            .await
+            .unwrap();
+
+        let ctx = ToolContext::new(session_id)
+            .with_storage_store_arc(storage.clone() as Arc<dyn crate::traits::SessionStorageStore>)
+            .with_session_task_registry(registry.clone());
+
+        let task = fake_task_with_spec(session_id, &run_id, 2);
+        let executor = ExternalAgentTaskExecutor;
+        executor
+            .start(&task, &ctx)
+            .await
+            .expect("start should succeed");
+
+        // The registry task should now reflect the terminal state.
+        let updated = registry.get(session_id, &task_id).await.unwrap().unwrap();
+        assert_eq!(
+            updated.state,
+            SessionTaskState::Succeeded,
+            "terminal run should mirror to succeeded"
+        );
+    }
+
+    /// start() with a run that has no remote_task_id should return an error.
+    #[tokio::test]
+    async fn external_agent_executor_start_errors_on_missing_remote_task_id() {
+        let storage = Arc::new(TestStorageStore::default());
+        let session_id = crate::typed_id::SessionId::new();
+
+        let run_id = "run-no-remote".to_string();
+        let config = ExternalA2aAgentConfig {
+            id: "echo".to_string(),
+            name: "Echo".to_string(),
+            description: None,
+            base_url: None,
+            agent_card: None,
+            headers: BTreeMap::new(),
+            preferred_binding: None,
+            poll_interval_ms: None,
+            allow_local_urls: false,
+        };
+
+        // Create a run record without a remote_task_id (never reached the remote agent).
+        let record = AgentRunRecord::new(
+            run_id.clone(),
+            &config,
+            "instructions".to_string(),
+            AgentRunMode::Background,
+            false,
+        );
+        assert!(record.remote_task_id.is_none());
+
+        let serialized = serde_json::to_string(&record).unwrap();
+        storage
+            .set_value(session_id, &run_key(&run_id), &serialized)
+            .await
+            .unwrap();
+
+        let ctx = ToolContext::new(session_id)
+            .with_storage_store_arc(storage.clone() as Arc<dyn crate::traits::SessionStorageStore>);
+
+        let task = fake_task_with_spec(session_id, &run_id, 2);
+        let executor = ExternalAgentTaskExecutor;
+        let result = executor.start(&task, &ctx).await;
+        assert!(
+            result.is_err(),
+            "start() should error when remote_task_id is absent"
+        );
+        let err = result.unwrap_err();
+        assert!(
+            err.to_string().contains("remote_task_id"),
+            "error should mention remote_task_id: {err}"
+        );
     }
 
     /// Roundtrip: save_run → load_run → load_run_for_task all resolve consistently.

--- a/crates/core/src/capabilities/a2a_delegation.rs
+++ b/crates/core/src/capabilities/a2a_delegation.rs
@@ -37,6 +37,11 @@ use url::Url;
 pub const A2A_AGENT_DELEGATION_CAPABILITY_ID: &str = "a2a_agent_delegation";
 const DEFAULT_WAIT_TIMEOUT_SECS: u64 = 300;
 const DEFAULT_POLL_INTERVAL_MS: u64 = 1_000;
+
+/// Error prefix returned by `wait_for_run` when the attempt fence reveals the
+/// executor was superseded (reaper re-attached the task elsewhere). The
+/// background monitor exits without writing failure state on this error.
+const SUPERSEDED_ERROR_PREFIX: &str = "Superseded external agent poll for";
 const MAX_RESULT_CHARS: usize = 8_192;
 
 /// Outbound A2A delegation capability.
@@ -1044,12 +1049,15 @@ async fn wait_for_run(
 
     while Instant::now() < deadline {
         // Heartbeat through the registry so the reaper sees a live worker.
+        // A fence miss (returned attempt differs from ours) means the reaper
+        // superseded this executor — stop polling immediately so we never
+        // write failure state over the new attempt's work.
         if let (Some(attempt), Some(registry), Some(task_id)) = (
             heartbeat_attempt,
             &context.session_task_registry,
             record.task_id.as_deref(),
         ) {
-            let _ = registry
+            let heartbeat = registry
                 .update(
                     context.session_id,
                     task_id,
@@ -1060,6 +1068,14 @@ async fn wait_for_run(
                     },
                 )
                 .await;
+            if let Ok(Some(task)) = heartbeat
+                && task.attempt != attempt
+            {
+                return Err(format!(
+                    "{SUPERSEDED_ERROR_PREFIX} run {} (attempt {attempt} superseded by {})",
+                    record.run_id, task.attempt
+                ));
+            }
         }
 
         let task = client
@@ -1128,6 +1144,13 @@ async fn background_monitor(
     let record = match wait_for_run(&context, &agent, record, timeout_secs, heartbeat_attempt).await
     {
         Ok(record) => record,
+        // Superseded by a newer attempt (reaper re-attached the task to
+        // another executor): exit silently — the new owner reports state;
+        // writing failure here would overwrite its work.
+        Err(error) if error.starts_with(SUPERSEDED_ERROR_PREFIX) => {
+            tracing::info!(run_id = %run_id, "A2A background monitor superseded; exiting");
+            return;
+        }
         Err(error) => {
             let mut failed = load_run(&context, &run_id).await.unwrap_or(fallback_record);
             failed.status = AgentRunStatus::Failed;
@@ -2702,6 +2725,105 @@ mod tests {
             updated.state,
             SessionTaskState::Succeeded,
             "terminal run should mirror to succeeded"
+        );
+    }
+
+    /// A heartbeat fence miss (task attempt moved past ours) must abort the
+    /// poll loop with the superseded error before any remote call or write.
+    #[tokio::test]
+    async fn wait_for_run_exits_superseded_on_fence_miss() {
+        let storage = Arc::new(TestStorageStore::default());
+        let registry = Arc::new(InMemRegistry::default());
+        let session_id = crate::typed_id::SessionId::new();
+
+        let run_id = "run-superseded".to_string();
+        // Inline card so build_client performs no network discovery; the
+        // heartbeat fence check fires before any remote get_task call.
+        let inline_card = AgentCard {
+            name: "Echo".to_string(),
+            description: "Echo".to_string(),
+            version: "1".to_string(),
+            supported_interfaces: vec![AgentInterface::new(
+                "https://agent.example.com/api".to_string(),
+                "JSONRPC",
+            )],
+            capabilities: AgentCapabilities {
+                streaming: None,
+                push_notifications: None,
+                extensions: None,
+                extended_agent_card: None,
+            },
+            default_input_modes: vec![],
+            default_output_modes: vec![],
+            skills: vec![],
+            provider: None,
+            documentation_url: None,
+            icon_url: None,
+            security_schemes: None,
+            security_requirements: None,
+            signatures: None,
+        };
+        let config = ExternalA2aAgentConfig {
+            id: "echo".to_string(),
+            name: "Echo".to_string(),
+            description: None,
+            base_url: Some("https://agent.example.com".to_string()),
+            agent_card: Some(inline_card),
+            headers: BTreeMap::new(),
+            preferred_binding: None,
+            poll_interval_ms: None,
+            allow_local_urls: false,
+        };
+        let task_id = format!("task_{run_id}");
+
+        let mut record = AgentRunRecord::new(
+            run_id.clone(),
+            &config,
+            "instructions".to_string(),
+            AgentRunMode::Background,
+            false,
+        );
+        record.remote_task_id = Some("remote-xyz".to_string());
+        record.task_id = Some(task_id.clone());
+
+        // Task in the registry already at attempt 2 (reaper superseded us).
+        registry
+            .create(crate::session_task::CreateSessionTask {
+                session_id,
+                id: Some(task_id.clone()),
+                kind: TASK_KIND_EXTERNAL_AGENT.to_string(),
+                display_name: "Echo".to_string(),
+                spec: json!({ "run_id": &run_id }),
+                state: SessionTaskState::Running,
+                links: TaskLinks::default(),
+                wake_policy: TaskWakePolicy::Silent,
+            })
+            .await
+            .unwrap();
+        registry
+            .update(
+                session_id,
+                &task_id,
+                crate::session_task::SessionTaskUpdate {
+                    increment_attempt: true,
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+
+        let ctx = ToolContext::new(session_id)
+            .with_storage_store_arc(storage.clone() as Arc<dyn crate::traits::SessionStorageStore>)
+            .with_session_task_registry(registry.clone());
+
+        // Poll as the old executor (attempt 1): the first heartbeat reveals
+        // the supersession and the loop exits before any remote call.
+        let err = wait_for_run(&ctx, &config, record, 30, Some(1))
+            .await
+            .expect_err("superseded poll must error");
+        assert!(
+            err.starts_with(SUPERSEDED_ERROR_PREFIX),
+            "expected superseded error, got: {err}"
         );
     }
 

--- a/crates/core/src/session_task.rs
+++ b/crates/core/src/session_task.rs
@@ -645,7 +645,22 @@ pub trait SessionTaskRegistry: Send + Sync {
 pub trait TaskExecutor: Send + Sync {
     fn kind(&self) -> &str;
 
+    /// Whether this executor can re-attach to a running task after worker loss.
+    ///
+    /// Kinds returning `true` must implement `start` such that calling it with
+    /// a re-attached task snapshot (attempt already bumped by the reaper)
+    /// resumes the work idempotently and heartbeats with the new attempt.
+    /// Kinds returning `false` (the default) are failed as orphaned immediately
+    /// by the reaper.
+    fn can_reattach(&self) -> bool {
+        false
+    }
+
     /// Begin execution, or re-attach after worker loss.
+    ///
+    /// Called by the reaper when re-attaching a task (attempt already bumped).
+    /// Implementations must heartbeat using `task.attempt` so stale writes from
+    /// the previous executor are rejected by the fence.
     async fn start(&self, task: &SessionTask, context: &crate::traits::ToolContext) -> Result<()> {
         let _ = (task, context);
         Err(crate::error::AgentLoopError::tool(format!(

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -1443,12 +1443,14 @@ impl ToolContext {
     }
 
     /// Set the outbound egress service on this context when available.
-    /// A no-op when `service` is `None`.
+    /// Preserves any already-set service when `service` is `None`.
     pub fn with_egress_service_opt(
         mut self,
         service: Option<Arc<dyn crate::EgressService>>,
     ) -> Self {
-        self.egress_service = service;
+        if let Some(service) = service {
+            self.egress_service = Some(service);
+        }
         self
     }
 

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -1442,6 +1442,22 @@ impl ToolContext {
         self
     }
 
+    /// Set the outbound egress service on this context when available.
+    /// A no-op when `service` is `None`.
+    pub fn with_egress_service_opt(
+        mut self,
+        service: Option<Arc<dyn crate::EgressService>>,
+    ) -> Self {
+        self.egress_service = service;
+        self
+    }
+
+    /// Set the session storage store on this context (builder method).
+    pub fn with_storage_store_arc(mut self, store: Arc<dyn SessionStorageStore>) -> Self {
+        self.storage_store = Some(store);
+        self
+    }
+
     /// Add a session schedule store to this context.
     pub fn with_schedule_store(mut self, store: Arc<dyn SessionScheduleStore>) -> Self {
         self.schedule_store = Some(store);

--- a/crates/worker/src/session_task_reaper.rs
+++ b/crates/worker/src/session_task_reaper.rs
@@ -19,8 +19,8 @@
 //         (state stays running so the fence is correct).
 //      b. If update was accepted (attempt bumped): build a minimal ToolContext
 //         and call executor.start(&updated_task, &ctx).
-//      c. On start() error: log and fall back to failing as orphaned (the fence
-//         already incremented attempt, so we increment again here).
+//      c. On start() error: log and fall back to failing as orphaned, fenced
+//         on the already-bumped attempt (no further increment).
 //   4. Otherwise: fail as orphaned (existing path).
 
 use anyhow::Result;
@@ -306,6 +306,9 @@ pub async fn execute_reaper_activity<A: WorkerAdapters>(
                 kind: "orphaned".to_string(),
                 message: "worker heartbeat stopped".to_string(),
             }),
+            // Guard against a concurrent reaper double-bumping: only apply if
+            // the attempt still matches the snapshot we inspected.
+            expected_attempt: Some(task.attempt),
             // Supersede the executor's attempt so its fenced writes
             // (heartbeats, progress, messages) are rejected from now on.
             increment_attempt: true,
@@ -1022,8 +1025,8 @@ mod tests {
         let updated = registry.get(session_id, &task.id).await.unwrap().unwrap();
         assert_eq!(updated.state, SessionTaskState::Failed);
         assert_eq!(updated.error.as_ref().unwrap().kind, "orphaned");
-        // Attempt bumped twice: once for re-attach supersede, used in fail
-        // (expected_attempt=new_attempt matches so fail applies).
+        // Attempt bumped once (1 -> 2) by the re-attach supersede; the fail
+        // update is fenced on that bumped attempt and does not bump again.
         assert_eq!(updated.attempt, 2);
     }
 }

--- a/crates/worker/src/session_task_reaper.rs
+++ b/crates/worker/src/session_task_reaper.rs
@@ -2,15 +2,32 @@
 //
 // Decision: mirrors the leased-resource-cleanup activity end-to-end: same
 // durable schedule seeding, same cadence, same activity registration pattern.
-// The reaper finds tasks whose worker heartbeat has gone stale and fails them
-// via the registry so lifecycle invariants, events, and wake_policy all fire
-// exactly as they do for any other terminal transition.
+// The reaper finds tasks whose worker heartbeat has gone stale and either
+// re-attaches them (for kinds that support it, up to `max_attempts`) or fails
+// them via the registry so lifecycle invariants, events, and wake_policy all
+// fire exactly as they do for any other terminal transition.
 //
 // Tasks with NULL heartbeat_at are never reaped (foreground subagent tasks
 // are covered by EVE-535 spawn handles, not by this reconciler).
+//
+// Re-attach flow (per candidate):
+//   1. registry.get() to obtain the current task snapshot.
+//   2. find_task_executor(kind) → executor; skip if absent.
+//   3. If executor.can_reattach() and task.attempt < max_attempts:
+//      a. registry.update with expected_attempt=task.attempt, increment_attempt,
+//         heartbeat_at=now, worker_id="reaper", state_detail="re-attached (attempt N)"
+//         (state stays running so the fence is correct).
+//      b. If update was accepted (attempt bumped): build a minimal ToolContext
+//         and call executor.start(&updated_task, &ctx).
+//      c. On start() error: log and fall back to failing as orphaned (the fence
+//         already incremented attempt, so we increment again here).
+//   4. Otherwise: fail as orphaned (existing path).
 
 use anyhow::Result;
-use everruns_core::session_task::{SessionTaskState, SessionTaskUpdate, TaskError};
+use everruns_core::session_task::{
+    SessionTaskState, SessionTaskUpdate, TaskError, find_task_executor,
+};
+use everruns_core::traits::ToolContext;
 use serde::{Deserialize, Serialize};
 use tracing::{info, warn};
 
@@ -22,6 +39,9 @@ const DEFAULT_STALE_AFTER_SECONDS: i64 = 5 * 60; // 5 minutes
 /// How many orphaned tasks to process per reaper pass.
 const DEFAULT_LIMIT: i64 = 50;
 
+/// Default maximum re-attach attempts before a task is failed as orphaned.
+const DEFAULT_MAX_ATTEMPTS: i64 = 3;
+
 /// Durable activity input for the session-task reaper.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SessionTaskReaperInput {
@@ -29,6 +49,15 @@ pub struct SessionTaskReaperInput {
     pub stale_after_seconds: i64,
     /// Max tasks to reap per pass.
     pub limit: i64,
+    /// Maximum re-attach attempts before falling back to orphaned-fail.
+    /// Re-attachable kinds are re-started up to this many times total;
+    /// on the (max_attempts)th attempt they are failed as orphaned instead.
+    #[serde(default = "default_max_attempts")]
+    pub max_attempts: i64,
+}
+
+fn default_max_attempts() -> i64 {
+    DEFAULT_MAX_ATTEMPTS
 }
 
 impl Default for SessionTaskReaperInput {
@@ -36,6 +65,7 @@ impl Default for SessionTaskReaperInput {
         Self {
             stale_after_seconds: DEFAULT_STALE_AFTER_SECONDS,
             limit: DEFAULT_LIMIT,
+            max_attempts: DEFAULT_MAX_ATTEMPTS,
         }
     }
 }
@@ -52,15 +82,18 @@ struct ReapOutcome {
 struct ReapSummary {
     candidates: usize,
     reaped: usize,
+    reattached: usize,
     skipped: usize,
     outcomes: Vec<ReapOutcome>,
 }
 
 /// Execute one orphaned-session-task reconciliation pass.
 ///
-/// For each stale task the reaper calls `registry.update` with
-/// `state=Failed, error={kind:"orphaned"}` so lifecycle invariants hold and
-/// `task.updated` events + wake_policy fire via the registry.
+/// For each stale task the reaper either:
+/// - re-attaches (start on a new executor, attempt+1) if the kind supports it
+///   and the attempt count is below `max_attempts`; or
+/// - calls `registry.update` with `state=Failed, error={kind:"orphaned"}` so
+///   lifecycle invariants hold and `task.updated` events + wake_policy fire.
 pub async fn execute_reaper_activity<A: WorkerAdapters>(
     adapters: &A,
     input: &SessionTaskReaperInput,
@@ -76,11 +109,197 @@ pub async fn execute_reaper_activity<A: WorkerAdapters>(
     let mut summary = ReapSummary {
         candidates: candidates.len(),
         reaped: 0,
+        reattached: 0,
         skipped: 0,
         outcomes: Vec::with_capacity(candidates.len()),
     };
 
     for (session_id, task_id) in candidates {
+        // Fetch the current task snapshot so we can inspect kind and attempt.
+        let task = match registry.get(session_id, &task_id).await {
+            Ok(Some(t)) => t,
+            Ok(None) => {
+                summary.skipped += 1;
+                summary.outcomes.push(ReapOutcome {
+                    session_id: session_id.to_string(),
+                    task_id: task_id.clone(),
+                    status: "skipped".to_string(),
+                    detail: "task not found".to_string(),
+                });
+                continue;
+            }
+            Err(e) => {
+                warn!(
+                    session_id = %session_id,
+                    task_id = %task_id,
+                    error = %e,
+                    "Session task reaper: failed to get task"
+                );
+                summary.skipped += 1;
+                summary.outcomes.push(ReapOutcome {
+                    session_id: session_id.to_string(),
+                    task_id: task_id.clone(),
+                    status: "error".to_string(),
+                    detail: e.to_string(),
+                });
+                continue;
+            }
+        };
+
+        // Skip tasks that are already terminal (heartbeat query may race).
+        if task.state.is_terminal() {
+            summary.skipped += 1;
+            summary.outcomes.push(ReapOutcome {
+                session_id: session_id.to_string(),
+                task_id: task_id.clone(),
+                status: "skipped".to_string(),
+                detail: "already terminal".to_string(),
+            });
+            continue;
+        }
+
+        // Try to find a re-attachable executor for this kind.
+        let should_reattach = find_task_executor(&task.kind)
+            .is_some_and(|exec| exec.can_reattach())
+            && (task.attempt as i64) < input.max_attempts;
+
+        if should_reattach {
+            let new_attempt = task.attempt + 1;
+            let supersede_update = SessionTaskUpdate {
+                // Do not set state — keep running so the fence works correctly.
+                worker_id: Some("reaper".to_string()),
+                heartbeat_at: Some(chrono::Utc::now()),
+                state_detail: Some(format!("re-attached (attempt {new_attempt})")),
+                // Atomically guard against double-reap: only apply if the
+                // attempt hasn't already been bumped by another worker.
+                expected_attempt: Some(task.attempt),
+                increment_attempt: true,
+                ..Default::default()
+            };
+
+            let updated_task = match registry
+                .update(session_id, &task_id, supersede_update)
+                .await
+            {
+                Ok(Some(t)) if t.attempt == new_attempt => t,
+                Ok(_) => {
+                    // Fence fired — another reaper already processed this task.
+                    summary.skipped += 1;
+                    summary.outcomes.push(ReapOutcome {
+                        session_id: session_id.to_string(),
+                        task_id: task_id.clone(),
+                        status: "skipped".to_string(),
+                        detail: "superseded by concurrent reaper".to_string(),
+                    });
+                    continue;
+                }
+                Err(e) => {
+                    warn!(
+                        session_id = %session_id,
+                        task_id = %task_id,
+                        error = %e,
+                        "Session task reaper: failed to supersede task for re-attach"
+                    );
+                    summary.skipped += 1;
+                    summary.outcomes.push(ReapOutcome {
+                        session_id: session_id.to_string(),
+                        task_id: task_id.clone(),
+                        status: "error".to_string(),
+                        detail: e.to_string(),
+                    });
+                    continue;
+                }
+            };
+
+            // Build a minimal ToolContext for the executor.
+            let ctx = ToolContext::new(session_id)
+                .with_storage_store_arc(adapters.storage_store())
+                .with_session_task_registry(registry.clone())
+                .with_egress_service_opt(adapters.egress_service());
+
+            let executor = find_task_executor(&task.kind).expect("checked above");
+            match executor.start(&updated_task, &ctx).await {
+                Ok(()) => {
+                    info!(
+                        session_id = %session_id,
+                        task_id = %task_id,
+                        attempt = new_attempt,
+                        kind = %task.kind,
+                        "Session task reaper: re-attached task"
+                    );
+                    summary.reattached += 1;
+                    summary.outcomes.push(ReapOutcome {
+                        session_id: session_id.to_string(),
+                        task_id: task_id.clone(),
+                        status: "reattached".to_string(),
+                        detail: format!("re-attached at attempt {new_attempt}"),
+                    });
+                    continue;
+                }
+                Err(e) => {
+                    warn!(
+                        session_id = %session_id,
+                        task_id = %task_id,
+                        attempt = new_attempt,
+                        kind = %task.kind,
+                        error = %e,
+                        "Session task reaper: start() failed after re-attach; falling back to orphaned-fail"
+                    );
+                    // Fall through to the orphaned-fail path below.
+                    // The attempt was already incremented by the supersede update,
+                    // so we don't need to increment again — but we do need to set
+                    // the failed state. Use expected_attempt=new_attempt so the
+                    // fence matches the current attempt (we just bumped it).
+                    let fail_update = SessionTaskUpdate {
+                        state: Some(SessionTaskState::Failed),
+                        error: Some(TaskError {
+                            kind: "orphaned".to_string(),
+                            message: format!("worker heartbeat stopped; re-attach failed: {e}"),
+                        }),
+                        expected_attempt: Some(new_attempt),
+                        ..Default::default()
+                    };
+                    match registry.update(session_id, &task_id, fail_update).await {
+                        Ok(Some(t)) if t.state == SessionTaskState::Failed => {
+                            summary.reaped += 1;
+                            summary.outcomes.push(ReapOutcome {
+                                session_id: session_id.to_string(),
+                                task_id: task_id.clone(),
+                                status: "reaped".to_string(),
+                                detail: format!("marked failed: re-attach error: {e}"),
+                            });
+                        }
+                        Ok(_) => {
+                            summary.skipped += 1;
+                            summary.outcomes.push(ReapOutcome {
+                                session_id: session_id.to_string(),
+                                task_id: task_id.clone(),
+                                status: "skipped".to_string(),
+                                detail: "already terminal after re-attach failure".to_string(),
+                            });
+                        }
+                        Err(fe) => {
+                            warn!(
+                                session_id = %session_id,
+                                task_id = %task_id,
+                                error = %fe,
+                                "Session task reaper: failed to mark task as orphaned after re-attach failure"
+                            );
+                            summary.skipped += 1;
+                            summary.outcomes.push(ReapOutcome {
+                                session_id: session_id.to_string(),
+                                task_id: task_id.clone(),
+                                status: "error".to_string(),
+                                detail: fe.to_string(),
+                            });
+                        }
+                    }
+                    continue;
+                }
+            }
+        }
+
+        // Non-reattachable or attempts exhausted: fail as orphaned.
         let update = SessionTaskUpdate {
             state: Some(SessionTaskState::Failed),
             error: Some(TaskError {
@@ -139,6 +358,7 @@ pub async fn execute_reaper_activity<A: WorkerAdapters>(
     info!(
         candidates = summary.candidates,
         reaped = summary.reaped,
+        reattached = summary.reattached,
         skipped = summary.skipped,
         "Session task reaper pass completed"
     );
@@ -152,7 +372,7 @@ mod tests {
     use async_trait::async_trait;
     use everruns_core::session_task::{
         CreateSessionTask, NewTaskMessage, SessionTask, SessionTaskFilter, SessionTaskRegistry,
-        SessionTaskState, TaskLinks, TaskMessage, TaskWakePolicy, apply_task_update,
+        SessionTaskState, TaskExecutor, TaskLinks, TaskMessage, TaskWakePolicy, apply_task_update,
         new_session_task,
     };
     use everruns_core::{Result as CoreResult, SessionId};
@@ -236,25 +456,245 @@ mod tests {
         }
     }
 
-    // We only need list_orphaned_session_task_ids and reaper_session_task_registry.
-    // Inline the reaper logic in `run_reaper` rather than wiring a full WorkerAdapters
-    // stub (which would require many unrelated async methods).
+    // -------------------------------------------------------------------------
+    // Test executor: records start() calls, optionally fails them.
+    // -------------------------------------------------------------------------
 
-    async fn run_reaper(
+    const TEST_REATTACHABLE_KIND: &str = "test_reattachable";
+    const TEST_NON_REATTACHABLE_KIND: &str = "test_non_reattachable";
+    const TEST_START_FAIL_KIND: &str = "test_start_fail";
+
+    struct TestReattachableExecutor {
+        start_calls: Arc<Mutex<Vec<i32>>>, // records attempt numbers seen by start()
+    }
+
+    #[async_trait]
+    impl TaskExecutor for TestReattachableExecutor {
+        fn kind(&self) -> &str {
+            TEST_REATTACHABLE_KIND
+        }
+
+        fn can_reattach(&self) -> bool {
+            true
+        }
+
+        async fn start(
+            &self,
+            task: &SessionTask,
+            _context: &everruns_core::traits::ToolContext,
+        ) -> CoreResult<()> {
+            self.start_calls.lock().unwrap().push(task.attempt);
+            Ok(())
+        }
+
+        async fn cancel(
+            &self,
+            _task: &SessionTask,
+            _context: &everruns_core::traits::ToolContext,
+        ) -> CoreResult<()> {
+            Ok(())
+        }
+    }
+
+    struct TestNonReattachableExecutor;
+
+    #[async_trait]
+    impl TaskExecutor for TestNonReattachableExecutor {
+        fn kind(&self) -> &str {
+            TEST_NON_REATTACHABLE_KIND
+        }
+
+        async fn cancel(
+            &self,
+            _task: &SessionTask,
+            _context: &everruns_core::traits::ToolContext,
+        ) -> CoreResult<()> {
+            Ok(())
+        }
+    }
+
+    struct TestStartFailExecutor;
+
+    #[async_trait]
+    impl TaskExecutor for TestStartFailExecutor {
+        fn kind(&self) -> &str {
+            TEST_START_FAIL_KIND
+        }
+
+        fn can_reattach(&self) -> bool {
+            true
+        }
+
+        async fn start(
+            &self,
+            _task: &SessionTask,
+            _context: &everruns_core::traits::ToolContext,
+        ) -> CoreResult<()> {
+            Err(everruns_core::error::AgentLoopError::tool(
+                "simulated start failure",
+            ))
+        }
+
+        async fn cancel(
+            &self,
+            _task: &SessionTask,
+            _context: &everruns_core::traits::ToolContext,
+        ) -> CoreResult<()> {
+            Ok(())
+        }
+    }
+
+    // Minimal in-memory storage for test ToolContext construction.
+    #[derive(Default)]
+    struct MockStorageStore;
+
+    #[async_trait]
+    impl everruns_core::traits::SessionStorageStore for MockStorageStore {
+        async fn set_value(
+            &self,
+            _session_id: SessionId,
+            _key: &str,
+            _value: &str,
+        ) -> CoreResult<()> {
+            Ok(())
+        }
+
+        async fn get_value(
+            &self,
+            _session_id: SessionId,
+            _key: &str,
+        ) -> CoreResult<Option<String>> {
+            Ok(None)
+        }
+
+        async fn delete_value(&self, _session_id: SessionId, _key: &str) -> CoreResult<bool> {
+            Ok(false)
+        }
+
+        async fn list_keys(
+            &self,
+            _session_id: SessionId,
+        ) -> CoreResult<Vec<everruns_core::KeyInfo>> {
+            Ok(vec![])
+        }
+
+        async fn set_secret(
+            &self,
+            _session_id: SessionId,
+            _name: &str,
+            _value: &str,
+        ) -> CoreResult<()> {
+            Ok(())
+        }
+
+        async fn get_secret(
+            &self,
+            _session_id: SessionId,
+            _name: &str,
+        ) -> CoreResult<Option<String>> {
+            Ok(None)
+        }
+
+        async fn delete_secret(&self, _session_id: SessionId, _name: &str) -> CoreResult<bool> {
+            Ok(false)
+        }
+
+        async fn list_secrets(
+            &self,
+            _session_id: SessionId,
+        ) -> CoreResult<Vec<everruns_core::SecretInfo>> {
+            Ok(vec![])
+        }
+    }
+
+    // Helper: run the reaper logic inline, calling executors directly via the
+    // provided lookup function instead of inventory, so tests don't need
+    // `inventory::submit!` in a lib-test context.
+    async fn run_reaper_with_executor_lookup(
         orphans: Vec<(SessionId, String)>,
         registry: Arc<MockRegistry>,
         input: &SessionTaskReaperInput,
+        // executor_for(kind) → None means "not found / non-reattachable"
+        executor_for: impl Fn(&str) -> Option<Arc<dyn TaskExecutor>>,
     ) -> serde_json::Value {
-        // Inline the reaper logic using the mock data directly so we avoid
-        // needing a full WorkerAdapters impl (which drags in many unrelated
-        // async methods). This mirrors execute_reaper_activity exactly.
-        let stale_after = chrono::Duration::seconds(input.stale_after_seconds);
-        let _ = stale_after; // used only in the real adapters call
+        let storage: Arc<dyn everruns_core::traits::SessionStorageStore> =
+            Arc::new(MockStorageStore);
 
         let mut reaped = 0usize;
+        let mut reattached = 0usize;
         let mut skipped = 0usize;
 
         for (session_id, task_id) in &orphans {
+            // Get current task snapshot.
+            let task = match registry.get(*session_id, task_id).await {
+                Ok(Some(t)) => t,
+                _ => {
+                    skipped += 1;
+                    continue;
+                }
+            };
+
+            if task.state.is_terminal() {
+                skipped += 1;
+                continue;
+            }
+
+            let should_reattach = executor_for(&task.kind).is_some_and(|exec| exec.can_reattach())
+                && (task.attempt as i64) < input.max_attempts;
+
+            if should_reattach {
+                let new_attempt = task.attempt + 1;
+                let supersede = SessionTaskUpdate {
+                    worker_id: Some("reaper".to_string()),
+                    heartbeat_at: Some(chrono::Utc::now()),
+                    state_detail: Some(format!("re-attached (attempt {new_attempt})")),
+                    expected_attempt: Some(task.attempt),
+                    increment_attempt: true,
+                    ..Default::default()
+                };
+                let updated_task = match registry.update(*session_id, task_id, supersede).await {
+                    Ok(Some(t)) if t.attempt == new_attempt => t,
+                    _ => {
+                        skipped += 1;
+                        continue;
+                    }
+                };
+
+                let ctx = everruns_core::traits::ToolContext::new(*session_id)
+                    .with_storage_store_arc(storage.clone())
+                    .with_session_task_registry(registry.clone());
+
+                let executor = executor_for(&task.kind).unwrap();
+                match executor.start(&updated_task, &ctx).await {
+                    Ok(()) => {
+                        reattached += 1;
+                        continue;
+                    }
+                    Err(e) => {
+                        // Fall back to orphaned-fail.
+                        let fail = SessionTaskUpdate {
+                            state: Some(SessionTaskState::Failed),
+                            error: Some(TaskError {
+                                kind: "orphaned".to_string(),
+                                message: format!("worker heartbeat stopped; re-attach failed: {e}"),
+                            }),
+                            expected_attempt: Some(new_attempt),
+                            ..Default::default()
+                        };
+                        match registry.update(*session_id, task_id, fail).await {
+                            Ok(Some(t)) if t.state == SessionTaskState::Failed => {
+                                reaped += 1;
+                            }
+                            _ => {
+                                skipped += 1;
+                            }
+                        }
+                        continue;
+                    }
+                }
+            }
+
+            // Non-reattachable or exhausted: fail as orphaned.
             let update = SessionTaskUpdate {
                 state: Some(SessionTaskState::Failed),
                 error: Some(TaskError {
@@ -277,8 +717,19 @@ mod tests {
         serde_json::json!({
             "candidates": orphans.len(),
             "reaped": reaped,
+            "reattached": reattached,
             "skipped": skipped,
         })
+    }
+
+    // Legacy helper: original tests that don't need executor lookup.
+    async fn run_reaper(
+        orphans: Vec<(SessionId, String)>,
+        registry: Arc<MockRegistry>,
+        input: &SessionTaskReaperInput,
+    ) -> serde_json::Value {
+        // No executor registered for the background_tool kind in these tests.
+        run_reaper_with_executor_lookup(orphans, registry, input, |_| None).await
     }
 
     // -------------------------------------------------------------------------
@@ -364,5 +815,215 @@ mod tests {
         assert_eq!(result["candidates"], 0);
         assert_eq!(result["reaped"], 0);
         assert_eq!(result["skipped"], 0);
+    }
+
+    // -------------------------------------------------------------------------
+    // Re-attach tests
+    // -------------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn reaper_reattaches_reattachable_kind() {
+        let registry = Arc::new(MockRegistry::default());
+        let session_id = SessionId::new();
+        let start_calls = Arc::new(Mutex::new(Vec::<i32>::new()));
+        let start_calls_clone = start_calls.clone();
+
+        let task = registry
+            .create(CreateSessionTask {
+                session_id,
+                id: None,
+                kind: TEST_REATTACHABLE_KIND.to_string(),
+                display_name: "Re-attachable".to_string(),
+                spec: serde_json::json!({}),
+                state: SessionTaskState::Running,
+                links: TaskLinks::default(),
+                wake_policy: TaskWakePolicy::Silent,
+            })
+            .await
+            .unwrap();
+        assert_eq!(task.attempt, 1);
+
+        let orphans = vec![(session_id, task.id.clone())];
+        let input = SessionTaskReaperInput::default();
+        let result =
+            run_reaper_with_executor_lookup(orphans, registry.clone(), &input, move |kind| {
+                if kind == TEST_REATTACHABLE_KIND {
+                    Some(Arc::new(TestReattachableExecutor {
+                        start_calls: start_calls_clone.clone(),
+                    }) as Arc<dyn TaskExecutor>)
+                } else {
+                    None
+                }
+            })
+            .await;
+
+        assert_eq!(result["reattached"], 1, "should re-attach");
+        assert_eq!(result["reaped"], 0, "should not fail as orphaned");
+
+        let updated = registry.get(session_id, &task.id).await.unwrap().unwrap();
+        // Attempt bumped, state still running.
+        assert_eq!(updated.attempt, 2, "attempt must be bumped on re-attach");
+        assert_eq!(updated.state, SessionTaskState::Running);
+
+        // start() was called with the new attempt.
+        let calls = start_calls.lock().unwrap();
+        assert_eq!(*calls, vec![2i32]);
+    }
+
+    #[tokio::test]
+    async fn reaper_fails_non_reattachable_kind_as_orphaned() {
+        let registry = Arc::new(MockRegistry::default());
+        let session_id = SessionId::new();
+
+        let task = registry
+            .create(CreateSessionTask {
+                session_id,
+                id: None,
+                kind: TEST_NON_REATTACHABLE_KIND.to_string(),
+                display_name: "Non-reattachable".to_string(),
+                spec: serde_json::json!({}),
+                state: SessionTaskState::Running,
+                links: TaskLinks::default(),
+                wake_policy: TaskWakePolicy::Silent,
+            })
+            .await
+            .unwrap();
+
+        let orphans = vec![(session_id, task.id.clone())];
+        let input = SessionTaskReaperInput::default();
+        let result = run_reaper_with_executor_lookup(orphans, registry.clone(), &input, |kind| {
+            if kind == TEST_NON_REATTACHABLE_KIND {
+                Some(Arc::new(TestNonReattachableExecutor) as Arc<dyn TaskExecutor>)
+            } else {
+                None
+            }
+        })
+        .await;
+
+        assert_eq!(result["reaped"], 1, "should fail as orphaned");
+        assert_eq!(result["reattached"], 0);
+
+        let updated = registry.get(session_id, &task.id).await.unwrap().unwrap();
+        assert_eq!(updated.state, SessionTaskState::Failed);
+        assert_eq!(updated.error.as_ref().unwrap().kind, "orphaned");
+        assert_eq!(updated.attempt, 2);
+    }
+
+    #[tokio::test]
+    async fn reaper_fails_as_orphaned_when_attempts_exhausted() {
+        let registry = Arc::new(MockRegistry::default());
+        let session_id = SessionId::new();
+
+        // Create a task and manually bump its attempt to 3 (== max_attempts).
+        let task = registry
+            .create(CreateSessionTask {
+                session_id,
+                id: None,
+                kind: TEST_REATTACHABLE_KIND.to_string(),
+                display_name: "Exhausted".to_string(),
+                spec: serde_json::json!({}),
+                state: SessionTaskState::Running,
+                links: TaskLinks::default(),
+                wake_policy: TaskWakePolicy::Silent,
+            })
+            .await
+            .unwrap();
+        // Simulate two prior re-attaches (attempt = 3).
+        registry
+            .update(
+                session_id,
+                &task.id,
+                SessionTaskUpdate {
+                    increment_attempt: true,
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        registry
+            .update(
+                session_id,
+                &task.id,
+                SessionTaskUpdate {
+                    increment_attempt: true,
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        let task = registry.get(session_id, &task.id).await.unwrap().unwrap();
+        assert_eq!(task.attempt, 3);
+
+        let orphans = vec![(session_id, task.id.clone())];
+        // max_attempts = 3: attempt 3 >= 3 so no re-attach.
+        let input = SessionTaskReaperInput {
+            max_attempts: 3,
+            ..Default::default()
+        };
+        let result = run_reaper_with_executor_lookup(orphans, registry.clone(), &input, |kind| {
+            if kind == TEST_REATTACHABLE_KIND {
+                Some(Arc::new(TestReattachableExecutor {
+                    start_calls: Arc::new(Mutex::new(vec![])),
+                }) as Arc<dyn TaskExecutor>)
+            } else {
+                None
+            }
+        })
+        .await;
+
+        assert_eq!(
+            result["reaped"], 1,
+            "should fail as orphaned when exhausted"
+        );
+        assert_eq!(result["reattached"], 0);
+
+        let updated = registry.get(session_id, &task.id).await.unwrap().unwrap();
+        assert_eq!(updated.state, SessionTaskState::Failed);
+        assert_eq!(updated.error.as_ref().unwrap().kind, "orphaned");
+    }
+
+    #[tokio::test]
+    async fn reaper_falls_back_to_orphaned_fail_when_start_errors() {
+        let registry = Arc::new(MockRegistry::default());
+        let session_id = SessionId::new();
+
+        let task = registry
+            .create(CreateSessionTask {
+                session_id,
+                id: None,
+                kind: TEST_START_FAIL_KIND.to_string(),
+                display_name: "Fails on start".to_string(),
+                spec: serde_json::json!({}),
+                state: SessionTaskState::Running,
+                links: TaskLinks::default(),
+                wake_policy: TaskWakePolicy::Silent,
+            })
+            .await
+            .unwrap();
+
+        let orphans = vec![(session_id, task.id.clone())];
+        let input = SessionTaskReaperInput::default();
+        let result = run_reaper_with_executor_lookup(orphans, registry.clone(), &input, |kind| {
+            if kind == TEST_START_FAIL_KIND {
+                Some(Arc::new(TestStartFailExecutor) as Arc<dyn TaskExecutor>)
+            } else {
+                None
+            }
+        })
+        .await;
+
+        // Falls back to orphaned-fail.
+        assert_eq!(
+            result["reaped"], 1,
+            "should fail as orphaned after start error"
+        );
+        assert_eq!(result["reattached"], 0);
+
+        let updated = registry.get(session_id, &task.id).await.unwrap().unwrap();
+        assert_eq!(updated.state, SessionTaskState::Failed);
+        assert_eq!(updated.error.as_ref().unwrap().kind, "orphaned");
+        // Attempt bumped twice: once for re-attach supersede, used in fail
+        // (expected_attempt=new_attempt matches so fail applies).
+        assert_eq!(updated.attempt, 2);
     }
 }

--- a/specs/session-tasks.md
+++ b/specs/session-tasks.md
@@ -316,20 +316,37 @@ No backward compatibility is required; data migrates forward once:
 - Durability: `attempt`/`worker_id`/`heartbeat_at` are stored. The orphan
   reconciler (`session_task_reaper` durable activity, every 60 s) finds tasks
   with stale heartbeats (`heartbeat_at IS NOT NULL AND heartbeat_at < now -
-  5m`) and fails them via the registry using `FOR UPDATE SKIP LOCKED` on the
-  PG backend. Tasks with `NULL heartbeat_at` (foreground subagent tasks) are
-  excluded (covered by EVE-535 spawn handles). The reconciler now runs on gRPC
-  workers via the `ListOrphanedSessionTasks` RPC (added to the internal worker
-  protocol); `session_task_reaper` is included in the gRPC DurableWorker's
-  default activity types. Stale-attempt fencing is built: `SessionTaskUpdate`
-  carries an optional `expected_attempt` field; `apply_task_update` silently
-  drops any update where `expected_attempt` is set but does not match
-  `task.attempt`. When the reaper fails an orphan it sets `increment_attempt`,
-  bumping `task.attempt` so the superseded executor's heartbeats, state writes,
-  and message posts (`NewTaskMessage.expected_attempt`, enforced in
+  5m`) and, for re-attachable kinds, re-attaches them; otherwise fails them via
+  the registry using `FOR UPDATE SKIP LOCKED` on the PG backend. Tasks with
+  `NULL heartbeat_at` (foreground subagent tasks) are excluded (covered by
+  EVE-535 spawn handles). The reconciler now runs on gRPC workers via the
+  `ListOrphanedSessionTasks` RPC (added to the internal worker protocol);
+  `session_task_reaper` is included in the gRPC DurableWorker's default
+  activity types. Stale-attempt fencing is built: `SessionTaskUpdate` carries
+  an optional `expected_attempt` field; `apply_task_update` silently drops any
+  update where `expected_attempt` is set but does not match `task.attempt`.
+  When the reaper fails an orphan it sets `increment_attempt`, bumping
+  `task.attempt` so the superseded executor's heartbeats, state writes, and
+  message posts (`NewTaskMessage.expected_attempt`, enforced in
   `record_message`) are rejected. Writers that do not track attempts
   (e.g. `cancel_task` from the API) leave `expected_attempt: None` and are
-  unaffected. Re-attach (attempt+1 restart) remains deferred.
+  unaffected.
+- Re-attach: `TaskExecutor` now has `fn can_reattach(&self) -> bool` (default
+  `false`). Kinds returning `true` must implement `start` to resume idempotently
+  with the new attempt. The reaper re-attaches up to `max_attempts` (default 3,
+  configurable in `SessionTaskReaperInput`): it atomically supersedes with
+  `increment_attempt` + `expected_attempt` fence, builds a minimal `ToolContext`
+  (storage_store + registry + egress), calls `executor.start(&updated_task,
+  &ctx)`, and on `start` error falls back to orphaned-fail with the attempt
+  already bumped. On attempt ≥ max_attempts the task is failed as orphaned
+  immediately. `ExternalAgentTaskExecutor` (`external_agent` kind) implements
+  `can_reattach → true`: loads the `AgentRunRecord` from session storage; if
+  terminal mirrors the state and returns; if `remote_task_id` is absent returns
+  an error (caller falls back to orphaned); otherwise rebuilds the A2A client
+  and resumes `background_monitor` with `heartbeat_attempt = task.attempt`.
+  The background poll loop now heartbeats the registry on every poll iteration
+  when `heartbeat_attempt` is provided, fencing stale writes from superseded
+  executors. All other kinds still fail immediately as orphaned.
 - Wake-ups: `wake_policy` is enforced at the registry level
   (`DbSessionTaskRegistry`). `OnTerminal` wakes on any transition into
   `succeeded`/`failed`/`canceled`. `OnActivity` additionally wakes on


### PR DESCRIPTION
## What
Implements the re-attach half of the orphan reconciler contract in `specs/session-tasks.md`: instead of always failing stale-heartbeat tasks as `orphaned`, the `session_task_reaper` now resumes work for kinds that support it.

- `TaskExecutor::can_reattach()` (default false). `ExternalAgentTaskExecutor` opts in: `start()` reloads the persisted `AgentRunRecord` (`agent_run:{run_id}` KV), mirrors already-terminal runs (idempotent reconcile), errors when there's nothing to poll (no `remote_task_id`), and otherwise rebuilds the A2A client from the stored config snapshot and resumes the background poll loop.
- The reaper re-attaches up to `max_attempts` (default 3, on `SessionTaskReaperInput`): an `expected_attempt`-guarded `increment_attempt` supersede (state stays `running`, fresh heartbeat, `state_detail: "re-attached (attempt N)"`), then `executor.start()` with a minimal `ToolContext` built from `WorkerAdapters` (storage KV + reaper task registry + egress). Any error falls back to the existing fail-as-orphaned path. Other kinds (`background_tool`: side-effect duplication risk) still fail immediately.
- The A2A poll loop (fresh spawns and re-attaches) now heartbeats through the registry with `expected_attempt`, completing the fencing story from #2152: once the reaper bumps `attempt`, the dead executor's writes are rejected while the new one owns the task.

## Why
Remote A2A tasks keep running on the remote agent when our worker dies; failing them locally as `orphaned` loses real work. The `AgentRunRecord` already persists everything needed to resume polling (config snapshot, `remote_task_id`), so resumption is cheap and safe. This was the documented follow-up for which #2152's fencing was the prerequisite.

## How
Single shared poll loop (`wait_for_run`) gained an optional `heartbeat_attempt`; fresh spawns pass 1, re-attaches pass the bumped attempt, foreground waits pass None. Double-reap races are excluded by the `expected_attempt` guard on the supersede update (a second reaper's bump is dropped by the fence and reported as skipped).

## Risk
- Medium
- Re-attached polls run on the reaper's worker; a crash there re-orphans the task and the next pass re-attaches (bounded by `max_attempts`). A re-attached run gets a fresh poll timeout window. Worst-case behavior change for existing deployments: external_agent orphans now retry up to 2 times before failing — terminal outcome unchanged otherwise.

## Security
- Threat categories reviewed: TM-API/TM-DATA — no new RPCs or trust boundaries; `start()` consumes only the org's own persisted run record (non-secret headers by config schema contract) and reuses the existing A2A client/egress path. The reaper still only touches tasks surfaced by the heartbeat query.
- Findings and resolutions: none.

## Follow-ups
- Re-attach for other kinds (`background_tool` needs idempotency contracts) — deferred deliberately.
- `sessions.subagent_*` column retirement and `subagent.*` event retirement — unchanged backlog (see specs/session-tasks.md).

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_011yqDiQ2GyoDdwFQTFTw12R)_