### PR TITLE
feat(session-tasks): background_tool re-attach on orphan for idempotent tools

### DIFF
--- a/crates/core/src/capabilities/background_execution.rs
+++ b/crates/core/src/capabilities/background_execution.rs
@@ -74,6 +74,25 @@ impl crate::session_task::TaskExecutor for BackgroundToolTaskExecutor {
         crate::session_task::TASK_KIND_BACKGROUND_TOOL
     }
 
+    /// Re-attach when `spec["reattachable"]` is true (set at spawn time when
+    /// the tool declared `idempotent` or `readonly` hints). Tools without this
+    /// flag are still failed as orphaned so side-effecting runs are not doubled.
+    fn can_reattach_task(&self, task: &crate::session_task::SessionTask) -> bool {
+        task.spec
+            .get("reattachable")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false)
+    }
+
+    /// Re-execute the tool from spec after worker loss.
+    async fn start(
+        &self,
+        task: &crate::session_task::SessionTask,
+        context: &crate::traits::ToolContext,
+    ) -> crate::error::Result<()> {
+        crate::tools::reattach_background_run(task, context).await
+    }
+
     /// Cooperative cancellation: `cancel_task` records `cancel_requested_at`
     /// in the registry; the background run's heartbeat loop polls it every ~2 s
     /// and winds down when set.  No in-process token is needed — the record-
@@ -133,5 +152,108 @@ mod tests {
             .expect("background_execution must be registered as a built-in capability");
         assert_eq!(cap.id(), BACKGROUND_EXECUTION_CAPABILITY_ID);
         assert_eq!(cap.tools().len(), 1);
+    }
+
+    #[test]
+    fn can_reattach_task_true_when_spec_reattachable_true() {
+        use crate::session_task::{SessionTask, SessionTaskState, TaskExecutor, TaskWakePolicy};
+        use chrono::Utc;
+
+        let exec = BackgroundToolTaskExecutor;
+        let task = SessionTask {
+            id: "t1".to_string(),
+            session_id: crate::SessionId::new(),
+            kind: crate::session_task::TASK_KIND_BACKGROUND_TOOL.to_string(),
+            display_name: "test".to_string(),
+            spec: serde_json::json!({ "tool": "get_current_time", "reattachable": true }),
+            state: SessionTaskState::Running,
+            state_detail: None,
+            progress: None,
+            input_request: None,
+            cancel_requested_at: None,
+            summary: None,
+            result_path: None,
+            artifacts: vec![],
+            error: None,
+            attempt: 1,
+            worker_id: None,
+            heartbeat_at: None,
+            links: crate::session_task::TaskLinks::default(),
+            wake_policy: TaskWakePolicy::Silent,
+            created_at: Utc::now(),
+            started_at: None,
+            finished_at: None,
+            updated_at: Utc::now(),
+        };
+        assert!(exec.can_reattach_task(&task));
+    }
+
+    #[test]
+    fn can_reattach_task_false_when_spec_reattachable_false() {
+        use crate::session_task::{SessionTask, SessionTaskState, TaskExecutor, TaskWakePolicy};
+        use chrono::Utc;
+
+        let exec = BackgroundToolTaskExecutor;
+        let task = SessionTask {
+            id: "t2".to_string(),
+            session_id: crate::SessionId::new(),
+            kind: crate::session_task::TASK_KIND_BACKGROUND_TOOL.to_string(),
+            display_name: "test".to_string(),
+            spec: serde_json::json!({ "tool": "some_side_effecting_tool", "reattachable": false }),
+            state: SessionTaskState::Running,
+            state_detail: None,
+            progress: None,
+            input_request: None,
+            cancel_requested_at: None,
+            summary: None,
+            result_path: None,
+            artifacts: vec![],
+            error: None,
+            attempt: 1,
+            worker_id: None,
+            heartbeat_at: None,
+            links: crate::session_task::TaskLinks::default(),
+            wake_policy: TaskWakePolicy::Silent,
+            created_at: Utc::now(),
+            started_at: None,
+            finished_at: None,
+            updated_at: Utc::now(),
+        };
+        assert!(!exec.can_reattach_task(&task));
+    }
+
+    #[test]
+    fn can_reattach_task_false_when_spec_has_no_reattachable_field() {
+        use crate::session_task::{SessionTask, SessionTaskState, TaskExecutor, TaskWakePolicy};
+        use chrono::Utc;
+
+        let exec = BackgroundToolTaskExecutor;
+        let task = SessionTask {
+            id: "t3".to_string(),
+            session_id: crate::SessionId::new(),
+            kind: crate::session_task::TASK_KIND_BACKGROUND_TOOL.to_string(),
+            display_name: "test".to_string(),
+            spec: serde_json::json!({ "tool": "old_task_without_reattachable_flag" }),
+            state: SessionTaskState::Running,
+            state_detail: None,
+            progress: None,
+            input_request: None,
+            cancel_requested_at: None,
+            summary: None,
+            result_path: None,
+            artifacts: vec![],
+            error: None,
+            attempt: 1,
+            worker_id: None,
+            heartbeat_at: None,
+            links: crate::session_task::TaskLinks::default(),
+            wake_policy: TaskWakePolicy::Silent,
+            created_at: Utc::now(),
+            started_at: None,
+            finished_at: None,
+            updated_at: Utc::now(),
+        };
+        // Old tasks without the flag are conservatively treated as non-reattachable.
+        assert!(!exec.can_reattach_task(&task));
     }
 }

--- a/crates/core/src/session_task.rs
+++ b/crates/core/src/session_task.rs
@@ -656,6 +656,17 @@ pub trait TaskExecutor: Send + Sync {
         false
     }
 
+    /// Whether this executor can re-attach to a *specific* task instance.
+    ///
+    /// Defaults to `self.can_reattach()`. Override to inspect per-task spec
+    /// fields (e.g. whether the spawned tool declared itself idempotent).
+    /// The reaper calls this instead of `can_reattach()` when a task snapshot
+    /// is available.
+    fn can_reattach_task(&self, task: &SessionTask) -> bool {
+        let _ = task;
+        self.can_reattach()
+    }
+
     /// Begin execution, or re-attach after worker loss.
     ///
     /// Called by the reaper when re-attaching a task (attempt already bumped).

--- a/crates/core/src/tools.rs
+++ b/crates/core/src/tools.rs
@@ -1246,6 +1246,10 @@ impl Tool for SpawnBackgroundTool {
                 spec: json!({
                     "tool": tool_name,
                     "arguments": &tool_args,
+                    // Reaper uses this to decide whether to re-run on orphan.
+                    // Only idempotent/readonly tools are safe to re-execute.
+                    "reattachable": tool.hints().idempotent.unwrap_or(false)
+                        || tool.hints().readonly.unwrap_or(false),
                 }),
                 state: crate::session_task::SessionTaskState::Running,
                 links: crate::session_task::TaskLinks::default(),
@@ -1712,6 +1716,153 @@ fn is_canceled_outcome(
     outcome: &std::result::Result<BackgroundOutcome, ToolExecutionResult>,
 ) -> bool {
     matches!(outcome, Err(ToolExecutionResult::ToolError(msg)) if msg == BACKGROUND_CANCEL_SENTINEL)
+}
+
+/// Re-attach a `background_tool` task after worker loss.
+///
+/// Called by `BackgroundToolTaskExecutor::start()` when the reaper decides the
+/// task is safe to restart. Reads `spec["tool"]` and `spec["arguments"]` from
+/// the task, looks up the tool in the built-in default registry, and spawns a
+/// fresh background run with `task.attempt` as the heartbeat fence. New artifact
+/// paths are generated so old partial artifacts do not conflict.
+///
+/// Returns an error (→ reaper falls back to orphaned-fail) when:
+/// - `spec["tool"]` is absent or empty
+/// - the tool is not in the built-in default registry
+/// - the tool does not implement `BackgroundExecutable`
+pub(crate) async fn reattach_background_run(
+    task: &crate::session_task::SessionTask,
+    context: &crate::traits::ToolContext,
+) -> crate::error::Result<()> {
+    let tool_name: String = task
+        .spec
+        .get("tool")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .map(str::to_owned)
+        .ok_or_else(|| {
+            crate::error::AgentLoopError::tool(
+                "background_tool spec missing 'tool' field; cannot re-attach",
+            )
+        })?;
+
+    let tool_args = task
+        .spec
+        .get("arguments")
+        .cloned()
+        .unwrap_or_else(|| serde_json::Value::Object(Default::default()));
+
+    let registry = std::sync::Arc::new(ToolRegistry::with_defaults());
+
+    let Some(tool) = registry.get(&tool_name).cloned() else {
+        return Err(crate::error::AgentLoopError::tool(format!(
+            "tool '{tool_name}' not found in built-in registry; cannot re-attach"
+        )));
+    };
+
+    if tool.as_background_executable().is_none() {
+        return Err(crate::error::AgentLoopError::tool(format!(
+            "tool '{tool_name}' does not support background execution; cannot re-attach"
+        )));
+    }
+
+    let run_id = format!("bg_{}", uuid::Uuid::now_v7().simple());
+    let artifact_dir = format!("/.background/{run_id}");
+    let log_path = format!("{artifact_dir}/output.log");
+    let result_path = format!("{artifact_dir}/result.json");
+
+    let task_id = task.id.clone();
+    let task_attempt = task.attempt;
+    let session_id = task.session_id;
+
+    let sink_context = context.clone().with_tool_registry(registry);
+    let sink = std::sync::Arc::new(SessionBackgroundSink::new(
+        sink_context.clone(),
+        run_id.clone(),
+        task.display_name.clone(),
+        tool_name.to_string(),
+        log_path,
+        result_path,
+        true, // always signal session on re-attach completion
+        Some(task_id.clone()),
+    ));
+
+    let cancel_registry = context.session_task_registry.clone();
+    let run_id_for_log = run_id.clone();
+
+    tokio::spawn(async move {
+        let _ = sink.status("Re-attaching").await;
+
+        let outcome: std::result::Result<BackgroundOutcome, ToolExecutionResult> =
+            match (cancel_registry.as_ref(), Some(task_id.as_str())) {
+                (Some(registry), Some(task_id_str)) => {
+                    let registry = registry.clone();
+                    let task_id_str = task_id_str.to_string();
+                    let tool_fut = async {
+                        match tool.as_background_executable() {
+                            Some(bg) => {
+                                bg.execute_background(tool_args, sink_context.clone(), sink.clone())
+                                    .await
+                            }
+                            None => Err(ToolExecutionResult::tool_error(format!(
+                                "tool '{tool_name}' lost background support during re-attach"
+                            ))),
+                        }
+                    };
+                    let watch_fut = async {
+                        loop {
+                            tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+                            let _ = registry
+                                .update(
+                                    session_id,
+                                    &task_id_str,
+                                    crate::session_task::SessionTaskUpdate {
+                                        heartbeat_at: Some(chrono::Utc::now()),
+                                        expected_attempt: Some(task_attempt),
+                                        ..Default::default()
+                                    },
+                                )
+                                .await;
+                            if let Ok(Some(t)) = registry.get(session_id, &task_id_str).await
+                                && t.cancel_requested_at.is_some()
+                            {
+                                break;
+                            }
+                        }
+                    };
+                    tokio::select! {
+                        result = tool_fut => result,
+                        () = watch_fut => Err(ToolExecutionResult::ToolError(
+                            BACKGROUND_CANCEL_SENTINEL.to_string(),
+                        )),
+                    }
+                }
+                _ => match tool.as_background_executable() {
+                    Some(bg) => {
+                        bg.execute_background(tool_args, sink_context, sink.clone())
+                            .await
+                    }
+                    None => Err(ToolExecutionResult::tool_error(format!(
+                        "tool '{tool_name}' lost background support during re-attach"
+                    ))),
+                },
+            };
+
+        let finalize_result = if is_canceled_outcome(&outcome) {
+            sink.finalize_canceled().await
+        } else {
+            sink.finalize(outcome).await
+        };
+        if let Err(err) = finalize_result {
+            tracing::warn!(
+                run_id = run_id_for_log,
+                error = %err,
+                "Background run re-attach finalization failed"
+            );
+        }
+    });
+
+    Ok(())
 }
 
 async fn ensure_directory(

--- a/crates/core/src/tools.rs
+++ b/crates/core/src/tools.rs
@@ -1250,6 +1250,8 @@ impl Tool for SpawnBackgroundTool {
                     // Only idempotent/readonly tools are safe to re-execute.
                     "reattachable": tool.hints().idempotent.unwrap_or(false)
                         || tool.hints().readonly.unwrap_or(false),
+                    // Persisted so re-attach can restore the original signaling behavior.
+                    "signal_on_completion": signal_on_completion,
                 }),
                 state: crate::session_task::SessionTaskState::Running,
                 links: crate::session_task::TaskLinks::default(),
@@ -1727,13 +1729,29 @@ fn is_canceled_outcome(
 /// paths are generated so old partial artifacts do not conflict.
 ///
 /// Returns an error (→ reaper falls back to orphaned-fail) when:
+/// - `context.file_store` or `context.session_task_registry` is absent
 /// - `spec["tool"]` is absent or empty
 /// - the tool is not in the built-in default registry
 /// - the tool does not implement `BackgroundExecutable`
+/// - the tool's current hints are not `idempotent` or `readonly`
+/// - per-worker or per-session background concurrency caps are exhausted
 pub(crate) async fn reattach_background_run(
     task: &crate::session_task::SessionTask,
     context: &crate::traits::ToolContext,
 ) -> crate::error::Result<()> {
+    // Fail fast before spawning a tokio task so the reaper can fall back to
+    // orphaned-fail rather than leaving the task stuck in Running forever.
+    if context.file_store.is_none() {
+        return Err(crate::error::AgentLoopError::tool(
+            "file store not available; cannot re-attach background run",
+        ));
+    }
+    if context.session_task_registry.is_none() {
+        return Err(crate::error::AgentLoopError::tool(
+            "task registry not available; cannot re-attach background run",
+        ));
+    }
+
     let tool_name: String = task
         .spec
         .get("tool")
@@ -1766,6 +1784,39 @@ pub(crate) async fn reattach_background_run(
         )));
     }
 
+    // Re-verify tool hints from the live registry rather than trusting
+    // spec["reattachable"], which could be forged via task creation APIs.
+    let hints = tool.hints();
+    if !hints.idempotent.unwrap_or(false) && !hints.readonly.unwrap_or(false) {
+        return Err(crate::error::AgentLoopError::tool(format!(
+            "tool '{tool_name}' is not idempotent or readonly; re-attach declined",
+        )));
+    }
+
+    // Enforce the same concurrency caps as spawn_background so many concurrent
+    // re-attaches cannot exhaust worker or session limits.
+    let background_run_permit = ACTIVE_BACKGROUND_RUNS_PER_WORKER
+        .try_acquire()
+        .map_err(|_| {
+            crate::error::AgentLoopError::tool(
+                "worker background run limit reached; re-attach deferred",
+            )
+        })?;
+    let session_run_permit =
+        try_acquire_session_background_permit(task.session_id).map_err(|_| {
+            crate::error::AgentLoopError::tool(
+                "session background run limit reached; re-attach deferred",
+            )
+        })?;
+
+    // Restore original signaling behavior; default true for tasks created before
+    // this field was persisted.
+    let signal_on_completion = task
+        .spec
+        .get("signal_on_completion")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(true);
+
     let run_id = format!("bg_{}", uuid::Uuid::now_v7().simple());
     let artifact_dir = format!("/.background/{run_id}");
     let log_path = format!("{artifact_dir}/output.log");
@@ -1783,7 +1834,7 @@ pub(crate) async fn reattach_background_run(
         tool_name.to_string(),
         log_path,
         result_path,
-        true, // always signal session on re-attach completion
+        signal_on_completion,
         Some(task_id.clone()),
     ));
 
@@ -1791,6 +1842,9 @@ pub(crate) async fn reattach_background_run(
     let run_id_for_log = run_id.clone();
 
     tokio::spawn(async move {
+        // Hold permits for the duration of the re-attached run.
+        let _background_run_permit = background_run_permit;
+        let _session_run_permit = session_run_permit;
         let _ = sink.status("Re-attaching").await;
 
         let outcome: std::result::Result<BackgroundOutcome, ToolExecutionResult> =
@@ -3773,6 +3827,129 @@ mod tests {
                 .as_deref()
                 .unwrap_or_default()
                 .contains("Canceled by request.")
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // reattach_background_run early-guard tests
+    // -------------------------------------------------------------------------
+
+    fn make_reattach_task(spec: serde_json::Value) -> crate::session_task::SessionTask {
+        use crate::session_task::{SessionTaskState, TaskLinks, TaskWakePolicy};
+        crate::session_task::SessionTask {
+            id: "t-reattach".to_string(),
+            session_id: SessionId::new(),
+            kind: crate::session_task::TASK_KIND_BACKGROUND_TOOL.to_string(),
+            display_name: "Reattach test".to_string(),
+            spec,
+            state: SessionTaskState::Running,
+            state_detail: None,
+            progress: None,
+            input_request: None,
+            cancel_requested_at: None,
+            summary: None,
+            result_path: None,
+            artifacts: vec![],
+            error: None,
+            attempt: 2,
+            worker_id: None,
+            heartbeat_at: None,
+            links: TaskLinks::default(),
+            wake_policy: TaskWakePolicy::Silent,
+            created_at: chrono::Utc::now(),
+            started_at: None,
+            finished_at: None,
+            updated_at: chrono::Utc::now(),
+        }
+    }
+
+    #[tokio::test]
+    async fn reattach_fails_with_missing_file_store() {
+        let session_id = SessionId::new();
+        // Context with no file_store — only session_task_registry is wired.
+        let task_registry = Arc::new(InMemoryTaskRegistry::default());
+        let context =
+            crate::traits::ToolContext::new(session_id).with_session_task_registry(task_registry);
+        let task = make_reattach_task(serde_json::json!({
+            "tool": "get_current_time",
+            "arguments": {},
+            "reattachable": true,
+            "signal_on_completion": true,
+        }));
+        let err = reattach_background_run(&task, &context)
+            .await
+            .expect_err("should fail without file store");
+        assert!(
+            err.to_string().contains("file store"),
+            "error should mention file store, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn reattach_fails_with_missing_task_registry() {
+        let session_id = SessionId::new();
+        let file_store = Arc::new(TestFileStore::default());
+        let storage_store = Arc::new(NoopStorageStore);
+        // Context has a file_store but no session_task_registry.
+        let context =
+            crate::traits::ToolContext::with_stores(session_id, file_store, storage_store);
+        let task = make_reattach_task(serde_json::json!({
+            "tool": "get_current_time",
+            "arguments": {},
+            "reattachable": true,
+            "signal_on_completion": true,
+        }));
+        let err = reattach_background_run(&task, &context)
+            .await
+            .expect_err("should fail without task registry");
+        assert!(
+            err.to_string().contains("task registry"),
+            "error should mention task registry, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn reattach_fails_with_unknown_tool_name() {
+        let session_id = SessionId::new();
+        let file_store = Arc::new(TestFileStore::default());
+        let storage_store = Arc::new(NoopStorageStore);
+        let task_registry = Arc::new(InMemoryTaskRegistry::default());
+        let context =
+            crate::traits::ToolContext::with_stores(session_id, file_store, storage_store)
+                .with_session_task_registry(task_registry);
+        // "test_background" is not in ToolRegistry::with_defaults().
+        let task = make_reattach_task(serde_json::json!({
+            "tool": "test_background",
+            "arguments": {},
+            "reattachable": true,
+            "signal_on_completion": true,
+        }));
+        let err = reattach_background_run(&task, &context)
+            .await
+            .expect_err("should fail for unknown tool");
+        assert!(
+            err.to_string().contains("not found in built-in registry"),
+            "error should mention built-in registry, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn reattach_fails_with_missing_tool_spec_field() {
+        let session_id = SessionId::new();
+        let file_store = Arc::new(TestFileStore::default());
+        let storage_store = Arc::new(NoopStorageStore);
+        let task_registry = Arc::new(InMemoryTaskRegistry::default());
+        let context =
+            crate::traits::ToolContext::with_stores(session_id, file_store, storage_store)
+                .with_session_task_registry(task_registry);
+        // Spec has no "tool" field.
+        let task = make_reattach_task(serde_json::json!({ "reattachable": true }));
+        let err = reattach_background_run(&task, &context)
+            .await
+            .expect_err("should fail with missing tool field");
+        assert!(
+            err.to_string().contains("missing 'tool' field"),
+            "error should mention missing tool field, got: {err}"
         );
     }
 }

--- a/crates/worker/src/session_task_reaper.rs
+++ b/crates/worker/src/session_task_reaper.rs
@@ -160,7 +160,7 @@ pub async fn execute_reaper_activity<A: WorkerAdapters>(
 
         // Try to find a re-attachable executor for this kind.
         let should_reattach = find_task_executor(&task.kind)
-            .is_some_and(|exec| exec.can_reattach())
+            .is_some_and(|exec| exec.can_reattach_task(&task))
             && (task.attempt as i64) < input.max_attempts;
 
         if should_reattach {
@@ -642,7 +642,8 @@ mod tests {
                 continue;
             }
 
-            let should_reattach = executor_for(&task.kind).is_some_and(|exec| exec.can_reattach())
+            let should_reattach = executor_for(&task.kind)
+                .is_some_and(|exec| exec.can_reattach_task(&task))
                 && (task.attempt as i64) < input.max_attempts;
 
             if should_reattach {


### PR DESCRIPTION
## What

Orphaned `background_tool` tasks are now re-attached by the reaper when the spawned tool declared itself idempotent or readonly — matching the durability parity that `external_agent` already has (#2153).

## Why

EVE-577: The reaper previously failed all `background_tool` orphans immediately as `error.kind="orphaned"`. That's safe for side-effecting tools but wastes work for pure/idempotent tools (e.g. a long-running read-only fetch that lost its worker mid-run).

## How

- **`spec["reattachable"]`**: stored at task-creation time (`true` when `tool.hints().idempotent || tool.hints().readonly`). Pre-existing tasks without this flag are treated conservatively as non-reattachable.
- **`TaskExecutor::can_reattach_task(&SessionTask)`**: new default trait method that falls back to `can_reattach()`. Allows per-task spec inspection without breaking existing executors.
- **`BackgroundToolTaskExecutor`** overrides `can_reattach_task` to read `spec["reattachable"]` and `start()` to call `reattach_background_run()`.
- **`reattach_background_run()`** (pub(crate), `crates/core/src/tools.rs`): looks up the tool in `ToolRegistry::with_defaults()`, generates fresh artifact paths, and spawns the same heartbeat + cancel-watch loop as the original run with `task.attempt` as the fence. Returns an error when the tool is absent from the built-in registry or lacks background-execution support (→ reaper falls back to orphaned-fail).
- **Reaper** updated to call `executor.can_reattach_task(&task)` instead of `executor.can_reattach()`.
- 3 new unit tests for `can_reattach_task` (true/false/absent spec field).

## Risk

- Low
- Non-reattachable tasks (no `reattachable` flag or `false`) continue to fail as orphaned — no change from today.
- Re-attached runs use new artifact paths so partial artifacts from the failed attempt do not interfere.
- Only tools in `ToolRegistry::with_defaults()` can re-attach; custom session-registry tools fall back to orphaned-fail, same as before.

## Security

- **TM-TOOL**: `reattach_background_run()` only looks up tools from the built-in default registry — spec can't cause unknown code to load. Tool name from `spec["tool"]` is used as a registry key with a `None` → fail-safe on miss.
- **TM-DOS**: One re-attach attempt spawns at most one tokio task with the same resource consumption as the original run. Attempt counter caps re-attach iterations (default `max_attempts = 3`).
- **TM-AUTHZ**: Re-attachment runs under the same session context as the original task — no privilege escalation.
- No other threat categories affected.

## Follow-ups

- Re-attachment for custom-registry tools: would require the reaper to carry a full per-session registry, which is architecturally significant. Deferred — built-in tool coverage is sufficient for current use cases.
- Probe timeout/cancellation for re-attached runs uses the same cancel-watch polling as original runs. A hard timeout could be added later if needed.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_018Tg24uHiisFVa5dRxogoux)_