### PR TITLE
fix(chat): validate MCP card URI, size, and tool provenance before rendering

### DIFF
--- a/apps/ui/jest.setup.js
+++ b/apps/ui/jest.setup.js
@@ -1,1 +1,6 @@
 import "@testing-library/jest-dom";
+
+// jsdom does not expose TextEncoder/TextDecoder from Node's util module.
+// Polyfill them so code using the Encoding API works in tests.
+import { TextDecoder, TextEncoder } from "util";
+Object.assign(global, { TextDecoder, TextEncoder });

--- a/apps/ui/src/__tests__/tool-call-utils.test.ts
+++ b/apps/ui/src/__tests__/tool-call-utils.test.ts
@@ -167,11 +167,22 @@ describe("tool-call-utils MCP App resources", () => {
       },
     ];
 
+    const expected: McpAppResource[] = [
+      { uri: "ui://everruns/agent/agent_01/card", mimeType: "text/html", html },
+    ];
+
+    // First-party and Everruns-prefixed MCP tools are accepted.
+    expect(extractMcpAppResources(result, "agent_get_card")).toEqual(expected);
+    expect(extractMcpAppResources(result, "mcp_everruns__agent_get_card")).toEqual(expected);
+
     // Generic remote MCP tool or no tool name — must be rejected.
     expect(extractMcpAppResources(result, "some_remote_tool")).toEqual([]);
     expect(extractMcpAppResources(result, "get_agent")).toEqual([]);
     expect(extractMcpAppResources(result, undefined)).toEqual([]);
     expect(extractMcpAppResources(result)).toEqual([]);
+    // Non-everruns MCP server ending in _get_card is rejected.
+    expect(extractMcpAppResources(result, "mcp_evil__agent_get_card")).toEqual([]);
+    expect(extractMcpAppResources(result, "mcp_other__agent_get_card")).toEqual([]);
   });
 
   it("rejects ui://everruns URIs that don't match the strict entity/id/card pattern", () => {

--- a/apps/ui/src/__tests__/tool-call-utils.test.ts
+++ b/apps/ui/src/__tests__/tool-call-utils.test.ts
@@ -26,7 +26,7 @@ describe("tool-call-utils MCP App resources", () => {
       },
     ];
 
-    expect(extractMcpAppResources(result)).toEqual<McpAppResource[]>([
+    expect(extractMcpAppResources(result, "agent_get_card")).toEqual<McpAppResource[]>([
       {
         uri: "ui://everruns/agent/agent_01/card",
         mimeType: "text/html",
@@ -49,7 +49,7 @@ describe("tool-call-utils MCP App resources", () => {
       },
     ];
 
-    expect(extractMcpAppResources(result)).toEqual([
+    expect(extractMcpAppResources(result, "agent_get_card")).toEqual([
       {
         uri: "ui://everruns/agent/agent_01/card",
         mimeType: "text/html",
@@ -69,7 +69,7 @@ describe("tool-call-utils MCP App resources", () => {
       },
     ];
 
-    expect(extractMcpAppResources(result)).toEqual([
+    expect(extractMcpAppResources(result, "agent_get_card")).toEqual([
       {
         uri: "ui://everruns/agent/agent_01/card",
         mimeType: "text/html",
@@ -113,7 +113,7 @@ describe("tool-call-utils MCP App resources", () => {
       },
     ];
 
-    expect(extractMcpAppResources(result)).toEqual([]);
+    expect(extractMcpAppResources(result, "agent_get_card")).toEqual([]);
   });
 
   it("ignores non-ui and non-html resources", () => {
@@ -139,7 +139,7 @@ describe("tool-call-utils MCP App resources", () => {
       },
     ];
 
-    expect(extractMcpAppResources(result)).toEqual([]);
+    expect(extractMcpAppResources(result, "agent_get_card")).toEqual([]);
     expect(getFullText(result)).toBe("");
   });
 
@@ -147,6 +147,77 @@ describe("tool-call-utils MCP App resources", () => {
     const text = `${"x".repeat(512 * 1024 + 1)}{"content":[]}`;
 
     expect(getFullText([{ type: "text", text }])).toBe(text);
-    expect(extractMcpAppResources([{ type: "text", text }])).toEqual([]);
+    expect(extractMcpAppResources([{ type: "text", text }], "agent_get_card")).toEqual([]);
+  });
+
+  it("rejects forged ui://everruns card from a non-get_card tool name", () => {
+    const result: ContentPart[] = [
+      {
+        type: "text",
+        text: JSON.stringify({
+          content: [
+            {
+              type: "resource",
+              uri: "ui://everruns/agent/agent_01/card",
+              mime_type: "text/html",
+              text: html,
+            },
+          ],
+        }),
+      },
+    ];
+
+    // Generic remote MCP tool or no tool name — must be rejected.
+    expect(extractMcpAppResources(result, "some_remote_tool")).toEqual([]);
+    expect(extractMcpAppResources(result, "get_agent")).toEqual([]);
+    expect(extractMcpAppResources(result, undefined)).toEqual([]);
+    expect(extractMcpAppResources(result)).toEqual([]);
+  });
+
+  it("rejects ui://everruns URIs that don't match the strict entity/id/card pattern", () => {
+    const makeResult = (uri: string): ContentPart[] => [
+      {
+        type: "resource",
+        uri,
+        mimeType: "text/html",
+        text: html,
+      },
+    ];
+
+    // Bare prefix only
+    expect(extractMcpAppResources(makeResult("ui://everruns/"), "agent_get_card")).toEqual([]);
+    // Missing /card suffix
+    expect(
+      extractMcpAppResources(makeResult("ui://everruns/agent/agent_01"), "agent_get_card"),
+    ).toEqual([]);
+    // Extra path segments after /card
+    expect(
+      extractMcpAppResources(
+        makeResult("ui://everruns/agent/agent_01/card/extra"),
+        "agent_get_card",
+      ),
+    ).toEqual([]);
+    // ID too short (< 2 chars)
+    expect(
+      extractMcpAppResources(makeResult("ui://everruns/agent/x/card"), "agent_get_card"),
+    ).toEqual([]);
+    // Query string injection
+    expect(
+      extractMcpAppResources(makeResult("ui://everruns/agent/agent_01/card?x=1"), "agent_get_card"),
+    ).toEqual([]);
+  });
+
+  it("rejects HTML exceeding the 64 KiB card size limit", () => {
+    const oversized = "x".repeat(64 * 1024 + 1);
+    const result: ContentPart[] = [
+      {
+        type: "resource",
+        uri: "ui://everruns/agent/agent_01/card",
+        mimeType: "text/html",
+        text: oversized,
+      },
+    ];
+
+    expect(extractMcpAppResources(result, "agent_get_card")).toEqual([]);
   });
 });

--- a/apps/ui/src/components/chat/tool-activity-row.tsx
+++ b/apps/ui/src/components/chat/tool-activity-row.tsx
@@ -36,7 +36,7 @@ export function ToolActivityRow({
   const { t } = useLocale();
   const [isExpanded, setIsExpanded] = useState(false);
   const fullText = getFullText(toolResult?.result);
-  const mcpAppResources = extractMcpAppResources(toolResult?.result);
+  const mcpAppResources = extractMcpAppResources(toolResult?.result, toolCall.name);
   const detailsId = `tool-activity-details-${toolCall.id}`;
   const hasOutput = fullText.length > 0;
   const hasToolError = Boolean(toolResult?.error);

--- a/apps/ui/src/components/chat/tool-activity-timeline-group.tsx
+++ b/apps/ui/src/components/chat/tool-activity-timeline-group.tsx
@@ -40,7 +40,7 @@ function TimelineRow({ row }: { row: TimelineToolRow }) {
         getFullText(row.result.result),
       )
     : "";
-  const mcpAppResources = extractMcpAppResources(row.result?.result);
+  const mcpAppResources = extractMcpAppResources(row.result?.result, row.result?.tool_name);
   const preview = resultPreview(row.result);
   const hasDetails = fullText.length > 0;
 

--- a/apps/ui/src/components/chat/tool-call-card-from-event.tsx
+++ b/apps/ui/src/components/chat/tool-call-card-from-event.tsx
@@ -86,7 +86,7 @@ export function ToolCallCardFromEvent({
 
   const fullText = toolResult?.result ? getFullText(toolResult.result) : "";
   const hasOutput = fullText.length > 0;
-  const mcpAppResources = extractMcpAppResources(toolResult?.result);
+  const mcpAppResources = extractMcpAppResources(toolResult?.result, toolCall.name);
 
   return (
     <div className="text-xs text-muted-foreground/70">

--- a/apps/ui/src/components/chat/tool-call-utils.ts
+++ b/apps/ui/src/components/chat/tool-call-utils.ts
@@ -32,6 +32,10 @@ export interface McpAppResource {
 }
 
 const MCP_CONTENT_WRAPPER_PARSE_LIMIT = 512 * 1024;
+const MCP_CARD_HTML_MAX_BYTES = 64 * 1024;
+// Validates ui://everruns/{entity}/{id}/card — entity is kebab-case, id is
+// prefixed alphanumeric. Rejects bare prefix matches and forged authorities.
+const MCP_CARD_URI_RE = /^ui:\/\/everruns\/[a-z][a-z-]*\/[A-Za-z0-9_-]{2,}\/card$/;
 
 /**
  * Extract tool call content from ContentPart array
@@ -125,8 +129,16 @@ export function formatResult(result: unknown): string {
   return typeof result === "string" ? result : JSON.stringify(result, null, 2);
 }
 
-export function extractMcpAppResources(result: ContentPart[] | undefined): McpAppResource[] {
+/**
+ * toolName must end with `_get_card` to accept any ui://everruns card resources.
+ * Callers that cannot supply a tool name pass undefined, which rejects all cards.
+ */
+export function extractMcpAppResources(
+  result: ContentPart[] | undefined,
+  toolName?: string,
+): McpAppResource[] {
   if (!result || result.length === 0) return [];
+  if (!toolName?.endsWith("_get_card")) return [];
 
   return result.flatMap((part) => {
     if (part.type === "text") {
@@ -189,9 +201,9 @@ function normalizeMcpAppResource(value: unknown): McpAppResource[] {
         ? value.text
         : undefined;
 
-  if (!uri?.startsWith("ui://everruns/")) return [];
+  if (!uri || !MCP_CARD_URI_RE.test(uri)) return [];
   if (mimeType?.toLowerCase() !== "text/html") return [];
-  if (!html) return [];
+  if (!html || html.length > MCP_CARD_HTML_MAX_BYTES) return [];
 
   return [{ uri, mimeType, html }];
 }

--- a/apps/ui/src/components/chat/tool-call-utils.ts
+++ b/apps/ui/src/components/chat/tool-call-utils.ts
@@ -33,9 +33,14 @@ export interface McpAppResource {
 
 const MCP_CONTENT_WRAPPER_PARSE_LIMIT = 512 * 1024;
 const MCP_CARD_HTML_MAX_BYTES = 64 * 1024;
-// Validates ui://everruns/{entity}/{id}/card — entity is kebab-case, id is
-// prefixed alphanumeric. Rejects bare prefix matches and forged authorities.
-const MCP_CARD_URI_RE = /^ui:\/\/everruns\/[a-z][a-z-]*\/[A-Za-z0-9_-]{2,}\/card$/;
+// Validates ui://everruns/{entity}/{id}/card — entity is kebab-case, id starts
+// with a lowercase alphanumeric char. Rejects uppercase, leading separators,
+// single-char IDs, and forged authorities.
+const MCP_CARD_URI_RE = /^ui:\/\/everruns\/[a-z][a-z-]*\/[a-z0-9][a-z0-9_-]+\/card$/;
+// Accepts first-party card tools (no mcp_ prefix, e.g. agent_get_card) or
+// Everruns' own MCP server tools (mcp_everruns__<entity>_get_card).
+// External servers that happen to name a tool *_get_card are rejected.
+const MCP_CARD_TOOL_RE = /^(?:[a-z]+_get_card|mcp_everruns__[a-z]+_get_card)$/;
 
 /**
  * Extract tool call content from ContentPart array
@@ -130,7 +135,7 @@ export function formatResult(result: unknown): string {
 }
 
 /**
- * toolName must end with `_get_card` to accept any ui://everruns card resources.
+ * toolName must be a first-party `<entity>_get_card` or `mcp_everruns__<entity>_get_card`.
  * Callers that cannot supply a tool name pass undefined, which rejects all cards.
  */
 export function extractMcpAppResources(
@@ -138,7 +143,7 @@ export function extractMcpAppResources(
   toolName?: string,
 ): McpAppResource[] {
   if (!result || result.length === 0) return [];
-  if (!toolName?.endsWith("_get_card")) return [];
+  if (!toolName || !MCP_CARD_TOOL_RE.test(toolName)) return [];
 
   return result.flatMap((part) => {
     if (part.type === "text") {
@@ -203,7 +208,7 @@ function normalizeMcpAppResource(value: unknown): McpAppResource[] {
 
   if (!uri || !MCP_CARD_URI_RE.test(uri)) return [];
   if (mimeType?.toLowerCase() !== "text/html") return [];
-  if (!html || html.length > MCP_CARD_HTML_MAX_BYTES) return [];
+  if (!html || new TextEncoder().encode(html).length > MCP_CARD_HTML_MAX_BYTES) return [];
 
   return [{ uri, mimeType, html }];
 }


### PR DESCRIPTION
## What changed

Adds three host-side guards to `extractMcpAppResources` in `tool-call-utils.ts` so that arbitrary tool results from remote MCP servers cannot masquerade as trusted Everruns MCP card HTML.

**Before:** `normalizeMcpAppResource` accepted any resource whose URI started with `ui://everruns/` regardless of tool name, URI structure, or HTML size.

**After:**

1. **Strict URI regex** — `ui://everruns/{entity}/{id}/card` must match exactly. Bare prefix (`ui://everruns/`), missing `/card` suffix, extra path segments, short IDs, and query strings are all rejected.
2. **64 KiB HTML cap** — HTML exceeding the spec contract (`MAX_CARD_BYTES` in the Rust renderer) is rejected before reaching the iframe.
3. **Tool name allowlist** — `extractMcpAppResources` now accepts a `toolName` parameter; only tool names ending with `_get_card` produce card resources. All three call sites pass `toolCall.name` / `toolResult.tool_name`. Generic remote tools, absent tool names, and non-card tool names return an empty result.

## Security

- `TM-WEB` reviewed: this is the fix — closes the forged-card injection path identified in EVE-553.
- `TM-TOOL` reviewed: tool name allowlist ensures only first-party `*_get_card` tools can produce card HTML.
- No new network surface; the iframe sandbox model (`allow-scripts` only, no `allow-same-origin`) is unchanged.

## Tests

Updated all existing tests to pass a `toolName` and added:
- Forged card from non-`_get_card` tool (generic remote tool, `get_agent`, `undefined`, no arg) → all rejected
- Malformed URIs: bare prefix, missing `/card`, extra segments, single-char ID, query string → all rejected
- HTML exceeding 64 KiB → rejected

All 9 tests pass.

## Validation

```
pnpm run format:check && pnpm run lint && pnpm run build
pnpm run test -- tool-call-utils  # 9 passed
```

## Follow-ups

No follow-ups.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XsZXDkJR7dzHG1eAivmwAL)_