### PR TITLE
fix(sessions): reserve active turn slots

### DIFF
--- a/crates/server/src/domains/messages/commands.rs
+++ b/crates/server/src/domains/messages/commands.rs
@@ -59,12 +59,6 @@ impl Command for CreateMessage {
             .map_err(classify_anyhow)?
             .ok_or_else(|| CommandError::not_found("Session"))?;
 
-        if session.status == everruns_core::SessionStatus::WaitingForToolResults {
-            let _ = q::session_service(ctx)?
-                .update_status(&ctx.caller, session_id.uuid(), "active".to_string())
-                .await;
-        }
-
         q::message_service(ctx)?
             .create(
                 CreateMessageContext {

--- a/crates/server/src/domains/messages/service.rs
+++ b/crates/server/src/domains/messages/service.rs
@@ -8,10 +8,11 @@
 use crate::api::messages::{ContentPart, CreateMessageRequest, Message, MessageRole};
 use crate::domains::notifications::NotificationService;
 use crate::domains::sessions::limits::OrgCaps;
-use crate::errors::BadRequestError;
+use crate::errors::{BadRequestError, ResourceNotFoundError};
 use crate::execution_metadata;
 use crate::services::{EventService, PrincipalService};
 use crate::storage::StorageBackend;
+use crate::storage::models::ReserveActiveTurnSlotResult;
 use anyhow::Result;
 use chrono::Utc;
 use everruns_core::Event;
@@ -85,140 +86,179 @@ impl MessageService {
             "Creating user message"
         );
 
-        // EVE-508: check per-org active turn cap before persisting the message.
-        let active_turns = self.db.count_active_turns_for_org(ctx.org_id).await?;
-        if active_turns >= self.caps.max_active_turns as i64 {
-            return Err(BadRequestError::new(format!(
-                "Too many active turns: org has {} turns executing (limit {}); retry later",
-                active_turns, self.caps.max_active_turns
-            ))
-            .into());
-        }
-
-        // Convert InputContentPart array to ContentPart array
-        let content: Vec<ContentPart> = req
-            .message
-            .content
-            .into_iter()
-            .map(ContentPart::from)
-            .collect();
-
-        // Generate a new message ID
-        let message_id = Uuid::now_v7();
-        let now = Utc::now();
-
-        // Build the core message
-        let core_message = everruns_core::Message {
-            id: message_id.into(),
-            role: everruns_core::MessageRole::User,
-            content: content.clone(),
-            phase: None,
-            thinking: None,
-            thinking_signature: None,
-            controls: req.controls.clone(),
-            metadata: req.metadata.clone(),
-            external_actor: req.external_actor.clone(),
-            created_at: now,
-        };
-
-        // Convert to typed IDs for emit/runner
-        let session_id_typed = SessionId::from_uuid(ctx.session_id);
-        let harness_id_typed = HarnessId::from_uuid(ctx.harness_id);
-        let agent_id_typed = ctx.agent_id.map(AgentId::from_uuid);
-        let message_id_typed = MessageId::from_uuid(message_id);
-
-        // Emit as typed event using EventService
-        let event_metadata = if let Some(metadata) = ctx.event_metadata {
-            Some(metadata)
-        } else if let Some(user_id) = ctx.user_id {
-            let principal_id = match PrincipalService::new(self.db.clone())
-                .ensure_user_principal(ctx.org_id, user_id)
-                .await
-            {
-                Ok(principal) => Some(principal.id),
-                Err(err) => {
-                    tracing::warn!(
-                        org_id = ctx.org_id,
-                        user_id = %user_id,
-                        session_id = %ctx.session_id,
-                        error = %err,
-                        "Failed to resolve user principal for message metadata"
-                    );
-                    None
-                }
-            };
-            execution_metadata::interactive_user_metadata(Some(user_id), principal_id)
-        } else {
-            None
-        };
-        let mut event_request = EventRequest::new(
-            session_id_typed,
-            EventContext::empty(),
-            InputMessageData::new(core_message),
-        );
-        if let Some(metadata) = event_metadata {
-            event_request = event_request.with_metadata(metadata);
-        }
-        let stored_event = self.event_service.emit(event_request).await?;
-
-        // Construct API Message
-        let message = Message {
-            id: message_id_typed,
-            session_id: session_id_typed,
-            sequence: stored_event.sequence.unwrap_or(0),
-            role: MessageRole::User,
-            content,
-            controls: req.controls,
-            metadata: req.metadata,
-            external_actor: req.external_actor,
-            created_at: now,
-        };
-
-        if self.notifications_enabled
-            && let Some(user_id) = ctx.user_id
+        let previous_status = match self
+            .db
+            .reserve_active_turn_slot_for_org(
+                ctx.org_id,
+                SessionId::from_uuid(ctx.session_id),
+                self.caps.max_active_turns as i64,
+            )
+            .await?
         {
-            self.notification_service
-                .create_turn_request(ctx.org_id, user_id, session_id_typed, message_id_typed)
-                .await?;
-        }
+            ReserveActiveTurnSlotResult::Reserved { previous_status } => previous_status,
+            ReserveActiveTurnSlotResult::AtCapacity { active_turns } => {
+                return Err(BadRequestError::new(format!(
+                    "Too many active turns: org has {} turns executing (limit {}); retry later",
+                    active_turns, self.caps.max_active_turns
+                ))
+                .into());
+            }
+            ReserveActiveTurnSlotResult::SessionNotFound => {
+                return Err(ResourceNotFoundError::new("Session").into());
+            }
+        };
 
-        // Start workflow for user message in background (don't block the response)
-        // The message is already persisted, so we can return immediately
-        let runner = self.runner.clone();
-        let request_id = ctx.request_id.clone();
-        let request_id_str = request_id.as_deref().unwrap_or("").to_string();
-        let session_id_str = ctx.session_id.to_string();
-        let message_id_str = message_id.to_string();
-        tokio::spawn(async move {
-            if let Err(e) = runner
-                .start_run(
-                    ctx.org_id,
-                    session_id_typed,
-                    harness_id_typed,
-                    agent_id_typed,
-                    message_id_typed,
-                    request_id,
+        // The slot is now reserved (session marked `active`). Run the remaining
+        // work under a guard that releases the reservation if anything fails, so
+        // a rejected turn never leaks active-turn capacity.
+        let reservation_org_id = ctx.org_id;
+        let reservation_session_id = SessionId::from_uuid(ctx.session_id);
+        let result: Result<Message> = async {
+            // Convert InputContentPart array to ContentPart array
+            let content: Vec<ContentPart> = req
+                .message
+                .content
+                .into_iter()
+                .map(ContentPart::from)
+                .collect();
+
+            // Generate a new message ID
+            let message_id = Uuid::now_v7();
+            let now = Utc::now();
+
+            // Build the core message
+            let core_message = everruns_core::Message {
+                id: message_id.into(),
+                role: everruns_core::MessageRole::User,
+                content: content.clone(),
+                phase: None,
+                thinking: None,
+                thinking_signature: None,
+                controls: req.controls.clone(),
+                metadata: req.metadata.clone(),
+                external_actor: req.external_actor.clone(),
+                created_at: now,
+            };
+
+            // Convert to typed IDs for emit/runner
+            let session_id_typed = SessionId::from_uuid(ctx.session_id);
+            let harness_id_typed = HarnessId::from_uuid(ctx.harness_id);
+            let agent_id_typed = ctx.agent_id.map(AgentId::from_uuid);
+            let message_id_typed = MessageId::from_uuid(message_id);
+
+            // Emit as typed event using EventService
+            let event_metadata = if let Some(metadata) = ctx.event_metadata {
+                Some(metadata)
+            } else if let Some(user_id) = ctx.user_id {
+                let principal_id = match PrincipalService::new(self.db.clone())
+                    .ensure_user_principal(ctx.org_id, user_id)
+                    .await
+                {
+                    Ok(principal) => Some(principal.id),
+                    Err(err) => {
+                        tracing::warn!(
+                            org_id = ctx.org_id,
+                            user_id = %user_id,
+                            session_id = %ctx.session_id,
+                            error = %err,
+                            "Failed to resolve user principal for message metadata"
+                        );
+                        None
+                    }
+                };
+                execution_metadata::interactive_user_metadata(Some(user_id), principal_id)
+            } else {
+                None
+            };
+            let mut event_request = EventRequest::new(
+                session_id_typed,
+                EventContext::empty(),
+                InputMessageData::new(core_message),
+            );
+            if let Some(metadata) = event_metadata {
+                event_request = event_request.with_metadata(metadata);
+            }
+            let stored_event = self.event_service.emit(event_request).await?;
+
+            // Construct API Message
+            let message = Message {
+                id: message_id_typed,
+                session_id: session_id_typed,
+                sequence: stored_event.sequence.unwrap_or(0),
+                role: MessageRole::User,
+                content,
+                controls: req.controls,
+                metadata: req.metadata,
+                external_actor: req.external_actor,
+                created_at: now,
+            };
+
+            if self.notifications_enabled
+                && let Some(user_id) = ctx.user_id
+            {
+                self.notification_service
+                    .create_turn_request(ctx.org_id, user_id, session_id_typed, message_id_typed)
+                    .await?;
+            }
+
+            // Start workflow for user message in background (don't block the response)
+            // The message is already persisted, so we can return immediately
+            let runner = self.runner.clone();
+            let request_id = ctx.request_id.clone();
+            let request_id_str = request_id.as_deref().unwrap_or("").to_string();
+            let session_id_str = ctx.session_id.to_string();
+            let message_id_str = message_id.to_string();
+            tokio::spawn(async move {
+                if let Err(e) = runner
+                    .start_run(
+                        ctx.org_id,
+                        session_id_typed,
+                        harness_id_typed,
+                        agent_id_typed,
+                        message_id_typed,
+                        request_id,
+                    )
+                    .await
+                {
+                    tracing::error!(
+                        session_id = %session_id_str,
+                        input_message_id = %message_id_str,
+                        request_id = %request_id_str,
+                        error = %e,
+                        "Failed to start turn workflow"
+                    );
+                } else {
+                    tracing::info!(
+                        session_id = %session_id_str,
+                        input_message_id = %message_id_str,
+                        request_id = %request_id_str,
+                        "Turn workflow started"
+                    );
+                }
+            });
+
+            Ok(message)
+        }
+        .await;
+
+        if result.is_err()
+            && let Err(release_err) = self
+                .db
+                .release_active_turn_slot_for_org(
+                    reservation_org_id,
+                    reservation_session_id,
+                    &previous_status,
                 )
                 .await
-            {
-                tracing::error!(
-                    session_id = %session_id_str,
-                    input_message_id = %message_id_str,
-                    request_id = %request_id_str,
-                    error = %e,
-                    "Failed to start turn workflow"
-                );
-            } else {
-                tracing::info!(
-                    session_id = %session_id_str,
-                    input_message_id = %message_id_str,
-                    request_id = %request_id_str,
-                    "Turn workflow started"
-                );
-            }
-        });
-
-        Ok(message)
+        {
+            tracing::warn!(
+                org_id = reservation_org_id,
+                session_id = %reservation_session_id,
+                error = %release_err,
+                "Failed to release active-turn slot after message-create failure"
+            );
+        }
+        result
     }
 
     /// Access the registered durable runner. Used by sibling callers that
@@ -422,6 +462,39 @@ mod tests {
         }
     }
 
+    async fn create_test_session(
+        db: &StorageBackend,
+        org_id: i64,
+    ) -> crate::storage::models::SessionRow {
+        db.create_session(crate::storage::models::CreateSessionRow {
+            workspace_id: None,
+            org_id,
+            harness_id: None,
+            app_id: None,
+            agent_id: None,
+            agent_identity_id: None,
+            owner_principal_id: everruns_core::PrincipalId::from_seed(org_id as u128),
+            resolved_owner_user_id: None,
+            title: None,
+            locale: None,
+            tags: vec![],
+            model_id: None,
+            capabilities: serde_json::json!([]),
+            tools: serde_json::json!([]),
+            mcp_servers: serde_json::json!({}),
+            system_prompt: None,
+            initial_files: serde_json::json!([]),
+            hints: None,
+            network_access: None,
+            max_iterations: None,
+            blueprint_id: None,
+            blueprint_config: None,
+            parent_session_id: None,
+        })
+        .await
+        .unwrap()
+    }
+
     #[tokio::test]
     async fn active_turn_cap_enforced() {
         let db = Arc::new(StorageBackend::in_memory());
@@ -435,34 +508,7 @@ mod tests {
 
         // Seed an 'active' session so count_active_turns_for_org returns 1.
         // max_active_turns = 1 so 1 active turn exactly hits the cap.
-        let session = db
-            .create_session(crate::storage::models::CreateSessionRow {
-                workspace_id: None,
-                org_id: 1,
-                harness_id: None,
-                app_id: None,
-                agent_id: None,
-                agent_identity_id: None,
-                owner_principal_id: everruns_core::PrincipalId::from_seed(1),
-                resolved_owner_user_id: None,
-                title: None,
-                locale: None,
-                tags: vec![],
-                model_id: None,
-                capabilities: serde_json::json!([]),
-                tools: serde_json::json!([]),
-                mcp_servers: serde_json::json!({}),
-                system_prompt: None,
-                initial_files: serde_json::json!([]),
-                hints: None,
-                network_access: None,
-                max_iterations: None,
-                blueprint_id: None,
-                blueprint_config: None,
-                parent_session_id: None,
-            })
-            .await
-            .unwrap();
+        let session = create_test_session(&db, 1).await;
         db.update_session(
             1,
             session.id,
@@ -495,6 +541,71 @@ mod tests {
         assert!(
             err.to_string().contains("Too many active turns"),
             "got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn active_turn_cap_reserves_started_session_before_persisting() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let runner: Arc<dyn AgentRunner> = Arc::new(NoopRunner);
+        let delivery = crate::event_delivery::EventDelivery::in_memory();
+
+        let svc = MessageService::new(db.clone(), runner, false, delivery).with_caps(OrgCaps {
+            max_concurrent_sessions: 10_000,
+            max_active_turns: 1,
+        });
+
+        let first = create_test_session(&db, 1).await;
+        let second = create_test_session(&db, 1).await;
+
+        let first_message = svc
+            .create(
+                CreateMessageContext {
+                    org_id: 1,
+                    user_id: None,
+                    harness_id: first.id.uuid(),
+                    agent_id: None,
+                    session_id: first.id.uuid(),
+                    event_metadata: None,
+                    request_id: None,
+                },
+                CreateMessageRequest::user("first"),
+            )
+            .await
+            .unwrap();
+        assert_eq!(first_message.session_id, first.id);
+        assert_eq!(db.count_active_turns_for_org(1).await.unwrap(), 1);
+
+        let err = svc
+            .create(
+                CreateMessageContext {
+                    org_id: 1,
+                    user_id: None,
+                    harness_id: second.id.uuid(),
+                    agent_id: None,
+                    session_id: second.id.uuid(),
+                    event_metadata: None,
+                    request_id: None,
+                },
+                CreateMessageRequest::user("second"),
+            )
+            .await
+            .unwrap_err();
+        assert!(
+            err.downcast_ref::<BadRequestError>().is_some(),
+            "expected BadRequestError, got: {err}"
+        );
+        assert!(
+            err.to_string().contains("Too many active turns"),
+            "got: {err}"
+        );
+        assert_eq!(db.count_active_turns_for_org(1).await.unwrap(), 1);
+        assert!(
+            db.list_message_events_limited(second.id, None)
+                .await
+                .unwrap()
+                .is_empty(),
+            "rejected turn must not persist a queued message"
         );
     }
 }

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -672,6 +672,39 @@ impl StorageBackend {
         dispatch!(self, count_active_turns_for_org, org_id)
     }
 
+    pub async fn reserve_active_turn_slot_for_org(
+        &self,
+        org_id: i64,
+        session_id: SessionId,
+        max_active_turns: i64,
+    ) -> Result<ReserveActiveTurnSlotResult> {
+        dispatch!(
+            self,
+            reserve_active_turn_slot_for_org,
+            org_id,
+            session_id,
+            max_active_turns
+        )
+    }
+
+    /// Release a previously reserved active-turn slot, restoring the session's
+    /// status captured at reservation time (best-effort; only reverts a session
+    /// still `active`).
+    pub async fn release_active_turn_slot_for_org(
+        &self,
+        org_id: i64,
+        session_id: SessionId,
+        previous_status: &str,
+    ) -> Result<()> {
+        dispatch!(
+            self,
+            release_active_turn_slot_for_org,
+            org_id,
+            session_id,
+            previous_status
+        )
+    }
+
     /// Aggregate session and execution stats for an optional agent or harness scope.
     pub async fn session_aggregate_stats(
         &self,

--- a/crates/server/src/storage/memory/sessions.rs
+++ b/crates/server/src/storage/memory/sessions.rs
@@ -222,6 +222,60 @@ impl InMemoryDatabase {
         Ok(count as i64)
     }
 
+    /// Atomically reserve active-turn capacity by marking the accepted
+    /// session active before the user message is persisted.
+    pub async fn reserve_active_turn_slot_for_org(
+        &self,
+        org_id: i64,
+        session_id: SessionId,
+        max_active_turns: i64,
+    ) -> Result<ReserveActiveTurnSlotResult> {
+        let mut sessions = self.sessions.write();
+
+        // Existence/ownership before capacity (mirror Postgres): capture the
+        // prior status for release, and report a missing/foreign session as
+        // SessionNotFound rather than AtCapacity.
+        let previous_status = match sessions.get(&session_id) {
+            Some(session) if session.org_id == org_id => session.status.clone(),
+            _ => return Ok(ReserveActiveTurnSlotResult::SessionNotFound),
+        };
+
+        let active_turns = sessions
+            .values()
+            .filter(|s| s.org_id == org_id && s.status == "active")
+            .count() as i64;
+
+        if active_turns >= max_active_turns {
+            return Ok(ReserveActiveTurnSlotResult::AtCapacity { active_turns });
+        }
+
+        let session = sessions
+            .get_mut(&session_id)
+            .expect("session presence checked above");
+        session.status = "active".to_string();
+        session.updated_at = Self::now();
+        Ok(ReserveActiveTurnSlotResult::Reserved { previous_status })
+    }
+
+    /// Release a previously reserved active-turn slot by restoring the prior
+    /// status. Best-effort: only reverts a session still in `active`.
+    pub async fn release_active_turn_slot_for_org(
+        &self,
+        org_id: i64,
+        session_id: SessionId,
+        previous_status: &str,
+    ) -> Result<()> {
+        let mut sessions = self.sessions.write();
+        if let Some(session) = sessions.get_mut(&session_id)
+            && session.org_id == org_id
+            && session.status == "active"
+        {
+            session.status = previous_status.to_string();
+            session.updated_at = Self::now();
+        }
+        Ok(())
+    }
+
     /// Aggregate session and turn execution stats for an optional agent or harness scope.
     pub async fn session_aggregate_stats(
         &self,

--- a/crates/server/src/storage/models.rs
+++ b/crates/server/src/storage/models.rs
@@ -758,6 +758,20 @@ pub struct UpdateSession {
     pub finished_at: Option<DateTime<Utc>>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReserveActiveTurnSlotResult {
+    /// Slot reserved (session marked `active`). Carries the status the session
+    /// held beforehand so a caller can release the reservation on a later
+    /// failure by restoring it.
+    Reserved {
+        previous_status: String,
+    },
+    AtCapacity {
+        active_turns: i64,
+    },
+    SessionNotFound,
+}
+
 // ============================================
 // Event models (source of truth for messages)
 // ============================================

--- a/crates/server/src/storage/repositories/sessions.rs
+++ b/crates/server/src/storage/repositories/sessions.rs
@@ -306,6 +306,84 @@ impl Database {
         Ok(row.0)
     }
 
+    /// Atomically reserve active-turn capacity by marking the accepted
+    /// session active before the user message is persisted.
+    pub async fn reserve_active_turn_slot_for_org(
+        &self,
+        org_id: i64,
+        session_id: SessionId,
+        max_active_turns: i64,
+    ) -> Result<ReserveActiveTurnSlotResult> {
+        let mut tx = self.pool.begin().await?;
+
+        // Serialize per-org reservations so the soft cap covers accepted queued
+        // turns, not only turns workers have already begun executing.
+        sqlx::query("SELECT pg_advisory_xact_lock($1)")
+            .bind(org_id)
+            .execute(&mut *tx)
+            .await?;
+
+        // Verify the session exists and belongs to the org *before* the capacity
+        // check, so a missing/foreign session returns SessionNotFound rather
+        // than a misleading AtCapacity, and capture its prior status so the
+        // reservation can be released on a later failure.
+        let existing: Option<(String,)> =
+            sqlx::query_as("SELECT status FROM sessions WHERE org_id = $1 AND id = $2")
+                .bind(org_id)
+                .bind(session_id)
+                .fetch_optional(&mut *tx)
+                .await?;
+        let Some((previous_status,)) = existing else {
+            tx.commit().await?;
+            return Ok(ReserveActiveTurnSlotResult::SessionNotFound);
+        };
+
+        let active_turns: (i64,) = sqlx::query_as(
+            "SELECT COUNT(*)::bigint FROM sessions WHERE org_id = $1 AND status = 'active'",
+        )
+        .bind(org_id)
+        .fetch_one(&mut *tx)
+        .await?;
+
+        if active_turns.0 >= max_active_turns {
+            tx.commit().await?;
+            return Ok(ReserveActiveTurnSlotResult::AtCapacity {
+                active_turns: active_turns.0,
+            });
+        }
+
+        sqlx::query("UPDATE sessions SET status = 'active' WHERE org_id = $1 AND id = $2")
+            .bind(org_id)
+            .bind(session_id)
+            .execute(&mut *tx)
+            .await?;
+
+        tx.commit().await?;
+
+        Ok(ReserveActiveTurnSlotResult::Reserved { previous_status })
+    }
+
+    /// Release a previously reserved active-turn slot by restoring the session's
+    /// prior status. Best-effort and idempotent: only reverts a session that is
+    /// still `active`, so it never clobbers a status a worker legitimately
+    /// advanced to after the reservation.
+    pub async fn release_active_turn_slot_for_org(
+        &self,
+        org_id: i64,
+        session_id: SessionId,
+        previous_status: &str,
+    ) -> Result<()> {
+        sqlx::query(
+            "UPDATE sessions SET status = $3 WHERE org_id = $1 AND id = $2 AND status = 'active'",
+        )
+        .bind(org_id)
+        .bind(session_id)
+        .bind(previous_status)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
     /// Aggregate session and turn execution stats for an optional agent or harness scope.
     pub async fn session_aggregate_stats(
         &self,


### PR DESCRIPTION
### Motivation

- The per-org active-turn cap checked only sessions already marked `active`, so accepted but not-yet-started turns (queued before workers mark the session active) could exceed `ORG_MAX_ACTIVE_TURNS` and bypass the intended DoS backstop.
- Waiting-for-tool-results sessions were sometimes set `active` before the cap check, which could leave stale `active` sessions when a later rejection occurred.

### Description

- Add a storage-level reservation API `reserve_active_turn_slot_for_org` and result type `ReserveActiveTurnSlotResult` in `crates/server/src/storage/models.rs` and expose it on the `StorageBackend` dispatch surface via `reserve_active_turn_slot_for_org`.
- Implement atomic reservation in Postgres (`crates/server/src/storage/repositories/sessions.rs`) using a transaction-scoped per-org advisory lock, a `COUNT(*)` for `status = 'active'`, and an `UPDATE ... SET status = 'active'` inside the same TX; return capacity or session-not-found results accordingly.
- Mirror reservation semantics in the in-memory backend (`crates/server/src/storage/memory/sessions.rs`) under its write lock so tests and dev mode behave the same.
- Change message acceptance path to call the reservation API before persisting the message/workflow spawn (`crates/server/src/domains/messages/service.rs`), and handle `AtCapacity` / `SessionNotFound` results with appropriate `BadRequestError` responses.
- Remove command-layer pre-activation for `waiting_for_tool_results` sessions to avoid leaving sessions `active` after a cap rejection (`crates/server/src/domains/messages/commands.rs`).
- Add a regression test `active_turn_cap_reserves_started_session_before_persisting` that proves a started session consumes the active-turn slot before message persistence and a second queued turn is rejected and not persisted (`crates/server/src/domains/messages/service.rs` tests).

### Testing

- Ran `cargo fmt --check` and formatting checks passed after fixes.
- Ran focused unit tests `cargo test -p everruns-server --lib active_turn_cap -- --nocapture` and the two tests in the module passed: `active_turn_cap_enforced` and `active_turn_cap_reserves_started_session_before_persisting` (2 passed, 0 failed).
- An initial test run failed on a test-helper type mismatch which was corrected immediately and the subsequent test run succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30510614b0832ba1b9437a193ade58)