### PR TITLE
fix(core): bound tool output distillation work

### DIFF
--- a/crates/core/src/capabilities/tool_output_distillation.rs
+++ b/crates/core/src/capabilities/tool_output_distillation.rs
@@ -32,7 +32,7 @@
 //   budget + persistence pipeline already solves the problem, and distilling
 //   their already-budgeted inline view would fight that design.
 
-use std::sync::Arc;
+use std::{io, sync::Arc};
 
 use async_trait::async_trait;
 use serde_json::{Value, json};
@@ -59,6 +59,11 @@ const MAX_DEPTH: usize = 8;
 
 /// Maximum number of nodes visited while distilling (DoS bound).
 const MAX_NODES: usize = 100_000;
+
+/// Maximum serialized JSON bytes this hook will process before handing off to
+/// the final hard-limit hook. This must be checked before cloning or
+/// pretty-printing attacker-controlled tool output.
+const MAX_DISTILL_INPUT_BYTES: usize = 1024 * 1024;
 
 pub const TOOL_OUTPUT_DISTILLATION_CAPABILITY_ID: &str = "tool_output_distillation";
 
@@ -139,8 +144,12 @@ impl PostToolExecHook for DistillOutputHook {
             return;
         }
 
-        // Size gate: only act on large results.
-        let serialized = serde_json::to_string(result_value).unwrap_or_default();
+        // Size gate: only act on large results. Serialize through a bounded
+        // writer before any clone or traversal so untrusted MCP/web_fetch
+        // output cannot force unbounded allocations in this pre-hard-limit hook.
+        let Ok(serialized) = serialize_json_bounded(result_value, MAX_DISTILL_INPUT_BYTES) else {
+            return;
+        };
         if serialized.len() < MIN_DISTILL_BYTES {
             return;
         }
@@ -165,15 +174,15 @@ impl PostToolExecHook for DistillOutputHook {
             *result_value = Value::String(head_tail(&serialized, MAX_FIELD_BYTES));
         }
 
-        // Persist the full original (pretty-printed JSON) for lossless retrieval.
-        let original_text =
-            serde_json::to_string_pretty(&original).unwrap_or_else(|_| original.to_string());
-        let original_len = original_text.len();
+        // Persist the full original for lossless retrieval. Reuse the bounded
+        // size-gate serialization rather than pretty-printing the original into
+        // a second large string before persistence applies its own cap.
+        let original_len = serialized.len();
         let persisted = persist_output(
             file_store,
             context.session_id,
             &tool_call.id,
-            &original_text,
+            &serialized,
             "",
         )
         .await;
@@ -212,12 +221,9 @@ fn distill_value(value: &mut Value, depth: usize, stats: &mut DistillStats) {
             }
         }
         Value::Array(arr) => {
-            // Only arrays longer than the sample size can ever be sampled, so
-            // check length first and let `&&` short-circuit the O(n)
-            // serialization for small arrays.
-            if arr.len() > SAMPLE_ROWS
-                && serde_json::to_string(arr).map(|s| s.len()).unwrap_or(0) > MAX_FIELD_BYTES
-            {
+            // Avoid serializing the full array while walking untrusted output:
+            // long arrays are sampled based on element count alone.
+            if arr.len() > SAMPLE_ROWS {
                 let omitted = arr.len() - SAMPLE_ROWS;
                 arr.truncate(SAMPLE_ROWS);
                 for el in arr.iter_mut() {
@@ -239,6 +245,48 @@ fn distill_value(value: &mut Value, depth: usize, stats: &mut DistillStats) {
             }
         }
         _ => {}
+    }
+}
+
+fn serialize_json_bounded(value: &Value, max_bytes: usize) -> Result<String, serde_json::Error> {
+    let mut writer = BoundedJsonWriter::new(max_bytes);
+    serde_json::to_writer(&mut writer, value)?;
+    writer.finish().map_err(serde_json::Error::io)
+}
+
+struct BoundedJsonWriter {
+    bytes: Vec<u8>,
+    max_bytes: usize,
+}
+
+impl BoundedJsonWriter {
+    fn new(max_bytes: usize) -> Self {
+        Self {
+            bytes: Vec::with_capacity(max_bytes.min(MIN_DISTILL_BYTES)),
+            max_bytes,
+        }
+    }
+
+    fn finish(self) -> io::Result<String> {
+        String::from_utf8(self.bytes).map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))
+    }
+}
+
+impl io::Write for BoundedJsonWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        if self.bytes.len().saturating_add(buf.len()) > self.max_bytes {
+            // Intentional policy limit, not a real allocation failure — keep it
+            // out of `OutOfMemory` so OOM telemetry/handling isn't triggered.
+            return Err(io::Error::other(
+                "tool result JSON exceeds distillation byte limit",
+            ));
+        }
+        self.bytes.extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
     }
 }
 
@@ -448,6 +496,22 @@ mod tests {
         distill_value(&mut value, 0, &mut stats);
         assert!(!stats.changed);
         assert_eq!(value["items"].as_array().unwrap().len(), 3);
+    }
+
+    #[test]
+    fn test_serialize_json_bounded_rejects_oversized_output() {
+        let value = json!({ "body": "x".repeat(MAX_DISTILL_INPUT_BYTES + 1) });
+        let err = serialize_json_bounded(&value, MAX_DISTILL_INPUT_BYTES).unwrap_err();
+        assert!(err.is_io());
+    }
+
+    #[test]
+    fn test_distill_value_samples_long_array_without_serialized_size_gate() {
+        let mut value = json!({ "rows": [1, 2, 3, 4, 5, 6] });
+        let mut stats = DistillStats::default();
+        distill_value(&mut value, 0, &mut stats);
+        assert!(stats.changed);
+        assert_eq!(value["rows"].as_array().unwrap().len(), SAMPLE_ROWS + 1);
     }
 
     #[test]

--- a/specs/tool-output-distillation.md
+++ b/specs/tool-output-distillation.md
@@ -38,10 +38,10 @@ Both the in-process host and the durable worker assemble hooks through the same 
 1. **Skip** if the tool declares `persist_output: true` (exec/sandbox — handled elsewhere).
 2. **Skip** on error results (kept verbatim — usually small and diagnostically important).
 3. **Skip** if the result already carries `output_files` (already recoverable / distilled).
-4. **Size gate:** skip if the serialized result is below `MIN_DISTILL_BYTES`.
+4. **Bounded size gate:** serialize through a hard-capped writer before cloning or traversal. Skip if the serialized result is below `MIN_DISTILL_BYTES`; also skip if it exceeds `MAX_DISTILL_INPUT_BYTES`, leaving the always-on hard-limit hook to cap the inline output without this hook doing extra large-output work.
 5. **Require a session file store** (reversibility); skip if absent.
-6. Clone the original, then **distill the value in place**. If the shape walker changes nothing (a large result made entirely of sub-threshold fields), **fall back** to a head+tail window over the serialized value — so a large result is always bounded, persisted, and recoverable rather than risking an irrecoverable head-truncation by the 64 KiB hard-limit hook.
-7. **Persist the full original** (pretty-printed JSON) via `persist_output`. On failure, restore the verbatim original and return.
+6. Clone the original, then **distill the value in place**. If the shape walker changes nothing (a large result made entirely of sub-threshold fields), **fall back** to a head+tail window over the bounded serialized value — so a large result is always bounded, persisted, and recoverable rather than risking an irrecoverable head-truncation by the 64 KiB hard-limit hook.
+7. **Persist the full original** using the bounded JSON string already created for the size gate. On failure, restore the verbatim original and return.
 8. **Inject the recovery pointer** (`output_files`, `full_output`, `distilled`, `distill_note`).
 
 ### Content-shape routing (`distill_value`)
@@ -51,11 +51,11 @@ Recursive, bounded by `MAX_DEPTH` and `MAX_NODES`:
 | Shape | Transform |
 |-------|-----------|
 | Long string (> `MAX_FIELD_BYTES`) | `distill_text`: unified-diff → diffstat summary (file/hunk headers + `+a/-r` line counts); otherwise head+tail window with a byte-elision marker (preserves both ends, unlike head truncation). |
-| Large array (len > `SAMPLE_ROWS` and serialized > `MAX_FIELD_BYTES`) | Keep the first `SAMPLE_ROWS` elements (each recursively distilled) + an elision marker `[… N more item(s) elided …]`. |
+| Large array (len > `SAMPLE_ROWS`) | Keep the first `SAMPLE_ROWS` elements (each recursively distilled) + an elision marker `[… N more item(s) elided …]`. The walker never serializes each array in full just to decide whether to sample it. |
 | Object | Recurse into each field; small fields untouched. |
 | Scalar / small value | Unchanged. |
 
-Constants (no per-agent config in v1): `MIN_DISTILL_BYTES = 8 KiB`, `MAX_FIELD_BYTES = 2 KiB`, `SAMPLE_ROWS = 5`, `MAX_DEPTH = 8`, `MAX_NODES = 100_000`. See `crates/core/src/capabilities/tool_output_distillation.rs`.
+Constants (no per-agent config in v1): `MIN_DISTILL_BYTES = 8 KiB`, `MAX_FIELD_BYTES = 2 KiB`, `SAMPLE_ROWS = 5`, `MAX_DEPTH = 8`, `MAX_NODES = 100_000`, `MAX_DISTILL_INPUT_BYTES = 1 MiB`. See `crates/core/src/capabilities/tool_output_distillation.rs`.
 
 ## Recovery Contract
 
@@ -69,7 +69,7 @@ It is included by default in the **generic harness** (`crates/server/src/harness
 
 ## Security
 
-- **TM-DOS** — traversal is bounded by `MAX_DEPTH` / `MAX_NODES`; persisted size is capped at 1 MiB by `persist_output`. Distillation only ever shrinks the in-context payload.
+- **TM-DOS** — initial serialization is capped before cloning/traversal, traversal is bounded by `MAX_DEPTH` / `MAX_NODES`, arrays are sampled without full per-array serialization, and persisted size is capped at 1 MiB by `persist_output`. Distillation only ever shrinks the in-context payload it processes; oversized inputs fall through to the final hard-limit hook.
 - **TM-FS** — VFS writes reuse `tool_output_persistence::persist_output`, which sanitizes the tool-call id (no path traversal) and is session-scoped.
 - **TM-TOOL / prompt injection** — distillation reduces content; it never executes tool output. Markers and notes are static strings. The result remains untrusted tool output, governed by the same instruction hierarchy as before.
 


### PR DESCRIPTION
### Motivation

- The default-enabled `tool_output_distillation` hook performed unbounded full-JSON serialization, cloning, per-array serialization checks, and pretty-printing on untrusted MCP/web_fetch results, creating a TM-DOS risk. 
- The change aims to prevent large attacker-controlled tool outputs from forcing excessive memory and CPU work in the pre-hard-limit capability hook. 
- Preserve distillation's reversibility and functionality for reasonable-sized results while ensuring worker stability under malicious/oversized inputs.

### Description

- Add a hard upstream ceiling `MAX_DISTILL_INPUT_BYTES = 1 MiB` and gate pre-processing via `serialize_json_bounded` so the hook refuses to work on inputs that would exceed that bound and avoid unbounded allocations. 
- Reuse the bounded serialized JSON for persistence instead of producing a second pretty-printed string, and avoid cloning/pretty-printing the full original after the size gate. 
- Remove per-array full-serialization checks during traversal and sample arrays by element count only, and add `BoundedJsonWriter` to implement the bounded serialization. 
- Update the durable spec `specs/tool-output-distillation.md` to document the bounded size gate, array-sampling behavior, and the new cap, and add unit tests covering the new behavior.

### Testing

- Ran `cargo fmt --check` which succeeded. 
- Ran targeted unit tests `RUSTUP_TOOLCHAIN=1.96.0 cargo test -p everruns-core tool_output_distillation --all-features` and all tests passed (`22 passed`). 
- Ran `RUSTUP_TOOLCHAIN=1.96.0 cargo clippy -p everruns-core --all-targets --all-features -- -D warnings` which completed with no warnings. 
- Ran repository pre-push checks with `just pre-push`; the first run failed only because this checkout lacks an `origin/main` ref for the migration-immutability check, and `MIGRATION_IMMUTABILITY_BASE_REF=HEAD just pre-push` passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a305105c5dc832b8f6f678df6df86b7)