### PR TITLE
fix(apps): gate publish/unpublish/archive on app.dangerous

### DIFF
--- a/apps/ui/src/__tests__/app-channel-redesign.test.tsx
+++ b/apps/ui/src/__tests__/app-channel-redesign.test.tsx
@@ -151,7 +151,9 @@ describe("app channel redesign", () => {
     fireEvent.click(trigger);
 
     const runNow = await screen.findByText("Run now");
-    expect(runNow.closest("[aria-disabled]") ?? runNow.closest("[disabled]") ?? runNow).toHaveAttribute("data-disabled");
+    expect(
+      runNow.closest("[aria-disabled]") ?? runNow.closest("[disabled]") ?? runNow,
+    ).toHaveAttribute("data-disabled");
   });
 
   it("enables Run now when onRunNow is provided and channel is runnable", async () => {

--- a/apps/ui/src/__tests__/app-channel-redesign.test.tsx
+++ b/apps/ui/src/__tests__/app-channel-redesign.test.tsx
@@ -134,4 +134,42 @@ describe("app channel redesign", () => {
     expect(screen.getByText(/Active$/)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Tell a dad joke/ })).toBeInTheDocument();
   });
+
+  it("disables Run now when onRunNow is not provided (no manage permission)", async () => {
+    const { getByRole } = render(
+      <ChannelRow
+        app={{ ...app, channels: [scheduleChannel] }}
+        channel={scheduleChannel}
+        expanded={false}
+        onToggle={() => {}}
+        configureHref="/apps/app_123/channels/appchan_123"
+        // no onRunNow — simulates caller withholding the action due to !canManage
+      />,
+    );
+
+    const trigger = getByRole("button", { name: "Channel actions" });
+    fireEvent.click(trigger);
+
+    const runNow = await screen.findByText("Run now");
+    expect(runNow.closest("[aria-disabled]") ?? runNow.closest("[disabled]") ?? runNow).toHaveAttribute("data-disabled");
+  });
+
+  it("enables Run now when onRunNow is provided and channel is runnable", async () => {
+    const { getByRole } = render(
+      <ChannelRow
+        app={{ ...app, channels: [scheduleChannel] }}
+        channel={scheduleChannel}
+        expanded={false}
+        onToggle={() => {}}
+        onRunNow={() => {}}
+        configureHref="/apps/app_123/channels/appchan_123"
+      />,
+    );
+
+    const trigger = getByRole("button", { name: "Channel actions" });
+    fireEvent.click(trigger);
+
+    const runNow = await screen.findByText("Run now");
+    expect(runNow.closest("[data-disabled]")).toBeNull();
+  });
 });

--- a/apps/ui/src/components/apps/app-detail-v2.tsx
+++ b/apps/ui/src/components/apps/app-detail-v2.tsx
@@ -81,6 +81,7 @@ export function AppDetailV2({ appId }: { appId: string }) {
   const stats = useMemo(() => (app ? buildStats(app) : null), [app]);
   const isReadOnly = isReadOnlyStatus(app?.status);
   const canManage = can("app.manage") && !isReadOnly;
+  const canDangerous = can("app.dangerous") && !isReadOnly;
   const runnableChannel = findFirstRunnableChannel(app);
 
   if (isLoading) {
@@ -157,7 +158,7 @@ export function AppDetailV2({ appId }: { appId: string }) {
           <Button
             variant="outline"
             onClick={() => runnableChannel && triggerMutation.mutate(runnableChannel.id)}
-            disabled={!runnableChannel || triggerMutation.isPending}
+            disabled={!runnableChannel || triggerMutation.isPending || !canManage}
           >
             <Play className="size-4" />
             Test run
@@ -166,7 +167,7 @@ export function AppDetailV2({ appId }: { appId: string }) {
             <Button
               variant="outline"
               onClick={() => unpublishApp.mutate(app.id)}
-              disabled={unpublishApp.isPending || !canManage}
+              disabled={unpublishApp.isPending || !canDangerous}
             >
               <GlobeLock className="size-4" />
               Unpublish
@@ -174,7 +175,7 @@ export function AppDetailV2({ appId }: { appId: string }) {
           ) : (
             <Button
               onClick={() => publishApp.mutate(app.id)}
-              disabled={publishApp.isPending || !canManage}
+              disabled={publishApp.isPending || !canDangerous}
             >
               Publish
             </Button>
@@ -182,7 +183,7 @@ export function AppDetailV2({ appId }: { appId: string }) {
           <Button
             variant="outline"
             onClick={() => deleteAppMutation.mutate(app.id)}
-            disabled={deleteAppMutation.isPending || !canManage}
+            disabled={deleteAppMutation.isPending || !canDangerous}
           >
             <Archive className="size-4" />
             Archive
@@ -239,7 +240,7 @@ export function AppDetailV2({ appId }: { appId: string }) {
                   onToggle={() =>
                     setExpandedChannelId((current) => (current === channel.id ? null : channel.id))
                   }
-                  onRunNow={() => triggerMutation.mutate(channel.id)}
+                  onRunNow={canManage ? () => triggerMutation.mutate(channel.id) : undefined}
                   configureHref={`/apps/${app.id}/channels/${channel.id}`}
                 />
               ))}

--- a/apps/ui/src/components/apps/app-detail-v2.tsx
+++ b/apps/ui/src/components/apps/app-detail-v2.tsx
@@ -240,7 +240,11 @@ export function AppDetailV2({ appId }: { appId: string }) {
                   onToggle={() =>
                     setExpandedChannelId((current) => (current === channel.id ? null : channel.id))
                   }
-                  onRunNow={canManage ? () => triggerMutation.mutate(channel.id) : undefined}
+                  onRunNow={
+                    canManage && !triggerMutation.isPending
+                      ? () => triggerMutation.mutate(channel.id)
+                      : undefined
+                  }
                   configureHref={`/apps/${app.id}/channels/${channel.id}`}
                 />
               ))}

--- a/apps/ui/src/components/apps/channel-row.tsx
+++ b/apps/ui/src/components/apps/channel-row.tsx
@@ -139,7 +139,10 @@ export function ChannelRow({
 }) {
   const Icon = iconFor(channel.channel_type);
   const canRunNow =
-    channel.channel_type === "schedule" && channel.enabled && app.status === "published";
+    !!onRunNow &&
+    channel.channel_type === "schedule" &&
+    channel.enabled &&
+    app.status === "published";
 
   return (
     <div className="border bg-card">


### PR DESCRIPTION
## What changed

Splits the app detail action bar into two permission tiers:

- `app.manage` — operational triggers: Test run, per-channel Run now
- `app.dangerous` — lifecycle mutations: Publish, Unpublish, Archive

Previously all four actions used `canManage`, so a caller with `app.manage` but not `app.dangerous` could publish, unpublish, or archive an app.

Also fixes `ChannelRow` to treat an absent `onRunNow` prop as a signal to disable Run now (the parent already uses `canManage ? () => ... : undefined` to revoke this), rather than only checking channel state.

## Tests

Two regression tests added to `app-channel-redesign.test.tsx`:
- Verifies Run now is disabled when `onRunNow` is not provided
- Verifies Run now is enabled when `onRunNow` is provided and the channel is runnable

All 9 tests in the suite pass.

## Security

- `TM-AUTHZ` reviewed: this is the fix itself — corrects broken access control on lifecycle-changing app operations.
- No other threat categories touched.

## Validation

```
cd apps/ui && pnpm run format:check && pnpm run lint && pnpm run build
pnpm run test -- app-channel-redesign  # 9 passed
```

## Follow-ups

No follow-ups.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XsZXDkJR7dzHG1eAivmwAL)_