### PR TITLE
fix(ui): address session file browser by the session's workspace_id

### DIFF
--- a/apps/ui/src/__tests__/file-browser.test.tsx
+++ b/apps/ui/src/__tests__/file-browser.test.tsx
@@ -90,7 +90,7 @@ describe("FileBrowser States", () => {
       refetch: mockRefetch,
     });
 
-    renderWithProviders(<FileBrowser sessionId="test-session" />);
+    renderWithProviders(<FileBrowser workspaceId="test-session" />);
 
     expect(screen.getByTestId("loader-icon")).toBeInTheDocument();
     expect(screen.getByText("Loading files...")).toBeInTheDocument();
@@ -103,7 +103,7 @@ describe("FileBrowser States", () => {
       refetch: mockRefetch,
     });
 
-    renderWithProviders(<FileBrowser sessionId="test-session" />);
+    renderWithProviders(<FileBrowser workspaceId="test-session" />);
 
     expect(screen.getByText("Empty workspace")).toBeInTheDocument();
     expect(screen.getByText("Create a file or folder to get started")).toBeInTheDocument();
@@ -125,28 +125,28 @@ describe("FileBrowser Toolbar", () => {
   });
 
   it("renders refresh button", () => {
-    renderWithProviders(<FileBrowser sessionId="test-session" />);
+    renderWithProviders(<FileBrowser workspaceId="test-session" />);
 
     expect(screen.getByTitle("Refresh")).toBeInTheDocument();
     expect(screen.getByText("Refresh")).toBeInTheDocument();
   });
 
   it("renders new folder button", () => {
-    renderWithProviders(<FileBrowser sessionId="test-session" />);
+    renderWithProviders(<FileBrowser workspaceId="test-session" />);
 
     expect(screen.getByTitle("New folder")).toBeInTheDocument();
     expect(screen.getByText("Folder")).toBeInTheDocument();
   });
 
   it("renders new file button", () => {
-    renderWithProviders(<FileBrowser sessionId="test-session" />);
+    renderWithProviders(<FileBrowser workspaceId="test-session" />);
 
     expect(screen.getByTitle("New file")).toBeInTheDocument();
     expect(screen.getByText("File")).toBeInTheDocument();
   });
 
   it("calls refetch when refresh button is clicked", async () => {
-    renderWithProviders(<FileBrowser sessionId="test-session" />);
+    renderWithProviders(<FileBrowser workspaceId="test-session" />);
 
     fireEvent.click(screen.getByTitle("Refresh"));
     await waitFor(() => {
@@ -195,7 +195,7 @@ describe("FileBrowser FileTree", () => {
       refetch: mockRefetch,
     });
 
-    renderWithProviders(<FileBrowser sessionId="test-session" />);
+    renderWithProviders(<FileBrowser workspaceId="test-session" />);
 
     expect(screen.getByText("test.ts")).toBeInTheDocument();
     expect(screen.getByText("1024 B")).toBeInTheDocument();
@@ -208,7 +208,7 @@ describe("FileBrowser FileTree", () => {
       refetch: mockRefetch,
     });
 
-    renderWithProviders(<FileBrowser sessionId="test-session" />);
+    renderWithProviders(<FileBrowser workspaceId="test-session" />);
 
     expect(screen.getByText("src")).toBeInTheDocument();
   });
@@ -220,7 +220,7 @@ describe("FileBrowser FileTree", () => {
       refetch: mockRefetch,
     });
 
-    renderWithProviders(<FileBrowser sessionId="test-session" />);
+    renderWithProviders(<FileBrowser workspaceId="test-session" />);
 
     const items = screen.getAllByRole("treeitem");
     // Directory should come first
@@ -235,7 +235,7 @@ describe("FileBrowser FileTree", () => {
       refetch: mockRefetch,
     });
 
-    renderWithProviders(<FileBrowser sessionId="test-session" onFileSelect={onFileSelect} />);
+    renderWithProviders(<FileBrowser workspaceId="test-session" onFileSelect={onFileSelect} />);
 
     fireEvent.click(screen.getByText("test.ts"));
     expect(onFileSelect).toHaveBeenCalledWith(mockFile);
@@ -249,7 +249,7 @@ describe("FileBrowser FileTree", () => {
       refetch: mockRefetch,
     });
 
-    renderWithProviders(<FileBrowser sessionId="test-session" onFileSelect={onFileSelect} />);
+    renderWithProviders(<FileBrowser workspaceId="test-session" onFileSelect={onFileSelect} />);
 
     fireEvent.click(screen.getByText("src"));
     expect(onFileSelect).not.toHaveBeenCalled();
@@ -263,7 +263,7 @@ describe("FileBrowser FileTree", () => {
       refetch: mockRefetch,
     });
 
-    renderWithProviders(<FileBrowser sessionId="test-session" />);
+    renderWithProviders(<FileBrowser workspaceId="test-session" />);
 
     expect(screen.getByTestId("lock-icon")).toBeInTheDocument();
   });
@@ -276,7 +276,7 @@ describe("FileBrowser FileTree", () => {
       refetch: mockRefetch,
     });
 
-    renderWithProviders(<FileBrowser sessionId="test-session" />);
+    renderWithProviders(<FileBrowser workspaceId="test-session" />);
 
     // Hover over the file to reveal actions
     const fileItem = screen.getByText("test.ts").closest("[role='treeitem']");
@@ -293,7 +293,9 @@ describe("FileBrowser FileTree", () => {
       refetch: mockRefetch,
     });
 
-    renderWithProviders(<FileBrowser sessionId="test-session" selectedPath="/workspace/test.ts" />);
+    renderWithProviders(
+      <FileBrowser workspaceId="test-session" selectedPath="/workspace/test.ts" />,
+    );
 
     const selectedItem = screen.getByText("test.ts").closest("[role='treeitem']");
     expect(selectedItem).toHaveClass("bg-accent/20");
@@ -328,7 +330,7 @@ describe("FileBrowser File Icons", () => {
       refetch: mockRefetch,
     });
 
-    renderWithProviders(<FileBrowser sessionId="test-session" />);
+    renderWithProviders(<FileBrowser workspaceId="test-session" />);
 
     expect(screen.getByTestId(expectedIconTestId)).toBeInTheDocument();
   };
@@ -372,7 +374,7 @@ describe("FileBrowser Create File Dialog", () => {
   });
 
   it("renders new file button in toolbar", () => {
-    renderWithProviders(<FileBrowser sessionId="test-session" />);
+    renderWithProviders(<FileBrowser workspaceId="test-session" />);
 
     expect(screen.getByTitle("New file")).toBeInTheDocument();
   });
@@ -395,7 +397,7 @@ describe("FileBrowser Create Folder Dialog", () => {
   });
 
   it("renders new folder button in toolbar", () => {
-    renderWithProviders(<FileBrowser sessionId="test-session" />);
+    renderWithProviders(<FileBrowser workspaceId="test-session" />);
 
     expect(screen.getByTitle("New folder")).toBeInTheDocument();
   });
@@ -430,7 +432,7 @@ describe("FileBrowser Delete", () => {
   });
 
   it("shows delete button on hover", () => {
-    renderWithProviders(<FileBrowser sessionId="test-session" />);
+    renderWithProviders(<FileBrowser workspaceId="test-session" />);
 
     // The delete button should exist but be hidden until hover
     const deleteButton = screen.getByTitle("Delete");
@@ -438,7 +440,7 @@ describe("FileBrowser Delete", () => {
   });
 
   it("confirms before deleting", async () => {
-    renderWithProviders(<FileBrowser sessionId="test-session" />);
+    renderWithProviders(<FileBrowser workspaceId="test-session" />);
 
     fireEvent.click(screen.getByTitle("Delete"));
 
@@ -446,13 +448,13 @@ describe("FileBrowser Delete", () => {
   });
 
   it("deletes file when confirmed", async () => {
-    renderWithProviders(<FileBrowser sessionId="test-session" />);
+    renderWithProviders(<FileBrowser workspaceId="test-session" />);
 
     fireEvent.click(screen.getByTitle("Delete"));
 
     await waitFor(() => {
       expect(mockDeleteFile).toHaveBeenCalledWith({
-        sessionId: "test-session",
+        workspaceId: "test-session",
         path: "/workspace/test.ts",
         recursive: false,
       });
@@ -462,7 +464,7 @@ describe("FileBrowser Delete", () => {
   it("does not delete when cancelled", async () => {
     (window.confirm as jest.Mock).mockReturnValue(false);
 
-    renderWithProviders(<FileBrowser sessionId="test-session" />);
+    renderWithProviders(<FileBrowser workspaceId="test-session" />);
 
     fireEvent.click(screen.getByTitle("Delete"));
 
@@ -516,7 +518,7 @@ describe("FileBrowser Directory Expansion", () => {
 
     mockListFiles.mockResolvedValue([mockSubFile]);
 
-    renderWithProviders(<FileBrowser sessionId="test-session" />);
+    renderWithProviders(<FileBrowser workspaceId="test-session" />);
 
     // Click to expand directory
     fireEvent.click(screen.getByText("src"));
@@ -535,7 +537,7 @@ describe("FileBrowser Directory Expansion", () => {
 
     mockListFiles.mockResolvedValue([mockSubFile]);
 
-    renderWithProviders(<FileBrowser sessionId="test-session" />);
+    renderWithProviders(<FileBrowser workspaceId="test-session" />);
 
     fireEvent.click(screen.getByText("src"));
 
@@ -555,7 +557,7 @@ describe("FileBrowser Directory Expansion", () => {
 
     mockListFiles.mockResolvedValue([mockSubFile]);
 
-    renderWithProviders(<FileBrowser sessionId="test-session" />);
+    renderWithProviders(<FileBrowser workspaceId="test-session" />);
 
     // Expand directory first
     fireEvent.click(screen.getByText("src"));
@@ -628,7 +630,7 @@ describe("FileBrowser recursion guard", () => {
 
     // Before the fix this would throw RangeError: Maximum call stack size exceeded
     expect(() => {
-      renderWithProviders(<FileBrowser sessionId="test-session" />);
+      renderWithProviders(<FileBrowser workspaceId="test-session" />);
     }).not.toThrow();
 
     // The normal file should still render
@@ -663,7 +665,7 @@ describe("FileBrowser recursion guard", () => {
       refetch: mockRefetch,
     });
 
-    renderWithProviders(<FileBrowser sessionId="test-session" />);
+    renderWithProviders(<FileBrowser workspaceId="test-session" />);
 
     expect(screen.getByText("src")).toBeInTheDocument();
     expect(screen.getByText("README.md")).toBeInTheDocument();
@@ -704,7 +706,7 @@ describe("FileBrowser recursion guard", () => {
     });
 
     expect(() => {
-      renderWithProviders(<FileBrowser sessionId="test-session" />);
+      renderWithProviders(<FileBrowser workspaceId="test-session" />);
     }).not.toThrow();
 
     // Expand dir A
@@ -743,7 +745,7 @@ describe("FileBrowser recursion guard", () => {
     });
 
     expect(() => {
-      renderWithProviders(<FileBrowser sessionId="test-session" />);
+      renderWithProviders(<FileBrowser workspaceId="test-session" />);
     }).not.toThrow();
 
     expect(screen.getByText("empty")).toBeInTheDocument();
@@ -772,7 +774,7 @@ describe("FileBrowser recursion guard", () => {
 
     // All entries filtered → falls through to empty workspace
     expect(() => {
-      renderWithProviders(<FileBrowser sessionId="test-session" />);
+      renderWithProviders(<FileBrowser workspaceId="test-session" />);
     }).not.toThrow();
   });
 
@@ -795,7 +797,7 @@ describe("FileBrowser recursion guard", () => {
     });
 
     expect(() => {
-      renderWithProviders(<FileBrowser sessionId="test-session" />);
+      renderWithProviders(<FileBrowser workspaceId="test-session" />);
     }).not.toThrow();
 
     // Both render (keyed by unique id)
@@ -827,7 +829,7 @@ describe("FileBrowser recursion guard", () => {
       refetch: mockRefetch,
     });
 
-    renderWithProviders(<FileBrowser sessionId="test-session" />);
+    renderWithProviders(<FileBrowser workspaceId="test-session" />);
 
     const items = screen.getAllByRole("treeitem");
     // Directory "z-dir" should come before file "a-file.ts" despite alphabetical order

--- a/apps/ui/src/__tests__/session-files.test.ts
+++ b/apps/ui/src/__tests__/session-files.test.ts
@@ -19,9 +19,7 @@ jest.mock("@/lib/api/client", () => ({
 
 const mockedApi = api as jest.Mocked<typeof api>;
 
-const SESSION_ID = "session_5c7f3a91b24e48d6a0e91f3b7c4d2e85";
-// Derived workspace ID — same hex suffix, different prefix.
-const WSP_ID = "wsp_5c7f3a91b24e48d6a0e91f3b7c4d2e85";
+const WORKSPACE_ID = "wsp_5c7f3a91b24e48d6a0e91f3b7c4d2e85";
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -30,39 +28,43 @@ beforeEach(() => {
 describe("fsPath encoding (EVE-558 / EVE-555)", () => {
   it("encodes ? in a filename so it is not treated as a query delimiter", async () => {
     mockedApi.get.mockResolvedValueOnce({ data: { data: [] } });
-    await listFiles(SESSION_ID, "/dir?recursive=true");
+    await listFiles(WORKSPACE_ID, "/dir?recursive=true");
     expect(mockedApi.get).toHaveBeenCalledWith(
-      `/v1/workspaces/${WSP_ID}/fs/dir%3Frecursive%3Dtrue`,
+      `/v1/workspaces/${WORKSPACE_ID}/fs/dir%3Frecursive%3Dtrue`,
     );
   });
 
   it("encodes # in a filename so it is not treated as a fragment delimiter", async () => {
     mockedApi.get.mockResolvedValueOnce({ data: {} });
-    await readFile(SESSION_ID, "/notes#section");
-    expect(mockedApi.get).toHaveBeenCalledWith(`/v1/workspaces/${WSP_ID}/fs/notes%23section`);
+    await readFile(WORKSPACE_ID, "/notes#section");
+    expect(mockedApi.get).toHaveBeenCalledWith(`/v1/workspaces/${WORKSPACE_ID}/fs/notes%23section`);
   });
 
   it("encodes % in a filename so pre-encoded sequences are not double-decoded", async () => {
     mockedApi.get.mockResolvedValueOnce({ data: {} });
-    await readFile(SESSION_ID, "/file%20name.txt");
-    expect(mockedApi.get).toHaveBeenCalledWith(`/v1/workspaces/${WSP_ID}/fs/file%2520name.txt`);
+    await readFile(WORKSPACE_ID, "/file%20name.txt");
+    expect(mockedApi.get).toHaveBeenCalledWith(
+      `/v1/workspaces/${WORKSPACE_ID}/fs/file%2520name.txt`,
+    );
   });
 
   it("preserves directory structure while encoding each segment independently", async () => {
     mockedApi.get.mockResolvedValueOnce({ data: {} });
-    await readFile(SESSION_ID, "/a?b/c#d/e%f");
-    expect(mockedApi.get).toHaveBeenCalledWith(`/v1/workspaces/${WSP_ID}/fs/a%3Fb/c%23d/e%25f`);
+    await readFile(WORKSPACE_ID, "/a?b/c#d/e%f");
+    expect(mockedApi.get).toHaveBeenCalledWith(
+      `/v1/workspaces/${WORKSPACE_ID}/fs/a%3Fb/c%23d/e%25f`,
+    );
   });
 
   it("root path produces bare fs base URL without trailing slash", async () => {
     mockedApi.get.mockResolvedValueOnce({ data: { data: [] } });
-    await listFiles(SESSION_ID, "/");
-    expect(mockedApi.get).toHaveBeenCalledWith(`/v1/workspaces/${WSP_ID}/fs`);
+    await listFiles(WORKSPACE_ID, "/");
+    expect(mockedApi.get).toHaveBeenCalledWith(`/v1/workspaces/${WORKSPACE_ID}/fs`);
   });
 
   it("recursive=true is appended as a separate query param after the encoded path", async () => {
     mockedApi.get.mockResolvedValueOnce({ data: { data: [] } });
-    await listFiles(SESSION_ID, "/dir?x=1", true);
+    await listFiles(WORKSPACE_ID, "/dir?x=1", true);
     const url = mockedApi.get.mock.calls[0][0] as string;
     // Path segment is encoded; recursive flag is a distinct query param.
     expect(url).toMatch(/\/dir%3Fx%3D1\?recursive=true$/);
@@ -70,8 +72,8 @@ describe("fsPath encoding (EVE-558 / EVE-555)", () => {
 
   it("delete with recursive=true encodes path and appends query param correctly", async () => {
     mockedApi.delete.mockResolvedValueOnce({ data: { deleted: true } });
-    await deleteFile(SESSION_ID, "/tmp?dir", true);
+    await deleteFile(WORKSPACE_ID, "/tmp?dir", true);
     const url = mockedApi.delete.mock.calls[0][0] as string;
-    expect(url).toBe(`/v1/workspaces/${WSP_ID}/fs/tmp%3Fdir?recursive=true`);
+    expect(url).toBe(`/v1/workspaces/${WORKSPACE_ID}/fs/tmp%3Fdir?recursive=true`);
   });
 });

--- a/apps/ui/src/app/(main)/sessions/[sessionId]/files/page.tsx
+++ b/apps/ui/src/app/(main)/sessions/[sessionId]/files/page.tsx
@@ -8,7 +8,12 @@ import { File, Upload, Loader2, CheckCircle2, XCircle } from "lucide-react";
 import { useFileDropUpload } from "@/hooks/use-file-drop-upload";
 
 export default function FilesPage() {
-  const { sessionId } = useSessionContext();
+  // Address files by the session's attached workspace (the canonical fs
+  // surface), not the session id — they differ when the session is attached to
+  // a shared workspace. `workspace_id` is undefined only while the session is
+  // still loading.
+  const { session } = useSessionContext();
+  const workspaceId = session?.workspace_id;
   const [selectedFile, setSelectedFile] = useState<FileInfo | null>(null);
   const [refreshToken, setRefreshToken] = useState(0);
 
@@ -17,7 +22,7 @@ export default function FilesPage() {
   }, []);
 
   const { isDragging, uploads, isUploading, dragHandlers } = useFileDropUpload(
-    sessionId,
+    workspaceId,
     "/workspace",
     handleUploadComplete,
   );
@@ -27,7 +32,7 @@ export default function FilesPage() {
       {/* File browser sidebar */}
       <div className="w-72 border-r flex-shrink-0 overflow-hidden bg-card/50">
         <FileBrowser
-          sessionId={sessionId}
+          workspaceId={workspaceId}
           onFileSelect={setSelectedFile}
           selectedPath={selectedFile?.path}
           refreshToken={refreshToken}
@@ -38,7 +43,7 @@ export default function FilesPage() {
       <div className="flex-1 overflow-hidden">
         {selectedFile && !selectedFile.is_directory ? (
           <FileViewer
-            sessionId={sessionId}
+            workspaceId={workspaceId}
             file={selectedFile}
             onClose={() => setSelectedFile(null)}
           />

--- a/apps/ui/src/components/files/file-browser.tsx
+++ b/apps/ui/src/components/files/file-browser.tsx
@@ -42,7 +42,8 @@ import { formatFileSize, joinPath, listFiles } from "@/lib/api/session-files";
 import type { FileInfo } from "@/lib/api/types";
 
 interface FileBrowserProps {
-  sessionId: string;
+  /** The session's attached workspace id; undefined while the session loads. */
+  workspaceId: string | undefined;
   onFileSelect?: (file: FileInfo) => void;
   selectedPath?: string;
   /** Increment to trigger a full refresh (e.g. after file upload) */
@@ -105,7 +106,7 @@ function getFileIcon(filename: string) {
 }
 
 export function FileBrowser({
-  sessionId,
+  workspaceId,
   onFileSelect,
   selectedPath,
   refreshToken,
@@ -124,7 +125,7 @@ export function FileBrowser({
     data: rootFiles,
     isLoading,
     refetch: refetchRoot,
-  } = useFiles(sessionId, "/workspace", false);
+  } = useFiles(workspaceId, "/workspace", false);
   const createFile = useCreateFile();
   const createDir = useCreateDirectory();
   const deleteFile = useDeleteFile();
@@ -162,14 +163,15 @@ export function FileBrowser({
   // Function to load a directory's contents
   const loadDirectory = useCallback(
     async (path: string) => {
+      if (!workspaceId) return;
       try {
-        const files = await listFiles(sessionId, path);
+        const files = await listFiles(workspaceId, path);
         setLoadedDirs((prev) => new Map(prev).set(path, files));
       } catch {
         // Error loading directory
       }
     },
-    [sessionId],
+    [workspaceId],
   );
 
   const handleExpandedChange = useCallback(
@@ -212,11 +214,11 @@ export function FileBrowser({
   }, [refreshToken, handleRefresh]);
 
   const handleCreateFile = async () => {
-    if (!newFileName.trim()) return;
+    if (!newFileName.trim() || !workspaceId) return;
 
     try {
       await createFile.mutateAsync({
-        sessionId,
+        workspaceId,
         request: {
           path: joinPath(createPath, newFileName),
           content: newFileContent,
@@ -233,11 +235,11 @@ export function FileBrowser({
   };
 
   const handleCreateDir = async () => {
-    if (!newDirName.trim()) return;
+    if (!newDirName.trim() || !workspaceId) return;
 
     try {
       await createDir.mutateAsync({
-        sessionId,
+        workspaceId,
         path: joinPath(createPath, newDirName),
       });
       setIsCreateDirOpen(false);
@@ -250,13 +252,14 @@ export function FileBrowser({
 
   const handleDelete = async (file: FileInfo, e: React.MouseEvent) => {
     e.stopPropagation();
+    if (!workspaceId) return;
     if (!confirm(`Delete ${file.is_directory ? "directory" : "file"} "${file.name}"?`)) {
       return;
     }
 
     try {
       await deleteFile.mutateAsync({
-        sessionId,
+        workspaceId,
         path: file.path,
         recursive: file.is_directory,
       });

--- a/apps/ui/src/components/files/file-viewer.tsx
+++ b/apps/ui/src/components/files/file-viewer.tsx
@@ -13,19 +13,20 @@ import { formatFileSize, getFileExtension } from "@/lib/api/session-files";
 import type { FileInfo } from "@/lib/api/types";
 
 interface FileViewerProps {
-  sessionId: string;
+  /** The session's attached workspace id; undefined while the session loads. */
+  workspaceId: string | undefined;
   file: FileInfo;
   onClose: () => void;
 }
 
 type ViewMode = "preview" | "source";
 
-export function FileViewer({ sessionId, file, onClose }: FileViewerProps) {
+export function FileViewer({ workspaceId, file, onClose }: FileViewerProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [editContent, setEditContent] = useState("");
   const [viewMode, setViewMode] = useState<ViewMode>("preview");
 
-  const { data: fileData, isLoading, refetch } = useFile(sessionId, file.path);
+  const { data: fileData, isLoading, refetch } = useFile(workspaceId, file.path);
   const updateFile = useUpdateFile();
 
   const handleEdit = () => {
@@ -36,9 +37,10 @@ export function FileViewer({ sessionId, file, onClose }: FileViewerProps) {
   };
 
   const handleSave = async () => {
+    if (!workspaceId) return;
     try {
       await updateFile.mutateAsync({
-        sessionId,
+        workspaceId,
         path: file.path,
         request: {
           content: editContent,

--- a/apps/ui/src/hooks/use-file-drop-upload.ts
+++ b/apps/ui/src/hooks/use-file-drop-upload.ts
@@ -118,7 +118,7 @@ function readAsBase64(file: File): Promise<string> {
 }
 
 export function useFileDropUpload(
-  sessionId: string,
+  workspaceId: string | undefined,
   targetDir: string = "/workspace",
   onComplete?: () => void,
 ) {
@@ -128,7 +128,10 @@ export function useFileDropUpload(
 
   const uploadFiles = useCallback(
     async (files: File[]) => {
-      if (files.length === 0) return;
+      if (files.length === 0 || !workspaceId) return;
+      // Bind the narrowed (non-undefined) id so it stays `string` inside the
+      // nested map closure below.
+      const wsId = workspaceId;
 
       const items: FileUploadItem[] = files.map((f) => ({
         name: f.name,
@@ -147,7 +150,7 @@ export function useFileDropUpload(
               prev.map((item, j) => (j === i ? { ...item, status: "uploading" as const } : item)),
             );
 
-            await createFile(sessionId, {
+            await createFile(wsId, {
               path: joinPath(targetDir, file.name),
               content,
               encoding,
@@ -175,7 +178,7 @@ export function useFileDropUpload(
       onComplete?.();
       setTimeout(() => setUploads([]), 3000);
     },
-    [sessionId, targetDir, onComplete],
+    [workspaceId, targetDir, onComplete],
   );
 
   const handleDragEnter = useCallback((e: React.DragEvent) => {

--- a/apps/ui/src/hooks/use-session-files.ts
+++ b/apps/ui/src/hooks/use-session-files.ts
@@ -25,13 +25,13 @@ import { useOrg } from "@/providers/org-provider";
 
 // Query key factory
 const fileKeys = {
-  all: (org: string, sessionId: string) => ["files", org, sessionId] as const,
-  list: (org: string, sessionId: string, path: string, recursive: boolean) =>
-    [...fileKeys.all(org, sessionId), "list", path, recursive] as const,
-  file: (org: string, sessionId: string, path: string) =>
-    [...fileKeys.all(org, sessionId), "file", path] as const,
-  stat: (org: string, sessionId: string, path: string) =>
-    [...fileKeys.all(org, sessionId), "stat", path] as const,
+  all: (org: string, workspaceId: string) => ["files", org, workspaceId] as const,
+  list: (org: string, workspaceId: string, path: string, recursive: boolean) =>
+    [...fileKeys.all(org, workspaceId), "list", path, recursive] as const,
+  file: (org: string, workspaceId: string, path: string) =>
+    [...fileKeys.all(org, workspaceId), "file", path] as const,
+  stat: (org: string, workspaceId: string, path: string) =>
+    [...fileKeys.all(org, workspaceId), "stat", path] as const,
 };
 
 // ============================================
@@ -40,7 +40,7 @@ const fileKeys = {
 
 /** List files in a directory */
 export function useFiles(
-  sessionId: string | undefined,
+  workspaceId: string | undefined,
   path: string = "/",
   recursive: boolean = false,
 ) {
@@ -48,9 +48,9 @@ export function useFiles(
   const org = currentOrg?.public_id;
 
   const query = useQuery({
-    queryKey: fileKeys.list(org!, sessionId!, path, recursive),
-    queryFn: () => listFiles(sessionId!, path, recursive),
-    enabled: !!org && !!sessionId,
+    queryKey: fileKeys.list(org!, workspaceId!, path, recursive),
+    queryFn: () => listFiles(workspaceId!, path, recursive),
+    enabled: !!org && !!workspaceId,
   });
 
   // Include org loading state so pages show skeleton while org initializes
@@ -61,14 +61,14 @@ export function useFiles(
 }
 
 /** Read a file */
-export function useFile(sessionId: string | undefined, path: string | undefined) {
+export function useFile(workspaceId: string | undefined, path: string | undefined) {
   const { currentOrg, isLoading: orgLoading } = useOrg();
   const org = currentOrg?.public_id;
 
   const query = useQuery({
-    queryKey: fileKeys.file(org!, sessionId!, path!),
-    queryFn: () => readFile(sessionId!, path!),
-    enabled: !!org && !!sessionId && !!path,
+    queryKey: fileKeys.file(org!, workspaceId!, path!),
+    queryFn: () => readFile(workspaceId!, path!),
+    enabled: !!org && !!workspaceId && !!path,
   });
 
   // Include org loading state so pages show skeleton while org initializes
@@ -79,14 +79,14 @@ export function useFile(sessionId: string | undefined, path: string | undefined)
 }
 
 /** Get file stat */
-export function useFileStat(sessionId: string | undefined, path: string | undefined) {
+export function useFileStat(workspaceId: string | undefined, path: string | undefined) {
   const { currentOrg, isLoading: orgLoading } = useOrg();
   const org = currentOrg?.public_id;
 
   const query = useQuery({
-    queryKey: fileKeys.stat(org!, sessionId!, path!),
-    queryFn: () => statFile(sessionId!, path!),
-    enabled: !!org && !!sessionId && !!path,
+    queryKey: fileKeys.stat(org!, workspaceId!, path!),
+    queryFn: () => statFile(workspaceId!, path!),
+    enabled: !!org && !!workspaceId && !!path,
   });
 
   // Include org loading state so pages show skeleton while org initializes
@@ -107,11 +107,11 @@ export function useCreateFile() {
   const org = currentOrg?.public_id;
 
   return useMutation({
-    mutationFn: ({ sessionId, request }: { sessionId: string; request: CreateFileRequest }) =>
-      createFile(sessionId, request),
-    onSuccess: (_, { sessionId }) => {
+    mutationFn: ({ workspaceId, request }: { workspaceId: string; request: CreateFileRequest }) =>
+      createFile(workspaceId, request),
+    onSuccess: (_, { workspaceId }) => {
       queryClient.invalidateQueries({
-        queryKey: fileKeys.all(org!, sessionId),
+        queryKey: fileKeys.all(org!, workspaceId),
       });
     },
   });
@@ -124,11 +124,11 @@ export function useCreateDirectory() {
   const org = currentOrg?.public_id;
 
   return useMutation({
-    mutationFn: ({ sessionId, path }: { sessionId: string; path: string }) =>
-      mkdir(sessionId, path),
-    onSuccess: (_, { sessionId }) => {
+    mutationFn: ({ workspaceId, path }: { workspaceId: string; path: string }) =>
+      mkdir(workspaceId, path),
+    onSuccess: (_, { workspaceId }) => {
       queryClient.invalidateQueries({
-        queryKey: fileKeys.all(org!, sessionId),
+        queryKey: fileKeys.all(org!, workspaceId),
       });
     },
   });
@@ -142,20 +142,20 @@ export function useUpdateFile() {
 
   return useMutation({
     mutationFn: ({
-      sessionId,
+      workspaceId,
       path,
       request,
     }: {
-      sessionId: string;
+      workspaceId: string;
       path: string;
       request: UpdateFileRequest;
-    }) => updateFile(sessionId, path, request),
-    onSuccess: (_, { sessionId, path }) => {
+    }) => updateFile(workspaceId, path, request),
+    onSuccess: (_, { workspaceId, path }) => {
       queryClient.invalidateQueries({
-        queryKey: fileKeys.all(org!, sessionId),
+        queryKey: fileKeys.all(org!, workspaceId),
       });
       queryClient.invalidateQueries({
-        queryKey: fileKeys.file(org!, sessionId, path),
+        queryKey: fileKeys.file(org!, workspaceId, path),
       });
     },
   });
@@ -169,17 +169,17 @@ export function useDeleteFile() {
 
   return useMutation({
     mutationFn: ({
-      sessionId,
+      workspaceId,
       path,
       recursive = false,
     }: {
-      sessionId: string;
+      workspaceId: string;
       path: string;
       recursive?: boolean;
-    }) => deleteFile(sessionId, path, recursive),
-    onSuccess: (_, { sessionId }) => {
+    }) => deleteFile(workspaceId, path, recursive),
+    onSuccess: (_, { workspaceId }) => {
       queryClient.invalidateQueries({
-        queryKey: fileKeys.all(org!, sessionId),
+        queryKey: fileKeys.all(org!, workspaceId),
       });
     },
   });
@@ -192,11 +192,11 @@ export function useMoveFile() {
   const org = currentOrg?.public_id;
 
   return useMutation({
-    mutationFn: ({ sessionId, request }: { sessionId: string; request: MoveFileRequest }) =>
-      moveFile(sessionId, request),
-    onSuccess: (_, { sessionId }) => {
+    mutationFn: ({ workspaceId, request }: { workspaceId: string; request: MoveFileRequest }) =>
+      moveFile(workspaceId, request),
+    onSuccess: (_, { workspaceId }) => {
       queryClient.invalidateQueries({
-        queryKey: fileKeys.all(org!, sessionId),
+        queryKey: fileKeys.all(org!, workspaceId),
       });
     },
   });
@@ -209,11 +209,11 @@ export function useCopyFile() {
   const org = currentOrg?.public_id;
 
   return useMutation({
-    mutationFn: ({ sessionId, request }: { sessionId: string; request: CopyFileRequest }) =>
-      copyFile(sessionId, request),
-    onSuccess: (_, { sessionId }) => {
+    mutationFn: ({ workspaceId, request }: { workspaceId: string; request: CopyFileRequest }) =>
+      copyFile(workspaceId, request),
+    onSuccess: (_, { workspaceId }) => {
       queryClient.invalidateQueries({
-        queryKey: fileKeys.all(org!, sessionId),
+        queryKey: fileKeys.all(org!, workspaceId),
       });
     },
   });
@@ -222,7 +222,7 @@ export function useCopyFile() {
 /** Search files using grep */
 export function useGrepFiles() {
   return useMutation({
-    mutationFn: ({ sessionId, request }: { sessionId: string; request: GrepRequest }) =>
-      grepFiles(sessionId, request),
+    mutationFn: ({ workspaceId, request }: { workspaceId: string; request: GrepRequest }) =>
+      grepFiles(workspaceId, request),
   });
 }

--- a/apps/ui/src/lib/api/session-files.ts
+++ b/apps/ui/src/lib/api/session-files.ts
@@ -1,14 +1,11 @@
 // Session Files (Virtual Filesystem) API functions
 // Org is sent via everruns_org cookie (set by OrgProvider via /v1/users/me/switch-org)
 //
-// Target endpoints are the canonical Workspace filesystem surface
-// (/v1/workspaces/{workspace_id}/fs/*). The hooks/components keep passing a
-// `sessionId` because every UI flow today operates on the default per-session
-// Workspace; the API client derives the workspace public ID from it via
-// `workspaceIdFromSessionId` (the migration backs each session with a default
-// Workspace whose UUID equals the session's UUID, so the hex portion of the
-// public IDs is identical). Move/copy and download still live on the legacy
-// session routes — those are not exposed through the workspace surface yet.
+// All file operations target the canonical Workspace filesystem surface
+// (/v1/workspaces/{workspace_id}/fs/*). Callers pass the session's attached
+// `workspace_id` (from the session response) rather than deriving it from the
+// session id — the derivation only holds under the default 1:1 invariant and
+// breaks for a session attached to a shared Workspace.
 
 import { api } from "./client";
 import type {
@@ -25,20 +22,12 @@ import type {
   ListResponse,
 } from "./types";
 
-// Derive the default Workspace public ID for a Session. The server creates a
-// 1:1 default Workspace with the same UUID per session, so the public IDs
-// share the same 32-hex suffix and only differ by prefix.
-function workspaceIdFromSessionId(sessionId: string): string {
-  return sessionId.startsWith("session_") ? `wsp_${sessionId.slice("session_".length)}` : sessionId;
-}
-
-// Base path for the workspace filesystem.
+// Base path for the session's virtual filesystem.
 // Each path segment is percent-encoded so that URL delimiter characters
-// (?, #, %) in workspace filenames are treated as literal bytes, not as
-// query-string or fragment delimiters. E.g. a file named "foo?x=1" becomes
-// "foo%3Fx%3D1" in the URL and reaches the server as a literal path.
-function fsPath(sessionId: string, path?: string): string {
-  const workspaceId = workspaceIdFromSessionId(sessionId);
+// (?, #, %) in filenames are treated as literal bytes, not as query-string or
+// fragment delimiters. E.g. a file named "foo?x=1" becomes "foo%3Fx%3D1" in the
+// URL and reaches the server as a literal path.
+function fsPath(workspaceId: string, path?: string): string {
   const base = `/v1/workspaces/${workspaceId}/fs`;
   if (!path || path === "/") return base;
   const normalizedPath = path.startsWith("/") ? path.slice(1) : path;
@@ -46,15 +35,8 @@ function fsPath(sessionId: string, path?: string): string {
   return `${base}/${encodedPath}`;
 }
 
-function actionPath(sessionId: string, action: string): string {
-  const workspaceId = workspaceIdFromSessionId(sessionId);
+function actionPath(workspaceId: string, action: string): string {
   return `/v1/workspaces/${workspaceId}/fs/_/${action}`;
-}
-
-// Legacy session-scoped path: used only for move/copy which the workspace
-// surface does not yet expose.
-function legacySessionActionPath(sessionId: string, action: string): string {
-  return `/v1/sessions/${sessionId}/fs/_/${action}`;
 }
 
 // ============================================
@@ -63,11 +45,11 @@ function legacySessionActionPath(sessionId: string, action: string): string {
 
 /** List files in a directory */
 export async function listFiles(
-  sessionId: string,
+  workspaceId: string,
   path: string = "/",
   recursive: boolean = false,
 ): Promise<FileInfo[]> {
-  const base = fsPath(sessionId, path);
+  const base = fsPath(workspaceId, path);
   const url = recursive ? `${base}?${new URLSearchParams({ recursive: "true" })}` : base;
   const response = await api.get<ListResponse<FileInfo>>(url);
   return response.data.data;
@@ -75,43 +57,43 @@ export async function listFiles(
 
 /** Create a new file */
 export async function createFile(
-  sessionId: string,
+  workspaceId: string,
   request: CreateFileRequest,
 ): Promise<SessionFile> {
   const { path, ...body } = request;
-  const response = await api.post<SessionFile>(fsPath(sessionId, path), body);
+  const response = await api.post<SessionFile>(fsPath(workspaceId, path), body);
   return response.data;
 }
 
 /** Read a file */
-export async function readFile(sessionId: string, path: string): Promise<SessionFile> {
-  const response = await api.get<SessionFile>(fsPath(sessionId, path));
+export async function readFile(workspaceId: string, path: string): Promise<SessionFile> {
+  const response = await api.get<SessionFile>(fsPath(workspaceId, path));
   return response.data;
 }
 
 /** Update a file */
 export async function updateFile(
-  sessionId: string,
+  workspaceId: string,
   path: string,
   request: UpdateFileRequest,
 ): Promise<SessionFile> {
-  const response = await api.put<SessionFile>(fsPath(sessionId, path), request);
+  const response = await api.put<SessionFile>(fsPath(workspaceId, path), request);
   return response.data;
 }
 
 /** Get file stat (metadata) */
-export async function statFile(sessionId: string, path: string): Promise<FileStat> {
-  const response = await api.post<FileStat>(actionPath(sessionId, "stat"), { path });
+export async function statFile(workspaceId: string, path: string): Promise<FileStat> {
+  const response = await api.post<FileStat>(actionPath(workspaceId, "stat"), { path });
   return response.data;
 }
 
 /** Delete a file or directory */
 export async function deleteFile(
-  sessionId: string,
+  workspaceId: string,
   path: string,
   recursive: boolean = false,
 ): Promise<boolean> {
-  const base = fsPath(sessionId, path);
+  const base = fsPath(workspaceId, path);
   const url = recursive ? `${base}?${new URLSearchParams({ recursive: "true" })}` : base;
   const response = await api.delete<DeleteFileResponse>(url);
   return response.data.deleted;
@@ -122,8 +104,8 @@ export async function deleteFile(
 // ============================================
 
 /** Create a directory */
-export async function mkdir(sessionId: string, path: string): Promise<SessionFile> {
-  const response = await api.post<SessionFile>(fsPath(sessionId, path), { is_directory: true });
+export async function mkdir(workspaceId: string, path: string): Promise<SessionFile> {
+  const response = await api.post<SessionFile>(fsPath(workspaceId, path), { is_directory: true });
   return response.data;
 }
 
@@ -132,14 +114,20 @@ export async function mkdir(sessionId: string, path: string): Promise<SessionFil
 // ============================================
 
 /** Move/rename a file or directory */
-export async function moveFile(sessionId: string, request: MoveFileRequest): Promise<SessionFile> {
-  const response = await api.post<SessionFile>(legacySessionActionPath(sessionId, "move"), request);
+export async function moveFile(
+  workspaceId: string,
+  request: MoveFileRequest,
+): Promise<SessionFile> {
+  const response = await api.post<SessionFile>(actionPath(workspaceId, "move"), request);
   return response.data;
 }
 
 /** Copy a file */
-export async function copyFile(sessionId: string, request: CopyFileRequest): Promise<SessionFile> {
-  const response = await api.post<SessionFile>(legacySessionActionPath(sessionId, "copy"), request);
+export async function copyFile(
+  workspaceId: string,
+  request: CopyFileRequest,
+): Promise<SessionFile> {
+  const response = await api.post<SessionFile>(actionPath(workspaceId, "copy"), request);
   return response.data;
 }
 
@@ -148,8 +136,11 @@ export async function copyFile(sessionId: string, request: CopyFileRequest): Pro
 // ============================================
 
 /** Search files using grep-like pattern matching */
-export async function grepFiles(sessionId: string, request: GrepRequest): Promise<GrepResult[]> {
-  const response = await api.post<ListResponse<GrepResult>>(actionPath(sessionId, "grep"), request);
+export async function grepFiles(workspaceId: string, request: GrepRequest): Promise<GrepResult[]> {
+  const response = await api.post<ListResponse<GrepResult>>(
+    actionPath(workspaceId, "grep"),
+    request,
+  );
   return response.data.data;
 }
 


### PR DESCRIPTION
## What

Make the session-detail file browser address files by the session's attached
`workspace_id` (the canonical `/v1/workspaces/{workspace_id}/fs/*` surface)
instead of deriving the workspace id from the session id.

## Why

`session-files.ts` built workspace URLs as `wsp_${sessionId.slice("session_".length)}`
— a shortcut that only holds under the default 1:1 `workspace.id == session.id`
invariant. After #2207 a session can attach to a *shared* workspace whose id
differs from the session id, so the derivation produced a non-existent workspace
id and the file browser would 404 / show empty for attached sessions. This was
the last functional gap from the workspace re-keying (the backend was already
correct).

## How

Plumb the session's `workspace_id` (already on the session response, read from
`useSessionContext()`) from the files page through the file-browser boundary:
`FileBrowser`, `FileViewer`, and `useFileDropUpload` now take `workspaceId`
(typed `string | undefined`, guarded before each mutation), and the API client
calls the canonical workspace endpoints directly — no client-side derivation and
no reliance on the deprecated session alias. The file-store query keys also key
by `workspace_id`, so two sessions sharing a workspace share one cache. The
percent-encoding logic is unchanged.

## Risk

- **Low.** UI-only. Default 1:1 sessions resolve to the same workspace id they
  did before; behavior is identical for them.

## Security

- No security-relevant change: same authenticated endpoints and org cookie; the
  workspace fs handlers enforce the same `WORKSPACE_VIEW`/`WORKSPACE_MANAGE`
  authorization server-side.

## Validation

- Local `format:check`, `lint`, `tsc --noEmit` (project-wide), and the affected
  jest suites (47 tests) all pass; CI green.

## Follow-ups

No follow-ups — this closes the last functional gap in the workspace re-keying.