### PR TITLE
chore: publish everruns-openrouter to crates.io

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -148,6 +148,9 @@ jobs:
               "crates/anthropic/Cargo.toml": [
                   "everruns-core",
               ],
+              "crates/openrouter/Cargo.toml": [
+                  "everruns-core",
+              ],
               "crates/bedrock/Cargo.toml": [
                   "everruns-core",
               ],
@@ -224,6 +227,7 @@ jobs:
             everruns-mcp
             everruns-openai
             everruns-anthropic
+            everruns-openrouter
             everruns-bedrock
             everruns-gemini
             everruns-integrations-duckduckgo


### PR DESCRIPTION
## What
Add `everruns-openrouter` to the `Publish Crates` workflow: both the version-verification map and the ordered `CRATES` publish list.

## Why
`everruns-openrouter` is a published-shaped crate (`version.workspace`, README, docs.rs link, no `publish = false`) and already exists at the `v0.13.0` tag, but it is missing from crates.io. The reason is that `publish-crates.yml` carries a hardcoded crate list that never included it, so every release skipped it.

This also unblocks publishing the **current** `0.13.0` openrouter without cutting a new runtime release — see Follow-ups.

## How
- Added `crates/openrouter/Cargo.toml -> ["everruns-core"]` to the `dependency_versions` verification map.
- Added `everruns-openrouter` to the `CRATES` array, after `everruns-core` (which it depends on) and alongside the other provider crates.

Validated locally:
- `cargo package --locked -p everruns-openrouter` succeeds (full verify build against published `everruns-core` 0.13.0).
- The workflow's version-verification logic passes for `0.13.0` with the new entry.

## Risk
- Low. CI-only workflow change. The publish step already skips already-published crates and only uploads missing ones, so re-running for an existing tag publishes only the missing `everruns-openrouter`.

## Security
- Threat categories reviewed: No security-relevant code changes. The publish step keeps the existing upload-only, `--no-verify` token handling unchanged; verification still runs without registry credentials.
- Findings and resolutions: None.

## Follow-ups
- To publish `everruns-openrouter 0.13.0` without a new release: after this merges, run **Actions → Publish Crates → Run workflow** with `tag = v0.13.0` and `sha = a4242b4e7f9c3a052b3de2bb6126c7e4c1187e0e`. The workflow checks out the trusted v0.13.0 commit (which contains the crate at 0.13.0), skips the already-published 0.13.0 crates, and publishes only `everruns-openrouter`. Future releases pick it up automatically.

## Checklist
- [x] Tests added or updated (N/A — CI workflow change; validated via local `cargo package` and the verification snippet)
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_018TpWmdxkBAzENehARUmMm4)_