### PR TITLE
fix(evals): require EVAL_RUN policy for CreateEvalRun

### DIFF
--- a/crates/server/src/domains/evals/commands.rs
+++ b/crates/server/src/domains/evals/commands.rs
@@ -401,7 +401,7 @@ impl Command for CreateEvalRun {
     }
 
     fn policy() -> Option<&'static everruns_core::Policy> {
-        Some(&crate::domains::evals::EVAL_MANAGE)
+        Some(&crate::domains::evals::EVAL_RUN)
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<EvalRun, CommandError> {

--- a/crates/server/tests/command_policy_enforcement_test.rs
+++ b/crates/server/tests/command_policy_enforcement_test.rs
@@ -23,9 +23,11 @@ use everruns_core::{
     Caller, DEFAULT_ORG_ID, DEFAULT_ORG_PUBLIC_ID, DefaultPermissionResolver, OrgRole, Permission,
     PermissionResolver,
 };
+use everruns_server::api::evals::CreateEvalRunRequest;
 use everruns_server::domains::common::{
     Command, CommandError, CommandErrorKind, Ctx, catalog_entries, dispatch,
 };
+use everruns_server::domains::evals::{CreateEvalRun, ListEvals};
 use everruns_server::domains::harnesses::types::CreateHarnessRequest;
 use everruns_server::domains::harnesses::{CreateHarness, ListHarnesses};
 use everruns_server::domains::session_tasks::{
@@ -364,6 +366,62 @@ fn mcp_query_read_only_overrides_are_allowlisted() {
         "MCP query exposes every read_only() command. Non-GET read-only overrides \
          must stay intentionally reviewed so mutating commands do not drift into query."
     );
+}
+
+/// Grants OrgAgentsManage but denies OrgSessionsManage — models an eval-only
+/// SaaS tier that can manage eval definitions but cannot start runs.
+struct AgentsOnlyResolver;
+
+impl PermissionResolver for AgentsOnlyResolver {
+    fn has_permission(&self, _caller: &Caller, permission: &Permission) -> bool {
+        matches!(permission, Permission::OrgAgentsManage)
+    }
+    fn caller_permissions(&self, _caller: &Caller) -> Vec<Permission> {
+        vec![Permission::OrgAgentsManage]
+    }
+}
+
+// ============================================================================
+// EVE-549: CreateEvalRun must require EVAL_RUN (OrgAgentsManage +
+//           OrgSessionsManage), not just EVAL_MANAGE (OrgAgentsManage).
+// ============================================================================
+
+#[tokio::test]
+async fn eval_run_creation_requires_session_permission() {
+    // Regression for EVE-549: a caller with eval management but denied
+    // OrgSessionsManage must not be able to trigger real session creation.
+    let ctx = make_ctx(
+        caller_with_role(OrgRole::Owner),
+        Arc::new(AgentsOnlyResolver),
+    );
+    let err = CreateEvalRun {
+        eval_id: "eval_nonexistent".to_string(),
+        req: CreateEvalRunRequest {
+            target: None,
+            model_override: None,
+        },
+    }
+    .run(&ctx)
+    .await
+    .expect_err("CreateEvalRun must require OrgSessionsManage");
+    assert_forbidden(err);
+}
+
+#[tokio::test]
+async fn eval_manage_without_session_permission_still_allows_list() {
+    // A caller with only OrgAgentsManage can still list evals — the EVAL_VIEW
+    // policy only requires OrgAgentsManage. Only run creation needs more.
+    let ctx = make_ctx(
+        caller_with_role(OrgRole::Owner),
+        Arc::new(AgentsOnlyResolver),
+    );
+    ListEvals {
+        search: None,
+        include_archived: false,
+    }
+    .run(&ctx)
+    .await
+    .expect("ListEvals must be allowed with only OrgAgentsManage");
 }
 
 /// Commands intentionally exposed without a policy (public reads, probes).


### PR DESCRIPTION
## What

`CreateEvalRun::policy()` previously returned `&EVAL_MANAGE`, which only requires `OrgAgentsManage`. A caller granted eval management but denied session management by custom RBAC could trigger real session creation and background eval execution.

Changed to `&EVAL_RUN`, which requires both `OrgAgentsManage` and `OrgSessionsManage`. The `EVAL_RUN` policy was already defined with this intent in `service.rs` — only the command wasn't using it.

## Why

DeepSec finding EVE-549. Eval runs create real sessions and consume agent/LLM resources. The session-management permission gate needs to apply here, consistent with every other session-creating path.

## How

- One-line change in `crates/server/src/domains/evals/commands.rs`: `EVAL_MANAGE` → `EVAL_RUN`.
- Added two regression tests in `command_policy_enforcement_test.rs`:
  - `eval_run_creation_requires_session_permission` — a resolver granting only `OrgAgentsManage` receives `Forbidden` on `CreateEvalRun`.
  - `eval_manage_without_session_permission_still_allows_list` — same resolver still allows `ListEvals` (EVAL_VIEW only needs `OrgAgentsManage`), confirming we did not over-restrict.

## Validation

- `cargo test -p everruns-server --test command_policy_enforcement_test` — all pass including two new tests.
- `cargo clippy -p everruns-server --all-features -- -D warnings` — clean.
- `cargo fmt --check` — clean.
- `bash scripts/lib/check-migration-ordering.sh` — migrations sequential (001..057).

## Risk

- Minimal. Single policy constant swap on a command that creates sessions. Callers with both `OrgAgentsManage` and `OrgSessionsManage` are unaffected. Callers with only `OrgAgentsManage` are now correctly blocked from starting runs (they can still manage eval definitions).

## Security

- **TM-AUTHZ**: this is the fix — enforcing the intended authorization boundary for session-creating eval runs.
- No new attack surface introduced.

## Follow-ups

- EVE-548: `ListEvalCases`, `GetEvalCase`, `ListEvalRuns`, `GetEvalRun`, `ExportEvalRunArtifacts` (GET commands) also lack `EVAL_VIEW` policy — tracked separately, affects read-only callers only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XsZXDkJR7dzHG1eAivmwAL)_