### PR TITLE
feat(workspace): attach sessions to a shared workspace, re-key file I/O

### DIFF
--- a/crates/core/src/atoms/act.rs
+++ b/crates/core/src/atoms/act.rs
@@ -1463,6 +1463,19 @@ where
         } else {
             ToolContext::new(context.session_id)
         };
+        // Key file I/O by the attached workspace when known: pin the file store
+        // to the workspace so shared-workspace sessions address the workspace's
+        // files, not the session's own keyspace. For the default 1:1 case this
+        // is a transparent pass-through.
+        if let Some(workspace_id) = context.workspace_id {
+            tool_context.workspace_id = workspace_id;
+            if let Some(store) = tool_context.file_store.take() {
+                tool_context.file_store = Some(crate::traits::WorkspaceScopedFileSystem::wrap(
+                    store,
+                    workspace_id,
+                ));
+            }
+        }
         if let Some(ref store) = self.sqldb_store {
             tool_context.sqldb_store = Some(store.clone());
         }

--- a/crates/core/src/atoms/mod.rs
+++ b/crates/core/src/atoms/mod.rs
@@ -15,7 +15,7 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
 use crate::error::Result;
-use crate::typed_id::{ExecId, MessageId, SessionId, TurnId};
+use crate::typed_id::{ExecId, MessageId, SessionId, TurnId, WorkspaceId};
 
 // ============================================================================
 // Atom Modules
@@ -68,6 +68,14 @@ pub struct AtomContext {
     /// Execution ID - unique identifier for this specific atom execution
     /// Also serves as a version identifier for the execution
     pub exec_id: ExecId,
+
+    /// Workspace the session is attached to (the virtual-file-store key). `None`
+    /// means "derive from session id" (the default 1:1 case, and how older
+    /// durable records — serialized before this field existed — replay). The
+    /// runtime injects `Some(session.workspace_id)` so shared-workspace sessions
+    /// address the attached workspace's files. See specs/workspace.md.
+    #[serde(default)]
+    pub workspace_id: Option<WorkspaceId>,
 }
 
 impl AtomContext {
@@ -78,7 +86,14 @@ impl AtomContext {
             turn_id,
             input_message_id,
             exec_id: ExecId::new(),
+            workspace_id: None,
         }
+    }
+
+    /// Attach the workspace this session uses (the file-store key).
+    pub fn with_workspace_id(mut self, workspace_id: WorkspaceId) -> Self {
+        self.workspace_id = Some(workspace_id);
+        self
     }
 
     /// Create a new execution context for a new atom within the same turn
@@ -88,6 +103,7 @@ impl AtomContext {
             turn_id: self.turn_id,
             input_message_id: self.input_message_id,
             exec_id: ExecId::new(),
+            workspace_id: self.workspace_id,
         }
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -211,6 +211,7 @@ pub use traits::{
     SessionFileSystemFactoryContext, SessionMutator, SessionResourceRegistry, SessionSqlDbStoreRef,
     SessionStorageStore, SessionStore, SpawnClaimResult, StreamHeartbeater, StreamProgress,
     SubagentSpawnStore, ToolCallClaimResult, ToolContext, ToolExecutor, UserConnectionResolver,
+    WorkspaceScopedFileSystem,
 };
 pub use user_facing_error::{
     ErrorDisclosure, UserFacingError, UserFacingErrorContext, UserFacingErrorFields,

--- a/crates/core/src/runtime_context.rs
+++ b/crates/core/src/runtime_context.rs
@@ -208,6 +208,11 @@ async fn assemble_turn_context_with_mode(
     .await?;
 
     let resolved_locale = extract_locale_override(&messages).or_else(|| session.locale.clone());
+    // Pin system-prompt file reads (AGENTS.md, skills, …) to the session's
+    // workspace so an attached shared workspace's instructions are used. For the
+    // default 1:1 session this is a transparent pass-through.
+    let file_store = file_store
+        .map(|fs| crate::traits::WorkspaceScopedFileSystem::wrap(fs, session.workspace_id));
     // The resolved model is known here, so model-adaptive capabilities (e.g.
     // `auto_tool_search`) can pick the right mechanism during collection in
     // `build_runtime_agent` below.

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -10,7 +10,7 @@ use crate::harness::Harness;
 use crate::provider::DriverId;
 use crate::session_file::{FileInfo, FileStat, GrepMatch, InitialFile, SessionFile};
 use crate::tool_types::{ToolCall, ToolDefinition, ToolResult};
-use crate::typed_id::{AgentId, HarnessId, ImageId, ModelId, SessionId};
+use crate::typed_id::{AgentId, HarnessId, ImageId, ModelId, SessionId, WorkspaceId};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use std::any::{Any, TypeId};
@@ -440,6 +440,99 @@ pub trait SessionFileSystem: Send + Sync {
         self.write_file(session_id, &file.path, &file.content, &file.encoding)
             .await?;
         Ok(())
+    }
+}
+
+/// A [`SessionFileSystem`] decorator that pins every operation to a fixed
+/// workspace key, ignoring the per-call `session_id`.
+///
+/// Used to re-key file I/O for a session attached to a shared workspace (where
+/// `workspace.id != session.id`): wrap the session's file store once with the
+/// session's `workspace_id`, and all downstream capability/tool access then
+/// addresses the attached workspace rather than the session's own keyspace. For
+/// the default 1:1 session the key equals the session id, so the wrapper is a
+/// transparent pass-through. See `specs/workspace.md`.
+pub struct WorkspaceScopedFileSystem {
+    inner: Arc<dyn SessionFileSystem>,
+    key: SessionId,
+}
+
+impl WorkspaceScopedFileSystem {
+    /// Wrap `inner`, pinning all operations to `workspace_id`'s key.
+    pub fn wrap(
+        inner: Arc<dyn SessionFileSystem>,
+        workspace_id: WorkspaceId,
+    ) -> Arc<dyn SessionFileSystem> {
+        Arc::new(Self {
+            inner,
+            key: SessionId::from_uuid(workspace_id.uuid()),
+        })
+    }
+}
+
+#[async_trait]
+impl SessionFileSystem for WorkspaceScopedFileSystem {
+    async fn read_file(&self, _session_id: SessionId, path: &str) -> Result<Option<SessionFile>> {
+        self.inner.read_file(self.key, path).await
+    }
+    async fn write_file(
+        &self,
+        _session_id: SessionId,
+        path: &str,
+        content: &str,
+        encoding: &str,
+    ) -> Result<SessionFile> {
+        self.inner
+            .write_file(self.key, path, content, encoding)
+            .await
+    }
+    async fn write_file_if_content_matches(
+        &self,
+        _session_id: SessionId,
+        path: &str,
+        expected_content: &str,
+        expected_encoding: &str,
+        content: &str,
+        encoding: &str,
+    ) -> Result<Option<SessionFile>> {
+        self.inner
+            .write_file_if_content_matches(
+                self.key,
+                path,
+                expected_content,
+                expected_encoding,
+                content,
+                encoding,
+            )
+            .await
+    }
+    async fn delete_file(
+        &self,
+        _session_id: SessionId,
+        path: &str,
+        recursive: bool,
+    ) -> Result<bool> {
+        self.inner.delete_file(self.key, path, recursive).await
+    }
+    async fn list_directory(&self, _session_id: SessionId, path: &str) -> Result<Vec<FileInfo>> {
+        self.inner.list_directory(self.key, path).await
+    }
+    async fn stat_file(&self, _session_id: SessionId, path: &str) -> Result<Option<FileStat>> {
+        self.inner.stat_file(self.key, path).await
+    }
+    async fn grep_files(
+        &self,
+        _session_id: SessionId,
+        pattern: &str,
+        path_pattern: Option<&str>,
+    ) -> Result<Vec<GrepMatch>> {
+        self.inner.grep_files(self.key, pattern, path_pattern).await
+    }
+    async fn create_directory(&self, _session_id: SessionId, path: &str) -> Result<FileInfo> {
+        self.inner.create_directory(self.key, path).await
+    }
+    async fn seed_initial_file(&self, _session_id: SessionId, file: &InitialFile) -> Result<()> {
+        self.inner.seed_initial_file(self.key, file).await
     }
 }
 
@@ -1091,6 +1184,13 @@ impl PartialStreamStore for NoopPartialStreamStore {
 pub struct ToolContext {
     /// The session ID for the current execution
     pub session_id: SessionId,
+    /// The workspace this session is attached to — the key for the virtual
+    /// file store. For the default 1:1 session this equals
+    /// `WorkspaceId::from_uuid(session_id.uuid())`; for a shared workspace it
+    /// differs. File-system tools MUST key by this (via `workspace_fs_key`)
+    /// rather than `session_id` so shared-workspace sessions read/write the
+    /// attached workspace's files. See specs/workspace.md.
+    pub workspace_id: WorkspaceId,
 
     /// Optional file store for filesystem operations
     pub file_store: Option<Arc<dyn SessionFileSystem>>,
@@ -1191,10 +1291,25 @@ pub struct ToolContext {
 }
 
 impl ToolContext {
+    /// The virtual-file-store key for this execution, derived from the attached
+    /// workspace. Carried through the `SessionFileSystem` trait's `SessionId`
+    /// parameter (the store keys by `.uuid()`), so a shared-workspace session
+    /// addresses the workspace's files rather than its own session-id keyspace.
+    pub fn workspace_fs_key(&self) -> SessionId {
+        SessionId::from_uuid(self.workspace_id.uuid())
+    }
+
+    /// Override the attached workspace (default is the 1:1 session-derived id).
+    pub fn with_workspace_id(mut self, workspace_id: WorkspaceId) -> Self {
+        self.workspace_id = workspace_id;
+        self
+    }
+
     /// Create a new tool context with just a session ID
     pub fn new(session_id: SessionId) -> Self {
         Self {
             session_id,
+            workspace_id: WorkspaceId::from_uuid(session_id.uuid()),
             file_store: None,
             storage_store: None,
             image_store: None,
@@ -1231,6 +1346,7 @@ impl ToolContext {
     pub fn with_file_store(session_id: SessionId, file_store: Arc<dyn SessionFileSystem>) -> Self {
         Self {
             session_id,
+            workspace_id: WorkspaceId::from_uuid(session_id.uuid()),
             file_store: Some(file_store),
             storage_store: None,
             image_store: None,
@@ -1270,6 +1386,7 @@ impl ToolContext {
     ) -> Self {
         Self {
             session_id,
+            workspace_id: WorkspaceId::from_uuid(session_id.uuid()),
             file_store: None,
             storage_store: Some(storage_store),
             image_store: None,
@@ -1310,6 +1427,7 @@ impl ToolContext {
     ) -> Self {
         Self {
             session_id,
+            workspace_id: WorkspaceId::from_uuid(session_id.uuid()),
             file_store: Some(file_store),
             storage_store: Some(storage_store),
             sqldb_store: None,
@@ -1388,6 +1506,7 @@ impl ToolContext {
     ) -> Self {
         Self {
             session_id,
+            workspace_id: WorkspaceId::from_uuid(session_id.uuid()),
             file_store: None,
             storage_store: None,
             image_store: Some(image_store),

--- a/crates/runtime/src/host.rs
+++ b/crates/runtime/src/host.rs
@@ -381,7 +381,12 @@ async fn load_execution_capabilities<A: RuntimeHostAdapter>(
     let prompt_ctx = SystemPromptContext {
         session_id,
         locale: locale.or(session.locale.clone()),
-        file_store: Some(adapter.file_store()),
+        // Pin system-prompt file reads to the session's workspace (the default
+        // 1:1 case is a transparent pass-through).
+        file_store: Some(everruns_core::WorkspaceScopedFileSystem::wrap(
+            adapter.file_store(),
+            session.workspace_id,
+        )),
         model: None,
     };
     let collected = collect_capabilities_with_configs(

--- a/crates/runtime/src/runtime.rs
+++ b/crates/runtime/src/runtime.rs
@@ -1117,8 +1117,11 @@ async fn seed_runtime_initial_files(
         None => None,
     };
     let overlay = effective_overlay(&harness_chain, agent.as_ref(), session);
+    // Seed into the session's workspace (a shared workspace differs from the
+    // session id; the default 1:1 case is equal).
+    let seed_key = SessionId::from_uuid(session.workspace_id.uuid());
     for file in &overlay.initial_files {
-        file_store.seed_initial_file(session.id, file).await?;
+        file_store.seed_initial_file(seed_key, file).await?;
     }
     Ok(())
 }

--- a/crates/runtime/src/runtime.rs
+++ b/crates/runtime/src/runtime.rs
@@ -626,7 +626,8 @@ impl InProcessRuntime {
                 TurnAction::ExecuteInput => {
                     let ctx = state_machine.context();
                     let base_context =
-                        AtomContext::new(ctx.session_id, ctx.turn_id, ctx.input_message_id);
+                        AtomContext::new(ctx.session_id, ctx.turn_id, ctx.input_message_id)
+                            .with_workspace_id(session.workspace_id);
                     execute_input_activity(
                         self,
                         org_id,
@@ -640,7 +641,8 @@ impl InProcessRuntime {
                 TurnAction::ExecuteReason => {
                     let ctx = state_machine.context();
                     let base_context =
-                        AtomContext::new(ctx.session_id, ctx.turn_id, ctx.input_message_id);
+                        AtomContext::new(ctx.session_id, ctx.turn_id, ctx.input_message_id)
+                            .with_workspace_id(session.workspace_id);
                     let reason_result = execute_reason_activity(
                         self,
                         org_id,
@@ -674,7 +676,8 @@ impl InProcessRuntime {
                         .expect("ExecuteAct requires a prior ReasonResult");
                     let ctx = state_machine.context();
                     let base_context =
-                        AtomContext::new(ctx.session_id, ctx.turn_id, ctx.input_message_id);
+                        AtomContext::new(ctx.session_id, ctx.turn_id, ctx.input_message_id)
+                            .with_workspace_id(session.workspace_id);
                     execute_act_activity(
                         self,
                         ActInput {

--- a/crates/runtime/src/turn_strategy.rs
+++ b/crates/runtime/src/turn_strategy.rs
@@ -199,11 +199,14 @@ pub async fn plan_next_host_turn<A: RuntimeHostAdapter>(
             let summarized_state = state.with_reason_summary(&reason_result);
 
             if reason_result.has_tool_calls && reason_result.success {
-                let session_blueprint_id = adapter
+                let session = adapter
                     .session_store(state.org_id)
                     .get_session(state.session_id)
-                    .await?
-                    .and_then(|session| session.blueprint_id);
+                    .await?;
+                let session_blueprint_id = session.as_ref().and_then(|s| s.blueprint_id.clone());
+                // Attach the session's workspace so tool file I/O addresses the
+                // (possibly shared) workspace, not the session's own keyspace.
+                let workspace_id = session.as_ref().map(|s| s.workspace_id);
                 let plan = RuntimeActPlan {
                     input: ActInput {
                         org_id: Some(state.org_id),
@@ -212,6 +215,7 @@ pub async fn plan_next_host_turn<A: RuntimeHostAdapter>(
                             turn_id: state.turn_id.unwrap_or_default(),
                             input_message_id: state.input_message_id,
                             exec_id: ExecId::new(),
+                            workspace_id,
                         },
                         harness_id: state.harness_id,
                         agent_id: state.agent_id,

--- a/crates/server/src/api/ag_ui.rs
+++ b/crates/server/src/api/ag_ui.rs
@@ -762,6 +762,7 @@ async fn find_or_create_session(
                     app.owner_principal_id,
                     app.resolved_owner_user_id,
                     CreateSessionRequest {
+                        workspace_id: None,
                         harness_id: Some(app.harness_id),
                         harness_name: None,
                         agent_id: app.agent_id,

--- a/crates/server/src/api/fcp.rs
+++ b/crates/server/src/api/fcp.rs
@@ -668,6 +668,7 @@ async fn resolve_session(
             app.owner_principal_id,
             app.resolved_owner_user_id,
             CreateSessionRequest {
+                workspace_id: None,
                 harness_id: Some(app.harness_id),
                 harness_name: None,
                 agent_id: app.agent_id,

--- a/crates/server/src/api/sessions.rs
+++ b/crates/server/src/api/sessions.rs
@@ -18,7 +18,9 @@ use axum::{
     routing::{get, post},
 };
 use everruns_core::capability_types::AgentCapabilityConfig;
-use everruns_core::typed_id::{AgentId, AgentIdentityId, HarnessId, ModelId, SessionId};
+use everruns_core::typed_id::{
+    AgentId, AgentIdentityId, HarnessId, ModelId, SessionId, WorkspaceId,
+};
 use everruns_core::{
     BuiltInHarnessRole, Caller, PlatformDefinition, ResourceConfigResponse, ScopedMcpServers,
     Session, SessionContextReport, ToolDefinition, evaluate_policies_with,
@@ -120,6 +122,13 @@ pub struct CreateSessionRequest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schema(ignore)]
     pub parent_session_id: Option<SessionId>,
+    /// Attach this session to an existing Workspace (format: `wsp_<32-hex>`)
+    /// instead of auto-creating a default per-session workspace. The workspace
+    /// must exist in the caller's org and be `active`. Lets multiple sessions
+    /// share one working filesystem. Omit for the default 1:1 behavior.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schema(value_type = Option<String>, example = "wsp_01933b5a00007000800000000000001")]
+    pub workspace_id: Option<WorkspaceId>,
 }
 
 // Trust boundary (client-side tools deprecation rollout): the `tools` field

--- a/crates/server/src/api/slack_events.rs
+++ b/crates/server/src/api/slack_events.rs
@@ -638,6 +638,7 @@ async fn process_slack_message(
             );
             let title = build_session_title(slack_config, event);
             let req = CreateSessionRequest {
+                workspace_id: None,
                 harness_id: Some(app.harness_id),
                 harness_name: None,
                 agent_id: app.agent_id,
@@ -2413,6 +2414,7 @@ mod tests {
         use crate::storage::models::CreateSessionRow;
 
         let row = CreateSessionRow {
+            workspace_id: None,
             org_id: 1,
             app_id: None,
             harness_id: Some(everruns_core::typed_id::HarnessId::from_uuid(

--- a/crates/server/src/api/voice.rs
+++ b/crates/server/src/api/voice.rs
@@ -501,6 +501,7 @@ pub async fn create_agent_voice_session(
 > {
     ensure_voice_enabled(&state)?;
     let session = CreateSession(crate::api::sessions::CreateSessionRequest {
+        workspace_id: None,
         harness_id: None,
         harness_name: None,
         agent_id: Some(agent_id),

--- a/crates/server/src/api/workspaces.rs
+++ b/crates/server/src/api/workspaces.rs
@@ -130,13 +130,19 @@ pub async fn create_workspace(
             Json(ErrorResponse::new("name must be at most 255 characters")),
         ));
     }
-    let public_id = WorkspaceId::new().to_string();
+    // Pin the internal primary key to the public id's uuid so
+    // `id.hex == public_id suffix` holds universally (matching default
+    // per-session workspaces). This keeps `WorkspaceId::from_uuid(id)` equal to
+    // the public id, so callers — e.g. the `workspace_id` rendered on a session
+    // response — round-trip correctly.
+    let workspace_id = WorkspaceId::new();
+    let public_id = workspace_id.to_string();
     let row = state
         .db
         .create_workspace(
             org.org_id,
             CreateWorkspaceRow {
-                id: None,
+                id: Some(workspace_id.uuid()),
                 public_id,
                 name: name.to_string(),
                 description: req.description,

--- a/crates/server/src/direct_worker_adapters.rs
+++ b/crates/server/src/direct_worker_adapters.rs
@@ -3185,6 +3185,7 @@ mod tests {
         use crate::storage::models::CreateSessionRow;
 
         db.create_session(CreateSessionRow {
+            workspace_id: None,
             org_id,
             app_id: None,
             harness_id: Some(harness_id),
@@ -4006,6 +4007,7 @@ mod tests {
         let row = adapters
             .db
             .create_session(CreateSessionRow {
+                workspace_id: None,
                 org_id: everruns_core::DEFAULT_ORG_ID,
                 app_id: None,
                 agent_id: Some(AgentId::from_uuid(agent_id)),

--- a/crates/server/src/domains/apps/commands.rs
+++ b/crates/server/src/domains/apps/commands.rs
@@ -1201,6 +1201,7 @@ async fn find_or_create_invocation_session(
             app.owner_principal_id,
             app.resolved_owner_user_id,
             CreateSessionRequest {
+                workspace_id: None,
                 harness_id: Some(app.harness_id),
                 harness_name: None,
                 agent_id: app.agent_id,

--- a/crates/server/src/domains/budgets/tests.rs
+++ b/crates/server/src/domains/budgets/tests.rs
@@ -40,6 +40,7 @@ async fn create_session_with_owner_and_tags(
     tags: Vec<String>,
 ) -> SessionRow {
     db.create_session(CreateSessionRow {
+        workspace_id: None,
         org_id,
         app_id: None,
         harness_id: None,

--- a/crates/server/src/domains/evals/runner.rs
+++ b/crates/server/src/domains/evals/runner.rs
@@ -291,6 +291,7 @@ async fn execute_case_inner(
             agent_id,
             agent_id.map(everruns_core::typed_id::AgentId::from_uuid),
             CreateSessionRequest {
+                workspace_id: None,
                 harness_id: None, // Already resolved
                 harness_name: None,
                 agent_id: None,

--- a/crates/server/src/domains/messages/service.rs
+++ b/crates/server/src/domains/messages/service.rs
@@ -437,6 +437,7 @@ mod tests {
         // max_active_turns = 1 so 1 active turn exactly hits the cap.
         let session = db
             .create_session(crate::storage::models::CreateSessionRow {
+                workspace_id: None,
                 org_id: 1,
                 harness_id: None,
                 app_id: None,

--- a/crates/server/src/domains/notifications/service.rs
+++ b/crates/server/src/domains/notifications/service.rs
@@ -267,6 +267,7 @@ mod tests {
 
         let session = db
             .create_session(CreateSessionRow {
+                workspace_id: None,
                 org_id: 1,
                 app_id: None,
                 harness_id: None,

--- a/crates/server/src/domains/observers/worker.rs
+++ b/crates/server/src/domains/observers/worker.rs
@@ -210,6 +210,7 @@ mod tests {
 
     fn session_row(agent: AgentId, harness: HarnessId, tags: Vec<String>) -> CreateSessionRow {
         CreateSessionRow {
+            workspace_id: None,
             org_id: ORG,
             app_id: None,
             harness_id: Some(harness),

--- a/crates/server/src/domains/session_files/commands.rs
+++ b/crates/server/src/domains/session_files/commands.rs
@@ -93,16 +93,16 @@ impl Command for ListWorkspaceFiles {
 
     async fn execute(self, ctx: &Ctx) -> Result<GetResponse, CommandError> {
         let session_id = q::parse_session_id(&self.session_id)?;
-        q::verify_session(ctx, session_id).await?;
+        let workspace_key = q::verify_session(ctx, session_id).await?;
 
         let files = if self.recursive {
             q::service(ctx)
-                .list_all(session_id.uuid())
+                .list_all(workspace_key)
                 .await
                 .map_err(q::classify_storage)?
         } else {
             q::service(ctx)
-                .list_directory(session_id.uuid(), "/")
+                .list_directory(workspace_key, "/")
                 .await
                 .map_err(q::classify_storage)?
         };
@@ -140,10 +140,10 @@ impl Command for GetWorkspaceFile {
 
     async fn execute(self, ctx: &Ctx) -> Result<GetResponse, CommandError> {
         let session_id = q::parse_session_id(&self.session_id)?;
-        q::verify_session(ctx, session_id).await?;
+        let workspace_key = q::verify_session(ctx, session_id).await?;
         let path = q::normalize_path(&self.path);
         let stat = q::service(ctx)
-            .stat(session_id.uuid(), &path)
+            .stat(workspace_key, &path)
             .await
             .map_err(q::classify_storage)?;
 
@@ -151,12 +151,12 @@ impl Command for GetWorkspaceFile {
             Some(s) if s.is_directory => {
                 let files = if self.recursive {
                     q::service(ctx)
-                        .list_all(session_id.uuid())
+                        .list_all(workspace_key)
                         .await
                         .map_err(q::classify_storage)?
                 } else {
                     q::service(ctx)
-                        .list_directory(session_id.uuid(), &path)
+                        .list_directory(workspace_key, &path)
                         .await
                         .map_err(q::classify_storage)?
                 };
@@ -164,7 +164,7 @@ impl Command for GetWorkspaceFile {
             }
             Some(_) => {
                 let file = q::service(ctx)
-                    .read_file(session_id.uuid(), &path)
+                    .read_file(workspace_key, &path)
                     .await
                     .map_err(q::classify_storage)?
                     .ok_or_else(|| CommandError::not_found("File"))?;
@@ -206,7 +206,7 @@ impl Command for CreateWorkspaceFile {
 
     async fn execute(self, ctx: &Ctx) -> Result<SessionFile, CommandError> {
         let session_id = q::parse_session_id(&self.session_id)?;
-        q::verify_session(ctx, session_id).await?;
+        let workspace_key = q::verify_session(ctx, session_id).await?;
         let path = q::normalize_path(&self.path);
         if q::is_reserved_path(&path) {
             return Err(CommandError::bad_request(
@@ -216,7 +216,7 @@ impl Command for CreateWorkspaceFile {
 
         let file = if self.req.is_directory.unwrap_or(false) {
             let dir = q::service(ctx)
-                .create_directory(session_id.uuid(), CreateDirectoryInput { path })
+                .create_directory(workspace_key, CreateDirectoryInput { path })
                 .await
                 .map_err(|e| map_create_error(e, true))?;
             SessionFile {
@@ -235,7 +235,7 @@ impl Command for CreateWorkspaceFile {
         } else {
             q::service(ctx)
                 .create_file(
-                    session_id.uuid(),
+                    workspace_key,
                     CreateFileInput {
                         path,
                         content: self.req.content,
@@ -299,7 +299,7 @@ impl Command for UpdateWorkspaceFile {
 
     async fn execute(self, ctx: &Ctx) -> Result<SessionFile, CommandError> {
         let session_id = q::parse_session_id(&self.session_id)?;
-        q::verify_session(ctx, session_id).await?;
+        let workspace_key = q::verify_session(ctx, session_id).await?;
         let path = q::normalize_path(&self.path);
         if q::is_reserved_path(&path) {
             return Err(CommandError::bad_request(
@@ -309,7 +309,7 @@ impl Command for UpdateWorkspaceFile {
 
         let file = q::service(ctx)
             .update_file(
-                session_id.uuid(),
+                workspace_key,
                 &path,
                 UpdateFileInput {
                     content: self.req.content,
@@ -371,10 +371,10 @@ impl Command for DeleteWorkspaceFile {
 
     async fn execute(self, ctx: &Ctx) -> Result<DeleteResponse, CommandError> {
         let session_id = q::parse_session_id(&self.session_id)?;
-        q::verify_session(ctx, session_id).await?;
+        let workspace_key = q::verify_session(ctx, session_id).await?;
         let path = q::normalize_path(&self.path);
         let deleted = q::service(ctx)
-            .delete(session_id.uuid(), &path, self.recursive)
+            .delete(workspace_key, &path, self.recursive)
             .await
             .map_err(map_delete_error)?;
         Ok(DeleteResponse { deleted })
@@ -410,10 +410,10 @@ impl Command for MoveWorkspaceFile {
 
     async fn execute(self, ctx: &Ctx) -> Result<SessionFile, CommandError> {
         let session_id = q::parse_session_id(&self.session_id)?;
-        q::verify_session(ctx, session_id).await?;
+        let workspace_key = q::verify_session(ctx, session_id).await?;
         q::service(ctx)
             .move_file(
-                session_id.uuid(),
+                workspace_key,
                 MoveFileInput {
                     src_path: self.req.src_path,
                     dst_path: self.req.dst_path,
@@ -454,10 +454,10 @@ impl Command for CopyWorkspaceFile {
 
     async fn execute(self, ctx: &Ctx) -> Result<SessionFile, CommandError> {
         let session_id = q::parse_session_id(&self.session_id)?;
-        q::verify_session(ctx, session_id).await?;
+        let workspace_key = q::verify_session(ctx, session_id).await?;
         q::service(ctx)
             .copy_file(
-                session_id.uuid(),
+                workspace_key,
                 CopyFileInput {
                     src_path: self.req.src_path,
                     dst_path: self.req.dst_path,
@@ -502,10 +502,10 @@ impl Command for GrepWorkspaceFiles {
 
     async fn execute(self, ctx: &Ctx) -> Result<Vec<GrepResult>, CommandError> {
         let session_id = q::parse_session_id(&self.session_id)?;
-        q::verify_session(ctx, session_id).await?;
+        let workspace_key = q::verify_session(ctx, session_id).await?;
         q::service(ctx)
             .grep(
-                session_id.uuid(),
+                workspace_key,
                 GrepInput {
                     pattern: self.req.pattern,
                     path_pattern: self.req.path_pattern,
@@ -556,10 +556,10 @@ impl Command for StatWorkspaceFile {
 
     async fn execute(self, ctx: &Ctx) -> Result<FileStat, CommandError> {
         let session_id = q::parse_session_id(&self.session_id)?;
-        q::verify_session(ctx, session_id).await?;
+        let workspace_key = q::verify_session(ctx, session_id).await?;
         let path = q::normalize_path(&self.req.path);
         q::service(ctx)
-            .stat(session_id.uuid(), &path)
+            .stat(workspace_key, &path)
             .await
             .map_err(q::classify_storage)?
             .ok_or_else(|| CommandError::not_found("Path"))

--- a/crates/server/src/domains/session_files/queries.rs
+++ b/crates/server/src/domains/session_files/queries.rs
@@ -2,6 +2,7 @@ use crate::domains::common::{CommandError, Ctx};
 use crate::domains::session_files::WorkspaceFileService;
 use everruns_core::typed_id::SessionId;
 use std::sync::Arc;
+use uuid::Uuid;
 
 const WORKSPACE_PREFIX: &str = "/workspace";
 
@@ -17,13 +18,18 @@ pub fn parse_session_id(session_id: &str) -> Result<SessionId, CommandError> {
         .map_err(|e| CommandError::bad_request(format!("Invalid session ID: {e}")))
 }
 
-pub async fn verify_session(ctx: &Ctx, session_id: SessionId) -> Result<(), CommandError> {
-    ctx.db
+/// Verify the session exists in the caller's org and return the internal id of
+/// the workspace it is attached to — i.e. the file-store key. For the default
+/// 1:1 session this equals the session uuid; for a shared workspace it differs,
+/// so file operations must key by this value rather than `session_id.uuid()`.
+pub async fn verify_session(ctx: &Ctx, session_id: SessionId) -> Result<Uuid, CommandError> {
+    let row = ctx
+        .db
         .get_session(ctx.org_id(), session_id)
         .await
         .map_err(classify_storage)?
         .ok_or_else(|| CommandError::not_found("Session"))?;
-    Ok(())
+    Ok(row.workspace_id)
 }
 
 pub fn normalize_path(path: &str) -> String {

--- a/crates/server/src/domains/session_sandbox/commands.rs
+++ b/crates/server/src/domains/session_sandbox/commands.rs
@@ -400,6 +400,7 @@ mod tests {
         .unwrap();
 
         db.create_session(CreateSessionRow {
+            workspace_id: None,
             org_id: DEFAULT_ORG_ID,
             app_id: None,
             harness_id: Some(harness_id),

--- a/crates/server/src/domains/session_sandbox/service.rs
+++ b/crates/server/src/domains/session_sandbox/service.rs
@@ -587,6 +587,7 @@ mod tests {
 
         let session = db
             .create_session(CreateSessionRow {
+                workspace_id: None,
                 org_id: DEFAULT_ORG_ID,
                 app_id: None,
                 harness_id: Some(harness_id),
@@ -644,6 +645,7 @@ mod tests {
         .unwrap();
         let session = db
             .create_session(CreateSessionRow {
+                workspace_id: None,
                 org_id: DEFAULT_ORG_ID,
                 app_id: None,
                 harness_id: Some(harness_id),
@@ -703,6 +705,7 @@ mod tests {
 
         let session = db
             .create_session(CreateSessionRow {
+                workspace_id: None,
                 org_id: DEFAULT_ORG_ID,
                 app_id: None,
                 harness_id: Some(harness_id),

--- a/crates/server/src/domains/session_tasks/commands.rs
+++ b/crates/server/src/domains/session_tasks/commands.rs
@@ -354,6 +354,7 @@ mod tests {
     /// Create a session in the in-memory database, returning its ID.
     async fn create_session(db: &Arc<StorageBackend>) -> everruns_core::SessionId {
         db.create_session(CreateSessionRow {
+            workspace_id: None,
             org_id: DEFAULT_ORG_ID,
             app_id: None,
             harness_id: None,
@@ -680,6 +681,7 @@ mod tests {
         let session_network_access = NetworkAccessList::allow_only(["b.example.com"]);
         let session_id = db
             .create_session(CreateSessionRow {
+                workspace_id: None,
                 org_id: DEFAULT_ORG_ID,
                 app_id: None,
                 harness_id: Some(harness.id),

--- a/crates/server/src/domains/sessions/commands.rs
+++ b/crates/server/src/domains/sessions/commands.rs
@@ -152,6 +152,17 @@ impl Command for CreateSession {
                 .map_err(limit_validation_error)?;
         }
 
+        // Attaching a session to an existing workspace grants the session (and
+        // its agent) read/write access to that workspace's files, so require
+        // WORKSPACE_MANAGE on the caller — SESSION_MANAGE alone must not be a
+        // path to a workspace the caller cannot otherwise manage. The service
+        // additionally validates the target exists, is active, and is in-org.
+        if req.workspace_id.is_some() {
+            crate::domains::workspaces::WORKSPACE_MANAGE
+                .evaluate_with(ctx.permission_resolver.as_ref(), &ctx.caller)
+                .map_err(|e| CommandError::forbidden(e.to_string()))?;
+        }
+
         q::session_service(ctx)?
             .create(
                 &ctx.caller,

--- a/crates/server/src/domains/sessions/service.rs
+++ b/crates/server/src/domains/sessions/service.rs
@@ -388,6 +388,22 @@ impl SessionService {
                     ))
                     .into());
                 }
+                // The session's rendered workspace_id is derived from the
+                // internal id, so it only round-trips when id.hex == public_id
+                // suffix. New workspaces pin this at creation, but a workspace
+                // created before that invariant (random internal PK) would make
+                // the session report a workspace_id that 404s against the
+                // workspace API. Reject it with actionable guidance rather than
+                // silently misrendering.
+                if everruns_core::WorkspaceId::from_uuid(workspace.id).to_string()
+                    != workspace.public_id
+                {
+                    return Err(BadRequestError::new(format!(
+                        "Workspace {public_id} predates the id/public-id invariant \
+                         and cannot be attached; recreate it via POST /v1/workspaces"
+                    ))
+                    .into());
+                }
                 Some(workspace.id)
             }
             None => None,

--- a/crates/server/src/domains/sessions/service.rs
+++ b/crates/server/src/domains/sessions/service.rs
@@ -371,6 +371,28 @@ impl SessionService {
             }
         };
 
+        // Optional attach to an existing shared workspace. When absent, the
+        // storage layer auto-creates a default 1:1 workspace (see
+        // specs/workspace.md, "Default Workspace per Session").
+        let workspace_id = match req.workspace_id {
+            Some(public_id) => {
+                let workspace = self
+                    .db
+                    .get_workspace(org_id, public_id)
+                    .await?
+                    .ok_or_else(|| ResourceNotFoundError::new("Workspace"))?;
+                if workspace.status != "active" {
+                    return Err(BadRequestError::new(format!(
+                        "Workspace {public_id} is {} and cannot accept new sessions",
+                        workspace.status
+                    ))
+                    .into());
+                }
+                Some(workspace.id)
+            }
+            None => None,
+        };
+
         let input = CreateSessionRow {
             org_id,
             app_id,
@@ -397,6 +419,7 @@ impl SessionService {
             blueprint_id: None,
             blueprint_config: None,
             parent_session_id: req.parent_session_id,
+            workspace_id,
         };
         let row = self.db.create_session(input).await?;
         let row = if let Some(version) = resolved_agent_version.as_ref() {
@@ -516,6 +539,7 @@ impl SessionService {
             .await?;
 
         let input = CreateSessionRow {
+            workspace_id: None,
             org_id,
             app_id: None,
             harness_id: Some(harness_id),
@@ -1142,6 +1166,7 @@ impl SessionService {
         // Create a new chat session
         let harness_id_typed = HarnessId::from_uuid(harness_id);
         let input = CreateSessionRow {
+            workspace_id: None,
             org_id,
             app_id: None,
             harness_id: Some(harness_id_typed),
@@ -1880,6 +1905,7 @@ mod tests {
         model_id: Option<ModelId>,
     ) -> CreateSessionRequest {
         CreateSessionRequest {
+            workspace_id: None,
             harness_id: Some(harness_id),
             harness_name: None,
             agent_id,
@@ -2481,6 +2507,7 @@ mod tests {
 
         let session_row = db
             .create_session(CreateSessionRow {
+                workspace_id: None,
                 org_id: caller.org_id,
                 app_id: None,
                 harness_id: Some(other_harness.id),
@@ -2746,6 +2773,7 @@ mod tests {
 
         let session_row = db
             .create_session(CreateSessionRow {
+                workspace_id: None,
                 org_id: caller.org_id,
                 app_id: None,
                 harness_id: None,

--- a/crates/server/src/domains/sessions/service.rs
+++ b/crates/server/src/domains/sessions/service.rs
@@ -447,13 +447,16 @@ impl SessionService {
         // Override agent_id with public_id (DB stores internal UUID as FK)
         session.agent_id = agent_public_id;
 
-        // Apply capability mounts (harness + agent + session capabilities)
+        // Apply capability mounts (harness + agent + session capabilities) and
+        // seed initial files into the session's workspace. Key by workspace_id
+        // (not session id) so an attached shared workspace receives them; for
+        // the default 1:1 session these are equal.
         self.apply_capability_mounts(
             org_id,
             harness_id.uuid(),
             agent_id.map(|a| a.uuid()),
             &session_capabilities,
-            session.id.uuid(),
+            session.workspace_id.uuid(),
         )
         .await?;
 
@@ -462,7 +465,7 @@ impl SessionService {
             harness_id.uuid(),
             agent_id.map(|a| a.uuid()),
             &req.initial_files,
-            session.id.uuid(),
+            session.workspace_id.uuid(),
         )
         .await?;
 

--- a/crates/server/src/grpc_service/worker_service_impl.rs
+++ b/crates/server/src/grpc_service/worker_service_impl.rs
@@ -3719,6 +3719,7 @@ impl WorkerService for WorkerServiceImpl {
             .and_then(|s| serde_json::from_str(s).ok());
 
         let create_req = crate::api::sessions::CreateSessionRequest {
+            workspace_id: None,
             harness_id: Some(everruns_core::HarnessId::from_uuid(harness_id)),
             harness_name: None,
             agent_id: agent_public_id,

--- a/crates/server/src/slack_delivery.rs
+++ b/crates/server/src/slack_delivery.rs
@@ -1393,6 +1393,7 @@ mod tests {
 
             let session = db
                 .create_session(CreateSessionRow {
+                    workspace_id: None,
                     org_id,
                     app_id,
                     harness_id: Some(HarnessId::from_uuid(uuid::Uuid::nil())),

--- a/crates/server/src/storage/leased_resource_store.rs
+++ b/crates/server/src/storage/leased_resource_store.rs
@@ -271,6 +271,7 @@ mod tests {
 
     async fn create_test_session(db: &StorageBackend) -> SessionId {
         db.create_session(CreateSessionRow {
+            workspace_id: None,
             org_id: DEFAULT_ORG_ID,
             app_id: None,
             harness_id: None,

--- a/crates/server/src/storage/memory/sessions.rs
+++ b/crates/server/src/storage/memory/sessions.rs
@@ -17,34 +17,38 @@ impl InMemoryDatabase {
         let now = Self::now();
         let id = SessionId::new();
 
-        // Auto-create a default workspace whose UUID equals the session id —
-        // matches the Postgres path and the migration's equality invariant
-        // (see specs/workspace.md, Decision 3).
+        // Attach to an existing workspace when requested (validated by the
+        // service before reaching storage); otherwise auto-create a default
+        // workspace whose UUID equals the session id — matches the Postgres
+        // path and the migration's equality invariant (see specs/workspace.md).
         let session_uuid = id.uuid();
-        let ws_id_hex = session_uuid.simple().to_string();
-        let ws_name = format!("session-{ws_id_hex}");
-        let public_id = format!("wsp_{ws_id_hex}");
-        self.workspaces.write().insert(
-            session_uuid,
-            crate::storage::models::WorkspaceRow {
-                id: session_uuid,
-                org_id: input.org_id,
-                public_id,
-                name: ws_name.clone(),
-                description: Some(format!("Default workspace for session {session_uuid}")),
-                owner_principal_id: None,
-                resolved_owner_user_id: input.resolved_owner_user_id,
-                status: "active".to_string(),
-                created_at: now,
-                updated_at: now,
-                archived_at: None,
-                deleted_at: None,
-            },
-        );
+        let workspace_id = input.workspace_id.unwrap_or(session_uuid);
+        if input.workspace_id.is_none() {
+            let ws_id_hex = session_uuid.simple().to_string();
+            let ws_name = format!("session-{ws_id_hex}");
+            let public_id = format!("wsp_{ws_id_hex}");
+            self.workspaces.write().insert(
+                session_uuid,
+                crate::storage::models::WorkspaceRow {
+                    id: session_uuid,
+                    org_id: input.org_id,
+                    public_id,
+                    name: ws_name.clone(),
+                    description: Some(format!("Default workspace for session {session_uuid}")),
+                    owner_principal_id: None,
+                    resolved_owner_user_id: input.resolved_owner_user_id,
+                    status: "active".to_string(),
+                    created_at: now,
+                    updated_at: now,
+                    archived_at: None,
+                    deleted_at: None,
+                },
+            );
+        }
         let row = SessionRow {
             id,
             org_id: input.org_id,
-            workspace_id: session_uuid,
+            workspace_id,
             app_id: input.app_id,
             harness_id: input.harness_id,
             agent_id: input.agent_id,

--- a/crates/server/src/storage/memory/tests.rs
+++ b/crates/server/src/storage/memory/tests.rs
@@ -128,6 +128,7 @@ async fn test_create_and_list_sessions() {
 
     let session = db
         .create_session(CreateSessionRow {
+            workspace_id: None,
             org_id: DEFAULT_ORG_ID,
             app_id: None,
             harness_id: None,
@@ -210,6 +211,7 @@ async fn test_session_aggregate_stats_by_agent_and_harness() {
 
     let session = db
         .create_session(CreateSessionRow {
+            workspace_id: None,
             org_id: DEFAULT_ORG_ID,
             app_id: None,
             harness_id: Some(harness.id),
@@ -307,6 +309,7 @@ async fn test_session_updated_at() {
     // Create session - updated_at should equal created_at
     let session = db
         .create_session(CreateSessionRow {
+            workspace_id: None,
             org_id: DEFAULT_ORG_ID,
             app_id: None,
             harness_id: None,
@@ -386,6 +389,7 @@ async fn test_events_sequence() {
 
     let session = db
         .create_session(CreateSessionRow {
+            workspace_id: None,
             org_id: DEFAULT_ORG_ID,
             app_id: None,
             harness_id: None,
@@ -479,6 +483,7 @@ async fn test_session_connection_resolution_uses_resolved_owner_user() {
 
     let session = db
         .create_session(CreateSessionRow {
+            workspace_id: None,
             org_id: DEFAULT_ORG_ID,
             app_id: None,
             harness_id: None,
@@ -625,6 +630,7 @@ async fn test_unpin_session_is_scoped_by_org() {
 
     let session = db
         .create_session(CreateSessionRow {
+            workspace_id: None,
             org_id: DEFAULT_ORG_ID,
             app_id: None,
             harness_id: None,
@@ -699,6 +705,7 @@ async fn create_session_with_events(db: &InMemoryDatabase) -> SessionId {
 
     let session = db
         .create_session(CreateSessionRow {
+            workspace_id: None,
             org_id: DEFAULT_ORG_ID,
             app_id: None,
             harness_id: None,
@@ -1408,6 +1415,7 @@ async fn test_list_events_empty_session_with_limit() {
 
     let session = db
         .create_session(CreateSessionRow {
+            workspace_id: None,
             org_id: DEFAULT_ORG_ID,
             app_id: None,
             harness_id: None,
@@ -1470,6 +1478,7 @@ async fn test_sessions_pagination() {
     // Create 15 sessions
     for i in 0..15 {
         db.create_session(CreateSessionRow {
+            workspace_id: None,
             org_id: DEFAULT_ORG_ID,
             app_id: None,
             harness_id: None,
@@ -1571,6 +1580,7 @@ async fn test_sessions_pagination_ordering() {
     // Create sessions with sequential titles
     for i in 1..=5 {
         db.create_session(CreateSessionRow {
+            workspace_id: None,
             org_id: DEFAULT_ORG_ID,
             app_id: None,
             harness_id: None,
@@ -2301,6 +2311,7 @@ async fn test_search_sessions_by_title() {
     let agent = create_test_agent(&db, "Agent", None).await;
 
     db.create_session(CreateSessionRow {
+        workspace_id: None,
         org_id: DEFAULT_ORG_ID,
         app_id: None,
         harness_id: None,
@@ -2328,6 +2339,7 @@ async fn test_search_sessions_by_title() {
     .unwrap();
 
     db.create_session(CreateSessionRow {
+        workspace_id: None,
         org_id: DEFAULT_ORG_ID,
         app_id: None,
         harness_id: None,
@@ -2371,6 +2383,7 @@ async fn test_search_sessions_with_agent_filter() {
     let agent2 = create_test_agent(&db, "Agent2", None).await;
 
     db.create_session(CreateSessionRow {
+        workspace_id: None,
         org_id: DEFAULT_ORG_ID,
         app_id: None,
         harness_id: None,
@@ -2398,6 +2411,7 @@ async fn test_search_sessions_with_agent_filter() {
     .unwrap();
 
     db.create_session(CreateSessionRow {
+        workspace_id: None,
         org_id: DEFAULT_ORG_ID,
         app_id: None,
         harness_id: None,
@@ -2626,6 +2640,7 @@ async fn create_session_with_content_events(db: &InMemoryDatabase) -> SessionId 
 
     let session = db
         .create_session(CreateSessionRow {
+            workspace_id: None,
             org_id: DEFAULT_ORG_ID,
             app_id: None,
             harness_id: None,
@@ -2817,6 +2832,7 @@ async fn test_list_sessions_waiting_tool_results_before() {
     // Create 3 sessions: one waiting+old, one waiting+recent, one active+old
     let s1 = db
         .create_session(CreateSessionRow {
+            workspace_id: None,
             org_id: DEFAULT_ORG_ID,
             app_id: None,
             harness_id: None,
@@ -2844,6 +2860,7 @@ async fn test_list_sessions_waiting_tool_results_before() {
         .unwrap();
     let s2 = db
         .create_session(CreateSessionRow {
+            workspace_id: None,
             org_id: DEFAULT_ORG_ID,
             app_id: None,
             harness_id: None,
@@ -2871,6 +2888,7 @@ async fn test_list_sessions_waiting_tool_results_before() {
         .unwrap();
     let s3 = db
         .create_session(CreateSessionRow {
+            workspace_id: None,
             org_id: DEFAULT_ORG_ID,
             app_id: None,
             harness_id: None,
@@ -2964,6 +2982,7 @@ async fn test_session_system_prompt_and_initial_files_round_trip() {
 
     let session = db
         .create_session(CreateSessionRow {
+            workspace_id: None,
             org_id: DEFAULT_ORG_ID,
             app_id: None,
             harness_id: None,
@@ -3015,6 +3034,7 @@ async fn test_session_system_prompt_defaults_to_none() {
 
     let session = db
         .create_session(CreateSessionRow {
+            workspace_id: None,
             org_id: DEFAULT_ORG_ID,
             app_id: None,
             harness_id: None,

--- a/crates/server/src/storage/models.rs
+++ b/crates/server/src/storage/models.rs
@@ -697,6 +697,11 @@ pub struct CreateSessionRow {
     pub blueprint_config: Option<serde_json::Value>,
     /// Parent session ID for subagent nesting guard (set by spawn_subagent).
     pub parent_session_id: Option<everruns_core::SessionId>,
+    /// Internal id of an existing workspace to attach this session to. When
+    /// `None`, `create_session` auto-creates a default 1:1 workspace whose id
+    /// equals the new session id (the equality invariant). When `Some`, the
+    /// session attaches to that workspace and no new workspace is created.
+    pub workspace_id: Option<Uuid>,
 }
 
 #[derive(Debug, Clone, Default)]

--- a/crates/server/src/storage/repositories/sessions.rs
+++ b/crates/server/src/storage/repositories/sessions.rs
@@ -17,42 +17,44 @@ impl Database {
     // ============================================
 
     pub async fn create_session(&self, input: CreateSessionRow) -> Result<SessionRow> {
-        // Auto-create a default workspace for this session in the same
-        // transaction. We pre-generate the session UUID so the workspace's
-        // primary key equals the session's id — that invariant lets all
-        // existing app code that uses session.id as the file-store key keep
-        // working unchanged. See specs/workspace.md, Decision 3.
         let session_id = uuid::Uuid::now_v7();
+        // Attach to an existing workspace when requested; otherwise auto-create
+        // a default workspace whose primary key equals the session's id. That
+        // equality invariant lets existing app code that uses session.id as the
+        // file-store key keep working unchanged. See specs/workspace.md.
+        let workspace_id = input.workspace_id.unwrap_or(session_id);
 
         let mut tx = self.pool.begin().await?;
 
-        sqlx::query(
-            r#"
-            INSERT INTO workspaces (
-                id, org_id, public_id, name, description, status, created_at, updated_at
+        if input.workspace_id.is_none() {
+            sqlx::query(
+                r#"
+                INSERT INTO workspaces (
+                    id, org_id, public_id, name, description, status, created_at, updated_at
+                )
+                VALUES (
+                    $1, $2,
+                    'wsp_' || replace($1::text, '-', ''),
+                    -- Use the full 32-hex so per-org name uniqueness holds under
+                    -- bursty creation (UUIDv7 prefixes repeat in short windows).
+                    'session-' || replace($1::text, '-', ''),
+                    'Default workspace for session ' || $1::text,
+                    'active',
+                    NOW(),
+                    NOW()
+                )
+                "#,
             )
-            VALUES (
-                $1, $2,
-                'wsp_' || replace($1::text, '-', ''),
-                -- Use the full 32-hex so per-org name uniqueness holds under
-                -- bursty creation (UUIDv7 prefixes repeat in short windows).
-                'session-' || replace($1::text, '-', ''),
-                'Default workspace for session ' || $1::text,
-                'active',
-                NOW(),
-                NOW()
-            )
-            "#,
-        )
-        .bind(session_id)
-        .bind(input.org_id)
-        .execute(&mut *tx)
-        .await?;
+            .bind(session_id)
+            .bind(input.org_id)
+            .execute(&mut *tx)
+            .await?;
+        }
 
         let row = sqlx::query_as::<_, SessionRow>(
             r#"
             INSERT INTO sessions (id, org_id, app_id, harness_id, agent_id, agent_identity_id, owner_principal_id, resolved_owner_user_id, title, locale, tags, model_id, capabilities, tools, mcp_servers, system_prompt, initial_files, hints, network_access, max_iterations, blueprint_id, blueprint_config, parent_session_id, workspace_id, status)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $1, 'started')
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, 'started')
             RETURNING id, org_id, workspace_id, app_id, harness_id, agent_id, agent_version_id, agent_config_hash, agent_identity_id, owner_principal_id, resolved_owner_user_id, title, locale, tags, model_id, capabilities, tools, mcp_servers, system_prompt, initial_files, hints, network_access, max_iterations, status, created_at, updated_at, started_at, finished_at,
                       total_input_tokens, total_output_tokens, total_cache_read_tokens, total_cache_creation_tokens, total_actual_cost_usd, total_estimated_cost_usd, total_cost_usd, parent_session_id,
                       blueprint_id, blueprint_config
@@ -81,6 +83,7 @@ impl Database {
         .bind(&input.blueprint_id)
         .bind(&input.blueprint_config)
         .bind(input.parent_session_id.map(|id| id.uuid()))
+        .bind(workspace_id)
         .fetch_one(&mut *tx)
         .await?;
 

--- a/crates/server/tests/org_isolation_test.rs
+++ b/crates/server/tests/org_isolation_test.rs
@@ -938,6 +938,7 @@ async fn create_second_org_backend(backend: &StorageBackend) -> i64 {
 async fn create_session_in_org(backend: &StorageBackend, org_id: i64) -> everruns_core::SessionId {
     let row = backend
         .create_session(CreateSessionRow {
+            workspace_id: None,
             org_id,
             app_id: None,
             harness_id: None,

--- a/crates/server/tests/repository_integration_test.rs
+++ b/crates/server/tests/repository_integration_test.rs
@@ -422,6 +422,7 @@ async fn test_session_connection_resolution_uses_resolved_owner_user() {
     let owner_principal_id = create_test_user_principal(&backend, TEST_ORG_ID, owner.id).await;
     let session = backend
         .create_session(CreateSessionRow {
+            workspace_id: None,
             org_id: TEST_ORG_ID,
             app_id: None,
             harness_id: None,
@@ -647,6 +648,7 @@ async fn test_session_crud() {
         .expect("Failed to create app");
     let session = backend
         .create_session(CreateSessionRow {
+            workspace_id: None,
             org_id: TEST_ORG_ID,
             app_id: Some(app.id),
             harness_id: None,
@@ -800,6 +802,7 @@ async fn test_event_crud() {
     let owner_principal_id = create_test_principal(&backend, TEST_ORG_ID).await;
     let session = backend
         .create_session(CreateSessionRow {
+            workspace_id: None,
             org_id: TEST_ORG_ID,
             app_id: None,
             harness_id: None,
@@ -892,6 +895,7 @@ async fn test_event_exclude_types() {
     let owner_principal_id = create_test_principal(&backend, TEST_ORG_ID).await;
     let session = backend
         .create_session(CreateSessionRow {
+            workspace_id: None,
             org_id: TEST_ORG_ID,
             app_id: None,
             harness_id: None,
@@ -992,6 +996,7 @@ async fn test_message_events_filtered_offset_and_latest_limit() {
     let owner_principal_id = create_test_principal(&backend, TEST_ORG_ID).await;
     let session = backend
         .create_session(CreateSessionRow {
+            workspace_id: None,
             org_id: TEST_ORG_ID,
             app_id: None,
             harness_id: None,
@@ -1086,6 +1091,7 @@ async fn test_event_filter_types() {
     let owner_principal_id = create_test_principal(&backend, TEST_ORG_ID).await;
     let session = backend
         .create_session(CreateSessionRow {
+            workspace_id: None,
             org_id: TEST_ORG_ID,
             app_id: None,
             harness_id: None,
@@ -1389,6 +1395,7 @@ async fn test_session_file_crud() {
     let owner_principal_id = create_test_principal(&backend, TEST_ORG_ID).await;
     let session = backend
         .create_session(CreateSessionRow {
+            workspace_id: None,
             org_id: TEST_ORG_ID,
             app_id: None,
             harness_id: None,
@@ -1852,6 +1859,7 @@ async fn test_session_usage_tracking() {
     let owner_principal_id = create_test_principal(&backend, TEST_ORG_ID).await;
     let session = backend
         .create_session(CreateSessionRow {
+            workspace_id: None,
             org_id: TEST_ORG_ID,
             app_id: None,
             harness_id: None,
@@ -1953,6 +1961,7 @@ async fn test_session_previews() {
     let owner_principal_id = create_test_principal(&backend, TEST_ORG_ID).await;
     let session = backend
         .create_session(CreateSessionRow {
+            workspace_id: None,
             org_id: TEST_ORG_ID,
             app_id: None,
             harness_id: None,
@@ -2559,6 +2568,7 @@ async fn list_monitor_tasks_with_inactive_schedules_pg() {
     let owner_principal_id = create_test_principal(&backend, TEST_ORG_ID).await;
     let session = backend
         .create_session(CreateSessionRow {
+            workspace_id: None,
             org_id: TEST_ORG_ID,
             app_id: None,
             harness_id: None,

--- a/crates/server/tests/session_workspace_attach_test.rs
+++ b/crates/server/tests/session_workspace_attach_test.rs
@@ -1,0 +1,189 @@
+//! Integration tests for attaching a session to an existing shared workspace
+//! via `CreateSession { workspace_id }`, and for the file-store re-keying that
+//! makes the attached workspace's files visible through the session-scoped
+//! filesystem alias. Runs on the in-memory backend (no PostgreSQL).
+
+mod test_harness;
+
+use axum::http::StatusCode;
+use serde_json::{Value, json};
+use std::sync::atomic::{AtomicU64, Ordering};
+use test_harness::TestServer;
+
+fn unique(prefix: &str) -> String {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    format!("{prefix}-{}", COUNTER.fetch_add(1, Ordering::Relaxed))
+}
+
+async fn create_workspace(server: &TestServer) -> String {
+    let ws: Value = server
+        .post("/v1/workspaces", json!({ "name": unique("shared-ws") }))
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json_value();
+    ws["id"].as_str().expect("workspace id").to_string()
+}
+
+async fn create_session_attached(server: &TestServer, workspace_id: &str) -> Value {
+    server
+        .post(
+            "/v1/sessions",
+            json!({
+                "harness_id": server.seed_base_harness_id,
+                "workspace_id": workspace_id,
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json_value()
+}
+
+#[tokio::test]
+async fn attached_sessions_share_the_workspace_filesystem() {
+    let server = TestServer::in_memory().await;
+    let wsp = create_workspace(&server).await;
+
+    // Seed a file directly into the shared workspace.
+    server
+        .post(
+            &format!("/v1/workspaces/{wsp}/fs/shared/notes.txt"),
+            json!({ "content": "hello shared", "encoding": "text" }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED);
+
+    // Two distinct sessions attach to the same workspace.
+    let a = create_session_attached(&server, &wsp).await;
+    let b = create_session_attached(&server, &wsp).await;
+    assert_eq!(a["workspace_id"].as_str(), Some(wsp.as_str()));
+    assert_eq!(b["workspace_id"].as_str(), Some(wsp.as_str()));
+    assert_ne!(a["id"], b["id"], "sessions must be distinct");
+
+    let sid_a = a["id"].as_str().unwrap();
+    let sid_b = b["id"].as_str().unwrap();
+
+    // Each session sees the workspace-seeded file via its session-fs alias
+    // (proves the alias resolves session -> workspace, not session id).
+    for sid in [sid_a, sid_b] {
+        let file = server
+            .get(&format!("/v1/sessions/{sid}/fs/shared/notes.txt"))
+            .await
+            .assert_status(StatusCode::OK)
+            .json_value();
+        assert_eq!(
+            file["content"].as_str(),
+            Some("hello shared"),
+            "session {sid} should see the shared workspace file"
+        );
+    }
+
+    // A file written through session A's alias is visible through session B's
+    // alias — they share one underlying workspace keyspace.
+    server
+        .post(
+            &format!("/v1/sessions/{sid_a}/fs/from_a.txt"),
+            json!({ "content": "written by A", "encoding": "text" }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED);
+    let via_b = server
+        .get(&format!("/v1/sessions/{sid_b}/fs/from_a.txt"))
+        .await
+        .assert_status(StatusCode::OK)
+        .json_value();
+    assert_eq!(via_b["content"].as_str(), Some("written by A"));
+
+    // And it is the same file the workspace API exposes.
+    let via_ws = server
+        .get(&format!("/v1/workspaces/{wsp}/fs/from_a.txt"))
+        .await
+        .assert_status(StatusCode::OK)
+        .json_value();
+    assert_eq!(via_ws["content"].as_str(), Some("written by A"));
+}
+
+#[tokio::test]
+async fn default_session_keeps_its_own_isolated_workspace() {
+    let server = TestServer::in_memory().await;
+
+    // Two plain sessions (no workspace_id) must NOT share files.
+    let a: Value = server
+        .post(
+            "/v1/sessions",
+            json!({ "harness_id": server.seed_base_harness_id }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json_value();
+    let b: Value = server
+        .post(
+            "/v1/sessions",
+            json!({ "harness_id": server.seed_base_harness_id }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json_value();
+
+    // Each default session's workspace mirrors its own id.
+    let sid_a = a["id"].as_str().unwrap();
+    let sid_b = b["id"].as_str().unwrap();
+    let hex_a = sid_a.strip_prefix("session_").unwrap();
+    assert_eq!(
+        a["workspace_id"].as_str(),
+        Some(format!("wsp_{hex_a}").as_str())
+    );
+    assert_ne!(a["workspace_id"], b["workspace_id"]);
+
+    server
+        .post(
+            &format!("/v1/sessions/{sid_a}/fs/private.txt"),
+            json!({ "content": "only A", "encoding": "text" }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED);
+
+    // Session B must not see A's private file.
+    server
+        .get(&format!("/v1/sessions/{sid_b}/fs/private.txt"))
+        .await
+        .assert_status(StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn create_session_rejects_unknown_workspace() {
+    let server = TestServer::in_memory().await;
+    server
+        .post(
+            "/v1/sessions",
+            json!({
+                "harness_id": server.seed_base_harness_id,
+                "workspace_id": "wsp_ffffffffffffffffffffffffffffffff",
+            }),
+        )
+        .await
+        .assert_status(StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn create_session_rejects_archived_workspace() {
+    let server = TestServer::in_memory().await;
+    let wsp = create_workspace(&server).await;
+
+    // Archive the workspace.
+    server
+        .delete(&format!("/v1/workspaces/{wsp}"))
+        .await
+        .assert_success();
+
+    // Attaching a new session to an archived workspace is rejected.
+    server
+        .post(
+            "/v1/sessions",
+            json!({
+                "harness_id": server.seed_base_harness_id,
+                "workspace_id": wsp,
+            }),
+        )
+        .await
+        .assert_status(StatusCode::BAD_REQUEST);
+}

--- a/crates/server/tests/session_workspace_attach_test.rs
+++ b/crates/server/tests/session_workspace_attach_test.rs
@@ -165,6 +165,48 @@ async fn create_session_rejects_unknown_workspace() {
 }
 
 #[tokio::test]
+async fn create_session_rejects_legacy_workspace_with_mismatched_id() {
+    use everruns_core::DEFAULT_ORG_ID;
+    use everruns_core::typed_id::WorkspaceId;
+    use everruns_server::storage::models::CreateWorkspaceRow;
+
+    let server = TestServer::in_memory().await;
+    // Simulate a workspace created before the `id.hex == public_id` invariant:
+    // a random internal PK unrelated to the public id.
+    let public = WorkspaceId::new();
+    let internal = uuid::Uuid::now_v7();
+    assert_ne!(internal, public.uuid());
+    server
+        .db
+        .create_workspace(
+            DEFAULT_ORG_ID,
+            CreateWorkspaceRow {
+                id: Some(internal),
+                public_id: public.to_string(),
+                name: unique("legacy-ws"),
+                description: None,
+                owner_principal_id: None,
+                resolved_owner_user_id: None,
+            },
+        )
+        .await
+        .expect("seed legacy workspace");
+
+    // Attaching to it is rejected (the session would otherwise report a
+    // non-round-tripping workspace_id).
+    server
+        .post(
+            "/v1/sessions",
+            json!({
+                "harness_id": server.seed_base_harness_id,
+                "workspace_id": public.to_string(),
+            }),
+        )
+        .await
+        .assert_status(StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
 async fn create_session_rejects_archived_workspace() {
     let server = TestServer::in_memory().await;
     let wsp = create_workspace(&server).await;

--- a/crates/worker/src/durable_worker.rs
+++ b/crates/worker/src/durable_worker.rs
@@ -1655,6 +1655,7 @@ mod tests {
             act_input: ActInput {
                 org_id: Some(7),
                 context: AtomContext {
+                    workspace_id: None,
                     session_id,
                     turn_id,
                     input_message_id,
@@ -1716,6 +1717,7 @@ mod tests {
             act_input: ActInput {
                 org_id: Some(7),
                 context: AtomContext {
+                    workspace_id: None,
                     session_id: SessionId::new(),
                     turn_id: TurnId::new(),
                     input_message_id: MessageId::new(),
@@ -1755,6 +1757,7 @@ mod tests {
             act_input: ActInput {
                 org_id: Some(42),
                 context: AtomContext {
+                    workspace_id: None,
                     session_id,
                     turn_id,
                     input_message_id,
@@ -1799,6 +1802,7 @@ mod tests {
             act_input: ActInput {
                 org_id: None,
                 context: AtomContext {
+                    workspace_id: None,
                     session_id,
                     turn_id,
                     input_message_id,

--- a/crates/worker/src/durable_worker.rs
+++ b/crates/worker/src/durable_worker.rs
@@ -1195,6 +1195,9 @@ impl DurableWorker {
 
         // Create AtomContext for this execution
         let context = AtomContext {
+            // Input/Reason atoms do not key file I/O by AtomContext; the act
+            // path receives its workspace-set context from the orchestration.
+            workspace_id: None,
             session_id: input.session_id,
             turn_id: TurnId::new(),
             input_message_id: input.input_message_id,
@@ -1281,6 +1284,9 @@ impl DurableWorker {
         // Create AtomContext - use turn_id from input if available (from input activity)
         let turn_id = input.turn_id.unwrap_or_default();
         let context = AtomContext {
+            // Input/Reason atoms do not key file I/O by AtomContext; the act
+            // path receives its workspace-set context from the orchestration.
+            workspace_id: None,
             session_id: input.session_id,
             turn_id,
             input_message_id: input.input_message_id,

--- a/crates/worker/src/unified_worker.rs
+++ b/crates/worker/src/unified_worker.rs
@@ -621,6 +621,9 @@ async fn execute_input_activity<A: WorkerAdapters>(
 
     // Create AtomContext
     let context = AtomContext {
+        // Input/Reason atoms do not key file I/O by AtomContext; the act
+        // path receives its workspace-set context from the orchestration.
+        workspace_id: None,
         session_id: input.session_id,
         turn_id: TurnId::new(),
         input_message_id: input.input_message_id,
@@ -662,6 +665,9 @@ async fn execute_reason_activity<A: WorkerAdapters>(
     // Create AtomContext - use turn_id from input if available
     let turn_id = input.turn_id.unwrap_or_default();
     let context = AtomContext {
+        // Input/Reason atoms do not key file I/O by AtomContext; the act
+        // path receives its workspace-set context from the orchestration.
+        workspace_id: None,
         session_id: input.session_id,
         turn_id,
         input_message_id: input.input_message_id,

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -15830,6 +15830,14 @@
                 "type": "client_side"
               }
             ]
+          },
+          "workspace_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Attach this session to an existing Workspace (format: `wsp_<32-hex>`)\ninstead of auto-creating a default per-session workspace. The workspace\nmust exist in the caller's org and be `active`. Lets multiple sessions\nshare one working filesystem. Omit for the default 1:1 behavior.",
+            "example": "wsp_01933b5a00007000800000000000001"
           }
         }
       },

--- a/specs/workspace.md
+++ b/specs/workspace.md
@@ -48,11 +48,25 @@ removed; otherwise `DELETE` archives the row.
 
 ## Default Workspace per Session
 
-For backward compatibility, every newly created session auto-creates a
-**default Workspace** named after the session (`session-<session-id-suffix>`)
-and attaches the session to it. Power users who want to share working
-state across sessions can pre-create a Workspace via the API and pass its
-`workspace_id` to `CreateSession`.
+For backward compatibility, a session created without an explicit
+`workspace_id` auto-creates a **default Workspace** named after the session
+(`session-<session-id-suffix>`) whose primary key equals the session id (the
+equality invariant), and attaches the session to it.
+
+Power users who want to share working state across sessions pre-create a
+Workspace via the API and pass its `workspace_id` (the `wsp_<32-hex>` public id)
+to `CreateSession`. The attach target is validated at create time: it must
+exist in the caller's org (else `404`) and be `active` (an `archived`/`deleted`
+target is rejected `400`). When attached, no default workspace is created and
+the session's `workspace_id` points at the shared workspace.
+
+File access re-keys by the session's `workspace_id`, not its id, so a shared
+workspace is addressed consistently everywhere: the agent's `file_system` /
+`virtual_bash` tools (a [`WorkspaceScopedFileSystem`] decorator pins tool I/O to
+the workspace), system-prompt file reads, initial-file seeding and capability
+mounts, and the legacy `/v1/sessions/{session_id}/fs/*` alias. For the default
+1:1 session these all reduce to the session id, so the re-keying is a
+transparent pass-through.
 
 This preserves the legacy 1:1 session→files invariant for clients that
 don't yet think about Workspaces, while exposing the multi-session-share

--- a/specs/workspace.md
+++ b/specs/workspace.md
@@ -55,10 +55,14 @@ equality invariant), and attaches the session to it.
 
 Power users who want to share working state across sessions pre-create a
 Workspace via the API and pass its `workspace_id` (the `wsp_<32-hex>` public id)
-to `CreateSession`. The attach target is validated at create time: it must
-exist in the caller's org (else `404`) and be `active` (an `archived`/`deleted`
-target is rejected `400`). When attached, no default workspace is created and
-the session's `workspace_id` points at the shared workspace.
+to `CreateSession`. The attach target is validated at create time: an unknown
+or `deleted` target returns `404` (the lookup excludes `deleted` rows), an
+`archived` target `400`, and a target the caller lacks `WORKSPACE_MANAGE` for
+`403`. When attached, no default workspace is created and the session's
+`workspace_id` points at the shared workspace. A workspace created before the
+`id.hex == public_id` invariant (legacy random internal PK) is also rejected
+`400`, since the session would otherwise report a non-round-tripping
+`workspace_id`.
 
 File access re-keys by the session's `workspace_id`, not its id, so a shared
 workspace is addressed consistently everywhere: the agent's `file_system` /


### PR DESCRIPTION
## What

Make shared workspaces usable end-to-end: a session can attach to an existing
Workspace via `CreateSession { workspace_id }`, and **all** file access for that
session is keyed by the attached workspace rather than the session id.

- `CreateSessionRequest` gains an optional `workspace_id` (`wsp_<32-hex>`). When
  set, the session attaches to that workspace instead of auto-creating a default
  1:1 one. Validated at create time: must exist in-org (`404`), be `active`
  (`400`), and the caller must hold `WORKSPACE_MANAGE` (`403`).
- File I/O re-keys from `session.id` to `session.workspace_id` across every
  surface: the agent's `file_system`/`virtual_bash` tools, system-prompt file
  reads, initial-file seeding, capability mounts, and the legacy
  `/v1/sessions/{id}/fs/*` alias.
- Fix a latent #2140 bug: a standalone workspace's internal PK was random and
  unrelated to its public id, so `Session.workspace_id` (rendered from the
  internal id) didn't match the public id. Pin the internal id to the public
  id's uuid at creation, restoring the `id.hex == public_id` invariant. Attaches
  to legacy workspaces that still violate it are rejected `400`.

## Why

#2140 split Workspace out as a durable entity but kept the equality invariant
(`workspace.id == session.id`) so the whole codebase could keep using
`session.id` as the file-store key. That made attaching to a *shared* workspace
(where the ids differ) a no-op for the agent and the session alias — they'd
read/write the session's own empty keyspace, not the workspace. This wires the
attach path the spec already described and re-keys file access so sharing
actually works.

## How

- **Tool path:** add `WorkspaceScopedFileSystem`, a `SessionFileSystem`
  decorator that pins every call to a fixed workspace key. `AtomContext` carries
  the attached `workspace_id` (Option, `#[serde(default)]` for durable replay);
  the orchestration (`runtime.rs`, `turn_strategy.rs`) injects
  `session.workspace_id`, and `ActAtom` wraps the tool file store with it. For
  the default 1:1 session the key equals the session id, so it's a transparent
  pass-through.
- **Non-tool paths:** `assemble_turn_context` and the embedded host wrap the
  system-prompt file store; session creation keys mounts + seeding by
  `workspace_id`; the server session-fs commands resolve session → `workspace_id`
  (`verify_session` returns the workspace key).
- **Storage:** `CreateSessionRow.workspace_id: Option<Uuid>`; `create_session`
  (Postgres + in-memory) attaches to it and skips default-workspace creation
  when present.

## Risk

- **Medium** — touches the agent file hot path across core/worker/runtime/server.
  Mitigated by the pass-through-for-1:1 design (default sessions are unchanged)
  and end-to-end tests. No migrations. The durable `AtomContext` field is
  serde-default so in-flight turns replay cleanly.

## Security

- **Threat categories reviewed: TM-AUTHZ, TM-TENANT, TM-API.**
- **TM-AUTHZ:** attaching grants the session's agent read/write to the
  workspace's files, so `CreateSession` now requires `WORKSPACE_MANAGE` when
  `workspace_id` is supplied — `SESSION_MANAGE` alone is not a path to a
  workspace the caller can't otherwise manage.
- **TM-TENANT:** the attach target is resolved via `db.get_workspace(org_id, …)`,
  so a session can only attach to a workspace in its own org; cross-org attach is
  impossible at the storage layer.
- **TM-API:** `workspace_id` is validated (exists / active / in-org / invariant)
  before use; invalid targets return `404`/`400`, unauthorized `403`.
- No new external surface, no new secrets. The re-keying narrows access (a
  session addresses exactly its workspace), it does not widen it.

## Validation

- New `session_workspace_attach_test` (in-memory): attached sessions share the
  workspace filesystem via the session alias and the workspace API; default
  sessions stay isolated; unknown/archived/legacy-invariant targets rejected.
- Full `cargo check --workspace --tests`, clippy clean, core + runtime unit
  tests, and CI's **PostgreSQL integration suite** all green. OpenAPI
  regenerated; `specs/workspace.md` updated.

## Follow-ups

- Promote per-session **git / sqldb / key-value / secrets** to workspace scope
  (still session-scoped; tracked as open questions in `specs/workspace.md`).
- A dedicated **Workspaces UI** (listing/detail) — out of scope.
- The `SessionFileSystem` trait still takes a `SessionId` carrying the workspace
  key (via the decorator); a future cleanup could switch the trait to
  `WorkspaceId` outright. Deferred to bound blast radius.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered (default 1:1 sessions are a transparent
  pass-through; no migrations; durable AtomContext field is serde-default)
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed