### PR TITLE
fix(fs): expose real disk workspace display paths

### DIFF
--- a/crates/core/src/capabilities/file_system.rs
+++ b/crates/core/src/capabilities/file_system.rs
@@ -12,12 +12,12 @@
 //! - `delete_file`: Delete a file or directory
 //! - `stat_file`: Get file metadata
 
-use super::{Capability, CapabilityLocalization, CapabilityStatus};
+use super::{Capability, CapabilityLocalization, CapabilityStatus, SystemPromptContext};
 use crate::session_file::SessionFile;
 use crate::tool_output_sanitizer::build_binary_read_file_result;
 use crate::tool_types::ToolHints;
 use crate::tools::{Tool, ToolExecutionResult, ToolResultImage};
-use crate::traits::ToolContext;
+use crate::traits::{SessionFileSystem, ToolContext};
 use crate::truncation_info::{TruncationInfo, TruncationReason};
 use async_trait::async_trait;
 use serde_json::{Value, json};
@@ -161,15 +161,8 @@ fn normalize_path(path: &str) -> String {
     }
 }
 
-/// Add workspace prefix back to a path for display to the user
-fn add_workspace_prefix(path: &str) -> String {
-    if path == "/" {
-        WORKSPACE_PREFIX.to_string()
-    } else if path.starts_with('/') {
-        format!("{}{}", WORKSPACE_PREFIX, path)
-    } else {
-        format!("{}/{}", WORKSPACE_PREFIX, path)
-    }
+fn fs_display_path(file_store: &dyn SessionFileSystem, path: &str) -> String {
+    file_store.display_path(path)
 }
 
 fn file_content_hash(content: &str, encoding: &str) -> crate::error::Result<String> {
@@ -435,6 +428,7 @@ pub const SESSION_FILE_SYSTEM_CAPABILITY_ID: &str = "session_file_system";
 /// Session File System capability - provides file operations for session storage
 pub struct FileSystemCapability;
 
+#[async_trait]
 impl Capability for FileSystemCapability {
     fn id(&self) -> &str {
         SESSION_FILE_SYSTEM_CAPABILITY_ID
@@ -480,20 +474,34 @@ impl Capability for FileSystemCapability {
         Some("File Operations")
     }
 
-    fn system_prompt_addition(&self) -> Option<&str> {
+    async fn system_prompt_contribution(&self, ctx: &SystemPromptContext) -> Option<String> {
         use crate::tool_output_sanitizer::READ_ECONOMY_HINT;
-        // Constraints the model cannot infer from tool schemas: workspace
-        // root path and a behavioral nudge against guessing. Sandbox-tool
-        // routing is dynamic — when sandbox tools are present, their own
-        // capability prompt names them; we don't preadvertise here.
-        const BASE: &str = concat!(
-            "Workspace root: `/workspace`. All file paths must start with `/workspace`. ",
-            "Directories are created on write. ",
-            "Read files before claiming what they contain — never speculate about code you have not opened.",
-        );
-        static PROMPT: std::sync::LazyLock<String> =
-            std::sync::LazyLock::new(|| format!("{}{}", BASE, READ_ECONOMY_HINT));
-        Some(PROMPT.as_str())
+        let root = ctx
+            .file_store
+            .as_ref()
+            .map(|store| store.display_root())
+            .unwrap_or_else(|| WORKSPACE_PREFIX.to_string());
+        let root_guidance = if root == WORKSPACE_PREFIX {
+            format!(
+                "Workspace root: `{WORKSPACE_PREFIX}`. All file paths must start with `{WORKSPACE_PREFIX}`. "
+            )
+        } else {
+            format!(
+                "Workspace root: `{root}`. `{WORKSPACE_PREFIX}` is also accepted as an alias for this root. "
+            )
+        };
+        Some(format!(
+            "<capability id=\"{}\">\n{}Directories are created on write. Read files before claiming what they contain — never speculate about code you have not opened.{}\n</capability>",
+            self.id(),
+            root_guidance,
+            READ_ECONOMY_HINT
+        ))
+    }
+
+    fn system_prompt_preview(&self) -> Option<String> {
+        Some(format!(
+            "Workspace root: `{WORKSPACE_PREFIX}`. All file paths must start with `{WORKSPACE_PREFIX}`."
+        ))
     }
 
     fn tools(&self) -> Vec<Box<dyn Tool>> {
@@ -609,7 +617,7 @@ impl Tool for ReadFileTool {
 
         // Normalize path to strip /workspace prefix for storage
         let normalized_path = normalize_path(path);
-        let display_path = add_workspace_prefix(&normalized_path);
+        let display_path = fs_display_path(file_store.as_ref(), &normalized_path);
 
         match file_store
             .read_file(context.session_id, &normalized_path)
@@ -906,7 +914,7 @@ impl Tool for WriteFileTool {
 
         // Normalize path to strip /workspace prefix for storage
         let normalized_path = normalize_path(path);
-        let display_path = add_workspace_prefix(&normalized_path);
+        let display_path = fs_display_path(file_store.as_ref(), &normalized_path);
 
         match file_store
             .write_file(context.session_id, &normalized_path, content, encoding)
@@ -1052,7 +1060,7 @@ impl Tool for EditFileTool {
         };
 
         let normalized_path = normalize_path(path);
-        let display_path = add_workspace_prefix(&normalized_path);
+        let display_path = fs_display_path(file_store.as_ref(), &normalized_path);
 
         let existing = match file_store
             .read_file(context.session_id, &normalized_path)
@@ -1282,7 +1290,7 @@ impl Tool for ListDirectoryTool {
 
         // Normalize path to strip /workspace prefix for storage
         let normalized_path = normalize_path(path);
-        let display_path = add_workspace_prefix(&normalized_path);
+        let display_path = fs_display_path(file_store.as_ref(), &normalized_path);
 
         match file_store
             .list_directory(context.session_id, &normalized_path)
@@ -1297,7 +1305,7 @@ impl Tool for ListDirectoryTool {
                     .map(|f| {
                         json!({
                             "name": f.name,
-                            "path": add_workspace_prefix(&f.path),
+                            "path": fs_display_path(file_store.as_ref(), &f.path),
                             "is_directory": f.is_directory,
                             "size_bytes": f.size_bytes,
                             "is_readonly": f.is_readonly
@@ -1457,7 +1465,7 @@ impl Tool for GrepFilesTool {
                     .take(limit)
                     .map(|m| {
                         json!({
-                            "path": add_workspace_prefix(&m.path),
+                            "path": fs_display_path(file_store.as_ref(), &m.path),
                             "line_number": m.line_number,
                             "line": m.line
                         })
@@ -1591,7 +1599,7 @@ impl Tool for DeleteFileTool {
 
         // Normalize path to strip /workspace prefix for storage
         let normalized_path = normalize_path(path);
-        let display_path = add_workspace_prefix(&normalized_path);
+        let display_path = fs_display_path(file_store.as_ref(), &normalized_path);
 
         match file_store
             .delete_file(context.session_id, &normalized_path, recursive)
@@ -1691,14 +1699,14 @@ impl Tool for StatFileTool {
 
         // Normalize path to strip /workspace prefix for storage
         let normalized_path = normalize_path(path);
-        let display_path = add_workspace_prefix(&normalized_path);
+        let display_path = fs_display_path(file_store.as_ref(), &normalized_path);
 
         match file_store
             .stat_file(context.session_id, &normalized_path)
             .await
         {
             Ok(Some(stat)) => ToolExecutionResult::success(json!({
-                "path": add_workspace_prefix(&stat.path),
+                "path": fs_display_path(file_store.as_ref(), &stat.path),
                 "name": stat.name,
                 "exists": true,
                 "is_directory": stat.is_directory,
@@ -1790,9 +1798,17 @@ mod tests {
     struct MockFileStore {
         files: Mutex<HashMap<String, StoredFile>>,
         conditional_write_injections: Mutex<HashMap<String, StoredFile>>,
+        display_root: Option<String>,
     }
 
     impl MockFileStore {
+        fn with_display_root(root: &str) -> Self {
+            Self {
+                display_root: Some(root.to_string()),
+                ..Self::default()
+            }
+        }
+
         fn insert(&self, path: &str, file: StoredFile) {
             self.files.lock().unwrap().insert(path.to_string(), file);
         }
@@ -1857,6 +1873,26 @@ mod tests {
 
     #[async_trait]
     impl SessionFileSystem for MockFileStore {
+        fn display_root(&self) -> String {
+            self.display_root
+                .clone()
+                .unwrap_or_else(|| WORKSPACE_PREFIX.to_string())
+        }
+
+        fn display_path(&self, path: &str) -> String {
+            match &self.display_root {
+                Some(root) if path == "/" => root.clone(),
+                Some(root) => format!(
+                    "{}/{}",
+                    root.trim_end_matches('/'),
+                    path.trim_start_matches('/')
+                ),
+                None if path == "/" => WORKSPACE_PREFIX.to_string(),
+                None if path.starts_with('/') => format!("{WORKSPACE_PREFIX}{path}"),
+                None => format!("{WORKSPACE_PREFIX}/{path}"),
+            }
+        }
+
         async fn read_file(
             &self,
             _session_id: SessionId,
@@ -2119,26 +2155,44 @@ mod tests {
     }
 
     #[test]
-    fn test_add_workspace_prefix_root() {
-        assert_eq!(add_workspace_prefix("/"), "/workspace");
+    fn test_display_path_root_defaults_to_workspace_namespace() {
+        let store = MockFileStore::default();
+        assert_eq!(fs_display_path(&store, "/"), "/workspace");
     }
 
     #[test]
-    fn test_add_workspace_prefix_file() {
-        assert_eq!(add_workspace_prefix("/test.txt"), "/workspace/test.txt");
+    fn test_display_path_file_defaults_to_workspace_namespace() {
+        let store = MockFileStore::default();
+        assert_eq!(fs_display_path(&store, "/test.txt"), "/workspace/test.txt");
     }
 
     #[test]
-    fn test_add_workspace_prefix_nested() {
+    fn test_display_path_nested_defaults_to_workspace_namespace() {
+        let store = MockFileStore::default();
         assert_eq!(
-            add_workspace_prefix("/foo/bar.txt"),
+            fs_display_path(&store, "/foo/bar.txt"),
             "/workspace/foo/bar.txt"
         );
     }
 
     #[test]
-    fn test_add_workspace_prefix_no_leading_slash() {
-        assert_eq!(add_workspace_prefix("test.txt"), "/workspace/test.txt");
+    fn test_display_path_no_leading_slash_defaults_to_workspace_namespace() {
+        let store = MockFileStore::default();
+        assert_eq!(fs_display_path(&store, "test.txt"), "/workspace/test.txt");
+    }
+
+    #[tokio::test]
+    async fn read_file_uses_store_display_path() {
+        let store = Arc::new(MockFileStore::with_display_root("/host/repo"));
+        store.add_text_file("/notes.txt", "hello");
+        let context = make_context(store);
+
+        let result = ReadFileTool
+            .execute_with_context(json!({ "path": "/workspace/notes.txt" }), &context)
+            .await;
+        let value = expect_success(result);
+
+        assert_eq!(value["path"], "/host/repo/notes.txt");
     }
 
     #[test]
@@ -2201,14 +2255,32 @@ mod tests {
         assert!(tool_names.contains(&"stat_file"));
     }
 
-    #[test]
-    fn test_capability_has_system_prompt() {
+    #[tokio::test]
+    async fn test_capability_has_system_prompt() {
         let cap = FileSystemCapability;
-        let prompt = cap.system_prompt_addition().unwrap();
+        let ctx = SystemPromptContext::without_file_store(SessionId::new());
+        let prompt = cap.system_prompt_contribution(&ctx).await.unwrap();
         assert!(prompt.contains("/workspace"));
         assert!(prompt.contains("File reading economy"));
         assert!(prompt.contains("offset"));
         assert!(prompt.contains("total_lines"));
+    }
+
+    #[tokio::test]
+    async fn system_prompt_uses_store_display_root() {
+        let cap = FileSystemCapability;
+        let store = Arc::new(MockFileStore::with_display_root("/host/repo"));
+        let ctx = SystemPromptContext {
+            session_id: SessionId::new(),
+            locale: None,
+            file_store: Some(store),
+            model: None,
+        };
+
+        let prompt = cap.system_prompt_contribution(&ctx).await.unwrap();
+
+        assert!(prompt.contains("Workspace root: `/host/repo`"));
+        assert!(prompt.contains("`/workspace` is also accepted"));
     }
 
     #[test]

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -18,6 +18,16 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use uuid::Uuid;
 
+fn workspace_display_path(path: &str) -> String {
+    if path == "/" {
+        "/workspace".to_string()
+    } else if path.starts_with('/') {
+        format!("/workspace{path}")
+    } else {
+        format!("/workspace/{path}")
+    }
+}
+
 /// Build a map of tool names to definitions for efficient lookup
 fn build_tool_map(tool_defs: &[ToolDefinition]) -> HashMap<&str, &ToolDefinition> {
     tool_defs.iter().map(|def| (def.name(), def)).collect()
@@ -366,6 +376,20 @@ impl ToolExecutor for std::sync::Arc<dyn ToolExecutor> {
 /// - Project files onto real disk or object storage
 #[async_trait]
 pub trait SessionFileSystem: Send + Sync {
+    /// Human-facing root path for this filesystem.
+    ///
+    /// `/workspace` remains the stable agent namespace, but embedded runtimes
+    /// backed by a host directory can expose the real root here so shared
+    /// capabilities can avoid misleading users about where files live.
+    fn display_root(&self) -> String {
+        "/workspace".to_string()
+    }
+
+    /// Convert a canonical session path into a human-facing path.
+    fn display_path(&self, path: &str) -> String {
+        workspace_display_path(path)
+    }
+
     /// Read a file by path
     async fn read_file(&self, session_id: SessionId, path: &str) -> Result<Option<SessionFile>>;
 
@@ -534,10 +558,26 @@ impl SessionFileSystem for WorkspaceScopedFileSystem {
     async fn seed_initial_file(&self, _session_id: SessionId, file: &InitialFile) -> Result<()> {
         self.inner.seed_initial_file(self.key, file).await
     }
+
+    fn display_root(&self) -> String {
+        self.inner.display_root()
+    }
+
+    fn display_path(&self, path: &str) -> String {
+        self.inner.display_path(path)
+    }
 }
 
 #[async_trait]
 impl<T: SessionFileSystem + ?Sized> SessionFileSystem for std::sync::Arc<T> {
+    fn display_root(&self) -> String {
+        (**self).display_root()
+    }
+
+    fn display_path(&self, path: &str) -> String {
+        (**self).display_path(path)
+    }
+
     async fn read_file(&self, session_id: SessionId, path: &str) -> Result<Option<SessionFile>> {
         (**self).read_file(session_id, path).await
     }

--- a/crates/runtime/src/real_disk.rs
+++ b/crates/runtime/src/real_disk.rs
@@ -118,6 +118,17 @@ impl RealDiskFileStore {
         &self.root
     }
 
+    fn normalize_path(&self, path: &str) -> String {
+        let input = Path::new(path);
+        if input.is_absolute()
+            && let Ok(relative) = input.strip_prefix(&self.root)
+            && let Ok(path) = capability_path_from_relative(relative)
+        {
+            return path;
+        }
+        normalize_path(path)
+    }
+
     /// Resolve a capability-facing path to an absolute host path.
     ///
     /// Returns an error if the input contains a `..` segment or if joining
@@ -125,7 +136,7 @@ impl RealDiskFileStore {
     /// `reject_symlink_path` at each filesystem access so missing write
     /// targets can still be created safely.
     fn resolve(&self, path: &str) -> Result<PathBuf> {
-        let normalized = normalize_path(path);
+        let normalized = self.normalize_path(path);
         if normalized == "/" {
             return Ok(self.root.clone());
         }
@@ -212,40 +223,61 @@ impl RealDiskFileStore {
                 absolute.display()
             ))
         })?;
-        if rel.as_os_str().is_empty() {
-            return Ok("/".to_string());
-        }
-        let mut out = String::from("/");
-        let mut first = true;
-        for component in rel.components() {
-            if !first {
-                out.push('/');
-            }
-            first = false;
-            match component {
-                Component::Normal(s) => {
-                    let segment = s.to_str().ok_or_else(|| {
-                        AgentLoopError::tool(format!(
-                            "non-UTF-8 path component: {}",
-                            absolute.display()
-                        ))
-                    })?;
-                    out.push_str(segment);
-                }
-                _ => {
-                    return Err(AgentLoopError::tool(format!(
-                        "unexpected path component in {}",
-                        absolute.display()
-                    )));
-                }
-            }
-        }
-        Ok(out)
+        capability_path_from_relative(rel)
     }
+}
+
+fn capability_path_from_relative(relative: &Path) -> Result<String> {
+    if relative.as_os_str().is_empty() {
+        return Ok("/".to_string());
+    }
+    let mut segments = Vec::new();
+    for component in relative.components() {
+        match component {
+            Component::CurDir => {}
+            Component::Normal(s) => {
+                let segment = s.to_str().ok_or_else(|| {
+                    AgentLoopError::tool(format!(
+                        "non-UTF-8 path component: {}",
+                        relative.display()
+                    ))
+                })?;
+                segments.push(segment);
+            }
+            _ => {
+                return Err(AgentLoopError::tool(format!(
+                    "unexpected path component in {}",
+                    relative.display()
+                )));
+            }
+        }
+    }
+    if segments.is_empty() {
+        Ok("/".to_string())
+    } else {
+        Ok(format!("/{}", segments.join("/")))
+    }
+}
+
+fn display_join(root: &Path, path: &str) -> String {
+    if path == "/" {
+        return root.display().to_string();
+    }
+    root.join(path.trim_start_matches('/'))
+        .display()
+        .to_string()
 }
 
 #[async_trait]
 impl SessionFileSystem for RealDiskFileStore {
+    fn display_root(&self) -> String {
+        self.root.display().to_string()
+    }
+
+    fn display_path(&self, path: &str) -> String {
+        display_join(&self.root, &self.normalize_path(path))
+    }
+
     async fn seed_initial_file(&self, session_id: SessionId, file: &InitialFile) -> Result<()> {
         // Clear any prior readonly mark so seeding always wins over a
         // previous starter-file declaration with the same path.
@@ -545,7 +577,11 @@ impl SessionFileSystem for RealDiskFileStore {
     ) -> Result<Vec<GrepMatch>> {
         let root = self.root.clone();
         let pattern = pattern.to_string();
-        let path_pattern = path_pattern.map(str::to_string);
+        let path_pattern = path_pattern.map(|path| {
+            self.normalize_path(path)
+                .trim_start_matches('/')
+                .to_string()
+        });
 
         // `ignore::WalkBuilder` is sync; reading file content per match is
         // sync too. Push the whole walk onto `spawn_blocking` so we don't
@@ -798,6 +834,84 @@ mod tests {
             .expect("present");
         assert_eq!(via_canonical.content, via_workspace.content);
         assert_eq!(via_canonical.path, "/sub/dir/file.txt");
+    }
+
+    #[tokio::test]
+    async fn real_disk_display_paths_use_host_root() {
+        let (store, dir) = make_store();
+        let root = std::fs::canonicalize(dir.path()).expect("canonical tempdir");
+
+        assert_eq!(store.display_root(), root.display().to_string());
+        assert_eq!(
+            store.display_path("/sub/dir/file.txt"),
+            root.join("sub/dir/file.txt").display().to_string()
+        );
+    }
+
+    #[tokio::test]
+    async fn host_absolute_paths_under_root_are_workspace_aliases() {
+        let (store, _dir) = make_store();
+        let session = sid();
+        let host_path = store.display_path("/sub/dir/file.txt");
+
+        store
+            .write_file(session, &host_path, "hi", "text")
+            .await
+            .expect("write via host path");
+
+        let via_workspace = store
+            .read_file(session, "/workspace/sub/dir/file.txt")
+            .await
+            .expect("read")
+            .expect("present");
+        assert_eq!(via_workspace.content.as_deref(), Some("hi"));
+        assert_eq!(via_workspace.path, "/sub/dir/file.txt");
+    }
+
+    #[tokio::test]
+    async fn host_absolute_aliases_allow_current_dir_segments() {
+        let (store, _dir) = make_store();
+        let session = sid();
+        let host_path = Path::new(&store.display_root())
+            .join("./sub/dir/file.txt")
+            .display()
+            .to_string();
+
+        store
+            .write_file(session, &host_path, "hi", "text")
+            .await
+            .expect("write via host path");
+
+        let via_workspace = store
+            .read_file(session, "/workspace/sub/dir/file.txt")
+            .await
+            .expect("read")
+            .expect("present");
+        assert_eq!(via_workspace.content.as_deref(), Some("hi"));
+        assert_eq!(via_workspace.path, "/sub/dir/file.txt");
+    }
+
+    #[tokio::test]
+    async fn grep_path_pattern_accepts_host_absolute_path_alias() {
+        let (store, _dir) = make_store();
+        let session = sid();
+        store
+            .write_file(session, "/src/lib.rs", "needle", "text")
+            .await
+            .expect("write src");
+        store
+            .write_file(session, "/docs/readme.md", "needle", "text")
+            .await
+            .expect("write docs");
+        let host_filter = store.display_path("/src");
+
+        let matches = store
+            .grep_files(session, "needle", Some(&host_filter))
+            .await
+            .expect("grep");
+
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].path, "/src/lib.rs");
     }
 
     #[tokio::test]

--- a/specs/file-store.md
+++ b/specs/file-store.md
@@ -91,6 +91,19 @@ Implementations MUST:
 - Never interpret backslashes as separators or environment variables as
   expansions. Paths are opaque strings of slash-separated segments.
 
+### Display Paths
+
+`/workspace` is the canonical tool namespace, but it is not always the most
+accurate user-facing label. `SessionFileSystem` implementations may expose a
+display root and display paths for capability results and prompt guidance.
+
+Default in-memory and storage-backed implementations display `/workspace`,
+matching the server workspace model. `RealDiskFileStore` displays its
+canonical host root and accepts host-absolute paths under that root as aliases
+for the same canonical session paths. This lets embedders show paths like
+`/Users/alex/project/src/lib.rs` while preserving `/workspace/src/lib.rs` as a
+valid compatibility input.
+
 ### Encoding
 
 File content is round-tripped through two encodings:


### PR DESCRIPTION
## What
- Add display root/display path metadata to `SessionFileSystem`.
- Teach the shared file-system capability to use filesystem display paths in prompt guidance and tool results.
- Teach `RealDiskFileStore` to display its canonical host root and accept displayed host-absolute paths under that root as aliases.
- Document the display path contract in `specs/file-store.md`.

## Why
Real-disk embedders such as Yolop map `/workspace` to a real host worktree. The shared file tools reported `/workspace` as if it were the actual directory, which made sessions look like they were operating in the wrong place.

## How
- Keep `/workspace` as the stable capability namespace and default display root.
- Add overridable `display_root` and `display_path` methods to `SessionFileSystem`.
- Have `RealDiskFileStore` override those methods with the canonical host root.
- Normalize host-absolute paths under the real-disk root back into canonical capability paths before existing traversal/symlink checks run.

## Risk
- Low / Medium / High: Low
- What can break: Real-disk-backed file tool result `path` fields now show host display paths instead of `/workspace` paths. `/workspace` remains accepted as a compatibility input.

## Security
- Threat categories reviewed: TM-FS, TM-LLM
- Findings and resolutions: Host-absolute aliases only apply when the path is under the canonical configured root, then still pass existing traversal and symlink checks. Prompt changes expose configured backend path metadata only; no new secrets, logging, or dependencies were added.

## Follow-ups
Yolop should bump or point to this Everruns revision and persist the session workspace/worktree root on resume.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)