### PR TITLE
fix(context): anchor the original task in infinity_context and compaction

### DIFF
--- a/crates/core/src/capabilities/compaction.rs
+++ b/crates/core/src/capabilities/compaction.rs
@@ -556,7 +556,7 @@ pub fn aggressive_trim(
 
     // Identify protected messages (skill tool results and their call messages).
     // Reserve budget for them first so they are never dropped.
-    let protected_indices: std::collections::HashSet<usize> = conversation
+    let mut protected_indices: std::collections::HashSet<usize> = conversation
         .iter()
         .enumerate()
         .filter(|(_, m)| {
@@ -564,6 +564,14 @@ pub fn aggressive_trim(
         })
         .map(|(i, _)| i)
         .collect();
+
+    // Anchor the first conversation message (the original task / goal). Like
+    // infinity context's head anchor, this is the one eviction we never want:
+    // without it the model loses track of what it is doing once the window
+    // slides. Protecting it reserves its budget first, newest-first if tight.
+    if !conversation.is_empty() {
+        protected_indices.insert(0);
+    }
 
     let mut protected_budget: usize = 0;
     for &idx in &protected_indices {
@@ -2569,6 +2577,32 @@ mod tests {
     fn test_aggressive_trim_empty() {
         let result = aggressive_trim(&[], 100, false);
         assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_aggressive_trim_anchors_first_conversation_message() {
+        // messages[0] = system prompt; messages[1] = the original task (old, big);
+        // the rest are newer. Under a tight budget the task must still survive so
+        // the model does not lose track of what it is doing.
+        let messages = vec![
+            make_user_msg("sys"),                 // system prompt (small)
+            make_user_msg(&"TASK ".repeat(80)),   // the task: old + big
+            make_assistant_msg(&"x".repeat(400)), // filler old
+            make_user_msg(&"c".repeat(400)),      // recent
+            make_assistant_msg(&"d".repeat(400)), // recent
+        ];
+        let result = aggressive_trim(&messages, 250, true);
+
+        assert!(
+            result.len() < messages.len(),
+            "expected a trim, got {} messages",
+            result.len()
+        );
+        let kept_task = result.iter().any(|m| match &m.content {
+            LlmMessageContent::Text(t) => t.contains("TASK"),
+            _ => false,
+        });
+        assert!(kept_task, "the original task must be anchored, not dropped");
     }
 
     #[test]

--- a/crates/core/src/capabilities/compaction.rs
+++ b/crates/core/src/capabilities/compaction.rs
@@ -565,10 +565,13 @@ pub fn aggressive_trim(
         .map(|(i, _)| i)
         .collect();
 
-    // Anchor the first conversation message (the original task / goal). Like
-    // infinity context's head anchor, this is the one eviction we never want:
-    // without it the model loses track of what it is doing once the window
-    // slides. Protecting it reserves its budget first, newest-first if tight.
+    // Anchor the first conversation message (the original task / goal) by
+    // adding it to the protected set, so its budget is reserved before any
+    // non-protected message — like infinity context's head anchor, this is the
+    // eviction we most want to avoid once the window slides. Under extreme
+    // pressure (protected messages alone exceed the budget) the oldest
+    // protected messages, including this one, may still be dropped, matching how
+    // protected tool results are handled.
     if !conversation.is_empty() {
         protected_indices.insert(0);
     }

--- a/crates/core/src/capabilities/infinity_context.rs
+++ b/crates/core/src/capabilities/infinity_context.rs
@@ -5,7 +5,9 @@
 
 use super::{Capability, CapabilityLocalization, CapabilityStatus};
 use crate::message::{ContentPart, Message, MessageRole};
-use crate::message_filter::{ExcludedNoticeTransform, MessageFilterProvider, MessageQuery};
+use crate::message_filter::{
+    ExcludedNoticeTransform, MessageFilterProvider, MessageQuery, anchored_window,
+};
 use crate::tool_types::ToolHints;
 use crate::tools::{Tool, ToolExecutionResult};
 use crate::traits::ToolContext;
@@ -89,6 +91,13 @@ impl Capability for InfinityContextCapability {
                     "title": "Maximum recent messages",
                     "description": "Optional hard cap on recent messages kept in the live prompt.",
                     "minimum": 1
+                },
+                "keep_first_messages": {
+                    "type": "integer",
+                    "title": "Anchored first messages",
+                    "description": "Leading messages always kept as an anchor (the original task), even under a tight budget. Additional to the maximum recent messages.",
+                    "minimum": 0,
+                    "default": default_keep_first_messages()
                 }
             }
         }))
@@ -179,6 +188,20 @@ struct InfinityContextConfig {
     /// when the token-budget estimate would allow more messages.
     #[serde(default)]
     max_recent_messages: Option<usize>,
+
+    /// Number of leading messages always kept as an anchor (the original task /
+    /// goal), regardless of token budget. Defaults to 1 so the model never loses
+    /// what it is doing when the window slides. The anchor is additional to
+    /// `max_recent_messages`.
+    #[serde(default = "default_keep_first_messages")]
+    keep_first_messages: usize,
+
+    /// Derived (not user-facing): set by capability collection when the
+    /// `compaction` capability is also enabled. When true, infinity context
+    /// stops doing token-budget eviction and lets compaction own reduction, so
+    /// compaction's summary — not a bare "hidden" notice — covers old turns.
+    #[serde(default)]
+    compaction_active: bool,
 }
 
 fn default_context_budget_tokens() -> usize {
@@ -189,12 +212,18 @@ fn default_min_recent_messages() -> usize {
     10
 }
 
+fn default_keep_first_messages() -> usize {
+    1
+}
+
 impl Default for InfinityContextConfig {
     fn default() -> Self {
         Self {
             context_budget_tokens: default_context_budget_tokens(),
             min_recent_messages: default_min_recent_messages(),
             max_recent_messages: None,
+            keep_first_messages: default_keep_first_messages(),
+            compaction_active: false,
         }
     }
 }
@@ -218,17 +247,23 @@ impl MessageFilterProvider for InfinityContextFilterProvider {
         let config: InfinityContextConfig =
             serde_json::from_value(config.clone()).unwrap_or_default();
         let existing_notice_count = take_existing_excluded_notice(messages);
-        let trimmed_count = trim_messages_to_token_budget(messages, &config);
-        let total_excluded_count = existing_notice_count.saturating_add(trimmed_count);
+
+        // P2 composition: when compaction is the active reducer, defer
+        // token-budget eviction to it. Only re-surface any candidate-window
+        // overflow notice (messages the DB load could not fetch).
+        if config.compaction_active {
+            if existing_notice_count > 0 {
+                insert_excluded_notice(messages, config.keep_first_messages, existing_notice_count);
+            }
+            return;
+        }
+
+        let outcome = trim_messages_to_token_budget(messages, &config);
+        let total_excluded_count = existing_notice_count.saturating_add(outcome.hidden_count);
         if total_excluded_count > 0 {
-            messages.insert(
-                0,
-                Message::system(
-                    ExcludedNoticeTransform::infinity_context()
-                        .format
-                        .replace("{}", &total_excluded_count.to_string()),
-                ),
-            );
+            // Place the notice right after the anchored head so the layout reads
+            // [task anchor] -> [N hidden] -> [recent window].
+            insert_excluded_notice(messages, outcome.head_len, total_excluded_count);
         }
     }
 
@@ -327,45 +362,55 @@ fn parse_excluded_notice_count(message: &Message) -> Option<usize> {
     count.parse().ok()
 }
 
+/// Outcome of token-budget trimming.
+#[derive(Default)]
+struct TrimOutcome {
+    /// Messages dropped from the middle.
+    hidden_count: usize,
+    /// Length of the preserved leading anchor (where the notice is inserted).
+    head_len: usize,
+}
+
+/// Insert the hidden-history notice at `position`, clamped to the message list.
+fn insert_excluded_notice(messages: &mut Vec<Message>, position: usize, count: usize) {
+    let text = ExcludedNoticeTransform::infinity_context()
+        .format
+        .replace("{}", &count.to_string());
+    messages.insert(position.min(messages.len()), Message::system(text));
+}
+
+/// Trim the live window to the token budget while always keeping the first
+/// `keep_first_messages` (the original task/goal) and the recent tail. Drops a
+/// single contiguous block from the middle and reports how many were hidden.
 fn trim_messages_to_token_budget(
     messages: &mut Vec<Message>,
     config: &InfinityContextConfig,
-) -> usize {
+) -> TrimOutcome {
     if messages.is_empty() {
-        return 0;
+        return TrimOutcome::default();
     }
 
-    let original_count = messages.len();
-    if let Some(max_recent_messages) = config.max_recent_messages {
-        let max_recent_messages = max_recent_messages.max(1);
-        if messages.len() > max_recent_messages {
-            let drop_count = messages.len() - max_recent_messages;
-            messages.drain(0..drop_count);
-        }
+    let costs: Vec<usize> = messages.iter().map(estimate_message_tokens).collect();
+    let window = anchored_window(
+        &costs,
+        config.keep_first_messages,
+        config.min_recent_messages,
+        config.max_recent_messages,
+        config.context_budget_tokens,
+    );
+
+    let hidden_count = window.hidden();
+    if hidden_count > 0 {
+        // Rebuild as [0, head_len) ++ [recent_start, len) without cloning.
+        let tail = messages.split_off(window.recent_start);
+        messages.truncate(window.head_len);
+        messages.extend(tail);
     }
 
-    let capped_count = messages.len();
-    let min_recent_start = capped_count.saturating_sub(config.min_recent_messages);
-    let mut selected = Vec::new();
-    let mut selected_tokens = 0usize;
-
-    for (idx, message) in messages.iter().enumerate().skip(min_recent_start) {
-        selected.push((idx, message.clone()));
-        selected_tokens = selected_tokens.saturating_add(estimate_message_tokens(message));
+    TrimOutcome {
+        hidden_count,
+        head_len: window.head_len,
     }
-
-    let mut remaining_budget = config.context_budget_tokens.saturating_sub(selected_tokens);
-    for (idx, message) in messages[..min_recent_start].iter().enumerate().rev() {
-        let tokens = estimate_message_tokens(message);
-        if tokens <= remaining_budget {
-            selected.push((idx, message.clone()));
-            remaining_budget -= tokens;
-        }
-    }
-
-    selected.sort_by_key(|(idx, _)| *idx);
-    *messages = selected.into_iter().map(|(_, message)| message).collect();
-    original_count.saturating_sub(messages.len())
 }
 
 /// Tool for querying earlier conversation history.
@@ -799,7 +844,7 @@ mod tests {
     fn test_filter_provider_trims_loaded_messages_by_token_budget() {
         let provider = InfinityContextFilterProvider;
         let mut messages = vec![
-            Message::user("old tiny"),
+            Message::user("the original task"),
             Message::assistant("old ".repeat(400)),
             Message::user("recent one"),
             Message::assistant("recent two"),
@@ -810,13 +855,16 @@ mod tests {
             &json!({"context_budget_tokens": 1, "min_recent_messages": 2}),
         );
 
-        assert_eq!(messages.len(), 3);
+        // Layout: [task anchor] -> [N hidden notice] -> [recent window].
+        // The original task survives even under a 1-token budget.
+        assert_eq!(messages.len(), 4);
+        assert_eq!(extract_text_content(&messages[0]), "the original task");
         assert!(
-            extract_text_content(&messages[0])
-                .contains("earlier messages are NOT visible in this context")
+            extract_text_content(&messages[1])
+                .contains("1 earlier messages are NOT visible in this context")
         );
-        assert_eq!(extract_text_content(&messages[1]), "recent one");
-        assert_eq!(extract_text_content(&messages[2]), "recent two");
+        assert_eq!(extract_text_content(&messages[2]), "recent one");
+        assert_eq!(extract_text_content(&messages[3]), "recent two");
     }
 
     #[test]
@@ -826,6 +874,8 @@ mod tests {
             Message::user("one"),
             Message::assistant("two"),
             Message::user("three"),
+            Message::assistant("four"),
+            Message::user("five"),
         ];
 
         provider.post_load(
@@ -837,41 +887,107 @@ mod tests {
             }),
         );
 
-        assert_eq!(messages.len(), 3);
+        // Hard cap keeps 2 recent; the head anchor ("one") is additional to it.
+        assert_eq!(messages.len(), 4);
+        assert_eq!(extract_text_content(&messages[0]), "one");
         assert!(
-            extract_text_content(&messages[0])
-                .contains("earlier messages are NOT visible in this context")
+            extract_text_content(&messages[1])
+                .contains("2 earlier messages are NOT visible in this context")
         );
-        assert_eq!(extract_text_content(&messages[1]), "two");
-        assert_eq!(extract_text_content(&messages[2]), "three");
+        assert_eq!(extract_text_content(&messages[2]), "four");
+        assert_eq!(extract_text_content(&messages[3]), "five");
     }
 
     #[test]
-    fn test_filter_provider_preserves_hard_cap_notice_through_full_flow() {
+    fn test_filter_provider_anchors_task_through_full_flow() {
         let provider = InfinityContextFilterProvider;
+        // Budget large enough that the candidate load fetches every message, but
+        // small enough that the big middle turns are dropped by token budget.
         let config = json!({
-            "context_budget_tokens": 10_000,
-            "min_recent_messages": 10,
-            "max_recent_messages": 2
+            "context_budget_tokens": 600,
+            "min_recent_messages": 2
         });
         let mut query = MessageQuery::new(SessionId::new());
         provider.apply_filters(&mut query, &config);
         let mut messages = vec![
-            Message::user("one"),
-            Message::assistant("two"),
-            Message::user("three"),
+            Message::user("TASK: build the widget"),
+            Message::assistant("X".repeat(2000)),
+            Message::assistant("Y".repeat(2000)),
+            Message::user("recent a"),
+            Message::assistant("recent b"),
         ];
 
         query.apply_windowing(&mut messages);
         provider.post_load(&mut messages, &config);
 
-        assert_eq!(messages.len(), 3);
+        // The original task is anchored at the front, the notice follows it, and
+        // the recent tail is intact — the model still knows what it is doing.
+        assert_eq!(extract_text_content(&messages[0]), "TASK: build the widget");
         assert!(
-            extract_text_content(&messages[0])
-                .contains("1 earlier messages are NOT visible in this context")
+            extract_text_content(&messages[1])
+                .contains("earlier messages are NOT visible in this context")
         );
-        assert_eq!(extract_text_content(&messages[1]), "two");
-        assert_eq!(extract_text_content(&messages[2]), "three");
+        assert_eq!(extract_text_content(messages.last().unwrap()), "recent b");
+        // The huge first assistant turn was dropped from the middle.
+        assert!(
+            !messages
+                .iter()
+                .any(|m| extract_text_content(m).starts_with("XXX"))
+        );
+    }
+
+    #[test]
+    fn test_filter_provider_defers_eviction_to_compaction() {
+        let provider = InfinityContextFilterProvider;
+        let mut messages = vec![
+            Message::user("task"),
+            Message::assistant("old ".repeat(400)),
+            Message::user("recent one"),
+            Message::assistant("recent two"),
+        ];
+
+        provider.post_load(
+            &mut messages,
+            &json!({
+                "context_budget_tokens": 1,
+                "min_recent_messages": 2,
+                "compaction_active": true
+            }),
+        );
+
+        // Compaction owns reduction: infinity context neither trims nor injects a
+        // notice when compaction is active.
+        assert_eq!(messages.len(), 4);
+        assert!(
+            messages
+                .iter()
+                .all(|m| !extract_text_content(m).contains("NOT visible"))
+        );
+    }
+
+    #[test]
+    fn test_filter_provider_keep_first_messages_anchors_multiple() {
+        let provider = InfinityContextFilterProvider;
+        let mut messages = vec![
+            Message::user("anchor one"),
+            Message::user("anchor two"),
+            Message::assistant("mid ".repeat(400)),
+            Message::user("recent"),
+        ];
+
+        provider.post_load(
+            &mut messages,
+            &json!({
+                "context_budget_tokens": 1,
+                "min_recent_messages": 1,
+                "keep_first_messages": 2
+            }),
+        );
+
+        assert_eq!(extract_text_content(&messages[0]), "anchor one");
+        assert_eq!(extract_text_content(&messages[1]), "anchor two");
+        assert!(extract_text_content(&messages[2]).contains("NOT visible"));
+        assert_eq!(extract_text_content(messages.last().unwrap()), "recent");
     }
 
     #[test]

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -1601,6 +1601,54 @@ impl CollectedModelViewProviders {
     }
 }
 
+/// True when the `compaction` capability is present and available in this set.
+///
+/// Infinity context defers token-budget eviction to compaction when both are
+/// enabled (see specs/infinity-context.md) so that compaction's summary — not a
+/// bare "hidden" notice — covers trimmed history.
+fn compaction_is_enabled(
+    capability_configs: &[AgentCapabilityConfig],
+    registry: &CapabilityRegistry,
+) -> bool {
+    capability_configs.iter().any(|cap_config| {
+        cap_config.capability_ref.as_str() == COMPACTION_CAPABILITY_ID
+            && registry
+                .get(cap_config.capability_ref.as_str())
+                .is_some_and(|cap| cap.status() == CapabilityStatus::Available)
+    })
+}
+
+/// Per-agent message-filter config for a capability, injecting the derived
+/// `compaction_active` signal into infinity context when compaction is enabled.
+///
+/// This is the one place capability composition is encoded: infinity context and
+/// compaction are otherwise independent, but if infinity context evicts history
+/// before compaction can summarize it, compaction only ever sees the recent
+/// window. The flag tells infinity context to anchor + provide `query_history`
+/// and let compaction own reduction.
+fn message_filter_config_for(
+    cap_id: &str,
+    base: &serde_json::Value,
+    compaction_on: bool,
+) -> serde_json::Value {
+    if cap_id != INFINITY_CONTEXT_CAPABILITY_ID || !compaction_on {
+        return base.clone();
+    }
+    let mut config = base.clone();
+    match config.as_object_mut() {
+        Some(map) => {
+            map.insert(
+                "compaction_active".to_string(),
+                serde_json::Value::Bool(true),
+            );
+        }
+        None => {
+            config = serde_json::json!({ "compaction_active": true });
+        }
+    }
+    config
+}
+
 /// Collect only message filter providers from capabilities, skipping system
 /// prompt contributions, tools, mounts, and other expensive work.
 ///
@@ -1612,6 +1660,7 @@ pub fn collect_message_filters_only(
 ) -> CollectedMessageFilters {
     let mut message_filter_providers: Vec<(Arc<dyn MessageFilterProvider>, serde_json::Value)> =
         Vec::new();
+    let compaction_on = compaction_is_enabled(capability_configs, registry);
 
     for cap_config in capability_configs {
         let cap_id = cap_config.capability_ref.as_str();
@@ -1625,7 +1674,8 @@ pub fn collect_message_filters_only(
                 .resolve_for_model(None)
                 .unwrap_or_else(|| capability.as_ref());
             if let Some(provider) = effective.message_filter_provider() {
-                message_filter_providers.push((provider, cap_config.config.clone()));
+                let config = message_filter_config_for(cap_id, &cap_config.config, compaction_on);
+                message_filter_providers.push((provider, config));
             }
         }
     }
@@ -2071,6 +2121,7 @@ pub async fn collect_capabilities_with_configs(
     let mut tool_definition_hooks: Vec<Arc<dyn ToolDefinitionHook>> = Vec::new();
     let mut tool_call_hooks: Vec<Arc<dyn ToolCallHook>> = Vec::new();
     let mut mcp_servers = ScopedMcpServers::default();
+    let compaction_on = compaction_is_enabled(capability_configs, registry);
 
     for cap_config in capability_configs {
         let cap_id = cap_config.capability_ref.as_str();
@@ -2234,7 +2285,8 @@ pub async fn collect_capabilities_with_configs(
 
             // Collect message filter provider
             if let Some(provider) = effective.message_filter_provider() {
-                message_filter_providers.push((provider, cap_config.config.clone()));
+                let config = message_filter_config_for(cap_id, &cap_config.config, compaction_on);
+                message_filter_providers.push((provider, config));
             }
 
             applied_ids.push(cap_id.to_string());
@@ -3557,6 +3609,106 @@ mod tests {
 
         assert_eq!(query.filters.len(), 1);
         assert!(matches!(&query.filters[0], MessageFilter::Search(s) if s == "test_query"));
+    }
+
+    #[test]
+    fn test_message_filter_config_injects_compaction_active_for_infinity_context() {
+        let base = serde_json::json!({ "context_budget_tokens": 1000 });
+
+        // Infinity context gets the derived flag only when compaction is enabled.
+        let with = message_filter_config_for(INFINITY_CONTEXT_CAPABILITY_ID, &base, true);
+        assert_eq!(with["compaction_active"], serde_json::json!(true));
+        assert_eq!(with["context_budget_tokens"], serde_json::json!(1000));
+
+        let without = message_filter_config_for(INFINITY_CONTEXT_CAPABILITY_ID, &base, false);
+        assert!(without.get("compaction_active").is_none());
+
+        // Other capabilities are never touched.
+        let other = message_filter_config_for("other", &base, true);
+        assert!(other.get("compaction_active").is_none());
+
+        // A null base is upgraded to an object carrying the flag.
+        let null_base = message_filter_config_for(
+            INFINITY_CONTEXT_CAPABILITY_ID,
+            &serde_json::Value::Null,
+            true,
+        );
+        assert_eq!(null_base["compaction_active"], serde_json::json!(true));
+    }
+
+    #[test]
+    fn test_infinity_context_defers_to_compaction_end_to_end() {
+        use crate::message::Message;
+
+        let mut registry = CapabilityRegistry::new();
+        registry.register(InfinityContextCapability);
+        registry.register(CompactionCapability);
+
+        let tight = serde_json::json!({
+            "context_budget_tokens": 1,
+            "min_recent_messages": 1
+        });
+
+        // Infinity context alone (tight budget): it trims and injects a notice.
+        let solo = vec![AgentCapabilityConfig {
+            capability_ref: CapabilityId::new(INFINITY_CONTEXT_CAPABILITY_ID),
+            config: tight.clone(),
+        }];
+        let mut messages = vec![
+            Message::user("task"),
+            Message::assistant("old ".repeat(400)),
+            Message::user("recent"),
+        ];
+        collect_message_filters_only(&solo, &registry).apply_post_load_filters(&mut messages);
+        assert!(
+            messages
+                .iter()
+                .any(|m| m.text().is_some_and(|t| t.contains("NOT visible"))),
+            "infinity context alone should trim and notice"
+        );
+
+        // Infinity context + compaction: infinity context defers, no eviction.
+        let both = vec![
+            AgentCapabilityConfig {
+                capability_ref: CapabilityId::new(INFINITY_CONTEXT_CAPABILITY_ID),
+                config: tight,
+            },
+            AgentCapabilityConfig {
+                capability_ref: CapabilityId::new(COMPACTION_CAPABILITY_ID),
+                config: serde_json::json!({}),
+            },
+        ];
+        let mut messages = vec![
+            Message::user("task"),
+            Message::assistant("old ".repeat(400)),
+            Message::user("recent"),
+        ];
+        collect_message_filters_only(&both, &registry).apply_post_load_filters(&mut messages);
+        assert_eq!(messages.len(), 3, "compaction owns reduction; no eviction");
+        assert!(
+            messages
+                .iter()
+                .all(|m| !m.text().is_some_and(|t| t.contains("NOT visible"))),
+            "no hidden-history notice when compaction is the active reducer"
+        );
+    }
+
+    #[test]
+    fn test_compaction_is_enabled_detects_compaction() {
+        let mut registry = CapabilityRegistry::new();
+        registry.register(CompactionCapability);
+
+        let with_compaction = vec![AgentCapabilityConfig {
+            capability_ref: CapabilityId::new(COMPACTION_CAPABILITY_ID),
+            config: serde_json::json!({}),
+        }];
+        assert!(compaction_is_enabled(&with_compaction, &registry));
+
+        let without = vec![AgentCapabilityConfig {
+            capability_ref: CapabilityId::new("current_time"),
+            config: serde_json::json!({}),
+        }];
+        assert!(!compaction_is_enabled(&without, &registry));
     }
 
     #[test]

--- a/crates/core/src/message_filter.rs
+++ b/crates/core/src/message_filter.rs
@@ -466,6 +466,102 @@ impl MessageQuery {
 }
 
 // ============================================================================
+// AnchoredWindow - "protect head + tail, drop the middle" selection
+// ============================================================================
+
+/// Which messages survive anchored token-budget trimming.
+///
+/// Kept messages are `[0, head_len)` (the anchor: the system goal / original
+/// task) followed by `[recent_start, len)` (recent state). Messages in
+/// `[head_len, recent_start)` — the middle — are dropped. [`Self::hidden`]
+/// reports how many.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AnchoredWindow {
+    /// Number of leading messages kept as the anchor.
+    pub head_len: usize,
+    /// Index where the contiguous recent block begins.
+    pub recent_start: usize,
+}
+
+impl AnchoredWindow {
+    /// Count of messages dropped from the middle.
+    pub fn hidden(&self) -> usize {
+        self.recent_start.saturating_sub(self.head_len)
+    }
+}
+
+/// Select an anchored window over `costs.len()` messages.
+///
+/// Always preserves the first `keep_head` messages (the conversation's goal) and
+/// the last `min_tail` messages (recent state), even if their combined token
+/// `cost` exceeds `budget`. The recent block then grows backward toward the head
+/// while the running total stays within `budget` and the tail stays within
+/// `max_tail` (when set).
+///
+/// This is the "protect head + tail, drop the middle" policy. It keeps a single
+/// contiguous recent block so tool-call/result adjacency and conversational flow
+/// are preserved, leaving at most one gap (between the anchor and the recent
+/// block). Anchoring the head is the conversational analog of StreamingLLM's
+/// attention sinks and the "lost in the middle" finding: the first message (the
+/// task/goal) is the one eviction you never want.
+///
+/// `max_tail` is a hard cap on the recent block and bounds `min_tail`; the head
+/// anchor is additional to it.
+pub fn anchored_window(
+    costs: &[usize],
+    keep_head: usize,
+    min_tail: usize,
+    max_tail: Option<usize>,
+    budget: usize,
+) -> AnchoredWindow {
+    let len = costs.len();
+    let keep_head = keep_head.min(len);
+
+    // A hard recent cap also bounds the guaranteed tail.
+    let mut min_tail = min_tail.min(len);
+    if let Some(max_tail) = max_tail {
+        min_tail = min_tail.min(max_tail.max(1));
+    }
+
+    let mut recent_start = len - min_tail;
+    if recent_start <= keep_head {
+        // Head and tail meet or overlap: keep everything, no middle to drop.
+        return AnchoredWindow {
+            head_len: keep_head,
+            recent_start: keep_head,
+        };
+    }
+
+    let head_cost: usize = costs[..keep_head].iter().sum();
+    let mut window_cost: usize = head_cost + costs[recent_start..].iter().sum::<usize>();
+    let mut tail_count = min_tail;
+
+    // Grow the recent block backward (newest-first) while it fits both the token
+    // budget and the optional hard recent cap. Head + min_tail are guaranteed
+    // even when already over budget.
+    while recent_start > keep_head {
+        if let Some(max_tail) = max_tail
+            && tail_count >= max_tail
+        {
+            break;
+        }
+        let next = recent_start - 1;
+        let next_cost = costs[next];
+        if window_cost + next_cost > budget {
+            break;
+        }
+        recent_start = next;
+        window_cost += next_cost;
+        tail_count += 1;
+    }
+
+    AnchoredWindow {
+        head_len: keep_head,
+        recent_start,
+    }
+}
+
+// ============================================================================
 // MessageFilterProvider - Trait for capabilities to contribute filters
 // ============================================================================
 
@@ -901,6 +997,61 @@ mod tests {
         assert_eq!(low_priority.priority(), -10);
         assert_eq!(high_priority.priority(), 10);
         assert_eq!(default_priority.priority(), 0);
+    }
+
+    #[test]
+    fn test_anchored_window_keeps_head_and_tail_drops_middle() {
+        // 5 messages, anchor 1, min tail 2, tiny budget: only head + tail survive.
+        let costs = [10, 10, 10, 10, 10];
+        let win = anchored_window(&costs, 1, 2, None, 1);
+        assert_eq!(win.head_len, 1);
+        assert_eq!(win.recent_start, 3);
+        assert_eq!(win.hidden(), 2); // messages 1 and 2 dropped
+    }
+
+    #[test]
+    fn test_anchored_window_grows_recent_block_within_budget() {
+        // Generous budget pulls older messages back into the contiguous tail.
+        let costs = [10, 10, 10, 10, 10];
+        let win = anchored_window(&costs, 1, 1, None, 1_000);
+        assert_eq!(win.head_len, 1);
+        assert_eq!(win.recent_start, 1); // everything kept
+        assert_eq!(win.hidden(), 0);
+    }
+
+    #[test]
+    fn test_anchored_window_respects_max_tail_cap() {
+        // max_tail caps the recent block; the head anchor is additional to it.
+        let costs = [10; 10];
+        let win = anchored_window(&costs, 1, 5, Some(2), 1_000);
+        assert_eq!(win.head_len, 1);
+        assert_eq!(win.recent_start, 8); // keep msg 0 + msgs 8,9
+        assert_eq!(win.hidden(), 7);
+    }
+
+    #[test]
+    fn test_anchored_window_keeps_anchor_and_tail_even_when_over_budget() {
+        let costs = [100, 100, 100, 100];
+        // Budget 0 still preserves head (1) and min tail (1): never drops anchors.
+        let win = anchored_window(&costs, 1, 1, None, 0);
+        assert_eq!(win.head_len, 1);
+        assert_eq!(win.recent_start, 3);
+        assert_eq!(win.hidden(), 2);
+    }
+
+    #[test]
+    fn test_anchored_window_no_middle_when_head_and_tail_overlap() {
+        let costs = [10, 10, 10];
+        let win = anchored_window(&costs, 1, 10, None, 1);
+        assert_eq!(win.hidden(), 0);
+    }
+
+    #[test]
+    fn test_anchored_window_empty() {
+        let win = anchored_window(&[], 1, 2, None, 100);
+        assert_eq!(win.head_len, 0);
+        assert_eq!(win.recent_start, 0);
+        assert_eq!(win.hidden(), 0);
     }
 
     #[test]

--- a/crates/core/src/openresponses_protocol.rs
+++ b/crates/core/src/openresponses_protocol.rs
@@ -577,8 +577,13 @@ impl OpenResponsesProtocolChatDriver {
 
         for msg in messages {
             if msg.role == LlmMessageRole::System {
-                // Extract system message as instructions
-                instructions = Some(match &msg.content {
+                // Accumulate system messages into `instructions`. Multiple system
+                // messages legitimately occur in one request — the agent system
+                // prompt plus, e.g., infinity context's hidden-history notice or
+                // compaction's conversation summary. Overwriting would drop the
+                // real system prompt and keep only the last notice, so join them
+                // in order instead.
+                let text = match &msg.content {
                     LlmMessageContent::Text(text) => text.clone(),
                     LlmMessageContent::Parts(parts) => parts
                         .iter()
@@ -588,6 +593,10 @@ impl OpenResponsesProtocolChatDriver {
                         })
                         .collect::<Vec<_>>()
                         .join(""),
+                };
+                instructions = Some(match instructions.take() {
+                    Some(existing) if !existing.is_empty() => format!("{existing}\n\n{text}"),
+                    _ => text,
                 });
             } else if msg.role == LlmMessageRole::Assistant {
                 // For assistant messages, emit Reasoning item BEFORE message content if present
@@ -2318,6 +2327,32 @@ mod tests {
             Some("You are a helpful assistant".to_string())
         );
         assert_eq!(input.len(), 1); // Only user message, system converted to instructions
+    }
+
+    #[test]
+    fn test_build_input_concatenates_multiple_system_messages() {
+        // The agent system prompt plus a later system message (e.g. infinity
+        // context's hidden-history notice or compaction's summary) must both
+        // survive — the later one must not overwrite the real system prompt.
+        let messages = vec![
+            LlmMessage::text(LlmMessageRole::System, "You are a helpful assistant"),
+            LlmMessage::text(LlmMessageRole::User, "Hello"),
+            LlmMessage::text(
+                LlmMessageRole::System,
+                "[IMPORTANT: 3 earlier messages are NOT visible in this context.]",
+            ),
+        ];
+
+        let (instructions, input) = OpenResponsesProtocolChatDriver::build_input(&messages, false);
+
+        assert_eq!(
+            instructions,
+            Some(
+                "You are a helpful assistant\n\n[IMPORTANT: 3 earlier messages are NOT visible in this context.]"
+                    .to_string()
+            )
+        );
+        assert_eq!(input.len(), 1); // Only the user message remains as input
     }
 
     #[test]

--- a/crates/server/src/session_scheduler.rs
+++ b/crates/server/src/session_scheduler.rs
@@ -882,7 +882,7 @@ mod tests {
 
         // The outbound message must be the tool result, not the "Monitor fired" placeholder.
         let messages = registry
-            .list_messages(session_id, &task.id, Some(10))
+            .list_messages(session_id, &task.id, Some(10), None)
             .await
             .unwrap();
         assert_eq!(messages.len(), 1, "exactly one message must be recorded");
@@ -929,7 +929,7 @@ mod tests {
         );
 
         let messages = registry
-            .list_messages(session_id, &task.id, Some(10))
+            .list_messages(session_id, &task.id, Some(10), None)
             .await
             .unwrap();
         assert_eq!(messages.len(), 1);
@@ -963,7 +963,7 @@ mod tests {
         assert!(!probe_ran, "no registry → probe_ran must be false");
 
         let messages = registry
-            .list_messages(session_id, &task.id, Some(10))
+            .list_messages(session_id, &task.id, Some(10), None)
             .await
             .unwrap();
         assert_eq!(messages.len(), 1);

--- a/specs/compaction.md
+++ b/specs/compaction.md
@@ -31,8 +31,8 @@ Provider cache telemetry feeds this same model-view step. If the previous call r
 - Emits `context.compacting` / `context.compacted` events and records `LlmCompactionInfo` on `llm.generation` when native provider compaction runs.
 
 **Infinity Context** (`crates/core/src/capabilities/infinity_context.rs`):
-- Separate, optional capability — not part of compaction. Trims messages + provides `query_history` tool.
-- Complementary to compaction but independent. See `specs/infinity-context.md`.
+- Separate, optional capability — not part of compaction. Keeps a recent window + provides the `query_history` tool.
+- **Not freely composable with compaction.** Infinity context evicts during message loading, before compaction runs, so enabling both naively means compaction only sees the recent window. Compaction is the stronger primary strategy (always-present summary); infinity context is a pull-based backstop. When both are enabled, infinity context defers token-budget eviction to compaction. See `specs/infinity-context.md`.
 
 ### Current Caveats
 
@@ -362,6 +362,14 @@ Tool results from `PROTECTED_TOOL_NAMES` (currently `activate_skill`) are exempt
 3. **Hierarchical memory**: rescued from cold tier into output verbatim
 4. **Summarization**: `skill_instructions` in default preserve list; prompt instructs LLM to include skill content verbatim
 
+### Anchored Task Message
+
+Aggressive trim also anchors the **first conversation message** (the original
+task/goal), reserving its budget alongside protected tool results so it is never
+dropped. Like infinity context's head anchor, losing the opening task leaves the
+model unable to tell what it is doing once the window slides; the system prompt
+is assembled separately and is already exempt.
+
 See `crates/core/src/capabilities/compaction.rs` for implementation (`PROTECTED_TOOL_NAMES`, `is_protected_tool_result`).
 
 ## Summarization
@@ -476,7 +484,7 @@ visibility rather than changing the capability ownership model.
 - [NAACL 2025: Prompt Compression Survey](https://aclanthology.org/2025.naacl-long.368.pdf)
 - [OpenAI: GPT-5.2 Codex Context Compaction](https://openai.com/index/introducing-gpt-5-2/)
 - [Google ADK: Context Compaction](https://google.github.io/adk-docs/context/compaction/)
-- `specs/infinity-context.md` — complementary capability (optional, independent)
+- `specs/infinity-context.md` — pull-based backstop capability; defers to compaction when both are enabled
 - `specs/events.md` — event schema
 - `specs/capabilities.md` — capability system
 - `crates/core/src/llm_driver_registry.rs` — `ChatDriver` trait with `supports_compact()` / `compact()`

--- a/specs/infinity-context.md
+++ b/specs/infinity-context.md
@@ -10,7 +10,13 @@ Current LLM context windows (128k-200k tokens) impose hard limits on agent conve
 
 This approach lets the model "pull" relevant context rather than us "pushing" everything, enabling arbitrarily long conversations while preserving access to all historical information.
 
-**Relationship to Compaction:** Compaction (`specs/compaction.md`) actively reduces message size by stripping reproducible content or summarizing. Infinity Context manages what to send when history is too large. They are complementary and independent — compaction reduces tokens per message, infinity context manages which messages to include.
+**Relationship to Compaction:** Compaction (`specs/compaction.md`) actively reduces what is sent by stripping reproducible tool output (observation masking) and summarizing older turns into an always-present `[CONVERSATION_SUMMARY]`. Infinity Context instead keeps a recent window and exposes evicted history through `query_history` (pull-based retrieval).
+
+These are two answers to the same problem and they are **not** freely composable. Infinity Context evicts older messages during message loading (`post_load`), before compaction runs in the reason atom, so when both are enabled infinity context would destroy history before compaction could summarize it — leaving compaction only the recent window. Therefore:
+
+- **Compaction is the stronger primary strategy** for long-running agents: its summary keeps the gist always present, so the model never has to know to query. Pull-based retrieval has a well-known failure mode — the model does not know what it does not know — and on its own loses the original task once the window slides.
+- **Infinity Context is a backstop**, valuable mainly for its lossless `query_history` search over full storage.
+- When both are enabled, infinity context detects compaction (via the derived `compaction_active` flag set during capability collection) and **defers token-budget eviction to compaction**: it anchors the task, provides `query_history`, and stops trimming, so compaction owns reduction.
 
 ## Problem Statement
 
@@ -77,9 +83,13 @@ When searching history:
   {
     "context_budget_tokens": 100000,
     "min_recent_messages": 10,
-    "max_recent_messages": null
+    "max_recent_messages": null,
+    "keep_first_messages": 1
   }
   ```
+- `keep_first_messages` (default 1) is the number of leading messages always kept
+  as an anchor — the original task/goal. The anchor is **additional** to
+  `max_recent_messages` (which caps only the recent tail).
 
 ## Design
 
@@ -119,37 +129,52 @@ More accurate estimation can use tiktoken for OpenAI or anthropic-tokenizer for 
 
 ### Message Selection Algorithm
 
+Selection is "protect the head + tail, drop the middle" (see
+`anchored_window` in `crates/core/src/message_filter.rs`). The agent system
+prompt is assembled separately and is never part of this list, so the head
+anchor here protects the **first conversation message — the original task/goal**.
+
 ```python
-def select_messages(all_messages, budget_tokens, min_recent):
-    # Always include system message
-    selected = [system_message]
-    budget -= estimate_tokens(system_message)
+def select_messages(all_messages, budget, keep_head, min_tail, max_tail=None):
+    n = len(all_messages)
+    # Always keep the first `keep_head` (the task) and last `min_tail` (recent),
+    # even if they exceed budget. A hard `max_tail` cap bounds the tail.
+    if max_tail is not None:
+        min_tail = min(min_tail, max(max_tail, 1))
+    recent_start = n - min_tail
+    if recent_start <= keep_head:
+        return all_messages, []  # head and tail meet: nothing to drop
 
-    # Always include min_recent most recent messages
-    recent = all_messages[-min_recent:]
-    for msg in recent:
-        selected.append(msg)
-        budget -= estimate_tokens(msg)
-
-    # Add older messages while budget allows (newest first)
-    remaining = all_messages[:-min_recent]
-    for msg in reversed(remaining):
-        msg_tokens = estimate_tokens(msg)
-        if budget - msg_tokens < 0:
+    # Grow the recent block backward (newest-first) while it fits the token
+    # budget and the optional max_tail cap. This keeps a single contiguous tail
+    # so tool-call/result adjacency is preserved.
+    cost = sum_tokens(all_messages[:keep_head]) + sum_tokens(all_messages[recent_start:])
+    tail = min_tail
+    while recent_start > keep_head and (max_tail is None or tail < max_tail):
+        c = estimate_tokens(all_messages[recent_start - 1])
+        if cost + c > budget:
             break
-        selected.insert(1, msg)  # After system, before recent
-        budget -= msg_tokens
+        recent_start -= 1; cost += c; tail += 1
 
-    excluded = [m for m in all_messages if m not in selected]
-    return selected, excluded
+    kept = all_messages[:keep_head] + all_messages[recent_start:]
+    excluded = all_messages[keep_head:recent_start]   # the dropped middle
+    return kept, excluded
 ```
 
-Implementations MAY expose `max_recent_messages` as a hard cap for constrained
-surfaces such as public support chat. When set, the live prompt keeps no more
-than that many persisted messages, even if `context_budget_tokens` would allow
-more. Message limits always mean the latest N messages, returned in
-chronological order; older excluded messages remain available through
-`query_history`.
+The notice is inserted between the anchor and the recent block, so the live
+prompt reads `[task anchor] -> [N earlier messages hidden] -> [recent window]`.
+
+`max_recent_messages` is a hard cap for constrained surfaces such as public
+support chat; it bounds only the recent tail (the head anchor is additional).
+Message limits always mean the latest N messages, returned in chronological
+order; older excluded messages remain available through `query_history`.
+
+**Known limitation:** the anchor is guaranteed only within the candidate load
+window (`resolve_candidate_load_limit`). For conversations longer than that
+window — or when `max_recent_messages` is set very low — the DB loads only the
+latest N messages, so the true first message is never fetched and the anchor
+degrades to the oldest loaded message. Guaranteeing the head for arbitrarily
+long histories needs a head+tail DB fetch (tracked as a follow-up).
 
 ### History Notice Format
 


### PR DESCRIPTION
## What
Long-running agents lose track of their goal once the conversation window slides. `infinity_context` kept only a recent window (+ budget-filled older turns), and compaction's `aggressive_trim` walked newest-first — so the **first user message (the original task) was evicted**. The model was left with a bare "use `query_history`" notice and no idea what it was doing.

This anchors the original task so it is never dropped, fixes how the two context-management capabilities compose, and aligns the specs.

## Why
Pull-based retrieval (`query_history`) cannot rescue the situation: the model doesn't know what to query for once the goal is gone ("doesn't know what it doesn't know"). Keeping the head is the conversational analog of StreamingLLM's attention sinks and the "lost in the middle" finding — the first message is the one eviction you never want.

## How
**P0 — anchor the head**
- New `anchored_window` helper in `message_filter.rs` — "protect head + tail, drop the middle" (single contiguous gap so tool-call/result adjacency is preserved).
- `infinity_context`: new `keep_first_messages` config (default 1); rewrote `trim_messages_to_token_budget` to use the helper; the hidden notice now sits **between** the anchor and the recent window → `[task] → [N hidden] → [recent]`. The hard `max_recent_messages` cap now bounds only the recent tail; the anchor is additional.
- `compaction` `aggressive_trim`: anchors the first conversation message (the task) by reserving its budget like a protected tool result.

**P2 — composition**
- `infinity_context` and `compaction` are **not** freely composable: infinity context evicts during message loading, before compaction runs, so naively enabling both means compaction only ever sees the recent window. Capability collection now sets a derived `compaction_active` flag; when compaction is enabled, infinity context **defers token-budget eviction** to it (anchors + provides `query_history`, stops trimming).

**P1/P3 — docs**
- Corrected the false "complementary and independent" claim in `specs/infinity-context.md` and `specs/compaction.md`; documented compaction-as-primary / infinity-context-as-backstop and the candidate-window anchor limitation.

## Risk
- **Low.** Pure in-memory message-list logic; no auth/API/SQL/migration/FS surface.
- Behavior change for agents running **both** capabilities: infinity context no longer trims when compaction is enabled (compaction owns reduction) — this is the intended fix.
- Three existing tests were updated to assert the **fixed** behavior (the anchor is now preserved where it was previously dropped).

## Security
- Threat categories reviewed: **TM-LLM** (prompt construction). No TM-AUTH/AUTHZ/API/SQL/FS/TENANT surface touched.
- Findings and resolutions: none. The notice format is a compile-time constant and the excluded count is numeric (no injection vector); `anchored_window` is a single bounded O(n) pass over already-loaded messages (no new unbounded allocation or DoS surface). Session storage remains lossless; only the model view changes.

## Note: incidental CI fix (second commit)
Rebasing onto latest `main` surfaced a **pre-existing breakage on `main`**: the cursor-pagination change (EVE-582, #2220) added a fourth `after_id` param to the `list_messages` trait but left three `#[cfg(test)]` call sites in `crates/server/src/session_scheduler.rs` at the old 3-arg signature, which fails `--all-targets` clippy / lib-test compilation. The second commit passes `None` (no cursor; behavior-preserving) at those sites to unblock CI for this PR. Unrelated to the context change but required for green CI.

## Follow-ups
- **Guarantee the anchor for histories larger than the candidate load window.** Today the anchor holds only within `resolve_candidate_load_limit` (default ~1600 messages; smaller if `max_recent_messages` is very low). Beyond that the DB loads only the latest N via SQL `LIMIT`, so the true first message isn't fetched and the anchor degrades to the oldest loaded message. A guaranteed fix needs a head+tail DB fetch (`MessageQuery.keep_head` + a UNION across the postgres and in-memory backends) — separable and riskier, so deferred. The reported ~247-message case and the realistic majority are fully fixed.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (internal; behavior change for both-enabled agents is the intended fix)
- [x] Security review performed against relevant threat model categories (TM-LLM)
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

## Validation
- `everruns-core` lib: **2475 tests pass**. New coverage: `anchored_window` (head/tail/middle, max_tail cap, over-budget guarantee, empty), infinity-context anchoring under tight budget + `keep_first` + full windowing pipeline + compaction-defer (unit **and** end-to-end through `collect_message_filters_only` → `apply_post_load_filters`), and the `aggressive_trim` task anchor.
- `bash scripts/lib/pre-push.sh`: green (fmt, clippy `-D warnings` on the full workspace, lockfile, migrations, specs index, author attribution).