### PR TITLE
fix(anthropic): use renamed AnthropicChatDriver in tool_search tests

### DIFF
--- a/crates/anthropic/src/driver.rs
+++ b/crates/anthropic/src/driver.rs
@@ -1926,7 +1926,7 @@ mod tests {
             make_tool("write_todos", DeferrablePolicy::Never),
         ];
 
-        let converted = AnthropicLlmDriver::convert_tools_with_search(&tools, 3, false);
+        let converted = AnthropicChatDriver::convert_tools_with_search(&tools, 3, false);
         let json = serde_json::to_value(&converted).unwrap();
         let arr = json.as_array().unwrap();
 
@@ -1963,7 +1963,7 @@ mod tests {
             })
         };
         let tools = vec![make_tool("one"), make_tool("two")];
-        let converted = AnthropicLlmDriver::convert_tools_with_search(&tools, 3, false);
+        let converted = AnthropicChatDriver::convert_tools_with_search(&tools, 3, false);
         let json = serde_json::to_value(&converted).unwrap();
         let arr = json.as_array().unwrap();
         // Below threshold: no search tool, no deferral.
@@ -1977,7 +1977,7 @@ mod tests {
         // Below threshold must preserve the standard prompt-cache behavior:
         // `prompt_cache_enabled` is threaded through, so the last tool still gets
         // a cache breakpoint (regression guard for the dropped-marker bug).
-        let cached = AnthropicLlmDriver::convert_tools_with_search(
+        let cached = AnthropicChatDriver::convert_tools_with_search(
             &tools, 3, /* prompt_cache_enabled */ true,
         );
         let cached_json = serde_json::to_value(&cached).unwrap();


### PR DESCRIPTION
## What
Renames three test references from `AnthropicLlmDriver` to `AnthropicChatDriver` in `crates/anthropic/src/driver.rs`.

## Why
**Main CI is currently red** (`Unit Tests (Pure)` → `everruns-anthropic` lib-test build fails). This is a semantic merge conflict between two PRs that were each individually green:
- #2166 (hosted `claude_tool_search`) added new driver tests calling `AnthropicLlmDriver::convert_tools_with_search(...)`.
- A concurrent PR renamed the driver struct `AnthropicLlmDriver` → `AnthropicChatDriver`.

The rename touched the *existing* references; #2166 *added* new ones nearby. Neither textually conflicted, so GitHub reported the merge as clean, but the squashed result references a struct name that no longer exists (`error[E0433]: cannot find type AnthropicLlmDriver`). The non-test code uses `Self::`, so only the three test call sites broke.

## How
Three-identifier rename to match the current struct name. No logic change.

## Risk
- **Trivial.** Test-only identifier rename; build-fix forward (a revert would needlessly drop the whole #2166 feature for a 3-line typo).

## How validated
- `cargo test -p everruns-anthropic --lib` → 41 passed (including the three affected `convert_tools_with_search` tests).
- `cargo fmt --all --check` clean. `grep AnthropicLlmDriver crates/` → no remaining references.

## Security
- No security-relevant code changes (test-only identifier rename).

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (test-only)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

https://claude.ai/code/session_01FZoqGvhE8wqd4GFBzGoxRY

---
_Generated by [Claude Code](https://claude.ai/code/session_01FZoqGvhE8wqd4GFBzGoxRY)_