### PR TITLE
refactor(core): retire legacy per-kind task tools for generic ones

### DIFF
--- a/crates/core/src/capabilities/a2a_delegation.rs
+++ b/crates/core/src/capabilities/a2a_delegation.rs
@@ -240,13 +240,7 @@ impl Capability for A2aAgentDelegationCapability {
 
     fn tools_with_config(&self, config: &Value) -> Vec<Box<dyn Tool>> {
         let config = A2aDelegationConfig::from_value(config).unwrap_or_default();
-        vec![
-            Box::new(SpawnAgentTool::new(config.clone())),
-            Box::new(GetAgentRunsTool),
-            Box::new(WaitAgentTool::new(config.clone())),
-            Box::new(MessageAgentTool::new(config.clone())),
-            Box::new(CancelAgentTool::new(config)),
-        ]
+        vec![Box::new(SpawnAgentTool::new(config))]
     }
 
     fn tools(&self) -> Vec<Box<dyn Tool>> {
@@ -279,8 +273,8 @@ impl Capability for A2aAgentDelegationCapability {
         Some(format!(
             "<capability id=\"{}\">\n\
 Delegate work to configured external A2A agents with spawn_agent.\n\
-Use mode=\"background\" for long-running work; use wait_agent later for results.\n\
-Use message_agent for follow-up input or input_required tasks; use cancel_agent to stop a remote task.\n\
+Use mode=\"background\" for long-running work; use wait_task (from session_tasks) later for results.\n\
+Use message_task for follow-up input or input_required tasks; use cancel_task to stop a remote task.\n\
 Available external agents:\n{}\n\
 </capability>",
             self.id(),
@@ -613,12 +607,12 @@ fn run_key(run_id: &str) -> String {
     format!("agent_run:{run_id}")
 }
 
-/// Prefix shared by all agent run KV keys.
+/// Prefix shared by all agent run KV keys (used in tests to verify prefix-based lookup).
+#[cfg(test)]
 const AGENT_RUN_KEY_PREFIX: &str = "agent_run:";
 
-/// List run_ids by prefix-filtering the session's KV keys. Derived from
-/// `list_keys` rather than a maintained index key, so concurrent spawns
-/// cannot race a read-modify-write and drop runs.
+/// List run_ids by prefix-filtering the session's KV keys (test helper).
+#[cfg(test)]
 async fn list_run_ids(
     storage: &dyn SessionStorageStore,
     session_id: crate::typed_id::SessionId,
@@ -1364,381 +1358,6 @@ impl Tool for SpawnAgentTool {
     }
 }
 
-#[derive(Clone)]
-pub struct GetAgentRunsTool;
-
-#[async_trait]
-impl Tool for GetAgentRunsTool {
-    fn name(&self) -> &str {
-        "get_agent_runs"
-    }
-
-    fn display_name(&self) -> Option<&str> {
-        Some("Get Agent Runs")
-    }
-
-    fn description(&self) -> &str {
-        "List external A2A agent runs or fetch one run by id."
-    }
-
-    fn parameters_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "agent_run_id": {"type": "string"},
-                "status_filter": {
-                    "type": "string",
-                    "enum": ["all", "submitted", "working", "input_required", "auth_required", "completed", "failed", "canceled", "rejected"]
-                }
-            },
-            "additionalProperties": false
-        })
-    }
-
-    fn hints(&self) -> ToolHints {
-        ToolHints::default()
-            .with_readonly(true)
-            .with_idempotent(true)
-    }
-
-    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
-        ToolExecutionResult::tool_error("get_agent_runs requires session context")
-    }
-
-    async fn execute_with_context(
-        &self,
-        arguments: Value,
-        context: &ToolContext,
-    ) -> ToolExecutionResult {
-        if let Some(run_id) = arguments
-            .get("agent_run_id")
-            .and_then(Value::as_str)
-            .map(str::trim)
-            .filter(|s| !s.is_empty())
-        {
-            return match load_run(context, run_id).await {
-                Ok(record) => ToolExecutionResult::success(record.public_json()),
-                Err(e) => e,
-            };
-        }
-        let storage = match require_storage(context) {
-            Ok(s) => s,
-            Err(e) => return e,
-        };
-        let run_ids = list_run_ids(storage.as_ref(), context.session_id).await;
-        let status_filter = arguments
-            .get("status_filter")
-            .and_then(Value::as_str)
-            .unwrap_or("all");
-        let mut runs = Vec::new();
-        for run_id in run_ids {
-            if let Ok(Some(serialized)) = storage
-                .get_value(context.session_id, &run_key(&run_id))
-                .await
-                && let Ok(record) = serde_json::from_str::<AgentRunRecord>(&serialized)
-                && (status_filter == "all" || record.status.to_string() == status_filter)
-            {
-                runs.push(record.public_json());
-            }
-        }
-        let count = runs.len();
-        ToolExecutionResult::success(json!({
-            "agent_runs": runs,
-            "count": count
-        }))
-    }
-
-    fn requires_context(&self) -> bool {
-        true
-    }
-}
-
-#[derive(Clone)]
-pub struct WaitAgentTool {
-    config: A2aDelegationConfig,
-}
-
-impl WaitAgentTool {
-    fn new(config: A2aDelegationConfig) -> Self {
-        Self { config }
-    }
-}
-
-#[async_trait]
-impl Tool for WaitAgentTool {
-    fn name(&self) -> &str {
-        "wait_agent"
-    }
-
-    fn display_name(&self) -> Option<&str> {
-        Some("Wait Agent")
-    }
-
-    fn description(&self) -> &str {
-        "Wait for an external A2A agent run to complete or reach an interrupted state."
-    }
-
-    fn parameters_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "agent_run_id": {"type": "string"},
-                "timeout_secs": {"type": "integer", "minimum": 1, "maximum": 86400}
-            },
-            "required": ["agent_run_id"],
-            "additionalProperties": false
-        })
-    }
-
-    fn hints(&self) -> ToolHints {
-        ToolHints::default()
-            .with_long_running(true)
-            .with_open_world(true)
-    }
-
-    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
-        ToolExecutionResult::tool_error("wait_agent requires session context")
-    }
-
-    async fn execute_with_context(
-        &self,
-        arguments: Value,
-        context: &ToolContext,
-    ) -> ToolExecutionResult {
-        let run_id = match require_str(&arguments, "agent_run_id") {
-            Ok(id) => id,
-            Err(e) => return e,
-        };
-        let record = match load_run(context, run_id).await {
-            Ok(record) => record,
-            Err(e) => return e,
-        };
-        let Some(agent) = self.config.agent(&record.external_agent_id).cloned() else {
-            return ToolExecutionResult::tool_error(format!(
-                "External A2A agent no longer configured: {}",
-                record.external_agent_id
-            ));
-        };
-        let timeout_secs = arguments
-            .get("timeout_secs")
-            .and_then(Value::as_u64)
-            .unwrap_or(DEFAULT_WAIT_TIMEOUT_SECS);
-        // wait_agent is foreground; no separate heartbeat thread needed.
-        match wait_for_run(context, &agent, record, timeout_secs, None).await {
-            Ok(record) => ToolExecutionResult::success(record.public_json()),
-            Err(error) => timeout_or_error_result(context, run_id, error).await,
-        }
-    }
-
-    fn requires_context(&self) -> bool {
-        true
-    }
-}
-
-#[derive(Clone)]
-pub struct MessageAgentTool {
-    config: A2aDelegationConfig,
-}
-
-impl MessageAgentTool {
-    fn new(config: A2aDelegationConfig) -> Self {
-        Self { config }
-    }
-}
-
-#[async_trait]
-impl Tool for MessageAgentTool {
-    fn name(&self) -> &str {
-        "message_agent"
-    }
-
-    fn display_name(&self) -> Option<&str> {
-        Some("Message Agent")
-    }
-
-    fn description(&self) -> &str {
-        "Send follow-up input to an existing external A2A agent run."
-    }
-
-    fn parameters_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "agent_run_id": {"type": "string"},
-                "message": {"type": "string"},
-                "wait_timeout_secs": {"type": "integer", "minimum": 1, "maximum": 86400}
-            },
-            "required": ["agent_run_id", "message"],
-            "additionalProperties": false
-        })
-    }
-
-    fn hints(&self) -> ToolHints {
-        ToolHints::default()
-            .with_long_running(true)
-            .with_open_world(true)
-    }
-
-    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
-        ToolExecutionResult::tool_error("message_agent requires session context")
-    }
-
-    async fn execute_with_context(
-        &self,
-        arguments: Value,
-        context: &ToolContext,
-    ) -> ToolExecutionResult {
-        let run_id = match require_str(&arguments, "agent_run_id") {
-            Ok(id) => id,
-            Err(e) => return e,
-        };
-        let message = match require_str(&arguments, "message") {
-            Ok(message) => message.to_string(),
-            Err(e) => return e,
-        };
-        let mut record = match load_run(context, run_id).await {
-            Ok(record) => record,
-            Err(e) => return e,
-        };
-        let Some(agent) = self.config.agent(&record.external_agent_id).cloned() else {
-            return ToolExecutionResult::tool_error(format!(
-                "External A2A agent no longer configured: {}",
-                record.external_agent_id
-            ));
-        };
-        let remote_task_id = record.remote_task_id.clone();
-        let remote_context_id = record.remote_context_id.clone();
-        if let Err(error) = submit_run(
-            context,
-            &agent,
-            &mut record,
-            &message,
-            remote_task_id,
-            remote_context_id,
-        )
-        .await
-        {
-            record.status = AgentRunStatus::Failed;
-            set_error(&mut record, error);
-            let _ = save_run(context, &record).await;
-            return ToolExecutionResult::success(record.public_json());
-        }
-        let timeout_secs = arguments
-            .get("wait_timeout_secs")
-            .and_then(Value::as_u64)
-            .unwrap_or(DEFAULT_WAIT_TIMEOUT_SECS);
-        // message_agent is foreground; no separate heartbeat thread needed.
-        match wait_for_run(context, &agent, record, timeout_secs, None).await {
-            Ok(record) => ToolExecutionResult::success(record.public_json()),
-            Err(error) => timeout_or_error_result(context, run_id, error).await,
-        }
-    }
-
-    fn requires_context(&self) -> bool {
-        true
-    }
-}
-
-#[derive(Clone)]
-pub struct CancelAgentTool {
-    config: A2aDelegationConfig,
-}
-
-impl CancelAgentTool {
-    fn new(config: A2aDelegationConfig) -> Self {
-        Self { config }
-    }
-}
-
-#[async_trait]
-impl Tool for CancelAgentTool {
-    fn name(&self) -> &str {
-        "cancel_agent"
-    }
-
-    fn display_name(&self) -> Option<&str> {
-        Some("Cancel Agent")
-    }
-
-    fn description(&self) -> &str {
-        "Cancel an existing external A2A agent run."
-    }
-
-    fn parameters_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "agent_run_id": {"type": "string"}
-            },
-            "required": ["agent_run_id"],
-            "additionalProperties": false
-        })
-    }
-
-    fn hints(&self) -> ToolHints {
-        ToolHints::default().with_open_world(true)
-    }
-
-    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
-        ToolExecutionResult::tool_error("cancel_agent requires session context")
-    }
-
-    async fn execute_with_context(
-        &self,
-        arguments: Value,
-        context: &ToolContext,
-    ) -> ToolExecutionResult {
-        let run_id = match require_str(&arguments, "agent_run_id") {
-            Ok(id) => id,
-            Err(e) => return e,
-        };
-        let mut record = match load_run(context, run_id).await {
-            Ok(record) => record,
-            Err(e) => return e,
-        };
-        if record.status.is_terminal() {
-            return ToolExecutionResult::success(record.public_json());
-        }
-        let Some(remote_task_id) = record.remote_task_id.clone() else {
-            record.status = AgentRunStatus::Canceled;
-            let _ = save_run(context, &record).await;
-            return ToolExecutionResult::success(record.public_json());
-        };
-        let Some(agent) = self.config.agent(&record.external_agent_id).cloned() else {
-            return ToolExecutionResult::tool_error(format!(
-                "External A2A agent no longer configured: {}",
-                record.external_agent_id
-            ));
-        };
-        match build_client(&agent, context).await {
-            Ok(client) => match client
-                .cancel_task(&CancelTaskRequest {
-                    id: remote_task_id,
-                    metadata: None,
-                    tenant: None,
-                })
-                .await
-            {
-                Ok(task) => apply_task(&mut record, &task),
-                Err(error) => {
-                    record.status = AgentRunStatus::Failed;
-                    set_error(&mut record, format!("A2A cancel_task failed: {error}"));
-                }
-            },
-            Err(error) => {
-                record.status = AgentRunStatus::Failed;
-                set_error(&mut record, error);
-            }
-        }
-        let _ = save_run(context, &record).await;
-        ToolExecutionResult::success(record.public_json())
-    }
-
-    fn requires_context(&self) -> bool {
-        true
-    }
-}
-
 // ============================================================================
 // Task executor: external_agent
 // ============================================================================
@@ -1769,7 +1388,7 @@ async fn load_run_for_task(
 fn agent_snapshot(record: &AgentRunRecord) -> std::result::Result<ExternalA2aAgentConfig, String> {
     record.agent_config.clone().ok_or_else(|| {
         format!(
-            "Agent run {} has no stored agent config snapshot (created before task support); use message_agent/cancel_agent instead",
+            "Agent run {} has no stored agent config snapshot (created before task support); use message_task/cancel_task instead",
             record.run_id
         )
     })
@@ -1958,8 +1577,6 @@ mod tests {
     use std::collections::{BTreeMap, HashMap};
     use std::sync::Mutex;
     use tokio::net::TcpListener;
-    use tokio::time::timeout;
-
     #[derive(Default)]
     struct TestStorageStore {
         values: Mutex<HashMap<String, String>>,
@@ -2284,46 +1901,6 @@ mod tests {
         assert_eq!(value["status"], "completed");
         assert_eq!(value["result"], "echo: hello");
         assert!(value["result_path"].as_str().is_some());
-    }
-
-    #[tokio::test]
-    async fn spawn_agent_background_can_be_waited() {
-        let base_url = spawn_real_a2a_agent().await;
-        let config = configured_capability(base_url);
-        let spawn = SpawnAgentTool::new(config.clone());
-        let wait = WaitAgentTool::new(config);
-        let storage_store = Arc::new(TestStorageStore::default());
-        let file_store = Arc::new(TestFileStore::default());
-        let ctx = context(storage_store, file_store);
-
-        let result = spawn
-            .execute_with_context(
-                json!({
-                    "instructions": "background",
-                    "target": {"type": "external_a2a", "external_agent_id": "echo"},
-                    "mode": "background",
-                    "wait_timeout_secs": 5,
-                    "wake_on_completion": false
-                }),
-                &ctx,
-            )
-            .await;
-        let ToolExecutionResult::Success(value) = result else {
-            panic!("expected success: {result:?}");
-        };
-        let run_id = value["agent_run_id"].as_str().unwrap();
-
-        let waited = timeout(
-            Duration::from_secs(5),
-            wait.execute_with_context(json!({"agent_run_id": run_id, "timeout_secs": 5}), &ctx),
-        )
-        .await
-        .unwrap();
-        let ToolExecutionResult::Success(value) = waited else {
-            panic!("expected success: {waited:?}");
-        };
-        assert_eq!(value["status"], "completed");
-        assert_eq!(value["result"], "echo: background");
     }
 
     #[test]

--- a/crates/core/src/capabilities/a2a_delegation.rs
+++ b/crates/core/src/capabilities/a2a_delegation.rs
@@ -2195,6 +2195,58 @@ mod tests {
         }
     }
 
+    /// Parity check for the retired `wait_agent`: a background `spawn_agent`
+    /// run is observable end-to-end through the generic `wait_task` tool.
+    /// The background poll loop mirrors each remote snapshot onto the session
+    /// task via `save_run`, so `wait_task` converges to the terminal state.
+    #[tokio::test]
+    async fn background_spawn_is_waitable_via_generic_wait_task() {
+        use crate::capabilities::session_tasks::WaitTaskTool;
+
+        let base_url = spawn_real_a2a_agent().await;
+        let config = configured_capability(base_url);
+        let spawn = SpawnAgentTool::new(config);
+
+        // A context WITH a task registry so the background run creates and
+        // mirrors a session task (the registry is what wait_task reads).
+        let storage_store = Arc::new(TestStorageStore::default());
+        let file_store = Arc::new(TestFileStore::default());
+        let registry = Arc::new(InMemRegistry::default());
+        let ctx = ToolContext::with_stores(SessionId::new(), file_store, storage_store)
+            .with_session_task_registry(registry.clone());
+
+        let result = spawn
+            .execute_with_context(
+                json!({
+                    "instructions": "background",
+                    "target": {"type": "external_a2a", "external_agent_id": "echo"},
+                    "mode": "background",
+                    "wait_timeout_secs": 5,
+                    "wake_on_completion": false
+                }),
+                &ctx,
+            )
+            .await;
+        let ToolExecutionResult::Success(value) = result else {
+            panic!("expected spawn success: {result:?}");
+        };
+        let task_id = value["task_id"]
+            .as_str()
+            .expect("background spawn returns a task_id when a registry is present");
+
+        let waited = WaitTaskTool
+            .execute_with_context(json!({"task_id": task_id, "timeout_seconds": 5}), &ctx)
+            .await;
+        let ToolExecutionResult::Success(value) = waited else {
+            panic!("expected wait_task success: {waited:?}");
+        };
+        assert_eq!(
+            value["timed_out"], false,
+            "wait_task should observe a terminal state, got {value:?}"
+        );
+        assert_eq!(value["task"]["state"], "succeeded");
+    }
+
     /// Build a SessionTask snapshot for testing (not persisted in any store).
     fn fake_task_with_spec(
         session_id: crate::typed_id::SessionId,

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -145,8 +145,7 @@ mod web_fetch_egress;
 
 // Re-export capabilities
 pub use a2a_delegation::{
-    A2A_AGENT_DELEGATION_CAPABILITY_ID, A2aAgentDelegationCapability, CancelAgentTool,
-    GetAgentRunsTool, MessageAgentTool, SpawnAgentTool, WaitAgentTool,
+    A2A_AGENT_DELEGATION_CAPABILITY_ID, A2aAgentDelegationCapability, SpawnAgentTool,
 };
 #[cfg(feature = "ui-capabilities")]
 pub use a2ui::{A2UI_CAPABILITY_ID, A2UiCapability};

--- a/crates/core/src/capabilities/subagents.rs
+++ b/crates/core/src/capabilities/subagents.rs
@@ -1,9 +1,7 @@
 // Subagent Capability
 //
-// Decision: 3 tools only — spawn_subagent, get_subagents, message_subagent.
+// Decision: 1 creation tool — spawn_subagent.
 // - spawn_subagent creates a child session with parent_session_id set
-// - get_subagents lists/details child sessions by querying parent_session_id
-// - message_subagent sends steering messages (by name or id)
 //
 // Blueprint support: spawn_subagent accepts optional `blueprint` and `config`
 // params. When blueprint is set, the child session uses the blueprint's
@@ -18,9 +16,9 @@
 use super::{Capability, CapabilityLocalization, CapabilityStatus};
 use crate::platform_store::PlatformStore;
 use crate::session_task::{
-    CreateSessionTask, NewTaskMessage, SessionTask, SessionTaskFilter, SessionTaskState,
-    SessionTaskUpdate, TASK_KIND_SUBAGENT, TaskError, TaskExecutor, TaskExecutorPlugin, TaskLinks,
-    TaskMessage, TaskWakePolicy, task_message_text,
+    CreateSessionTask, SessionTask, SessionTaskFilter, SessionTaskState, SessionTaskUpdate,
+    TASK_KIND_SUBAGENT, TaskError, TaskExecutor, TaskExecutorPlugin, TaskLinks, TaskMessage,
+    TaskWakePolicy, task_message_text,
 };
 use crate::tool_types::ToolHints;
 use crate::tools::{Tool, ToolExecutionResult};
@@ -76,11 +74,7 @@ impl Capability for SubagentCapability {
     }
 
     fn tools(&self) -> Vec<Box<dyn Tool>> {
-        vec![
-            Box::new(SpawnSubagentTool),
-            Box::new(GetSubagentsTool),
-            Box::new(MessageSubagentTool),
-        ]
+        vec![Box::new(SpawnSubagentTool)]
     }
 }
 
@@ -209,23 +203,6 @@ async fn find_subagent_task(
     tasks
         .into_iter()
         .find(|task| task.links.child_session_id == Some(child_id))
-}
-
-/// Find a child session by name (case-insensitive) or ID within a list of sessions.
-fn find_child_session<'a>(
-    sessions: &'a [crate::session::Session],
-    parent_id: crate::typed_id::SessionId,
-    name_or_id: &str,
-) -> Option<&'a crate::session::Session> {
-    sessions
-        .iter()
-        .filter(|s| s.parent_session_id == Some(parent_id))
-        .find(|s| {
-            s.subagent_name
-                .as_ref()
-                .is_some_and(|n| n.eq_ignore_ascii_case(name_or_id))
-                || s.id.to_string() == name_or_id
-        })
 }
 
 // =============================================================================
@@ -768,307 +745,12 @@ async fn run_subagent_wait_and_settle(
 }
 
 // =============================================================================
-// Tool: get_subagents
-// =============================================================================
-
-pub struct GetSubagentsTool;
-
-#[async_trait]
-impl Tool for GetSubagentsTool {
-    fn name(&self) -> &str {
-        "get_subagents"
-    }
-
-    fn display_name(&self) -> Option<&str> {
-        Some("Get Subagents")
-    }
-
-    fn description(&self) -> &str {
-        "List all subagents or get detailed status of a specific one (by name or ID)."
-    }
-
-    fn parameters_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "name_or_id": {
-                    "type": "string",
-                    "description": "Subagent name or session ID for detailed view. Omit to list all."
-                },
-                "status_filter": {
-                    "type": "string",
-                    "enum": ["all", "running", "completed", "failed"],
-                    "description": "Filter by status when listing all subagents."
-                }
-            },
-            "additionalProperties": false
-        })
-    }
-
-    fn hints(&self) -> ToolHints {
-        ToolHints::default()
-            .with_readonly(true)
-            .with_idempotent(true)
-    }
-
-    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
-        ToolExecutionResult::tool_error("get_subagents requires context.")
-    }
-
-    async fn execute_with_context(
-        &self,
-        arguments: Value,
-        context: &ToolContext,
-    ) -> ToolExecutionResult {
-        let store = match get_platform_store(context) {
-            Ok(s) => s,
-            Err(e) => return e,
-        };
-
-        let all_sessions = match store.list_sessions(Some(100), None).await {
-            Ok(s) => s,
-            Err(e) => return ToolExecutionResult::internal_error(e),
-        };
-
-        let name_or_id = arguments
-            .get("name_or_id")
-            .and_then(|v| v.as_str())
-            .filter(|s| !s.trim().is_empty());
-
-        if let Some(query) = name_or_id {
-            let found = find_child_session(&all_sessions, context.session_id, query);
-
-            match found {
-                Some(child) => {
-                    let messages = store
-                        .get_messages(child.id, Some(10))
-                        .await
-                        .unwrap_or_default();
-
-                    let last_response = last_agent_message(&messages);
-
-                    ToolExecutionResult::success(json!({
-                        "subagent_id": child.id.to_string(),
-                        "name": child.subagent_name,
-                        "instructions": child.subagent_task,
-                        "status": child.subagent_status.as_ref().map(|s| s.to_string())
-                            .unwrap_or_else(|| child.status.to_string()),
-                        "session_status": child.status.to_string(),
-                        "created_at": child.created_at.to_rfc3339(),
-                        "result": last_response,
-                        "blueprint_id": child.blueprint_id,
-                    }))
-                }
-                None => ToolExecutionResult::tool_error(format!(
-                    "No subagent found with name or ID: {query}"
-                )),
-            }
-        } else {
-            // List all subagents
-            let status_filter = arguments.get("status_filter").and_then(|v| v.as_str());
-
-            let filtered: Vec<_> = all_sessions
-                .iter()
-                .filter(|s| s.parent_session_id == Some(context.session_id))
-                .filter(|s| {
-                    if let Some(filter) = status_filter {
-                        if filter == "all" {
-                            return true;
-                        }
-                        s.subagent_status
-                            .as_ref()
-                            .is_some_and(|st| st.to_string() == filter)
-                    } else {
-                        true
-                    }
-                })
-                .map(|s| {
-                    json!({
-                        "subagent_id": s.id.to_string(),
-                        "name": s.subagent_name,
-                        "instructions": s.subagent_task,
-                        "status": s.subagent_status.as_ref().map(|st| st.to_string())
-                            .unwrap_or_else(|| s.status.to_string()),
-                        "created_at": s.created_at.to_rfc3339(),
-                        "blueprint_id": s.blueprint_id,
-                    })
-                })
-                .collect();
-
-            ToolExecutionResult::success(json!({
-                "subagents": filtered,
-                "count": filtered.len(),
-            }))
-        }
-    }
-
-    fn requires_context(&self) -> bool {
-        true
-    }
-}
-
-// =============================================================================
-// Tool: message_subagent
-// =============================================================================
-
-pub struct MessageSubagentTool;
-
-#[async_trait]
-impl Tool for MessageSubagentTool {
-    fn name(&self) -> &str {
-        "message_subagent"
-    }
-
-    fn display_name(&self) -> Option<&str> {
-        Some("Message Subagent")
-    }
-
-    fn description(&self) -> &str {
-        "Send a message to a subagent by name or ID. Steers running subagents, resumes completed/failed ones."
-    }
-
-    fn parameters_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "name_or_id": {
-                    "type": "string",
-                    "description": "Subagent name or session ID."
-                },
-                "message": {
-                    "type": "string",
-                    "description": "Message to send to the subagent."
-                },
-                "cancel": {
-                    "type": "boolean",
-                    "description": "If true, deliver the message then gracefully stop the subagent.",
-                    "default": false
-                }
-            },
-            "required": ["name_or_id", "message"],
-            "additionalProperties": false
-        })
-    }
-
-    fn hints(&self) -> ToolHints {
-        ToolHints::default().with_long_running(true)
-    }
-
-    async fn execute(&self, _arguments: Value) -> ToolExecutionResult {
-        ToolExecutionResult::tool_error("message_subagent requires context.")
-    }
-
-    async fn execute_with_context(
-        &self,
-        arguments: Value,
-        context: &ToolContext,
-    ) -> ToolExecutionResult {
-        let store = match get_platform_store(context) {
-            Ok(s) => s,
-            Err(e) => return e,
-        };
-
-        let name_or_id = match require_str(&arguments, "name_or_id") {
-            Ok(s) => s.to_string(),
-            Err(e) => return e,
-        };
-        let message = match require_str(&arguments, "message") {
-            Ok(s) => s.to_string(),
-            Err(e) => return e,
-        };
-        let cancel = arguments
-            .get("cancel")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false);
-
-        let all_sessions = match store.list_sessions(Some(100), None).await {
-            Ok(s) => s,
-            Err(e) => return ToolExecutionResult::internal_error(e),
-        };
-
-        let child = match find_child_session(&all_sessions, context.session_id, &name_or_id) {
-            Some(c) => c,
-            None => {
-                return ToolExecutionResult::tool_error(format!(
-                    "No subagent found with name or ID: {name_or_id}"
-                ));
-            }
-        };
-
-        let child_id = child.id;
-
-        // Send the message
-        if let Err(e) = store.send_message(child_id, &message).await {
-            return ToolExecutionResult::internal_error(e);
-        }
-
-        // Record the inbound message on the subagent's task channel (best-effort).
-        if let Some(ref task_registry) = context.session_task_registry
-            && let Some(subagent_task) = find_subagent_task(context, child_id).await
-        {
-            let _ = task_registry
-                .record_message(
-                    context.session_id,
-                    &subagent_task.id,
-                    NewTaskMessage::inbound_text(&message),
-                )
-                .await;
-        }
-
-        if cancel {
-            // For cancel, just send the message and report
-            // (actual cancellation mechanism to be added when background mode lands)
-            return ToolExecutionResult::success(json!({
-                "subagent_id": child_id.to_string(),
-                "name": child.subagent_name,
-                "delivered": true,
-                "cancel_requested": true,
-                "note": "Message delivered. Cancellation will take effect after current turn.",
-            }));
-        }
-
-        // Wait for the subagent to process the message
-        let status = match store.wait_for_idle(child_id, Some(300)).await {
-            Ok(s) => s,
-            Err(e) => {
-                return ToolExecutionResult::success(json!({
-                    "subagent_id": child_id.to_string(),
-                    "name": child.subagent_name,
-                    "delivered": true,
-                    "status": "error",
-                    "error": e.to_string(),
-                }));
-            }
-        };
-
-        // Get the latest response
-        let messages = match store.get_messages(child_id, Some(5)).await {
-            Ok(m) => m,
-            Err(e) => return ToolExecutionResult::internal_error(e),
-        };
-
-        ToolExecutionResult::success(json!({
-            "subagent_id": child_id.to_string(),
-            "name": child.subagent_name,
-            "delivered": true,
-            "status": status,
-            "result": last_agent_message(&messages),
-        }))
-    }
-
-    fn requires_context(&self) -> bool {
-        true
-    }
-}
-
-// =============================================================================
 // Task executor: subagent
 // =============================================================================
 
 /// Control plane for `subagent` tasks. Inbound messages and cooperative
 /// cancellation route through the child session's message channel — there is
-/// no hard kill, so cancel delivers a graceful stop request (same mechanics
-/// as `message_subagent(cancel=true)`).
+/// no hard kill, so cancel delivers a graceful stop request via `cancel_task`.
 pub struct SubagentTaskExecutor;
 
 #[async_trait]
@@ -1135,7 +817,7 @@ mod tests {
     fn capability_basics() {
         let cap = SubagentCapability;
         assert_eq!(cap.id(), "subagents");
-        assert_eq!(cap.tools().len(), 3);
+        assert_eq!(cap.tools().len(), 1);
         assert!(cap.system_prompt_addition().is_some());
         assert_eq!(cap.features(), vec!["subagents"]);
     }
@@ -1145,10 +827,7 @@ mod tests {
         let cap = SubagentCapability;
         let tools = cap.tools();
         let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
-        assert_eq!(
-            names,
-            vec!["spawn_subagent", "get_subagents", "message_subagent"]
-        );
+        assert_eq!(names, vec!["spawn_subagent"]);
     }
 
     #[test]
@@ -1208,22 +887,6 @@ mod tests {
         let tool = SpawnSubagentTool;
         let result = tool
             .execute(json!({"name": "Test", "instructions": "test"}))
-            .await;
-        assert!(matches!(result, ToolExecutionResult::ToolError(_)));
-    }
-
-    #[tokio::test]
-    async fn get_subagents_without_context_returns_error() {
-        let tool = GetSubagentsTool;
-        let result = tool.execute(json!({})).await;
-        assert!(matches!(result, ToolExecutionResult::ToolError(_)));
-    }
-
-    #[tokio::test]
-    async fn message_subagent_without_context_returns_error() {
-        let tool = MessageSubagentTool;
-        let result = tool
-            .execute(json!({"name_or_id": "Test", "message": "hello"}))
             .await;
         assert!(matches!(result, ToolExecutionResult::ToolError(_)));
     }

--- a/crates/core/src/context_report.rs
+++ b/crates/core/src/context_report.rs
@@ -349,10 +349,7 @@ fn is_skill_tool_source(name: &str, category: &str, capability_id: &str) -> bool
 }
 
 fn is_subagent_tool_name(name: &str) -> bool {
-    matches!(
-        name,
-        "spawn_subagent" | "get_subagents" | "message_subagent"
-    )
+    matches!(name, "spawn_subagent")
 }
 
 fn tool_definition_contribution_source(

--- a/crates/core/src/localization.rs
+++ b/crates/core/src/localization.rs
@@ -265,8 +265,6 @@ pub fn localized_tool_display_name(
         "secret_store" => Some("Сховище секретів"),
         "kv_store" => Some("Сховище значень"),
         "spawn_subagent" => Some("Запуск субагента"),
-        "get_subagents" => Some("Субагенти"),
-        "message_subagent" => Some("Повідомлення субагенту"),
         "write_todos" => Some("Список задач"),
         "setup_connection" => Some("Налаштування підключення"),
         _ => None,

--- a/crates/core/src/tool_narration.rs
+++ b/crates/core/src/tool_narration.rs
@@ -54,10 +54,6 @@ fn arg_str<'a>(arguments: &'a Value, keys: &[&str]) -> Option<&'a str> {
         .filter(|value| !value.is_empty())
 }
 
-fn arg_bool(arguments: &Value, key: &str) -> Option<bool> {
-    arguments.get(key).and_then(Value::as_bool)
-}
-
 fn basename(path: &str) -> &str {
     let trimmed = path.trim_end_matches('/');
     trimmed
@@ -420,39 +416,6 @@ fn ukrainian_phrase(
                 ToolNarrationPhase::Failed => format!("Не вдалося запустити {target}"),
             }
         }
-        "get_subagents" => {
-            let target = arg_str(args, &["name_or_id"])
-                .map(|value| format!("субагента {value}"))
-                .unwrap_or_else(|| "субагентів".to_string());
-            match phase {
-                ToolNarrationPhase::Started | ToolNarrationPhase::Waiting => {
-                    format!("Перевіряю {target}")
-                }
-                ToolNarrationPhase::Completed => format!("Перевірив {target}"),
-                ToolNarrationPhase::Failed => format!("Не вдалося перевірити {target}"),
-            }
-        }
-        "message_subagent" => {
-            let target = arg_str(args, &["name_or_id"])
-                .map(|value| format!("повідомлення для {value}"))
-                .unwrap_or_else(|| "повідомлення субагенту".to_string());
-            if matches!(phase, ToolNarrationPhase::Completed)
-                && arg_bool(args, "cancel").unwrap_or(false)
-            {
-                format!(
-                    "Поставив у чергу запит на зупинку {}",
-                    target.trim_start_matches("повідомлення для ")
-                )
-            } else {
-                match phase {
-                    ToolNarrationPhase::Started | ToolNarrationPhase::Waiting => {
-                        format!("Ставлю у чергу {target}")
-                    }
-                    ToolNarrationPhase::Completed => format!("Поставив у чергу {target}"),
-                    ToolNarrationPhase::Failed => format!("Не вдалося поставити у чергу {target}"),
-                }
-            }
-        }
         "write_todos" => match phase {
             ToolNarrationPhase::Started | ToolNarrationPhase::Waiting => {
                 "Оновлюю список задач".to_string()
@@ -629,33 +592,6 @@ pub fn render_tool_narration_with_locale(
                 .map(|name| format!("{name} subagent"))
                 .or_else(|| Some("subagent".to_string()));
             generic_phrase("Launching", "Launched", "Failed to launch", target, phase)
-        }
-        "get_subagents" => {
-            let target = arg_str(args, &["name_or_id"])
-                .map(|value| format!("subagent {value}"))
-                .unwrap_or_else(|| "subagent status".to_string());
-            generic_phrase(
-                "Checking",
-                "Checked",
-                "Failed to check",
-                Some(target),
-                phase,
-            )
-        }
-        "message_subagent" => {
-            let target = arg_str(args, &["name_or_id"])
-                .map(|value| format!("message for {value}"))
-                .unwrap_or_else(|| "subagent message".to_string());
-            if matches!(phase, ToolNarrationPhase::Completed)
-                && arg_bool(args, "cancel").unwrap_or(false)
-            {
-                format!(
-                    "Queued stop request for {}",
-                    target.trim_start_matches("message for ")
-                )
-            } else {
-                generic_phrase("Queueing", "Queued", "Failed to queue", Some(target), phase)
-            }
         }
         "write_todos" => generic_phrase(
             "Updating",

--- a/crates/core/tests/subagent_test.rs
+++ b/crates/core/tests/subagent_test.rs
@@ -1,7 +1,9 @@
 // Integration tests for SubagentCapability
 //
-// Tests the subagent tools (spawn_subagent, get_subagents, message_subagent)
-// via the Capability trait since the individual tool structs are not publicly exported.
+// Tests the subagent tools (spawn_subagent) via the Capability trait since
+// the individual tool structs are not publicly exported.
+// get_subagents and message_subagent were retired; their coverage moved to
+// the generic session_tasks tools (list_tasks, get_task, message_task).
 
 use everruns_core::capabilities::{Capability, CapabilityStatus, SubagentCapability};
 use everruns_core::tools::{Tool, ToolExecutionResult};
@@ -43,7 +45,7 @@ fn test_subagent_capability_registration() {
     assert_eq!(cap.id(), "subagents");
     assert_eq!(cap.name(), "Subagents");
     assert_eq!(cap.status(), CapabilityStatus::Available);
-    assert_eq!(cap.tools().len(), 3);
+    assert_eq!(cap.tools().len(), 1);
     assert!(cap.system_prompt_addition().is_some());
     assert_eq!(cap.features(), vec!["subagents"]);
 
@@ -117,72 +119,7 @@ async fn test_spawn_subagent_missing_instructions() {
 }
 
 // =============================================================================
-// 4. get_subagents — no context (execute without context)
-// =============================================================================
-
-#[tokio::test]
-async fn test_get_subagents_no_context() {
-    let tool = find_tool("get_subagents");
-    let result = tool.execute(json!({})).await;
-    assert!(
-        matches!(result, ToolExecutionResult::ToolError(_)),
-        "Expected ToolError when calling get_subagents without context, got: {result:?}"
-    );
-}
-
-// =============================================================================
-// 5. message_subagent — missing params
-// =============================================================================
-
-#[tokio::test]
-async fn test_message_subagent_missing_params() {
-    let tool = find_tool("message_subagent");
-
-    // Without context
-    let result = tool
-        .execute(json!({"name_or_id": "Test", "message": "hello"}))
-        .await;
-    assert!(
-        matches!(result, ToolExecutionResult::ToolError(_)),
-        "Expected ToolError without context"
-    );
-
-    // With context but missing name_or_id
-    let ctx = empty_context();
-    let result = tool
-        .execute_with_context(json!({"message": "hello"}), &ctx)
-        .await;
-    match &result {
-        ToolExecutionResult::ToolError(msg) => {
-            assert!(
-                msg.contains("name_or_id")
-                    || msg.contains("parameter")
-                    || msg.contains("platform_store"),
-                "Error should reference missing param, got: {msg}"
-            );
-        }
-        _ => panic!("Expected ToolError for missing name_or_id, got: {result:?}"),
-    }
-
-    // With context but missing message
-    let result = tool
-        .execute_with_context(json!({"name_or_id": "Test"}), &ctx)
-        .await;
-    match &result {
-        ToolExecutionResult::ToolError(msg) => {
-            assert!(
-                msg.contains("message")
-                    || msg.contains("parameter")
-                    || msg.contains("platform_store"),
-                "Error should reference missing param, got: {msg}"
-            );
-        }
-        _ => panic!("Expected ToolError for missing message, got: {result:?}"),
-    }
-}
-
-// =============================================================================
-// 6. spawn_subagent — schema validation
+// 4. spawn_subagent — schema validation
 // =============================================================================
 
 #[test]
@@ -208,68 +145,7 @@ fn test_spawn_subagent_schema_validation() {
 }
 
 // =============================================================================
-// 7. get_subagents — schema validation
-// =============================================================================
-
-#[test]
-fn test_get_subagents_schema_validation() {
-    let tool = find_tool("get_subagents");
-    let schema = tool.parameters_schema();
-
-    // No required fields
-    assert!(
-        schema.get("required").is_none()
-            || schema["required"].as_array().is_none_or(|a| a.is_empty()),
-        "get_subagents should have no required fields"
-    );
-
-    // Check optional properties
-    let props = &schema["properties"];
-    assert_eq!(props["name_or_id"]["type"], "string");
-    assert_eq!(props["status_filter"]["type"], "string");
-
-    // status_filter should have enum values
-    let status_enum = props["status_filter"]["enum"]
-        .as_array()
-        .expect("status_filter should have enum");
-    assert!(status_enum.contains(&json!("all")));
-    assert!(status_enum.contains(&json!("running")));
-    assert!(status_enum.contains(&json!("completed")));
-    assert!(status_enum.contains(&json!("failed")));
-}
-
-// =============================================================================
-// 8. message_subagent — schema validation
-// =============================================================================
-
-#[test]
-fn test_message_subagent_schema_validation() {
-    let tool = find_tool("message_subagent");
-    let schema = tool.parameters_schema();
-
-    // Check required fields
-    let required = schema["required"]
-        .as_array()
-        .expect("required should be array");
-    assert!(required.contains(&json!("name_or_id")));
-    assert!(required.contains(&json!("message")));
-    assert_eq!(required.len(), 2);
-
-    // Check property types
-    let props = &schema["properties"];
-    assert_eq!(props["name_or_id"]["type"], "string");
-    assert_eq!(props["message"]["type"], "string");
-    assert_eq!(props["cancel"]["type"], "boolean");
-
-    // cancel should have a default value
-    assert_eq!(props["cancel"]["default"], json!(false));
-
-    // cancel should NOT be in required
-    assert!(!required.contains(&json!("cancel")));
-}
-
-// =============================================================================
-// 9. Tool display names
+// 5. Tool display names
 // =============================================================================
 
 #[test]
@@ -279,12 +155,10 @@ fn test_tool_display_names() {
     let display_names: Vec<Option<&str>> = tools.iter().map(|t| t.display_name()).collect();
 
     assert_eq!(display_names[0], Some("Spawn Subagent"));
-    assert_eq!(display_names[1], Some("Get Subagents"));
-    assert_eq!(display_names[2], Some("Message Subagent"));
 }
 
 // =============================================================================
-// 10. All tools require context
+// 6. All tools require context
 // =============================================================================
 
 #[test]
@@ -301,7 +175,7 @@ fn test_tool_requires_context() {
 }
 
 // =============================================================================
-// Additional: tool names are correct and in expected order
+// Additional: tool names are correct
 // =============================================================================
 
 #[test]
@@ -309,10 +183,7 @@ fn test_tool_names_and_order() {
     let tools = subagent_tools();
     let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
 
-    assert_eq!(
-        names,
-        vec!["spawn_subagent", "get_subagents", "message_subagent"]
-    );
+    assert_eq!(names, vec!["spawn_subagent"]);
 }
 
 // =============================================================================
@@ -326,44 +197,6 @@ async fn test_spawn_subagent_no_platform_store() {
 
     let result = tool
         .execute_with_context(json!({"name": "Runner", "instructions": "run tests"}), &ctx)
-        .await;
-
-    match &result {
-        ToolExecutionResult::ToolError(msg) => {
-            assert!(
-                msg.contains("platform_store") || msg.contains("context"),
-                "Should mention platform_store requirement, got: {msg}"
-            );
-        }
-        _ => panic!("Expected ToolError for missing platform_store, got: {result:?}"),
-    }
-}
-
-#[tokio::test]
-async fn test_get_subagents_no_platform_store() {
-    let tool = find_tool("get_subagents");
-    let ctx = empty_context();
-
-    let result = tool.execute_with_context(json!({}), &ctx).await;
-
-    match &result {
-        ToolExecutionResult::ToolError(msg) => {
-            assert!(
-                msg.contains("platform_store") || msg.contains("context"),
-                "Should mention platform_store requirement, got: {msg}"
-            );
-        }
-        _ => panic!("Expected ToolError for missing platform_store, got: {result:?}"),
-    }
-}
-
-#[tokio::test]
-async fn test_message_subagent_no_platform_store() {
-    let tool = find_tool("message_subagent");
-    let ctx = empty_context();
-
-    let result = tool
-        .execute_with_context(json!({"name_or_id": "Runner", "message": "hello"}), &ctx)
         .await;
 
     match &result {

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -1300,8 +1300,8 @@ This shows your key metrics at the top, revenue trend in the middle, and recent 
 
 1. **Analyze the request**: Break down the user's task into independent subtasks
 2. **Spawn subagents**: Create a named subagent for each subtask (e.g. "Research", "Code Review", "Test Runner")
-3. **Monitor progress**: Use get_subagents to check on running subagents
-4. **Steer if needed**: Use message_subagent to redirect or provide additional context
+3. **Monitor progress**: Use list_tasks (filter by kind="subagent") or get_task to check on running subagents
+4. **Steer if needed**: Use message_task with the subagent's task_id to redirect or provide additional context
 5. **Synthesize**: Combine subagent results into a coherent final response
 
 ## Guidelines

--- a/docs/capabilities/github-scout.md
+++ b/docs/capabilities/github-scout.md
@@ -10,7 +10,7 @@ description: Blueprint-only GitHub repository exploration capability that spawns
 | **Features** | None |
 | **Dependencies** | [`subagents`](/capabilities/sub-agents/) |
 
-GitHub Scout lets an agent spawn a specialist subagent for read-only GitHub repository exploration. The host agent receives the `spawn_subagent`, `get_subagents`, and `message_subagent` tools through the dependency on `subagents`; the GitHub API tools stay private inside the spawned `github_scout` blueprint session.
+GitHub Scout lets an agent spawn a specialist subagent for read-only GitHub repository exploration. The host agent receives the `spawn_subagent` tool through the dependency on `subagents`; monitoring and steering are handled by the generic `session_tasks` tools (`list_tasks`, `get_task`, `message_task`, `cancel_task`). The GitHub API tools stay private inside the spawned `github_scout` blueprint session.
 
 ## How to Use
 

--- a/docs/capabilities/sub-agents.md
+++ b/docs/capabilities/sub-agents.md
@@ -1,6 +1,6 @@
 ---
 title: Sub Agents
-description: Spawn and manage subagents for parallel task execution in isolated context windows. Orchestrate multi-agent workflows with message passing and lifecycle control.
+description: Spawn subagents for parallel task execution in isolated context windows. Orchestrate multi-agent workflows with the generic session task tools.
 ---
 
 | | |
@@ -10,13 +10,13 @@ description: Spawn and manage subagents for parallel task execution in isolated 
 | **Features** | `subagents` |
 | **Dependencies** | None |
 
-Spawn and manage subagents for parallel task execution. Each subagent runs in its own isolated context window, allowing the parent agent to delegate verbose or independent tasks without cluttering the main conversation. Subagents inherit the parent's harness and agent configuration but operate with their own message history.
+Spawn subagents for parallel task execution. Each subagent runs in its own isolated context window, allowing the parent agent to delegate verbose or independent tasks without cluttering the main conversation. Subagents inherit the parent's harness and agent configuration but operate with their own message history.
 
 ## Tools
 
 ### `spawn_subagent`
 
-Create and start a new subagent. The subagent begins executing immediately in the background unless foreground mode is used.
+Create and start a new subagent. The subagent begins executing immediately. Returns a `task_id` that can be used with the generic session task tools to monitor, message, or cancel the subagent.
 
 | Parameter | Type | Required | Description |
 |---|---|---|---|
@@ -25,35 +25,26 @@ Create and start a new subagent. The subagent begins executing immediately in th
 | `blueprint` | string | no | Optional specialist blueprint ID, such as `github_scout`, that supplies its own prompt, model, and private tools. |
 | `config` | object | no | Blueprint-specific configuration. Only valid when `blueprint` is set. |
 
-### `get_subagents`
+## Managing subagents after spawn
 
-List subagents or retrieve details for a specific one, including status and output.
+Use the generic `session_tasks` tools to monitor and steer subagents after spawning. The `task_id` is returned by `spawn_subagent`.
 
-| Parameter | Type | Required | Description |
-|---|---|---|---|
-| `name_or_id` | string | no | Specific subagent by name or session ID. Omit to list all subagents. |
-| `status_filter` | string | no | Filter by status: `all`, `running`, `completed`, `failed`. Defaults to `all`. |
-
-### `message_subagent`
-
-Send a follow-up message to an existing subagent. Use this to steer a running subagent, ask clarifying questions, or gracefully stop it.
-
-| Parameter | Type | Required | Description |
-|---|---|---|---|
-| `name_or_id` | string | yes | Subagent name or session ID. |
-| `message` | string | yes | Message to send to the subagent. |
-| `cancel` | boolean | no | Gracefully stop the subagent after delivering the message. |
+- `list_tasks` with `kind: "subagent"` — list all subagent tasks and their status
+- `get_task` with the task ID — get detailed status and result for a specific subagent
+- `message_task` — send a steering message or additional context to a running subagent
+- `cancel_task` — request cooperative cancellation of a subagent
+- `wait_task` — block until a subagent reaches a terminal or interrupted state
 
 ## Notes
 
 - **No nesting** — subagents cannot spawn other subagents.
-- **Case-insensitive matching** — names are matched case-insensitively when using `name_or_id`.
-- **Foreground mode** — spawning can block until the subagent completes. Foreground execution has a 5-minute timeout.
+- **Foreground mode** — spawning blocks until the subagent completes. Foreground execution has a 5-minute timeout.
 - **Inherited configuration** — subagents inherit the parent's harness and agent configuration.
 - **Blueprints** — specialist blueprints can run with their own prompt, model, and private tools while still using the same subagent lifecycle.
 
 ## See Also
 
+- [Session Tasks](/capabilities/session-tasks/) — generic task monitoring and control
 - [GitHub Scout](/capabilities/github-scout/) — blueprint-only GitHub repository exploration
 - [Session](/capabilities/session/) — session metadata and lifecycle
 - [Platform Management](/capabilities/platform-management/) — agent and platform configuration

--- a/docs/capabilities/sub-agents.md
+++ b/docs/capabilities/sub-agents.md
@@ -44,7 +44,7 @@ Use the generic `session_tasks` tools to monitor and steer subagents after spawn
 
 ## See Also
 
-- [Session Tasks](/capabilities/session-tasks/) — generic task monitoring and control
+- [`specs/session-tasks.md`](https://github.com/everruns/everruns/blob/main/specs/session-tasks.md) — generic task monitoring and control (`list_tasks`, `get_task`, `message_task`, `cancel_task`, `wait_task`)
 - [GitHub Scout](/capabilities/github-scout/) — blueprint-only GitHub repository exploration
 - [Session](/capabilities/session/) — session metadata and lifecycle
 - [Platform Management](/capabilities/platform-management/) — agent and platform configuration

--- a/integrations/github/README.md
+++ b/integrations/github/README.md
@@ -38,8 +38,9 @@ A read-only scout agent for repository exploration:
 - Resolves credentials from the existing `github` user connection.
 - Returns `connection_required` when no GitHub connection is available.
 - Depends on the built-in `subagents` capability, so hosts that enable
-  `github_scout` also get `spawn_subagent`, `get_subagents`, and
-  `message_subagent`.
+  `github_scout` also get `spawn_subagent`. Monitoring and steering use the
+  generic `session_tasks` tools (`list_tasks`, `get_task`, `message_task`,
+  `cancel_task`).
 
 ## Tool Privacy
 

--- a/specs/a2a-capability.md
+++ b/specs/a2a-capability.md
@@ -4,10 +4,11 @@
   - V1 is outbound-only: Everruns agents can delegate to external A2A agents.
   - Do not expose Everruns agents over A2A by default.
   - Inbound A2A is an explicit future App channel, not a global agent endpoint.
-  - Runtime surface is unified agent delegation: spawn_agent/get_agent_runs/wait_agent/message_agent/cancel_agent.
+  - Runtime surface is unified agent delegation: spawn_agent + generic session_tasks tools.
   - V1 stores external agents in capability config; future org-managed external_agents can replace this source.
   - Run state is registered as session_resources.kind = agent_run for visibility and wake-up.
   - Official Rust A2A SDK crates provide wire types, client, and integration-test server.
+  - get_agent_runs, wait_agent, message_agent, cancel_agent retired in favour of generic tools (see migration below).
 -->
 
 ## Abstract
@@ -21,9 +22,9 @@ V1 supports:
 - AgentCard discovery from configured external A2A agents.
 - JSON-RPC and HTTP+JSON transport negotiation through the official Rust A2A client.
 - `spawn_agent` in `wait` or `background` mode.
-- `wait_agent` for pending runs.
-- `message_agent` for follow-up or `input_required` runs.
-- `cancel_agent` for remote task cancellation.
+- `wait_task` for pending runs (generic session task tool).
+- `message_task` for follow-up or `input_required` runs (generic session task tool).
+- `cancel_task` for remote task cancellation (generic session task tool).
 - Wake-up by synthetic session message when a background run completes.
 - Result persistence under `/.agent-runs/{agent_run_id}/result.json` when session files are available.
 
@@ -93,15 +94,15 @@ This keeps external A2A and local subagent delegation visible through the same s
 
 Each run is additionally tracked as a session task (`kind = external_agent`)
 with the full lifecycle, message thread, and `task.*` events — see
-[`specs/session-tasks.md`](./session-tasks.md). The generic `message_task` /
-`cancel_task` / `wait_task` tools work on agent runs via the
-`ExternalAgentTaskExecutor`.
+[`specs/session-tasks.md`](./session-tasks.md). The generic `list_tasks`,
+`get_task`, `message_task`, `cancel_task`, and `wait_task` tools work on
+agent runs via the `ExternalAgentTaskExecutor`.
 
 ## Tools
 
 ### `spawn_agent`
 
-Creates an external A2A run.
+Creates an external A2A run. Returns an `agent_run_id` and `task_id`.
 
 Parameters:
 
@@ -114,21 +115,28 @@ Parameters:
 
 `mode = wait` blocks until the remote task reaches a terminal state or timeout. `mode = background` returns an `agent_run_id` immediately and monitors completion in a detached task.
 
-### `get_agent_runs`
+### Monitoring and steering agent runs
 
-Lists all session `agent_run` resources or returns one run by `agent_run_id`.
+Use the generic `session_tasks` tools after spawning. The `task_id` is returned by `spawn_agent`.
 
-### `wait_agent`
+| Tool | Description |
+|------|-------------|
+| `list_tasks` with `kind: "external_agent"` | List all agent run tasks |
+| `get_task` | Get detailed status for a specific run |
+| `message_task` | Send follow-up input using the saved remote taskId/contextId |
+| `cancel_task` | Call A2A task cancellation and update local run state |
+| `wait_task` | Poll until terminal state or timeout |
 
-Polls the remote A2A task by `remote_task_id` until terminal state or timeout.
+### Retired tools (removed)
 
-### `message_agent`
+The following per-kind tools were retired in favour of the generic tools above:
 
-Sends follow-up input using the saved remote `taskId` and `contextId`.
-
-### `cancel_agent`
-
-Calls A2A task cancellation and updates the local run state from the returned task.
+| Retired | Replacement |
+|---------|-------------|
+| `get_agent_runs` | `list_tasks(kind="external_agent")` + `get_task` |
+| `wait_agent` | `wait_task` |
+| `message_agent` | `message_task` |
+| `cancel_agent` | `cancel_task` |
 
 ## A2A Mapping
 
@@ -141,7 +149,7 @@ Calls A2A task cancellation and updates the local run state from the returned ta
 | result summary | first text artifact, else status message text |
 | `input_required` | non-terminal interrupted run |
 | `auth_required` | non-terminal interrupted run |
-| `cancel_agent` | A2A `CancelTask` |
+| `cancel_task` | A2A `CancelTask` |
 
 ## Wake-Up
 
@@ -177,5 +185,5 @@ Integration tests use the official Rust `a2a-server-lf` crate to start a real lo
 
 - AgentCard discovery.
 - `spawn_agent` wait mode.
-- Background mode plus `wait_agent`.
+- Background mode (background spawn).
 - Local URL blocking unless `allow_local_urls` is set.

--- a/specs/agent-blueprints.md
+++ b/specs/agent-blueprints.md
@@ -206,8 +206,8 @@ No new event types needed. The `subagent.spawned` event gains an optional `bluep
 ### Statefulness and Follow-ups
 
 The spawned session is **fully stateful** — real session with messages, events, durable workflow state. The host can:
-- `message_subagent("Scout", "also check the auth middleware tests")` — sends a follow-up
-- `get_subagents("Scout")` — checks status and reads messages
+- `message_task(task_id, "also check the auth middleware tests")` — sends a follow-up
+- `get_task(task_id)` or `list_tasks(kind="subagent")` — checks status and reads messages
 
 The `AgentBlueprint` definition is stateless (code template). The session instance is stateful.
 

--- a/specs/events.md
+++ b/specs/events.md
@@ -1039,7 +1039,7 @@ Emitted when a subagent encounters an error.
 
 #### `subagent.cancelled`
 
-Emitted when a subagent is cancelled via `message_subagent` with `cancel: true`.
+Emitted when a subagent is cancelled (via `cancel_task` or the `SubagentTaskExecutor` cancel path).
 
 All four events share the same `SubagentEventData` shape: `subagent_session_id`, `subagent_name`, `task`, `status`, and optional `result`/`error` fields.
 

--- a/specs/session-tasks.md
+++ b/specs/session-tasks.md
@@ -305,7 +305,10 @@ No backward compatibility is required; data migrates forward once:
   record; `parent_session_id` stays.
 - `subagent.*` event types are superseded by `task.*` events.
 - `get_subagents`, `get_agent_runs`, `wait_agent`, `message_agent`,
-  `message_subagent` retire in favor of the generic tools.
+  `message_subagent`, `cancel_agent` — **retired (done)**. These per-kind tools have
+  been removed; all listing, waiting, messaging, and cancellation now routes
+  through the generic tools (`list_tasks`, `get_task`, `message_task`,
+  `cancel_task`, `wait_task`).
 - `GET /v1/sessions/{id}/resources` keeps serving infrastructure resources.
 
 ## Implementation notes (v1)

--- a/specs/subagents.md
+++ b/specs/subagents.md
@@ -3,17 +3,16 @@
 Each spawned subagent is also tracked as a session task (`kind = subagent`,
 `links.child_session_id` pointing at the child) with lifecycle `task.*`
 events and a message channel — see
-[`specs/session-tasks.md`](./session-tasks.md). The generic `message_task` /
-`cancel_task` tools work on subagents via the `SubagentTaskExecutor`.
+[`specs/session-tasks.md`](./session-tasks.md). The generic `list_tasks`,
+`get_task`, `message_task`, and `cancel_task` tools work on subagents via
+the `SubagentTaskExecutor`.
 
 <!-- Design Decisions:
-  - 3 tools only: spawn_subagent, get_subagents, message_subagent
+  - 1 creation tool: spawn_subagent (get/message/cancel handled by generic session_tasks tools)
   - Foreground execution blocks parent tool call (Phase 1); background mode deferred
   - No nesting: subagents cannot spawn subagents
   - Human-readable names by default ("Test Runner" not "test-runner")
-  - Case-insensitive name matching for get/message operations
-  - Completion notifications use steering messages (injected mid-turn)
-  - message_subagent unifies cancel + resume + mid-execution steering
+  - message_task / cancel_task unify steering and cancellation via the task registry
   - Subagent inherits parent's harness and agent configuration
   - UI: dedicated Subagents tab with master-detail layout
 -->
@@ -28,12 +27,12 @@ Inspired by Claude Code's Agent tool, Cursor's sub-agents, and OpenAI Codex's mu
 
 | Principle | Rationale |
 |-----------|-----------|
-| Exactly 3 tools | Minimal surface area. spawn/get/message covers full lifecycle. |
+| Single creation tool | Minimal surface area. `spawn_subagent` covers creation; lifecycle is managed via generic task tools. |
 | Foreground-first | Simpler mental model: agent calls tool, blocks, gets result. Background deferred to Phase 1b. |
 | No nesting | Prevents runaway resource consumption and simplifies reasoning about execution depth. |
-| Human-readable names | "Test Runner" is more natural than `test-runner` in conversation. Case-insensitive matching for ergonomics. |
+| Human-readable names | "Test Runner" is more natural than `test-runner` in conversation. |
 | Inherit parent config | Subagent uses same harness, agent, and model. No capability escalation. |
-| Steering via messages | `message_subagent` unifies cancel, resume, and mid-execution guidance into one tool. |
+| Generic lifecycle tools | `list_tasks`, `get_task`, `message_task`, `cancel_task` work for all task kinds including subagents. |
 
 ## Data Model
 
@@ -65,7 +64,7 @@ Spawning → Running → Completed
 | `Running` | Task sent, agentic loop active |
 | `Completed` | Child session idled after processing task |
 | `Failed` | Child session encountered an unrecoverable error |
-| `Cancelled` | Parent cancelled via `message_subagent(cancel: true)` |
+| `Cancelled` | Parent cancelled via `cancel_task` |
 | `MaxIterationsReached` | Child hit iteration limit |
 
 ### Database Migration
@@ -76,14 +75,14 @@ See `crates/server/migrations/009_subagents.sql` for schema changes.
 
 ### spawn_subagent
 
-Creates a child session and sends the instructions as the first user message. In foreground mode, blocks until the child idles.
+Creates a child session and sends the instructions as the first user message. In foreground mode, blocks until the child idles. Returns a `task_id` that can be used with the generic session task tools.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `name` | string | Yes | Human-readable name for the subagent |
 | `instructions` | string | Yes | Instructions sent as first user message |
 
-**Returns:** Last assistant message from the child session (the subagent's response to the instructions).
+**Returns:** Last assistant message from the child session plus a `task_id` for the session task record.
 
 **Behavior:**
 1. Creates child session with `parent_session_id` set to current session
@@ -94,30 +93,17 @@ Creates a child session and sends the instructions as the first user message. In
 6. On child idle: returns last assistant message, status → `Completed`
 7. On child failure: returns error, status → `Failed`
 
-### get_subagents
+### Monitoring and steering subagents
 
-Lists or retrieves detail for subagents spawned by the current session.
+Use the generic `session_tasks` tools after spawning. The `task_id` is returned by `spawn_subagent`.
 
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `name_or_id` | string | No | Filter by name (case-insensitive) or session ID |
-| `status_filter` | string | No | Filter by SubagentStatus value |
-
-**Returns:** Array of subagent summaries (name, status, instructions, created_at), or single subagent detail when `name_or_id` matches exactly one.
-
-### message_subagent
-
-Sends a follow-up message to an existing subagent. Unifies steering, resuming, and cancellation.
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `name_or_id` | string | Yes | Subagent name (case-insensitive) or session ID |
-| `message` | string | Yes* | Message content to send (* not required when `cancel: true`) |
-| `cancel` | bool | No | If true, cancel the subagent instead of messaging |
-
-**Returns:** Last assistant message after the subagent processes the message, or cancellation confirmation.
-
-**Cancel behavior:** Sets `subagent_status = Cancelled`, cancels any active turn in the child session.
+| Tool | Description |
+|------|-------------|
+| `list_tasks` with `kind: "subagent"` | List all subagent tasks and their status |
+| `get_task` | Get detailed status and result for a specific subagent |
+| `message_task` | Send a steering message or additional context to a running subagent |
+| `cancel_task` | Request cooperative cancellation of a subagent |
+| `wait_task` | Block until a subagent reaches a terminal or interrupted state |
 
 ## Events
 

--- a/test_cases/api/subagents/TC002_get_subagents_list.md
+++ b/test_cases/api/subagents/TC002_get_subagents_list.md
@@ -1,8 +1,8 @@
-# TC002: Get Subagents - List After Spawning
+# TC002: List Subagent Tasks After Spawning
 
 ## Description
 
-Verify that after spawning multiple subagents, the `get_subagents` tool (with no arguments) returns all child sessions with correct names, statuses, and count.
+Verify that after spawning multiple subagents, `list_tasks` (from the generic session_tasks capability) returns all subagent tasks with correct names, statuses, and count. This test was previously titled "Get Subagents - List After Spawning" using the retired `get_subagents` tool; it now uses the generic `list_tasks` replacement.
 
 ## Preconditions
 
@@ -14,9 +14,9 @@ Verify that after spawning multiple subagents, the `get_subagents` tool (with no
 | Field | Value |
 |-------|-------|
 | Agent Name | Multi-Spawner |
-| Capabilities | `subagents` |
-| System Prompt | You are an orchestrator. When asked, spawn subagents as instructed, then call get_subagents to list them. |
-| User Message | Spawn two subagents: one named "Alpha" with task "Count to 5", and one named "Beta" with task "List 3 colors". After both complete, call get_subagents to list all subagents. |
+| Capabilities | `subagents`, `session_tasks` |
+| System Prompt | You are an orchestrator. When asked, spawn subagents as instructed, then call list_tasks with kind="subagent" to list them. |
+| User Message | Spawn two subagents: one named "Alpha" with task "Count to 5", and one named "Beta" with task "List 3 colors". After both complete, call list_tasks with kind="subagent" to list all subagent tasks. |
 
 ## Steps
 
@@ -26,8 +26,8 @@ Verify that after spawning multiple subagents, the `get_subagents` tool (with no
      -H "Content-Type: application/json" \
      -d '{
        "name": "Multi-Spawner",
-       "system_prompt": "You are an orchestrator. When asked, spawn subagents as instructed, then call get_subagents to list them.",
-       "capabilities": ["subagents"]
+       "system_prompt": "You are an orchestrator. When asked, spawn subagents as instructed, then call list_tasks with kind=\"subagent\" to list them.",
+       "capabilities": ["subagents", "session_tasks"]
      }'
    ```
    Save `agent_id` from response.
@@ -47,7 +47,7 @@ Verify that after spawning multiple subagents, the `get_subagents` tool (with no
      -d '{
        "message": {
          "role": "user",
-         "content": [{"type": "text", "text": "Spawn two subagents: one named \"Alpha\" with task \"Count to 5\", and one named \"Beta\" with task \"List 3 colors\". After both complete, call get_subagents to list all subagents."}]
+         "content": [{"type": "text", "text": "Spawn two subagents: one named \"Alpha\" with task \"Count to 5\", and one named \"Beta\" with task \"List 3 colors\". After both complete, call list_tasks with kind=\"subagent\" to list all subagent tasks."}]
        }
      }'
    ```
@@ -69,17 +69,17 @@ Verify that after spawning multiple subagents, the `get_subagents` tool (with no
 | Beta spawned | `tool.called` event with `tool_name: "spawn_subagent"` and `arguments.name: "Beta"` |
 | Both completed | Two `tool.completed` events for `spawn_subagent` with `status` in result |
 
-### Get Subagents Assertions
+### List Tasks Assertions
 
 | Check | Expected |
 |-------|----------|
-| get_subagents called | `tool.called` event with `tool_name: "get_subagents"` |
-| Result has subagents array | `tool.completed` result contains `subagents` array |
+| list_tasks called | `tool.called` event with `tool_name: "list_tasks"` |
+| Result has tasks array | `tool.completed` result contains `tasks` array |
 | Count is 2 | Result `count` equals `2` |
-| Alpha in list | `subagents` array contains entry with `name: "Alpha"` |
-| Beta in list | `subagents` array contains entry with `name: "Beta"` |
-| Each has status | Each entry has `status` field (e.g. `"completed"` or `"idle"`) |
-| Each has subagent_id | Each entry has non-empty `subagent_id` |
+| Alpha in list | `tasks` array contains entry with `display_name: "Alpha"` |
+| Beta in list | `tasks` array contains entry with `display_name: "Beta"` |
+| Each has state | Each entry has `state` field (e.g. `"succeeded"`) |
+| Each has task id | Each entry has non-empty `id` field |
 
 ## Validation Commands
 
@@ -87,12 +87,12 @@ Verify that after spawning multiple subagents, the `get_subagents` tool (with no
 # Assert: spawn_subagent called twice
 curl -s ".../events" | jq '[.data[] | select(.type == "tool.called" and .data.tool_name == "spawn_subagent")] | length == 2'
 
-# Assert: get_subagents called
-curl -s ".../events" | jq '[.data[] | select(.type == "tool.called" and .data.tool_name == "get_subagents")] | length > 0'
+# Assert: list_tasks called
+curl -s ".../events" | jq '[.data[] | select(.type == "tool.called" and .data.tool_name == "list_tasks")] | length > 0'
 
-# Assert: get_subagents result has count 2
-curl -s ".../events" | jq '[.data[] | select(.type == "tool.completed" and .data.tool_name == "get_subagents")] | .[0].data.result | fromjson | .count == 2'
+# Assert: list_tasks result has count 2
+curl -s ".../events" | jq '[.data[] | select(.type == "tool.completed" and .data.tool_name == "list_tasks")] | .[0].data.result | fromjson | .count == 2'
 
 # Assert: both names present in listing
-curl -s ".../events" | jq '[.data[] | select(.type == "tool.completed" and .data.tool_name == "get_subagents")] | .[0].data.result | fromjson | .subagents | map(.name) | sort == ["Alpha", "Beta"]'
+curl -s ".../events" | jq '[.data[] | select(.type == "tool.completed" and .data.tool_name == "list_tasks")] | .[0].data.result | fromjson | .tasks | map(.display_name) | sort == ["Alpha", "Beta"]'
 ```

--- a/test_cases/api/subagents/TC003_message_subagent.md
+++ b/test_cases/api/subagents/TC003_message_subagent.md
@@ -88,7 +88,7 @@ Verify that `message_task` can send a follow-up message to a subagent's task cha
 | Check | Expected |
 |-------|----------|
 | message_task called | `tool.called` event with `tool_name: "message_task"` |
-| Message delivered | `tool.completed` result contains confirmation |
+| Message recorded and delivered | `tool.completed` for `message_task` whose result has `recorded: true` and `delivery: "delivered"` |
 | Two turns completed | Two `turn.completed` events |
 
 ## Validation Commands
@@ -99,6 +99,9 @@ curl -s ".../events" | jq '[.data[] | select(.type == "tool.called" and .data.to
 
 # Assert: message_task was called
 curl -s ".../events" | jq '[.data[] | select(.type == "tool.called" and .data.tool_name == "message_task")] | length > 0'
+
+# Assert: message_task recorded and delivered the message
+curl -s ".../events" | jq '[.data[] | select(.type == "tool.completed" and .data.tool_name == "message_task" and (.data.result.recorded == true) and (.data.result.delivery == "delivered"))] | length > 0'
 
 # Assert: two turns completed
 curl -s ".../events" | jq '[.data[] | select(.type == "turn.completed")] | length == 2'

--- a/test_cases/api/subagents/TC003_message_subagent.md
+++ b/test_cases/api/subagents/TC003_message_subagent.md
@@ -1,8 +1,8 @@
-# TC003: Message Subagent - Send Follow-Up Message
+# TC003: Message Task - Send Follow-Up to Subagent
 
 ## Description
 
-Verify that `message_subagent` can send a follow-up message to a completed subagent, resuming it and receiving a new response.
+Verify that `message_task` can send a follow-up message to a subagent's task channel and that the subagent processes the message. This test was previously titled "Message Subagent" using the retired `message_subagent` tool; it now uses the generic `message_task` replacement.
 
 ## Preconditions
 
@@ -14,10 +14,10 @@ Verify that `message_subagent` can send a follow-up message to a completed subag
 | Field | Value |
 |-------|-------|
 | Agent Name | Messenger Orchestrator |
-| Capabilities | `subagents` |
-| System Prompt | You are an orchestrator. Spawn subagents and message them as instructed. |
-| First Message | Spawn a subagent named "Helper" with task "Introduce yourself briefly." |
-| Second Message | Now send a message to Helper saying "What is 2 + 2?" |
+| Capabilities | `subagents`, `session_tasks` |
+| System Prompt | You are an orchestrator. Spawn subagents and message them as instructed. Use message_task with the task_id from spawn_subagent to send follow-up messages. |
+| First Message | Spawn a subagent named "Helper" with task "Introduce yourself briefly." Record the task_id. |
+| Second Message | Now send a message to Helper's task saying "What is 2 + 2?" using message_task with Helper's task_id. |
 
 ## Steps
 
@@ -27,8 +27,8 @@ Verify that `message_subagent` can send a follow-up message to a completed subag
      -H "Content-Type: application/json" \
      -d '{
        "name": "Messenger Orchestrator",
-       "system_prompt": "You are an orchestrator. Spawn subagents and message them as instructed.",
-       "capabilities": ["subagents"]
+       "system_prompt": "You are an orchestrator. Spawn subagents and message them as instructed. Use message_task with the task_id from spawn_subagent to send follow-up messages.",
+       "capabilities": ["subagents", "session_tasks"]
      }'
    ```
    Save `agent_id` from response.
@@ -48,21 +48,21 @@ Verify that `message_subagent` can send a follow-up message to a completed subag
      -d '{
        "message": {
          "role": "user",
-         "content": [{"type": "text", "text": "Spawn a subagent named \"Helper\" with task \"Introduce yourself briefly.\""}]
+         "content": [{"type": "text", "text": "Spawn a subagent named \"Helper\" with task \"Introduce yourself briefly.\" Record the task_id."}]
        }
      }'
    ```
 
 4. Wait for first turn to complete (60-120 seconds).
 
-5. Send second message to message the subagent:
+5. Send second message to message the subagent via task:
    ```bash
    curl -s -X POST "http://localhost:9300/api/v1/sessions/{session_id}/messages" \
      -H "Content-Type: application/json" \
      -d '{
        "message": {
          "role": "user",
-         "content": [{"type": "text", "text": "Now send a message to Helper saying \"What is 2 + 2?\""}]
+         "content": [{"type": "text", "text": "Now send a message to Helper’s task saying \"What is 2 + 2?\" using message_task with Helper’s task_id."}]
        }
      }'
    ```
@@ -81,24 +81,14 @@ Verify that `message_subagent` can send a follow-up message to a completed subag
 | Check | Expected |
 |-------|----------|
 | spawn_subagent called | `tool.called` event with `tool_name: "spawn_subagent"` and `arguments.name: "Helper"` |
-| Spawn completed | `tool.completed` for `spawn_subagent` with `subagent_id` in result |
+| Spawn completed | `tool.completed` for `spawn_subagent` with `task_id` in result |
 
 ### Message Phase Assertions
 
 | Check | Expected |
 |-------|----------|
-| message_subagent called | `tool.called` event with `tool_name: "message_subagent"` |
-| Target is Helper | `arguments.name_or_id` is `"Helper"` |
-| Message delivered | `tool.completed` result contains `delivered: true` |
-| Response received | Result contains `result` with non-empty text |
-| Status present | Result contains `status` field |
-| subagent_id in result | Result contains `subagent_id` matching the spawned session |
-
-### Event Lifecycle Assertions
-
-| Check | Expected |
-|-------|----------|
-| Two turns started | Two `turn.started` events |
+| message_task called | `tool.called` event with `tool_name: "message_task"` |
+| Message delivered | `tool.completed` result contains confirmation |
 | Two turns completed | Two `turn.completed` events |
 
 ## Validation Commands
@@ -107,14 +97,8 @@ Verify that `message_subagent` can send a follow-up message to a completed subag
 # Assert: spawn_subagent was called
 curl -s ".../events" | jq '[.data[] | select(.type == "tool.called" and .data.tool_name == "spawn_subagent")] | length > 0'
 
-# Assert: message_subagent was called
-curl -s ".../events" | jq '[.data[] | select(.type == "tool.called" and .data.tool_name == "message_subagent")] | length > 0'
-
-# Assert: message delivered
-curl -s ".../events" | jq '[.data[] | select(.type == "tool.completed" and .data.tool_name == "message_subagent")] | .[0].data.result | fromjson | .delivered == true'
-
-# Assert: response received
-curl -s ".../events" | jq '[.data[] | select(.type == "tool.completed" and .data.tool_name == "message_subagent")] | .[0].data.result | fromjson | .result | length > 0'
+# Assert: message_task was called
+curl -s ".../events" | jq '[.data[] | select(.type == "tool.called" and .data.tool_name == "message_task")] | length > 0'
 
 # Assert: two turns completed
 curl -s ".../events" | jq '[.data[] | select(.type == "turn.completed")] | length == 2'

--- a/test_cases/api/subagents/TC005_subagent_cancel.md
+++ b/test_cases/api/subagents/TC005_subagent_cancel.md
@@ -1,8 +1,8 @@
-# TC005: Subagent Cancel
+# TC005: Cancel Task - Subagent Cancellation
 
 ## Description
 
-Verify that `message_subagent` with `cancel=true` delivers the message and returns `cancel_requested: true` in the response.
+Verify that `cancel_task` delivers a cooperative cancellation request to a subagent task and that the task transitions to a canceled state. This test was previously titled "Subagent Cancel" using the retired `message_subagent(cancel=true)` mechanism; it now uses the generic `cancel_task` replacement.
 
 ## Preconditions
 
@@ -14,10 +14,10 @@ Verify that `message_subagent` with `cancel=true` delivers the message and retur
 | Field | Value |
 |-------|-------|
 | Agent Name | Cancel Tester |
-| Capabilities | `subagents` |
-| System Prompt | You are an orchestrator. Spawn subagents and cancel them as instructed. Always use the cancel parameter when asked to cancel. |
-| First Message | Spawn a subagent named "Worker" with task "Write a long story about a dragon." |
-| Second Message | Cancel the Worker subagent with the message "Stop now, we no longer need this." |
+| Capabilities | `subagents`, `session_tasks` |
+| System Prompt | You are an orchestrator. Spawn subagents and cancel them using cancel_task when instructed. Use the task_id returned by spawn_subagent. |
+| First Message | Spawn a subagent named "Worker" with task "Write a long story about a dragon." Record the task_id. |
+| Second Message | Cancel the Worker subagent using cancel_task with Worker's task_id. |
 
 ## Steps
 
@@ -27,8 +27,8 @@ Verify that `message_subagent` with `cancel=true` delivers the message and retur
      -H "Content-Type: application/json" \
      -d '{
        "name": "Cancel Tester",
-       "system_prompt": "You are an orchestrator. Spawn subagents and cancel them as instructed. Always use the cancel parameter when asked to cancel.",
-       "capabilities": ["subagents"]
+       "system_prompt": "You are an orchestrator. Spawn subagents and cancel them using cancel_task when instructed. Use the task_id returned by spawn_subagent.",
+       "capabilities": ["subagents", "session_tasks"]
      }'
    ```
    Save `agent_id` from response.
@@ -48,7 +48,7 @@ Verify that `message_subagent` with `cancel=true` delivers the message and retur
      -d '{
        "message": {
          "role": "user",
-         "content": [{"type": "text", "text": "Spawn a subagent named \"Worker\" with task \"Write a long story about a dragon.\""}]
+         "content": [{"type": "text", "text": "Spawn a subagent named \"Worker\" with task \"Write a long story about a dragon.\" Record the task_id."}]
        }
      }'
    ```
@@ -62,7 +62,7 @@ Verify that `message_subagent` with `cancel=true` delivers the message and retur
      -d '{
        "message": {
          "role": "user",
-         "content": [{"type": "text", "text": "Cancel the Worker subagent with the message \"Stop now, we no longer need this.\""}]
+         "content": [{"type": "text", "text": "Cancel the Worker subagent using cancel_task with Worker's task_id."}]
        }
      }'
    ```
@@ -81,28 +81,22 @@ Verify that `message_subagent` with `cancel=true` delivers the message and retur
 | Check | Expected |
 |-------|----------|
 | Worker spawned | `tool.called` with `tool_name: "spawn_subagent"` and `arguments.name: "Worker"` |
-| Spawn completed | `tool.completed` for `spawn_subagent` with `subagent_id` in result |
+| Spawn completed | `tool.completed` for `spawn_subagent` with `task_id` in result |
 
 ### Cancel Phase Assertions
 
 | Check | Expected |
 |-------|----------|
-| message_subagent called | `tool.called` with `tool_name: "message_subagent"` |
-| cancel flag set | `arguments.cancel` is `true` |
-| Target is Worker | `arguments.name_or_id` is `"Worker"` |
-| Message delivered | Result `delivered` is `true` |
-| Cancel requested | Result `cancel_requested` is `true` |
-| Note present | Result `note` contains "Cancellation will take effect" |
+| cancel_task called | `tool.called` with `tool_name: "cancel_task"` |
+| Cancel succeeds | `tool.completed` for `cancel_task` without error |
+| Task state reflects cancellation | `task.updated` event with `state: "canceled"` for the Worker task |
 
 ## Validation Commands
 
 ```bash
-# Assert: message_subagent called with cancel=true
-curl -s ".../events" | jq '[.data[] | select(.type == "tool.called" and .data.tool_name == "message_subagent" and .data.arguments.cancel == true)] | length > 0'
+# Assert: cancel_task called
+curl -s ".../events" | jq '[.data[] | select(.type == "tool.called" and .data.tool_name == "cancel_task")] | length > 0'
 
-# Assert: cancel_requested in result
-curl -s ".../events" | jq '[.data[] | select(.type == "tool.completed" and .data.tool_name == "message_subagent")] | .[0].data.result | fromjson | .cancel_requested == true'
-
-# Assert: delivered
-curl -s ".../events" | jq '[.data[] | select(.type == "tool.completed" and .data.tool_name == "message_subagent")] | .[0].data.result | fromjson | .delivered == true'
+# Assert: task.updated event shows canceled state
+curl -s ".../events" | jq '[.data[] | select(.type == "task.updated" and .data.task.state == "canceled")] | length > 0'
 ```

--- a/test_cases/api/subagents/TC005_subagent_cancel.md
+++ b/test_cases/api/subagents/TC005_subagent_cancel.md
@@ -88,8 +88,8 @@ Verify that `cancel_task` delivers a cooperative cancellation request to a subag
 | Check | Expected |
 |-------|----------|
 | cancel_task called | `tool.called` with `tool_name: "cancel_task"` |
-| Cancel succeeds | `tool.completed` for `cancel_task` without error |
-| Task state reflects cancellation | `task.updated` event with `state: "canceled"` for the Worker task |
+| Cancel intent recorded | `tool.completed` for `cancel_task` whose result has `cancel_requested: true` |
+| Cooperative wind-down | The task reaches a terminal state (`canceled`, or `succeeded`/`failed` if it finished first) — `cancel_task` requests, it does not force |
 
 ## Validation Commands
 
@@ -97,6 +97,9 @@ Verify that `cancel_task` delivers a cooperative cancellation request to a subag
 # Assert: cancel_task called
 curl -s ".../events" | jq '[.data[] | select(.type == "tool.called" and .data.tool_name == "cancel_task")] | length > 0'
 
-# Assert: task.updated event shows canceled state
-curl -s ".../events" | jq '[.data[] | select(.type == "task.updated" and .data.task.state == "canceled")] | length > 0'
+# Assert: cancel_task result recorded the cancel intent
+curl -s ".../events" | jq '[.data[] | select(.type == "tool.completed" and .data.tool_name == "cancel_task" and (.data.result.cancel_requested == true))] | length > 0'
+
+# Assert: the task reaches some terminal state (cooperative cancel may settle as canceled/succeeded/failed)
+curl -s ".../events" | jq '[.data[] | select(.type == "task.updated" and (.data.task.state | IN("canceled","succeeded","failed")))] | length > 0'
 ```


### PR DESCRIPTION
## What
Hard-removes the six legacy per-kind session-task tools in favor of the generic ones, completing the `specs/session-tasks.md` migration plan:

| Removed | Generic replacement |
|---|---|
| `get_subagents` | `list_tasks(kind="subagent")` + `get_task` |
| `message_subagent` | `message_task` |
| `get_agent_runs` | `list_tasks(kind="external_agent")` + `get_task` |
| `wait_agent` | `wait_task` |
| `message_agent` | `message_task` |
| `cancel_agent` | `cancel_task` |

`spawn_subagent` and `spawn_agent` (the creation tools) stay. The generic `session_tasks` capability is always registered, so the surface is available unconditionally.

## Why
The session-task registry unified subagents, A2A runs, background tools, and monitors behind one lifecycle. The per-kind list/wait/message/cancel tools were redundant duplicates of `list_tasks`/`get_task`/`message_task`/`cancel_task`/`wait_task`. Removing them shrinks the model-facing tool set (−1,185 lines) and is the prerequisite for retiring the `sessions.subagent_*` columns and the `get_subagents`-driven status flow.

## How
- Deleted the 6 tool structs + `impl Tool` blocks and their capability wiring; cleaned dead helpers the compiler flagged (`find_child_session`, `arg_bool`; `AGENT_RUN_KEY_PREFIX`/`list_run_ids` are now test-only).
- Updated narration, localization, context-report tool-name matches.
- Rewrote the subagent blueprint system prompt (seed), docs, specs, and the `test_cases/` suite to the generic tools; marked the retirement done in `specs/session-tasks.md`.
- No backward-compat shims (AGENTS.md: no backward compat for internal code; the spec mandates retirement). Parity confirmed: `wait_task` reconciles polled external_agent kinds exactly as `wait_agent` did.

## Risk
- Medium
- Model-facing tool-set change: agents/blueprints that referenced the removed names must use the generic tools. The default subagent blueprint prompt is updated in this PR; any user-authored prompt naming the old tools would need updating. Behavior is otherwise preserved — the generic tools are already the tested path.

## Security
- No security-relevant code changes: tool removal + prose. The generic tools carry the same `SESSION_MANAGE`/context gating. `message_agent_handoff` (a separate handoff tool) is unaffected. Reviewed against TM categories; none apply.

## Follow-ups
- Retire the `sessions.subagent_*` columns and the gRPC subagent-status flow now that `get_subagents` is gone (the remaining blocker is the spawn-handle proto; tracked in specs/session-tasks.md).

## Checklist
- [x] Tests added or updated (removed dead tool tests; generic-tool coverage already exists in session_tasks.rs)
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_011yqDiQ2GyoDdwFQTFTw12R)_