### PR TITLE
feat(core): open LLM driver model for embedder-defined providers

### DIFF
--- a/crates/anthropic/src/driver.rs
+++ b/crates/anthropic/src/driver.rs
@@ -963,8 +963,9 @@ impl std::fmt::Debug for AnthropicLlmDriver {
 /// register_driver(&mut registry);
 /// ```
 pub fn register_driver(registry: &mut DriverRegistry) {
-    registry.register(ProviderType::Anthropic, |api_key, base_url| {
-        let driver = match base_url {
+    registry.register(ProviderType::Anthropic, |config| {
+        let api_key = config.api_key.as_deref().unwrap_or("");
+        let driver = match config.base_url.as_deref() {
             Some(url) => AnthropicLlmDriver::with_base_url(api_key, url),
             None => AnthropicLlmDriver::new(api_key),
         };

--- a/crates/bedrock/src/driver.rs
+++ b/crates/bedrock/src/driver.rs
@@ -70,13 +70,13 @@ impl BedrockLlmDriver {
 
 /// Register the Bedrock driver with the given registry.
 pub fn register_driver(registry: &mut DriverRegistry) {
-    registry.register(
-        ProviderType::Bedrock,
-        |api_key, _base_url| match BedrockLlmDriver::new(api_key) {
+    registry.register(ProviderType::Bedrock, |config| {
+        let api_key = config.api_key.as_deref().unwrap_or("");
+        match BedrockLlmDriver::new(api_key) {
             Ok(driver) => Box::new(driver) as BoxedLlmDriver,
             Err(e) => Box::new(FailDriver(e.to_string())) as BoxedLlmDriver,
-        },
-    );
+        }
+    });
 }
 
 /// Driver that immediately fails with a credential error.

--- a/crates/core/src/command_host.rs
+++ b/crates/core/src/command_host.rs
@@ -650,6 +650,7 @@ mod tests {
                 provider_type: LlmProviderType::LlmSim,
                 api_key: Some("fake-key".into()),
                 base_url: None,
+                provider_metadata: None,
             })
             .await;
 
@@ -658,7 +659,7 @@ mod tests {
 
         let mut driver_registry = DriverRegistry::new();
         let driver = LlmSimDriver::new(LlmSimConfig::fixed(response));
-        driver_registry.register(ProviderType::LlmSim, move |_api_key, _base_url| {
+        driver_registry.register(ProviderType::LlmSim, move |_config| {
             Box::new(driver.clone())
         });
 

--- a/crates/core/src/in_memory.rs
+++ b/crates/core/src/in_memory.rs
@@ -360,6 +360,7 @@ impl InMemoryLlmProviderStore {
                 provider_type: LlmProviderType::Openai,
                 api_key: Some(api_key),
                 base_url: std::env::var("OPENAI_BASE_URL").ok(),
+                provider_metadata: None,
             };
             store.set_default_model(model).await;
         } else if let Ok(api_key) = std::env::var("ANTHROPIC_API_KEY") {
@@ -368,6 +369,7 @@ impl InMemoryLlmProviderStore {
                 provider_type: LlmProviderType::Anthropic,
                 api_key: Some(api_key),
                 base_url: std::env::var("ANTHROPIC_BASE_URL").ok(),
+                provider_metadata: None,
             };
             store.set_default_model(model).await;
         }

--- a/crates/core/src/in_memory_loop.rs
+++ b/crates/core/src/in_memory_loop.rs
@@ -443,6 +443,7 @@ impl InMemoryAgenticLoopBuilder {
                     provider_type: LlmProviderType::LlmSim,
                     api_key: Some("fake-key".to_string()),
                     base_url: None,
+                    provider_metadata: None,
                 };
                 provider_store.set_default_model(model).await;
 
@@ -451,7 +452,7 @@ impl InMemoryAgenticLoopBuilder {
                 // because the Arc counters are shared.
                 let driver = LlmSimDriver::new(config);
                 let mut registry = DriverRegistry::new();
-                registry.register(ProviderType::LlmSim, move |_api_key, _base_url| {
+                registry.register(ProviderType::LlmSim, move |_config| {
                     Box::new(driver.clone())
                 });
                 registry

--- a/crates/core/src/llm_driver_registry.rs
+++ b/crates/core/src/llm_driver_registry.rs
@@ -1306,7 +1306,8 @@ impl DriverRegistry {
     where
         F: Fn(&DriverConfig) -> BoxedLlmDriver + Send + Sync + 'static,
     {
-        self.factories.insert(provider_type.into(), Arc::new(factory));
+        self.factories
+            .insert(provider_type.into(), Arc::new(factory));
     }
 
     /// Register a driver factory for an embedder-defined external provider,
@@ -1737,11 +1738,12 @@ mod tests {
         assert!(registry.has_driver(&ProviderType::external("openai-codex")));
 
         // No api_key required for external providers.
-        let config = ProviderConfig::new(ProviderType::external("openai-codex"))
-            .with_metadata(ProviderMetadata {
+        let config = ProviderConfig::new(ProviderType::external("openai-codex")).with_metadata(
+            ProviderMetadata {
                 refresh_token: Some("rt".into()),
                 ..Default::default()
-            });
+            },
+        );
         assert!(registry.create_driver(&config).is_ok());
     }
 

--- a/crates/core/src/llm_driver_registry.rs
+++ b/crates/core/src/llm_driver_registry.rs
@@ -1080,13 +1080,22 @@ pub enum ProviderType {
 impl ProviderType {
     /// Construct an external provider type from its canonical id.
     ///
+    /// The id is normalized to lowercase so registration and lookup match
+    /// case-insensitively, consistent with built-in parsing.
+    ///
     /// ```
     /// use everruns_core::llm_driver_registry::ProviderType;
-    /// let p = ProviderType::external("openai-codex");
+    /// let p = ProviderType::external("OpenAI-Codex");
     /// assert_eq!(p.as_str(), "openai-codex");
     /// ```
     pub fn external(id: impl Into<Arc<str>>) -> Self {
-        ProviderType::External(id.into())
+        let id: Arc<str> = id.into();
+        // Avoid reallocating when the id is already lowercase.
+        if id.bytes().any(|b| b.is_ascii_uppercase()) {
+            ProviderType::External(Arc::from(id.to_lowercase().as_str()))
+        } else {
+            ProviderType::External(id)
+        }
     }
 
     /// Canonical string identifier for this provider.
@@ -1110,7 +1119,10 @@ impl std::str::FromStr for ProviderType {
     type Err = std::convert::Infallible;
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
-        Ok(match s.to_lowercase().as_str() {
+        // Normalize once: built-in matching and the External id share the same
+        // lowercased form so casing variance never produces duplicate externals.
+        let lower = s.to_lowercase();
+        Ok(match lower.as_str() {
             "openai" => ProviderType::OpenAI,
             "openrouter" => ProviderType::OpenRouter,
             "azure_openai" => ProviderType::AzureOpenAI,
@@ -1119,7 +1131,7 @@ impl std::str::FromStr for ProviderType {
             "gemini" => ProviderType::Gemini,
             "llmsim" => ProviderType::LlmSim,
             "bedrock" => ProviderType::Bedrock,
-            _ => ProviderType::External(Arc::from(s)),
+            _ => ProviderType::External(Arc::from(lower.as_str())),
         })
     }
 }
@@ -1311,12 +1323,14 @@ impl DriverRegistry {
     }
 
     /// Register a driver factory for an embedder-defined external provider,
-    /// keyed by its canonical id.
+    /// keyed by its canonical id. The id is normalized to lowercase (via
+    /// [`ProviderType::external`]) so it matches parsed lookups regardless of
+    /// the casing stored in the database or sent on the wire.
     pub fn register_external<F>(&mut self, id: impl Into<Arc<str>>, factory: F)
     where
         F: Fn(&DriverConfig) -> BoxedLlmDriver + Send + Sync + 'static,
     {
-        self.register(ProviderType::External(id.into()), factory);
+        self.register(ProviderType::external(id), factory);
     }
 
     /// Create an LLM driver based on configuration
@@ -1615,6 +1629,29 @@ mod tests {
         assert_eq!(
             "custom".parse::<ProviderType>().unwrap(),
             ProviderType::external("custom")
+        );
+    }
+
+    #[test]
+    fn test_external_provider_id_is_case_insensitive() {
+        // Built-in matching and external normalization are both case-folding,
+        // so the same id in different casing resolves to one provider.
+        assert_eq!(
+            "OpenAI".parse::<ProviderType>().unwrap(),
+            ProviderType::OpenAI
+        );
+        assert_eq!(
+            "Ollama".parse::<ProviderType>().unwrap(),
+            "ollama".parse::<ProviderType>().unwrap()
+        );
+        assert_eq!(
+            ProviderType::external("OpenAI-Codex").as_str(),
+            "openai-codex"
+        );
+        // Registration and parsed lookup agree regardless of casing.
+        assert_eq!(
+            ProviderType::external("MyProvider"),
+            "myprovider".parse::<ProviderType>().unwrap()
         );
     }
 

--- a/crates/core/src/llm_driver_registry.rs
+++ b/crates/core/src/llm_driver_registry.rs
@@ -1049,7 +1049,11 @@ impl LlmMessage {
 // Driver Factory Types
 // ============================================================================
 
-/// Provider type enumeration matching the database/contracts
+/// Provider type enumeration matching the database/contracts.
+///
+/// Built-in variants are compiled into everruns. [`ProviderType::External`]
+/// (or [`ProviderType::external`]) identifies providers an embedder defines and
+/// registers itself, keyed by their canonical wire id.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ProviderType {
     /// OpenAI using Open Responses API (<https://www.openresponses.org/>)
@@ -1069,39 +1073,76 @@ pub enum ProviderType {
     LlmSim,
     /// AWS Bedrock Runtime (ConverseStream API)
     Bedrock,
+    /// Embedder-defined provider identified by its canonical wire id.
+    External(Arc<str>),
+}
+
+impl ProviderType {
+    /// Construct an external provider type from its canonical id.
+    ///
+    /// ```
+    /// use everruns_core::llm_driver_registry::ProviderType;
+    /// let p = ProviderType::external("openai-codex");
+    /// assert_eq!(p.as_str(), "openai-codex");
+    /// ```
+    pub fn external(id: impl Into<Arc<str>>) -> Self {
+        ProviderType::External(id.into())
+    }
+
+    /// Canonical string identifier for this provider.
+    pub fn as_str(&self) -> &str {
+        match self {
+            ProviderType::OpenAI => "openai",
+            ProviderType::OpenRouter => "openrouter",
+            ProviderType::AzureOpenAI => "azure_openai",
+            ProviderType::OpenAICompletions => "openai_completions",
+            ProviderType::Anthropic => "anthropic",
+            ProviderType::Gemini => "gemini",
+            ProviderType::LlmSim => "llmsim",
+            ProviderType::Bedrock => "bedrock",
+            ProviderType::External(id) => id.as_ref(),
+        }
+    }
 }
 
 impl std::str::FromStr for ProviderType {
-    type Err = String;
+    // Parsing never fails: unknown ids become `External`.
+    type Err = std::convert::Infallible;
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
-        match s.to_lowercase().as_str() {
-            "openai" => Ok(ProviderType::OpenAI),
-            "openrouter" => Ok(ProviderType::OpenRouter),
-            "azure_openai" => Ok(ProviderType::AzureOpenAI),
-            "openai_completions" => Ok(ProviderType::OpenAICompletions),
-            "anthropic" => Ok(ProviderType::Anthropic),
-            "gemini" => Ok(ProviderType::Gemini),
-            "llmsim" => Ok(ProviderType::LlmSim),
-            "bedrock" => Ok(ProviderType::Bedrock),
-            _ => Err(format!("Unknown provider type: {}", s)),
-        }
+        Ok(match s.to_lowercase().as_str() {
+            "openai" => ProviderType::OpenAI,
+            "openrouter" => ProviderType::OpenRouter,
+            "azure_openai" => ProviderType::AzureOpenAI,
+            "openai_completions" => ProviderType::OpenAICompletions,
+            "anthropic" => ProviderType::Anthropic,
+            "gemini" => ProviderType::Gemini,
+            "llmsim" => ProviderType::LlmSim,
+            "bedrock" => ProviderType::Bedrock,
+            _ => ProviderType::External(Arc::from(s)),
+        })
     }
 }
 
 impl std::fmt::Display for ProviderType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            ProviderType::OpenAI => write!(f, "openai"),
-            ProviderType::OpenRouter => write!(f, "openrouter"),
-            ProviderType::AzureOpenAI => write!(f, "azure_openai"),
-            ProviderType::OpenAICompletions => write!(f, "openai_completions"),
-            ProviderType::Anthropic => write!(f, "anthropic"),
-            ProviderType::Gemini => write!(f, "gemini"),
-            ProviderType::LlmSim => write!(f, "llmsim"),
-            ProviderType::Bedrock => write!(f, "bedrock"),
-        }
+        f.write_str(self.as_str())
     }
+}
+
+/// Extra provider-specific authentication/metadata beyond an API key.
+///
+/// Built-in providers ignore this; embedder-defined ([`ProviderType::External`])
+/// providers use it to carry OAuth tokens, account ids, or arbitrary extras
+/// their driver factory needs.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ProviderMetadata {
+    /// OAuth refresh token, when the provider authenticates via OAuth.
+    pub refresh_token: Option<String>,
+    /// Provider-side account identifier, when required.
+    pub account_id: Option<String>,
+    /// Arbitrary extra fields the driver factory understands.
+    pub extra: Option<serde_json::Value>,
 }
 
 /// Configuration for creating an LLM provider
@@ -1113,6 +1154,8 @@ pub struct ProviderConfig {
     pub api_key: Option<String>,
     /// Base URL override (optional)
     pub base_url: Option<String>,
+    /// Extra provider-specific metadata (OAuth tokens, account ids, etc.).
+    pub metadata: ProviderMetadata,
 }
 
 impl ProviderConfig {
@@ -1122,6 +1165,7 @@ impl ProviderConfig {
             provider_type,
             api_key: None,
             base_url: None,
+            metadata: ProviderMetadata::default(),
         }
     }
 
@@ -1136,6 +1180,30 @@ impl ProviderConfig {
         self.base_url = Some(base_url.into());
         self
     }
+
+    /// Set provider-specific metadata.
+    pub fn with_metadata(mut self, metadata: ProviderMetadata) -> Self {
+        self.metadata = metadata;
+        self
+    }
+}
+
+/// Everything a [`DriverFactory`] receives to build a driver instance.
+///
+/// Replaces the old `(api_key, base_url)` factory arguments so that
+/// embedder-defined providers can receive richer auth via [`ProviderMetadata`]
+/// without changing the factory signature again.
+#[derive(Debug, Clone)]
+pub struct DriverConfig {
+    /// Provider type being created.
+    pub provider_type: ProviderType,
+    /// API key, when one is configured. `None` for keyless providers (LlmSim,
+    /// or external providers that authenticate via [`ProviderMetadata`]).
+    pub api_key: Option<String>,
+    /// Base URL override, when configured.
+    pub base_url: Option<String>,
+    /// Extra provider-specific metadata.
+    pub metadata: ProviderMetadata,
 }
 
 impl From<crate::llm_models::LlmProviderType> for ProviderType {
@@ -1150,6 +1218,7 @@ impl From<crate::llm_models::LlmProviderType> for ProviderType {
             LlmProviderType::Gemini => ProviderType::Gemini,
             LlmProviderType::LlmSim => ProviderType::LlmSim,
             LlmProviderType::Bedrock => ProviderType::Bedrock,
+            LlmProviderType::External(id) => ProviderType::External(id),
         }
     }
 }
@@ -1160,6 +1229,7 @@ impl From<&crate::traits::ModelWithProvider> for ProviderConfig {
             provider_type: model.provider_type.clone().into(),
             api_key: model.api_key.clone(),
             base_url: model.base_url.clone(),
+            metadata: model.provider_metadata.clone().unwrap_or_default(),
         }
     }
 }
@@ -1171,10 +1241,11 @@ pub type BoxedLlmDriver = Box<dyn LlmDriver>;
 // Driver Registry
 // ============================================================================
 
-/// Factory function type for creating LLM drivers
+/// Factory function type for creating LLM drivers.
 ///
-/// Takes api_key and optional base_url, returns a boxed driver
-pub type DriverFactory = Arc<dyn Fn(&str, Option<&str>) -> BoxedLlmDriver + Send + Sync>;
+/// Receives a [`DriverConfig`] (provider type, optional key/base URL, and
+/// provider metadata) and returns a boxed driver.
+pub type DriverFactory = Arc<dyn Fn(&DriverConfig) -> BoxedLlmDriver + Send + Sync>;
 
 /// Registry for LLM drivers
 ///
@@ -1208,33 +1279,65 @@ impl DriverRegistry {
         }
     }
 
-    /// Register a driver factory for a provider type
-    pub fn register<F>(&mut self, provider_type: ProviderType, factory: F)
+    /// Register a driver factory for a provider type.
+    ///
+    /// Panics if a factory is already registered for `provider_type` — silent
+    /// overwrites hide double-registration bugs. Use
+    /// [`Self::register_or_replace`] to overwrite intentionally.
+    pub fn register<F>(&mut self, provider_type: impl Into<ProviderType>, factory: F)
     where
-        F: Fn(&str, Option<&str>) -> BoxedLlmDriver + Send + Sync + 'static,
+        F: Fn(&DriverConfig) -> BoxedLlmDriver + Send + Sync + 'static,
     {
+        let provider_type = provider_type.into();
+        if self.factories.contains_key(&provider_type) {
+            panic!(
+                "driver already registered for provider '{provider_type}'; \
+                 use register_or_replace to overwrite intentionally"
+            );
+        }
         self.factories.insert(provider_type, Arc::new(factory));
+    }
+
+    /// Register a driver factory, replacing any existing one for the provider.
+    ///
+    /// Use when overwriting is intentional (e.g. swapping in an `LlmSim` driver
+    /// for tests). Prefer [`Self::register`] otherwise so duplicates surface.
+    pub fn register_or_replace<F>(&mut self, provider_type: impl Into<ProviderType>, factory: F)
+    where
+        F: Fn(&DriverConfig) -> BoxedLlmDriver + Send + Sync + 'static,
+    {
+        self.factories.insert(provider_type.into(), Arc::new(factory));
+    }
+
+    /// Register a driver factory for an embedder-defined external provider,
+    /// keyed by its canonical id.
+    pub fn register_external<F>(&mut self, id: impl Into<Arc<str>>, factory: F)
+    where
+        F: Fn(&DriverConfig) -> BoxedLlmDriver + Send + Sync + 'static,
+    {
+        self.register(ProviderType::External(id.into()), factory);
     }
 
     /// Create an LLM driver based on configuration
     ///
     /// API keys must be provided in the config for real providers. This function does NOT fall back to
     /// environment variables. Keys should be decrypted from the database and passed here.
-    /// Exception: LlmSim provider does not require an API key.
+    /// Exception: `LlmSim` and `External` providers do not require an API key
+    /// (external providers may authenticate via [`ProviderMetadata`]).
     ///
     /// Returns `DriverNotRegistered` error if no driver is registered for the provider type.
     pub fn create_driver(&self, config: &ProviderConfig) -> Result<BoxedLlmDriver> {
-        // API key is required for real providers, but not for LlmSim (testing)
-        let api_key = if config.provider_type == ProviderType::LlmSim {
-            // LlmSim doesn't need a real API key
-            config.api_key.as_deref().unwrap_or("")
-        } else {
-            config.api_key.as_ref().ok_or_else(|| {
-                AgentLoopError::llm(
-                    "API key is required. Configure the API key in provider settings.",
-                )
-            })?
-        };
+        // API key is required for real built-in providers, but not for LlmSim
+        // (testing) or External providers (which may use metadata-based auth).
+        let requires_api_key = !matches!(
+            config.provider_type,
+            ProviderType::LlmSim | ProviderType::External(_)
+        );
+        if requires_api_key && config.api_key.is_none() {
+            return Err(AgentLoopError::llm(
+                "API key is required. Configure the API key in provider settings.",
+            ));
+        }
 
         // Look up the factory for this provider type
         let factory = self.factories.get(&config.provider_type).ok_or_else(|| {
@@ -1242,7 +1345,13 @@ impl DriverRegistry {
         })?;
 
         // Create the driver using the factory
-        Ok(factory(api_key, config.base_url.as_deref()))
+        let driver_config = DriverConfig {
+            provider_type: config.provider_type.clone(),
+            api_key: config.api_key.clone(),
+            base_url: config.base_url.clone(),
+            metadata: config.metadata.clone(),
+        };
+        Ok(factory(&driver_config))
     }
 
     /// Check if a driver is registered for a provider type
@@ -1497,9 +1606,15 @@ mod tests {
             "gemini".parse::<ProviderType>().unwrap(),
             ProviderType::Gemini
         );
-        // Ollama and Custom are no longer supported
-        assert!("ollama".parse::<ProviderType>().is_err());
-        assert!("custom".parse::<ProviderType>().is_err());
+        // Unknown ids parse to External rather than erroring.
+        assert_eq!(
+            "ollama".parse::<ProviderType>().unwrap(),
+            ProviderType::external("ollama")
+        );
+        assert_eq!(
+            "custom".parse::<ProviderType>().unwrap(),
+            ProviderType::external("custom")
+        );
     }
 
     #[test]
@@ -1530,7 +1645,7 @@ mod tests {
     fn test_driver_registry_requires_api_key() {
         // Register a mock factory
         let mut registry = DriverRegistry::new();
-        registry.register(ProviderType::OpenAI, |_api_key, _base_url| {
+        registry.register(ProviderType::OpenAI, |_config| {
             // Return a mock driver - just need something that compiles
             struct MockDriver;
             #[async_trait]
@@ -1579,7 +1694,7 @@ mod tests {
         assert!(!registry.has_driver(&ProviderType::OpenAI));
         assert!(!registry.has_driver(&ProviderType::Anthropic));
 
-        registry.register(ProviderType::OpenAI, |_, _| {
+        registry.register(ProviderType::OpenAI, |_config| {
             struct MockDriver;
             #[async_trait]
             impl LlmDriver for MockDriver {
@@ -1596,6 +1711,80 @@ mod tests {
 
         assert!(registry.has_driver(&ProviderType::OpenAI));
         assert!(!registry.has_driver(&ProviderType::Anthropic));
+    }
+
+    #[test]
+    fn test_register_external_and_create_driver_without_api_key() {
+        struct MockDriver;
+        #[async_trait]
+        impl LlmDriver for MockDriver {
+            async fn chat_completion_stream(
+                &self,
+                _messages: Vec<LlmMessage>,
+                _config: &LlmCallConfig,
+            ) -> Result<LlmResponseStream> {
+                unimplemented!()
+            }
+        }
+
+        let mut registry = DriverRegistry::new();
+        registry.register_external("openai-codex", |config| {
+            // External providers may authenticate via metadata, not an api_key.
+            assert_eq!(config.provider_type, ProviderType::external("openai-codex"));
+            Box::new(MockDriver)
+        });
+
+        assert!(registry.has_driver(&ProviderType::external("openai-codex")));
+
+        // No api_key required for external providers.
+        let config = ProviderConfig::new(ProviderType::external("openai-codex"))
+            .with_metadata(ProviderMetadata {
+                refresh_token: Some("rt".into()),
+                ..Default::default()
+            });
+        assert!(registry.create_driver(&config).is_ok());
+    }
+
+    #[test]
+    #[should_panic(expected = "already registered")]
+    fn test_register_duplicate_panics() {
+        struct MockDriver;
+        #[async_trait]
+        impl LlmDriver for MockDriver {
+            async fn chat_completion_stream(
+                &self,
+                _messages: Vec<LlmMessage>,
+                _config: &LlmCallConfig,
+            ) -> Result<LlmResponseStream> {
+                unimplemented!()
+            }
+        }
+
+        let mut registry = DriverRegistry::new();
+        registry.register(ProviderType::OpenAI, |_config| Box::new(MockDriver));
+        // Second registration for the same provider must panic.
+        registry.register(ProviderType::OpenAI, |_config| Box::new(MockDriver));
+    }
+
+    #[test]
+    fn test_register_or_replace_overwrites() {
+        struct MockDriver;
+        #[async_trait]
+        impl LlmDriver for MockDriver {
+            async fn chat_completion_stream(
+                &self,
+                _messages: Vec<LlmMessage>,
+                _config: &LlmCallConfig,
+            ) -> Result<LlmResponseStream> {
+                unimplemented!()
+            }
+        }
+
+        let mut registry = DriverRegistry::new();
+        registry.register(ProviderType::LlmSim, |_config| Box::new(MockDriver));
+        // Replacing intentionally must not panic.
+        registry.register_or_replace(ProviderType::LlmSim, |_config| Box::new(MockDriver));
+        assert!(registry.has_driver(&ProviderType::LlmSim));
     }
 
     // ========================================================================

--- a/crates/core/src/llm_models.rs
+++ b/crates/core/src/llm_models.rs
@@ -11,62 +11,114 @@ use crate::typed_id::{ModelId, ProviderId};
 #[cfg(feature = "openapi")]
 use utoipa::ToSchema;
 
-/// LLM provider type
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(feature = "openapi", derive(ToSchema))]
-#[cfg_attr(feature = "openapi", schema(example = "anthropic"))]
-#[serde(rename_all = "snake_case")]
+/// LLM provider type identifier.
+///
+/// Built-in variants cover providers shipped with everruns. Any string that
+/// does not match a built-in id becomes `External(id)`, so embedders can store
+/// and use custom provider ids without schema migrations.
+///
+/// Serializes to/from a plain string (e.g. `"anthropic"`, `"openai-codex"`).
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum LlmProviderType {
     /// OpenAI using Open Responses API (<https://www.openresponses.org/>)
     Openai,
     /// OpenRouter using the OpenAI-compatible Responses API
     Openrouter,
     /// Azure OpenAI using the Azure-hosted OpenAI v1 API
-    #[serde(rename = "azure_openai")]
     AzureOpenai,
     /// OpenAI using Chat Completions API (for backward compatibility)
-    #[serde(rename = "openai_completions")]
     OpenaiCompletions,
     Anthropic,
     /// Google Gemini API
     Gemini,
     /// LLM simulator for testing
-    #[serde(rename = "llmsim")]
     LlmSim,
     /// AWS Bedrock Runtime (ConverseStream API)
     Bedrock,
+    /// Embedder-defined provider not compiled into everruns-core. The inner id
+    /// is the canonical wire string (e.g. `"openai-codex"`).
+    External(std::sync::Arc<str>),
 }
 
 impl std::fmt::Display for LlmProviderType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl LlmProviderType {
+    /// Return the canonical string identifier for this provider.
+    pub fn as_str(&self) -> &str {
         match self {
-            LlmProviderType::Openai => write!(f, "openai"),
-            LlmProviderType::Openrouter => write!(f, "openrouter"),
-            LlmProviderType::AzureOpenai => write!(f, "azure_openai"),
-            LlmProviderType::OpenaiCompletions => write!(f, "openai_completions"),
-            LlmProviderType::Anthropic => write!(f, "anthropic"),
-            LlmProviderType::Gemini => write!(f, "gemini"),
-            LlmProviderType::LlmSim => write!(f, "llmsim"),
-            LlmProviderType::Bedrock => write!(f, "bedrock"),
+            LlmProviderType::Openai => "openai",
+            LlmProviderType::Openrouter => "openrouter",
+            LlmProviderType::AzureOpenai => "azure_openai",
+            LlmProviderType::OpenaiCompletions => "openai_completions",
+            LlmProviderType::Anthropic => "anthropic",
+            LlmProviderType::Gemini => "gemini",
+            LlmProviderType::LlmSim => "llmsim",
+            LlmProviderType::Bedrock => "bedrock",
+            LlmProviderType::External(id) => id.as_ref(),
         }
     }
 }
 
 impl std::str::FromStr for LlmProviderType {
-    type Err = String;
+    // Parsing never fails: unknown ids become `External`.
+    type Err = std::convert::Infallible;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "openai" => Ok(LlmProviderType::Openai),
-            "openrouter" => Ok(LlmProviderType::Openrouter),
-            "azure_openai" => Ok(LlmProviderType::AzureOpenai),
-            "openai_completions" => Ok(LlmProviderType::OpenaiCompletions),
-            "anthropic" => Ok(LlmProviderType::Anthropic),
-            "gemini" => Ok(LlmProviderType::Gemini),
-            "llmsim" => Ok(LlmProviderType::LlmSim),
-            "bedrock" => Ok(LlmProviderType::Bedrock),
-            _ => Err(format!("Unknown provider type: {}", s)),
-        }
+        Ok(match s {
+            "openai" => LlmProviderType::Openai,
+            "openrouter" => LlmProviderType::Openrouter,
+            "azure_openai" => LlmProviderType::AzureOpenai,
+            "openai_completions" => LlmProviderType::OpenaiCompletions,
+            "anthropic" => LlmProviderType::Anthropic,
+            "gemini" => LlmProviderType::Gemini,
+            "llmsim" => LlmProviderType::LlmSim,
+            "bedrock" => LlmProviderType::Bedrock,
+            other => LlmProviderType::External(std::sync::Arc::from(other)),
+        })
+    }
+}
+
+impl Serialize for LlmProviderType {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for LlmProviderType {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(d)?;
+        // FromStr is infallible (unknown ids become External).
+        Ok(s.parse().unwrap_or_else(|_| unreachable!()))
+    }
+}
+
+// `Arc<str>` does not implement `ToSchema`, so the schema is written by hand.
+// It is a plain string at the wire level regardless of the variant.
+#[cfg(feature = "openapi")]
+impl utoipa::ToSchema for LlmProviderType {
+    fn name() -> std::borrow::Cow<'static, str> {
+        std::borrow::Cow::Borrowed("LlmProviderType")
+    }
+}
+
+#[cfg(feature = "openapi")]
+impl utoipa::PartialSchema for LlmProviderType {
+    fn schema() -> utoipa::openapi::RefOr<utoipa::openapi::Schema> {
+        utoipa::openapi::ObjectBuilder::new()
+            .schema_type(utoipa::openapi::schema::SchemaType::new(
+                utoipa::openapi::schema::Type::String,
+            ))
+            .description(Some(
+                "LLM provider type. Built-in: openai, openrouter, azure_openai, \
+                 openai_completions, anthropic, gemini, llmsim, bedrock. \
+                 Any other string is treated as an embedder-defined external provider.",
+            ))
+            .build()
+            .into()
     }
 }
 

--- a/crates/core/src/llm_models.rs
+++ b/crates/core/src/llm_models.rs
@@ -68,7 +68,10 @@ impl std::str::FromStr for LlmProviderType {
     type Err = std::convert::Infallible;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(match s {
+        // Normalize once so built-in matching and the External id share the
+        // same lowercased form; casing variance never yields duplicate ids.
+        let lower = s.to_lowercase();
+        Ok(match lower.as_str() {
             "openai" => LlmProviderType::Openai,
             "openrouter" => LlmProviderType::Openrouter,
             "azure_openai" => LlmProviderType::AzureOpenai,
@@ -77,7 +80,7 @@ impl std::str::FromStr for LlmProviderType {
             "gemini" => LlmProviderType::Gemini,
             "llmsim" => LlmProviderType::LlmSim,
             "bedrock" => LlmProviderType::Bedrock,
-            other => LlmProviderType::External(std::sync::Arc::from(other)),
+            _ => LlmProviderType::External(std::sync::Arc::from(lower.as_str())),
         })
     }
 }

--- a/crates/core/src/llmsim_driver.rs
+++ b/crates/core/src/llmsim_driver.rs
@@ -716,7 +716,7 @@ impl std::fmt::Debug for LlmSimDriver {
 /// register_driver(&mut registry);
 /// ```
 pub fn register_driver(registry: &mut DriverRegistry) {
-    registry.register(ProviderType::LlmSim, |_api_key, _base_url| {
+    registry.register(ProviderType::LlmSim, |_config| {
         // Default driver - tests can create custom drivers directly
         Box::new(LlmSimDriver::default_driver()) as BoxedLlmDriver
     });
@@ -732,7 +732,7 @@ pub fn register_driver(registry: &mut DriverRegistry) {
 /// shared across invocations.
 pub fn register_driver_with_config(registry: &mut DriverRegistry, config: LlmSimConfig) {
     let driver = LlmSimDriver::new(config);
-    registry.register(ProviderType::LlmSim, move |_api_key, _base_url| {
+    registry.register(ProviderType::LlmSim, move |_config| {
         Box::new(driver.clone()) as BoxedLlmDriver
     });
 }

--- a/crates/core/src/runtime_context.rs
+++ b/crates/core/src/runtime_context.rs
@@ -552,6 +552,7 @@ mod tests {
                 provider_type: crate::llm_models::LlmProviderType::LlmSim,
                 api_key: Some("fake-key".into()),
                 base_url: None,
+                provider_metadata: None,
             })
             .await;
 
@@ -620,6 +621,7 @@ mod tests {
                 provider_type: crate::llm_models::LlmProviderType::LlmSim,
                 api_key: Some("fake-key".into()),
                 base_url: None,
+                provider_metadata: None,
             })
             .await;
 
@@ -674,6 +676,7 @@ mod tests {
                 provider_type: crate::llm_models::LlmProviderType::LlmSim,
                 api_key: Some("fake-key".into()),
                 base_url: None,
+                provider_metadata: None,
             })
             .await;
 
@@ -733,6 +736,7 @@ mod tests {
                 provider_type: crate::llm_models::LlmProviderType::LlmSim,
                 api_key: Some("fake-key".into()),
                 base_url: None,
+                provider_metadata: None,
             })
             .await;
 

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -132,6 +132,9 @@ pub struct ModelWithProvider {
     pub api_key: Option<String>,
     /// Optional base URL override
     pub base_url: Option<String>,
+    /// Extra provider-specific metadata (OAuth tokens, account ids, etc.).
+    /// Used by embedder-defined providers that authenticate without an API key.
+    pub provider_metadata: Option<crate::llm_driver_registry::ProviderMetadata>,
 }
 
 /// Trait for retrieving LLM provider and model configurations

--- a/crates/core/tests/reason_atom_test.rs
+++ b/crates/core/tests/reason_atom_test.rs
@@ -1679,9 +1679,7 @@ async fn test_reason_atom_still_fails_on_pure_stream_error() {
         .await;
 
     let mut driver_registry = DriverRegistry::new();
-    driver_registry.register(ProviderType::LlmSim, |_config| {
-        Box::new(PureErrorDriver)
-    });
+    driver_registry.register(ProviderType::LlmSim, |_config| Box::new(PureErrorDriver));
 
     let event_emitter = InMemoryEventEmitter::new();
 

--- a/crates/core/tests/reason_atom_test.rs
+++ b/crates/core/tests/reason_atom_test.rs
@@ -155,6 +155,7 @@ async fn setup_test_environment() -> (
         provider_type: LlmProviderType::LlmSim,
         api_key: Some("fake-api-key".to_string()), // Required by registry but unused by LlmSim
         base_url: None,
+        provider_metadata: None,
     };
     provider_store.set_default_model(model).await;
 
@@ -173,7 +174,7 @@ async fn setup_test_environment() -> (
 /// Create a custom driver registry with a specific LlmSim configuration
 fn create_custom_driver_registry(config: LlmSimConfig) -> DriverRegistry {
     let mut registry = DriverRegistry::new();
-    registry.register(ProviderType::LlmSim, move |_api_key, _base_url| {
+    registry.register(ProviderType::LlmSim, move |_config| {
         Box::new(LlmSimDriver::new(config.clone()))
     });
     registry
@@ -1044,7 +1045,7 @@ async fn test_reason_atom_does_not_retry_transient_stream_error() {
     let attempts = Arc::new(AtomicUsize::new(0));
     let attempts_for_registry = Arc::clone(&attempts);
     let mut driver_registry = DriverRegistry::new();
-    driver_registry.register(ProviderType::LlmSim, move |_api_key, _base_url| {
+    driver_registry.register(ProviderType::LlmSim, move |_config| {
         Box::new(FlakyStreamDriver {
             attempts: Arc::clone(&attempts_for_registry),
         })
@@ -1505,7 +1506,7 @@ async fn test_reason_atom_preserves_tool_calls_on_trailing_stream_error() {
         .await;
 
     let mut driver_registry = DriverRegistry::new();
-    driver_registry.register(ProviderType::LlmSim, |_api_key, _base_url| {
+    driver_registry.register(ProviderType::LlmSim, |_config| {
         Box::new(ToolCallsThenErrorDriver)
     });
 
@@ -1594,7 +1595,7 @@ async fn test_reason_atom_preserves_text_on_trailing_stream_error() {
         .await;
 
     let mut driver_registry = DriverRegistry::new();
-    driver_registry.register(ProviderType::LlmSim, |_api_key, _base_url| {
+    driver_registry.register(ProviderType::LlmSim, |_config| {
         Box::new(TextThenErrorDriver)
     });
 
@@ -1678,7 +1679,7 @@ async fn test_reason_atom_still_fails_on_pure_stream_error() {
         .await;
 
     let mut driver_registry = DriverRegistry::new();
-    driver_registry.register(ProviderType::LlmSim, |_api_key, _base_url| {
+    driver_registry.register(ProviderType::LlmSim, |_config| {
         Box::new(PureErrorDriver)
     });
 
@@ -2016,7 +2017,7 @@ fn create_conversation_capturing_driver_registry(
     captured_messages: Arc<Mutex<Vec<everruns_core::LlmMessage>>>,
 ) -> DriverRegistry {
     let mut registry = DriverRegistry::new();
-    registry.register(ProviderType::LlmSim, move |_api_key, _base_url| {
+    registry.register(ProviderType::LlmSim, move |_config| {
         Box::new(ConversationCapturingDriver {
             captured_messages: captured_messages.clone(),
         })
@@ -2101,7 +2102,7 @@ async fn test_session_system_prompt_is_prepended_to_agent_prompt() {
 
     let mut driver_registry = DriverRegistry::new();
     let driver_clone = driver.clone();
-    driver_registry.register(ProviderType::LlmSim, move |_api_key, _base_url| {
+    driver_registry.register(ProviderType::LlmSim, move |_config| {
         Box::new(driver_clone.clone())
     });
 
@@ -2224,7 +2225,7 @@ async fn test_empty_session_system_prompt_is_ignored() {
 
     let mut driver_registry = DriverRegistry::new();
     let driver_clone = driver.clone();
-    driver_registry.register(ProviderType::LlmSim, move |_api_key, _base_url| {
+    driver_registry.register(ProviderType::LlmSim, move |_config| {
         Box::new(driver_clone.clone())
     });
 
@@ -2516,7 +2517,7 @@ async fn test_prompt_canary_guardrail_replaces_leaked_thinking() {
         answer: "safe answer".to_string(),
     };
     let mut driver_registry = DriverRegistry::new();
-    driver_registry.register(ProviderType::LlmSim, move |_api_key, _base_url| {
+    driver_registry.register(ProviderType::LlmSim, move |_config| {
         Box::new(thinking_driver.clone())
     });
 

--- a/crates/gemini/src/driver.rs
+++ b/crates/gemini/src/driver.rs
@@ -835,8 +835,9 @@ impl std::fmt::Debug for GeminiLlmDriver {
 
 /// Register the Gemini driver with the driver registry
 pub fn register_driver(registry: &mut DriverRegistry) {
-    registry.register(ProviderType::Gemini, |api_key, base_url| {
-        let driver = match base_url {
+    registry.register(ProviderType::Gemini, |config| {
+        let api_key = config.api_key.as_deref().unwrap_or("");
+        let driver = match config.base_url.as_deref() {
             Some(url) => GeminiLlmDriver::with_base_url(api_key, url),
             None => GeminiLlmDriver::new(api_key),
         };

--- a/crates/llm-tests/examples/dad_jokes_agent.rs
+++ b/crates/llm-tests/examples/dad_jokes_agent.rs
@@ -64,6 +64,7 @@ async fn main() -> anyhow::Result<()> {
         provider_type: LlmProviderType::Anthropic,
         api_key: Some(api_key),
         base_url: None,
+        provider_metadata: None,
     };
 
     // Build the agent with current_time capability

--- a/crates/llm-tests/tests/agent_run_basic.rs
+++ b/crates/llm-tests/tests/agent_run_basic.rs
@@ -167,6 +167,7 @@ async fn test_model_not_available_returns_user_friendly_error(
         provider_type,
         api_key: Some(api_key),
         base_url: None,
+        provider_metadata: None,
     };
 
     let runner = InMemoryAgenticLoop::builder()

--- a/crates/llm-tests/tests/llm_test_matrix/mod.rs
+++ b/crates/llm-tests/tests/llm_test_matrix/mod.rs
@@ -53,6 +53,7 @@ impl ProviderModelConfig {
             provider_type: self.provider_type.clone(),
             api_key: Some(api_key),
             base_url: None,
+            provider_metadata: None,
         })
     }
 

--- a/crates/openai/src/driver.rs
+++ b/crates/openai/src/driver.rs
@@ -537,24 +537,27 @@ fn apply_models_auth(request: RequestBuilder, api_url: &str, api_key: &str) -> R
 /// ```
 pub fn register_driver(registry: &mut DriverRegistry) {
     // Register OpenAI with Open Responses API (recommended)
-    registry.register(ProviderType::OpenAI, |api_key, base_url| {
-        let driver = match base_url {
+    registry.register(ProviderType::OpenAI, |config| {
+        let api_key = config.api_key.as_deref().unwrap_or("");
+        let driver = match config.base_url.as_deref() {
             Some(url) => OpenAILlmDriver::with_base_url(api_key, url),
             None => OpenAILlmDriver::new(api_key),
         };
         Box::new(driver) as BoxedLlmDriver
     });
 
-    registry.register(ProviderType::OpenRouter, |api_key, base_url| {
-        let driver = match base_url {
+    registry.register(ProviderType::OpenRouter, |config| {
+        let api_key = config.api_key.as_deref().unwrap_or("");
+        let driver = match config.base_url.as_deref() {
             Some(url) => OpenRouterLlmDriver::with_base_url(api_key, url),
             None => OpenRouterLlmDriver::new(api_key),
         };
         Box::new(driver) as BoxedLlmDriver
     });
 
-    registry.register(ProviderType::AzureOpenAI, |api_key, base_url| {
-        let driver = match base_url {
+    registry.register(ProviderType::AzureOpenAI, |config| {
+        let api_key = config.api_key.as_deref().unwrap_or("");
+        let driver = match config.base_url.as_deref() {
             Some(url) => OpenAILlmDriver::with_base_url(api_key, url),
             None => OpenAILlmDriver::new(api_key),
         };
@@ -562,8 +565,9 @@ pub fn register_driver(registry: &mut DriverRegistry) {
     });
 
     // Register OpenAI Completions with Chat Completions API
-    registry.register(ProviderType::OpenAICompletions, |api_key, base_url| {
-        let driver = match base_url {
+    registry.register(ProviderType::OpenAICompletions, |config| {
+        let api_key = config.api_key.as_deref().unwrap_or("");
+        let driver = match config.base_url.as_deref() {
             Some(url) => OpenAICompletionsLlmDriver::with_base_url(api_key, url),
             None => OpenAICompletionsLlmDriver::new(api_key),
         };

--- a/crates/runtime/examples/in_process_runtime.rs
+++ b/crates/runtime/examples/in_process_runtime.rs
@@ -49,6 +49,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             provider_type: LlmProviderType::LlmSim,
             api_key: Some("fake-key".into()),
             base_url: None,
+            provider_metadata: None,
         })
         .single_session(|s| {
             s.harness("math", "You are a math assistant.")

--- a/crates/runtime/examples/inspect_context.rs
+++ b/crates/runtime/examples/inspect_context.rs
@@ -28,6 +28,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             provider_type: LlmProviderType::LlmSim,
             api_key: Some("fake-key".into()),
             base_url: None,
+            provider_metadata: None,
         })
         .harness(Harness {
             id: harness_id,

--- a/crates/runtime/examples/lua_code_mode_agent.rs
+++ b/crates/runtime/examples/lua_code_mode_agent.rs
@@ -111,6 +111,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             provider_type: LlmProviderType::LlmSim,
             api_key: Some("fake-key".to_string()),
             base_url: None,
+            provider_metadata: None,
         })
         .harness(harness)
         .agent(agent)

--- a/crates/runtime/examples/real_disk_agent_instructions.rs
+++ b/crates/runtime/examples/real_disk_agent_instructions.rs
@@ -61,6 +61,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             provider_type: LlmProviderType::LlmSim,
             api_key: Some("fake-key".into()),
             base_url: None,
+            provider_metadata: None,
         })
         .harness(Harness {
             id: harness_id,

--- a/crates/runtime/examples/real_disk_file_system_tools.rs
+++ b/crates/runtime/examples/real_disk_file_system_tools.rs
@@ -81,6 +81,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             provider_type: LlmProviderType::LlmSim,
             api_key: Some("fake-key".into()),
             base_url: None,
+            provider_metadata: None,
         })
         .harness(Harness {
             id: harness_id,

--- a/crates/runtime/src/runtime.rs
+++ b/crates/runtime/src/runtime.rs
@@ -401,9 +401,11 @@ impl InProcessRuntimeBuilder {
 
         if let Some(config) = self.llm_sim_config.take() {
             let driver = LlmSimDriver::new(config);
+            // Replace intentionally: the platform may already register a
+            // built-in LlmSim driver, and the builder's config takes precedence.
             self.platform_definition
                 .driver_registry_mut()
-                .register(ProviderType::LlmSim, move |_api_key, _base_url| {
+                .register_or_replace(ProviderType::LlmSim, move |_config| {
                     Box::new(driver.clone())
                 });
 
@@ -413,6 +415,7 @@ impl InProcessRuntimeBuilder {
                     provider_type: LlmProviderType::LlmSim,
                     api_key: Some("fake-key".to_string()),
                     base_url: None,
+                    provider_metadata: None,
                 });
             }
         }

--- a/crates/runtime/tests/in_process_runtime_test.rs
+++ b/crates/runtime/tests/in_process_runtime_test.rs
@@ -127,6 +127,7 @@ async fn runtime_executes_tool_loop_and_persists_messages() {
             provider_type: LlmProviderType::LlmSim,
             api_key: Some("fake-key".into()),
             base_url: None,
+            provider_metadata: None,
         })
         .harness(harness(harness_id))
         .agent(agent(agent_id))
@@ -306,6 +307,7 @@ async fn runtime_seeds_initial_files_from_harness_chain() {
             provider_type: LlmProviderType::LlmSim,
             api_key: Some("fake-key".into()),
             base_url: None,
+            provider_metadata: None,
         })
         .harness(math_harness)
         .agent(agent(agent_id))
@@ -337,6 +339,7 @@ async fn runtime_runs_session_without_agent_entity() {
             provider_type: LlmProviderType::LlmSim,
             api_key: Some("fake-key".into()),
             base_url: None,
+            provider_metadata: None,
         })
         .harness(harness(harness_id))
         .session(session(session_id, harness_id, None))
@@ -373,6 +376,7 @@ async fn runtime_accepts_explicit_backend_bundle() {
             provider_type: LlmProviderType::LlmSim,
             api_key: Some("fake-key".into()),
             base_url: None,
+            provider_metadata: None,
         })
         .harness(harness(harness_id))
         .agent(agent(agent_id))
@@ -447,6 +451,7 @@ async fn runtime_exposes_assembled_context() {
             provider_type: LlmProviderType::LlmSim,
             api_key: Some("fake-key".into()),
             base_url: None,
+            provider_metadata: None,
         })
         .harness(harness(harness_id))
         .agent(agent(agent_id))
@@ -899,6 +904,7 @@ async fn injected_resolver_reaches_tool_context_during_a_turn() {
             provider_type: LlmProviderType::LlmSim,
             api_key: Some("fake-key".into()),
             base_url: None,
+            provider_metadata: None,
         })
         .harness(
             HarnessBuilder::new("conn", "You resolve connection tokens.")

--- a/crates/runtime/tests/lua_code_mode_test.rs
+++ b/crates/runtime/tests/lua_code_mode_test.rs
@@ -77,6 +77,7 @@ async fn hides_math_tools_but_runs_them_via_lua() {
             provider_type: LlmProviderType::LlmSim,
             api_key: Some("fake-key".to_string()),
             base_url: None,
+            provider_metadata: None,
         })
         .harness(harness)
         .agent(agent)

--- a/crates/runtime/tests/mcp_runtime_test.rs
+++ b/crates/runtime/tests/mcp_runtime_test.rs
@@ -130,6 +130,7 @@ async fn runtime_discovers_and_executes_scoped_mcp_tool() {
             provider_type: LlmProviderType::LlmSim,
             api_key: Some("fake-key".into()),
             base_url: None,
+            provider_metadata: None,
         })
         .harness(
             HarnessBuilder::new("mcp", "You are an MCP test assistant.")

--- a/crates/runtime/tests/runtime_host_test.rs
+++ b/crates/runtime/tests/runtime_host_test.rs
@@ -516,6 +516,7 @@ async fn set_default_model(adapter: &MockHostAdapter) {
             provider_type: LlmProviderType::LlmSim,
             api_key: None,
             base_url: None,
+            provider_metadata: None,
         })
         .await;
 }

--- a/crates/runtime/tests/tool_scheduler_e2e_test.rs
+++ b/crates/runtime/tests/tool_scheduler_e2e_test.rs
@@ -208,6 +208,7 @@ async fn runtime_emitting_batch(
             provider_type: LlmProviderType::LlmSim,
             api_key: Some("fake-key".into()),
             base_url: None,
+            provider_metadata: None,
         })
         .harness(harness(harness_id))
         .agent(agent(agent_id))

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -688,6 +688,7 @@ impl WorkerAdapters for DirectWorkerAdapters {
             provider_type: string_to_provider_type(&r.provider_type),
             api_key: r.api_key,
             base_url: r.base_url,
+            provider_metadata: None,
         }))
     }
 
@@ -706,6 +707,7 @@ impl WorkerAdapters for DirectWorkerAdapters {
             provider_type: string_to_provider_type(&r.provider_type),
             api_key: r.api_key,
             base_url: r.base_url,
+            provider_metadata: None,
         }))
     }
 
@@ -1940,20 +1942,9 @@ impl DirectWorkerAdapters {
 // =============================================================================
 
 fn string_to_provider_type(s: &str) -> LlmProviderType {
-    match s.to_lowercase().as_str() {
-        "openai" => LlmProviderType::Openai,
-        "openrouter" => LlmProviderType::Openrouter,
-        "azure_openai" => LlmProviderType::AzureOpenai,
-        "openai_completions" => LlmProviderType::OpenaiCompletions,
-        "anthropic" => LlmProviderType::Anthropic,
-        "gemini" => LlmProviderType::Gemini,
-        "llmsim" => LlmProviderType::LlmSim,
-        "bedrock" => LlmProviderType::Bedrock,
-        _ => {
-            tracing::warn!(provider_type = %s, "Unknown provider_type in database; falling back to llmsim");
-            LlmProviderType::LlmSim
-        }
-    }
+    // FromStr is infallible: unknown ids become External providers, preserving
+    // the id so embedder-defined providers resolve correctly.
+    s.to_lowercase().parse().unwrap_or_else(|_| unreachable!())
 }
 
 /// Convert an event to a message
@@ -3035,10 +3026,11 @@ mod tests {
     }
 
     #[test]
-    fn string_to_provider_type_falls_back_for_unknown() {
+    fn string_to_provider_type_maps_unknown_to_external() {
+        // Unknown ids resolve to External, preserving the id.
         assert_eq!(
             string_to_provider_type("custom-provider").to_string(),
-            "llmsim"
+            "custom-provider"
         );
     }
 

--- a/crates/server/src/services/model_sync.rs
+++ b/crates/server/src/services/model_sync.rs
@@ -93,24 +93,19 @@ impl ModelSyncService {
             });
         };
 
-        // Create driver for the provider
-        let driver_type = match provider_type {
-            LlmProviderType::Openai => ProviderType::OpenAI,
-            LlmProviderType::Openrouter => ProviderType::OpenRouter,
-            LlmProviderType::AzureOpenai => ProviderType::AzureOpenAI,
-            LlmProviderType::OpenaiCompletions => ProviderType::OpenAICompletions,
-            LlmProviderType::Anthropic => ProviderType::Anthropic,
-            LlmProviderType::Gemini => ProviderType::Gemini,
-            LlmProviderType::LlmSim => {
-                return Ok(SyncResult::NotSupported);
-            }
-            LlmProviderType::Bedrock => ProviderType::Bedrock,
-        };
+        // Create driver for the provider; the open conversion handles built-in
+        // and External providers uniformly.
+        let driver_type: ProviderType = provider_type.into();
+        // LlmSim is a test-only provider with no models to sync.
+        if driver_type == ProviderType::LlmSim {
+            return Ok(SyncResult::NotSupported);
+        }
 
         let config = ProviderConfig {
             provider_type: driver_type,
             api_key: Some(api_key),
             base_url: provider_row.base_url.clone(),
+            metadata: Default::default(),
         };
 
         let driver = self
@@ -283,6 +278,9 @@ fn supports_sync_with_base_url(provider_type: &LlmProviderType) -> bool {
             | LlmProviderType::Openrouter
             | LlmProviderType::AzureOpenai
             | LlmProviderType::OpenaiCompletions
+            // External providers are custom by nature: a configured base URL is
+            // the embedder's endpoint, so do not skip discovery for them.
+            | LlmProviderType::External(_)
     )
 }
 

--- a/crates/server/src/storage/llm_provider_store.rs
+++ b/crates/server/src/storage/llm_provider_store.rs
@@ -8,7 +8,7 @@
 
 use async_trait::async_trait;
 use everruns_core::{
-    ModelId, Result, StoreResultExt,
+    AgentLoopError, ModelId, Result, StoreResultExt,
     llm_models::LlmProviderType,
     traits::{LlmProviderStore, ModelWithProvider},
 };
@@ -134,15 +134,19 @@ impl LlmProviderStore for DbLlmProviderStore {
     }
 }
 
-/// Parse a provider type string to its enum. Unknown ids map to the open
-/// `External` variant so embedder-defined providers stored in the database
-/// resolve to a usable provider type instead of erroring.
+/// Parse a provider type string to its enum. Unknown non-empty ids map to the
+/// open `External` variant so embedder-defined providers stored in the database
+/// resolve to a usable provider type instead of erroring. An empty/whitespace
+/// value is a corrupt row and surfaces as a configuration error rather than a
+/// silent `External("")`.
 fn parse_provider_type(provider_type_str: &str) -> Result<LlmProviderType> {
+    if provider_type_str.trim().is_empty() {
+        return Err(AgentLoopError::Configuration(
+            "empty provider_type in database".to_string(),
+        ));
+    }
     // FromStr is infallible: unknown ids become External.
-    Ok(provider_type_str
-        .to_lowercase()
-        .parse()
-        .unwrap_or_else(|_| unreachable!()))
+    Ok(provider_type_str.parse().unwrap_or_else(|_| unreachable!()))
 }
 
 // ============================================================================
@@ -167,6 +171,13 @@ mod tests {
         // Unknown ids resolve to External, preserving the stored id.
         let parsed = parse_provider_type("totally-custom").unwrap();
         assert_eq!(parsed.to_string(), "totally-custom");
+    }
+
+    #[test]
+    fn parse_provider_type_rejects_empty_value() {
+        // Empty/whitespace is a corrupt row, not a valid external provider.
+        assert!(parse_provider_type("").is_err());
+        assert!(parse_provider_type("   ").is_err());
     }
 
     #[test]

--- a/crates/server/src/storage/llm_provider_store.rs
+++ b/crates/server/src/storage/llm_provider_store.rs
@@ -8,7 +8,7 @@
 
 use async_trait::async_trait;
 use everruns_core::{
-    AgentLoopError, ModelId, Result, StoreResultExt,
+    ModelId, Result, StoreResultExt,
     llm_models::LlmProviderType,
     traits::{LlmProviderStore, ModelWithProvider},
 };
@@ -86,6 +86,7 @@ impl LlmProviderStore for DbLlmProviderStore {
             provider_type,
             api_key: provider_with_key.api_key,
             base_url: provider_with_key.base_url,
+            provider_metadata: None,
         }))
     }
 
@@ -128,26 +129,20 @@ impl LlmProviderStore for DbLlmProviderStore {
             provider_type,
             api_key: provider_with_key.api_key,
             base_url: provider_with_key.base_url,
+            provider_metadata: None,
         }))
     }
 }
 
-/// Parse provider type string to enum
+/// Parse a provider type string to its enum. Unknown ids map to the open
+/// `External` variant so embedder-defined providers stored in the database
+/// resolve to a usable provider type instead of erroring.
 fn parse_provider_type(provider_type_str: &str) -> Result<LlmProviderType> {
-    match provider_type_str.to_lowercase().as_str() {
-        "openai" => Ok(LlmProviderType::Openai),
-        "openrouter" => Ok(LlmProviderType::Openrouter),
-        "azure_openai" => Ok(LlmProviderType::AzureOpenai),
-        "openai_completions" => Ok(LlmProviderType::OpenaiCompletions),
-        "anthropic" => Ok(LlmProviderType::Anthropic),
-        "gemini" => Ok(LlmProviderType::Gemini),
-        "llmsim" => Ok(LlmProviderType::LlmSim),
-        "bedrock" => Ok(LlmProviderType::Bedrock),
-        _ => Err(AgentLoopError::Configuration(format!(
-            "Unsupported provider_type in database: {}",
-            provider_type_str
-        ))),
-    }
+    // FromStr is infallible: unknown ids become External.
+    Ok(provider_type_str
+        .to_lowercase()
+        .parse()
+        .unwrap_or_else(|_| unreachable!()))
 }
 
 // ============================================================================
@@ -168,12 +163,10 @@ mod tests {
     use super::*;
 
     #[test]
-    fn parse_provider_type_returns_error_for_unknown_value() {
-        let err = parse_provider_type("totally-custom").unwrap_err();
-        assert!(
-            err.to_string()
-                .contains("Unsupported provider_type in database")
-        );
+    fn parse_provider_type_returns_external_for_unknown_value() {
+        // Unknown ids resolve to External, preserving the stored id.
+        let parsed = parse_provider_type("totally-custom").unwrap();
+        assert_eq!(parsed.to_string(), "totally-custom");
     }
 
     #[test]

--- a/crates/worker/src/adapters.rs
+++ b/crates/worker/src/adapters.rs
@@ -4,7 +4,7 @@
 // This module only contains LLM driver factory helpers.
 
 use everruns_core::{
-    AgentLoopError, BoxedLlmDriver, DriverRegistry, ProviderConfig, ProviderType, Result,
+    BoxedLlmDriver, DriverRegistry, ProviderConfig, ProviderType, Result,
 };
 
 /// Create and configure the driver registry with all supported LLM providers
@@ -103,9 +103,8 @@ pub fn create_llm_driver(
     api_key: Option<&str>,
     base_url: Option<&str>,
 ) -> Result<BoxedLlmDriver> {
-    let ptype: ProviderType = provider_type
-        .parse()
-        .map_err(|e: String| AgentLoopError::llm(e))?;
+    // Parsing is infallible: unknown ids become External providers.
+    let ptype: ProviderType = provider_type.parse().unwrap_or_else(|_| unreachable!());
 
     let mut config = ProviderConfig::new(ptype);
     if let Some(key) = api_key {

--- a/crates/worker/src/adapters.rs
+++ b/crates/worker/src/adapters.rs
@@ -3,9 +3,7 @@
 // Decision: Workers use gRPC adapters for database operations, not direct DB access.
 // This module only contains LLM driver factory helpers.
 
-use everruns_core::{
-    BoxedLlmDriver, DriverRegistry, ProviderConfig, ProviderType, Result,
-};
+use everruns_core::{BoxedLlmDriver, DriverRegistry, ProviderConfig, ProviderType, Result};
 
 /// Create and configure the driver registry with all supported LLM providers
 ///

--- a/crates/worker/src/grpc_adapters.rs
+++ b/crates/worker/src/grpc_adapters.rs
@@ -1457,7 +1457,14 @@ impl ProviderCredentialStore for GrpcOrgAdapter {
 fn proto_model_with_provider_to_model(
     proto: proto::ModelWithProvider,
 ) -> Result<ModelWithProvider> {
-    // Parsing is infallible: unknown ids become External providers, so
+    // An empty provider_type is a corrupt/missing proto field; fail fast with
+    // a clear store error rather than parsing it into an unusable External("").
+    if proto.provider_type.trim().is_empty() {
+        return Err(AgentLoopError::store(
+            "empty provider_type in ModelWithProvider proto",
+        ));
+    }
+    // Parsing is otherwise infallible: unknown ids become External providers, so
     // embedder-defined providers round-trip across the worker boundary.
     let provider_type: everruns_core::LlmProviderType = proto
         .provider_type

--- a/crates/worker/src/grpc_adapters.rs
+++ b/crates/worker/src/grpc_adapters.rs
@@ -1457,27 +1457,19 @@ impl ProviderCredentialStore for GrpcOrgAdapter {
 fn proto_model_with_provider_to_model(
     proto: proto::ModelWithProvider,
 ) -> Result<ModelWithProvider> {
-    let provider_type = match proto.provider_type.to_lowercase().as_str() {
-        "openai" => everruns_core::LlmProviderType::Openai,
-        "openrouter" => everruns_core::LlmProviderType::Openrouter,
-        "azure_openai" => everruns_core::LlmProviderType::AzureOpenai,
-        "openai_completions" => everruns_core::LlmProviderType::OpenaiCompletions,
-        "anthropic" => everruns_core::LlmProviderType::Anthropic,
-        "gemini" => everruns_core::LlmProviderType::Gemini,
-        "llmsim" => everruns_core::LlmProviderType::LlmSim,
-        _ => {
-            return Err(AgentLoopError::store(format!(
-                "Unknown provider type: {}",
-                proto.provider_type
-            )));
-        }
-    };
+    // Parsing is infallible: unknown ids become External providers, so
+    // embedder-defined providers round-trip across the worker boundary.
+    let provider_type: everruns_core::LlmProviderType = proto
+        .provider_type
+        .parse()
+        .unwrap_or_else(|_| unreachable!());
 
     Ok(ModelWithProvider {
         model: proto.model,
         provider_type,
         api_key: proto.api_key.filter(|s| !s.is_empty()),
         base_url: proto.base_url.filter(|s| !s.is_empty()),
+        provider_metadata: None,
     })
 }
 

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -22199,18 +22199,7 @@
       },
       "LlmProviderType": {
         "type": "string",
-        "description": "LLM provider type",
-        "enum": [
-          "openai",
-          "openrouter",
-          "azure_openai",
-          "openai_completions",
-          "anthropic",
-          "gemini",
-          "llmsim",
-          "bedrock"
-        ],
-        "example": "anthropic"
+        "description": "LLM provider type. Built-in: openai, openrouter, azure_openai, openai_completions, anthropic, gemini, llmsim, bedrock. Any other string is treated as an embedder-defined external provider."
       },
       "LlmRequestOptions": {
         "type": "object",

--- a/examples/coding-cli/src/runtime.rs
+++ b/examples/coding-cli/src/runtime.rs
@@ -604,6 +604,7 @@ impl ProviderChoice {
                     provider_type: LlmProviderType::Anthropic,
                     api_key: Some(key),
                     base_url: None,
+                    provider_metadata: None,
                 })
             }
             ProviderChoice::OpenAi { model, .. } => {
@@ -614,6 +615,7 @@ impl ProviderChoice {
                     provider_type: LlmProviderType::Openai,
                     api_key: Some(key),
                     base_url: None,
+                    provider_metadata: None,
                 })
             }
             ProviderChoice::OpenRouter { model, base_url } => {
@@ -624,6 +626,7 @@ impl ProviderChoice {
                     provider_type: LlmProviderType::Openai,
                     api_key: Some(key),
                     base_url: Some(base_url.clone()),
+                    provider_metadata: None,
                 })
             }
             ProviderChoice::Ollama { model, base_url } => Ok(ModelWithProvider {
@@ -631,12 +634,14 @@ impl ProviderChoice {
                 provider_type: LlmProviderType::Openai,
                 api_key: Some(env_or_default("OLLAMA_API_KEY", DEFAULT_OLLAMA_API_KEY)),
                 base_url: Some(base_url.clone()),
+                provider_metadata: None,
             }),
             ProviderChoice::Sim => Ok(ModelWithProvider {
                 model: "llmsim-coding-cli".into(),
                 provider_type: LlmProviderType::LlmSim,
                 api_key: Some("fake-key".into()),
                 base_url: None,
+                provider_metadata: None,
             }),
         }
     }
@@ -893,6 +898,7 @@ pub async fn build(
             provider_type: LlmProviderType::LlmSim,
             api_key: Some("fake-key".into()),
             base_url: None,
+            provider_metadata: None,
         },
     };
 

--- a/examples/weekend-concierge-host/src/lib.rs
+++ b/examples/weekend-concierge-host/src/lib.rs
@@ -365,6 +365,7 @@ pub async fn run_weekend_concierge_demo() -> ExampleResult<ExampleRun> {
             provider_type: LlmProviderType::LlmSim,
             api_key: Some("fake-key".into()),
             base_url: None,
+            provider_metadata: None,
         })
         .harness(harness(harness_id))
         .agent(agent(agent_id, None))

--- a/research/infinity_context/src/runner.rs
+++ b/research/infinity_context/src/runner.rs
@@ -215,6 +215,8 @@ fn get_api_key(provider_type: &LlmProviderType) -> Result<String> {
         LlmProviderType::Anthropic => "ANTHROPIC_API_KEY",
         LlmProviderType::Openai | LlmProviderType::OpenaiCompletions => "OPENAI_API_KEY",
         LlmProviderType::LlmSim => return Ok(String::new()),
+        // This research harness only drives the providers above.
+        other => anyhow::bail!("unsupported provider for eval harness: {other}"),
     };
     std::env::var(key_name).map_err(|_| anyhow::anyhow!("{} not set", key_name))
 }
@@ -407,6 +409,7 @@ async fn execute_with_agentic_loop(
             provider_type: provider_type.clone(),
             api_key: Some(api_key.clone()),
             base_url: None,
+            provider_metadata: None,
         };
 
         // Build the agentic loop with seed events

--- a/research/lua-vs-bash/src/main.rs
+++ b/research/lua-vs-bash/src/main.rs
@@ -250,6 +250,7 @@ async fn main() -> anyhow::Result<()> {
         provider_type: LlmProviderType::Anthropic,
         api_key: Some(api_key),
         base_url: None,
+        provider_metadata: None,
     };
 
     // `--dump-prompts` prints the assembled prompts and exits (no model call).


### PR DESCRIPTION
## What
Opens the LLM provider model so embedders can register and use their own LLM
providers without modifying core enums.

- `LlmProviderType` and `ProviderType` gain an `External(Arc<str>)` variant.
  Unknown provider ids parse to `External` instead of erroring (`FromStr` is
  now `Infallible`); serialization stays a plain wire string. External ids are
  normalized to lowercase so casing variance never yields duplicate providers.
- Driver factories now receive a single `DriverConfig` (provider type,
  optional api_key/base_url, and a new `ProviderMetadata`) instead of
  `(api_key, base_url)`, so providers can authenticate via OAuth tokens /
  account ids without another signature change.
- `DriverRegistry::register` panics on duplicate registration (silent
  overwrites hid bugs); `register_or_replace` and `register_external` are
  added for intentional overwrite and external registration.
- `create_driver` no longer requires an api_key for `External` providers
  (they may authenticate via metadata).
- `ModelWithProvider` and `ProviderConfig` carry the new metadata; worker/
  server provider-type parsing maps unknown non-empty ids to `External` so
  embedder-defined providers round-trip through gRPC and the database, and
  empty/whitespace ids fail fast as a config/store error.

## Why
EVE-561. Adding a provider previously meant editing closed enums in core and
threading a new factory signature everywhere. Embedders need to plug in custom
providers (e.g. OAuth-based gateways) without forking core.

## How
- Manual `Serialize`/`Deserialize` + `ToSchema`/`PartialSchema` for
  `LlmProviderType` (an open string at the wire level; `Arc<str>` has no
  derive support).
- `From<LlmProviderType> for ProviderType` and `From<&ModelWithProvider> for
  ProviderConfig` carry `External` and metadata through.
- All built-in driver factories (OpenAI/OpenRouter/Azure/Completions,
  Anthropic, Gemini, Bedrock, LlmSim) adopt the `DriverConfig` argument.
- Regenerated `docs/api/openapi.json`: `LlmProviderType` is now an open
  string schema.

## Risk
- Low / Medium. Behavior change: duplicate driver registration now panics at
  startup (intended). Unknown DB provider ids now resolve to `External`
  instead of erroring / silently falling back to llmsim.
- No backward-compatibility shims (internal code; no spec requires them).

## Security
- Threat categories reviewed: TM-LLM. Provider credentials still never cross
  the command-host trait boundary; `ProviderMetadata` (OAuth tokens, account
  ids) lives only inside driver construction, mirroring the existing api_key
  handling. No new credential exposure surface.
- Findings and resolutions: none.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated (external registration, duplicate-panic,
  register_or_replace, external parsing, case-insensitivity, empty-rejection;
  all call sites updated)
- [x] Backward compatibility considered (internal-only; no shims needed)
- [x] Security review performed (TM-LLM; credentials stay in driver layer)
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed

## Validation
- `cargo build --all-features --workspace` clean.
- Tests: core 2325, server lib 1483, worker lib 95, runtime lib 48, runtime
  integration 46 — all pass.
- `cargo fmt --check` clean; clippy clean on touched crates.
- OpenAPI spec freshness: regenerated; only the `LlmProviderType` schema
  changed.
- Three Copilot review comments addressed (external id casing normalization;
  empty `provider_type` rejection in DB and gRPC paths).