### PR TITLE
fix(openrouter): handle Responses [DONE] sentinel + live coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -652,6 +652,10 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          # OpenRouter cases skip automatically when this secret is absent
+          # (matrix `model()` filters empty keys), so this is safe to reference
+          # before the secret is provisioned.
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
         run: cargo test -p everruns-llm-tests --test agent_run_basic --test agent_run_with_thinking --all-features
 
   # Build release binaries and upload as artifacts for E2E jobs and openapi-check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2788,6 +2788,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "everruns-core",
+ "futures",
  "reqwest 0.13.4",
  "serde",
  "serde_json",

--- a/crates/core/src/openresponses_protocol.rs
+++ b/crates/core/src/openresponses_protocol.rs
@@ -999,6 +999,15 @@ impl ChatDriver for OpenResponsesProtocolChatDriver {
                     Ok(event) => {
                         let event_data = &event.data;
 
+                        // OpenAI-compatible gateways (e.g. OpenRouter) terminate the
+                        // Responses SSE stream with a chat-completions-style `[DONE]`
+                        // sentinel, which OpenAI's native Responses API does not send.
+                        // It is not JSON, so skip it instead of surfacing a spurious
+                        // "Failed to parse event" error after the real completion.
+                        if event_data == "[DONE]" {
+                            return Ok(LlmStreamEvent::TextDelta(String::new()));
+                        }
+
                         // Try to parse as typed StreamingEvent first for type safety
                         if let Ok(streaming_event) =
                             serde_json::from_str::<StreamingEvent>(event_data)
@@ -3115,6 +3124,64 @@ mod tests {
         // even though the session id rides along in `metadata`.
         assert!(body.get("session_id").is_none(), "body: {body}");
         assert_eq!(body["metadata"]["session_id"], "session_abc123");
+    }
+
+    /// OpenAI-compatible gateways (e.g. OpenRouter) terminate the Responses SSE
+    /// stream with a chat-completions-style `[DONE]` sentinel that OpenAI's
+    /// native API does not send. It must be skipped, not surfaced as a spurious
+    /// `Error` event after the real completion. (EVE: caught by the OpenRouter
+    /// live chat smoke test.)
+    #[tokio::test]
+    async fn openresponses_stream_skips_done_sentinel() {
+        use futures::StreamExt;
+        use wiremock::matchers::method;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        // A normal text delta followed by the trailing `[DONE]` sentinel.
+        let body =
+            "data: {\"type\":\"response.output_text.delta\",\"delta\":\"hi\"}\n\ndata: [DONE]\n\n";
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(body),
+            )
+            .mount(&server)
+            .await;
+
+        let api_url = format!("{}/v1/responses", server.uri());
+        let driver = OpenResponsesProtocolChatDriver::with_base_url("test-key", api_url);
+        let config = LlmCallConfig {
+            model: "openai/gpt-4o-mini".to_string(),
+            temperature: None,
+            max_tokens: None,
+            tools: vec![],
+            reasoning_effort: None,
+            metadata: std::collections::HashMap::new(),
+            previous_response_id: None,
+            tool_search: None,
+            prompt_cache: None,
+            openrouter_routing: None,
+        };
+
+        let stream = driver
+            .chat_completion_stream(vec![LlmMessage::text(LlmMessageRole::User, "hi")], &config)
+            .await
+            .expect("stream should start");
+        let events: Vec<_> = stream.collect().await;
+
+        let mut text = String::new();
+        for ev in &events {
+            match ev.as_ref().expect("no transport error") {
+                LlmStreamEvent::TextDelta(d) => text.push_str(d),
+                LlmStreamEvent::Error(e) => {
+                    panic!("[DONE] sentinel must not surface as an error: {e}")
+                }
+                _ => {}
+            }
+        }
+        assert_eq!(text, "hi");
     }
 
     // ========================================================================

--- a/crates/llm-tests/tests/agent_run_basic.rs
+++ b/crates/llm-tests/tests/agent_run_basic.rs
@@ -37,6 +37,7 @@ use everruns_core::traits::ResolvedModel;
 #[case::openai_gpt4o_mini(OPENAI_GPT4O_MINI)]
 #[case::openai_gpt54(OPENAI_GPT54)]
 #[case::gemini_flash(GEMINI_FLASH)]
+#[case::openrouter_gpt4o_mini(OPENROUTER_GPT4O_MINI)]
 #[tokio::test]
 async fn test_basic_completion(#[case] config: ProviderModelConfig) {
     let Some(model) = config.model() else {
@@ -71,6 +72,7 @@ async fn test_basic_completion(#[case] config: ProviderModelConfig) {
 #[case::openai_gpt4o_mini(OPENAI_GPT4O_MINI)]
 #[case::openai_gpt54(OPENAI_GPT54)]
 #[case::gemini_flash(GEMINI_FLASH)]
+#[case::openrouter_gpt4o_mini(OPENROUTER_GPT4O_MINI)]
 #[tokio::test]
 async fn test_tool_call(#[case] config: ProviderModelConfig) {
     let Some(model) = config.model() else {

--- a/crates/llm-tests/tests/llm_test_matrix/mod.rs
+++ b/crates/llm-tests/tests/llm_test_matrix/mod.rs
@@ -107,6 +107,15 @@ pub const OPENAI_GPT55: ProviderModelConfig =
 pub const GEMINI_FLASH: ProviderModelConfig =
     ProviderModelConfig::new(DriverId::Gemini, "gemini-2.0-flash", "GEMINI_API_KEY");
 
+// OpenRouter routes to upstream providers; gpt-4o-mini is cheap and reliably
+// available. Exercises the Open Responses streaming path (incl. the `[DONE]`
+// terminator) and the OpenRouter request decoration (session_id, routing).
+pub const OPENROUTER_GPT4O_MINI: ProviderModelConfig = ProviderModelConfig::new(
+    DriverId::OpenRouter,
+    "openai/gpt-4o-mini",
+    "OPENROUTER_API_KEY",
+);
+
 // Bedrock: credentials are JSON in the env var, not a plain API key.
 // Set AWS_BEDROCK_CREDENTIALS to the JSON credential object.
 pub const BEDROCK_HAIKU: ProviderModelConfig = ProviderModelConfig::new(

--- a/crates/openrouter/Cargo.toml
+++ b/crates/openrouter/Cargo.toml
@@ -32,6 +32,8 @@ chrono.workspace = true
 everruns-core.workspace = true
 
 [dev-dependencies]
-# tokio powers `#[tokio::test]`; wiremock captures driver requests.
+# tokio powers `#[tokio::test]`; wiremock captures driver requests; futures
+# drains the live chat stream.
 tokio = { workspace = true, features = ["full", "test-util"] }
+futures.workspace = true
 wiremock = "0.6"

--- a/crates/openrouter/tests/chat_live.rs
+++ b/crates/openrouter/tests/chat_live.rs
@@ -1,0 +1,89 @@
+//! Live smoke test for OpenRouter chat + session tracking.
+//!
+//! Exercises a real streamed chat completion through `OpenRouterChatDriver`,
+//! including the `OpenRouterRequestExtension` that forwards `session_id` and
+//! routing controls. Confirms OpenRouter accepts the decorated request and
+//! streams back a non-empty response — the live counterpart to the wiremock
+//! request-contract tests.
+//!
+//! Ignored by default (requires network + `OPENROUTER_API_KEY`); run manually:
+//!   `doppler run -- cargo test -p everruns-openrouter --test chat_live -- --ignored --nocapture`
+
+use everruns_core::llm_driver_registry::{
+    ChatDriver, LlmCallConfig, LlmMessage, LlmMessageRole, LlmStreamEvent, OpenRouterRoute,
+    OpenRouterRoutingConfig,
+};
+use everruns_openrouter::OpenRouterChatDriver;
+use futures::StreamExt;
+
+#[tokio::test]
+#[ignore = "live network + OPENROUTER_API_KEY"]
+async fn openrouter_chat_with_session_id_and_routing_succeeds() {
+    let api_key = std::env::var("OPENROUTER_API_KEY")
+        .expect("OPENROUTER_API_KEY must be set for the live smoke test");
+
+    let driver = OpenRouterChatDriver::new(api_key);
+
+    let mut metadata = std::collections::HashMap::new();
+    metadata.insert("session_id".to_string(), "session_live_smoke".to_string());
+
+    let config = LlmCallConfig {
+        model: "openai/gpt-4o-mini".to_string(),
+        temperature: Some(0.0),
+        max_tokens: Some(16),
+        tools: vec![],
+        reasoning_effort: None,
+        metadata,
+        previous_response_id: None,
+        tool_search: None,
+        prompt_cache: None,
+        // Exercise the routing-decoration path alongside session_id forwarding.
+        openrouter_routing: Some(OpenRouterRoutingConfig {
+            models: vec![
+                "openai/gpt-4o-mini".to_string(),
+                "openai/gpt-4o".to_string(),
+            ],
+            route: Some(OpenRouterRoute::Fallback),
+            ..Default::default()
+        }),
+    };
+
+    let messages = vec![LlmMessage::text(
+        LlmMessageRole::User,
+        "Reply with exactly one word: pong",
+    )];
+
+    let mut stream = driver
+        .chat_completion_stream(messages, &config)
+        .await
+        .expect("OpenRouter should accept the decorated chat request");
+
+    let mut text = String::new();
+    let mut done = false;
+    let mut error: Option<String> = None;
+    while let Some(event) = stream.next().await {
+        match event.expect("stream item should not be a transport error") {
+            LlmStreamEvent::TextDelta(delta) => text.push_str(&delta),
+            LlmStreamEvent::Done(meta) => {
+                done = true;
+                eprintln!(
+                    "OpenRouter chat done: finish={:?} tokens in/out={:?}/{:?} cost_usd={:?}",
+                    meta.finish_reason,
+                    meta.prompt_tokens,
+                    meta.completion_tokens,
+                    meta.provider_cost_usd,
+                );
+            }
+            LlmStreamEvent::Error(e) => error = Some(e),
+            _ => {}
+        }
+    }
+
+    assert!(error.is_none(), "stream returned an error: {error:?}");
+    assert!(done, "stream did not complete with a Done event");
+    assert!(
+        !text.trim().is_empty(),
+        "expected non-empty assistant text, got {text:?}"
+    );
+    eprintln!("OpenRouter chat reply: {text:?}");
+}


### PR DESCRIPTION
## What
Two things, both surfaced by finally running OpenRouter **live**:
1. **Fix:** skip the trailing `[DONE]` sentinel in the Open Responses SSE stream.
2. **Coverage:** a live OpenRouter chat smoke test, an offline regression test, and an OpenRouter cell in the push-gated LLM CI matrix.

## Why
After #2217/#2218, nothing exercised OpenRouter chat against the real API (the discovery test is `#[ignore]`d; the LLM matrix had no OpenRouter cell and no `OPENROUTER_API_KEY` in CI). Running it live revealed that OpenRouter's Responses endpoint terminates the SSE stream with a chat-completions-style `data: [DONE]` line that OpenAI's native Responses API never sends. Core's Open Responses parser tried to JSON-parse it and emitted a spurious `Failed to parse event` **error after the real completion**. The Chat Completions driver already handled `[DONE]`; the Open Responses driver did not.

## How
- **core** (`openresponses_protocol.rs`): short-circuit the streaming closure when `event.data == "[DONE]"`, mirroring the Chat Completions driver. Added an offline wiremock regression test (`openresponses_stream_skips_done_sentinel`) so CI guards it without network.
- **everruns-openrouter**: new `tests/chat_live.rs` — an `#[ignore]`d live smoke test that drives a real streamed chat completion through the driver + `OpenRouterRequestExtension` (session_id + fallback routing) and asserts a clean, error-free response. `futures` added as a dev-dependency to drain the stream.
- **CI / llm-tests**: added an `OpenRouter (openai/gpt-4o-mini)` cell to the parametrized matrix (`test_basic_completion`, `test_tool_call`) and `OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}` to the push-gated LLM step.

## Validation (live, via Doppler `OPENROUTER_API_KEY`)
- Live discovery: 337 models, 191 reasoning-capable — passes.
- Live chat smoke test: returns `"pong"`, `finish="stop"`, cost ~$0.0000033, **no spurious error** after the fix (it reported the error before).
- Live matrix cases (`test_basic_completion`, `test_tool_call`) through the full agent harness: both pass.
- Offline: core 2430 tests, clippy, fmt all green.

## Risk
- **Low.** The `[DONE]` guard is a no-op for OpenAI's native API (which never sends it) and only suppresses a spurious post-completion error elsewhere. The CI matrix cell **skips automatically** when `OPENROUTER_API_KEY` is absent, so it is inert until the secret is provisioned — no risk of breaking CI.

## Security
- Threat categories reviewed: **TM-LLM** (stream parsing, API key handling). The fix only drops a non-JSON sentinel token before parsing — no new trust boundary. The live test and CI cell read `OPENROUTER_API_KEY` from env/secret; the push-gated step already restricts provider keys to non-fork pushes. No SQL/auth/authz/tenant/migration changes.

## Follow-ups
- **Action needed:** add `OPENROUTER_API_KEY` as a GitHub Actions secret (it currently lives in Doppler; the push-gated LLM step reads GH `secrets.*`, not Doppler). Until then the OpenRouter matrix cases skip cleanly.
- Phase 3 (still open): move `openrouter_workspace` + model-sync into the crate.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (stream parsing unchanged for OpenAI; additive CI cell)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)
