### PR TITLE
test(ui): cover A2UI renderer parsing and URL allowlist

### DIFF
--- a/apps/ui/src/__tests__/a2ui-renderer.test.tsx
+++ b/apps/ui/src/__tests__/a2ui-renderer.test.tsx
@@ -1,0 +1,101 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { A2UIBlock } from "@/components/chat/a2ui-renderer";
+
+// A2UI blocks render inside session-scoped pages; mock the session context and
+// route params that useActionDispatch depends on so the component can render.
+const mockMutate = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useParams: () => ({ sessionId: "session_test" }),
+}));
+
+jest.mock("@/app/(main)/sessions/[sessionId]/session-context", () => ({
+  useSessionContext: () => ({ sendMessage: { mutate: mockMutate } }),
+}));
+
+function renderA2UI(node: unknown, isStreaming?: boolean) {
+  return render(<A2UIBlock code={JSON.stringify(node)} isStreaming={isStreaming} />);
+}
+
+beforeEach(() => {
+  mockMutate.mockClear();
+});
+
+describe("A2UIBlock structured rendering", () => {
+  it("renders a Heading's text", () => {
+    renderA2UI({ type: "Heading", props: { text: "Hello world" } });
+    expect(screen.getByText("Hello world")).toBeInTheDocument();
+  });
+
+  it("renders a Badge label nested inside a Stack", () => {
+    renderA2UI({
+      type: "Stack",
+      children: [{ type: "Badge", props: { label: "Beta" } }],
+    });
+    expect(screen.getByText("Beta")).toBeInTheDocument();
+  });
+});
+
+describe("A2UIBlock URL allowlist (THREAT[TM-WEB-A2UI-01])", () => {
+  it("renders an Image with a safe https src", () => {
+    renderA2UI({
+      type: "Image",
+      props: { src: "https://example.com/a.png", alt: "pic" },
+    });
+    const img = screen.getByRole("img");
+    expect(img).toHaveAttribute("src", "https://example.com/a.png");
+  });
+
+  it.each(["javascript:alert(1)", "data:text/html,<script>alert(1)</script>"])(
+    "does not render an Image for unsafe src %s",
+    (src) => {
+      renderA2UI({ type: "Image", props: { src, alt: "x" } });
+      expect(screen.queryByRole("img")).not.toBeInTheDocument();
+    },
+  );
+
+  it("opens a window for a Button open_url action with a safe url", () => {
+    const openSpy = jest.spyOn(window, "open").mockImplementation(() => null);
+    renderA2UI({
+      type: "Button",
+      props: { label: "Open", action: { type: "open_url", url: "https://example.com" } },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Open" }));
+
+    expect(openSpy).toHaveBeenCalledTimes(1);
+    expect(openSpy).toHaveBeenCalledWith("https://example.com", "_blank", "noopener,noreferrer");
+    openSpy.mockRestore();
+  });
+
+  it("does not open a window for a Button open_url action with an unsafe url", () => {
+    const openSpy = jest.spyOn(window, "open").mockImplementation(() => null);
+    renderA2UI({
+      type: "Button",
+      props: { label: "Bad", action: { type: "open_url", url: "javascript:alert(1)" } },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Bad" }));
+
+    expect(openSpy).not.toHaveBeenCalled();
+    openSpy.mockRestore();
+  });
+});
+
+describe("A2UIBlock parse fallbacks", () => {
+  it("shows the raw code when JSON is unrecoverable and not streaming", () => {
+    render(<A2UIBlock code="not json at all" />);
+    expect(screen.getByText("not json at all")).toBeInTheDocument();
+  });
+
+  it("shows a placeholder (not raw code) when unrecoverable JSON is still streaming", () => {
+    render(<A2UIBlock code="not json at all" isStreaming />);
+    expect(screen.getByText("…")).toBeInTheDocument();
+    expect(screen.queryByText("not json at all")).not.toBeInTheDocument();
+  });
+
+  it("renders nothing for empty code", () => {
+    const { container } = render(<A2UIBlock code="" />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/apps/ui/src/__tests__/a2ui-renderer.test.tsx
+++ b/apps/ui/src/__tests__/a2ui-renderer.test.tsx
@@ -21,6 +21,12 @@ beforeEach(() => {
   mockMutate.mockClear();
 });
 
+// Restore spies (e.g. window.open) even if a test throws before its own
+// mockRestore, so a leaked spy can't affect later tests.
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
 describe("A2UIBlock structured rendering", () => {
   it("renders a Heading's text", () => {
     renderA2UI({ type: "Heading", props: { text: "Hello world" } });


### PR DESCRIPTION
## What
Add a test suite for `A2UIBlock` (`components/chat/a2ui-renderer.tsx`), which previously had zero tests.

## Why
`A2UIBlock` renders **untrusted LLM-generated JSON** into live React UI inside chat — including images, interactive buttons, and forms — and contains a security-critical URL allowlist (`isSafeUrl`, tagged `THREAT[TM-WEB-A2UI-01]`). With no tests, any change to the parser, the URL guard, or the node switch could silently regress rendering or the security boundary.

## How
Tests-only; no source changes. Coverage (10 cases):
- **Structured rendering**: `Heading` text; `Badge` label nested in a `Stack`.
- **URL allowlist**: `Image` renders for a safe `https` src but not for `javascript:`/`data:` srcs; a `Button` `open_url` action calls `window.open(..., "noopener,noreferrer")` for a safe url and does **not** for `javascript:`.
- **Parse fallbacks**: unrecoverable JSON shows raw code when not streaming, shows a `…` placeholder when streaming, and empty code renders nothing.

The session context and route params that `useActionDispatch` depends on are mocked; clicks use `fireEvent` (the repo's existing pattern — no new test deps).

## Risk
- **Low** — adds tests only; no production code touched.

## Security
- Threat categories reviewed: **TM-WEB-A2UI** — these tests characterize and lock in the existing `isSafeUrl` allowlist behavior for both `Image` src and `open_url` actions. No code changed; no findings.

## Follow-ups
No follow-ups. (If new A2UI node types are added to `renderNode`, add a render assertion here so the switch stays covered.)

## Checklist
- [x] Tests added or updated (new `a2ui-renderer.test.tsx`, 10 cases)
- [x] Backward compatibility considered (no source changes)
- [x] Security review performed against relevant threat model categories (locks in TM-WEB-A2UI-01 URL guard)
- [x] Final CI ran checks affected by this PR (local: tests, lint, format green)
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MueCGvBuzcSifPXWudBuc9)_