### PR TITLE
feat(openrouter): support BYOK-first organization routing strategy

### DIFF
--- a/crates/core/src/llm_driver_registry.rs
+++ b/crates/core/src/llm_driver_registry.rs
@@ -517,6 +517,29 @@ pub struct PromptCacheConfig {
 
 /// OpenRouter model fallback and provider routing controls.
 ///
+/// Organization-level strategy for how OpenRouter should allocate compute capacity.
+///
+/// Controls whether requests use OpenRouter shared credits, prefer customer-owned
+/// upstream keys (BYOK), or require BYOK-only routing. Compiled into OpenRouter
+/// `provider` routing controls before dispatch; not sent verbatim on the wire.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum OpenRouterCapacityStrategy {
+    /// Use OpenRouter shared capacity (credits). No routing changes. Default.
+    #[default]
+    SharedCapacity,
+    /// Prefer providers where the org has registered its own upstream key.
+    /// Falls back to shared capacity when BYOK providers are unavailable.
+    /// Sets `provider.allow_fallbacks = true` unless the caller overrides it.
+    ByokFirst,
+    /// Require a provider where the org has its own upstream key.
+    /// Routing fails if `provider.only` is not explicitly configured with at
+    /// least one BYOK provider slug.
+    /// Sets `provider.allow_fallbacks = false`.
+    ByokOnly,
+}
+
 /// These fields mirror OpenRouter's request-level routing extensions. Drivers
 /// must only forward this config to OpenRouter-compatible endpoints.
 #[derive(Debug, Clone, Default, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -535,6 +558,11 @@ pub struct OpenRouterRoutingConfig {
     /// Optional plugin activations (web search, file reader).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub plugins: Option<OpenRouterPluginConfig>,
+    /// Org-level capacity strategy. Compiled into `provider` routing before
+    /// dispatch; not forwarded verbatim. `None` and `SharedCapacity` are
+    /// equivalent (no routing changes).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub capacity_strategy: Option<OpenRouterCapacityStrategy>,
 }
 
 impl OpenRouterRoutingConfig {
@@ -543,6 +571,10 @@ impl OpenRouterRoutingConfig {
             && self.route.is_none()
             && self.provider.is_none()
             && self.plugins.as_ref().is_none_or(|p| p.is_empty())
+            && matches!(
+                self.capacity_strategy,
+                None | Some(OpenRouterCapacityStrategy::SharedCapacity)
+            )
     }
 
     /// Build an ordered model-fallback routing config.
@@ -554,6 +586,7 @@ impl OpenRouterRoutingConfig {
             route,
             provider: None,
             plugins: None,
+            capacity_strategy: None,
         }
     }
 
@@ -576,6 +609,44 @@ impl OpenRouterRoutingConfig {
         }
 
         Ok(())
+    }
+
+    /// Apply the capacity strategy, returning a derived config with `provider`
+    /// routing adjusted accordingly.
+    ///
+    /// - `SharedCapacity` / `None` — returns `self` unchanged.
+    /// - `ByokFirst` — sets `provider.allow_fallbacks = true` when not already set.
+    /// - `ByokOnly` — requires `provider.only` to list at least one provider slug;
+    ///   sets `provider.allow_fallbacks = false`.
+    ///
+    /// Returns `Err` when the strategy constraints cannot be satisfied.
+    pub fn apply_capacity_strategy(&self) -> std::result::Result<Self, String> {
+        match self.capacity_strategy {
+            None | Some(OpenRouterCapacityStrategy::SharedCapacity) => Ok(self.clone()),
+            Some(OpenRouterCapacityStrategy::ByokFirst) => {
+                let mut result = self.clone();
+                let provider = result.provider.get_or_insert_with(Default::default);
+                if provider.allow_fallbacks.is_none() {
+                    provider.allow_fallbacks = Some(true);
+                }
+                Ok(result)
+            }
+            Some(OpenRouterCapacityStrategy::ByokOnly) => {
+                let only_is_empty = self.provider.as_ref().is_none_or(|p| p.only.is_empty());
+                if only_is_empty {
+                    return Err(
+                        "OpenRouter BYOK-only strategy requires provider.only to list at least \
+                         one upstream provider slug. Configure the provider list to match the \
+                         BYOK providers registered in your OpenRouter workspace."
+                            .to_string(),
+                    );
+                }
+                let mut result = self.clone();
+                let provider = result.provider.get_or_insert_with(Default::default);
+                provider.allow_fallbacks = Some(false);
+                Ok(result)
+            }
+        }
     }
 }
 
@@ -2411,5 +2482,112 @@ mod tests {
         let json = serde_json::to_value(&plugin).unwrap();
         assert!(json.get("max_results").is_none());
         assert!(json.get("search_prompt").is_none());
+    }
+
+    #[test]
+    fn test_capacity_strategy_shared_capacity_is_noop() {
+        let base = OpenRouterRoutingConfig {
+            models: vec!["openai/gpt-5-mini".to_string()],
+            capacity_strategy: Some(OpenRouterCapacityStrategy::SharedCapacity),
+            ..Default::default()
+        };
+        let result = base.apply_capacity_strategy().unwrap();
+        assert_eq!(
+            result.capacity_strategy,
+            Some(OpenRouterCapacityStrategy::SharedCapacity)
+        );
+        assert!(result.provider.is_none());
+    }
+
+    #[test]
+    fn test_capacity_strategy_none_is_noop() {
+        let base = OpenRouterRoutingConfig {
+            models: vec!["openai/gpt-5-mini".to_string()],
+            capacity_strategy: None,
+            ..Default::default()
+        };
+        let result = base.apply_capacity_strategy().unwrap();
+        assert!(result.provider.is_none());
+    }
+
+    #[test]
+    fn test_capacity_strategy_byok_first_sets_allow_fallbacks() {
+        let base = OpenRouterRoutingConfig {
+            models: vec!["openai/gpt-5-mini".to_string()],
+            capacity_strategy: Some(OpenRouterCapacityStrategy::ByokFirst),
+            ..Default::default()
+        };
+        let result = base.apply_capacity_strategy().unwrap();
+        let provider = result.provider.as_ref().expect("provider set by ByokFirst");
+        assert_eq!(provider.allow_fallbacks, Some(true));
+    }
+
+    #[test]
+    fn test_capacity_strategy_byok_first_preserves_explicit_allow_fallbacks() {
+        // If allow_fallbacks was already set explicitly, ByokFirst must not override it.
+        let base = OpenRouterRoutingConfig {
+            models: vec!["openai/gpt-5-mini".to_string()],
+            capacity_strategy: Some(OpenRouterCapacityStrategy::ByokFirst),
+            provider: Some(OpenRouterProviderRouting {
+                allow_fallbacks: Some(false),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let result = base.apply_capacity_strategy().unwrap();
+        let provider = result.provider.as_ref().unwrap();
+        assert_eq!(provider.allow_fallbacks, Some(false));
+    }
+
+    #[test]
+    fn test_capacity_strategy_byok_only_requires_provider_only() {
+        let base = OpenRouterRoutingConfig {
+            models: vec!["openai/gpt-5-mini".to_string()],
+            capacity_strategy: Some(OpenRouterCapacityStrategy::ByokOnly),
+            ..Default::default()
+        };
+        let err = base.apply_capacity_strategy().unwrap_err();
+        assert!(
+            err.contains("provider.only"),
+            "error should mention provider.only: {err}"
+        );
+    }
+
+    #[test]
+    fn test_capacity_strategy_byok_only_disables_fallbacks() {
+        let base = OpenRouterRoutingConfig {
+            models: vec!["openai/gpt-5-mini".to_string()],
+            capacity_strategy: Some(OpenRouterCapacityStrategy::ByokOnly),
+            provider: Some(OpenRouterProviderRouting {
+                only: vec!["my-byok-provider".to_string()],
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let result = base.apply_capacity_strategy().unwrap();
+        let provider = result.provider.as_ref().unwrap();
+        assert_eq!(provider.allow_fallbacks, Some(false));
+        assert_eq!(provider.only, vec!["my-byok-provider"]);
+    }
+
+    #[test]
+    fn test_capacity_strategy_byok_only_not_empty_in_is_empty() {
+        let with_strategy = OpenRouterRoutingConfig {
+            capacity_strategy: Some(OpenRouterCapacityStrategy::ByokOnly),
+            ..Default::default()
+        };
+        assert!(!with_strategy.is_empty());
+
+        let byok_first = OpenRouterRoutingConfig {
+            capacity_strategy: Some(OpenRouterCapacityStrategy::ByokFirst),
+            ..Default::default()
+        };
+        assert!(!byok_first.is_empty());
+
+        let shared = OpenRouterRoutingConfig {
+            capacity_strategy: Some(OpenRouterCapacityStrategy::SharedCapacity),
+            ..Default::default()
+        };
+        assert!(shared.is_empty());
     }
 }

--- a/crates/core/src/openresponses_protocol.rs
+++ b/crates/core/src/openresponses_protocol.rs
@@ -793,17 +793,24 @@ impl ChatDriver for OpenResponsesProtocolChatDriver {
                 .validate_for_primary_model(&config.model)
                 .map_err(AgentLoopError::llm)?;
         }
-        let effective_routing_owned;
-        let effective_routing: Option<&crate::llm_driver_registry::OpenRouterRoutingConfig> =
-            match openrouter_routing {
-                Some(routing) => {
-                    effective_routing_owned = routing
-                        .apply_capacity_strategy()
-                        .map_err(AgentLoopError::llm)?;
-                    Some(&effective_routing_owned)
+        // Apply capacity strategy without cloning when the strategy is a no-op.
+        let effective_routing_cow: Option<
+            std::borrow::Cow<'_, crate::llm_driver_registry::OpenRouterRoutingConfig>,
+        > = match openrouter_routing {
+            None => None,
+            Some(routing) => match routing.capacity_strategy {
+                None
+                | Some(crate::llm_driver_registry::OpenRouterCapacityStrategy::SharedCapacity) => {
+                    Some(std::borrow::Cow::Borrowed(routing))
                 }
-                None => None,
-            };
+                _ => Some(std::borrow::Cow::Owned(
+                    routing
+                        .apply_capacity_strategy()
+                        .map_err(AgentLoopError::llm)?,
+                )),
+            },
+        };
+        let effective_routing = effective_routing_cow.as_deref();
         let openrouter_provider = effective_routing.and_then(|routing| {
             routing
                 .provider

--- a/crates/core/src/openresponses_protocol.rs
+++ b/crates/core/src/openresponses_protocol.rs
@@ -793,14 +793,25 @@ impl ChatDriver for OpenResponsesProtocolChatDriver {
                 .validate_for_primary_model(&config.model)
                 .map_err(AgentLoopError::llm)?;
         }
-        let openrouter_provider = openrouter_routing.and_then(|routing| {
+        let effective_routing_owned;
+        let effective_routing: Option<&crate::llm_driver_registry::OpenRouterRoutingConfig> =
+            match openrouter_routing {
+                Some(routing) => {
+                    effective_routing_owned = routing
+                        .apply_capacity_strategy()
+                        .map_err(AgentLoopError::llm)?;
+                    Some(&effective_routing_owned)
+                }
+                None => None,
+            };
+        let openrouter_provider = effective_routing.and_then(|routing| {
             routing
                 .provider
                 .as_ref()
                 .filter(|provider| !provider.is_empty())
                 .cloned()
         });
-        let openrouter_plugins = openrouter_routing.and_then(|routing| {
+        let openrouter_plugins = effective_routing.and_then(|routing| {
             routing
                 .plugins
                 .as_ref()
@@ -810,9 +821,9 @@ impl ChatDriver for OpenResponsesProtocolChatDriver {
 
         let request = ResponsesRequest {
             model: config.model.clone(),
-            models: openrouter_routing
+            models: effective_routing
                 .and_then(|routing| (!routing.models.is_empty()).then_some(routing.models.clone())),
-            route: openrouter_routing.and_then(|routing| routing.route),
+            route: effective_routing.and_then(|routing| routing.route),
             provider: openrouter_provider,
             input: input_items,
             instructions,

--- a/specs/llm-drivers.md
+++ b/specs/llm-drivers.md
@@ -344,6 +344,25 @@ Plugins serialize as a `plugins` array on the wire, each entry carrying an `"id"
 (`"web"` or `"file"`) plus any plugin-specific options. The field is omitted entirely for
 non-OpenRouter providers and when no plugins are configured.
 
+### OpenRouter Capacity Strategy
+
+`OpenRouterRoutingConfig.capacity_strategy` lets callers express an organization-level
+allocation intent without encoding raw OpenRouter provider flags directly:
+
+| Variant | Behaviour |
+|---------|-----------|
+| `SharedCapacity` (default / `None`) | No changes — uses OpenRouter's shared capacity pool as-is. |
+| `ByokFirst` | Sets `provider.allow_fallbacks = true` (if not already set) so OpenRouter tries BYOK providers first and falls back to shared capacity when exhausted. |
+| `ByokOnly` | Requires `provider.only` to list at least one BYOK provider slug; sets `provider.allow_fallbacks = false` so no fallback to shared capacity occurs. Returns an error at request time if `provider.only` is empty. |
+
+The strategy is compiled into the low-level `OpenRouterProviderRouting` by
+`apply_capacity_strategy()` before the request is serialized. The
+`capacity_strategy` field itself is never sent to the API.
+
+`is_empty()` treats `SharedCapacity` and `None` as equivalent (both represent the
+default, no-op state) and returns `false` for `ByokFirst`/`ByokOnly` so those
+configs are not silently discarded.
+
 ### Stateful Continuation Invariant
 
 When a request to the OpenAI Responses API sets `previous_response_id`, the provider already holds the prior transcript server-side. The request must NOT also carry the full reconstructed transcript in `input` — that double-counts context and inflates prompt-cache keys.


### PR DESCRIPTION
## What

Adds `OpenRouterCapacityStrategy` to `OpenRouterRoutingConfig`, letting callers express an organization-level BYOK (Bring Your Own Key) routing intent without encoding raw OpenRouter provider flags directly.

Three variants:
- `SharedCapacity` (default / `None`) — no changes, uses OpenRouter's shared capacity pool.
- `ByokFirst` — sets `provider.allow_fallbacks = true` (if not already set), so BYOK providers are tried first with shared capacity as fallback.
- `ByokOnly` — requires `provider.only` to list at least one BYOK provider slug; sets `provider.allow_fallbacks = false`. Returns an error at request time if `provider.only` is empty.

`apply_capacity_strategy()` compiles the high-level strategy into low-level `OpenRouterProviderRouting` flags before the wire request is built, so the wire format stays clean.

## Why

EVE-565. Organizations that register BYOK providers in OpenRouter need a way to prefer or mandate those providers without bypassing the `OpenRouterProviderRouting` abstraction. The strategy enum is the natural place to express that intent.

## How

- New `OpenRouterCapacityStrategy` enum on `OpenRouterRoutingConfig` with serde snake_case.
- `apply_capacity_strategy()` method compiles strategy into derived `OpenRouterProviderRouting`.
- `is_empty()` treats `SharedCapacity`/`None` as equivalent no-op; returns `false` for `ByokFirst`/`ByokOnly`.
- `openresponses_protocol.rs` calls `apply_capacity_strategy()` on the routing config before serializing any fields to the wire request.
- 7 unit tests covering all strategy variants, the `is_empty` semantics, and the constraint that `ByokOnly` rejects an empty `provider.only` list.
- `specs/llm-drivers.md` documents the strategy table and compilation behaviour.

## Risk

- Low. No existing callers set `capacity_strategy` (field defaults to `None`), so all current behaviour is unchanged. The only new error path is `ByokOnly` with empty `provider.only`, which fails fast before any network call.

## Security

- Threat categories reviewed: TM-LLM (prompt/routing config forwarded to upstream LLM API), TM-API (new field on routing config struct).
- No authentication or authorization surface changes.
- `ByokOnly` validation ensures misconfigured calls fail loudly rather than silently routing to shared capacity.
- No new dependencies.

## Follow-ups

No follow-ups.

---
_Generated by [Claude Code](https://claude.ai/code/session_014zWDagYxaty9q19wfeA3Hw)_