### PR TITLE
fix(server): fail closed on missing task harness ACL

### DIFF
--- a/crates/server/src/domains/session_tasks/commands.rs
+++ b/crates/server/src/domains/session_tasks/commands.rs
@@ -357,7 +357,7 @@ mod tests {
         TASK_KIND_BACKGROUND_TOOL, TASK_KIND_MONITOR, TASK_KIND_SUBAGENT, TaskLinks,
         TaskMessagePart, TaskWakePolicy,
     };
-    use everruns_core::{Caller, DEFAULT_ORG_ID, PrincipalId};
+    use everruns_core::{Caller, DEFAULT_ORG_ID, HarnessId, PrincipalId};
     use std::sync::Arc;
 
     // -------------------------------------------------------------------------
@@ -369,10 +369,53 @@ mod tests {
         Ctx::minimal_for_test(Caller::internal(DEFAULT_ORG_ID), db, None)
     }
 
+    async fn ensure_base_harness(
+        db: &Arc<StorageBackend>,
+        network_access: Option<NetworkAccessList>,
+    ) -> HarnessId {
+        if let Some(existing) = db
+            .get_harness_by_name(DEFAULT_ORG_ID, "base")
+            .await
+            .unwrap()
+        {
+            // `org_init::base_harness_id` resolves the *built-in* base harness,
+            // so the helper must guarantee that same row — otherwise a stray
+            // user-created "base" harness would make these tests diverge from
+            // production resolution.
+            assert!(
+                existing.is_built_in,
+                "expected the built-in base harness, found a non-built-in one"
+            );
+            return existing.id;
+        }
+
+        db.create_harness(
+            DEFAULT_ORG_ID,
+            CreateHarnessRow {
+                name: "base".to_string(),
+                display_name: Some("Base".to_string()),
+                description: None,
+                system_prompt: String::new(),
+                parent_harness_id: None,
+                default_model_id: None,
+                tags: vec![],
+                initial_files: serde_json::json!([]),
+                mcp_servers: serde_json::json!({}),
+                network_access: network_access.map(|acl| serde_json::to_value(&acl).unwrap()),
+                is_built_in: true,
+                embedder_metadata: Default::default(),
+            },
+        )
+        .await
+        .unwrap()
+        .id
+    }
+
     /// Create a session in the in-memory database, returning its ID.
     async fn create_session(db: &Arc<StorageBackend>) -> everruns_core::SessionId {
+        ensure_base_harness(db, None).await;
+
         db.create_session(CreateSessionRow {
-            workspace_id: None,
             org_id: DEFAULT_ORG_ID,
             app_id: None,
             harness_id: None,
@@ -395,6 +438,7 @@ mod tests {
             blueprint_id: None,
             blueprint_config: None,
             parent_session_id: None,
+            workspace_id: None,
         })
         .await
         .unwrap()
@@ -835,7 +879,6 @@ mod tests {
         let session_network_access = NetworkAccessList::allow_only(["b.example.com"]);
         let session_id = db
             .create_session(CreateSessionRow {
-                workspace_id: None,
                 org_id: DEFAULT_ORG_ID,
                 app_id: None,
                 harness_id: Some(harness.id),
@@ -858,6 +901,7 @@ mod tests {
                 blueprint_id: None,
                 blueprint_config: None,
                 parent_session_id: None,
+                workspace_id: None,
             })
             .await
             .unwrap()
@@ -886,6 +930,78 @@ mod tests {
         assert!(
             !acl.is_url_allowed("https://other.example.com/ok"),
             "other.example.com must be blocked"
+        );
+    }
+    /// Legacy sessions can have NULL harness_id. The ToolContext builder must
+    /// resolve the normal base-harness fallback so executor ACLs remain scoped.
+    #[tokio::test]
+    async fn tool_context_for_ctx_uses_base_harness_for_null_session_harness() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let base_network_access = NetworkAccessList::allow_only(["base.example.com"]);
+        ensure_base_harness(&db, Some(base_network_access)).await;
+        let session_id = create_session(&db).await;
+        let ctx = test_ctx(db.clone());
+
+        let tool_ctx = q::tool_context_for_ctx(&ctx, session_id)
+            .await
+            .expect("tool_context_for_ctx must resolve the base harness");
+
+        let acl = tool_ctx
+            .network_access
+            .expect("base harness network_access must be applied");
+        assert!(
+            acl.is_url_allowed("https://base.example.com/ok"),
+            "base harness allowlist must permit listed hosts"
+        );
+        assert!(
+            !acl.is_url_allowed("https://other.example.com/blocked"),
+            "base harness allowlist must block unlisted hosts"
+        );
+    }
+
+    /// A session that references a deleted/stale harness must fail closed rather
+    /// than building an unrestricted ToolContext for executor network calls.
+    #[tokio::test]
+    async fn tool_context_for_ctx_fails_closed_for_missing_session_harness() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let stale_harness_id = HarnessId::new();
+        let session_id = db
+            .create_session(CreateSessionRow {
+                org_id: DEFAULT_ORG_ID,
+                app_id: None,
+                harness_id: Some(stale_harness_id),
+                agent_id: None,
+                agent_identity_id: None,
+                owner_principal_id: PrincipalId::from_seed(1),
+                resolved_owner_user_id: None,
+                title: Some("stale harness session".to_string()),
+                locale: None,
+                tags: vec![],
+                model_id: None,
+                capabilities: serde_json::json!([]),
+                tools: serde_json::json!([]),
+                mcp_servers: serde_json::json!({}),
+                system_prompt: None,
+                initial_files: serde_json::json!([]),
+                hints: None,
+                network_access: None,
+                max_iterations: None,
+                blueprint_id: None,
+                blueprint_config: None,
+                parent_session_id: None,
+                workspace_id: None,
+            })
+            .await
+            .unwrap()
+            .id;
+        let ctx = test_ctx(db.clone());
+
+        let err = q::tool_context_for_ctx(&ctx, session_id)
+            .await
+            .expect_err("missing harness must fail closed");
+        assert!(
+            err.to_string().contains("Leaf harness not found"),
+            "unexpected error: {err}"
         );
     }
 }

--- a/crates/server/src/domains/session_tasks/queries.rs
+++ b/crates/server/src/domains/session_tasks/queries.rs
@@ -1,10 +1,10 @@
 use crate::domains::agents::queries::row_to_agent;
 use crate::domains::common::{CommandError, Ctx, classify_anyhow};
-use crate::max_iterations;
 use crate::storage::{
     DbSessionScheduleStore, StorageBackend, create_db_session_storage_store,
     create_db_session_storage_store_without_encryption, session_task_store::DbSessionTaskRegistry,
 };
+use crate::{max_iterations, org_init};
 use everruns_core::config_layer::AgentConfigOverlay;
 use everruns_core::harness::{Harness, HarnessStatus};
 use everruns_core::session_task::SessionTaskRegistry;
@@ -88,10 +88,18 @@ pub async fn tool_context_for_ctx(
     };
 
     // --- Load harness chain (root-to-leaf) ---
+    // Legacy sessions may have NULL harness_id. Resolve the same base-harness
+    // fallback used by normal session reconstruction before folding ACLs so
+    // executor calls never silently drop the harness policy.
+    let harness_id = match session_row.harness_id {
+        Some(id) => id,
+        None => org_init::base_harness_id(ctx.db.as_ref(), org_id)
+            .await
+            .map_err(classify_anyhow)?,
+    };
     // Mirrors DbHarnessStore::get_harness_chain, using ctx.db directly so
     // both Postgres and InMemory backends are supported.
-    let harness_layers: Vec<Harness> =
-        load_harness_chain(&ctx.db, org_id, session_row.harness_id).await?;
+    let harness_layers: Vec<Harness> = load_harness_chain(&ctx.db, org_id, harness_id).await?;
 
     // --- Load agent (if any) ---
     let agent_layer: Option<everruns_core::Agent> = if let Some(agent_id) = session_row.agent_id {
@@ -160,18 +168,15 @@ pub async fn tool_context_for_ctx(
 
 /// Walk the harness parent chain (leaf → root), then reverse to root-to-leaf.
 ///
-/// Mirrors `DbHarnessStore::get_harness_chain` exactly, including cycle
-/// protection. Returns `Err` if a referenced parent is missing.
-/// Returns an empty vec if the session has no harness_id.
+/// Mirrors `DbHarnessStore::get_harness_chain`'s cycle protection, but
+/// intentionally **fails closed**: where that helper returns an empty chain for
+/// a missing leaf, this returns `Err` if the leaf or any referenced parent is
+/// missing, so executor calls never silently drop the harness ACL.
 async fn load_harness_chain(
     db: &Arc<StorageBackend>,
     org_id: i64,
-    start: Option<HarnessId>,
+    start_id: HarnessId,
 ) -> Result<Vec<Harness>, CommandError> {
-    let Some(start_id) = start else {
-        return Ok(vec![]);
-    };
-
     let mut visited: HashSet<HarnessId> = HashSet::new();
     let mut chain: Vec<Harness> = Vec::new();
     let mut cursor: Option<HarnessId> = Some(start_id);
@@ -188,12 +193,13 @@ async fn load_harness_chain(
             .await
             .map_err(classify_anyhow)?
         else {
-            if chain.is_empty() {
-                // Leaf harness not found — treat as empty chain (no restrictions)
-                return Ok(vec![]);
-            }
+            let kind = if chain.is_empty() {
+                "Leaf harness"
+            } else {
+                "Parent harness"
+            };
             return Err(CommandError::internal(anyhow::anyhow!(
-                "Parent harness not found"
+                "{kind} not found (org_id={org_id}, harness_id={current_id})"
             )));
         };
 


### PR DESCRIPTION
### Motivation
- API-driven session-task executor calls must enforce the same harness→agent→session network ACL as in-turn execution and must not fail open when the harness layer is missing or unresolved.

### Description
- Resolve legacy `NULL` session `harness_id` via `org_init::base_harness_id` in `tool_context_for_ctx` so the normal base-harness fallback is applied before folding network ACL overlays.
- Change `load_harness_chain` to require a concrete `HarnessId` start and return an error when the leaf or a parent harness cannot be found, preventing an empty chain that would drop harness restrictions.
- Propagate the effective overlay ACL into the constructed `ToolContext` unchanged, so executors run under the derived ACL or the call fails closed.
- Add regression tests and test helpers that provision the built-in `base` harness and cover (1) NULL-harness sessions using the base harness and (2) sessions referencing a missing/stale harness which must error rather than produce an unrestricted `ToolContext`.

### Testing
- Ran `cargo fmt` / `cargo fmt --check` and applied formatting corrections; check passed after formatting.
- Ran focused tests `domains::session_tasks::commands::tests::tool_context_for_ctx` (three new/updated tests) with `cargo test -p everruns-server ... --all-features`, and all targeted tests passed (3 passed; 0 failed).
- Verified `git diff --check` and staged/committed the two modified files (`crates/server/src/domains/session_tasks/queries.rs`, `crates/server/src/domains/session_tasks/commands.rs`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c4f964ea4832b904fc1ac7d689389)