### PR TITLE
fix(core): prevent raw error details in fallback text

### DIFF
--- a/crates/core/src/user_facing_error.rs
+++ b/crates/core/src/user_facing_error.rs
@@ -218,11 +218,7 @@ impl UserFacingError {
     }
 
     pub fn fallback_message(&self) -> String {
-        let base = self.base_fallback_message();
-        match string_field(&self.fields, "detail") {
-            Some(detail) => format!("{base}\n\nDetails: {detail}"),
-            None => base,
-        }
+        self.base_fallback_message()
     }
 
     fn base_fallback_message(&self) -> String {
@@ -622,21 +618,22 @@ mod tests {
     }
 
     #[test]
-    fn disclosure_detailed_attaches_detail_and_renders_it() {
+    fn disclosure_detailed_attaches_detail_without_rendering_it() {
         let error = UserFacingError::new(codes::PROVIDER_QUOTA_EXHAUSTED);
         let disclosed = error.apply_disclosure(
             ErrorDisclosure::Detailed,
-            Some("OpenAI API error (429): insufficient_quota"),
+            Some("OpenAI API error (429): insufficient_quota Authorization: Bearer sk-secret"),
         );
 
         assert_eq!(disclosed.code, codes::PROVIDER_QUOTA_EXHAUSTED);
         assert_eq!(
             string_field(&disclosed.fields, "detail"),
-            Some("OpenAI API error (429): insufficient_quota")
+            Some("OpenAI API error (429): insufficient_quota Authorization: Bearer sk-secret")
         );
         let message = disclosed.fallback_message();
         assert!(message.contains("out of credits or quota"));
-        assert!(message.contains("Details: OpenAI API error (429): insufficient_quota"));
+        assert!(!message.contains("insufficient_quota"));
+        assert!(!message.contains("sk-secret"));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Prevent raw provider/driver error bodies (which may include upstream diagnostics or echoed secrets) from being rendered into assistant-visible fallback text that public adapters forward before sanitized failure handling.
- Preserve the ability to attach a truncated `detail` field to errors for trusted event/metadata consumers while ensuring public output does not leak it.

### Description
- Stop appending the `detail` interpolation field to the assistant fallback text by making `UserFacingError::fallback_message()` return only the localized/base fallback string (file: `crates/core/src/user_facing_error.rs`).
- Keep `apply_disclosure()` behavior intact so `ErrorDisclosure::Detailed` still attaches a truncated `detail` field to the structured error fields for trusted consumers.
- Update the detailed-disclosure regression test to assert the `detail` field is preserved but not rendered into fallback text (test name updated in `crates/core/src/user_facing_error.rs`).
- Commit message: `fix(core): prevent raw error details in fallback text`.

### Testing
- Ran the focused unit test `disclosure_detailed_attaches_detail_without_rendering_it` which passed.
- Ran `cargo test -p everruns-core user_facing_error::tests` (12 tests) and all tests passed.
- `cargo fmt --check` and focused test runs were executed as part of validation; tests passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3051059e04832b9751dd4e3bd51757)