### PR TITLE
fix(session-tasks): reject HTTP message delivery for subagent tasks

### DIFF
--- a/apps/ui/src/lib/api/session-tasks.ts
+++ b/apps/ui/src/lib/api/session-tasks.ts
@@ -38,7 +38,8 @@ export async function getSessionTask(
   return response.data;
 }
 
-/** Post an inbound message (steering or input answer) to a task. */
+/** Post an inbound message (steering or input answer) to a task.
+ *  Not supported for subagent tasks; the server returns 400 for that kind. */
 export async function postSessionTaskMessage(
   sessionId: string,
   taskId: string,

--- a/crates/server/src/domains/session_tasks/commands.rs
+++ b/crates/server/src/domains/session_tasks/commands.rs
@@ -3,8 +3,8 @@ use crate::domains::common::*;
 use crate::domains::sessions::{SESSION_MANAGE, SESSION_VIEW};
 use everruns_core::SessionTask;
 use everruns_core::session_task::{
-    NewTaskMessage, SessionTaskFilter, SessionTaskRegistry, SessionTaskState, TaskMessage,
-    TaskMessagePart, find_task_executor,
+    NewTaskMessage, SessionTaskFilter, SessionTaskRegistry, SessionTaskState, TASK_KIND_SUBAGENT,
+    TaskMessage, TaskMessagePart, find_task_executor,
 };
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
@@ -159,9 +159,16 @@ impl Command for PostSessionTaskMessage {
 
     async fn execute(self, ctx: &Ctx) -> Result<TaskMessage, CommandError> {
         let session_id = q::parse_session_id(&self.session_id)?;
-        q::get_task_in_org(ctx, ctx.org_id(), session_id, &self.task_id)
+        let task = q::get_task_in_org(ctx, ctx.org_id(), session_id, &self.task_id)
             .await?
             .ok_or_else(|| CommandError::not_found("Session task"))?;
+
+        if task.kind == TASK_KIND_SUBAGENT {
+            return Err(CommandError::bad_request(
+                "Subagent tasks are steered by their parent agent via the message_task tool; \
+                 HTTP message delivery is not supported for this task kind.",
+            ));
+        }
 
         let content = match (self.content, self.text) {
             (Some(content), _) if !content.is_empty() => content,
@@ -337,7 +344,7 @@ mod tests {
     use everruns_core::network_access::NetworkAccessList;
     use everruns_core::session_task::{
         CreateSessionTask, SessionTaskRegistry, SessionTaskState, TASK_KIND_BACKGROUND_TOOL,
-        TASK_KIND_MONITOR, TaskLinks, TaskWakePolicy,
+        TASK_KIND_MONITOR, TASK_KIND_SUBAGENT, TaskLinks, TaskWakePolicy,
     };
     use everruns_core::{Caller, DEFAULT_ORG_ID, PrincipalId};
     use std::sync::Arc;
@@ -455,6 +462,59 @@ mod tests {
             !updated_schedule.enabled,
             "schedule must be disabled after monitor task cancel"
         );
+    }
+
+    // -------------------------------------------------------------------------
+    // PostSessionTaskMessage — subagent kind (must be rejected)
+    // -------------------------------------------------------------------------
+
+    /// Posting a message to a subagent task must return 400; subagent steering
+    /// is internal-channel only (parent agent's message_task tool).
+    #[tokio::test]
+    async fn post_message_to_subagent_task_returns_bad_request() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let session_id = create_session(&db).await;
+        let ctx = test_ctx(db.clone());
+
+        let registry = q::registry_for_ctx(&ctx);
+        let task = registry
+            .create(CreateSessionTask {
+                session_id,
+                id: None,
+                kind: TASK_KIND_SUBAGENT.to_string(),
+                display_name: "Subagent Task".to_string(),
+                spec: serde_json::json!({}),
+                state: SessionTaskState::Running,
+                links: TaskLinks::default(),
+                wake_policy: TaskWakePolicy::Silent,
+            })
+            .await
+            .unwrap();
+
+        let result = PostSessionTaskMessage {
+            session_id: session_id.to_string(),
+            task_id: task.id.clone(),
+            text: Some("steer me".to_string()),
+            content: None,
+            in_reply_to: None,
+        }
+        .execute(&ctx)
+        .await;
+
+        assert!(result.is_err(), "subagent task message must be rejected");
+        let err = result.unwrap_err();
+        assert!(
+            matches!(err.kind, CommandErrorKind::BadRequest(_)),
+            "must be a BadRequest error, got: {:?}",
+            err.kind
+        );
+
+        // No message must have been recorded.
+        let messages = registry
+            .list_messages(session_id, &task.id, Some(10))
+            .await
+            .unwrap();
+        assert!(messages.is_empty(), "no message must be persisted for subagent tasks");
     }
 
     // -------------------------------------------------------------------------

--- a/crates/server/src/domains/session_tasks/commands.rs
+++ b/crates/server/src/domains/session_tasks/commands.rs
@@ -514,7 +514,10 @@ mod tests {
             .list_messages(session_id, &task.id, Some(10))
             .await
             .unwrap();
-        assert!(messages.is_empty(), "no message must be persisted for subagent tasks");
+        assert!(
+            messages.is_empty(),
+            "no message must be persisted for subagent tasks"
+        );
     }
 
     // -------------------------------------------------------------------------

--- a/specs/session-tasks.md
+++ b/specs/session-tasks.md
@@ -281,15 +281,13 @@ session's effective network ACL (harness chain → agent → session overlay fol
 if the ACL cannot be computed the executor call is skipped with a `warn`.
 
 Specifically:
-- `POST …/messages`: only supported for task kinds without an internal
-  addressing channel (`external_agent`, `monitor`, `background_tool`). For
-  `subagent` tasks, the endpoint returns 400 — subagent steering is done
-  exclusively by the parent agent via the `message_task` tool; the
-  `links.child_session_id` on the task exposes the child session the parent
-  can address instead. For supported kinds, the message is recorded durably,
-  the task is re-fetched (it may have transitioned to `running` if the message
-  answered an input request), and `executor.deliver` is called. For kinds
-  without a registered executor the message is still recorded (delivery = no-op).
+- `POST …/messages`: rejected with 400 for `subagent`-kind tasks — subagent
+  steering is done exclusively by the parent agent via the `message_task` tool;
+  `links.child_session_id` exposes the child session for direct addressing. For
+  all other kinds the message is recorded durably, the task is re-fetched (it
+  may have transitioned to `running` if the message answered an input request),
+  and `executor.deliver` is called. For kinds without a registered executor the
+  message is still recorded (delivery = no-op).
 - `POST …/cancel`: sets `cancel_requested_at`, then calls `executor.cancel`.
   `MonitorTaskExecutor.cancel` disables the linked schedule and transitions
   the task to `canceled` — so API cancel of a monitor task now atomically

--- a/specs/session-tasks.md
+++ b/specs/session-tasks.md
@@ -281,10 +281,15 @@ session's effective network ACL (harness chain → agent → session overlay fol
 if the ACL cannot be computed the executor call is skipped with a `warn`.
 
 Specifically:
-- `POST …/messages`: records the message durably, then re-fetches the task
-  (it may have transitioned to `running` if the message answered an input
-  request) and calls `executor.deliver`. For kinds without a registered
-  executor the message is still recorded (delivery = no-op).
+- `POST …/messages`: only supported for task kinds without an internal
+  addressing channel (`external_agent`, `monitor`, `background_tool`). For
+  `subagent` tasks, the endpoint returns 400 — subagent steering is done
+  exclusively by the parent agent via the `message_task` tool; the
+  `links.child_session_id` on the task exposes the child session the parent
+  can address instead. For supported kinds, the message is recorded durably,
+  the task is re-fetched (it may have transitioned to `running` if the message
+  answered an input request), and `executor.deliver` is called. For kinds
+  without a registered executor the message is still recorded (delivery = no-op).
 - `POST …/cancel`: sets `cancel_requested_at`, then calls `executor.cancel`.
   `MonitorTaskExecutor.cancel` disables the linked schedule and transitions
   the task to `canceled` — so API cancel of a monitor task now atomically


### PR DESCRIPTION
## What

`POST /v1/sessions/{id}/tasks/{task_id}/messages` now returns 400 for `subagent`-kind tasks with a clear error message directing callers to the correct channel (`message_task` tool via the parent agent).

Fixes EVE-578.

## Why

Subagent communication is internal-channel only — the parent agent's `message_task` tool. The HTTP endpoint previously silently accepted message posts for subagent tasks, recorded them, then attempted `executor.deliver` which always failed with a `warn!` because `tool_context_for_ctx` doesn't populate `platform_store` (needed by `SubagentTaskExecutor::deliver`). The result: a recorded message that the subagent never received, with no indication of failure to the caller.

The fix surfaces the restriction as a proper 400 error before any message is recorded. The child session is reachable via `links.child_session_id` on the task if the parent needs to address it directly.

## How

- `PostSessionTaskMessage::execute` fetches and checks `task.kind == TASK_KIND_SUBAGENT` before recording anything; returns `CommandError::bad_request` with a descriptive message.
- `tool_context_for_ctx` no longer needs `platform_store` for the task-message path (the subagent path is rejected before reaching it).
- UI `postSessionTaskMessage` function doc updated to note the server-side restriction (the function is legitimately used for non-subagent tasks — e.g. answering `awaiting_input` prompts in the resources page).
- Spec (`specs/session-tasks.md`) updated to document the per-kind restriction on `POST …/messages`.

## Risk

- **Low** — additive restriction on a code path that was already silently no-op for the subagent case. No live consumer posts subagent task messages over HTTP; the UI function is only called from the `TaskInputPrompt` component which is only shown for `awaiting_input` tasks (non-subagent by design).

## Security

- **TM-API**: New 400 check is added before any durable write. The error message is static with no user-controlled content. Org-scoped `get_task_in_org` precedes the kind check — no cross-tenant data exposure.
- No new attack surface introduced; the change actually removes a silent partial-write path.
- No new THREAT comments required.

## Follow-ups

- `tool_context_for_ctx` still lists `platform_store` as a missing field in comments — a separate cleanup to remove those comments can follow, but it's purely cosmetic and safe to defer.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered (no live HTTP consumer of subagent task messages; reject before record)
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_018Tg24uHiisFVa5dRxogoux)_