### PR TITLE
docs(tool-search): document optimizations, add benchmarks and flow diagram

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -16,6 +16,8 @@ export default defineConfig({
   redirects: {
     // virtual_bash capability renamed to bashkit_shell
     "/capabilities/virtual-bash/": "/capabilities/bashkit-shell/",
+    // generic-tool-search page renamed to tool-search
+    "/capabilities/generic-tool-search/": "/capabilities/tool-search/",
   },
   vite: {
     resolve: {

--- a/crates/core/src/capabilities/tool_search.rs
+++ b/crates/core/src/capabilities/tool_search.rs
@@ -1164,6 +1164,104 @@ mod tests {
         }
     }
 
+    /// Measure the prompt-size reduction from deferral on a realistic agent
+    /// surface built from production capabilities. Prints a breakdown (run with
+    /// `--nocapture`) and guards that deferral keeps cutting the tool-list size
+    /// by a wide margin. The printed numbers back the benchmark table in
+    /// `docs/capabilities/tool-search.md`; re-run this test to refresh them.
+    #[test]
+    fn benchmark_prompt_size_reduction() {
+        use crate::capabilities::{
+            BashkitShellCapability, Capability, CurrentTimeCapability, FileSystemCapability,
+            SessionCapability, SessionStorageCapability, StatelessTodoListCapability,
+            SubagentCapability, WebFetchCapability,
+        };
+
+        // A representative generic-agent surface: file, shell, fetch, session,
+        // storage, todo, time, and subagent tools.
+        let caps: Vec<Box<dyn Capability>> = vec![
+            Box::new(CurrentTimeCapability),
+            Box::new(FileSystemCapability),
+            Box::new(BashkitShellCapability),
+            Box::new(WebFetchCapability::from_env()),
+            Box::new(SessionCapability),
+            Box::new(SessionStorageCapability),
+            Box::new(StatelessTodoListCapability),
+            Box::new(SubagentCapability),
+        ];
+
+        let mut defs: Vec<ToolDefinition> = caps
+            .iter()
+            .flat_map(|c| c.tools())
+            .map(|t| t.to_definition())
+            .collect();
+        // Add the search tool itself, as the live capability does.
+        defs.push(ToolSearchTool::default().to_definition());
+
+        // What the driver serializes per tool: name + description + parameters.
+        let llm_view = |defs: &[ToolDefinition]| -> usize {
+            defs.iter()
+                .map(|d| {
+                    json!({
+                        "name": d.name(),
+                        "description": d.description(),
+                        "parameters": d.parameters(),
+                    })
+                    .to_string()
+                    .len()
+                })
+                .sum()
+        };
+
+        let total = defs.len();
+        let full_bytes = llm_view(&defs);
+
+        // Raw parameter-schema bytes (what stripping actually compresses) on the
+        // full surface, before deferral.
+        let params_full: usize = defs.iter().map(|d| d.parameters().to_string().len()).sum();
+
+        // First model turn: every deferrable schema is stubbed.
+        let deferred = hook(1).transform(defs);
+        let deferred_count = deferred.iter().filter(|d| is_stubbed(d)).count();
+        let deferred_bytes = llm_view(&deferred);
+        let params_deferred: usize = deferred
+            .iter()
+            .map(|d| d.parameters().to_string().len())
+            .sum();
+
+        let saved = full_bytes - deferred_bytes;
+        let pct = (saved as f64 / full_bytes as f64) * 100.0;
+        let params_pct = ((params_full - params_deferred) as f64 / params_full as f64) * 100.0;
+        // ~4 chars/token is the usual rule of thumb for JSON tool schemas.
+        let approx_tokens_full = full_bytes / 4;
+        let approx_tokens_deferred = deferred_bytes / 4;
+
+        eprintln!("tool-search prompt-size benchmark");
+        eprintln!("  tools on surface .......... {total}");
+        eprintln!("  schemas deferred .......... {deferred_count}");
+        eprintln!(
+            "  full tool list ............ {full_bytes} bytes (~{approx_tokens_full} tokens)"
+        );
+        eprintln!(
+            "  deferred tool list ........ {deferred_bytes} bytes (~{approx_tokens_deferred} tokens)"
+        );
+        eprintln!("  tool-list saved ........... {saved} bytes ({pct:.0}%)");
+        eprintln!(
+            "  parameter schemas ......... {params_full} -> {params_deferred} bytes ({params_pct:.0}% smaller)"
+        );
+
+        // Sanity guard: a many-tool surface must shrink substantially.
+        assert!(total >= 15, "surface should exceed the default threshold");
+        assert!(
+            pct > 30.0,
+            "deferral should cut the whole tool list by a wide margin (was {pct:.0}%)"
+        );
+        assert!(
+            params_pct > 45.0,
+            "parameter schemas should compress substantially (was {params_pct:.0}%)"
+        );
+    }
+
     #[tokio::test]
     async fn test_execute_filters_registry_to_visible_tools() {
         use crate::tools::ToolRegistry;

--- a/crates/core/src/capabilities/tool_search.rs
+++ b/crates/core/src/capabilities/tool_search.rs
@@ -1220,14 +1220,24 @@ mod tests {
         // full surface, before deferral.
         let params_full: usize = defs.iter().map(|d| d.parameters().to_string().len()).sum();
 
-        // First model turn: every deferrable schema is stubbed.
-        let deferred = hook(1).transform(defs);
+        // First model turn at the real default threshold: a surface this size is
+        // above it, so every deferrable schema is stubbed.
+        let threshold = DEFAULT_TOOL_SEARCH_THRESHOLD;
+        let deferred = hook(threshold).transform(defs);
         let deferred_count = deferred.iter().filter(|d| is_stubbed(d)).count();
         let deferred_bytes = llm_view(&deferred);
         let params_deferred: usize = deferred
             .iter()
             .map(|d| d.parameters().to_string().len())
             .sum();
+
+        // Deferral must shrink the surface; guard against underflow so a
+        // regression fails with a clear message instead of a subtraction panic.
+        assert!(
+            deferred_bytes < full_bytes && params_deferred < params_full,
+            "deferral must not grow the serialized surface \
+             (tool list {full_bytes}->{deferred_bytes}, params {params_full}->{params_deferred})"
+        );
 
         let saved = full_bytes - deferred_bytes;
         let pct = (saved as f64 / full_bytes as f64) * 100.0;
@@ -1251,7 +1261,10 @@ mod tests {
         );
 
         // Sanity guard: a many-tool surface must shrink substantially.
-        assert!(total >= 15, "surface should exceed the default threshold");
+        assert!(
+            total >= threshold,
+            "surface should meet or exceed the default threshold ({total} < {threshold})"
+        );
         assert!(
             pct > 30.0,
             "deferral should cut the whole tool list by a wide margin (was {pct:.0}%)"

--- a/crates/core/src/capability_dto.rs
+++ b/crates/core/src/capability_dto.rs
@@ -188,7 +188,7 @@ pub fn builtin_capability_docs_slug(id: &str) -> Option<&'static str> {
         "infinity_context" => Some("infinity-context"),
         "openai_image_generation" => Some("openai-image-generation"),
         "openai_tool_search" => Some("openai-tool-search"),
-        "tool_search" => Some("generic-tool-search"),
+        "tool_search" => Some("tool-search"),
         "auto_tool_search" => Some("auto-tool-search"),
         "platform_management" => Some("platform-management"),
         "prompt_canary_guardrail" => Some("prompt-canary-guardrail"),

--- a/docs/capabilities/auto-tool-search.md
+++ b/docs/capabilities/auto-tool-search.md
@@ -21,7 +21,7 @@ This is the recommended default for harnesses that may run on different models. 
 `auto_tool_search` resolves to one of two underlying mechanisms based on the model:
 
 - **Models with native tool search** (OpenAI GPT-5.4 and newer) → the hosted mechanism described in [OpenAI Tool Search](/capabilities/openai-tool-search/): namespaces + `defer_loading` + a `{"type": "tool_search"}` activator. No extra tool is added; the provider handles search server-side.
-- **All other models** (Anthropic, Gemini, OpenAI Completions, …) → the client-side mechanism described in [Tool Search](/capabilities/generic-tool-search/): schemas are stripped to stubs and a `tool_search` tool loads them back on demand.
+- **All other models** (Anthropic, Gemini, OpenAI Completions, …) → the client-side mechanism described in [Tool Search](/capabilities/tool-search/): schemas are stripped to stubs and a `tool_search` tool loads them back on demand.
 
 The choice is made when the agent's capabilities are assembled, once the model is known. You don't have to know in advance which provider an agent will use.
 
@@ -59,12 +59,12 @@ The threshold (minimum tool count before deferral activates) applies to both mec
 Prefer the single-mechanism capabilities when you know the model and want explicit behavior:
 
 - [OpenAI Tool Search](/capabilities/openai-tool-search/) (`openai_tool_search`) — hosted only; silently disabled on unsupported models (full schemas sent, no fallback).
-- [Tool Search](/capabilities/generic-tool-search/) (`tool_search`) — client-side only; works on any model including OpenAI.
+- [Tool Search](/capabilities/tool-search/) (`tool_search`) — client-side only; works on any model including OpenAI.
 
 Do not combine `auto_tool_search` with either of the above on the same agent — it already provides both paths.
 
 ## See Also
 
 - [OpenAI Tool Search](/capabilities/openai-tool-search/) — the hosted mechanism
-- [Tool Search](/capabilities/generic-tool-search/) — the client-side mechanism
+- [Tool Search](/capabilities/tool-search/) — the client-side mechanism
 - [Capabilities Overview](/capabilities/)

--- a/docs/capabilities/index.md
+++ b/docs/capabilities/index.md
@@ -83,7 +83,7 @@ Performance and cost optimization for LLM interactions.
 | [Infinity Context](/capabilities/infinity-context/) | `infinity_context` | 1 |
 | [Auto Tool Search](/capabilities/auto-tool-search/) | `auto_tool_search` | 1 |
 | [OpenAI Tool Search](/capabilities/openai-tool-search/) | `openai_tool_search` | 0 |
-| [Tool Search](/capabilities/generic-tool-search/) | `tool_search` | 1 |
+| [Tool Search](/capabilities/tool-search/) | `tool_search` | 1 |
 | [Budgeting](/capabilities/budgeting/) | `budgeting` | 1 |
 | [Self-Budget](/capabilities/self-budget/) | `self_budget` | 0 |
 

--- a/docs/capabilities/tool-search.md
+++ b/docs/capabilities/tool-search.md
@@ -22,6 +22,10 @@ Unlike [OpenAI Tool Search](/capabilities/openai-tool-search/), which relies on 
 
 ## How It Works
 
+The diagram below traces one deferred tool through a full round-trip — from schema stripping at context-assembly time, through the `tool_search` call, to calling the real tool with its restored parameters.
+
+![Tool Search deferred-loading flow: the Agent Runtime strips parameter schemas to stubs before sending tools to the model; the model calls tool_search, which ranks visible tools in the registry and returns full schemas while recording a session-scoped reveal; on the next iteration the hook restores the revealed tool's registered schema so the model can call it with full parameters.](../images/capabilities/tool-search-flow.svg)
+
 1. **Threshold check** — deferral only activates when the total tool count meets or exceeds the threshold (default: 15). Below it, full schemas are sent unchanged.
 2. **Schema stripping** — a tool-definition hook replaces the parameter schema of every deferrable tool with a small stub (name + description survive). This runs when the runtime agent is built, so the model never receives the full schemas upfront.
 3. **`tool_search` tool** — a real tool is added to the agent. When the model calls it with a query, the tool inspects its sibling tools and returns the full JSON parameter schemas of the matches.

--- a/docs/capabilities/tool-search.md
+++ b/docs/capabilities/tool-search.md
@@ -50,6 +50,19 @@ The `tool_search` tool itself is never deferred.
 
 Allowlisted tools behave exactly like `DeferrablePolicy::Never` tools — their full schema is always sent — so the agent is never forced through a `tool_search` round-trip before its first read/edit/shell call.
 
+### Search ranking and result bounding
+
+Because there is no hosted semantic index, `tool_search` ranks matches client-side with a deliberately simple, predictable scheme:
+
+- **Field-weighted keyword overlap** — each whitespace-separated query term scores **3** if it appears in a tool's *name* and **1** if it only appears in the *description*. A name hit is a far stronger signal of intent than an incidental word in prose, so it dominates.
+- **Exact-name bonus** — a query that is exactly a tool name gets a large bonus (**+100**), so "load this specific tool" always ranks that tool first. The deferred stub tells the model to query the exact tool name, so this is the common path. Wrapping punctuation is stripped first, so a quoted or backticked name (`"read_file"`, `` `read_file` ``) still matches.
+- **Top-band cutoff** — only results scoring at least **half the top score** are returned, trimming weak tail matches so a loose query does not drag in loosely related tools.
+- **Result cap** — at most **8** tools are returned per call. Every returned tool is also *revealed* (its full schema is un-deferred for the rest of the session), so the cap bounds both the response payload and how much of the catalogue a single search can permanently un-defer.
+- **Visible-tool scoping** — the search only considers tools visible in the current turn (the turn-scoped allowlist), so it never reveals a tool the agent could not otherwise call.
+- **No-match fallback** — if nothing matches, the tool returns the catalogue of available tool *names* (not schemas) so the model can refine its query instead of dead-ending. An empty query lists tools so the model can browse.
+
+The session reveal set that drives progressive disclosure is itself bounded: it is keyed per session and evicts the oldest sessions past a fixed cap, so reveals never leak across sessions or grow without limit (an evicted session simply re-runs `tool_search`).
+
 ### Model Support
 
 None required. Because deferral and search are implemented client-side, every model works the same way. For GPT-5.4+ you may prefer [OpenAI Tool Search](/capabilities/openai-tool-search/), which uses the provider's hosted index; use this capability for all other models.
@@ -74,6 +87,27 @@ The activation threshold defaults to 15 tools (`DEFAULT_TOOL_SEARCH_THRESHOLD`).
   }
 }
 ```
+
+## Benchmarks
+
+Deferral only touches how tool *parameter schemas* reach the model — names and descriptions still go out in full — so the savings scale with how many tools an agent carries and how rich their schemas are.
+
+Measured on a representative 19-tool generic-agent surface (file, shell, web-fetch, session, storage, todo, time, and subagent tools, plus `tool_search` itself), comparing the serialized tool list the driver sends to the model **with and without** deferral on the first turn:
+
+| Metric | Full schemas | Deferred (first turn) | Saving |
+|---|---|---|---|
+| Tool list sent to model | ~11.6 KB (~2,900 tokens) | ~7.0 KB (~1,760 tokens) | **39% smaller** |
+| Parameter-schema bytes only | ~8.3 KB | ~3.7 KB | **55% smaller** |
+
+Token figures use the ~4-chars-per-token rule of thumb for JSON. 18 of the 19 tools were deferred (`tool_search` keeps its schema). Net savings grow with tool count: an agent with dozens of MCP tools defers proportionally more.
+
+These numbers come from the `benchmark_prompt_size_reduction` test in `crates/core/src/capabilities/tool_search.rs`, which also guards the reduction against regressions. Reproduce them with:
+
+```bash
+cargo test -p everruns-core --lib benchmark_prompt_size_reduction -- --nocapture
+```
+
+The trade-off is one extra `tool_search` round-trip per deferred tool before its first use; for many-tool agents the upfront token savings dominate.
 
 ## Limitations
 

--- a/docs/images/capabilities/tool-search-flow.mmd
+++ b/docs/images/capabilities/tool-search-flow.mmd
@@ -1,0 +1,16 @@
+sequenceDiagram
+    participant M as Model
+    participant R as Agent Runtime
+    participant T as tool_search
+    participant G as Tool Registry
+
+    R->>R: Strip schemas: 18/19 → stubs
+    R->>M: Send names + descriptions only
+    M->>T: tool_search("read file")
+    T->>G: Rank visible tools by keyword
+    G->>T: Top matches + full schemas
+    T->>T: Record reveal (session-scoped)
+    T->>M: Return matching schemas
+    R->>R: Re-run hook → restore schema
+    M->>G: Call read_file(path), full params
+    G-->>M: Result

--- a/docs/images/capabilities/tool-search-flow.svg
+++ b/docs/images/capabilities/tool-search-flow.svg
@@ -1,0 +1,102 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 440" fill="none">
+  <style>
+    text { font-family: 'Geist', 'Inter', system-ui, sans-serif; }
+    .label { font-size: 13px; fill: #0A0A0A; font-weight: 600; }
+    .mono { font-family: 'Geist Mono', 'SF Mono', monospace; font-size: 12px; fill: #0A0A0A; font-weight: 600; }
+    .step-num { font-size: 10px; fill: #FFFFFF; font-weight: 600; }
+    .arrow-label { font-size: 10px; fill: #0A1636; font-weight: 500; }
+    .arrow-mono { font-family: 'Geist Mono', 'SF Mono', monospace; font-size: 10px; fill: #0A1636; font-weight: 500; }
+  </style>
+
+  <!-- Background -->
+  <rect width="800" height="440" fill="#FFFFFF"/>
+
+  <!-- Participant boxes -->
+  <rect x="30" y="20" width="120" height="36" fill="#F5F5F5" stroke="#0A0A0A" stroke-width="1"/>
+  <text x="90" y="43" text-anchor="middle" class="label">Model</text>
+
+  <rect x="240" y="20" width="120" height="36" fill="#F5F5F5" stroke="#0A0A0A" stroke-width="1"/>
+  <text x="300" y="43" text-anchor="middle" class="label">Agent Runtime</text>
+
+  <rect x="450" y="20" width="120" height="36" fill="#F5F5F5" stroke="#0A0A0A" stroke-width="1"/>
+  <text x="510" y="43" text-anchor="middle" class="mono">tool_search</text>
+
+  <rect x="650" y="20" width="120" height="36" fill="#F5F5F5" stroke="#0A0A0A" stroke-width="1"/>
+  <text x="710" y="43" text-anchor="middle" class="label">Tool Registry</text>
+
+  <!-- Lifelines -->
+  <line x1="90" y1="56" x2="90" y2="420" stroke="#A0A0A0" stroke-width="1" stroke-dasharray="3 3"/>
+  <line x1="300" y1="56" x2="300" y2="420" stroke="#A0A0A0" stroke-width="1" stroke-dasharray="3 3"/>
+  <line x1="510" y1="56" x2="510" y2="420" stroke="#A0A0A0" stroke-width="1" stroke-dasharray="3 3"/>
+  <line x1="710" y1="56" x2="710" y2="420" stroke="#A0A0A0" stroke-width="1" stroke-dasharray="3 3"/>
+
+  <!-- Step 1: Agent Runtime self — strip schemas -->
+  <rect x="306" y="76" width="18" height="18" fill="#0A1636"/>
+  <text x="315" y="89" text-anchor="middle" class="step-num">1</text>
+  <polyline points="300,80 335,80 335,92 300,92" stroke="#0A1636" stroke-width="1.5" fill="none"/>
+  <polygon points="305,87 295,92 305,97" fill="#0A1636"/>
+  <text x="340" y="89" text-anchor="start" class="arrow-label">Strip schemas: 18/19 → stubs</text>
+
+  <!-- Step 2: Agent Runtime -> Model (left) — send names + descriptions -->
+  <rect x="96" y="111" width="18" height="18" fill="#0A1636"/>
+  <text x="105" y="124" text-anchor="middle" class="step-num">2</text>
+  <line x1="300" y1="120" x2="98" y2="120" stroke="#0A1636" stroke-width="1.5"/>
+  <polygon points="103,115 93,120 103,125" fill="#0A1636"/>
+  <text x="199" y="114" text-anchor="middle" class="arrow-label">Send names + descriptions only</text>
+
+  <!-- Step 3: Model -> tool_search (right) — call tool_search -->
+  <rect x="96" y="146" width="18" height="18" fill="#0A1636"/>
+  <text x="105" y="159" text-anchor="middle" class="step-num">3</text>
+  <line x1="90" y1="155" x2="502" y2="155" stroke="#0A1636" stroke-width="1.5"/>
+  <polygon points="497,150 507,155 497,160" fill="#0A1636"/>
+  <text x="300" y="149" text-anchor="middle" class="arrow-mono">tool_search("read file")</text>
+
+  <!-- Step 4: tool_search -> Tool Registry (right) — rank visible tools -->
+  <rect x="516" y="181" width="18" height="18" fill="#0A1636"/>
+  <text x="525" y="194" text-anchor="middle" class="step-num">4</text>
+  <line x1="510" y1="190" x2="702" y2="190" stroke="#0A1636" stroke-width="1.5"/>
+  <polygon points="697,185 707,190 697,195" fill="#0A1636"/>
+  <text x="610" y="184" text-anchor="middle" class="arrow-label">Rank visible tools by keyword</text>
+
+  <!-- Step 5: Tool Registry -> tool_search (left) — top matches + schemas -->
+  <rect x="516" y="216" width="18" height="18" fill="#0A1636"/>
+  <text x="525" y="229" text-anchor="middle" class="step-num">5</text>
+  <line x1="710" y1="225" x2="518" y2="225" stroke="#0A1636" stroke-width="1.5"/>
+  <polygon points="523,220 513,225 523,230" fill="#0A1636"/>
+  <text x="610" y="219" text-anchor="middle" class="arrow-label">Top matches + full schemas</text>
+
+  <!-- Step 6: tool_search self — record reveal -->
+  <rect x="516" y="251" width="18" height="18" fill="#0A1636"/>
+  <text x="525" y="264" text-anchor="middle" class="step-num">6</text>
+  <polyline points="510,255 545,255 545,267 510,267" stroke="#0A1636" stroke-width="1.5" fill="none"/>
+  <polygon points="515,262 505,267 515,272" fill="#0A1636"/>
+  <text x="550" y="264" text-anchor="start" class="arrow-label">Record reveal (session-scoped)</text>
+
+  <!-- Step 7: tool_search -> Model (left) — return matching schemas -->
+  <rect x="96" y="286" width="18" height="18" fill="#0A1636"/>
+  <text x="105" y="299" text-anchor="middle" class="step-num">7</text>
+  <line x1="510" y1="295" x2="98" y2="295" stroke="#0A1636" stroke-width="1.5"/>
+  <polygon points="103,290 93,295 103,300" fill="#0A1636"/>
+  <text x="300" y="289" text-anchor="middle" class="arrow-label">Return matching schemas</text>
+
+  <!-- Step 8: Agent Runtime self — re-run hook, restore schema -->
+  <rect x="306" y="321" width="18" height="18" fill="#0A1636"/>
+  <text x="315" y="334" text-anchor="middle" class="step-num">8</text>
+  <polyline points="300,325 335,325 335,337 300,337" stroke="#0A1636" stroke-width="1.5" fill="none"/>
+  <polygon points="305,332 295,337 305,342" fill="#0A1636"/>
+  <text x="340" y="334" text-anchor="start" class="arrow-label">Re-run hook → restore schema</text>
+
+  <!-- Step 9: Model -> Tool Registry (right) — call real tool with full params -->
+  <rect x="96" y="356" width="18" height="18" fill="#0A1636"/>
+  <text x="105" y="369" text-anchor="middle" class="step-num">9</text>
+  <line x1="90" y1="365" x2="702" y2="365" stroke="#0A1636" stroke-width="1.5"/>
+  <polygon points="697,360 707,365 697,370" fill="#0A1636"/>
+  <text x="400" y="359" text-anchor="middle" class="arrow-mono">Call read_file(path), full params</text>
+
+  <!-- Step 10: Tool Registry -> Model (left, dashed) — result -->
+  <rect x="96" y="391" width="18" height="18" fill="#0A1636"/>
+  <text x="105" y="404" text-anchor="middle" class="step-num">10</text>
+  <line x1="710" y1="400" x2="98" y2="400" stroke="#0A1636" stroke-width="1.5" stroke-dasharray="4 3"/>
+  <polygon points="103,395 93,400 103,405" fill="#0A1636"/>
+  <text x="400" y="394" text-anchor="middle" class="arrow-label">Result</text>
+</svg>


### PR DESCRIPTION
## What
Improves the Tool Search capability docs page and renames it from `generic-tool-search` to `tool-search`:

- **Documents the previously-undocumented client-side search optimizations**: field-weighted keyword ranking (name×3 / description×1), exact-name bonus with quote tolerance, top-score-band cutoff, result cap, visible-tool scoping, no-match catalogue fallback, and the bounded per-session reveal registry.
- **Adds a Benchmarks section** with measured prompt-size reduction (39% smaller tool list, 55% smaller parameter schemas on a representative 19-tool agent surface), backed by a new `benchmark_prompt_size_reduction` regression test in `crates/core/src/capabilities/tool_search.rs`.
- **Adds a house-style sequence diagram** (`.mmd` source + hand-authored `.svg`) tracing one deferred tool through schema stripping → `tool_search` round-trip → session-scoped reveal → restored full-parameter call.
- **Renames the page** `capabilities/generic-tool-search` → `capabilities/tool-search` with a permanent redirect; updates cross-page links, the capabilities index, and the `builtin_capability_docs_slug` mapping.

## Why
The page covered the deferral mechanism but omitted the entire search/ranking and result-bounding side of the implementation, and had no quantitative evidence of the savings. The `generic-` prefix was also redundant — the page title is already "Tool Search".

## How
Read the implementation in `crates/core/src/capabilities/tool_search.rs` to enumerate the undocumented optimizations, then added them to the page. Wrote a measurement test against a real production-capability tool surface (file/shell/web-fetch/session/storage/todo/time/subagent) that serializes the LLM-facing tool list before and after the defer hook; the doc's numbers come from that test, which also guards against regressions. The diagram follows the repo's existing convention (bespoke SVG in Everruns house style, `.mmd` kept as logical source).

## Risk
- Low
- Worst case: a stale link to the old slug — mitigated by the `/capabilities/generic-tool-search/` → `/capabilities/tool-search/` redirect. The only runtime change is the static `docs_slug` string for the `tool_search` capability.

## Security
- Threat categories reviewed: **TM-API** (the `builtin_capability_docs_slug` change alters a static, read-only `docs_slug` string surfaced in capability metadata — no user input, no injection vector). All other changes are docs content, a redirect config entry, and a test-only addition.
- Findings and resolutions: None. No new threat surface; no auth/authz/tenant/tool-execution/input-handling paths touched.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated (`benchmark_prompt_size_reduction`)
- [x] Backward compatibility considered (old URL redirects; slug mapping updated)
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

## Validation
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -D warnings` (via `pre-push`): pass
- `cargo test -p everruns-core` for `capabilities::tool_search` (25) and `capability_dto` (11): pass
- `pnpm run build` in `apps/docs`: 371 pages built; verified the renamed page, the old-slug redirect (`meta refresh → /capabilities/tool-search/`), the embedded diagram, and the benchmark table all present in `dist`
- Benchmark numbers reproduced via `cargo test -p everruns-core --lib benchmark_prompt_size_reduction -- --nocapture`


---
_Generated by [Claude Code](https://claude.ai/code/session_017iN63mTtJZxJKwFNUVf3b4)_