### PR TITLE
chore(release): prepare v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,85 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- New changes go here. Use `/prepare-release X.Y.Z` to generate draft from commits. -->
 
+## [0.12.0] - 2026-06-13
+
+### Highlights
+
+- **Adoptable Guardrail Gallery** - Browse and adopt guardrail configurations from a curated gallery ([#2214](https://github.com/everruns/everruns/pull/2214)).
+- **Plugins Subsystem** - Marketplace of plugins with install management for orgs ([#2150](https://github.com/everruns/everruns/pull/2150)).
+- **OpenRouter Advanced Routing** - Capacity strategies (shared/BYOK-first/BYOK-only), quality routing presets, workspace inspection, and model scout benchmark (EVE-564, EVE-565, EVE-566, [#2204](https://github.com/everruns/everruns/pull/2204), [#2206](https://github.com/everruns/everruns/pull/2206)).
+- **Workspace-Attached Sessions** - Sessions now attach to a shared workspace with unified file I/O and move/copy/download ([#2207](https://github.com/everruns/everruns/pull/2207)).
+- **Config-Driven Guardrails** - Deterministic guardrail capability configurable per workspace ([#2193](https://github.com/everruns/everruns/pull/2193)).
+- **Hosted Tool Search** - `claude_tool_search` available as a hosted capability with name-weighted ranking ([#2166](https://github.com/everruns/everruns/pull/2166)).
+- **Online Session Scoring** - Automatic online scoring of production sessions for quality observability ([#2191](https://github.com/everruns/everruns/pull/2191)).
+
+### What's Changed
+
+- feat(guardrails): adoptable guardrail gallery (EVE-571) ([#2214](https://github.com/everruns/everruns/pull/2214)) by [@chaliy](https://github.com/chaliy)
+- feat(openrouter): add provider-quality routing presets (EVE-564) by [@chaliy](https://github.com/chaliy)
+- refactor(server): drop dead subagent_name/task columns from spawn handles ([#2209](https://github.com/everruns/everruns/pull/2209)) by [@chaliy](https://github.com/chaliy)
+- feat(providers): service-kind resolution + voice realtime rerouting (phase 4) ([#2210](https://github.com/everruns/everruns/pull/2210)) by [@chaliy](https://github.com/chaliy)
+- fix(ui): address session file browser by the session's workspace_id ([#2212](https://github.com/everruns/everruns/pull/2212)) by [@chaliy](https://github.com/chaliy)
+- feat(openrouter): add capacity strategy (shared/BYOK-first/BYOK-only) (EVE-565) by [@chaliy](https://github.com/chaliy)
+- feat(openrouter): add workspace inspection and policy compatibility tools (EVE-566) by [@chaliy](https://github.com/chaliy)
+- feat(workspace): attach sessions to a shared workspace + re-key I/O ([#2207](https://github.com/everruns/everruns/pull/2207)) by [@chaliy](https://github.com/chaliy)
+- feat(openrouter): expose optional plugin-style provider capabilities ([#2206](https://github.com/everruns/everruns/pull/2206)) by [@chaliy](https://github.com/chaliy)
+- feat(openrouter): add model scout benchmark blueprint ([#2204](https://github.com/everruns/everruns/pull/2204)) by [@chaliy](https://github.com/chaliy)
+- refactor(api): rename provider/model routes to /v1/providers,/v1/models ([#2188](https://github.com/everruns/everruns/pull/2188)) by [@chaliy](https://github.com/chaliy)
+- refactor: retire sessions.subagent_* columns for the task registry ([#2202](https://github.com/everruns/everruns/pull/2202)) by [@chaliy](https://github.com/chaliy)
+- feat(guardrails): config-driven deterministic guardrail capability ([#2193](https://github.com/everruns/everruns/pull/2193)) by [@chaliy](https://github.com/chaliy)
+- feat(agents): on-demand LLM analysis of agent configs (phase 2) ([#2194](https://github.com/everruns/everruns/pull/2194)) by [@chaliy](https://github.com/chaliy)
+- refactor(providers): rename LLM types, modules, and DB tables (phase 2) by [@chaliy](https://github.com/chaliy)
+- feat(providers): add EmbeddingsDriver trait and knowledge-base embedding config (phase 6) by [@chaliy](https://github.com/chaliy)
+- fix(auth): require proxy secret for mTLS endpoint auth (EVE-545) by [@chaliy](https://github.com/chaliy)
+- feat(observers): online scoring of production sessions (Phase 1) ([#2191](https://github.com/everruns/everruns/pull/2191)) by [@chaliy](https://github.com/chaliy)
+- refactor(providers): rename ConnectionProvider → Connector across core, server, and plugin crates (phase 5) by [@chaliy](https://github.com/chaliy)
+- refactor(core): retire legacy per-kind task tools for generic ones ([#2196](https://github.com/everruns/everruns/pull/2196)) by [@chaliy](https://github.com/chaliy)
+- test(policy): enforce SESSION_VIEW on ListSessionFiles and GetSessionFile (EVE-551) by [@chaliy](https://github.com/chaliy)
+- feat(workspace): fs move/copy/download, workspace_id, file rename ([#2189](https://github.com/everruns/everruns/pull/2189)) by [@chaliy](https://github.com/chaliy)
+- refactor(core): nest web_fetch egress transport as a submodule ([#2195](https://github.com/everruns/everruns/pull/2195)) by [@chaliy](https://github.com/chaliy)
+- fix(auth): validate expires_in_days range for personal access tokens by [@chaliy](https://github.com/chaliy)
+- feat(core): configurable multi-scope skills capability ([#2185](https://github.com/everruns/everruns/pull/2185)) by [@chaliy](https://github.com/chaliy)
+- fix(files): encode special chars in workspace filesystem URL paths (EVE-558, EVE-555) by [@chaliy](https://github.com/chaliy)
+- fix(chat): validate MCP card URI, size, and tool provenance before rendering ([#2187](https://github.com/everruns/everruns/pull/2187)) by [@chaliy](https://github.com/chaliy)
+- refactor(capabilities): regroup capabilities into Core and Sandboxes ([#2183](https://github.com/everruns/everruns/pull/2183)) by [@chaliy](https://github.com/chaliy)
+- fix(apps): gate publish/unpublish/archive on app.dangerous ([#2186](https://github.com/everruns/everruns/pull/2186)) by [@chaliy](https://github.com/chaliy)
+- feat(mcp-servers): add custom headers management UI ([#2184](https://github.com/everruns/everruns/pull/2184)) by [@chaliy](https://github.com/chaliy)
+- fix(ui): guard against invalid scheduledAt in formatScheduledDateTime (EVE-559) by [@chaliy](https://github.com/chaliy)
+- fix(mcp-servers): redact header values in API responses (EVE-550) by [@chaliy](https://github.com/chaliy)
+- fix(schedule): fix default cron and add minimum-interval validation by [@chaliy](https://github.com/chaliy)
+- feat(cli): render session task lifecycle events in session follow ([#2177](https://github.com/everruns/everruns/pull/2177)) by [@chaliy](https://github.com/chaliy)
+- fix(authz): add EVAL_VIEW and SESSION_VIEW to GET read commands by [@chaliy](https://github.com/chaliy)
+- fix(security): allowlist raster MIME types in read-file image rendering by [@chaliy](https://github.com/chaliy)
+- fix(core): match profile-key vendor segment case-insensitively ([#2174](https://github.com/everruns/everruns/pull/2174)) by [@chaliy](https://github.com/chaliy)
+- fix(evals): CreateEvalRun requires session permission (EVE-549) by [@chaliy](https://github.com/chaliy)
+- feat(server): seed default everruns plugin marketplace per org ([#2160](https://github.com/everruns/everruns/pull/2160)) by [@chaliy](https://github.com/chaliy)
+- refactor(capabilities): align all built-in capabilities to pub const ID pattern ([#2173](https://github.com/everruns/everruns/pull/2173)) by [@chaliy](https://github.com/chaliy)
+- feat(core): driver descriptors with services and credential schemas ([#2170](https://github.com/everruns/everruns/pull/2170)) by [@chaliy](https://github.com/chaliy)
+- feat(tool-search): add hosted claude_tool_search and wire into auto ([#2166](https://github.com/everruns/everruns/pull/2166)) by [@chaliy](https://github.com/chaliy)
+- refactor(core): rename LlmDriver to ChatDriver ([#2169](https://github.com/everruns/everruns/pull/2169)) by [@chaliy](https://github.com/chaliy)
+- feat(agents): advisory agent config checks (phase 1) ([#2167](https://github.com/everruns/everruns/pull/2167)) by [@chaliy](https://github.com/chaliy)
+- feat(server): reconcile monitors when schedules are canceled ([#2164](https://github.com/everruns/everruns/pull/2164)) by [@chaliy](https://github.com/chaliy)
+- fix(tool-search): preserve deferred schemas across serde ([#2135](https://github.com/everruns/everruns/pull/2135)) by [@chaliy](https://github.com/chaliy)
+- fix(core): ignore empty stream events for stall timeout ([#2132](https://github.com/everruns/everruns/pull/2132)) by [@chaliy](https://github.com/chaliy)
+- feat(core): compact model-facing output after tool output persistence ([#2151](https://github.com/everruns/everruns/pull/2151)) by [@chaliy](https://github.com/chaliy)
+- feat(core): open LLM driver model for embedder-defined providers ([#2161](https://github.com/everruns/everruns/pull/2161)) by [@chaliy](https://github.com/chaliy)
+- feat(workspace): decouple Workspace from Session, add fs API by [@chaliy](https://github.com/chaliy)
+- feat(server): invoke task executors from the session-task API ([#2159](https://github.com/everruns/everruns/pull/2159)) by [@chaliy](https://github.com/chaliy)
+- feat(core): semantic driver errors and error-disclosure capability ([#2147](https://github.com/everruns/everruns/pull/2147)) by [@chaliy](https://github.com/chaliy)
+- feat(worker): re-attach orphaned external_agent tasks ([#2153](https://github.com/everruns/everruns/pull/2153)) by [@chaliy](https://github.com/chaliy)
+- feat: plugins subsystem — marketplaces and installed plugins ([#2150](https://github.com/everruns/everruns/pull/2150)) by [@chaliy](https://github.com/chaliy)
+- feat(worker): gRPC session task reaper and stale-attempt fencing ([#2152](https://github.com/everruns/everruns/pull/2152)) by [@chaliy](https://github.com/chaliy)
+- fix(memory): enforce file API RBAC with RFC 9457-compliant errors ([#2128](https://github.com/everruns/everruns/pull/2128)) by [@chaliy](https://github.com/chaliy)
+- fix(session-tasks): enforce command policies ([#2127](https://github.com/everruns/everruns/pull/2127)) by [@chaliy](https://github.com/chaliy)
+- fix(voice): redact provider error bodies ([#2105](https://github.com/everruns/everruns/pull/2105)) by [@chaliy](https://github.com/chaliy)
+- fix(core): prune background session permits ([#2104](https://github.com/everruns/everruns/pull/2104)) by [@chaliy](https://github.com/chaliy)
+- fix(core): guard OpenAI tool call DONE fallback ([#2134](https://github.com/everruns/everruns/pull/2134)) by [@chaliy](https://github.com/chaliy)
+- fix(lua): avoid multibyte catalog truncation panic ([#2133](https://github.com/everruns/everruns/pull/2133)) by [@chaliy](https://github.com/chaliy)
+- feat(capabilities): add tool_output_distillation capability ([#2148](https://github.com/everruns/everruns/pull/2148)) by [@chaliy](https://github.com/chaliy)
+- feat(core): name-weighted tool_search ranking with top-band reveal ([#2146](https://github.com/everruns/everruns/pull/2146)) by [@chaliy](https://github.com/chaliy)
+- feat: retire session_resources dual-write for work kinds ([#2143](https://github.com/everruns/everruns/pull/2143)) by [@chaliy](https://github.com/chaliy)
+
 ## [0.11.0] - 2026-06-12
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -461,9 +461,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.7.4"
+version = "1.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ed8e8c52d2dc2390ad9f15647fe663f71e9780b4262c190fbb823a32721566"
+checksum = "6c9b9de216a988dd54b754a82a7660cfe14cee4f6782ae4524470972fa0ccb39"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -487,9 +487,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-bedrockruntime"
-version = "1.133.0"
+version = "1.134.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76314880945928a4ee3956e92af451ef29ef04b734d008bb94b11158a60a1034"
+checksum = "09525553211416fd3c18ead2dd6a29908dcdeb1a032809a23417e7ab848dc23e"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -549,9 +549,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-eventstream"
-version = "0.60.20"
+version = "0.60.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faf09d74e5e32f76b8762da505a3cd59303e367a664ca67295387baa8c1d7548"
+checksum = "78d8391e65fcea47c586a22e1a41f173b38615b112b2c6b7a44e80cec3e6b706"
 dependencies = [
  "aws-smithy-types",
  "bytes",
@@ -692,9 +692,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.4.9"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53f93074121a1be41317b9aa607143ae17900631f7f59a99f2b905d519d6783b"
+checksum = "32b42fcf341259d85ca10fac9a2f6448a8ec691c6955a18e45bc3b71a85fab85"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -999,9 +999,9 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
  "hybrid-array",
 ]
@@ -1143,9 +1143,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.63"
+version = "1.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1953,7 +1953,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer 0.12.0",
+ "block-buffer 0.12.1",
  "const-oid 0.10.2",
  "crypto-common 0.2.2",
  "ctutils",
@@ -2303,11 +2303,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-a2ui"
-version = "0.11.0"
+version = "0.12.0"
 
 [[package]]
 name = "everruns-anthropic"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2323,7 +2323,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-bedrock"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "aws-sdk-bedrockruntime",
@@ -2340,7 +2340,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-cli"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2394,14 +2394,14 @@ dependencies = [
 
 [[package]]
 name = "everruns-config"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "everruns-container-sandbox"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2421,7 +2421,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-core"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -2477,7 +2477,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-durable"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2502,7 +2502,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-gemini"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2516,7 +2516,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-brave-search"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2532,7 +2532,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-browserless"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2553,7 +2553,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-cursor"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2568,7 +2568,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-daytona"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2585,7 +2585,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-deno"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2608,7 +2608,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-docker"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2623,7 +2623,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-duckduckgo"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2638,7 +2638,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-e2b"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "buffa",
@@ -2665,7 +2665,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-github"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2682,7 +2682,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-parallel"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "everruns-core",
@@ -2695,7 +2695,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-integrations-sprites"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2711,7 +2711,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-internal-protocol"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "chrono",
  "everruns-core",
@@ -2728,7 +2728,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-llm-tests"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2748,7 +2748,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-mcp"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2762,7 +2762,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-openai"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2782,11 +2782,11 @@ dependencies = [
 
 [[package]]
 name = "everruns-openui"
-version = "0.11.0"
+version = "0.12.0"
 
 [[package]]
 name = "everruns-runtime"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2825,7 +2825,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-server"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -2918,7 +2918,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-session-sqldb"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2935,7 +2935,7 @@ dependencies = [
 
 [[package]]
 name = "everruns-worker"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4192,9 +4192,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.47.2"
+version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
+checksum = "86f0f8fee8c926415c58d6ae43a08523a26faccb2323f5e6b644fe7dd4ef6b82"
 dependencies = [
  "console",
  "once_cell",
@@ -4272,9 +4272,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jaq-core"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca0f164c8e9c55fc5aefe60b371df735c719b09930dac185878f2f8c7ab6b68"
+checksum = "7561783b20275a6c9cb576e39208b0c635f34ef14357f1f05a2927a774f3adec"
 dependencies = [
  "dyn-clone",
  "once_cell",
@@ -4283,9 +4283,9 @@ dependencies = [
 
 [[package]]
 name = "jaq-json"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5c5baabe63d1d72cde60ec7548a098036773e3541dbc65c6a44fb38e9cfb272"
+checksum = "d4ec9aaad7340e6990c6c1878ef3b46dbec624e535d7f786cc9ddcf94f773d33"
 dependencies = [
  "bstr",
  "bytes",
@@ -4302,9 +4302,9 @@ dependencies = [
 
 [[package]]
 name = "jaq-std"
-version = "3.0.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a11bb307027b20b3dc7b212ad687e7e410cbc43933eec5d498672ab2bc60666"
+checksum = "8bdc5a74b0feeb5e6a1dc2dd08c34280a61e37668d10a6a3b27ad69d0fb9ce2e"
 dependencies = [
  "aho-corasick",
  "base64 0.22.1",
@@ -4419,9 +4419,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.100"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2025f20d7a4fa7785846e7b63d10a76d3f1cee98ee5cb79ea59703f95e42162"
+checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -4807,9 +4807,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.1"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memmem"
@@ -5333,9 +5333,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.80"
+version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
  "bitflags 2.13.0",
  "cfg-if",
@@ -5370,9 +5370,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.116"
+version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",
@@ -6421,9 +6421,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui-textarea"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2950274c0e155944158cf766848dd87bd6db6dad27da1c23ee4a7c8de71dbf1f"
+checksum = "3c78d5ba0f26f97baed69a4c479f268a31c7b5b89d68ab939842152e383d6e73"
 dependencies = [
  "ratatui-core",
  "ratatui-crossterm",
@@ -7456,9 +7456,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 dependencies = [
  "serde",
 ]
@@ -8930,9 +8930,9 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen 0.57.1",
 ]
@@ -8948,9 +8948,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.123"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a254a4b10c19a76f09a27640e7ffbf9bc30bf67e16a3bf28aaefa4920fe81563"
+checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -8961,9 +8961,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.73"
+version = "0.4.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54568702fabf5d4849ce2b90fadfa64168a097eaf4b351ce9df8b687a0086aaf"
+checksum = "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -8971,9 +8971,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.123"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a40fc75b0ec6f3746ceb10d36f53a93dcd68a93b11b6445983945d79eba0dc"
+checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -8981,9 +8981,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.123"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "908f34bd9b9ce3d4caf07b72dfab63d61504d156856c6bd3cd87fa350cf3985b"
+checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -8994,9 +8994,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.123"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7acbf7616c27b194bbb550bf77ed0c2c3e5b7fd1260a93082b95fb7f47959b92"
+checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
 dependencies = [
  "unicode-ident",
 ]
@@ -9063,9 +9063,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.100"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e0871acf327f283dc6da28a1696cdc64fb355ba9f935d052021fa77f35cce69"
+checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -9828,18 +9828,18 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.11.0"
+version = "0.12.0"
 edition = "2024"
 # Published crate MSRV: Rust 2024 plus current published dependency floors.
 rust-version = "1.94.0"
@@ -136,8 +136,8 @@ futures-util = "0.3"
 
 # Everruns SDK
 everruns-sdk = "0.1.9"
-everruns-core = { path = "crates/core", version = "0.11.0" }
-everruns-mcp = { path = "crates/mcp", version = "0.11.0" }
+everruns-core = { path = "crates/core", version = "0.12.0" }
+everruns-mcp = { path = "crates/mcp", version = "0.12.0" }
 
 # A2A protocol
 a2a = { package = "a2a-lf", version = "0.3" }

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "everruns-ui",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "exports": {

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -20,7 +20,7 @@ readme = "README.md"
 
 [dependencies]
 # Core dependencies
-everruns-config = { path = "../config", version = "0.11.0" }
+everruns-config = { path = "../config", version = "0.12.0" }
 anyhow.workspace = true
 thiserror.workspace = true
 async-trait.workspace = true
@@ -109,10 +109,10 @@ inventory.workspace = true
 llmsim = "0.4.0"
 
 # OpenUI component definitions and prompt generator
-everruns-openui = { path = "../openui", version = "0.11.0", optional = true }
+everruns-openui = { path = "../openui", version = "0.12.0", optional = true }
 
 # A2UI component catalog and prompt generator
-everruns-a2ui = { path = "../a2ui", version = "0.11.0", optional = true }
+everruns-a2ui = { path = "../a2ui", version = "0.12.0", optional = true }
 
 # A2A outbound agent delegation
 a2a.workspace = true


### PR DESCRIPTION
## Release v0.12.0

This PR prepares the v0.12.0 release.

### Highlights

- **Adoptable Guardrail Gallery** - Browse and adopt guardrail configurations from a curated gallery
- **Plugins Subsystem** - Marketplace of plugins with install management for orgs
- **OpenRouter Advanced Routing** - Capacity strategies, quality routing presets, workspace inspection, and model scout benchmark
- **Workspace-Attached Sessions** - Sessions attach to a shared workspace with unified file I/O
- **Config-Driven Guardrails** - Deterministic guardrail capability configurable per workspace
- **Hosted Tool Search** - `claude_tool_search` as a hosted capability with name-weighted ranking
- **Online Session Scoring** - Automatic online scoring of production sessions

### Checklist
- [x] CHANGELOG.md entries reviewed
- [x] Version numbers updated (Cargo.toml, package.json, crates/core/Cargo.toml)
- [x] Lock files regenerated (Cargo.lock, pnpm-lock.yaml)
- [x] Migration ordering verified (001..063, no gaps or duplicates)
- [ ] CI passes

### Post-merge
After merging, the release workflow will automatically:
- Create git tag `v0.12.0`
- Create GitHub Release with notes from CHANGELOG.md
- Trigger Docker image build with version tag
- Publish CLI binaries and update Homebrew formula

---
_Generated by [Claude Code](https://claude.ai/code/session_01KiAAAPUymBTdhwGAdDMCF9)_