### PR TITLE
feat(tool-search): add hosted claude_tool_search and wire into auto

### DIFF
--- a/crates/anthropic/src/driver.rs
+++ b/crates/anthropic/src/driver.rs
@@ -34,7 +34,7 @@ use everruns_core::llm_driver_registry::{
 use everruns_core::llm_retry::{
     LlmRetryConfig, RateLimitInfo, RetryMetadata, is_rate_limit_status, is_transient_error,
 };
-use everruns_core::tool_types::{ToolCall, ToolDefinition};
+use everruns_core::tool_types::{DeferrablePolicy, ToolCall, ToolDefinition};
 
 const DEFAULT_API_URL: &str = "https://api.anthropic.com/v1/messages";
 const ANTHROPIC_MODELS_URL: &str = "https://api.anthropic.com/v1/models";
@@ -349,19 +349,83 @@ impl AnthropicLlmDriver {
         (system_prompt, converted)
     }
 
-    fn convert_tools(tools: &[ToolDefinition], prompt_cache_enabled: bool) -> Vec<AnthropicTool> {
+    fn convert_tools(
+        tools: &[ToolDefinition],
+        prompt_cache_enabled: bool,
+    ) -> Vec<AnthropicToolEntry> {
         let last_index = tools.len().saturating_sub(1);
         tools
             .iter()
             .enumerate()
-            .map(|(index, tool)| AnthropicTool {
+            .map(|(index, tool)| {
+                AnthropicToolEntry::Function(AnthropicTool {
+                    name: tool.name().to_string(),
+                    description: tool.description().to_string(),
+                    input_schema: tool.parameters().clone(),
+                    cache_control: (prompt_cache_enabled && index == last_index)
+                        .then(AnthropicCacheControl::ephemeral),
+                    defer_loading: None,
+                })
+            })
+            .collect()
+    }
+
+    /// Convert tools with Anthropic's hosted tool_search: mark deferrable tools
+    /// `defer_loading: true` and prepend a `tool_search_tool_bm25_20251119` server
+    /// tool entry. The model sees names + descriptions for deferred tools and
+    /// loads their full schemas on demand via a natural-language search query.
+    ///
+    /// See `crates/anthropic/src/driver.rs` callers and
+    /// docs.claude.com/.../tool-search-tool for the wire format. Mirrors the
+    /// OpenAI Responses `convert_tools_with_search`, minus namespaces (Anthropic
+    /// defers each tool individually).
+    ///
+    /// `DeferrablePolicy::Never` tools keep full schemas (hot-path tools the model
+    /// shouldn't have to search for). The search-tool entry is always
+    /// non-deferred, which also satisfies Anthropic's "at least one tool must be
+    /// non-deferred" constraint even when every function tool is deferrable.
+    ///
+    /// When deferral is active (above threshold), per-tool prompt-cache
+    /// breakpoints are skipped: deferred tools are not part of the cached prefix,
+    /// so a `cache_control` marker on them is pointless (system-prompt caching
+    /// still applies via `mark_last_text_block_for_cache`). Below threshold this
+    /// delegates to the standard `convert_tools`, so `prompt_cache_enabled` is
+    /// threaded through — hardcoding it would silently drop the tools-list cache
+    /// breakpoint whenever tool_search is configured but inactive.
+    fn convert_tools_with_search(
+        tools: &[ToolDefinition],
+        threshold: usize,
+        prompt_cache_enabled: bool,
+    ) -> Vec<AnthropicToolEntry> {
+        // Below threshold the full schemas fit comfortably; don't defer, and keep
+        // the standard cache behavior.
+        if tools.len() < threshold {
+            return Self::convert_tools(tools, prompt_cache_enabled);
+        }
+
+        let mut entries: Vec<AnthropicToolEntry> = Vec::with_capacity(tools.len() + 1);
+
+        // The hosted search tool — natural-language (BM25) variant. Never deferred.
+        entries.push(AnthropicToolEntry::Search(AnthropicToolSearchTool {
+            r#type: "tool_search_tool_bm25_20251119".to_string(),
+            name: "tool_search_tool_bm25".to_string(),
+        }));
+
+        for tool in tools {
+            let should_defer = match tool.deferrable() {
+                DeferrablePolicy::Never => false,
+                DeferrablePolicy::Automatic | DeferrablePolicy::Always => true,
+            };
+            entries.push(AnthropicToolEntry::Function(AnthropicTool {
                 name: tool.name().to_string(),
                 description: tool.description().to_string(),
                 input_schema: tool.parameters().clone(),
-                cache_control: (prompt_cache_enabled && index == last_index)
-                    .then(AnthropicCacheControl::ephemeral),
-            })
-            .collect()
+                cache_control: None,
+                defer_loading: should_defer.then_some(true),
+            }));
+        }
+
+        entries
     }
 }
 
@@ -380,12 +444,6 @@ impl LlmDriver for AnthropicLlmDriver {
             Self::convert_messages(&messages, prompt_cache_enabled);
         let system = Self::system_prompt_for_request(system_prompt, prompt_cache_enabled);
 
-        let tools = if config.tools.is_empty() {
-            None
-        } else {
-            Some(Self::convert_tools(&config.tools, prompt_cache_enabled))
-        };
-
         // `[1m]` model ids (e.g. `claude-opus-4-8[1m]`) are the gateway's
         // large-context twins of the 200K base models. Anthropic's wire `model`
         // field only accepts the bare id; the 1M window is requested via the
@@ -398,6 +456,30 @@ impl LlmDriver for AnthropicLlmDriver {
             &everruns_core::LlmProviderType::Anthropic,
             wire_model,
         );
+
+        // Hosted tool_search (deferred tool loading) is gated on the Anthropic
+        // model profile. When a hosted `ToolSearchConfig` is present and the
+        // model supports it, defer tool schemas server-side via
+        // `tool_search_tool_bm25_20251119` + per-tool `defer_loading`; otherwise
+        // send full schemas. The config is provider-agnostic — set by the
+        // `claude_tool_search` / `auto_tool_search` capability — and reaches here
+        // on `config.tool_search`.
+        let supports_tool_search = profile.as_ref().is_some_and(|p| p.tool_search);
+        let tools = if config.tools.is_empty() {
+            None
+        } else if let Some(ref ts_config) = config.tool_search {
+            if ts_config.enabled && supports_tool_search {
+                Some(Self::convert_tools_with_search(
+                    &config.tools,
+                    ts_config.threshold,
+                    prompt_cache_enabled,
+                ))
+            } else {
+                Some(Self::convert_tools(&config.tools, prompt_cache_enabled))
+            }
+        } else {
+            Some(Self::convert_tools(&config.tools, prompt_cache_enabled))
+        };
 
         // Sampling parameters are removed on Fable 5 and Opus 4.8/4.7 —
         // sending `temperature` returns 400 ("`temperature` is deprecated for
@@ -1010,7 +1092,7 @@ struct AnthropicRequest {
     system: Option<AnthropicSystem>,
     stream: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
-    tools: Option<Vec<AnthropicTool>>,
+    tools: Option<Vec<AnthropicToolEntry>>,
     /// Extended thinking configuration (for Claude models that support it)
     #[serde(skip_serializing_if = "Option::is_none")]
     thinking: Option<AnthropicThinking>,
@@ -1237,6 +1319,25 @@ enum AnthropicImageSource {
     Url { url: String },
 }
 
+/// A tools-array entry: either a regular function tool or the hosted
+/// `tool_search_tool_*_20251119` server tool. Untagged so each variant
+/// serializes to its own object shape (the server tool has only `type`/`name`,
+/// no `input_schema`).
+#[derive(Debug, Serialize)]
+#[serde(untagged)]
+enum AnthropicToolEntry {
+    Search(AnthropicToolSearchTool),
+    Function(AnthropicTool),
+}
+
+/// The hosted tool-search server tool, e.g.
+/// `{"type": "tool_search_tool_bm25_20251119", "name": "tool_search_tool_bm25"}`.
+#[derive(Debug, Serialize)]
+struct AnthropicToolSearchTool {
+    r#type: String,
+    name: String,
+}
+
 #[derive(Debug, Serialize)]
 struct AnthropicTool {
     name: String,
@@ -1244,6 +1345,10 @@ struct AnthropicTool {
     input_schema: Value,
     #[serde(skip_serializing_if = "Option::is_none")]
     cache_control: Option<AnthropicCacheControl>,
+    /// When `Some(true)`, the tool's schema is loaded on demand via hosted
+    /// tool_search instead of being sent in the prefix. Omitted otherwise.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    defer_loading: Option<bool>,
 }
 
 // Streaming response types
@@ -1796,6 +1901,89 @@ mod tests {
         assert!(json[0].get("cache_control").is_none());
         assert!(json[1].get("cache_control").is_none());
         assert_eq!(json[2]["cache_control"]["type"], "ephemeral");
+    }
+
+    #[test]
+    fn test_convert_tools_with_search_defers_and_adds_search_tool() {
+        let make_tool = |name: &str, deferrable: DeferrablePolicy| {
+            ToolDefinition::Builtin(BuiltinTool {
+                name: name.to_string(),
+                display_name: None,
+                description: "test tool".to_string(),
+                parameters: json!({"type": "object", "properties": {}}),
+                policy: ToolPolicy::Auto,
+                category: None,
+                deferrable,
+                hints: ToolHints::default(),
+                full_parameters: None,
+            })
+        };
+        // 3 deferrable tools + 1 hot-path (Never) tool, threshold 3 → active.
+        let tools = vec![
+            make_tool("alpha", DeferrablePolicy::Automatic),
+            make_tool("bravo", DeferrablePolicy::Automatic),
+            make_tool("charlie", DeferrablePolicy::Automatic),
+            make_tool("write_todos", DeferrablePolicy::Never),
+        ];
+
+        let converted = AnthropicLlmDriver::convert_tools_with_search(&tools, 3, false);
+        let json = serde_json::to_value(&converted).unwrap();
+        let arr = json.as_array().unwrap();
+
+        // First entry is the hosted BM25 search tool (no input_schema).
+        assert_eq!(arr[0]["type"], "tool_search_tool_bm25_20251119");
+        assert_eq!(arr[0]["name"], "tool_search_tool_bm25");
+        assert!(arr[0].get("input_schema").is_none());
+
+        let by_name = |name: &str| {
+            arr.iter()
+                .find(|e| e["name"] == name)
+                .unwrap_or_else(|| panic!("missing {name}"))
+        };
+        // Deferrable tools carry defer_loading: true.
+        assert_eq!(by_name("alpha")["defer_loading"], json!(true));
+        assert_eq!(by_name("charlie")["defer_loading"], json!(true));
+        // The Never tool stays non-deferred (no defer_loading field).
+        assert!(by_name("write_todos").get("defer_loading").is_none());
+    }
+
+    #[test]
+    fn test_convert_tools_with_search_below_threshold_sends_full_schemas() {
+        let make_tool = |name: &str| {
+            ToolDefinition::Builtin(BuiltinTool {
+                name: name.to_string(),
+                display_name: None,
+                description: "test tool".to_string(),
+                parameters: json!({"type": "object", "properties": {}}),
+                policy: ToolPolicy::Auto,
+                category: None,
+                deferrable: DeferrablePolicy::Automatic,
+                hints: ToolHints::default(),
+                full_parameters: None,
+            })
+        };
+        let tools = vec![make_tool("one"), make_tool("two")];
+        let converted = AnthropicLlmDriver::convert_tools_with_search(&tools, 3, false);
+        let json = serde_json::to_value(&converted).unwrap();
+        let arr = json.as_array().unwrap();
+        // Below threshold: no search tool, no deferral.
+        assert_eq!(arr.len(), 2);
+        assert!(arr.iter().all(|e| e.get("defer_loading").is_none()));
+        assert!(
+            arr.iter()
+                .all(|e| e["type"] != "tool_search_tool_bm25_20251119")
+        );
+
+        // Below threshold must preserve the standard prompt-cache behavior:
+        // `prompt_cache_enabled` is threaded through, so the last tool still gets
+        // a cache breakpoint (regression guard for the dropped-marker bug).
+        let cached = AnthropicLlmDriver::convert_tools_with_search(
+            &tools, 3, /* prompt_cache_enabled */ true,
+        );
+        let cached_json = serde_json::to_value(&cached).unwrap();
+        let cached_arr = cached_json.as_array().unwrap();
+        assert!(cached_arr[0].get("cache_control").is_none());
+        assert_eq!(cached_arr[1]["cache_control"]["type"], "ephemeral");
     }
 
     #[test]

--- a/crates/core/src/capabilities/auto_tool_search.rs
+++ b/crates/core/src/capabilities/auto_tool_search.rs
@@ -1,26 +1,38 @@
 // Auto Tool Search Capability
 //
-// A model-adaptive dispatcher over the two real tool-search mechanisms:
+// A model-adaptive dispatcher over the three real tool-search mechanisms:
 //
-//   - `openai_tool_search` (hosted): on models with native tool_search support
-//     (OpenAI GPT-5.4+), the LLM driver hides parameter schemas server-side via
+//   - `openai_tool_search` (hosted): on models with native OpenAI tool_search
+//     support (GPT-5.4+), the LLM driver hides parameter schemas server-side via
 //     namespaces + defer_loading. No client-side tool is added.
-//   - `tool_search` (generic, client-side): on every other model (Anthropic,
-//     Gemini, OpenAI Completions, ...), a `DeferSchemaHook` strips schemas and a
-//     `tool_search` tool loads them back on demand.
+//   - `claude_tool_search` (hosted): on Claude models with native Anthropic
+//     tool_search support (Sonnet 4 / Opus 4 / Haiku 4.5 / Fable 5 and newer),
+//     the Anthropic driver marks tools `defer_loading: true` and adds a hosted
+//     `tool_search_tool_*_20251119` entry. No client-side tool is added.
+//   - `tool_search` (generic, client-side): on every other model (Gemini, OpenAI
+//     Completions, Claude/GPT reached via a gateway that masks the hosted format,
+//     ...), a `DeferSchemaHook` strips schemas and a `tool_search` tool loads
+//     them back on demand.
 //
 // Unlike picking one of those capabilities by hand, this one chooses at runtime.
-// It OWNS an `OpenAiToolSearchCapability` and a `ToolSearchCapability` and
-// implements `Capability::resolve_for_model`: capability collection knows the
-// agent's model (via `SystemPromptContext::model`) and delegates to whichever
-// inner capability fits. Only that one capability's contributions are collected —
-// the hosted config for the OpenAI one, or the hook + tool + system prompt for
-// the generic one. No "contribute both, prune later" step is needed.
+// It OWNS the two hosted capabilities and the generic one and implements
+// `Capability::resolve_for_model`: capability collection knows the agent's model
+// (via `SystemPromptContext::model`) and delegates to whichever inner capability
+// fits. Only that one capability's contributions are collected — the hosted
+// config for a hosted one, or the hook + tool + system prompt for the generic
+// one. No "contribute both, prune later" step is needed.
 //
-// Use this instead of `openai_tool_search` or `tool_search` when a harness must
-// work well across providers.
+// Use this instead of the individual capabilities when a harness must work well
+// across providers.
 
-use super::openai_tool_search::{OpenAiToolSearchCapability, model_supports_native_tool_search};
+use super::claude_tool_search::{
+    ClaudeToolSearchCapability,
+    model_supports_native_tool_search as model_supports_native_claude_tool_search,
+};
+use super::openai_tool_search::{
+    OpenAiToolSearchCapability,
+    model_supports_native_tool_search as model_supports_native_openai_tool_search,
+};
 use super::tool_search::ToolSearchCapability;
 use super::{Capability, CapabilityLocalization, CapabilityStatus};
 
@@ -31,11 +43,12 @@ pub const AUTO_TOOL_SEARCH_CAPABILITY_ID: &str = "auto_tool_search";
 
 /// Auto Tool Search capability.
 ///
-/// Holds the two real tool-search capabilities and dispatches to one of them
+/// Holds the three real tool-search capabilities and dispatches to one of them
 /// based on the agent's model. `threshold` (minimum number of tools before
-/// deferral activates) is shared by both and forwarded at construction.
+/// deferral activates) is shared by all and forwarded at construction.
 pub struct AutoToolSearchCapability {
     openai: OpenAiToolSearchCapability,
+    claude: ClaudeToolSearchCapability,
     generic: ToolSearchCapability,
 }
 
@@ -47,6 +60,7 @@ impl AutoToolSearchCapability {
     pub fn with_threshold(threshold: usize) -> Self {
         Self {
             openai: OpenAiToolSearchCapability::with_threshold(threshold),
+            claude: ClaudeToolSearchCapability::with_threshold(threshold),
             generic: ToolSearchCapability::with_threshold(threshold),
         }
     }
@@ -81,17 +95,18 @@ impl Capability for AutoToolSearchCapability {
     }
 
     fn description(&self) -> &str {
-        "Model-adaptive deferred tool loading. Uses OpenAI's hosted tool_search \
-         on models that support it (GPT-5.4 and newer) and a provider-agnostic \
-         client-side fallback on every other model. Reduces token usage for \
-         agents with many tools, regardless of provider."
+        "Model-adaptive deferred tool loading. Uses the provider's hosted \
+         tool_search on models that support it (OpenAI GPT-5.4+ and Claude \
+         Sonnet 4 / Opus 4 / Haiku 4.5 / Fable 5 and newer) and a \
+         provider-agnostic client-side fallback on every other model. Reduces \
+         token usage for agents with many tools, regardless of provider."
     }
 
     fn localizations(&self) -> Vec<CapabilityLocalization> {
         vec![CapabilityLocalization::text(
             "uk",
             "Автоматичний пошук інструментів",
-            "Відкладене завантаження інструментів, що адаптується до моделі. Використовує хостований tool_search від OpenAI на моделях, які його підтримують (GPT-5.4 і новіші), та незалежний від провайдера клієнтський резервний механізм на всіх інших моделях. Зменшує використання токенів для агентів із багатьма інструментами незалежно від провайдера.",
+            "Відкладене завантаження інструментів, що адаптується до моделі. Використовує хостований tool_search провайдера на моделях, які його підтримують (OpenAI GPT-5.4+ та Claude Sonnet 4 / Opus 4 / Haiku 4.5 / Fable 5 і новіші), та незалежний від провайдера клієнтський резервний механізм на всіх інших моделях. Зменшує використання токенів для агентів із багатьма інструментами незалежно від провайдера.",
         )]
     }
 
@@ -105,14 +120,16 @@ impl Capability for AutoToolSearchCapability {
 
     // The dispatch itself: capability collection calls this with the agent's
     // model and collects the resolved capability's contributions in place of this
-    // one's. Models with native support get the hosted OpenAI mechanism (no
-    // client-side tool or hook); everything else — including an unknown model —
-    // gets the provider-agnostic client-side mechanism, which is safe everywhere.
+    // one's. Models with native OpenAI or Anthropic support get the matching
+    // hosted mechanism (no client-side tool or hook); everything else — including
+    // an unknown model — gets the provider-agnostic client-side mechanism, which
+    // is safe everywhere. OpenAI and Anthropic profiles never both claim the same
+    // model id, so the order between the two hosted checks is immaterial.
     fn resolve_for_model(&self, model: Option<&str>) -> Option<&dyn Capability> {
-        if model.is_some_and(model_supports_native_tool_search) {
-            Some(&self.openai)
-        } else {
-            Some(&self.generic)
+        match model {
+            Some(m) if model_supports_native_openai_tool_search(m) => Some(&self.openai),
+            Some(m) if model_supports_native_claude_tool_search(m) => Some(&self.claude),
+            _ => Some(&self.generic),
         }
     }
 }
@@ -121,7 +138,8 @@ impl Capability for AutoToolSearchCapability {
 mod tests {
     use super::*;
     use crate::capabilities::{
-        CapabilityRegistry, OPENAI_TOOL_SEARCH_CAPABILITY_ID, TOOL_SEARCH_CAPABILITY_ID,
+        CLAUDE_TOOL_SEARCH_CAPABILITY_ID, CapabilityRegistry, OPENAI_TOOL_SEARCH_CAPABILITY_ID,
+        TOOL_SEARCH_CAPABILITY_ID,
     };
 
     #[test]
@@ -145,19 +163,33 @@ mod tests {
 
     #[test]
     fn test_resolves_to_generic_on_non_native_model() {
+        // A model with no hosted tool_search support on either provider (here a
+        // pre-4 Claude) falls back to the safe client-side mechanism.
         let cap = AutoToolSearchCapability::new();
         let resolved = cap
-            .resolve_for_model(Some("claude-sonnet-4-5-20250514"))
+            .resolve_for_model(Some("claude-3-5-haiku"))
             .expect("dispatches");
         assert_eq!(resolved.id(), TOOL_SEARCH_CAPABILITY_ID);
     }
 
     #[test]
-    fn test_resolves_to_hosted_on_native_model() {
+    fn test_resolves_to_hosted_on_native_openai_model() {
         let cap = AutoToolSearchCapability::new();
         let resolved = cap.resolve_for_model(Some("gpt-5.4")).expect("dispatches");
         assert_eq!(resolved.id(), OPENAI_TOOL_SEARCH_CAPABILITY_ID);
         // The hosted mechanism contributes no client-side tool or hook.
+        assert!(resolved.tools().is_empty());
+        assert!(resolved.tool_definition_hooks().is_empty());
+    }
+
+    #[test]
+    fn test_resolves_to_hosted_on_native_claude_model() {
+        let cap = AutoToolSearchCapability::new();
+        let resolved = cap
+            .resolve_for_model(Some("claude-opus-4-8"))
+            .expect("dispatches");
+        assert_eq!(resolved.id(), CLAUDE_TOOL_SEARCH_CAPABILITY_ID);
+        // Hosted: no client-side tool or hook contributed.
         assert!(resolved.tools().is_empty());
         assert!(resolved.tool_definition_hooks().is_empty());
     }

--- a/crates/core/src/capabilities/claude_tool_search.rs
+++ b/crates/core/src/capabilities/claude_tool_search.rs
@@ -1,0 +1,160 @@
+// Claude (Anthropic) Tool Search Capability
+//
+// When added to an agent, enables Anthropic's hosted tool_search (deferred tool
+// loading) for Claude models with tool_search=true in their profile. Each tool's
+// full parameter schema is loaded on-demand by the model via a server-side
+// `tool_search_tool_*_20251119` tool instead of being sent upfront.
+//
+// Like `openai_tool_search`, this capability provides no tools itself — it sets a
+// provider-agnostic `ToolSearchConfig`. The Anthropic driver consumes that config
+// and renders the hosted format (`defer_loading: true` per tool plus a
+// `tool_search_tool_bm25_20251119` entry). See `crates/anthropic/src/driver.rs`.
+//
+// If the model does not support tool_search (tool_search=false in the Anthropic
+// profile), this capability is silently ignored — no error, no crash. Use
+// `auto_tool_search` for a model-adaptive default that picks this on native
+// Claude models and the generic client-side mechanism elsewhere.
+
+use super::{Capability, CapabilityLocalization, CapabilityStatus, SystemPromptContext};
+use crate::llm_driver_registry::ToolSearchConfig;
+use async_trait::async_trait;
+
+pub use super::openai_tool_search::DEFAULT_TOOL_SEARCH_THRESHOLD;
+
+/// Capability ID for Claude (Anthropic) tool search.
+pub const CLAUDE_TOOL_SEARCH_CAPABILITY_ID: &str = "claude_tool_search";
+
+/// Claude Tool Search capability.
+///
+/// Adding this capability to an agent/harness enables deferred tool loading for
+/// Claude models that support it. The `threshold` controls the minimum number of
+/// tools before tool_search activates (default: [`DEFAULT_TOOL_SEARCH_THRESHOLD`]).
+pub struct ClaudeToolSearchCapability {
+    threshold: usize,
+}
+
+impl ClaudeToolSearchCapability {
+    pub fn new() -> Self {
+        Self {
+            threshold: DEFAULT_TOOL_SEARCH_THRESHOLD,
+        }
+    }
+
+    pub fn with_threshold(threshold: usize) -> Self {
+        Self { threshold }
+    }
+
+    /// Returns the `ToolSearchConfig` for this capability.
+    ///
+    /// The config is provider-agnostic — the same shape `openai_tool_search`
+    /// produces. The Anthropic driver renders it into the hosted Messages-API
+    /// format; the OpenAI Responses driver renders it into the Responses format.
+    /// Whichever driver handles the request decides the wire shape, so this
+    /// carries no provider tag.
+    pub fn tool_search_config(&self) -> ToolSearchConfig {
+        ToolSearchConfig {
+            enabled: true,
+            threshold: self.threshold,
+        }
+    }
+}
+
+/// Whether `model` natively supports Anthropic's hosted tool_search.
+///
+/// This is the single source of truth for the native-Claude decision, consulted
+/// by `auto_tool_search`'s runtime dispatch (at capability-collection time) and
+/// by `RuntimeAgentBuilder::build` (when reconciling a hosted config with the
+/// model). Native Claude tool_search is an Anthropic Messages-API feature, so the
+/// lookup is against the Anthropic provider profile regardless of how the model
+/// is otherwise routed (a Claude model reached via OpenRouter/Bedrock has the
+/// flag masked off in `get_model_profile` and falls back to client-side search).
+pub fn model_supports_native_tool_search(model: &str) -> bool {
+    crate::llm_model_profiles::get_model_profile(
+        &crate::llm_models::LlmProviderType::Anthropic,
+        model,
+    )
+    .is_some_and(|profile| profile.tool_search)
+}
+
+impl Default for ClaudeToolSearchCapability {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Capability for ClaudeToolSearchCapability {
+    fn id(&self) -> &str {
+        CLAUDE_TOOL_SEARCH_CAPABILITY_ID
+    }
+
+    fn name(&self) -> &str {
+        "Claude Tool Search"
+    }
+
+    fn description(&self) -> &str {
+        "Enables deferred tool loading for Claude models that support it \
+         (Sonnet 4, Opus 4, Haiku 4.5, and Fable 5 and newer). Reduces token \
+         usage by loading tool schemas on-demand instead of upfront."
+    }
+
+    fn localizations(&self) -> Vec<CapabilityLocalization> {
+        vec![CapabilityLocalization::text(
+            "uk",
+            "Пошук інструментів Claude",
+            "Вмикає відкладене завантаження інструментів для моделей Claude, які його підтримують (Sonnet 4, Opus 4, Haiku 4.5 та Fable 5 і новіші). Зменшує використання токенів, завантажуючи схеми інструментів на вимогу, а не заздалегідь.",
+        )]
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+
+    fn category(&self) -> Option<&str> {
+        Some("Optimization")
+    }
+
+    async fn system_prompt_contribution(&self, _ctx: &SystemPromptContext) -> Option<String> {
+        None // No system prompt needed — deferral is handled server-side.
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_capability_metadata() {
+        let cap = ClaudeToolSearchCapability::new();
+        assert_eq!(cap.id(), CLAUDE_TOOL_SEARCH_CAPABILITY_ID);
+        assert_eq!(cap.name(), "Claude Tool Search");
+        assert_eq!(cap.status(), CapabilityStatus::Available);
+        assert!(cap.tools().is_empty());
+    }
+
+    #[test]
+    fn test_default_threshold() {
+        let cap = ClaudeToolSearchCapability::new();
+        let config = cap.tool_search_config();
+        assert!(config.enabled);
+        assert_eq!(config.threshold, DEFAULT_TOOL_SEARCH_THRESHOLD);
+    }
+
+    #[test]
+    fn test_custom_threshold() {
+        let cap = ClaudeToolSearchCapability::with_threshold(5);
+        assert_eq!(cap.tool_search_config().threshold, 5);
+    }
+
+    #[test]
+    fn test_native_support_lookup() {
+        // Claude 4-family models support hosted tool_search; 3.x do not.
+        assert!(model_supports_native_tool_search("claude-opus-4-8"));
+        assert!(model_supports_native_tool_search("claude-sonnet-4-6"));
+        assert!(model_supports_native_tool_search("claude-haiku-4-5"));
+        assert!(model_supports_native_tool_search("claude-fable-5"));
+        assert!(!model_supports_native_tool_search("claude-3-5-haiku"));
+        // Unknown / non-Anthropic models are not native.
+        assert!(!model_supports_native_tool_search("gpt-5.5"));
+    }
+}

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -93,6 +93,7 @@ mod background_execution;
 mod bashkit_shell;
 mod btw;
 mod budgeting;
+mod claude_tool_search;
 pub mod compaction;
 mod current_time;
 mod data_knowledge;
@@ -167,6 +168,7 @@ pub use auto_tool_search::{AUTO_TOOL_SEARCH_CAPABILITY_ID, AutoToolSearchCapabil
 pub use background_execution::{BACKGROUND_EXECUTION_CAPABILITY_ID, BackgroundExecutionCapability};
 pub use btw::{BTW_CAPABILITY_ID, BtwCapability};
 pub use budgeting::BudgetingCapability;
+pub use claude_tool_search::{CLAUDE_TOOL_SEARCH_CAPABILITY_ID, ClaudeToolSearchCapability};
 pub use compaction::{
     COMPACTION_CAPABILITY_ID, CompactionCapability, CompactionConfig, CompactionStep,
     CompactionStrategy, CostControlConfig, CostControlMaskingResult, HierarchicalMemoryConfig,
@@ -1115,6 +1117,8 @@ impl CapabilityRegistry {
 
         // OpenAI tool_search (deferred tool loading, all environments)
         registry.register(OpenAiToolSearchCapability::new());
+        // Claude (Anthropic) tool_search (hosted deferred tool loading)
+        registry.register(ClaudeToolSearchCapability::new());
         // Generic, provider-agnostic tool_search (client-side deferred loading)
         registry.register(ToolSearchCapability::new());
         // Model-adaptive tool_search (hosted on capable models, generic elsewhere)
@@ -2098,11 +2102,16 @@ pub async fn collect_capabilities_with_configs(
                 tool_definitions.push(def);
             }
 
-            // Detect the hosted tool_search mechanism. `auto_tool_search` resolves
-            // to `openai_tool_search` (this id) only on models with native support;
-            // on every other model it resolves to the generic `tool_search`, which
-            // sets no hosted config and instead contributes the hook + tool above.
-            if effective_id == OPENAI_TOOL_SEARCH_CAPABILITY_ID {
+            // Detect a hosted tool_search mechanism (OpenAI or Anthropic). Both
+            // hosted capabilities produce the same provider-agnostic
+            // `ToolSearchConfig`; the driver that handles the request picks the
+            // wire format. `auto_tool_search` resolves to one of these ids only on
+            // models with native support; on every other model it resolves to the
+            // generic `tool_search`, which sets no hosted config and instead
+            // contributes the hook + tool above.
+            if effective_id == OPENAI_TOOL_SEARCH_CAPABILITY_ID
+                || effective_id == CLAUDE_TOOL_SEARCH_CAPABILITY_ID
+            {
                 // Parse threshold from config, fall back to default
                 let threshold = cap_config
                     .config
@@ -2363,6 +2372,7 @@ mod tests {
             "memory",
             "message_metadata",
             "openai_tool_search",
+            "claude_tool_search",
             "tool_search",
             "auto_tool_search",
             "prompt_caching",
@@ -4448,9 +4458,10 @@ mod tests {
             },
         ];
 
-        // No native support → resolves to the generic client-side mechanism: no
-        // hosted config, but the tool_search tool + DeferSchemaHook are collected.
-        let ctx = test_ctx().with_model("claude-sonnet-4-5-20250514");
+        // No native support (pre-4 Claude) → resolves to the generic client-side
+        // mechanism: no hosted config, but the tool_search tool + DeferSchemaHook
+        // are collected.
+        let ctx = test_ctx().with_model("claude-3-5-haiku");
         let collected = collect_capabilities_with_configs(&configs, &registry, &ctx).await;
 
         assert!(
@@ -4503,6 +4514,39 @@ mod tests {
             .expect("auto_tool_search must set a hosted config on a native model");
         assert!(ts.enabled);
         assert_eq!(ts.threshold, 7);
+        assert!(
+            !collected
+                .tools
+                .iter()
+                .any(|t| t.name() == TOOL_SEARCH_TOOL_NAME),
+            "hosted mechanism must not contribute the client-side tool_search tool"
+        );
+        assert!(
+            collected.tool_definition_hooks.is_empty(),
+            "hosted mechanism must not contribute a client-side deferral hook"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_collect_capabilities_auto_tool_search_resolves_to_hosted_on_anthropic() {
+        let registry = CapabilityRegistry::with_builtins();
+
+        let configs = vec![AgentCapabilityConfig {
+            capability_ref: CapabilityId::new("auto_tool_search"),
+            config: serde_json::json!({"threshold": 9}),
+        }];
+
+        // Native Claude support → resolves to the hosted Anthropic mechanism: a
+        // hosted config (honoring the threshold) and no client-side tool/hook.
+        let ctx = test_ctx().with_model("claude-opus-4-8");
+        let collected = collect_capabilities_with_configs(&configs, &registry, &ctx).await;
+
+        let ts = collected
+            .tool_search
+            .as_ref()
+            .expect("auto_tool_search must set a hosted config on a native Claude model");
+        assert!(ts.enabled);
+        assert_eq!(ts.threshold, 9);
         assert!(
             !collected
                 .tools

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -314,8 +314,9 @@ pub use session_sandbox::{
 pub use capabilities::SystemPromptContext;
 pub use capabilities::{
     AUTO_TOOL_SEARCH_CAPABILITY_ID, AddTool, AgentBlueprint, AgentCapabilityConfig,
-    AppliedCapabilities, AutoToolSearchCapability, BlueprintModel, Capability, CapabilityId,
-    CapabilityRegistry, CapabilityRegistryBuilder, CapabilityStatus, CollectedCapabilities,
+    AppliedCapabilities, AutoToolSearchCapability, BlueprintModel,
+    CLAUDE_TOOL_SEARCH_CAPABILITY_ID, Capability, CapabilityId, CapabilityRegistry,
+    CapabilityRegistryBuilder, CapabilityStatus, ClaudeToolSearchCapability, CollectedCapabilities,
     CurrentTimeCapability, DECLARATIVE_CAPABILITY_PREFIX, DeleteFileTool, DependencyError,
     DivideTool, FileSystemCapability, GetCurrentTimeTool, GetForecastTool, GetSessionInfoTool,
     GetWeatherTool, GrepFilesTool, HUMAN_INTENT_CAPABILITY_ID, HumanIntentCapability,

--- a/crates/core/src/llm_model_profiles.rs
+++ b/crates/core/src/llm_model_profiles.rs
@@ -363,12 +363,25 @@ pub fn get_model_profile(
 ) -> Option<LlmModelProfile> {
     let descriptor = resolve_descriptor(provider_type, model_id)?;
     let mut profile = profile_data(descriptor.ids[0])?;
-    // Native execution phases and tool_search are advertised only for the
-    // `openai` provider type. OpenRouter uses a compatible but stateless
-    // Responses endpoint, so it keeps the base model profile while masking
-    // native OpenAI-only request options.
+    // Native execution phases are an OpenAI Responses-only feature. OpenRouter
+    // uses a compatible but stateless Responses endpoint, so it keeps the base
+    // model profile while masking native OpenAI-only request options.
     if !matches!(provider_type, LlmProviderType::Openai) {
         profile.supports_phases = false;
+    }
+    // Hosted tool_search is rendered by the OpenAI Responses driver and the
+    // Anthropic Messages driver. Other provider types reach the same models
+    // through transports that don't implement the hosted format and must fall
+    // back to client-side `tool_search` (see `auto_tool_search`):
+    //   - OpenRouter: stateless `/responses` shim, no tool_search extension.
+    //   - Bedrock: ConverseStream; Anthropic's server-side tool search there is
+    //     only on the InvokeModel API, which this driver does not use.
+    //   - OpenAI Completions / Gemini: no hosted tool_search at all.
+    // So mask the flag for everything except the two first-party providers.
+    if !matches!(
+        provider_type,
+        LlmProviderType::Openai | LlmProviderType::Anthropic
+    ) {
         profile.tool_search = false;
     }
     Some(profile)
@@ -2023,7 +2036,44 @@ fn anthropic_1m_variant(mut profile: LlmModelProfile) -> LlmModelProfile {
     profile
 }
 
+/// Whether a Claude model `family` supports Anthropic's hosted tool_search
+/// (the `tool_search_tool_*_20251119` server tools). Per docs.claude.com, this
+/// is Sonnet 4.0+, Opus 4.0+, Haiku 4.5+, and Fable 5 — the 3.x families do not
+/// support it. Centralized here (rather than per-literal) because the rule is a
+/// clean family cutoff; contrast the OpenAI profiles, which set `tool_search`
+/// per model literal.
+///
+/// Only families with a corresponding profile in `anthropic_profile_data_inner`
+/// belong here — Anthropic docs also list Mythos 5, but this registry has no
+/// `claude-mythos-5` descriptor, so including it would be a dead branch. Add the
+/// family here when (and if) its profile lands.
+fn anthropic_family_supports_tool_search(family: &str) -> bool {
+    matches!(
+        family,
+        "claude-fable-5"
+            | "claude-opus-4-8"
+            | "claude-opus-4-7"
+            | "claude-opus-4-6"
+            | "claude-opus-4-5"
+            | "claude-opus-4-1"
+            | "claude-opus-4"
+            | "claude-sonnet-4-6"
+            | "claude-sonnet-4-5"
+            | "claude-sonnet-4"
+            | "claude-haiku-4-5"
+    )
+}
+
 fn anthropic_profile_data(model_id: &str) -> Option<LlmModelProfile> {
+    // `tool_search` is assigned centrally by family below, so the per-literal
+    // `tool_search` value in the match arms is a placeholder and is overwritten.
+    anthropic_profile_data_inner(model_id).map(|mut profile| {
+        profile.tool_search = anthropic_family_supports_tool_search(&profile.family);
+        profile
+    })
+}
+
+fn anthropic_profile_data_inner(model_id: &str) -> Option<LlmModelProfile> {
     match model_id {
         // Claude Fable 5 (newest — top tier above Opus)
         // Source: Anthropic model card (claude-api skill `shared/models.md`) and
@@ -4078,6 +4128,47 @@ mod tests {
             get_model_profile(&LlmProviderType::OpenaiCompletions, "gpt-5.4").unwrap();
         assert!(!completions.supports_phases);
         assert!(!completions.tool_search);
+    }
+
+    #[test]
+    fn test_anthropic_native_tool_search_by_family() {
+        // Claude 4-family + Fable advertise Anthropic's hosted tool_search.
+        for id in [
+            "claude-fable-5",
+            "claude-opus-4-8",
+            "claude-opus-4-7",
+            "claude-opus-4-6",
+            "claude-opus-4-5",
+            "claude-opus-4-1",
+            "claude-opus-4",
+            "claude-sonnet-4-6",
+            "claude-sonnet-4-5",
+            "claude-sonnet-4",
+            "claude-haiku-4-5",
+        ] {
+            let p = get_model_profile(&LlmProviderType::Anthropic, id)
+                .unwrap_or_else(|| panic!("{id} should resolve under anthropic"));
+            assert!(p.tool_search, "{id} should advertise native tool_search");
+        }
+        // The 1M twin inherits the flag.
+        assert!(
+            get_model_profile(&LlmProviderType::Anthropic, "claude-opus-4-8[1m]")
+                .unwrap()
+                .tool_search
+        );
+        // Pre-4 Claude does not support it.
+        assert!(
+            !get_model_profile(&LlmProviderType::Anthropic, "claude-3-5-haiku")
+                .map(|p| p.tool_search)
+                .unwrap_or(false)
+        );
+        // Reached via a non-first-party transport (Bedrock ConverseStream lacks
+        // server-side tool search; OpenRouter's stateless shim doesn't implement
+        // it), the same model must not advertise hosted tool_search — it falls
+        // back to client-side search via auto_tool_search.
+        if let Some(bedrock) = get_model_profile(&LlmProviderType::Bedrock, "claude-opus-4-8") {
+            assert!(!bedrock.tool_search);
+        }
     }
 
     #[test]

--- a/crates/core/src/runtime_agent.rs
+++ b/crates/core/src/runtime_agent.rs
@@ -391,13 +391,15 @@ impl RuntimeAgentBuilder {
 
     /// Build the runtime agent.
     ///
-    /// Validates that tool_search is only enabled for models that support it
-    /// (currently GPT-5.4 and newer). Clears tool_search for unsupported models to
-    /// prevent 400 errors from the OpenAI API.
+    /// Validates that a hosted tool_search config is only kept for models that
+    /// support it (OpenAI GPT-5.4+ and Claude Sonnet 4 / Opus 4 / Haiku 4.5 /
+    /// Fable 5 and newer). Clears it for unsupported models to prevent 400 errors
+    /// from the provider API.
     ///
-    /// tool_search is capability-driven: it is only set when the
-    /// `openai_tool_search` capability is explicitly added to the agent
-    /// or harness. This method does NOT auto-enable it.
+    /// tool_search is capability-driven: a hosted config is only set when the
+    /// `openai_tool_search` / `claude_tool_search` capability (directly or via
+    /// `auto_tool_search`) is added to the agent or harness. This method does NOT
+    /// auto-enable it.
     pub fn build(mut self) -> RuntimeAgent {
         // Deduplicate tools by name (last wins). Tools are collected additively
         // from harness, agent, MCP servers, session capabilities, and client-side
@@ -423,9 +425,16 @@ impl RuntimeAgentBuilder {
         // plus a `tool_search` tool. This step only reconciles a hosted config
         // with the model — collection may have set one (via a direct
         // `openai_tool_search` capability) that the model can't honor.
-        let model_supports_native =
-            get_model_profile(&LlmProviderType::Openai, &self.runtime_agent.model)
-                .is_some_and(|p| p.tool_search);
+        // A hosted config is honorable when any provider with a driver that
+        // renders the hosted format advertises tool_search for this model:
+        // OpenAI (Responses) and Anthropic (Messages). A model id resolves under
+        // at most one of these provider profiles, so the other lookup is None.
+        let model_supports_native = [LlmProviderType::Openai, LlmProviderType::Anthropic]
+            .iter()
+            .any(|provider| {
+                get_model_profile(provider, &self.runtime_agent.model)
+                    .is_some_and(|p| p.tool_search)
+            });
 
         // Hosted (native) deferral hides schemas server-side, so client-side
         // opt-out hooks (DeferSchemaHook) must be skipped while a hosted config
@@ -1030,9 +1039,11 @@ mod tests {
     }
 
     #[test]
-    fn test_build_clears_tool_search_for_non_openai_model() {
+    fn test_build_clears_tool_search_for_non_native_model() {
+        // A pre-4 Claude model has no hosted tool_search support on either
+        // provider, so a hosted config is cleared (full schemas sent).
         let agent = RuntimeAgentBuilder::new()
-            .model("claude-sonnet-4-5-20250514")
+            .model("claude-3-5-haiku")
             .tool_search(ToolSearchConfig {
                 enabled: true,
                 threshold: 15,
@@ -1041,7 +1052,25 @@ mod tests {
 
         assert!(
             agent.tool_search.is_none(),
-            "tool_search should be cleared for non-OpenAI models"
+            "tool_search should be cleared for models with no hosted support"
+        );
+    }
+
+    #[test]
+    fn test_build_keeps_tool_search_for_native_anthropic_model() {
+        // Claude 4-family models support Anthropic's hosted tool_search, so the
+        // hosted config survives build() (the Anthropic driver renders it).
+        let agent = RuntimeAgentBuilder::new()
+            .model("claude-opus-4-8")
+            .tool_search(ToolSearchConfig {
+                enabled: true,
+                threshold: 15,
+            })
+            .build();
+
+        assert!(
+            agent.tool_search.is_some(),
+            "tool_search should be kept for native Anthropic models"
         );
     }
 

--- a/crates/llm-tests/tests/tool_search_test.rs
+++ b/crates/llm-tests/tests/tool_search_test.rs
@@ -18,9 +18,10 @@ mod llm_test_matrix;
 use llm_test_matrix::*;
 
 use everruns_core::capabilities::{
-    AutoToolSearchCapability, CurrentTimeCapability, FileSystemCapability,
-    OpenAiToolSearchCapability, SessionCapability, StatelessTodoListCapability,
-    TOOL_SEARCH_TOOL_NAME, TestMathCapability, TestWeatherCapability, ToolSearchCapability,
+    AutoToolSearchCapability, ClaudeToolSearchCapability, CurrentTimeCapability,
+    FileSystemCapability, OpenAiToolSearchCapability, SessionCapability,
+    StatelessTodoListCapability, TOOL_SEARCH_TOOL_NAME, TestMathCapability, TestWeatherCapability,
+    ToolSearchCapability,
 };
 use everruns_core::events::{EventData, LLM_GENERATION};
 use everruns_core::in_memory_loop::InMemoryAgenticLoop;
@@ -369,6 +370,110 @@ async fn test_anthropic_generic_tool_search_low_threshold() {
         result.tool_calls_count > 0,
         "Model should call add tool even with deferred schemas"
     );
+}
+
+// ============================================================================
+// Scenario: hosted Anthropic (Claude) tool_search (deferred loading)
+// ============================================================================
+
+/// Tests Anthropic's hosted tool_search end-to-end with Claude Haiku 4.5.
+///
+/// Verifies both halves of the contract against the live API: the hosted
+/// `ToolSearchConfig` is present on the request (deferred-load wire format), and
+/// the deferred tool can still be discovered, loaded, and called by the loop.
+#[tokio::test]
+async fn test_anthropic_claude_tool_search_low_threshold() {
+    let Some(model) = ANTHROPIC_HAIKU.model() else {
+        eprintln!("Skipping: {} not set", ANTHROPIC_HAIKU.label());
+        return;
+    };
+
+    let runner = InMemoryAgenticLoop::builder()
+        .agent_name("Claude Tool Search Agent")
+        .system_prompt("When asked to add numbers, use the add tool.")
+        .model(model)
+        .driver_registry(all_providers_registry())
+        .capability(TestMathCapability)
+        .capability(CurrentTimeCapability)
+        // Low threshold: hosted tool_search activates even with few tools (5 > 3).
+        .capability(ClaudeToolSearchCapability::with_threshold(3))
+        .max_iterations(6)
+        .build()
+        .await
+        .unwrap();
+
+    let result = runner.run_turn("What is 7 + 3?").await.unwrap();
+
+    assert!(result.success, "Turn should succeed: {:?}", result.error);
+    assert!(
+        result.tool_calls_count > 0,
+        "Claude should call the add tool even with deferred schemas"
+    );
+    assert_hosted_tool_search_was_enabled(&runner).await;
+
+    // The hosted path must not also offer the client-side `tool_search` tool —
+    // its presence would mean the generic fallback was selected instead.
+    let generations = runner.events_by_type(LLM_GENERATION).await;
+    for event in &generations {
+        let EventData::LlmGeneration(data) = &event.data else {
+            continue;
+        };
+        assert!(
+            !data.tools.iter().any(|t| t.name == TOOL_SEARCH_TOOL_NAME),
+            "hosted claude_tool_search must not offer the client-side \
+             `{TOOL_SEARCH_TOOL_NAME}` tool"
+        );
+    }
+}
+
+/// Tests model-adaptive hosted resolution on Claude Haiku 4.5.
+///
+/// On a native Claude model, `auto_tool_search` must resolve (at
+/// capability-collection time, via `Capability::resolve_for_model`) to the hosted
+/// Anthropic mechanism — not the client-side fallback. The hosted mechanism adds
+/// *no* client-side `tool_search` tool, so its absence from the model's tool list
+/// proves hosted resolution, independent of whether a tool was called on a turn.
+#[tokio::test]
+async fn test_anthropic_auto_tool_search_resolves_to_hosted() {
+    let Some(model) = ANTHROPIC_HAIKU.model() else {
+        eprintln!("Skipping: {} not set", ANTHROPIC_HAIKU.label());
+        return;
+    };
+
+    let runner = InMemoryAgenticLoop::builder()
+        .agent_name("Claude Auto Tool Search Agent")
+        .system_prompt("When asked to add numbers, use the add tool.")
+        .model(model)
+        .driver_registry(all_providers_registry())
+        .capability(TestMathCapability)
+        .capability(CurrentTimeCapability)
+        // Model-adaptive: on Claude 4.5 this must resolve to the hosted mechanism.
+        .capability(AutoToolSearchCapability::with_threshold(3))
+        .max_iterations(6)
+        .build()
+        .await
+        .unwrap();
+
+    let result = runner.run_turn("What is 7 + 3?").await.unwrap();
+
+    assert!(result.success, "Turn should succeed: {:?}", result.error);
+    assert!(
+        result.tool_calls_count > 0,
+        "Claude auto_tool_search should call add through hosted deferred loading"
+    );
+    assert_hosted_tool_search_was_enabled(&runner).await;
+
+    let generations = runner.events_by_type(LLM_GENERATION).await;
+    for event in &generations {
+        let EventData::LlmGeneration(data) = &event.data else {
+            continue;
+        };
+        assert!(
+            !data.tools.iter().any(|t| t.name == TOOL_SEARCH_TOOL_NAME),
+            "auto_tool_search on Claude 4.5 must resolve to hosted: the client-side \
+             `{TOOL_SEARCH_TOOL_NAME}` tool must not be offered to the model"
+        );
+    }
 }
 
 /// Tests that tool_search gracefully works when below threshold

--- a/docs/capabilities/auto-tool-search.md
+++ b/docs/capabilities/auto-tool-search.md
@@ -1,6 +1,6 @@
 ---
 title: Auto Tool Search
-description: Model-adaptive deferred tool loading. Uses OpenAI's hosted tool search where available and a provider-agnostic client-side fallback everywhere else, reducing prompt token usage for agents with many tools.
+description: Model-adaptive deferred tool loading. Uses the provider's hosted tool search where available (OpenAI or Claude) and a provider-agnostic client-side fallback everywhere else, reducing prompt token usage for agents with many tools.
 sidebar:
   order: 89
 ---
@@ -18,12 +18,17 @@ This is the recommended default for harnesses that may run on different models. 
 
 ## How It Works
 
-`auto_tool_search` resolves to one of two underlying mechanisms based on the model:
+`auto_tool_search` resolves to one of three underlying mechanisms based on the model:
 
-- **Models with native tool search** (OpenAI GPT-5.4 and newer) → the hosted mechanism described in [OpenAI Tool Search](/capabilities/openai-tool-search/): namespaces + `defer_loading` + a `{"type": "tool_search"}` activator. No extra tool is added; the provider handles search server-side.
-- **All other models** (Anthropic, Gemini, OpenAI Completions, …) → the client-side mechanism described in [Tool Search](/capabilities/tool-search/): schemas are stripped to stubs and a `tool_search` tool loads them back on demand.
+- **Models with native OpenAI tool search** (GPT-5.4 and newer) → the hosted mechanism described in [OpenAI Tool Search](/capabilities/openai-tool-search/): namespaces + `defer_loading` + a `{"type": "tool_search"}` activator. No extra tool is added; the provider handles search server-side.
+- **Models with native Claude tool search** (Sonnet 4, Opus 4, Haiku 4.5, and Fable 5 and newer) → the hosted mechanism described in [Claude Tool Search](/capabilities/claude-tool-search/): per-tool `defer_loading` + a `tool_search_tool_bm25_20251119` server tool. No extra tool is added; the provider handles search server-side.
+- **All other models** (Gemini, OpenAI Completions, Claude/GPT reached via a gateway that doesn't implement the hosted format, …) → the client-side mechanism described in [Tool Search](/capabilities/tool-search/): schemas are stripped to stubs and a `tool_search` tool loads them back on demand.
 
 The choice is made when the agent's capabilities are assembled, once the model is known. You don't have to know in advance which provider an agent will use.
+
+The dispatch looks at the **model id** (matched against the first-party OpenAI/Anthropic profiles), not the transport. In practice that handles the common gateway cases: a Claude model served via Amazon Bedrock or OpenRouter carries a distinct id (`anthropic.claude-…`, `anthropic/claude-…`) that doesn't match the bare first-party profile, so `auto_tool_search` resolves to the client-side mechanism there.
+
+> **Edge case:** if a masked transport presents a *bare* first-party id that does resolve (e.g. a `gpt-5.4` served through an OpenAI-compatible gateway), `auto_tool_search` picks the hosted capability, but the driver then suppresses the hosted wire format for that transport — so full schemas are sent with **no** client-side fallback (a missed optimization, not a failure). If you run a first-party model id through such a gateway, add the [Tool Search](/capabilities/tool-search/) capability explicitly to force client-side deferral.
 
 ## Tools
 
@@ -58,13 +63,15 @@ The threshold (minimum tool count before deferral activates) applies to both mec
 
 Prefer the single-mechanism capabilities when you know the model and want explicit behavior:
 
-- [OpenAI Tool Search](/capabilities/openai-tool-search/) (`openai_tool_search`) — hosted only; silently disabled on unsupported models (full schemas sent, no fallback).
-- [Tool Search](/capabilities/tool-search/) (`tool_search`) — client-side only; works on any model including OpenAI.
+- [OpenAI Tool Search](/capabilities/openai-tool-search/) (`openai_tool_search`) — hosted, OpenAI only; silently disabled on unsupported models (full schemas sent, no fallback).
+- [Claude Tool Search](/capabilities/claude-tool-search/) (`claude_tool_search`) — hosted, Claude only; silently disabled on unsupported models (full schemas sent, no fallback).
+- [Tool Search](/capabilities/tool-search/) (`tool_search`) — client-side only; works on any model including OpenAI and Claude.
 
-Do not combine `auto_tool_search` with either of the above on the same agent — it already provides both paths.
+Do not combine `auto_tool_search` with any of the above on the same agent — it already provides all three paths.
 
 ## See Also
 
-- [OpenAI Tool Search](/capabilities/openai-tool-search/) — the hosted mechanism
+- [OpenAI Tool Search](/capabilities/openai-tool-search/) — the hosted mechanism for OpenAI
+- [Claude Tool Search](/capabilities/claude-tool-search/) — the hosted mechanism for Claude
 - [Tool Search](/capabilities/tool-search/) — the client-side mechanism
 - [Capabilities Overview](/capabilities/)

--- a/docs/capabilities/claude-tool-search.md
+++ b/docs/capabilities/claude-tool-search.md
@@ -1,0 +1,103 @@
+---
+title: Claude Tool Search
+description: Deferred tool loading for agents with many tools on supported Claude models, reducing prompt token usage. Tools are loaded on demand via Anthropic's hosted tool search.
+sidebar:
+  order: 91
+---
+
+| | |
+|---|---|
+| **ID** | `claude_tool_search` |
+| **Category** | Optimization |
+| **Features** | None |
+| **Dependencies** | None |
+
+Enables [Anthropic's hosted tool search](https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-search-tool) for agents with many tools. Instead of sending full parameter schemas for every tool upfront, only tool names and descriptions reach the model initially. The model discovers and loads full schemas on demand by searching the catalog.
+
+This reduces prompt token usage significantly for agents with 15+ tools, without changing how tools are called or how results are returned. It is the Claude counterpart to [OpenAI Tool Search](/capabilities/openai-tool-search/); for a model-adaptive default that picks the right mechanism automatically, use [Auto Tool Search](/capabilities/auto-tool-search/).
+
+## Tools
+
+None — this capability configures the LLM driver, it does not provide tools.
+
+## How It Works
+
+1. **Threshold check** — tool search only activates when the total tool count meets or exceeds the threshold (default: 15). Below the threshold, full schemas are sent as usual.
+2. **Deferred schemas** — every deferrable tool gets `defer_loading: true`, so only its name and description reach the model upfront. Anthropic defers each tool individually (there is no namespace grouping).
+3. **Hosted search tool** — a `tool_search_tool_bm25_20251119` server tool is added to the request. The model issues a natural-language query against the catalog (tool names, descriptions, argument names, and argument descriptions) and Anthropic returns the 3–5 most relevant tools, expanding them into full definitions inline.
+4. **Transparent execution** — the model then calls a discovered tool with a normal `tool_use`; tool calls and results work identically. The only difference is how tools are presented to the model.
+
+Because the hosted search tool is itself never deferred, Anthropic's requirement that *at least one tool be non-deferred* is always satisfied — even when every function tool is deferrable.
+
+### DeferrablePolicy
+
+Each tool has a `deferrable` policy that controls whether its schema can be deferred:
+
+| Policy | Behavior |
+|---|---|
+| `never` | Full schema always sent (use for high-frequency tools like `write_todos`) |
+| `automatic` | Deferred when tool search is active and above threshold (default) |
+| `always` | Always deferred when tool search is active, regardless of threshold |
+
+Keeping the 3–5 most frequently used tools non-deferred (via `never`) avoids a search round-trip before the agent's first hot-path call.
+
+### Model Support
+
+Tool search requires model-level support. Per Anthropic, it is available on:
+
+| Model family | Supported |
+|---|---|
+| Opus 4.x (`claude-opus-4*`) | Yes |
+| Sonnet 4.x (`claude-sonnet-4*`) | Yes |
+| Haiku 4.5 (`claude-haiku-4-5`) | Yes |
+| Fable 5 (`claude-fable-5`) | Yes |
+| Claude 3.x and earlier | No (capability is silently ignored) |
+
+When the capability is enabled but the model doesn't support tool search, the feature is **silently skipped — full tool schemas are sent as usual**. This standalone capability does *not* add a client-side fallback: on an unsupported model it simply does nothing (no error, no behavior change). For automatic fallback to client-side deferral, use [Auto Tool Search](/capabilities/auto-tool-search/) (or add the [Tool Search](/capabilities/tool-search/) capability explicitly).
+
+Claude models reached through a non–first-party transport don't get hosted tool search either, because those transports don't implement the hosted format:
+
+- **Amazon Bedrock** — this integration uses the ConverseStream API; Anthropic's server-side tool search on Bedrock is only available via the InvokeModel API.
+- **OpenRouter** — its stateless OpenAI-compatible endpoint accepts but does not implement Anthropic's hosted tool search.
+
+With `claude_tool_search` alone, those transports also send full schemas; pair with [Auto Tool Search](/capabilities/auto-tool-search/) to get client-side deferral there instead.
+
+## Configuration
+
+### Default (threshold: 15)
+
+```json
+{
+  "capabilities": ["claude_tool_search"]
+}
+```
+
+### Custom threshold
+
+```json
+{
+  "capabilities": [
+    {
+      "capability_ref": "claude_tool_search",
+      "config": { "threshold": 10 }
+    }
+  ]
+}
+```
+
+Lower thresholds activate tool search with fewer tools. Set to `1` to always activate when the capability is present.
+
+## Limitations
+
+- **Claude-only** — this is an Anthropic Messages API feature; other providers (OpenAI, Gemini) ignore this capability. Use [Auto Tool Search](/capabilities/auto-tool-search/) for cross-provider agents.
+- **Supported Claude models only** — Claude 3.x and earlier don't support hosted tool search.
+- **First-party transport only** — Claude models reached via Bedrock (ConverseStream) or OpenRouter don't get hosted tool search; with this capability alone they send full schemas. Use [Auto Tool Search](/capabilities/auto-tool-search/) for client-side deferral there.
+- **No standalone fallback** — on an unsupported model/transport this capability is a no-op (full schemas), not a switch to client-side deferral. Combine with `auto_tool_search`, or add `tool_search`, if you want a fallback.
+
+## See Also
+
+- [Anthropic Tool search tool documentation](https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-search-tool) — official Anthropic guide
+- [Auto Tool Search](/capabilities/auto-tool-search/) — model-adaptive default (recommended for multi-provider harnesses)
+- [OpenAI Tool Search](/capabilities/openai-tool-search/) — the equivalent for OpenAI models
+- [Tool Search](/capabilities/tool-search/) — the provider-agnostic client-side fallback
+- [Capabilities Overview](/capabilities/)

--- a/docs/capabilities/index.md
+++ b/docs/capabilities/index.md
@@ -83,6 +83,7 @@ Performance and cost optimization for LLM interactions.
 | [Infinity Context](/capabilities/infinity-context/) | `infinity_context` | 1 |
 | [Auto Tool Search](/capabilities/auto-tool-search/) | `auto_tool_search` | 1 |
 | [OpenAI Tool Search](/capabilities/openai-tool-search/) | `openai_tool_search` | 0 |
+| [Claude Tool Search](/capabilities/claude-tool-search/) | `claude_tool_search` | 0 |
 | [Tool Search](/capabilities/tool-search/) | `tool_search` | 1 |
 | [Budgeting](/capabilities/budgeting/) | `budgeting` | 1 |
 | [Self-Budget](/capabilities/self-budget/) | `self_budget` | 0 |

--- a/docs/capabilities/openai-tool-search.md
+++ b/docs/capabilities/openai-tool-search.md
@@ -77,7 +77,7 @@ Lower thresholds activate tool_search with fewer tools. Set to `1` to always act
 
 ## Limitations
 
-- **OpenAI-only** — tool_search is an OpenAI Responses API feature; other providers (Anthropic, Gemini) ignore this capability
+- **OpenAI-only** — tool_search here is an OpenAI Responses API feature; other providers ignore this capability. For Claude, use [Claude Tool Search](/capabilities/claude-tool-search/); for a provider-adaptive default, use [Auto Tool Search](/capabilities/auto-tool-search/).
 - **Supported OpenAI reasoning models only** — earlier OpenAI models don't support tool_search
 - **No client-side tools** — currently only applies to built-in (server-executed) tools
 
@@ -85,4 +85,6 @@ Lower thresholds activate tool_search with fewer tools. Set to `1` to always act
 
 - [OpenAI Tool Search documentation](https://platform.openai.com/docs/guides/tool-search) — official OpenAI guide
 - [OpenAI Responses API: tools parameter](https://platform.openai.com/docs/api-reference/responses/create#responses-create-tools) — API reference for namespace and tool_search types
+- [Claude Tool Search](/capabilities/claude-tool-search/) — the equivalent for Claude models
+- [Auto Tool Search](/capabilities/auto-tool-search/) — model-adaptive default
 - [Capabilities Overview](/capabilities/)

--- a/docs/capabilities/tool-search.md
+++ b/docs/capabilities/tool-search.md
@@ -2,7 +2,7 @@
 title: Tool Search
 description: Provider-agnostic deferred tool loading for agents with many tools. Hides tool parameter schemas until the model loads them on demand, reducing prompt token usage on any model.
 sidebar:
-  order: 91
+  order: 92
 ---
 
 | | |
@@ -14,7 +14,7 @@ sidebar:
 
 Enables deferred tool loading for agents with many tools, on **any** model. Instead of sending full parameter schemas for every tool upfront, only tool names and descriptions are sent initially. The model loads full schemas on demand by calling the `tool_search` tool.
 
-Unlike [OpenAI Tool Search](/capabilities/openai-tool-search/), which relies on OpenAI's hosted `tool_search` feature, this capability implements tool search entirely client-side. It therefore works with Anthropic, Gemini, OpenAI Completions, and any other provider — not just GPT-5.4+.
+Unlike the hosted [OpenAI Tool Search](/capabilities/openai-tool-search/) and [Claude Tool Search](/capabilities/claude-tool-search/), which rely on the provider's server-side `tool_search` feature, this capability implements tool search entirely client-side. It therefore works with Gemini, OpenAI Completions, models reached through gateways that don't implement hosted search, and any other provider — not just GPT-5.4+ or Claude 4. For a default that automatically picks hosted search where available and this client-side path everywhere else, use [Auto Tool Search](/capabilities/auto-tool-search/).
 
 ## Tools
 
@@ -120,5 +120,7 @@ The trade-off is one extra `tool_search` round-trip per deferred tool before its
 
 ## See Also
 
+- [Auto Tool Search](/capabilities/auto-tool-search/) — model-adaptive default (hosted where available, this client-side path elsewhere)
 - [OpenAI Tool Search](/capabilities/openai-tool-search/) — hosted deferred loading for GPT-5.4+
+- [Claude Tool Search](/capabilities/claude-tool-search/) — hosted deferred loading for Claude 4+
 - [Capabilities Overview](/capabilities/)

--- a/specs/tool-search.md
+++ b/specs/tool-search.md
@@ -47,22 +47,27 @@ Model sees name + description upfront, parameters loaded only when needed. For n
 
 Model emits `tool_search_call` → client responds with `tool_search_output` containing matched tools. Multi-turn handshake.
 
-## Three Capabilities
+## Four Capabilities
 
-There are three capabilities, two mechanisms:
+There are four capabilities, two mechanisms (hosted vs client-side). The two hosted capabilities produce the *same* provider-agnostic `ToolSearchConfig`; the driver that handles the request renders the provider-specific wire format.
 
-- **`openai_tool_search`** — uses OpenAI's hosted tool_search (namespaces + `defer_loading` + `{"type":"tool_search"}`). Gated on `LlmModelProfile.tool_search`; cleared for unsupported models in `RuntimeAgentBuilder::build()`. Hosted mode only. See `crates/core/src/capabilities/openai_tool_search.rs`.
-- **`tool_search`** — generic, provider-agnostic client-side deferral that works with any model (Anthropic, Gemini, OpenAI Completions, ...). See `crates/core/src/capabilities/tool_search.rs` and below.
-- **`auto_tool_search`** — model-adaptive: picks the hosted mechanism on models that support it and the generic client-side mechanism everywhere else. This is the right default for a multi-provider harness (it is what the `generic` harness uses). See `crates/core/src/capabilities/auto_tool_search.rs`.
+- **`openai_tool_search`** — uses OpenAI's hosted tool_search (namespaces + `defer_loading` + `{"type":"tool_search"}`). Gated on the OpenAI `LlmModelProfile.tool_search`. Hosted mode only. See `crates/core/src/capabilities/openai_tool_search.rs`.
+- **`claude_tool_search`** — uses Anthropic's hosted tool_search: each deferrable tool gets `defer_loading: true` and a `tool_search_tool_bm25_20251119` server-tool entry is added (no namespaces — Anthropic defers each tool individually). Gated on the Anthropic `LlmModelProfile.tool_search`. The Anthropic driver renders it; see `crates/anthropic/src/driver.rs::convert_tools_with_search` and `crates/core/src/capabilities/claude_tool_search.rs`.
+- **`tool_search`** — generic, provider-agnostic client-side deferral that works with any model (Gemini, OpenAI Completions, Claude/GPT reached via a gateway that masks the hosted format, ...). See `crates/core/src/capabilities/tool_search.rs` and below.
+- **`auto_tool_search`** — model-adaptive: picks the matching hosted mechanism on models that support it and the generic client-side mechanism everywhere else. This is the right default for a multi-provider harness (it is what the `generic` harness uses). See `crates/core/src/capabilities/auto_tool_search.rs`.
 
 ### Auto resolution
 
-`auto_tool_search` is a runtime dispatcher, not a third mechanism. `AutoToolSearchCapability` owns an `OpenAiToolSearchCapability` and a `ToolSearchCapability` and implements `Capability::resolve_for_model`. The agent's model is carried on `SystemPromptContext::model`, so capability collection knows it and delegates to exactly one inner capability — collecting *its* contributions in place of the dispatcher's:
+`auto_tool_search` is a runtime dispatcher, not a separate mechanism. `AutoToolSearchCapability` owns an `OpenAiToolSearchCapability`, a `ClaudeToolSearchCapability`, and a `ToolSearchCapability`, and implements `Capability::resolve_for_model`. The agent's model is carried on `SystemPromptContext::model`, so capability collection knows it and delegates to exactly one inner capability — collecting *its* contributions in place of the dispatcher's:
 
-- **Model supports native tool_search** (`model_supports_native_tool_search`, OpenAI GPT-5.4+): resolves to `openai_tool_search`. Collection sets the hosted `ToolSearchConfig` (keyed on the resolved `effective.id()`); no client-side tool or hook is contributed.
+- **Model has native OpenAI support** (`openai_tool_search::model_supports_native_tool_search`, GPT-5.4+): resolves to `openai_tool_search`.
+- **Model has native Anthropic support** (`claude_tool_search::model_supports_native_tool_search`, Claude Sonnet 4 / Opus 4 / Haiku 4.5 / Fable 5 and newer): resolves to `claude_tool_search`.
+- Either hosted branch makes collection set the hosted `ToolSearchConfig` (keyed on the resolved `effective.id()`, which is one of the two hosted ids); no client-side tool or hook is contributed.
 - **Model lacks native support, or model is unknown:** resolves to the generic `tool_search`. Collection contributes its `DeferSchemaHook` + `tool_search` tool + system-prompt note and sets no hosted config.
 
-Because the mechanism is chosen during collection, `RuntimeAgentBuilder::build()` does no `auto`-specific pruning. There is no `auto` flag on `ToolSearchConfig`: a hosted config present after collection always means "use hosted deferral" (build only clears it if a *directly* configured `openai_tool_search` lands on a model that can't honor it — see below).
+A model id resolves under at most one of the OpenAI/Anthropic profiles, so the order between the two hosted checks is immaterial.
+
+Because the mechanism is chosen during collection, `RuntimeAgentBuilder::build()` does no `auto`-specific pruning. There is no `auto` flag on `ToolSearchConfig`: a hosted config present after collection always means "use hosted deferral" (build only clears it if a *directly* configured `openai_tool_search` / `claude_tool_search` lands on a model that can't honor it — see below). `build()` reconciles by checking the model against **both** hosted providers — `get_model_profile(Openai, …)` and `get_model_profile(Anthropic, …)` — and clears the config only when neither advertises `tool_search`.
 
 The executor (act) path collects without a model and so resolves to the generic mechanism. This registers the `tool_search` tool in the worker registry as a harmless superset: on native models the reason path never shows that tool to the model, so it is never called.
 
@@ -194,18 +199,37 @@ let use_tool_search = profile.tool_search && config.tools.len() >= TOOL_SEARCH_T
 
 ## Model Profile Updates
 
-Set `tool_search: true` for models that support it. Default `false` for all others. See `crates/core/src/llm_model_profiles.rs` for current profile definitions.
+Set `tool_search: true` for models that support it. Default `false` for all others. See `crates/core/src/llm_model_profiles.rs` for current profile definitions. OpenAI sets the flag per model literal (the `gpt-5.4*` / `gpt-5.5*` families); Anthropic sets it centrally by family in `anthropic_family_supports_tool_search` (Sonnet 4.0+, Opus 4.0+, Haiku 4.5+, Fable 5 — per docs.claude.com), since the support rule is a clean family cutoff.
 
 A model's `tool_search: true` flag must be backed by a verified end-to-end round-trip
 (deferred-load → schema fetch → tool call) against the live provider, not just the
 request-shaping unit tests. The `gpt-5.4*` and `gpt-5.5*` families are covered by
-live OpenAI integration tests in `crates/llm-tests/tests/tool_search_test.rs`.
+live OpenAI integration tests in `crates/llm-tests/tests/tool_search_test.rs`; the
+Claude families are covered by the live Anthropic tests
+`test_anthropic_claude_tool_search_low_threshold` and
+`test_anthropic_auto_tool_search_resolves_to_hosted` in the same file (run against
+Claude Haiku 4.5).
 
-## OpenAI Driver Changes
+### Provider gating (which transports honor the flag)
 
-The OpenAI driver extends `ResponsesTool` with `Namespace` and `ToolSearch` variants and adds `convert_tools_with_search()` to handle namespace grouping and defer_loading. See `crates/core/src/openresponses_protocol.rs` for the implementation.
+There are two enforcement points, and they sit at different layers:
 
-Non-OpenAI providers (Anthropic, Gemini) send full tool definitions (current behavior) with `tool_search: false` in their profiles. When providers adopt similar features, flip the flag per model.
+1. **Driver layer (authoritative).** `get_model_profile(provider_type, model)` masks `tool_search` to `false` for every provider type **except** `Openai` and `Anthropic` — the two whose drivers render a hosted format (OpenAI Responses; Anthropic Messages). Each driver looks up the profile for *its own* `provider_type`, so the hosted wire format is only emitted on a transport that implements it:
+   - **OpenRouter** — stateless OpenAI-compatible `/responses` shim that accepts but does not implement the hosted tool_search extension. Masked.
+   - **Bedrock** — ConverseStream; Anthropic's server-side tool search on Bedrock is only available via the InvokeModel API, which we do not use. Masked.
+   - **OpenAI Completions / Gemini** — no hosted tool_search at all. Masked.
+
+2. **Dispatcher layer (`auto_tool_search`).** The dispatcher only sees the **model id** (`SystemPromptContext::model`), *not* the transport, so it cannot consult the transport-masked profile. It checks the bare first-party profiles (`get_model_profile(Openai, …)` / `get_model_profile(Anthropic, …)`). In practice this still routes masked transports to the generic mechanism, because they carry **distinct model ids** (`anthropic.claude-…`, `anthropic/claude-…`, `openai/gpt-…`) that don't resolve to the bare first-party profile.
+
+**Residual edge case.** If a masked transport presents a *bare* first-party id that does resolve (e.g. a `gpt-5.4` served through an OpenAI-compatible gateway), the dispatcher resolves to the hosted capability and sets a hosted config, but the driver (step 1) then suppresses the hosted format for that transport. Because a hosted config is present, the client-side `DeferSchemaHook` is skipped too — so **full schemas are sent with no client-side fallback**. This is a graceful degradation (baseline behavior, no error), not a correctness bug, and it predates Claude support (it applies to `openai_tool_search` + OpenRouter just the same). To force client-side deferral on such a setup, add the generic `tool_search` capability explicitly. Making the dispatcher provider-aware (threading `provider_type` into capability collection) would close the gap but is out of scope here.
+
+## Driver Changes
+
+The OpenAI driver extends `ResponsesTool` with `Namespace` and `ToolSearch` variants and adds `convert_tools_with_search()` (namespace grouping + defer_loading + `{"type":"tool_search"}`). See `crates/core/src/openresponses_protocol.rs`.
+
+The Anthropic driver adds an `AnthropicToolEntry` (untagged: a function tool or a `tool_search_tool_bm25_20251119` server tool) and `convert_tools_with_search()`, which marks deferrable tools `defer_loading: true` and prepends the search-tool entry. No namespaces — Anthropic defers each tool individually. The hosted search-tool entry is always non-deferred, which also satisfies Anthropic's "at least one tool must be non-deferred" constraint. No beta header is required. See `crates/anthropic/src/driver.rs`. The streaming parser ignores the server-side `server_tool_use` / `tool_search_tool_result` blocks (parse-or-skip) and captures the model's subsequent normal `tool_use` for the discovered tool.
+
+Remaining providers (Gemini, OpenAI Completions) send full tool definitions with `tool_search: false`. When a provider adopts a hosted feature, set the flag and un-mask the provider type.
 
 ## LlmCallConfig Changes
 


### PR DESCRIPTION
## What
Adds Anthropic's native **hosted tool search** as a first-class capability (`claude_tool_search`), a peer to `openai_tool_search`, and teaches `auto_tool_search` to dispatch to it on native Claude models. Previously every non-OpenAI provider — including Claude — fell back to the client-side `tool_search` mechanism even though Anthropic now ships a server-side tool search.

## Why
Anthropic shipped server-side tool search (`tool_search_tool_*_20251119` + per-tool `defer_loading`). Our `specs/tool-search.md` already anticipated this ("When providers adopt similar features, flip the flag per model"). Routing native Claude models to the hosted mechanism preserves the prompt cache (schemas are appended, not stripped) and matches the OpenAI hosted path, instead of paying the client-side stub/reveal round-trips.

## How
- **New `claude_tool_search` capability** (`crates/core/src/capabilities/claude_tool_search.rs`) sets the same provider-agnostic `ToolSearchConfig` as `openai_tool_search`. The driver that handles the request picks the wire format, so the config carries no provider tag.
- **Anthropic driver** (`crates/anthropic/src/driver.rs`): `convert_tools_with_search` marks deferrable tools `defer_loading: true` and prepends a `tool_search_tool_bm25_20251119` server-tool entry (no namespaces — Anthropic defers each tool individually). `DeferrablePolicy::Never` tools stay non-deferred; the always-present search-tool entry satisfies Anthropic's "≥1 non-deferred" rule. The streaming parser already ignores the server-side `server_tool_use`/`tool_search_tool_result` blocks and captures the discovered tool's normal `tool_use`. No beta header required.
- **`auto_tool_search`** now owns all three mechanisms and resolves: OpenAI-native → `openai`, Claude-native → `claude`, else generic client-side.
- **Provider gating** (`get_model_profile`): `tool_search` is kept for the `Anthropic` provider type and still masked for OpenRouter / Bedrock / Completions / Gemini, whose transports don't implement the hosted format (those fall back to client-side search). Anthropic's flag is set by family (Sonnet 4.0+, Opus 4.0+, Haiku 4.5+, Fable 5) per docs.claude.com. `RuntimeAgentBuilder::build()` reconciles a hosted config against both first-party providers.
- **Docs**: new `docs/capabilities/claude-tool-search.md` + updates to the auto / openai / generic / index capability pages. **Spec**: `specs/tool-search.md` (capabilities, auto resolution, provider gating, driver changes, verification note).

## Risk
- **Low.** Additive capability + request-shaping change. Normal (non-search) Anthropic requests are unchanged (covered by the existing 41 driver tests). The only behavioral change for a Claude-4 agent that *already* uses `auto_tool_search` with 15+ tools is that deferral now happens server-side instead of client-side — same tool set, fewer round-trips, prompt cache preserved.
- The `tool_search` profile flag now propagates `true` for Claude-4 models into synced DB model profiles (surfaces the capability in the UI); this is metadata, not a runtime gate.

## How validated
- `cargo fmt --all --check`, `cargo clippy` (touched crates, `-D warnings`), full `everruns-core` lib suite (2309 passed), `everruns-anthropic` (41 passed), workspace `cargo check`.
- Unit tests: capability metadata + native-support lookup, three-way `auto` dispatch, collection sets the hosted config on native Claude, `build()` keeps/clears per model, Anthropic `convert_tools_with_search` wire shape (incl. the below-threshold prompt-cache regression guard), profile gating + masking.
- **Live end-to-end against the real Anthropic API (Claude Haiku 4.5)** — two integration tests in `crates/llm-tests/tests/tool_search_test.rs` exercise deferred-load → hosted search → tool call, assert the client-side `tool_search` tool is *not* offered, and that `auto` resolves to hosted. Both pass. This satisfies the spec's live-verification rule.

## Security
- Threat categories reviewed: **TM-LLM** (request construction / model parameters) and **TM-TOOL** (tool definitions). The change only alters how the tool list is *serialized* to Anthropic (adds a `defer_loading` flag and a server-tool entry) — the same tool names/descriptions/schemas already sent. No new endpoints (TM-API), auth/authz, SQL, FS/bash, tenant scoping, or web rendering. No new dependencies. No untrusted-input parsing or unbounded allocation introduced. No `THREAT` comments in the touched regions.
- Findings and resolutions: none.

## Follow-ups
- **Provider-aware `auto_tool_search` dispatch (documented limitation, optional).** The dispatcher resolves on the model id only, not the transport. In practice masked transports (Bedrock/OpenRouter) carry distinct ids and route to the client-side mechanism correctly; but a *bare* first-party id served through a masked gateway (e.g. `gpt-5.4` via an OpenAI-compatible endpoint) resolves to hosted, the driver then suppresses the hosted format, and full schemas are sent with **no** client-side fallback. This is a graceful degradation, not a correctness bug, and it predates this PR (it applies to `openai_tool_search` + OpenRouter identically). It's now documented in `specs/tool-search.md` and `docs/capabilities/auto-tool-search.md`, with the explicit-`tool_search` workaround. Threading `provider_type` into capability collection would close the gap; left out of scope here. (Raised by the Copilot review.)

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (additive; non-search path unchanged)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

https://claude.ai/code/session_01FZoqGvhE8wqd4GFBzGoxRY