### PR TITLE
feat(providers): service-kind resolution + voice realtime rerouting (phase 4)

### DIFF
--- a/crates/server/src/api/voice.rs
+++ b/crates/server/src/api/voice.rs
@@ -30,8 +30,8 @@ use everruns_core::message::ExecutionPhase;
 use everruns_core::traits::LeasedResourceStore;
 use everruns_core::typed_id::{AgentId, MessageId, SessionId};
 use everruns_core::{
-    Caller, ContentPart, Event, FeatureFlags, InputContentPart, LeasedResource, ToolCall,
-    UpsertLeasedResource,
+    Caller, ContentPart, Event, FeatureFlags, InputContentPart, LeasedResource, ServiceKind,
+    ToolCall, UpsertLeasedResource,
 };
 use futures_util::{SinkExt, StreamExt};
 use reqwest::multipart;
@@ -51,8 +51,10 @@ use tokio_tungstenite::{
 use utoipa::ToSchema;
 use uuid::Uuid;
 
-const OPENAI_PROVIDER: &str = "openai";
 const VOICE_RESOURCE_TYPE: &str = "voice_connection";
+/// Provider label reported in voice responses. Realtime is OpenAI-only in OSS;
+/// the provider connection itself is selected by service-kind resolution.
+const OPENAI_PROVIDER: &str = "openai";
 const DEFAULT_MODEL: &str = "gpt-realtime-2";
 const DEFAULT_VOICE: &str = "marin";
 const DEFAULT_REASONING_EFFORT: &str = "low";
@@ -323,7 +325,7 @@ pub async fn create_client_secret(
     let session_id = parse_session_id(&session_id)?;
     authorize_session(&state, &org, session_id).await?;
     let normalized = normalize_options(req.options)?;
-    let credentials = resolve_openai_credentials(&state, org.org_id).await?;
+    let credentials = resolve_realtime_credentials(&state, org.org_id).await?;
     let voice_connection_id = new_voice_connection_id();
     let lease = upsert_voice_resource(VoiceResourceUpsert {
         state: &state,
@@ -415,7 +417,7 @@ pub async fn attach_call(
         );
     }
     let normalized = normalize_options(req.options)?;
-    let credentials = resolve_openai_credentials(&state, org.org_id).await?;
+    let credentials = resolve_realtime_credentials(&state, org.org_id).await?;
     let lease = upsert_voice_resource(VoiceResourceUpsert {
         state: &state,
         session_id,
@@ -563,7 +565,7 @@ async fn bootstrap_call(
         return Err(ErrorResponse::new("Missing SDP").into_response(StatusCode::BAD_REQUEST));
     }
     let normalized = normalize_options(req.options)?;
-    let credentials = resolve_openai_credentials(state, org.org_id).await?;
+    let credentials = resolve_realtime_credentials(state, org.org_id).await?;
     let voice_connection_id = new_voice_connection_id();
     let form = multipart::Form::new()
         .part(
@@ -760,16 +762,21 @@ async fn authorize_session(
         })
 }
 
-async fn resolve_openai_credentials(
+/// Resolve the realtime-voice provider connection for an org via service-bound
+/// resolution (specs/providers.md): the active provider whose driver declares
+/// `ServiceKind::Realtime`, fail-closed. Replaces the previous "first active
+/// provider matching the `openai` type string" behavior — only realtime-capable
+/// drivers are eligible now.
+async fn resolve_realtime_credentials(
     state: &AppState,
     org_id: i64,
 ) -> Result<ResolvedProviderCredentials, (StatusCode, Json<ErrorResponse>)> {
     state
         .provider_resolver
-        .resolve_provider_credentials(org_id, OPENAI_PROVIDER)
+        .resolve_service(org_id, ServiceKind::Realtime, None)
         .await
-        .map_err(provider_error)?
-        .ok_or_else(ErrorResponse::bad_gateway)
+        .map(|resolved| resolved.credentials)
+        .map_err(provider_error)
 }
 
 fn parse_session_id(session_id: &str) -> Result<SessionId, (StatusCode, Json<ErrorResponse>)> {

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -798,10 +798,10 @@ impl ServerAppBuilder {
             }
         });
         let driver_registry = Arc::new(platform_definition.driver_registry().clone());
-        let provider_resolver = Arc::new(services::ProviderResolverService::new(
-            db.clone(),
-            encryption.clone(),
-        ));
+        let provider_resolver = Arc::new(
+            services::ProviderResolverService::new(db.clone(), encryption.clone())
+                .with_driver_registry((*driver_registry).clone()),
+        );
         let providers_state = api::providers::AppState::new(
             db.clone(),
             encryption.clone(),

--- a/crates/server/src/grpc_service/mod.rs
+++ b/crates/server/src/grpc_service/mod.rs
@@ -529,7 +529,10 @@ impl WorkerServiceImpl {
             WorkspaceFileService::new(db.clone())
         };
         let provider_resolver_service = provider_resolver_service.unwrap_or_else(|| {
-            Arc::new(ProviderResolverService::new(db.clone(), encryption.clone()))
+            Arc::new(
+                ProviderResolverService::new(db.clone(), encryption.clone())
+                    .with_driver_registry(platform_definition.driver_registry().clone()),
+            )
         });
         let mcp_server_service = McpServerService::with_egress_service(
             db.clone(),

--- a/crates/server/src/services/provider_resolver.rs
+++ b/crates/server/src/services/provider_resolver.rs
@@ -17,7 +17,7 @@
 
 use crate::storage::{EncryptionService, StorageBackend, models::ProviderRow};
 use anyhow::Result;
-use everruns_core::{DriverId, DriverRegistry, ServiceKind};
+use everruns_core::{DriverId, DriverRegistry, ProviderId, ServiceKind};
 use moka::future::Cache;
 use std::sync::Arc;
 use std::time::Duration;
@@ -292,9 +292,12 @@ impl ProviderResolverService {
         // Tier 1: an explicit provider binding wins, but only if its driver
         // actually declares the requested service.
         if let Some(binding) = binding {
+            let binding_id: ProviderId = binding
+                .parse()
+                .map_err(|_| anyhow::anyhow!("malformed provider binding: {binding}"))?;
             let provider = providers
                 .iter()
-                .find(|provider| provider.id.to_string() == binding)
+                .find(|provider| provider.id == binding_id)
                 .ok_or_else(|| anyhow::anyhow!("provider {binding} not found for org"))?;
             if !self.driver_supports(&provider.provider_type, service) {
                 return Err(anyhow::anyhow!(
@@ -341,12 +344,16 @@ impl ProviderResolverService {
     }
 
     /// Whether the driver behind a provider-type string declares `service`.
-    /// Unknown type strings parse to [`DriverId::External`], which declares no
-    /// services, so they correctly never match.
+    ///
+    /// The registry is the source of truth: a type string maps to a [`DriverId`]
+    /// ([`DriverId::from_str`] is infallible — unknown strings become
+    /// [`DriverId::External`]), and `supports` returns `true` only when that id
+    /// is registered *and* its descriptor declares the service. An unregistered
+    /// id (external or otherwise) therefore never matches.
     fn driver_supports(&self, provider_type: &str, service: ServiceKind) -> bool {
         let driver_id: DriverId = provider_type
             .parse()
-            .unwrap_or_else(|_| DriverId::external(provider_type.to_string()));
+            .expect("DriverId::from_str is infallible");
         self.driver_registry.supports(&driver_id, service)
     }
 

--- a/crates/server/src/services/provider_resolver.rs
+++ b/crates/server/src/services/provider_resolver.rs
@@ -17,6 +17,7 @@
 
 use crate::storage::{EncryptionService, StorageBackend, models::ProviderRow};
 use anyhow::Result;
+use everruns_core::{DriverId, DriverRegistry, ServiceKind};
 use moka::future::Cache;
 use std::sync::Arc;
 use std::time::Duration;
@@ -139,6 +140,17 @@ pub struct ResolvedProviderCredentials {
     pub base_url: Option<String>,
 }
 
+/// A provider connection resolved for a specific non-chat [`ServiceKind`].
+#[derive(Debug, Clone)]
+pub struct ResolvedServiceProvider {
+    /// Driver/provider type string of the selected provider (e.g. "openai").
+    pub provider_type: String,
+    /// Public id of the selected provider connection.
+    pub provider_id: String,
+    /// Decrypted credentials for the provider connection.
+    pub credentials: ResolvedProviderCredentials,
+}
+
 /// Cache key: (org_id, model_uuid). Default-model lookups use DEFAULT_MODEL_SENTINEL.
 type CacheKey = (i64, Uuid);
 
@@ -146,6 +158,10 @@ pub struct ProviderResolverService {
     db: Arc<StorageBackend>,
     encryption: Option<Arc<EncryptionService>>,
     cache: Cache<CacheKey, Option<ResolvedModel>>,
+    /// Driver registry powering service-bound resolution (`resolve_service`):
+    /// it declares which drivers implement which [`ServiceKind`]. Empty by
+    /// default; the server composition root wires in the platform registry.
+    driver_registry: DriverRegistry,
 }
 
 impl ProviderResolverService {
@@ -158,7 +174,17 @@ impl ProviderResolverService {
             db,
             encryption,
             cache,
+            driver_registry: DriverRegistry::new(),
         }
+    }
+
+    /// Attach the driver registry that powers [`Self::resolve_service`].
+    ///
+    /// Without it, service-bound resolution fails closed (no driver declares
+    /// any service), so the server composition root must call this.
+    pub fn with_driver_registry(mut self, driver_registry: DriverRegistry) -> Self {
+        self.driver_registry = driver_registry;
+        self
     }
 
     /// Resolve a model by ID with decrypted provider credentials.
@@ -238,6 +264,90 @@ impl ProviderResolverService {
         }
 
         Ok(None)
+    }
+
+    /// Service-bound resolution: select a provider connection that serves the
+    /// requested [`ServiceKind`], fail-closed (specs/providers.md).
+    ///
+    /// Selection order:
+    /// 1. An explicit `binding` (a provider public id supplied by the consumer,
+    ///    e.g. a voice connection's provider) wins — but only when that
+    ///    provider's driver declares the service.
+    /// 2. *(org default provider per service — not yet implemented.)*
+    /// 3. Otherwise the first active provider whose driver declares the service.
+    ///
+    /// Returns a structured "no provider configured for {service}" error when
+    /// nothing matches. Like chat resolution, this never falls back to
+    /// environment-only credentials in tenant paths (the fail-closed key
+    /// contract in specs/llm-drivers.md): a provider row without a usable key
+    /// is skipped, not satisfied from the host environment.
+    pub async fn resolve_service(
+        &self,
+        org_id: i64,
+        service: ServiceKind,
+        binding: Option<&str>,
+    ) -> Result<ResolvedServiceProvider> {
+        let providers = self.db.list_providers(org_id).await?;
+
+        // Tier 1: an explicit provider binding wins, but only if its driver
+        // actually declares the requested service.
+        if let Some(binding) = binding {
+            let provider = providers
+                .iter()
+                .find(|provider| provider.id.to_string() == binding)
+                .ok_or_else(|| anyhow::anyhow!("provider {binding} not found for org"))?;
+            if !self.driver_supports(&provider.provider_type, service) {
+                return Err(anyhow::anyhow!(
+                    "provider {binding} does not provide the {service} service"
+                ));
+            }
+            let api_key = self.resolve_api_key(provider)?.ok_or_else(|| {
+                anyhow::anyhow!("no credentials configured for provider {binding}")
+            })?;
+            return Ok(ResolvedServiceProvider {
+                provider_type: provider.provider_type.clone(),
+                provider_id: provider.id.to_string(),
+                credentials: ResolvedProviderCredentials {
+                    api_key,
+                    base_url: provider.base_url.clone(),
+                },
+            });
+        }
+
+        // Tier 2 (org-level default provider per service) is not implemented
+        // yet; no consumer requires it. See specs/providers.md follow-ups.
+
+        // Tier 3: the first active provider whose driver declares the service.
+        for provider in providers
+            .iter()
+            .filter(|provider| provider.status.eq_ignore_ascii_case("active"))
+            .filter(|provider| self.driver_supports(&provider.provider_type, service))
+        {
+            if let Some(api_key) = self.resolve_api_key(provider)? {
+                return Ok(ResolvedServiceProvider {
+                    provider_type: provider.provider_type.clone(),
+                    provider_id: provider.id.to_string(),
+                    credentials: ResolvedProviderCredentials {
+                        api_key,
+                        base_url: provider.base_url.clone(),
+                    },
+                });
+            }
+        }
+
+        Err(anyhow::anyhow!(
+            "no provider configured for the {service} service"
+        ))
+    }
+
+    /// Whether the driver behind a provider-type string declares `service`.
+    /// Unknown type strings parse to [`DriverId::External`], which declares no
+    /// services, so they correctly never match.
+    fn driver_supports(&self, provider_type: &str, service: ServiceKind) -> bool {
+        let driver_id: DriverId = provider_type
+            .parse()
+            .unwrap_or_else(|_| DriverId::external(provider_type.to_string()));
+        self.driver_registry.supports(&driver_id, service)
     }
 
     /// Invalidate all cached resolutions for an org.
@@ -947,5 +1057,134 @@ mod tests {
             result.is_none(),
             "default model must not resolve in another org"
         );
+    }
+
+    // --- resolve_service (service-bound resolution) tests ---
+
+    /// Resolver wired with the real OSS driver registry: `openai` declares
+    /// `Realtime`/`Chat`, `openrouter` is chat-only — exactly the asymmetry the
+    /// service-kind selection must respect.
+    fn service_resolver(
+        db: Arc<StorageBackend>,
+        encryption: Option<Arc<EncryptionService>>,
+    ) -> ProviderResolverService {
+        ProviderResolverService::new(db, encryption)
+            .with_driver_registry(everruns_worker::create_driver_registry())
+    }
+
+    async fn seed_active_provider(
+        db: &StorageBackend,
+        encryption: &EncryptionService,
+        provider_type: &str,
+    ) -> everruns_core::ProviderId {
+        use crate::storage::models::CreateProviderRow;
+        let encrypted = encryption.encrypt_string("sk-test").unwrap();
+        db.create_provider(
+            DEFAULT_ORG_ID,
+            CreateProviderRow {
+                name: provider_type.to_string(),
+                provider_type: provider_type.to_string(),
+                base_url: None,
+                api_key_encrypted: Some(encrypted),
+                settings: None,
+            },
+        )
+        .await
+        .unwrap()
+        .id
+    }
+
+    #[tokio::test]
+    async fn resolve_service_selects_active_provider_declaring_service() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let encryption = test_encryption();
+        seed_active_provider(&db, &encryption, "openai").await;
+        let resolver = service_resolver(db, Some(encryption));
+
+        let resolved = resolver
+            .resolve_service(DEFAULT_ORG_ID, ServiceKind::Realtime, None)
+            .await
+            .expect("openai declares Realtime and has a key");
+        assert_eq!(resolved.provider_type, "openai");
+        assert_eq!(resolved.credentials.api_key, "sk-test");
+    }
+
+    #[tokio::test]
+    async fn resolve_service_fails_closed_when_no_provider() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let resolver = service_resolver(db, Some(test_encryption()));
+
+        let err = resolver
+            .resolve_service(DEFAULT_ORG_ID, ServiceKind::Realtime, None)
+            .await
+            .expect_err("no provider configured");
+        assert!(
+            err.to_string().contains("no provider configured"),
+            "got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_service_skips_driver_without_service() {
+        // OpenRouter is chat-only; it must not satisfy a Realtime request,
+        // but it must still serve Chat.
+        let db = Arc::new(StorageBackend::in_memory());
+        let encryption = test_encryption();
+        seed_active_provider(&db, &encryption, "openrouter").await;
+        let resolver = service_resolver(db, Some(encryption));
+
+        let err = resolver
+            .resolve_service(DEFAULT_ORG_ID, ServiceKind::Realtime, None)
+            .await
+            .expect_err("openrouter does not declare Realtime");
+        assert!(
+            err.to_string().contains("no provider configured"),
+            "got: {err}"
+        );
+
+        resolver
+            .resolve_service(DEFAULT_ORG_ID, ServiceKind::Chat, None)
+            .await
+            .expect("openrouter declares Chat");
+    }
+
+    #[tokio::test]
+    async fn resolve_service_binding_requires_service_support() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let encryption = test_encryption();
+        let openrouter = seed_active_provider(&db, &encryption, "openrouter").await;
+        let resolver = service_resolver(db, Some(encryption));
+
+        let err = resolver
+            .resolve_service(
+                DEFAULT_ORG_ID,
+                ServiceKind::Realtime,
+                Some(&openrouter.to_string()),
+            )
+            .await
+            .expect_err("bound provider's driver lacks Realtime");
+        assert!(err.to_string().contains("does not provide"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn resolve_service_binding_selects_explicit_provider() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let encryption = test_encryption();
+        // Two realtime-capable providers; the binding must pick the named one,
+        // not just the first active match.
+        let first = seed_active_provider(&db, &encryption, "openai").await;
+        let second = seed_active_provider(&db, &encryption, "openai").await;
+        let resolver = service_resolver(db, Some(encryption));
+
+        let resolved = resolver
+            .resolve_service(
+                DEFAULT_ORG_ID,
+                ServiceKind::Realtime,
+                Some(&second.to_string()),
+            )
+            .await
+            .expect("explicit binding resolves");
+        assert_eq!(resolved.provider_id, second.to_string());
+        assert_ne!(resolved.provider_id, first.to_string());
     }
 }

--- a/specs/providers.md
+++ b/specs/providers.md
@@ -135,7 +135,7 @@ Consumers and their paths:
 | Consumer | Path |
 |---|---|
 | Agent chat turns | Model-bound resolution (above) |
-| Voice realtime | `resolve_service(org, Realtime, voice_connection.provider_id)` |
+| Voice realtime | `resolve_service(org, Realtime, None)` today (single realtime-capable provider); passes `voice_connection.provider_id` once per-connection provider selection is plumbed |
 | Knowledge-base embeddings (future) | `resolve_service` with an embedding model selection |
 | Model sync | Per-provider, via the driver's `list_models` with the provider's connection |
 | Utility LLM | **Not a provider consumer.** Stays system-owned and env-configured by design (`specs/utility-llm.md`) |

--- a/specs/providers.md
+++ b/specs/providers.md
@@ -126,7 +126,9 @@ New entry point for consumers that need a service rather than a chat model:
 resolve_service(org, ServiceKind, binding) -> (ProviderConnection, service client)
 ```
 
-Selection: explicit `provider_id` on the consumer's binding (e.g. the voice connection's `provider_id` field) wins; otherwise an org-level default provider per service; otherwise the single active provider whose driver declares the service. "First active provider matching a type string" — the current voice behavior — is removed. Resolution failures surface structured "no provider configured for {service}" errors, fail-closed.
+Selection: explicit `provider_id` on the consumer's binding (e.g. the voice connection's `provider_id` field) wins; otherwise an org-level default provider per service; otherwise the single active provider whose driver declares the service. "First active provider matching a type string" — the old voice behavior — is removed. Resolution failures surface structured "no provider configured for {service}" errors, fail-closed.
+
+Implemented today: the explicit-binding tier (validated against the driver's declared services) and the active-provider-declaring-service tier. The org-default-per-service tier is not built yet (no consumer needs it). Voice realtime currently calls `resolve_service(org, Realtime, None)` — a per-connection provider binding is not plumbed, so it resolves the single realtime-capable provider; the binding parameter exists for when that selection lands.
 
 Consumers and their paths:
 
@@ -208,7 +210,7 @@ PR-sized slices, each leaving the tree green and self-consistent (code + specs +
 1. **Core domain types and registry** — `ServiceKind`, driver descriptor with credential schema and service factories (building on `DriverConfig`/`External` from EVE-561), `ChatDriver` rename, profile keys. No DB change.
 2. **DB + storage rename** — migrations, storage traits, repositories, seeds, resolver rename, `profile_key` backfill.
 3. **API + UI rename** — routes, OpenAPI, UI pages/hooks/clients, profile catalog endpoint, picker grouping.
-4. **Service resolution** — `resolve_service`, voice rerouted, org default provider per service.
+4. ✅ **Service resolution** — `resolve_service(org, ServiceKind, binding)` (explicit-binding and active-provider-declaring-service tiers), voice realtime rerouted through it (`ServiceKind::Realtime`, fail-closed). The org-level default-provider-per-service tier is deferred — no consumer requires it yet (chat already has `default_model_id`; voice resolves the single realtime-capable provider).
 5. **Connector alignment** — shared credential primitives, `ConnectorPlugin` rename.
 6. ✅ **First new service** — `EmbeddingsDriver` + knowledge-base hybrid retrieval configuration (closes the open question in `specs/knowledge-bases.md`).
 


### PR DESCRIPTION
## What

Phase 4 of the providers refactor (spec: `specs/providers.md`). Adds **service-bound resolution** — a way for non-chat consumers to resolve a provider by `ServiceKind` rather than by a chat model — and reroutes voice realtime through it.

- `ProviderResolverService::resolve_service(org, ServiceKind, binding) -> ResolvedServiceProvider`, fail-closed:
  1. an explicit provider `binding` wins, but only when that provider's driver declares the requested service;
  2. otherwise the first **active** provider whose driver declares the service;
  3. structured `"no provider configured for {service}"` error when none match.
- `ProviderResolverService::with_driver_registry(...)` threads the platform `DriverRegistry` into the resolver so it knows which drivers implement which `ServiceKind`. The two production composition roots (`app_builder`, `grpc_service`) wire it in; without it, service resolution fails closed.
- **Voice realtime** now calls `resolve_service(org, Realtime, None)` instead of matching the hardcoded `"openai"` type string. Only realtime-*capable* drivers are eligible — OpenRouter (chat-only) is correctly excluded.

## Why

The "first active provider matching a type string" behavior the old voice path used is exactly what `specs/providers.md` removes: it ignores what a driver can actually do. Service-kind resolution makes non-chat consumers (voice today, embeddings/rerank later) select providers by capability, fail-closed.

## How

`resolve_service` reuses the existing org-scoped provider listing and the DB-only `resolve_api_key` path (so the fail-closed, no-env-fallback credential contract from `specs/llm-drivers.md` carries over unchanged). `DriverDescriptor::supports(ServiceKind)` / `DriverRegistry::supports(driver_id, service)` (already present from phases 1/6) do the capability check. The explicit binding is parsed once into a typed `ProviderId` (validated; clear error on malformed input) and compared by id.

## Risk
- **Low** — additive resolver method + an internal rerouting of voice credential lookup. No schema, no API shape change, no migration. Voice responses still report `provider: "openai"` (realtime is OpenAI-only in OSS).
- Behavior change: a misconfigured provider that previously matched purely by the `"openai"` type string but whose driver doesn't declare `Realtime` is now (correctly) not selected.

## Security
- Threat categories reviewed: **TM-TENANT**, **TM-LLM**, **TM-API**.
  - *TM-TENANT:* `resolve_service` scopes to `list_providers(org_id)`; an explicit `binding` only matches within the caller's org, so it cannot reference another org's provider (returns "not found"). No cross-tenant access.
  - *TM-LLM:* credentials resolve via the same DB-only `resolve_api_key`; never falls back to env in tenant paths. The existing `resolve_provider_api_key_env_key_set_does_not_leak` invariant still holds; a provider row without a usable key is skipped, not satisfied from the host environment.
  - *TM-API:* no new endpoints; voice endpoints unchanged in shape.
- Findings: none. The change tightens selection (capability-gated) and preserves org scoping + fail-closed credentials. No threat-model entries needed.

## Validation
- `cargo clippy -p everruns-server --all-targets --all-features -- -D warnings` clean; `cargo fmt --check` clean.
- 5 new unit tests for `resolve_service`: active-provider selection, fail-closed-when-none, driver-without-service exclusion (OpenRouter ≠ Realtime, but ✓ Chat), binding requires service support, binding selects the explicit provider. All pass.
- Existing voice unit tests (17) pass.
- Smoke: dev server boots cleanly with the new `with_driver_registry` wiring (HTTP listening, `/health` 200, feature flags computed, no panic in the resolution path).

## Follow-ups
- **Org-level default-provider-per-service tier** (selection tier 2) — deferred. No consumer requires it yet: chat uses `default_model_id`, and voice resolves the single realtime-capable provider. Needs an org-settings schema addition; best as its own slice.
- **Per-connection voice provider binding** — voice passes `None` today; the `binding` parameter is in place for when explicit per-connection realtime-provider selection is plumbed through the voice API.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (internal resolution; no external API/SDK shape change)
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)