### PR TITLE
fix(feature-flags): enforce org-scoped runtime gates

### DIFF
--- a/crates/server/src/api/agents.rs
+++ b/crates/server/src/api/agents.rs
@@ -15,7 +15,7 @@ use axum::{
 use chrono::Utc;
 use everruns_core::typed_id::{AgentId, AgentVersionId, ModelId};
 use everruns_core::{
-    Agent, AgentCapabilityConfig, Caller, DeploymentGrade, FeatureFlags, InitialFile, OrgRole,
+    Agent, AgentCapabilityConfig, Caller, DeploymentGrade, InitialFile, OrgRole,
     PlatformDefinition, ResourceConfigResponse, ScopedMcpServers, evaluate_policies_with,
 };
 use futures::future::try_join_all;
@@ -183,9 +183,9 @@ impl AppState {
 }
 
 fn require_agent_versions_enabled(
-    state: &AppState,
+    org: &ResolvedOrg,
 ) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
-    if FeatureFlags::from_env(&state.grade).agent_versions {
+    if org.feature_flags.agent_versions {
         Ok(())
     } else {
         Err(ErrorResponse::not_found("Agent versions"))
@@ -596,7 +596,7 @@ pub async fn list_agent_versions(
     State(state): State<AppState>,
     Path(agent_id): Path<String>,
 ) -> ApiResult<Vec<everruns_core::AgentVersion>> {
-    require_agent_versions_enabled(&state)?;
+    require_agent_versions_enabled(&org)?;
     state
         .dispatcher(&org)
         .run(crate::domains::agents::ListAgentVersions { agent_id })
@@ -624,7 +624,7 @@ pub async fn create_agent_version(
     Path(agent_id): Path<String>,
     Json(req): Json<CreateAgentVersionRequest>,
 ) -> ApiResult<everruns_core::AgentVersion> {
-    require_agent_versions_enabled(&state)?;
+    require_agent_versions_enabled(&org)?;
     state
         .dispatcher(&org)
         .run(crate::domains::agents::CreateAgentVersionCmd { agent_id, req })
@@ -652,7 +652,7 @@ pub async fn set_default_agent_version(
     Path(agent_id): Path<String>,
     Json(req): Json<SetDefaultAgentVersionRequest>,
 ) -> ApiResult<WithUrls<Agent>> {
-    require_agent_versions_enabled(&state)?;
+    require_agent_versions_enabled(&org)?;
     state
         .dispatcher(&org)
         .run_with_urls(crate::domains::agents::SetDefaultAgentVersion { agent_id, req })
@@ -681,7 +681,7 @@ pub async fn rollback_agent_version(
     Path((agent_id, version_id)): Path<(String, AgentVersionId)>,
     Json(req): Json<RollbackAgentVersionRequest>,
 ) -> ApiResult<WithUrls<Agent>> {
-    require_agent_versions_enabled(&state)?;
+    require_agent_versions_enabled(&org)?;
     state
         .dispatcher(&org)
         .run_with_urls(crate::domains::agents::RollbackAgentVersion {
@@ -714,7 +714,7 @@ pub async fn fork_agent_version(
     Path((agent_id, version_id)): Path<(String, AgentVersionId)>,
     Json(req): Json<ForkAgentVersionRequest>,
 ) -> ApiResult<WithUrls<Agent>> {
-    require_agent_versions_enabled(&state)?;
+    require_agent_versions_enabled(&org)?;
     state
         .dispatcher(&org)
         .run_with_urls(crate::domains::agents::ForkAgentVersion {
@@ -749,7 +749,7 @@ pub async fn diff_agent_versions(
         AgentVersionId,
     )>,
 ) -> ApiResult<crate::domains::agents::types::AgentVersionDiffResponse> {
-    require_agent_versions_enabled(&state)?;
+    require_agent_versions_enabled(&org)?;
     state
         .dispatcher(&org)
         .run(crate::domains::agents::DiffAgentVersions {
@@ -1506,7 +1506,7 @@ mod high_risk_admin_gate_tests {
             user_id: None,
             role,
             is_platform_user: false,
-            feature_flags: FeatureFlags::default(),
+            feature_flags: everruns_core::FeatureFlags::default(),
         }
     }
 

--- a/crates/server/src/api/budgets.rs
+++ b/crates/server/src/api/budgets.rs
@@ -58,6 +58,9 @@ impl AppState {
             None,
             self.auth.permission_resolver.clone(),
         )
+        // Seed org-effective flags so the `app_budgets` gate honors org opt-out
+        // rather than falling back to deployment-level `FeatureFlags::current()`.
+        .with_feature_flags(org.feature_flags.clone())
     }
 }
 

--- a/crates/server/src/api/evals.rs
+++ b/crates/server/src/api/evals.rs
@@ -66,6 +66,7 @@ impl AppState {
             None,
             self.auth.permission_resolver.clone(),
         )
+        .with_feature_flags(org.feature_flags.clone())
         .with_eval_service(self.service.clone())
     }
 }

--- a/crates/server/src/api/mcp_endpoint/mod.rs
+++ b/crates/server/src/api/mcp_endpoint/mod.rs
@@ -363,6 +363,14 @@ async fn handle_mcp(
     headers: HeaderMap,
     Json(req): Json<JsonRpcRequest>,
 ) -> Response {
+    if !org.feature_flags.mcp_endpoint {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(JsonRpcResponse::method_not_found(req.id)),
+        )
+            .into_response();
+    }
+
     let protocol_version = if req.method == "initialize" {
         None
     } else {
@@ -535,6 +543,7 @@ fn mcp_ctx(org: &ResolvedOrg, state: &AppState) -> Ctx {
         state.encryption.clone(),
         state.auth.permission_resolver.clone(),
     )
+    .with_feature_flags(org.feature_flags.clone())
     .with_utility_llm_service(state.utility_llm_service.clone());
     if let Some(service) = &state.health_check_service {
         ctx = ctx.with_health_check_service(service.clone());

--- a/crates/server/src/api/voice.rs
+++ b/crates/server/src/api/voice.rs
@@ -321,7 +321,7 @@ pub async fn create_client_secret(
     Path(session_id): Path<String>,
     Json(req): Json<VoiceClientSecretRequest>,
 ) -> Result<Json<VoiceClientSecretResponse>, (StatusCode, Json<ErrorResponse>)> {
-    ensure_voice_enabled(&state)?;
+    ensure_voice_enabled(&org)?;
     let session_id = parse_session_id(&session_id)?;
     authorize_session(&state, &org, session_id).await?;
     let normalized = normalize_options(req.options)?;
@@ -386,7 +386,7 @@ pub async fn create_call(
     Path(session_id): Path<String>,
     Json(req): Json<VoiceCallRequest>,
 ) -> Result<Json<VoiceCallResponse>, (StatusCode, Json<ErrorResponse>)> {
-    ensure_voice_enabled(&state)?;
+    ensure_voice_enabled(&org)?;
     let session_id = parse_session_id(&session_id)?;
     authorize_session(&state, &org, session_id).await?;
     bootstrap_call(&state, &org, session_id, req)
@@ -408,7 +408,7 @@ pub async fn attach_call(
     Path((session_id, voice_connection_id)): Path<(String, String)>,
     Json(req): Json<VoiceAttachRequest>,
 ) -> Result<Json<VoiceAttachResponse>, (StatusCode, Json<ErrorResponse>)> {
-    ensure_voice_enabled(&state)?;
+    ensure_voice_enabled(&org)?;
     let session_id = parse_session_id(&session_id)?;
     authorize_session(&state, &org, session_id).await?;
     if voice_connection_id.trim().is_empty() || req.provider_call_id.trim().is_empty() {
@@ -470,7 +470,7 @@ pub async fn end_call(
     Path((session_id, voice_connection_id)): Path<(String, String)>,
     Json(req): Json<VoiceEndRequest>,
 ) -> Result<Json<VoiceEndResponse>, (StatusCode, Json<ErrorResponse>)> {
-    ensure_voice_enabled(&state)?;
+    ensure_voice_enabled(&org)?;
     let session_id = parse_session_id(&session_id)?;
     authorize_session(&state, &org, session_id).await?;
     release_voice_resource(&state, session_id, &voice_connection_id).await?;
@@ -501,7 +501,7 @@ pub async fn create_agent_voice_session(
     (StatusCode, Json<VoiceSessionResponse<VoiceCallResponse>>),
     (StatusCode, Json<ErrorResponse>),
 > {
-    ensure_voice_enabled(&state)?;
+    ensure_voice_enabled(&org)?;
     let session = CreateSession(crate::api::sessions::CreateSessionRequest {
         workspace_id: None,
         harness_id: None,
@@ -547,7 +547,7 @@ pub async fn create_chat_voice_session(
     State(state): State<AppState>,
     Json(req): Json<VoiceCallRequest>,
 ) -> Result<Json<VoiceSessionResponse<VoiceCallResponse>>, (StatusCode, Json<ErrorResponse>)> {
-    ensure_voice_enabled(&state)?;
+    ensure_voice_enabled(&org)?;
     let session = GetOrCreateChatSession { locale: None }
         .run(&state.ctx(&org))
         .await?;
@@ -665,8 +665,8 @@ struct NormalizedVoiceOptions {
     instructions: Option<String>,
 }
 
-fn ensure_voice_enabled(state: &AppState) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
-    if state.feature_flags.voice {
+fn ensure_voice_enabled(org: &ResolvedOrg) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
+    if org.feature_flags.voice {
         Ok(())
     } else {
         Err(ErrorResponse::not_found("Voice"))

--- a/crates/server/src/domains/budgets/commands.rs
+++ b/crates/server/src/domains/budgets/commands.rs
@@ -7,14 +7,14 @@ use everruns_core::budget::{Budget, BudgetCheckResult, LedgerEntry};
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
-fn validate_subject_type(subject_type: &str) -> Result<(), CommandError> {
+fn validate_subject_type(ctx: &Ctx, subject_type: &str) -> Result<(), CommandError> {
     const ALWAYS_ON: &[&str] = &["session", "agent", "user", "org"];
     const APP_BUDGET_TYPES: &[&str] = &["app", "app_channel"];
     if ALWAYS_ON.contains(&subject_type) {
         return Ok(());
     }
     if APP_BUDGET_TYPES.contains(&subject_type) {
-        if everruns_core::FeatureFlags::current().app_budgets {
+        if ctx.feature_flags.app_budgets {
             return Ok(());
         }
         return Err(CommandError::bad_request(
@@ -82,7 +82,7 @@ impl Command for CreateBudget {
     async fn execute(self, ctx: &Ctx) -> Result<Budget, CommandError> {
         require_budget_manage(ctx)?;
         let req = self.0;
-        validate_subject_type(&req.subject_type)?;
+        validate_subject_type(ctx, &req.subject_type)?;
         validate_limit(req.limit, req.soft_limit)?;
 
         let input = CreateBudgetRow {
@@ -613,7 +613,7 @@ impl Command for ListAppBudgets {
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<Vec<Budget>, CommandError> {
-        if !everruns_core::FeatureFlags::current().app_budgets {
+        if !ctx.feature_flags.app_budgets {
             return Err(CommandError::bad_request(
                 "App-scoped budgets are gated behind the app_budgets feature flag",
             ));
@@ -740,13 +740,34 @@ mod tests {
     #[test]
     fn validate_subject_type_accepts_classic_subjects() {
         for kind in ["session", "agent", "user", "org"] {
-            assert!(validate_subject_type(kind).is_ok(), "expected {kind} ok");
+            assert!(
+                validate_subject_type(&ctx_for_role(OrgRole::Owner), kind).is_ok(),
+                "expected {kind} ok"
+            );
         }
     }
 
     #[test]
     fn validate_subject_type_rejects_unknown_subjects() {
-        assert!(validate_subject_type("unknown").is_err());
-        assert!(validate_subject_type("").is_err());
+        let ctx = ctx_for_role(OrgRole::Owner);
+        assert!(validate_subject_type(&ctx, "unknown").is_err());
+        assert!(validate_subject_type(&ctx, "").is_err());
+    }
+
+    #[test]
+    fn validate_subject_type_app_budgets_honor_org_flag() {
+        // Default (flag off): app-scoped budget subjects are rejected.
+        let disabled = ctx_for_role(OrgRole::Owner);
+        assert!(validate_subject_type(&disabled, "app").is_err());
+        assert!(validate_subject_type(&disabled, "app_channel").is_err());
+
+        // Flag on (org opted in): app-scoped subjects are accepted.
+        let enabled =
+            ctx_for_role(OrgRole::Owner).with_feature_flags(everruns_core::FeatureFlags {
+                app_budgets: true,
+                ..Default::default()
+            });
+        assert!(validate_subject_type(&enabled, "app").is_ok());
+        assert!(validate_subject_type(&enabled, "app_channel").is_ok());
     }
 }

--- a/crates/server/src/domains/evals/commands.rs
+++ b/crates/server/src/domains/evals/commands.rs
@@ -13,6 +13,14 @@ pub struct EvalArtifactExport {
     pub body: String,
 }
 
+fn require_evals_enabled(ctx: &Ctx) -> Result<(), CommandError> {
+    if ctx.feature_flags.evals {
+        Ok(())
+    } else {
+        Err(CommandError::not_found("Evals"))
+    }
+}
+
 #[derive(Debug, Deserialize)]
 pub struct CreateEval(pub CreateEvalRequest);
 
@@ -40,6 +48,7 @@ impl Command for CreateEval {
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<Eval, CommandError> {
+        require_evals_enabled(ctx)?;
         q::service(ctx)
             .create(&ctx.caller, self.0)
             .await
@@ -80,6 +89,7 @@ impl Command for ListEvals {
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<Vec<Eval>, CommandError> {
+        require_evals_enabled(ctx)?;
         q::service(ctx)
             .list(&ctx.caller, self.search.as_deref(), self.include_archived)
             .await
@@ -116,6 +126,7 @@ impl Command for GetEval {
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<Eval, CommandError> {
+        require_evals_enabled(ctx)?;
         let eval_id = q::parse_eval_id(&self.eval_id)?;
         q::service(ctx)
             .get_by_public_id(&ctx.caller, &eval_id.to_string())
@@ -152,6 +163,7 @@ impl Command for UpdateEval {
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<Eval, CommandError> {
+        require_evals_enabled(ctx)?;
         let eval_id = q::parse_eval_id(&self.eval_id)?;
         q::service(ctx)
             .update(&ctx.caller, &eval_id.to_string(), self.req)
@@ -186,6 +198,7 @@ impl Command for DeleteEval {
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<bool, CommandError> {
+        require_evals_enabled(ctx)?;
         let eval_id = q::parse_eval_id(&self.eval_id)?;
         let deleted = q::service(ctx)
             .delete(&ctx.caller, &eval_id.to_string())
@@ -226,6 +239,7 @@ impl Command for CreateEvalCase {
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<EvalCase, CommandError> {
+        require_evals_enabled(ctx)?;
         let eval_id = q::parse_eval_id(&self.eval_id)?;
         q::service(ctx)
             .create_case(&ctx.caller, &eval_id.to_string(), self.req)
@@ -259,6 +273,7 @@ impl Command for ListEvalCases {
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<Vec<EvalCase>, CommandError> {
+        require_evals_enabled(ctx)?;
         let eval_id = q::parse_eval_id(&self.eval_id)?;
         q::service(ctx)
             .list_cases(&ctx.caller, &eval_id.to_string())
@@ -293,6 +308,7 @@ impl Command for GetEvalCase {
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<EvalCase, CommandError> {
+        require_evals_enabled(ctx)?;
         let eval_id = q::parse_eval_id(&self.eval_id)?;
         let case_id = q::parse_case_id(&self.case_id)?;
         q::service(ctx)
@@ -331,6 +347,7 @@ impl Command for UpdateEvalCase {
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<EvalCase, CommandError> {
+        require_evals_enabled(ctx)?;
         let eval_id = q::parse_eval_id(&self.eval_id)?;
         let case_id = q::parse_case_id(&self.case_id)?;
         q::service(ctx)
@@ -372,6 +389,7 @@ impl Command for DeleteEvalCase {
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<bool, CommandError> {
+        require_evals_enabled(ctx)?;
         let eval_id = q::parse_eval_id(&self.eval_id)?;
         let case_id = q::parse_case_id(&self.case_id)?;
         let deleted = q::service(ctx)
@@ -413,6 +431,7 @@ impl Command for CreateEvalRun {
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<EvalRun, CommandError> {
+        require_evals_enabled(ctx)?;
         let eval_id = q::parse_eval_id(&self.eval_id)?;
         q::service(ctx)
             .create_run(&ctx.caller, &eval_id.to_string(), self.req)
@@ -446,6 +465,7 @@ impl Command for ListEvalRuns {
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<Vec<EvalRun>, CommandError> {
+        require_evals_enabled(ctx)?;
         let eval_id = q::parse_eval_id(&self.eval_id)?;
         q::service(ctx)
             .list_runs(&ctx.caller, &eval_id.to_string())
@@ -480,6 +500,7 @@ impl Command for GetEvalRun {
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<EvalRun, CommandError> {
+        require_evals_enabled(ctx)?;
         let eval_id = q::parse_eval_id(&self.eval_id)?;
         let run_id = q::parse_run_id(&self.run_id)?;
         q::service(ctx)
@@ -516,6 +537,7 @@ impl Command for ExportEvalRunArtifacts {
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<EvalArtifactExport, CommandError> {
+        require_evals_enabled(ctx)?;
         let eval_id = q::parse_eval_id(&self.eval_id)?;
         let run_id = q::parse_run_id(&self.run_id)?;
         let run = q::service(ctx)
@@ -562,6 +584,7 @@ impl Command for CancelEvalRun {
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<EvalRun, CommandError> {
+        require_evals_enabled(ctx)?;
         let eval_id = q::parse_eval_id(&self.eval_id)?;
         let run_id = q::parse_run_id(&self.run_id)?;
         q::service(ctx)
@@ -601,6 +624,7 @@ impl Command for UpdateEvalResultScores {
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<EvalCaseResult, CommandError> {
+        require_evals_enabled(ctx)?;
         let eval_id = q::parse_eval_id(&self.eval_id)?;
         let run_id = q::parse_run_id(&self.run_id)?;
         let result_id = q::parse_result_id(&self.result_id)?;
@@ -646,6 +670,7 @@ impl Command for BulkUpdateEvalRunScores {
     }
 
     async fn execute(self, ctx: &Ctx) -> Result<Vec<EvalCaseResult>, CommandError> {
+        require_evals_enabled(ctx)?;
         let eval_id = q::parse_eval_id(&self.eval_id)?;
         let run_id = q::parse_run_id(&self.run_id)?;
         q::service(ctx)

--- a/crates/server/tests/test_harness.rs
+++ b/crates/server/tests/test_harness.rs
@@ -254,6 +254,40 @@ impl TestServer {
         let mut feature_flags = everruns_core::FeatureFlags::from_env(&grade);
         feature_flags.evals = true;
         feature_flags.observers = true;
+        // System side of the experimental gates exercised by integration tests.
+        // Org-effective = system && org-opt-in, so both must be on (see the
+        // org opt-in seeded just below).
+        feature_flags.voice = true;
+        feature_flags.mcp_endpoint = true;
+        feature_flags.agent_versions = true;
+        feature_flags.app_budgets = true;
+
+        // Org-effective flags are `system && org-opt-in`, so opt the default
+        // test org into the experimental flags whose runtime gates now consult
+        // the org-effective flags (evals, voice, mcp_endpoint, agent_versions,
+        // app_budgets). Without this those gates reject requests in tests even
+        // though the system flags are on. Deliberately scoped to these flags —
+        // e.g. `notifications` is left off so tests asserting its default-off
+        // org state still hold.
+        let org_flag_overrides: std::collections::HashMap<String, bool> = [
+            "evals",
+            "voice",
+            "mcp_endpoint",
+            "agent_versions",
+            "app_budgets",
+        ]
+        .into_iter()
+        .map(|name| (name.to_string(), true))
+        .collect();
+        db.replace_org_feature_flags(everruns_core::DEFAULT_ORG_ID, &org_flag_overrides)
+            .await
+            .expect("seed org feature flags for test org");
+
+        // The auth middleware resolves each request's org-effective flags as
+        // `system && org-opt-in`, taking the system side from
+        // `AuthState::system_feature_flags` (defaults to `FeatureFlags::current()`).
+        // Point it at the harness's system flags so the gates above see them on.
+        let auth_state = auth_state.with_system_feature_flags(feature_flags.clone());
 
         // Create module-specific states
         let sessions_state = api::sessions::AppState::with_platform_definition(


### PR DESCRIPTION
### Motivation
- Several runtime enforcement points consulted deployment-level flags (`FeatureFlags::from_env` / `FeatureFlags::current`) instead of the org-effective flags, allowing orgs that opted out to still access gated API surfaces when the deployment enabled them.
- The change restores the intended model where effective flags are `system_enabled && org_enabled` by making runtime guards consult `ResolvedOrg.feature_flags` or `Ctx.feature_flags` when org context is available.

### Description
- Agent versions: route guards now call `require_agent_versions_enabled(&org)` which checks `org.feature_flags.agent_versions` before listing/creating/rolling back/forging/diffing versions instead of using deployment flags.
- Voice: replaced checks of `state.feature_flags.voice` with `org.feature_flags.voice` by changing `ensure_voice_enabled` to accept `&ResolvedOrg` and updating all call sites to `ensure_voice_enabled(&org)`.
- MCP endpoint: handler now returns not-found when `org.feature_flags.mcp_endpoint` is disabled and `mcp_ctx` now seeds the returned `Ctx` with `org.feature_flags` using `.with_feature_flags(org.feature_flags.clone())`.
- Evals: `AppState::ctx` for evals now injects `org.feature_flags` and eval command implementations call a new `require_evals_enabled(ctx)` gate so both HTTP and MCP command paths enforce the org-effective `evals` flag.
- Budgets: `validate_subject_type` and the `ListAppBudgets` command now consult `ctx.feature_flags.app_budgets` instead of `FeatureFlags::current()` so app-scoped budget operations honor org opt-in.

### Testing
- Ran `cargo fmt --check` which succeeded. 
- Ran focused unit tests with `cargo test -p everruns-server validate_subject_type --lib` which succeeded (the `validate_subject_type` tests passed).
- Ran `cargo check -p everruns-server --lib` which succeeded to validate type/compile-time correctness across the patched code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3051057998832baf6f9d7343dff03b)