### PR TITLE
fix(server): pass after_id cursor to list_messages in scheduler tests

### DIFF
--- a/crates/server/src/session_scheduler.rs
+++ b/crates/server/src/session_scheduler.rs
@@ -882,7 +882,7 @@ mod tests {
 
         // The outbound message must be the tool result, not the "Monitor fired" placeholder.
         let messages = registry
-            .list_messages(session_id, &task.id, Some(10))
+            .list_messages(session_id, &task.id, Some(10), None)
             .await
             .unwrap();
         assert_eq!(messages.len(), 1, "exactly one message must be recorded");
@@ -929,7 +929,7 @@ mod tests {
         );
 
         let messages = registry
-            .list_messages(session_id, &task.id, Some(10))
+            .list_messages(session_id, &task.id, Some(10), None)
             .await
             .unwrap();
         assert_eq!(messages.len(), 1);
@@ -963,7 +963,7 @@ mod tests {
         assert!(!probe_ran, "no registry → probe_ran must be false");
 
         let messages = registry
-            .list_messages(session_id, &task.id, Some(10))
+            .list_messages(session_id, &task.id, Some(10), None)
             .await
             .unwrap();
         assert_eq!(messages.len(), 1);


### PR DESCRIPTION
## What
Fix the broken build on `main`: 3 session-scheduler test calls to `list_messages` pass 3 args, but the trait now requires a 4th (`after_id`).

## Why
`main` (`f882bc8`) is red — Clippy / Build Check / Integration Tests fail. EVE-582 (`3808c5d`, cursor pagination) added `after_id: Option<&str>` to `SessionTaskRegistry::list_messages`; #2222 (`f882bc8`, orphaned-run re-attach) added scheduler tests calling the 3-arg form. Each PR was green alone; together they don't compile (semantic merge conflict).

## How
Pass `None` as the `after_id` cursor at the three call sites in `crates/server/src/session_scheduler.rs`, preserving the prior "return all messages up to `limit`" behavior.

## Risk
- Minimal. Test-only call sites; `None` is the documented no-cursor behavior. `cargo clippy -p everruns-server --all-targets --all-features -- -D warnings` passes.

## Security
- No security-relevant changes (test-only argument fix).

## Follow-ups
- No follow-ups.

## Checklist
- [x] Tests added or updated (fixes existing tests)
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed
