### PR TITLE
refactor(core): rename ConnectionProvider to Connector (phase 5)

### DIFF
--- a/crates/core/src/capabilities/fake_aws.rs
+++ b/crates/core/src/capabilities/fake_aws.rs
@@ -20,9 +20,9 @@
 
 use super::{Capability, CapabilityLocalization, CapabilityStatus};
 use crate::SessionId;
-use crate::connection_provider::{
-    ConnectionFormSchema, ConnectionProvider, ConnectionProviderPlugin, ConnectionType,
-    ConnectionValidation, FieldType, FormField,
+use crate::connector::{
+    Connector, ConnectorFormSchema, ConnectorPlugin, ConnectorType, ConnectorValidation, FieldType,
+    FormField,
 };
 use crate::tool_types::ToolHints;
 use crate::tools::{Tool, ToolExecutionResult};
@@ -34,9 +34,9 @@ use std::sync::OnceLock;
 use std::time::Duration;
 
 inventory::submit! {
-    ConnectionProviderPlugin {
+    ConnectorPlugin {
         experimental_only: true,
-        factory: || Box::new(FakeAwsConnectionProvider),
+        factory: || Box::new(FakeAwsConnector),
     }
 }
 
@@ -44,10 +44,10 @@ inventory::submit! {
 ///
 /// The key is intentionally opaque to agents: it is captured through the normal
 /// Connections flow and resolved server-side by handoff gates or tools.
-pub struct FakeAwsConnectionProvider;
+pub struct FakeAwsConnector;
 
 #[async_trait]
-impl ConnectionProvider for FakeAwsConnectionProvider {
+impl Connector for FakeAwsConnector {
     fn provider_id(&self) -> &str {
         "fake_aws"
     }
@@ -64,12 +64,12 @@ impl ConnectionProvider for FakeAwsConnectionProvider {
         "cloud"
     }
 
-    fn connection_type(&self) -> ConnectionType {
-        ConnectionType::ApiKey
+    fn connection_type(&self) -> ConnectorType {
+        ConnectorType::ApiKey
     }
 
-    fn form_schema(&self) -> Option<ConnectionFormSchema> {
-        Some(ConnectionFormSchema {
+    fn form_schema(&self) -> Option<ConnectorFormSchema> {
+        Some(ConnectorFormSchema {
             fields: vec![FormField {
                 name: "api_key".to_string(),
                 label: "Fake AWS API key".to_string(),
@@ -84,11 +84,11 @@ impl ConnectionProvider for FakeAwsConnectionProvider {
         })
     }
 
-    async fn validate(&self, credential: &str) -> Result<ConnectionValidation, String> {
+    async fn validate(&self, credential: &str) -> Result<ConnectorValidation, String> {
         if credential.trim().is_empty() {
             return Err("Fake AWS API key cannot be empty".to_string());
         }
-        Ok(ConnectionValidation {
+        Ok(ConnectorValidation {
             provider_username: Some("fake-aws-account".to_string()),
             provider_metadata: Some(json!({
                 "account_alias": "fake-aws-account",

--- a/crates/core/src/connector.rs
+++ b/crates/core/src/connector.rs
@@ -1,10 +1,10 @@
-// Connection Provider Plugin System
+// Connector Plugin System
 //
 // Decision: Parallel to IntegrationPlugin, allows integration crates to register
-// connection providers via inventory::submit! without core knowing about them.
-// Decision: Form schema is backend-driven — providers define their own UI fields
+// connectors via inventory::submit! without core knowing about them.
+// Decision: Form schema is backend-driven — connectors define their own UI fields
 // and instructions, frontend renders generically.
-// Decision: Validation is async — providers can call external APIs to verify credentials.
+// Decision: Validation is async — connectors can call external APIs to verify credentials.
 
 use async_trait::async_trait;
 use serde::Serialize;
@@ -15,39 +15,39 @@ use std::sync::Arc;
 // Plugin Registration
 // ============================================================================
 
-/// Plugin registration point for connection provider crates.
+/// Plugin registration point for connector crates.
 ///
-/// Integration crates use `inventory::submit!` to register their connection
-/// providers. The server discovers them at runtime to serve form schemas
+/// Integration crates use `inventory::submit!` to register their connectors.
+/// The server discovers them at runtime to serve form schemas
 /// and handle credential submission.
 ///
 /// # Example
 ///
 /// ```ignore
 /// inventory::submit! {
-///     ConnectionProviderPlugin {
+///     ConnectorPlugin {
 ///         experimental_only: true,
-///         factory: || Box::new(DaytonaConnectionProvider),
+///         factory: || Box::new(DaytonaConnector),
 ///     }
 /// }
 /// ```
-pub struct ConnectionProviderPlugin {
+pub struct ConnectorPlugin {
     /// If true, only registered when experimental features are enabled.
     pub experimental_only: bool,
     /// Factory function that creates the provider instance.
-    pub factory: fn() -> Box<dyn ConnectionProvider>,
+    pub factory: fn() -> Box<dyn Connector>,
 }
 
-inventory::collect!(ConnectionProviderPlugin);
+inventory::collect!(ConnectorPlugin);
 
 // ============================================================================
-// ConnectionProvider Trait
+// Connector Trait
 // ============================================================================
 
 /// How the user provides credentials for this connection.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
-pub enum ConnectionType {
+pub enum ConnectorType {
     /// OAuth flow (redirect-based, e.g. GitHub)
     OAuth,
     /// Direct API key entry (form-based, e.g. Daytona)
@@ -56,7 +56,7 @@ pub enum ConnectionType {
 
 /// A connection provider that can validate credentials and describe its UI form.
 #[async_trait]
-pub trait ConnectionProvider: Send + Sync {
+pub trait Connector: Send + Sync {
     /// Unique provider identifier (e.g. "daytona"). Must match `user_connections.provider`.
     fn provider_id(&self) -> &str;
 
@@ -70,41 +70,41 @@ pub trait ConnectionProvider: Send + Sync {
     fn icon(&self) -> &str;
 
     /// Whether this provider uses OAuth or direct API key entry.
-    fn connection_type(&self) -> ConnectionType;
+    fn connection_type(&self) -> ConnectorType;
 
     /// Form schema for API key providers. OAuth providers return None.
-    fn form_schema(&self) -> Option<ConnectionFormSchema>;
+    fn form_schema(&self) -> Option<ConnectorFormSchema>;
 
     /// Validate a credential before saving. Called for API key providers.
     /// Returns Ok with optional metadata on success, Err with user-facing message on failure.
-    async fn validate(&self, credential: &str) -> Result<ConnectionValidation, String>;
+    async fn validate(&self, credential: &str) -> Result<ConnectorValidation, String>;
 
     /// Validate with all form fields. Default delegates to `validate()` using the `api_key` field.
     /// Override this when the provider needs extra fields (e.g. org slug for personal tokens).
     async fn validate_fields(
         &self,
         fields: &HashMap<String, String>,
-    ) -> Result<ConnectionValidation, String> {
+    ) -> Result<ConnectorValidation, String> {
         let api_key = fields.get("api_key").map(|s| s.as_str()).unwrap_or("");
         self.validate(api_key).await
     }
 }
 
 // ============================================================================
-// ConnectionProvider Registry
+// Connector Registry
 // ============================================================================
 
 /// Registry of connection providers available to a platform.
 ///
-/// This is the explicit counterpart to `ConnectionProviderPlugin`. Inventory-based
+/// This is the explicit counterpart to `ConnectorPlugin`. Inventory-based
 /// discovery remains useful for the default OSS platform, but embedders need a
 /// concrete registry they can edit before handing the platform to the server.
 #[derive(Clone, Default)]
-pub struct ConnectionProviderRegistry {
-    providers: HashMap<String, Arc<dyn ConnectionProvider>>,
+pub struct ConnectorRegistry {
+    providers: HashMap<String, Arc<dyn Connector>>,
 }
 
-impl ConnectionProviderRegistry {
+impl ConnectorRegistry {
     /// Create an empty provider registry.
     pub fn new() -> Self {
         Self {
@@ -115,30 +115,30 @@ impl ConnectionProviderRegistry {
     /// Register a connection provider.
     ///
     /// If a provider with the same `provider_id()` already exists, it is replaced.
-    pub fn register(&mut self, provider: impl ConnectionProvider + 'static) {
+    pub fn register(&mut self, provider: impl Connector + 'static) {
         self.providers
             .insert(provider.provider_id().to_string(), Arc::new(provider));
     }
 
     /// Register a boxed connection provider.
-    pub fn register_boxed(&mut self, provider: Box<dyn ConnectionProvider>) {
+    pub fn register_boxed(&mut self, provider: Box<dyn Connector>) {
         self.providers
             .insert(provider.provider_id().to_string(), Arc::from(provider));
     }
 
     /// Register an `Arc`-wrapped connection provider.
-    pub fn register_arc(&mut self, provider: Arc<dyn ConnectionProvider>) {
+    pub fn register_arc(&mut self, provider: Arc<dyn Connector>) {
         self.providers
             .insert(provider.provider_id().to_string(), provider);
     }
 
     /// Remove a provider by ID.
-    pub fn unregister(&mut self, provider_id: &str) -> Option<Arc<dyn ConnectionProvider>> {
+    pub fn unregister(&mut self, provider_id: &str) -> Option<Arc<dyn Connector>> {
         self.providers.remove(provider_id)
     }
 
     /// Get a provider by ID.
-    pub fn get(&self, provider_id: &str) -> Option<&Arc<dyn ConnectionProvider>> {
+    pub fn get(&self, provider_id: &str) -> Option<&Arc<dyn Connector>> {
         self.providers.get(provider_id)
     }
 
@@ -148,7 +148,7 @@ impl ConnectionProviderRegistry {
     }
 
     /// List all registered providers.
-    pub fn list(&self) -> Vec<&Arc<dyn ConnectionProvider>> {
+    pub fn list(&self) -> Vec<&Arc<dyn Connector>> {
         self.providers.values().collect()
     }
 
@@ -163,46 +163,46 @@ impl ConnectionProviderRegistry {
     }
 
     /// Create a builder for fluent registration.
-    pub fn builder() -> ConnectionProviderRegistryBuilder {
-        ConnectionProviderRegistryBuilder::new()
+    pub fn builder() -> ConnectorRegistryBuilder {
+        ConnectorRegistryBuilder::new()
     }
 }
 
-impl std::fmt::Debug for ConnectionProviderRegistry {
+impl std::fmt::Debug for ConnectorRegistry {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let ids: Vec<_> = self.providers.keys().collect();
-        f.debug_struct("ConnectionProviderRegistry")
+        f.debug_struct("ConnectorRegistry")
             .field("providers", &ids)
             .finish()
     }
 }
 
-/// Builder for creating a `ConnectionProviderRegistry`.
-pub struct ConnectionProviderRegistryBuilder {
-    registry: ConnectionProviderRegistry,
+/// Builder for creating a `ConnectorRegistry`.
+pub struct ConnectorRegistryBuilder {
+    registry: ConnectorRegistry,
 }
 
-impl ConnectionProviderRegistryBuilder {
+impl ConnectorRegistryBuilder {
     /// Create a new empty builder.
     pub fn new() -> Self {
         Self {
-            registry: ConnectionProviderRegistry::new(),
+            registry: ConnectorRegistry::new(),
         }
     }
 
     /// Add a connection provider to the registry.
-    pub fn provider(mut self, provider: impl ConnectionProvider + 'static) -> Self {
+    pub fn provider(mut self, provider: impl Connector + 'static) -> Self {
         self.registry.register(provider);
         self
     }
 
     /// Build the registry.
-    pub fn build(self) -> ConnectionProviderRegistry {
+    pub fn build(self) -> ConnectorRegistry {
         self.registry
     }
 }
 
-impl Default for ConnectionProviderRegistryBuilder {
+impl Default for ConnectorRegistryBuilder {
     fn default() -> Self {
         Self::new()
     }
@@ -216,15 +216,12 @@ impl Default for ConnectionProviderRegistryBuilder {
 // `crate::credential_schema` and specs/providers.md "Credentials".
 pub use crate::credential_schema::{FieldType, FormField};
 
-/// Connection-provider name for the shared credential form schema.
-///
-/// Transitional alias until the connector rename (specs/providers.md,
-/// "Providers vs Connections") makes `CredentialFormSchema` the only name.
-pub type ConnectionFormSchema = crate::credential_schema::CredentialFormSchema;
+/// Credential form schema for connectors.
+pub type ConnectorFormSchema = crate::credential_schema::CredentialFormSchema;
 
 /// Result of credential validation.
 #[derive(Debug, Clone)]
-pub struct ConnectionValidation {
+pub struct ConnectorValidation {
     /// Display name from the provider (e.g. organization name, username).
     pub provider_username: Option<String>,
     /// Provider-specific metadata to store alongside the connection (e.g. org slug).

--- a/crates/core/src/credential_schema.rs
+++ b/crates/core/src/credential_schema.rs
@@ -6,7 +6,7 @@
 //
 // - Provider drivers (`DriverDescriptor::credential_schema`) — org-scoped
 //   vendor accounts that power agent execution.
-// - Connection providers (`ConnectionProvider::form_schema`) — user-scoped
+// - Connectors (`Connector::form_schema`) — user-scoped
 //   accounts on external services used by tools.
 
 use serde::Serialize;

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -84,7 +84,7 @@ pub mod agent;
 pub mod agent_identity;
 pub mod app;
 pub mod capability_dto;
-pub mod connection_provider;
+pub mod connector;
 pub mod credential_schema;
 pub mod eval;
 pub mod events;
@@ -293,11 +293,10 @@ pub use tools::{
 // Shared credential form schema (provider drivers + connection providers)
 pub use credential_schema::CredentialFormSchema;
 
-// Capability re-exports
-// Connection provider plugin system (API key connections like Daytona)
-pub use connection_provider::{
-    ConnectionFormSchema, ConnectionProvider, ConnectionProviderPlugin, ConnectionProviderRegistry,
-    ConnectionProviderRegistryBuilder, ConnectionType, ConnectionValidation, FieldType, FormField,
+// Connector plugin system (user-scoped API key / OAuth connections)
+pub use connector::{
+    Connector, ConnectorFormSchema, ConnectorPlugin, ConnectorRegistry, ConnectorRegistryBuilder,
+    ConnectorType, ConnectorValidation, FieldType, FormField,
 };
 pub use platform_definition::{
     BuiltInCapabilityDefinition, BuiltInHarnessDefinition, BuiltInHarnessRole, PlatformDefinition,

--- a/crates/core/src/platform_definition.rs
+++ b/crates/core/src/platform_definition.rs
@@ -231,12 +231,12 @@ impl PlatformDefinition {
         &mut self.driver_registry
     }
 
-    /// Immutable access to the connection-provider registry.
+    /// Immutable access to the connector registry.
     pub fn connectors(&self) -> &ConnectorRegistry {
         &self.connectors
     }
 
-    /// Mutable access to the connection-provider registry.
+    /// Mutable access to the connector registry.
     pub fn connectors_mut(&mut self) -> &mut ConnectorRegistry {
         &mut self.connectors
     }

--- a/crates/core/src/platform_definition.rs
+++ b/crates/core/src/platform_definition.rs
@@ -11,8 +11,8 @@
 //! server-owned concrete dependencies.
 
 use crate::{
-    Capability, CapabilityRegistry, ConnectionProvider, ConnectionProviderRegistry, DriverRegistry,
-    EgressService, EmailSender, UtilityLlmService,
+    Capability, CapabilityRegistry, Connector, ConnectorRegistry, DriverRegistry, EgressService,
+    EmailSender, UtilityLlmService,
     traits::{DisabledSessionFileSystemFactory, SessionFileSystemFactory},
 };
 use serde_json::Value;
@@ -183,7 +183,7 @@ impl BuiltInHarnessDefinition {
 pub struct PlatformDefinition {
     capability_registry: CapabilityRegistry,
     driver_registry: DriverRegistry,
-    connection_providers: ConnectionProviderRegistry,
+    connectors: ConnectorRegistry,
     built_in_harnesses: Vec<BuiltInHarnessDefinition>,
     egress_service: Arc<dyn EgressService>,
     email_sender: Arc<dyn EmailSender>,
@@ -197,7 +197,7 @@ impl PlatformDefinition {
         Self {
             capability_registry,
             driver_registry,
-            connection_providers: ConnectionProviderRegistry::new(),
+            connectors: ConnectorRegistry::new(),
             built_in_harnesses: Vec::new(),
             egress_service: Arc::new(crate::DirectEgressService::default()),
             email_sender: Arc::new(crate::DisabledEmailSender),
@@ -232,13 +232,13 @@ impl PlatformDefinition {
     }
 
     /// Immutable access to the connection-provider registry.
-    pub fn connection_providers(&self) -> &ConnectionProviderRegistry {
-        &self.connection_providers
+    pub fn connectors(&self) -> &ConnectorRegistry {
+        &self.connectors
     }
 
     /// Mutable access to the connection-provider registry.
-    pub fn connection_providers_mut(&mut self) -> &mut ConnectionProviderRegistry {
-        &mut self.connection_providers
+    pub fn connectors_mut(&mut self) -> &mut ConnectorRegistry {
+        &mut self.connectors
     }
 
     /// Built-in harness templates provisioned by this platform.
@@ -294,7 +294,7 @@ impl std::fmt::Debug for PlatformDefinition {
         f.debug_struct("PlatformDefinition")
             .field("capabilities", &self.capability_registry)
             .field("drivers", &self.driver_registry.registered_providers())
-            .field("connection_providers", &self.connection_providers)
+            .field("connectors", &self.connectors)
             .field("built_in_harnesses", &harness_keys)
             .field("egress_service", &self.egress_service.name())
             .field("email_sender", &self.email_sender.name())
@@ -339,14 +339,14 @@ impl PlatformDefinitionBuilder {
     }
 
     /// Replace the connection-provider registry.
-    pub fn connection_providers(mut self, registry: ConnectionProviderRegistry) -> Self {
-        self.platform.connection_providers = registry;
+    pub fn connectors(mut self, registry: ConnectorRegistry) -> Self {
+        self.platform.connectors = registry;
         self
     }
 
-    /// Register a connection provider on the platform.
-    pub fn connection_provider(mut self, provider: impl ConnectionProvider + 'static) -> Self {
-        self.platform.connection_providers.register(provider);
+    /// Register a connector on the platform.
+    pub fn connector(mut self, provider: impl Connector + 'static) -> Self {
+        self.platform.connectors.register(provider);
         self
     }
 
@@ -407,8 +407,8 @@ impl Default for PlatformDefinitionBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::connection_provider::{
-        ConnectionFormSchema, ConnectionType, ConnectionValidation, FieldType, FormField,
+    use crate::connector::{
+        ConnectorFormSchema, ConnectorType, ConnectorValidation, FieldType, FormField,
     };
     use crate::{CapabilityStatus, CurrentTimeCapability};
     use async_trait::async_trait;
@@ -416,7 +416,7 @@ mod tests {
     struct TestProvider;
 
     #[async_trait]
-    impl ConnectionProvider for TestProvider {
+    impl Connector for TestProvider {
         fn provider_id(&self) -> &str {
             "test_provider"
         }
@@ -433,12 +433,12 @@ mod tests {
             "plug"
         }
 
-        fn connection_type(&self) -> ConnectionType {
-            ConnectionType::ApiKey
+        fn connection_type(&self) -> ConnectorType {
+            ConnectorType::ApiKey
         }
 
-        fn form_schema(&self) -> Option<ConnectionFormSchema> {
-            Some(ConnectionFormSchema {
+        fn form_schema(&self) -> Option<ConnectorFormSchema> {
+            Some(ConnectorFormSchema {
                 fields: vec![FormField {
                     name: "api_key".to_string(),
                     label: "API Key".to_string(),
@@ -451,8 +451,8 @@ mod tests {
             })
         }
 
-        async fn validate(&self, _credential: &str) -> Result<ConnectionValidation, String> {
-            Ok(ConnectionValidation {
+        async fn validate(&self, _credential: &str) -> Result<ConnectorValidation, String> {
+            Ok(ConnectorValidation {
                 provider_username: Some("test-user".to_string()),
                 provider_metadata: None,
             })
@@ -467,7 +467,7 @@ mod tests {
         let platform = PlatformDefinition::builder()
             .driver_registry(drivers.clone())
             .capability(CurrentTimeCapability)
-            .connection_provider(TestProvider)
+            .connector(TestProvider)
             .add_built_in_harness(
                 BuiltInHarnessDefinition::new(
                     "minimal",
@@ -480,7 +480,7 @@ mod tests {
             .build();
 
         assert!(platform.capability_registry().has("current_time"));
-        assert!(platform.connection_providers().has("test_provider"));
+        assert!(platform.connectors().has("test_provider"));
         assert_eq!(
             platform
                 .harness_for_role(BuiltInHarnessRole::Base)
@@ -501,7 +501,7 @@ mod tests {
         platform
             .capability_registry_mut()
             .register(CurrentTimeCapability);
-        platform.connection_providers_mut().register(TestProvider);
+        platform.connectors_mut().register(TestProvider);
         platform.add_built_in_harness(
             BuiltInHarnessDefinition::new("chat", "Chat", "Chat harness", "You are helpful.")
                 .with_roles([BuiltInHarnessRole::Chat]),
@@ -515,7 +515,7 @@ mod tests {
                 .as_ref(),
         );
         assert_eq!(info.status, CapabilityStatus::Available);
-        assert!(platform.connection_providers().has("test_provider"));
+        assert!(platform.connectors().has("test_provider"));
         assert_eq!(
             platform
                 .harness_for_role(BuiltInHarnessRole::Chat)

--- a/crates/server/specs/user-connections.md
+++ b/crates/server/specs/user-connections.md
@@ -37,9 +37,9 @@ Two connection types:
 
 For `api_key` connections, OAuth-specific fields (`provider_user_id`, `scopes`, `refresh_token_encrypted`, `expires_at`) are NULL. The API key is stored in `access_token_encrypted`.
 
-### Connection Provider Plugin System
+### Connector Plugin System
 
-API-key providers register themselves via `ConnectionProviderPlugin` (parallel to `IntegrationPlugin`). Each provider defines:
+API-key providers register themselves via `ConnectorPlugin` (parallel to `IntegrationPlugin`). Each provider defines:
 - `provider_id`, `display_name`, `description`, `icon`
 - `connection_type` (OAuth vs ApiKey)
 - `form_schema` — fields and instructions for the UI dialog

--- a/crates/server/src/api/agent_identity_connections.rs
+++ b/crates/server/src/api/agent_identity_connections.rs
@@ -16,7 +16,7 @@ use axum::{
     routing::{get, post},
 };
 use chrono::{DateTime, Utc};
-use everruns_core::connection_provider::{ConnectionProviderRegistry, ConnectionType};
+use everruns_core::connector::{ConnectorRegistry, ConnectorType};
 use everruns_core::{AgentIdentityId, Caller};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -29,7 +29,7 @@ pub struct AppState {
     pub db: Arc<StorageBackend>,
     pub encryption: Option<Arc<EncryptionService>>,
     pub auth: AuthState,
-    pub connection_providers: ConnectionProviderRegistry,
+    pub connectors: ConnectorRegistry,
 }
 
 impl AppState {
@@ -37,13 +37,13 @@ impl AppState {
         db: Arc<StorageBackend>,
         encryption: Option<Arc<EncryptionService>>,
         auth: AuthState,
-        connection_providers: ConnectionProviderRegistry,
+        connectors: ConnectorRegistry,
     ) -> Self {
         Self {
             db,
             encryption,
             auth,
-            connection_providers,
+            connectors,
         }
     }
 }
@@ -192,15 +192,12 @@ pub async fn create_api_key_connection(
 ) -> Result<(StatusCode, Json<ConnectionResponse>), (StatusCode, Json<ErrorResponse>)> {
     let (_, identity_id) = resolve_identity(&state, &org, &identity_id).await?;
 
-    let provider = state
-        .connection_providers
-        .get(&provider_id)
-        .ok_or_else(|| {
-            ErrorResponse::new(format!("Unknown connection provider: {provider_id}"))
-                .into_response(StatusCode::NOT_FOUND)
-        })?;
+    let provider = state.connectors.get(&provider_id).ok_or_else(|| {
+        ErrorResponse::new(format!("Unknown connection provider: {provider_id}"))
+            .into_response(StatusCode::NOT_FOUND)
+    })?;
 
-    if provider.connection_type() != ConnectionType::ApiKey {
+    if provider.connection_type() != ConnectorType::ApiKey {
         return Err(ErrorResponse::new(format!(
             "Provider '{provider_id}' uses OAuth, not API key"
         ))
@@ -339,13 +336,10 @@ pub async fn verify_connection(
             .into_response(StatusCode::INTERNAL_SERVER_ERROR)
     })?;
 
-    let provider = state
-        .connection_providers
-        .get(&provider_id)
-        .ok_or_else(|| {
-            ErrorResponse::new(format!("Unknown connection provider: {provider_id}"))
-                .into_response(StatusCode::NOT_FOUND)
-        })?;
+    let provider = state.connectors.get(&provider_id).ok_or_else(|| {
+        ErrorResponse::new(format!("Unknown connection provider: {provider_id}"))
+            .into_response(StatusCode::NOT_FOUND)
+    })?;
 
     // Build fields map from stored credential + metadata for full validation
     let mut fields = std::collections::HashMap::new();

--- a/crates/server/src/api/agent_identity_connections.rs
+++ b/crates/server/src/api/agent_identity_connections.rs
@@ -193,7 +193,7 @@ pub async fn create_api_key_connection(
     let (_, identity_id) = resolve_identity(&state, &org, &identity_id).await?;
 
     let provider = state.connectors.get(&provider_id).ok_or_else(|| {
-        ErrorResponse::new(format!("Unknown connection provider: {provider_id}"))
+        ErrorResponse::new(format!("Unknown connector: {provider_id}"))
             .into_response(StatusCode::NOT_FOUND)
     })?;
 
@@ -337,7 +337,7 @@ pub async fn verify_connection(
     })?;
 
     let provider = state.connectors.get(&provider_id).ok_or_else(|| {
-        ErrorResponse::new(format!("Unknown connection provider: {provider_id}"))
+        ErrorResponse::new(format!("Unknown connector: {provider_id}"))
             .into_response(StatusCode::NOT_FOUND)
     })?;
 

--- a/crates/server/src/api/user_connections.rs
+++ b/crates/server/src/api/user_connections.rs
@@ -275,10 +275,10 @@ pub async fn list_connections(
     Ok(Json(connections))
 }
 
-/// GET /v1/user/connections/providers — List available connection providers
+/// GET /v1/user/connections/providers — List available connectors
 ///
-/// Returns both hardcoded providers (GitHub/OAuth) and plugin-registered
-/// providers (Daytona/API-key). Frontend uses this to render connection forms.
+/// Returns both hardcoded connectors (GitHub/OAuth) and plugin-registered
+/// connectors (Daytona/API-key). Frontend uses this to render connection forms.
 pub async fn list_connectors(
     State(state): State<AppState>,
     org: ResolvedOrg,
@@ -351,7 +351,7 @@ pub async fn create_api_key_connection(
     let provider = state.connectors.get(&provider_id).ok_or_else(|| {
         (
             StatusCode::NOT_FOUND,
-            format!("Unknown connection provider: {provider_id}"),
+            format!("Unknown connector: {provider_id}"),
         )
     })?;
 
@@ -525,7 +525,7 @@ pub async fn verify_connection(
     let provider = state.connectors.get(&provider_id).ok_or_else(|| {
         (
             StatusCode::NOT_FOUND,
-            format!("Unknown connection provider: {provider_id}"),
+            format!("Unknown connector: {provider_id}"),
         )
     })?;
 

--- a/crates/server/src/api/user_connections.rs
+++ b/crates/server/src/api/user_connections.rs
@@ -1,7 +1,7 @@
 // User Connections API routes
 // Decision: User-scoped (not org-scoped) — token represents user's identity
 // Decision: GitHub App installation flow replaces OAuth App for repo access
-// Decision: API-key providers (Daytona etc.) register via ConnectionProviderPlugin
+// Decision: API-key providers (Daytona etc.) register via ConnectorPlugin
 //   and define their own form schema + validation. Server discovers them at runtime.
 
 use crate::auth::ResolvedOrg;
@@ -20,8 +20,8 @@ use axum::{
 use axum_extra::extract::cookie::{Cookie, CookieJar, SameSite};
 use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
 use chrono::{DateTime, Utc};
-use everruns_core::connection_provider::{
-    ConnectionFormSchema as CoreFormSchema, ConnectionProviderRegistry, ConnectionType,
+use everruns_core::connector::{
+    ConnectorFormSchema as CoreFormSchema, ConnectorRegistry, ConnectorType,
 };
 use everruns_core::{
     Caller, McpServerAuthMode, SessionId, mcp_oauth_provider_id_for_uuid,
@@ -44,7 +44,7 @@ pub struct AppState {
     pub encryption: Option<Arc<EncryptionService>>,
     pub auth: AuthState,
     pub auth_config: AuthConfig,
-    pub connection_providers: ConnectionProviderRegistry,
+    pub connectors: ConnectorRegistry,
     pub mcp_service: Arc<McpServerService>,
 }
 
@@ -54,7 +54,7 @@ impl AppState {
         encryption: Option<Arc<EncryptionService>>,
         auth: AuthState,
         auth_config: AuthConfig,
-        connection_providers: ConnectionProviderRegistry,
+        connectors: ConnectorRegistry,
         mcp_service: Arc<McpServerService>,
     ) -> Self {
         Self {
@@ -62,7 +62,7 @@ impl AppState {
             encryption,
             auth,
             auth_config,
-            connection_providers,
+            connectors,
             mcp_service,
         }
     }
@@ -134,7 +134,7 @@ pub struct ApiKeyConnectionRequest {
     pub api_key: String,
 }
 
-/// Providers that support API-key-based connections (legacy, prefer ConnectionProviderPlugin).
+/// Providers that support API-key-based connections (legacy, prefer ConnectorPlugin).
 const API_KEY_PROVIDERS: &[&str] = &[];
 
 /// Cookie name for GitHub App installation CSRF state
@@ -218,10 +218,7 @@ struct OAuthTokenResponse {
 pub fn routes(state: AppState) -> Router {
     Router::new()
         .route("/v1/user/connections", get(list_connections))
-        .route(
-            "/v1/user/connections/providers",
-            get(list_connection_providers),
-        )
+        .route("/v1/user/connections/providers", get(list_connectors))
         .route(
             "/v1/user/connections/{provider}",
             delete(delete_connection).post(create_api_key_connection),
@@ -282,7 +279,7 @@ pub async fn list_connections(
 ///
 /// Returns both hardcoded providers (GitHub/OAuth) and plugin-registered
 /// providers (Daytona/API-key). Frontend uses this to render connection forms.
-pub async fn list_connection_providers(
+pub async fn list_connectors(
     State(state): State<AppState>,
     org: ResolvedOrg,
 ) -> Json<Vec<ProviderResponse>> {
@@ -301,11 +298,11 @@ pub async fn list_connection_providers(
     }
 
     // Platform-registered providers (API-key based)
-    for provider in state.connection_providers.list() {
+    for provider in state.connectors.list() {
         let form_schema = provider.form_schema().map(|s| form_schema_to_response(&s));
         let conn_type = match provider.connection_type() {
-            ConnectionType::OAuth => "oauth",
-            ConnectionType::ApiKey => "api_key",
+            ConnectorType::OAuth => "oauth",
+            ConnectorType::ApiKey => "api_key",
         };
         providers.push(ProviderResponse {
             provider_id: provider.provider_id().to_string(),
@@ -351,18 +348,15 @@ pub async fn create_api_key_connection(
     Path(provider_id): Path<String>,
     Json(body): Json<CreateApiKeyConnectionRequest>,
 ) -> Result<(StatusCode, Json<ConnectionResponse>), (StatusCode, String)> {
-    let provider = state
-        .connection_providers
-        .get(&provider_id)
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                format!("Unknown connection provider: {provider_id}"),
-            )
-        })?;
+    let provider = state.connectors.get(&provider_id).ok_or_else(|| {
+        (
+            StatusCode::NOT_FOUND,
+            format!("Unknown connection provider: {provider_id}"),
+        )
+    })?;
 
     // Only API-key providers support direct creation
-    if provider.connection_type() != ConnectionType::ApiKey {
+    if provider.connection_type() != ConnectorType::ApiKey {
         return Err((
             StatusCode::BAD_REQUEST,
             format!("Provider '{provider_id}' uses OAuth, not API key"),
@@ -386,7 +380,7 @@ pub async fn create_api_key_connection(
     }
 
     // Validate all fields via the provider
-    let validation: everruns_core::connection_provider::ConnectionValidation =
+    let validation: everruns_core::connector::ConnectorValidation =
         provider.validate_fields(&fields).await.map_err(|e| {
             (
                 StatusCode::BAD_REQUEST,
@@ -473,7 +467,7 @@ pub struct VerifyConnectionResponse {
 ///
 /// Generic endpoint: decrypts the stored credential and calls the provider's
 /// validate() method. Works for any API-key provider that implements
-/// ConnectionProvider::validate().
+/// Connector::validate().
 pub async fn verify_connection(
     State(state): State<AppState>,
     auth: AuthUser,
@@ -528,15 +522,12 @@ pub async fn verify_connection(
         )
     })?;
 
-    let provider = state
-        .connection_providers
-        .get(&provider_id)
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                format!("Unknown connection provider: {provider_id}"),
-            )
-        })?;
+    let provider = state.connectors.get(&provider_id).ok_or_else(|| {
+        (
+            StatusCode::NOT_FOUND,
+            format!("Unknown connection provider: {provider_id}"),
+        )
+    })?;
 
     // Build fields map from stored credential + metadata for full validation
     let mut fields = std::collections::HashMap::new();
@@ -1123,9 +1114,9 @@ fn form_schema_to_response(schema: &CoreFormSchema) -> FormSchemaResponse {
             .iter()
             .map(|f| {
                 let field_type = match f.field_type {
-                    everruns_core::connection_provider::FieldType::Password => "password",
-                    everruns_core::connection_provider::FieldType::Text => "text",
-                    everruns_core::connection_provider::FieldType::Url => "url",
+                    everruns_core::connector::FieldType::Password => "password",
+                    everruns_core::connector::FieldType::Text => "text",
+                    everruns_core::connector::FieldType::Url => "url",
                 };
                 FormFieldResponse {
                     name: f.name.clone(),

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -887,7 +887,7 @@ impl ServerAppBuilder {
             db.clone(),
             encryption.clone(),
             auth_state.clone(),
-            platform_definition.connection_providers().clone(),
+            platform_definition.connectors().clone(),
         );
         let eval_run_ctx = Arc::new(crate::domains::evals::runner::EvalRunContext {
             db: db.clone(),
@@ -1061,7 +1061,7 @@ impl ServerAppBuilder {
             encryption.clone(),
             auth_state.clone(),
             auth_config.clone(),
-            platform_definition.connection_providers().clone(),
+            platform_definition.connectors().clone(),
             mcp_server_service,
         );
         let session_schedule_service =

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -50,7 +50,7 @@ pub mod storage;
 pub mod openapi;
 pub mod platform;
 pub use platform::{
-    oss_built_in_harnesses, oss_connection_provider_registry, oss_platform_definition,
+    oss_built_in_harnesses, oss_connector_registry, oss_platform_definition,
     oss_platform_definition_for_grade,
 };
 pub mod harnesses;

--- a/crates/server/src/platform.rs
+++ b/crates/server/src/platform.rs
@@ -46,12 +46,12 @@ pub fn oss_platform_definition_for_grade(grade: DeploymentGrade) -> PlatformDefi
         .build()
 }
 
-/// Build the default OSS connection-provider registry.
+/// Build the default OSS connector registry.
 pub fn oss_connector_registry() -> ConnectorRegistry {
     oss_connector_registry_for_grade(DeploymentGrade::from_env())
 }
 
-/// Build the default OSS connection-provider registry for an explicit grade.
+/// Build the default OSS connector registry for an explicit grade.
 pub fn oss_connector_registry_for_grade(grade: DeploymentGrade) -> ConnectorRegistry {
     let mut registry = ConnectorRegistry::new();
 

--- a/crates/server/src/platform.rs
+++ b/crates/server/src/platform.rs
@@ -6,7 +6,7 @@
 //! can start from the OSS preset or construct a `PlatformDefinition` manually
 //! without depending on inventory registration.
 
-use everruns_core::connection_provider::{ConnectionProviderPlugin, ConnectionProviderRegistry};
+use everruns_core::connector::{ConnectorPlugin, ConnectorRegistry};
 use everruns_core::deployment::DeploymentGrade;
 use everruns_core::{
     BuiltInHarnessDefinition, CapabilityRegistry, DirectEgressService, PlatformDefinition,
@@ -23,7 +23,7 @@ pub fn oss_platform_definition() -> PlatformDefinition {
 pub fn oss_platform_definition_for_grade(grade: DeploymentGrade) -> PlatformDefinition {
     let capability_registry = CapabilityRegistry::with_builtins_for_grade(grade);
     let driver_registry = everruns_worker::create_driver_registry();
-    let connection_providers = oss_connection_provider_registry_for_grade(grade);
+    let connectors = oss_connector_registry_for_grade(grade);
     // Resolve the optional host-wide system allowlist from the environment
     // (EVERRUNS_SYSTEM_ALLOWLIST_ENABLED). Disabled by default.
     let egress_service = Arc::new(DirectEgressService::from_env());
@@ -35,7 +35,7 @@ pub fn oss_platform_definition_for_grade(grade: DeploymentGrade) -> PlatformDefi
     PlatformDefinition::builder()
         .capability_registry(capability_registry)
         .driver_registry(driver_registry)
-        .connection_providers(connection_providers)
+        .connectors(connectors)
         .built_in_harnesses(oss_built_in_harnesses())
         .egress_service(egress_service)
         .email_sender(email_sender)
@@ -47,17 +47,15 @@ pub fn oss_platform_definition_for_grade(grade: DeploymentGrade) -> PlatformDefi
 }
 
 /// Build the default OSS connection-provider registry.
-pub fn oss_connection_provider_registry() -> ConnectionProviderRegistry {
-    oss_connection_provider_registry_for_grade(DeploymentGrade::from_env())
+pub fn oss_connector_registry() -> ConnectorRegistry {
+    oss_connector_registry_for_grade(DeploymentGrade::from_env())
 }
 
 /// Build the default OSS connection-provider registry for an explicit grade.
-pub fn oss_connection_provider_registry_for_grade(
-    grade: DeploymentGrade,
-) -> ConnectionProviderRegistry {
-    let mut registry = ConnectionProviderRegistry::new();
+pub fn oss_connector_registry_for_grade(grade: DeploymentGrade) -> ConnectorRegistry {
+    let mut registry = ConnectorRegistry::new();
 
-    for plugin in inventory::iter::<ConnectionProviderPlugin> {
+    for plugin in inventory::iter::<ConnectorPlugin> {
         if plugin.experimental_only && !grade.experimental_features_enabled() {
             continue;
         }

--- a/crates/server/tests/api_integration_test.rs
+++ b/crates/server/tests/api_integration_test.rs
@@ -3680,7 +3680,7 @@ async fn test_verify_connection_no_connection_returns_404() {
 }
 
 #[tokio::test]
-async fn test_verify_connection_providers_listed() {
+async fn test_verify_connectors_listed() {
     let server = TestServer::in_memory().await;
 
     let resp: Value = server

--- a/crates/server/tests/command_policy_enforcement_test.rs
+++ b/crates/server/tests/command_policy_enforcement_test.rs
@@ -30,7 +30,7 @@ use everruns_server::domains::common::{
 use everruns_server::domains::evals::{CreateEvalRun, ListEvals};
 use everruns_server::domains::harnesses::types::CreateHarnessRequest;
 use everruns_server::domains::harnesses::{CreateHarness, ListHarnesses};
-use everruns_server::domains::session_files::{GetSessionFile, ListSessionFiles};
+use everruns_server::domains::session_files::{GetWorkspaceFile, ListWorkspaceFiles};
 use everruns_server::domains::session_tasks::{
     CancelSessionTask, GetSessionTask, ListSessionTasks, PostSessionTaskMessage,
 };
@@ -426,7 +426,7 @@ async fn eval_manage_without_session_permission_still_allows_list() {
 }
 
 // ============================================================================
-// EVE-551: ListSessionFiles and GetSessionFile must enforce SESSION_VIEW.
+// EVE-551: ListWorkspaceFiles and GetWorkspaceFile must enforce SESSION_VIEW.
 // A resolver denying OrgSessionsManage must get 403 before any file lookup.
 // ============================================================================
 
@@ -434,23 +434,23 @@ async fn eval_manage_without_session_permission_still_allows_list() {
 async fn session_file_read_commands_enforce_session_view_policy() {
     let ctx = make_ctx(caller_with_role(OrgRole::Owner), Arc::new(DenyAllResolver));
 
-    let list_err = ListSessionFiles {
+    let list_err = ListWorkspaceFiles {
         session_id: "session_00000000000000000000000000000001".to_string(),
         recursive: false,
     }
     .run(&ctx)
     .await
-    .expect_err("ListSessionFiles must require SESSION_VIEW");
+    .expect_err("ListWorkspaceFiles must require SESSION_VIEW");
     assert_forbidden(list_err);
 
-    let get_err = GetSessionFile {
+    let get_err = GetWorkspaceFile {
         session_id: "session_00000000000000000000000000000001".to_string(),
         path: "/".to_string(),
         recursive: false,
     }
     .run(&ctx)
     .await
-    .expect_err("GetSessionFile must require SESSION_VIEW");
+    .expect_err("GetWorkspaceFile must require SESSION_VIEW");
     assert_forbidden(get_err);
 }
 

--- a/crates/server/tests/test_harness.rs
+++ b/crates/server/tests/test_harness.rs
@@ -433,7 +433,7 @@ impl TestServer {
             encryption.clone(),
             auth_state.clone(),
             auth_config.clone(),
-            platform_definition.connection_providers().clone(),
+            platform_definition.connectors().clone(),
             mcp_service,
         );
         let reporting_state = api::reporting::AppState::new(db.clone(), auth_state.clone());
@@ -447,7 +447,7 @@ impl TestServer {
             db.clone(),
             encryption.clone(),
             auth_state.clone(),
-            platform_definition.connection_providers().clone(),
+            platform_definition.connectors().clone(),
         );
         let apps_state = api::apps::AppState::new(
             db.clone(),

--- a/integrations/brave-search/src/connection.rs
+++ b/integrations/brave-search/src/connection.rs
@@ -6,17 +6,16 @@
 //   lives in this crate, not in the server crate.
 
 use async_trait::async_trait;
-use everruns_core::connection_provider::{
-    ConnectionFormSchema, ConnectionProvider, ConnectionType, ConnectionValidation, FieldType,
-    FormField,
+use everruns_core::connector::{
+    Connector, ConnectorFormSchema, ConnectorType, ConnectorValidation, FieldType, FormField,
 };
 
 use crate::BRAVE_SEARCH_API_BASE;
 
-pub struct BraveSearchConnectionProvider;
+pub struct BraveSearchConnector;
 
 #[async_trait]
-impl ConnectionProvider for BraveSearchConnectionProvider {
+impl Connector for BraveSearchConnector {
     fn provider_id(&self) -> &str {
         "brave_search"
     }
@@ -33,12 +32,12 @@ impl ConnectionProvider for BraveSearchConnectionProvider {
         "search"
     }
 
-    fn connection_type(&self) -> ConnectionType {
-        ConnectionType::ApiKey
+    fn connection_type(&self) -> ConnectorType {
+        ConnectorType::ApiKey
     }
 
-    fn form_schema(&self) -> Option<ConnectionFormSchema> {
-        Some(ConnectionFormSchema {
+    fn form_schema(&self) -> Option<ConnectorFormSchema> {
+        Some(ConnectorFormSchema {
             fields: vec![FormField {
                 name: "api_key".to_string(),
                 label: "API Key".to_string(),
@@ -56,7 +55,7 @@ impl ConnectionProvider for BraveSearchConnectionProvider {
         })
     }
 
-    async fn validate(&self, credential: &str) -> Result<ConnectionValidation, String> {
+    async fn validate(&self, credential: &str) -> Result<ConnectorValidation, String> {
         let client = reqwest::Client::new();
         let response = client
             .get(format!("{BRAVE_SEARCH_API_BASE}/web/search?q=test&count=1"))
@@ -67,7 +66,7 @@ impl ConnectionProvider for BraveSearchConnectionProvider {
             .map_err(|e| format!("Failed to reach Brave Search API: {e}"))?;
 
         match response.status().as_u16() {
-            200 => Ok(ConnectionValidation {
+            200 => Ok(ConnectorValidation {
                 provider_username: None,
                 provider_metadata: None,
             }),
@@ -86,16 +85,16 @@ mod tests {
 
     #[test]
     fn test_provider_metadata() {
-        let p = BraveSearchConnectionProvider;
+        let p = BraveSearchConnector;
         assert_eq!(p.provider_id(), "brave_search");
         assert_eq!(p.display_name(), "Brave Search");
-        assert_eq!(p.connection_type(), ConnectionType::ApiKey);
+        assert_eq!(p.connection_type(), ConnectorType::ApiKey);
         assert_eq!(p.icon(), "search");
     }
 
     #[test]
     fn test_form_schema() {
-        let p = BraveSearchConnectionProvider;
+        let p = BraveSearchConnector;
         let schema = p.form_schema().expect("should have form schema");
         assert_eq!(schema.fields.len(), 1);
         assert_eq!(schema.fields[0].name, "api_key");

--- a/integrations/brave-search/src/lib.rs
+++ b/integrations/brave-search/src/lib.rs
@@ -14,10 +14,10 @@ mod tools;
 use everruns_core::capabilities::{
     Capability, CapabilityLocalization, CapabilityStatus, IntegrationPlugin,
 };
-use everruns_core::connection_provider::ConnectionProviderPlugin;
+use everruns_core::connector::ConnectorPlugin;
 use everruns_core::tools::Tool;
 
-use connection::BraveSearchConnectionProvider;
+use connection::BraveSearchConnector;
 use tools::BraveWebSearchTool;
 
 // ============================================================================
@@ -33,9 +33,9 @@ inventory::submit! {
 }
 
 inventory::submit! {
-    ConnectionProviderPlugin {
+    ConnectorPlugin {
         experimental_only: true,
-        factory: || Box::new(BraveSearchConnectionProvider),
+        factory: || Box::new(BraveSearchConnector),
     }
 }
 

--- a/integrations/brave-search/tests/plugin_registration.rs
+++ b/integrations/brave-search/tests/plugin_registration.rs
@@ -1,7 +1,7 @@
 //! Integration test: verify Brave Search plugin registers via inventory.
 
 use everruns_core::capabilities::{CapabilityRegistry, IntegrationPlugin};
-use everruns_core::connection_provider::ConnectionProviderPlugin;
+use everruns_core::connector::ConnectorPlugin;
 use everruns_core::deployment::DeploymentGrade;
 
 // Force linker to include the integration crate's inventory submissions.
@@ -71,21 +71,19 @@ fn test_brave_search_capability_metadata() {
 
 #[test]
 fn test_brave_search_connection_provider_is_submitted() {
-    let plugins: Vec<&ConnectionProviderPlugin> =
-        inventory::iter::<ConnectionProviderPlugin>().collect();
+    let plugins: Vec<&ConnectorPlugin> = inventory::iter::<ConnectorPlugin>().collect();
     assert!(
         plugins.iter().any(|p| {
             let provider = (p.factory)();
             provider.provider_id() == "brave_search"
         }),
-        "Brave Search ConnectionProviderPlugin should be submitted via inventory"
+        "Brave Search ConnectorPlugin should be submitted via inventory"
     );
 }
 
 #[test]
 fn test_brave_search_connection_provider_is_experimental() {
-    let plugins: Vec<&ConnectionProviderPlugin> =
-        inventory::iter::<ConnectionProviderPlugin>().collect();
+    let plugins: Vec<&ConnectorPlugin> = inventory::iter::<ConnectorPlugin>().collect();
     let brave_search = plugins
         .iter()
         .find(|p| {
@@ -102,8 +100,7 @@ fn test_brave_search_connection_provider_is_experimental() {
 
 #[test]
 fn test_brave_search_connection_provider_has_form_schema() {
-    let plugins: Vec<&ConnectionProviderPlugin> =
-        inventory::iter::<ConnectionProviderPlugin>().collect();
+    let plugins: Vec<&ConnectorPlugin> = inventory::iter::<ConnectorPlugin>().collect();
     let plugin = plugins
         .iter()
         .find(|p| {

--- a/integrations/browserless/src/connection.rs
+++ b/integrations/browserless/src/connection.rs
@@ -7,16 +7,15 @@
 //      401/403 means token lacks CDP access.
 
 use async_trait::async_trait;
-use everruns_core::connection_provider::{
-    ConnectionFormSchema, ConnectionProvider, ConnectionType, ConnectionValidation, FieldType,
-    FormField,
+use everruns_core::connector::{
+    Connector, ConnectorFormSchema, ConnectorType, ConnectorValidation, FieldType, FormField,
 };
 use tracing::warn;
 
-pub struct BrowserlessConnectionProvider;
+pub struct BrowserlessConnector;
 
 #[async_trait]
-impl ConnectionProvider for BrowserlessConnectionProvider {
+impl Connector for BrowserlessConnector {
     fn provider_id(&self) -> &str {
         "browserless"
     }
@@ -33,12 +32,12 @@ impl ConnectionProvider for BrowserlessConnectionProvider {
         "browserless"
     }
 
-    fn connection_type(&self) -> ConnectionType {
-        ConnectionType::ApiKey
+    fn connection_type(&self) -> ConnectorType {
+        ConnectorType::ApiKey
     }
 
-    fn form_schema(&self) -> Option<ConnectionFormSchema> {
-        Some(ConnectionFormSchema {
+    fn form_schema(&self) -> Option<ConnectorFormSchema> {
+        Some(ConnectorFormSchema {
             fields: vec![FormField {
                 name: "api_key".to_string(),
                 label: "API Token".to_string(),
@@ -55,7 +54,7 @@ impl ConnectionProvider for BrowserlessConnectionProvider {
         })
     }
 
-    async fn validate(&self, credential: &str) -> Result<ConnectionValidation, String> {
+    async fn validate(&self, credential: &str) -> Result<ConnectorValidation, String> {
         let client = reqwest::Client::new();
         let api_base = crate::browserless_api_base();
         let response = client
@@ -116,7 +115,7 @@ impl ConnectionProvider for BrowserlessConnectionProvider {
             }
         }
 
-        Ok(ConnectionValidation {
+        Ok(ConnectorValidation {
             provider_username: None,
             provider_metadata: None,
         })
@@ -129,16 +128,16 @@ mod tests {
 
     #[test]
     fn test_provider_metadata() {
-        let p = BrowserlessConnectionProvider;
+        let p = BrowserlessConnector;
         assert_eq!(p.provider_id(), "browserless");
         assert_eq!(p.display_name(), "Browserless");
-        assert_eq!(p.connection_type(), ConnectionType::ApiKey);
+        assert_eq!(p.connection_type(), ConnectorType::ApiKey);
         assert_eq!(p.icon(), "browserless");
     }
 
     #[test]
     fn test_form_schema() {
-        let p = BrowserlessConnectionProvider;
+        let p = BrowserlessConnector;
         let schema = p.form_schema().expect("should have form schema");
         assert_eq!(schema.fields.len(), 1);
         assert_eq!(schema.fields[0].name, "api_key");

--- a/integrations/browserless/src/lib.rs
+++ b/integrations/browserless/src/lib.rs
@@ -27,10 +27,10 @@ use everruns_core::LEASED_RESOURCES_FEATURE;
 use everruns_core::capabilities::{
     Capability, CapabilityLocalization, CapabilityStatus, IntegrationPlugin, RiskLevel,
 };
-use everruns_core::connection_provider::ConnectionProviderPlugin;
+use everruns_core::connector::ConnectorPlugin;
 use everruns_core::tools::Tool;
 
-use connection::BrowserlessConnectionProvider;
+use connection::BrowserlessConnector;
 
 use session_tools::{BrowserlessCloseBrowserTool, BrowserlessOpenBrowserTool};
 use tools::{
@@ -51,9 +51,9 @@ inventory::submit! {
 }
 
 inventory::submit! {
-    ConnectionProviderPlugin {
+    ConnectorPlugin {
         experimental_only: true,
-        factory: || Box::new(BrowserlessConnectionProvider),
+        factory: || Box::new(BrowserlessConnector),
     }
 }
 

--- a/integrations/browserless/tests/tool_integration.rs
+++ b/integrations/browserless/tests/tool_integration.rs
@@ -390,7 +390,7 @@ async fn test_validate_rest_ok_cdp_probe_400() {
         .mount(&mock_server)
         .await;
 
-    // BrowserlessConnectionProvider uses BROWSERLESS_API_BASE which is hardcoded,
+    // BrowserlessConnector uses BROWSERLESS_API_BASE which is hardcoded,
     // so we test the validate logic directly by hitting the mock endpoints.
     let client = reqwest::Client::new();
 

--- a/integrations/cursor/src/connection.rs
+++ b/integrations/cursor/src/connection.rs
@@ -6,18 +6,17 @@
 // connection setup.
 
 use async_trait::async_trait;
-use everruns_core::connection_provider::{
-    ConnectionFormSchema, ConnectionProvider, ConnectionType, ConnectionValidation, FieldType,
-    FormField,
+use everruns_core::connector::{
+    Connector, ConnectorFormSchema, ConnectorType, ConnectorValidation, FieldType, FormField,
 };
 use serde_json::json;
 
 use crate::client::CursorClient;
 
-pub struct CursorConnectionProvider;
+pub struct CursorConnector;
 
 #[async_trait]
-impl ConnectionProvider for CursorConnectionProvider {
+impl Connector for CursorConnector {
     fn provider_id(&self) -> &str {
         "cursor"
     }
@@ -34,12 +33,12 @@ impl ConnectionProvider for CursorConnectionProvider {
         "code"
     }
 
-    fn connection_type(&self) -> ConnectionType {
-        ConnectionType::ApiKey
+    fn connection_type(&self) -> ConnectorType {
+        ConnectorType::ApiKey
     }
 
-    fn form_schema(&self) -> Option<ConnectionFormSchema> {
-        Some(ConnectionFormSchema {
+    fn form_schema(&self) -> Option<ConnectorFormSchema> {
+        Some(ConnectorFormSchema {
             fields: vec![FormField {
                 name: "api_key".to_string(),
                 label: "Cloud Agents API Key".to_string(),
@@ -61,7 +60,7 @@ Cursor must also have GitHub access to any repositories you want agents to work 
         })
     }
 
-    async fn validate(&self, credential: &str) -> Result<ConnectionValidation, String> {
+    async fn validate(&self, credential: &str) -> Result<ConnectorValidation, String> {
         let api_base = std::env::var(crate::CURSOR_API_BASE_ENV)
             .ok()
             .filter(|v| !v.trim().is_empty())
@@ -75,7 +74,7 @@ Cursor must also have GitHub access to any repositories you want agents to work 
             }
         })?;
 
-        Ok(ConnectionValidation {
+        Ok(ConnectorValidation {
             provider_username: info.user_email.clone(),
             provider_metadata: Some(json!({
                 "api_key_name": info.api_key_name,
@@ -92,16 +91,16 @@ mod tests {
 
     #[test]
     fn provider_metadata() {
-        let p = CursorConnectionProvider;
+        let p = CursorConnector;
         assert_eq!(p.provider_id(), "cursor");
         assert_eq!(p.display_name(), "Cursor");
-        assert_eq!(p.connection_type(), ConnectionType::ApiKey);
+        assert_eq!(p.connection_type(), ConnectorType::ApiKey);
         assert_eq!(p.icon(), "code");
     }
 
     #[test]
     fn form_schema_mentions_cloud_agents_key() {
-        let p = CursorConnectionProvider;
+        let p = CursorConnector;
         let schema = p.form_schema().expect("should have form schema");
         assert_eq!(schema.fields.len(), 1);
         assert_eq!(schema.fields[0].name, "api_key");

--- a/integrations/cursor/src/lib.rs
+++ b/integrations/cursor/src/lib.rs
@@ -16,12 +16,12 @@ use everruns_core::capabilities::{
     Capability, CapabilityLocalization, CapabilityStatus, IntegrationPlugin, RiskLevel,
     ToolCallHook,
 };
-use everruns_core::connection_provider::ConnectionProviderPlugin;
+use everruns_core::connector::ConnectorPlugin;
 use everruns_core::tool_narration::ToolNarrationPhase;
 use everruns_core::tool_types::{ToolCall, ToolDefinition};
 use everruns_core::tools::Tool;
 
-use connection::CursorConnectionProvider;
+use connection::CursorConnector;
 use tools::{
     CursorAddFollowupTool, CursorDeleteAgentTool, CursorGetAgentTool, CursorGetConversationTool,
     CursorKeyInfoTool, CursorLaunchAgentTool, CursorListAgentsTool, CursorListModelsTool,
@@ -37,9 +37,9 @@ inventory::submit! {
 }
 
 inventory::submit! {
-    ConnectionProviderPlugin {
+    ConnectorPlugin {
         experimental_only: false,
-        factory: || Box::new(CursorConnectionProvider),
+        factory: || Box::new(CursorConnector),
     }
 }
 

--- a/integrations/cursor/tests/plugin_registration.rs
+++ b/integrations/cursor/tests/plugin_registration.rs
@@ -1,7 +1,7 @@
 //! Integration test: verify Cursor plugin and connection provider registration.
 
 use everruns_core::capabilities::{CapabilityRegistry, IntegrationPlugin, ToolCallHook};
-use everruns_core::connection_provider::ConnectionProviderPlugin;
+use everruns_core::connector::ConnectorPlugin;
 use everruns_core::deployment::DeploymentGrade;
 use everruns_core::tool_narration::ToolNarrationPhase;
 use everruns_core::tool_types::ToolCall;
@@ -43,8 +43,7 @@ fn cursor_capability_metadata() {
 
 #[test]
 fn cursor_connection_provider_is_submitted() {
-    let plugins: Vec<&ConnectionProviderPlugin> =
-        inventory::iter::<ConnectionProviderPlugin>().collect();
+    let plugins: Vec<&ConnectorPlugin> = inventory::iter::<ConnectorPlugin>().collect();
     let plugin = plugins
         .iter()
         .find(|p| {

--- a/integrations/daytona/src/connection.rs
+++ b/integrations/daytona/src/connection.rs
@@ -6,17 +6,16 @@
 //   lives in this crate, not in the server crate.
 
 use async_trait::async_trait;
-use everruns_core::connection_provider::{
-    ConnectionFormSchema, ConnectionProvider, ConnectionType, ConnectionValidation, FieldType,
-    FormField,
+use everruns_core::connector::{
+    Connector, ConnectorFormSchema, ConnectorType, ConnectorValidation, FieldType, FormField,
 };
 
 use crate::DAYTONA_API_BASE;
 
-pub struct DaytonaConnectionProvider;
+pub struct DaytonaConnector;
 
 #[async_trait]
-impl ConnectionProvider for DaytonaConnectionProvider {
+impl Connector for DaytonaConnector {
     fn provider_id(&self) -> &str {
         "daytona"
     }
@@ -33,12 +32,12 @@ impl ConnectionProvider for DaytonaConnectionProvider {
         "daytona"
     }
 
-    fn connection_type(&self) -> ConnectionType {
-        ConnectionType::ApiKey
+    fn connection_type(&self) -> ConnectorType {
+        ConnectorType::ApiKey
     }
 
-    fn form_schema(&self) -> Option<ConnectionFormSchema> {
-        Some(ConnectionFormSchema {
+    fn form_schema(&self) -> Option<ConnectorFormSchema> {
+        Some(ConnectorFormSchema {
             fields: vec![FormField {
                 name: "api_key".to_string(),
                 label: "API Key".to_string(),
@@ -56,7 +55,7 @@ impl ConnectionProvider for DaytonaConnectionProvider {
         })
     }
 
-    async fn validate(&self, credential: &str) -> Result<ConnectionValidation, String> {
+    async fn validate(&self, credential: &str) -> Result<ConnectorValidation, String> {
         let client = reqwest::Client::new();
         let response = client
             .get(format!("{DAYTONA_API_BASE}/sandbox"))
@@ -66,7 +65,7 @@ impl ConnectionProvider for DaytonaConnectionProvider {
             .map_err(|e| format!("Failed to reach Daytona API: {e}"))?;
 
         match response.status().as_u16() {
-            200 => Ok(ConnectionValidation {
+            200 => Ok(ConnectorValidation {
                 provider_username: None,
                 provider_metadata: None,
             }),
@@ -84,16 +83,16 @@ mod tests {
 
     #[test]
     fn test_provider_metadata() {
-        let p = DaytonaConnectionProvider;
+        let p = DaytonaConnector;
         assert_eq!(p.provider_id(), "daytona");
         assert_eq!(p.display_name(), "Daytona");
-        assert_eq!(p.connection_type(), ConnectionType::ApiKey);
+        assert_eq!(p.connection_type(), ConnectorType::ApiKey);
         assert_eq!(p.icon(), "daytona");
     }
 
     #[test]
     fn test_form_schema() {
-        let p = DaytonaConnectionProvider;
+        let p = DaytonaConnector;
         let schema = p.form_schema().expect("should have form schema");
         assert_eq!(schema.fields.len(), 1);
         assert_eq!(schema.fields[0].name, "api_key");

--- a/integrations/daytona/src/lib.rs
+++ b/integrations/daytona/src/lib.rs
@@ -40,10 +40,10 @@ use everruns_core::capabilities::{
     Capability, CapabilityLocalization, CapabilityStatus, IntegrationPlugin, MountDirectoryBuilder,
     MountPoint, RiskLevel, SystemPromptContext,
 };
-use everruns_core::connection_provider::ConnectionProviderPlugin;
+use everruns_core::connector::ConnectorPlugin;
 use everruns_core::tools::Tool;
 
-use connection::DaytonaConnectionProvider;
+use connection::DaytonaConnector;
 use session_sandbox_provider::DaytonaSessionSandboxProvider;
 use std::sync::LazyLock;
 use std::time::Duration;
@@ -68,9 +68,9 @@ inventory::submit! {
 }
 
 inventory::submit! {
-    ConnectionProviderPlugin {
+    ConnectorPlugin {
         experimental_only: true,
-        factory: || Box::new(DaytonaConnectionProvider),
+        factory: || Box::new(DaytonaConnector),
     }
 }
 

--- a/integrations/deno/src/connection.rs
+++ b/integrations/deno/src/connection.rs
@@ -5,16 +5,15 @@
 
 use crate::client::DenoClient;
 use async_trait::async_trait;
-use everruns_core::connection_provider::{
-    ConnectionFormSchema, ConnectionProvider, ConnectionType, ConnectionValidation, FieldType,
-    FormField,
+use everruns_core::connector::{
+    Connector, ConnectorFormSchema, ConnectorType, ConnectorValidation, FieldType, FormField,
 };
 use std::collections::HashMap;
 
-pub struct DenoConnectionProvider;
+pub struct DenoConnector;
 
 #[async_trait]
-impl ConnectionProvider for DenoConnectionProvider {
+impl Connector for DenoConnector {
     fn provider_id(&self) -> &str {
         "deno"
     }
@@ -31,12 +30,12 @@ impl ConnectionProvider for DenoConnectionProvider {
         "server"
     }
 
-    fn connection_type(&self) -> ConnectionType {
-        ConnectionType::ApiKey
+    fn connection_type(&self) -> ConnectorType {
+        ConnectorType::ApiKey
     }
 
-    fn form_schema(&self) -> Option<ConnectionFormSchema> {
-        Some(ConnectionFormSchema {
+    fn form_schema(&self) -> Option<ConnectorFormSchema> {
+        Some(ConnectorFormSchema {
             fields: vec![
                 FormField {
                     name: "api_key".to_string(),
@@ -67,7 +66,7 @@ impl ConnectionProvider for DenoConnectionProvider {
         })
     }
 
-    async fn validate(&self, credential: &str) -> Result<ConnectionValidation, String> {
+    async fn validate(&self, credential: &str) -> Result<ConnectorValidation, String> {
         // Single-field validation: only org tokens work without extra fields.
         if credential.starts_with("ddp_") {
             return Err(
@@ -79,7 +78,7 @@ impl ConnectionProvider for DenoConnectionProvider {
         client
             .list_sandboxes(&std::collections::BTreeMap::new())
             .await?;
-        Ok(ConnectionValidation {
+        Ok(ConnectorValidation {
             provider_username: None,
             provider_metadata: None,
         })
@@ -88,7 +87,7 @@ impl ConnectionProvider for DenoConnectionProvider {
     async fn validate_fields(
         &self,
         fields: &HashMap<String, String>,
-    ) -> Result<ConnectionValidation, String> {
+    ) -> Result<ConnectorValidation, String> {
         let api_key = fields.get("api_key").map(|s| s.as_str()).unwrap_or("");
         if api_key.is_empty() {
             return Err("Access token is required.".to_string());
@@ -121,7 +120,7 @@ impl ConnectionProvider for DenoConnectionProvider {
             None
         };
 
-        Ok(ConnectionValidation {
+        Ok(ConnectorValidation {
             provider_username: None,
             provider_metadata,
         })
@@ -134,16 +133,16 @@ mod tests {
 
     #[test]
     fn test_provider_metadata() {
-        let provider = DenoConnectionProvider;
+        let provider = DenoConnector;
         assert_eq!(provider.provider_id(), "deno");
         assert_eq!(provider.display_name(), "Deno Deploy");
-        assert_eq!(provider.connection_type(), ConnectionType::ApiKey);
+        assert_eq!(provider.connection_type(), ConnectorType::ApiKey);
         assert_eq!(provider.icon(), "server");
     }
 
     #[test]
     fn test_form_schema() {
-        let provider = DenoConnectionProvider;
+        let provider = DenoConnector;
         let schema = provider.form_schema().expect("schema");
         assert_eq!(schema.fields.len(), 2);
         assert_eq!(schema.fields[0].name, "api_key");
@@ -153,14 +152,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_validate_rejects_personal_token_without_org() {
-        let provider = DenoConnectionProvider;
+        let provider = DenoConnector;
         let err = provider.validate("ddp_test_token").await.unwrap_err();
         assert!(err.contains("organization slug"));
     }
 
     #[tokio::test]
     async fn test_validate_fields_rejects_personal_token_without_org() {
-        let provider = DenoConnectionProvider;
+        let provider = DenoConnector;
         let mut fields = HashMap::new();
         fields.insert("api_key".to_string(), "ddp_test_token".to_string());
         let err = provider.validate_fields(&fields).await.unwrap_err();

--- a/integrations/deno/src/lib.rs
+++ b/integrations/deno/src/lib.rs
@@ -19,12 +19,12 @@ use everruns_core::LEASED_RESOURCES_FEATURE;
 use everruns_core::capabilities::{
     Capability, CapabilityLocalization, CapabilityStatus, IntegrationPlugin, RiskLevel,
 };
-use everruns_core::connection_provider::ConnectionProviderPlugin;
+use everruns_core::connector::ConnectorPlugin;
 use everruns_core::tools::Tool;
 use std::sync::LazyLock;
 use std::time::Duration;
 
-use connection::DenoConnectionProvider;
+use connection::DenoConnector;
 use tools::{
     DenoCreateSandboxTool, DenoExecTool, DenoListSandboxesTool, DenoManageSandboxTool,
     DenoReadFileTool, DenoWriteFileTool,
@@ -39,9 +39,9 @@ inventory::submit! {
 }
 
 inventory::submit! {
-    ConnectionProviderPlugin {
+    ConnectorPlugin {
         experimental_only: true,
-        factory: || Box::new(DenoConnectionProvider),
+        factory: || Box::new(DenoConnector),
     }
 }
 

--- a/integrations/deno/tests/plugin_registration.rs
+++ b/integrations/deno/tests/plugin_registration.rs
@@ -1,7 +1,7 @@
 //! Integration tests for Deno plugin registration and capability.
 
 use everruns_core::capabilities::{CapabilityRegistry, IntegrationPlugin};
-use everruns_core::connection_provider::ConnectionProviderPlugin;
+use everruns_core::connector::ConnectorPlugin;
 use everruns_core::deployment::DeploymentGrade;
 use everruns_integrations_deno as _;
 
@@ -25,13 +25,12 @@ fn test_deno_registered_in_prod_registry() {
 
 #[test]
 fn test_deno_connection_provider_is_submitted() {
-    let plugins: Vec<&ConnectionProviderPlugin> =
-        inventory::iter::<ConnectionProviderPlugin>().collect();
+    let plugins: Vec<&ConnectorPlugin> = inventory::iter::<ConnectorPlugin>().collect();
     assert!(
         plugins.iter().any(|plugin| {
             let provider = (plugin.factory)();
             provider.provider_id() == "deno"
         }),
-        "Deno ConnectionProviderPlugin should be submitted via inventory"
+        "Deno ConnectorPlugin should be submitted via inventory"
     );
 }

--- a/integrations/e2b/src/connection.rs
+++ b/integrations/e2b/src/connection.rs
@@ -5,17 +5,16 @@
 // Decision: All E2B-specific connection config lives in this crate, not in the server crate.
 
 use async_trait::async_trait;
-use everruns_core::connection_provider::{
-    ConnectionFormSchema, ConnectionProvider, ConnectionType, ConnectionValidation, FieldType,
-    FormField,
+use everruns_core::connector::{
+    Connector, ConnectorFormSchema, ConnectorType, ConnectorValidation, FieldType, FormField,
 };
 
 use crate::E2B_API_BASE;
 
-pub struct E2BConnectionProvider;
+pub struct E2BConnector;
 
 #[async_trait]
-impl ConnectionProvider for E2BConnectionProvider {
+impl Connector for E2BConnector {
     fn provider_id(&self) -> &str {
         "e2b"
     }
@@ -32,12 +31,12 @@ impl ConnectionProvider for E2BConnectionProvider {
         "cloud"
     }
 
-    fn connection_type(&self) -> ConnectionType {
-        ConnectionType::ApiKey
+    fn connection_type(&self) -> ConnectorType {
+        ConnectorType::ApiKey
     }
 
-    fn form_schema(&self) -> Option<ConnectionFormSchema> {
-        Some(ConnectionFormSchema {
+    fn form_schema(&self) -> Option<ConnectorFormSchema> {
+        Some(ConnectorFormSchema {
             fields: vec![FormField {
                 name: "api_key".to_string(),
                 label: "API Key".to_string(),
@@ -55,7 +54,7 @@ impl ConnectionProvider for E2BConnectionProvider {
         })
     }
 
-    async fn validate(&self, credential: &str) -> Result<ConnectionValidation, String> {
+    async fn validate(&self, credential: &str) -> Result<ConnectorValidation, String> {
         let client = reqwest::Client::new();
         let response = client
             .get(format!("{E2B_API_BASE}/sandboxes"))
@@ -65,7 +64,7 @@ impl ConnectionProvider for E2BConnectionProvider {
             .map_err(|e| format!("Failed to reach E2B API: {e}"))?;
 
         match response.status().as_u16() {
-            200..=299 => Ok(ConnectionValidation {
+            200..=299 => Ok(ConnectorValidation {
                 provider_username: None,
                 provider_metadata: None,
             }),
@@ -83,16 +82,16 @@ mod tests {
 
     #[test]
     fn provider_metadata() {
-        let p = E2BConnectionProvider;
+        let p = E2BConnector;
         assert_eq!(p.provider_id(), "e2b");
         assert_eq!(p.display_name(), "E2B");
-        assert_eq!(p.connection_type(), ConnectionType::ApiKey);
+        assert_eq!(p.connection_type(), ConnectorType::ApiKey);
         assert_eq!(p.icon(), "cloud");
     }
 
     #[test]
     fn form_schema_has_api_key_field() {
-        let p = E2BConnectionProvider;
+        let p = E2BConnector;
         let schema = p.form_schema().expect("should have form schema");
         assert_eq!(schema.fields.len(), 1);
         assert_eq!(schema.fields[0].name, "api_key");

--- a/integrations/e2b/src/lib.rs
+++ b/integrations/e2b/src/lib.rs
@@ -33,12 +33,12 @@ use everruns_core::LEASED_RESOURCES_FEATURE;
 use everruns_core::capabilities::{
     Capability, CapabilityLocalization, CapabilityStatus, IntegrationPlugin, RiskLevel,
 };
-use everruns_core::connection_provider::ConnectionProviderPlugin;
+use everruns_core::connector::ConnectorPlugin;
 use everruns_core::tools::Tool;
 
 use std::sync::LazyLock;
 
-use connection::E2BConnectionProvider;
+use connection::E2BConnector;
 use tools::{
     E2BCreateSandboxTool, E2BExecTool, E2BListSandboxesTool, E2BManageSandboxTool, E2BReadFileTool,
     E2BWriteFileTool,
@@ -53,9 +53,9 @@ inventory::submit! {
 }
 
 inventory::submit! {
-    ConnectionProviderPlugin {
+    ConnectorPlugin {
         experimental_only: false,
-        factory: || Box::new(E2BConnectionProvider),
+        factory: || Box::new(E2BConnector),
     }
 }
 

--- a/integrations/e2b/tests/plugin_registration.rs
+++ b/integrations/e2b/tests/plugin_registration.rs
@@ -1,7 +1,7 @@
 //! Integration tests for E2B plugin registration and capability.
 
 use everruns_core::capabilities::{CapabilityRegistry, IntegrationPlugin};
-use everruns_core::connection_provider::ConnectionProviderPlugin;
+use everruns_core::connector::ConnectorPlugin;
 use everruns_core::deployment::DeploymentGrade;
 
 // Force linker to include the integration crate's inventory submissions.
@@ -63,13 +63,12 @@ fn test_e2b_capability_metadata() {
 
 #[test]
 fn test_e2b_connection_provider_is_submitted() {
-    let plugins: Vec<&ConnectionProviderPlugin> =
-        inventory::iter::<ConnectionProviderPlugin>().collect();
+    let plugins: Vec<&ConnectorPlugin> = inventory::iter::<ConnectorPlugin>().collect();
     assert!(
         plugins.iter().any(|plugin| {
             let provider = (plugin.factory)();
             provider.provider_id() == "e2b"
         }),
-        "E2B ConnectionProviderPlugin should be submitted via inventory"
+        "E2B ConnectorPlugin should be submitted via inventory"
     );
 }

--- a/integrations/parallel/src/connection.rs
+++ b/integrations/parallel/src/connection.rs
@@ -5,18 +5,17 @@
 // storing any credential.
 
 use async_trait::async_trait;
-use everruns_core::connection_provider::{
-    ConnectionFormSchema, ConnectionProvider, ConnectionType, ConnectionValidation, FieldType,
-    FormField,
+use everruns_core::connector::{
+    Connector, ConnectorFormSchema, ConnectorType, ConnectorValidation, FieldType, FormField,
 };
 use everruns_core::{McpToolsListRequest, McpToolsListResponse};
 
 use crate::{PARALLEL_MCP_URL, PARALLEL_PROVIDER_ID};
 
-pub struct ParallelConnectionProvider;
+pub struct ParallelConnector;
 
 #[async_trait]
-impl ConnectionProvider for ParallelConnectionProvider {
+impl Connector for ParallelConnector {
     fn provider_id(&self) -> &str {
         PARALLEL_PROVIDER_ID
     }
@@ -33,12 +32,12 @@ impl ConnectionProvider for ParallelConnectionProvider {
         "search"
     }
 
-    fn connection_type(&self) -> ConnectionType {
-        ConnectionType::ApiKey
+    fn connection_type(&self) -> ConnectorType {
+        ConnectorType::ApiKey
     }
 
-    fn form_schema(&self) -> Option<ConnectionFormSchema> {
-        Some(ConnectionFormSchema {
+    fn form_schema(&self) -> Option<ConnectorFormSchema> {
+        Some(ConnectorFormSchema {
             fields: vec![FormField {
                 name: "api_key".to_string(),
                 label: "API Key".to_string(),
@@ -59,7 +58,7 @@ To use authenticated mode:\n\
         })
     }
 
-    async fn validate(&self, credential: &str) -> Result<ConnectionValidation, String> {
+    async fn validate(&self, credential: &str) -> Result<ConnectorValidation, String> {
         let response = reqwest::Client::new()
             .post(PARALLEL_MCP_URL)
             .bearer_auth(credential)
@@ -77,7 +76,7 @@ To use authenticated mode:\n\
                 if let Some(error) = mcp_response.error {
                     return Err(format!("Parallel MCP error: {}", error.message));
                 }
-                Ok(ConnectionValidation {
+                Ok(ConnectorValidation {
                     provider_username: None,
                     provider_metadata: None,
                 })
@@ -97,16 +96,16 @@ mod tests {
 
     #[test]
     fn provider_metadata() {
-        let p = ParallelConnectionProvider;
+        let p = ParallelConnector;
         assert_eq!(p.provider_id(), "parallel");
         assert_eq!(p.display_name(), "Parallel");
-        assert_eq!(p.connection_type(), ConnectionType::ApiKey);
+        assert_eq!(p.connection_type(), ConnectorType::ApiKey);
         assert_eq!(p.icon(), "search");
     }
 
     #[test]
     fn form_schema_describes_optional_key() {
-        let p = ParallelConnectionProvider;
+        let p = ParallelConnector;
         let schema = p.form_schema().expect("should have form schema");
         assert_eq!(schema.fields.len(), 1);
         assert_eq!(schema.fields[0].name, "api_key");

--- a/integrations/parallel/src/lib.rs
+++ b/integrations/parallel/src/lib.rs
@@ -30,11 +30,11 @@ pub mod payments;
 use everruns_core::capabilities::{
     Capability, CapabilityLocalization, CapabilityStatus, IntegrationPlugin,
 };
-use everruns_core::connection_provider::ConnectionProviderPlugin;
+use everruns_core::connector::ConnectorPlugin;
 use everruns_core::{McpServerAuthMode, ScopedMcpServer, ScopedMcpServers};
 use serde_json::{Value, json};
 
-use connection::ParallelConnectionProvider;
+use connection::ParallelConnector;
 pub use payments::ParallelPaymentsCapability;
 
 inventory::submit! {
@@ -58,9 +58,9 @@ inventory::submit! {
 }
 
 inventory::submit! {
-    ConnectionProviderPlugin {
+    ConnectorPlugin {
         experimental_only: true,
-        factory: || Box::new(ParallelConnectionProvider),
+        factory: || Box::new(ParallelConnector),
     }
 }
 

--- a/integrations/parallel/tests/plugin_registration.rs
+++ b/integrations/parallel/tests/plugin_registration.rs
@@ -1,7 +1,7 @@
 //! Integration test: verify Parallel plugin registers via inventory.
 
 use everruns_core::capabilities::{CapabilityRegistry, IntegrationPlugin};
-use everruns_core::connection_provider::ConnectionProviderPlugin;
+use everruns_core::connector::ConnectorPlugin;
 use everruns_core::deployment::DeploymentGrade;
 
 use everruns_integrations_parallel as _;
@@ -93,21 +93,19 @@ fn payments_capability_enabled_by_flag() {
 
 #[test]
 fn connection_provider_is_submitted() {
-    let plugins: Vec<&ConnectionProviderPlugin> =
-        inventory::iter::<ConnectionProviderPlugin>().collect();
+    let plugins: Vec<&ConnectorPlugin> = inventory::iter::<ConnectorPlugin>().collect();
     assert!(
         plugins.iter().any(|p| {
             let provider = (p.factory)();
             provider.provider_id() == "parallel"
         }),
-        "Parallel ConnectionProviderPlugin should be submitted via inventory"
+        "Parallel ConnectorPlugin should be submitted via inventory"
     );
 }
 
 #[test]
 fn connection_provider_has_api_key_form() {
-    let plugins: Vec<&ConnectionProviderPlugin> =
-        inventory::iter::<ConnectionProviderPlugin>().collect();
+    let plugins: Vec<&ConnectorPlugin> = inventory::iter::<ConnectorPlugin>().collect();
     let plugin = plugins
         .iter()
         .find(|p| {

--- a/integrations/sprites/src/connection.rs
+++ b/integrations/sprites/src/connection.rs
@@ -4,17 +4,16 @@
 // Decision: Validate token by calling GET /v1/sprites — 200 means valid, 401 means invalid.
 
 use async_trait::async_trait;
-use everruns_core::connection_provider::{
-    ConnectionFormSchema, ConnectionProvider, ConnectionType, ConnectionValidation, FieldType,
-    FormField,
+use everruns_core::connector::{
+    Connector, ConnectorFormSchema, ConnectorType, ConnectorValidation, FieldType, FormField,
 };
 
 use crate::SPRITES_API_BASE;
 
-pub struct SpritesConnectionProvider;
+pub struct SpritesConnector;
 
 #[async_trait]
-impl ConnectionProvider for SpritesConnectionProvider {
+impl Connector for SpritesConnector {
     fn provider_id(&self) -> &str {
         "sprites"
     }
@@ -31,12 +30,12 @@ impl ConnectionProvider for SpritesConnectionProvider {
         "sprites"
     }
 
-    fn connection_type(&self) -> ConnectionType {
-        ConnectionType::ApiKey
+    fn connection_type(&self) -> ConnectorType {
+        ConnectorType::ApiKey
     }
 
-    fn form_schema(&self) -> Option<ConnectionFormSchema> {
-        Some(ConnectionFormSchema {
+    fn form_schema(&self) -> Option<ConnectorFormSchema> {
+        Some(ConnectorFormSchema {
             fields: vec![FormField {
                 name: "api_key".to_string(),
                 label: "API Token".to_string(),
@@ -54,7 +53,7 @@ impl ConnectionProvider for SpritesConnectionProvider {
         })
     }
 
-    async fn validate(&self, credential: &str) -> Result<ConnectionValidation, String> {
+    async fn validate(&self, credential: &str) -> Result<ConnectorValidation, String> {
         let client = reqwest::Client::new();
         let response = client
             .get(format!("{SPRITES_API_BASE}/sprites"))
@@ -64,7 +63,7 @@ impl ConnectionProvider for SpritesConnectionProvider {
             .map_err(|e| format!("Failed to reach Sprites API: {e}"))?;
 
         match response.status().as_u16() {
-            200 => Ok(ConnectionValidation {
+            200 => Ok(ConnectorValidation {
                 provider_username: None,
                 provider_metadata: None,
             }),
@@ -84,16 +83,16 @@ mod tests {
 
     #[test]
     fn test_provider_metadata() {
-        let p = SpritesConnectionProvider;
+        let p = SpritesConnector;
         assert_eq!(p.provider_id(), "sprites");
         assert_eq!(p.display_name(), "Sprites");
-        assert_eq!(p.connection_type(), ConnectionType::ApiKey);
+        assert_eq!(p.connection_type(), ConnectorType::ApiKey);
         assert_eq!(p.icon(), "sprites");
     }
 
     #[test]
     fn test_form_schema() {
-        let p = SpritesConnectionProvider;
+        let p = SpritesConnector;
         let schema = p.form_schema().expect("should have form schema");
         assert_eq!(schema.fields.len(), 1);
         assert_eq!(schema.fields[0].name, "api_key");

--- a/integrations/sprites/src/lib.rs
+++ b/integrations/sprites/src/lib.rs
@@ -18,12 +18,12 @@ use everruns_core::LEASED_RESOURCES_FEATURE;
 use everruns_core::capabilities::{
     Capability, CapabilityLocalization, CapabilityStatus, IntegrationPlugin, RiskLevel,
 };
-use everruns_core::connection_provider::ConnectionProviderPlugin;
+use everruns_core::connector::ConnectorPlugin;
 use everruns_core::tools::Tool;
 
 use std::sync::LazyLock;
 
-use connection::SpritesConnectionProvider;
+use connection::SpritesConnector;
 
 use tools::{
     SpritesCheckpointTool, SpritesCreateSpriteTool, SpritesExecTool, SpritesListSpritesTool,
@@ -44,9 +44,9 @@ inventory::submit! {
 }
 
 inventory::submit! {
-    ConnectionProviderPlugin {
+    ConnectorPlugin {
         experimental_only: true,
-        factory: || Box::new(SpritesConnectionProvider),
+        factory: || Box::new(SpritesConnector),
     }
 }
 

--- a/specs/embedding.md
+++ b/specs/embedding.md
@@ -345,7 +345,7 @@ Those may be added later, but they are outside the current embedding contract.
 ## Source Index
 
 - `crates/core/src/platform_definition.rs`
-- `crates/core/src/connection_provider.rs`
+- `crates/core/src/connector.rs`
 - `crates/core/src/error_reporter.rs`
 - `apps/ui/src/providers/error-reporter-provider.tsx`
 - `crates/server/src/auth/cli_auth.rs`

--- a/specs/providers.md
+++ b/specs/providers.md
@@ -237,5 +237,5 @@ Until the refactor lands, current implementations live at:
 - `crates/server/src/services/model_sync.rs` — model discovery
 - `crates/server/src/api/llm_providers.rs`, `crates/server/src/api/llm_models.rs` — REST API
 - `crates/server/src/api/voice.rs` — realtime credential resolution (to be rerouted)
-- `crates/core/src/connection_provider.rs` — connector plugin trait (to be renamed)
+- `crates/core/src/connector.rs` — connector plugin trait
 - `apps/ui/src/app/(main)/settings/providers/` — provider settings UI


### PR DESCRIPTION
## What

Phase 5 of the providers refactor (spec: `specs/providers.md`). Renames all connection-provider types to align with the generic "provider" vocabulary introduced in phases 1–4.

**Core crate:**
- `connection_provider.rs` → `connector.rs`
- `ConnectionProvider` trait → `Connector`
- `ConnectionProviderPlugin` → `ConnectorPlugin`
- `ConnectionProviderRegistry` → `ConnectorRegistry` (+ builder)
- `ConnectionProviderRegistryBuilder` → `ConnectorRegistryBuilder`

**PlatformDefinition:**
- Field `connection_providers` → `connectors`
- Builder methods `.connection_providers()` / `.connection_providers_mut()` → `.connectors()` / `.connectors_mut()`
- Builder method `.connection_provider()` → `.connector()`

**Integration crates** (daytona, e2b, brave-search, cursor, deno, browserless, parallel, sprites):
- `*ConnectionProvider` structs renamed to `*Connector`
- `impl Connector for *Connector` in each `connection.rs`
- `lib.rs` `inventory::submit!` blocks updated to `ConnectorPlugin`
- Plugin registration tests updated

**Server:**
- `oss_connection_provider_registry()` → `oss_connector_registry()`
- `api/user_connections.rs`, `api/agent_identity_connections.rs`, `app_builder.rs` updated

**Specs:** `specs/providers.md`, `specs/embedding.md`, `crates/server/specs/user-connections.md`

## Why

`ConnectionProvider` predates the unified "provider" vocabulary. Renaming to `Connector` makes the distinction clear: `Connector` is a user-scoped integration (API key / OAuth), while `Provider` is an org-level LLM driver. Spec: `specs/providers.md`.

## How

- Rename `connection_provider.rs` → `connector.rs` and update all type names
- Update all integration crate `connection.rs` and `lib.rs` files
- Update server platform, API handlers, and app builder
- `cargo fmt` + `cargo clippy --all-targets --all-features -- -D warnings` clean
- `just pre-push` green

## Risk
- Low — pure rename, no logic changes
- All integration tests exercise the renamed plugin discovery path

## Security
- No security-relevant code changes. Pure rename refactor.

## Follow-ups
- Phase 6: `EmbeddingsDriver` trait + knowledge-base hybrid retrieval configuration

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (internal only; no public API shape changes)
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VjuNjETooc6GJ99vmLBftL)_