### PR TITLE
fix(mcp): bound stale tool cache serving

### DIFF
--- a/crates/server/src/domains/mcp_servers/service.rs
+++ b/crates/server/src/domains/mcp_servers/service.rs
@@ -30,8 +30,15 @@ use uuid::Uuid;
 
 use crate::domains::mcp_servers::types::{CreateMcpServerRequest, UpdateMcpServerRequest};
 
-/// How long cached tools are considered fresh (1 hour)
+/// How long cached tools are considered fresh (1 hour).
 const TOOL_CACHE_TTL: Duration = Duration::from_secs(3600);
+
+/// Maximum age for serving stale MCP tool definitions while revalidating.
+///
+/// MCP servers are untrusted inputs to agent tool resolution. Stale caches make
+/// upstream outages less disruptive, but an unbounded stale window would let a
+/// poisoned tool list persist indefinitely if future `tools/list` calls fail.
+const TOOL_CACHE_MAX_STALE: Duration = Duration::from_secs(24 * 3600);
 
 /// Identifies a server's tool cache for single-flight coordination.
 type RefreshKey = (i64, Uuid);
@@ -401,11 +408,16 @@ impl McpServerService {
         if settings.auth_mode == McpServerAuthMode::OAuth {
             let tools: Vec<McpToolDefinition> =
                 serde_json::from_value(row.cached_tools.clone()).unwrap_or_default();
-            if !tools.is_empty() {
+            // OAuth servers can't self-refresh here (no user connection token to
+            // mint), so we fall back to the last good cache — but still bound it
+            // by the max-stale window so revoked/poisoned tool metadata can't be
+            // served indefinitely. Past the window the caller must reconnect.
+            if !tools.is_empty() && Self::cache_within_max_stale(&row) {
                 return Ok(tools);
             }
             anyhow::bail!(
-                "OAuth MCP servers require a user connection before tools can be refreshed"
+                "OAuth MCP servers require a user connection before tools can be refreshed \
+                 (or the cached tools have exceeded the maximum stale window)"
             );
         }
 
@@ -454,16 +466,36 @@ impl McpServerService {
         Ok(tools)
     }
 
+    /// Age of a cached tool list, if one exists. A small future timestamp
+    /// (within `CACHE_FUTURE_SKEW`) is tolerated and treated as age zero so
+    /// minor clock skew does not force needless refreshes. A timestamp further
+    /// in the future is treated as invalid (`None`) so a corrupt/skewed
+    /// "future" `cached_at` can't make a cache look perpetually fresh and bypass
+    /// the bounded-stale window.
+    fn cache_age(row: &McpServerRow) -> Option<chrono::Duration> {
+        const CACHE_FUTURE_SKEW_SECS: i64 = 300;
+        let cached_at = row.tools_cached_at?;
+        let age = Utc::now().signed_duration_since(cached_at);
+        if age < chrono::Duration::seconds(-CACHE_FUTURE_SKEW_SECS) {
+            return None;
+        }
+        Some(age.max(chrono::Duration::zero()))
+    }
+
     /// Whether a server row's cached tools are still within the freshness TTL.
     fn cache_fresh(row: &McpServerRow) -> bool {
-        match row.tools_cached_at {
-            Some(cached_at) => {
-                let age = Utc::now().signed_duration_since(cached_at);
-                age < chrono::Duration::from_std(TOOL_CACHE_TTL)
-                    .unwrap_or_else(|_| chrono::Duration::hours(1))
-            }
-            None => false,
-        }
+        Self::cache_age(row).is_some_and(|age| {
+            age < chrono::Duration::from_std(TOOL_CACHE_TTL)
+                .unwrap_or_else(|_| chrono::Duration::hours(1))
+        })
+    }
+
+    /// Whether a stale cache is still young enough to serve while revalidating.
+    fn cache_within_max_stale(row: &McpServerRow) -> bool {
+        Self::cache_age(row).is_some_and(|age| {
+            age < chrono::Duration::from_std(TOOL_CACHE_MAX_STALE)
+                .unwrap_or_else(|_| chrono::Duration::hours(24))
+        })
     }
 
     fn cached_tools(row: &McpServerRow) -> Vec<McpToolDefinition> {
@@ -510,8 +542,9 @@ impl McpServerService {
 
     /// Resolve tools for an already-loaded row, applying stale-while-revalidate
     /// and single-flight refresh. Never errors: a hard refresh failure degrades
-    /// to whatever is cached (possibly empty), matching the batch-load contract
-    /// where one unreachable server must not fail tool resolution for the rest.
+    /// to cached tools only while the cache is inside the maximum stale window,
+    /// matching the batch-load contract without registering indefinitely stale
+    /// tool definitions.
     async fn tools_for_row(&self, org_id: i64, row: &McpServerRow) -> Vec<McpToolDefinition> {
         if Self::cache_fresh(row) {
             return Self::cached_tools(row);
@@ -528,23 +561,32 @@ impl McpServerService {
         {
             Ok(tools) => tools,
             Err(err) => {
-                tracing::warn!(
-                    server_id = %row.id.uuid(),
-                    error = %err,
-                    "Failed to refresh MCP tool cache; serving cached tools"
-                );
-                Self::cached_tools(row)
+                if Self::cache_within_max_stale(row) {
+                    tracing::warn!(
+                        server_id = %row.id.uuid(),
+                        error = %err,
+                        "Failed to refresh MCP tool cache; serving cached tools within max stale window"
+                    );
+                    Self::cached_tools(row)
+                } else {
+                    tracing::warn!(
+                        server_id = %row.id.uuid(),
+                        error = %err,
+                        "Failed to refresh expired MCP tool cache; omitting stale tools"
+                    );
+                    Vec::new()
+                }
             }
         }
     }
 
     /// Stale-while-revalidate is only safe when a real upstream refresh can
-    /// succeed: there must be a prior successful fetch to serve, and the server
-    /// must be self-refreshable (OAuth servers need a user connection token that
-    /// `refresh_tools` cannot mint, so revalidating them in the background would
-    /// just spawn no-op tasks on every call).
+    /// succeed: there must be a recent prior successful fetch to serve, and the
+    /// server must be self-refreshable (OAuth servers need a user connection
+    /// token that `refresh_tools` cannot mint, so revalidating them in the
+    /// background would just spawn no-op tasks on every call).
     fn can_revalidate_in_background(&self, row: &McpServerRow) -> bool {
-        row.tools_cached_at.is_some()
+        Self::cache_within_max_stale(row)
             && Self::settings_from_row(row).auth_mode != McpServerAuthMode::OAuth
     }
 
@@ -577,7 +619,7 @@ impl McpServerService {
 
     /// Trigger a background refresh for a server, deduplicated so at most one
     /// runs per server at a time. Failures are logged, not surfaced: the caller
-    /// has already been served the stale cache.
+    /// has already been served a cache still inside the maximum stale window.
     fn spawn_background_refresh(&self, org_id: i64, id: Uuid) {
         let lock = REFRESH_LOCKS.lock_for((org_id, id));
         let Ok(guard) = lock.try_lock_owned() else {
@@ -592,7 +634,7 @@ impl McpServerService {
                 tracing::warn!(
                     server_id = %id,
                     error = %err,
-                    "Background MCP tool refresh failed; cache left stale"
+                    "Background MCP tool refresh failed; cache remains stale until max stale age"
                 );
             }
         });
@@ -1141,6 +1183,20 @@ mod tests {
         assert!(!McpServerService::cache_fresh(&row));
     }
 
+    #[test]
+    fn cache_within_max_stale_bounds_stale_serving() {
+        let mut row = sample_row();
+
+        row.tools_cached_at = None;
+        assert!(!McpServerService::cache_within_max_stale(&row));
+
+        row.tools_cached_at = Some(Utc::now() - chrono::Duration::hours(2));
+        assert!(McpServerService::cache_within_max_stale(&row));
+
+        row.tools_cached_at = Some(Utc::now() - chrono::Duration::hours(25));
+        assert!(!McpServerService::cache_within_max_stale(&row));
+    }
+
     #[tokio::test]
     async fn keyed_locks_coalesce_and_prune() {
         let locks = KeyedLocks::default();
@@ -1208,6 +1264,93 @@ mod tests {
         let tools = svc.get_tools(&caller, id, false).await.unwrap();
         assert_eq!(tools.len(), 1);
         assert_eq!(tools[0].name, "alpha");
+    }
+
+    #[tokio::test]
+    async fn get_tools_rejects_expired_stale_cache_when_refresh_fails() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let svc = McpServerService::new(db.clone(), Some(test_encryption()));
+        let caller = test_caller(1);
+
+        let row = db
+            .create_mcp_server(
+                1,
+                CreateMcpServerRow {
+                    name: "expired-stale-server".into(),
+                    description: None,
+                    url: "http://10.0.0.1/mcp".into(),
+                    transport_type: "streamable_http".into(),
+                    api_key_encrypted: None,
+                    headers: None,
+                    settings: None,
+                },
+            )
+            .await
+            .unwrap();
+        let id = row.id.uuid();
+
+        db.update_mcp_server_tools(
+            1,
+            id,
+            UpdateMcpServerTools {
+                cached_tools: serde_json::json!([
+                    {"name": "poisoned", "description": "P", "inputSchema": {"type": "object"}}
+                ]),
+            },
+        )
+        .await
+        .unwrap();
+        let StorageBackend::InMemory(mem) = db.as_ref() else {
+            panic!("expected in-memory backend");
+        };
+        mem.set_tools_cached_at_for_test(id, Utc::now() - chrono::Duration::hours(25));
+
+        let result = svc.get_tools(&caller, id, false).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn batch_omits_expired_stale_cache_when_refresh_fails() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let svc = McpServerService::new(db.clone(), Some(test_encryption()));
+        let caller = test_caller(1);
+
+        let row = db
+            .create_mcp_server(
+                1,
+                CreateMcpServerRow {
+                    name: "expired-batch-server".into(),
+                    description: None,
+                    url: "http://10.0.0.1/mcp".into(),
+                    transport_type: "streamable_http".into(),
+                    api_key_encrypted: None,
+                    headers: None,
+                    settings: None,
+                },
+            )
+            .await
+            .unwrap();
+        let id = row.id.uuid();
+
+        db.update_mcp_server_tools(
+            1,
+            id,
+            UpdateMcpServerTools {
+                cached_tools: serde_json::json!([
+                    {"name": "poisoned", "description": "P", "inputSchema": {"type": "object"}}
+                ]),
+            },
+        )
+        .await
+        .unwrap();
+        let StorageBackend::InMemory(mem) = db.as_ref() else {
+            panic!("expected in-memory backend");
+        };
+        mem.set_tools_cached_at_for_test(id, Utc::now() - chrono::Duration::hours(25));
+
+        let servers = svc.get_batch_with_tools(&caller, &[id]).await.unwrap();
+        let (_, tools) = servers.get(&id).expect("server is returned");
+        assert!(tools.is_empty());
     }
 
     #[tokio::test]

--- a/specs/concepts.md
+++ b/specs/concepts.md
@@ -234,7 +234,7 @@ A specific model within a provider (e.g., `gpt-4o`, `claude-sonnet-4`).
 A remote server that exposes tools via the Model Context Protocol. Integrated as a virtual capability.
 
 - Becomes a capability with ID `mcp:{server_uuid}`
-- Tools are discovered at runtime and cached with a 24-hour TTL
+- Tools are discovered at runtime, cached with a 1-hour freshness TTL, and have a 24-hour maximum stale-serving window
 - Tool names are prefixed to avoid conflicts: `mcp_{server}__{tool}`
 - Execution happens via HTTP JSON-RPC
 

--- a/specs/mcp-servers.md
+++ b/specs/mcp-servers.md
@@ -219,16 +219,24 @@ Tools are discovered from MCP servers via the `tools/list` JSON-RPC method:
 ### Tool Caching
 
 Tools are cached per server (`cached_tools` + `tools_cached_at`) and served with
-a stale-while-revalidate strategy so a *stale* cache never blocks agent tool
-resolution on an upstream `tools/list` (cold and forced refreshes still block —
-see below):
+a bounded stale-while-revalidate strategy so recent stale caches avoid blocking
+agent tool resolution on an upstream `tools/list`, while untrusted tool
+definitions cannot remain registered indefinitely after refresh failures:
 
 - **Fresh** (within the 1h TTL): cached tools are returned directly.
-- **Stale** (older than the TTL, with a prior successful fetch): the cached tools
-  are returned immediately and a refresh is kicked off in the background. OAuth
-  servers are excluded — they cannot self-refresh without a user connection
-  token, so they serve cached tools without spawning a no-op background refresh.
-- **Cold** (never fetched) or **forced**: the caller blocks on a refresh.
+- **Stale but within the maximum stale lifetime** (older than the TTL, under 24h,
+  with a prior successful fetch): cached tools are returned immediately and a
+  refresh is kicked off in the background. OAuth servers are excluded — they
+  cannot self-refresh without a user connection token, so they take the blocking
+  path instead of spawning a no-op background refresh.
+- **Expired stale** (24h or older), **cold** (never fetched), or **forced**: the
+  caller blocks on a refresh. Batch agent tool resolution omits expired stale
+  tools if that refresh fails rather than registering the old definitions.
+- The 24h max-stale window also bounds **OAuth** servers: since they can't
+  self-refresh without a user connection token, their cached tools are served
+  only while inside the window. Past 24h the blocking refresh fails (and batch
+  resolution omits them) until the user reconnects — so revoked/poisoned OAuth
+  tool metadata can't be served indefinitely either.
 - Concurrent refreshes for the same server are coalesced (single-flight), so a
   burst of agent runs triggers at most one upstream fetch rather than a herd.
 - Force refresh is available via API.


### PR DESCRIPTION
### Motivation
- Prevent untrusted MCP tool definitions from being served indefinitely when background refreshes fail by enforcing a maximum stale lifetime. 
- Keep the performance benefit of stale-while-revalidate for recent caches while ensuring poisoned or revoked tool metadata cannot persist beyond a safe window.

### Description
- Add `TOOL_CACHE_MAX_STALE` (24 hours) and a `cache_age` helper, and introduce `cache_within_max_stale` to track whether a stale cache may still be served while revalidating. 
- Restrict background revalidation (`can_revalidate_in_background`) to only caches inside the maximum stale window and update background-refresh logging to reflect the bounded stale lifetime. 
- When a blocking refresh fails during batch resolution, omit expired stale tools instead of registering them; when single `get_tools` is called, expired stale caches now require a successful refresh (or error) rather than being silently served. 
- Add regression tests for `cache_within_max_stale`, rejecting expired stale `get_tools`, and omitting expired stale caches in batch resolution, and update MCP spec docs to document the 1-hour freshness TTL with a 24-hour maximum stale-serving window.

### Testing
- Ran the focused unit test subset with `cargo test -p everruns-server --lib domains::mcp_servers::service::tests:: --all-features` and all tests passed. 
- Ran formatting and lint checks with `cargo fmt --check` and `cargo clippy -p everruns-server --lib --all-features -- -D warnings`, both of which completed successfully. 
- Verified `git diff --check` and added tests asserting both single and batch behavior for expired stale caches, all automated checks succeeding locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a305105de6c832b970bfb228dfac40b)