### PR TITLE
docs: group capabilities sidebar by category

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -150,7 +150,102 @@ export default defineConfig({
                 },
                 {
                   label: "Capabilities",
-                  items: [{ autogenerate: { directory: "capabilities" } }],
+                  // Grouped to mirror the category taxonomy in
+                  // docs/capabilities/index.md. Keep the two in sync when
+                  // adding or recategorizing a capability.
+                  items: [
+                    { label: "Overview", slug: "capabilities" },
+                    {
+                      label: "Core",
+                      collapsed: true,
+                      items: [
+                        { label: "File System", slug: "capabilities/file-system" },
+                        { label: "Bashkit Shell", slug: "capabilities/bashkit-shell" },
+                        { label: "Session", slug: "capabilities/session" },
+                        { label: "Session Storage", slug: "capabilities/session-storage" },
+                        { label: "Web Fetch", slug: "capabilities/web-fetch" },
+                        { label: "Browserless", slug: "capabilities/browserless" },
+                        { label: "Daytona", slug: "capabilities/daytona" },
+                      ],
+                    },
+                    {
+                      label: "Data & Productivity",
+                      collapsed: true,
+                      items: [
+                        { label: "SQL Database", slug: "capabilities/sql-database" },
+                        { label: "Current Time", slug: "capabilities/current-time" },
+                        { label: "Message Metadata", slug: "capabilities/message-metadata" },
+                        { label: "Task Management", slug: "capabilities/task-management" },
+                        { label: "Schedules", slug: "capabilities/session-schedules" },
+                      ],
+                    },
+                    {
+                      label: "Media",
+                      collapsed: true,
+                      items: [
+                        { label: "OpenAI Image Generation", slug: "capabilities/openai-image-generation" },
+                      ],
+                    },
+                    {
+                      label: "Orchestration",
+                      collapsed: true,
+                      items: [
+                        { label: "Sub Agents", slug: "capabilities/sub-agents" },
+                      ],
+                    },
+                    {
+                      label: "Integrations",
+                      collapsed: true,
+                      items: [
+                        { label: "GitHub Scout", slug: "capabilities/github-scout" },
+                      ],
+                    },
+                    {
+                      label: "Platform & Configuration",
+                      collapsed: true,
+                      items: [
+                        { label: "Platform Management", slug: "capabilities/platform-management" },
+                        { label: "AGENTS.md", slug: "capabilities/agent-instructions" },
+                        { label: "Agent Skills", slug: "capabilities/agent-skills" },
+                      ],
+                    },
+                    {
+                      label: "Optimization",
+                      collapsed: true,
+                      items: [
+                        { label: "Infinity Context", slug: "capabilities/infinity-context" },
+                        { label: "Auto Tool Search", slug: "capabilities/auto-tool-search" },
+                        { label: "OpenAI Tool Search", slug: "capabilities/openai-tool-search" },
+                        { label: "Claude Tool Search", slug: "capabilities/claude-tool-search" },
+                        { label: "Tool Search", slug: "capabilities/tool-search" },
+                        { label: "Budgeting", slug: "capabilities/budgeting" },
+                        { label: "Self-Budget", slug: "capabilities/self-budget" },
+                      ],
+                    },
+                    {
+                      label: "Safety",
+                      collapsed: true,
+                      items: [
+                        { label: "Prompt Canary Guardrail", slug: "capabilities/prompt-canary-guardrail" },
+                      ],
+                    },
+                    {
+                      label: "Automation",
+                      collapsed: true,
+                      items: [
+                        { label: "User Hooks", slug: "capabilities/user-hooks" },
+                      ],
+                    },
+                    {
+                      label: "Demo",
+                      collapsed: true,
+                      items: [
+                        { label: "Fake Warehouse", slug: "capabilities/fake-warehouse" },
+                        { label: "Fake AWS", slug: "capabilities/fake-aws" },
+                        { label: "Fake CRM", slug: "capabilities/fake-crm" },
+                      ],
+                    },
+                  ],
                 },
               ],
             },

--- a/docs/capabilities/index.md
+++ b/docs/capabilities/index.md
@@ -26,6 +26,7 @@ Fundamental capabilities for file operations, command execution, web access, and
 | [Session](/capabilities/session/) | `session` | 2 |
 | [Storage](/capabilities/session-storage/) | `session_storage` | 2 |
 | [Web Fetch](/capabilities/web-fetch/) | `web_fetch` | 1 |
+| [Browserless](/capabilities/browserless/) | `browserless` | 7 |
 | [Daytona](/capabilities/daytona/) | `daytona` | 9 |
 
 ### Data & Productivity


### PR DESCRIPTION
## What
Replace the flat, autogenerated capabilities list in the docs sidebar (one long alphabetical list under Built-ins → Capabilities) with collapsible groups that mirror the category taxonomy already defined in `docs/capabilities/index.md`: Core, Data & Productivity, Media, Orchestration, Integrations, Platform & Configuration, Optimization, Safety, Automation, Demo.

Also adds the missing **Browserless** row to the Core table in the overview page (it had a published page but wasn't listed).

## Why
The sidebar rendered every capability page as one long alphabetical list, so finding any given capability meant scanning the whole thing. The overview page already had a clean category taxonomy — the sidebar just wasn't reflecting it.

## How
- `apps/docs/astro.config.mjs`: swapped the single `autogenerate: { directory: "capabilities" }` for explicit nested groups, each `collapsed: true`. Entries reference existing page slugs, so **all URLs are unchanged** — no file moves, no redirects, no broken links.
- A comment points to `capabilities/index.md` as the source of truth to keep the two in sync.
- Rebased onto latest `main`, which had renamed `generic-tool-search` → `tool-search` and added a new `claude-tool-search` page; reconciled the Optimization group accordingly.

## Validation
- `pnpm run check` — 0 errors.
- `pnpm run build` — 373 pages, 0 errors; every referenced slug resolves (incl. `tool-search` and `claude-tool-search`), no capability dropped.
- Docs/config-only change with no runtime behavior; smoke test not applicable beyond the site build above.

## Risk
- Low
- Sidebar-only nesting change; worst case is a mislabeled/mis-grouped entry. No code paths, no URL changes.

## Security
- No security-relevant code changes (documentation and static-site config only). No threat-model categories touched.

## Follow-ups
- The code defines ~64 capabilities but only ~31 are documented. Several user-facing ones are missing (e.g. `fake_financial`; the Execution-sandbox family `e2b`/`docker_container`/`deno`/`session_sandbox`; web-search `brave_search`/`duckduckgo`; orchestration `agent_handoff`/`a2a_delegation`/`session_tasks`; `memory`/`knowledge_base`). Deferred per request — tracking separately.
- The capability `category()` already exists in code; long term the sidebar groups and overview table could be generated from it to prevent drift.

## Checklist
- [ ] Tests added or updated — N/A (docs site config; verified via full build)
- [x] Backward compatibility considered — URLs unchanged
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)