### PR TITLE
fix(authz): add EVAL_VIEW and SESSION_VIEW to GET read commands

### DIFF
--- a/crates/server/src/domains/evals/commands.rs
+++ b/crates/server/src/domains/evals/commands.rs
@@ -254,6 +254,10 @@ impl Command for ListEvalCases {
         }
     }
 
+    fn policy() -> Option<&'static everruns_core::Policy> {
+        Some(&crate::domains::evals::EVAL_VIEW)
+    }
+
     async fn execute(self, ctx: &Ctx) -> Result<Vec<EvalCase>, CommandError> {
         let eval_id = q::parse_eval_id(&self.eval_id)?;
         q::service(ctx)
@@ -282,6 +286,10 @@ impl Command for GetEvalCase {
             method: "GET",
             path: "/v1/evals/{eval_id}/cases/{case_id}",
         }
+    }
+
+    fn policy() -> Option<&'static everruns_core::Policy> {
+        Some(&crate::domains::evals::EVAL_VIEW)
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<EvalCase, CommandError> {
@@ -433,6 +441,10 @@ impl Command for ListEvalRuns {
         }
     }
 
+    fn policy() -> Option<&'static everruns_core::Policy> {
+        Some(&crate::domains::evals::EVAL_VIEW)
+    }
+
     async fn execute(self, ctx: &Ctx) -> Result<Vec<EvalRun>, CommandError> {
         let eval_id = q::parse_eval_id(&self.eval_id)?;
         q::service(ctx)
@@ -461,6 +473,10 @@ impl Command for GetEvalRun {
             method: "GET",
             path: "/v1/evals/{eval_id}/runs/{run_id}",
         }
+    }
+
+    fn policy() -> Option<&'static everruns_core::Policy> {
+        Some(&crate::domains::evals::EVAL_VIEW)
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<EvalRun, CommandError> {
@@ -493,6 +509,10 @@ impl Command for ExportEvalRunArtifacts {
             method: "GET",
             path: "/v1/evals/{eval_id}/runs/{run_id}/artifacts",
         }
+    }
+
+    fn policy() -> Option<&'static everruns_core::Policy> {
+        Some(&crate::domains::evals::EVAL_VIEW)
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<EvalArtifactExport, CommandError> {

--- a/crates/server/src/domains/session_files/commands.rs
+++ b/crates/server/src/domains/session_files/commands.rs
@@ -87,6 +87,10 @@ impl Command for ListSessionFiles {
         Some("session_id")
     }
 
+    fn policy() -> Option<&'static everruns_core::Policy> {
+        Some(&crate::domains::sessions::SESSION_VIEW)
+    }
+
     async fn execute(self, ctx: &Ctx) -> Result<GetResponse, CommandError> {
         let session_id = q::parse_session_id(&self.session_id)?;
         q::verify_session(ctx, session_id).await?;
@@ -128,6 +132,10 @@ impl Command for GetSessionFile {
             method: "GET",
             path: "/v1/sessions/{session_id}/fs/{path}",
         }
+    }
+
+    fn policy() -> Option<&'static everruns_core::Policy> {
+        Some(&crate::domains::sessions::SESSION_VIEW)
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<GetResponse, CommandError> {


### PR DESCRIPTION
## What

Adds missing `policy()` declarations to seven GET commands that were accessible without authorization checks.

**EVE-548 — Eval subresource reads bypass eval view policy**

Five commands in `crates/server/src/domains/evals/commands.rs` returned data without any policy check:
- `ListEvalCases`
- `GetEvalCase`
- `ListEvalRuns`
- `GetEvalRun`
- `ExportEvalRunArtifacts`

Each now returns `Some(&EVAL_VIEW)`, consistent with `ListEvals` and `GetEval`.

**EVE-551 — Session file list and read endpoints bypass session policy**

Two commands in `crates/server/src/domains/session_files/commands.rs` returned file data without any policy check:
- `ListSessionFiles`
- `GetSessionFile`

Both now return `Some(&SESSION_VIEW)`, consistent with `GrepSessionFiles` and `StatSessionFile` which already had the policy.

## Why

DeepSec findings EVE-548 and EVE-551. The `Command::run()` enforcement path evaluates `policy()` before `execute()`. GET commands that omit `policy()` are callable by any authenticated principal regardless of role or SaaS tier restrictions. The existing inventory test (`every_non_readonly_command_declares_policy`) only covers non-GET commands — these fixes close the complementary GET-command gap.

## How

Seven one-line `policy()` additions. No logic changes. Pattern matches the existing `EVAL_VIEW` and `SESSION_VIEW` usages already in the same files.

## Validation

- `cargo clippy -p everruns-server --all-features -- -D warnings` — clean
- `cargo fmt --check` — clean
- `bash scripts/lib/check-migration-ordering.sh` — sequential (001..057)
- `cargo test -p everruns-server --test command_policy_enforcement_test` — all 12 tests pass (no new tests needed; the existing policy coverage test already enforces that non-GET commands have policies, and the session/eval regression tests added in #2175 cover the broader enforcement path)

## Risk

Minimal. These commands only enforce the policy that was already intended. Callers with `OrgAgentsManage` (EVAL_VIEW) or `OrgSessionsView`/`OrgSessionsManage` (SESSION_VIEW) are unaffected. Callers previously reaching these endpoints without that permission are now correctly blocked.

## Security

- **TM-AUTHZ**: direct fix — enforce the authorization boundary that `EVAL_VIEW` and `SESSION_VIEW` were designed to provide on eval and session-file read endpoints.
- No new attack surface introduced.

## Follow-ups

- EVE-550: MCP server reads expose raw authentication headers (separate backend fix — different crate and pattern).
- EVE-547: Unsandboxed SVG in read-file tool cards (frontend fix — separate).
- Remaining DeepSec backlog items tracked in their own Linear issues.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XsZXDkJR7dzHG1eAivmwAL)_