### PR TITLE
fix(security): reserve internal session kv keys

### DIFF
--- a/crates/core/src/capabilities/a2a_delegation.rs
+++ b/crates/core/src/capabilities/a2a_delegation.rs
@@ -608,14 +608,16 @@ fn require_storage(
     })
 }
 
+/// Prefix shared by all agent run KV keys. Single source of truth: `run_key`
+/// builds keys from it, and `session_storage` reserves it from the user-facing
+/// `kv_store` tool (see `is_internal_session_kv_key`) so session/tool actors
+/// cannot forge or read A2A run records.
+pub(crate) const AGENT_RUN_KEY_PREFIX: &str = "agent_run:";
+
 /// KV key for a specific agent run record.
 fn run_key(run_id: &str) -> String {
-    format!("agent_run:{run_id}")
+    format!("{AGENT_RUN_KEY_PREFIX}{run_id}")
 }
-
-/// Prefix shared by all agent run KV keys (used in tests to verify prefix-based lookup).
-#[cfg(test)]
-const AGENT_RUN_KEY_PREFIX: &str = "agent_run:";
 
 /// List run_ids by prefix-filtering the session's KV keys (test helper).
 #[cfg(test)]

--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -287,6 +287,7 @@ pub use session_sql_database::{
 };
 pub use session_storage::{
     KvStoreTool, SESSION_STORAGE_CAPABILITY_ID, SecretStoreTool, SessionStorageCapability,
+    is_internal_session_kv_key,
 };
 pub use session_tasks::{SESSION_TASKS_CAPABILITY_ID, SessionTasksCapability};
 pub use skills::{SKILLS_CAPABILITY_ID, SkillsCapability};

--- a/crates/core/src/capabilities/session_storage.rs
+++ b/crates/core/src/capabilities/session_storage.rs
@@ -14,7 +14,21 @@ use crate::traits::ToolContext;
 use async_trait::async_trait;
 use serde_json::{Value, json};
 
+// Reserve the A2A run-record prefix from the user-facing kv_store. Reference
+// the canonical constant so this never drifts from how `a2a_delegation` writes
+// those keys (`run_key`).
+const INTERNAL_KV_PREFIXES: &[&str] = &[super::a2a_delegation::AGENT_RUN_KEY_PREFIX];
 const INTERNAL_SECRET_PREFIXES: &[&str] = &["browserless_internal:"];
+
+pub fn is_internal_session_kv_key(key: &str) -> bool {
+    INTERNAL_KV_PREFIXES
+        .iter()
+        .any(|prefix| key.starts_with(prefix))
+}
+
+fn reserved_kv_key_error() -> ToolExecutionResult {
+    ToolExecutionResult::tool_error("Key is reserved for internal system use")
+}
 
 fn is_internal_secret_name(name: &str) -> bool {
     INTERNAL_SECRET_PREFIXES
@@ -185,6 +199,9 @@ impl Tool for KvStoreTool {
                 if key.len() > 255 {
                     return ToolExecutionResult::tool_error("Key must be 255 characters or less");
                 }
+                if is_internal_session_kv_key(key) {
+                    return reserved_kv_key_error();
+                }
                 match storage_store
                     .set_value(context.session_id, key, value)
                     .await
@@ -206,6 +223,9 @@ impl Tool for KvStoreTool {
                         );
                     }
                 };
+                if is_internal_session_kv_key(key) {
+                    return reserved_kv_key_error();
+                }
                 match storage_store.get_value(context.session_id, key).await {
                     Ok(Some(value)) => ToolExecutionResult::success(json!({
                         "operation": "get",
@@ -231,6 +251,9 @@ impl Tool for KvStoreTool {
                         );
                     }
                 };
+                if is_internal_session_kv_key(key) {
+                    return reserved_kv_key_error();
+                }
                 match storage_store.delete_value(context.session_id, key).await {
                     Ok(deleted) => ToolExecutionResult::success(json!({
                         "operation": "delete",
@@ -244,6 +267,7 @@ impl Tool for KvStoreTool {
                 Ok(keys) => {
                     let key_list: Vec<Value> = keys
                         .iter()
+                        .filter(|k| !is_internal_session_kv_key(&k.key))
                         .map(|k| {
                             json!({
                                 "key": k.key,
@@ -504,7 +528,77 @@ impl Tool for SecretStoreTool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::traits::SessionStorageStore;
     use crate::typed_id::SessionId;
+    use crate::{KeyInfo, Result};
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
+
+    #[derive(Default)]
+    struct TestStorageStore {
+        values: Mutex<HashMap<String, String>>,
+    }
+
+    #[async_trait]
+    impl crate::traits::SessionStorageStore for TestStorageStore {
+        async fn set_value(&self, _session_id: SessionId, key: &str, value: &str) -> Result<()> {
+            self.values
+                .lock()
+                .unwrap()
+                .insert(key.to_string(), value.to_string());
+            Ok(())
+        }
+
+        async fn get_value(&self, _session_id: SessionId, key: &str) -> Result<Option<String>> {
+            Ok(self.values.lock().unwrap().get(key).cloned())
+        }
+
+        async fn delete_value(&self, _session_id: SessionId, key: &str) -> Result<bool> {
+            Ok(self.values.lock().unwrap().remove(key).is_some())
+        }
+
+        async fn list_keys(&self, _session_id: SessionId) -> Result<Vec<KeyInfo>> {
+            let now = chrono::Utc::now();
+            Ok(self
+                .values
+                .lock()
+                .unwrap()
+                .keys()
+                .map(|key| KeyInfo {
+                    key: key.clone(),
+                    created_at: now,
+                    updated_at: now,
+                })
+                .collect())
+        }
+
+        async fn set_secret(
+            &self,
+            _session_id: SessionId,
+            _name: &str,
+            _value: &str,
+        ) -> Result<()> {
+            Ok(())
+        }
+
+        async fn get_secret(&self, _session_id: SessionId, _name: &str) -> Result<Option<String>> {
+            Ok(None)
+        }
+
+        async fn delete_secret(&self, _session_id: SessionId, _name: &str) -> Result<bool> {
+            Ok(false)
+        }
+
+        async fn list_secrets(&self, _session_id: SessionId) -> Result<Vec<crate::SecretInfo>> {
+            Ok(Vec::new())
+        }
+    }
+
+    #[test]
+    fn test_internal_kv_key_filtering() {
+        assert!(is_internal_session_kv_key("agent_run:abc"));
+        assert!(!is_internal_session_kv_key("user:agent_run:abc"));
+    }
 
     #[test]
     fn test_internal_secret_name_filtering() {
@@ -596,6 +690,52 @@ mod tests {
         } else {
             panic!("Expected tool error for missing storage store");
         }
+    }
+
+    #[tokio::test]
+    async fn test_kv_store_rejects_reserved_internal_keys() {
+        let tool = KvStoreTool;
+        let session_id = SessionId::new();
+        let storage = Arc::new(TestStorageStore::default());
+        storage
+            .set_value(session_id, "agent_run:trusted", "trusted-record")
+            .await
+            .unwrap();
+        storage
+            .set_value(session_id, "public", "public-record")
+            .await
+            .unwrap();
+        let context = ToolContext::with_storage_store(session_id, storage.clone());
+
+        for arguments in [
+            json!({"operation": "set", "key": "agent_run:trusted", "value": "forged"}),
+            json!({"operation": "get", "key": "agent_run:trusted"}),
+            json!({"operation": "delete", "key": "agent_run:trusted"}),
+        ] {
+            let result = tool.execute_with_context(arguments, &context).await;
+            assert!(
+                matches!(result, ToolExecutionResult::ToolError(ref msg) if msg.contains("reserved")),
+                "expected reserved-key error, got {result:?}"
+            );
+        }
+
+        assert_eq!(
+            storage
+                .get_value(session_id, "agent_run:trusted")
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("trusted-record")
+        );
+
+        let result = tool
+            .execute_with_context(json!({"operation": "list"}), &context)
+            .await;
+        let ToolExecutionResult::Success(value) = result else {
+            panic!("expected successful list");
+        };
+        assert_eq!(value["count"], 1);
+        assert_eq!(value["keys"][0]["key"], "public");
     }
 
     #[tokio::test]

--- a/crates/server/src/domains/session_storage/commands.rs
+++ b/crates/server/src/domains/session_storage/commands.rs
@@ -1,6 +1,7 @@
 use super::queries as q;
 use super::types::{BatchSetSecretsResponse, KeyValueInfo, SecretInfo};
 use crate::domains::common::*;
+use everruns_core::capabilities::is_internal_session_kv_key;
 use serde::Deserialize;
 use utoipa::ToSchema;
 
@@ -39,6 +40,10 @@ impl Command for ListSessionStorage {
 
         let mut items = Vec::with_capacity(keys.len());
         for key_info in keys {
+            if is_internal_session_kv_key(&key_info.key) {
+                continue;
+            }
+
             let value = ctx
                 .db
                 .get_session_key_value(session_id.uuid(), &key_info.key)


### PR DESCRIPTION
### Motivation
- The A2A run records are persisted under predictable `agent_run:{run_id}` keys in the session KV store while the user-facing `kv_store` tool previously allowed arbitrary keys, letting a session/tool actor overwrite or forge trusted A2A run records. 
- This could let an attacker corrupt A2A control-plane state (including `agent_config` snapshots) and induce attacker-chosen outbound requests unless an external network ACL blocked them.

### Description
- Add a reserved-key predicate `is_internal_session_kv_key` and a reserved-prefix set (currently `agent_run:`) to protect internal session KV keys. 
- Block `kv_store` `set`/`get`/`delete` on reserved keys and filter them out of `kv_store` `list` results in `crates/core/src/capabilities/session_storage.rs` by returning a `ToolExecutionResult` error for user attempts. 
- Export the same predicate from the capabilities module and apply it to the server-side HTTP session storage listing (`ListSessionStorage`) so internal keys are not exposed via the API (`crates/core/src/capabilities/mod.rs`, `crates/server/src/domains/session_storage/commands.rs`). 
- Add unit/regression tests that prove `agent_run:*` keys cannot be overwritten/read/deleted/listed through `kv_store` and preserve the existing internal storage behavior used by A2A run persistence.

### Testing
- Ran `cargo fmt --check` which succeeded. 
- Ran `cargo test -p everruns-core capabilities::session_storage` and all tests passed, including the new `test_kv_store_rejects_reserved_internal_keys`. 
- Ran `cargo test -p everruns-core capabilities::a2a_delegation::tests::agent_run_storage_roundtrip` and it passed to validate A2A run storage roundtrip. 
- Ran `cargo check -p everruns-server` which succeeded to validate the server-side listing change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2bca01cabc832ba785de1a358c2b85)