### PR TITLE
test(authz): add deny-policy tests for session file read commands (EVE-551)

### DIFF
--- a/crates/server/tests/command_policy_enforcement_test.rs
+++ b/crates/server/tests/command_policy_enforcement_test.rs
@@ -30,6 +30,7 @@ use everruns_server::domains::common::{
 use everruns_server::domains::evals::{CreateEvalRun, ListEvals};
 use everruns_server::domains::harnesses::types::CreateHarnessRequest;
 use everruns_server::domains::harnesses::{CreateHarness, ListHarnesses};
+use everruns_server::domains::session_files::{GetSessionFile, ListSessionFiles};
 use everruns_server::domains::session_tasks::{
     CancelSessionTask, GetSessionTask, ListSessionTasks, PostSessionTaskMessage,
 };
@@ -422,6 +423,35 @@ async fn eval_manage_without_session_permission_still_allows_list() {
     .run(&ctx)
     .await
     .expect("ListEvals must be allowed with only OrgAgentsManage");
+}
+
+// ============================================================================
+// EVE-551: ListSessionFiles and GetSessionFile must enforce SESSION_VIEW.
+// A resolver denying OrgSessionsManage must get 403 before any file lookup.
+// ============================================================================
+
+#[tokio::test]
+async fn session_file_read_commands_enforce_session_view_policy() {
+    let ctx = make_ctx(caller_with_role(OrgRole::Owner), Arc::new(DenyAllResolver));
+
+    let list_err = ListSessionFiles {
+        session_id: "session_00000000000000000000000000000001".to_string(),
+        recursive: false,
+    }
+    .run(&ctx)
+    .await
+    .expect_err("ListSessionFiles must require SESSION_VIEW");
+    assert_forbidden(list_err);
+
+    let get_err = GetSessionFile {
+        session_id: "session_00000000000000000000000000000001".to_string(),
+        path: "/".to_string(),
+        recursive: false,
+    }
+    .run(&ctx)
+    .await
+    .expect_err("GetSessionFile must require SESSION_VIEW");
+    assert_forbidden(get_err);
 }
 
 /// Commands intentionally exposed without a policy (public reads, probes).


### PR DESCRIPTION
## What

Adds regression tests proving that `ListSessionFiles` and `GetSessionFile` enforce `SESSION_VIEW` policy before any file lookup.

The code fix (adding `policy()` to both commands) landed earlier in `dfd834ce`. This PR closes the acceptance-criteria gap from EVE-551 by adding the deny-resolver tests required by the issue.

## Why

EVE-551 (DeepSec HIGH/high-confidence finding): session file list and read endpoints bypassed session policy — authenticated org users denied session view/manage could enumerate and read workspace files. The fix was in the server code; this PR proves it holds via automation.

## How

- Added `session_file_read_commands_enforce_session_view_policy` to `command_policy_enforcement_test.rs`
- Uses `DenyAllResolver` (denies all permissions) to verify both `ListSessionFiles` and `GetSessionFile` return `Forbidden` before any session or file lookup
- Follows the same pattern as `session_task_commands_honor_session_permissions_before_access` and `eval_run_creation_requires_session_permission`

## Validation

```
cargo test -p everruns-server --test command_policy_enforcement_test session_file_read_commands
test session_file_read_commands_enforce_session_view_policy ... ok
```

## Security

- `TM-AUTHZ` — verifies SESSION_VIEW policy fires on the two GET-method file read commands that were identified as missing enforcement
- No new code paths; test-only change

## Follow-ups

No follow-ups.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XsZXDkJR7dzHG1eAivmwAL)_