### PR TITLE
refactor(core): rename LlmDriver to ChatDriver

### DIFF
--- a/crates/anthropic/README.md
+++ b/crates/anthropic/README.md
@@ -21,15 +21,15 @@ or run with no key at all using the built-in LLM simulator in
 ## Quick Example
 
 ```rust
-use everruns_anthropic::{AnthropicLlmDriver, register_driver};
+use everruns_anthropic::{AnthropicChatDriver, register_driver};
 use everruns_core::DriverRegistry;
 
-let driver = AnthropicLlmDriver::new("your-api-key");
+let driver = AnthropicChatDriver::new("your-api-key");
 
 let mut registry = DriverRegistry::new();
 register_driver(&mut registry);
 
-assert!(format!("{driver:?}").contains("AnthropicLlmDriver"));
+assert!(format!("{driver:?}").contains("AnthropicChatDriver"));
 ```
 
 Register the driver into a platform and drive a full turn with

--- a/crates/anthropic/src/driver.rs
+++ b/crates/anthropic/src/driver.rs
@@ -1,4 +1,4 @@
-// Anthropic Claude LLM Driver
+// Anthropic Claude Chat Driver
 //
 // Implementation of ChatDriver for Anthropic's Claude API.
 // Uses the Messages API with streaming support.
@@ -40,7 +40,7 @@ const DEFAULT_API_URL: &str = "https://api.anthropic.com/v1/messages";
 const ANTHROPIC_MODELS_URL: &str = "https://api.anthropic.com/v1/models";
 const ANTHROPIC_VERSION: &str = "2023-06-01";
 
-/// Anthropic Claude LLM Driver
+/// Anthropic Claude Chat Driver
 ///
 /// Implements `ChatDriver` for Anthropic's Messages API.
 /// Supports streaming responses and tool calls.

--- a/crates/anthropic/src/driver.rs
+++ b/crates/anthropic/src/driver.rs
@@ -1,6 +1,6 @@
 // Anthropic Claude LLM Driver
 //
-// Implementation of LlmDriver for Anthropic's Claude API.
+// Implementation of ChatDriver for Anthropic's Claude API.
 // Uses the Messages API with streaming support.
 //
 // Rate limit handling: On 429 errors, the driver automatically retries with
@@ -27,9 +27,9 @@ use everruns_core::llm_driver_helpers::{
     parse_data_url,
 };
 use everruns_core::llm_driver_registry::{
-    BoxedLlmDriver, DiscoveredModel, DriverRegistry, LlmCallConfig, LlmCompletionMetadata,
-    LlmContentPart, LlmDriver, LlmMessage, LlmMessageContent, LlmMessageRole, LlmResponseStream,
-    LlmStreamEvent, ProviderType,
+    BoxedChatDriver, ChatDriver, DiscoveredModel, DriverRegistry, LlmCallConfig,
+    LlmCompletionMetadata, LlmContentPart, LlmMessage, LlmMessageContent, LlmMessageRole,
+    LlmResponseStream, LlmStreamEvent, ProviderType,
 };
 use everruns_core::llm_retry::{
     LlmRetryConfig, RateLimitInfo, RetryMetadata, is_rate_limit_status, is_transient_error,
@@ -42,7 +42,7 @@ const ANTHROPIC_VERSION: &str = "2023-06-01";
 
 /// Anthropic Claude LLM Driver
 ///
-/// Implements `LlmDriver` for Anthropic's Messages API.
+/// Implements `ChatDriver` for Anthropic's Messages API.
 /// Supports streaming responses and tool calls.
 ///
 /// Rate limit handling: On 429 errors, automatically retries with exponential
@@ -51,19 +51,19 @@ const ANTHROPIC_VERSION: &str = "2023-06-01";
 /// # Example
 ///
 /// ```ignore
-/// use everruns_anthropic::AnthropicLlmDriver;
+/// use everruns_anthropic::AnthropicChatDriver;
 ///
-/// let driver = AnthropicLlmDriver::from_env()?;
+/// let driver = AnthropicChatDriver::from_env()?;
 /// // or
-/// let driver = AnthropicLlmDriver::new("your-api-key");
+/// let driver = AnthropicChatDriver::new("your-api-key");
 /// // or with custom endpoint
-/// let driver = AnthropicLlmDriver::with_base_url("your-api-key", "https://api.example.com/v1/messages");
+/// let driver = AnthropicChatDriver::with_base_url("your-api-key", "https://api.example.com/v1/messages");
 /// // or with custom retry config
-/// let driver = AnthropicLlmDriver::new("your-api-key")
+/// let driver = AnthropicChatDriver::new("your-api-key")
 ///     .with_retry_config(LlmRetryConfig::aggressive());
 /// ```
 #[derive(Clone)]
-pub struct AnthropicLlmDriver {
+pub struct AnthropicChatDriver {
     client: Client,
     api_key: String,
     api_url: String,
@@ -73,7 +73,7 @@ pub struct AnthropicLlmDriver {
     retry_config: LlmRetryConfig,
 }
 
-impl AnthropicLlmDriver {
+impl AnthropicChatDriver {
     /// Create a new provider with the given API key
     pub fn new(api_key: impl Into<String>) -> Self {
         Self {
@@ -366,7 +366,7 @@ impl AnthropicLlmDriver {
 }
 
 #[async_trait]
-impl LlmDriver for AnthropicLlmDriver {
+impl ChatDriver for AnthropicChatDriver {
     async fn chat_completion_stream(
         &self,
         messages: Vec<LlmMessage>,
@@ -936,9 +936,9 @@ impl LlmDriver for AnthropicLlmDriver {
     }
 }
 
-impl std::fmt::Debug for AnthropicLlmDriver {
+impl std::fmt::Debug for AnthropicChatDriver {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("AnthropicLlmDriver")
+        f.debug_struct("AnthropicChatDriver")
             .field("api_url", &self.api_url)
             .field("api_key", &"[REDACTED]")
             .finish()
@@ -966,10 +966,10 @@ pub fn register_driver(registry: &mut DriverRegistry) {
     registry.register(ProviderType::Anthropic, |config| {
         let api_key = config.api_key.as_deref().unwrap_or("");
         let driver = match config.base_url.as_deref() {
-            Some(url) => AnthropicLlmDriver::with_base_url(api_key, url),
-            None => AnthropicLlmDriver::new(api_key),
+            Some(url) => AnthropicChatDriver::with_base_url(api_key, url),
+            None => AnthropicChatDriver::new(api_key),
         };
-        Box::new(driver) as BoxedLlmDriver
+        Box::new(driver) as BoxedChatDriver
     });
 }
 
@@ -1682,7 +1682,7 @@ mod tests {
     fn test_convert_content_filters_empty_text() {
         // Empty text content should produce empty vec
         let content = LlmMessageContent::Text(String::new());
-        let blocks = AnthropicLlmDriver::convert_content(&content);
+        let blocks = AnthropicChatDriver::convert_content(&content);
         assert!(blocks.is_empty(), "Empty text should be filtered out");
     }
 
@@ -1753,7 +1753,7 @@ mod tests {
             },
         ];
 
-        let (_, converted) = AnthropicLlmDriver::convert_messages(&messages, true);
+        let (_, converted) = AnthropicChatDriver::convert_messages(&messages, true);
         let json = serde_json::to_value(&converted).unwrap();
         let cache_controls = json.to_string().matches("cache_control").count();
 
@@ -1763,7 +1763,7 @@ mod tests {
     #[test]
     fn test_system_prompt_uses_cacheable_block_when_enabled() {
         let system =
-            AnthropicLlmDriver::system_prompt_for_request(Some("System prompt".to_string()), true)
+            AnthropicChatDriver::system_prompt_for_request(Some("System prompt".to_string()), true)
                 .unwrap();
         let json = serde_json::to_value(&system).unwrap();
 
@@ -1788,7 +1788,7 @@ mod tests {
         };
         let tools = vec![make_tool("first"), make_tool("second"), make_tool("third")];
 
-        let converted = AnthropicLlmDriver::convert_tools(&tools, true);
+        let converted = AnthropicChatDriver::convert_tools(&tools, true);
         let json = serde_json::to_value(&converted).unwrap();
         let cache_controls = json.to_string().matches("cache_control").count();
 
@@ -1802,7 +1802,7 @@ mod tests {
     fn test_convert_content_keeps_non_empty_text() {
         // Non-empty text should be kept
         let content = LlmMessageContent::Text("Hello, world!".to_string());
-        let blocks = AnthropicLlmDriver::convert_content(&content);
+        let blocks = AnthropicChatDriver::convert_content(&content);
         assert_eq!(blocks.len(), 1, "Non-empty text should be kept");
     }
 
@@ -1820,7 +1820,7 @@ mod tests {
                 text: String::new(),
             },
         ]);
-        let blocks = AnthropicLlmDriver::convert_content(&content);
+        let blocks = AnthropicChatDriver::convert_content(&content);
         assert_eq!(blocks.len(), 1, "Only non-empty text should be kept");
     }
 
@@ -1835,7 +1835,7 @@ mod tests {
                 url: "https://example.com/image.png".to_string(),
             },
         ]);
-        let blocks = AnthropicLlmDriver::convert_content(&content);
+        let blocks = AnthropicChatDriver::convert_content(&content);
         assert_eq!(blocks.len(), 1, "Image should be kept, empty text filtered");
     }
 
@@ -1850,7 +1850,7 @@ mod tests {
                 text: String::new(),
             },
         ]);
-        let blocks = AnthropicLlmDriver::convert_content(&content);
+        let blocks = AnthropicChatDriver::convert_content(&content);
         assert!(blocks.is_empty(), "All empty text should produce empty vec");
     }
 
@@ -1872,7 +1872,7 @@ mod tests {
             thinking_signature: None,
         }];
 
-        let (_, converted) = AnthropicLlmDriver::convert_messages(&messages, false);
+        let (_, converted) = AnthropicChatDriver::convert_messages(&messages, false);
 
         assert_eq!(converted.len(), 1);
         // Content should have tool_use block but no empty text block
@@ -1887,7 +1887,7 @@ mod tests {
     fn test_convert_content_whitespace_is_kept() {
         // Whitespace-only text is kept (not empty after is_empty() check)
         let content = LlmMessageContent::Text("   ".to_string());
-        let blocks = AnthropicLlmDriver::convert_content(&content);
+        let blocks = AnthropicChatDriver::convert_content(&content);
         assert_eq!(blocks.len(), 1, "Whitespace-only text is kept");
     }
 
@@ -1897,7 +1897,7 @@ mod tests {
         let content = LlmMessageContent::Parts(vec![LlmContentPart::Image {
             url: "data:image/png;base64,iVBORw0KGgo=".to_string(),
         }]);
-        let blocks = AnthropicLlmDriver::convert_content(&content);
+        let blocks = AnthropicChatDriver::convert_content(&content);
         assert_eq!(blocks.len(), 1, "Base64 image should be converted");
         match &blocks[0] {
             AnthropicContentBlock::Image { source } => match source {
@@ -1916,7 +1916,7 @@ mod tests {
         let content = LlmMessageContent::Parts(vec![LlmContentPart::Image {
             url: "https://example.com/photo.jpg".to_string(),
         }]);
-        let blocks = AnthropicLlmDriver::convert_content(&content);
+        let blocks = AnthropicChatDriver::convert_content(&content);
         assert_eq!(blocks.len(), 1, "HTTP image should be converted");
         match &blocks[0] {
             AnthropicContentBlock::Image { source } => match source {
@@ -1935,7 +1935,7 @@ mod tests {
         let content = LlmMessageContent::Parts(vec![LlmContentPart::Audio {
             url: "data:audio/wav;base64,AAAA".to_string(),
         }]);
-        let blocks = AnthropicLlmDriver::convert_content(&content);
+        let blocks = AnthropicChatDriver::convert_content(&content);
         assert_eq!(blocks.len(), 1, "Audio should fallback to text note");
         match &blocks[0] {
             AnthropicContentBlock::Text { text, .. } => {
@@ -1969,7 +1969,7 @@ mod tests {
             },
         ];
 
-        let (system, converted) = AnthropicLlmDriver::convert_messages(&messages, false);
+        let (system, converted) = AnthropicChatDriver::convert_messages(&messages, false);
 
         assert_eq!(system, Some("You are helpful".to_string()));
         assert_eq!(converted.len(), 1); // Only user message
@@ -1988,7 +1988,7 @@ mod tests {
             thinking_signature: None,
         }];
 
-        let (_, converted) = AnthropicLlmDriver::convert_messages(&messages, false);
+        let (_, converted) = AnthropicChatDriver::convert_messages(&messages, false);
 
         assert_eq!(converted.len(), 1);
         assert_eq!(converted[0].role, "user");
@@ -2031,7 +2031,7 @@ mod tests {
             thinking_signature: None,
         };
 
-        let (_, converted) = AnthropicLlmDriver::convert_messages(&[msg], false);
+        let (_, converted) = AnthropicChatDriver::convert_messages(&[msg], false);
 
         assert_eq!(converted.len(), 1);
         assert_eq!(converted[0].role, "user");
@@ -2084,7 +2084,7 @@ mod tests {
             thinking_signature: None,
         };
 
-        let (_, converted) = AnthropicLlmDriver::convert_messages(&[msg], false);
+        let (_, converted) = AnthropicChatDriver::convert_messages(&[msg], false);
 
         match &converted[0].content[0] {
             AnthropicContentBlock::ToolResult { content, .. } => match content {

--- a/crates/anthropic/src/lib.rs
+++ b/crates/anthropic/src/lib.rs
@@ -1,7 +1,7 @@
 //! Anthropic Claude provider driver for Everruns.
 //!
 //! `everruns-anthropic` is part of the [Everruns](https://everruns.com)
-//! ecosystem. It implements the [`LlmDriver`] contract from `everruns-core` and
+//! ecosystem. It implements the [`ChatDriver`] contract from `everruns-core` and
 //! registers Anthropic's Messages API driver into a [`DriverRegistry`].
 //!
 //! Provider crates depend on `everruns-core`; `everruns-core` does not depend on
@@ -11,15 +11,15 @@
 //! # Example
 //!
 //! ```
-//! use everruns_anthropic::{AnthropicLlmDriver, register_driver};
+//! use everruns_anthropic::{AnthropicChatDriver, register_driver};
 //! use everruns_core::DriverRegistry;
 //!
-//! let driver = AnthropicLlmDriver::new("your-api-key");
+//! let driver = AnthropicChatDriver::new("your-api-key");
 //!
 //! let mut registry = DriverRegistry::new();
 //! register_driver(&mut registry);
 //!
-//! assert!(format!("{driver:?}").contains("AnthropicLlmDriver"));
+//! assert!(format!("{driver:?}").contains("AnthropicChatDriver"));
 //! ```
 
 mod driver;
@@ -27,7 +27,7 @@ mod driver;
 #[cfg(test)]
 mod tests;
 
-pub use driver::{AnthropicLlmDriver, register_driver};
+pub use driver::{AnthropicChatDriver, register_driver};
 
 // Re-export core types for convenience
-pub use everruns_core::llm_driver_registry::{DriverRegistry, LlmDriver};
+pub use everruns_core::llm_driver_registry::{ChatDriver, DriverRegistry};

--- a/crates/anthropic/src/tests.rs
+++ b/crates/anthropic/src/tests.rs
@@ -14,6 +14,6 @@ fn test_register_driver() {
 
     // Verify driver can be created via registry
     let config = ProviderConfig::new(ProviderType::Anthropic).with_api_key("test-key");
-    let driver = registry.create_driver(&config);
+    let driver = registry.create_chat_driver(&config);
     assert!(driver.is_ok());
 }

--- a/crates/bedrock/README.md
+++ b/crates/bedrock/README.md
@@ -9,7 +9,7 @@
 `everruns-bedrock` registers an AWS Bedrock driver with
 [`everruns-core`](https://crates.io/crates/everruns-core) so
 the same Everruns agent loop can run against models hosted on Amazon Bedrock. It
-implements the provider-neutral `LlmDriver` contract using the Bedrock Runtime
+implements the provider-neutral `ChatDriver` contract using the Bedrock Runtime
 `ConverseStream` API, mapping Everruns' messages, tools, and reasoning onto the
 Bedrock wire format.
 
@@ -23,7 +23,7 @@ backends, or run with no key using the built-in LLM simulator in
 ## Quick Example
 
 ```rust
-use everruns_bedrock::{BedrockLlmDriver, register_driver};
+use everruns_bedrock::{BedrockChatDriver, register_driver};
 use everruns_core::DriverRegistry;
 
 let mut registry = DriverRegistry::new();

--- a/crates/bedrock/src/driver.rs
+++ b/crates/bedrock/src/driver.rs
@@ -1,4 +1,4 @@
-// AWS Bedrock Runtime LLM Driver
+// AWS Bedrock Runtime Chat Driver
 //
 // Implements ChatDriver using the AWS Bedrock Runtime ConverseStream API.
 // Uses the aws-sdk-bedrockruntime crate for typed event stream handling,
@@ -36,7 +36,7 @@ const BEDROCK_STREAM_BUFFER_SIZE: usize = 64;
 
 use crate::credential::BedrockCredential;
 
-/// AWS Bedrock Runtime LLM Driver.
+/// AWS Bedrock Runtime Chat Driver.
 ///
 /// Implements `ChatDriver` using the `ConverseStream` API.
 /// Credentials are parsed from the JSON-encoded `api_key` field.

--- a/crates/bedrock/src/driver.rs
+++ b/crates/bedrock/src/driver.rs
@@ -1,6 +1,6 @@
 // AWS Bedrock Runtime LLM Driver
 //
-// Implements LlmDriver using the AWS Bedrock Runtime ConverseStream API.
+// Implements ChatDriver using the AWS Bedrock Runtime ConverseStream API.
 // Uses the aws-sdk-bedrockruntime crate for typed event stream handling,
 // which handles SigV4 signing and binary event stream framing internally.
 //
@@ -22,9 +22,9 @@ use aws_smithy_types::Document;
 use base64::prelude::*;
 use everruns_core::error::{AgentLoopError, LlmErrorKind, Result};
 use everruns_core::llm_driver_registry::{
-    BoxedLlmDriver, DiscoveredModel, DriverRegistry, LlmCallConfig, LlmCompletionMetadata,
-    LlmContentPart, LlmDriver, LlmMessage, LlmMessageContent, LlmMessageRole, LlmResponseStream,
-    LlmStreamEvent, ProviderType,
+    BoxedChatDriver, ChatDriver, DiscoveredModel, DriverRegistry, LlmCallConfig,
+    LlmCompletionMetadata, LlmContentPart, LlmMessage, LlmMessageContent, LlmMessageRole,
+    LlmResponseStream, LlmStreamEvent, ProviderType,
 };
 use everruns_core::tool_types::{ToolCall, ToolDefinition};
 use serde_json::Value;
@@ -38,14 +38,14 @@ use crate::credential::BedrockCredential;
 
 /// AWS Bedrock Runtime LLM Driver.
 ///
-/// Implements `LlmDriver` using the `ConverseStream` API.
+/// Implements `ChatDriver` using the `ConverseStream` API.
 /// Credentials are parsed from the JSON-encoded `api_key` field.
 #[derive(Clone, Debug)]
-pub struct BedrockLlmDriver {
+pub struct BedrockChatDriver {
     credential: BedrockCredential,
 }
 
-impl BedrockLlmDriver {
+impl BedrockChatDriver {
     pub fn new(api_key: &str) -> Result<Self> {
         let credential = BedrockCredential::from_api_key(api_key)?;
         Ok(Self { credential })
@@ -72,9 +72,9 @@ impl BedrockLlmDriver {
 pub fn register_driver(registry: &mut DriverRegistry) {
     registry.register(ProviderType::Bedrock, |config| {
         let api_key = config.api_key.as_deref().unwrap_or("");
-        match BedrockLlmDriver::new(api_key) {
-            Ok(driver) => Box::new(driver) as BoxedLlmDriver,
-            Err(e) => Box::new(FailDriver(e.to_string())) as BoxedLlmDriver,
+        match BedrockChatDriver::new(api_key) {
+            Ok(driver) => Box::new(driver) as BoxedChatDriver,
+            Err(e) => Box::new(FailDriver(e.to_string())) as BoxedChatDriver,
         }
     });
 }
@@ -83,7 +83,7 @@ pub fn register_driver(registry: &mut DriverRegistry) {
 struct FailDriver(String);
 
 #[async_trait]
-impl LlmDriver for FailDriver {
+impl ChatDriver for FailDriver {
     async fn chat_completion_stream(
         &self,
         _messages: Vec<LlmMessage>,
@@ -94,7 +94,7 @@ impl LlmDriver for FailDriver {
 }
 
 #[async_trait]
-impl LlmDriver for BedrockLlmDriver {
+impl ChatDriver for BedrockChatDriver {
     async fn chat_completion_stream(
         &self,
         messages: Vec<LlmMessage>,

--- a/crates/bedrock/src/lib.rs
+++ b/crates/bedrock/src/lib.rs
@@ -1,6 +1,6 @@
 //! AWS Bedrock Runtime provider driver for Everruns.
 //!
-//! `everruns-bedrock` implements the [`LlmDriver`] contract from `everruns-core`
+//! `everruns-bedrock` implements the [`ChatDriver`] contract from `everruns-core`
 //! using the AWS Bedrock Runtime `ConverseStream` API.
 //!
 //! Credentials are encoded as JSON in the `api_key` field:
@@ -12,7 +12,7 @@
 //! # Example
 //!
 //! ```
-//! use everruns_bedrock::{BedrockLlmDriver, register_driver};
+//! use everruns_bedrock::{BedrockChatDriver, register_driver};
 //! use everruns_core::DriverRegistry;
 //!
 //! let mut registry = DriverRegistry::new();
@@ -22,6 +22,6 @@
 mod credential;
 mod driver;
 
-pub use driver::{BedrockLlmDriver, register_driver};
+pub use driver::{BedrockChatDriver, register_driver};
 
-pub use everruns_core::llm_driver_registry::{DriverRegistry, LlmDriver};
+pub use everruns_core::llm_driver_registry::{ChatDriver, DriverRegistry};

--- a/crates/core/src/atoms/reason.rs
+++ b/crates/core/src/atoms/reason.rs
@@ -1088,7 +1088,7 @@ impl ReasonAtom {
             .collect();
 
         // 7. Create LLM driver using factory
-        let llm_driver = self.create_llm_driver(&model_with_provider)?;
+        let chat_driver = self.create_chat_driver(&model_with_provider)?;
 
         // 8. Extract reasoning effort from the last user message's controls,
         //    but only if the model actually supports reasoning (per its profile).
@@ -1545,7 +1545,7 @@ impl ReasonAtom {
             completion_metadata,
             time_to_first_token_ms,
         ) = {
-            let mut stream = match llm_driver
+            let mut stream = match chat_driver
                 .chat_completion_stream(llm_messages_for_call.clone(), &llm_config)
                 .await
             {
@@ -1602,7 +1602,7 @@ impl ReasonAtom {
                     let run_native = matches!(
                         config.strategy,
                         CompactionStrategy::Auto | CompactionStrategy::Native
-                    ) && llm_driver.supports_compact();
+                    ) && chat_driver.supports_compact();
                     let run_summarization = matches!(
                         config.strategy,
                         CompactionStrategy::Auto | CompactionStrategy::Summarization
@@ -1670,7 +1670,7 @@ impl ReasonAtom {
                             },
                         };
 
-                        match llm_driver.compact(compact_request).await {
+                        match chat_driver.compact(compact_request).await {
                             Ok(Some(compact_response)) => {
                                 let (compacted_messages, compaction_items) =
                                     compact_output_to_messages(&compact_response.output);
@@ -1799,7 +1799,7 @@ impl ReasonAtom {
                                 openrouter_routing: None,
                             };
 
-                            match llm_driver
+                            match chat_driver
                                 .chat_completion(summary_messages, &summary_config)
                                 .await
                             {
@@ -1906,7 +1906,7 @@ impl ReasonAtom {
                         "ReasonAtom: compaction cascade completed, retrying LLM call"
                     );
 
-                    llm_driver
+                    chat_driver
                         .chat_completion_stream(llm_messages_for_call.clone(), &llm_config)
                         .await?
                 }
@@ -2614,12 +2614,12 @@ impl ReasonAtom {
 
     /// Resolve model using priority chain: controls > session > agent > harness > system default
     /// Create LLM driver using the driver registry
-    fn create_llm_driver(
+    fn create_chat_driver(
         &self,
         model: &ModelWithProvider,
-    ) -> Result<crate::llm_driver_registry::BoxedLlmDriver> {
+    ) -> Result<crate::llm_driver_registry::BoxedChatDriver> {
         self.driver_registry
-            .create_driver(&ProviderConfig::from(model))
+            .create_chat_driver(&ProviderConfig::from(model))
     }
 
     /// Resolve image_file references to actual image data

--- a/crates/core/src/command_host.rs
+++ b/crates/core/src/command_host.rs
@@ -15,7 +15,7 @@ use crate::capabilities::CapabilityRegistry;
 use crate::command::CommandResult;
 use crate::error::{AgentLoopError, Result};
 use crate::llm_driver_registry::{
-    BoxedLlmDriver, DriverRegistry, LlmCallConfig, LlmCallConfigBuilder, LlmMessage,
+    BoxedChatDriver, DriverRegistry, LlmCallConfig, LlmCallConfigBuilder, LlmMessage,
     LlmMessageRole, LlmResponseStream, ProviderConfig, ToolSearchConfig,
 };
 use crate::message::{Controls, Message, MessageRole, patch_dangling_tool_calls};
@@ -398,7 +398,7 @@ impl StoreCommandHost {
 
         let driver = self
             .driver_registry
-            .create_driver(&ProviderConfig::from(&model))
+            .create_chat_driver(&ProviderConfig::from(&model))
             .map_err(|error| SessionCompletionError::Completion {
                 error: error.to_string(),
                 context: context.clone(),
@@ -418,7 +418,7 @@ impl StoreCommandHost {
 struct PreparedCompletion {
     llm_messages: Vec<LlmMessage>,
     llm_config: LlmCallConfig,
-    driver: BoxedLlmDriver,
+    driver: BoxedChatDriver,
     context: UserFacingErrorContext,
 }
 

--- a/crates/core/src/in_memory.rs
+++ b/crates/core/src/in_memory.rs
@@ -570,7 +570,7 @@ impl ToolExecutor for FailingToolExecutor {
 
 use crate::events::{Event, EventRequest};
 use crate::llm_driver_registry::{
-    LlmCallConfig, LlmDriver, LlmMessage, LlmResponseStream, LlmStreamEvent,
+    ChatDriver, LlmCallConfig, LlmMessage, LlmResponseStream, LlmStreamEvent,
 };
 use crate::traits::EventEmitter;
 use futures::stream;
@@ -645,7 +645,7 @@ impl MockLlmProvider {
 }
 
 #[async_trait]
-impl LlmDriver for MockLlmProvider {
+impl ChatDriver for MockLlmProvider {
     async fn chat_completion_stream(
         &self,
         messages: Vec<LlmMessage>,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -168,7 +168,7 @@ pub mod in_memory_loop;
 // Turn orchestration (state machine, context, outcomes)
 pub mod turn;
 
-// Note: LLM Driver implementations (AnthropicLlmDriver, OpenAILlmDriver) are now in
+// Note: LLM Driver implementations (AnthropicChatDriver, OpenAIChatDriver) are now in
 // separate crates (everruns-anthropic, everruns-openai) that depend on everruns-core.
 // This enables dependency inversion - provider crates register their drivers at startup.
 
@@ -263,23 +263,22 @@ pub use utility_llm::{
 
 // LLM driver types re-exports
 pub use llm_driver_registry::{
-    BoxedLlmDriver, DiscoveredModel, DriverFactory, DriverRegistry, LlmCallConfig,
-    LlmCallConfigBuilder, LlmCompletionMetadata, LlmContentPart, LlmDriver, LlmMessage,
-    LlmMessageContent, LlmMessageRole, LlmResponse, LlmResponseStream, LlmStreamEvent,
-    ProviderConfig, ProviderType,
+    BoxedChatDriver, ChatDriver, DiscoveredModel, DriverFactory, DriverRegistry, LlmCallConfig,
+    LlmCallConfigBuilder, LlmCompletionMetadata, LlmContentPart, LlmMessage, LlmMessageContent,
+    LlmMessageRole, LlmResponse, LlmResponseStream, LlmStreamEvent, ProviderConfig, ProviderType,
 };
 
 // LLM retry types re-exports
 pub use llm_retry::{LlmRetryConfig, RateLimitInfo, RateLimitType, RetryMetadata};
 
 // OpenAI Protocol driver (Chat Completions API for backward compatibility)
-pub use openai_protocol::OpenAIProtocolLlmDriver;
+pub use openai_protocol::OpenAIProtocolChatDriver;
 
 // Open Responses Protocol driver (https://www.openresponses.org/)
 // Vendor-neutral API standard, recommended for new projects
 pub use openresponses_protocol::{
     CompactContent, CompactContentPart, CompactInputItem, CompactOutputItem, CompactRequest,
-    CompactResponse, CompactUsage, OpenResponsesProtocolLlmDriver, compact_output_to_messages,
+    CompactResponse, CompactUsage, OpenResponsesProtocolChatDriver, compact_output_to_messages,
     messages_to_compact_input,
 };
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -168,7 +168,7 @@ pub mod in_memory_loop;
 // Turn orchestration (state machine, context, outcomes)
 pub mod turn;
 
-// Note: LLM Driver implementations (AnthropicChatDriver, OpenAIChatDriver) are now in
+// Note: Chat Driver implementations (AnthropicChatDriver, OpenAIChatDriver) are now in
 // separate crates (everruns-anthropic, everruns-openai) that depend on everruns-core.
 // This enables dependency inversion - provider crates register their drivers at startup.
 

--- a/crates/core/src/llm_driver_helpers.rs
+++ b/crates/core/src/llm_driver_helpers.rs
@@ -1,4 +1,4 @@
-// Shared LLM Driver Helpers
+// Shared Chat Driver Helpers
 //
 // Common utilities extracted from individual LLM driver implementations
 // (Anthropic, Gemini, OpenAI) to eliminate duplication.

--- a/crates/core/src/llm_driver_registry.rs
+++ b/crates/core/src/llm_driver_registry.rs
@@ -1,7 +1,7 @@
 // LLM Driver Abstractions
 //
 // This module encapsulates all abstractions needed to interact with LLM Providers:
-// - LlmDriver trait and types for provider-agnostic LLM interactions
+// - ChatDriver trait and types for provider-agnostic LLM interactions
 // - DriverRegistry for dynamic driver registration at startup
 // - Message types for LLM calls
 //
@@ -26,7 +26,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 // ============================================================================
-// LlmDriver Trait
+// ChatDriver Trait
 // ============================================================================
 
 /// Type alias for the LLM response stream
@@ -154,7 +154,7 @@ pub struct LlmCompletionMetadata {
 /// and must not be retried by driver retry loops even when the provider
 /// reports it under a transient status like 429.
 #[async_trait]
-pub trait LlmDriver: Send + Sync {
+pub trait ChatDriver: Send + Sync {
     /// Call the LLM with streaming response
     async fn chat_completion_stream(
         &self,
@@ -262,9 +262,9 @@ pub trait LlmDriver: Send + Sync {
     }
 }
 
-/// Implement LlmDriver for `Box<dyn LlmDriver>` to allow dynamic dispatch
+/// Implement ChatDriver for `Box<dyn ChatDriver>` to allow dynamic dispatch
 #[async_trait]
-impl LlmDriver for Box<dyn LlmDriver> {
+impl ChatDriver for Box<dyn ChatDriver> {
     async fn chat_completion_stream(
         &self,
         messages: Vec<LlmMessage>,
@@ -1247,7 +1247,7 @@ impl From<&crate::traits::ModelWithProvider> for ProviderConfig {
 }
 
 /// Boxed LLM driver for dynamic dispatch
-pub type BoxedLlmDriver = Box<dyn LlmDriver>;
+pub type BoxedChatDriver = Box<dyn ChatDriver>;
 
 // ============================================================================
 // Driver Registry
@@ -1257,7 +1257,7 @@ pub type BoxedLlmDriver = Box<dyn LlmDriver>;
 ///
 /// Receives a [`DriverConfig`] (provider type, optional key/base URL, and
 /// provider metadata) and returns a boxed driver.
-pub type DriverFactory = Arc<dyn Fn(&DriverConfig) -> BoxedLlmDriver + Send + Sync>;
+pub type DriverFactory = Arc<dyn Fn(&DriverConfig) -> BoxedChatDriver + Send + Sync>;
 
 /// Registry for LLM drivers
 ///
@@ -1276,7 +1276,7 @@ pub type DriverFactory = Arc<dyn Fn(&DriverConfig) -> BoxedLlmDriver + Send + Sy
 /// everruns_openai::register_driver(&mut registry);
 ///
 /// // Later, create a driver from config
-/// let driver = registry.create_driver(&config)?;
+/// let driver = registry.create_chat_driver(&config)?;
 /// ```
 #[derive(Clone, Default)]
 pub struct DriverRegistry {
@@ -1298,7 +1298,7 @@ impl DriverRegistry {
     /// [`Self::register_or_replace`] to overwrite intentionally.
     pub fn register<F>(&mut self, provider_type: impl Into<ProviderType>, factory: F)
     where
-        F: Fn(&DriverConfig) -> BoxedLlmDriver + Send + Sync + 'static,
+        F: Fn(&DriverConfig) -> BoxedChatDriver + Send + Sync + 'static,
     {
         let provider_type = provider_type.into();
         if self.factories.contains_key(&provider_type) {
@@ -1316,7 +1316,7 @@ impl DriverRegistry {
     /// for tests). Prefer [`Self::register`] otherwise so duplicates surface.
     pub fn register_or_replace<F>(&mut self, provider_type: impl Into<ProviderType>, factory: F)
     where
-        F: Fn(&DriverConfig) -> BoxedLlmDriver + Send + Sync + 'static,
+        F: Fn(&DriverConfig) -> BoxedChatDriver + Send + Sync + 'static,
     {
         self.factories
             .insert(provider_type.into(), Arc::new(factory));
@@ -1328,7 +1328,7 @@ impl DriverRegistry {
     /// the casing stored in the database or sent on the wire.
     pub fn register_external<F>(&mut self, id: impl Into<Arc<str>>, factory: F)
     where
-        F: Fn(&DriverConfig) -> BoxedLlmDriver + Send + Sync + 'static,
+        F: Fn(&DriverConfig) -> BoxedChatDriver + Send + Sync + 'static,
     {
         self.register(ProviderType::external(id), factory);
     }
@@ -1341,7 +1341,7 @@ impl DriverRegistry {
     /// (external providers may authenticate via [`ProviderMetadata`]).
     ///
     /// Returns `DriverNotRegistered` error if no driver is registered for the provider type.
-    pub fn create_driver(&self, config: &ProviderConfig) -> Result<BoxedLlmDriver> {
+    pub fn create_chat_driver(&self, config: &ProviderConfig) -> Result<BoxedChatDriver> {
         // API key is required for real built-in providers, but not for LlmSim
         // (testing) or External providers (which may use metadata-based auth).
         let requires_api_key = !matches!(
@@ -1687,7 +1687,7 @@ mod tests {
             // Return a mock driver - just need something that compiles
             struct MockDriver;
             #[async_trait]
-            impl LlmDriver for MockDriver {
+            impl ChatDriver for MockDriver {
                 async fn chat_completion_stream(
                     &self,
                     _messages: Vec<LlmMessage>,
@@ -1701,12 +1701,12 @@ mod tests {
 
         // Driver without API key should fail
         let config = ProviderConfig::new(ProviderType::OpenAI);
-        let result = registry.create_driver(&config);
+        let result = registry.create_chat_driver(&config);
         assert!(result.is_err());
 
         // Driver with API key should succeed
         let config_with_key = ProviderConfig::new(ProviderType::OpenAI).with_api_key("test-key");
-        let result = registry.create_driver(&config_with_key);
+        let result = registry.create_chat_driver(&config_with_key);
         assert!(result.is_ok());
     }
 
@@ -1715,7 +1715,7 @@ mod tests {
         let registry = DriverRegistry::new();
         let config = ProviderConfig::new(ProviderType::Anthropic).with_api_key("test-key");
 
-        let result = registry.create_driver(&config);
+        let result = registry.create_chat_driver(&config);
 
         // Should fail with DriverNotRegistered error
         if let Err(AgentLoopError::DriverNotRegistered(provider)) = result {
@@ -1735,7 +1735,7 @@ mod tests {
         registry.register(ProviderType::OpenAI, |_config| {
             struct MockDriver;
             #[async_trait]
-            impl LlmDriver for MockDriver {
+            impl ChatDriver for MockDriver {
                 async fn chat_completion_stream(
                     &self,
                     _messages: Vec<LlmMessage>,
@@ -1755,7 +1755,7 @@ mod tests {
     fn test_register_external_and_create_driver_without_api_key() {
         struct MockDriver;
         #[async_trait]
-        impl LlmDriver for MockDriver {
+        impl ChatDriver for MockDriver {
             async fn chat_completion_stream(
                 &self,
                 _messages: Vec<LlmMessage>,
@@ -1781,7 +1781,7 @@ mod tests {
                 ..Default::default()
             },
         );
-        assert!(registry.create_driver(&config).is_ok());
+        assert!(registry.create_chat_driver(&config).is_ok());
     }
 
     #[test]
@@ -1789,7 +1789,7 @@ mod tests {
     fn test_register_duplicate_panics() {
         struct MockDriver;
         #[async_trait]
-        impl LlmDriver for MockDriver {
+        impl ChatDriver for MockDriver {
             async fn chat_completion_stream(
                 &self,
                 _messages: Vec<LlmMessage>,
@@ -1809,7 +1809,7 @@ mod tests {
     fn test_register_or_replace_overwrites() {
         struct MockDriver;
         #[async_trait]
-        impl LlmDriver for MockDriver {
+        impl ChatDriver for MockDriver {
             async fn chat_completion_stream(
                 &self,
                 _messages: Vec<LlmMessage>,

--- a/crates/core/src/llm_driver_registry.rs
+++ b/crates/core/src/llm_driver_registry.rs
@@ -1,4 +1,4 @@
-// LLM Driver Abstractions
+// Chat Driver Abstractions
 //
 // This module encapsulates all abstractions needed to interact with LLM Providers:
 // - ChatDriver trait and types for provider-agnostic LLM interactions
@@ -1246,7 +1246,7 @@ impl From<&crate::traits::ModelWithProvider> for ProviderConfig {
     }
 }
 
-/// Boxed LLM driver for dynamic dispatch
+/// Boxed chat driver for dynamic dispatch
 pub type BoxedChatDriver = Box<dyn ChatDriver>;
 
 // ============================================================================
@@ -1267,7 +1267,7 @@ pub type DriverFactory = Arc<dyn Fn(&DriverConfig) -> BoxedChatDriver + Send + S
 /// # Example
 ///
 /// ```ignore
-/// use everruns_core::llm_drivers::{DriverRegistry, ProviderType};
+/// use everruns_core::{DriverRegistry, ProviderType};
 /// use everruns_anthropic::register_driver;
 /// use everruns_openai::register_driver as register_openai;
 ///

--- a/crates/core/src/llmsim_driver.rs
+++ b/crates/core/src/llmsim_driver.rs
@@ -18,7 +18,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use crate::error::{AgentLoopError, Result};
 use crate::llm_driver_registry::{
-    BoxedLlmDriver, DriverRegistry, LlmCallConfig, LlmCompletionMetadata, LlmDriver, LlmMessage,
+    BoxedChatDriver, ChatDriver, DriverRegistry, LlmCallConfig, LlmCompletionMetadata, LlmMessage,
     LlmMessageRole, LlmResponseStream, LlmStreamEvent, ProviderType,
 };
 use crate::tool_types::ToolCall;
@@ -588,7 +588,7 @@ impl LlmSimDriver {
 }
 
 #[async_trait]
-impl LlmDriver for LlmSimDriver {
+impl ChatDriver for LlmSimDriver {
     async fn chat_completion_stream(
         &self,
         messages: Vec<LlmMessage>,
@@ -718,7 +718,7 @@ impl std::fmt::Debug for LlmSimDriver {
 pub fn register_driver(registry: &mut DriverRegistry) {
     registry.register(ProviderType::LlmSim, |_config| {
         // Default driver - tests can create custom drivers directly
-        Box::new(LlmSimDriver::default_driver()) as BoxedLlmDriver
+        Box::new(LlmSimDriver::default_driver()) as BoxedChatDriver
     });
 }
 
@@ -733,7 +733,7 @@ pub fn register_driver(registry: &mut DriverRegistry) {
 pub fn register_driver_with_config(registry: &mut DriverRegistry, config: LlmSimConfig) {
     let driver = LlmSimDriver::new(config);
     registry.register(ProviderType::LlmSim, move |_config| {
-        Box::new(driver.clone()) as BoxedLlmDriver
+        Box::new(driver.clone()) as BoxedChatDriver
     });
 }
 
@@ -766,14 +766,14 @@ fn parse_ttft_from_model_name(model_name: &str) -> Option<std::time::Duration> {
 /// # Example
 ///
 /// ```ignore
-/// use everruns_core::llmsim_driver::{create_driver, LlmSimConfig};
+/// use everruns_core::llmsim_driver::{create_chat_driver, LlmSimConfig};
 ///
-/// let driver = create_driver(
+/// let driver = create_chat_driver(
 ///     LlmSimConfig::fixed("I'll help you with that!")
 ///         .with_tool_calls(vec![...])
 /// );
 /// ```
-pub fn create_driver(config: LlmSimConfig) -> BoxedLlmDriver {
+pub fn create_chat_driver(config: LlmSimConfig) -> BoxedChatDriver {
     Box::new(LlmSimDriver::new(config))
 }
 
@@ -1424,7 +1424,7 @@ mod tests {
         // Creating a driver should work (with any API key since it's simulated)
         let config = crate::llm_driver_registry::ProviderConfig::new(ProviderType::LlmSim)
             .with_api_key("fake-key");
-        let driver = registry.create_driver(&config);
+        let driver = registry.create_chat_driver(&config);
         assert!(driver.is_ok());
     }
 

--- a/crates/core/src/openai_protocol.rs
+++ b/crates/core/src/openai_protocol.rs
@@ -1,4 +1,4 @@
-// OpenAI Protocol LLM Driver
+// OpenAI Protocol Chat Driver
 //
 // Base implementation of the OpenAI chat completion protocol.
 // This driver can be used with any OpenAI-compatible API endpoint.
@@ -66,7 +66,7 @@ pub fn is_openai_api_url(api_url: &str) -> bool {
         .is_some_and(|host| host == "api.openai.com")
 }
 
-/// OpenAI Protocol LLM Driver
+/// OpenAI Protocol Chat Driver
 ///
 /// Base implementation of `ChatDriver` for OpenAI-compatible APIs.
 /// Supports streaming responses and tool calls.

--- a/crates/core/src/openai_protocol.rs
+++ b/crates/core/src/openai_protocol.rs
@@ -8,7 +8,7 @@
 // Retry metadata is included in the response for observability.
 //
 // This is the base protocol implementation used in examples.
-// For production use with OpenAI-specific features, use OpenAILlmDriver from everruns-openai.
+// For production use with OpenAI-specific features, use OpenAIChatDriver from everruns-openai.
 //
 // Note: OTel instrumentation is handled via the event-listener pattern.
 // llm.generation events are emitted by ReasonAtom, and OtelEventListener
@@ -24,8 +24,8 @@ use std::sync::{Arc, Mutex};
 
 use crate::error::{AgentLoopError, LlmErrorKind, Result};
 use crate::llm_driver_registry::{
-    LlmCallConfig, LlmCompletionMetadata, LlmContentPart, LlmDriver, LlmMessage, LlmMessageContent,
-    LlmMessageRole, LlmResponseStream, LlmStreamEvent,
+    ChatDriver, LlmCallConfig, LlmCompletionMetadata, LlmContentPart, LlmMessage,
+    LlmMessageContent, LlmMessageRole, LlmResponseStream, LlmStreamEvent,
 };
 use crate::llm_retry::{
     LlmRetryConfig, RateLimitInfo, RetryMetadata, is_rate_limit_status, is_transient_error,
@@ -68,31 +68,31 @@ pub fn is_openai_api_url(api_url: &str) -> bool {
 
 /// OpenAI Protocol LLM Driver
 ///
-/// Base implementation of `LlmDriver` for OpenAI-compatible APIs.
+/// Base implementation of `ChatDriver` for OpenAI-compatible APIs.
 /// Supports streaming responses and tool calls.
 ///
 /// Rate limit handling: On 429 errors, automatically retries with exponential
 /// backoff, respecting `x-ratelimit-reset-*` and `retry-after` headers.
 ///
 /// This is the base protocol driver used in examples and for OpenAI-compatible endpoints.
-/// For production use with OpenAI, consider using `OpenAILlmDriver` from the `everruns-openai` crate.
+/// For production use with OpenAI, consider using `OpenAIChatDriver` from the `everruns-openai` crate.
 ///
 /// # Example
 ///
 /// ```ignore
-/// use everruns_core::OpenAIProtocolLlmDriver;
+/// use everruns_core::OpenAIProtocolChatDriver;
 ///
-/// let driver = OpenAIProtocolLlmDriver::from_env()?;
+/// let driver = OpenAIProtocolChatDriver::from_env()?;
 /// // or
-/// let driver = OpenAIProtocolLlmDriver::new("your-api-key");
+/// let driver = OpenAIProtocolChatDriver::new("your-api-key");
 /// // or with custom endpoint
-/// let driver = OpenAIProtocolLlmDriver::with_base_url("your-api-key", "https://api.example.com/v1/chat/completions");
+/// let driver = OpenAIProtocolChatDriver::with_base_url("your-api-key", "https://api.example.com/v1/chat/completions");
 /// // or with custom retry config
-/// let driver = OpenAIProtocolLlmDriver::new("your-api-key")
+/// let driver = OpenAIProtocolChatDriver::new("your-api-key")
 ///     .with_retry_config(LlmRetryConfig::aggressive());
 /// ```
 #[derive(Clone)]
-pub struct OpenAIProtocolLlmDriver {
+pub struct OpenAIProtocolChatDriver {
     client: Client,
     api_key: String,
     api_url: String,
@@ -100,7 +100,7 @@ pub struct OpenAIProtocolLlmDriver {
     retry_config: LlmRetryConfig,
 }
 
-impl OpenAIProtocolLlmDriver {
+impl OpenAIProtocolChatDriver {
     /// Create a new driver with the given API key
     pub fn new(api_key: impl Into<String>) -> Self {
         Self {
@@ -265,7 +265,7 @@ fn drop_orphaned_tool_messages(messages: &[LlmMessage]) -> Vec<LlmMessage> {
 }
 
 #[async_trait]
-impl LlmDriver for OpenAIProtocolLlmDriver {
+impl ChatDriver for OpenAIProtocolChatDriver {
     async fn chat_completion_stream(
         &self,
         messages: Vec<LlmMessage>,
@@ -570,9 +570,9 @@ impl LlmDriver for OpenAIProtocolLlmDriver {
     }
 }
 
-impl std::fmt::Debug for OpenAIProtocolLlmDriver {
+impl std::fmt::Debug for OpenAIProtocolChatDriver {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("OpenAIProtocolLlmDriver")
+        f.debug_struct("OpenAIProtocolChatDriver")
             .field("api_url", &self.api_url)
             .field("api_key", &"[REDACTED]")
             .finish()
@@ -957,17 +957,17 @@ mod tests {
 
     #[test]
     fn test_driver_with_api_key() {
-        let driver = OpenAIProtocolLlmDriver::new("test-key");
-        assert!(format!("{:?}", driver).contains("OpenAIProtocolLlmDriver"));
+        let driver = OpenAIProtocolChatDriver::new("test-key");
+        assert!(format!("{:?}", driver).contains("OpenAIProtocolChatDriver"));
     }
 
     #[test]
     fn test_driver_with_base_url() {
-        let driver = OpenAIProtocolLlmDriver::with_base_url(
+        let driver = OpenAIProtocolChatDriver::with_base_url(
             "test-key",
             "https://custom.api.com/v1/completions",
         );
-        assert!(format!("{:?}", driver).contains("OpenAIProtocolLlmDriver"));
+        assert!(format!("{:?}", driver).contains("OpenAIProtocolChatDriver"));
         assert_eq!(driver.api_url(), "https://custom.api.com/v1/completions");
     }
 

--- a/crates/core/src/openresponses_protocol.rs
+++ b/crates/core/src/openresponses_protocol.rs
@@ -31,8 +31,9 @@ use std::sync::{Arc, Mutex};
 
 use crate::error::{AgentLoopError, LlmErrorKind, Result};
 use crate::llm_driver_registry::{
-    LlmCallConfig, LlmCompletionMetadata, LlmContentPart, LlmDriver, LlmMessage, LlmMessageContent,
-    LlmMessageRole, LlmResponseStream, LlmStreamEvent, OpenRouterProviderRouting,
+    ChatDriver, LlmCallConfig, LlmCompletionMetadata, LlmContentPart, LlmMessage,
+    LlmMessageContent, LlmMessageRole, LlmResponseStream, LlmStreamEvent,
+    OpenRouterProviderRouting,
 };
 use crate::llm_models::LlmProviderType;
 use crate::llm_retry::{
@@ -51,7 +52,7 @@ const PROMPT_CACHE_KEY_PREFIX: &str = "everruns:";
 
 /// Open Responses Protocol Driver (OpenAI implementation)
 ///
-/// Implements `LlmDriver` using the Open Responses specification
+/// Implements `ChatDriver` using the Open Responses specification
 /// (<https://www.openresponses.org/>). This driver targets OpenAI's API
 /// but follows the vendor-neutral Open Responses standard.
 ///
@@ -66,19 +67,19 @@ const PROMPT_CACHE_KEY_PREFIX: &str = "everruns:";
 /// # Example
 ///
 /// ```ignore
-/// use everruns_core::OpenResponsesProtocolLlmDriver;
+/// use everruns_core::OpenResponsesProtocolChatDriver;
 ///
-/// let driver = OpenResponsesProtocolLlmDriver::from_env()?;
+/// let driver = OpenResponsesProtocolChatDriver::from_env()?;
 /// // or
-/// let driver = OpenResponsesProtocolLlmDriver::new("your-api-key");
+/// let driver = OpenResponsesProtocolChatDriver::new("your-api-key");
 /// // or with custom endpoint
-/// let driver = OpenResponsesProtocolLlmDriver::with_base_url("your-api-key", "https://api.example.com/v1/responses");
+/// let driver = OpenResponsesProtocolChatDriver::with_base_url("your-api-key", "https://api.example.com/v1/responses");
 /// // or with custom retry config
-/// let driver = OpenResponsesProtocolLlmDriver::new("your-api-key")
+/// let driver = OpenResponsesProtocolChatDriver::new("your-api-key")
 ///     .with_retry_config(LlmRetryConfig::aggressive());
 /// ```
 #[derive(Clone)]
-pub struct OpenResponsesProtocolLlmDriver {
+pub struct OpenResponsesProtocolChatDriver {
     client: Client,
     api_key: String,
     api_url: String,
@@ -87,7 +88,7 @@ pub struct OpenResponsesProtocolLlmDriver {
     retry_config: LlmRetryConfig,
 }
 
-impl OpenResponsesProtocolLlmDriver {
+impl OpenResponsesProtocolChatDriver {
     /// Create a new driver with the given API key
     pub fn new(api_key: impl Into<String>) -> Self {
         Self {
@@ -382,9 +383,9 @@ impl OpenResponsesProtocolLlmDriver {
     /// # Example
     ///
     /// ```ignore
-    /// use everruns_core::{OpenResponsesProtocolLlmDriver, CompactRequest, CompactInputItem, CompactContent};
+    /// use everruns_core::{OpenResponsesProtocolChatDriver, CompactRequest, CompactInputItem, CompactContent};
     ///
-    /// let driver = OpenResponsesProtocolLlmDriver::new("your-api-key");
+    /// let driver = OpenResponsesProtocolChatDriver::new("your-api-key");
     ///
     /// let request = CompactRequest {
     ///     model: "gpt-4o".to_string(),
@@ -708,7 +709,7 @@ fn endpoint_persists_responses(api_url: &str) -> bool {
 }
 
 #[async_trait]
-impl LlmDriver for OpenResponsesProtocolLlmDriver {
+impl ChatDriver for OpenResponsesProtocolChatDriver {
     async fn chat_completion_stream(
         &self,
         messages: Vec<LlmMessage>,
@@ -1266,7 +1267,7 @@ impl LlmDriver for OpenResponsesProtocolLlmDriver {
 
     fn supports_compact(&self) -> bool {
         // Delegate to the inherent method
-        OpenResponsesProtocolLlmDriver::supports_compact(self)
+        OpenResponsesProtocolChatDriver::supports_compact(self)
     }
 
     async fn compact(
@@ -1275,14 +1276,14 @@ impl LlmDriver for OpenResponsesProtocolLlmDriver {
     ) -> Result<Option<crate::openresponses_protocol::CompactResponse>> {
         // Delegate to the inherent method and wrap in Some
         Ok(Some(
-            OpenResponsesProtocolLlmDriver::compact(self, request).await?,
+            OpenResponsesProtocolChatDriver::compact(self, request).await?,
         ))
     }
 }
 
-impl std::fmt::Debug for OpenResponsesProtocolLlmDriver {
+impl std::fmt::Debug for OpenResponsesProtocolChatDriver {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("OpenResponsesProtocolLlmDriver")
+        f.debug_struct("OpenResponsesProtocolChatDriver")
             .field("api_url", &self.api_url)
             .field("provider_type", &self.provider_type)
             .field("api_key", &"[REDACTED]")
@@ -1968,17 +1969,17 @@ mod tests {
 
     #[test]
     fn test_driver_with_api_key() {
-        let driver = OpenResponsesProtocolLlmDriver::new("test-key");
-        assert!(format!("{:?}", driver).contains("OpenResponsesProtocolLlmDriver"));
+        let driver = OpenResponsesProtocolChatDriver::new("test-key");
+        assert!(format!("{:?}", driver).contains("OpenResponsesProtocolChatDriver"));
     }
 
     #[test]
     fn test_driver_with_base_url() {
-        let driver = OpenResponsesProtocolLlmDriver::with_base_url(
+        let driver = OpenResponsesProtocolChatDriver::with_base_url(
             "test-key",
             "https://custom.api.com/v1/responses",
         );
-        assert!(format!("{:?}", driver).contains("OpenResponsesProtocolLlmDriver"));
+        assert!(format!("{:?}", driver).contains("OpenResponsesProtocolChatDriver"));
         assert_eq!(driver.api_url(), "https://custom.api.com/v1/responses");
     }
 
@@ -2105,7 +2106,7 @@ mod tests {
             phase: None,
         }];
 
-        let key = OpenResponsesProtocolLlmDriver::build_prompt_cache_key(
+        let key = OpenResponsesProtocolChatDriver::build_prompt_cache_key(
             &config,
             &input,
             &Some("You are helpful".to_string()),
@@ -2149,13 +2150,13 @@ mod tests {
             phase: None,
         }];
 
-        let first = OpenResponsesProtocolLlmDriver::build_prompt_cache_key(
+        let first = OpenResponsesProtocolChatDriver::build_prompt_cache_key(
             &config,
             &first_input,
             &Some("You are helpful".to_string()),
             &None,
         );
-        let second = OpenResponsesProtocolLlmDriver::build_prompt_cache_key(
+        let second = OpenResponsesProtocolChatDriver::build_prompt_cache_key(
             &config,
             &second_input,
             &Some("You are helpful".to_string()),
@@ -2194,13 +2195,13 @@ mod tests {
             phase: None,
         }];
 
-        let first = OpenResponsesProtocolLlmDriver::build_prompt_cache_key(
+        let first = OpenResponsesProtocolChatDriver::build_prompt_cache_key(
             &make_config(first_metadata),
             &input,
             &Some("You are helpful".to_string()),
             &None,
         );
-        let second = OpenResponsesProtocolLlmDriver::build_prompt_cache_key(
+        let second = OpenResponsesProtocolChatDriver::build_prompt_cache_key(
             &make_config(second_metadata),
             &input,
             &Some("You are helpful".to_string()),
@@ -2235,7 +2236,7 @@ mod tests {
             phase: None,
         }];
 
-        let key = OpenResponsesProtocolLlmDriver::build_prompt_cache_key(
+        let key = OpenResponsesProtocolChatDriver::build_prompt_cache_key(
             &config,
             &input,
             &Some("You are helpful".to_string()),
@@ -2312,7 +2313,7 @@ mod tests {
             LlmMessage::text(LlmMessageRole::User, "Hello"),
         ];
 
-        let (instructions, input) = OpenResponsesProtocolLlmDriver::build_input(&messages, false);
+        let (instructions, input) = OpenResponsesProtocolChatDriver::build_input(&messages, false);
 
         assert_eq!(
             instructions,
@@ -2324,19 +2325,19 @@ mod tests {
     #[test]
     fn test_convert_role() {
         assert_eq!(
-            OpenResponsesProtocolLlmDriver::convert_role(&LlmMessageRole::System),
+            OpenResponsesProtocolChatDriver::convert_role(&LlmMessageRole::System),
             "developer"
         );
         assert_eq!(
-            OpenResponsesProtocolLlmDriver::convert_role(&LlmMessageRole::User),
+            OpenResponsesProtocolChatDriver::convert_role(&LlmMessageRole::User),
             "user"
         );
         assert_eq!(
-            OpenResponsesProtocolLlmDriver::convert_role(&LlmMessageRole::Assistant),
+            OpenResponsesProtocolChatDriver::convert_role(&LlmMessageRole::Assistant),
             "assistant"
         );
         assert_eq!(
-            OpenResponsesProtocolLlmDriver::convert_role(&LlmMessageRole::Tool),
+            OpenResponsesProtocolChatDriver::convert_role(&LlmMessageRole::Tool),
             "tool"
         );
     }
@@ -2392,7 +2393,7 @@ mod tests {
             },
         ];
 
-        let (instructions, input) = OpenResponsesProtocolLlmDriver::build_input(&messages, false);
+        let (instructions, input) = OpenResponsesProtocolChatDriver::build_input(&messages, false);
 
         // System message becomes instructions
         assert_eq!(instructions, Some("You are helpful".to_string()));
@@ -2435,7 +2436,7 @@ mod tests {
             },
         ];
 
-        let (_, input) = OpenResponsesProtocolLlmDriver::build_input(&messages, false);
+        let (_, input) = OpenResponsesProtocolChatDriver::build_input(&messages, false);
 
         // Should have: user message, assistant message, function_call
         assert_eq!(input.len(), 3);
@@ -2504,7 +2505,7 @@ mod tests {
 
         // Build the full transcript the same way the driver does.
         let (instructions, full_input) =
-            OpenResponsesProtocolLlmDriver::build_input(&messages, false);
+            OpenResponsesProtocolChatDriver::build_input(&messages, false);
 
         // Without trimming the full transcript leaks user + assistant + function_call
         // + function_call_output — exactly the bug.
@@ -2911,7 +2912,7 @@ mod tests {
         // server.uri() is a 127.0.0.1 host — not OpenAI/Azure — so it is treated
         // as a stateless gateway.
         let api_url = format!("{}/v1/responses", server.uri());
-        let driver = OpenResponsesProtocolLlmDriver::with_base_url("test-key", api_url);
+        let driver = OpenResponsesProtocolChatDriver::with_base_url("test-key", api_url);
 
         let messages = vec![
             LlmMessage::text(LlmMessageRole::System, "You are helpful"),
@@ -3010,7 +3011,7 @@ mod tests {
             .await;
 
         let api_url = format!("{}/v1/responses", server.uri());
-        let driver = OpenResponsesProtocolLlmDriver::with_base_url("test-key", api_url)
+        let driver = OpenResponsesProtocolChatDriver::with_base_url("test-key", api_url)
             .with_provider_type(LlmProviderType::Openrouter);
 
         let tools: Vec<ToolDefinition> = (0..16)
@@ -3082,7 +3083,7 @@ mod tests {
             .await;
 
         let api_url = format!("{}/v1/responses", server.uri());
-        let driver = OpenResponsesProtocolLlmDriver::with_base_url("test-key", api_url)
+        let driver = OpenResponsesProtocolChatDriver::with_base_url("test-key", api_url)
             .with_provider_type(LlmProviderType::Openrouter);
 
         let config = LlmCallConfig {
@@ -3171,7 +3172,7 @@ mod tests {
             .await;
 
         let api_url = format!("{}/v1/responses", server.uri());
-        let driver = OpenResponsesProtocolLlmDriver::with_base_url("test-key", api_url);
+        let driver = OpenResponsesProtocolChatDriver::with_base_url("test-key", api_url);
 
         let config = LlmCallConfig {
             model: "gpt-5-mini".to_string(),
@@ -3218,7 +3219,7 @@ mod tests {
             .await;
 
         let api_url = format!("{}/v1/responses", server.uri());
-        let driver = OpenResponsesProtocolLlmDriver::with_base_url("test-key", api_url)
+        let driver = OpenResponsesProtocolChatDriver::with_base_url("test-key", api_url)
             .with_provider_type(LlmProviderType::Openrouter);
 
         let mismatch_config = LlmCallConfig {
@@ -3435,14 +3436,14 @@ mod tests {
 
     #[test]
     fn test_supports_compact_default_url() {
-        let driver = OpenResponsesProtocolLlmDriver::new("test-key");
+        let driver = OpenResponsesProtocolChatDriver::new("test-key");
         // Default URL is OpenAI, should support compact
         assert!(driver.supports_compact());
     }
 
     #[test]
     fn test_supports_compact_custom_url() {
-        let driver = OpenResponsesProtocolLlmDriver::with_base_url(
+        let driver = OpenResponsesProtocolChatDriver::with_base_url(
             "test-key",
             "https://custom.api.com/v1/responses",
         );
@@ -3488,7 +3489,7 @@ mod tests {
             LlmMessage::text(LlmMessageRole::User, "What else?"),
         ];
 
-        let (_, input) = OpenResponsesProtocolLlmDriver::build_input(&messages, false);
+        let (_, input) = OpenResponsesProtocolChatDriver::build_input(&messages, false);
 
         // Should have: user message, reasoning item, assistant message, user message
         assert_eq!(input.len(), 4);
@@ -3544,7 +3545,7 @@ mod tests {
             },
         ];
 
-        let (_, input) = OpenResponsesProtocolLlmDriver::build_input(&messages, false);
+        let (_, input) = OpenResponsesProtocolChatDriver::build_input(&messages, false);
 
         // Should have: user, reasoning, assistant, function_call, function_call_output
         assert_eq!(input.len(), 5);
@@ -3584,7 +3585,7 @@ mod tests {
             },
         ];
 
-        let (_, input) = OpenResponsesProtocolLlmDriver::build_input(&messages, false);
+        let (_, input) = OpenResponsesProtocolChatDriver::build_input(&messages, false);
 
         // Should have: user message, assistant message (no reasoning item)
         assert_eq!(input.len(), 2);
@@ -3941,7 +3942,7 @@ mod tests {
             },
         ];
 
-        let (_, input) = OpenResponsesProtocolLlmDriver::build_input(&messages, false);
+        let (_, input) = OpenResponsesProtocolChatDriver::build_input(&messages, false);
 
         assert_eq!(input.len(), 2);
         let json = serde_json::to_value(&input[1]).unwrap();
@@ -3975,7 +3976,7 @@ mod tests {
             },
         ];
 
-        let (_, input) = OpenResponsesProtocolLlmDriver::build_input(&messages, false);
+        let (_, input) = OpenResponsesProtocolChatDriver::build_input(&messages, false);
 
         // Should have: user, reasoning_1, assistant, user, reasoning_2, assistant
         assert_eq!(input.len(), 6);
@@ -4022,12 +4023,12 @@ mod tests {
         ];
 
         // With supports_phases=true, assistant message should include phase
-        let (_, input) = OpenResponsesProtocolLlmDriver::build_input(&messages, true);
+        let (_, input) = OpenResponsesProtocolChatDriver::build_input(&messages, true);
         let assistant_json = serde_json::to_value(&input[1]).unwrap();
         assert_eq!(assistant_json["phase"], "commentary");
 
         // With supports_phases=false, phase should be absent
-        let (_, input_no_phases) = OpenResponsesProtocolLlmDriver::build_input(&messages, false);
+        let (_, input_no_phases) = OpenResponsesProtocolChatDriver::build_input(&messages, false);
         let assistant_json_no = serde_json::to_value(&input_no_phases[1]).unwrap();
         assert!(assistant_json_no.get("phase").is_none() || assistant_json_no["phase"].is_null());
     }
@@ -4070,7 +4071,7 @@ mod tests {
             .collect();
 
         // threshold=15, only 5 tools → should fall back to standard convert_tools
-        let result = OpenResponsesProtocolLlmDriver::convert_tools_with_search(&tools, 15);
+        let result = OpenResponsesProtocolChatDriver::convert_tools_with_search(&tools, 15);
         assert_eq!(result.len(), 5);
         // No ToolSearch entry, no namespaces
         let json = serde_json::to_value(&result).unwrap();
@@ -4101,7 +4102,7 @@ mod tests {
             ));
         }
 
-        let result = OpenResponsesProtocolLlmDriver::convert_tools_with_search(&tools, 15);
+        let result = OpenResponsesProtocolChatDriver::convert_tools_with_search(&tools, 15);
         let json = serde_json::to_value(&result).unwrap();
         let arr = json.as_array().unwrap();
 
@@ -4159,7 +4160,7 @@ mod tests {
             ));
         }
 
-        let result = OpenResponsesProtocolLlmDriver::convert_tools_with_search(&tools, 15);
+        let result = OpenResponsesProtocolChatDriver::convert_tools_with_search(&tools, 15);
         let json = serde_json::to_value(&result).unwrap();
         let arr = json.as_array().unwrap();
 
@@ -4203,7 +4204,7 @@ mod tests {
             ));
         }
 
-        let result = OpenResponsesProtocolLlmDriver::convert_tools_with_search(&tools, 15);
+        let result = OpenResponsesProtocolChatDriver::convert_tools_with_search(&tools, 15);
         let json = serde_json::to_value(&result).unwrap();
         let arr = json.as_array().unwrap();
 
@@ -4245,7 +4246,7 @@ mod tests {
         ));
 
         // Exactly at threshold (15 tools, threshold=15)
-        let result = OpenResponsesProtocolLlmDriver::convert_tools_with_search(&tools, 15);
+        let result = OpenResponsesProtocolChatDriver::convert_tools_with_search(&tools, 15);
         let json = serde_json::to_value(&result).unwrap();
         let arr = json.as_array().unwrap();
 
@@ -4384,7 +4385,7 @@ mod tests {
     #[test]
     fn test_sanitize_parameters_adds_missing_properties() {
         let params = json!({"type": "object", "additionalProperties": false});
-        let sanitized = OpenResponsesProtocolLlmDriver::sanitize_parameters(&params);
+        let sanitized = OpenResponsesProtocolChatDriver::sanitize_parameters(&params);
         assert_eq!(
             sanitized,
             json!({"type": "object", "properties": {}, "additionalProperties": false})
@@ -4394,14 +4395,14 @@ mod tests {
     #[test]
     fn test_sanitize_parameters_preserves_existing_properties() {
         let params = json!({"type": "object", "properties": {"x": {"type": "string"}}, "additionalProperties": false});
-        let sanitized = OpenResponsesProtocolLlmDriver::sanitize_parameters(&params);
+        let sanitized = OpenResponsesProtocolChatDriver::sanitize_parameters(&params);
         assert_eq!(sanitized, params);
     }
 
     #[test]
     fn test_sanitize_parameters_ignores_non_object_types() {
         let params = json!({"type": "string"});
-        let sanitized = OpenResponsesProtocolLlmDriver::sanitize_parameters(&params);
+        let sanitized = OpenResponsesProtocolChatDriver::sanitize_parameters(&params);
         assert_eq!(sanitized, params);
     }
 }

--- a/crates/core/src/utility_llm.rs
+++ b/crates/core/src/utility_llm.rs
@@ -5,8 +5,8 @@
 //! the model fixed so call sites cannot turn it into a user-selectable model.
 
 use crate::{
-    AgentLoopError, LlmCallConfig, LlmDriver, LlmMessage, LlmResponse, LlmResponseStream,
-    OpenResponsesProtocolLlmDriver, Result,
+    AgentLoopError, ChatDriver, LlmCallConfig, LlmMessage, LlmResponse, LlmResponseStream,
+    OpenResponsesProtocolChatDriver, Result,
 };
 use async_trait::async_trait;
 use std::collections::HashMap;
@@ -145,7 +145,7 @@ impl UtilityLlmService for DisabledUtilityLlmService {
 
 #[derive(Clone)]
 pub struct OpenAiUtilityLlmService {
-    driver: OpenResponsesProtocolLlmDriver,
+    driver: OpenResponsesProtocolChatDriver,
 }
 
 impl std::fmt::Debug for OpenAiUtilityLlmService {
@@ -162,7 +162,7 @@ impl OpenAiUtilityLlmService {
         // THREAT[TM-LLM-021]: Utility LLM credentials must not become agent- or
         // session-configurable. Keep the key inside this host service.
         Self {
-            driver: OpenResponsesProtocolLlmDriver::new(api_key),
+            driver: OpenResponsesProtocolChatDriver::new(api_key),
         }
     }
 }

--- a/crates/core/tests/reason_atom_test.rs
+++ b/crates/core/tests/reason_atom_test.rs
@@ -193,7 +193,7 @@ struct FlakyStreamDriver {
 }
 
 #[async_trait]
-impl everruns_core::LlmDriver for FlakyStreamDriver {
+impl everruns_core::ChatDriver for FlakyStreamDriver {
     async fn chat_completion_stream(
         &self,
         _messages: Vec<everruns_core::LlmMessage>,
@@ -234,7 +234,7 @@ struct ThinkingLeakDriver {
 }
 
 #[async_trait]
-impl everruns_core::LlmDriver for ThinkingLeakDriver {
+impl everruns_core::ChatDriver for ThinkingLeakDriver {
     async fn chat_completion_stream(
         &self,
         _messages: Vec<everruns_core::LlmMessage>,
@@ -468,7 +468,7 @@ async fn test_reason_atom_with_echo_response() {
 async fn test_reason_atom_with_different_configs() {
     // Test that different LlmSimConfig settings produce different results
     // Note: Sequence responses work within a single driver instance, but each
-    // registry.create_driver() call creates a fresh driver. For registry-based
+    // registry.create_chat_driver() call creates a fresh driver. For registry-based
     // usage, use fixed responses or test sequences at the driver level.
 
     let (
@@ -1113,12 +1113,12 @@ async fn test_driver_registry_integration() {
         .with_api_key("test-key");
 
     let driver = registry
-        .create_driver(&config)
+        .create_chat_driver(&config)
         .expect("Should create LlmSim driver");
 
     // Test the driver
     use everruns_core::llm_driver_registry::{
-        LlmCallConfig, LlmDriver, LlmMessage, LlmMessageRole,
+        ChatDriver, LlmCallConfig, LlmMessage, LlmMessageRole,
     };
 
     let messages = vec![LlmMessage::text(LlmMessageRole::User, "Hello")];
@@ -1465,7 +1465,7 @@ async fn test_llm_call_config_previous_response_id() {
 struct ToolCallsThenErrorDriver;
 
 #[async_trait]
-impl everruns_core::LlmDriver for ToolCallsThenErrorDriver {
+impl everruns_core::ChatDriver for ToolCallsThenErrorDriver {
     async fn chat_completion_stream(
         &self,
         _messages: Vec<everruns_core::LlmMessage>,
@@ -1558,7 +1558,7 @@ async fn test_reason_atom_preserves_tool_calls_on_trailing_stream_error() {
 struct TextThenErrorDriver;
 
 #[async_trait]
-impl everruns_core::LlmDriver for TextThenErrorDriver {
+impl everruns_core::ChatDriver for TextThenErrorDriver {
     async fn chat_completion_stream(
         &self,
         _messages: Vec<everruns_core::LlmMessage>,
@@ -1647,7 +1647,7 @@ async fn test_reason_atom_preserves_text_on_trailing_stream_error() {
 struct PureErrorDriver;
 
 #[async_trait]
-impl everruns_core::LlmDriver for PureErrorDriver {
+impl everruns_core::ChatDriver for PureErrorDriver {
     async fn chat_completion_stream(
         &self,
         _messages: Vec<everruns_core::LlmMessage>,
@@ -1951,7 +1951,7 @@ struct SystemPromptCapturingDriver {
 }
 
 #[async_trait]
-impl everruns_core::LlmDriver for SystemPromptCapturingDriver {
+impl everruns_core::ChatDriver for SystemPromptCapturingDriver {
     async fn chat_completion_stream(
         &self,
         messages: Vec<everruns_core::LlmMessage>,
@@ -1987,7 +1987,7 @@ struct ConversationCapturingDriver {
 }
 
 #[async_trait]
-impl everruns_core::LlmDriver for ConversationCapturingDriver {
+impl everruns_core::ChatDriver for ConversationCapturingDriver {
     async fn chat_completion_stream(
         &self,
         messages: Vec<everruns_core::LlmMessage>,

--- a/crates/gemini/README.md
+++ b/crates/gemini/README.md
@@ -9,7 +9,7 @@
 `everruns-gemini` registers a Google Gemini driver with
 [`everruns-core`](https://crates.io/crates/everruns-core) so
 the same Everruns agent loop can run against Gemini models. It implements the
-provider-neutral `LlmDriver` contract and maps Everruns' messages, tools, and
+provider-neutral `ChatDriver` contract and maps Everruns' messages, tools, and
 reasoning onto the Gemini API. Core has no knowledge of specific providers; hosts
 register whichever drivers they want available.
 
@@ -23,7 +23,7 @@ backends, or run with no key using the built-in LLM simulator in
 ## Quick Example
 
 ```rust
-use everruns_gemini::{GeminiLlmDriver, register_driver};
+use everruns_gemini::{GeminiChatDriver, register_driver};
 use everruns_core::DriverRegistry;
 
 let mut registry = DriverRegistry::new();

--- a/crates/gemini/src/driver.rs
+++ b/crates/gemini/src/driver.rs
@@ -1,4 +1,4 @@
-// Google Gemini LLM Driver
+// Google Gemini Chat Driver
 //
 // Implementation of ChatDriver for Google's Gemini API.
 // Uses the generateContent API with streaming support.
@@ -31,7 +31,7 @@ use everruns_core::tool_types::{ToolCall, ToolDefinition};
 
 const DEFAULT_BASE_URL: &str = "https://generativelanguage.googleapis.com/v1beta";
 
-/// Google Gemini LLM Driver
+/// Google Gemini Chat Driver
 ///
 /// Implements `ChatDriver` for Google's Gemini API.
 /// Supports streaming responses and tool calls.

--- a/crates/gemini/src/driver.rs
+++ b/crates/gemini/src/driver.rs
@@ -1,6 +1,6 @@
 // Google Gemini LLM Driver
 //
-// Implementation of LlmDriver for Google's Gemini API.
+// Implementation of ChatDriver for Google's Gemini API.
 // Uses the generateContent API with streaming support.
 //
 // API docs: https://ai.google.dev/api/generate-content
@@ -22,9 +22,9 @@ use everruns_core::llm_driver_helpers::{
     parse_data_url,
 };
 use everruns_core::llm_driver_registry::{
-    BoxedLlmDriver, DiscoveredModel, DriverRegistry, LlmCallConfig, LlmCompletionMetadata,
-    LlmContentPart, LlmDriver, LlmMessage, LlmMessageContent, LlmMessageRole, LlmResponseStream,
-    LlmStreamEvent, ProviderType,
+    BoxedChatDriver, ChatDriver, DiscoveredModel, DriverRegistry, LlmCallConfig,
+    LlmCompletionMetadata, LlmContentPart, LlmMessage, LlmMessageContent, LlmMessageRole,
+    LlmResponseStream, LlmStreamEvent, ProviderType,
 };
 use everruns_core::llm_retry::{LlmRetryConfig, RetryMetadata, is_transient_error};
 use everruns_core::tool_types::{ToolCall, ToolDefinition};
@@ -33,10 +33,10 @@ const DEFAULT_BASE_URL: &str = "https://generativelanguage.googleapis.com/v1beta
 
 /// Google Gemini LLM Driver
 ///
-/// Implements `LlmDriver` for Google's Gemini API.
+/// Implements `ChatDriver` for Google's Gemini API.
 /// Supports streaming responses and tool calls.
 #[derive(Clone)]
-pub struct GeminiLlmDriver {
+pub struct GeminiChatDriver {
     client: Client,
     api_key: String,
     base_url: String,
@@ -44,7 +44,7 @@ pub struct GeminiLlmDriver {
     retry_config: LlmRetryConfig,
 }
 
-impl GeminiLlmDriver {
+impl GeminiChatDriver {
     /// Create a new driver with the given API key
     pub fn new(api_key: impl Into<String>) -> Self {
         Self {
@@ -287,7 +287,7 @@ impl GeminiLlmDriver {
 }
 
 #[async_trait]
-impl LlmDriver for GeminiLlmDriver {
+impl ChatDriver for GeminiChatDriver {
     async fn chat_completion_stream(
         &self,
         messages: Vec<LlmMessage>,
@@ -820,9 +820,9 @@ impl LlmDriver for GeminiLlmDriver {
     }
 }
 
-impl std::fmt::Debug for GeminiLlmDriver {
+impl std::fmt::Debug for GeminiChatDriver {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("GeminiLlmDriver")
+        f.debug_struct("GeminiChatDriver")
             .field("base_url", &self.base_url)
             .field("api_key", &"[REDACTED]")
             .finish()
@@ -838,10 +838,10 @@ pub fn register_driver(registry: &mut DriverRegistry) {
     registry.register(ProviderType::Gemini, |config| {
         let api_key = config.api_key.as_deref().unwrap_or("");
         let driver = match config.base_url.as_deref() {
-            Some(url) => GeminiLlmDriver::with_base_url(api_key, url),
-            None => GeminiLlmDriver::new(api_key),
+            Some(url) => GeminiChatDriver::with_base_url(api_key, url),
+            None => GeminiChatDriver::new(api_key),
         };
-        Box::new(driver) as BoxedLlmDriver
+        Box::new(driver) as BoxedChatDriver
     });
 }
 
@@ -1071,14 +1071,14 @@ mod tests {
     #[test]
     fn test_convert_content_text() {
         let content = LlmMessageContent::Text("Hello, world!".to_string());
-        let parts = GeminiLlmDriver::convert_content(&content);
+        let parts = GeminiChatDriver::convert_content(&content);
         assert_eq!(parts.len(), 1);
     }
 
     #[test]
     fn test_convert_content_empty_text() {
         let content = LlmMessageContent::Text(String::new());
-        let parts = GeminiLlmDriver::convert_content(&content);
+        let parts = GeminiChatDriver::convert_content(&content);
         assert!(parts.is_empty());
     }
 
@@ -1105,7 +1105,7 @@ mod tests {
             },
         ];
 
-        let (system, contents) = GeminiLlmDriver::convert_messages(&messages);
+        let (system, contents) = GeminiChatDriver::convert_messages(&messages);
 
         assert!(system.is_some());
         assert_eq!(contents.len(), 1); // Only user message
@@ -1132,7 +1132,7 @@ mod tests {
             full_parameters: None,
         })];
 
-        let gemini_tools = GeminiLlmDriver::convert_tools(&tools);
+        let gemini_tools = GeminiChatDriver::convert_tools(&tools);
         assert!(gemini_tools.is_some());
         let tools = gemini_tools.unwrap();
         assert_eq!(tools.len(), 1);
@@ -1162,7 +1162,7 @@ mod tests {
             full_parameters: None,
         })];
 
-        let gemini_tools = GeminiLlmDriver::convert_tools(&tools).unwrap();
+        let gemini_tools = GeminiChatDriver::convert_tools(&tools).unwrap();
         let params = &gemini_tools[0].function_declarations[0].parameters;
         assert!(params.get("additionalProperties").is_none());
         assert!(
@@ -1217,7 +1217,7 @@ mod tests {
             full_parameters: None,
         })];
 
-        let gemini_tools = GeminiLlmDriver::convert_tools(&tools).unwrap();
+        let gemini_tools = GeminiChatDriver::convert_tools(&tools).unwrap();
         let params = &gemini_tools[0].function_declarations[0].parameters;
 
         fn assert_no_additional_properties(v: &Value) {
@@ -1268,7 +1268,7 @@ mod tests {
             full_parameters: None,
         })];
 
-        let gemini_tools = GeminiLlmDriver::convert_tools(&tools).unwrap();
+        let gemini_tools = GeminiChatDriver::convert_tools(&tools).unwrap();
         let params = &gemini_tools[0].function_declarations[0].parameters;
 
         assert!(params.get("additionalProperties").is_none());
@@ -1285,7 +1285,7 @@ mod tests {
     #[test]
     fn test_convert_file_system_capability_strips_nested_additional_properties() {
         let tools = FileSystemCapability.tool_definitions();
-        let gemini_tools = GeminiLlmDriver::convert_tools(&tools).unwrap();
+        let gemini_tools = GeminiChatDriver::convert_tools(&tools).unwrap();
 
         fn assert_no_additional_properties(v: &Value) {
             match v {
@@ -1315,7 +1315,7 @@ mod tests {
     #[test]
     fn test_convert_tools_empty() {
         let tools: Vec<ToolDefinition> = vec![];
-        let gemini_tools = GeminiLlmDriver::convert_tools(&tools);
+        let gemini_tools = GeminiChatDriver::convert_tools(&tools);
         assert!(gemini_tools.is_none());
     }
 
@@ -1359,7 +1359,7 @@ mod tests {
 
     #[test]
     fn test_stream_url() {
-        let driver = GeminiLlmDriver::new("test-key");
+        let driver = GeminiChatDriver::new("test-key");
         let url = driver.stream_url("gemini-2.5-pro");
         assert!(url.contains("gemini-2.5-pro:streamGenerateContent"));
         assert!(url.contains("alt=sse"));
@@ -1378,7 +1378,7 @@ mod tests {
             thinking_signature: None,
         }];
 
-        let (_, contents) = GeminiLlmDriver::convert_messages(&messages);
+        let (_, contents) = GeminiChatDriver::convert_messages(&messages);
 
         assert_eq!(contents.len(), 1);
         assert_eq!(contents[0].role.as_deref(), Some("user"));

--- a/crates/gemini/src/lib.rs
+++ b/crates/gemini/src/lib.rs
@@ -1,7 +1,7 @@
 //! Google Gemini LLM provider driver for Everruns.
 //!
 //! `everruns-gemini` is part of the [Everruns](https://everruns.com) ecosystem.
-//! It implements the `LlmDriver` contract from `everruns-core`, so the agent
+//! It implements the `ChatDriver` contract from `everruns-core`, so the agent
 //! loop can run against Google's Gemini API, and registers itself through
 //! [`register_driver`].
 //!
@@ -20,7 +20,7 @@
 
 mod driver;
 
-pub use driver::{GeminiLlmDriver, register_driver};
+pub use driver::{GeminiChatDriver, register_driver};
 
 // Re-export core types for convenience
-pub use everruns_core::llm_driver_registry::{DriverRegistry, LlmDriver};
+pub use everruns_core::llm_driver_registry::{ChatDriver, DriverRegistry};

--- a/crates/openai/README.md
+++ b/crates/openai/README.md
@@ -62,9 +62,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ## Driver-Only Example
 
 ```rust
-use everruns_openai::OpenAILlmDriver;
+use everruns_openai::OpenAIChatDriver;
 
-let driver = OpenAILlmDriver::new("your-api-key");
+let driver = OpenAIChatDriver::new("your-api-key");
 assert!(!driver.uses_custom_url());
 ```
 

--- a/crates/openai/src/driver.rs
+++ b/crates/openai/src/driver.rs
@@ -2,10 +2,10 @@
 //
 // This module provides two separate drivers for OpenAI:
 //
-// 1. OpenAILlmDriver - Uses Open Responses API (https://www.openresponses.org/)
+// 1. OpenAIChatDriver - Uses Open Responses API (https://www.openresponses.org/)
 //    Recommended for new projects. Better performance with reasoning models.
 //
-// 2. OpenAICompletionsLlmDriver - Uses Chat Completions API
+// 2. OpenAICompletionsChatDriver - Uses Chat Completions API
 //    For backward compatibility with /v1/chat/completions endpoint.
 
 use async_trait::async_trait;
@@ -13,11 +13,11 @@ use chrono::TimeZone;
 use reqwest::RequestBuilder;
 use reqwest::Url;
 
-use everruns_core::OpenAIProtocolLlmDriver;
-use everruns_core::OpenResponsesProtocolLlmDriver;
+use everruns_core::OpenAIProtocolChatDriver;
+use everruns_core::OpenResponsesProtocolChatDriver;
 use everruns_core::error::{AgentLoopError, Result};
 use everruns_core::llm_driver_registry::{
-    BoxedLlmDriver, DiscoveredModel, DriverRegistry, LlmCallConfig, LlmDriver, LlmMessage,
+    BoxedChatDriver, ChatDriver, DiscoveredModel, DriverRegistry, LlmCallConfig, LlmMessage,
     LlmResponseStream, ProviderType,
 };
 use everruns_core::llm_models::LlmProviderType;
@@ -44,33 +44,33 @@ const OPENROUTER_RESPONSES_URL: &str = "https://openrouter.ai/api/v1/responses";
 /// - 40-80% better cache utilization
 ///
 /// For backward compatibility with the Chat Completions API, use
-/// `OpenAICompletionsLlmDriver` instead.
+/// `OpenAICompletionsChatDriver` instead.
 ///
 /// # Example
 ///
 /// ```ignore
-/// use everruns_openai::OpenAILlmDriver;
+/// use everruns_openai::OpenAIChatDriver;
 ///
-/// let driver = OpenAILlmDriver::new("your-api-key");
+/// let driver = OpenAIChatDriver::new("your-api-key");
 ///
 /// // With custom endpoint
-/// let driver = OpenAILlmDriver::with_base_url(
+/// let driver = OpenAIChatDriver::with_base_url(
 ///     "your-api-key",
 ///     "https://api.example.com/v1/responses",
 /// );
 /// ```
 #[derive(Clone)]
-pub struct OpenAILlmDriver {
-    inner: OpenResponsesProtocolLlmDriver,
+pub struct OpenAIChatDriver {
+    inner: OpenResponsesProtocolChatDriver,
     /// Whether using a custom base URL (not OpenAI's API)
     uses_custom_url: bool,
 }
 
-impl OpenAILlmDriver {
+impl OpenAIChatDriver {
     /// Create a new driver with the given API key
     pub fn new(api_key: impl Into<String>) -> Self {
         Self {
-            inner: OpenResponsesProtocolLlmDriver::new(api_key),
+            inner: OpenResponsesProtocolChatDriver::new(api_key),
             uses_custom_url: false,
         }
     }
@@ -78,7 +78,7 @@ impl OpenAILlmDriver {
     /// Create a new driver from the OPENAI_API_KEY environment variable
     pub fn from_env() -> Result<Self> {
         Ok(Self {
-            inner: OpenResponsesProtocolLlmDriver::from_env()?,
+            inner: OpenResponsesProtocolChatDriver::from_env()?,
             uses_custom_url: false,
         })
     }
@@ -87,7 +87,7 @@ impl OpenAILlmDriver {
     pub fn with_base_url(api_key: impl Into<String>, api_url: impl Into<String>) -> Self {
         let api_url = normalize_api_url(&api_url.into(), "/responses");
         Self {
-            inner: OpenResponsesProtocolLlmDriver::with_base_url(api_key, api_url),
+            inner: OpenResponsesProtocolChatDriver::with_base_url(api_key, api_url),
             uses_custom_url: true,
         }
     }
@@ -130,7 +130,7 @@ impl OpenAILlmDriver {
 }
 
 #[async_trait]
-impl LlmDriver for OpenAILlmDriver {
+impl ChatDriver for OpenAIChatDriver {
     async fn chat_completion_stream(
         &self,
         messages: Vec<LlmMessage>,
@@ -158,9 +158,9 @@ impl LlmDriver for OpenAILlmDriver {
     }
 }
 
-impl std::fmt::Debug for OpenAILlmDriver {
+impl std::fmt::Debug for OpenAIChatDriver {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("OpenAILlmDriver")
+        f.debug_struct("OpenAIChatDriver")
             .field("api_url", &self.api_url())
             .field("api", &"Open Responses")
             .field("api_key", &"[REDACTED]")
@@ -174,18 +174,21 @@ impl std::fmt::Debug for OpenAILlmDriver {
 
 /// OpenRouter driver using its OpenAI-compatible Responses API.
 #[derive(Clone)]
-pub struct OpenRouterLlmDriver {
-    inner: OpenResponsesProtocolLlmDriver,
+pub struct OpenRouterChatDriver {
+    inner: OpenResponsesProtocolChatDriver,
     /// Whether constructed with an explicit base URL override via [`with_base_url`].
     uses_custom_url: bool,
 }
 
-impl OpenRouterLlmDriver {
+impl OpenRouterChatDriver {
     /// Create a new OpenRouter driver with the default Responses API endpoint.
     pub fn new(api_key: impl Into<String>) -> Self {
         Self {
-            inner: OpenResponsesProtocolLlmDriver::with_base_url(api_key, OPENROUTER_RESPONSES_URL)
-                .with_provider_type(LlmProviderType::Openrouter),
+            inner: OpenResponsesProtocolChatDriver::with_base_url(
+                api_key,
+                OPENROUTER_RESPONSES_URL,
+            )
+            .with_provider_type(LlmProviderType::Openrouter),
             uses_custom_url: false,
         }
     }
@@ -194,7 +197,7 @@ impl OpenRouterLlmDriver {
     pub fn with_base_url(api_key: impl Into<String>, api_url: impl Into<String>) -> Self {
         let api_url = normalize_api_url(&api_url.into(), "/responses");
         Self {
-            inner: OpenResponsesProtocolLlmDriver::with_base_url(api_key, api_url)
+            inner: OpenResponsesProtocolChatDriver::with_base_url(api_key, api_url)
                 .with_provider_type(LlmProviderType::Openrouter),
             uses_custom_url: true,
         }
@@ -217,7 +220,7 @@ impl OpenRouterLlmDriver {
 }
 
 #[async_trait]
-impl LlmDriver for OpenRouterLlmDriver {
+impl ChatDriver for OpenRouterChatDriver {
     async fn chat_completion_stream(
         &self,
         messages: Vec<LlmMessage>,
@@ -238,9 +241,9 @@ impl LlmDriver for OpenRouterLlmDriver {
     }
 }
 
-impl std::fmt::Debug for OpenRouterLlmDriver {
+impl std::fmt::Debug for OpenRouterChatDriver {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("OpenRouterLlmDriver")
+        f.debug_struct("OpenRouterChatDriver")
             .field("api_url", &self.api_url())
             .field("api", &"OpenRouter Responses")
             .field("api_key", &"[REDACTED]")
@@ -258,34 +261,34 @@ impl std::fmt::Debug for OpenRouterLlmDriver {
 /// (/v1/chat/completions). Use this for backward compatibility with
 /// existing integrations or when Open Responses API is not suitable.
 ///
-/// For new projects, prefer `OpenAILlmDriver` which uses the Open Responses
+/// For new projects, prefer `OpenAIChatDriver` which uses the Open Responses
 /// specification (<https://www.openresponses.org/>).
 ///
 /// # Example
 ///
 /// ```ignore
-/// use everruns_openai::OpenAICompletionsLlmDriver;
+/// use everruns_openai::OpenAICompletionsChatDriver;
 ///
-/// let driver = OpenAICompletionsLlmDriver::new("your-api-key");
+/// let driver = OpenAICompletionsChatDriver::new("your-api-key");
 ///
 /// // With custom endpoint
-/// let driver = OpenAICompletionsLlmDriver::with_base_url(
+/// let driver = OpenAICompletionsChatDriver::with_base_url(
 ///     "your-api-key",
 ///     "https://api.example.com/v1/chat/completions",
 /// );
 /// ```
 #[derive(Clone)]
-pub struct OpenAICompletionsLlmDriver {
-    inner: OpenAIProtocolLlmDriver,
+pub struct OpenAICompletionsChatDriver {
+    inner: OpenAIProtocolChatDriver,
     /// Whether using a custom base URL (not OpenAI's API)
     uses_custom_url: bool,
 }
 
-impl OpenAICompletionsLlmDriver {
+impl OpenAICompletionsChatDriver {
     /// Create a new driver with the given API key
     pub fn new(api_key: impl Into<String>) -> Self {
         Self {
-            inner: OpenAIProtocolLlmDriver::new(api_key),
+            inner: OpenAIProtocolChatDriver::new(api_key),
             uses_custom_url: false,
         }
     }
@@ -293,7 +296,7 @@ impl OpenAICompletionsLlmDriver {
     /// Create a new driver from the OPENAI_API_KEY environment variable
     pub fn from_env() -> Result<Self> {
         Ok(Self {
-            inner: OpenAIProtocolLlmDriver::from_env()?,
+            inner: OpenAIProtocolChatDriver::from_env()?,
             uses_custom_url: false,
         })
     }
@@ -302,7 +305,7 @@ impl OpenAICompletionsLlmDriver {
     pub fn with_base_url(api_key: impl Into<String>, api_url: impl Into<String>) -> Self {
         let api_url = normalize_api_url(&api_url.into(), "/chat/completions");
         Self {
-            inner: OpenAIProtocolLlmDriver::with_base_url(api_key, api_url),
+            inner: OpenAIProtocolChatDriver::with_base_url(api_key, api_url),
             uses_custom_url: true,
         }
     }
@@ -319,7 +322,7 @@ impl OpenAICompletionsLlmDriver {
 }
 
 #[async_trait]
-impl LlmDriver for OpenAICompletionsLlmDriver {
+impl ChatDriver for OpenAICompletionsChatDriver {
     async fn chat_completion_stream(
         &self,
         messages: Vec<LlmMessage>,
@@ -339,9 +342,9 @@ impl LlmDriver for OpenAICompletionsLlmDriver {
     }
 }
 
-impl std::fmt::Debug for OpenAICompletionsLlmDriver {
+impl std::fmt::Debug for OpenAICompletionsChatDriver {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("OpenAICompletionsLlmDriver")
+        f.debug_struct("OpenAICompletionsChatDriver")
             .field("api_url", &self.api_url())
             .field("api", &"Chat Completions")
             .field("api_key", &"[REDACTED]")
@@ -540,38 +543,38 @@ pub fn register_driver(registry: &mut DriverRegistry) {
     registry.register(ProviderType::OpenAI, |config| {
         let api_key = config.api_key.as_deref().unwrap_or("");
         let driver = match config.base_url.as_deref() {
-            Some(url) => OpenAILlmDriver::with_base_url(api_key, url),
-            None => OpenAILlmDriver::new(api_key),
+            Some(url) => OpenAIChatDriver::with_base_url(api_key, url),
+            None => OpenAIChatDriver::new(api_key),
         };
-        Box::new(driver) as BoxedLlmDriver
+        Box::new(driver) as BoxedChatDriver
     });
 
     registry.register(ProviderType::OpenRouter, |config| {
         let api_key = config.api_key.as_deref().unwrap_or("");
         let driver = match config.base_url.as_deref() {
-            Some(url) => OpenRouterLlmDriver::with_base_url(api_key, url),
-            None => OpenRouterLlmDriver::new(api_key),
+            Some(url) => OpenRouterChatDriver::with_base_url(api_key, url),
+            None => OpenRouterChatDriver::new(api_key),
         };
-        Box::new(driver) as BoxedLlmDriver
+        Box::new(driver) as BoxedChatDriver
     });
 
     registry.register(ProviderType::AzureOpenAI, |config| {
         let api_key = config.api_key.as_deref().unwrap_or("");
         let driver = match config.base_url.as_deref() {
-            Some(url) => OpenAILlmDriver::with_base_url(api_key, url),
-            None => OpenAILlmDriver::new(api_key),
+            Some(url) => OpenAIChatDriver::with_base_url(api_key, url),
+            None => OpenAIChatDriver::new(api_key),
         };
-        Box::new(driver) as BoxedLlmDriver
+        Box::new(driver) as BoxedChatDriver
     });
 
     // Register OpenAI Completions with Chat Completions API
     registry.register(ProviderType::OpenAICompletions, |config| {
         let api_key = config.api_key.as_deref().unwrap_or("");
         let driver = match config.base_url.as_deref() {
-            Some(url) => OpenAICompletionsLlmDriver::with_base_url(api_key, url),
-            None => OpenAICompletionsLlmDriver::new(api_key),
+            Some(url) => OpenAICompletionsChatDriver::with_base_url(api_key, url),
+            None => OpenAICompletionsChatDriver::new(api_key),
         };
-        Box::new(driver) as BoxedLlmDriver
+        Box::new(driver) as BoxedChatDriver
     });
 }
 

--- a/crates/openai/src/driver.rs
+++ b/crates/openai/src/driver.rs
@@ -1,4 +1,4 @@
-// OpenAI LLM Drivers
+// OpenAI Chat Drivers
 //
 // This module provides two separate drivers for OpenAI:
 //
@@ -30,10 +30,10 @@ const OPENAI_MODELS_URL: &str = "https://api.openai.com/v1/models";
 const OPENROUTER_RESPONSES_URL: &str = "https://openrouter.ai/api/v1/responses";
 
 // ============================================================================
-// OpenAI LLM Driver (Open Responses API)
+// OpenAI Chat Driver (Open Responses API)
 // ============================================================================
 
-/// OpenAI LLM Driver using Open Responses API
+/// OpenAI Chat Driver using Open Responses API
 ///
 /// Production driver for OpenAI using the Open Responses specification
 /// (<https://www.openresponses.org/>). This is the recommended driver for
@@ -169,7 +169,7 @@ impl std::fmt::Debug for OpenAIChatDriver {
 }
 
 // ============================================================================
-// OpenRouter LLM Driver (OpenAI-compatible Responses API)
+// OpenRouter Chat Driver (OpenAI-compatible Responses API)
 // ============================================================================
 
 /// OpenRouter driver using its OpenAI-compatible Responses API.
@@ -252,10 +252,10 @@ impl std::fmt::Debug for OpenRouterChatDriver {
 }
 
 // ============================================================================
-// OpenAI Completions LLM Driver (Chat Completions API)
+// OpenAI Completions Chat Driver (Chat Completions API)
 // ============================================================================
 
-/// OpenAI LLM Driver using Chat Completions API
+/// OpenAI Chat Driver using Chat Completions API
 ///
 /// Driver for OpenAI using the traditional Chat Completions API
 /// (/v1/chat/completions). Use this for backward compatibility with

--- a/crates/openai/src/lib.rs
+++ b/crates/openai/src/lib.rs
@@ -1,14 +1,14 @@
 //! OpenAI provider drivers for Everruns.
 //!
 //! `everruns-openai` is part of the [Everruns](https://everruns.com)
-//! ecosystem. It implements the [`LlmDriver`] contract from `everruns-core` and
+//! ecosystem. It implements the [`ChatDriver`] contract from `everruns-core` and
 //! registers OpenAI providers into a [`DriverRegistry`].
 //!
 //! The crate exposes three drivers:
 //!
-//! - [`OpenAILlmDriver`], the recommended Responses API driver.
-//! - [`OpenRouterLlmDriver`], the OpenRouter Responses API driver.
-//! - [`OpenAICompletionsLlmDriver`], a Chat Completions compatibility driver.
+//! - [`OpenAIChatDriver`], the recommended Responses API driver.
+//! - [`OpenRouterChatDriver`], the OpenRouter Responses API driver.
+//! - [`OpenAICompletionsChatDriver`], a Chat Completions compatibility driver.
 //!
 //! # Registering the Driver
 //!
@@ -62,7 +62,7 @@ mod types;
 mod tests;
 
 pub use driver::{
-    OpenAICompletionsLlmDriver, OpenAILlmDriver, OpenRouterLlmDriver, register_driver,
+    OpenAIChatDriver, OpenAICompletionsChatDriver, OpenRouterChatDriver, register_driver,
 };
 pub use image_capability::{EditImageTool, GenerateImageTool, GptImageGenCapability};
 pub use types::{
@@ -70,4 +70,4 @@ pub use types::{
 };
 
 // Re-export core types for convenience
-pub use everruns_core::llm_driver_registry::{DriverRegistry, LlmDriver};
+pub use everruns_core::llm_driver_registry::{ChatDriver, DriverRegistry};

--- a/crates/openai/src/tests.rs
+++ b/crates/openai/src/tests.rs
@@ -3,17 +3,17 @@
 #[cfg(test)]
 mod driver_tests {
     use crate::{
-        DriverRegistry, OpenAICompletionsLlmDriver, OpenAILlmDriver, OpenRouterLlmDriver,
+        DriverRegistry, OpenAIChatDriver, OpenAICompletionsChatDriver, OpenRouterChatDriver,
         register_driver,
     };
-    use everruns_core::llm_driver_registry::{LlmDriver, ProviderConfig, ProviderType};
+    use everruns_core::llm_driver_registry::{ChatDriver, ProviderConfig, ProviderType};
     use everruns_core::llm_models::LlmProviderType;
 
     #[test]
     fn test_driver_with_api_key() {
-        let driver = OpenAILlmDriver::new("test-key");
+        let driver = OpenAIChatDriver::new("test-key");
         // Just verify it can be created
-        assert!(format!("{:?}", driver).contains("OpenAILlmDriver"));
+        assert!(format!("{:?}", driver).contains("OpenAIChatDriver"));
         assert!(format!("{:?}", driver).contains("Open Responses"));
         // URL should be for Open Responses API
         assert!(driver.api_url().contains("responses"));
@@ -22,21 +22,21 @@ mod driver_tests {
     #[test]
     fn test_driver_with_base_url() {
         let driver =
-            OpenAILlmDriver::with_base_url("test-key", "https://custom.api.com/v1/responses");
-        assert!(format!("{:?}", driver).contains("OpenAILlmDriver"));
+            OpenAIChatDriver::with_base_url("test-key", "https://custom.api.com/v1/responses");
+        assert!(format!("{:?}", driver).contains("OpenAIChatDriver"));
         assert_eq!(driver.api_url(), "https://custom.api.com/v1/responses");
         assert!(driver.uses_custom_url());
     }
 
     #[test]
     fn test_driver_normalizes_v1_base_url() {
-        let driver = OpenAILlmDriver::with_base_url("test-key", "https://api.openai.com/v1");
+        let driver = OpenAIChatDriver::with_base_url("test-key", "https://api.openai.com/v1");
         assert_eq!(driver.api_url(), "https://api.openai.com/v1/responses");
     }
 
     #[test]
     fn test_driver_normalizes_azure_v1_base_url() {
-        let driver = OpenAILlmDriver::with_base_url(
+        let driver = OpenAIChatDriver::with_base_url(
             "test-key",
             "https://resource.openai.azure.com/openai/v1/",
         );
@@ -48,8 +48,8 @@ mod driver_tests {
 
     #[test]
     fn test_completions_driver_with_api_key() {
-        let driver = OpenAICompletionsLlmDriver::new("test-key");
-        assert!(format!("{:?}", driver).contains("OpenAICompletionsLlmDriver"));
+        let driver = OpenAICompletionsChatDriver::new("test-key");
+        assert!(format!("{:?}", driver).contains("OpenAICompletionsChatDriver"));
         assert!(format!("{:?}", driver).contains("Chat Completions"));
         // URL should be for Chat Completions API
         assert!(driver.api_url().contains("chat/completions"));
@@ -57,15 +57,15 @@ mod driver_tests {
 
     #[test]
     fn test_openrouter_driver_defaults_to_responses_api() {
-        let driver = OpenRouterLlmDriver::new("test-key");
-        assert!(format!("{:?}", driver).contains("OpenRouterLlmDriver"));
+        let driver = OpenRouterChatDriver::new("test-key");
+        assert!(format!("{:?}", driver).contains("OpenRouterChatDriver"));
         assert_eq!(driver.api_url(), "https://openrouter.ai/api/v1/responses");
         assert_eq!(driver.provider_type(), &LlmProviderType::Openrouter);
     }
 
     #[test]
     fn test_openrouter_driver_with_base_url_marks_custom_url() {
-        let driver = OpenRouterLlmDriver::with_base_url(
+        let driver = OpenRouterChatDriver::with_base_url(
             "test-key",
             "https://openrouter.ai/api/v1/responses",
         );
@@ -75,7 +75,7 @@ mod driver_tests {
 
     #[tokio::test]
     async fn test_openrouter_custom_non_openrouter_host_skips_model_listing() {
-        let driver = OpenRouterLlmDriver::with_base_url(
+        let driver = OpenRouterChatDriver::with_base_url(
             "test-key",
             "https://custom.api.example/v1/responses",
         );
@@ -90,11 +90,11 @@ mod driver_tests {
 
     #[test]
     fn test_completions_driver_with_base_url() {
-        let driver = OpenAICompletionsLlmDriver::with_base_url(
+        let driver = OpenAICompletionsChatDriver::with_base_url(
             "test-key",
             "https://custom.api.com/v1/chat/completions",
         );
-        assert!(format!("{:?}", driver).contains("OpenAICompletionsLlmDriver"));
+        assert!(format!("{:?}", driver).contains("OpenAICompletionsChatDriver"));
         assert_eq!(
             driver.api_url(),
             "https://custom.api.com/v1/chat/completions"
@@ -119,24 +119,24 @@ mod driver_tests {
 
         // Verify OpenAI driver can be created
         let config = ProviderConfig::new(ProviderType::OpenAI).with_api_key("test-key");
-        let driver = registry.create_driver(&config);
+        let driver = registry.create_chat_driver(&config);
         assert!(driver.is_ok());
 
         let openrouter_config =
             ProviderConfig::new(ProviderType::OpenRouter).with_api_key("test-key");
-        let openrouter_driver = registry.create_driver(&openrouter_config);
+        let openrouter_driver = registry.create_chat_driver(&openrouter_config);
         assert!(openrouter_driver.is_ok());
 
         let azure_config = ProviderConfig::new(ProviderType::AzureOpenAI)
             .with_api_key("test-key")
             .with_base_url("https://resource.openai.azure.com/openai/v1");
-        let azure_driver = registry.create_driver(&azure_config);
+        let azure_driver = registry.create_chat_driver(&azure_config);
         assert!(azure_driver.is_ok());
 
         // Verify OpenAI Completions driver can be created
         let completions_config =
             ProviderConfig::new(ProviderType::OpenAICompletions).with_api_key("test-key");
-        let completions_driver = registry.create_driver(&completions_config);
+        let completions_driver = registry.create_chat_driver(&completions_config);
         assert!(completions_driver.is_ok());
     }
 }

--- a/crates/openai/tests/openrouter_discovery_live.rs
+++ b/crates/openai/tests/openrouter_discovery_live.rs
@@ -1,13 +1,13 @@
 //! Live smoke test for OpenRouter model discovery.
 //!
-//! Exercises the real `OpenAILlmDriver::list_models` path against OpenRouter's
+//! Exercises the real `OpenAIChatDriver::list_models` path against OpenRouter's
 //! `/models` endpoint: HTTP fetch, deserialization, and capability profiling.
 //!
 //! Ignored by default (requires network + `OPENROUTER_API_KEY`); run manually:
 //!   `doppler run -- cargo test -p everruns-openai --test openrouter_discovery_live -- --ignored --nocapture`
 
-use everruns_core::llm_driver_registry::LlmDriver;
-use everruns_openai::OpenAILlmDriver;
+use everruns_core::llm_driver_registry::ChatDriver;
+use everruns_openai::OpenAIChatDriver;
 
 #[tokio::test]
 #[ignore = "live network + OPENROUTER_API_KEY"]
@@ -15,7 +15,7 @@ async fn openrouter_discovers_nemotron_reasoning_profile() {
     let api_key = std::env::var("OPENROUTER_API_KEY")
         .expect("OPENROUTER_API_KEY must be set for the live smoke test");
 
-    let driver = OpenAILlmDriver::with_base_url(api_key, "https://openrouter.ai/api/v1");
+    let driver = OpenAIChatDriver::with_base_url(api_key, "https://openrouter.ai/api/v1");
 
     let models = driver
         .list_models()

--- a/crates/server/src/services/model_sync.rs
+++ b/crates/server/src/services/model_sync.rs
@@ -110,7 +110,7 @@ impl ModelSyncService {
 
         let driver = self
             .driver_registry
-            .create_driver(&config)
+            .create_chat_driver(&config)
             .map_err(|e| anyhow::anyhow!("Failed to create driver: {}", e))?;
 
         // Call list_models on the driver

--- a/crates/worker/src/adapters.rs
+++ b/crates/worker/src/adapters.rs
@@ -3,7 +3,7 @@
 // Decision: Workers use gRPC adapters for database operations, not direct DB access.
 // This module only contains LLM driver factory helpers.
 
-use everruns_core::{BoxedLlmDriver, DriverRegistry, ProviderConfig, ProviderType, Result};
+use everruns_core::{BoxedChatDriver, DriverRegistry, ProviderConfig, ProviderType, Result};
 
 /// Create and configure the driver registry with all supported LLM providers
 ///
@@ -96,11 +96,11 @@ pub fn create_driver_registry() -> DriverRegistry {
 /// Create an LLM driver based on configuration
 ///
 /// This factory supports all provider types: OpenAI, OpenAI Completions, Anthropic.
-pub fn create_llm_driver(
+pub fn create_chat_driver(
     provider_type: &str,
     api_key: Option<&str>,
     base_url: Option<&str>,
-) -> Result<BoxedLlmDriver> {
+) -> Result<BoxedChatDriver> {
     // Parsing is infallible: unknown ids become External providers.
     let ptype: ProviderType = provider_type.parse().unwrap_or_else(|_| unreachable!());
 
@@ -113,5 +113,5 @@ pub fn create_llm_driver(
     }
 
     let registry = create_driver_registry();
-    registry.create_driver(&config)
+    registry.create_chat_driver(&config)
 }

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -45,7 +45,7 @@ pub use grpc_durable_store::{
 pub use runner::{AgentRunner, RunnerBackend, create_runner, create_runner_with_backend};
 
 // Re-export LLM driver factory helpers
-pub use adapters::{create_driver_registry, create_llm_driver};
+pub use adapters::{create_chat_driver, create_driver_registry};
 pub use platform::{default_platform_definition, default_platform_definition_for_grade};
 
 // Re-export gRPC adapters for worker communication with control plane
@@ -65,7 +65,7 @@ pub use worker_adapters::{
 };
 
 // Re-export OpenAI driver from the openai crate
-pub use everruns_openai::OpenAILlmDriver;
+pub use everruns_openai::OpenAIChatDriver;
 
 // Re-export app builder for composable worker configurations
 pub use app_builder::WorkerAppBuilder;

--- a/docs/advanced/embedding-everruns.md
+++ b/docs/advanced/embedding-everruns.md
@@ -142,7 +142,7 @@ built-in provider slot:
 
 ```rust
 use everruns_core::llm_driver_registry::{
-    BoxedLlmDriver, DriverConfig, DriverRegistry,
+    BoxedChatDriver, DriverConfig, DriverRegistry,
 };
 
 fn drivers() -> DriverRegistry {
@@ -156,7 +156,7 @@ fn drivers() -> DriverRegistry {
     //   config.metadata  — ProviderMetadata { refresh_token, account_id, extra }
     // External providers may authenticate via metadata instead of an api_key.
     drivers.register_external("openai-codex", |config: &DriverConfig| {
-        Box::new(MyCodexDriver::new(config)) as BoxedLlmDriver
+        Box::new(MyCodexDriver::new(config)) as BoxedChatDriver
     });
 
     drivers

--- a/specs/architecture.md
+++ b/specs/architecture.md
@@ -426,7 +426,7 @@ The core crate provides DB-agnostic agent abstractions with pluggable backends:
 
 OpenAI-specific LLM provider implementation:
 
-1. **Implements Core Traits**: `LlmDriver` trait from `everruns-core`
+1. **Implements Core Traits**: `ChatDriver` trait from `everruns-core`
 2. **OpenAI + Azure OpenAI Support**: Supports OpenAI-hosted and Azure-hosted OpenAI v1 endpoints
 3. **Streaming Support**: Full SSE streaming with tool call support
 4. **Native API Access**: Direct methods for OpenAI-specific functionality
@@ -445,7 +445,7 @@ a vendor-neutral, open-source API standard for multi-provider LLM interfaces.
 - **Better caching**: 40-80% better cache utilization vs Chat Completions API
 - **Provider-agnostic**: Events and responses follow a standardized format
 
-**Driver Selection**: `OpenAILlmDriver` (Responses API, recommended) or `OpenAICompletionsLlmDriver` (Chat Completions). See `crates/openai/src/driver.rs` and the protocol implementations in `crates/core/src/`.
+**Driver Selection**: `OpenAIChatDriver` (Responses API, recommended) or `OpenAICompletionsChatDriver` (Chat Completions). See `crates/openai/src/driver.rs` and the protocol implementations in `crates/core/src/`.
 
 ### LlmSim Driver (Testing)
 

--- a/specs/compaction.md
+++ b/specs/compaction.md
@@ -49,7 +49,7 @@ Provider cache telemetry feeds this same model-view step. If the previous call r
 ```rust
 pub enum CompactionStrategy {
     /// Use provider's native compact endpoint (e.g., OpenAI /responses/compact).
-    /// Highest fidelity, opaque output. Only works if LlmDriver::supports_compact().
+    /// Highest fidelity, opaque output. Only works if ChatDriver::supports_compact().
     Native,
 
     /// Strip tool outputs from older turns, replace with one-line summaries.
@@ -479,5 +479,5 @@ visibility rather than changing the capability ownership model.
 - `specs/infinity-context.md` — complementary capability (optional, independent)
 - `specs/events.md` — event schema
 - `specs/capabilities.md` — capability system
-- `crates/core/src/llm_driver_registry.rs` — `LlmDriver` trait with `supports_compact()` / `compact()`
+- `crates/core/src/llm_driver_registry.rs` — `ChatDriver` trait with `supports_compact()` / `compact()`
 - `crates/core/src/openresponses_protocol.rs` — `CompactRequest` / `CompactResponse` types

--- a/specs/dismissed-options.md
+++ b/specs/dismissed-options.md
@@ -81,7 +81,7 @@ This document records technical options that were considered but dismissed for s
 
 **Status**: Dismissed (implemented then reverted)
 
-**What it was**: Per-provider semaphore-based concurrency limiter wrapping `BoxedLlmDriver`. Each LLM call would acquire a permit from a per-provider `tokio::Semaphore` (default 50 concurrent calls per provider type), held for the full streaming duration. Configured via `LLM_MAX_CONCURRENT_PER_PROVIDER` env var.
+**What it was**: Per-provider semaphore-based concurrency limiter wrapping `BoxedChatDriver`. Each LLM call would acquire a permit from a per-provider `tokio::Semaphore` (default 50 concurrent calls per provider type), held for the full streaming duration. Configured via `LLM_MAX_CONCURRENT_PER_PROVIDER` env var.
 
 **Why considered**: Workers call LLM APIs with no in-process concurrency control. 100 workers simultaneously calling the same provider could burst past rate limits, causing mass 429 errors and wasted tokens on retries.
 

--- a/specs/llm-drivers.md
+++ b/specs/llm-drivers.md
@@ -2,11 +2,11 @@
 
 > **Domain model note:** the canonical provider domain model (drivers, services,
 > providers, models, model profiles) is [providers.md](providers.md). That
-> refactor is in progress: as its phases land, `LlmDriver` will be renamed
-> `ChatDriver` and the entity/resolution content will move out of this document,
-> leaving this spec as the chat-service wire contract (streaming, error types,
-> retries, thinking, prompt cache, compaction). Until then, this document still
-> describes the current names in code.
+> refactor is in progress: the driver trait is now `ChatDriver` (it implements
+> the chat service of a provider). As later phases land, the entity/resolution
+> content will move out of this document, leaving this spec as the chat-service
+> wire contract (streaming, error types, retries, thinking, prompt cache,
+> compaction).
 
 ## Abstract
 

--- a/specs/llm-drivers.md
+++ b/specs/llm-drivers.md
@@ -17,7 +17,7 @@ LLM drivers provide a provider-agnostic interface for interacting with Large Lan
 ```mermaid
 graph TD
     subgraph Core [everruns-core]
-        LlmDriver[LlmDriver Trait]
+        ChatDriver[ChatDriver Trait]
         Registry[DriverRegistry]
         Errors[AgentLoopError]
     end
@@ -36,9 +36,9 @@ graph TD
         ReasonAtom[ReasonAtom]
     end
 
-    OpenAI -->|implements| LlmDriver
-    Anthropic -->|implements| LlmDriver
-    Gemini -->|implements| LlmDriver
+    OpenAI -->|implements| ChatDriver
+    Anthropic -->|implements| ChatDriver
+    Gemini -->|implements| ChatDriver
     OpenAI -->|registers| Registry
     Anthropic -->|registers| Registry
     Gemini -->|registers| Registry
@@ -51,9 +51,9 @@ graph TD
 
 ## Requirements
 
-### LlmDriver Trait
+### ChatDriver Trait
 
-1. **Trait Definition**: See `crates/core/src/llm_driver_registry.rs` for `LlmDriver` trait, `LlmStreamEvent`, `ProviderType`, and `LlmCallConfig`.
+1. **Trait Definition**: See `crates/core/src/llm_driver_registry.rs` for `ChatDriver` trait, `LlmStreamEvent`, `ProviderType`, and `LlmCallConfig`.
 
 2. **Streaming Response**: Drivers return a stream of `LlmStreamEvent` (TextDelta, ToolCalls, ThinkingDelta, ThinkingSignature, Done, Error).
 
@@ -204,7 +204,7 @@ The UI also prevents setting reasoning on non-thinking models (checks `profile.r
 
 ### Realtime Voice Driver
 
-Realtime voice does not use `LlmDriver::chat_completion_stream()` because a
+Realtime voice does not use `ChatDriver::chat_completion_stream()` because a
 voice connection is a long-lived bidirectional provider session, not a bounded
 request/response generation. Voice support adds a separate Realtime provider
 adapter owned by the server voice domain. See [voice.md](voice.md).
@@ -235,7 +235,7 @@ the UI is explicitly rendering a voice-capable picker.
 ```mermaid
 sequenceDiagram
     participant R as ReasonAtom
-    participant D as LlmDriver
+    participant D as ChatDriver
     participant A as API
 
     R->>D: chat_completion_stream()
@@ -270,7 +270,7 @@ sequenceDiagram
 
 | Component | Location |
 |-----------|----------|
-| LlmDriver trait | `crates/core/src/llm_driver_registry.rs` |
+| ChatDriver trait | `crates/core/src/llm_driver_registry.rs` |
 | AgentLoopError | `crates/core/src/error.rs` |
 | OpenAI driver | `crates/openai/src/driver.rs` |
 | Open Responses protocol | `crates/core/src/openresponses_protocol.rs` |
@@ -284,20 +284,20 @@ sequenceDiagram
 
 The OpenAI crate provides three driver implementations:
 
-1. **OpenAILlmDriver** (`ProviderType::OpenAI`)
+1. **OpenAIChatDriver** (`ProviderType::OpenAI`)
    - Uses Open Responses API (https://www.openresponses.org/)
    - Recommended for new projects
-   - Wraps `OpenResponsesProtocolLlmDriver`
+   - Wraps `OpenResponsesProtocolChatDriver`
 
-2. **OpenAICompletionsLlmDriver** (`ProviderType::OpenAICompletions`)
+2. **OpenAICompletionsChatDriver** (`ProviderType::OpenAICompletions`)
    - Uses Chat Completions API (`/v1/chat/completions`)
    - For backward compatibility with legacy integrations
-   - Wraps `OpenAIProtocolLlmDriver`
+   - Wraps `OpenAIProtocolChatDriver`
 
-3. **OpenRouterLlmDriver** (`ProviderType::OpenRouter`)
+3. **OpenRouterChatDriver** (`ProviderType::OpenRouter`)
    - Uses OpenRouter's OpenAI-compatible Responses API
    - Defaults to `https://openrouter.ai/api/v1/responses`
-   - Wraps `OpenResponsesProtocolLlmDriver` with the OpenRouter provider profile
+   - Wraps `OpenResponsesProtocolChatDriver` with the OpenRouter provider profile
 
 The Responses drivers share the same base URL handling and can work with
 OpenAI-compatible endpoints while keeping provider-specific request features
@@ -332,7 +332,7 @@ When a request to the OpenAI Responses API sets `previous_response_id`, the prov
 
 Invariant: **a request with `previous_response_id` only carries delta items in `input`** — typically tool results (`function_call_output`) for the prior assistant turn plus any fresh user messages. Prior assistant messages, reasoning items, and the assistant's own function calls are dropped because they live in server-side state. `instructions` (system message) is sent separately and is exempt. Empty `input` is allowed.
 
-`OpenResponsesProtocolLlmDriver` enforces this by trimming `input` via `compute_delta_input_items` whenever `previous_response_id` is `Some(_)` (see `crates/core/src/openresponses_protocol.rs`).
+`OpenResponsesProtocolChatDriver` enforces this by trimming `input` via `compute_delta_input_items` whenever `previous_response_id` is `Some(_)` (see `crates/core/src/openresponses_protocol.rs`).
 
 ### Stateless Gateways
 
@@ -405,9 +405,9 @@ The `/v1/responses/compact` endpoint is a context-compression feature for the Op
    - Prior assistant messages, tool calls/results, and encrypted reasoning are replaced by one encrypted **compaction item**
 3. Use the returned `output` array as the `input` for the next `/v1/responses` call
 
-### LlmDriver Compact Methods
+### ChatDriver Compact Methods
 
-The `LlmDriver` trait includes `supports_compact()` and `compact()` methods. See `crates/core/src/llm_driver_registry.rs` for `CompactRequest`, `CompactInputItem`, `CompactResponse`, and `CompactOutputItem` types.
+The `ChatDriver` trait includes `supports_compact()` and `compact()` methods. See `crates/core/src/llm_driver_registry.rs` for `CompactRequest`, `CompactInputItem`, `CompactResponse`, and `CompactOutputItem` types.
 
 ### Provider Support
 
@@ -446,7 +446,7 @@ Environment variable reads (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_K
 `DEFAULT_*_API_KEY`) remain valid only for explicit standalone/dev entrypoints:
 
 - `InMemoryLlmProviderStore::from_env()` — in-memory dev store used by `just start-dev`
-- `AnthropicLlmDriver::from_env()`, `OpenAIProtocolLlmDriver::from_env()`, etc. — CLI tools
+- `AnthropicChatDriver::from_env()`, `OpenAIProtocolChatDriver::from_env()`, etc. — CLI tools
 
 These constructors must **never** be called from org-scoped agent execution paths.
 

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -574,7 +574,7 @@ Worker needs LLM key
     → Control plane fetches llm_providers row
     → EncryptionService.decrypt(api_key_encrypted)
     → Key returned in gRPC response (in-memory only)
-    → Worker creates LlmDriver with key
+    → Worker creates ChatDriver with key
     → LLM API call over HTTPS
     → Key dropped when driver goes out of scope
 ```

--- a/specs/tool-search.md
+++ b/specs/tool-search.md
@@ -138,7 +138,7 @@ Capability.tools()  →  collect_capabilities() sets tool_search config
                     ↓                      ↓
               RuntimeAgent.tool_search=None    RuntimeAgent.tool_search=Some(config)
                     ↓                      ↓
-              LlmCallConfig.tools    LlmDriver restructures:
+              LlmCallConfig.tools    ChatDriver restructures:
               (full schemas)         - Namespace groupings
                                      - defer_loading: true
                                      - { "type": "tool_search" }


### PR DESCRIPTION
## What
Mechanical rename implementing the first slice of phase 1 of `specs/providers.md`:

- Trait `LlmDriver` → `ChatDriver`, `BoxedLlmDriver` → `BoxedChatDriver`
- Per-vendor driver structs: `AnthropicLlmDriver` → `AnthropicChatDriver`, `OpenAILlmDriver` → `OpenAIChatDriver`, `OpenRouterLlmDriver`, `OpenAICompletionsLlmDriver`, `GeminiLlmDriver`, `BedrockLlmDriver`, `OpenResponsesProtocolLlmDriver`, `OpenAIProtocolLlmDriver` likewise
- `DriverRegistry::create_driver` → `create_chat_driver`; worker `create_llm_driver` → `create_chat_driver`
- Spec/README/docs mentions follow (`specs/llm-drivers.md` banner now states the rename has landed)

No behavior change; no DB or API surface change.

## Why
Per the providers domain model (#2163): a driver implements *services* of a provider, and this trait is specifically the **chat** service. The old name blocked the upcoming driver descriptor with per-service factories (`chat`, `embeddings`, `realtime`).

## How
Literal rename across all Rust sources (incl. debug strings and tests), specs, and crate READMEs. Verified zero remaining `LlmDriver` references outside historical notes in `specs/providers.md`.

## Risk
- Low — purely mechanical rename; compiler-verified.
- What can break: external embedders pinned to git `everruns-core` will need the rename (intentional, no-backward-compat refactor).

## Security
- No security-relevant code changes — identifier rename only; no logic, auth, key-handling, or boundary changes. The fail-closed key resolution path is untouched (verified by the unchanged `resolve_provider_api_key_env_key_set_does_not_leak` test).

## Follow-ups
- Phase 1 continues in the next PR: `ServiceKind` + driver descriptor (credential schema, per-service factories) per `specs/providers.md`.

## Checklist
- [x] Tests added or updated — existing suites cover the rename; `cargo test --workspace --all-features` green locally (except the live Docker-daemon tests, which require a live daemon not present in the dev sandbox)
- [x] Backward compatibility considered — intentionally none, per specs/providers.md
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VjuNjETooc6GJ99vmLBftL)_