### PR TITLE
fix(agents): gate health checks on session limits

### DIFF
--- a/crates/server/src/api/agents.rs
+++ b/crates/server/src/api/agents.rs
@@ -1,6 +1,7 @@
 // Agent CRUD HTTP routes (M2)
 // Routes use ResolvedOrg: org derived from auth context (API key or cookie)
 
+use crate::auth::rate_limit::OrgRateLimiter;
 use crate::auth::{AuthState, ResolvedOrg};
 use crate::storage::StorageBackend;
 use axum::{
@@ -128,6 +129,7 @@ pub struct AppState {
     pub grade: DeploymentGrade,
     pub platform_definition: Arc<PlatformDefinition>,
     pub health_check_service: Option<Arc<crate::domains::agents::AgentHealthCheckService>>,
+    pub org_rate_limiter: OrgRateLimiter,
 }
 
 impl AppState {
@@ -145,6 +147,7 @@ impl AppState {
             grade,
             platform_definition,
             health_check_service: None,
+            org_rate_limiter: OrgRateLimiter::default(),
         }
     }
 
@@ -153,6 +156,11 @@ impl AppState {
         service: Arc<crate::domains::agents::AgentHealthCheckService>,
     ) -> Self {
         self.health_check_service = Some(service);
+        self
+    }
+
+    pub fn with_org_rate_limiter(mut self, limiter: OrgRateLimiter) -> Self {
+        self.org_rate_limiter = limiter;
         self
     }
 
@@ -1386,6 +1394,20 @@ pub async fn trigger_health_check(
     State(state): State<AppState>,
     Path(agent_id): Path<String>,
 ) -> ApiResult<crate::domains::agents::health_check::types::HealthCheckRun> {
+    if state
+        .org_rate_limiter
+        .check_session_create(org.org_id)
+        .await
+        .is_err()
+    {
+        return Err(
+            ErrorResponse::new("Too many requests. Please try again later.")
+                .with_code("rate_limited")
+                .with_retry_after(60)
+                .into_response(StatusCode::TOO_MANY_REQUESTS),
+        );
+    }
+
     let run = crate::domains::agents::health_check::commands::TriggerAgentHealthCheck { agent_id }
         .run(&state.ctx(&org))
         .await?;

--- a/crates/server/src/api/agents.rs
+++ b/crates/server/src/api/agents.rs
@@ -1394,6 +1394,22 @@ pub async fn trigger_health_check(
     State(state): State<AppState>,
     Path(agent_id): Path<String>,
 ) -> ApiResult<crate::domains::agents::health_check::types::HealthCheckRun> {
+    let ctx = state.ctx(&org);
+
+    // Authorize *before* consuming the org's session-create rate budget.
+    // Otherwise a caller lacking AGENT_HEALTH_CHECK_RUN (a more restrictive
+    // policy than plain session creation) would be rejected by the command yet
+    // still burn the org's quota, starving legitimate session creation — a DoS.
+    // The command re-checks the policy in `run`; paying it twice is cheap and
+    // keeps the command the single source of truth.
+    if let Some(policy) =
+        crate::domains::agents::health_check::commands::TriggerAgentHealthCheck::policy()
+    {
+        policy
+            .evaluate_with(ctx.permission_resolver.as_ref(), &ctx.caller)
+            .map_err(|e| crate::domains::common::CommandError::forbidden(e.message))?;
+    }
+
     if state
         .org_rate_limiter
         .check_session_create(org.org_id)
@@ -1409,7 +1425,7 @@ pub async fn trigger_health_check(
     }
 
     let run = crate::domains::agents::health_check::commands::TriggerAgentHealthCheck { agent_id }
-        .run(&state.ctx(&org))
+        .run(&ctx)
         .await?;
     Ok(Json(run))
 }

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -915,7 +915,8 @@ impl ServerAppBuilder {
             auth_state.clone(),
             grade,
             platform_definition.clone(),
-        );
+        )
+        .with_org_rate_limiter(org_rate_limiter.clone());
         let agent_identities_state = api::agent_identities::AppState::new(
             db.clone(),
             capability_service.clone(),

--- a/crates/server/src/domains/agents/health_check/commands.rs
+++ b/crates/server/src/domains/agents/health_check/commands.rs
@@ -192,7 +192,7 @@ impl Command for TriggerAgentHealthCheck {
     }
 
     fn policy() -> Option<&'static everruns_core::Policy> {
-        Some(&crate::domains::agents::AGENT_MANAGE)
+        Some(&crate::domains::agents::AGENT_HEALTH_CHECK_RUN)
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<HealthCheckRun, CommandError> {

--- a/crates/server/src/domains/agents/mod.rs
+++ b/crates/server/src/domains/agents/mod.rs
@@ -27,6 +27,18 @@ pub const AGENT_MANAGE: Policy = Policy {
     rules: &[Rule::UserHasPermission(Permission::OrgAgentsManage)],
 };
 
+/// Policy: Run agent health checks.
+///
+/// Health checks create real sessions and messages in the background, so require
+/// the same session-execution boundary as eval runs.
+pub const AGENT_HEALTH_CHECK_RUN: Policy = Policy {
+    id: "agent.health_check.run",
+    rules: &[
+        Rule::UserHasPermission(Permission::OrgAgentsManage),
+        Rule::UserHasPermission(Permission::OrgSessionsManage),
+    ],
+};
+
 pub const AGENT_DANGEROUS: Policy = Policy {
     id: "agent.dangerous",
     rules: &[

--- a/crates/server/tests/command_policy_enforcement_test.rs
+++ b/crates/server/tests/command_policy_enforcement_test.rs
@@ -24,6 +24,7 @@ use everruns_core::{
     PermissionResolver,
 };
 use everruns_server::api::evals::CreateEvalRunRequest;
+use everruns_server::domains::agents::health_check::commands::TriggerAgentHealthCheck;
 use everruns_server::domains::common::{
     Command, CommandError, CommandErrorKind, Ctx, catalog_entries, dispatch,
 };
@@ -408,6 +409,24 @@ async fn eval_run_creation_requires_session_permission() {
     .run(&ctx)
     .await
     .expect_err("CreateEvalRun must require OrgSessionsManage");
+    assert_forbidden(err);
+}
+
+#[tokio::test]
+async fn agent_health_check_requires_session_permission() {
+    // Health checks launch real sessions/messages in the background, so an
+    // agent manager without OrgSessionsManage must be blocked before agent
+    // lookup or run creation.
+    let ctx = make_ctx(
+        caller_with_role(OrgRole::Owner),
+        Arc::new(AgentsOnlyResolver),
+    );
+    let err = TriggerAgentHealthCheck {
+        agent_id: "agent_nonexistent".to_string(),
+    }
+    .run(&ctx)
+    .await
+    .expect_err("TriggerAgentHealthCheck must require OrgSessionsManage");
     assert_forbidden(err);
 }
 


### PR DESCRIPTION
### Motivation
- Health-check triggers created real sessions/messages in background work while being authorized only by the agent-manage policy, which allowed callers without session-execution rights to start expensive runs and bypassed the per-org session-create limiter.
- This opened a DoS/cost risk by permitting unbounded background runs and session creation outside the existing expensive-operation rate limits.

### Description
- Added a new policy `AGENT_HEALTH_CHECK_RUN` that requires both `OrgAgentsManage` and `OrgSessionsManage` to match the session-execution boundary used by eval runs (`crates/server/src/domains/agents/mod.rs`).
- Switched `TriggerAgentHealthCheck` to require the new `AGENT_HEALTH_CHECK_RUN` policy (`crates/server/src/domains/agents/health_check/commands.rs`).
- Plumbed the shared `OrgRateLimiter` into the agents HTTP state and applied `check_session_create` in the HTTP trigger handler to rate-limit expensive health-check triggers (`crates/server/src/api/agents.rs`, `crates/server/src/app_builder.rs`).
- Added a regression test asserting that a caller with only agent-manage (but not session-manage) is denied when running `TriggerAgentHealthCheck` (`crates/server/tests/command_policy_enforcement_test.rs`).

### Testing
- Ran `cargo test -p everruns-server --test command_policy_enforcement_test agent_health_check_requires_session_permission`, which passed. 
- Ran the full `cargo test -p everruns-server --test command_policy_enforcement_test`, and all tests in that file passed (14 passed, 0 failed).
- Ran `cargo fmt --check` and `git diff --check` as part of validation and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2fc086223c832b936ce296e00f9118)