### PR TITLE
fix(schedule): prevent double-throw on invalid scheduledAt values

### DIFF
--- a/apps/ui/src/__tests__/schedule-display.test.ts
+++ b/apps/ui/src/__tests__/schedule-display.test.ts
@@ -34,6 +34,15 @@ describe("schedule-display", () => {
     expect(formatScheduledDateTime("2026-04-16T15:30:00Z", "Bad/Zone")).toBe("Apr 16, 3:30 PM UTC");
   });
 
+  it("returns the raw string for an invalid date without throwing", () => {
+    expect(formatScheduledDateTime("not-a-date")).toBe("not-a-date");
+    expect(formatScheduledDateTime("not-a-date", "Bad/Zone")).toBe("not-a-date");
+  });
+
+  it("does not throw for an empty date string", () => {
+    expect(() => formatScheduledDateTime("")).not.toThrow();
+  });
+
   it("extracts background monitor titles from synthetic schedule descriptions", () => {
     expect(
       getScheduleDisplayTitle(`Monitor: Watch PR 1319

--- a/apps/ui/src/lib/schedule-display.ts
+++ b/apps/ui/src/lib/schedule-display.ts
@@ -105,6 +105,11 @@ export function formatScheduleCadence(input: {
 }
 
 export function formatScheduledDateTime(dateString: string, timezone = "UTC"): string {
+  const date = new Date(dateString);
+  if (Number.isNaN(date.getTime())) {
+    return dateString;
+  }
+
   const options: Intl.DateTimeFormatOptions = {
     month: "short",
     day: "numeric",
@@ -115,12 +120,10 @@ export function formatScheduledDateTime(dateString: string, timezone = "UTC"): s
   };
 
   try {
-    return new Intl.DateTimeFormat("en-US", options).format(new Date(dateString));
+    return new Intl.DateTimeFormat("en-US", options).format(date);
   } catch {
-    return new Intl.DateTimeFormat("en-US", {
-      ...options,
-      timeZone: "UTC",
-    }).format(new Date(dateString));
+    // Fall back to UTC when the timezone string is invalid.
+    return new Intl.DateTimeFormat("en-US", { ...options, timeZone: "UTC" }).format(date);
   }
 }
 


### PR DESCRIPTION
## What

`formatScheduledDateTime` in `schedule-display.ts` now validates the parsed date before passing it to `Intl.DateTimeFormat`, returning the raw input string for invalid dates instead of throwing.

## Why

EVE-559 (DeepSec): passing an invalid `scheduledAt` string (e.g. `"not-a-date"`) caused `new Date(dateString)` to produce an invalid `Date`. When that invalid `Date` was passed to `Intl.DateTimeFormat.format()` it threw a `RangeError` inside the `try` block; the `catch` then called `format()` again with the same invalid date, throwing a second uncaught `RangeError` that propagated to the component and crashed the schedule row display.

## How

- Parse the date once with `new Date(dateString)`.
- Check `Number.isNaN(date.getTime())` immediately; if invalid, return the raw `dateString` without touching `Intl.DateTimeFormat`.
- The existing `catch` block now only fires for timezone string failures, not date parse failures.
- Two regression tests added: one for invalid date strings (including a bad timezone), one for the empty-string edge case.

## Risk

- Low
- No behavior change for valid dates. Invalid dates now surface the raw string rather than crashing the component.

## Security

- Threat categories reviewed: TM-WEB
- No new attack surface. This is a defensive fix for a crash path; the raw string returned for invalid dates is displayed as-is, which is safe since it originates from the app's own API response (trusted internal data).

## Follow-ups

No follow-ups.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XsZXDkJR7dzHG1eAivmwAL)_