### PR TITLE
fix(session-files): guard shared workspace writes

### DIFF
--- a/crates/server/src/domains/session_files/commands.rs
+++ b/crates/server/src/domains/session_files/commands.rs
@@ -206,7 +206,7 @@ impl Command for CreateWorkspaceFile {
 
     async fn execute(self, ctx: &Ctx) -> Result<SessionFile, CommandError> {
         let session_id = q::parse_session_id(&self.session_id)?;
-        let workspace_key = q::verify_session(ctx, session_id).await?;
+        let workspace_key = q::verify_session_for_write(ctx, session_id).await?;
         let path = q::normalize_path(&self.path);
         if q::is_reserved_path(&path) {
             return Err(CommandError::bad_request(
@@ -299,7 +299,7 @@ impl Command for UpdateWorkspaceFile {
 
     async fn execute(self, ctx: &Ctx) -> Result<SessionFile, CommandError> {
         let session_id = q::parse_session_id(&self.session_id)?;
-        let workspace_key = q::verify_session(ctx, session_id).await?;
+        let workspace_key = q::verify_session_for_write(ctx, session_id).await?;
         let path = q::normalize_path(&self.path);
         if q::is_reserved_path(&path) {
             return Err(CommandError::bad_request(
@@ -371,7 +371,7 @@ impl Command for DeleteWorkspaceFile {
 
     async fn execute(self, ctx: &Ctx) -> Result<DeleteResponse, CommandError> {
         let session_id = q::parse_session_id(&self.session_id)?;
-        let workspace_key = q::verify_session(ctx, session_id).await?;
+        let workspace_key = q::verify_session_for_write(ctx, session_id).await?;
         let path = q::normalize_path(&self.path);
         let deleted = q::service(ctx)
             .delete(workspace_key, &path, self.recursive)
@@ -410,7 +410,7 @@ impl Command for MoveWorkspaceFile {
 
     async fn execute(self, ctx: &Ctx) -> Result<SessionFile, CommandError> {
         let session_id = q::parse_session_id(&self.session_id)?;
-        let workspace_key = q::verify_session(ctx, session_id).await?;
+        let workspace_key = q::verify_session_for_write(ctx, session_id).await?;
         q::service(ctx)
             .move_file(
                 workspace_key,
@@ -454,7 +454,7 @@ impl Command for CopyWorkspaceFile {
 
     async fn execute(self, ctx: &Ctx) -> Result<SessionFile, CommandError> {
         let session_id = q::parse_session_id(&self.session_id)?;
-        let workspace_key = q::verify_session(ctx, session_id).await?;
+        let workspace_key = q::verify_session_for_write(ctx, session_id).await?;
         q::service(ctx)
             .copy_file(
                 workspace_key,

--- a/crates/server/src/domains/session_files/queries.rs
+++ b/crates/server/src/domains/session_files/queries.rs
@@ -32,6 +32,24 @@ pub async fn verify_session(ctx: &Ctx, session_id: SessionId) -> Result<Uuid, Co
     Ok(row.workspace_id)
 }
 
+/// Verify a session-scoped filesystem write and return the file-store key.
+///
+/// Default 1:1 sessions keep the historical SESSION_MANAGE authorization. When
+/// the alias targets a shared workspace, preserve the workspace write boundary
+/// used by `/v1/workspaces/{workspace_id}/fs/*`.
+pub async fn verify_session_for_write(
+    ctx: &Ctx,
+    session_id: SessionId,
+) -> Result<Uuid, CommandError> {
+    let workspace_key = verify_session(ctx, session_id).await?;
+    if workspace_key != session_id.uuid() {
+        crate::domains::workspaces::WORKSPACE_MANAGE
+            .evaluate_with(ctx.permission_resolver.as_ref(), &ctx.caller)
+            .map_err(|e| CommandError::forbidden(e.message))?;
+    }
+    Ok(workspace_key)
+}
+
 pub fn normalize_path(path: &str) -> String {
     let path = path.trim_start_matches('/');
     if path.is_empty() {

--- a/crates/server/tests/command_policy_enforcement_test.rs
+++ b/crates/server/tests/command_policy_enforcement_test.rs
@@ -30,12 +30,15 @@ use everruns_server::domains::common::{
 use everruns_server::domains::evals::{CreateEvalRun, ListEvals};
 use everruns_server::domains::harnesses::types::CreateHarnessRequest;
 use everruns_server::domains::harnesses::{CreateHarness, ListHarnesses};
-use everruns_server::domains::session_files::{GetWorkspaceFile, ListWorkspaceFiles};
+use everruns_server::domains::session_files::{
+    CreateWorkspaceFile, GetWorkspaceFile, ListWorkspaceFiles,
+};
 use everruns_server::domains::session_tasks::{
     CancelSessionTask, GetSessionTask, ListSessionTasks, PostSessionTaskMessage,
 };
 use everruns_server::services::CapabilityService;
 use everruns_server::storage::StorageBackend;
+use everruns_server::storage::models::CreateSessionRow;
 use uuid::Uuid;
 
 // ============================================================================
@@ -75,6 +78,34 @@ fn minimal_harness(name: &str) -> CreateHarnessRequest {
     }
 }
 
+fn minimal_session_row(workspace_id: Option<Uuid>) -> CreateSessionRow {
+    CreateSessionRow {
+        workspace_id,
+        org_id: DEFAULT_ORG_ID,
+        app_id: None,
+        harness_id: None,
+        agent_id: None,
+        agent_identity_id: None,
+        owner_principal_id: everruns_core::PrincipalId::from_seed(1),
+        resolved_owner_user_id: None,
+        title: Some("Test Session".to_string()),
+        locale: None,
+        tags: vec![],
+        model_id: None,
+        capabilities: serde_json::json!([]),
+        tools: serde_json::json!([]),
+        mcp_servers: serde_json::json!({}),
+        system_prompt: None,
+        initial_files: serde_json::Value::Array(vec![]),
+        hints: None,
+        network_access: None,
+        max_iterations: None,
+        blueprint_id: None,
+        blueprint_config: None,
+        parent_session_id: None,
+    }
+}
+
 /// Denies every permission — models a SaaS tier that blocks all writes.
 struct DenyAllResolver;
 
@@ -84,6 +115,18 @@ impl PermissionResolver for DenyAllResolver {
     }
     fn caller_permissions(&self, _caller: &Caller) -> Vec<Permission> {
         Vec::new()
+    }
+}
+
+/// Grants session management but not workspace management.
+struct SessionsOnlyResolver;
+
+impl PermissionResolver for SessionsOnlyResolver {
+    fn has_permission(&self, _caller: &Caller, permission: &Permission) -> bool {
+        matches!(permission, Permission::OrgSessionsManage)
+    }
+    fn caller_permissions(&self, _caller: &Caller) -> Vec<Permission> {
+        vec![Permission::OrgSessionsManage]
     }
 }
 
@@ -430,6 +473,66 @@ async fn eval_manage_without_session_permission_still_allows_list() {
 // A resolver denying OrgSessionsManage must get 403 before any file lookup.
 // (Commands were renamed from ListSessionFiles/GetSessionFile in #2189.)
 // ============================================================================
+
+#[tokio::test]
+async fn session_file_write_alias_requires_workspace_manage_for_shared_workspace() {
+    // Regression for the shared-workspace authorization boundary: session-fs
+    // aliases keep SESSION_MANAGE for default sessions, but must not let that
+    // weaker permission modify an attached shared workspace.
+    let ctx = make_ctx(
+        caller_with_role(OrgRole::Owner),
+        Arc::new(SessionsOnlyResolver),
+    );
+    let row = ctx
+        .db
+        .create_session(minimal_session_row(Some(Uuid::new_v4())))
+        .await
+        .expect("seed attached session");
+
+    let err = CreateWorkspaceFile {
+        session_id: row.id.to_string(),
+        path: "/shared.txt".to_string(),
+        req: everruns_server::api::session_files::CreateFileRequest {
+            content: Some("blocked".to_string()),
+            encoding: Some("text".to_string()),
+            is_readonly: None,
+            is_directory: None,
+        },
+    }
+    .run(&ctx)
+    .await
+    .expect_err("attached workspace writes must require WORKSPACE_MANAGE");
+    assert_forbidden(err);
+}
+
+#[tokio::test]
+async fn session_file_write_alias_keeps_default_session_manage_behavior() {
+    // Default sessions own a 1:1 workspace keyed by the session UUID, so the
+    // legacy alias remains writable with SESSION_MANAGE.
+    let ctx = make_ctx(
+        caller_with_role(OrgRole::Owner),
+        Arc::new(SessionsOnlyResolver),
+    );
+    let row = ctx
+        .db
+        .create_session(minimal_session_row(None))
+        .await
+        .expect("seed default session");
+
+    CreateWorkspaceFile {
+        session_id: row.id.to_string(),
+        path: "/default.txt".to_string(),
+        req: everruns_server::api::session_files::CreateFileRequest {
+            content: Some("allowed".to_string()),
+            encoding: Some("text".to_string()),
+            is_readonly: None,
+            is_directory: None,
+        },
+    }
+    .run(&ctx)
+    .await
+    .expect("default session writes should still require only SESSION_MANAGE");
+}
 
 #[tokio::test]
 async fn session_file_read_commands_enforce_session_view_policy() {


### PR DESCRIPTION
### Motivation
- Prevent an authorization bypass where legacy session filesystem aliases could mutate a shared workspace using only `SESSION_MANAGE` even when the canonical workspace API requires `WORKSPACE_MANAGE`.
- Preserve backward compatibility for default 1:1 sessions so existing session-scoped workspaces (where the workspace id == session id) keep the historical `SESSION_MANAGE` behavior.

### Description
- Add `verify_session_for_write` in `crates/server/src/domains/session_files/queries.rs` that returns the file-store key and enforces `WORKSPACE_MANAGE` when the resolved workspace key differs from the session UUID.
- Update session FS write commands (`CreateWorkspaceFile`, `UpdateWorkspaceFile`, `DeleteWorkspaceFile`, `MoveWorkspaceFile`, `CopyWorkspaceFile`) to call `verify_session_for_write` before performing mutations so attached shared workspaces require the stronger policy.
- Add regression tests in `crates/server/tests/command_policy_enforcement_test.rs` that assert: a sessions-only resolver is denied when writing to an attached shared workspace and default session writes continue to work with `SESSION_MANAGE`.
- Leave read-only/session-view paths unchanged so listing/reading via the legacy alias still uses `SESSION_VIEW`.

### Testing
- Ran `cargo fmt --check` and it passed.
- Ran focused tests with `cargo test -p everruns-server --test command_policy_enforcement_test session_file_write_alias -- --nocapture` and both added tests passed.
- Verified the modified code paths with the new regression tests which succeeded (2 passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d930a4d38832ba02b8c5d11864b21)