### PR TITLE
fix(ui): encode workspace path segments to prevent URL delimiter injection

### DIFF
--- a/apps/ui/src/__tests__/session-files.test.ts
+++ b/apps/ui/src/__tests__/session-files.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Regression tests for EVE-558 / EVE-555: workspace paths with URL delimiter
+ * characters must be encoded before they are appended to URLs so that `?`, `#`,
+ * and `%` in filenames are treated as literal bytes and do not alter the HTTP
+ * method, query string, or fragment.
+ */
+
+import { listFiles, readFile, deleteFile } from "@/lib/api/session-files";
+import { api } from "@/lib/api/client";
+
+jest.mock("@/lib/api/client", () => ({
+  api: {
+    get: jest.fn(),
+    post: jest.fn(),
+    put: jest.fn(),
+    delete: jest.fn(),
+  },
+}));
+
+const mockedApi = api as jest.Mocked<typeof api>;
+
+const SESSION_ID = "session_5c7f3a91b24e48d6a0e91f3b7c4d2e85";
+// Derived workspace ID — same hex suffix, different prefix.
+const WSP_ID = "wsp_5c7f3a91b24e48d6a0e91f3b7c4d2e85";
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("fsPath encoding (EVE-558 / EVE-555)", () => {
+  it("encodes ? in a filename so it is not treated as a query delimiter", async () => {
+    mockedApi.get.mockResolvedValueOnce({ data: { data: [] } });
+    await listFiles(SESSION_ID, "/dir?recursive=true");
+    expect(mockedApi.get).toHaveBeenCalledWith(
+      `/v1/workspaces/${WSP_ID}/fs/dir%3Frecursive%3Dtrue`,
+    );
+  });
+
+  it("encodes # in a filename so it is not treated as a fragment delimiter", async () => {
+    mockedApi.get.mockResolvedValueOnce({ data: {} });
+    await readFile(SESSION_ID, "/notes#section");
+    expect(mockedApi.get).toHaveBeenCalledWith(`/v1/workspaces/${WSP_ID}/fs/notes%23section`);
+  });
+
+  it("encodes % in a filename so pre-encoded sequences are not double-decoded", async () => {
+    mockedApi.get.mockResolvedValueOnce({ data: {} });
+    await readFile(SESSION_ID, "/file%20name.txt");
+    expect(mockedApi.get).toHaveBeenCalledWith(`/v1/workspaces/${WSP_ID}/fs/file%2520name.txt`);
+  });
+
+  it("preserves directory structure while encoding each segment independently", async () => {
+    mockedApi.get.mockResolvedValueOnce({ data: {} });
+    await readFile(SESSION_ID, "/a?b/c#d/e%f");
+    expect(mockedApi.get).toHaveBeenCalledWith(`/v1/workspaces/${WSP_ID}/fs/a%3Fb/c%23d/e%25f`);
+  });
+
+  it("root path produces bare fs base URL without trailing slash", async () => {
+    mockedApi.get.mockResolvedValueOnce({ data: { data: [] } });
+    await listFiles(SESSION_ID, "/");
+    expect(mockedApi.get).toHaveBeenCalledWith(`/v1/workspaces/${WSP_ID}/fs`);
+  });
+
+  it("recursive=true is appended as a separate query param after the encoded path", async () => {
+    mockedApi.get.mockResolvedValueOnce({ data: { data: [] } });
+    await listFiles(SESSION_ID, "/dir?x=1", true);
+    const url = mockedApi.get.mock.calls[0][0] as string;
+    // Path segment is encoded; recursive flag is a distinct query param.
+    expect(url).toMatch(/\/dir%3Fx%3D1\?recursive=true$/);
+  });
+
+  it("delete with recursive=true encodes path and appends query param correctly", async () => {
+    mockedApi.delete.mockResolvedValueOnce({ data: { deleted: true } });
+    await deleteFile(SESSION_ID, "/tmp?dir", true);
+    const url = mockedApi.delete.mock.calls[0][0] as string;
+    expect(url).toBe(`/v1/workspaces/${WSP_ID}/fs/tmp%3Fdir?recursive=true`);
+  });
+});

--- a/apps/ui/src/lib/api/session-files.ts
+++ b/apps/ui/src/lib/api/session-files.ts
@@ -33,12 +33,17 @@ function workspaceIdFromSessionId(sessionId: string): string {
 }
 
 // Base path for the workspace filesystem.
+// Each path segment is percent-encoded so that URL delimiter characters
+// (?, #, %) in workspace filenames are treated as literal bytes, not as
+// query-string or fragment delimiters. E.g. a file named "foo?x=1" becomes
+// "foo%3Fx%3D1" in the URL and reaches the server as a literal path.
 function fsPath(sessionId: string, path?: string): string {
   const workspaceId = workspaceIdFromSessionId(sessionId);
   const base = `/v1/workspaces/${workspaceId}/fs`;
   if (!path || path === "/") return base;
   const normalizedPath = path.startsWith("/") ? path.slice(1) : path;
-  return `${base}/${normalizedPath}`;
+  const encodedPath = normalizedPath.split("/").map(encodeURIComponent).join("/");
+  return `${base}/${encodedPath}`;
 }
 
 function actionPath(sessionId: string, action: string): string {
@@ -62,7 +67,8 @@ export async function listFiles(
   path: string = "/",
   recursive: boolean = false,
 ): Promise<FileInfo[]> {
-  const url = recursive ? `${fsPath(sessionId, path)}?recursive=true` : fsPath(sessionId, path);
+  const base = fsPath(sessionId, path);
+  const url = recursive ? `${base}?${new URLSearchParams({ recursive: "true" })}` : base;
   const response = await api.get<ListResponse<FileInfo>>(url);
   return response.data.data;
 }
@@ -105,7 +111,8 @@ export async function deleteFile(
   path: string,
   recursive: boolean = false,
 ): Promise<boolean> {
-  const url = recursive ? `${fsPath(sessionId, path)}?recursive=true` : fsPath(sessionId, path);
+  const base = fsPath(sessionId, path);
+  const url = recursive ? `${base}?${new URLSearchParams({ recursive: "true" })}` : base;
   const response = await api.delete<DeleteFileResponse>(url);
   return response.data.deleted;
 }


### PR DESCRIPTION
## What

Percent-encode each workspace path segment before appending it to API URLs in `session-files.ts`. Also separate query parameters (`recursive=true`) from the path via `URLSearchParams`.

## Why

`fsPath()` concatenated raw file paths directly into URLs. A workspace file whose name contains URL delimiter characters (`?`, `#`, `%`) would cause the browser to misinterpret the URL:

- Deleting `/dir?recursive=true` with `recursive=false` would send `DELETE /v1/workspaces/{id}/fs/dir?recursive=true` — triggering a recursive delete instead of a no-op.
- A path containing `#` would be silently truncated at the fragment delimiter.

Fixes EVE-558 and EVE-555.

## How

- `fsPath`: split the path on `/`, run `encodeURIComponent` over every segment, rejoin. The workspace ID itself (`wsp_…`) is never user-controlled and doesn't need encoding.
- `listFiles` / `deleteFile`: use `URLSearchParams` to append the `recursive` flag as a proper query parameter, keeping it structurally separate from the encoded path.

## Validation

- 7 new unit tests in `session-files.test.ts` covering `?`, `#`, `%`, multi-segment paths, root path, and the `recursive` flag interaction.
- `pnpm run format:check`, `pnpm run lint`, `pnpm jest` — all green locally.

## Security

- `TM-WEB`: fixes URL path confusion. URL delimiters in agent/tool-created workspace filenames could redirect UI file operations to a different path or add unintended query parameters.
- No auth, authz, session handling, or server-side code was modified.

## Follow-ups

No follow-ups. The `moveFile` and `copyFile` operations pass paths as JSON body fields (not URL segments) so they are not affected by this bug.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XsZXDkJR7dzHG1eAivmwAL)_