### PR TITLE
feat(core): configurable multi-scope skills capability

### DIFF
--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -131,6 +131,7 @@ mod session_sql_database;
 mod session_storage;
 mod session_tasks;
 mod skills;
+mod skills_scoped;
 mod stateless_todo_list;
 mod subagents;
 mod system_commands;
@@ -278,6 +279,9 @@ pub use session_storage::{
 };
 pub use session_tasks::{SESSION_TASKS_CAPABILITY_ID, SessionTasksCapability};
 pub use skills::{SKILLS_CAPABILITY_ID, SkillsCapability};
+pub use skills_scoped::{
+    ScopedSkillsCapability, SkillDirResolver, SkillScope, SkillsConfig, VfsSkillDirResolver,
+};
 pub use stateless_todo_list::{
     STATELESS_TODO_LIST_CAPABILITY_ID, StatelessTodoListCapability, WriteTodosTool,
 };

--- a/crates/core/src/capabilities/skills_scoped.rs
+++ b/crates/core/src/capabilities/skills_scoped.rs
@@ -1,0 +1,1060 @@
+// Configurable, multi-scope Skills Capability (built on the session VFS)
+//
+// `SkillsCapability` (see `skills.rs`) scans a single VFS path
+// (`/.agents/skills`) and exposes exactly `list_skills` + `activate_skill`.
+// That is the right default for the hosted server, where the only skill
+// source is the session virtual filesystem and extra skills arrive via the
+// mount mechanism (`attach_skill.rs`).
+//
+// Embedders that want **multiple labeled skill sources** — for example a
+// terminal coding agent with workspace, per-user "global", and binary-bundled
+// "system" scopes — need three things this default does not provide: merged
+// discovery across scopes with precedence, the ability to install/update a
+// skill (`write_skill`), and a way to render `${SKILL_DIR}` in whatever
+// namespace the embedder's shell actually runs in. `ScopedSkillsCapability`
+// adds exactly those, while reusing the upstream `crate::skill` parser,
+// validator, and substitution verbatim.
+//
+// SECURITY — sources are VFS-bound by construction. A scope is a *labeled VFS
+// root* (e.g. `/.agents/skills`), never a host filesystem path. Every read,
+// write, and discovery call goes through the injected `SessionFileSystem`
+// (`ToolContext::file_store`), so the capability can never be pointed at the
+// worker host: it can only ever see what that file store exposes. The embedder
+// decides how each VFS root maps to storage (a sandboxed overlay on the server;
+// a real on-disk directory in a single-user CLI), and that mapping lives behind
+// the file store — it is not a configuration knob on this capability. There is
+// deliberately no API here that accepts a host path.
+//
+// COMMAND-SUBSTITUTION GATE — unchanged from `skills.rs`. `!`cmd`` placeholders
+// are never expanded; activating a skill never spawns a shell. Re-enabling that
+// is gated upstream behind a non-user-spoofable provenance signal and a
+// session-sandbox-backed executor (EVE-388 / TM-TOOL-020) and is intentionally
+// out of scope here.
+
+use super::{Capability, CapabilityStatus, SystemPromptContext};
+use crate::skill::{
+    SkillContext, expand_skill_arguments, parse_skill_md, substitute_activation_vars,
+    validate_skill_name,
+};
+use crate::tool_types::{BuiltinTool, DeferrablePolicy, ToolDefinition, ToolHints, ToolPolicy};
+use crate::tools::{Tool, ToolExecutionResult};
+use crate::traits::{SessionFileSystem, ToolContext};
+use crate::typed_id::SessionId;
+use async_trait::async_trait;
+use serde_json::{Value, json};
+use std::path::{Component, Path, PathBuf};
+use std::sync::Arc;
+
+use super::skills::SKILLS_CAPABILITY_ID;
+
+/// Default VFS root for the workspace scope (matches `skills.rs`).
+const DEFAULT_WORKSPACE_ROOT: &str = "/.agents/skills";
+/// Workspace prefix for agent-facing display paths.
+const WORKSPACE_PREFIX: &str = "/workspace";
+/// Max skills listed in the system prompt (the rest reachable via `list_skills`).
+const MAX_SKILLS_IN_PROMPT: usize = 15;
+/// Max skill directories scanned per scope when building the system prompt.
+const MAX_SKILLS_SCAN_PER_SCOPE: usize = 64;
+/// Max description length in the system-prompt listing (truncated with "…").
+const MAX_DESCRIPTION_CHARS: usize = 76;
+/// Defensive cap for extra files installed alongside a skill.
+const MAX_EXTRA_SKILL_FILES: usize = 64;
+/// Defensive cap for one skill file body.
+const MAX_SKILL_FILE_BYTES: usize = 1024 * 1024;
+/// Registry kind used to make `activate_skill` idempotent within a session.
+const SKILL_ACTIVATION_KIND: &str = "skill_activation";
+
+fn skill_activation_resource_id(name: &str) -> String {
+    format!("{SKILL_ACTIVATION_KIND}:{name}")
+}
+
+fn truncate_description(s: &str, max_chars: usize) -> String {
+    if s.chars().count() <= max_chars {
+        return s.to_string();
+    }
+    let truncated: String = s.chars().take(max_chars.saturating_sub(1)).collect();
+    format!("{}…", truncated.trim_end())
+}
+
+// ============================================================================
+// Scopes, resolver, and configuration
+// ============================================================================
+
+/// One labeled skill source: a VFS root plus whether the agent may write to it.
+///
+/// `vfs_root` is always a session-VFS path (e.g. `/.agents/skills`). It is never
+/// a host filesystem path — see the module security note.
+#[derive(Clone, Debug)]
+pub struct SkillScope {
+    /// Stable label surfaced to the model (e.g. `workspace`, `global`, `system`).
+    pub label: String,
+    /// VFS root scanned for `<name>/SKILL.md` skill directories.
+    pub vfs_root: String,
+    /// Whether `write_skill` may install/update skills in this scope.
+    pub writable: bool,
+}
+
+impl SkillScope {
+    pub fn new(label: impl Into<String>, vfs_root: impl Into<String>, writable: bool) -> Self {
+        Self {
+            label: label.into(),
+            vfs_root: vfs_root.into(),
+            writable,
+        }
+    }
+
+    /// The VFS path of a skill directory under this scope.
+    fn dir_vfs(&self, name: &str) -> String {
+        format!("{}/{name}", self.vfs_root.trim_end_matches('/'))
+    }
+
+    /// The VFS path of a skill's `SKILL.md` under this scope.
+    fn skill_md_vfs(&self, name: &str) -> String {
+        format!("{}/SKILL.md", self.dir_vfs(name))
+    }
+}
+
+/// Resolves the on-execution path of a skill directory.
+///
+/// `${SKILL_DIR}` (and the agent-facing display path) must be valid in the
+/// namespace where the skill's commands and bundled-file reads actually run.
+/// The default ([`VfsSkillDirResolver`]) keeps everything in the session VFS,
+/// which is correct when the shell shares that namespace (the hosted server's
+/// session sandbox). An embedder whose shell runs elsewhere — e.g. a CLI whose
+/// `bash` runs on the host — implements this to return a path valid there.
+pub trait SkillDirResolver: Send + Sync {
+    /// Value substituted for `${SKILL_DIR}` during activation.
+    fn skill_dir(&self, scope: &SkillScope, name: &str) -> String;
+
+    /// Agent-facing display path for the skill directory (shown in
+    /// `list_skills` / `read_skill`). Defaults to the workspace-prefixed VFS
+    /// path, matching the `file_system` capability's display convention.
+    fn display_dir(&self, scope: &SkillScope, name: &str) -> String {
+        let vfs = scope.dir_vfs(name);
+        if vfs.starts_with('/') {
+            format!("{WORKSPACE_PREFIX}{vfs}")
+        } else {
+            format!("{WORKSPACE_PREFIX}/{vfs}")
+        }
+    }
+}
+
+/// Default resolver: `${SKILL_DIR}` and the display path stay in the VFS.
+pub struct VfsSkillDirResolver;
+
+impl SkillDirResolver for VfsSkillDirResolver {
+    fn skill_dir(&self, scope: &SkillScope, name: &str) -> String {
+        scope.dir_vfs(name)
+    }
+}
+
+/// Configuration for [`ScopedSkillsCapability`].
+#[derive(Clone)]
+pub struct SkillsConfig {
+    /// Skill scopes in precedence order, highest first. A skill directory name
+    /// found in an earlier scope shadows the same name in a later one.
+    pub scopes: Vec<SkillScope>,
+    /// Resolver for `${SKILL_DIR}` and display paths.
+    pub resolver: Arc<dyn SkillDirResolver>,
+    /// When `true`, expose the `read_skill` and `write_skill` management tools.
+    /// Off by default so the management surface is strictly opt-in.
+    pub manage_tools: bool,
+}
+
+impl Default for SkillsConfig {
+    fn default() -> Self {
+        Self {
+            scopes: vec![SkillScope::new("workspace", DEFAULT_WORKSPACE_ROOT, true)],
+            resolver: Arc::new(VfsSkillDirResolver),
+            manage_tools: false,
+        }
+    }
+}
+
+impl SkillsConfig {
+    /// Locate the first writable scope matching `label` (or any writable scope
+    /// when `label` is `None`).
+    fn writable_scope(&self, label: Option<&str>) -> Option<&SkillScope> {
+        self.scopes
+            .iter()
+            .find(|s| s.writable && label.is_none_or(|l| l == s.label))
+    }
+
+    fn scope_by_label(&self, label: &str) -> Option<&SkillScope> {
+        self.scopes.iter().find(|s| s.label == label)
+    }
+}
+
+// ============================================================================
+// Capability
+// ============================================================================
+
+const SCOPED_SKILLS_SYSTEM_PROMPT: &str = "Skills are reusable instruction packs \
+discovered across one or more scopes (e.g. your workspace, global config, and ones \
+bundled with the agent). Use `list_skills` to see what's available and `activate_skill` \
+(by name) to load one. Only activate skills relevant to the current task.";
+
+/// Configurable, multi-scope skills capability. Discovers, activates, and
+/// (optionally) manages skills across the configured scopes, entirely through
+/// the session `SessionFileSystem`.
+pub struct ScopedSkillsCapability {
+    config: Arc<SkillsConfig>,
+}
+
+impl ScopedSkillsCapability {
+    pub fn new(config: SkillsConfig) -> Self {
+        Self {
+            config: Arc::new(config),
+        }
+    }
+}
+
+#[async_trait]
+impl Capability for ScopedSkillsCapability {
+    fn id(&self) -> &str {
+        SKILLS_CAPABILITY_ID
+    }
+
+    fn name(&self) -> &str {
+        "Agent Skills"
+    }
+
+    fn description(&self) -> &str {
+        "Discover, activate, and manage skills across multiple scopes (workspace, \
+         global config, and bundled), all through the session filesystem."
+    }
+
+    fn status(&self) -> CapabilityStatus {
+        CapabilityStatus::Available
+    }
+
+    fn icon(&self) -> Option<&str> {
+        Some("wand")
+    }
+
+    fn category(&self) -> Option<&str> {
+        Some("Skills")
+    }
+
+    fn system_prompt_addition(&self) -> Option<&str> {
+        Some(SCOPED_SKILLS_SYSTEM_PROMPT)
+    }
+
+    async fn system_prompt_contribution(&self, ctx: &SystemPromptContext) -> Option<String> {
+        let mut prompt = String::from(SCOPED_SKILLS_SYSTEM_PROMPT);
+
+        if let Some(file_store) = ctx.file_store.as_ref() {
+            let discovered =
+                discover_skills(&self.config, file_store.as_ref(), ctx.session_id).await;
+            let visible: Vec<&DiscoveredSkill> = discovered
+                .iter()
+                .filter(|s| s.error.is_none() && !s.disable_model_invocation)
+                .collect();
+
+            if !visible.is_empty() {
+                prompt.push_str("\n\nAvailable skills:\n");
+                for skill in visible.iter().take(MAX_SKILLS_IN_PROMPT) {
+                    let desc = truncate_description(&skill.description, MAX_DESCRIPTION_CHARS);
+                    let invocable = if skill.user_invocable {
+                        format!(" (/{})", skill.name)
+                    } else {
+                        String::new()
+                    };
+                    prompt.push_str(&format!(
+                        "- **{}** [{}]: {}{}\n",
+                        skill.name, skill.scope_label, desc, invocable
+                    ));
+                }
+                if visible.len() > MAX_SKILLS_IN_PROMPT {
+                    prompt.push_str(&format!(
+                        "\n({} more — use `list_skills` to see all)\n",
+                        visible.len() - MAX_SKILLS_IN_PROMPT
+                    ));
+                }
+            }
+        }
+
+        Some(format!(
+            "<capability id=\"{}\">\n{}\n</capability>",
+            self.id(),
+            prompt
+        ))
+    }
+
+    fn tools(&self) -> Vec<Box<dyn Tool>> {
+        let mut tools: Vec<Box<dyn Tool>> = vec![
+            Box::new(ListSkillsTool {
+                config: self.config.clone(),
+            }),
+            Box::new(ActivateSkillTool {
+                config: self.config.clone(),
+            }),
+        ];
+        if self.config.manage_tools {
+            tools.push(Box::new(ReadSkillTool {
+                config: self.config.clone(),
+            }));
+            tools.push(Box::new(WriteSkillTool {
+                config: self.config.clone(),
+            }));
+        }
+        tools
+    }
+
+    fn tool_definitions(&self) -> Vec<ToolDefinition> {
+        let readonly = ToolHints::default()
+            .with_readonly(true)
+            .with_idempotent(true);
+        let mut defs = vec![
+            ToolDefinition::Builtin(BuiltinTool {
+                name: "list_skills".to_string(),
+                display_name: Some("List Skills".to_string()),
+                description: "Discover available skills across all configured scopes.".to_string(),
+                parameters: list_skills_schema(),
+                policy: ToolPolicy::Auto,
+                category: None,
+                deferrable: DeferrablePolicy::default(),
+                hints: readonly.clone(),
+                full_parameters: None,
+            }),
+            ToolDefinition::Builtin(BuiltinTool {
+                name: "activate_skill".to_string(),
+                display_name: Some("Activate Skill".to_string()),
+                description: "Activate a skill by name to load its full instructions.".to_string(),
+                parameters: activate_skill_schema(),
+                policy: ToolPolicy::Auto,
+                category: None,
+                deferrable: DeferrablePolicy::default(),
+                hints: readonly.clone(),
+                full_parameters: None,
+            }),
+        ];
+        if self.config.manage_tools {
+            defs.push(ToolDefinition::Builtin(BuiltinTool {
+                name: "read_skill".to_string(),
+                display_name: Some("Read Skill".to_string()),
+                description: "Read one installed skill's SKILL.md and file manifest.".to_string(),
+                parameters: read_skill_schema(),
+                policy: ToolPolicy::Auto,
+                category: None,
+                deferrable: DeferrablePolicy::default(),
+                hints: readonly,
+                full_parameters: None,
+            }));
+            defs.push(ToolDefinition::Builtin(BuiltinTool {
+                name: "write_skill".to_string(),
+                display_name: Some("Write Skill".to_string()),
+                description: "Install or update a skill in a writable scope.".to_string(),
+                parameters: write_skill_schema(),
+                policy: ToolPolicy::Auto,
+                category: None,
+                deferrable: DeferrablePolicy::default(),
+                hints: ToolHints::default().with_idempotent(true),
+                full_parameters: None,
+            }));
+        }
+        defs
+    }
+
+    fn dependencies(&self) -> Vec<&'static str> {
+        vec!["session_file_system"]
+    }
+}
+
+// ============================================================================
+// Discovery
+// ============================================================================
+
+/// One discovered skill after parsing its `SKILL.md`.
+struct DiscoveredSkill {
+    scope_label: String,
+    scope_index: usize,
+    dir_name: String,
+    name: String,
+    description: String,
+    version: String,
+    user_invocable: bool,
+    disable_model_invocation: bool,
+    error: Option<String>,
+}
+
+/// Discover every unique skill across scopes, in precedence order. The first
+/// occurrence of a directory name wins; later (farther-scope) duplicates drop.
+async fn discover_skills(
+    config: &SkillsConfig,
+    fs: &dyn SessionFileSystem,
+    session_id: SessionId,
+) -> Vec<DiscoveredSkill> {
+    let mut seen = std::collections::HashSet::new();
+    let mut out = Vec::new();
+    for (scope_index, scope) in config.scopes.iter().enumerate() {
+        let entries = match fs.list_directory(session_id, &scope.vfs_root).await {
+            Ok(entries) => entries,
+            Err(_) => continue, // absent scope is silently empty
+        };
+        let mut dirs: Vec<_> = entries.into_iter().filter(|e| e.is_directory).collect();
+        dirs.sort_by(|a, b| a.name.cmp(&b.name));
+        for entry in dirs.into_iter().take(MAX_SKILLS_SCAN_PER_SCOPE) {
+            if !seen.insert(entry.name.clone()) {
+                continue;
+            }
+            let md_path = scope.skill_md_vfs(&entry.name);
+            let content = match fs.read_file(session_id, &md_path).await {
+                Ok(Some(file)) => file.content.unwrap_or_default(),
+                _ => continue,
+            };
+            let discovered = match parse_skill_md(&content) {
+                Ok(parsed) => DiscoveredSkill {
+                    scope_label: scope.label.clone(),
+                    scope_index,
+                    dir_name: entry.name.clone(),
+                    name: parsed.name,
+                    description: parsed.description,
+                    version: parsed.version,
+                    user_invocable: parsed.user_invocable,
+                    disable_model_invocation: parsed.disable_model_invocation,
+                    error: None,
+                },
+                Err(errors) => DiscoveredSkill {
+                    scope_label: scope.label.clone(),
+                    scope_index,
+                    name: entry.name.clone(),
+                    description: String::new(),
+                    version: String::new(),
+                    user_invocable: false,
+                    disable_model_invocation: false,
+                    error: Some(format!("Invalid SKILL.md: {}", errors.join(", "))),
+                    dir_name: entry.name.clone(),
+                },
+            };
+            out.push(discovered);
+        }
+    }
+    out
+}
+
+/// Locate the activatable skill `name`, honoring precedence. Returns the scope
+/// index and the raw `SKILL.md` content.
+async fn locate_skill(
+    config: &SkillsConfig,
+    fs: &dyn SessionFileSystem,
+    session_id: SessionId,
+    name: &str,
+) -> Option<(usize, String)> {
+    for (idx, scope) in config.scopes.iter().enumerate() {
+        if let Ok(Some(file)) = fs.read_file(session_id, &scope.skill_md_vfs(name)).await {
+            return Some((idx, file.content.unwrap_or_default()));
+        }
+    }
+    None
+}
+
+// ============================================================================
+// list_skills
+// ============================================================================
+
+fn list_skills_schema() -> Value {
+    json!({ "type": "object", "properties": {}, "required": [] })
+}
+
+struct ListSkillsTool {
+    config: Arc<SkillsConfig>,
+}
+
+#[async_trait]
+impl Tool for ListSkillsTool {
+    fn name(&self) -> &str {
+        "list_skills"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("List Skills")
+    }
+
+    fn description(&self) -> &str {
+        "Discover available skills across all configured scopes. Returns each \
+         skill's name, description, and scope."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        list_skills_schema()
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_idempotent(true)
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error("list_skills requires session context.")
+    }
+
+    async fn execute_with_context(
+        &self,
+        _arguments: Value,
+        ctx: &ToolContext,
+    ) -> ToolExecutionResult {
+        let Some(fs) = &ctx.file_store else {
+            return ToolExecutionResult::tool_error(
+                "File store not available. The session_file_system capability is required.",
+            );
+        };
+        let discovered = discover_skills(&self.config, fs.as_ref(), ctx.session_id).await;
+        let skills: Vec<Value> = discovered
+            .into_iter()
+            .map(|s| {
+                let scope = &self.config.scopes[s.scope_index];
+                let display = self.config.resolver.display_dir(scope, &s.dir_name);
+                match s.error {
+                    Some(error) => json!({
+                        "name": s.dir_name,
+                        "scope": s.scope_label,
+                        "path": format!("{display}/SKILL.md"),
+                        "error": error,
+                    }),
+                    None => json!({
+                        "name": s.name,
+                        "description": s.description,
+                        "scope": s.scope_label,
+                        "version": s.version,
+                        "user_invocable": s.user_invocable,
+                        "disable_model_invocation": s.disable_model_invocation,
+                        "path": format!("{display}/SKILL.md"),
+                    }),
+                }
+            })
+            .collect();
+        ToolExecutionResult::success(json!({ "count": skills.len(), "skills": skills }))
+    }
+}
+
+// ============================================================================
+// activate_skill
+// ============================================================================
+
+fn activate_skill_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "name": { "type": "string", "description": "The skill directory name (e.g., 'pdf-processing')" },
+            "arguments": { "type": "string", "description": "Optional arguments to pass to the skill for $ARGUMENTS substitution" }
+        },
+        "required": ["name"]
+    })
+}
+
+struct ActivateSkillTool {
+    config: Arc<SkillsConfig>,
+}
+
+#[async_trait]
+impl Tool for ActivateSkillTool {
+    fn name(&self) -> &str {
+        "activate_skill"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("Activate Skill")
+    }
+
+    fn description(&self) -> &str {
+        "Activate a skill by name to load its full instructions. Skills resolve \
+         across the configured scopes (earlier scopes win on conflict)."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        activate_skill_schema()
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_idempotent(true)
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error("activate_skill requires session context.")
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        ctx: &ToolContext,
+    ) -> ToolExecutionResult {
+        let Some(name) = arguments.get("name").and_then(|v| v.as_str()) else {
+            return ToolExecutionResult::tool_error("Missing required parameter: name");
+        };
+        let skill_args = arguments
+            .get("arguments")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+
+        if let Err(msg) = validate_requested_skill_name(name) {
+            return ToolExecutionResult::tool_error(msg);
+        }
+
+        // Idempotence (EVE-337): re-activating the same skill within a session
+        // re-emits the cached result with `already_active: true`.
+        if let Some(registry) = &ctx.session_resource_registry {
+            let resource_id = skill_activation_resource_id(name);
+            if let Ok(Some(entry)) = registry.get(ctx.session_id, &resource_id).await
+                && entry.status == crate::session_resource::SessionResourceStatus::Active
+                && entry.kind == SKILL_ACTIVATION_KIND
+                && let Value::Object(mut map) = entry.metadata
+            {
+                map.insert("already_active".to_string(), Value::Bool(true));
+                return ToolExecutionResult::success(Value::Object(map));
+            }
+        }
+
+        let Some(fs) = &ctx.file_store else {
+            return ToolExecutionResult::tool_error(
+                "File store not available. The session_file_system capability is required.",
+            );
+        };
+
+        let Some((scope_index, content)) =
+            locate_skill(&self.config, fs.as_ref(), ctx.session_id, name).await
+        else {
+            return ToolExecutionResult::tool_error(format!(
+                "Skill '{name}' not found in any scope. Use list_skills to see what's available."
+            ));
+        };
+        let scope = &self.config.scopes[scope_index];
+
+        match parse_skill_md(&content) {
+            Ok(parsed) => {
+                // Substitution pipeline: arguments then activation vars. Command
+                // injection (`!`cmd``) is intentionally NOT expanded — see the
+                // module-level gate note.
+                let expanded = expand_skill_arguments(&parsed.instructions, skill_args);
+                let skill_dir = self.config.resolver.skill_dir(scope, name);
+                let substituted =
+                    substitute_activation_vars(&expanded, &ctx.session_id.to_string(), &skill_dir);
+                let instructions = format!(
+                    "<skill name=\"{}\">\n{}\n</skill>",
+                    parsed.name, substituted
+                );
+
+                let mut result = json!({
+                    "skill": parsed.name,
+                    "scope": scope.label,
+                    "description": parsed.description,
+                    "instructions": instructions,
+                });
+                if parsed.context == SkillContext::Fork {
+                    result["context"] = json!("fork");
+                    result["agent"] = json!(parsed.agent.as_deref().unwrap_or("general-purpose"));
+                    if let Some(model) = &parsed.model {
+                        result["model"] = json!(model);
+                    }
+                }
+
+                if let Some(registry) = &ctx.session_resource_registry {
+                    let entry = crate::session_resource::RegisterSessionResource {
+                        session_id: ctx.session_id,
+                        resource_id: skill_activation_resource_id(name),
+                        kind: SKILL_ACTIVATION_KIND.to_string(),
+                        display_name: format!("skill:{name}"),
+                        status: crate::session_resource::SessionResourceStatus::Active,
+                        metadata: result.clone(),
+                    };
+                    if let Err(e) = registry.register(entry).await {
+                        tracing::warn!(error = %e, skill = %parsed.name, "activate_skill: failed to record activation");
+                    }
+                }
+
+                ToolExecutionResult::success(result)
+            }
+            Err(errors) => ToolExecutionResult::tool_error(format!(
+                "Invalid SKILL.md for '{name}': {}",
+                errors.join(", ")
+            )),
+        }
+    }
+}
+
+// ============================================================================
+// read_skill
+// ============================================================================
+
+fn read_skill_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "name": { "type": "string", "description": "The skill directory name." },
+            "scope": { "type": "string", "description": "Optional scope label to read from. Omit to use normal precedence." }
+        },
+        "required": ["name"],
+        "additionalProperties": false
+    })
+}
+
+struct ReadSkillTool {
+    config: Arc<SkillsConfig>,
+}
+
+#[async_trait]
+impl Tool for ReadSkillTool {
+    fn name(&self) -> &str {
+        "read_skill"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("Read Skill")
+    }
+
+    fn description(&self) -> &str {
+        "Read one installed skill's SKILL.md and file manifest. Use before \
+         modifying or upgrading a skill."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        read_skill_schema()
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default()
+            .with_readonly(true)
+            .with_idempotent(true)
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error("read_skill requires session context.")
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        ctx: &ToolContext,
+    ) -> ToolExecutionResult {
+        let Some(name) = arguments.get("name").and_then(|v| v.as_str()) else {
+            return ToolExecutionResult::tool_error("Missing required parameter: name");
+        };
+        if let Err(msg) = validate_requested_skill_name(name) {
+            return ToolExecutionResult::tool_error(msg);
+        }
+        let Some(fs) = &ctx.file_store else {
+            return ToolExecutionResult::tool_error(
+                "File store not available. The session_file_system capability is required.",
+            );
+        };
+
+        let located = match arguments.get("scope").and_then(|v| v.as_str()) {
+            Some(label) => {
+                let Some(scope) = self.config.scope_by_label(label) else {
+                    return ToolExecutionResult::tool_error(format!("Unknown scope '{label}'"));
+                };
+                let idx = self
+                    .config
+                    .scopes
+                    .iter()
+                    .position(|s| s.label == scope.label)
+                    .unwrap();
+                match fs
+                    .read_file(ctx.session_id, &scope.skill_md_vfs(name))
+                    .await
+                {
+                    Ok(Some(file)) => Some((idx, file.content.unwrap_or_default())),
+                    _ => None,
+                }
+            }
+            None => locate_skill(&self.config, fs.as_ref(), ctx.session_id, name).await,
+        };
+
+        let Some((scope_index, content)) = located else {
+            return ToolExecutionResult::tool_error(format!(
+                "Skill '{name}' not found. Use list_skills to see what's available."
+            ));
+        };
+        let scope = &self.config.scopes[scope_index];
+        let display = self.config.resolver.display_dir(scope, name);
+        let files = skill_file_manifest(fs.as_ref(), ctx.session_id, &scope.dir_vfs(name)).await;
+
+        ToolExecutionResult::success(json!({
+            "name": name,
+            "scope": scope.label,
+            "path": format!("{display}/SKILL.md"),
+            "skill_md": content,
+            "files": files,
+        }))
+    }
+}
+
+/// Relative file manifest (excluding `SKILL.md`) for a skill directory, walked
+/// through the VFS. Bounded by `MAX_EXTRA_SKILL_FILES`.
+async fn skill_file_manifest(
+    fs: &dyn SessionFileSystem,
+    session_id: SessionId,
+    dir_vfs: &str,
+) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut queue = vec![dir_vfs.to_string()];
+    while let Some(dir) = queue.pop() {
+        let Ok(entries) = fs.list_directory(session_id, &dir).await else {
+            continue;
+        };
+        for entry in entries {
+            if entry.is_directory {
+                queue.push(entry.path.clone());
+            } else {
+                if let Some(rel) = entry.path.strip_prefix(&format!("{dir_vfs}/"))
+                    && rel != "SKILL.md"
+                {
+                    out.push(rel.to_string());
+                }
+                if out.len() >= MAX_EXTRA_SKILL_FILES {
+                    out.sort();
+                    return out;
+                }
+            }
+        }
+    }
+    out.sort();
+    out
+}
+
+// ============================================================================
+// write_skill
+// ============================================================================
+
+fn write_skill_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "scope": { "type": "string", "description": "Writable scope label to install into (e.g. 'workspace' or 'global'). Omit to use the first writable scope." },
+            "name": { "type": "string", "description": "Skill directory name. Must match the SKILL.md frontmatter name." },
+            "skill_md": { "type": "string", "description": "The complete SKILL.md contents, including frontmatter." },
+            "files": {
+                "type": "object",
+                "description": "Optional bundled files keyed by relative path. Do not include SKILL.md here.",
+                "additionalProperties": { "type": "string" }
+            },
+            "overwrite": { "type": "boolean", "description": "Whether to replace an existing skill. Defaults to true." }
+        },
+        "required": ["name", "skill_md"],
+        "additionalProperties": false
+    })
+}
+
+struct WriteSkillTool {
+    config: Arc<SkillsConfig>,
+}
+
+#[async_trait]
+impl Tool for WriteSkillTool {
+    fn name(&self) -> &str {
+        "write_skill"
+    }
+
+    fn display_name(&self) -> Option<&str> {
+        Some("Write Skill")
+    }
+
+    fn description(&self) -> &str {
+        "Install or update a skill in a writable scope. Provide the full SKILL.md \
+         and optional bundled files. Recreates skills from a registry/GitHub \
+         source without requiring an installer."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        write_skill_schema()
+    }
+
+    fn hints(&self) -> ToolHints {
+        ToolHints::default().with_idempotent(true)
+    }
+
+    fn requires_context(&self) -> bool {
+        true
+    }
+
+    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
+        ToolExecutionResult::tool_error("write_skill requires session context.")
+    }
+
+    async fn execute_with_context(
+        &self,
+        arguments: Value,
+        ctx: &ToolContext,
+    ) -> ToolExecutionResult {
+        let Some(name) = arguments.get("name").and_then(|v| v.as_str()) else {
+            return ToolExecutionResult::tool_error("'name' is required");
+        };
+        if let Err(msg) = validate_requested_skill_name(name) {
+            return ToolExecutionResult::tool_error(msg);
+        }
+        let Some(skill_md) = arguments.get("skill_md").and_then(|v| v.as_str()) else {
+            return ToolExecutionResult::tool_error("'skill_md' is required");
+        };
+        if skill_md.len() > MAX_SKILL_FILE_BYTES {
+            return ToolExecutionResult::tool_error(format!(
+                "'skill_md' exceeds the {MAX_SKILL_FILE_BYTES} byte limit"
+            ));
+        }
+
+        let parsed = match parse_skill_md(skill_md) {
+            Ok(parsed) => parsed,
+            Err(errors) => {
+                return ToolExecutionResult::tool_error(format!(
+                    "Invalid SKILL.md: {}",
+                    errors.join(", ")
+                ));
+            }
+        };
+        if parsed.name != name {
+            return ToolExecutionResult::tool_error(format!(
+                "'name' must match SKILL.md frontmatter name (got '{}')",
+                parsed.name
+            ));
+        }
+
+        let requested_label = arguments.get("scope").and_then(|v| v.as_str());
+        // Reject a known-but-non-writable scope explicitly (e.g. a read-only
+        // bundled "system" scope) rather than silently falling through.
+        if let Some(label) = requested_label
+            && let Some(scope) = self.config.scope_by_label(label)
+            && !scope.writable
+        {
+            return ToolExecutionResult::tool_error(format!(
+                "Scope '{label}' is read-only; choose a writable scope"
+            ));
+        }
+        let Some(scope) = self.config.writable_scope(requested_label) else {
+            return ToolExecutionResult::tool_error(match requested_label {
+                Some(label) => format!("No writable scope named '{label}'"),
+                None => "No writable skill scope is configured".to_string(),
+            });
+        };
+
+        let overwrite = arguments
+            .get("overwrite")
+            .and_then(Value::as_bool)
+            .unwrap_or(true);
+        let files = match collect_extra_files(arguments.get("files")) {
+            Ok(files) => files,
+            Err(e) => return ToolExecutionResult::tool_error(e),
+        };
+
+        let fs = match &ctx.file_store {
+            Some(fs) => fs,
+            None => {
+                return ToolExecutionResult::tool_error(
+                    "File store not available. The session_file_system capability is required.",
+                );
+            }
+        };
+
+        let md_path = scope.skill_md_vfs(name);
+        if !overwrite && matches!(fs.read_file(ctx.session_id, &md_path).await, Ok(Some(_))) {
+            return ToolExecutionResult::tool_error(format!(
+                "Skill '{name}' already exists in '{}' scope; pass overwrite=true to update it",
+                scope.label
+            ));
+        }
+
+        if let Err(e) = fs
+            .write_file(ctx.session_id, &md_path, skill_md, "text")
+            .await
+        {
+            return ToolExecutionResult::tool_error(format!("could not write SKILL.md: {e}"));
+        }
+        for (rel, content) in &files {
+            let target = format!("{}/{}", scope.dir_vfs(name), rel.display());
+            if let Err(e) = fs
+                .write_file(ctx.session_id, &target, content, "text")
+                .await
+            {
+                return ToolExecutionResult::tool_error(format!(
+                    "could not write '{}': {e}",
+                    rel.display()
+                ));
+            }
+        }
+
+        let display = self.config.resolver.display_dir(scope, name);
+        ToolExecutionResult::success(json!({
+            "ok": true,
+            "name": name,
+            "scope": scope.label,
+            "path": format!("{display}/SKILL.md"),
+            "files_written": files.len() + 1,
+            "message": "skill written; discoverable immediately via list_skills and activate_skill",
+        }))
+    }
+}
+
+// ============================================================================
+// Validation helpers
+// ============================================================================
+
+fn validate_requested_skill_name(name: &str) -> Result<(), String> {
+    if name.contains("..") || name.contains('/') || name.contains('\\') {
+        return Err(
+            "Invalid skill name. Must be a simple directory name without path separators."
+                .to_string(),
+        );
+    }
+    validate_skill_name(name)
+        .map_err(|errors| format!("Invalid skill name '{name}': {}", errors.join(", ")))
+}
+
+fn collect_extra_files(value: Option<&Value>) -> Result<Vec<(PathBuf, String)>, String> {
+    let Some(value) = value else {
+        return Ok(Vec::new());
+    };
+    let Some(map) = value.as_object() else {
+        return Err("'files' must be an object of relative path to string content".to_string());
+    };
+    if map.len() > MAX_EXTRA_SKILL_FILES {
+        return Err(format!(
+            "'files' contains too many entries (max {MAX_EXTRA_SKILL_FILES})"
+        ));
+    }
+    let mut out = Vec::with_capacity(map.len());
+    for (raw_path, value) in map {
+        let Some(content) = value.as_str() else {
+            return Err(format!("file '{raw_path}' content must be a string"));
+        };
+        if content.len() > MAX_SKILL_FILE_BYTES {
+            return Err(format!(
+                "file '{raw_path}' exceeds the {MAX_SKILL_FILE_BYTES} byte limit"
+            ));
+        }
+        out.push((validate_skill_file_path(raw_path)?, content.to_string()));
+    }
+    Ok(out)
+}
+
+/// Reject absolute paths, traversal, backslashes, and `SKILL.md` itself.
+fn validate_skill_file_path(raw: &str) -> Result<PathBuf, String> {
+    if raw.trim().is_empty() || raw.contains('\\') {
+        return Err(format!("invalid skill file path '{raw}'"));
+    }
+    let path = PathBuf::from(raw);
+    if path == Path::new("SKILL.md") || path.is_absolute() {
+        return Err(format!("invalid skill file path '{raw}'"));
+    }
+    for component in path.components() {
+        if !matches!(component, Component::Normal(_)) {
+            return Err(format!("invalid skill file path '{raw}'"));
+        }
+    }
+    Ok(path)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/capabilities/skills_scoped.rs
+++ b/crates/core/src/capabilities/skills_scoped.rs
@@ -244,8 +244,13 @@ impl Capability for ScopedSkillsCapability {
         let mut prompt = String::from(SCOPED_SKILLS_SYSTEM_PROMPT);
 
         if let Some(file_store) = ctx.file_store.as_ref() {
-            let discovered =
-                discover_skills(&self.config, file_store.as_ref(), ctx.session_id).await;
+            let discovered = discover_skills(
+                &self.config,
+                file_store.as_ref(),
+                ctx.session_id,
+                Some(MAX_SKILLS_SCAN_PER_SCOPE),
+            )
+            .await;
             let visible: Vec<&DiscoveredSkill> = discovered
                 .iter()
                 .filter(|s| s.error.is_none() && !s.disable_model_invocation)
@@ -380,10 +385,15 @@ struct DiscoveredSkill {
 
 /// Discover every unique skill across scopes, in precedence order. The first
 /// occurrence of a directory name wins; later (farther-scope) duplicates drop.
+/// `scan_limit` bounds the number of skill directories read per scope. It is
+/// `Some(MAX_SKILLS_SCAN_PER_SCOPE)` only when building the system prompt (to
+/// bound per-turn reads); `list_skills` passes `None` so the full set is
+/// returned, matching the existing `SkillsCapability` behavior.
 async fn discover_skills(
     config: &SkillsConfig,
     fs: &dyn SessionFileSystem,
     session_id: SessionId,
+    scan_limit: Option<usize>,
 ) -> Vec<DiscoveredSkill> {
     let mut seen = std::collections::HashSet::new();
     let mut out = Vec::new();
@@ -394,7 +404,10 @@ async fn discover_skills(
         };
         let mut dirs: Vec<_> = entries.into_iter().filter(|e| e.is_directory).collect();
         dirs.sort_by(|a, b| a.name.cmp(&b.name));
-        for entry in dirs.into_iter().take(MAX_SKILLS_SCAN_PER_SCOPE) {
+        if let Some(limit) = scan_limit {
+            dirs.truncate(limit);
+        }
+        for entry in dirs {
             if !seen.insert(entry.name.clone()) {
                 continue;
             }
@@ -504,7 +517,9 @@ impl Tool for ListSkillsTool {
                 "File store not available. The session_file_system capability is required.",
             );
         };
-        let discovered = discover_skills(&self.config, fs.as_ref(), ctx.session_id).await;
+        // `list_skills` is uncapped (scan_limit = None); the per-scope scan cap
+        // applies only to system-prompt building.
+        let discovered = discover_skills(&self.config, fs.as_ref(), ctx.session_id, None).await;
         let skills: Vec<Value> = discovered
             .into_iter()
             .map(|s| {

--- a/crates/core/src/capabilities/skills_scoped/tests.rs
+++ b/crates/core/src/capabilities/skills_scoped/tests.rs
@@ -1,0 +1,504 @@
+use super::*;
+use crate::capabilities::Capability;
+use crate::error::Result;
+use crate::session_file::{FileInfo, FileStat, GrepMatch, SessionFile};
+use crate::traits::SessionFileSystem;
+use crate::typed_id::SessionId;
+use std::collections::{HashMap, HashSet};
+use std::sync::Mutex;
+
+// ----------------------------------------------------------------------------
+// In-memory mock file store (files + directories), keyed by VFS path.
+// ----------------------------------------------------------------------------
+
+struct MockFs {
+    files: Mutex<HashMap<(SessionId, String), String>>,
+    dirs: Mutex<HashSet<(SessionId, String)>>,
+}
+
+impl MockFs {
+    fn new() -> Self {
+        Self {
+            files: Mutex::new(HashMap::new()),
+            dirs: Mutex::new(HashSet::new()),
+        }
+    }
+
+    fn add_file(&self, session_id: SessionId, path: &str, content: &str) {
+        self.files
+            .lock()
+            .unwrap()
+            .insert((session_id, path.to_string()), content.to_string());
+        let mut dir = path.to_string();
+        while let Some(idx) = dir.rfind('/') {
+            if idx == 0 {
+                break;
+            }
+            dir = dir[..idx].to_string();
+            self.dirs.lock().unwrap().insert((session_id, dir.clone()));
+        }
+    }
+}
+
+#[async_trait]
+impl SessionFileSystem for MockFs {
+    async fn read_file(&self, session_id: SessionId, path: &str) -> Result<Option<SessionFile>> {
+        let files = self.files.lock().unwrap();
+        Ok(files
+            .get(&(session_id, path.to_string()))
+            .map(|content| session_file(session_id, path, content)))
+    }
+
+    async fn write_file(
+        &self,
+        session_id: SessionId,
+        path: &str,
+        content: &str,
+        _encoding: &str,
+    ) -> Result<SessionFile> {
+        self.add_file(session_id, path, content);
+        Ok(session_file(session_id, path, content))
+    }
+
+    async fn delete_file(
+        &self,
+        _session_id: SessionId,
+        _path: &str,
+        _recursive: bool,
+    ) -> Result<bool> {
+        Ok(false)
+    }
+
+    async fn list_directory(&self, session_id: SessionId, path: &str) -> Result<Vec<FileInfo>> {
+        let files = self.files.lock().unwrap();
+        let dirs = self.dirs.lock().unwrap();
+        let prefix = if path.ends_with('/') {
+            path.to_string()
+        } else {
+            format!("{path}/")
+        };
+        let mut entries = Vec::new();
+        let mut seen = HashSet::new();
+        for ((sid, file_path), content) in files.iter() {
+            if *sid != session_id || !file_path.starts_with(&prefix) {
+                continue;
+            }
+            let remainder = &file_path[prefix.len()..];
+            if !remainder.contains('/') {
+                entries.push(file_info(
+                    session_id,
+                    file_path,
+                    remainder,
+                    false,
+                    content.len(),
+                ));
+            }
+        }
+        for (sid, dir_path) in dirs.iter() {
+            if *sid != session_id || !dir_path.starts_with(&prefix) {
+                continue;
+            }
+            let remainder = &dir_path[prefix.len()..];
+            if !remainder.contains('/') && !remainder.is_empty() && seen.insert(dir_path.clone()) {
+                entries.push(file_info(session_id, dir_path, remainder, true, 0));
+            }
+        }
+        Ok(entries)
+    }
+
+    async fn stat_file(&self, _session_id: SessionId, _path: &str) -> Result<Option<FileStat>> {
+        Ok(None)
+    }
+
+    async fn grep_files(
+        &self,
+        _session_id: SessionId,
+        _pattern: &str,
+        _path_pattern: Option<&str>,
+    ) -> Result<Vec<GrepMatch>> {
+        Ok(vec![])
+    }
+
+    async fn create_directory(&self, session_id: SessionId, path: &str) -> Result<FileInfo> {
+        self.dirs
+            .lock()
+            .unwrap()
+            .insert((session_id, path.to_string()));
+        Ok(file_info(session_id, path, path, true, 0))
+    }
+}
+
+fn session_file(session_id: SessionId, path: &str, content: &str) -> SessionFile {
+    SessionFile {
+        id: uuid::Uuid::new_v4(),
+        session_id: session_id.into(),
+        path: path.to_string(),
+        name: path.split('/').next_back().unwrap_or("").to_string(),
+        is_directory: false,
+        is_readonly: false,
+        content: Some(content.to_string()),
+        encoding: "text".to_string(),
+        size_bytes: content.len() as i64,
+        created_at: chrono::Utc::now(),
+        updated_at: chrono::Utc::now(),
+    }
+}
+
+fn file_info(session_id: SessionId, path: &str, name: &str, is_dir: bool, size: usize) -> FileInfo {
+    FileInfo {
+        id: uuid::Uuid::new_v4(),
+        session_id: session_id.into(),
+        path: path.to_string(),
+        name: name.to_string(),
+        is_directory: is_dir,
+        is_readonly: false,
+        size_bytes: size as i64,
+        created_at: chrono::Utc::now(),
+        updated_at: chrono::Utc::now(),
+    }
+}
+
+fn valid_skill_md(name: &str, desc: &str) -> String {
+    format!("---\nname: {name}\ndescription: {desc}\n---\n\n# Instructions\nDo {name}.")
+}
+
+fn ctx(fs: Arc<MockFs>, session_id: SessionId) -> ToolContext {
+    ToolContext::with_file_store(session_id, fs)
+}
+
+// Two scopes, with `workspace` shadowing `global`.
+fn two_scope_config() -> SkillsConfig {
+    SkillsConfig {
+        scopes: vec![
+            SkillScope::new("workspace", "/.agents/skills", true),
+            SkillScope::new("global", "/.global/skills", true),
+        ],
+        manage_tools: true,
+        ..Default::default()
+    }
+}
+
+// ----------------------------------------------------------------------------
+// Capability metadata / tool gating
+// ----------------------------------------------------------------------------
+
+#[test]
+fn default_config_exposes_two_tools() {
+    let cap = ScopedSkillsCapability::new(SkillsConfig::default());
+    let tools = cap.tools();
+    assert_eq!(tools.len(), 2);
+    assert_eq!(tools[0].name(), "list_skills");
+    assert_eq!(tools[1].name(), "activate_skill");
+    assert_eq!(cap.tool_definitions().len(), 2);
+    assert_eq!(cap.id(), "skills");
+    assert_eq!(cap.dependencies(), vec!["session_file_system"]);
+}
+
+#[test]
+fn manage_tools_adds_read_and_write() {
+    let cap = ScopedSkillsCapability::new(two_scope_config());
+    let tools = cap.tools();
+    let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
+    assert_eq!(tools.len(), 4);
+    assert!(names.contains(&"read_skill"));
+    assert!(names.contains(&"write_skill"));
+    assert_eq!(cap.tool_definitions().len(), 4);
+}
+
+// ----------------------------------------------------------------------------
+// Discovery / list_skills
+// ----------------------------------------------------------------------------
+
+#[tokio::test]
+async fn list_skills_default_scope_uses_workspace_display_path() {
+    let fs = Arc::new(MockFs::new());
+    let sid = SessionId::new();
+    fs.add_file(
+        sid,
+        "/.agents/skills/pdf-tool/SKILL.md",
+        &valid_skill_md("pdf-tool", "Extract text from PDFs"),
+    );
+    let cap = ScopedSkillsCapability::new(SkillsConfig::default());
+    let tool = &cap.tools()[0];
+    let result = tool.execute_with_context(json!({}), &ctx(fs, sid)).await;
+    match result {
+        ToolExecutionResult::Success(val) => {
+            assert_eq!(val["count"], 1);
+            let s = &val["skills"][0];
+            assert_eq!(s["name"], "pdf-tool");
+            assert_eq!(s["scope"], "workspace");
+            assert_eq!(s["path"], "/workspace/.agents/skills/pdf-tool/SKILL.md");
+        }
+        other => panic!("expected success, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn list_skills_merges_scopes_with_precedence() {
+    let fs = Arc::new(MockFs::new());
+    let sid = SessionId::new();
+    // Same dir name in both scopes — workspace must win.
+    fs.add_file(
+        sid,
+        "/.agents/skills/shared/SKILL.md",
+        &valid_skill_md("shared", "workspace copy"),
+    );
+    fs.add_file(
+        sid,
+        "/.global/skills/shared/SKILL.md",
+        &valid_skill_md("shared", "global copy"),
+    );
+    fs.add_file(
+        sid,
+        "/.global/skills/only-global/SKILL.md",
+        &valid_skill_md("only-global", "global only"),
+    );
+
+    let cap = ScopedSkillsCapability::new(two_scope_config());
+    let list = &cap.tools()[0];
+    let result = list.execute_with_context(json!({}), &ctx(fs, sid)).await;
+    let val = match result {
+        ToolExecutionResult::Success(v) => v,
+        other => panic!("expected success, got {other:?}"),
+    };
+    assert_eq!(val["count"], 2);
+    let skills = val["skills"].as_array().unwrap();
+    let shared = skills.iter().find(|s| s["name"] == "shared").unwrap();
+    assert_eq!(shared["scope"], "workspace");
+    assert_eq!(shared["description"], "workspace copy");
+    let og = skills.iter().find(|s| s["name"] == "only-global").unwrap();
+    assert_eq!(og["scope"], "global");
+}
+
+// ----------------------------------------------------------------------------
+// activate_skill
+// ----------------------------------------------------------------------------
+
+#[tokio::test]
+async fn activate_skill_default_resolver_substitutes_vfs_skill_dir() {
+    let fs = Arc::new(MockFs::new());
+    let sid = SessionId::new();
+    fs.add_file(
+        sid,
+        "/.agents/skills/echo/SKILL.md",
+        "---\nname: echo\ndescription: echo dir\n---\nDir is ${SKILL_DIR}.",
+    );
+    let cap = ScopedSkillsCapability::new(SkillsConfig::default());
+    let activate = &cap.tools()[1];
+    let result = activate
+        .execute_with_context(json!({ "name": "echo" }), &ctx(fs, sid))
+        .await;
+    match result {
+        ToolExecutionResult::Success(val) => {
+            assert_eq!(val["skill"], "echo");
+            assert_eq!(val["scope"], "workspace");
+            let instructions = val["instructions"].as_str().unwrap();
+            assert!(instructions.contains("Dir is /.agents/skills/echo."));
+            assert!(instructions.contains("<skill name=\"echo\">"));
+        }
+        other => panic!("expected success, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn activate_skill_custom_resolver_overrides_skill_dir() {
+    struct HostResolver;
+    impl SkillDirResolver for HostResolver {
+        fn skill_dir(&self, scope: &SkillScope, name: &str) -> String {
+            format!("/host/{}/{name}", scope.label)
+        }
+    }
+    let fs = Arc::new(MockFs::new());
+    let sid = SessionId::new();
+    fs.add_file(
+        sid,
+        "/.agents/skills/echo/SKILL.md",
+        "---\nname: echo\ndescription: echo dir\n---\nDir is ${SKILL_DIR}.",
+    );
+    let config = SkillsConfig {
+        resolver: Arc::new(HostResolver),
+        ..Default::default()
+    };
+    let cap = ScopedSkillsCapability::new(config);
+    let activate = &cap.tools()[1];
+    let result = activate
+        .execute_with_context(json!({ "name": "echo" }), &ctx(fs, sid))
+        .await;
+    match result {
+        ToolExecutionResult::Success(val) => {
+            let instructions = val["instructions"].as_str().unwrap();
+            assert!(instructions.contains("Dir is /host/workspace/echo."));
+        }
+        other => panic!("expected success, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn activate_skill_rejects_path_traversal() {
+    let fs = Arc::new(MockFs::new());
+    let sid = SessionId::new();
+    let cap = ScopedSkillsCapability::new(SkillsConfig::default());
+    let activate = &cap.tools()[1];
+    let result = activate
+        .execute_with_context(json!({ "name": "../etc/passwd" }), &ctx(fs, sid))
+        .await;
+    assert!(matches!(result, ToolExecutionResult::ToolError(_)));
+}
+
+#[tokio::test]
+async fn activate_skill_not_found() {
+    let fs = Arc::new(MockFs::new());
+    let sid = SessionId::new();
+    let cap = ScopedSkillsCapability::new(SkillsConfig::default());
+    let activate = &cap.tools()[1];
+    let result = activate
+        .execute_with_context(json!({ "name": "nope" }), &ctx(fs, sid))
+        .await;
+    match result {
+        ToolExecutionResult::ToolError(msg) => assert!(msg.contains("not found")),
+        other => panic!("expected error, got {other:?}"),
+    }
+}
+
+// ----------------------------------------------------------------------------
+// write_skill / read_skill
+// ----------------------------------------------------------------------------
+
+#[tokio::test]
+async fn write_then_discover_and_read_skill() {
+    let fs = Arc::new(MockFs::new());
+    let sid = SessionId::new();
+    let cap = ScopedSkillsCapability::new(two_scope_config());
+    let tools = cap.tools();
+    let write = tools.iter().find(|t| t.name() == "write_skill").unwrap();
+    let read = tools.iter().find(|t| t.name() == "read_skill").unwrap();
+    let list = tools.iter().find(|t| t.name() == "list_skills").unwrap();
+
+    let result = write
+        .execute_with_context(
+            json!({
+                "scope": "global",
+                "name": "greeter",
+                "skill_md": valid_skill_md("greeter", "say hi"),
+                "files": { "data/notes.txt": "hello" }
+            }),
+            &ctx(fs.clone(), sid),
+        )
+        .await;
+    match result {
+        ToolExecutionResult::Success(val) => {
+            assert_eq!(val["ok"], true);
+            assert_eq!(val["scope"], "global");
+            assert_eq!(val["files_written"], 2);
+        }
+        other => panic!("expected success, got {other:?}"),
+    }
+
+    // Discoverable immediately.
+    let listed = list
+        .execute_with_context(json!({}), &ctx(fs.clone(), sid))
+        .await;
+    let val = match listed {
+        ToolExecutionResult::Success(v) => v,
+        other => panic!("expected success, got {other:?}"),
+    };
+    assert_eq!(val["count"], 1);
+    assert_eq!(val["skills"][0]["name"], "greeter");
+
+    // read_skill returns SKILL.md + the bundled file manifest.
+    let read_res = read
+        .execute_with_context(json!({ "name": "greeter" }), &ctx(fs, sid))
+        .await;
+    match read_res {
+        ToolExecutionResult::Success(val) => {
+            assert_eq!(val["scope"], "global");
+            assert!(val["skill_md"].as_str().unwrap().contains("name: greeter"));
+            let files = val["files"].as_array().unwrap();
+            assert_eq!(files.len(), 1);
+            assert_eq!(files[0], "data/notes.txt");
+        }
+        other => panic!("expected success, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn write_skill_rejects_readonly_scope() {
+    let fs = Arc::new(MockFs::new());
+    let sid = SessionId::new();
+    let config = SkillsConfig {
+        scopes: vec![
+            SkillScope::new("workspace", "/.agents/skills", true),
+            SkillScope::new("system", "/.system/skills", false),
+        ],
+        manage_tools: true,
+        ..Default::default()
+    };
+    let cap = ScopedSkillsCapability::new(config);
+    let write = cap
+        .tools()
+        .into_iter()
+        .find(|t| t.name() == "write_skill")
+        .unwrap();
+    let result = write
+        .execute_with_context(
+            json!({
+                "scope": "system",
+                "name": "greeter",
+                "skill_md": valid_skill_md("greeter", "say hi"),
+            }),
+            &ctx(fs, sid),
+        )
+        .await;
+    match result {
+        ToolExecutionResult::ToolError(msg) => assert!(msg.contains("read-only")),
+        other => panic!("expected error, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn write_skill_name_must_match_frontmatter() {
+    let fs = Arc::new(MockFs::new());
+    let sid = SessionId::new();
+    let cap = ScopedSkillsCapability::new(two_scope_config());
+    let write = cap
+        .tools()
+        .into_iter()
+        .find(|t| t.name() == "write_skill")
+        .unwrap();
+    let result = write
+        .execute_with_context(
+            json!({
+                "name": "greeter",
+                "skill_md": valid_skill_md("different", "mismatch"),
+            }),
+            &ctx(fs, sid),
+        )
+        .await;
+    match result {
+        ToolExecutionResult::ToolError(msg) => assert!(msg.contains("must match")),
+        other => panic!("expected error, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn write_skill_rejects_skill_md_in_files() {
+    let fs = Arc::new(MockFs::new());
+    let sid = SessionId::new();
+    let cap = ScopedSkillsCapability::new(two_scope_config());
+    let write = cap
+        .tools()
+        .into_iter()
+        .find(|t| t.name() == "write_skill")
+        .unwrap();
+    let result = write
+        .execute_with_context(
+            json!({
+                "name": "greeter",
+                "skill_md": valid_skill_md("greeter", "hi"),
+                "files": { "SKILL.md": "nope" }
+            }),
+            &ctx(fs, sid),
+        )
+        .await;
+    assert!(matches!(result, ToolExecutionResult::ToolError(_)));
+}

--- a/crates/core/src/capabilities/skills_scoped/tests.rs
+++ b/crates/core/src/capabilities/skills_scoped/tests.rs
@@ -124,7 +124,8 @@ impl SessionFileSystem for MockFs {
             .lock()
             .unwrap()
             .insert((session_id, path.to_string()));
-        Ok(file_info(session_id, path, path, true, 0))
+        let name = path.rsplit('/').next().unwrap_or(path);
+        Ok(file_info(session_id, path, name, true, 0))
     }
 }
 
@@ -268,6 +269,29 @@ async fn list_skills_merges_scopes_with_precedence() {
     assert_eq!(shared["description"], "workspace copy");
     let og = skills.iter().find(|s| s["name"] == "only-global").unwrap();
     assert_eq!(og["scope"], "global");
+}
+
+#[tokio::test]
+async fn list_skills_is_not_capped_by_prompt_scan_limit() {
+    // Regression: discovery is shared with the system prompt (which caps at
+    // MAX_SKILLS_SCAN_PER_SCOPE=64), but list_skills must return the full set.
+    let fs = Arc::new(MockFs::new());
+    let sid = SessionId::new();
+    for i in 0..70 {
+        let name = format!("skill-{i:03}");
+        fs.add_file(
+            sid,
+            &format!("/.agents/skills/{name}/SKILL.md"),
+            &valid_skill_md(&name, "many"),
+        );
+    }
+    let cap = ScopedSkillsCapability::new(SkillsConfig::default());
+    let list = &cap.tools()[0];
+    let result = list.execute_with_context(json!({}), &ctx(fs, sid)).await;
+    match result {
+        ToolExecutionResult::Success(val) => assert_eq!(val["count"], 70),
+        other => panic!("expected success, got {other:?}"),
+    }
 }
 
 // ----------------------------------------------------------------------------

--- a/specs/skills-registry.md
+++ b/specs/skills-registry.md
@@ -651,8 +651,8 @@ filesystem path, and every discovery/read/write goes through the injected
 how each VFS root maps to storage (a sandboxed overlay on the server, a real on-disk
 directory in a single-user CLI) is decided by the file store, not by any configuration
 knob on the capability. There is deliberately no API that accepts a host path. The
-command-injection trust gate is unchanged — `!`cmd`` is never expanded (EVE-388 /
-TM-TOOL-020).
+command-injection trust gate is unchanged — `` !`cmd` `` is never expanded
+(EVE-388 / TM-TOOL-020).
 
 ## Example Skills
 

--- a/specs/skills-registry.md
+++ b/specs/skills-registry.md
@@ -623,6 +623,37 @@ Skills can also be discovered from the session filesystem at `/.agents/skills/`.
 
 A third source — **capability-contributed skills** — also feeds this pipeline. Any `Capability` can ship skills in code via `contribute_skills()` (see `specs/capabilities.md`); those contributions mount at the same `/.agents/skills/{name}/` path and are served through the same `skills` capability. They are per-session (scoped to the contributing capability's activation) and best for bundling a reusable workflow with the capability that powers it — e.g., a `gpt_image_gen` capability shipping a "prompt an image" skill alongside its tools.
 
+### Multi-Scope Discovery (`ScopedSkillsCapability`)
+
+The default `SkillsCapability` scans the single `/.agents/skills/` root and exposes
+`list_skills` + `activate_skill`. Embedders that need **multiple labeled skill
+sources** — for example a terminal coding agent with workspace, per-user *global*,
+and binary-bundled *system* scopes — can register `ScopedSkillsCapability` instead.
+It takes a `SkillsConfig`:
+
+- **`scopes`** — an ordered list of `SkillScope { label, vfs_root, writable }`, highest
+  precedence first. Discovery merges all scopes and de-duplicates by skill directory
+  name, so a nearer scope shadows a farther one. Each `list_skills` entry is tagged
+  with its scope.
+- **`resolver`** — a `SkillDirResolver` that produces the `${SKILL_DIR}` value and the
+  agent-facing display path. The default keeps both in the VFS namespace; an embedder
+  whose shell runs in a different namespace (e.g. a CLI whose `bash` runs on the host)
+  overrides it to return a path valid there. This is the seam that lets `${SKILL_DIR}`
+  and the discovery file store stay namespace-consistent.
+- **`manage_tools`** — when set, additionally exposes `read_skill` and `write_skill`.
+  `write_skill` installs/updates a skill in a **writable** scope (system/bundled scopes
+  are read-only), validating the name, matching the frontmatter `name`, bounding extra
+  files, and rejecting path traversal and `SKILL.md` overrides.
+
+**Sources are VFS-bound by construction.** A scope is a *labeled VFS root*, never a host
+filesystem path, and every discovery/read/write goes through the injected
+`SessionFileSystem`. The capability therefore cannot be pointed outside the session VFS:
+how each VFS root maps to storage (a sandboxed overlay on the server, a real on-disk
+directory in a single-user CLI) is decided by the file store, not by any configuration
+knob on the capability. There is deliberately no API that accepts a host path. The
+command-injection trust gate is unchanged — `!`cmd`` is never expanded (EVE-388 /
+TM-TOOL-020).
+
 ## Example Skills
 
 Example skills are provided in `examples/skills/`:


### PR DESCRIPTION
## What

Adds `ScopedSkillsCapability`, a configurable, VFS-bound alternative to the single-path `SkillsCapability`. Embedders that need **multiple labeled skill sources** (e.g. a terminal coding agent with workspace, per-user *global*, and binary-bundled *system* scopes) construct it with a `SkillsConfig`:

- **`scopes`** — ordered `SkillScope { label, vfs_root, writable }`, highest precedence first. Discovery merges all scopes and de-duplicates by skill directory name (nearer scope shadows farther); each `list_skills` entry is scope-tagged.
- **`resolver`** (`SkillDirResolver`) — produces the `${SKILL_DIR}` value and display path in the namespace where the skill's shell actually runs. Default keeps everything in the VFS; an embedder whose shell runs elsewhere (e.g. a CLI whose `bash` runs on the host) overrides it. This is the seam that keeps `${SKILL_DIR}` and the discovery file store namespace-consistent.
- **`manage_tools`** — opt-in `read_skill` / `write_skill`. Writes target a **writable** scope (system/bundled scopes stay read-only) with name, frontmatter-match, traversal, `SKILL.md`-override, and file-bound validation.

## Why

Downstream embedders (e.g. the `coding-cli` example / the `yolop` fork) currently have to vendor the skills capability to get multi-scope discovery, skill management, and host-namespace `${SKILL_DIR}` resolution. This lifts that into core so the vendoring can be retired, without changing the default.

## Security — sources are VFS-bound by construction

A scope is a *labeled VFS root*, never a host filesystem path, and every discovery/read/write flows through the injected `SessionFileSystem`. How each VFS root maps to storage (a sandboxed overlay on the server; a real on-disk dir in a single-user CLI) is the file store's concern, **not a capability config knob** — so the capability can never be pointed outside the session VFS. There is deliberately no API that accepts a host path. The command-injection trust gate is unchanged: `` !`cmd` `` is never expanded (EVE-388 / TM-TOOL-020).

## Scope / blast radius

Purely **additive** — the existing `SkillsCapability`, its tests, the default builtin, and all current consumers (server, `coding-cli`) are untouched. New public types are re-exported from `everruns_core::capabilities`. A short subsection was added to `specs/skills-registry.md`.

## Tests

- `cargo build -p everruns-core` ✅
- `cargo test -p everruns-core --lib skills` → **71 passed** (12 new + 27 existing) ✅
- `cargo clippy -p everruns-core --all-targets --all-features -- -D warnings` ✅