### PR TITLE
refactor(server): drop dead subagent_name/task columns from spawn handles

### DIFF
--- a/crates/core/src/capabilities/subagents.rs
+++ b/crates/core/src/capabilities/subagents.rs
@@ -383,13 +383,7 @@ impl Tool for SpawnSubagentTool {
             let claim_token = uuid::Uuid::new_v4();
 
             let claim = match spawn_store
-                .try_claim_spawn(
-                    context.session_id,
-                    tool_call_id,
-                    &name,
-                    &instructions,
-                    claim_token,
-                )
+                .try_claim_spawn(context.session_id, tool_call_id, claim_token)
                 .await
             {
                 Ok(c) => c,
@@ -876,7 +870,7 @@ mod tests {
         let token = uuid::Uuid::new_v4();
 
         let result = store
-            .try_claim_spawn(parent, "call-1", "Worker", "do work", token)
+            .try_claim_spawn(parent, "call-1", token)
             .await
             .expect("noop should not error");
 
@@ -914,7 +908,7 @@ mod tests {
         let token = uuid::Uuid::new_v4();
 
         let result = store
-            .try_claim_spawn(parent, "call-arc", "ArcWorker", "arc task", token)
+            .try_claim_spawn(parent, "call-arc", token)
             .await
             .expect("arc delegation should not error");
 

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -1814,8 +1814,6 @@ pub trait SubagentSpawnStore: Send + Sync + 'static {
         &self,
         parent_session_id: crate::typed_id::SessionId,
         tool_call_id: &str,
-        subagent_name: &str,
-        subagent_task: &str,
         claim_token: uuid::Uuid,
     ) -> Result<SpawnClaimResult>;
 
@@ -1852,18 +1850,10 @@ impl<S: SubagentSpawnStore + ?Sized> SubagentSpawnStore for Arc<S> {
         &self,
         parent_session_id: crate::typed_id::SessionId,
         tool_call_id: &str,
-        subagent_name: &str,
-        subagent_task: &str,
         claim_token: uuid::Uuid,
     ) -> Result<SpawnClaimResult> {
         (**self)
-            .try_claim_spawn(
-                parent_session_id,
-                tool_call_id,
-                subagent_name,
-                subagent_task,
-                claim_token,
-            )
+            .try_claim_spawn(parent_session_id, tool_call_id, claim_token)
             .await
     }
 
@@ -1909,8 +1899,6 @@ impl SubagentSpawnStore for NoopSubagentSpawnStore {
         &self,
         _parent_session_id: crate::typed_id::SessionId,
         _tool_call_id: &str,
-        _subagent_name: &str,
-        _subagent_task: &str,
         claim_token: uuid::Uuid,
     ) -> Result<SpawnClaimResult> {
         Ok(SpawnClaimResult::Claimed {

--- a/crates/server/migrations/063_drop_spawn_handle_dead_columns.sql
+++ b/crates/server/migrations/063_drop_spawn_handle_dead_columns.sql
@@ -1,0 +1,9 @@
+-- Drop dead-weight metadata columns from subagent_spawn_handles.
+--
+-- subagent_name and subagent_task were written at claim time but never read:
+-- the EVE-535 dedup/claim/reattach logic keys on (parent_session_id,
+-- tool_call_id) and only reads id, child_session_id, status, terminal_status,
+-- terminal_result, claim_token. The columns are pure storage overhead.
+ALTER TABLE subagent_spawn_handles
+    DROP COLUMN IF EXISTS subagent_name,
+    DROP COLUMN IF EXISTS subagent_task;

--- a/crates/server/migrations/063_drop_spawn_handle_dead_columns.sql
+++ b/crates/server/migrations/063_drop_spawn_handle_dead_columns.sql
@@ -4,6 +4,13 @@
 -- the EVE-535 dedup/claim/reattach logic keys on (parent_session_id,
 -- tool_call_id) and only reads id, child_session_id, status, terminal_status,
 -- terminal_result, claim_token. The columns are pure storage overhead.
+--
+-- Deploy note: the columns were NOT NULL (migration 052), so a pre-this-change
+-- server binary still INSERTs them. This is a coordinated-deploy drop (matching
+-- AGENTS.md "no backward compatibility for internal code") — apply with the
+-- server build that stopped writing the columns. An old binary spawning a
+-- subagent against the migrated schema would fail its claim INSERT until
+-- redeployed; the dropped data itself was never read, so nothing else breaks.
 ALTER TABLE subagent_spawn_handles
     DROP COLUMN IF EXISTS subagent_name,
     DROP COLUMN IF EXISTS subagent_task;

--- a/crates/server/src/storage/memory/subagent_spawn_handles.rs
+++ b/crates/server/src/storage/memory/subagent_spawn_handles.rs
@@ -54,8 +54,6 @@ impl SubagentSpawnStore for InMemorySubagentSpawnStore {
         &self,
         parent_session_id: SessionId,
         tool_call_id: &str,
-        _subagent_name: &str,
-        _subagent_task: &str,
         claim_token: Uuid,
     ) -> Result<SpawnClaimResult, AgentLoopError> {
         let key = (parent_session_id, tool_call_id.to_string());

--- a/crates/server/src/storage/subagent_spawn_handles.rs
+++ b/crates/server/src/storage/subagent_spawn_handles.rs
@@ -32,8 +32,6 @@ impl SubagentSpawnStore for PgSubagentSpawnStore {
         &self,
         parent_session_id: SessionId,
         tool_call_id: &str,
-        subagent_name: &str,
-        subagent_task: &str,
         claim_token: Uuid,
     ) -> Result<SpawnClaimResult, AgentLoopError> {
         let parent_uuid: Uuid = parent_session_id.into();
@@ -42,15 +40,13 @@ impl SubagentSpawnStore for PgSubagentSpawnStore {
         let inserted = sqlx::query(
             r#"
             INSERT INTO subagent_spawn_handles
-                (parent_session_id, tool_call_id, subagent_name, subagent_task, claim_token)
-            VALUES ($1, $2, $3, $4, $5)
+                (parent_session_id, tool_call_id, claim_token)
+            VALUES ($1, $2, $3)
             ON CONFLICT (parent_session_id, tool_call_id) DO NOTHING
             "#,
         )
         .bind(parent_uuid)
         .bind(tool_call_id)
-        .bind(subagent_name)
-        .bind(subagent_task)
         .bind(claim_token)
         .execute(&self.pool)
         .await

--- a/crates/server/tests/subagent_spawn_handles_test.rs
+++ b/crates/server/tests/subagent_spawn_handles_test.rs
@@ -19,7 +19,7 @@ async fn test_spawn_handle_claimed_on_first_call() {
     let token = Uuid::new_v4();
 
     let result = store
-        .try_claim_spawn(parent, "call-1", "Worker", "do work", token)
+        .try_claim_spawn(parent, "call-1", token)
         .await
         .expect("claim should not error");
 
@@ -44,13 +44,13 @@ async fn test_spawn_handle_reattach_pending() {
 
     // First call: claim (no register_child_session — simulates crash before register)
     store
-        .try_claim_spawn(parent, "call-pending", "Worker", "task", token)
+        .try_claim_spawn(parent, "call-pending", token)
         .await
         .expect("first claim");
 
     // Replay: row exists but child not registered → ClaimedPendingChild
     let result = store
-        .try_claim_spawn(parent, "call-pending", "Worker", "task", Uuid::new_v4())
+        .try_claim_spawn(parent, "call-pending", Uuid::new_v4())
         .await
         .expect("replay should not error");
 
@@ -76,7 +76,7 @@ async fn test_spawn_handle_reattach_running() {
 
     // Claim
     let claim = store
-        .try_claim_spawn(parent, "call-2", "Worker", "task", token)
+        .try_claim_spawn(parent, "call-2", token)
         .await
         .expect("first claim");
 
@@ -96,7 +96,7 @@ async fn test_spawn_handle_reattach_running() {
 
     // Replay: should return AlreadyRunning with the stored (not fresh) token
     let result = store
-        .try_claim_spawn(parent, "call-2", "Worker", "task", Uuid::new_v4())
+        .try_claim_spawn(parent, "call-2", Uuid::new_v4())
         .await
         .expect("second call should not error");
 
@@ -128,7 +128,7 @@ async fn test_spawn_handle_reattach_settled() {
 
     // Claim + register
     let claim = store
-        .try_claim_spawn(parent, "call-3", "Worker", "task", token)
+        .try_claim_spawn(parent, "call-3", token)
         .await
         .expect("claim");
     let (handle_id, _) = match claim {
@@ -151,7 +151,7 @@ async fn test_spawn_handle_reattach_settled() {
 
     // Replay — should return AlreadySettled with correct status and result
     let result = store
-        .try_claim_spawn(parent, "call-3", "Worker", "task", Uuid::new_v4())
+        .try_claim_spawn(parent, "call-3", Uuid::new_v4())
         .await
         .expect("replay");
 
@@ -179,7 +179,7 @@ async fn test_settle_wrong_token_is_ignored() {
     let wrong_token = Uuid::new_v4();
 
     let claim = store
-        .try_claim_spawn(parent, "call-4", "Worker", "task", token)
+        .try_claim_spawn(parent, "call-4", token)
         .await
         .expect("claim");
     let (handle_id, _) = match claim {
@@ -202,7 +202,7 @@ async fn test_settle_wrong_token_is_ignored() {
 
     // State should still be running
     let result = store
-        .try_claim_spawn(parent, "call-4", "Worker", "task", Uuid::new_v4())
+        .try_claim_spawn(parent, "call-4", Uuid::new_v4())
         .await
         .expect("replay after bad settle");
 
@@ -225,7 +225,7 @@ async fn test_different_tool_call_ids_are_independent() {
     let token_b = Uuid::new_v4();
 
     let claim_a = store
-        .try_claim_spawn(parent, "call-a", "WorkerA", "task a", token_a)
+        .try_claim_spawn(parent, "call-a", token_a)
         .await
         .expect("claim a");
     let (handle_a, _) = match claim_a {
@@ -237,7 +237,7 @@ async fn test_different_tool_call_ids_are_independent() {
     };
 
     let claim_b = store
-        .try_claim_spawn(parent, "call-b", "WorkerB", "task b", token_b)
+        .try_claim_spawn(parent, "call-b", token_b)
         .await
         .expect("claim b");
     let (handle_b, _) = match claim_b {
@@ -264,7 +264,7 @@ async fn test_different_tool_call_ids_are_independent() {
 
     // call-b should still be running
     let result_b = store
-        .try_claim_spawn(parent, "call-b", "WorkerB", "task b", Uuid::new_v4())
+        .try_claim_spawn(parent, "call-b", Uuid::new_v4())
         .await
         .expect("replay b");
 


### PR DESCRIPTION
## What
Drops the dead `subagent_name` / `subagent_task` columns from the `subagent_spawn_handles` table and removes the two corresponding params from `SubagentSpawnStore::try_claim_spawn`.

## Why
These columns were written at claim time but **never read**. The EVE-535 spawn dedup/claim/reattach logic keys on `(parent_session_id, tool_call_id)` (the UNIQUE constraint) and the only `SELECT`s read `id, child_session_id, status, terminal_status, terminal_result, claim_token`. The in-memory store already ignored them (`_subagent_name`, `_subagent_task`). Pure storage and API overhead.

This is the trivial follow-up noted when the `sessions.subagent_*` retirement (#2202) landed — it completes the subagent-column cleanup.

## How
- Removed `subagent_name`/`subagent_task` from `try_claim_spawn` (trait, `Arc<S>` blanket impl, `NoopSubagentSpawnStore`, PG impl, in-memory impl), the single real caller in `spawn_subagent`, and all test callers.
- PG `INSERT` no longer lists/binds the two columns.
- Migration 063 drops them.

No proto/gRPC involvement (spawn handles are a server-side storage trait, not exposed over the worker protocol).

## Risk
- Low
- Pure removal of write-only columns; the claim/dedup contract is unchanged (still keyed on `(parent_session_id, tool_call_id)`). Migration is an irreversible column drop of never-read data.

## Security
- No security-relevant changes (reviewed against TM categories; none apply).

## Follow-ups
- No follow-ups. The session-tasks migration plan (`specs/session-tasks.md`) and its column cleanups are now fully complete.

## Checklist
- [x] Tests added or updated (existing spawn-handle suite covers the path; updated for the signature)
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_011yqDiQ2GyoDdwFQTFTw12R)_