### PR TITLE
feat(openrouter): add attribution headers

### DIFF
--- a/crates/core/src/llm_driver_registry.rs
+++ b/crates/core/src/llm_driver_registry.rs
@@ -987,6 +987,11 @@ impl OpenRouterPluginConfig {
     }
 }
 
+/// Metadata key consumed by the OpenRouter driver as `HTTP-Referer`.
+pub const OPENROUTER_HTTP_REFERER_METADATA_KEY: &str = "openrouter.http_referer";
+/// Metadata key consumed by the OpenRouter driver as `X-Title`.
+pub const OPENROUTER_X_TITLE_METADATA_KEY: &str = "openrouter.x_title";
+
 /// Configuration for an LLM call
 #[derive(Debug, Clone)]
 pub struct LlmCallConfig {

--- a/crates/core/src/openresponses_protocol.rs
+++ b/crates/core/src/openresponses_protocol.rs
@@ -22,7 +22,7 @@
 use async_trait::async_trait;
 use eventsource_stream::Eventsource;
 use futures::StreamExt;
-use reqwest::Client;
+use reqwest::{Client, header::HeaderMap};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
@@ -77,16 +77,20 @@ const PROMPT_CACHE_KEY_PREFIX: &str = "everruns:";
 /// let driver = OpenResponsesProtocolChatDriver::new("your-api-key")
 ///     .with_retry_config(LlmRetryConfig::aggressive());
 /// ```
-/// Hook for provider-specific augmentation of an Open Responses request body.
+/// Hook for provider-specific augmentation of an Open Responses request.
 ///
 /// The Open Responses request shape this driver builds is vendor-neutral.
 /// Providers reached through it (e.g. OpenRouter) layer extra top-level fields
-/// onto the outgoing JSON via this seam, so the core driver stays free of
-/// provider branching. `decorate` runs once per request, after the base body is
-/// serialized and before it is sent; it may mutate `body` in place and may
-/// return an error to abort the request (e.g. failed routing validation).
+/// onto the outgoing JSON or HTTP headers via this seam, so the core driver
+/// stays free of provider branching. `decorate` and `decorate_headers` run once
+/// per request, after the base body is serialized and before it is sent; either
+/// may return an error to abort the request (e.g. failed routing validation).
 pub trait OpenResponsesRequestExtension: Send + Sync {
     fn decorate(&self, body: &mut Value, config: &LlmCallConfig) -> Result<()>;
+
+    fn decorate_headers(&self, _headers: &mut HeaderMap, _config: &LlmCallConfig) -> Result<()> {
+        Ok(())
+    }
 }
 
 #[derive(Clone)]
@@ -854,11 +858,15 @@ impl ChatDriver for OpenResponsesProtocolChatDriver {
         }
 
         // Serialize the vendor-neutral request, then let any provider-specific
-        // extension (e.g. OpenRouter) layer extra top-level fields onto the body.
+        // extension (e.g. OpenRouter) layer extra fields and headers onto it.
         let mut request_body = serde_json::to_value(&request)
             .map_err(|e| AgentLoopError::llm(format!("Failed to serialize request: {}", e)))?;
         if let Some(extension) = &self.request_extension {
             extension.decorate(&mut request_body, config)?;
+        }
+        let mut extension_headers = HeaderMap::new();
+        if let Some(extension) = &self.request_extension {
+            extension.decorate_headers(&mut extension_headers, config)?;
         }
 
         // Retry loop for rate limit (429) and transient errors
@@ -866,16 +874,21 @@ impl ChatDriver for OpenResponsesProtocolChatDriver {
         let mut last_error: Option<String> = None;
 
         let response = loop {
-            let response = apply_openai_api_auth(
+            let mut request_builder = apply_openai_api_auth(
                 self.client.post(&self.api_url),
                 &self.api_url,
                 &self.api_key,
             )
-            .header("Content-Type", "application/json")
-            .json(&request_body)
-            .send()
-            .await
-            .map_err(|e| AgentLoopError::llm(format!("Failed to send request: {}", e)))?;
+            .header("Content-Type", "application/json");
+            if !extension_headers.is_empty() {
+                request_builder = request_builder.headers(extension_headers.clone());
+            }
+
+            let response = request_builder
+                .json(&request_body)
+                .send()
+                .await
+                .map_err(|e| AgentLoopError::llm(format!("Failed to send request: {}", e)))?;
 
             let status = response.status();
 

--- a/crates/openrouter/src/request_ext.rs
+++ b/crates/openrouter/src/request_ext.rs
@@ -8,6 +8,7 @@
 //   - `plugins` — web-search / file-reader activations
 //   - `session_id` — OpenRouter session grouping (the Everruns session id)
 //   - `reasoning.exclude` — keep provider reasoning private by default
+//   - `HTTP-Referer` / `X-Title` — app attribution headers
 
 use std::borrow::Cow;
 
@@ -16,7 +17,13 @@ use everruns_core::error::{AgentLoopError, Result};
 use everruns_core::llm_driver_registry::{
     LlmCallConfig, OpenRouterCapacityStrategy, OpenRouterPluginConfig, OpenRouterRoutingConfig,
 };
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use serde_json::{Value, json};
+
+const ATTRIBUTION_REFERER_METADATA_KEY: &str = "openrouter.http_referer";
+const ATTRIBUTION_TITLE_METADATA_KEY: &str = "openrouter.x_title";
+const HTTP_REFERER_HEADER: HeaderName = HeaderName::from_static("http-referer");
+const X_TITLE_HEADER: HeaderName = HeaderName::from_static("x-title");
 
 /// Layers OpenRouter-specific fields onto an Open Responses request body.
 #[derive(Debug, Default, Clone)]
@@ -35,6 +42,7 @@ impl OpenResponsesRequestExtension for OpenRouterRequestExtension {
         if let Some(session_id) = config.metadata.get("session_id") {
             obj.insert("session_id".to_string(), json!(session_id));
         }
+        remove_attribution_metadata(obj);
 
         apply_private_reasoning_policy(obj, config);
 
@@ -70,6 +78,56 @@ impl OpenResponsesRequestExtension for OpenRouterRequestExtension {
 
         Ok(())
     }
+
+    fn decorate_headers(&self, headers: &mut HeaderMap, config: &LlmCallConfig) -> Result<()> {
+        insert_metadata_header(
+            headers,
+            HTTP_REFERER_HEADER,
+            config.metadata.get(ATTRIBUTION_REFERER_METADATA_KEY),
+        )?;
+        insert_metadata_header(
+            headers,
+            X_TITLE_HEADER,
+            config.metadata.get(ATTRIBUTION_TITLE_METADATA_KEY),
+        )?;
+
+        Ok(())
+    }
+}
+
+fn remove_attribution_metadata(obj: &mut serde_json::Map<String, Value>) {
+    let Some(Value::Object(metadata)) = obj.get_mut("metadata") else {
+        return;
+    };
+
+    metadata.remove(ATTRIBUTION_REFERER_METADATA_KEY);
+    metadata.remove(ATTRIBUTION_TITLE_METADATA_KEY);
+    if metadata.is_empty() {
+        obj.remove("metadata");
+    }
+}
+
+fn insert_metadata_header(
+    headers: &mut HeaderMap,
+    name: HeaderName,
+    value: Option<&String>,
+) -> Result<()> {
+    let Some(value) = value
+        .map(String::as_str)
+        .map(str::trim)
+        .filter(|v| !v.is_empty())
+    else {
+        return Ok(());
+    };
+
+    let header_value = HeaderValue::from_str(value).map_err(|e| {
+        AgentLoopError::llm(format!(
+            "Invalid OpenRouter attribution header '{}': {}",
+            name, e
+        ))
+    })?;
+    headers.insert(name, header_value);
+    Ok(())
 }
 
 fn apply_private_reasoning_policy(

--- a/crates/openrouter/src/request_ext.rs
+++ b/crates/openrouter/src/request_ext.rs
@@ -15,13 +15,12 @@ use std::borrow::Cow;
 use everruns_core::OpenResponsesRequestExtension;
 use everruns_core::error::{AgentLoopError, Result};
 use everruns_core::llm_driver_registry::{
-    LlmCallConfig, OpenRouterCapacityStrategy, OpenRouterPluginConfig, OpenRouterRoutingConfig,
+    LlmCallConfig, OPENROUTER_HTTP_REFERER_METADATA_KEY, OPENROUTER_X_TITLE_METADATA_KEY,
+    OpenRouterCapacityStrategy, OpenRouterPluginConfig, OpenRouterRoutingConfig,
 };
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use serde_json::{Value, json};
 
-const ATTRIBUTION_REFERER_METADATA_KEY: &str = "openrouter.http_referer";
-const ATTRIBUTION_TITLE_METADATA_KEY: &str = "openrouter.x_title";
 const HTTP_REFERER_HEADER: HeaderName = HeaderName::from_static("http-referer");
 const X_TITLE_HEADER: HeaderName = HeaderName::from_static("x-title");
 
@@ -83,12 +82,12 @@ impl OpenResponsesRequestExtension for OpenRouterRequestExtension {
         insert_metadata_header(
             headers,
             HTTP_REFERER_HEADER,
-            config.metadata.get(ATTRIBUTION_REFERER_METADATA_KEY),
+            config.metadata.get(OPENROUTER_HTTP_REFERER_METADATA_KEY),
         )?;
         insert_metadata_header(
             headers,
             X_TITLE_HEADER,
-            config.metadata.get(ATTRIBUTION_TITLE_METADATA_KEY),
+            config.metadata.get(OPENROUTER_X_TITLE_METADATA_KEY),
         )?;
 
         Ok(())
@@ -100,8 +99,8 @@ fn remove_attribution_metadata(obj: &mut serde_json::Map<String, Value>) {
         return;
     };
 
-    metadata.remove(ATTRIBUTION_REFERER_METADATA_KEY);
-    metadata.remove(ATTRIBUTION_TITLE_METADATA_KEY);
+    metadata.remove(OPENROUTER_HTTP_REFERER_METADATA_KEY);
+    metadata.remove(OPENROUTER_X_TITLE_METADATA_KEY);
     if metadata.is_empty() {
         obj.remove("metadata");
     }

--- a/crates/openrouter/tests/request_wire.rs
+++ b/crates/openrouter/tests/request_wire.rs
@@ -128,6 +128,86 @@ async fn sends_routing_controls_and_session_id() {
 }
 
 #[tokio::test]
+async fn sends_openrouter_attribution_headers_from_metadata() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(""))
+        .mount(&server)
+        .await;
+
+    let api_url = format!("{}/v1/responses", server.uri());
+    let driver = OpenRouterChatDriver::with_base_url("test-key", api_url);
+
+    let mut config = base_config("openai/gpt-5-mini");
+    config.metadata.insert(
+        "openrouter.http_referer".to_string(),
+        "https://app.example".to_string(),
+    );
+    config
+        .metadata
+        .insert("openrouter.x_title".to_string(), "Example App".to_string());
+
+    let messages = vec![LlmMessage::text(LlmMessageRole::User, "hello")];
+    let _ = driver.chat_completion_stream(messages, &config).await;
+
+    let requests = server
+        .received_requests()
+        .await
+        .expect("mock server recorded requests");
+    assert_eq!(requests.len(), 1, "exactly one request should be sent");
+    assert_eq!(
+        requests[0]
+            .headers
+            .get("http-referer")
+            .and_then(|v| v.to_str().ok()),
+        Some("https://app.example")
+    );
+    assert_eq!(
+        requests[0]
+            .headers
+            .get("x-title")
+            .and_then(|v| v.to_str().ok()),
+        Some("Example App")
+    );
+    let body: serde_json::Value = requests[0].body_json().expect("request body is JSON");
+    assert!(
+        body.get("metadata").is_none(),
+        "attribution keys are header-only and should not be mirrored in body metadata"
+    );
+}
+
+#[tokio::test]
+async fn skips_blank_openrouter_attribution_metadata() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(""))
+        .mount(&server)
+        .await;
+
+    let api_url = format!("{}/v1/responses", server.uri());
+    let driver = OpenRouterChatDriver::with_base_url("test-key", api_url);
+
+    let mut config = base_config("openai/gpt-5-mini");
+    config
+        .metadata
+        .insert("openrouter.http_referer".to_string(), "  ".to_string());
+    config
+        .metadata
+        .insert("openrouter.x_title".to_string(), "\t".to_string());
+
+    let messages = vec![LlmMessage::text(LlmMessageRole::User, "hello")];
+    let _ = driver.chat_completion_stream(messages, &config).await;
+
+    let requests = server
+        .received_requests()
+        .await
+        .expect("mock server recorded requests");
+    assert_eq!(requests.len(), 1, "exactly one request should be sent");
+    assert!(requests[0].headers.get("http-referer").is_none());
+    assert!(requests[0].headers.get("x-title").is_none());
+}
+
+#[tokio::test]
 async fn excludes_reasoning_by_default() {
     let config = base_config("nvidia/nemotron-3-super-120b-a12b:free");
 

--- a/crates/openrouter/tests/request_wire.rs
+++ b/crates/openrouter/tests/request_wire.rs
@@ -146,6 +146,9 @@ async fn sends_openrouter_attribution_headers_from_metadata() {
     config
         .metadata
         .insert("openrouter.x_title".to_string(), "Example App".to_string());
+    config
+        .metadata
+        .insert("custom_key".to_string(), "custom_value".to_string());
 
     let messages = vec![LlmMessage::text(LlmMessageRole::User, "hello")];
     let _ = driver.chat_completion_stream(messages, &config).await;
@@ -170,9 +173,14 @@ async fn sends_openrouter_attribution_headers_from_metadata() {
         Some("Example App")
     );
     let body: serde_json::Value = requests[0].body_json().expect("request body is JSON");
+    let metadata = body["metadata"]
+        .as_object()
+        .expect("metadata object remains");
+    assert_eq!(metadata.get("custom_key"), Some(&json!("custom_value")));
     assert!(
-        body.get("metadata").is_none(),
-        "attribution keys are header-only and should not be mirrored in body metadata"
+        !metadata.contains_key("openrouter.http_referer")
+            && !metadata.contains_key("openrouter.x_title"),
+        "attribution keys are header-only and should not be mirrored in body metadata: {metadata:?}"
     );
 }
 

--- a/crates/runtime/src/builders.rs
+++ b/crates/runtime/src/builders.rs
@@ -5,6 +5,9 @@
 use std::collections::HashMap;
 
 use chrono::{DateTime, Utc};
+pub use everruns_core::llm_driver_registry::{
+    OPENROUTER_HTTP_REFERER_METADATA_KEY, OPENROUTER_X_TITLE_METADATA_KEY,
+};
 use everruns_core::network_access::NetworkAccessList;
 use everruns_core::{
     Agent, AgentCapabilityConfig, AgentId, AgentStatus, DEFAULT_ORG_PUBLIC_ID, Harness, HarnessId,
@@ -12,11 +15,6 @@ use everruns_core::{
     ToolDefinition, plugin_capability_id,
 };
 use uuid::Uuid;
-
-/// Harness metadata key consumed by the OpenRouter driver as `HTTP-Referer`.
-pub const OPENROUTER_HTTP_REFERER_METADATA_KEY: &str = "openrouter.http_referer";
-/// Harness metadata key consumed by the OpenRouter driver as `X-Title`.
-pub const OPENROUTER_X_TITLE_METADATA_KEY: &str = "openrouter.x_title";
 
 /// Builds a [`Harness`] with runtime-friendly defaults.
 ///

--- a/crates/runtime/src/builders.rs
+++ b/crates/runtime/src/builders.rs
@@ -13,6 +13,11 @@ use everruns_core::{
 };
 use uuid::Uuid;
 
+/// Harness metadata key consumed by the OpenRouter driver as `HTTP-Referer`.
+pub const OPENROUTER_HTTP_REFERER_METADATA_KEY: &str = "openrouter.http_referer";
+/// Harness metadata key consumed by the OpenRouter driver as `X-Title`.
+pub const OPENROUTER_X_TITLE_METADATA_KEY: &str = "openrouter.x_title";
+
 /// Builds a [`Harness`] with runtime-friendly defaults.
 ///
 /// Use this when embedding Everruns directly and seeding a harness in code.
@@ -165,6 +170,24 @@ impl HarnessBuilder {
     {
         self.embedder_metadata
             .extend(entries.into_iter().map(|(k, v)| (k.into(), v.into())));
+        self
+    }
+
+    /// Set OpenRouter attribution headers for LLM calls made by this harness.
+    ///
+    /// The values flow through harness embedder metadata and are sent by the
+    /// OpenRouter driver as `HTTP-Referer` and `X-Title`.
+    pub fn openrouter_attribution(
+        mut self,
+        http_referer: impl Into<String>,
+        title: impl Into<String>,
+    ) -> Self {
+        self.embedder_metadata.insert(
+            OPENROUTER_HTTP_REFERER_METADATA_KEY.to_string(),
+            http_referer.into(),
+        );
+        self.embedder_metadata
+            .insert(OPENROUTER_X_TITLE_METADATA_KEY.to_string(), title.into());
         self
     }
 
@@ -748,6 +771,15 @@ impl SingleSessionBuilder {
         self
     }
 
+    pub fn openrouter_attribution(
+        mut self,
+        http_referer: impl Into<String>,
+        title: impl Into<String>,
+    ) -> Self {
+        self.harness = self.harness.openrouter_attribution(http_referer, title);
+        self
+    }
+
     pub fn agent_description(mut self, description: impl Into<String>) -> Self {
         self.agent = self.agent.description(description);
         self
@@ -863,5 +895,54 @@ impl SingleSessionBuilder {
             self.session.build(),
             session_id,
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn harness_builder_openrouter_attribution_adds_metadata_keys() {
+        let harness = HarnessBuilder::new("app", "prompt")
+            .openrouter_attribution("https://app.example", "Example App")
+            .build();
+
+        assert_eq!(
+            harness
+                .embedder_metadata
+                .get(OPENROUTER_HTTP_REFERER_METADATA_KEY)
+                .map(String::as_str),
+            Some("https://app.example")
+        );
+        assert_eq!(
+            harness
+                .embedder_metadata
+                .get(OPENROUTER_X_TITLE_METADATA_KEY)
+                .map(String::as_str),
+            Some("Example App")
+        );
+    }
+
+    #[test]
+    fn single_session_builder_openrouter_attribution_configures_harness() {
+        let (harness, _agent, _session, _session_id) = SingleSessionBuilder::default()
+            .openrouter_attribution("https://single.example", "Single App")
+            .build();
+
+        assert_eq!(
+            harness
+                .embedder_metadata
+                .get(OPENROUTER_HTTP_REFERER_METADATA_KEY)
+                .map(String::as_str),
+            Some("https://single.example")
+        );
+        assert_eq!(
+            harness
+                .embedder_metadata
+                .get(OPENROUTER_X_TITLE_METADATA_KEY)
+                .map(String::as_str),
+            Some("Single App")
+        );
     }
 }


### PR DESCRIPTION
## What
Add OpenRouter attribution support for embedded apps by sending `HTTP-Referer` and `X-Title` on OpenRouter chat requests.

## Why
OpenRouter recommends these headers so calling apps appear correctly in their rankings and dashboard.

## How
- Extend the Open Responses request extension seam so provider-specific drivers can add HTTP headers as well as JSON fields.
- Read OpenRouter attribution values from harness embedder metadata keys (`openrouter.http_referer`, `openrouter.x_title`) and send them as headers.
- Strip those OpenRouter-only metadata keys from the JSON request body so attribution is header-only.
- Add runtime builder helpers: `HarnessBuilder::openrouter_attribution(...)` and `SingleSessionBuilder::openrouter_attribution(...)`.
- Add wire tests that capture the outgoing OpenRouter request and assert the exact headers and blank-value behavior.

## Risk
- Low
- What can break: OpenRouter requests could miss attribution headers or reject invalid header values. Header parsing now fails fast on invalid header characters; blank values are skipped.

## Security
- Threat categories reviewed: TM-LLM, TM-OBS, TM-DOS.
- Findings and resolutions:
  - TM-LLM: Attribution values cross the LLM provider boundary intentionally and only for OpenRouter requests. Values are supplied by the embedder and validated as HTTP header values before dispatch.
  - TM-OBS: Attribution values are not logged by the changed code; existing request logs continue to log request shape only.
  - TM-DOS: No new unbounded loops or allocations. Blank values are skipped and invalid header values fail before request dispatch.
  - No new threat-model entry required; this uses the existing LLM provider request boundary and does not add secrets, auth, storage, or tenant access.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

## Validation
- `cargo fmt --check`
- `cargo test -p everruns-openrouter`
- `cargo test -p everruns-openrouter --test request_wire`
- `cargo test -p everruns-runtime openrouter_attribution`
- `cargo test -p everruns-core openrouter_provider_does_not_send_hosted_tool_search`
- `just pre-push`
- `bash scripts/lib/check-migration-ordering.sh`
- Smoke: `cargo test -p everruns-openrouter --test request_wire` exercises the end-to-end OpenRouter driver-to-HTTP request path with a mock server and asserts the emitted attribution headers.

