### PR TITLE
fix(secrets): redact MCP server header values in API responses

### DIFF
--- a/crates/server/src/domains/mcp_servers/queries.rs
+++ b/crates/server/src/domains/mcp_servers/queries.rs
@@ -15,8 +15,14 @@ use super::types::McpServerRow;
 // ============================================================================
 
 pub fn row_to_mcp_server(row: &McpServerRow) -> McpServer {
+    // Redact header values: keep key names so callers can see which headers are
+    // configured, but never return raw secrets through the API response path.
     let headers: HashMap<String, String> =
-        serde_json::from_value(row.headers.clone()).unwrap_or_default();
+        serde_json::from_value::<HashMap<String, String>>(row.headers.clone())
+            .unwrap_or_default()
+            .into_keys()
+            .map(|k| (k, String::new()))
+            .collect();
     let settings = McpServerService::settings_from_row(row);
     let oauth_provider_id = (settings.auth_mode == McpServerAuthMode::OAuth)
         .then(|| McpServerService::oauth_provider_id(row.id.uuid()));

--- a/crates/server/src/domains/mcp_servers/service.rs
+++ b/crates/server/src/domains/mcp_servers/service.rs
@@ -19,7 +19,7 @@ use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64_STANDARD};
 use chrono::{DateTime, Utc};
 use everruns_core::{
     Caller, DirectEgressService, EgressService, McpServer, McpServerAuthMode, McpServerStatus,
-    McpServerTransportType, McpToolDefinition, mcp_oauth_provider_id_for_uuid,
+    McpToolDefinition, mcp_oauth_provider_id_for_uuid,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -676,13 +676,12 @@ impl McpServerService {
             .db
             .get_mcp_server(caller.org_id, server.id.uuid())
             .await?;
-        let headers = raw_row
-            .as_ref()
-            .map(|r| {
-                serde_json::from_value::<HashMap<String, String>>(r.headers.clone())
-                    .unwrap_or_default()
-            })
-            .unwrap_or_default();
+        let Some(raw_row) = raw_row else {
+            // Server removed between list and resolve — treat as not found.
+            return Ok(None);
+        };
+        let headers =
+            serde_json::from_value::<HashMap<String, String>>(raw_row.headers).unwrap_or_default();
 
         Ok(Some(McpServerResolved {
             id: server.id.uuid(),
@@ -696,34 +695,7 @@ impl McpServerService {
     }
 
     fn row_to_mcp_server(row: &McpServerRow) -> McpServer {
-        // Redact header values: keep key names so callers can see which headers
-        // are configured, but never return raw secrets in API responses.
-        let headers: HashMap<String, String> =
-            serde_json::from_value::<HashMap<String, String>>(row.headers.clone())
-                .unwrap_or_default()
-                .into_keys()
-                .map(|k| (k, String::new()))
-                .collect();
-        let settings = Self::settings_from_row(row);
-        let oauth_provider_id = (settings.auth_mode == McpServerAuthMode::OAuth)
-            .then(|| Self::oauth_provider_id(row.id.uuid()));
-
-        McpServer {
-            id: row.id,
-            name: row.name.clone(),
-            description: row.description.clone(),
-            url: row.url.clone(),
-            transport_type: McpServerTransportType::from(row.transport_type.as_str()),
-            status: McpServerStatus::from(row.status.as_str()),
-            auth_mode: settings.auth_mode,
-            oauth_provider_id,
-            api_key_set: row.api_key_set,
-            headers,
-            created_at: row.created_at,
-            updated_at: row.updated_at,
-            archived_at: row.archived_at,
-            deleted_at: row.deleted_at,
-        }
+        super::queries::row_to_mcp_server(row)
     }
 
     fn row_to_mcp_server_with_tools(row: &McpServerRow) -> McpServerWithTools {
@@ -779,7 +751,7 @@ pub(crate) async fn fetch_mcp_tools(
 mod tests {
     use super::*;
     use crate::storage::{EncryptionService, StorageBackend, models::CreateMcpServerRow};
-    use everruns_core::OrgRole;
+    use everruns_core::{McpServerTransportType, OrgRole};
 
     fn test_caller(org_id: i64) -> Caller {
         Caller {

--- a/crates/server/src/domains/mcp_servers/service.rs
+++ b/crates/server/src/domains/mcp_servers/service.rs
@@ -671,6 +671,19 @@ impl McpServerService {
             None
         };
 
+        // Fetch raw headers from DB — server.headers has values redacted for API safety.
+        let raw_row = self
+            .db
+            .get_mcp_server(caller.org_id, server.id.uuid())
+            .await?;
+        let headers = raw_row
+            .as_ref()
+            .map(|r| {
+                serde_json::from_value::<HashMap<String, String>>(r.headers.clone())
+                    .unwrap_or_default()
+            })
+            .unwrap_or_default();
+
         Ok(Some(McpServerResolved {
             id: server.id.uuid(),
             name: server.name,
@@ -678,14 +691,19 @@ impl McpServerService {
             auth_mode: server.auth_mode,
             oauth_provider_id: server.oauth_provider_id,
             api_key,
-            headers: server.headers,
+            headers,
         }))
     }
 
     fn row_to_mcp_server(row: &McpServerRow) -> McpServer {
-        // Parse headers from JSON
+        // Redact header values: keep key names so callers can see which headers
+        // are configured, but never return raw secrets in API responses.
         let headers: HashMap<String, String> =
-            serde_json::from_value(row.headers.clone()).unwrap_or_default();
+            serde_json::from_value::<HashMap<String, String>>(row.headers.clone())
+                .unwrap_or_default()
+                .into_keys()
+                .map(|k| (k, String::new()))
+                .collect();
         let settings = Self::settings_from_row(row);
         let oauth_provider_id = (settings.auth_mode == McpServerAuthMode::OAuth)
             .then(|| Self::oauth_provider_id(row.id.uuid()));

--- a/crates/server/tests/workflow_test.rs
+++ b/crates/server/tests/workflow_test.rs
@@ -2921,9 +2921,16 @@ async fn test_mcp_server_crud() {
         .await
         .expect("Failed to parse MCP server");
     assert_eq!(server_with_headers.headers.len(), 2);
+    // Header names are present in API responses, but values are redacted to
+    // prevent secret exposure. Verify the key exists and value is cleared.
+    assert!(
+        server_with_headers.headers.contains_key("X-Custom-Header"),
+        "Header key must be present"
+    );
     assert_eq!(
         server_with_headers.headers.get("X-Custom-Header"),
-        Some(&"custom-value".to_string())
+        Some(&String::new()),
+        "Header values must be redacted in API responses"
     );
     println!(
         "Created MCP server with headers: {} ({} headers)",

--- a/crates/server/tests/workflow_test.rs
+++ b/crates/server/tests/workflow_test.rs
@@ -2928,8 +2928,11 @@ async fn test_mcp_server_crud() {
         "Header key must be present"
     );
     assert_eq!(
-        server_with_headers.headers.get("X-Custom-Header"),
-        Some(&String::new()),
+        server_with_headers
+            .headers
+            .get("X-Custom-Header")
+            .map(String::as_str),
+        Some(""),
         "Header values must be redacted in API responses"
     );
     println!(


### PR DESCRIPTION
## What

MCP server get/list API responses now return header keys with empty string values instead of the raw header values (e.g. Bearer tokens, API keys stored in custom headers).

The `resolve_by_prefix` path that actually needs raw header values for outbound HTTP connections to MCP servers fetches them directly from the DB, bypassing the redacted `McpServer` struct.

## Why

EVE-550 (DeepSec): MCP server reads exposed raw authentication header values through the standard API response path. Any caller with read access to an org's MCP servers could retrieve stored secrets.

## How

- `queries.rs`: `row_to_mcp_server()` now redacts all header values (keeps keys, clears values)
- `service.rs`: same redaction in the service's own `row_to_mcp_server()` copy; `resolve_by_prefix()` fetches raw headers in a second DB call when it needs them for actual HTTP connections
- `workflow_test.rs`: updated the existing MCP-server-with-headers test to assert values are redacted (empty strings), not raw values

## Risk

- Low
- The only behavior change is in API response content: header values are now `""` instead of actual secrets. Callers that were relying on reading back header values lose that capability (which was the bug — they should not have had it).
- The connection path (`resolve_by_prefix`) is unaffected; MCP servers continue to work with their configured headers.

## Security

- Threat categories reviewed: TM-API, TM-TENANT
- Finding: `row_to_mcp_server()` in both `queries.rs` and `service.rs` returned raw `serde_json::Value` headers including secret values in every API list/get response.
- Resolution: values cleared at the mapping layer. The second DB fetch in `resolve_by_prefix` is intentional and narrowly scoped to the resolution path that needs live credentials for outbound requests.
- No new threat surface introduced.

## Follow-ups

- EVE-546: MCP custom header secrets UI — the frontend side of this fix (showing redacted state correctly in the UI form). Deferred: separate issue, separate PR scope.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)


---
_Generated by [Claude Code](https://claude.ai/code/session_01XsZXDkJR7dzHG1eAivmwAL)_