### PR TITLE
feat(openrouter): expose optional plugin-style provider capabilities

### DIFF
--- a/crates/core/src/llm_driver_registry.rs
+++ b/crates/core/src/llm_driver_registry.rs
@@ -532,11 +532,17 @@ pub struct OpenRouterRoutingConfig {
     /// Provider ordering, policy, and sorting preferences.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub provider: Option<OpenRouterProviderRouting>,
+    /// Optional plugin activations (web search, file reader).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub plugins: Option<OpenRouterPluginConfig>,
 }
 
 impl OpenRouterRoutingConfig {
     pub fn is_empty(&self) -> bool {
-        self.models.is_empty() && self.route.is_none() && self.provider.is_none()
+        self.models.is_empty()
+            && self.route.is_none()
+            && self.provider.is_none()
+            && self.plugins.as_ref().is_none_or(|p| p.is_empty())
     }
 
     /// Build an ordered model-fallback routing config.
@@ -547,6 +553,7 @@ impl OpenRouterRoutingConfig {
             models,
             route,
             provider: None,
+            plugins: None,
         }
     }
 
@@ -694,6 +701,51 @@ pub struct OpenRouterMaxPrice {
     pub request: Option<f64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub image: Option<f64>,
+}
+
+/// OpenRouter web-search plugin configuration.
+///
+/// Instructs OpenRouter to retrieve and inject web search results before the
+/// model sees the prompt. Only sent when the resolved provider type is
+/// OpenRouter.
+#[derive(Debug, Clone, Default, PartialEq, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct OpenRouterWebSearchPlugin {
+    /// Maximum number of search results to include.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_results: Option<u32>,
+    /// Custom search prompt hint passed to the web-search step.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub search_prompt: Option<String>,
+}
+
+/// OpenRouter file-reader plugin configuration.
+///
+/// Instructs OpenRouter to read and attach file contents before the model
+/// sees the prompt. Only sent when the resolved provider type is OpenRouter.
+#[derive(Debug, Clone, Default, PartialEq, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct OpenRouterFilePlugin {}
+
+/// OpenRouter plugin configuration bundling optional plugin activations.
+///
+/// Any `None` plugin is omitted from the wire request. When all plugins are
+/// `None`, no `plugins` field is emitted.
+#[derive(Debug, Clone, Default, PartialEq, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct OpenRouterPluginConfig {
+    /// Web-search plugin.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub web: Option<OpenRouterWebSearchPlugin>,
+    /// File-reader plugin.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub file: Option<OpenRouterFilePlugin>,
+}
+
+impl OpenRouterPluginConfig {
+    pub fn is_empty(&self) -> bool {
+        self.web.is_none() && self.file.is_none()
+    }
 }
 
 /// Configuration for an LLM call
@@ -1707,6 +1759,7 @@ mod tests {
                 }),
                 ..Default::default()
             }),
+            ..Default::default()
         };
 
         let json = serde_json::to_value(routing).unwrap();
@@ -2302,5 +2355,61 @@ mod tests {
             }
             _ => panic!("Expected parts content"),
         }
+    }
+
+    #[test]
+    fn test_openrouter_plugin_config_is_empty() {
+        assert!(OpenRouterPluginConfig::default().is_empty());
+        assert!(
+            !OpenRouterPluginConfig {
+                web: Some(OpenRouterWebSearchPlugin::default()),
+                file: None,
+            }
+            .is_empty()
+        );
+        assert!(
+            !OpenRouterPluginConfig {
+                web: None,
+                file: Some(OpenRouterFilePlugin {}),
+            }
+            .is_empty()
+        );
+    }
+
+    #[test]
+    fn test_openrouter_routing_is_empty_with_plugins() {
+        let with_plugins = OpenRouterRoutingConfig {
+            plugins: Some(OpenRouterPluginConfig {
+                web: Some(OpenRouterWebSearchPlugin::default()),
+                file: None,
+            }),
+            ..Default::default()
+        };
+        assert!(!with_plugins.is_empty());
+
+        let empty_plugins = OpenRouterRoutingConfig {
+            plugins: Some(OpenRouterPluginConfig::default()),
+            ..Default::default()
+        };
+        assert!(empty_plugins.is_empty());
+    }
+
+    #[test]
+    fn test_openrouter_web_search_plugin_serialization() {
+        let plugin = OpenRouterWebSearchPlugin {
+            max_results: Some(10),
+            search_prompt: Some("search for Rust crates".to_string()),
+        };
+        let json = serde_json::to_value(&plugin).unwrap();
+        assert_eq!(json["max_results"], 10);
+        assert_eq!(json["search_prompt"], "search for Rust crates");
+    }
+
+    #[test]
+    fn test_openrouter_web_search_plugin_omits_none_fields() {
+        let plugin = OpenRouterWebSearchPlugin::default();
+        let json = serde_json::to_value(&plugin).unwrap();
+        assert!(json.get("max_results").is_none());
+        assert!(json.get("search_prompt").is_none());
     }
 }

--- a/crates/core/src/openresponses_protocol.rs
+++ b/crates/core/src/openresponses_protocol.rs
@@ -800,6 +800,13 @@ impl ChatDriver for OpenResponsesProtocolChatDriver {
                 .filter(|provider| !provider.is_empty())
                 .cloned()
         });
+        let openrouter_plugins = openrouter_routing.and_then(|routing| {
+            routing
+                .plugins
+                .as_ref()
+                .filter(|p| !p.is_empty())
+                .and_then(plugins_to_wire)
+        });
 
         let request = ResponsesRequest {
             model: config.model.clone(),
@@ -817,6 +824,7 @@ impl ChatDriver for OpenResponsesProtocolChatDriver {
             reasoning,
             metadata,
             prompt_cache_key,
+            plugins: openrouter_plugins,
         };
 
         // Log request details for debugging LLM errors.
@@ -1823,6 +1831,36 @@ pub fn compact_output_to_messages(
 // OpenAI Responses API Types
 // ============================================================================
 
+/// Convert an [`OpenRouterPluginConfig`] into the wire-format `plugins` array.
+///
+/// Each active plugin becomes a JSON object with an `"id"` field plus any
+/// plugin-specific options. Plugins whose struct is `None` are omitted.
+/// Returns `None` when no plugins are enabled so the field is skipped in
+/// serialization.
+fn plugins_to_wire(
+    config: &crate::llm_driver_registry::OpenRouterPluginConfig,
+) -> Option<Vec<Value>> {
+    let mut items: Vec<Value> = Vec::new();
+
+    if let Some(web) = &config.web {
+        let mut obj = serde_json::Map::new();
+        obj.insert("id".to_string(), json!("web"));
+        if let Some(max_results) = web.max_results {
+            obj.insert("max_results".to_string(), json!(max_results));
+        }
+        if let Some(ref prompt) = web.search_prompt {
+            obj.insert("search_prompt".to_string(), json!(prompt));
+        }
+        items.push(Value::Object(obj));
+    }
+
+    if config.file.is_some() {
+        items.push(json!({"id": "file"}));
+    }
+
+    if items.is_empty() { None } else { Some(items) }
+}
+
 #[derive(Debug, Serialize)]
 struct ResponsesRequest {
     model: String,
@@ -1852,6 +1890,10 @@ struct ResponsesRequest {
     metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     prompt_cache_key: Option<String>,
+    /// OpenRouter plugin activations (web search, file reader).
+    /// Only serialized for OpenRouter requests; `None` for all other providers.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    plugins: Option<Vec<serde_json::Value>>,
 }
 
 #[derive(Debug, Serialize)]
@@ -2005,6 +2047,7 @@ mod tests {
             reasoning: None,
             metadata: None,
             prompt_cache_key: None,
+            plugins: None,
         };
 
         let json = serde_json::to_value(&request).unwrap();
@@ -2039,6 +2082,7 @@ mod tests {
             }),
             metadata: None,
             prompt_cache_key: None,
+            plugins: None,
         };
 
         let json = serde_json::to_value(&request).unwrap();
@@ -2072,6 +2116,7 @@ mod tests {
             reasoning: None,
             metadata: Some(metadata),
             prompt_cache_key: None,
+            plugins: None,
         };
 
         let json = serde_json::to_value(&request).unwrap();
@@ -3121,6 +3166,7 @@ mod tests {
                     }),
                     ..Default::default()
                 }),
+                ..Default::default()
             }),
         };
 
@@ -3188,6 +3234,7 @@ mod tests {
                 models: vec!["openai/gpt-5-mini".to_string()],
                 route: Some(OpenRouterRoute::Fallback),
                 provider: None,
+                ..Default::default()
             }),
         };
 
@@ -3236,6 +3283,7 @@ mod tests {
                 models: vec!["anthropic/claude-sonnet-4.5".to_string()],
                 route: Some(OpenRouterRoute::Fallback),
                 provider: None,
+                ..Default::default()
             }),
         };
         let err = match driver
@@ -3264,6 +3312,7 @@ mod tests {
                 models: vec![],
                 route: Some(OpenRouterRoute::Fallback),
                 provider: None,
+                ..Default::default()
             }),
         };
         let err = match driver
@@ -4404,5 +4453,191 @@ mod tests {
         let params = json!({"type": "string"});
         let sanitized = OpenResponsesProtocolChatDriver::sanitize_parameters(&params);
         assert_eq!(sanitized, params);
+    }
+
+    // ========================================================================
+    // OpenRouter plugin tests
+    // ========================================================================
+
+    #[test]
+    fn test_plugins_to_wire_empty_is_none() {
+        use crate::llm_driver_registry::OpenRouterPluginConfig;
+        let cfg = OpenRouterPluginConfig::default();
+        assert!(plugins_to_wire(&cfg).is_none());
+    }
+
+    #[test]
+    fn test_plugins_to_wire_web_search_basic() {
+        use crate::llm_driver_registry::{OpenRouterPluginConfig, OpenRouterWebSearchPlugin};
+        let cfg = OpenRouterPluginConfig {
+            web: Some(OpenRouterWebSearchPlugin {
+                max_results: Some(5),
+                search_prompt: Some("find recent news".to_string()),
+            }),
+            file: None,
+        };
+        let wire = plugins_to_wire(&cfg).expect("should produce wire entries");
+        assert_eq!(wire.len(), 1);
+        assert_eq!(wire[0]["id"], "web");
+        assert_eq!(wire[0]["max_results"], 5);
+        assert_eq!(wire[0]["search_prompt"], "find recent news");
+    }
+
+    #[test]
+    fn test_plugins_to_wire_web_search_no_options() {
+        use crate::llm_driver_registry::{OpenRouterPluginConfig, OpenRouterWebSearchPlugin};
+        let cfg = OpenRouterPluginConfig {
+            web: Some(OpenRouterWebSearchPlugin::default()),
+            file: None,
+        };
+        let wire = plugins_to_wire(&cfg).expect("should produce wire entries");
+        assert_eq!(wire.len(), 1);
+        assert_eq!(wire[0]["id"], "web");
+        assert!(wire[0].get("max_results").is_none() || wire[0]["max_results"].is_null());
+        assert!(wire[0].get("search_prompt").is_none() || wire[0]["search_prompt"].is_null());
+    }
+
+    #[test]
+    fn test_plugins_to_wire_file_plugin() {
+        use crate::llm_driver_registry::{OpenRouterFilePlugin, OpenRouterPluginConfig};
+        let cfg = OpenRouterPluginConfig {
+            web: None,
+            file: Some(OpenRouterFilePlugin {}),
+        };
+        let wire = plugins_to_wire(&cfg).expect("should produce wire entries");
+        assert_eq!(wire.len(), 1);
+        assert_eq!(wire[0]["id"], "file");
+    }
+
+    #[test]
+    fn test_plugins_to_wire_both_plugins() {
+        use crate::llm_driver_registry::{
+            OpenRouterFilePlugin, OpenRouterPluginConfig, OpenRouterWebSearchPlugin,
+        };
+        let cfg = OpenRouterPluginConfig {
+            web: Some(OpenRouterWebSearchPlugin {
+                max_results: Some(3),
+                search_prompt: None,
+            }),
+            file: Some(OpenRouterFilePlugin {}),
+        };
+        let wire = plugins_to_wire(&cfg).expect("should produce wire entries");
+        assert_eq!(wire.len(), 2);
+        assert_eq!(wire[0]["id"], "web");
+        assert_eq!(wire[0]["max_results"], 3);
+        assert_eq!(wire[1]["id"], "file");
+    }
+
+    #[tokio::test]
+    async fn openrouter_provider_includes_plugins_in_request() {
+        use crate::llm_driver_registry::{
+            OpenRouterPluginConfig, OpenRouterRoutingConfig, OpenRouterWebSearchPlugin,
+        };
+        use wiremock::matchers::method;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(""))
+            .mount(&server)
+            .await;
+
+        let api_url = format!("{}/v1/responses", server.uri());
+        let driver = OpenResponsesProtocolChatDriver::with_base_url("test-key", api_url)
+            .with_provider_type(DriverId::OpenRouter);
+
+        let config = LlmCallConfig {
+            model: "openai/gpt-5-mini".to_string(),
+            temperature: None,
+            max_tokens: None,
+            tools: vec![],
+            reasoning_effort: None,
+            metadata: std::collections::HashMap::new(),
+            previous_response_id: None,
+            tool_search: None,
+            prompt_cache: None,
+            openrouter_routing: Some(OpenRouterRoutingConfig {
+                plugins: Some(OpenRouterPluginConfig {
+                    web: Some(OpenRouterWebSearchPlugin {
+                        max_results: Some(5),
+                        search_prompt: None,
+                    }),
+                    file: None,
+                }),
+                ..Default::default()
+            }),
+        };
+
+        let messages = vec![LlmMessage::text(LlmMessageRole::User, "search the web")];
+        let _ = driver.chat_completion_stream(messages, &config).await;
+
+        let requests = server
+            .received_requests()
+            .await
+            .expect("mock server recorded requests");
+        assert_eq!(requests.len(), 1);
+        let body: serde_json::Value = requests[0].body_json().expect("request body is JSON");
+
+        assert!(
+            body.get("plugins").is_some(),
+            "plugins field should be present: {body}"
+        );
+        let plugins = body["plugins"].as_array().unwrap();
+        assert_eq!(plugins.len(), 1);
+        assert_eq!(plugins[0]["id"], "web");
+        assert_eq!(plugins[0]["max_results"], 5);
+    }
+
+    #[tokio::test]
+    async fn non_openrouter_provider_omits_plugins() {
+        use crate::llm_driver_registry::{
+            OpenRouterPluginConfig, OpenRouterRoutingConfig, OpenRouterWebSearchPlugin,
+        };
+        use wiremock::matchers::method;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(""))
+            .mount(&server)
+            .await;
+
+        let api_url = format!("{}/v1/responses", server.uri());
+        // Default provider type is OpenAI, not OpenRouter
+        let driver = OpenResponsesProtocolChatDriver::with_base_url("test-key", api_url);
+
+        let config = LlmCallConfig {
+            model: "gpt-5-mini".to_string(),
+            temperature: None,
+            max_tokens: None,
+            tools: vec![],
+            reasoning_effort: None,
+            metadata: std::collections::HashMap::new(),
+            previous_response_id: None,
+            tool_search: None,
+            prompt_cache: None,
+            openrouter_routing: Some(OpenRouterRoutingConfig {
+                plugins: Some(OpenRouterPluginConfig {
+                    web: Some(OpenRouterWebSearchPlugin::default()),
+                    file: None,
+                }),
+                ..Default::default()
+            }),
+        };
+
+        let messages = vec![LlmMessage::text(LlmMessageRole::User, "search the web")];
+        let _ = driver.chat_completion_stream(messages, &config).await;
+
+        let requests = server
+            .received_requests()
+            .await
+            .expect("mock server recorded requests");
+        assert_eq!(requests.len(), 1);
+        let body: serde_json::Value = requests[0].body_json().expect("request body is JSON");
+
+        assert!(
+            body.get("plugins").is_none(),
+            "plugins must not be forwarded to non-OpenRouter providers: {body}"
+        );
     }
 }

--- a/specs/llm-drivers.md
+++ b/specs/llm-drivers.md
@@ -326,11 +326,23 @@ tell they support reasoning and hides the effort selector. The discovered profil
 is persisted via the model-sync pipeline and surfaces on existing rows on the next
 sync. Cost is left to hardcoded profiles.
 
-OpenRouter-specific routing controls (`models`, `route`, and `provider`) are
-represented as typed `LlmCallConfig` fields. The Open Responses protocol driver
-serializes them only when the resolved provider type is OpenRouter, so ordinary
-OpenAI-compatible requests do not receive non-standard OpenRouter routing
-extensions.
+OpenRouter-specific routing controls (`models`, `route`, `provider`, and `plugins`) are
+represented as typed `LlmCallConfig` fields inside `OpenRouterRoutingConfig`. The Open
+Responses protocol driver serializes them only when the resolved provider type is
+OpenRouter, so ordinary OpenAI-compatible requests do not receive non-standard OpenRouter
+routing extensions.
+
+`OpenRouterRoutingConfig.plugins` exposes optional OpenRouter plugin activations:
+
+- **Web-search plugin** (`OpenRouterWebSearchPlugin`): instructs OpenRouter to retrieve web
+  search results before the model sees the prompt. Accepts `max_results: Option<u32>` and
+  `search_prompt: Option<String>`.
+- **File-reader plugin** (`OpenRouterFilePlugin`): instructs OpenRouter to read and attach
+  file contents before the prompt. No options yet.
+
+Plugins serialize as a `plugins` array on the wire, each entry carrying an `"id"` field
+(`"web"` or `"file"`) plus any plugin-specific options. The field is omitted entirely for
+non-OpenRouter providers and when no plugins are configured.
 
 ### Stateful Continuation Invariant
 


### PR DESCRIPTION
## What

Add optional plugin support to `OpenRouterRoutingConfig`: `OpenRouterWebSearchPlugin`, `OpenRouterFilePlugin`, and an `OpenRouterPluginConfig` wrapper. The Open Responses protocol driver serializes them as a `plugins` array on the wire, guarded by the same OpenRouter-only check already in place for `models`, `route`, and `provider`.

## Why

OpenRouter exposes provider-side plugins (web search, file reader) that let models retrieve external context before answering. Without typed config fields there's no safe way to activate them — callers would have to hand-craft untyped JSON. This is EVE-567 in the OpenRouter follow-up sequence.

## How

- `OpenRouterWebSearchPlugin`: `max_results: Option<u32>`, `search_prompt: Option<String>`
- `OpenRouterFilePlugin`: empty placeholder (no options yet)
- `OpenRouterPluginConfig`: bundles both; added as `plugins: Option<OpenRouterPluginConfig>` to `OpenRouterRoutingConfig`
- `is_empty()` on both `OpenRouterPluginConfig` and `OpenRouterRoutingConfig` updated to reflect plugins
- `plugins_to_wire()` helper in `openresponses_protocol.rs` converts the config to the wire format (`[{"id":"web",...}, {"id":"file"}]`)
- `ResponsesRequest` gains a `plugins: Option<Vec<Value>>` field; `None` fields are skipped in serialization
- All existing `OpenRouterRoutingConfig` struct initializations in tests updated with `..Default::default()`

## Risk

- Low
- New optional fields — all `None` by default; no existing behavior changes

## Security

- Reviewed: `TM-API`, `TM-LLM`
- `TM-API`: New fields are fully typed and validated by Rust's type system. The `plugins` field is only forwarded when `provider_type == DriverId::OpenRouter` — the same guard that protects `models`/`route`/`provider`. No free-form string injection path.
- `TM-LLM`: Plugin options (`max_results`, `search_prompt`) are typed fields, not raw prompt injections. `search_prompt` is an `Option<String>` passed verbatim to OpenRouter; callers are trusted internal code, not user input at system boundaries.

## Follow-ups

- Expose `plugins` on the agent/harness config API surface so users can activate web search from the UI (deferred — that's a server/API change, out of scope for this driver-level PR).

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)