### PR TITLE
feat(agents): advisory agent config checks (phase 1)

### DIFF
--- a/apps/ui/src/components/agents/agent-preview.tsx
+++ b/apps/ui/src/components/agents/agent-preview.tsx
@@ -9,11 +9,13 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { InitialFilesPreview } from "@/components/files/initial-files-preview";
 import type {
   AgentCapabilityConfig,
+  AgentFinding,
   AgentPreviewResponse,
+  FindingSeverity,
   InitialFile,
   ToolDefinition,
 } from "@/lib/api/types";
-import { Wrench, FileText, AlertCircle } from "lucide-react";
+import { Wrench, FileText, AlertCircle, ShieldCheck } from "lucide-react";
 
 interface AgentPreviewProps {
   systemPrompt: string;
@@ -96,6 +98,8 @@ export function AgentPreview({
 
   return (
     <div className="space-y-6">
+      <FindingsCard findings={preview.findings ?? []} />
+
       {/* System Prompt Preview */}
       <Card>
         <CardHeader>
@@ -143,6 +147,50 @@ export function AgentPreview({
 
       <InitialFilesPreview files={initialFiles} />
     </div>
+  );
+}
+
+const SEVERITY_STYLES: Record<FindingSeverity, string> = {
+  warning: "border-amber-500/50 text-amber-600 dark:text-amber-400",
+  info: "border-sky-500/50 text-sky-600 dark:text-sky-400",
+  suggestion: "border-muted-foreground/50 text-muted-foreground",
+};
+
+function FindingsCard({ findings }: { findings: AgentFinding[] }) {
+  if (findings.length === 0) {
+    return null;
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <ShieldCheck className="w-5 h-5" />
+          Checks
+          <Badge variant="secondary" className="ml-2">
+            {findings.length}
+          </Badge>
+        </CardTitle>
+        <CardDescription>
+          Advisory findings about this configuration. They never block saving.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <ul className="space-y-3">
+          {findings.map((finding, index) => (
+            <li key={`${finding.rule_id}-${index}`} className="flex items-start gap-3">
+              <Badge variant="outline" className={`text-xs ${SEVERITY_STYLES[finding.severity]}`}>
+                {finding.severity}
+              </Badge>
+              <div className="space-y-0.5">
+                <p className="text-sm">{finding.message}</p>
+                <p className="text-xs text-muted-foreground font-mono">{finding.rule_id}</p>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </CardContent>
+    </Card>
   );
 }
 

--- a/apps/ui/src/lib/api/types/agent-types.ts
+++ b/apps/ui/src/lib/api/types/agent-types.ts
@@ -163,12 +163,40 @@ export interface PreviewAgentRequest {
   tools?: ToolDefinition[];
 }
 
+export type FindingSeverity = "warning" | "info" | "suggestion";
+
+export type FindingCategory = "structure" | "completeness" | "effectiveness" | "safety" | "cost";
+
+export type FindingSource = "builtin" | "llm" | "health_check";
+
+/** Pointer to the config field (and optional byte span) a finding refers to */
+export interface FindingLocation {
+  field: string;
+  start?: number;
+  end?: number;
+}
+
+/** Advisory finding from agent config checks (specs/agent-checks.md) */
+export interface AgentFinding {
+  /** Stable rule identifier, e.g. "prompt.duplicate_paragraphs" */
+  rule_id: string;
+  severity: FindingSeverity;
+  category: FindingCategory;
+  message: string;
+  location?: FindingLocation;
+  /** Proposed replacement text (phase 2+) */
+  fix?: string;
+  source: FindingSource;
+}
+
 /** Response showing the final agent shape after applying capabilities */
 export interface AgentPreviewResponse {
   /** The full system prompt with capability additions prepended */
   system_prompt: string;
   /** All tool definitions from capabilities */
   tools: ToolDefinition[];
+  /** Advisory findings from built-in checks (absent on harness preview) */
+  findings?: AgentFinding[];
 }
 
 // ============================================

--- a/crates/server/src/api/agents.rs
+++ b/crates/server/src/api/agents.rs
@@ -1306,6 +1306,7 @@ pub async fn preview_agent(
     Ok(Json(AgentPreviewResponse {
         system_prompt: result.system_prompt,
         tools: result.tools,
+        findings: result.findings,
     }))
 }
 

--- a/crates/server/src/domains/agents/checks.rs
+++ b/crates/server/src/domains/agents/checks.rs
@@ -1,0 +1,521 @@
+// Tier-1 deterministic agent config checks (specs/agent-checks.md).
+//
+// Pure functions over the authored prompt and the resolved preview shape.
+// Advisory only: findings never block any operation. LLM-backed checks
+// (tier 2) and health checks (tier 3) are separate phases and do not live
+// here.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::LazyLock;
+
+use everruns_core::{AgentCapabilityConfig, ToolDefinition};
+use regex::Regex;
+use serde::Serialize;
+use utoipa::ToSchema;
+
+/// Advisory severity. There is deliberately no `error`: checks never gate
+/// save/publish (specs/agent-checks.md, Non-Goals).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum FindingSeverity {
+    Warning,
+    Info,
+    Suggestion,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum FindingCategory {
+    Structure,
+    Completeness,
+    Effectiveness,
+    Safety,
+    Cost,
+}
+
+/// Which tier produced the finding.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum FindingSource {
+    Builtin,
+    Llm,
+    HealthCheck,
+}
+
+/// Pointer to the config field (and optional byte span within it) a finding
+/// refers to.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct FindingLocation {
+    /// Config field name, e.g. `system_prompt`, `tools`.
+    pub field: String,
+    /// Byte offset range into the field's authored text, when applicable.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub start: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub end: Option<u32>,
+}
+
+/// A single advisory finding about an agent configuration.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct Finding {
+    /// Stable rule identifier, e.g. `prompt.duplicate_paragraphs`.
+    pub rule_id: String,
+    pub severity: FindingSeverity,
+    pub category: FindingCategory,
+    /// Human-readable explanation. Safe to render in user-facing messages.
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub location: Option<FindingLocation>,
+    /// Proposed replacement text (phase 2+; always absent for builtin rules).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fix: Option<String>,
+    pub source: FindingSource,
+}
+
+impl Finding {
+    fn builtin(
+        rule_id: &str,
+        severity: FindingSeverity,
+        category: FindingCategory,
+        message: String,
+    ) -> Self {
+        Self {
+            rule_id: rule_id.to_string(),
+            severity,
+            category,
+            message,
+            location: None,
+            fix: None,
+            source: FindingSource::Builtin,
+        }
+    }
+
+    fn at(mut self, field: &str, span: Option<(usize, usize)>) -> Self {
+        self.location = Some(FindingLocation {
+            field: field.to_string(),
+            start: span.map(|(s, _)| s as u32),
+            end: span.map(|(_, e)| e as u32),
+        });
+        self
+    }
+}
+
+/// Authored prompt larger than this is flagged as recurring per-turn cost.
+const LONG_PROMPT_BYTES: usize = 32 * 1024;
+/// Paragraphs shorter than this (normalized) are too generic to call
+/// duplicates ("Be helpful." legitimately repeats).
+const DUP_PARAGRAPH_MIN_CHARS: usize = 80;
+
+static TEMPLATE_VAR: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\{\{\s*[A-Za-z0-9_.-]+\s*\}\}").expect("valid regex"));
+static BACKTICKED_IDENT: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"`([a-z][a-z0-9]*(?:_[a-z0-9]+)+)`").expect("valid regex"));
+
+const BREVITY_PHRASES: &[&str] = &[
+    "be brief",
+    "be concise",
+    "keep responses short",
+    "keep answers short",
+    "short answers",
+    "terse",
+    "minimal output",
+];
+const VERBOSITY_PHRASES: &[&str] = &[
+    "be detailed",
+    "be thorough",
+    "be exhaustive",
+    "comprehensive",
+    "verbose",
+    "in-depth",
+    "in depth",
+];
+
+/// Run all tier-1 rules against an agent preview.
+///
+/// `authored_prompt` is the user-authored system prompt; `resolved_prompt`
+/// is the full prompt after harness/capability contributions; `tools` is the
+/// resolved tool list.
+pub fn run_builtin_checks(
+    authored_prompt: &str,
+    resolved_prompt: &str,
+    capabilities: &[AgentCapabilityConfig],
+    tools: &[ToolDefinition],
+) -> Vec<Finding> {
+    let mut findings = Vec::new();
+    check_empty_prompt(authored_prompt, &mut findings);
+    check_long_prompt(authored_prompt, &mut findings);
+    check_template_variables(authored_prompt, &mut findings);
+    check_duplicate_paragraphs(authored_prompt, &mut findings);
+    check_restates_contribution(authored_prompt, resolved_prompt, &mut findings);
+    check_conflicting_style(authored_prompt, &mut findings);
+    check_unknown_tool_reference(authored_prompt, capabilities, tools, &mut findings);
+    check_duplicate_tool_names(tools, &mut findings);
+    findings
+}
+
+fn check_empty_prompt(authored: &str, findings: &mut Vec<Finding>) {
+    if authored.trim().is_empty() {
+        findings.push(
+            Finding::builtin(
+                "prompt.empty",
+                FindingSeverity::Info,
+                FindingCategory::Completeness,
+                "The agent has no system prompt of its own; its behavior comes entirely from \
+                 harness and capability contributions."
+                    .to_string(),
+            )
+            .at("system_prompt", None),
+        );
+    }
+}
+
+fn check_long_prompt(authored: &str, findings: &mut Vec<Finding>) {
+    if authored.len() > LONG_PROMPT_BYTES {
+        findings.push(
+            Finding::builtin(
+                "prompt.very_long",
+                FindingSeverity::Warning,
+                FindingCategory::Cost,
+                format!(
+                    "The system prompt is {} KiB and is sent on every model turn. Consider \
+                     moving reference material into skills or initial files.",
+                    authored.len() / 1024
+                ),
+            )
+            .at("system_prompt", None),
+        );
+    }
+}
+
+fn check_template_variables(authored: &str, findings: &mut Vec<Finding>) {
+    if let Some(m) = TEMPLATE_VAR.find(authored) {
+        findings.push(
+            Finding::builtin(
+                "prompt.template_variables",
+                FindingSeverity::Warning,
+                FindingCategory::Structure,
+                format!(
+                    "The prompt contains the template placeholder `{}`, which will be sent to \
+                     the model literally. Agent prompts do not support template variables.",
+                    m.as_str()
+                ),
+            )
+            .at("system_prompt", Some((m.start(), m.end()))),
+        );
+    }
+}
+
+/// Paragraphs of `text` with their byte offsets, normalized for comparison.
+fn paragraphs(text: &str) -> Vec<(usize, usize, String)> {
+    let mut out = Vec::new();
+    let mut start = None;
+    let mut pos = 0;
+    for line in text.split_inclusive('\n') {
+        if line.trim().is_empty() {
+            if let Some(s) = start.take() {
+                out.push((s, pos, normalize_paragraph(&text[s..pos])));
+            }
+        } else if start.is_none() {
+            start = Some(pos);
+        }
+        pos += line.len();
+    }
+    if let Some(s) = start {
+        out.push((s, text.len(), normalize_paragraph(&text[s..])));
+    }
+    out
+}
+
+fn normalize_paragraph(p: &str) -> String {
+    p.split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_lowercase()
+}
+
+fn paragraph_preview(normalized: &str) -> String {
+    let preview: String = normalized.chars().take(60).collect();
+    if normalized.chars().count() > 60 {
+        format!("{preview}…")
+    } else {
+        preview
+    }
+}
+
+fn check_duplicate_paragraphs(authored: &str, findings: &mut Vec<Finding>) {
+    let mut seen: HashSet<String> = HashSet::new();
+    for (start, end, normalized) in paragraphs(authored) {
+        if normalized.len() < DUP_PARAGRAPH_MIN_CHARS {
+            continue;
+        }
+        if !seen.insert(normalized.clone()) {
+            findings.push(
+                Finding::builtin(
+                    "prompt.duplicate_paragraphs",
+                    FindingSeverity::Warning,
+                    FindingCategory::Structure,
+                    format!(
+                        "The paragraph starting with \"{}\" appears more than once in the \
+                         system prompt.",
+                        paragraph_preview(&normalized)
+                    ),
+                )
+                .at("system_prompt", Some((start, end))),
+            );
+        }
+    }
+}
+
+fn check_restates_contribution(authored: &str, resolved: &str, findings: &mut Vec<Finding>) {
+    if authored.trim().is_empty() {
+        return;
+    }
+    // Contribution text = resolved prompt minus the authored portion.
+    // Substring match over whitespace-normalized text: contributions wrap
+    // content in XML tags that would defeat paragraph-set comparison.
+    let contributions = normalize_paragraph(&resolved.replacen(authored, "", 1));
+    for (start, end, normalized) in paragraphs(authored) {
+        if normalized.len() >= DUP_PARAGRAPH_MIN_CHARS && contributions.contains(&normalized) {
+            findings.push(
+                Finding::builtin(
+                    "prompt.restates_contribution",
+                    FindingSeverity::Info,
+                    FindingCategory::Structure,
+                    format!(
+                        "The paragraph starting with \"{}\" duplicates text already contributed \
+                         by the harness or an enabled capability.",
+                        paragraph_preview(&normalized)
+                    ),
+                )
+                .at("system_prompt", Some((start, end))),
+            );
+        }
+    }
+}
+
+fn check_conflicting_style(authored: &str, findings: &mut Vec<Finding>) {
+    let lower = authored.to_lowercase();
+    let brevity: Vec<&str> = BREVITY_PHRASES
+        .iter()
+        .copied()
+        .filter(|p| lower.contains(p))
+        .collect();
+    let verbosity: Vec<&str> = VERBOSITY_PHRASES
+        .iter()
+        .copied()
+        .filter(|p| lower.contains(p))
+        .collect();
+    if !brevity.is_empty() && !verbosity.is_empty() {
+        findings.push(
+            Finding::builtin(
+                "prompt.conflicting_style",
+                FindingSeverity::Info,
+                FindingCategory::Structure,
+                format!(
+                    "The prompt asks for both brevity (\"{}\") and detail (\"{}\"). If these \
+                     apply to different situations, consider stating the conditions explicitly.",
+                    brevity.join("\", \""),
+                    verbosity.join("\", \"")
+                ),
+            )
+            .at("system_prompt", None),
+        );
+    }
+}
+
+fn check_unknown_tool_reference(
+    authored: &str,
+    capabilities: &[AgentCapabilityConfig],
+    tools: &[ToolDefinition],
+    findings: &mut Vec<Finding>,
+) {
+    if tools.is_empty() {
+        return;
+    }
+    let known: HashSet<&str> = tools
+        .iter()
+        .map(|t| t.name())
+        .chain(capabilities.iter().map(|c| c.capability_ref.as_str()))
+        .collect();
+    let mut reported: HashSet<&str> = HashSet::new();
+    for caps in BACKTICKED_IDENT.captures_iter(authored) {
+        let ident = caps.get(1).expect("group 1 exists");
+        if !known.contains(ident.as_str()) && reported.insert(ident.as_str()) {
+            findings.push(
+                Finding::builtin(
+                    "tools.unknown_reference",
+                    FindingSeverity::Info,
+                    FindingCategory::Completeness,
+                    format!(
+                        "The prompt references `{}`, but no enabled tool or capability has that \
+                         name. The model cannot call it.",
+                        ident.as_str()
+                    ),
+                )
+                .at("system_prompt", Some((ident.start(), ident.end()))),
+            );
+        }
+    }
+}
+
+fn check_duplicate_tool_names(tools: &[ToolDefinition], findings: &mut Vec<Finding>) {
+    let mut counts: HashMap<&str, usize> = HashMap::new();
+    for tool in tools {
+        *counts.entry(tool.name()).or_default() += 1;
+    }
+    let mut dupes: Vec<&str> = counts
+        .into_iter()
+        .filter(|(_, c)| *c > 1)
+        .map(|(n, _)| n)
+        .collect();
+    dupes.sort_unstable();
+    for name in dupes {
+        findings.push(
+            Finding::builtin(
+                "tools.duplicate_names",
+                FindingSeverity::Warning,
+                FindingCategory::Completeness,
+                format!(
+                    "Multiple tools are named `{name}`. The model cannot distinguish them; \
+                     rename or remove one of the sources."
+                ),
+            )
+            .at("tools", None),
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use everruns_core::tool_types::ClientSideTool;
+
+    fn client_tool(name: &str) -> ToolDefinition {
+        ToolDefinition::ClientSide(ClientSideTool {
+            name: name.to_string(),
+            display_name: None,
+            description: "test tool".to_string(),
+            parameters: serde_json::json!({}),
+            category: None,
+            deferrable: Default::default(),
+            hints: Default::default(),
+            full_parameters: None,
+        })
+    }
+
+    fn capability(r#ref: &str) -> AgentCapabilityConfig {
+        AgentCapabilityConfig {
+            capability_ref: r#ref.into(),
+            config: serde_json::Value::Null,
+        }
+    }
+
+    fn rule_ids(findings: &[Finding]) -> Vec<&str> {
+        findings.iter().map(|f| f.rule_id.as_str()).collect()
+    }
+
+    #[test]
+    fn clean_prompt_produces_no_findings() {
+        let prompt = "You are a helpful support agent. Use the `search_docs` tool to look up \
+                      product documentation before answering.";
+        let findings = run_builtin_checks(prompt, prompt, &[], &[client_tool("search_docs")]);
+        assert!(findings.is_empty(), "unexpected findings: {findings:?}");
+    }
+
+    #[test]
+    fn empty_prompt_is_flagged() {
+        let findings = run_builtin_checks("  \n", "harness text", &[], &[]);
+        assert_eq!(rule_ids(&findings), vec!["prompt.empty"]);
+        assert_eq!(findings[0].severity, FindingSeverity::Info);
+    }
+
+    #[test]
+    fn long_prompt_is_flagged_as_cost() {
+        let prompt = "x".repeat(LONG_PROMPT_BYTES + 1);
+        let findings = run_builtin_checks(&prompt, &prompt, &[], &[]);
+        assert!(rule_ids(&findings).contains(&"prompt.very_long"));
+        let f = findings
+            .iter()
+            .find(|f| f.rule_id == "prompt.very_long")
+            .unwrap();
+        assert_eq!(f.category, FindingCategory::Cost);
+    }
+
+    #[test]
+    fn template_variables_are_flagged_with_span() {
+        let prompt = "Answer the question about {{product_name}} accurately.";
+        let findings = run_builtin_checks(prompt, prompt, &[], &[]);
+        assert_eq!(rule_ids(&findings), vec!["prompt.template_variables"]);
+        let loc = findings[0].location.as_ref().unwrap();
+        let (start, end) = (loc.start.unwrap() as usize, loc.end.unwrap() as usize);
+        assert_eq!(&prompt[start..end], "{{product_name}}");
+    }
+
+    #[test]
+    fn duplicate_paragraphs_are_flagged() {
+        let para = "Always verify the customer's account number before discussing any billing \
+                    details or making changes to their subscription plan.";
+        let prompt = format!("{para}\n\nSome other instruction here.\n\n{para}\n");
+        let findings = run_builtin_checks(&prompt, &prompt, &[], &[]);
+        assert_eq!(rule_ids(&findings), vec!["prompt.duplicate_paragraphs"]);
+    }
+
+    #[test]
+    fn short_repeated_lines_are_not_duplicates() {
+        let prompt = "Be helpful.\n\nDo the work.\n\nBe helpful.";
+        let findings = run_builtin_checks(prompt, prompt, &[], &[]);
+        assert!(findings.is_empty(), "unexpected findings: {findings:?}");
+    }
+
+    #[test]
+    fn restating_capability_contribution_is_flagged() {
+        let para = "When the user asks about the current date or time, use the current_time \
+                    tool instead of guessing from training data.";
+        let authored = format!("You are an assistant.\n\n{para}");
+        let resolved =
+            format!("<capability id=\"current_time\">\n{para}\n</capability>\n\n{authored}");
+        let findings = run_builtin_checks(&authored, &resolved, &[], &[]);
+        assert_eq!(rule_ids(&findings), vec!["prompt.restates_contribution"]);
+    }
+
+    #[test]
+    fn conflicting_style_keywords_are_flagged() {
+        let prompt = "Be concise in all replies. Provide comprehensive analysis of every issue.";
+        let findings = run_builtin_checks(prompt, prompt, &[], &[]);
+        assert_eq!(rule_ids(&findings), vec!["prompt.conflicting_style"]);
+    }
+
+    #[test]
+    fn unknown_backticked_tool_reference_is_flagged() {
+        let prompt = "Use `search_web` to find current information.";
+        let findings = run_builtin_checks(prompt, prompt, &[], &[client_tool("web_fetch")]);
+        assert_eq!(rule_ids(&findings), vec!["tools.unknown_reference"]);
+    }
+
+    #[test]
+    fn known_tool_and_capability_references_are_not_flagged() {
+        let prompt = "Use `web_fetch` to fetch pages. The `bashkit_shell` capability runs code.";
+        let findings = run_builtin_checks(
+            prompt,
+            prompt,
+            &[capability("bashkit_shell")],
+            &[client_tool("web_fetch")],
+        );
+        assert!(findings.is_empty(), "unexpected findings: {findings:?}");
+    }
+
+    #[test]
+    fn no_tool_reference_check_without_tools() {
+        // Backticked identifiers in a tool-less agent are usually code, not tools.
+        let prompt = "Wrap config keys like `max_retry_count` in backticks.";
+        let findings = run_builtin_checks(prompt, prompt, &[], &[]);
+        assert!(findings.is_empty(), "unexpected findings: {findings:?}");
+    }
+
+    #[test]
+    fn duplicate_tool_names_are_flagged() {
+        let tools = vec![client_tool("send_email"), client_tool("send_email")];
+        let findings = run_builtin_checks("Prompt.", "Prompt.", &[], &tools);
+        assert_eq!(rule_ids(&findings), vec!["tools.duplicate_names"]);
+    }
+}

--- a/crates/server/src/domains/agents/checks.rs
+++ b/crates/server/src/domains/agents/checks.rs
@@ -102,12 +102,22 @@ impl Finding {
 
 /// Authored prompt larger than this is flagged as recurring per-turn cost.
 const LONG_PROMPT_BYTES: usize = 32 * 1024;
+/// Resolved prompt (with harness/capability contributions) larger than this
+/// is flagged even when the authored share is small. Higher threshold:
+/// contributions are platform-curated, so only clearly oversized totals are
+/// worth a finding.
+const LONG_RESOLVED_PROMPT_BYTES: usize = 96 * 1024;
 /// Paragraphs shorter than this (normalized) are too generic to call
 /// duplicates ("Be helpful." legitimately repeats).
 const DUP_PARAGRAPH_MIN_CHARS: usize = 80;
 
 static TEMPLATE_VAR: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"\{\{\s*[A-Za-z0-9_.-]+\s*\}\}").expect("valid regex"));
+// Requires at least one underscore on purpose: backticked single words are
+// overwhelmingly code literals or jargon (`json`, `bash`, `main`), so flagging
+// them as tool references would be mostly noise. Multi-word snake_case matches
+// the platform's tool naming convention. Single-word tool names are accepted
+// as a known miss for precision.
 static BACKTICKED_IDENT: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"`([a-z][a-z0-9]*(?:_[a-z0-9]+)+)`").expect("valid regex"));
 
@@ -143,7 +153,7 @@ pub fn run_builtin_checks(
 ) -> Vec<Finding> {
     let mut findings = Vec::new();
     check_empty_prompt(authored_prompt, &mut findings);
-    check_long_prompt(authored_prompt, &mut findings);
+    check_long_prompt(authored_prompt, resolved_prompt, &mut findings);
     check_template_variables(authored_prompt, &mut findings);
     check_duplicate_paragraphs(authored_prompt, &mut findings);
     check_restates_contribution(authored_prompt, resolved_prompt, &mut findings);
@@ -169,7 +179,7 @@ fn check_empty_prompt(authored: &str, findings: &mut Vec<Finding>) {
     }
 }
 
-fn check_long_prompt(authored: &str, findings: &mut Vec<Finding>) {
+fn check_long_prompt(authored: &str, resolved: &str, findings: &mut Vec<Finding>) {
     if authored.len() > LONG_PROMPT_BYTES {
         findings.push(
             Finding::builtin(
@@ -183,6 +193,22 @@ fn check_long_prompt(authored: &str, findings: &mut Vec<Finding>) {
                 ),
             )
             .at("system_prompt", None),
+        );
+    } else if resolved.len() > LONG_RESOLVED_PROMPT_BYTES {
+        findings.push(
+            Finding::builtin(
+                "prompt.resolved_very_long",
+                FindingSeverity::Info,
+                FindingCategory::Cost,
+                format!(
+                    "The full system prompt is {} KiB after harness and capability \
+                     contributions ({} KiB authored here) and is sent on every model turn. \
+                     Consider disabling capabilities this agent does not need.",
+                    resolved.len() / 1024,
+                    authored.len() / 1024
+                ),
+            )
+            .at("capabilities", None),
         );
     }
 }
@@ -329,7 +355,10 @@ fn check_unknown_tool_reference(
     tools: &[ToolDefinition],
     findings: &mut Vec<Finding>,
 ) {
-    if tools.is_empty() {
+    // Tool-less, capability-less agents backtick code identifiers, not tool
+    // names; once anything is enabled the agent is in "tool world" and
+    // references are worth validating.
+    if tools.is_empty() && capabilities.is_empty() {
         return;
     }
     let known: HashSet<&str> = tools
@@ -505,8 +534,25 @@ mod tests {
     }
 
     #[test]
+    fn resolved_long_prompt_is_flagged_when_contributions_dominate() {
+        let authored = "Short prompt with `web_fetch` guidance.";
+        let resolved = format!("{}{}", "c".repeat(LONG_RESOLVED_PROMPT_BYTES + 1), authored);
+        let findings = run_builtin_checks(authored, &resolved, &[], &[client_tool("web_fetch")]);
+        assert_eq!(rule_ids(&findings), vec!["prompt.resolved_very_long"]);
+        assert_eq!(findings[0].severity, FindingSeverity::Info);
+    }
+
+    #[test]
+    fn unknown_reference_is_flagged_with_capabilities_but_no_tools() {
+        let prompt = "Use `search_web` to find current information.";
+        let findings = run_builtin_checks(prompt, prompt, &[capability("agent_instructions")], &[]);
+        assert_eq!(rule_ids(&findings), vec!["tools.unknown_reference"]);
+    }
+
+    #[test]
     fn no_tool_reference_check_without_tools() {
-        // Backticked identifiers in a tool-less agent are usually code, not tools.
+        // Backticked identifiers in a tool-less, capability-less agent are
+        // usually code, not tools.
         let prompt = "Wrap config keys like `max_retry_count` in backticks.";
         let findings = run_builtin_checks(prompt, prompt, &[], &[]);
         assert!(findings.is_empty(), "unexpected findings: {findings:?}");

--- a/crates/server/src/domains/agents/commands.rs
+++ b/crates/server/src/domains/agents/commands.rs
@@ -1506,6 +1506,8 @@ pub struct PreviewAgent {
 pub struct AgentPreview {
     pub system_prompt: String,
     pub tools: Vec<ToolDefinition>,
+    /// Advisory tier-1 findings about the previewed config (specs/agent-checks.md).
+    pub findings: Vec<super::checks::Finding>,
 }
 
 impl Command for PreviewAgent {
@@ -1532,13 +1534,10 @@ impl Command for PreviewAgent {
     async fn execute(self, ctx: &Ctx) -> Result<AgentPreview, CommandError> {
         crate::domains::mcp_servers::scoped_mcp::validate_scoped_mcp_servers(&self.mcp_servers)
             .map_err(classify_anyhow)?;
+        let authored_prompt = self.system_prompt.unwrap_or_default();
         let (prompt, mut tools) = ctx
             .capability_service
-            .preview(
-                ctx.org_id(),
-                &self.system_prompt.unwrap_or_default(),
-                &self.capabilities,
-            )
+            .preview(ctx.org_id(), &authored_prompt, &self.capabilities)
             .await
             .map_err(classify_anyhow)?;
         tools.extend(
@@ -1552,9 +1551,16 @@ impl Command for PreviewAgent {
             .map_err(classify_anyhow)?,
         );
         tools.extend(self.tools);
+        let findings = super::checks::run_builtin_checks(
+            &authored_prompt,
+            &prompt,
+            &self.capabilities,
+            &tools,
+        );
         Ok(AgentPreview {
             system_prompt: prompt,
             tools,
+            findings,
         })
     }
 }

--- a/crates/server/src/domains/agents/mod.rs
+++ b/crates/server/src/domains/agents/mod.rs
@@ -4,6 +4,7 @@
 
 use everruns_core::{Permission, Policy, Rule};
 
+pub mod checks;
 pub mod commands;
 pub mod queries;
 pub mod types;

--- a/crates/server/src/domains/agents/types.rs
+++ b/crates/server/src/domains/agents/types.rs
@@ -229,6 +229,8 @@ pub struct AgentPreviewResponse {
     /// All tool definitions from capabilities
     #[schema(value_type = Vec<Object>)]
     pub tools: Vec<ToolDefinition>,
+    /// Advisory findings from built-in checks (specs/agent-checks.md)
+    pub findings: Vec<super::checks::Finding>,
 }
 
 /// Query parameters for listing agents.

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -12245,9 +12245,17 @@
         "description": "Response showing the final agent shape after applying capabilities",
         "required": [
           "system_prompt",
-          "tools"
+          "tools",
+          "findings"
         ],
         "properties": {
+          "findings": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Finding"
+            },
+            "description": "Advisory findings from built-in checks (specs/agent-checks.md)"
+          },
           "system_prompt": {
             "type": "string",
             "description": "The full system prompt with capability additions prepended"
@@ -16814,6 +16822,111 @@
             "description": "File size in bytes after write."
           }
         }
+      },
+      "Finding": {
+        "type": "object",
+        "description": "A single advisory finding about an agent configuration.",
+        "required": [
+          "rule_id",
+          "severity",
+          "category",
+          "message",
+          "source"
+        ],
+        "properties": {
+          "category": {
+            "$ref": "#/components/schemas/FindingCategory"
+          },
+          "fix": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Proposed replacement text (phase 2+; always absent for builtin rules)."
+          },
+          "location": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/FindingLocation"
+              }
+            ]
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable explanation. Safe to render in user-facing messages."
+          },
+          "rule_id": {
+            "type": "string",
+            "description": "Stable rule identifier, e.g. `prompt.duplicate_paragraphs`."
+          },
+          "severity": {
+            "$ref": "#/components/schemas/FindingSeverity"
+          },
+          "source": {
+            "$ref": "#/components/schemas/FindingSource"
+          }
+        }
+      },
+      "FindingCategory": {
+        "type": "string",
+        "enum": [
+          "structure",
+          "completeness",
+          "effectiveness",
+          "safety",
+          "cost"
+        ]
+      },
+      "FindingLocation": {
+        "type": "object",
+        "description": "Pointer to the config field (and optional byte span within it) a finding\nrefers to.",
+        "required": [
+          "field"
+        ],
+        "properties": {
+          "end": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "minimum": 0
+          },
+          "field": {
+            "type": "string",
+            "description": "Config field name, e.g. `system_prompt`, `tools`."
+          },
+          "start": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "description": "Byte offset range into the field's authored text, when applicable.",
+            "minimum": 0
+          }
+        }
+      },
+      "FindingSeverity": {
+        "type": "string",
+        "description": "Advisory severity. There is deliberately no `error`: checks never gate\nsave/publish (specs/agent-checks.md, Non-Goals).",
+        "enum": [
+          "warning",
+          "info",
+          "suggestion"
+        ]
+      },
+      "FindingSource": {
+        "type": "string",
+        "description": "Which tier produced the finding.",
+        "enum": [
+          "builtin",
+          "llm",
+          "health_check"
+        ]
       },
       "ForkAgentVersionRequest": {
         "type": "object",

--- a/docs/features/agent-checks.md
+++ b/docs/features/agent-checks.md
@@ -34,7 +34,8 @@ Checks run against the *resolved* configuration — after harness and capability
 | Rule | Severity | What it catches |
 |------|----------|-----------------|
 | `prompt.empty` | info | Agent has no system prompt of its own |
-| `prompt.very_long` | warning | Prompt over 32 KiB, sent on every model turn |
+| `prompt.very_long` | warning | Authored prompt over 32 KiB, sent on every model turn |
+| `prompt.resolved_very_long` | info | Full prompt over 96 KiB after harness/capability contributions |
 | `prompt.template_variables` | warning | `{{placeholder}}` text that would reach the model literally |
 | `prompt.duplicate_paragraphs` | warning | The same paragraph appears more than once |
 | `prompt.restates_contribution` | info | Prompt duplicates text already contributed by the harness or a capability |

--- a/docs/features/agent-checks.md
+++ b/docs/features/agent-checks.md
@@ -1,0 +1,47 @@
+---
+title: Agent Checks
+description: Advisory quality checks for agent configurations — structural problems, completeness gaps, and cost warnings surfaced while you build.
+---
+
+# Agent Checks
+
+Agent checks review an agent configuration and surface advisory findings while you build: structural problems (duplicated instructions, conflicting style guidance), completeness gaps (tool references that do not exist), and cost warnings (oversized prompts).
+
+Checks are advisory only. Findings never block saving, publishing, or version creation.
+
+## Where Findings Appear
+
+- **Agent editor → Preview tab**: a Checks card lists findings for the current draft, updating as you edit.
+- **API**: `POST /v1/agents/preview` returns a `findings` array alongside the resolved system prompt and tools.
+- **MCP / platform commands**: the `preview_agent` command returns the same findings, so agents and automations can review configurations programmatically.
+
+## Findings
+
+Each finding includes:
+
+| Field | Description |
+|-------|-------------|
+| `rule_id` | Stable rule identifier, e.g. `prompt.duplicate_paragraphs` |
+| `severity` | `warning`, `info`, or `suggestion` — there is no `error`; checks never block |
+| `category` | `structure`, `completeness`, `effectiveness`, `safety`, or `cost` |
+| `message` | Human-readable explanation |
+| `location` | The config field (and byte span, when applicable) the finding points at |
+
+## Built-in Rules
+
+Checks run against the *resolved* configuration — after harness and capability contributions are merged — so they can catch issues that span layers.
+
+| Rule | Severity | What it catches |
+|------|----------|-----------------|
+| `prompt.empty` | info | Agent has no system prompt of its own |
+| `prompt.very_long` | warning | Prompt over 32 KiB, sent on every model turn |
+| `prompt.template_variables` | warning | `{{placeholder}}` text that would reach the model literally |
+| `prompt.duplicate_paragraphs` | warning | The same paragraph appears more than once |
+| `prompt.restates_contribution` | info | Prompt duplicates text already contributed by the harness or a capability |
+| `prompt.conflicting_style` | info | Asks for both brevity and detail without stating conditions |
+| `tools.unknown_reference` | info | Prompt references a tool that no enabled tool or capability provides |
+| `tools.duplicate_names` | warning | Two tools share a name, so the model cannot distinguish them |
+
+## Roadmap
+
+Later phases add on-demand LLM-powered analysis (contradiction and structure review with proposed fixes), behavioral health checks that run the agent against generated smoke tests, and org-configurable rules.

--- a/specs/README.md
+++ b/specs/README.md
@@ -126,6 +126,7 @@ Specs capture the "why" and "what", not exhaustive source detail. Link to code f
 
 - `specs/test-cases.md` - Manual test case format
 - `specs/evals.md` - User-facing behavioral evals
+- `specs/agent-checks.md` - Advisory agent config checks (lint, LLM analysis, health checks)
 - `specs/swe-bench-lite.md` - SWE-bench Lite evaluation harness
 - `specs/reporting.md` - Async reporting
 - `specs/reporting-backends.md` - Phase 3 reference evaluation

--- a/specs/agent-checks.md
+++ b/specs/agent-checks.md
@@ -1,0 +1,149 @@
+# Agent Checks
+
+<!-- Design Decisions:
+  - Advisory only: findings never block save, publish, or version creation.
+    Enforcement gates were considered and dismissed; suggestions/fixes are the
+    escalation path, not errors.
+  - Hybrid three-tier pipeline (deterministic rules → LLM checkers → health
+    checks) mirrors the converged industry architecture (OpenAI prompt
+    optimizer's parallel checker agents, Arbiter arXiv:2603.08993).
+  - No while-you-type linting: tier 1 runs with preview (cheap, sync); tiers
+    2-3 are explicit user actions with visible cost/time expectations. No
+    shipping product does continuous background analysis; on-demand is the
+    proven interaction model.
+  - Tier 2 uses the utility LLM service, not user-configured model providers
+    or session secrets (see specs/utility-llm.md, "system analysis tasks").
+  - Health checks are NOT part of the evals domain UI/entities. They reuse the
+    eval runner machinery internally but surface in the agent editor as a
+    one-click action. Evals stay user-curated; health checks are
+    system-generated and disposable.
+  - Findings are computed per resolved config (after harness/capability layer
+    merge) — cross-layer visibility is our structural advantage over
+    prompt-only linters. Cached by agent version config_hash.
+  - Extensibility (org-defined rules) is deliberately last: ship built-in
+    rules first, learn which ones users mute, then design the custom-rule
+    surface (declarative rules + natural-language rubric rules).
+  - "Fix with diff" beats raw lint lists: findings carry optional proposed
+    replacements rendered as diffs with one-click apply (Anthropic prompt
+    improver / OpenAI optimizer pattern).
+-->
+
+## Abstract
+
+Agent Checks give users feedback on the quality of an agent configuration
+while they build it: structural problems (contradictions, duplication,
+verbosity), completeness gaps (tools referenced in the prompt that do not
+exist, capabilities with no guidance), and behavioral signals (does the
+configured agent actually complete simple tasks). Think "linter plus
+mini-evals" for agents and harnesses.
+
+All findings are advisory. The system never blocks saving or publishing; at
+most it proposes a fix the user can apply with one click.
+
+## Concepts
+
+### Finding
+
+The atomic unit of feedback, analogous to an eval `Score`.
+
+| Field | Description |
+|-------|-------------|
+| `rule_id` | Stable identifier, e.g. `prompt.contradiction`, `tools.unknown_reference` |
+| `severity` | `warning`, `info`, `suggestion` (no `error` — advisory only) |
+| `category` | `structure`, `completeness`, `effectiveness`, `safety`, `cost` |
+| `message` | Human-readable explanation of the problem and why it matters |
+| `location` | Optional pointer: config field, or prompt span (byte offsets into the authored system prompt) |
+| `fix` | Optional proposed replacement text; UI renders as a diff with one-click apply |
+| `source` | `builtin` (tier 1), `llm` (tier 2), `health_check` (tier 3) |
+
+### Check tiers
+
+1. **Deterministic rules** (tier 1) — pure Rust, run synchronously as part of
+   agent preview. Free and instant. Examples: prompt references a tool absent
+   from the resolved tool list (and the inverse: enabled capability never
+   mentioned), near-duplicate instruction blocks, keyword-class conflicts
+   ("be brief" vs "be exhaustive"), agent prompt restating harness/capability
+   contributions, over-permissive `network_access`, unused `{{variables}}`,
+   prompt length relative to model context.
+2. **LLM checkers** (tier 2) — narrow single-purpose analysis prompts run
+   against the resolved config via the utility LLM service: contradiction and
+   interference detection across layers, ambiguity/vagueness, redundancy
+   beyond string matching, structure quality, missing per-tool guidance.
+   On-demand ("Analyze" action), asynchronous, seconds. Each checker is
+   narrowly scoped (contradiction checker, structure checker, ...) rather
+   than one mega-prompt — scoped checkers produce higher-precision findings.
+3. **Health checks** (tier 3) — behavioral mini-evals: the system synthesizes
+   a small set of smoke test cases from the agent's own description, prompt,
+   and capabilities, executes them as real sessions through the existing eval
+   runner machinery, and scores the results. On-demand ("Health check"
+   action), minutes, costs real model usage — the UI states this before
+   running.
+
+### Check run
+
+An on-demand execution of tier 2 and/or tier 3 against a specific agent
+config. Findings from tier 1 are not persisted (recomputed with every
+preview); tier 2/3 results are persisted keyed by the config hash so repeat
+views are free and version badges are possible.
+
+Health check runs reuse the durable execution and bounded-concurrency
+machinery of eval runs but are not `Eval` entities: they do not appear in
+`/evals`, are not user-editable collections, and their generated cases are
+disposable. Sessions created by health checks are tagged for filtering, and
+case results link to the real sessions for debugging — same debuggability
+contract as evals.
+
+## Phases
+
+Decided ordering (Option A → C → B from the design review):
+
+1. **Built-in rules in preview.** Tier-1 rules computed inside
+   `POST /v1/agents/preview`; response gains a `findings` array. Editor shows
+   a collapsible Checks panel with severity badges and deep links to the
+   offending field/span.
+2. **LLM analysis + fixes.** `Analyze` action runs tier-2 checkers on the
+   utility LLM. Findings gain span locations and proposed `fix` payloads
+   rendered as diffs with one-click apply. This phase delivers the
+   "too verbose / duplicated / contradictory / poor structure" feedback.
+3. **Health checks.** One-click behavioral smoke run: generated cases,
+   score card (pass rate, turns, tokens), per-case drill-down into sessions.
+   Results stored per agent version.
+4. **Extensible rules.** Org-level rule registry: per-rule enable/severity
+   config for built-ins, plus two custom rule types — declarative
+   (keyword/regex/structural, no code) and natural-language rubrics judged by
+   the utility LLM. Admin-managed.
+
+## UX
+
+- **Checks panel** in the agent editor (alongside Preview), not editor
+  squiggles. Findings grouped by category with severity badges; each finding
+  links to its field or highlights its prompt span. Finding counts surface as
+  a small badge on the editor tab and on agent cards.
+- **Tier triggers**: tier 1 is implicit (updates with preview); tiers 2 and 3
+  are buttons with cost/time expectations ("~30s", "runs N real sessions").
+- **Fix flow**: findings with a `fix` show a diff and an Apply button.
+  Applying edits the form state; the user still saves explicitly.
+- **Dismissal**: users can dismiss a finding for the current config; dismissed
+  findings stay hidden until the relevant content changes.
+
+## Non-Goals
+
+- No enforcement: findings never gate save/publish/version-creation.
+- No continuous background analysis while typing.
+- No public ad hoc LLM endpoint — tier 2 goes through the internal utility
+  LLM service only.
+- No user-facing dataset management for health checks — curated behavioral
+  testing is what Evals are for (`specs/evals.md`).
+
+## Relationship to existing systems
+
+- **Preview** (`POST /v1/agents/preview`): tier-1 carrier; already computes
+  the resolved shape findings are evaluated against.
+- **Utility LLM** (`specs/utility-llm.md`): engine for tier 2 and for health
+  check case generation, under the "system analysis tasks" allowance.
+- **Evals** (`specs/evals.md`): health checks reuse the runner and scorer
+  machinery (including `llm_judge` when available) without creating Eval
+  entities. If a user wants to keep generated cases, a "promote to eval"
+  action is a natural later addition.
+- **Agent versions** (`specs/agent-versions.md`): persisted findings and
+  health scores key off `config_hash`, enabling per-version badges.

--- a/specs/utility-llm.md
+++ b/specs/utility-llm.md
@@ -9,6 +9,12 @@ session/agent configuration surface. It is a host service exposed through
 capability execution context so capabilities can perform bounded internal model
 work without reusing user-configured model providers or session secrets.
 
+Server-side system analysis tasks are also sanctioned callers: bounded,
+system-initiated analysis of platform-owned data (e.g., agent configuration
+checks per `specs/agent-checks.md`). These run inside server domains via the
+`PlatformDefinition` service handle — never as a public ad hoc completion
+endpoint.
+
 ## Core Contract
 
 `everruns-core` owns the service abstraction:
@@ -48,6 +54,7 @@ bypass env-based setup by constructing a custom `PlatformDefinition` and calling
 ## Non-Goals
 
 - No user-facing model picker entry.
-- No REST API endpoint for ad hoc utility LLM calls.
+- No REST API endpoint for ad hoc utility LLM calls. System analysis tasks
+  expose their own purpose-specific endpoints; the model call stays internal.
 - No per-organization or per-session utility model configuration.
 - No access from ordinary agent model selection or provider records.


### PR DESCRIPTION
## What
Phase 1 of the Agent Checks system (specs/agent-checks.md, new): advisory tier-1 deterministic quality checks for agent configurations, surfaced in the agent preview.

- New spec `specs/agent-checks.md` — design and phasing for the full system (deterministic rules → LLM analysis → health checks → org-configurable rules), advisory-only by decision.
- `specs/utility-llm.md` extended to sanction internal "system analysis tasks" as callers (used by later phases; no public endpoint).
- New `crates/server/src/domains/agents/checks.rs`: `Finding` model (rule_id, severity `warning|info|suggestion`, category, message, byte-span location, optional `fix` reserved for phase 2, source tier) and eight built-in rules: empty prompt, prompt >32 KiB (cost), literal `{{template}}` placeholders, duplicate paragraphs, paragraphs restating harness/capability contributions (cross-layer), brevity-vs-detail conflicts, backticked tool references matching no enabled tool/capability, duplicate tool names.
- `POST /v1/agents/preview` response gains `findings`; flows automatically to the MCP command catalog and platform capability via the `preview_agent` Command.
- UI: Checks card on the agent Preview tab with severity badges; renders nothing when clean.
- Public docs: `docs/features/agent-checks.md`.
- OpenAPI export regenerated.

## Why
Users building agents in the UI get no quality feedback today — only hard size/format validation. This adds the first tier of "linter for agents": cheap, deterministic, always-on findings that catch real misconfigurations (tools referenced in the prompt that don't exist, duplicated instructions, template leftovers) without blocking anything.

## How
Pure-Rust rule functions run inside the existing `PreviewAgent` command against the resolved config (after harness/capability merge — which is what lets `prompt.restates_contribution` and `tools.unknown_reference` see across layers). No new endpoints, no persistence, no LLM calls in this phase.

## Risk
- Low. Additive response field on a read-only preview endpoint; no schema/migration changes; harness preview untouched (UI type treats `findings` as optional).
- Worst case is a false-positive finding — severities are capped at `warning` and nothing gates on them.

## Security
- Threat categories reviewed: TM-API (existing authenticated read-only endpoint, additive output field; input limits unchanged), TM-DOS (rule functions are linear scans; `regex` crate is non-backtracking, no ReDoS; input already bounded by the 1 MB prompt limit), TM-WEB (finding messages echo user-controlled text but render as React text nodes, no HTML injection path).
- Findings and resolutions: none.

## Validation
- 12 unit tests for the rules (each rule plus no-false-positive cases); full `everruns-server` lib suite green (1494 tests).
- `pre-push` green (fmt, clippy `-D warnings`, UI format/lint, migrations, specs index).
- Smoke tested on `start-dev`: `POST /api/v1/agents/preview` returns correct findings with accurate byte spans for dirty configs and `[]` for clean configs.
- `apps/docs` check + build green with the new page.

## Follow-ups
- Phase 2 (LLM analysis with proposed fixes), phase 3 (health checks), phase 4 (org-configurable rules) land as separate PRs per the spec phasing.
- Field deep-links/span highlighting in the editor UI arrives with phase 2, when findings get fixes worth navigating to.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)