### PR TITLE
chore(ui): type-check test files and gate in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1081,10 +1081,13 @@ jobs:
       - name: Lint
         run: pnpm run lint
 
+      - name: Type check
+        run: pnpm run typecheck
+
       - name: Run tests
         run: pnpm test
 
-      - name: Type check & build
+      - name: Build
         run: pnpm run build
 
   ui-e2e:

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -19,6 +19,7 @@
     "lint": "oxlint -c oxlint.json ./src",
     "format": "oxfmt --write ./src",
     "format:check": "oxfmt --check ./src",
+    "typecheck": "tsc --noEmit",
     "test": "jest",
     "test:watch": "jest --watch",
     "e2e": "playwright test",

--- a/apps/ui/src/__tests__/ag-ui-setup-guidance.test.tsx
+++ b/apps/ui/src/__tests__/ag-ui-setup-guidance.test.tsx
@@ -115,6 +115,7 @@ describe("formatSessionExpiration", () => {
         endpointUrl="https://example.com/api/v1/apps/app-123/ag-ui"
         isPublished={true}
         anonymousEnabled={true}
+        sessionExpirationSeconds={6 * 60 * 60}
         toolVisibility="generic"
         genericToolText="Working on it"
       />,

--- a/apps/ui/src/__tests__/agent-detail-model.test.tsx
+++ b/apps/ui/src/__tests__/agent-detail-model.test.tsx
@@ -66,6 +66,8 @@ const mockAgent: Agent = {
   status: "active",
   created_at: "2025-01-01T00:00:00Z",
   updated_at: "2025-01-01T00:00:00Z",
+  archived_at: null,
+  deleted_at: null,
 };
 
 // Session status: started → active → idle (cycles)
@@ -78,6 +80,7 @@ const mockSessions: Session[] = [
     organization_id: "org-1",
     harness_id: "harness-1",
     agent_id: "agent-1",
+    owner_principal_id: "principal_1",
     title: "Session with GPT-4o",
     tags: [],
     model_id: "model-1",
@@ -92,6 +95,7 @@ const mockSessions: Session[] = [
     organization_id: "org-1",
     harness_id: "harness-1",
     agent_id: "agent-1",
+    owner_principal_id: "principal_1",
     title: "Session with Claude",
     tags: [],
     model_id: "model-2",
@@ -106,6 +110,7 @@ const mockSessions: Session[] = [
     organization_id: "org-1",
     harness_id: "harness-1",
     agent_id: "agent-1",
+    owner_principal_id: "principal_1",
     title: "Session without model",
     tags: [],
     model_id: null,
@@ -130,6 +135,7 @@ const mockLlmModels: LlmModelWithProvider[] = [
     updated_at: "2025-01-01T00:00:00Z",
     provider_name: "OpenAI",
     provider_type: "openai",
+    is_favorite: false,
   },
   {
     id: "model-2",
@@ -143,6 +149,7 @@ const mockLlmModels: LlmModelWithProvider[] = [
     updated_at: "2025-01-01T00:00:00Z",
     provider_name: "Anthropic",
     provider_type: "anthropic",
+    is_favorite: false,
   },
 ];
 

--- a/apps/ui/src/__tests__/capability-settings-editor-localized.test.tsx
+++ b/apps/ui/src/__tests__/capability-settings-editor-localized.test.tsx
@@ -76,8 +76,8 @@ describe("translateValidationErrors", () => {
   it("maps known AJV keywords to localized catalog messages", () => {
     const errors = translateValidationErrors("uk", [
       { name: "required", message: "is a required property", stack: ".x is required" },
-      { name: "pattern", params: { pattern: "^mem_" }, message: "must match pattern" },
-      { name: "minimum", params: { limit: 1 }, message: "must be >= 1" },
+      { name: "pattern", params: { pattern: "^mem_" }, message: "must match pattern", stack: "" },
+      { name: "minimum", params: { limit: 1 }, message: "must be >= 1", stack: "" },
     ]);
 
     expect(errors[0].message).toBe(formatMessage("uk", "validation_required"));

--- a/apps/ui/src/__tests__/chat-panel.test.tsx
+++ b/apps/ui/src/__tests__/chat-panel.test.tsx
@@ -234,8 +234,8 @@ describe("ChatPanel compaction divider", () => {
       id: "evt-compacted-1",
       type: "context.compacted",
       session_id: "session-1",
-      turn_id: "turn-1",
-      created_at: new Date().toISOString(),
+      ts: new Date().toISOString(),
+      context: { turn_id: "turn-1" },
       data: {
         strategy_used: "observation_masking",
         messages_before: 42,
@@ -250,7 +250,7 @@ describe("ChatPanel compaction divider", () => {
         ],
       },
     };
-    mockSessionContext.chatEvents = [compactedEvent as unknown as Event];
+    mockSessionContext.chatEvents = [compactedEvent];
 
     render(<ChatPanel />);
 
@@ -264,8 +264,8 @@ describe("ChatPanel compaction divider", () => {
       id: "evt-compacted-2",
       type: "context.compacted",
       session_id: "session-1",
-      turn_id: "turn-1",
-      created_at: new Date().toISOString(),
+      ts: new Date().toISOString(),
+      context: { turn_id: "turn-1" },
       data: {
         strategy_used: "none",
         messages_before: 20,
@@ -274,7 +274,7 @@ describe("ChatPanel compaction divider", () => {
         steps: [],
       },
     };
-    mockSessionContext.chatEvents = [compactedEvent as unknown as Event];
+    mockSessionContext.chatEvents = [compactedEvent];
 
     render(<ChatPanel />);
 
@@ -289,8 +289,8 @@ describe("ChatPanel compaction divider", () => {
       id: "evt-compacted-3",
       type: "context.compacted",
       session_id: "session-1",
-      turn_id: "turn-1",
-      created_at: new Date().toISOString(),
+      ts: new Date().toISOString(),
+      context: { turn_id: "turn-1" },
       data: {
         strategy_used: "auto",
         messages_before: 100,
@@ -302,7 +302,7 @@ describe("ChatPanel compaction divider", () => {
         ],
       },
     };
-    mockSessionContext.chatEvents = [compactedEvent as unknown as Event];
+    mockSessionContext.chatEvents = [compactedEvent];
 
     render(<ChatPanel />);
 
@@ -369,15 +369,33 @@ describe("ChatPanel placeholder", () => {
   it("renders inline composer selects with non-native triggers to avoid nested picker chrome", () => {
     mockUseSessionCommands.mockReturnValue({ data: { commands: [] } });
     mockSessionContext.llmModel = {
+      id: "model-1",
+      provider_id: "provider-1",
+      model_id: "gpt-5.4",
       display_name: "GPT-5.4",
+      capabilities: ["chat"],
+      enabled: true,
+      healthy: true,
+      created_at: "2025-01-01T00:00:00Z",
+      updated_at: "2025-01-01T00:00:00Z",
+      provider_name: "OpenAI",
+      provider_type: "openai",
+      is_favorite: false,
       profile: {
+        name: "GPT-5.4",
+        family: "gpt-5",
+        attachment: false,
         reasoning: true,
+        temperature: true,
+        tool_call: true,
+        structured_output: true,
+        open_weights: false,
         reasoning_effort: {
           default: "medium",
           values: [{ value: "medium", name: "Medium" }],
         },
       },
-    } as unknown as LlmModelWithProvider;
+    };
 
     render(<ChatPanel />);
 
@@ -442,7 +460,7 @@ describe("ChatPanel placeholder", () => {
           error: "backend temporarily unavailable",
           error_code: "dependency_unavailable",
         },
-      } as unknown as Event,
+      },
     ];
 
     render(<ChatPanel />);
@@ -466,7 +484,7 @@ describe("ChatPanel placeholder", () => {
           turn_id: "turn-1",
           error: "provider token leaked in diagnostic payload",
         },
-      } as unknown as Event,
+      },
     ];
 
     render(<ChatPanel />);

--- a/apps/ui/src/__tests__/chat-panel.test.tsx
+++ b/apps/ui/src/__tests__/chat-panel.test.tsx
@@ -2,10 +2,11 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import React from "react";
 import { ChatPanel } from "@/components/chat/chat-panel";
 import { ApiError } from "@/lib/api/client";
+import type { Event, LlmModelWithProvider } from "@/lib/api/types";
 
 const mockUseSessionCommands = jest.fn();
 const mockExecuteSessionCommand = jest.fn();
-const mockUseFeatureFlag = jest.fn(() => false);
+const mockUseFeatureFlag = jest.fn((..._args: unknown[]) => false);
 const mockStartSessionVoice = jest.fn();
 const mockEndSessionVoice = jest.fn();
 const mockSelectTrigger = jest.fn(
@@ -24,8 +25,8 @@ const mockSessionContext = {
   agentId: "agent-1",
   events: [],
   sessionId: "session-1",
-  llmModel: null,
-  chatEvents: [],
+  llmModel: null as LlmModelWithProvider | null,
+  chatEvents: [] as Event[],
   toolResultsMap: new Map(),
   toolProgressMap: new Map(),
   toolOutputMap: new Map(),
@@ -249,7 +250,7 @@ describe("ChatPanel compaction divider", () => {
         ],
       },
     };
-    mockSessionContext.chatEvents = [compactedEvent];
+    mockSessionContext.chatEvents = [compactedEvent as unknown as Event];
 
     render(<ChatPanel />);
 
@@ -273,7 +274,7 @@ describe("ChatPanel compaction divider", () => {
         steps: [],
       },
     };
-    mockSessionContext.chatEvents = [compactedEvent];
+    mockSessionContext.chatEvents = [compactedEvent as unknown as Event];
 
     render(<ChatPanel />);
 
@@ -301,7 +302,7 @@ describe("ChatPanel compaction divider", () => {
         ],
       },
     };
-    mockSessionContext.chatEvents = [compactedEvent];
+    mockSessionContext.chatEvents = [compactedEvent as unknown as Event];
 
     render(<ChatPanel />);
 
@@ -376,7 +377,7 @@ describe("ChatPanel placeholder", () => {
           values: [{ value: "medium", name: "Medium" }],
         },
       },
-    };
+    } as unknown as LlmModelWithProvider;
 
     render(<ChatPanel />);
 
@@ -385,7 +386,7 @@ describe("ChatPanel placeholder", () => {
     for (const [triggerProps] of mockSelectTrigger.mock.calls) {
       expect(triggerProps?.nativeButton).toBe(false);
       expect(React.isValidElement(triggerProps?.render)).toBe(true);
-      expect(triggerProps?.render.type).toBe("div");
+      expect(triggerProps?.render?.type).toBe("div");
     }
   });
 
@@ -441,7 +442,7 @@ describe("ChatPanel placeholder", () => {
           error: "backend temporarily unavailable",
           error_code: "dependency_unavailable",
         },
-      },
+      } as unknown as Event,
     ];
 
     render(<ChatPanel />);
@@ -465,7 +466,7 @@ describe("ChatPanel placeholder", () => {
           turn_id: "turn-1",
           error: "provider token leaked in diagnostic payload",
         },
-      },
+      } as unknown as Event,
     ];
 
     render(<ChatPanel />);

--- a/apps/ui/src/__tests__/dropdown-menu.test.tsx
+++ b/apps/ui/src/__tests__/dropdown-menu.test.tsx
@@ -73,6 +73,6 @@ describe("DropdownMenuSubContent", () => {
     expect(positioner).not.toBeNull();
     expect(positioner).toHaveClass("z-50");
     expect(portal).not.toBeNull();
-    expect(portal).toContainElement(positioner);
+    expect(portal).toContainElement(positioner as HTMLElement | null);
   });
 });

--- a/apps/ui/src/__tests__/main-layout-auth.test.tsx
+++ b/apps/ui/src/__tests__/main-layout-auth.test.tsx
@@ -8,7 +8,12 @@ const mockPathname = jest.fn();
 const mockSearchParams = jest.fn();
 
 const authState = {
-  config: { mode: "password", oauth_providers: [] } as unknown as AuthConfigResponse | undefined,
+  config: {
+    mode: "full",
+    password_auth_enabled: true,
+    oauth_providers: [],
+    signup_enabled: false,
+  } as AuthConfigResponse | undefined,
   configLoading: false,
   configError: null as Error | null,
   user: {
@@ -74,9 +79,11 @@ describe("MainLayout auth availability", () => {
     mockSearchParams.mockReturnValue(new URLSearchParams("tab=models"));
 
     authState.config = {
-      mode: "password",
+      mode: "full",
+      password_auth_enabled: true,
       oauth_providers: [],
-    } as unknown as AuthConfigResponse;
+      signup_enabled: false,
+    };
     authState.configLoading = false;
     authState.configError = null;
     authState.user = {

--- a/apps/ui/src/__tests__/main-layout-auth.test.tsx
+++ b/apps/ui/src/__tests__/main-layout-auth.test.tsx
@@ -1,16 +1,22 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import { ApiError } from "@/lib/api/client";
 import MainLayout from "@/app/(main)/layout";
+import type { AuthConfigResponse, UserInfoResponse } from "@/lib/api/types";
 
 const mockReplace = jest.fn();
 const mockPathname = jest.fn();
 const mockSearchParams = jest.fn();
 
 const authState = {
-  config: { mode: "password", oauth_providers: [] },
+  config: { mode: "password", oauth_providers: [] } as unknown as AuthConfigResponse | undefined,
   configLoading: false,
   configError: null as Error | null,
-  user: { id: "user-1", email: "test@example.com", name: "Test User", roles: ["user"] },
+  user: {
+    id: "user-1",
+    email: "test@example.com",
+    name: "Test User",
+    roles: ["user"],
+  } as UserInfoResponse | null | undefined,
   userLoading: false,
   userError: null as Error | null,
   isAuthenticated: true,
@@ -67,7 +73,10 @@ describe("MainLayout auth availability", () => {
     mockPathname.mockReturnValue("/settings/providers");
     mockSearchParams.mockReturnValue(new URLSearchParams("tab=models"));
 
-    authState.config = { mode: "password", oauth_providers: [] };
+    authState.config = {
+      mode: "password",
+      oauth_providers: [],
+    } as unknown as AuthConfigResponse;
     authState.configLoading = false;
     authState.configError = null;
     authState.user = {

--- a/apps/ui/src/__tests__/middleware.test.ts
+++ b/apps/ui/src/__tests__/middleware.test.ts
@@ -20,7 +20,7 @@ describe("auth proxy", () => {
       cookies: { has: () => false },
       nextUrl: new URL("http://localhost/settings/providers?tab=models"),
       url: "http://localhost/settings/providers?tab=models",
-    } as Parameters<typeof proxy>[0];
+    } as unknown as Parameters<typeof proxy>[0];
 
     const response = proxy(request);
 
@@ -39,7 +39,7 @@ describe("auth proxy", () => {
         cookies: { has: () => false },
         nextUrl: new URL(`http://localhost${path}`),
         url: `http://localhost${path}`,
-      } as Parameters<typeof proxy>[0];
+      } as unknown as Parameters<typeof proxy>[0];
 
       const response = proxy(request);
 
@@ -53,7 +53,7 @@ describe("auth proxy", () => {
       cookies: { has: (name: string) => name === "access_token" },
       nextUrl: new URL("http://localhost/settings/providers?tab=models"),
       url: "http://localhost/settings/providers?tab=models",
-    } as Parameters<typeof proxy>[0];
+    } as unknown as Parameters<typeof proxy>[0];
 
     const response = proxy(request);
 
@@ -66,7 +66,7 @@ describe("auth proxy", () => {
       cookies: { has: () => false },
       nextUrl: new URL("http://localhost/"),
       url: "http://localhost/",
-    } as Parameters<typeof proxy>[0];
+    } as unknown as Parameters<typeof proxy>[0];
 
     const response = proxy(request);
 

--- a/apps/ui/src/__tests__/recent-sessions.test.tsx
+++ b/apps/ui/src/__tests__/recent-sessions.test.tsx
@@ -9,6 +9,7 @@ function createSession(overrides?: Partial<Session>): Session {
     organization_id: "default",
     harness_id: "harness-1",
     agent_id: "agent-1",
+    owner_principal_id: "principal_1",
     title: "Test Session",
     tags: [],
     model_id: null,
@@ -26,13 +27,17 @@ function createAgent(overrides?: Partial<Agent>): Agent {
   return {
     id: "agent-1",
     name: "Test Agent",
+    display_name: null,
     description: null,
     system_prompt: "You are helpful",
     default_model_id: null,
     tags: [],
+    capabilities: [],
     status: "active",
     created_at: "2025-01-01T00:00:00Z",
     updated_at: "2025-01-01T00:00:00Z",
+    archived_at: null,
+    deleted_at: null,
     ...overrides,
   };
 }
@@ -51,6 +56,7 @@ function createLlmModel(overrides?: Partial<LlmModelWithProvider>): LlmModelWith
     updated_at: "2025-01-01T00:00:00Z",
     provider_name: "OpenAI",
     provider_type: "openai",
+    is_favorite: false,
     ...overrides,
   };
 }

--- a/apps/ui/src/__tests__/session-detail-model.test.tsx
+++ b/apps/ui/src/__tests__/session-detail-model.test.tsx
@@ -41,6 +41,7 @@ const mockLlmModel: LlmModelWithProvider = {
   updated_at: "2025-01-01T00:00:00Z",
   provider_name: "OpenAI",
   provider_type: "openai",
+  is_favorite: false,
 };
 
 describe("SessionCard - LLM Model Display", () => {

--- a/apps/ui/src/__tests__/sidebar.test.tsx
+++ b/apps/ui/src/__tests__/sidebar.test.tsx
@@ -86,7 +86,10 @@ jest.mock("@/hooks/use-llm-providers", () => ({
 
 const mockUsePolicies = jest.fn(() => ({
   data: { policies: { "durable.view": true } },
-  can: (policyId: string) => policyId === "durable.view",
+  // Annotate the return as boolean so it matches the real usePolicies().can
+  // signature; without it, TS 5.5+ infers a `policyId is "durable.view"`
+  // predicate from the comparison, which then rejects plain boolean mocks.
+  can: (policyId: string): boolean => policyId === "durable.view",
 }));
 jest.mock("@/hooks/use-policies", () => ({
   usePolicies: () => mockUsePolicies(),
@@ -345,7 +348,7 @@ describe("Sidebar", () => {
   it("hides Durable Execution when durable policy is denied", () => {
     mockUsePolicies.mockReturnValue({
       data: { policies: { "durable.view": false } },
-      can: (_policyId: string): _policyId is "durable.view" => false,
+      can: () => false,
     });
 
     render(<Sidebar />);

--- a/apps/ui/src/__tests__/sidebar.test.tsx
+++ b/apps/ui/src/__tests__/sidebar.test.tsx
@@ -345,7 +345,7 @@ describe("Sidebar", () => {
   it("hides Durable Execution when durable policy is denied", () => {
     mockUsePolicies.mockReturnValue({
       data: { policies: { "durable.view": false } },
-      can: () => false,
+      can: (_policyId: string): _policyId is "durable.view" => false,
     });
 
     render(<Sidebar />);

--- a/apps/ui/src/__tests__/slack-setup-guidance.test.tsx
+++ b/apps/ui/src/__tests__/slack-setup-guidance.test.tsx
@@ -5,6 +5,8 @@ describe("SlackSetupGuidance", () => {
   const baseProps = {
     hasSlackConfig: true,
     isPublished: false,
+    webhookVerified: false,
+    firstMessageReceived: false,
     webhookUrl: "https://example.com/api/v1/apps/app-123/slack/events",
     webhookPath: "/api/v1/apps/app-123/slack/events",
     isLocalhost: false,

--- a/apps/ui/src/__tests__/use-apps.test.tsx
+++ b/apps/ui/src/__tests__/use-apps.test.tsx
@@ -46,6 +46,9 @@ function makeApp(overrides: Partial<App> = {}): App {
     description: "Slack bot",
     harness_id: "hrs-123",
     agent_id: "agt-123",
+    agent_version_policy: "default",
+    agent_version_id: null,
+    owner_principal_id: "principal_1",
     channels: [
       {
         id: "appchan-123",

--- a/apps/ui/src/__tests__/use-auth.test.tsx
+++ b/apps/ui/src/__tests__/use-auth.test.tsx
@@ -428,8 +428,8 @@ describe("Auth Hooks", () => {
           name: "Default Key",
           token_prefix: "evr_default",
           scopes: ["*"],
-          expires_at: null,
-          last_used_at: null,
+          expires_at: undefined,
+          last_used_at: undefined,
           created_at: "2024-01-01T00:00:00Z",
         },
       ]);
@@ -455,8 +455,8 @@ describe("Auth Hooks", () => {
           name: "Second Key",
           token_prefix: "evr_second",
           scopes: ["*"],
-          expires_at: null,
-          last_used_at: null,
+          expires_at: undefined,
+          last_used_at: undefined,
           created_at: "2024-01-02T00:00:00Z",
         },
       ]);
@@ -485,7 +485,7 @@ describe("Auth Hooks", () => {
         token: "evr_pat_secret",
         token_prefix: "evr_pat_created",
         scopes: ["*"],
-        expires_at: null,
+        expires_at: undefined,
         created_at: "2024-01-01T00:00:00Z",
       });
 

--- a/apps/ui/src/__tests__/use-page-title.test.ts
+++ b/apps/ui/src/__tests__/use-page-title.test.ts
@@ -25,7 +25,7 @@ describe("usePageTitle", () => {
     const { rerender } = renderHook(
       ({ name }: { name: string | null }) => usePageTitle(name, "Agent"),
       {
-        initialProps: { name: null },
+        initialProps: { name: null } as { name: string | null },
       },
     );
     expect(document.title).toBe("Agent · Everruns");

--- a/apps/ui/src/lib/__tests__/ui-route-manifest.test.ts
+++ b/apps/ui/src/lib/__tests__/ui-route-manifest.test.ts
@@ -99,7 +99,7 @@ describe("mergeUiRouteManifests", () => {
     const base = {
       version: 1 as const,
       sourcePackage: "everruns-ui",
-      appDir: "src/app",
+      appDir: "src/app" as const,
       artifacts: [
         {
           artifactId: "/(main)/dashboard:page.tsx",
@@ -116,7 +116,7 @@ describe("mergeUiRouteManifests", () => {
     const wrapper = {
       version: 1 as const,
       sourcePackage: "wrapper-ui",
-      appDir: "src/app",
+      appDir: "src/app" as const,
       artifacts: [
         {
           artifactId: "/(main)/dashboard:page.tsx",

--- a/apps/ui/tsconfig.json
+++ b/apps/ui/tsconfig.json
@@ -20,7 +20,8 @@
     ],
     "paths": {
       "@/*": ["./src/*"]
-    }
+    },
+    "types": ["node", "jest", "@testing-library/jest-dom"]
   },
   "include": [
     "next-env.d.ts",


### PR DESCRIPTION
## What
Make the whole `apps/ui` project type-check (including test files), add a `typecheck` script, wire a dedicated `Type check` step into CI, and fix the 41 latent type errors this surfaced in test fixtures.

## Why
The audit's original premise ("CI doesn't type-check the UI") turned out to be only half true:
- **App source** *is* already type-checked in CI via `next build` (the `ui-build` job's build step, and `next.config` doesn't set `ignoreBuildErrors`).
- **Test files are type-checked nowhere.** `next build` skips them, and there was no `tsc` script. As a result **41 test mocks had silently drifted from the production types** — e.g. `Session` mocks missing `owner_principal_id`, `LlmModelWithProvider` missing `is_favorite`, `Agent` missing `archived_at`/`deleted_at`, and PAT mocks using `null` where the type only allows `string | undefined`.

Tests asserting against wrong-shaped fixtures can hide real breakages (a test passes against a mock that no longer matches what the component receives at runtime). This PR closes that gap and prevents recurrence.

## How
- `tsconfig.json`: add `"types": ["node", "jest", "@testing-library/jest-dom"]` so jest/jest-dom globals resolve (they weren't being auto-included under pnpm's layout).
- `package.json`: add `"typecheck": "tsc --noEmit"` (covers the whole project, tests included).
- `.github/workflows/ci.yml`: add a dedicated `Type check` step to `ui-build` (it catches test files, which `next build` does not), and rename the build step accordingly.
- Fix all 41 test-fixture type errors. **Test-only changes — no production source modified, no assertions or expected values changed.** Fixes are: adding missing required fields with type-correct values; `as const` for literal-typed fields; type-guard signatures for mock predicates; and `as unknown as <Type>` only for deliberately partial stand-ins of large union/framework types (e.g. `NextRequest`, the `Event` union, partial auth responses).

## Risk
- **Low** — production code is untouched; the only behavioral surface is test fixtures, and the full suite stays green. The `types` array was verified not to affect `next build`.

## Security
- Threat categories reviewed: none applicable — tooling/config + test fixtures only; no auth/API/data-flow code changed.
- Findings and resolutions: none.

## Follow-ups
No follow-ups. (The drift this surfaced is now prevented by the CI gate.)

## Checklist
- [x] Tests added or updated (41 fixtures corrected; full suite passes)
- [x] Backward compatibility considered (no production/API changes)
- [x] Security review performed against relevant threat model categories (n/a, justified)
- [x] Final CI ran checks affected by this PR (local: `pnpm run typecheck` 0 errors, 895/895 tests, lint, format, `next build` all green)
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MueCGvBuzcSifPXWudBuc9)_