### PR TITLE
feat(core): driver descriptors with services and credential schemas

### DIFF
--- a/crates/anthropic/src/driver.rs
+++ b/crates/anthropic/src/driver.rs
@@ -20,6 +20,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::sync::{Arc, Mutex};
 
+use everruns_core::credential_schema::CredentialFormSchema;
 use everruns_core::error::{AgentLoopError, LlmErrorKind, Result};
 use everruns_core::is_provider_quota_message;
 use everruns_core::llm_driver_helpers::{
@@ -27,7 +28,7 @@ use everruns_core::llm_driver_helpers::{
     parse_data_url,
 };
 use everruns_core::llm_driver_registry::{
-    BoxedChatDriver, ChatDriver, DiscoveredModel, DriverRegistry, LlmCallConfig,
+    BoxedChatDriver, ChatDriver, DiscoveredModel, DriverDescriptor, DriverRegistry, LlmCallConfig,
     LlmCompletionMetadata, LlmContentPart, LlmMessage, LlmMessageContent, LlmMessageRole,
     LlmResponseStream, LlmStreamEvent, ProviderType,
 };
@@ -963,13 +964,18 @@ impl std::fmt::Debug for AnthropicChatDriver {
 /// register_driver(&mut registry);
 /// ```
 pub fn register_driver(registry: &mut DriverRegistry) {
-    registry.register(ProviderType::Anthropic, |config| {
-        let api_key = config.api_key.as_deref().unwrap_or("");
-        let driver = match config.base_url.as_deref() {
-            Some(url) => AnthropicChatDriver::with_base_url(api_key, url),
-            None => AnthropicChatDriver::new(api_key),
-        };
-        Box::new(driver) as BoxedChatDriver
+    registry.register_descriptor(DriverDescriptor {
+        credential_schema: CredentialFormSchema::api_key(
+            "Create an API key in the [Anthropic Console](https://console.anthropic.com/settings/keys).",
+        ),
+        ..DriverDescriptor::chat_only(ProviderType::Anthropic, |config| {
+            let api_key = config.api_key.as_deref().unwrap_or("");
+            let driver = match config.base_url.as_deref() {
+                Some(url) => AnthropicChatDriver::with_base_url(api_key, url),
+                None => AnthropicChatDriver::new(api_key),
+            };
+            Box::new(driver) as BoxedChatDriver
+        })
     });
 }
 

--- a/crates/bedrock/src/driver.rs
+++ b/crates/bedrock/src/driver.rs
@@ -20,9 +20,10 @@ use aws_sdk_bedrockruntime::types::{
 };
 use aws_smithy_types::Document;
 use base64::prelude::*;
+use everruns_core::credential_schema::{CredentialFormSchema, FieldType, FormField};
 use everruns_core::error::{AgentLoopError, LlmErrorKind, Result};
 use everruns_core::llm_driver_registry::{
-    BoxedChatDriver, ChatDriver, DiscoveredModel, DriverRegistry, LlmCallConfig,
+    BoxedChatDriver, ChatDriver, DiscoveredModel, DriverDescriptor, DriverRegistry, LlmCallConfig,
     LlmCompletionMetadata, LlmContentPart, LlmMessage, LlmMessageContent, LlmMessageRole,
     LlmResponseStream, LlmStreamEvent, ProviderType,
 };
@@ -70,12 +71,56 @@ impl BedrockChatDriver {
 
 /// Register the Bedrock driver with the given registry.
 pub fn register_driver(registry: &mut DriverRegistry) {
-    registry.register(ProviderType::Bedrock, |config| {
-        let api_key = config.api_key.as_deref().unwrap_or("");
-        match BedrockChatDriver::new(api_key) {
-            Ok(driver) => Box::new(driver) as BoxedChatDriver,
-            Err(e) => Box::new(FailDriver(e.to_string())) as BoxedChatDriver,
-        }
+    // The declared schema is the target credential shape (specs/providers.md).
+    // Until the credential-document storage phase lands, the runtime still
+    // receives these fields as a JSON document through `config.api_key`.
+    registry.register_descriptor(DriverDescriptor {
+        credential_schema: CredentialFormSchema {
+            fields: vec![
+                FormField {
+                    name: "access_key_id".to_string(),
+                    label: "Access Key ID".to_string(),
+                    field_type: FieldType::Password,
+                    required: true,
+                    placeholder: None,
+                    help_text: None,
+                },
+                FormField {
+                    name: "secret_access_key".to_string(),
+                    label: "Secret Access Key".to_string(),
+                    field_type: FieldType::Password,
+                    required: true,
+                    placeholder: None,
+                    help_text: None,
+                },
+                FormField {
+                    name: "region".to_string(),
+                    label: "Region".to_string(),
+                    field_type: FieldType::Text,
+                    required: true,
+                    placeholder: Some("us-east-1".to_string()),
+                    help_text: None,
+                },
+                FormField {
+                    name: "session_token".to_string(),
+                    label: "Session Token".to_string(),
+                    field_type: FieldType::Password,
+                    required: false,
+                    placeholder: None,
+                    help_text: Some("Only for temporary credentials.".to_string()),
+                },
+            ],
+            instructions_markdown:
+                "Create an IAM user or role with Bedrock invoke permissions and use its access keys."
+                    .to_string(),
+        },
+        ..DriverDescriptor::chat_only(ProviderType::Bedrock, |config| {
+            let api_key = config.api_key.as_deref().unwrap_or("");
+            match BedrockChatDriver::new(api_key) {
+                Ok(driver) => Box::new(driver) as BoxedChatDriver,
+                Err(e) => Box::new(FailDriver(e.to_string())) as BoxedChatDriver,
+            }
+        })
     });
 }
 
@@ -596,6 +641,38 @@ fn is_too_large(msg: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn registered_descriptor_declares_aws_credential_fields() {
+        let mut registry = DriverRegistry::new();
+        super::register_driver(&mut registry);
+
+        let descriptor = registry.descriptor(&ProviderType::Bedrock).unwrap();
+        assert_eq!(descriptor.display_name, "AWS Bedrock");
+        let names: Vec<&str> = descriptor
+            .credential_schema
+            .fields
+            .iter()
+            .map(|f| f.name.as_str())
+            .collect();
+        assert_eq!(
+            names,
+            [
+                "access_key_id",
+                "secret_access_key",
+                "region",
+                "session_token"
+            ]
+        );
+        // Session token is the only optional field.
+        assert!(
+            descriptor
+                .credential_schema
+                .fields
+                .iter()
+                .all(|f| f.required != (f.name == "session_token"))
+        );
+    }
+
     use super::*;
 
     #[test]

--- a/crates/bedrock/src/driver.rs
+++ b/crates/bedrock/src/driver.rs
@@ -97,9 +97,11 @@ pub fn register_driver(registry: &mut DriverRegistry) {
                     name: "region".to_string(),
                     label: "Region".to_string(),
                     field_type: FieldType::Text,
-                    required: true,
+                    // Optional to match BedrockCredential::from_api_key, which
+                    // defaults the region to us-east-1 when omitted.
+                    required: false,
                     placeholder: Some("us-east-1".to_string()),
-                    help_text: None,
+                    help_text: Some("Defaults to us-east-1.".to_string()),
                 },
                 FormField {
                     name: "session_token".to_string(),
@@ -663,14 +665,15 @@ mod tests {
                 "session_token"
             ]
         );
-        // Session token is the only optional field.
-        assert!(
-            descriptor
-                .credential_schema
-                .fields
-                .iter()
-                .all(|f| f.required != (f.name == "session_token"))
-        );
+        // Region (defaulted to us-east-1 at parse time) and session token are
+        // optional; the key pair is required.
+        let required: Vec<bool> = descriptor
+            .credential_schema
+            .fields
+            .iter()
+            .map(|f| f.required)
+            .collect();
+        assert_eq!(required, [true, true, false, false]);
     }
 
     use super::*;

--- a/crates/core/src/connection_provider.rs
+++ b/crates/core/src/connection_provider.rs
@@ -212,45 +212,15 @@ impl Default for ConnectionProviderRegistryBuilder {
 // Form Schema Types
 // ============================================================================
 
-/// Describes the form fields and instructions for an API key connection.
-#[derive(Debug, Clone, Serialize)]
-pub struct ConnectionFormSchema {
-    /// Input fields to render.
-    pub fields: Vec<FormField>,
-    /// Markdown instructions shown above the form (how to get the key, etc.).
-    pub instructions_markdown: String,
-}
+// Form schema types are shared with provider drivers; see
+// `crate::credential_schema` and specs/providers.md "Credentials".
+pub use crate::credential_schema::{FieldType, FormField};
 
-/// A single form field.
-#[derive(Debug, Clone, Serialize)]
-pub struct FormField {
-    /// Field name used as the key when submitting (e.g. "api_key").
-    pub name: String,
-    /// Label shown next to the input.
-    pub label: String,
-    /// Input type.
-    pub field_type: FieldType,
-    /// Whether the field is required.
-    pub required: bool,
-    /// Placeholder text inside the input.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub placeholder: Option<String>,
-    /// Help text shown below the input.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub help_text: Option<String>,
-}
-
-/// Input field type for rendering.
-#[derive(Debug, Clone, Copy, Serialize)]
-#[serde(rename_all = "snake_case")]
-pub enum FieldType {
-    /// Masked password/secret input.
-    Password,
-    /// Plain text input.
-    Text,
-    /// URL input.
-    Url,
-}
+/// Connection-provider name for the shared credential form schema.
+///
+/// Transitional alias until the connector rename (specs/providers.md,
+/// "Providers vs Connections") makes `CredentialFormSchema` the only name.
+pub type ConnectionFormSchema = crate::credential_schema::CredentialFormSchema;
 
 /// Result of credential validation.
 #[derive(Debug, Clone)]

--- a/crates/core/src/credential_schema.rs
+++ b/crates/core/src/credential_schema.rs
@@ -1,0 +1,77 @@
+// Shared credential form schema
+//
+// Declarative description of the credential fields an integration needs,
+// rendered by the Settings UI and validated before saving. Shared by two
+// front doors (see specs/providers.md "Credentials"):
+//
+// - Provider drivers (`DriverDescriptor::credential_schema`) — org-scoped
+//   vendor accounts that power agent execution.
+// - Connection providers (`ConnectionProvider::form_schema`) — user-scoped
+//   accounts on external services used by tools.
+
+use serde::Serialize;
+
+/// Describes the form fields and instructions for entering a credential.
+#[derive(Debug, Clone, Serialize)]
+pub struct CredentialFormSchema {
+    /// Input fields to render.
+    pub fields: Vec<FormField>,
+    /// Markdown instructions shown above the form (how to get the key, etc.).
+    pub instructions_markdown: String,
+}
+
+impl CredentialFormSchema {
+    /// Schema with no fields (keyless integrations, e.g. test simulators).
+    pub fn empty() -> Self {
+        Self {
+            fields: Vec::new(),
+            instructions_markdown: String::new(),
+        }
+    }
+
+    /// The common single-field API key schema.
+    pub fn api_key(instructions_markdown: impl Into<String>) -> Self {
+        Self {
+            fields: vec![FormField {
+                name: "api_key".to_string(),
+                label: "API Key".to_string(),
+                field_type: FieldType::Password,
+                required: true,
+                placeholder: None,
+                help_text: None,
+            }],
+            instructions_markdown: instructions_markdown.into(),
+        }
+    }
+}
+
+/// A single form field.
+#[derive(Debug, Clone, Serialize)]
+pub struct FormField {
+    /// Field name used as the key when submitting (e.g. "api_key").
+    pub name: String,
+    /// Label shown next to the input.
+    pub label: String,
+    /// Input type.
+    pub field_type: FieldType,
+    /// Whether the field is required.
+    pub required: bool,
+    /// Placeholder text inside the input.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub placeholder: Option<String>,
+    /// Help text shown below the input.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub help_text: Option<String>,
+}
+
+/// Input field type for rendering.
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FieldType {
+    /// Masked password/secret input.
+    Password,
+    /// Plain text input.
+    Text,
+    /// URL input.
+    Url,
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -85,6 +85,7 @@ pub mod agent_identity;
 pub mod app;
 pub mod capability_dto;
 pub mod connection_provider;
+pub mod credential_schema;
 pub mod eval;
 pub mod events;
 pub mod harness;
@@ -263,9 +264,10 @@ pub use utility_llm::{
 
 // LLM driver types re-exports
 pub use llm_driver_registry::{
-    BoxedChatDriver, ChatDriver, DiscoveredModel, DriverFactory, DriverRegistry, LlmCallConfig,
-    LlmCallConfigBuilder, LlmCompletionMetadata, LlmContentPart, LlmMessage, LlmMessageContent,
-    LlmMessageRole, LlmResponse, LlmResponseStream, LlmStreamEvent, ProviderConfig, ProviderType,
+    BoxedChatDriver, ChatDriver, DiscoveredModel, DriverDescriptor, DriverFactory, DriverRegistry,
+    LlmCallConfig, LlmCallConfigBuilder, LlmCompletionMetadata, LlmContentPart, LlmMessage,
+    LlmMessageContent, LlmMessageRole, LlmResponse, LlmResponseStream, LlmStreamEvent,
+    ProviderConfig, ProviderType, ServiceKind,
 };
 
 // LLM retry types re-exports
@@ -287,6 +289,9 @@ pub use tools::{
     EchoTool, FailingTool, SpawnBackgroundTool, Tool, ToolExecutionResult, ToolInternalError,
     ToolRegistry, ToolRegistryBuilder, ToolResultImage,
 };
+
+// Shared credential form schema (provider drivers + connection providers)
+pub use credential_schema::CredentialFormSchema;
 
 // Capability re-exports
 // Connection provider plugin system (API key connections like Daytona)

--- a/crates/core/src/llm_driver_registry.rs
+++ b/crates/core/src/llm_driver_registry.rs
@@ -1315,8 +1315,10 @@ pub struct DriverDescriptor {
 }
 
 impl DriverDescriptor {
-    /// Descriptor for a chat-only driver with the standard API-key credential
-    /// schema and a display name derived from the driver id.
+    /// Descriptor for a chat-only driver with the default credential schema
+    /// for the driver id (a single required `api_key` field for real
+    /// providers; empty for `LlmSim` and `External`, which may authenticate
+    /// via [`ProviderMetadata`]) and a display name derived from the id.
     pub fn chat_only<F>(id: impl Into<ProviderType>, factory: F) -> Self
     where
         F: Fn(&DriverConfig) -> BoxedChatDriver + Send + Sync + 'static,

--- a/crates/core/src/llm_driver_registry.rs
+++ b/crates/core/src/llm_driver_registry.rs
@@ -14,6 +14,7 @@
 // depend on core and register their drivers at startup. Core has no knowledge of
 // specific provider implementations.
 
+use crate::credential_schema::CredentialFormSchema;
 use crate::error::{AgentLoopError, Result};
 use crate::openresponses_protocol::{CompactRequest, CompactResponse};
 use crate::runtime_agent::RuntimeAgent;
@@ -21,6 +22,7 @@ use crate::tool_types::{ToolCall, ToolDefinition};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use futures::Stream;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -1253,11 +1255,120 @@ pub type BoxedChatDriver = Box<dyn ChatDriver>;
 // Driver Registry
 // ============================================================================
 
-/// Factory function type for creating LLM drivers.
+/// Factory function type for creating chat drivers.
 ///
 /// Receives a [`DriverConfig`] (provider type, optional key/base URL, and
 /// provider metadata) and returns a boxed driver.
 pub type DriverFactory = Arc<dyn Fn(&DriverConfig) -> BoxedChatDriver + Send + Sync>;
+
+/// A typed service a provider driver can offer (see specs/providers.md).
+///
+/// Declared in code by each driver, never stored in the database. Only `Chat`
+/// has a driver trait today; the set is additive and new kinds gain factories
+/// on [`DriverDescriptor`] when their first consumer lands.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ServiceKind {
+    /// Chat completion ([`ChatDriver`]).
+    Chat,
+    /// Text embeddings (planned: knowledge-base hybrid retrieval).
+    Embeddings,
+    /// Realtime voice sessions (server-side adapter using provider credentials).
+    Realtime,
+    /// Image generation.
+    Images,
+    /// Search-result reranking.
+    Rerank,
+}
+
+impl std::fmt::Display for ServiceKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            ServiceKind::Chat => "chat",
+            ServiceKind::Embeddings => "embeddings",
+            ServiceKind::Realtime => "realtime",
+            ServiceKind::Images => "images",
+            ServiceKind::Rerank => "rerank",
+        };
+        f.write_str(s)
+    }
+}
+
+/// A registered provider driver: identity, declared services, the credential
+/// shape its providers must supply, and per-service factories.
+///
+/// The descriptor is the code-side unit of the providers domain model
+/// (specs/providers.md): one descriptor per driver id, instantiated as many
+/// org-scoped providers.
+#[derive(Clone)]
+pub struct DriverDescriptor {
+    /// Driver id (also the registry key).
+    pub id: ProviderType,
+    /// Human-readable driver name (e.g. "OpenAI", "AWS Bedrock").
+    pub display_name: String,
+    /// Services this driver's providers can power. Declared, not stored.
+    pub services: Vec<ServiceKind>,
+    /// Credential fields a provider instance must supply.
+    pub credential_schema: CredentialFormSchema,
+    /// Chat service factory. `None` for drivers that only offer other services.
+    pub chat: Option<DriverFactory>,
+}
+
+impl DriverDescriptor {
+    /// Descriptor for a chat-only driver with the standard API-key credential
+    /// schema and a display name derived from the driver id.
+    pub fn chat_only<F>(id: impl Into<ProviderType>, factory: F) -> Self
+    where
+        F: Fn(&DriverConfig) -> BoxedChatDriver + Send + Sync + 'static,
+    {
+        let id = id.into();
+        Self {
+            display_name: default_display_name(&id),
+            credential_schema: default_credential_schema(&id),
+            services: vec![ServiceKind::Chat],
+            chat: Some(Arc::new(factory)),
+            id,
+        }
+    }
+
+    /// Whether the driver declares the given service.
+    pub fn supports(&self, service: ServiceKind) -> bool {
+        self.services.contains(&service)
+    }
+}
+
+impl std::fmt::Debug for DriverDescriptor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DriverDescriptor")
+            .field("id", &self.id)
+            .field("display_name", &self.display_name)
+            .field("services", &self.services)
+            .field("chat", &self.chat.is_some())
+            .finish()
+    }
+}
+
+fn default_display_name(id: &ProviderType) -> String {
+    match id {
+        ProviderType::OpenAI => "OpenAI".to_string(),
+        ProviderType::OpenRouter => "OpenRouter".to_string(),
+        ProviderType::AzureOpenAI => "Azure OpenAI".to_string(),
+        ProviderType::OpenAICompletions => "OpenAI (Chat Completions)".to_string(),
+        ProviderType::Anthropic => "Anthropic".to_string(),
+        ProviderType::Gemini => "Google Gemini".to_string(),
+        ProviderType::Bedrock => "AWS Bedrock".to_string(),
+        ProviderType::LlmSim => "LLM Simulator".to_string(),
+        ProviderType::External(id) => id.to_string(),
+    }
+}
+
+fn default_credential_schema(id: &ProviderType) -> CredentialFormSchema {
+    match id {
+        // Keyless: simulator always; external drivers may auth via metadata.
+        ProviderType::LlmSim | ProviderType::External(_) => CredentialFormSchema::empty(),
+        _ => CredentialFormSchema::api_key(String::new()),
+    }
+}
 
 /// Registry for LLM drivers
 ///
@@ -1280,15 +1391,36 @@ pub type DriverFactory = Arc<dyn Fn(&DriverConfig) -> BoxedChatDriver + Send + S
 /// ```
 #[derive(Clone, Default)]
 pub struct DriverRegistry {
-    factories: HashMap<ProviderType, DriverFactory>,
+    descriptors: HashMap<ProviderType, DriverDescriptor>,
 }
 
 impl DriverRegistry {
     /// Create a new empty registry
     pub fn new() -> Self {
         Self {
-            factories: HashMap::new(),
+            descriptors: HashMap::new(),
         }
+    }
+
+    /// Register a full driver descriptor.
+    ///
+    /// Panics if a descriptor is already registered for the same driver id —
+    /// silent overwrites hide double-registration bugs. Use
+    /// [`Self::register_descriptor_or_replace`] to overwrite intentionally.
+    pub fn register_descriptor(&mut self, descriptor: DriverDescriptor) {
+        if self.descriptors.contains_key(&descriptor.id) {
+            panic!(
+                "driver already registered for provider '{}'; \
+                 use register_descriptor_or_replace to overwrite intentionally",
+                descriptor.id
+            );
+        }
+        self.descriptors.insert(descriptor.id.clone(), descriptor);
+    }
+
+    /// Register a full driver descriptor, replacing any existing one.
+    pub fn register_descriptor_or_replace(&mut self, descriptor: DriverDescriptor) {
+        self.descriptors.insert(descriptor.id.clone(), descriptor);
     }
 
     /// Register a driver factory for a provider type.
@@ -1300,14 +1432,7 @@ impl DriverRegistry {
     where
         F: Fn(&DriverConfig) -> BoxedChatDriver + Send + Sync + 'static,
     {
-        let provider_type = provider_type.into();
-        if self.factories.contains_key(&provider_type) {
-            panic!(
-                "driver already registered for provider '{provider_type}'; \
-                 use register_or_replace to overwrite intentionally"
-            );
-        }
-        self.factories.insert(provider_type, Arc::new(factory));
+        self.register_descriptor(DriverDescriptor::chat_only(provider_type, factory));
     }
 
     /// Register a driver factory, replacing any existing one for the provider.
@@ -1318,8 +1443,7 @@ impl DriverRegistry {
     where
         F: Fn(&DriverConfig) -> BoxedChatDriver + Send + Sync + 'static,
     {
-        self.factories
-            .insert(provider_type.into(), Arc::new(factory));
+        self.register_descriptor_or_replace(DriverDescriptor::chat_only(provider_type, factory));
     }
 
     /// Register a driver factory for an embedder-defined external provider,
@@ -1354,9 +1478,15 @@ impl DriverRegistry {
             ));
         }
 
-        // Look up the factory for this provider type
-        let factory = self.factories.get(&config.provider_type).ok_or_else(|| {
+        // Look up the descriptor and its chat factory for this provider type
+        let descriptor = self.descriptors.get(&config.provider_type).ok_or_else(|| {
             AgentLoopError::driver_not_registered(config.provider_type.to_string())
+        })?;
+        let factory = descriptor.chat.as_ref().ok_or_else(|| {
+            AgentLoopError::llm(format!(
+                "Provider driver '{}' does not implement the chat service.",
+                config.provider_type
+            ))
         })?;
 
         // Create the driver using the factory
@@ -1371,12 +1501,33 @@ impl DriverRegistry {
 
     /// Check if a driver is registered for a provider type
     pub fn has_driver(&self, provider_type: &ProviderType) -> bool {
-        self.factories.contains_key(provider_type)
+        self.descriptors.contains_key(provider_type)
+    }
+
+    /// Get the registered descriptor for a provider type.
+    pub fn descriptor(&self, provider_type: &ProviderType) -> Option<&DriverDescriptor> {
+        self.descriptors.get(provider_type)
+    }
+
+    /// Whether the registered driver declares the given service.
+    pub fn supports(&self, provider_type: &ProviderType, service: ServiceKind) -> bool {
+        self.descriptors
+            .get(provider_type)
+            .is_some_and(|d| d.supports(service))
+    }
+
+    /// Driver ids whose descriptors declare the given service.
+    pub fn providers_for(&self, service: ServiceKind) -> Vec<ProviderType> {
+        self.descriptors
+            .values()
+            .filter(|d| d.supports(service))
+            .map(|d| d.id.clone())
+            .collect()
     }
 
     /// Get the list of registered provider types
     pub fn registered_providers(&self) -> Vec<ProviderType> {
-        self.factories.keys().cloned().collect()
+        self.descriptors.keys().cloned().collect()
     }
 }
 
@@ -1782,6 +1933,94 @@ mod tests {
             },
         );
         assert!(registry.create_chat_driver(&config).is_ok());
+    }
+
+    #[test]
+    fn test_register_defaults_to_chat_only_descriptor() {
+        struct MockDriver;
+        #[async_trait]
+        impl ChatDriver for MockDriver {
+            async fn chat_completion_stream(
+                &self,
+                _messages: Vec<LlmMessage>,
+                _config: &LlmCallConfig,
+            ) -> Result<LlmResponseStream> {
+                unimplemented!()
+            }
+        }
+
+        let mut registry = DriverRegistry::new();
+        registry.register(ProviderType::Anthropic, |_config| Box::new(MockDriver));
+
+        let descriptor = registry.descriptor(&ProviderType::Anthropic).unwrap();
+        assert_eq!(descriptor.display_name, "Anthropic");
+        assert_eq!(descriptor.services, vec![ServiceKind::Chat]);
+        assert!(descriptor.chat.is_some());
+        // Default credential shape is a single required api_key field.
+        assert_eq!(descriptor.credential_schema.fields.len(), 1);
+        assert_eq!(descriptor.credential_schema.fields[0].name, "api_key");
+        assert!(descriptor.credential_schema.fields[0].required);
+
+        // Keyless drivers default to an empty schema.
+        registry.register(ProviderType::LlmSim, |_config| Box::new(MockDriver));
+        let sim = registry.descriptor(&ProviderType::LlmSim).unwrap();
+        assert!(sim.credential_schema.fields.is_empty());
+    }
+
+    #[test]
+    fn test_descriptor_services_and_lookup() {
+        struct MockDriver;
+        #[async_trait]
+        impl ChatDriver for MockDriver {
+            async fn chat_completion_stream(
+                &self,
+                _messages: Vec<LlmMessage>,
+                _config: &LlmCallConfig,
+            ) -> Result<LlmResponseStream> {
+                unimplemented!()
+            }
+        }
+
+        let mut registry = DriverRegistry::new();
+        registry.register_descriptor(DriverDescriptor {
+            services: vec![ServiceKind::Chat, ServiceKind::Realtime],
+            ..DriverDescriptor::chat_only(ProviderType::OpenAI, |_config| Box::new(MockDriver))
+        });
+        registry.register(ProviderType::Anthropic, |_config| Box::new(MockDriver));
+
+        assert!(registry.supports(&ProviderType::OpenAI, ServiceKind::Chat));
+        assert!(registry.supports(&ProviderType::OpenAI, ServiceKind::Realtime));
+        assert!(!registry.supports(&ProviderType::Anthropic, ServiceKind::Realtime));
+        assert!(!registry.supports(&ProviderType::Gemini, ServiceKind::Chat));
+
+        let realtime = registry.providers_for(ServiceKind::Realtime);
+        assert_eq!(realtime, vec![ProviderType::OpenAI]);
+        let mut chat = registry.providers_for(ServiceKind::Chat);
+        chat.sort_by_key(|p| p.to_string());
+        assert_eq!(chat, vec![ProviderType::Anthropic, ProviderType::OpenAI]);
+    }
+
+    #[test]
+    fn test_create_chat_driver_fails_without_chat_factory() {
+        let mut registry = DriverRegistry::new();
+        registry.register_descriptor(DriverDescriptor {
+            id: ProviderType::external("embeddings-only"),
+            display_name: "Embeddings Only".to_string(),
+            services: vec![ServiceKind::Embeddings],
+            credential_schema: CredentialFormSchema::empty(),
+            chat: None,
+        });
+
+        let config = ProviderConfig::new(ProviderType::external("embeddings-only"));
+        let err = match registry.create_chat_driver(&config) {
+            Ok(_) => panic!("expected error for missing chat factory"),
+            Err(err) => err,
+        };
+        assert!(
+            err.to_string()
+                .contains("does not implement the chat service"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/crates/gemini/src/driver.rs
+++ b/crates/gemini/src/driver.rs
@@ -15,6 +15,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::sync::{Arc, Mutex};
 
+use everruns_core::credential_schema::CredentialFormSchema;
 use everruns_core::error::{AgentLoopError, LlmErrorKind, Result};
 use everruns_core::is_provider_quota_message;
 use everruns_core::llm_driver_helpers::{
@@ -22,7 +23,7 @@ use everruns_core::llm_driver_helpers::{
     parse_data_url,
 };
 use everruns_core::llm_driver_registry::{
-    BoxedChatDriver, ChatDriver, DiscoveredModel, DriverRegistry, LlmCallConfig,
+    BoxedChatDriver, ChatDriver, DiscoveredModel, DriverDescriptor, DriverRegistry, LlmCallConfig,
     LlmCompletionMetadata, LlmContentPart, LlmMessage, LlmMessageContent, LlmMessageRole,
     LlmResponseStream, LlmStreamEvent, ProviderType,
 };
@@ -835,13 +836,18 @@ impl std::fmt::Debug for GeminiChatDriver {
 
 /// Register the Gemini driver with the driver registry
 pub fn register_driver(registry: &mut DriverRegistry) {
-    registry.register(ProviderType::Gemini, |config| {
-        let api_key = config.api_key.as_deref().unwrap_or("");
-        let driver = match config.base_url.as_deref() {
-            Some(url) => GeminiChatDriver::with_base_url(api_key, url),
-            None => GeminiChatDriver::new(api_key),
-        };
-        Box::new(driver) as BoxedChatDriver
+    registry.register_descriptor(DriverDescriptor {
+        credential_schema: CredentialFormSchema::api_key(
+            "Create an API key in [Google AI Studio](https://aistudio.google.com/apikey).",
+        ),
+        ..DriverDescriptor::chat_only(ProviderType::Gemini, |config| {
+            let api_key = config.api_key.as_deref().unwrap_or("");
+            let driver = match config.base_url.as_deref() {
+                Some(url) => GeminiChatDriver::with_base_url(api_key, url),
+                None => GeminiChatDriver::new(api_key),
+            };
+            Box::new(driver) as BoxedChatDriver
+        })
     });
 }
 

--- a/crates/openai/src/driver.rs
+++ b/crates/openai/src/driver.rs
@@ -15,10 +15,11 @@ use reqwest::Url;
 
 use everruns_core::OpenAIProtocolChatDriver;
 use everruns_core::OpenResponsesProtocolChatDriver;
+use everruns_core::credential_schema::CredentialFormSchema;
 use everruns_core::error::{AgentLoopError, Result};
 use everruns_core::llm_driver_registry::{
-    BoxedChatDriver, ChatDriver, DiscoveredModel, DriverRegistry, LlmCallConfig, LlmMessage,
-    LlmResponseStream, ProviderType,
+    BoxedChatDriver, ChatDriver, DiscoveredModel, DriverDescriptor, DriverRegistry, LlmCallConfig,
+    LlmMessage, LlmResponseStream, ProviderType, ServiceKind,
 };
 use everruns_core::llm_models::LlmProviderType;
 use everruns_core::openai_protocol::is_azure_openai_api_url;
@@ -539,42 +540,65 @@ fn apply_models_auth(request: RequestBuilder, api_url: &str, api_key: &str) -> R
 /// register_driver(&mut registry);
 /// ```
 pub fn register_driver(registry: &mut DriverRegistry) {
-    // Register OpenAI with Open Responses API (recommended)
-    registry.register(ProviderType::OpenAI, |config| {
-        let api_key = config.api_key.as_deref().unwrap_or("");
-        let driver = match config.base_url.as_deref() {
-            Some(url) => OpenAIChatDriver::with_base_url(api_key, url),
-            None => OpenAIChatDriver::new(api_key),
-        };
-        Box::new(driver) as BoxedChatDriver
+    // Register OpenAI with Open Responses API (recommended). OpenAI providers
+    // also power realtime voice sessions (specs/voice.md), so the descriptor
+    // declares the Realtime service alongside Chat.
+    registry.register_descriptor(DriverDescriptor {
+        services: vec![ServiceKind::Chat, ServiceKind::Realtime],
+        credential_schema: CredentialFormSchema::api_key(
+            "Create an API key at [platform.openai.com/api-keys](https://platform.openai.com/api-keys).",
+        ),
+        ..DriverDescriptor::chat_only(ProviderType::OpenAI, |config| {
+            let api_key = config.api_key.as_deref().unwrap_or("");
+            let driver = match config.base_url.as_deref() {
+                Some(url) => OpenAIChatDriver::with_base_url(api_key, url),
+                None => OpenAIChatDriver::new(api_key),
+            };
+            Box::new(driver) as BoxedChatDriver
+        })
     });
 
-    registry.register(ProviderType::OpenRouter, |config| {
-        let api_key = config.api_key.as_deref().unwrap_or("");
-        let driver = match config.base_url.as_deref() {
-            Some(url) => OpenRouterChatDriver::with_base_url(api_key, url),
-            None => OpenRouterChatDriver::new(api_key),
-        };
-        Box::new(driver) as BoxedChatDriver
+    registry.register_descriptor(DriverDescriptor {
+        credential_schema: CredentialFormSchema::api_key(
+            "Create an API key at [openrouter.ai/settings/keys](https://openrouter.ai/settings/keys).",
+        ),
+        ..DriverDescriptor::chat_only(ProviderType::OpenRouter, |config| {
+            let api_key = config.api_key.as_deref().unwrap_or("");
+            let driver = match config.base_url.as_deref() {
+                Some(url) => OpenRouterChatDriver::with_base_url(api_key, url),
+                None => OpenRouterChatDriver::new(api_key),
+            };
+            Box::new(driver) as BoxedChatDriver
+        })
     });
 
-    registry.register(ProviderType::AzureOpenAI, |config| {
-        let api_key = config.api_key.as_deref().unwrap_or("");
-        let driver = match config.base_url.as_deref() {
-            Some(url) => OpenAIChatDriver::with_base_url(api_key, url),
-            None => OpenAIChatDriver::new(api_key),
-        };
-        Box::new(driver) as BoxedChatDriver
+    registry.register_descriptor(DriverDescriptor {
+        credential_schema: CredentialFormSchema::api_key(
+            "Use an API key for your Azure OpenAI resource and set the resource endpoint as the base URL.",
+        ),
+        ..DriverDescriptor::chat_only(ProviderType::AzureOpenAI, |config| {
+            let api_key = config.api_key.as_deref().unwrap_or("");
+            let driver = match config.base_url.as_deref() {
+                Some(url) => OpenAIChatDriver::with_base_url(api_key, url),
+                None => OpenAIChatDriver::new(api_key),
+            };
+            Box::new(driver) as BoxedChatDriver
+        })
     });
 
     // Register OpenAI Completions with Chat Completions API
-    registry.register(ProviderType::OpenAICompletions, |config| {
-        let api_key = config.api_key.as_deref().unwrap_or("");
-        let driver = match config.base_url.as_deref() {
-            Some(url) => OpenAICompletionsChatDriver::with_base_url(api_key, url),
-            None => OpenAICompletionsChatDriver::new(api_key),
-        };
-        Box::new(driver) as BoxedChatDriver
+    registry.register_descriptor(DriverDescriptor {
+        credential_schema: CredentialFormSchema::api_key(
+            "Create an API key at [platform.openai.com/api-keys](https://platform.openai.com/api-keys).",
+        ),
+        ..DriverDescriptor::chat_only(ProviderType::OpenAICompletions, |config| {
+            let api_key = config.api_key.as_deref().unwrap_or("");
+            let driver = match config.base_url.as_deref() {
+                Some(url) => OpenAICompletionsChatDriver::with_base_url(api_key, url),
+                None => OpenAICompletionsChatDriver::new(api_key),
+            };
+            Box::new(driver) as BoxedChatDriver
+        })
     });
 }
 

--- a/crates/openai/src/tests.rs
+++ b/crates/openai/src/tests.rs
@@ -232,3 +232,33 @@ mod provider_tests {
         }
     }
 }
+
+#[cfg(test)]
+mod descriptor_tests {
+    use crate::register_driver;
+    use everruns_core::llm_driver_registry::{DriverRegistry, ProviderType, ServiceKind};
+
+    #[test]
+    fn registered_descriptors_declare_services_and_credentials() {
+        let mut registry = DriverRegistry::new();
+        register_driver(&mut registry);
+
+        // OpenAI providers also power realtime voice sessions.
+        let openai = registry.descriptor(&ProviderType::OpenAI).unwrap();
+        assert_eq!(openai.display_name, "OpenAI");
+        assert!(openai.supports(ServiceKind::Chat));
+        assert!(openai.supports(ServiceKind::Realtime));
+        assert_eq!(openai.credential_schema.fields[0].name, "api_key");
+
+        // The other OpenAI-protocol drivers are chat-only.
+        for id in [
+            ProviderType::OpenRouter,
+            ProviderType::AzureOpenAI,
+            ProviderType::OpenAICompletions,
+        ] {
+            let descriptor = registry.descriptor(&id).unwrap();
+            assert_eq!(descriptor.services, vec![ServiceKind::Chat]);
+            assert_eq!(descriptor.credential_schema.fields[0].name, "api_key");
+        }
+    }
+}

--- a/specs/llm-drivers.md
+++ b/specs/llm-drivers.md
@@ -81,7 +81,13 @@ Each driver MUST implement provider-specific error detection to classify context
 
 ### Driver Registry
 
-Provider crates register factories at startup. Drivers created on-demand from `ProviderConfig`. All real providers require API keys; `LlmSim` exempted for testing. See `crates/core/src/llm_driver_registry.rs` for `DriverRegistry`.
+Provider crates register a `DriverDescriptor` at startup: driver id, display
+name, declared `ServiceKind`s (see `specs/providers.md`), a credential form
+schema, and per-service factories (chat today). Chat drivers are created
+on-demand from `ProviderConfig`. All real built-in providers require API keys;
+`LlmSim` and `External` drivers are exempted (external drivers may authenticate
+via `ProviderMetadata`). See `crates/core/src/llm_driver_registry.rs` for
+`DriverRegistry` and `DriverDescriptor`.
 
 ### Egress Boundary
 


### PR DESCRIPTION
## What
Second slice of phase 1 of `specs/providers.md`. Drivers now register a `DriverDescriptor` instead of a bare factory:

- **`ServiceKind`** enum (`chat`, `embeddings`, `realtime`, `images`, `rerank`) — declared by drivers in code, never stored in the DB
- **`DriverDescriptor`**: driver id, display name, declared services, credential form schema, chat factory. `DriverRegistry` stores descriptors and gains `descriptor()`, `supports()`, `providers_for()`
- **Credential form schema extracted to `everruns_core::credential_schema`** (`CredentialFormSchema`, `FormField`, `FieldType`), shared with connection providers — `ConnectionFormSchema` becomes a transitional alias until the phase-5 connector rename
- **OpenAI declares `Realtime` alongside `Chat`** so voice credential resolution can become service-bound in phase 4 (replacing the hardcoded `"openai"` lookup)
- **Bedrock declares its real multi-field AWS credential shape** (access key, secret, region, optional session token) instead of hiding it behind the JSON-in-`api_key` convention; the storage mapping lands with the credential-document phase
- `register()`/`register_or_replace()`/`register_external()` keep their signatures by wrapping factories into chat-only descriptors, so existing call sites and embedder code (EVE-561 docs) work unchanged

## Why
The registry previously expressed exactly one service per provider with a fixed `(api_key, base_url)` shape. The descriptor is the code-side unit of the providers domain model: one descriptor per driver, instantiated as many org-scoped providers, powering multiple services from one credential.

## How
Descriptor struct + registry storage swap in `llm_driver_registry.rs`; per-vendor crates register descriptors with real credential schemas and service sets; shared schema module with re-exports keeping the 34 existing `ConnectionFormSchema` usages compiling.

## Risk
- Low–Medium — registry behavior is covered by new and existing tests; `create_chat_driver` semantics (API-key requirement, `DriverNotRegistered`) unchanged.
- What can break: code matching on registry internals (none outside core), OpenAPI schema name for the connection form schema type (now `CredentialFormSchema`).

## Security
- Threat categories reviewed: TM-LLM (credential schema declarations, key handling). No key-resolution logic changed — fail-closed path untouched; credential schemas are declarative metadata only; no credential values are stored or logged by this change. Bedrock's schema marks all secret fields as `Password`.
- Findings: none.

## Follow-ups
- Driver descriptor `icon` and async `validate()` land with the UI/API phase (phase 3), where they get their first consumer.
- Phase 1 concludes with profile keys + service kinds (next PR, branch ready).

## Checklist
- [x] Tests added or updated — descriptor defaults, duplicate panic, service lookup, chat-factory-missing error, per-crate descriptor assertions (OpenAI realtime, Bedrock fields); 2340 core tests green
- [x] Backward compatibility considered — registration API kept source-compatible; `ConnectionFormSchema` aliased
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VjuNjETooc6GJ99vmLBftL)_