### PR TITLE
fix(auth): validate expires_in_days range for personal access tokens

### DIFF
--- a/crates/server/src/auth/personal_access_token_routes.rs
+++ b/crates/server/src/auth/personal_access_token_routes.rs
@@ -180,7 +180,23 @@ async fn create_personal_access_token(
 
     let expires_at = req
         .expires_in_days
-        .map(|days| Utc::now() + Duration::days(days));
+        .map(|days| -> Result<_, AuthError> {
+            if days <= 0 || days > 3650 {
+                return Err(AuthError {
+                    error: "expires_in_days must be between 1 and 3650".to_string(),
+                    status: StatusCode::BAD_REQUEST,
+                    code: Some("invalid_expires_in_days"),
+                });
+            }
+            Duration::try_days(days)
+                .and_then(|d| Utc::now().checked_add_signed(d))
+                .ok_or_else(|| AuthError {
+                    error: "expires_in_days out of range".to_string(),
+                    status: StatusCode::BAD_REQUEST,
+                    code: Some("invalid_expires_in_days"),
+                })
+        })
+        .transpose()?;
 
     let token_row = state
         .db

--- a/crates/server/src/auth/personal_access_token_routes.rs
+++ b/crates/server/src/auth/personal_access_token_routes.rs
@@ -178,12 +178,17 @@ async fn create_personal_access_token(
         req.scopes
     };
 
+    const PAT_EXPIRES_MIN_DAYS: i64 = 1;
+    const PAT_EXPIRES_MAX_DAYS: i64 = 3650;
+
     let expires_at = req
         .expires_in_days
         .map(|days| -> Result<_, AuthError> {
-            if days <= 0 || days > 3650 {
+            if !(PAT_EXPIRES_MIN_DAYS..=PAT_EXPIRES_MAX_DAYS).contains(&days) {
                 return Err(AuthError {
-                    error: "expires_in_days must be between 1 and 3650".to_string(),
+                    error: format!(
+                        "expires_in_days must be between {PAT_EXPIRES_MIN_DAYS} and {PAT_EXPIRES_MAX_DAYS}"
+                    ),
                     status: StatusCode::BAD_REQUEST,
                     code: Some("invalid_expires_in_days"),
                 });
@@ -191,7 +196,9 @@ async fn create_personal_access_token(
             Duration::try_days(days)
                 .and_then(|d| Utc::now().checked_add_signed(d))
                 .ok_or_else(|| AuthError {
-                    error: "expires_in_days out of range".to_string(),
+                    error: format!(
+                        "expires_in_days must be between {PAT_EXPIRES_MIN_DAYS} and {PAT_EXPIRES_MAX_DAYS}"
+                    ),
                     status: StatusCode::BAD_REQUEST,
                     code: Some("invalid_expires_in_days"),
                 })

--- a/crates/server/tests/org_lifecycle_test.rs
+++ b/crates/server/tests/org_lifecycle_test.rs
@@ -536,3 +536,87 @@ async fn test_api_key_creation_enforces_per_user_limit() {
         "expected personal access token limit error, got: {over_limit:?}"
     );
 }
+
+#[tokio::test]
+async fn test_api_key_expiry_validation() {
+    let server = TestServer::in_memory().await;
+
+    // Valid expiry creates the token and echoes the expiration timestamp.
+    let resp: Value = server
+        .post(
+            "/v1/auth/personal-access-tokens",
+            json!({"name": "expires-soon", "expires_in_days": 30}),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+    assert!(
+        resp["expires_at"].as_str().is_some(),
+        "token created with expires_in_days=30 should have expires_at set"
+    );
+
+    // Zero days is rejected.
+    let err: Value = server
+        .post(
+            "/v1/auth/personal-access-tokens",
+            json!({"name": "bad-zero", "expires_in_days": 0}),
+        )
+        .await
+        .assert_status(StatusCode::BAD_REQUEST)
+        .json();
+    assert!(
+        err["detail"]
+            .as_str()
+            .unwrap_or("")
+            .contains("expires_in_days must be between 1 and 3650"),
+        "zero days should be rejected: {err:?}"
+    );
+
+    // Negative days are rejected (previously could panic via Duration::days).
+    let err: Value = server
+        .post(
+            "/v1/auth/personal-access-tokens",
+            json!({"name": "bad-negative", "expires_in_days": -1}),
+        )
+        .await
+        .assert_status(StatusCode::BAD_REQUEST)
+        .json();
+    assert!(
+        err["detail"]
+            .as_str()
+            .unwrap_or("")
+            .contains("expires_in_days must be between 1 and 3650"),
+        "negative days should be rejected: {err:?}"
+    );
+
+    // Exceeding 3650 days is rejected.
+    let err: Value = server
+        .post(
+            "/v1/auth/personal-access-tokens",
+            json!({"name": "bad-huge", "expires_in_days": 3651}),
+        )
+        .await
+        .assert_status(StatusCode::BAD_REQUEST)
+        .json();
+    assert!(
+        err["detail"]
+            .as_str()
+            .unwrap_or("")
+            .contains("expires_in_days must be between 1 and 3650"),
+        "3651 days should be rejected: {err:?}"
+    );
+
+    // No expiry is fine — token is created without expires_at.
+    let resp: Value = server
+        .post(
+            "/v1/auth/personal-access-tokens",
+            json!({"name": "no-expiry"}),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json();
+    assert!(
+        resp["expires_at"].is_null(),
+        "token without expires_in_days should have null expires_at"
+    );
+}


### PR DESCRIPTION
## What

Add server-side validation for `expires_in_days` on personal access token creation. Values outside `1..=3650` are rejected with `400 Bad Request` before the duration arithmetic runs.

## Why

`Duration::days()` (and the underlying `chrono` arithmetic) can panic on out-of-range inputs. The UI today only ever sends one of a fixed set of preset values (30, 90, 365, never), so the bug was latent. A caller sending `0`, a negative value, or an astronomically large value directly via the API could trigger a panic.

Fixes EVE-556.

## How

- Replace the bare `Duration::try_days(days)` call with an explicit range guard using named constants `PAT_EXPIRES_MIN_DAYS = 1` / `PAT_EXPIRES_MAX_DAYS = 3650` and `!(min..=max).contains(&days)` (avoids clippy `manual_range_contains`).
- Both the range check and the overflow fallback return the same `format!("expires_in_days must be between {PAT_EXPIRES_MIN_DAYS} and {PAT_EXPIRES_MAX_DAYS}")` message for a consistent API response.
- The `try_days` + `checked_add_signed` chain is kept as a belt-and-suspenders fallback for any value that somehow slips past the range check.

## Validation

- 4 new integration test cases in `test_api_key_expiry_validation` (org_lifecycle_test):
  - `expires_in_days: 30` → `201 CREATED`, `expires_at` populated
  - `expires_in_days: 0` → `400 BAD REQUEST`
  - `expires_in_days: -1` → `400 BAD REQUEST`
  - `expires_in_days: 3651` → `400 BAD REQUEST`
  - no `expires_in_days` → `201 CREATED`, `expires_at` null

## Security

- `TM-API` / `TM-AUTH`: validates input at the auth endpoint boundary. Prevents panic-based availability attack via the PAT creation route.
- No auth bypass, data exposure, or privilege escalation.

## Follow-ups

No follow-ups.