### PR TITLE
feat(observers): online scoring of production sessions (Phase 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -605,6 +605,7 @@ jobs:
             --test cli_auth_no_org_test \
             --test client_side_tools_test \
             --test evals_integration_test \
+            --test observers_integration_test \
             --test llm_model_default_test \
             --test org_creation_test \
             --test org_isolation_test \

--- a/crates/core/src/feature_flags.rs
+++ b/crates/core/src/feature_flags.rs
@@ -42,6 +42,8 @@ pub struct FeatureFlags {
     /// Experimental: auto-enabled in dev, off in prod by default.
     /// When off, these capabilities are not registered and cannot be assigned to agents.
     pub agent_delegation: bool,
+    /// Observers (online scoring of production sessions). Experimental.
+    pub observers: bool,
 }
 
 /// Metadata for an API-visible feature flag (org opt-in UI + catalog).
@@ -107,6 +109,12 @@ pub const API_FEATURE_FLAG_DEFINITIONS: &[FeatureFlagDefinition] = &[
         description: "Channels-first app detail page and full-page channel forms.",
         experimental: true,
     },
+    FeatureFlagDefinition {
+        name: "observers",
+        label: "Observers",
+        description: "Online scoring of production sessions.",
+        experimental: true,
+    },
 ];
 
 impl FeatureFlags {
@@ -128,6 +136,7 @@ impl FeatureFlags {
             voice: opt_in("voice", system.voice),
             apps_detail_v2: opt_in("apps.detailV2", system.apps_detail_v2),
             agent_delegation: opt_in("agent_delegation", system.agent_delegation),
+            observers: opt_in("observers", system.observers),
         }
     }
 
@@ -143,6 +152,7 @@ impl FeatureFlags {
             voice: experimental_flag("FEATURE_VOICE", grade),
             apps_detail_v2: experimental_flag("FEATURE_APPS_DETAIL_V2", grade),
             agent_delegation: experimental_flag("FEATURE_AGENT_DELEGATION", grade),
+            observers: experimental_flag("FEATURE_OBSERVERS", grade),
         }
     }
 
@@ -164,6 +174,7 @@ impl FeatureFlags {
             "voice" => self.voice,
             "apps.detailV2" => self.apps_detail_v2,
             "agent_delegation" => self.agent_delegation,
+            "observers" => self.observers,
             _ => false,
         }
     }
@@ -181,6 +192,7 @@ impl FeatureFlags {
             voice: true,
             apps_detail_v2: true,
             agent_delegation: true,
+            observers: true,
         }
     }
 }
@@ -338,6 +350,7 @@ mod tests {
             voice: true,
             apps_detail_v2: true,
             agent_delegation: true,
+            observers: true,
         };
         assert!(flags.is_enabled("global_chat"));
         assert!(flags.is_enabled("notifications"));
@@ -348,6 +361,7 @@ mod tests {
         assert!(flags.is_enabled("voice"));
         assert!(flags.is_enabled("apps.detailV2"));
         assert!(flags.is_enabled("agent_delegation"));
+        assert!(flags.is_enabled("observers"));
         assert!(!flags.is_enabled("nonexistent"));
     }
 
@@ -363,6 +377,7 @@ mod tests {
             voice: true,
             apps_detail_v2: true,
             agent_delegation: true,
+            observers: true,
         };
         let json = serde_json::to_string(&flags).unwrap();
         assert!(json.contains("\"global_chat\":true"));
@@ -372,6 +387,7 @@ mod tests {
         assert!(json.contains("\"voice\":true"));
         assert!(json.contains("\"apps.detailV2\":true"));
         assert!(json.contains("\"agent_delegation\":true"));
+        assert!(json.contains("\"observers\":true"));
 
         let parsed: FeatureFlags = serde_json::from_str(&json).unwrap();
         assert_eq!(flags, parsed);

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -97,6 +97,7 @@ pub mod mcp_server;
 pub mod memory;
 pub mod model_router;
 pub mod network_access;
+pub mod observer;
 pub mod organization;
 pub mod payment;
 pub mod principal;

--- a/crates/core/src/observer.rs
+++ b/crates/core/src/observer.rs
@@ -1,0 +1,410 @@
+// Observer domain types — online scoring of production sessions.
+//
+// Design Decision: Observers watch real production traffic instead of creating
+// synthetic sessions (that is what Evals do). An Observer holds match rules
+// (which sessions to score) and scorer configs (how to score them). Scoring is
+// asynchronous: matching enqueues pending TraceScore rows, background workers
+// claim and complete them.
+//
+// Design Decision: Scores are derived data with their own lifecycle and live in
+// their own table; they are never appended to the immutable session event log.
+//
+// See specs/online-evals.md for full specification.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::eval::Scorer;
+use crate::typed_id::{AgentId, AgentVersionId, HarnessId, ObserverId, SessionId, TraceScoreId};
+
+#[cfg(feature = "openapi")]
+use utoipa::ToSchema;
+
+// ============================================
+// Observer status
+// ============================================
+
+/// Observer lifecycle status. `paused` keeps configuration but stops matching.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+#[serde(rename_all = "lowercase")]
+pub enum ObserverStatus {
+    Active,
+    Paused,
+    Archived,
+    Deleted,
+}
+
+impl std::fmt::Display for ObserverStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ObserverStatus::Active => write!(f, "active"),
+            ObserverStatus::Paused => write!(f, "paused"),
+            ObserverStatus::Archived => write!(f, "archived"),
+            ObserverStatus::Deleted => write!(f, "deleted"),
+        }
+    }
+}
+
+impl From<&str> for ObserverStatus {
+    fn from(s: &str) -> Self {
+        match s {
+            "paused" => ObserverStatus::Paused,
+            "archived" => ObserverStatus::Archived,
+            "deleted" => ObserverStatus::Deleted,
+            _ => ObserverStatus::Active,
+        }
+    }
+}
+
+// ============================================
+// Match rules
+// ============================================
+
+/// Predicates selecting which production sessions an observer scores.
+/// All present predicates must match (AND); within a list, any entry matches (OR).
+/// An empty match block matches all org traffic. Sessions tagged `eval` are
+/// always excluded so synthetic eval-run sessions are never scored.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct ObserverMatch {
+    /// Match sessions running any of these agents.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "openapi", schema(value_type = Option<Vec<String>>))]
+    pub agent_ids: Option<Vec<AgentId>>,
+    /// Match sessions on any of these harnesses.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "openapi", schema(value_type = Option<Vec<String>>))]
+    pub harness_ids: Option<Vec<HarnessId>>,
+    /// Match sessions carrying any of these tags.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_tags: Option<Vec<String>>,
+}
+
+impl ObserverMatch {
+    /// Evaluate predicates against session attributes.
+    pub fn matches(
+        &self,
+        agent_id: Option<AgentId>,
+        harness_id: Option<HarnessId>,
+        session_tags: &[String],
+    ) -> bool {
+        if let Some(agent_ids) = &self.agent_ids {
+            let Some(agent_id) = agent_id else {
+                return false;
+            };
+            if !agent_ids.contains(&agent_id) {
+                return false;
+            }
+        }
+        if let Some(harness_ids) = &self.harness_ids {
+            let Some(harness_id) = harness_id else {
+                return false;
+            };
+            if !harness_ids.contains(&harness_id) {
+                return false;
+            }
+        }
+        if let Some(tags) = &self.session_tags
+            && !tags.iter().any(|t| session_tags.contains(t))
+        {
+            return false;
+        }
+        true
+    }
+}
+
+// ============================================
+// Scorer config
+// ============================================
+
+/// What slice of the trace a scorer grades. Phase 1 implements `turn` only;
+/// `session` and `tool` scopes are specced in specs/online-evals.md.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+#[serde(rename_all = "lowercase")]
+pub enum ObserverScope {
+    #[default]
+    Turn,
+}
+
+impl std::fmt::Display for ObserverScope {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ObserverScope::Turn => write!(f, "turn"),
+        }
+    }
+}
+
+/// One scoring rule inside an observer. `key` names the score series in
+/// listings and future dashboards; `rule` reuses the eval scorer vocabulary.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct ObserverScorerConfig {
+    /// Stable name within the observer (score series name).
+    pub key: String,
+    /// Trace slice this scorer grades.
+    #[serde(default)]
+    pub scope: ObserverScope,
+    /// Scoring rule. `file_contains` is rejected for observers (session
+    /// filesystems are not part of the observable trace contract).
+    pub rule: Scorer,
+}
+
+// ============================================
+// Observer entity
+// ============================================
+
+/// An observer: online scoring config over production sessions.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct Observer {
+    /// External identifier (observer_<32-hex>). Shown as "id" in API.
+    #[serde(rename = "id")]
+    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "observer_01933b5a000070008000000000000001"))]
+    pub public_id: ObserverId,
+    /// Internal UUID primary key. Never exposed in API.
+    #[serde(skip, default = "Uuid::nil")]
+    pub internal_id: Uuid,
+    /// Organization ID. Internal only.
+    #[serde(skip, default)]
+    pub org_id: i64,
+    /// Display name.
+    pub name: String,
+    /// Optional description.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Which sessions to score.
+    #[serde(rename = "match", default)]
+    pub match_config: ObserverMatch,
+    /// Fraction of matching turns to score (0.0–1.0), applied after match.
+    pub sampling_rate: f64,
+    /// Scoring rules.
+    pub scorers: Vec<ObserverScorerConfig>,
+    /// Lifecycle status.
+    pub status: ObserverStatus,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub archived_at: Option<DateTime<Utc>>,
+}
+
+// ============================================
+// Trace scores
+// ============================================
+
+/// Lifecycle of one trace score. `pending` rows double as the scoring queue.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+#[serde(rename_all = "lowercase")]
+pub enum TraceScoreStatus {
+    Pending,
+    Scoring,
+    Completed,
+    Errored,
+    Skipped,
+}
+
+impl std::fmt::Display for TraceScoreStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TraceScoreStatus::Pending => write!(f, "pending"),
+            TraceScoreStatus::Scoring => write!(f, "scoring"),
+            TraceScoreStatus::Completed => write!(f, "completed"),
+            TraceScoreStatus::Errored => write!(f, "errored"),
+            TraceScoreStatus::Skipped => write!(f, "skipped"),
+        }
+    }
+}
+
+impl From<&str> for TraceScoreStatus {
+    fn from(s: &str) -> Self {
+        match s {
+            "scoring" => TraceScoreStatus::Scoring,
+            "completed" => TraceScoreStatus::Completed,
+            "errored" => TraceScoreStatus::Errored,
+            "skipped" => TraceScoreStatus::Skipped,
+            _ => TraceScoreStatus::Pending,
+        }
+    }
+}
+
+/// One score produced by an observer scorer for one trace slice. Linked back
+/// to the exact session/turn it graded; agent/harness identifiers are
+/// denormalized at scoring time for aggregation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct TraceScore {
+    /// External identifier (score_<32-hex>). Shown as "id" in API.
+    #[serde(rename = "id")]
+    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "score_01933b5a000070008000000000000001"))]
+    pub public_id: TraceScoreId,
+    /// Internal UUID primary key. Never exposed in API.
+    #[serde(skip, default = "Uuid::nil")]
+    pub internal_id: Uuid,
+    /// Organization ID. Internal only.
+    #[serde(skip, default)]
+    pub org_id: i64,
+    /// Observer that produced this score.
+    #[cfg_attr(feature = "openapi", schema(value_type = String))]
+    pub observer_id: ObserverId,
+    /// Scorer key within the observer.
+    pub scorer_key: String,
+    /// Session this score grades.
+    #[cfg_attr(feature = "openapi", schema(value_type = String))]
+    pub session_id: SessionId,
+    /// Turn this score grades (turn scope).
+    pub turn_id: String,
+    /// Agent active in the session at scoring time.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "openapi", schema(value_type = Option<String>))]
+    pub agent_id: Option<AgentId>,
+    /// Agent version active in the session at scoring time.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "openapi", schema(value_type = Option<String>))]
+    pub agent_version_id: Option<AgentVersionId>,
+    /// Harness of the session.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "openapi", schema(value_type = Option<String>))]
+    pub harness_id: Option<HarnessId>,
+    pub status: TraceScoreStatus,
+    /// Whether the scorer passed (set when completed).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pass: Option<bool>,
+    /// Score value 0.0–1.0 (set when completed).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value: Option<f64>,
+    /// Human-readable explanation (set when completed).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    /// Error details if errored.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_message: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn observer_status_roundtrip() {
+        for (s, v) in [
+            ("active", ObserverStatus::Active),
+            ("paused", ObserverStatus::Paused),
+            ("archived", ObserverStatus::Archived),
+            ("deleted", ObserverStatus::Deleted),
+        ] {
+            assert_eq!(ObserverStatus::from(s), v);
+            assert_eq!(v.to_string(), s);
+        }
+        assert_eq!(ObserverStatus::from("unknown"), ObserverStatus::Active);
+    }
+
+    #[test]
+    fn trace_score_status_roundtrip() {
+        for (s, v) in [
+            ("pending", TraceScoreStatus::Pending),
+            ("scoring", TraceScoreStatus::Scoring),
+            ("completed", TraceScoreStatus::Completed),
+            ("errored", TraceScoreStatus::Errored),
+            ("skipped", TraceScoreStatus::Skipped),
+        ] {
+            assert_eq!(TraceScoreStatus::from(s), v);
+            assert_eq!(v.to_string(), s);
+        }
+        assert_eq!(TraceScoreStatus::from("unknown"), TraceScoreStatus::Pending);
+    }
+
+    #[test]
+    fn empty_match_matches_everything() {
+        let m = ObserverMatch::default();
+        assert!(m.matches(None, None, &[]));
+        assert!(m.matches(Some(AgentId::new()), Some(HarnessId::new()), &["x".into()]));
+    }
+
+    #[test]
+    fn match_agent_predicate() {
+        let agent = AgentId::new();
+        let m = ObserverMatch {
+            agent_ids: Some(vec![agent]),
+            ..Default::default()
+        };
+        assert!(m.matches(Some(agent), None, &[]));
+        assert!(!m.matches(Some(AgentId::new()), None, &[]));
+        assert!(!m.matches(None, None, &[]));
+    }
+
+    #[test]
+    fn match_harness_predicate() {
+        let harness = HarnessId::new();
+        let m = ObserverMatch {
+            harness_ids: Some(vec![harness]),
+            ..Default::default()
+        };
+        assert!(m.matches(None, Some(harness), &[]));
+        assert!(!m.matches(None, Some(HarnessId::new()), &[]));
+        assert!(!m.matches(None, None, &[]));
+    }
+
+    #[test]
+    fn match_tags_any_of() {
+        let m = ObserverMatch {
+            session_tags: Some(vec!["prod".into(), "beta".into()]),
+            ..Default::default()
+        };
+        assert!(m.matches(None, None, &["beta".into()]));
+        assert!(!m.matches(None, None, &["other".into()]));
+        assert!(!m.matches(None, None, &[]));
+    }
+
+    #[test]
+    fn match_predicates_are_anded() {
+        let agent = AgentId::new();
+        let m = ObserverMatch {
+            agent_ids: Some(vec![agent]),
+            session_tags: Some(vec!["prod".into()]),
+            ..Default::default()
+        };
+        assert!(m.matches(Some(agent), None, &["prod".into()]));
+        assert!(!m.matches(Some(agent), None, &[]));
+        assert!(!m.matches(None, None, &["prod".into()]));
+    }
+
+    #[test]
+    fn scorer_config_serde_defaults_scope() {
+        let json = serde_json::json!({
+            "key": "greeting",
+            "rule": { "type": "contains", "text": "hello" }
+        });
+        let config: ObserverScorerConfig = serde_json::from_value(json).unwrap();
+        assert_eq!(config.scope, ObserverScope::Turn);
+        assert_eq!(config.key, "greeting");
+    }
+
+    #[test]
+    fn observer_serde_skips_internal_fields() {
+        let observer = Observer {
+            public_id: ObserverId::from_uuid(Uuid::nil()),
+            internal_id: Uuid::nil(),
+            org_id: 1,
+            name: "test".into(),
+            description: None,
+            match_config: ObserverMatch::default(),
+            sampling_rate: 0.1,
+            scorers: vec![],
+            status: ObserverStatus::Active,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            archived_at: None,
+        };
+        let json = serde_json::to_value(&observer).unwrap();
+        assert!(json.get("id").is_some());
+        assert!(json.get("match").is_some());
+        assert!(json.get("internal_id").is_none());
+        assert!(json.get("org_id").is_none());
+        assert_eq!(json["sampling_rate"], 0.1);
+    }
+}

--- a/crates/core/src/typed_id.rs
+++ b/crates/core/src/typed_id.rs
@@ -483,6 +483,20 @@ impl IdMarker for EvalResultIdMarker {
     const PREFIX: &'static str = "evalresult";
 }
 
+/// Marker for Observer IDs (online scoring of production sessions — see `specs/online-evals.md`)
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct ObserverIdMarker;
+impl IdMarker for ObserverIdMarker {
+    const PREFIX: &'static str = "observer";
+}
+
+/// Marker for Trace Score IDs (observer scoring output)
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct TraceScoreIdMarker;
+impl IdMarker for TraceScoreIdMarker {
+    const PREFIX: &'static str = "score";
+}
+
 /// Marker for Budget IDs
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct BudgetIdMarker;
@@ -613,6 +627,10 @@ pub type EvalCaseId = TypedId<EvalCaseIdMarker>;
 pub type EvalRunId = TypedId<EvalRunIdMarker>;
 /// Eval Case Result ID
 pub type EvalResultId = TypedId<EvalResultIdMarker>;
+/// Observer ID (online scoring — see `specs/online-evals.md`)
+pub type ObserverId = TypedId<ObserverIdMarker>;
+/// Trace Score ID (observer scoring output)
+pub type TraceScoreId = TypedId<TraceScoreIdMarker>;
 /// Budget ID
 pub type BudgetId = TypedId<BudgetIdMarker>;
 /// Payment account ID

--- a/crates/server/migrations/059_observers.sql
+++ b/crates/server/migrations/059_observers.sql
@@ -1,0 +1,73 @@
+-- Observers — online scoring of production sessions. See specs/online-evals.md.
+--
+-- trace_scores doubles as the scoring queue: matching inserts 'pending' rows,
+-- workers claim them (FOR UPDATE SKIP LOCKED) and write results in place.
+-- The unique (observer_id, scorer_key, session_id, turn_id) key makes
+-- enqueueing idempotent under at-least-once event delivery.
+
+CREATE TABLE observers (
+    id UUID PRIMARY KEY DEFAULT uuidv7(),
+    org_id BIGINT NOT NULL,
+    public_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    description TEXT,
+    match_config JSONB NOT NULL DEFAULT '{}',
+    sampling_rate DOUBLE PRECISION NOT NULL DEFAULT 0.1
+        CHECK (sampling_rate >= 0.0 AND sampling_rate <= 1.0),
+    scorers JSONB NOT NULL DEFAULT '[]',
+    status VARCHAR(50) NOT NULL DEFAULT 'active'
+        CHECK (status IN ('active', 'paused', 'archived', 'deleted')),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    archived_at TIMESTAMPTZ,
+    UNIQUE(org_id, public_id),
+    CONSTRAINT observers_public_id_format CHECK (public_id ~ '^observer_[0-9a-f]{32}$'),
+    CONSTRAINT observers_org_id_fk FOREIGN KEY (org_id) REFERENCES organizations(org_id)
+);
+
+CREATE INDEX idx_observers_org_id ON observers(org_id);
+CREATE INDEX idx_observers_public_id ON observers(public_id);
+-- Matching runs on every turn.completed: keep the active-observer lookup cheap.
+CREATE INDEX idx_observers_org_active ON observers(org_id) WHERE status = 'active';
+
+CREATE TRIGGER update_observers_updated_at
+    BEFORE UPDATE ON observers
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+CREATE TABLE trace_scores (
+    id UUID PRIMARY KEY DEFAULT uuidv7(),
+    org_id BIGINT NOT NULL,
+    public_id TEXT NOT NULL,
+    observer_id UUID NOT NULL,
+    scorer_key TEXT NOT NULL,
+    session_id UUID NOT NULL,
+    turn_id TEXT NOT NULL,
+    agent_id UUID,
+    agent_version_id UUID,
+    harness_id UUID,
+    status VARCHAR(50) NOT NULL DEFAULT 'pending'
+        CHECK (status IN ('pending', 'scoring', 'completed', 'errored', 'skipped')),
+    attempts INTEGER NOT NULL DEFAULT 0,
+    pass BOOLEAN,
+    value DOUBLE PRECISION,
+    reason TEXT,
+    error_message TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE(org_id, public_id),
+    UNIQUE(observer_id, scorer_key, session_id, turn_id),
+    CONSTRAINT trace_scores_public_id_format CHECK (public_id ~ '^score_[0-9a-f]{32}$'),
+    CONSTRAINT trace_scores_org_id_fk FOREIGN KEY (org_id) REFERENCES organizations(org_id),
+    CONSTRAINT trace_scores_observer_id_fk FOREIGN KEY (observer_id) REFERENCES observers(id) ON DELETE CASCADE,
+    CONSTRAINT trace_scores_session_id_fk FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_trace_scores_observer_created ON trace_scores(observer_id, created_at DESC);
+CREATE INDEX idx_trace_scores_session_id ON trace_scores(session_id);
+-- Worker claim scan: only queue-state rows.
+CREATE INDEX idx_trace_scores_queue ON trace_scores(created_at)
+    WHERE status IN ('pending', 'scoring');
+
+CREATE TRIGGER update_trace_scores_updated_at
+    BEFORE UPDATE ON trace_scores
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();

--- a/crates/server/src/api/mod.rs
+++ b/crates/server/src/api/mod.rs
@@ -39,6 +39,7 @@ pub mod memory;
 pub mod memory_files;
 pub mod messages;
 pub mod notifications;
+pub mod observers;
 pub mod org_feature_flags;
 pub mod organizations;
 pub mod payments;

--- a/crates/server/src/api/observers.rs
+++ b/crates/server/src/api/observers.rs
@@ -1,0 +1,204 @@
+// Observer API routes — online scoring of production sessions.
+// See specs/online-evals.md. Gated behind the `observers` feature flag.
+
+use axum::extract::{Path, Query, State};
+use axum::http::StatusCode;
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use serde::Deserialize;
+use std::sync::Arc;
+
+use everruns_core::Caller;
+use everruns_core::observer::{
+    Observer, ObserverMatch, ObserverScorerConfig, ObserverStatus, TraceScore,
+};
+
+use crate::api::common::{ApiResult, ErrorResponse, ListResponse};
+use crate::api::dispatch::{Dispatchable, impl_dispatchable};
+use crate::auth::{AuthState, ResolvedOrg};
+use crate::domains::common::Ctx;
+use crate::domains::observers::{
+    CreateObserver, DeleteObserver, GetObserver, ListObserverScores, ListObservers, UpdateObserver,
+};
+use crate::storage::StorageBackend;
+
+use utoipa::{IntoParams, ToSchema};
+
+// ============================================
+// State
+// ============================================
+
+#[derive(Clone)]
+pub struct AppState {
+    pub db: Arc<StorageBackend>,
+    pub auth: AuthState,
+}
+
+crate::api::common::impl_auth_state!(AppState);
+impl_dispatchable!(AppState);
+
+impl AppState {
+    pub fn new(db: Arc<StorageBackend>, auth: AuthState) -> Self {
+        Self { db, auth }
+    }
+
+    fn ctx(&self, org: &ResolvedOrg) -> Ctx {
+        Ctx::minimal(
+            Caller::from(org),
+            self.db.clone(),
+            None,
+            self.auth.permission_resolver.clone(),
+        )
+    }
+}
+
+// ============================================
+// Request/Response types
+// ============================================
+
+/// Request to create a new observer.
+#[derive(Debug, Clone, Deserialize, ToSchema)]
+pub struct CreateObserverRequest {
+    /// Human-readable name. Safe to render in user-facing messages.
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    /// Human-readable description. Safe to render in user-facing messages.
+    pub description: Option<String>,
+    /// Which production sessions to score. Empty matches all org traffic.
+    #[serde(rename = "match", skip_serializing_if = "Option::is_none")]
+    pub match_config: Option<ObserverMatch>,
+    /// Fraction of matching turns to score (0.0–1.0). Defaults to 0.1.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sampling_rate: Option<f64>,
+    /// Scoring rules. Must contain at least one.
+    pub scorers: Vec<ObserverScorerConfig>,
+}
+
+/// Request to update an observer. Omitted fields are unchanged.
+#[derive(Debug, Clone, Deserialize, ToSchema)]
+pub struct UpdateObserverRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    /// Human-readable name. Safe to render in user-facing messages.
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    /// Human-readable description. Safe to render in user-facing messages.
+    pub description: Option<String>,
+    #[serde(rename = "match", skip_serializing_if = "Option::is_none")]
+    pub match_config: Option<ObserverMatch>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sampling_rate: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scorers: Option<Vec<ObserverScorerConfig>>,
+    /// New lifecycle status (`active`, `paused`, or `archived`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<ObserverStatus>,
+}
+
+/// Query parameters for listing observers.
+#[derive(Debug, Clone, Deserialize, IntoParams, ToSchema)]
+pub struct ListObserversQuery {
+    pub include_archived: Option<bool>,
+}
+
+/// Query parameters for listing trace scores.
+#[derive(Debug, Clone, Deserialize, IntoParams, ToSchema)]
+pub struct ListTraceScoresQuery {
+    /// Filter to one session.
+    pub session_id: Option<String>,
+    pub limit: Option<i64>,
+    pub offset: Option<i64>,
+}
+
+// ============================================
+// Routes
+// ============================================
+
+pub fn routes(state: AppState) -> Router {
+    Router::new()
+        .route("/v1/observers", post(create).get(list))
+        .route(
+            "/v1/observers/{observer_id}",
+            get(get_observer).patch(update).delete(delete),
+        )
+        .route("/v1/observers/{observer_id}/scores", get(list_scores))
+        .with_state(state)
+}
+
+// ============================================
+// Handlers
+// ============================================
+
+async fn create(
+    org: ResolvedOrg,
+    State(state): State<AppState>,
+    Json(req): Json<CreateObserverRequest>,
+) -> Result<(StatusCode, Json<Observer>), (StatusCode, Json<ErrorResponse>)> {
+    state
+        .dispatcher(&org)
+        .run_created(CreateObserver(req))
+        .await
+}
+
+async fn list(
+    org: ResolvedOrg,
+    State(state): State<AppState>,
+    Query(query): Query<ListObserversQuery>,
+) -> ApiResult<ListResponse<Observer>> {
+    state
+        .dispatcher(&org)
+        .run_list(ListObservers {
+            include_archived: query.include_archived.unwrap_or(false),
+        })
+        .await
+}
+
+async fn get_observer(
+    org: ResolvedOrg,
+    State(state): State<AppState>,
+    Path(observer_id): Path<String>,
+) -> ApiResult<Observer> {
+    state
+        .dispatcher(&org)
+        .run(GetObserver { observer_id })
+        .await
+}
+
+async fn update(
+    org: ResolvedOrg,
+    State(state): State<AppState>,
+    Path(observer_id): Path<String>,
+    Json(req): Json<UpdateObserverRequest>,
+) -> ApiResult<Observer> {
+    state
+        .dispatcher(&org)
+        .run(UpdateObserver { observer_id, req })
+        .await
+}
+
+async fn delete(
+    org: ResolvedOrg,
+    State(state): State<AppState>,
+    Path(observer_id): Path<String>,
+) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
+    state
+        .dispatcher(&org)
+        .run_no_content(DeleteObserver { observer_id })
+        .await
+}
+
+async fn list_scores(
+    org: ResolvedOrg,
+    State(state): State<AppState>,
+    Path(observer_id): Path<String>,
+    Query(query): Query<ListTraceScoresQuery>,
+) -> ApiResult<ListResponse<TraceScore>> {
+    state
+        .dispatcher(&org)
+        .run_list(ListObserverScores {
+            observer_id,
+            session_id: query.session_id,
+            limit: query.limit.unwrap_or(100),
+            offset: query.offset.unwrap_or(0),
+        })
+        .await
+}

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -621,6 +621,25 @@ impl ServerAppBuilder {
             );
         }
 
+        // Observers: tap turn.completed to enqueue scoring; a background worker
+        // drains the queue. Same code path in dev (in-memory) and full mode.
+        // See specs/online-evals.md.
+        if feature_flags.observers {
+            let observer_wake = Arc::new(tokio::sync::Notify::new());
+            let observer_listener: Arc<dyn EventListener> =
+                Arc::new(crate::domains::observers::ObserverMatchListener::new(
+                    db.clone(),
+                    observer_wake.clone(),
+                ));
+            event_listeners.push(observer_listener);
+            crate::domains::observers::spawn_observer_worker(
+                db.clone(),
+                observer_wake,
+                crate::domains::observers::ObserverWorkerConfig::default(),
+            );
+            tracing::info!("Observers enabled: scoring worker started");
+        }
+
         if let Some(braintrust_listener) = BraintrustListener::from_env() {
             tracing::info!("Braintrust integration enabled");
             event_listeners.push(Arc::new(braintrust_listener));
@@ -1221,6 +1240,13 @@ impl ServerAppBuilder {
             api_routes = api_routes.merge(api::evals::routes(evals_state));
         } else {
             tracing::info!("Evals disabled via feature flag");
+        }
+
+        if feature_flags.observers {
+            let observers_state = api::observers::AppState::new(db.clone(), auth_state.clone());
+            api_routes = api_routes.merge(api::observers::routes(observers_state));
+        } else {
+            tracing::info!("Observers disabled via feature flag");
         }
 
         if let Some(session_sandbox_state) = session_sandbox_state {

--- a/crates/server/src/domains/evals/mod.rs
+++ b/crates/server/src/domains/evals/mod.rs
@@ -4,6 +4,7 @@ pub mod commands;
 pub mod limits;
 pub mod queries;
 pub mod runner;
+pub mod scoring;
 pub mod service;
 pub mod types;
 

--- a/crates/server/src/domains/evals/runner.rs
+++ b/crates/server/src/domains/evals/runner.rs
@@ -554,7 +554,9 @@ async fn send_message_and_wait(
     }
 }
 
-fn extract_final_assistant_content(events: &[crate::storage::models::EventRow]) -> String {
+pub(crate) fn extract_final_assistant_content(
+    events: &[crate::storage::models::EventRow],
+) -> String {
     // Find the last output.message.completed event.
     // Event data format: { "message": { "content": [{ "type": "text", "text": "..." }] } }
     for event in events.iter().rev() {
@@ -579,7 +581,7 @@ fn extract_final_assistant_content(events: &[crate::storage::models::EventRow]) 
     String::new()
 }
 
-fn extract_tool_calls(events: &[crate::storage::models::EventRow]) -> Vec<String> {
+pub(crate) fn extract_tool_calls(events: &[crate::storage::models::EventRow]) -> Vec<String> {
     events
         .iter()
         .filter(|e| e.event_type == "tool.completed")
@@ -651,90 +653,12 @@ async fn run_single_scorer(
     ctx: &EvalRunContext,
     session_uuid: Uuid,
 ) -> Score {
+    if let Some(score) =
+        crate::domains::evals::scoring::score_rule(scorer, final_content, tool_calls, turns)
+    {
+        return score;
+    }
     match scorer {
-        Scorer::Contains { text, .. } => {
-            let pass = final_content.contains(text.as_str());
-            Score {
-                pass,
-                value: if pass { 1.0 } else { 0.0 },
-                reason: if pass {
-                    format!("Output contains '{text}'")
-                } else {
-                    format!("Output does not contain '{text}'")
-                },
-            }
-        }
-        Scorer::NotContains { text, .. } => {
-            let pass = !final_content.contains(text.as_str());
-            Score {
-                pass,
-                value: if pass { 1.0 } else { 0.0 },
-                reason: if pass {
-                    format!("Output does not contain '{text}'")
-                } else {
-                    format!("Output contains '{text}'")
-                },
-            }
-        }
-        Scorer::Regex { pattern, .. } => {
-            let pass = regex::Regex::new(pattern)
-                .map(|re| re.is_match(final_content))
-                .unwrap_or(false);
-            Score {
-                pass,
-                value: if pass { 1.0 } else { 0.0 },
-                reason: if pass {
-                    format!("Output matches pattern '{pattern}'")
-                } else {
-                    format!("Output does not match pattern '{pattern}'")
-                },
-            }
-        }
-        Scorer::ToolCalled { tool, min, .. } => {
-            let count = tool_calls.iter().filter(|t| t == &tool).count() as u32;
-            let pass = count >= *min;
-            Score {
-                pass,
-                value: if pass { 1.0 } else { 0.0 },
-                reason: format!("Tool '{tool}' called {count} times (min: {min})"),
-            }
-        }
-        Scorer::ToolNotCalled { tool, .. } => {
-            let called = tool_calls.iter().any(|t| t == tool);
-            let pass = !called;
-            Score {
-                pass,
-                value: if pass { 1.0 } else { 0.0 },
-                reason: if pass {
-                    format!("Tool '{tool}' was not called")
-                } else {
-                    format!("Tool '{tool}' was called")
-                },
-            }
-        }
-        Scorer::ToolCallCount { min, max, .. } => {
-            let count = tool_calls.len() as u32;
-            let pass_min = min.map(|m| count >= m).unwrap_or(true);
-            let pass_max = max.map(|m| count <= m).unwrap_or(true);
-            let pass = pass_min && pass_max;
-            Score {
-                pass,
-                value: if pass { 1.0 } else { 0.0 },
-                reason: format!(
-                    "Total tool calls: {count} (min: {}, max: {})",
-                    min.map(|v| v.to_string()).unwrap_or("-".into()),
-                    max.map(|v| v.to_string()).unwrap_or("-".into())
-                ),
-            }
-        }
-        Scorer::TurnsWithin { max, .. } => {
-            let pass = turns <= *max;
-            Score {
-                pass,
-                value: if pass { 1.0 } else { 0.0 },
-                reason: format!("Turns: {turns} (max: {max})"),
-            }
-        }
         Scorer::FileContains { path, text, .. } => {
             let file = ctx.db.get_session_file(session_uuid, path).await;
             let pass = match file {
@@ -758,20 +682,8 @@ async fn run_single_scorer(
                 },
             }
         }
-        Scorer::JsonSchema { schema: _, .. } => {
-            // JSON schema validation requires a jsonschema crate dependency.
-            // For now, verify the output is valid JSON.
-            let is_json = serde_json::from_str::<serde_json::Value>(final_content).is_ok();
-            Score {
-                pass: is_json,
-                value: if is_json { 1.0 } else { 0.0 },
-                reason: if is_json {
-                    "Output is valid JSON (full schema validation not yet implemented)".to_string()
-                } else {
-                    "Output is not valid JSON".to_string()
-                },
-            }
-        }
+        // score_rule covers every other variant.
+        _ => unreachable!("score_rule handles all non-file scorer rules"),
     }
 }
 

--- a/crates/server/src/domains/evals/scoring.rs
+++ b/crates/server/src/domains/evals/scoring.rs
@@ -1,0 +1,168 @@
+// Pure scorer-rule evaluation shared by eval runs and observers
+// (specs/online-evals.md). Rules that need session context beyond the
+// trace (file_contains reads the session filesystem) return None and are
+// handled by the caller.
+
+use everruns_core::eval::{Score, Scorer};
+
+/// Evaluate a scorer rule against extracted trace data.
+///
+/// `final_content` is the final assistant message text, `tool_calls` the
+/// tool names invoked, and `turns` the turn count (eval runs) or iteration
+/// count (observer turn scope). Returns None for rules that need more than
+/// trace data (`file_contains`).
+pub fn score_rule(
+    scorer: &Scorer,
+    final_content: &str,
+    tool_calls: &[String],
+    turns: u32,
+) -> Option<Score> {
+    let score = match scorer {
+        Scorer::Contains { text, .. } => {
+            let pass = final_content.contains(text.as_str());
+            Score {
+                pass,
+                value: if pass { 1.0 } else { 0.0 },
+                reason: if pass {
+                    format!("Output contains '{text}'")
+                } else {
+                    format!("Output does not contain '{text}'")
+                },
+            }
+        }
+        Scorer::NotContains { text, .. } => {
+            let pass = !final_content.contains(text.as_str());
+            Score {
+                pass,
+                value: if pass { 1.0 } else { 0.0 },
+                reason: if pass {
+                    format!("Output does not contain '{text}'")
+                } else {
+                    format!("Output contains '{text}'")
+                },
+            }
+        }
+        Scorer::Regex { pattern, .. } => {
+            let pass = regex::Regex::new(pattern)
+                .map(|re| re.is_match(final_content))
+                .unwrap_or(false);
+            Score {
+                pass,
+                value: if pass { 1.0 } else { 0.0 },
+                reason: if pass {
+                    format!("Output matches pattern '{pattern}'")
+                } else {
+                    format!("Output does not match pattern '{pattern}'")
+                },
+            }
+        }
+        Scorer::ToolCalled { tool, min, .. } => {
+            let count = tool_calls.iter().filter(|t| t == &tool).count() as u32;
+            let pass = count >= *min;
+            Score {
+                pass,
+                value: if pass { 1.0 } else { 0.0 },
+                reason: format!("Tool '{tool}' called {count} times (min: {min})"),
+            }
+        }
+        Scorer::ToolNotCalled { tool, .. } => {
+            let called = tool_calls.iter().any(|t| t == tool);
+            let pass = !called;
+            Score {
+                pass,
+                value: if pass { 1.0 } else { 0.0 },
+                reason: if pass {
+                    format!("Tool '{tool}' was not called")
+                } else {
+                    format!("Tool '{tool}' was called")
+                },
+            }
+        }
+        Scorer::ToolCallCount { min, max, .. } => {
+            let count = tool_calls.len() as u32;
+            let pass_min = min.map(|m| count >= m).unwrap_or(true);
+            let pass_max = max.map(|m| count <= m).unwrap_or(true);
+            let pass = pass_min && pass_max;
+            Score {
+                pass,
+                value: if pass { 1.0 } else { 0.0 },
+                reason: format!(
+                    "Total tool calls: {count} (min: {}, max: {})",
+                    min.map(|v| v.to_string()).unwrap_or("-".into()),
+                    max.map(|v| v.to_string()).unwrap_or("-".into())
+                ),
+            }
+        }
+        Scorer::TurnsWithin { max, .. } => {
+            let pass = turns <= *max;
+            Score {
+                pass,
+                value: if pass { 1.0 } else { 0.0 },
+                reason: format!("Turns: {turns} (max: {max})"),
+            }
+        }
+        Scorer::JsonSchema { schema: _, .. } => {
+            // JSON schema validation requires a jsonschema crate dependency.
+            // For now, verify the output is valid JSON.
+            let is_json = serde_json::from_str::<serde_json::Value>(final_content).is_ok();
+            Score {
+                pass: is_json,
+                value: if is_json { 1.0 } else { 0.0 },
+                reason: if is_json {
+                    "Output is valid JSON (full schema validation not yet implemented)".to_string()
+                } else {
+                    "Output is not valid JSON".to_string()
+                },
+            }
+        }
+        Scorer::FileContains { .. } => return None,
+    };
+    Some(score)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn contains_rule() {
+        let scorer = Scorer::Contains {
+            text: "hello".into(),
+            weight: 1.0,
+        };
+        assert!(score_rule(&scorer, "say hello world", &[], 1).unwrap().pass);
+        assert!(!score_rule(&scorer, "goodbye", &[], 1).unwrap().pass);
+    }
+
+    #[test]
+    fn tool_called_rule() {
+        let scorer = Scorer::ToolCalled {
+            tool: "web_fetch".into(),
+            min: 2,
+            weight: 1.0,
+        };
+        let calls = vec!["web_fetch".to_string(), "web_fetch".to_string()];
+        assert!(score_rule(&scorer, "", &calls, 1).unwrap().pass);
+        assert!(!score_rule(&scorer, "", &calls[..1], 1).unwrap().pass);
+    }
+
+    #[test]
+    fn turns_within_rule() {
+        let scorer = Scorer::TurnsWithin {
+            max: 3,
+            weight: 1.0,
+        };
+        assert!(score_rule(&scorer, "", &[], 3).unwrap().pass);
+        assert!(!score_rule(&scorer, "", &[], 4).unwrap().pass);
+    }
+
+    #[test]
+    fn file_contains_needs_session_context() {
+        let scorer = Scorer::FileContains {
+            path: "/x".into(),
+            text: "y".into(),
+            weight: 1.0,
+        };
+        assert!(score_rule(&scorer, "", &[], 1).is_none());
+    }
+}

--- a/crates/server/src/domains/mod.rs
+++ b/crates/server/src/domains/mod.rs
@@ -22,6 +22,7 @@ pub mod mcp_servers;
 pub mod memory;
 pub mod messages;
 pub mod notifications;
+pub mod observers;
 pub mod org_resolver;
 pub mod organizations;
 pub mod payments;

--- a/crates/server/src/domains/observers/commands.rs
+++ b/crates/server/src/domains/observers/commands.rs
@@ -1,0 +1,278 @@
+use super::service::{OBSERVER_MANAGE, OBSERVER_VIEW, ObserverService};
+use super::types::{CreateObserverRequest, ListObserversQuery, UpdateObserverRequest};
+use crate::domains::common::*;
+use everruns_core::observer::{Observer, TraceScore};
+use everruns_core::typed_id::{ObserverId, SessionId};
+use serde::Deserialize;
+use utoipa::ToSchema;
+
+fn service(ctx: &Ctx) -> ObserverService {
+    ObserverService::new(ctx.db.clone())
+}
+
+fn parse_observer_id(id: &str) -> Result<ObserverId, CommandError> {
+    id.parse()
+        .map_err(|e| CommandError::bad_request(format!("Invalid observer ID: {e}")))
+}
+
+// ============================================
+// Create
+// ============================================
+
+#[derive(Debug, Deserialize)]
+pub struct CreateObserver(pub CreateObserverRequest);
+
+impl CommandSchema for CreateObserver {
+    fn param_schema() -> serde_json::Value {
+        delegated_param_schema::<CreateObserverRequest>()
+    }
+}
+
+impl Command for CreateObserver {
+    type Output = Observer;
+
+    fn meta() -> CommandMeta {
+        CommandMeta {
+            name: "create_observer",
+            category: "observers",
+            description: "Create an observer (online scoring).",
+            method: "POST",
+            path: "/v1/observers",
+        }
+    }
+
+    fn policy() -> Option<&'static everruns_core::Policy> {
+        Some(&OBSERVER_MANAGE)
+    }
+
+    async fn execute(self, ctx: &Ctx) -> Result<Observer, CommandError> {
+        service(ctx)
+            .create(&ctx.caller, self.0)
+            .await
+            .map_err(classify_anyhow)
+    }
+}
+
+inventory::submit! { CommandDescriptor::of::<CreateObserver>() }
+
+// ============================================
+// List
+// ============================================
+
+#[derive(Debug, Default, Deserialize)]
+pub struct ListObservers {
+    #[serde(default, deserialize_with = "deserialize_bool_lenient")]
+    pub include_archived: bool,
+}
+
+impl CommandSchema for ListObservers {
+    fn param_schema() -> serde_json::Value {
+        delegated_param_schema::<ListObserversQuery>()
+    }
+}
+
+impl Command for ListObservers {
+    type Output = Vec<Observer>;
+
+    fn meta() -> CommandMeta {
+        CommandMeta {
+            name: "list_observers",
+            category: "observers",
+            description: "List observers.",
+            method: "GET",
+            path: "/v1/observers",
+        }
+    }
+
+    fn policy() -> Option<&'static everruns_core::Policy> {
+        Some(&OBSERVER_VIEW)
+    }
+
+    async fn execute(self, ctx: &Ctx) -> Result<Vec<Observer>, CommandError> {
+        service(ctx)
+            .list(&ctx.caller, self.include_archived)
+            .await
+            .map_err(classify_anyhow)
+    }
+}
+
+inventory::submit! { CommandDescriptor::of::<ListObservers>() }
+
+// ============================================
+// Get
+// ============================================
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct GetObserver {
+    pub observer_id: String,
+}
+
+impl Command for GetObserver {
+    type Output = Observer;
+
+    fn meta() -> CommandMeta {
+        CommandMeta {
+            name: "get_observer",
+            category: "observers",
+            description: "Get a single observer.",
+            method: "GET",
+            path: "/v1/observers/{observer_id}",
+        }
+    }
+
+    fn positional_arg() -> Option<&'static str> {
+        Some("observer_id")
+    }
+
+    fn policy() -> Option<&'static everruns_core::Policy> {
+        Some(&OBSERVER_VIEW)
+    }
+
+    async fn execute(self, ctx: &Ctx) -> Result<Observer, CommandError> {
+        let observer_id = parse_observer_id(&self.observer_id)?;
+        service(ctx)
+            .get_by_public_id(&ctx.caller, &observer_id.to_string())
+            .await
+            .map_err(classify_anyhow)?
+            .ok_or_else(|| CommandError::not_found("Observer"))
+    }
+}
+
+inventory::submit! { CommandDescriptor::of::<GetObserver>() }
+
+// ============================================
+// Update
+// ============================================
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct UpdateObserver {
+    pub observer_id: String,
+    #[serde(flatten)]
+    pub req: UpdateObserverRequest,
+}
+
+impl Command for UpdateObserver {
+    type Output = Observer;
+
+    fn meta() -> CommandMeta {
+        CommandMeta {
+            name: "update_observer",
+            category: "observers",
+            description: "Update an observer.",
+            method: "PATCH",
+            path: "/v1/observers/{observer_id}",
+        }
+    }
+
+    fn policy() -> Option<&'static everruns_core::Policy> {
+        Some(&OBSERVER_MANAGE)
+    }
+
+    async fn execute(self, ctx: &Ctx) -> Result<Observer, CommandError> {
+        let observer_id = parse_observer_id(&self.observer_id)?;
+        service(ctx)
+            .update(&ctx.caller, &observer_id.to_string(), self.req)
+            .await
+            .map_err(classify_anyhow)?
+            .ok_or_else(|| CommandError::not_found("Observer"))
+    }
+}
+
+inventory::submit! { CommandDescriptor::of::<UpdateObserver>() }
+
+// ============================================
+// Delete
+// ============================================
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct DeleteObserver {
+    pub observer_id: String,
+}
+
+impl Command for DeleteObserver {
+    type Output = bool;
+
+    fn meta() -> CommandMeta {
+        CommandMeta {
+            name: "delete_observer",
+            category: "observers",
+            description: "Archive an observer.",
+            method: "DELETE",
+            path: "/v1/observers/{observer_id}",
+        }
+    }
+
+    fn policy() -> Option<&'static everruns_core::Policy> {
+        Some(&OBSERVER_MANAGE)
+    }
+
+    async fn execute(self, ctx: &Ctx) -> Result<bool, CommandError> {
+        let observer_id = parse_observer_id(&self.observer_id)?;
+        let deleted = service(ctx)
+            .delete(&ctx.caller, &observer_id.to_string())
+            .await
+            .map_err(classify_anyhow)?;
+        if deleted {
+            Ok(true)
+        } else {
+            Err(CommandError::not_found("Observer"))
+        }
+    }
+}
+
+inventory::submit! { CommandDescriptor::of::<DeleteObserver>() }
+
+// ============================================
+// List scores
+// ============================================
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct ListObserverScores {
+    pub observer_id: String,
+    pub session_id: Option<String>,
+    pub limit: i64,
+    pub offset: i64,
+}
+
+impl Command for ListObserverScores {
+    type Output = Vec<TraceScore>;
+
+    fn meta() -> CommandMeta {
+        CommandMeta {
+            name: "list_observer_scores",
+            category: "observers",
+            description: "List trace scores produced by an observer.",
+            method: "GET",
+            path: "/v1/observers/{observer_id}/scores",
+        }
+    }
+
+    fn policy() -> Option<&'static everruns_core::Policy> {
+        Some(&OBSERVER_VIEW)
+    }
+
+    async fn execute(self, ctx: &Ctx) -> Result<Vec<TraceScore>, CommandError> {
+        let observer_id = parse_observer_id(&self.observer_id)?;
+        let session_id = self
+            .session_id
+            .as_deref()
+            .map(|s| {
+                s.parse::<SessionId>()
+                    .map_err(|e| CommandError::bad_request(format!("Invalid session ID: {e}")))
+            })
+            .transpose()?;
+        service(ctx)
+            .list_scores(
+                &ctx.caller,
+                &observer_id.to_string(),
+                session_id,
+                self.limit,
+                self.offset,
+            )
+            .await
+            .map_err(classify_anyhow)?
+            .ok_or_else(|| CommandError::not_found("Observer"))
+    }
+}
+
+inventory::submit! { CommandDescriptor::of::<ListObserverScores>() }

--- a/crates/server/src/domains/observers/listener.rs
+++ b/crates/server/src/domains/observers/listener.rs
@@ -1,0 +1,162 @@
+// Observer matching listener — taps turn.completed, decides what to score.
+//
+// Design: the listener does only the cheap part on the event path — look up
+// active observers for the org, evaluate match predicates, sample, and
+// enqueue pending trace_scores. It never runs a judge or blocks the turn.
+// The background worker (worker.rs) drains the queue. A shared Notify wakes
+// the worker immediately after enqueue; the worker also polls for catch-up.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use everruns_core::EventListener;
+use everruns_core::events::{Event, EventData, TURN_COMPLETED};
+use everruns_core::observer::{ObserverMatch, ObserverScope, ObserverScorerConfig};
+use everruns_core::typed_id::TraceScoreId;
+use tracing::{error, instrument};
+use uuid::Uuid;
+
+use crate::storage::StorageBackend;
+use crate::storage::models::CreateTraceScoreRow;
+
+/// Tag marking synthetic eval-run sessions, which observers must never score.
+const EVAL_SESSION_TAG: &str = "eval";
+
+pub struct ObserverMatchListener {
+    db: Arc<StorageBackend>,
+    /// Wakes the scoring worker after enqueue for low-latency scoring.
+    wake: Arc<tokio::sync::Notify>,
+}
+
+impl ObserverMatchListener {
+    pub fn new(db: Arc<StorageBackend>, wake: Arc<tokio::sync::Notify>) -> Self {
+        Self { db, wake }
+    }
+
+    async fn handle_turn_completed(&self, event: &Event, turn_id: String) -> anyhow::Result<()> {
+        let session_id = event.session_id;
+
+        // Need org + session attributes to match. One unscoped lookup.
+        let Some(session) = self.db.get_session_unscoped(session_id).await? else {
+            return Ok(());
+        };
+
+        // Never score synthetic eval sessions.
+        if session.tags.iter().any(|t| t == EVAL_SESSION_TAG) {
+            return Ok(());
+        }
+
+        let observers = self.db.list_active_observers(session.org_id).await?;
+        if observers.is_empty() {
+            return Ok(());
+        }
+
+        let mut enqueue = Vec::new();
+        for observer in observers {
+            let match_config: ObserverMatch = match serde_json::from_value(observer.match_config) {
+                Ok(m) => m,
+                Err(e) => {
+                    error!(observer_id = %observer.public_id, error = %e, "Invalid observer match config");
+                    continue;
+                }
+            };
+            if !match_config.matches(session.agent_id, session.harness_id, &session.tags) {
+                continue;
+            }
+            // Sample per (turn, observer) after matching.
+            if !sample(observer.sampling_rate) {
+                continue;
+            }
+            let scorers: Vec<ObserverScorerConfig> = match serde_json::from_value(observer.scorers)
+            {
+                Ok(s) => s,
+                Err(e) => {
+                    error!(observer_id = %observer.public_id, error = %e, "Invalid observer scorers");
+                    continue;
+                }
+            };
+            for scorer in scorers {
+                // Phase 1 implements turn scope only.
+                if scorer.scope != ObserverScope::Turn {
+                    continue;
+                }
+                enqueue.push(CreateTraceScoreRow {
+                    public_id: TraceScoreId::from_uuid(Uuid::now_v7()).to_string(),
+                    observer_id: observer.id,
+                    scorer_key: scorer.key,
+                    session_id: session_id.uuid(),
+                    turn_id: turn_id.clone(),
+                    agent_id: session.agent_id.map(|a| a.uuid()),
+                    agent_version_id: session.agent_version_id.map(|a| a.uuid()),
+                    harness_id: session.harness_id.map(|h| h.uuid()),
+                });
+            }
+        }
+
+        if enqueue.is_empty() {
+            return Ok(());
+        }
+
+        let inserted = self
+            .db
+            .enqueue_trace_scores(session.org_id, &enqueue)
+            .await?;
+        if inserted > 0 {
+            self.wake.notify_one();
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl EventListener for ObserverMatchListener {
+    #[instrument(skip(self, event), fields(event_id = %event.id, session_id = %event.session_id))]
+    async fn on_event(&self, event: &Event) {
+        let EventData::TurnCompleted(data) = &event.data else {
+            return;
+        };
+        let turn_id = data.turn_id.to_string();
+        if let Err(e) = self.handle_turn_completed(event, turn_id).await {
+            error!(error = %e, "Observer matching failed");
+        }
+    }
+
+    fn event_types(&self) -> Option<Vec<&'static str>> {
+        Some(vec![TURN_COMPLETED])
+    }
+
+    fn name(&self) -> &'static str {
+        "ObserverMatchListener"
+    }
+}
+
+/// Bernoulli sample. `rate >= 1.0` always scores; `rate <= 0.0` never does.
+fn sample(rate: f64) -> bool {
+    if rate >= 1.0 {
+        return true;
+    }
+    if rate <= 0.0 {
+        return false;
+    }
+    rand::random::<f64>() < rate
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sample_boundaries() {
+        assert!(sample(1.0));
+        assert!(sample(2.0));
+        assert!(!sample(0.0));
+        assert!(!sample(-1.0));
+    }
+
+    #[test]
+    fn sample_full_rate_always_true() {
+        for _ in 0..100 {
+            assert!(sample(1.0));
+        }
+    }
+}

--- a/crates/server/src/domains/observers/mod.rs
+++ b/crates/server/src/domains/observers/mod.rs
@@ -1,0 +1,13 @@
+// Observers domain — online scoring of production sessions.
+// See specs/online-evals.md.
+
+pub mod commands;
+pub mod listener;
+pub mod service;
+pub mod types;
+pub mod worker;
+
+pub use commands::*;
+pub use listener::*;
+pub use service::*;
+pub use worker::*;

--- a/crates/server/src/domains/observers/service.rs
+++ b/crates/server/src/domains/observers/service.rs
@@ -1,0 +1,361 @@
+// Observer service — CRUD over observers and read access to trace scores.
+//
+// Decision: Observers reuse agent-management permissions; scores read also
+// requires session-management because scores expose production content.
+// Decision: The service is stateless (db only); scoring happens in the
+// background worker (worker.rs), triggered by the listener (listener.rs).
+
+use crate::api::observers::{CreateObserverRequest, UpdateObserverRequest};
+use crate::errors::BadRequestError;
+use crate::storage::StorageBackend;
+use crate::storage::models::{
+    CreateObserverRow, ListTraceScoresParams, ObserverRow, TraceScoreRow, UpdateObserverRow,
+};
+use anyhow::Result;
+use everruns_core::observer::*;
+use everruns_core::typed_id::{ObserverId, SessionId};
+use everruns_core::{Caller, Permission, Policy, Rule};
+use std::sync::Arc;
+use uuid::Uuid;
+
+/// Policy: View observers and their scores (read-only). Scores expose
+/// production content, so viewing requires session-management permission.
+pub const OBSERVER_VIEW: Policy = Policy {
+    id: "observer.view",
+    rules: &[
+        Rule::UserHasPermission(Permission::OrgAgentsManage),
+        Rule::UserHasPermission(Permission::OrgSessionsManage),
+    ],
+};
+
+/// Policy: Manage observers (create, update, delete).
+pub const OBSERVER_MANAGE: Policy = Policy {
+    id: "observer.manage",
+    rules: &[
+        Rule::UserHasPermission(Permission::OrgAgentsManage),
+        Rule::UserHasPermission(Permission::OrgSessionsManage),
+    ],
+};
+
+/// Default cap on active+paused observers per org. Bounds judge fan-out.
+const DEFAULT_MAX_OBSERVERS_PER_ORG: i64 = 50;
+
+fn max_observers_per_org() -> i64 {
+    std::env::var("OBSERVER_MAX_PER_ORG")
+        .ok()
+        .and_then(|v| v.parse::<i64>().ok())
+        .filter(|&v| v > 0)
+        .unwrap_or(DEFAULT_MAX_OBSERVERS_PER_ORG)
+}
+
+pub struct ObserverService {
+    db: Arc<StorageBackend>,
+}
+
+/// Validate observer configuration before persisting.
+fn validate(sampling_rate: f64, scorers: &[ObserverScorerConfig]) -> Result<()> {
+    if !(0.0..=1.0).contains(&sampling_rate) {
+        anyhow::bail!(BadRequestError::new(
+            "sampling_rate must be between 0.0 and 1.0"
+        ));
+    }
+    if scorers.is_empty() {
+        anyhow::bail!(BadRequestError::new(
+            "observer must define at least one scorer"
+        ));
+    }
+    let mut keys = std::collections::HashSet::new();
+    for scorer in scorers {
+        if scorer.key.trim().is_empty() {
+            anyhow::bail!(BadRequestError::new("scorer key must not be empty"));
+        }
+        if !keys.insert(&scorer.key) {
+            anyhow::bail!(BadRequestError::new(format!(
+                "duplicate scorer key '{}'",
+                scorer.key
+            )));
+        }
+        // file_contains needs the session filesystem, which is not part of the
+        // observable trace contract. Reject it for observers.
+        if matches!(
+            scorer.rule,
+            everruns_core::eval::Scorer::FileContains { .. }
+        ) {
+            anyhow::bail!(BadRequestError::new(
+                "file_contains scorer is not supported by observers"
+            ));
+        }
+    }
+    Ok(())
+}
+
+impl ObserverService {
+    pub fn new(db: Arc<StorageBackend>) -> Self {
+        Self { db }
+    }
+
+    pub async fn create(&self, caller: &Caller, req: CreateObserverRequest) -> Result<Observer> {
+        let sampling_rate = req.sampling_rate.unwrap_or(0.1);
+        validate(sampling_rate, &req.scorers)?;
+
+        let active = self.db.count_active_observers(caller.org_id).await?;
+        if active >= max_observers_per_org() {
+            anyhow::bail!(BadRequestError::new(format!(
+                "observer limit reached ({} max per org)",
+                max_observers_per_org()
+            )));
+        }
+
+        let internal_uuid = Uuid::now_v7();
+        let public_id = ObserverId::from_uuid(internal_uuid);
+
+        let input = CreateObserverRow {
+            public_id: public_id.to_string(),
+            name: req.name,
+            description: req.description,
+            match_config: serde_json::to_value(req.match_config.unwrap_or_default())?,
+            sampling_rate,
+            scorers: serde_json::to_value(&req.scorers)?,
+        };
+
+        let row = self.db.create_observer(caller.org_id, input).await?;
+        row_to_observer(row)
+    }
+
+    pub async fn get_by_public_id(
+        &self,
+        caller: &Caller,
+        public_id: &str,
+    ) -> Result<Option<Observer>> {
+        let row = self
+            .db
+            .get_observer_by_public_id(caller.org_id, public_id)
+            .await?;
+        match row {
+            Some(row) if row.status != "deleted" => Ok(Some(row_to_observer(row)?)),
+            _ => Ok(None),
+        }
+    }
+
+    pub async fn list(&self, caller: &Caller, include_archived: bool) -> Result<Vec<Observer>> {
+        let rows = self
+            .db
+            .list_observers(caller.org_id, include_archived)
+            .await?;
+        rows.into_iter().map(row_to_observer).collect()
+    }
+
+    pub async fn update(
+        &self,
+        caller: &Caller,
+        public_id: &str,
+        req: UpdateObserverRequest,
+    ) -> Result<Option<Observer>> {
+        let existing = self
+            .db
+            .get_observer_by_public_id(caller.org_id, public_id)
+            .await?;
+        let Some(existing) = existing.filter(|o| o.status != "deleted") else {
+            return Ok(None);
+        };
+
+        // Validate the effective configuration after applying the patch.
+        let effective_rate = req.sampling_rate.unwrap_or(existing.sampling_rate);
+        let effective_scorers: Vec<ObserverScorerConfig> = match &req.scorers {
+            Some(scorers) => scorers.clone(),
+            None => serde_json::from_value(existing.scorers.clone())?,
+        };
+        validate(effective_rate, &effective_scorers)?;
+
+        let status = match req.status {
+            Some(status) => {
+                let s = status.to_string();
+                if !matches!(s.as_str(), "active" | "paused" | "archived") {
+                    anyhow::bail!(BadRequestError::new("invalid observer status"));
+                }
+                Some(s)
+            }
+            None => None,
+        };
+
+        let input = UpdateObserverRow {
+            name: req.name,
+            description: req.description,
+            match_config: req.match_config.map(serde_json::to_value).transpose()?,
+            sampling_rate: req.sampling_rate,
+            scorers: req.scorers.map(serde_json::to_value).transpose()?,
+            status,
+        };
+
+        let row = self
+            .db
+            .update_observer(caller.org_id, existing.id, input)
+            .await?;
+        row.map(row_to_observer).transpose()
+    }
+
+    pub async fn delete(&self, caller: &Caller, public_id: &str) -> Result<bool> {
+        let existing = self
+            .db
+            .get_observer_by_public_id(caller.org_id, public_id)
+            .await?;
+        let Some(existing) = existing else {
+            return Ok(false);
+        };
+        self.db.delete_observer(caller.org_id, existing.id).await
+    }
+
+    pub async fn list_scores(
+        &self,
+        caller: &Caller,
+        observer_public_id: &str,
+        session_id: Option<SessionId>,
+        limit: i64,
+        offset: i64,
+    ) -> Result<Option<Vec<TraceScore>>> {
+        let observer = self
+            .db
+            .get_observer_by_public_id(caller.org_id, observer_public_id)
+            .await?;
+        let Some(observer) = observer.filter(|o| o.status != "deleted") else {
+            return Ok(None);
+        };
+
+        let rows = self
+            .db
+            .list_trace_scores(
+                caller.org_id,
+                ListTraceScoresParams {
+                    observer_id: observer.id,
+                    session_id: session_id.map(|s| s.uuid()),
+                    limit: limit.clamp(1, 500),
+                    offset: offset.max(0),
+                },
+            )
+            .await?;
+        // The observer's public id is the externally-visible identifier; the
+        // trace_scores row only carries the internal observer UUID.
+        let observer_public: ObserverId = observer.public_id.parse()?;
+        rows.into_iter()
+            .map(|row| row_to_trace_score(row, observer_public))
+            .collect::<Result<Vec<_>>>()
+            .map(Some)
+    }
+}
+
+pub fn row_to_observer(row: ObserverRow) -> Result<Observer> {
+    Ok(Observer {
+        public_id: row.public_id.parse()?,
+        internal_id: row.id,
+        org_id: row.org_id,
+        name: row.name,
+        description: row.description,
+        match_config: serde_json::from_value(row.match_config)?,
+        sampling_rate: row.sampling_rate,
+        scorers: serde_json::from_value(row.scorers)?,
+        status: ObserverStatus::from(row.status.as_str()),
+        created_at: row.created_at,
+        updated_at: row.updated_at,
+        archived_at: row.archived_at,
+    })
+}
+
+/// Map a stored trace-score row to the API type. `observer_id` is the
+/// observer's public id (the row only carries the internal observer UUID),
+/// and the score's own public id comes from the stored `public_id` column —
+/// neither is derivable from the row's internal UUID.
+pub fn row_to_trace_score(row: TraceScoreRow, observer_id: ObserverId) -> Result<TraceScore> {
+    Ok(TraceScore {
+        public_id: row.public_id.parse()?,
+        internal_id: row.id,
+        org_id: row.org_id,
+        observer_id,
+        scorer_key: row.scorer_key,
+        session_id: SessionId::from_uuid(row.session_id),
+        turn_id: row.turn_id,
+        agent_id: row
+            .agent_id
+            .map(everruns_core::typed_id::AgentId::from_uuid),
+        agent_version_id: row
+            .agent_version_id
+            .map(everruns_core::typed_id::AgentVersionId::from_uuid),
+        harness_id: row
+            .harness_id
+            .map(everruns_core::typed_id::HarnessId::from_uuid),
+        status: TraceScoreStatus::from(row.status.as_str()),
+        pass: row.pass,
+        value: row.value,
+        reason: row.reason,
+        error_message: row.error_message,
+        created_at: row.created_at,
+        updated_at: row.updated_at,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::observers::CreateObserverRequest;
+    use crate::storage::models::CreateTraceScoreRow;
+    use everruns_core::observer::{ObserverScope, ObserverScorerConfig};
+    use everruns_core::typed_id::TraceScoreId;
+
+    // The trace_scores row's internal UUID is DB-generated and independent of
+    // the externally-visible public ids, so the API must echo the stored
+    // public ids — not ones fabricated from the internal UUID.
+    #[tokio::test]
+    async fn list_scores_returns_stored_public_ids() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let svc = ObserverService::new(db.clone());
+        let caller = Caller::internal(1);
+
+        let observer = svc
+            .create(
+                &caller,
+                CreateObserverRequest {
+                    name: "o".into(),
+                    description: None,
+                    match_config: None,
+                    sampling_rate: Some(1.0),
+                    scorers: vec![ObserverScorerConfig {
+                        key: "k".into(),
+                        scope: ObserverScope::Turn,
+                        rule: everruns_core::eval::Scorer::Contains {
+                            text: "x".into(),
+                            weight: 1.0,
+                        },
+                    }],
+                },
+            )
+            .await
+            .unwrap();
+
+        let score_public = TraceScoreId::from_uuid(Uuid::now_v7());
+        db.enqueue_trace_scores(
+            1,
+            &[CreateTraceScoreRow {
+                public_id: score_public.to_string(),
+                observer_id: observer.internal_id,
+                scorer_key: "k".into(),
+                session_id: Uuid::now_v7(),
+                turn_id: "turn_x".into(),
+                agent_id: None,
+                agent_version_id: None,
+                harness_id: None,
+            }],
+        )
+        .await
+        .unwrap();
+
+        let scores = svc
+            .list_scores(&caller, &observer.public_id.to_string(), None, 10, 0)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(scores.len(), 1);
+        // The score's public id and observer id must match what was stored —
+        // not values derived from the internal row UUID.
+        assert_eq!(scores[0].public_id, score_public);
+        assert_eq!(scores[0].observer_id, observer.public_id);
+    }
+}

--- a/crates/server/src/domains/observers/types.rs
+++ b/crates/server/src/domains/observers/types.rs
@@ -1,0 +1,3 @@
+pub use crate::api::observers::{
+    CreateObserverRequest, ListObserversQuery, ListTraceScoresQuery, UpdateObserverRequest,
+};

--- a/crates/server/src/domains/observers/worker.rs
+++ b/crates/server/src/domains/observers/worker.rs
@@ -1,0 +1,448 @@
+// Observer scoring worker — drains the trace_scores queue and runs scorers.
+//
+// Dual-mode by construction: the queue (claim_trace_scores) is implemented by
+// both the PostgreSQL and in-memory backends, so the same worker loop runs in
+// full mode (durable, multi-instance-safe via FOR UPDATE SKIP LOCKED) and in
+// dev mode (in-memory, single process). It is woken immediately after enqueue
+// and also polls on an interval for catch-up.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use everruns_core::eval::Score;
+use everruns_core::observer::ObserverScorerConfig;
+use everruns_core::typed_id::SessionId;
+use tracing::{debug, error, warn};
+
+use crate::domains::evals::runner::{extract_final_assistant_content, extract_tool_calls};
+use crate::domains::evals::scoring::score_rule;
+use crate::storage::StorageBackend;
+use crate::storage::models::{CompleteTraceScoreRow, EventRow, ListEventsParams, TraceScoreRow};
+
+/// Worker tuning. Conservative defaults; bounded judge fan-out.
+#[derive(Clone, Copy, Debug)]
+pub struct ObserverWorkerConfig {
+    /// Max scores claimed per drain iteration.
+    pub batch_size: i64,
+    /// Catch-up poll interval (also heals missed wakeups).
+    pub poll_interval: Duration,
+    /// A `scoring` row older than this is considered abandoned and reclaimed.
+    pub stale_after: Duration,
+    /// Max scoring attempts before a score is finalized as errored.
+    pub max_attempts: i32,
+}
+
+impl Default for ObserverWorkerConfig {
+    fn default() -> Self {
+        Self {
+            batch_size: 32,
+            poll_interval: Duration::from_secs(5),
+            stale_after: Duration::from_secs(120),
+            max_attempts: 3,
+        }
+    }
+}
+
+/// Spawn the background scoring worker. Returns immediately; the loop runs
+/// until the process exits.
+pub fn spawn_observer_worker(
+    db: Arc<StorageBackend>,
+    wake: Arc<tokio::sync::Notify>,
+    config: ObserverWorkerConfig,
+) {
+    tokio::spawn(async move {
+        tracing::info!("Observer scoring worker started");
+        loop {
+            // Drain until a claim returns fewer than a full batch.
+            loop {
+                match drain_once(&db, config).await {
+                    Ok(0) => break,
+                    Ok(n) => {
+                        debug!(scored = n, "Observer scoring batch processed");
+                        if (n as i64) < config.batch_size {
+                            break;
+                        }
+                    }
+                    Err(e) => {
+                        error!(error = %e, "Observer scoring batch failed");
+                        break;
+                    }
+                }
+            }
+            // Wait for the next wakeup or the catch-up poll.
+            tokio::select! {
+                _ = wake.notified() => {}
+                _ = tokio::time::sleep(config.poll_interval) => {}
+            }
+        }
+    });
+}
+
+/// Claim and score one batch. Returns the number of scores processed.
+async fn drain_once(db: &StorageBackend, config: ObserverWorkerConfig) -> anyhow::Result<usize> {
+    let claimed = db
+        .claim_trace_scores(
+            config.batch_size,
+            config.stale_after.as_secs() as i64,
+            config.max_attempts,
+        )
+        .await?;
+    let count = claimed.len();
+    for score in claimed {
+        if let Err(e) = process_score(db, &score).await {
+            // Leave the row in `scoring`; a later claim retries it (or
+            // finalizes it errored once attempts are exhausted).
+            warn!(score_id = %score.public_id, error = %e, "Failed to process trace score");
+        }
+    }
+    Ok(count)
+}
+
+async fn process_score(db: &StorageBackend, score: &TraceScoreRow) -> anyhow::Result<()> {
+    // Load the observer to recover the scorer config for this key.
+    let Some(observer_row) = db.get_observer(score.observer_id).await? else {
+        // Observer deleted between enqueue and scoring — skip.
+        finalize_skipped(db, score, "observer no longer exists").await?;
+        return Ok(());
+    };
+    let scorers: Vec<ObserverScorerConfig> = serde_json::from_value(observer_row.scorers)?;
+    let Some(scorer) = scorers.into_iter().find(|s| s.key == score.scorer_key) else {
+        finalize_skipped(db, score, "scorer key no longer configured").await?;
+        return Ok(());
+    };
+
+    // Load this turn's trace slice.
+    let session_id = SessionId::from_uuid(score.session_id);
+    let msg_events =
+        list_turn_events(db, session_id, &score.turn_id, "output.message.completed").await?;
+    let tool_events = list_turn_events(db, session_id, &score.turn_id, "tool.completed").await?;
+    let turn_events = list_turn_events(db, session_id, &score.turn_id, "turn.completed").await?;
+
+    let final_content = extract_final_assistant_content(&msg_events);
+    let tool_calls = extract_tool_calls(&tool_events);
+    let iterations = extract_iterations(&turn_events);
+
+    let result = score_rule(&scorer.rule, &final_content, &tool_calls, iterations);
+    let Some(Score {
+        pass,
+        value,
+        reason,
+    }) = result
+    else {
+        // Rule unsupported for observers (file_contains is rejected at create
+        // time, so this should not happen); mark skipped to avoid retry loops.
+        finalize_skipped(db, score, "scorer rule unsupported for observers").await?;
+        return Ok(());
+    };
+
+    db.complete_trace_score(
+        score.id,
+        CompleteTraceScoreRow {
+            status: "completed".to_string(),
+            pass: Some(pass),
+            value: Some(value),
+            reason: Some(reason),
+            error_message: None,
+        },
+    )
+    .await?;
+    Ok(())
+}
+
+async fn finalize_skipped(
+    db: &StorageBackend,
+    score: &TraceScoreRow,
+    reason: &str,
+) -> anyhow::Result<()> {
+    db.complete_trace_score(
+        score.id,
+        CompleteTraceScoreRow {
+            status: "skipped".to_string(),
+            pass: None,
+            value: None,
+            reason: Some(reason.to_string()),
+            error_message: None,
+        },
+    )
+    .await?;
+    Ok(())
+}
+
+/// Fetch events of one type belonging to a single turn.
+async fn list_turn_events(
+    db: &StorageBackend,
+    session_id: SessionId,
+    turn_id: &str,
+    event_type: &str,
+) -> anyhow::Result<Vec<EventRow>> {
+    let params = ListEventsParams {
+        session_id,
+        turn_id: Some(turn_id.to_string()),
+        filter_types: vec![event_type.to_string()],
+        ..Default::default()
+    };
+    db.list_events_advanced(&params).await
+}
+
+/// Iteration count from this turn's `turn.completed` event (turn-scope
+/// equivalent of "turns" for the TurnsWithin rule).
+fn extract_iterations(turn_events: &[EventRow]) -> u32 {
+    turn_events
+        .iter()
+        .rev()
+        .find(|e| e.event_type == "turn.completed")
+        .and_then(|e| e.data.get("iterations"))
+        .and_then(|v| v.as_u64())
+        .unwrap_or(1) as u32
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::models::{
+        CreateEventRow, CreateObserverRow, CreateSessionRow, CreateTraceScoreRow,
+    };
+    use everruns_core::observer::{ObserverScope, ObserverScorerConfig};
+    use everruns_core::typed_id::{AgentId, HarnessId, ObserverId, PrincipalId, TraceScoreId};
+    use uuid::Uuid;
+
+    const ORG: i64 = 1;
+
+    fn session_row(agent: AgentId, harness: HarnessId, tags: Vec<String>) -> CreateSessionRow {
+        CreateSessionRow {
+            org_id: ORG,
+            app_id: None,
+            harness_id: Some(harness),
+            agent_id: Some(agent),
+            agent_identity_id: None,
+            owner_principal_id: PrincipalId::from_uuid(Uuid::nil()),
+            resolved_owner_user_id: None,
+            title: None,
+            locale: None,
+            tags,
+            model_id: None,
+            capabilities: serde_json::json!([]),
+            tools: serde_json::json!([]),
+            mcp_servers: serde_json::json!({}),
+            system_prompt: None,
+            initial_files: serde_json::json!([]),
+            hints: None,
+            network_access: None,
+            max_iterations: None,
+            blueprint_id: None,
+            blueprint_config: None,
+        }
+    }
+
+    async fn seed_turn(
+        db: &StorageBackend,
+        session_id: SessionId,
+        turn_id: &str,
+        final_text: &str,
+    ) {
+        let ctx = serde_json::json!({ "turn_id": turn_id });
+        db.create_event(CreateEventRow {
+            session_id,
+            event_type: "output.message.completed".to_string(),
+            ts: chrono::Utc::now(),
+            context: ctx.clone(),
+            data: serde_json::json!({
+                "message": { "content": [{ "type": "text", "text": final_text }] }
+            }),
+            metadata: None,
+            tags: None,
+        })
+        .await
+        .unwrap();
+        db.create_event(CreateEventRow {
+            session_id,
+            event_type: "turn.completed".to_string(),
+            ts: chrono::Utc::now(),
+            context: ctx,
+            data: serde_json::json!({ "turn_id": turn_id, "iterations": 2 }),
+            metadata: None,
+            tags: None,
+        })
+        .await
+        .unwrap();
+    }
+
+    fn contains_observer(agent: AgentId, key: &str, text: &str) -> CreateObserverRow {
+        let scorer = ObserverScorerConfig {
+            key: key.to_string(),
+            scope: ObserverScope::Turn,
+            rule: everruns_core::eval::Scorer::Contains {
+                text: text.to_string(),
+                weight: 1.0,
+            },
+        };
+        CreateObserverRow {
+            public_id: ObserverId::from_uuid(Uuid::now_v7()).to_string(),
+            name: "test".to_string(),
+            description: None,
+            match_config: serde_json::to_value(everruns_core::observer::ObserverMatch {
+                agent_ids: Some(vec![agent]),
+                ..Default::default()
+            })
+            .unwrap(),
+            sampling_rate: 1.0,
+            scorers: serde_json::to_value(vec![scorer]).unwrap(),
+        }
+    }
+
+    async fn enqueue(
+        db: &StorageBackend,
+        observer_id: Uuid,
+        key: &str,
+        session_id: SessionId,
+        turn_id: &str,
+        agent: AgentId,
+    ) {
+        db.enqueue_trace_scores(
+            ORG,
+            &[CreateTraceScoreRow {
+                public_id: TraceScoreId::from_uuid(Uuid::now_v7()).to_string(),
+                observer_id,
+                scorer_key: key.to_string(),
+                session_id: session_id.uuid(),
+                turn_id: turn_id.to_string(),
+                agent_id: Some(agent.uuid()),
+                agent_version_id: None,
+                harness_id: None,
+            }],
+        )
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn drains_and_scores_a_matching_turn() {
+        let db = StorageBackend::in_memory();
+        let agent = AgentId::new();
+        let harness = HarnessId::new();
+        let turn_id = "turn_01933b5a000070008000000000000abc";
+
+        let session = db
+            .create_session(session_row(agent, harness, vec!["prod".into()]))
+            .await
+            .unwrap();
+        seed_turn(&db, session.id, turn_id, "hello world from the agent").await;
+
+        let observer = db
+            .create_observer(ORG, contains_observer(agent, "greet", "hello"))
+            .await
+            .unwrap();
+        enqueue(&db, observer.id, "greet", session.id, turn_id, agent).await;
+
+        let processed = drain_once(&db, ObserverWorkerConfig::default())
+            .await
+            .unwrap();
+        assert_eq!(processed, 1);
+
+        let scores = db
+            .list_trace_scores(
+                ORG,
+                crate::storage::models::ListTraceScoresParams {
+                    observer_id: observer.id,
+                    session_id: None,
+                    limit: 10,
+                    offset: 0,
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(scores.len(), 1);
+        assert_eq!(scores[0].status, "completed");
+        assert_eq!(scores[0].pass, Some(true));
+        assert_eq!(scores[0].value, Some(1.0));
+    }
+
+    #[tokio::test]
+    async fn scores_failing_rule_as_not_passed() {
+        let db = StorageBackend::in_memory();
+        let agent = AgentId::new();
+        let harness = HarnessId::new();
+        let turn_id = "turn_01933b5a000070008000000000000def";
+
+        let session = db
+            .create_session(session_row(agent, harness, vec![]))
+            .await
+            .unwrap();
+        seed_turn(&db, session.id, turn_id, "goodbye").await;
+
+        let observer = db
+            .create_observer(ORG, contains_observer(agent, "greet", "hello"))
+            .await
+            .unwrap();
+        enqueue(&db, observer.id, "greet", session.id, turn_id, agent).await;
+
+        drain_once(&db, ObserverWorkerConfig::default())
+            .await
+            .unwrap();
+
+        let scores = db
+            .list_trace_scores(
+                ORG,
+                crate::storage::models::ListTraceScoresParams {
+                    observer_id: observer.id,
+                    session_id: None,
+                    limit: 10,
+                    offset: 0,
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(scores[0].status, "completed");
+        assert_eq!(scores[0].pass, Some(false));
+        assert_eq!(scores[0].value, Some(0.0));
+    }
+
+    #[tokio::test]
+    async fn skips_score_when_scorer_key_removed() {
+        let db = StorageBackend::in_memory();
+        let agent = AgentId::new();
+        let harness = HarnessId::new();
+        let turn_id = "turn_01933b5a000070008000000000000fed";
+
+        let session = db
+            .create_session(session_row(agent, harness, vec![]))
+            .await
+            .unwrap();
+        seed_turn(&db, session.id, turn_id, "hello").await;
+
+        let observer = db
+            .create_observer(ORG, contains_observer(agent, "greet", "hello"))
+            .await
+            .unwrap();
+        enqueue(&db, observer.id, "greet", session.id, turn_id, agent).await;
+        // Remove the scorer config so the worker cannot find the key.
+        db.update_observer(
+            ORG,
+            observer.id,
+            crate::storage::models::UpdateObserverRow {
+                scorers: Some(serde_json::json!([])),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+        drain_once(&db, ObserverWorkerConfig::default())
+            .await
+            .unwrap();
+
+        let scores = db
+            .list_trace_scores(
+                ORG,
+                crate::storage::models::ListTraceScoresParams {
+                    observer_id: observer.id,
+                    session_id: None,
+                    limit: 10,
+                    offset: 0,
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(scores[0].status, "skipped");
+    }
+}

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -3027,6 +3027,98 @@ impl StorageBackend {
     }
 
     // ============================================
+    // Observers (online scoring — specs/online-evals.md)
+    // ============================================
+
+    pub async fn create_observer(
+        &self,
+        org_id: i64,
+        input: CreateObserverRow,
+    ) -> Result<ObserverRow> {
+        dispatch!(self, create_observer, org_id, input)
+    }
+
+    pub async fn get_observer_by_public_id(
+        &self,
+        org_id: i64,
+        public_id: &str,
+    ) -> Result<Option<ObserverRow>> {
+        dispatch!(self, get_observer_by_public_id, org_id, public_id)
+    }
+
+    pub async fn get_observer(&self, id: Uuid) -> Result<Option<ObserverRow>> {
+        dispatch!(self, get_observer, id)
+    }
+
+    pub async fn list_observers(
+        &self,
+        org_id: i64,
+        include_archived: bool,
+    ) -> Result<Vec<ObserverRow>> {
+        dispatch!(self, list_observers, org_id, include_archived)
+    }
+
+    pub async fn list_active_observers(&self, org_id: i64) -> Result<Vec<ObserverRow>> {
+        dispatch!(self, list_active_observers, org_id)
+    }
+
+    pub async fn count_active_observers(&self, org_id: i64) -> Result<i64> {
+        dispatch!(self, count_active_observers, org_id)
+    }
+
+    pub async fn update_observer(
+        &self,
+        org_id: i64,
+        id: Uuid,
+        input: UpdateObserverRow,
+    ) -> Result<Option<ObserverRow>> {
+        dispatch!(self, update_observer, org_id, id, input)
+    }
+
+    pub async fn delete_observer(&self, org_id: i64, id: Uuid) -> Result<bool> {
+        dispatch!(self, delete_observer, org_id, id)
+    }
+
+    pub async fn enqueue_trace_scores(
+        &self,
+        org_id: i64,
+        inputs: &[CreateTraceScoreRow],
+    ) -> Result<u64> {
+        dispatch!(self, enqueue_trace_scores, org_id, inputs)
+    }
+
+    pub async fn claim_trace_scores(
+        &self,
+        limit: i64,
+        stale_after_seconds: i64,
+        max_attempts: i32,
+    ) -> Result<Vec<TraceScoreRow>> {
+        dispatch!(
+            self,
+            claim_trace_scores,
+            limit,
+            stale_after_seconds,
+            max_attempts
+        )
+    }
+
+    pub async fn complete_trace_score(
+        &self,
+        id: Uuid,
+        input: CompleteTraceScoreRow,
+    ) -> Result<Option<TraceScoreRow>> {
+        dispatch!(self, complete_trace_score, id, input)
+    }
+
+    pub async fn list_trace_scores(
+        &self,
+        org_id: i64,
+        params: ListTraceScoresParams,
+    ) -> Result<Vec<TraceScoreRow>> {
+        dispatch!(self, list_trace_scores, org_id, params)
+    }
+
+    // ============================================
     // Eval CRUD
     // ============================================
 

--- a/crates/server/src/storage/memory/mod.rs
+++ b/crates/server/src/storage/memory/mod.rs
@@ -24,6 +24,7 @@ mod llm;
 mod mcp_servers;
 mod memories;
 mod notifications;
+mod observers;
 mod org_feature_flags;
 mod organizations;
 mod payments;
@@ -152,6 +153,8 @@ pub struct InMemoryDatabase {
     eval_cases: RwLock<HashMap<Uuid, EvalCaseRow>>,
     eval_runs: RwLock<HashMap<Uuid, EvalRunRow>>,
     eval_case_results: RwLock<HashMap<Uuid, EvalCaseResultRow>>,
+    observers: RwLock<HashMap<Uuid, ObserverRow>>,
+    trace_scores: RwLock<HashMap<Uuid, TraceScoreRow>>,
     // Budgets
     budgets: RwLock<HashMap<Uuid, BudgetRow>>,
     usage_journal: RwLock<HashMap<Uuid, UsageJournalRow>>,
@@ -267,6 +270,8 @@ impl Default for InMemoryDatabase {
             eval_cases: RwLock::new(HashMap::new()),
             eval_runs: RwLock::new(HashMap::new()),
             eval_case_results: RwLock::new(HashMap::new()),
+            observers: RwLock::new(HashMap::new()),
+            trace_scores: RwLock::new(HashMap::new()),
             budgets: RwLock::new(HashMap::new()),
             usage_journal: RwLock::new(HashMap::new()),
             usage_ledger: RwLock::new(Vec::new()),

--- a/crates/server/src/storage/memory/observers.rs
+++ b/crates/server/src/storage/memory/observers.rs
@@ -1,0 +1,282 @@
+// In-memory observer storage. Same queue semantics as the PostgreSQL
+// implementation, minus durability: a single write lock replaces
+// FOR UPDATE SKIP LOCKED.
+
+use anyhow::Result;
+use uuid::Uuid;
+
+use super::InMemoryDatabase;
+use crate::storage::models::*;
+
+impl InMemoryDatabase {
+    // ============================================
+    // Observer CRUD
+    // ============================================
+
+    pub async fn create_observer(
+        &self,
+        org_id: i64,
+        input: CreateObserverRow,
+    ) -> Result<ObserverRow> {
+        let now = Self::now();
+        let id = Uuid::now_v7();
+        let row = ObserverRow {
+            id,
+            org_id,
+            public_id: input.public_id,
+            name: input.name,
+            description: input.description,
+            match_config: input.match_config,
+            sampling_rate: input.sampling_rate,
+            scorers: input.scorers,
+            status: "active".to_string(),
+            created_at: now,
+            updated_at: now,
+            archived_at: None,
+        };
+        self.observers.write().insert(id, row.clone());
+        Ok(row)
+    }
+
+    pub async fn get_observer_by_public_id(
+        &self,
+        org_id: i64,
+        public_id: &str,
+    ) -> Result<Option<ObserverRow>> {
+        let observers = self.observers.read();
+        Ok(observers
+            .values()
+            .find(|o| o.org_id == org_id && o.public_id == public_id)
+            .cloned())
+    }
+
+    pub async fn get_observer(&self, id: Uuid) -> Result<Option<ObserverRow>> {
+        Ok(self.observers.read().get(&id).cloned())
+    }
+
+    pub async fn list_observers(
+        &self,
+        org_id: i64,
+        include_archived: bool,
+    ) -> Result<Vec<ObserverRow>> {
+        let observers = self.observers.read();
+        let mut result: Vec<ObserverRow> = observers
+            .values()
+            .filter(|o| {
+                o.org_id == org_id
+                    && if include_archived {
+                        o.status != "deleted"
+                    } else {
+                        o.status != "archived" && o.status != "deleted"
+                    }
+            })
+            .cloned()
+            .collect();
+        result.sort_by_key(|o| std::cmp::Reverse(o.created_at));
+        Ok(result)
+    }
+
+    pub async fn list_active_observers(&self, org_id: i64) -> Result<Vec<ObserverRow>> {
+        let observers = self.observers.read();
+        Ok(observers
+            .values()
+            .filter(|o| o.org_id == org_id && o.status == "active")
+            .cloned()
+            .collect())
+    }
+
+    pub async fn count_active_observers(&self, org_id: i64) -> Result<i64> {
+        let observers = self.observers.read();
+        Ok(observers
+            .values()
+            .filter(|o| o.org_id == org_id && matches!(o.status.as_str(), "active" | "paused"))
+            .count() as i64)
+    }
+
+    pub async fn update_observer(
+        &self,
+        org_id: i64,
+        id: Uuid,
+        input: UpdateObserverRow,
+    ) -> Result<Option<ObserverRow>> {
+        let mut observers = self.observers.write();
+        let Some(observer) = observers.get_mut(&id) else {
+            return Ok(None);
+        };
+        if observer.org_id != org_id {
+            return Ok(None);
+        }
+        if let Some(name) = input.name {
+            observer.name = name;
+        }
+        if let Some(description) = input.description {
+            observer.description = Some(description);
+        }
+        if let Some(match_config) = input.match_config {
+            observer.match_config = match_config;
+        }
+        if let Some(sampling_rate) = input.sampling_rate {
+            observer.sampling_rate = sampling_rate;
+        }
+        if let Some(scorers) = input.scorers {
+            observer.scorers = scorers;
+        }
+        if let Some(status) = input.status {
+            observer.status = status;
+        }
+        observer.updated_at = Self::now();
+        Ok(Some(observer.clone()))
+    }
+
+    pub async fn delete_observer(&self, org_id: i64, id: Uuid) -> Result<bool> {
+        let mut observers = self.observers.write();
+        let Some(observer) = observers.get_mut(&id) else {
+            return Ok(false);
+        };
+        if observer.org_id != org_id || !matches!(observer.status.as_str(), "active" | "paused") {
+            return Ok(false);
+        }
+        observer.status = "archived".to_string();
+        observer.archived_at = Some(Self::now());
+        observer.updated_at = Self::now();
+        Ok(true)
+    }
+
+    // ============================================
+    // Trace scores (queue + results)
+    // ============================================
+
+    pub async fn enqueue_trace_scores(
+        &self,
+        org_id: i64,
+        inputs: &[CreateTraceScoreRow],
+    ) -> Result<u64> {
+        let now = Self::now();
+        let mut scores = self.trace_scores.write();
+        let mut inserted = 0u64;
+        for input in inputs {
+            let duplicate = scores.values().any(|s| {
+                s.observer_id == input.observer_id
+                    && s.scorer_key == input.scorer_key
+                    && s.session_id == input.session_id
+                    && s.turn_id == input.turn_id
+            });
+            if duplicate {
+                continue;
+            }
+            let id = Uuid::now_v7();
+            scores.insert(
+                id,
+                TraceScoreRow {
+                    id,
+                    org_id,
+                    public_id: input.public_id.clone(),
+                    observer_id: input.observer_id,
+                    scorer_key: input.scorer_key.clone(),
+                    session_id: input.session_id,
+                    turn_id: input.turn_id.clone(),
+                    agent_id: input.agent_id,
+                    agent_version_id: input.agent_version_id,
+                    harness_id: input.harness_id,
+                    status: "pending".to_string(),
+                    attempts: 0,
+                    pass: None,
+                    value: None,
+                    reason: None,
+                    error_message: None,
+                    created_at: now,
+                    updated_at: now,
+                },
+            );
+            inserted += 1;
+        }
+        Ok(inserted)
+    }
+
+    pub async fn claim_trace_scores(
+        &self,
+        limit: i64,
+        stale_after_seconds: i64,
+        max_attempts: i32,
+    ) -> Result<Vec<TraceScoreRow>> {
+        let now = Self::now();
+        let stale_cutoff = now - chrono::Duration::seconds(stale_after_seconds);
+        let mut scores = self.trace_scores.write();
+
+        for score in scores.values_mut() {
+            if score.status == "scoring"
+                && score.updated_at < stale_cutoff
+                && score.attempts >= max_attempts
+            {
+                score.status = "errored".to_string();
+                score.error_message = Some("scoring attempts exhausted".to_string());
+                score.updated_at = now;
+            }
+        }
+
+        let mut claimable: Vec<(chrono::DateTime<chrono::Utc>, Uuid)> = scores
+            .values()
+            .filter(|s| {
+                s.attempts < max_attempts
+                    && (s.status == "pending"
+                        || (s.status == "scoring" && s.updated_at < stale_cutoff))
+            })
+            .map(|s| (s.created_at, s.id))
+            .collect();
+        claimable.sort();
+        let claimable: Vec<Uuid> = claimable
+            .into_iter()
+            .take(limit.max(0) as usize)
+            .map(|(_, id)| id)
+            .collect();
+
+        let mut claimed = Vec::with_capacity(claimable.len());
+        for id in claimable {
+            if let Some(score) = scores.get_mut(&id) {
+                score.status = "scoring".to_string();
+                score.attempts += 1;
+                score.updated_at = now;
+                claimed.push(score.clone());
+            }
+        }
+        Ok(claimed)
+    }
+
+    pub async fn complete_trace_score(
+        &self,
+        id: Uuid,
+        input: CompleteTraceScoreRow,
+    ) -> Result<Option<TraceScoreRow>> {
+        let mut scores = self.trace_scores.write();
+        let Some(score) = scores.get_mut(&id) else {
+            return Ok(None);
+        };
+        score.status = input.status;
+        score.pass = input.pass;
+        score.value = input.value;
+        score.reason = input.reason;
+        score.error_message = input.error_message;
+        score.updated_at = Self::now();
+        Ok(Some(score.clone()))
+    }
+
+    pub async fn list_trace_scores(
+        &self,
+        org_id: i64,
+        params: ListTraceScoresParams,
+    ) -> Result<Vec<TraceScoreRow>> {
+        let scores = self.trace_scores.read();
+        let mut result: Vec<TraceScoreRow> = scores
+            .values()
+            .filter(|s| s.org_id == org_id && s.observer_id == params.observer_id)
+            .filter(|s| params.session_id.is_none_or(|sid| s.session_id == sid))
+            .cloned()
+            .collect();
+        result.sort_by_key(|s| std::cmp::Reverse(s.created_at));
+        Ok(result
+            .into_iter()
+            .skip(params.offset.max(0) as usize)
+            .take(params.limit.max(0) as usize)
+            .collect())
+    }
+}

--- a/crates/server/src/storage/models.rs
+++ b/crates/server/src/storage/models.rs
@@ -2372,6 +2372,105 @@ pub struct UpdateEvalCaseResultRow {
 }
 
 // ============================================================================
+// Observer models (online scoring — see specs/online-evals.md)
+// ============================================================================
+
+/// Observer row from database
+#[derive(Debug, Clone, FromRow)]
+pub struct ObserverRow {
+    pub id: Uuid,
+    pub org_id: i64,
+    pub public_id: String,
+    pub name: String,
+    pub description: Option<String>,
+    pub match_config: serde_json::Value,
+    pub sampling_rate: f64,
+    pub scorers: serde_json::Value,
+    pub status: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub archived_at: Option<DateTime<Utc>>,
+}
+
+/// Input for creating an observer
+#[derive(Debug, Clone)]
+pub struct CreateObserverRow {
+    pub public_id: String,
+    pub name: String,
+    pub description: Option<String>,
+    pub match_config: serde_json::Value,
+    pub sampling_rate: f64,
+    pub scorers: serde_json::Value,
+}
+
+/// Input for updating an observer
+#[derive(Debug, Clone, Default)]
+pub struct UpdateObserverRow {
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub match_config: Option<serde_json::Value>,
+    pub sampling_rate: Option<f64>,
+    pub scorers: Option<serde_json::Value>,
+    pub status: Option<String>,
+}
+
+/// Trace score row from database. Pending rows double as the scoring queue.
+#[derive(Debug, Clone, FromRow)]
+pub struct TraceScoreRow {
+    pub id: Uuid,
+    pub org_id: i64,
+    pub public_id: String,
+    pub observer_id: Uuid,
+    pub scorer_key: String,
+    pub session_id: Uuid,
+    pub turn_id: String,
+    pub agent_id: Option<Uuid>,
+    pub agent_version_id: Option<Uuid>,
+    pub harness_id: Option<Uuid>,
+    pub status: String,
+    pub attempts: i32,
+    pub pass: Option<bool>,
+    pub value: Option<f64>,
+    pub reason: Option<String>,
+    pub error_message: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// Input for enqueueing a trace score (one per matched scorer).
+#[derive(Debug, Clone)]
+pub struct CreateTraceScoreRow {
+    pub public_id: String,
+    pub observer_id: Uuid,
+    pub scorer_key: String,
+    pub session_id: Uuid,
+    pub turn_id: String,
+    pub agent_id: Option<Uuid>,
+    pub agent_version_id: Option<Uuid>,
+    pub harness_id: Option<Uuid>,
+}
+
+/// Terminal result written back by the scoring worker.
+#[derive(Debug, Clone)]
+pub struct CompleteTraceScoreRow {
+    /// `completed`, `errored`, or `skipped`.
+    pub status: String,
+    pub pass: Option<bool>,
+    pub value: Option<f64>,
+    pub reason: Option<String>,
+    pub error_message: Option<String>,
+}
+
+/// Filters for listing trace scores.
+#[derive(Debug, Clone, Default)]
+pub struct ListTraceScoresParams {
+    pub observer_id: Uuid,
+    pub session_id: Option<Uuid>,
+    pub limit: i64,
+    pub offset: i64,
+}
+
+// ============================================================================
 // Budget models
 // ============================================================================
 

--- a/crates/server/src/storage/repositories/mod.rs
+++ b/crates/server/src/storage/repositories/mod.rs
@@ -19,6 +19,7 @@ mod llm;
 mod mcp_servers;
 mod memory;
 mod notifications;
+mod observers;
 mod org_feature_flags;
 mod organizations;
 mod payments;

--- a/crates/server/src/storage/repositories/observers.rs
+++ b/crates/server/src/storage/repositories/observers.rs
@@ -1,0 +1,321 @@
+// Observer storage (PostgreSQL) — see specs/online-evals.md.
+//
+// trace_scores doubles as the scoring queue: claim_trace_scores uses
+// FOR UPDATE SKIP LOCKED so multiple server instances never double-claim,
+// and stale 'scoring' rows (crashed worker) are reclaimed until the
+// attempt budget is exhausted.
+
+use anyhow::Result;
+use uuid::Uuid;
+
+use crate::storage::Database;
+use crate::storage::models::*;
+
+impl Database {
+    // ============================================
+    // Observer CRUD
+    // ============================================
+
+    pub async fn create_observer(
+        &self,
+        org_id: i64,
+        input: CreateObserverRow,
+    ) -> Result<ObserverRow> {
+        let row = sqlx::query_as::<_, ObserverRow>(
+            r#"
+            INSERT INTO observers (org_id, public_id, name, description, match_config, sampling_rate, scorers)
+            VALUES ($1, $2, $3, $4, $5, $6, $7)
+            RETURNING id, org_id, public_id, name, description, match_config,
+                      sampling_rate, scorers, status, created_at, updated_at, archived_at
+            "#,
+        )
+        .bind(org_id)
+        .bind(&input.public_id)
+        .bind(&input.name)
+        .bind(&input.description)
+        .bind(&input.match_config)
+        .bind(input.sampling_rate)
+        .bind(&input.scorers)
+        .fetch_one(&self.pool)
+        .await?;
+        Ok(row)
+    }
+
+    pub async fn get_observer_by_public_id(
+        &self,
+        org_id: i64,
+        public_id: &str,
+    ) -> Result<Option<ObserverRow>> {
+        let row = sqlx::query_as::<_, ObserverRow>(
+            r#"
+            SELECT id, org_id, public_id, name, description, match_config,
+                   sampling_rate, scorers, status, created_at, updated_at, archived_at
+            FROM observers
+            WHERE org_id = $1 AND public_id = $2
+            "#,
+        )
+        .bind(org_id)
+        .bind(public_id)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(row)
+    }
+
+    pub async fn get_observer(&self, id: Uuid) -> Result<Option<ObserverRow>> {
+        let row = sqlx::query_as::<_, ObserverRow>(
+            r#"
+            SELECT id, org_id, public_id, name, description, match_config,
+                   sampling_rate, scorers, status, created_at, updated_at, archived_at
+            FROM observers
+            WHERE id = $1
+            "#,
+        )
+        .bind(id)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(row)
+    }
+
+    pub async fn list_observers(
+        &self,
+        org_id: i64,
+        include_archived: bool,
+    ) -> Result<Vec<ObserverRow>> {
+        let status_sql = if include_archived {
+            " AND status != 'deleted'"
+        } else {
+            " AND status NOT IN ('archived', 'deleted')"
+        };
+        let sql = format!(
+            r#"SELECT id, org_id, public_id, name, description, match_config,
+                      sampling_rate, scorers, status, created_at, updated_at, archived_at
+               FROM observers
+               WHERE org_id = $1{status_sql}
+               ORDER BY created_at DESC"#
+        );
+        let rows = sqlx::query_as::<_, ObserverRow>(sqlx::AssertSqlSafe(sql.as_str()))
+            .bind(org_id)
+            .fetch_all(&self.pool)
+            .await?;
+        Ok(rows)
+    }
+
+    /// Active observers for an org — the per-turn matching lookup.
+    pub async fn list_active_observers(&self, org_id: i64) -> Result<Vec<ObserverRow>> {
+        let rows = sqlx::query_as::<_, ObserverRow>(
+            r#"
+            SELECT id, org_id, public_id, name, description, match_config,
+                   sampling_rate, scorers, status, created_at, updated_at, archived_at
+            FROM observers
+            WHERE org_id = $1 AND status = 'active'
+            "#,
+        )
+        .bind(org_id)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows)
+    }
+
+    pub async fn count_active_observers(&self, org_id: i64) -> Result<i64> {
+        let row: (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM observers WHERE org_id = $1 AND status IN ('active', 'paused')",
+        )
+        .bind(org_id)
+        .fetch_one(&self.pool)
+        .await?;
+        Ok(row.0)
+    }
+
+    pub async fn update_observer(
+        &self,
+        org_id: i64,
+        id: Uuid,
+        input: UpdateObserverRow,
+    ) -> Result<Option<ObserverRow>> {
+        let row = sqlx::query_as::<_, ObserverRow>(
+            r#"
+            UPDATE observers
+            SET
+                name = COALESCE($3, name),
+                description = COALESCE($4, description),
+                match_config = COALESCE($5, match_config),
+                sampling_rate = COALESCE($6, sampling_rate),
+                scorers = COALESCE($7, scorers),
+                status = COALESCE($8, status),
+                updated_at = NOW()
+            WHERE org_id = $1 AND id = $2
+            RETURNING id, org_id, public_id, name, description, match_config,
+                      sampling_rate, scorers, status, created_at, updated_at, archived_at
+            "#,
+        )
+        .bind(org_id)
+        .bind(id)
+        .bind(&input.name)
+        .bind(&input.description)
+        .bind(&input.match_config)
+        .bind(input.sampling_rate)
+        .bind(&input.scorers)
+        .bind(&input.status)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(row)
+    }
+
+    pub async fn delete_observer(&self, org_id: i64, id: Uuid) -> Result<bool> {
+        let result = sqlx::query(
+            r#"
+            UPDATE observers
+            SET status = 'archived', archived_at = COALESCE(archived_at, NOW()), updated_at = NOW()
+            WHERE org_id = $1 AND id = $2 AND status IN ('active', 'paused')
+            "#,
+        )
+        .bind(org_id)
+        .bind(id)
+        .execute(&self.pool)
+        .await?;
+        Ok(result.rows_affected() > 0)
+    }
+
+    // ============================================
+    // Trace scores (queue + results)
+    // ============================================
+
+    /// Enqueue pending scores. Idempotent: re-delivered events hit the
+    /// (observer_id, scorer_key, session_id, turn_id) unique key and no-op.
+    pub async fn enqueue_trace_scores(
+        &self,
+        org_id: i64,
+        inputs: &[CreateTraceScoreRow],
+    ) -> Result<u64> {
+        let mut inserted = 0u64;
+        for input in inputs {
+            let result = sqlx::query(
+                r#"
+                INSERT INTO trace_scores (org_id, public_id, observer_id, scorer_key, session_id,
+                                          turn_id, agent_id, agent_version_id, harness_id)
+                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+                ON CONFLICT (observer_id, scorer_key, session_id, turn_id) DO NOTHING
+                "#,
+            )
+            .bind(org_id)
+            .bind(&input.public_id)
+            .bind(input.observer_id)
+            .bind(&input.scorer_key)
+            .bind(input.session_id)
+            .bind(&input.turn_id)
+            .bind(input.agent_id)
+            .bind(input.agent_version_id)
+            .bind(input.harness_id)
+            .execute(&self.pool)
+            .await?;
+            inserted += result.rows_affected();
+        }
+        Ok(inserted)
+    }
+
+    /// Claim up to `limit` queued scores for processing. Picks up fresh
+    /// `pending` rows plus stale `scoring` rows (worker died mid-flight)
+    /// older than `stale_after_seconds`, while attempts remain. Rows that
+    /// exhausted their attempt budget are finalized as errored first.
+    pub async fn claim_trace_scores(
+        &self,
+        limit: i64,
+        stale_after_seconds: i64,
+        max_attempts: i32,
+    ) -> Result<Vec<TraceScoreRow>> {
+        sqlx::query(
+            r#"
+            UPDATE trace_scores
+            SET status = 'errored', error_message = 'scoring attempts exhausted', updated_at = NOW()
+            WHERE status = 'scoring'
+              AND updated_at < NOW() - make_interval(secs => $1)
+              AND attempts >= $2
+            "#,
+        )
+        .bind(stale_after_seconds as f64)
+        .bind(max_attempts)
+        .execute(&self.pool)
+        .await?;
+
+        let rows = sqlx::query_as::<_, TraceScoreRow>(
+            r#"
+            UPDATE trace_scores
+            SET status = 'scoring', attempts = attempts + 1, updated_at = NOW()
+            WHERE id IN (
+                SELECT id FROM trace_scores
+                WHERE (status = 'pending'
+                       OR (status = 'scoring' AND updated_at < NOW() - make_interval(secs => $1)))
+                  AND attempts < $2
+                ORDER BY created_at
+                LIMIT $3
+                FOR UPDATE SKIP LOCKED
+            )
+            RETURNING id, org_id, public_id, observer_id, scorer_key, session_id,
+                      turn_id, agent_id, agent_version_id, harness_id, status, attempts,
+                      pass, value, reason, error_message, created_at, updated_at
+            "#,
+        )
+        .bind(stale_after_seconds as f64)
+        .bind(max_attempts)
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows)
+    }
+
+    pub async fn complete_trace_score(
+        &self,
+        id: Uuid,
+        input: CompleteTraceScoreRow,
+    ) -> Result<Option<TraceScoreRow>> {
+        let row = sqlx::query_as::<_, TraceScoreRow>(
+            r#"
+            UPDATE trace_scores
+            SET status = $2, pass = $3, value = $4, reason = $5, error_message = $6, updated_at = NOW()
+            WHERE id = $1
+            RETURNING id, org_id, public_id, observer_id, scorer_key, session_id,
+                      turn_id, agent_id, agent_version_id, harness_id, status, attempts,
+                      pass, value, reason, error_message, created_at, updated_at
+            "#,
+        )
+        .bind(id)
+        .bind(&input.status)
+        .bind(input.pass)
+        .bind(input.value)
+        .bind(&input.reason)
+        .bind(&input.error_message)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(row)
+    }
+
+    pub async fn list_trace_scores(
+        &self,
+        org_id: i64,
+        params: ListTraceScoresParams,
+    ) -> Result<Vec<TraceScoreRow>> {
+        let session_sql = if params.session_id.is_some() {
+            " AND session_id = $5"
+        } else {
+            ""
+        };
+        let sql = format!(
+            r#"SELECT id, org_id, public_id, observer_id, scorer_key, session_id,
+                      turn_id, agent_id, agent_version_id, harness_id, status, attempts,
+                      pass, value, reason, error_message, created_at, updated_at
+               FROM trace_scores
+               WHERE org_id = $1 AND observer_id = $2{session_sql}
+               ORDER BY created_at DESC
+               LIMIT $3 OFFSET $4"#
+        );
+        let mut query = sqlx::query_as::<_, TraceScoreRow>(sqlx::AssertSqlSafe(sql.as_str()))
+            .bind(org_id)
+            .bind(params.observer_id)
+            .bind(params.limit)
+            .bind(params.offset);
+        if let Some(session_id) = params.session_id {
+            query = query.bind(session_id);
+        }
+        Ok(query.fetch_all(&self.pool).await?)
+    }
+}

--- a/crates/server/tests/command_policy_enforcement_test.rs
+++ b/crates/server/tests/command_policy_enforcement_test.rs
@@ -30,7 +30,7 @@ use everruns_server::domains::common::{
 use everruns_server::domains::evals::{CreateEvalRun, ListEvals};
 use everruns_server::domains::harnesses::types::CreateHarnessRequest;
 use everruns_server::domains::harnesses::{CreateHarness, ListHarnesses};
-use everruns_server::domains::session_files::{GetSessionFile, ListSessionFiles};
+use everruns_server::domains::session_files::{GetWorkspaceFile, ListWorkspaceFiles};
 use everruns_server::domains::session_tasks::{
     CancelSessionTask, GetSessionTask, ListSessionTasks, PostSessionTaskMessage,
 };
@@ -426,7 +426,7 @@ async fn eval_manage_without_session_permission_still_allows_list() {
 }
 
 // ============================================================================
-// EVE-551: ListSessionFiles and GetSessionFile must enforce SESSION_VIEW.
+// EVE-551: ListWorkspaceFiles and GetWorkspaceFile must enforce SESSION_VIEW.
 // A resolver denying OrgSessionsManage must get 403 before any file lookup.
 // ============================================================================
 
@@ -434,23 +434,23 @@ async fn eval_manage_without_session_permission_still_allows_list() {
 async fn session_file_read_commands_enforce_session_view_policy() {
     let ctx = make_ctx(caller_with_role(OrgRole::Owner), Arc::new(DenyAllResolver));
 
-    let list_err = ListSessionFiles {
+    let list_err = ListWorkspaceFiles {
         session_id: "session_00000000000000000000000000000001".to_string(),
         recursive: false,
     }
     .run(&ctx)
     .await
-    .expect_err("ListSessionFiles must require SESSION_VIEW");
+    .expect_err("ListWorkspaceFiles must require SESSION_VIEW");
     assert_forbidden(list_err);
 
-    let get_err = GetSessionFile {
+    let get_err = GetWorkspaceFile {
         session_id: "session_00000000000000000000000000000001".to_string(),
         path: "/".to_string(),
         recursive: false,
     }
     .run(&ctx)
     .await
-    .expect_err("GetSessionFile must require SESSION_VIEW");
+    .expect_err("GetWorkspaceFile must require SESSION_VIEW");
     assert_forbidden(get_err);
 }
 

--- a/crates/server/tests/observers_integration_test.rs
+++ b/crates/server/tests/observers_integration_test.rs
@@ -1,0 +1,232 @@
+//! Observer CRUD and validation integration tests.
+//!
+//! End-to-end scoring (match → enqueue → worker → score) is covered by unit
+//! tests in `domains::observers::worker`. These tests exercise the public API
+//! surface: create/list/get/update/delete, validation, and score listing.
+
+mod test_harness;
+
+use axum::http::StatusCode;
+use serde_json::json;
+use test_harness::TestServer;
+
+#[tokio::test]
+async fn create_and_get_observer_roundtrip() {
+    let server = TestServer::in_memory().await;
+
+    let created = server
+        .post(
+            "/v1/observers",
+            json!({
+                "name": "Support quality",
+                "description": "Watch the support agent",
+                "sampling_rate": 0.25,
+                "scorers": [
+                    { "key": "has_greeting", "rule": { "type": "contains", "text": "hello" } }
+                ]
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json_value();
+
+    let id = created["id"].as_str().unwrap().to_string();
+    assert!(id.starts_with("observer_"));
+    assert_eq!(created["name"], "Support quality");
+    assert_eq!(created["sampling_rate"], 0.25);
+    assert_eq!(created["status"], "active");
+    assert_eq!(created["scorers"][0]["key"], "has_greeting");
+    assert_eq!(created["scorers"][0]["scope"], "turn");
+
+    let fetched = server
+        .get(&format!("/v1/observers/{id}"))
+        .await
+        .assert_status(StatusCode::OK)
+        .json_value();
+    assert_eq!(fetched["id"], id);
+    assert_eq!(fetched["description"], "Watch the support agent");
+}
+
+#[tokio::test]
+async fn sampling_rate_defaults_to_ten_percent() {
+    let server = TestServer::in_memory().await;
+    let created = server
+        .post(
+            "/v1/observers",
+            json!({
+                "name": "Default sampling",
+                "scorers": [
+                    { "key": "k", "rule": { "type": "contains", "text": "x" } }
+                ]
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json_value();
+    assert_eq!(created["sampling_rate"], 0.1);
+}
+
+#[tokio::test]
+async fn list_observers_excludes_archived_by_default() {
+    let server = TestServer::in_memory().await;
+    let created = server
+        .post(
+            "/v1/observers",
+            json!({
+                "name": "Temp",
+                "scorers": [{ "key": "k", "rule": { "type": "contains", "text": "x" } }]
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json_value();
+    let id = created["id"].as_str().unwrap().to_string();
+
+    let listed = server
+        .get("/v1/observers")
+        .await
+        .assert_status(StatusCode::OK)
+        .json_value();
+    assert_eq!(listed["data"].as_array().unwrap().len(), 1);
+
+    server
+        .delete(&format!("/v1/observers/{id}"))
+        .await
+        .assert_status(StatusCode::NO_CONTENT);
+
+    let after = server
+        .get("/v1/observers")
+        .await
+        .assert_status(StatusCode::OK)
+        .json_value();
+    assert_eq!(after["data"].as_array().unwrap().len(), 0);
+
+    let with_archived = server
+        .get("/v1/observers?include_archived=true")
+        .await
+        .assert_status(StatusCode::OK)
+        .json_value();
+    assert_eq!(with_archived["data"].as_array().unwrap().len(), 1);
+    assert_eq!(with_archived["data"][0]["status"], "archived");
+}
+
+#[tokio::test]
+async fn update_observer_changes_sampling_and_pause() {
+    let server = TestServer::in_memory().await;
+    let created = server
+        .post(
+            "/v1/observers",
+            json!({
+                "name": "Adjustable",
+                "scorers": [{ "key": "k", "rule": { "type": "contains", "text": "x" } }]
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json_value();
+    let id = created["id"].as_str().unwrap().to_string();
+
+    let updated = server
+        .patch(
+            &format!("/v1/observers/{id}"),
+            json!({ "sampling_rate": 0.5, "status": "paused" }),
+        )
+        .await
+        .assert_status(StatusCode::OK)
+        .json_value();
+    assert_eq!(updated["sampling_rate"], 0.5);
+    assert_eq!(updated["status"], "paused");
+}
+
+#[tokio::test]
+async fn rejects_invalid_sampling_rate() {
+    let server = TestServer::in_memory().await;
+    server
+        .post(
+            "/v1/observers",
+            json!({
+                "name": "Bad",
+                "sampling_rate": 1.5,
+                "scorers": [{ "key": "k", "rule": { "type": "contains", "text": "x" } }]
+            }),
+        )
+        .await
+        .assert_status(StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn rejects_empty_scorers() {
+    let server = TestServer::in_memory().await;
+    server
+        .post("/v1/observers", json!({ "name": "Empty", "scorers": [] }))
+        .await
+        .assert_status(StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn rejects_duplicate_scorer_keys() {
+    let server = TestServer::in_memory().await;
+    server
+        .post(
+            "/v1/observers",
+            json!({
+                "name": "Dupe",
+                "scorers": [
+                    { "key": "k", "rule": { "type": "contains", "text": "a" } },
+                    { "key": "k", "rule": { "type": "contains", "text": "b" } }
+                ]
+            }),
+        )
+        .await
+        .assert_status(StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn rejects_file_contains_scorer() {
+    let server = TestServer::in_memory().await;
+    server
+        .post(
+            "/v1/observers",
+            json!({
+                "name": "File",
+                "scorers": [
+                    { "key": "f", "rule": { "type": "file_contains", "path": "/x", "text": "y" } }
+                ]
+            }),
+        )
+        .await
+        .assert_status(StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn scores_endpoint_returns_empty_for_new_observer() {
+    let server = TestServer::in_memory().await;
+    let created = server
+        .post(
+            "/v1/observers",
+            json!({
+                "name": "Fresh",
+                "scorers": [{ "key": "k", "rule": { "type": "contains", "text": "x" } }]
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json_value();
+    let id = created["id"].as_str().unwrap().to_string();
+
+    let scores = server
+        .get(&format!("/v1/observers/{id}/scores"))
+        .await
+        .assert_status(StatusCode::OK)
+        .json_value();
+    assert_eq!(scores["data"].as_array().unwrap().len(), 0);
+}
+
+#[tokio::test]
+async fn get_missing_observer_is_404() {
+    let server = TestServer::in_memory().await;
+    server
+        .get("/v1/observers/observer_01933b5a000070008000000000000999")
+        .await
+        .assert_status(StatusCode::NOT_FOUND);
+}

--- a/crates/server/tests/test_harness.rs
+++ b/crates/server/tests/test_harness.rs
@@ -253,6 +253,7 @@ impl TestServer {
         ));
         let mut feature_flags = everruns_core::FeatureFlags::from_env(&grade);
         feature_flags.evals = true;
+        feature_flags.observers = true;
 
         // Create module-specific states
         let sessions_state = api::sessions::AppState::with_platform_definition(
@@ -575,6 +576,10 @@ impl TestServer {
         }
         if feature_flags.evals {
             api_routes = api_routes.merge(api::evals::routes(evals_state));
+        }
+        if feature_flags.observers {
+            let observers_state = api::observers::AppState::new(db.clone(), auth_state.clone());
+            api_routes = api_routes.merge(api::observers::routes(observers_state));
         }
 
         api_routes = api_routes.merge(auth::personal_access_token_routes(

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -16909,7 +16909,8 @@
           "agent_versions",
           "voice",
           "apps.detailV2",
-          "agent_delegation"
+          "agent_delegation",
+          "observers"
         ],
         "properties": {
           "agent_delegation": {
@@ -16943,6 +16944,10 @@
           "notifications": {
             "type": "boolean",
             "description": "In-app notifications (bell, toasts, notification SSE). Experimental."
+          },
+          "observers": {
+            "type": "boolean",
+            "description": "Observers (online scoring of production sessions). Experimental."
           },
           "voice": {
             "type": "boolean",

--- a/specs/README.md
+++ b/specs/README.md
@@ -128,6 +128,7 @@ Specs capture the "why" and "what", not exhaustive source detail. Link to code f
 - `specs/test-cases.md` - Manual test case format
 - `specs/evals.md` - User-facing behavioral evals
 - `specs/agent-checks.md` - Advisory agent config checks (lint, LLM analysis, health checks)
+- `specs/online-evals.md` - Online evals (Observers) over production sessions (proposed)
 - `specs/swe-bench-lite.md` - SWE-bench Lite evaluation harness
 - `specs/reporting.md` - Async reporting
 - `specs/reporting-backends.md` - Phase 3 reference evaluation

--- a/specs/feature-flags.md
+++ b/specs/feature-flags.md
@@ -54,6 +54,7 @@ Current API-visible experimental flags include:
 - `agent_versions`: gates immutable Agent snapshots, forks, rollback, version diffs, and App version binding. See `specs/agent-versions.md`.
 - `apps.detailV2`: gates the channels-first App detail page and full-page channel New/Edit routes. Env var: `FEATURE_APPS_DETAIL_V2`.
 - `agent_delegation`: gates outbound agent delegation capabilities (`a2a_agent_delegation`, `agent_handoff`). When off, these capabilities are not registered in the backend and are absent from the capability picker. Env var: `FEATURE_AGENT_DELEGATION`. See EVE-506.
+- `observers`: gates online scoring of production sessions (`/v1/observers`), the `turn.completed` matching listener, and the background scoring worker. When off, no observer routes are mounted and no listener/worker is registered. Env var: `FEATURE_OBSERVERS`. See `specs/online-evals.md`.
 
 ## Architecture
 

--- a/specs/online-evals.md
+++ b/specs/online-evals.md
@@ -1,0 +1,221 @@
+# Online Evals (Observers)
+
+Status: **Phase 1 implemented** (behind the `observers` feature flag) — turn-scope rule scoring of production sessions, with the design options below recording the broader direction. LLM-judge, session/tool scopes, aggregation, and the Phase 2 improvement loop remain proposed.
+
+Phase 1 surface: `Observer` entity (org-scoped, embedded match rules + rule scorers), `trace_scores` queue, an `ObserverMatchListener` on `turn.completed` that samples and enqueues, and a dual-mode `spawn_observer_worker` that drains the queue (durable `FOR UPDATE SKIP LOCKED` in full mode, in-process in dev mode). Code: `crates/core/src/observer.rs`, `crates/server/src/domains/observers/`, `crates/server/src/api/observers.rs`, migration `056_observers.sql`. API under `/v1/observers`.
+
+<!-- Design Decisions (proposed, not yet ratified):
+  - Observer is the single user-facing abstraction: create an Observer, configure match rules
+    (filters + sampling) and scorers inside it. Scorers/matchers are not standalone entities
+    in Phase 1; they are embedded config, extractable later if reuse demands it.
+  - Phase 1 is scoring only. No insights, no clustering, no proposals — those form a Phase 2
+    subsystem that gets its own name and spec (candidates: Monitor, Insights).
+  - Online scoring is a separate subsystem from offline Evals (specs/evals.md): it observes real
+    user traffic instead of creating synthetic sessions. They share the score vocabulary.
+  - Observable units: turn output, whole session, AND tool outputs — not just final results.
+    Scope is per-scorer, so one Observer can grade answers and tool calls together.
+  - Execution is async with two backends behind one trait: durable engine in full mode,
+    in-process tasks in dev/in-memory mode — same duality as dev_worker vs durable_worker.
+  - Matching runs on the event stream; scores are stored in their own table and link back to
+    the trace (session/turn/tool call) — never appended into the append-only session event log.
+  - Scoring never adds latency to user turns.
+  - Judge reasoning text is stored, not just scalar scores — it is the raw material for the
+    Phase 2 improvement loop (clustering, prompt-learning).
+  - Scores feed the reporting layer for aggregation; thresholds feed notifications.
+  - Complexity is contained in the UI by progressive disclosure: one-click observer creation
+    from an agent with catalog defaults; full editing only for those who open it.
+-->
+
+## Abstract
+
+Today evals are offline: a user authors cases, triggers a run, each case creates a synthetic session, scorers grade it (`specs/evals.md`). That answers "does my agent pass my tests?" but not "how is my agent doing with real users?".
+
+An **Observer** closes that gap. The user creates an Observer, configures inside it *what to watch* (match rules: agent/harness/app/tag filters + sampling) and *how to grade it* (scorers: rule checks and LLM-as-judge rubrics, each scoped to turns, whole sessions, or tool outputs). The Observer watches the live event stream, samples matching traffic, and produces per-trace scores asynchronously.
+
+Phase 1 is deliberately just that — scoring — and is the substrate for what comes after:
+
+1. **Phase 1 — Observers**: per-trace scores on live sessions + aggregation dashboards.
+2. **Phase 2 — (unnamed; candidates: Monitor, Insights)**: a subsystem that periodically analyzes scored traces in aggregate (clustering failure modes, missing answers, missing sources, frustration signals) and proposes concrete agent improvements via notifications and a built-in UI. Own spec when Phase 1 lands.
+
+The end state: user creates an agent → their customers use it → the platform scores usage, spots patterns, and proposes improvements → user applies them → repeat.
+
+## Prior art (landscape, June 2026)
+
+All major platforms converged on the same architecture: **rule = target + filter + sampling rate + evaluator(s)**, executed async server-side, scores attached to traces and charted/alerted on.
+
+| Platform | Trigger model | Evaluators | Scope | Closed loop |
+|----------|--------------|------------|-------|-------------|
+| LangSmith | Automation rules: filter + sampling rate + action; backfill jobs | LLM-judge (prompt templates over run fields), sandboxed no-network Python/JS | run, multi-turn | Insights Agent: hierarchical clustering of ≤1000 traces into usage/failure categories, scheduled reports |
+| Langfuse | Evaluator (judge prompt + variables) split from Evaluation Rule (target + filters + sampling + variable mapping, JSONPath) | LLM-judge with structured output; managed catalog (hallucination, helpfulness, toxicity) | observation, trace, session | — (scores + dashboards) |
+| Braintrust | Project-level online-scoring rules: scorers + sampling % + SQL filter | autoevals, code scorers, LLM-judge | span or trace | Loop agent: failures → filters → datasets → scorers → suggested prompt edits |
+| Arize AX | "Tasks" run every ~2 min on new traces; filters + sampling; backfills | Eval Hub templates + Python code | span, trace, session | Prompt Learning: meta-prompting optimizer driven by textual eval feedback |
+| Datadog LLM Obs | Per-evaluation filters + sampling | Custom LLM-judge (span attribute templating), managed evals | span, trace, session | Assessment Criteria normalize scores to pass/fail for monitors |
+
+Notably, the industry trend through 2025–2026 is toward **observation/span-level scoring** (Langfuse now recommends it over trace-level: cheaper, faster, more precise) alongside session-level for multi-turn quality — supporting the requirement that Observers grade tool outputs, not only final answers.
+
+Cross-cutting patterns worth copying:
+
+- **Sampling after filtering** (1–100%), with backfill over historical traces as a companion feature.
+- **Async queue with retries and visible execution status**; Langfuse records every judge execution as its own trace for debuggability.
+- **Typed score schema** — numeric / categorical / boolean + free-text reasoning — plus a normalization layer (pass/fail) so dashboards and alerts get a uniform signal.
+- **Store judge reasoning, not just scores.** Arize Prompt Learning and DSPy GEPA both show textual feedback ("the answer lacked a source citation") optimizes prompts far better than scalars. The reasoning corpus is the input to Phase 2.
+- **Cost levers**: sampling, scoring spans instead of whole sessions, cheap judge models, input truncation, judge-cost visibility.
+
+References: LangSmith online evaluations and Insights (docs.langchain.com/langsmith), Langfuse LLM-as-a-judge and scores (langfuse.com/docs/evaluation), Braintrust score-online and Loop (braintrust.dev/docs), Arize online evals and Prompt Learning (arize.com/docs/ax), Datadog LLM Observability evaluations (docs.datadoghq.com/llm_observability).
+
+## What we already have
+
+The building blocks exist; Observers are mostly composition:
+
+| Primitive | Where | Role for Observers |
+|-----------|-------|--------------------|
+| Persisted immutable event log | `events` table, `crates/core/src/events.rs`, `specs/events.md` | Traces are already durable and queryable after the fact (messages, tool calls with results, `llm.generation`, `turn.completed` with usage, `session.idled`). No new capture needed — including tool outputs. |
+| `EventListener` | `crates/core/src/event_listeners.rs` | In-process async tap after persistence; how OTel/Braintrust exporters and usage tracking hook in today. Where observer matching runs. |
+| Eval scorer rules | `crates/core/src/eval.rs` | The embedded `Scorer` enum (`contains`, `tool_called`, `turns_within`, …) supplies the rule-method vocabulary for observer scorers too. `llm_judge` is specced (Phase 2 of evals) but not implemented — Observers are the forcing function to build it once, shared by both systems. |
+| Durable engine + scheduler | `specs/durable-execution-engine.md`, `specs/scheduled-tasks.md` | At-least-once background work, multi-instance safe (SKIP LOCKED), cron schedules — production scoring backend. Existing precedent for dev/full duality: dev_worker (DEV_MODE) vs durable_worker. |
+| Tool output distillation | `specs/tool-output-distillation.md` | Large tool results are already distilled at capture time — reuse as judge-input truncation for tool-scope scoring. |
+| Utility LLM | `specs/utility-llm.md` | Candidate judge-model path for platform-internal scoring. |
+| Reporting outbox + facts | `specs/reporting.md` | Async projection pipeline for aggregations (`fact_trace_score` alongside `fact_turn`, `fact_tool_call`). |
+| Notifications | `specs/notifications.md` | Delivery channel for threshold alerts and Phase 2 improvement proposals. |
+| Usage tracking | `specs/usage-tracking.md` | Judge calls must be metered like any other LLM usage (cost visibility, budgets). |
+
+What does **not** exist yet: message-level user feedback (thumbs up/down), an `llm_judge` scorer, any score storage detached from eval runs, and score aggregation UI.
+
+## Proposed concepts
+
+### Observer
+
+The single user-facing entity. Org-scoped, standard building-block lifecycle (`active → paused → archived`). Everything else — match rules, scorers — is configuration *inside* the Observer (embedded JSONB, like scorers inside EvalCases). If cross-observer scorer reuse becomes a real need, scorers can be extracted into a referenced entity later without breaking the model.
+
+| Field | Description |
+|-------|-------------|
+| `name`, `description` | Display |
+| `match` | Predicates over session/turn metadata: `agent_id(s)`, `harness_id(s)`, `app_id(s)`, session tags, model, errors present, min turns. Empty = all org traffic. Sessions tagged `eval` are excluded by default to avoid scoring synthetic traffic. |
+| `sampling_rate` | 0.0–1.0, applied after the match predicates |
+| `scorers` | One or more embedded scorer configs (below) |
+| `status` | `active` / `paused` / `archived` |
+
+### Scorer config (embedded in Observer)
+
+| Field | Description |
+|-------|-------------|
+| `key` | Stable name within the observer; becomes the score series name in dashboards |
+| `scope` | `turn`, `session`, or `tool` (see below) |
+| `method` | `rule` (reuses the eval scorer-rule vocabulary: `contains`, `tool_called`, `turns_within`, …) or `llm_judge` (rubric prompt + variables mapped from the scoped trace slice; judge model reference; structured output `{ value, label?, reasoning }`) |
+| `tool_filter` | Tool scope only: which tool names to grade (e.g. just `web_fetch`, just a specific MCP tool) |
+| `pass_threshold` | Normalizes `value` to a boolean `pass` — uniform signal for dashboards/alerts (Datadog "assessment criteria" pattern) |
+
+**Scopes — what the scorer sees and when it triggers:**
+
+| Scope | Trigger event | Judge/rule input | Use case |
+|-------|--------------|------------------|----------|
+| `turn` | `turn.completed` | Input message + final assistant output + tool-call summary | Default. "Was this answer complete? Did it cite sources?" |
+| `session` | `session.idled` | Whole conversation transcript | Multi-turn quality: "Did the user get what they came for? Did they repeat themselves?" |
+| `tool` | `tool.completed` | Tool name + arguments + (distilled) output, plus the turn's input message for context | "Did retrieval return relevant chunks? Did the search come back empty? Did the tool error?" |
+
+Tool scope is where "observe not only results" lives: failures often originate in a bad tool result two steps before a bad answer. Tool outputs are already persisted on `tool.completed` events, and large ones are already distilled (`specs/tool-output-distillation.md`) — the judge reads the distilled form, which doubles as cost control.
+
+One Observer can mix scopes: e.g. a "Support Agent quality" observer with a turn-scope answer-completeness judge, a session-scope goal-completion judge, and a tool-scope retrieval-relevance judge on the KB search tool.
+
+**Naming collision.** `crates/core/src/eval.rs` already has an embedded `pub enum Scorer` (the per-case scoring rules). The two share the rule vocabulary on purpose, but code needs distinct names — e.g. rename the enum to `ScorerRule`, shared by both eval cases and observers. Decide at implementation time; no backward-compat constraint on internal code.
+
+### TraceScore
+
+The output record. One row per (observer, scorer key, scored unit):
+
+| Field | Description |
+|-------|-------------|
+| `observer_id`, `scorer_key` | Provenance |
+| `session_id`, `turn_id`, `tool_call_id` | What was scored (`turn_id` null for session scope; `tool_call_id` set only for tool scope) |
+| `agent_id`, `agent_version_id`, `harness_id` | Denormalized at scoring time — aggregations slice by agent and version ("did the new prompt help?") without joins |
+| `value` | 0.0–1.0 (matches eval `Score.value`) |
+| `label` | Optional categorical (e.g. `missing_source`, `frustrated_user`, `empty_result`) |
+| `pass` | Normalized boolean via the scorer's threshold |
+| `reasoning` | Judge explanation text — retained deliberately for Phase 2 |
+| `judge_usage` | Token usage of the judge call (also journaled via usage tracking) |
+| `status` | `pending` / `completed` / `errored` / `skipped` |
+
+Storage: a new `trace_scores` table that **links back to the trace** (`session_id` / `turn_id` / `tool_call_id`) — users can always click through from a score to the exact conversation or tool call it graded, same debuggability contract as evals. Scores are *not* written into the session event log: events are append-only and replayed by UI/exports, while scores are mutable derived data (re-scoring, observer versioning). Dismissed alternative recorded below.
+
+ID schema: `observer_`, `score_` — final prefixes open.
+
+## Execution
+
+Two requirements shape this: scoring must be **asynchronous on the durability framework** in production, and must **still work when the durable engine is not available** (in-memory dev mode). The codebase already has this exact duality — dev_worker (DEV_MODE) vs durable_worker — and observer scoring follows it.
+
+### Trigger (both modes)
+
+An `EventListener` on `turn.completed` / `session.idled` / `tool.completed` evaluates active observers: cheap predicate match + sampling decision. The match data (agent, harness, tags, tool name, error markers) is already on those events or one session lookup away. On match, it hands scoring jobs to the execution backend. Matching itself never runs a judge and never blocks the event path.
+
+### Backend trait, two implementations
+
+```
+ScoringBackend::enqueue(job)  // job = (observer_id, scorer_key, session_id, turn_id?, tool_call_id?)
+```
+
+- **Durable backend (full mode, recommended production path):** `pending` `TraceScore` rows double as the queue; durable workers claim them via SKIP LOCKED (same pattern as the durable engine), load the trace slice from the `events` table, run the scorer, write results with retry/backoff. At-least-once, multi-instance safe, bounded judge concurrency, per-score execution status visible (the Langfuse/Arize "task log" pattern falls out for free). Backfill = inserting `pending` rows for historical traces matching an observer; the same workers drain them.
+- **In-process backend (dev/in-memory mode):** the same jobs run on spawned tokio tasks with a bounded semaphore. No durability — in-flight scoring is lost on restart, no retries, no backfill. Acceptable for dev: the contract is "same behavior, weaker delivery guarantees", exactly like dev_worker today.
+
+A periodic catch-up scan (durable scheduler cron) heals missed enqueues in full mode and powers "apply to past sessions" backfill. Dismissed alternative — scheduler-only scanning as the *primary* trigger (Arize's model) — is recorded below.
+
+### Judge model selection
+
+Two viable paths; this is a real product decision, not just plumbing:
+
+1. **Org's own model drivers** (recommended default): judge calls go through the org's configured providers and are metered/billed via usage tracking like any agent call. Honest cost attribution; works for self-hosted OSS deployments with no platform key.
+2. **Utility LLM**: platform-internal key, hidden from the org. Right for built-in "system" observers (e.g. safety screening) but wrong for user-configured judges in an OSS platform — operators without `UTILITY_OPENAI_API_KEY` would lose the feature entirely.
+
+Proposal: scorer config names a model (default: a cheap model from the org's providers); utility LLM reserved for future platform-owned observers.
+
+## UI: containing the complexity
+
+Match rules × three scopes × per-scope scorers is genuinely a lot of surface. The UI strategy is progressive disclosure — the full model exists underneath, but nobody is forced through it:
+
+1. **One-click start.** On the agent page: "Observe this agent" → creates an Observer pre-filtered to the agent, 10% sampling, 2–3 catalog scorers at turn scope (answer completeness, source presence). No form. This is the 80% path.
+2. **Catalog, not blank rubrics.** Built-in scorer templates (answer completeness, source/citation presence, user-frustration signal, task completion, hallucination risk, tool-error rate, retrieval relevance) added by toggle. Writing a custom judge rubric is the advanced path, not the entry point.
+3. **Scope as a tab, not a concept.** Observer detail page shows scorers grouped under "Answers / Conversations / Tools" tabs rather than asking users to understand scope as configuration. Tool-scope scorers offer a dropdown of tools the agent actually uses (derivable from recent `tool.completed` events) instead of free-text tool names.
+4. **Score-first navigation.** The product surface users actually visit is the agent's **Quality tab** (trends, drill-down to traces); observer config is something they touch once. Optimize the reading surface over the authoring surface.
+5. **Later (Phase 2 adjacent):** natural-language setup — "watch my support agent for answers without sources" → generated observer config — once the structured model is proven. LangSmith's Insights configuration works this way (guided questions → generated attributes).
+
+## Aggregation and alerting (Phase 1.5)
+
+Per-score rows are necessary but the product value is trends:
+
+- Project `trace_scores` into the reporting layer (`fact_trace_score`) via the existing outbox pattern — avg score / pass rate / label distribution by agent, agent version, harness, observer, scorer key, scope, model, day.
+- Agent detail page gets a **Quality tab**: score time series, pass-rate trend, label breakdown, per-tool score breakdown, drill-down from any data point to the underlying sessions/tool calls.
+- Threshold alerts: per-observer rule "pass rate < X over window W → notification" via the existing notifications system (new kind, e.g. `observer.threshold_breached`). Webhook delivery can ride Apps/channels later.
+
+## Phase 2 sketch: the improvement loop (own name, own spec)
+
+Phase 2 is a distinct subsystem — naming candidates: **Monitor**, **Insights** — specced separately once Phase 1 lands. Phase 1 deliberately produces the substrate it consumes: sampled traces with scores, labels, and **judge reasoning text**, at answer, conversation, and tool granularity.
+
+- **Insight job**: scheduled (cron) durable workflow per agent that takes the last N scored traces (failing ones first), clusters them by label + reasoning embedding into failure modes — "12% of sessions: answer lacked a source", "8%: user repeated the question", "30% of KB searches returned nothing" (LangSmith Insights pattern).
+- **Improvement proposals**: a second pass turns clusters into concrete suggestions — system-prompt diffs, missing knowledge-base content, missing tools/capabilities, eval cases to add (Braintrust Loop pattern). Textual judge reasoning is the optimizer input (Arize Prompt Learning / GEPA result: English feedback beats scalar scores). Tool-scope scores let proposals point below the prompt: "retrieval quality, not prompt wording, is the bottleneck".
+- **Surface**: notification ("Weekly insight for Support Agent: 3 improvement proposals") linking to a built-in UI; each proposal shows evidence (linked sessions), the suggested change, and one-click actions: apply prompt diff (creates a new agent version, `specs/agent-versions.md`), add suggested eval case (closing the loop into offline evals as the regression gate).
+- The full loop: production traffic → trace scores → insight clusters → proposal → applied change → new agent version → offline eval gate + continued online scoring of the new version.
+
+Phase 2 changes no Phase 1 storage decisions except the requirement (already encoded) to keep reasoning text and version stamps.
+
+## Privacy and cost guardrails
+
+- Judges read raw production content. Observers must be **explicitly created** (nothing scored by default), and config is org-scoped like everything else (`specs/multitenancy.md`). Exporter-style redaction modes (cf. Braintrust listener's content controls) should apply to what judge prompts may include.
+- Sampling default conservative (e.g. 10%); per-org cap on judge calls/day; judge usage metered through `usage_journal` so budgets (`specs/budgeting.md`) can bound it. Tool scope multiplies score volume (many tool calls per turn) — per-scope sampling or tool filters are the lever.
+- Judge inputs are truncated; tool outputs use the already-distilled form (`specs/tool-output-distillation.md`).
+- Sessions created by offline eval runs (tagged `eval`) are excluded by default; observer-triggered judge calls must never themselves be matched (no recursion).
+
+## Dismissed options
+
+- **Scores as session events**: would reuse the event pipeline, but scores are mutable derived data (re-scoring, observer versioning) and the session event log is append-only and replayed by UI/exports — every consumer would need to filter score events. Scores link to the trace instead (`session_id`/`turn_id`/`tool_call_id` on `trace_scores`).
+- **Reuse `EvalRun`/`EvalCaseResult` for online scores**: tempting (shared UI), but the cardinality and lifecycle differ — runs are user-triggered finite batches; observers are unbounded streams. Shared vocabulary (`Score` shape, scorer-rule enum) yes; shared tables no.
+- **Standalone Scorer + Matcher entities** (earlier draft): Langfuse-style factoring with reusable scorers bound by separate matcher rules. More flexible, but two entities and an indirection for day one; Observer-with-embedded-config keeps one mental model ("create an observer, set it up") and the extraction remains possible later. The built-in catalog covers most reuse in practice.
+- **Scheduler-only scanning as primary trigger** (Arize's model): simplest durable design, but minutes of latency, watermark bookkeeping, and scan cost on idle traffic; kept only as catch-up/backfill.
+- **External-platform-only** (point users at Braintrust/Langfuse online scoring via the existing exporters): zero build, but the Phase 2 loop (proposals that mutate agent versions, eval-case generation) requires the scores and reasoning to live in-platform. Exporters remain complementary.
+
+## Open questions
+
+1. Code naming vs the existing embedded `Scorer` enum in `eval.rs` (proposal: rename enum to `ScorerRule`, shared by eval cases and observers).
+2. Match predicate expressiveness for Phase 1: fixed structured fields (agent/harness/app/tags/model/errors) vs a filter DSL. (Proposal: structured fields; a DSL can come later — every platform started structured.)
+3. Phase 1 scope set: all three (turn/session/tool) from the start, or turn first with session/tool fast-following? Tool scope is the differentiator but also the volume risk.
+4. Built-in scorer catalog contents and whether catalog judges count against org budgets.
+5. Message-level user feedback (thumbs up/down) — not strictly required, but every platform treats explicit feedback as the highest-signal filter ("score traces where users were unhappy"). Likely a small, high-leverage prerequisite worth its own line item.
+6. Observer versioning: re-score on edit, or only score forward? (Proposal: forward-only + explicit backfill.)


### PR DESCRIPTION
## What
Adds **Observers** — online scoring of real production sessions — as Phase 1 of `specs/online-evals.md`, behind the `observers` feature flag. An Observer watches live agent traffic, samples matching turns, and scores them with rule scorers, producing per-trace `TraceScore` rows that link back to the exact session/turn.

New surface:
- `Observer` entity (org-scoped) with embedded **match rules** (agent/harness/tag filters), a **sampling rate**, and **rule scorers** (reusing the eval scorer vocabulary).
- `trace_scores` table that doubles as a durable scoring **queue**.
- `ObserverMatchListener` on `turn.completed`: matches active observers, samples, and enqueues — never blocks the turn.
- `spawn_observer_worker`: drains the queue and runs scorers.
- `/v1/observers` CRUD + `/v1/observers/{id}/scores` listing.

## Why
Evals today are offline (synthetic sessions). Observers close the feedback loop on *real* usage — the substrate for the Phase 2 improvement loop (clustering failure modes, proposing agent improvements). See `specs/online-evals.md`.

## How
- Listener/worker split keeps judging off the event hot path: the listener does only the cheap match+sample+enqueue; the worker drains asynchronously.
- **Dual-mode execution** behind one queue contract: durable `FOR UPDATE SKIP LOCKED` claim in full mode (multi-instance-safe, retries, stale-row reclaim), in-process tokio drain in dev/in-memory mode — same code path, mirroring the dev_worker/durable_worker duality.
- Rule-scoring logic extracted from the eval runner into `domains/evals/scoring.rs` and shared by both systems (single source of truth; `file_contains` returns `None` there and is handled by the eval runner / rejected for observers).
- Enqueue is idempotent via a `(observer_id, scorer_key, session_id, turn_id)` unique key, so at-least-once event delivery never double-scores.
- Per-org observer cap, sampling, and bounded worker batches/retries bound fan-out.

## Risk
- **Low.** Entirely behind the `observers` feature flag (off in prod by default); no existing endpoint or schema changed. The only shared-code touch is extracting eval scorer-rule evaluation into a function the eval runner still calls (covered by existing eval tests + new unit tests).

## Security
- **Threat categories reviewed:** TM-API, TM-AUTHZ, TM-TENANT, TM-SQL, TM-DOS, TM-LLM.
- **Findings and resolutions:**
  - *TM-AUTHZ*: `OBSERVER_VIEW`/`OBSERVER_MANAGE` require `OrgAgentsManage` **and** `OrgSessionsManage` (scores expose production content).
  - *TM-TENANT*: all user-facing storage ops are org-scoped; the listener resolves org from the session and enqueues under that org; the worker is a system process (no user context).
  - *TM-SQL*: all queries use sqlx bind parameters; the only dynamic SQL interpolates static column-list / fixed clause constants, never user input.
  - *TM-DOS*: per-org observer cap (default 50), sampling rate, score listing clamped to 500, bounded worker batch size and `max_attempts`.
  - *TM-LLM*: none — Phase 1 is rule scorers only; no LLM/judge calls, no prompt construction.
  - Data exposure: `TraceScore.reason` echoes scorer config (e.g. "Output contains 'hello'"), not raw production output; scores are org-scoped on read.
- No new threat-model entries: this mirrors the existing org-scoped evals CRUD pattern.

## Validation
- `cargo fmt --check` + `cargo clippy --all-targets --all-features` clean (core + server).
- `everruns-core` lib: 2298 tests pass (incl. 9 new `observer` tests).
- `everruns-server` lib: 1486 tests pass (incl. observer worker/listener unit tests covering match→enqueue→drain→complete, failing-rule, and observer-deleted skip paths).
- New `observers_integration_test` (10 tests) + existing `evals_integration_test` (8) pass — added to CI's domain integration list.
- **Real PostgreSQL**: applied all 56 migrations to a fresh DB; exercised the full queue lifecycle (idempotent double-enqueue → 1 row, `FOR UPDATE SKIP LOCKED` claim with `make_interval`, complete, org-scoped read).
- **Live dev server**: booted with `FEATURE_OBSERVERS=true`, confirmed the scoring worker spawns and exercised CRUD + validation (400s for bad sampling / `file_contains` / empty scorers), update, and delete over HTTP.

## Follow-ups
Deferred (each tracked in `specs/online-evals.md` open questions / Phase 2 sketch):
- **LLM-judge scorer** — the highest-value next step; specced but needs a judge-model path and usage metering.
- **Session and tool scopes** — Phase 1 is turn-scope only; the scope enum and worker are structured to extend.
- **Aggregation + alerting** — project `trace_scores` into reporting facts; threshold notifications.
- **`trace_scores` retention/TTL** — rows accumulate over time; needs a retention policy before high-volume use.
- **Backfill / catch-up scan** — "apply to past sessions" and self-healing of missed enqueues.
- **UI** — agent Quality tab and one-click observer creation.
- **Phase 2 improvement loop** — its own spec when Phase 1 lands.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (new flag-gated surface; no breaking changes)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

https://claude.ai/code/session_013U9P51Z93bAA6CV3JhXUBQ

---
_Generated by [Claude Code](https://claude.ai/code/session_013U9P51Z93bAA6CV3JhXUBQ)_