### PR TITLE
fix(openrouter): keep reasoning private by default

### DIFF
--- a/crates/openrouter/src/request_ext.rs
+++ b/crates/openrouter/src/request_ext.rs
@@ -7,6 +7,7 @@
 //   - `models` / `route` / `provider` — model-fallback and provider routing
 //   - `plugins` — web-search / file-reader activations
 //   - `session_id` — OpenRouter session grouping (the Everruns session id)
+//   - `reasoning.exclude` — keep provider reasoning private by default
 
 use std::borrow::Cow;
 
@@ -34,6 +35,8 @@ impl OpenResponsesRequestExtension for OpenRouterRequestExtension {
         if let Some(session_id) = config.metadata.get("session_id") {
             obj.insert("session_id".to_string(), json!(session_id));
         }
+
+        apply_private_reasoning_policy(obj, config);
 
         let Some(routing) = config.openrouter_routing.as_ref() else {
             return Ok(());
@@ -67,6 +70,33 @@ impl OpenResponsesRequestExtension for OpenRouterRequestExtension {
 
         Ok(())
     }
+}
+
+fn apply_private_reasoning_policy(
+    obj: &mut serde_json::Map<String, Value>,
+    config: &LlmCallConfig,
+) {
+    let mut reasoning = match obj.remove("reasoning") {
+        Some(Value::Object(map)) => map,
+        _ => serde_json::Map::new(),
+    };
+
+    // OpenRouter may return reasoning tokens even when no effort is requested.
+    // Keep that reasoning internal unless a future explicit visible-reasoning
+    // option asks for summaries.
+    reasoning.remove("summary");
+    reasoning.insert("exclude".to_string(), Value::Bool(true));
+
+    if let Some(effort) = config
+        .reasoning_effort
+        .as_deref()
+        .map(str::trim)
+        .filter(|effort| !effort.is_empty())
+    {
+        reasoning.insert("effort".to_string(), Value::String(effort.to_string()));
+    }
+
+    obj.insert("reasoning".to_string(), Value::Object(reasoning));
 }
 
 /// Apply routing presets, then the capacity strategy, returning the resolved

--- a/crates/openrouter/tests/request_wire.rs
+++ b/crates/openrouter/tests/request_wire.rs
@@ -32,6 +32,27 @@ fn base_config(model: &str) -> LlmCallConfig {
     }
 }
 
+async fn capture_request_body(config: &LlmCallConfig) -> serde_json::Value {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(""))
+        .mount(&server)
+        .await;
+
+    let api_url = format!("{}/v1/responses", server.uri());
+    let driver = OpenRouterChatDriver::with_base_url("test-key", api_url);
+
+    let messages = vec![LlmMessage::text(LlmMessageRole::User, "hello")];
+    let _ = driver.chat_completion_stream(messages, config).await;
+
+    let requests = server
+        .received_requests()
+        .await
+        .expect("mock server recorded requests");
+    assert_eq!(requests.len(), 1);
+    requests[0].body_json().expect("request body is JSON")
+}
+
 #[tokio::test]
 async fn sends_routing_controls_and_session_id() {
     let server = MockServer::start().await;
@@ -104,6 +125,51 @@ async fn sends_routing_controls_and_session_id() {
     );
     // Session-tracking key is forwarded at the request root for OpenRouter.
     assert_eq!(body["session_id"], "session_abc123");
+}
+
+#[tokio::test]
+async fn excludes_reasoning_by_default() {
+    let config = base_config("nvidia/nemotron-3-super-120b-a12b:free");
+
+    let body = capture_request_body(&config).await;
+
+    assert_eq!(body["reasoning"], json!({ "exclude": true }));
+}
+
+#[tokio::test]
+async fn excludes_reasoning_with_explicit_effort() {
+    let mut config = base_config("nvidia/nemotron-3-super-120b-a12b:free");
+    config.reasoning_effort = Some("high".to_string());
+
+    let body = capture_request_body(&config).await;
+
+    assert_eq!(
+        body["reasoning"],
+        json!({
+            "effort": "high",
+            "exclude": true
+        })
+    );
+    assert!(
+        body["reasoning"].get("summary").is_none(),
+        "OpenRouter requests must not ask for visible reasoning summaries by default"
+    );
+}
+
+#[tokio::test]
+async fn sends_reasoning_none_to_disable_openrouter_reasoning() {
+    let mut config = base_config("nvidia/nemotron-3-super-120b-a12b:free");
+    config.reasoning_effort = Some("none".to_string());
+
+    let body = capture_request_body(&config).await;
+
+    assert_eq!(
+        body["reasoning"],
+        json!({
+            "effort": "none",
+            "exclude": true
+        })
+    );
 }
 
 #[tokio::test]

--- a/crates/openrouter/tests/request_wire.rs
+++ b/crates/openrouter/tests/request_wire.rs
@@ -150,10 +150,6 @@ async fn excludes_reasoning_with_explicit_effort() {
             "exclude": true
         })
     );
-    assert!(
-        body["reasoning"].get("summary").is_none(),
-        "OpenRouter requests must not ask for visible reasoning summaries by default"
-    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## What
OpenRouter requests now normalize the `reasoning` payload to keep reasoning private by default:

- default requests send `reasoning: { "exclude": true }`
- explicit efforts send `{ "effort": "...", "exclude": true }`
- explicit `none` is forwarded as `{ "effort": "none", "exclude": true }`
- OpenRouter no longer inherits core's default `summary: "detailed"` request

## Why
OpenRouter can return reasoning tokens even when the caller did not explicitly request visible reasoning. That made models such as Nemotron surface reasoning-like text instead of public assistant commentary. The privacy boundary should be: hidden reasoning stays hidden; user-visible commentary must come from assistant text or deterministic tool narration.

## How
The OpenRouter request extension rewrites the serialized Open Responses request body before dispatch. This keeps the provider-specific policy inside `everruns-openrouter` and leaves the vendor-neutral OpenAI Responses driver behavior unchanged.

Wire tests assert default, explicit effort, and explicit `none` request shapes.

## Risk
- Low
- OpenRouter models that previously relied on returned reasoning summaries will no longer receive them by default. Public assistant text and tool narration are unaffected.

## Security
- Threat categories reviewed: TM-LLM, TM-AGENT
- Findings and resolutions: reduces provider reasoning disclosure by excluding OpenRouter reasoning tokens unless a future explicit visible-reasoning control is added.

## Follow-ups
Add an explicit visible-reasoning control if product requirements call for showing provider-curated reasoning summaries. Do not reuse hidden reasoning streams as agent commentary.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

Validation:
- `cargo fmt --check`
- `cargo test -p everruns-openrouter --test request_wire`
- `cargo test -p everruns-openrouter`
- `cargo clippy -p everruns-openrouter --all-targets --all-features -- -D warnings`
- `just pre-push`