### PR TITLE
fix(schedule): fix default cron and add minimum-interval validation

### DIFF
--- a/apps/ui/src/__tests__/cron-label.test.ts
+++ b/apps/ui/src/__tests__/cron-label.test.ts
@@ -1,0 +1,49 @@
+import {
+  CRON_MIN_INTERVAL_SECONDS,
+  getCronIntervalSeconds,
+  isSupportedCronExpression,
+} from "@/components/apps/cron-label";
+
+describe("CRON_MIN_INTERVAL_SECONDS", () => {
+  it("equals 300 (matches server-side default)", () => {
+    expect(CRON_MIN_INTERVAL_SECONDS).toBe(300);
+  });
+});
+
+describe("getCronIntervalSeconds", () => {
+  it("returns 60 for every-minute 7-field expression", () => {
+    expect(getCronIntervalSeconds("0 * * * * * *")).toBe(60);
+  });
+
+  it("returns 300 for every-5-minute 7-field expression", () => {
+    expect(getCronIntervalSeconds("0 */5 * * * * *")).toBe(300);
+  });
+
+  it("returns 3600 for hourly expression", () => {
+    expect(getCronIntervalSeconds("0 0 * * * * *")).toBe(3600);
+  });
+
+  it("returns 300 for every-5-minute 5-field expression", () => {
+    expect(getCronIntervalSeconds("*/5 * * * *")).toBe(300);
+  });
+
+  it("returns null for an invalid expression", () => {
+    expect(getCronIntervalSeconds("not a cron")).toBeNull();
+  });
+
+  it("default expression 0 */5 * * * * * meets the minimum interval", () => {
+    const secs = getCronIntervalSeconds("0 */5 * * * * *");
+    expect(secs).not.toBeNull();
+    expect(secs!).toBeGreaterThanOrEqual(CRON_MIN_INTERVAL_SECONDS);
+  });
+});
+
+describe("isSupportedCronExpression", () => {
+  it("accepts the default 5-min expression", () => {
+    expect(isSupportedCronExpression("0 */5 * * * * *")).toBe(true);
+  });
+
+  it("rejects an invalid expression", () => {
+    expect(isSupportedCronExpression("bad")).toBe(false);
+  });
+});

--- a/apps/ui/src/__tests__/cron-label.test.ts
+++ b/apps/ui/src/__tests__/cron-label.test.ts
@@ -27,6 +27,14 @@ describe("getCronIntervalSeconds", () => {
     expect(getCronIntervalSeconds("*/5 * * * *")).toBe(300);
   });
 
+  it("returns the minimum gap for a minute-list with uneven spacing (0,4 -> 240s, 56s)", () => {
+    // Minutes 0 and 4 of every hour: gaps are 4 min (240s) and 56 min (3360s).
+    // The minimum is 240s, which is below CRON_MIN_INTERVAL_SECONDS (300s).
+    const secs = getCronIntervalSeconds("0,4 * * * *");
+    expect(secs).not.toBeNull();
+    expect(secs!).toBeLessThan(CRON_MIN_INTERVAL_SECONDS);
+  });
+
   it("returns null for an invalid expression", () => {
     expect(getCronIntervalSeconds("not a cron")).toBeNull();
   });

--- a/apps/ui/src/app/(main)/apps/new/page.tsx
+++ b/apps/ui/src/app/(main)/apps/new/page.tsx
@@ -37,6 +37,10 @@ import {
 } from "@/lib/app-channels";
 import { DEFAULT_AG_UI_GENERIC_TOOL_TEXT } from "@/lib/api/types/app-types";
 import { generateChannelToken } from "@/lib/channel-tokens";
+import {
+  CRON_MIN_INTERVAL_SECONDS,
+  getCronIntervalSeconds,
+} from "@/components/apps/cron-label";
 
 export default function NewAppPage() {
   usePageTitle("New App", "Apps");
@@ -55,7 +59,7 @@ export default function NewAppPage() {
   const [slackChannelId, setSlackChannelId] = useState("");
   const [slackSessionStrategy, setSlackSessionStrategy] = useState<SessionStrategy>("per_thread");
   const [slackReplyMode, setSlackReplyMode] = useState<SlackReplyMode>("all_messages");
-  const [scheduleCronExpression, setScheduleCronExpression] = useState("0 * * * * * *");
+  const [scheduleCronExpression, setScheduleCronExpression] = useState("0 */5 * * * * *");
   const [scheduleTimezone, setScheduleTimezone] = useState("UTC");
   const [invocationSessionMode, setInvocationSessionMode] =
     useState<InvocationSessionMode>("shared_session");
@@ -117,7 +121,9 @@ export default function NewAppPage() {
         : channelType === "slack"
           ? !!slackSigningSecret && !!slackBotToken
           : channelType === "schedule"
-            ? !!scheduleCronExpression && !!channelMessage
+            ? !!scheduleCronExpression &&
+              !!channelMessage &&
+              (getCronIntervalSeconds(scheduleCronExpression) ?? 0) >= CRON_MIN_INTERVAL_SECONDS
             : !!webhookToken && !!channelMessage;
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -385,8 +391,16 @@ export default function NewAppPage() {
                       id="schedule_cron_expression"
                       value={scheduleCronExpression}
                       onChange={(e) => setScheduleCronExpression(e.target.value)}
-                      placeholder="0 * * * * * *"
+                      placeholder="0 */5 * * * * *"
                     />
+                    {scheduleCronExpression &&
+                      (getCronIntervalSeconds(scheduleCronExpression) ?? 0) <
+                        CRON_MIN_INTERVAL_SECONDS && (
+                        <p className="text-xs text-destructive">
+                          Minimum interval is{" "}
+                          {Math.floor(CRON_MIN_INTERVAL_SECONDS / 60)} minutes.
+                        </p>
+                      )}
                   </div>
                   <div className="space-y-2">
                     <Label htmlFor="schedule_timezone">Timezone</Label>

--- a/apps/ui/src/app/(main)/apps/new/page.tsx
+++ b/apps/ui/src/app/(main)/apps/new/page.tsx
@@ -40,6 +40,7 @@ import { generateChannelToken } from "@/lib/channel-tokens";
 import {
   CRON_MIN_INTERVAL_SECONDS,
   getCronIntervalSeconds,
+  isSupportedCronExpression,
 } from "@/components/apps/cron-label";
 
 export default function NewAppPage() {
@@ -122,9 +123,10 @@ export default function NewAppPage() {
           ? !!slackSigningSecret && !!slackBotToken
           : channelType === "schedule"
             ? !!scheduleCronExpression &&
-              !!channelMessage &&
+              !!channelMessage.trim() &&
+              isSupportedCronExpression(scheduleCronExpression) &&
               (getCronIntervalSeconds(scheduleCronExpression) ?? 0) >= CRON_MIN_INTERVAL_SECONDS
-            : !!webhookToken && !!channelMessage;
+            : !!webhookToken && !!channelMessage.trim();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -394,11 +396,11 @@ export default function NewAppPage() {
                       placeholder="0 */5 * * * * *"
                     />
                     {scheduleCronExpression &&
+                      isSupportedCronExpression(scheduleCronExpression) &&
                       (getCronIntervalSeconds(scheduleCronExpression) ?? 0) <
                         CRON_MIN_INTERVAL_SECONDS && (
                         <p className="text-xs text-destructive">
-                          Minimum interval is{" "}
-                          {Math.floor(CRON_MIN_INTERVAL_SECONDS / 60)} minutes.
+                          Minimum interval is {Math.floor(CRON_MIN_INTERVAL_SECONDS / 60)} minutes.
                         </p>
                       )}
                   </div>

--- a/apps/ui/src/components/apps/cron-label.tsx
+++ b/apps/ui/src/components/apps/cron-label.tsx
@@ -39,6 +39,24 @@ export function isSupportedCronExpression(expression: string): boolean {
   return getNextRuns(expression, "UTC").length > 0;
 }
 
+// Mirror of the server-side SCHEDULE_CHANNEL_MIN_INTERVAL_SECONDS default.
+export const CRON_MIN_INTERVAL_SECONDS = 300;
+
+/** Returns the interval in seconds between the next two consecutive runs, or
+ *  null when the expression is invalid or produces no future runs. */
+export function getCronIntervalSeconds(expression: string): number | null {
+  try {
+    const parserExpression = previewExpression(expression);
+    if (!parserExpression) return null;
+    const interval = CronExpressionParser.parse(parserExpression, { tz: "UTC" });
+    const t1 = interval.next().getTime();
+    const t2 = interval.next().getTime();
+    return Math.round((t2 - t1) / 1000);
+  } catch {
+    return null;
+  }
+}
+
 export function CronLabel({
   expr,
   tz,

--- a/apps/ui/src/components/apps/cron-label.tsx
+++ b/apps/ui/src/components/apps/cron-label.tsx
@@ -42,16 +42,16 @@ export function isSupportedCronExpression(expression: string): boolean {
 // Mirror of the server-side SCHEDULE_CHANNEL_MIN_INTERVAL_SECONDS default.
 export const CRON_MIN_INTERVAL_SECONDS = 300;
 
-/** Returns the interval in seconds between the next two consecutive runs, or
- *  null when the expression is invalid or produces no future runs. */
+/** Returns the minimum interval in seconds across the next 8 runs, or null when
+ *  the expression is invalid. Mirrors the server's min-interval check. */
 export function getCronIntervalSeconds(expression: string): number | null {
   try {
     const parserExpression = previewExpression(expression);
     if (!parserExpression) return null;
-    const interval = CronExpressionParser.parse(parserExpression, { tz: "UTC" });
-    const t1 = interval.next().getTime();
-    const t2 = interval.next().getTime();
-    return Math.round((t2 - t1) / 1000);
+    const iter = CronExpressionParser.parse(parserExpression, { tz: "UTC" });
+    const times = Array.from({ length: 9 }, () => iter.next().getTime());
+    const deltas = times.slice(1).map((t, i) => Math.round((t - times[i]) / 1000));
+    return Math.min(...deltas);
   } catch {
     return null;
   }


### PR DESCRIPTION
## What

The schedule channel default and placeholder cron expression `"0 * * * * * *"` fires every 60 seconds, which is rejected by the backend's 300-second minimum interval. This PR changes the default to `"0 */5 * * * * *"` and adds client-side validation so users see an error before submitting.

## Why

EVE-554 (DeepSec): Users creating a schedule channel with the default expression always got a backend error, making the happy path broken out of the box.

## How

- `cron-label.tsx`: Export `getCronIntervalSeconds(expr)` (computes interval between consecutive runs) and `CRON_MIN_INTERVAL_SECONDS = 300` constant to mirror the server-side default.
- `apps/new/page.tsx`: Change default state and placeholder to `"0 */5 * * * * *"`; add interval check to `isChannelConfigValid`; render an inline error when the cron fires more often than allowed.
- `cron-label.test.ts`: Unit tests covering every-minute (60s), every-5-min (300s), hourly (3600s), 5-field form, invalid expression, and the default-expression happy path.

## Risk

- Low
- Only changes the default cron value and adds a client-side validation gate. Backend validation is unchanged.

## Security

No security-relevant code changes — this is a UX validation fix with no auth or data-access surface.

## Follow-ups

No follow-ups.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)


---
_Generated by [Claude Code](https://claude.ai/code/session_01XsZXDkJR7dzHG1eAivmwAL)_