### PR TITLE
feat(observers): LLM-as-judge scorer for online scoring

### DIFF
--- a/crates/core/src/observer.rs
+++ b/crates/core/src/observer.rs
@@ -137,8 +137,46 @@ impl std::fmt::Display for ObserverScope {
     }
 }
 
-/// One scoring rule inside an observer. `key` names the score series in
-/// listings and future dashboards; `rule` reuses the eval scorer vocabulary.
+/// Default value at/above which an LLM-judge score is considered a pass.
+fn default_pass_threshold() -> f64 {
+    0.5
+}
+
+/// LLM-as-judge scoring configuration. The judge grades the scoped trace
+/// slice against `rubric` and returns a 0.0–1.0 value, an optional
+/// categorical label, and free-text reasoning.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct LlmJudgeConfig {
+    /// Grading rubric shown to the judge model. Should describe what a high
+    /// vs. low score means.
+    pub rubric: String,
+    /// Org model to judge with. When `None`, the org's default model is used.
+    /// Judge calls go through the org's own providers and are billed to it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "openapi", schema(value_type = Option<String>))]
+    pub model_id: Option<crate::typed_id::ModelId>,
+    /// Score value at/above which `pass` is true.
+    #[serde(default = "default_pass_threshold")]
+    pub pass_threshold: f64,
+}
+
+/// How a scorer grades a trace slice: a deterministic `rule` (reusing the
+/// eval scorer vocabulary) or an `llm_judge`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+#[serde(tag = "method", rename_all = "snake_case")]
+pub enum ScorerMethod {
+    /// Deterministic rule. `file_contains` is rejected for observers (session
+    /// filesystems are not part of the observable trace contract).
+    Rule { rule: Scorer },
+    /// LLM-as-judge.
+    LlmJudge(LlmJudgeConfig),
+}
+
+/// One scorer inside an observer. `key` names the score series in listings
+/// and future dashboards; `scope` selects the trace slice; `method` is how
+/// it grades.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct ObserverScorerConfig {
@@ -147,9 +185,9 @@ pub struct ObserverScorerConfig {
     /// Trace slice this scorer grades.
     #[serde(default)]
     pub scope: ObserverScope,
-    /// Scoring rule. `file_contains` is rejected for observers (session
-    /// filesystems are not part of the observable trace contract).
-    pub rule: Scorer,
+    /// How this scorer grades (rule or llm_judge).
+    #[serde(flatten)]
+    pub method: ScorerMethod,
 }
 
 // ============================================
@@ -275,9 +313,23 @@ pub struct TraceScore {
     /// Score value 0.0–1.0 (set when completed).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub value: Option<f64>,
-    /// Human-readable explanation (set when completed).
+    /// Optional categorical label from an LLM judge (e.g. `missing_source`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    /// Human-readable explanation (set when completed). For LLM judges this is
+    /// the judge's reasoning — retained as the raw material for the Phase 2
+    /// improvement loop.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reason: Option<String>,
+    /// Judge LLM input tokens (llm_judge scores only).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub judge_input_tokens: Option<u64>,
+    /// Judge LLM output tokens (llm_judge scores only).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub judge_output_tokens: Option<u64>,
+    /// Judge call cost in USD when the provider reports it (llm_judge only).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub judge_cost_usd: Option<f64>,
     /// Error details if errored.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error_message: Option<String>,
@@ -377,11 +429,33 @@ mod tests {
     fn scorer_config_serde_defaults_scope() {
         let json = serde_json::json!({
             "key": "greeting",
+            "method": "rule",
             "rule": { "type": "contains", "text": "hello" }
         });
         let config: ObserverScorerConfig = serde_json::from_value(json).unwrap();
         assert_eq!(config.scope, ObserverScope::Turn);
         assert_eq!(config.key, "greeting");
+        assert!(matches!(config.method, ScorerMethod::Rule { .. }));
+    }
+
+    #[test]
+    fn scorer_config_llm_judge_serde() {
+        let json = serde_json::json!({
+            "key": "completeness",
+            "scope": "turn",
+            "method": "llm_judge",
+            "rubric": "Score 1 if the answer fully addresses the question."
+        });
+        let config: ObserverScorerConfig = serde_json::from_value(json).unwrap();
+        assert_eq!(config.key, "completeness");
+        match config.method {
+            ScorerMethod::LlmJudge(j) => {
+                assert!(j.model_id.is_none());
+                assert_eq!(j.pass_threshold, 0.5);
+                assert!(j.rubric.contains("fully addresses"));
+            }
+            _ => panic!("expected llm_judge"),
+        }
     }
 
     #[test]

--- a/crates/server/migrations/070_observer_llm_judge.sql
+++ b/crates/server/migrations/070_observer_llm_judge.sql
@@ -1,0 +1,10 @@
+-- LLM-judge scoring for Observers. See specs/online-evals.md.
+--
+-- Adds the judge output (categorical label) and judge token/cost accounting to
+-- trace_scores. Rule scores leave these NULL.
+
+ALTER TABLE trace_scores
+    ADD COLUMN label TEXT,
+    ADD COLUMN judge_input_tokens BIGINT,
+    ADD COLUMN judge_output_tokens BIGINT,
+    ADD COLUMN judge_cost_usd DOUBLE PRECISION;

--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -621,10 +621,11 @@ impl ServerAppBuilder {
             );
         }
 
-        // Observers: tap turn.completed to enqueue scoring; a background worker
-        // drains the queue. Same code path in dev (in-memory) and full mode.
+        // Observers: tap turn.completed to enqueue scoring (the listener needs
+        // only db + wake). The background worker — which may call an LLM judge —
+        // is spawned later, once the driver registry and provider resolver exist.
         // See specs/online-evals.md.
-        if feature_flags.observers {
+        let observer_wake = if feature_flags.observers {
             let observer_wake = Arc::new(tokio::sync::Notify::new());
             let observer_listener: Arc<dyn EventListener> =
                 Arc::new(crate::domains::observers::ObserverMatchListener::new(
@@ -632,13 +633,10 @@ impl ServerAppBuilder {
                     observer_wake.clone(),
                 ));
             event_listeners.push(observer_listener);
-            crate::domains::observers::spawn_observer_worker(
-                db.clone(),
-                observer_wake,
-                crate::domains::observers::ObserverWorkerConfig::default(),
-            );
-            tracing::info!("Observers enabled: scoring worker started");
-        }
+            Some(observer_wake)
+        } else {
+            None
+        };
 
         if let Some(braintrust_listener) = BraintrustListener::from_env() {
             tracing::info!("Braintrust integration enabled");
@@ -802,6 +800,27 @@ impl ServerAppBuilder {
             services::ProviderResolverService::new(db.clone(), encryption.clone())
                 .with_driver_registry((*driver_registry).clone()),
         );
+
+        // Now that the LLM stack exists, spawn the observer scoring worker with
+        // an LLM-judge client backed by the org's own configured providers.
+        if let Some(observer_wake) = observer_wake {
+            let judge: Arc<dyn crate::domains::observers::JudgeClient> =
+                Arc::new(crate::domains::observers::LlmJudgeClient::new(
+                    db.clone(),
+                    driver_registry.clone(),
+                    provider_resolver.clone(),
+                ));
+            crate::domains::observers::spawn_observer_worker(
+                crate::domains::observers::ObserverWorkerDeps {
+                    db: db.clone(),
+                    judge: Some(judge),
+                },
+                observer_wake,
+                crate::domains::observers::ObserverWorkerConfig::default(),
+            );
+            tracing::info!("Observers enabled: scoring worker started");
+        }
+
         let providers_state = api::providers::AppState::new(
             db.clone(),
             encryption.clone(),

--- a/crates/server/src/domains/observers/judge.rs
+++ b/crates/server/src/domains/observers/judge.rs
@@ -61,13 +61,18 @@ pub struct TurnEvidence {
 pub trait JudgeClient: Send + Sync {
     /// Grade `evidence` against `rubric` for `org_id`, using `model_id` (or the
     /// org's default model when `None`).
+    ///
+    /// Returns `Ok(None)` when the org has no judge model configured — a
+    /// permanent, org-specific condition the worker should treat as `skipped`
+    /// rather than a retryable error. `Err` is reserved for transient/real
+    /// failures (provider errors, unparseable responses) that warrant a retry.
     async fn judge(
         &self,
         org_id: i64,
         model_id: Option<ModelId>,
         rubric: &str,
         evidence: &TurnEvidence,
-    ) -> Result<JudgeResult>;
+    ) -> Result<Option<JudgeResult>>;
 }
 
 const JUDGE_SYSTEM_PREAMBLE: &str = "You are an evaluation judge scoring an AI agent's response. \
@@ -171,8 +176,10 @@ impl JudgeClient for LlmJudgeClient {
         model_id: Option<ModelId>,
         rubric: &str,
         evidence: &TurnEvidence,
-    ) -> Result<JudgeResult> {
-        // Resolve the org's model + decrypted provider credentials.
+    ) -> Result<Option<JudgeResult>> {
+        // Resolve the org's model + decrypted provider credentials. A missing
+        // model is a permanent config condition → Ok(None) so the worker skips
+        // (rather than retrying and finally erroring).
         let resolved = match model_id {
             Some(id) => {
                 self.provider_resolver
@@ -180,8 +187,10 @@ impl JudgeClient for LlmJudgeClient {
                     .await?
             }
             None => self.provider_resolver.resolve_default_model(org_id).await?,
-        }
-        .ok_or_else(|| anyhow::anyhow!("no judge model configured for org"))?;
+        };
+        let Some(resolved) = resolved else {
+            return Ok(None);
+        };
 
         // DriverId::from_str is infallible (unknown ids become External).
         let driver_id: DriverId = resolved.provider_type.parse().unwrap();
@@ -218,14 +227,14 @@ impl JudgeClient for LlmJudgeClient {
         let response = driver.chat_completion(messages, &config).await?;
         let parsed = parse_judge_output(&response.text)?;
         let meta = response.metadata;
-        Ok(JudgeResult {
+        Ok(Some(JudgeResult {
             value: parsed.value,
             label: parsed.label,
             reasoning: parsed.reasoning,
             input_tokens: meta.prompt_tokens.map(|t| t as u64),
             output_tokens: meta.completion_tokens.map(|t| t as u64),
             cost_usd: meta.provider_cost_usd,
-        })
+        }))
     }
 }
 

--- a/crates/server/src/domains/observers/judge.rs
+++ b/crates/server/src/domains/observers/judge.rs
@@ -1,0 +1,305 @@
+// LLM-as-judge for observer scoring. See specs/online-evals.md.
+//
+// The judge grades a trace slice against a rubric and returns a 0.0–1.0 value,
+// an optional categorical label, and free-text reasoning. Judge calls go
+// through the ORG's own configured model/provider (resolved via
+// ProviderResolverService) and are billed to that org.
+//
+// Prompt construction and response parsing are pure functions (unit-tested
+// here); the LLM call sits behind the `JudgeClient` trait so the worker stays
+// testable with a fake.
+
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use std::sync::Arc;
+
+use everruns_core::DriverRegistry;
+use everruns_core::llm_driver_registry::{
+    LlmCallConfig, LlmMessage, LlmMessageRole, ProviderConfig,
+};
+use everruns_core::provider::DriverId;
+use everruns_core::typed_id::ModelId;
+
+use crate::services::ProviderResolverService;
+use crate::storage::StorageBackend;
+
+/// Parsed structured output from the judge model.
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct JudgeOutput {
+    /// Score 0.0–1.0.
+    pub value: f64,
+    /// Optional categorical label.
+    #[serde(default)]
+    pub label: Option<String>,
+    /// Reasoning for the score.
+    #[serde(default)]
+    pub reasoning: String,
+}
+
+/// Result of a judge call: the parsed grade plus token/cost accounting.
+#[derive(Debug, Clone)]
+pub struct JudgeResult {
+    pub value: f64,
+    pub label: Option<String>,
+    pub reasoning: String,
+    pub input_tokens: Option<u64>,
+    pub output_tokens: Option<u64>,
+    pub cost_usd: Option<f64>,
+}
+
+/// What the judge grades: the user's question, the agent's answer, and a
+/// summary of tools used in the turn.
+#[derive(Debug, Clone, Default)]
+pub struct TurnEvidence {
+    pub input_message: String,
+    pub final_answer: String,
+    pub tool_names: Vec<String>,
+}
+
+/// Abstraction over the judge LLM call so the worker is testable with a fake.
+#[async_trait]
+pub trait JudgeClient: Send + Sync {
+    /// Grade `evidence` against `rubric` for `org_id`, using `model_id` (or the
+    /// org's default model when `None`).
+    async fn judge(
+        &self,
+        org_id: i64,
+        model_id: Option<ModelId>,
+        rubric: &str,
+        evidence: &TurnEvidence,
+    ) -> Result<JudgeResult>;
+}
+
+const JUDGE_SYSTEM_PREAMBLE: &str = "You are an evaluation judge scoring an AI agent's response. \
+Apply the rubric and respond with ONLY a JSON object of the form \
+{\"value\": <number 0.0-1.0>, \"label\": <short string or null>, \"reasoning\": <string>}. \
+`value` is the score where 1.0 fully satisfies the rubric and 0.0 fails it. \
+`label` is an optional short category for the outcome. Do not include any text outside the JSON.";
+
+/// Build (system, user) messages for the judge from the rubric and evidence.
+pub fn build_judge_messages(rubric: &str, evidence: &TurnEvidence) -> (String, String) {
+    let system = format!("{JUDGE_SYSTEM_PREAMBLE}\n\nRubric:\n{rubric}");
+
+    let tools = if evidence.tool_names.is_empty() {
+        "(none)".to_string()
+    } else {
+        evidence.tool_names.join(", ")
+    };
+    let user = format!(
+        "User message:\n{}\n\nAgent's final answer:\n{}\n\nTools used: {}",
+        truncate(&evidence.input_message, 4000),
+        truncate(&evidence.final_answer, 8000),
+        tools,
+    );
+    (system, user)
+}
+
+/// Parse the judge model's response into a [`JudgeOutput`]. Tolerates code
+/// fences and surrounding prose by extracting the first balanced JSON object.
+pub fn parse_judge_output(text: &str) -> Result<JudgeOutput> {
+    let json_slice = extract_json_object(text)
+        .ok_or_else(|| anyhow::anyhow!("judge response contained no JSON object"))?;
+    let mut out: JudgeOutput = serde_json::from_str(json_slice)
+        .context("judge response was not valid JudgeOutput JSON")?;
+    // Clamp to the contract range so a misbehaving judge can't store nonsense.
+    out.value = out.value.clamp(0.0, 1.0);
+    out.label = out.label.filter(|l| !l.trim().is_empty());
+    Ok(out)
+}
+
+/// Find the first balanced `{...}` object in `text` (handles ```json fences
+/// and chatty models). Naive brace matching is sufficient for judge outputs.
+fn extract_json_object(text: &str) -> Option<&str> {
+    let start = text.find('{')?;
+    let mut depth = 0usize;
+    let mut in_string = false;
+    let mut escaped = false;
+    for (i, ch) in text[start..].char_indices() {
+        match ch {
+            '"' if !escaped => in_string = !in_string,
+            '\\' if in_string => {
+                escaped = !escaped;
+                continue;
+            }
+            '{' if !in_string => depth += 1,
+            '}' if !in_string => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(&text[start..=start + i]);
+                }
+            }
+            _ => {}
+        }
+        escaped = false;
+    }
+    None
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        return s.to_string();
+    }
+    let mut out: String = s.chars().take(max).collect();
+    out.push_str("…[truncated]");
+    out
+}
+
+/// Production [`JudgeClient`] that calls the org's configured model.
+pub struct LlmJudgeClient {
+    driver_registry: Arc<DriverRegistry>,
+    provider_resolver: Arc<ProviderResolverService>,
+}
+
+impl LlmJudgeClient {
+    pub fn new(
+        _db: Arc<StorageBackend>,
+        driver_registry: Arc<DriverRegistry>,
+        provider_resolver: Arc<ProviderResolverService>,
+    ) -> Self {
+        Self {
+            driver_registry,
+            provider_resolver,
+        }
+    }
+}
+
+#[async_trait]
+impl JudgeClient for LlmJudgeClient {
+    async fn judge(
+        &self,
+        org_id: i64,
+        model_id: Option<ModelId>,
+        rubric: &str,
+        evidence: &TurnEvidence,
+    ) -> Result<JudgeResult> {
+        // Resolve the org's model + decrypted provider credentials.
+        let resolved = match model_id {
+            Some(id) => {
+                self.provider_resolver
+                    .resolve_model(org_id, id.uuid())
+                    .await?
+            }
+            None => self.provider_resolver.resolve_default_model(org_id).await?,
+        }
+        .ok_or_else(|| anyhow::anyhow!("no judge model configured for org"))?;
+
+        // DriverId::from_str is infallible (unknown ids become External).
+        let driver_id: DriverId = resolved.provider_type.parse().unwrap();
+        let mut provider_config = ProviderConfig::new(driver_id);
+        if let Some(key) = resolved.api_key {
+            provider_config = provider_config.with_api_key(key);
+        }
+        if let Some(base) = resolved.base_url {
+            provider_config = provider_config.with_base_url(base);
+        }
+        let driver = self.driver_registry.create_chat_driver(&provider_config)?;
+
+        let (system, user) = build_judge_messages(rubric, evidence);
+        let messages = vec![
+            LlmMessage::text(LlmMessageRole::System, system),
+            LlmMessage::text(LlmMessageRole::User, user),
+        ];
+        let config = LlmCallConfig {
+            model: resolved.model_id,
+            temperature: Some(0.0),
+            max_tokens: Some(700),
+            tools: Vec::new(),
+            reasoning_effort: None,
+            metadata: std::collections::HashMap::from([
+                ("org_id".to_string(), org_id.to_string()),
+                ("scorer".to_string(), "observer_llm_judge".to_string()),
+            ]),
+            previous_response_id: None,
+            tool_search: None,
+            prompt_cache: None,
+            openrouter_routing: None,
+        };
+
+        let response = driver.chat_completion(messages, &config).await?;
+        let parsed = parse_judge_output(&response.text)?;
+        let meta = response.metadata;
+        Ok(JudgeResult {
+            value: parsed.value,
+            label: parsed.label,
+            reasoning: parsed.reasoning,
+            input_tokens: meta.prompt_tokens.map(|t| t as u64),
+            output_tokens: meta.completion_tokens.map(|t| t as u64),
+            cost_usd: meta.provider_cost_usd,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_plain_json() {
+        let out =
+            parse_judge_output(r#"{"value": 0.8, "label": "ok", "reasoning": "good"}"#).unwrap();
+        assert_eq!(out.value, 0.8);
+        assert_eq!(out.label.as_deref(), Some("ok"));
+        assert_eq!(out.reasoning, "good");
+    }
+
+    #[test]
+    fn parses_fenced_json_with_prose() {
+        let text = "Here is my assessment:\n```json\n{\"value\": 1.0, \"reasoning\": \"complete\"}\n```\nDone.";
+        let out = parse_judge_output(text).unwrap();
+        assert_eq!(out.value, 1.0);
+        assert!(out.label.is_none());
+        assert_eq!(out.reasoning, "complete");
+    }
+
+    #[test]
+    fn clamps_out_of_range_value() {
+        let out = parse_judge_output(r#"{"value": 1.7, "reasoning": "x"}"#).unwrap();
+        assert_eq!(out.value, 1.0);
+        let out = parse_judge_output(r#"{"value": -0.3, "reasoning": "x"}"#).unwrap();
+        assert_eq!(out.value, 0.0);
+    }
+
+    #[test]
+    fn empty_label_becomes_none() {
+        let out = parse_judge_output(r#"{"value": 0.5, "label": "  ", "reasoning": "x"}"#).unwrap();
+        assert!(out.label.is_none());
+    }
+
+    #[test]
+    fn errors_on_no_json() {
+        assert!(parse_judge_output("the answer was great").is_err());
+    }
+
+    #[test]
+    fn handles_braces_inside_strings() {
+        let out =
+            parse_judge_output(r#"{"value": 0.5, "reasoning": "uses {curly} braces"}"#).unwrap();
+        assert_eq!(out.reasoning, "uses {curly} braces");
+    }
+
+    #[test]
+    fn build_messages_includes_rubric_and_evidence() {
+        let evidence = TurnEvidence {
+            input_message: "What is 2+2?".into(),
+            final_answer: "4".into(),
+            tool_names: vec!["calc".into()],
+        };
+        let (system, user) = build_judge_messages("Score correctness", &evidence);
+        assert!(system.contains("Score correctness"));
+        assert!(system.contains("JSON"));
+        assert!(user.contains("What is 2+2?"));
+        assert!(user.contains("4"));
+        assert!(user.contains("calc"));
+    }
+
+    #[test]
+    fn build_messages_handles_no_tools() {
+        let evidence = TurnEvidence {
+            input_message: "hi".into(),
+            final_answer: "hello".into(),
+            tool_names: vec![],
+        };
+        let (_system, user) = build_judge_messages("r", &evidence);
+        assert!(user.contains("Tools used: (none)"));
+    }
+}

--- a/crates/server/src/domains/observers/mod.rs
+++ b/crates/server/src/domains/observers/mod.rs
@@ -2,12 +2,14 @@
 // See specs/online-evals.md.
 
 pub mod commands;
+pub mod judge;
 pub mod listener;
 pub mod service;
 pub mod types;
 pub mod worker;
 
 pub use commands::*;
+pub use judge::*;
 pub use listener::*;
 pub use service::*;
 pub use worker::*;

--- a/crates/server/src/domains/observers/service.rs
+++ b/crates/server/src/domains/observers/service.rs
@@ -75,15 +75,26 @@ fn validate(sampling_rate: f64, scorers: &[ObserverScorerConfig]) -> Result<()> 
                 scorer.key
             )));
         }
-        // file_contains needs the session filesystem, which is not part of the
-        // observable trace contract. Reject it for observers.
-        if matches!(
-            scorer.rule,
-            everruns_core::eval::Scorer::FileContains { .. }
-        ) {
-            anyhow::bail!(BadRequestError::new(
-                "file_contains scorer is not supported by observers"
-            ));
+        match &scorer.method {
+            ScorerMethod::Rule { rule } => {
+                // file_contains needs the session filesystem, which is not part
+                // of the observable trace contract. Reject it for observers.
+                if matches!(rule, everruns_core::eval::Scorer::FileContains { .. }) {
+                    anyhow::bail!(BadRequestError::new(
+                        "file_contains scorer is not supported by observers"
+                    ));
+                }
+            }
+            ScorerMethod::LlmJudge(judge) => {
+                if judge.rubric.trim().is_empty() {
+                    anyhow::bail!(BadRequestError::new("llm_judge rubric must not be empty"));
+                }
+                if !(0.0..=1.0).contains(&judge.pass_threshold) {
+                    anyhow::bail!(BadRequestError::new(
+                        "llm_judge pass_threshold must be between 0.0 and 1.0"
+                    ));
+                }
+            }
         }
     }
     Ok(())
@@ -285,7 +296,11 @@ pub fn row_to_trace_score(row: TraceScoreRow, observer_id: ObserverId) -> Result
         status: TraceScoreStatus::from(row.status.as_str()),
         pass: row.pass,
         value: row.value,
+        label: row.label,
         reason: row.reason,
+        judge_input_tokens: row.judge_input_tokens.map(|t| t as u64),
+        judge_output_tokens: row.judge_output_tokens.map(|t| t as u64),
+        judge_cost_usd: row.judge_cost_usd,
         error_message: row.error_message,
         created_at: row.created_at,
         updated_at: row.updated_at,
@@ -297,7 +312,7 @@ mod tests {
     use super::*;
     use crate::api::observers::CreateObserverRequest;
     use crate::storage::models::CreateTraceScoreRow;
-    use everruns_core::observer::{ObserverScope, ObserverScorerConfig};
+    use everruns_core::observer::{ObserverScope, ObserverScorerConfig, ScorerMethod};
     use everruns_core::typed_id::TraceScoreId;
 
     // The trace_scores row's internal UUID is DB-generated and independent of
@@ -320,9 +335,11 @@ mod tests {
                     scorers: vec![ObserverScorerConfig {
                         key: "k".into(),
                         scope: ObserverScope::Turn,
-                        rule: everruns_core::eval::Scorer::Contains {
-                            text: "x".into(),
-                            weight: 1.0,
+                        method: ScorerMethod::Rule {
+                            rule: everruns_core::eval::Scorer::Contains {
+                                text: "x".into(),
+                                weight: 1.0,
+                            },
                         },
                     }],
                 },

--- a/crates/server/src/domains/observers/worker.rs
+++ b/crates/server/src/domains/observers/worker.rs
@@ -10,14 +10,24 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use everruns_core::eval::Score;
-use everruns_core::observer::ObserverScorerConfig;
+use everruns_core::observer::{ObserverScorerConfig, ScorerMethod};
 use everruns_core::typed_id::SessionId;
 use tracing::{debug, error, warn};
 
 use crate::domains::evals::runner::{extract_final_assistant_content, extract_tool_calls};
 use crate::domains::evals::scoring::score_rule;
+use crate::domains::observers::judge::{JudgeClient, TurnEvidence};
 use crate::storage::StorageBackend;
 use crate::storage::models::{CompleteTraceScoreRow, EventRow, ListEventsParams, TraceScoreRow};
+
+/// Dependencies the worker loop needs to score: storage plus an optional judge
+/// client. `judge` is `None` when no LLM path is available (e.g. dev without
+/// providers); llm_judge scores are then skipped with a clear reason.
+#[derive(Clone)]
+pub struct ObserverWorkerDeps {
+    pub db: Arc<StorageBackend>,
+    pub judge: Option<Arc<dyn JudgeClient>>,
+}
 
 /// Worker tuning. Conservative defaults; bounded judge fan-out.
 #[derive(Clone, Copy, Debug)]
@@ -46,7 +56,7 @@ impl Default for ObserverWorkerConfig {
 /// Spawn the background scoring worker. Returns immediately; the loop runs
 /// until the process exits.
 pub fn spawn_observer_worker(
-    db: Arc<StorageBackend>,
+    deps: ObserverWorkerDeps,
     wake: Arc<tokio::sync::Notify>,
     config: ObserverWorkerConfig,
 ) {
@@ -55,7 +65,7 @@ pub fn spawn_observer_worker(
         loop {
             // Drain until a claim returns fewer than a full batch.
             loop {
-                match drain_once(&db, config).await {
+                match drain_once(&deps, config).await {
                     Ok(0) => break,
                     Ok(n) => {
                         debug!(scored = n, "Observer scoring batch processed");
@@ -79,8 +89,12 @@ pub fn spawn_observer_worker(
 }
 
 /// Claim and score one batch. Returns the number of scores processed.
-async fn drain_once(db: &StorageBackend, config: ObserverWorkerConfig) -> anyhow::Result<usize> {
-    let claimed = db
+async fn drain_once(
+    deps: &ObserverWorkerDeps,
+    config: ObserverWorkerConfig,
+) -> anyhow::Result<usize> {
+    let claimed = deps
+        .db
         .claim_trace_scores(
             config.batch_size,
             config.stale_after.as_secs() as i64,
@@ -89,7 +103,7 @@ async fn drain_once(db: &StorageBackend, config: ObserverWorkerConfig) -> anyhow
         .await?;
     let count = claimed.len();
     for score in claimed {
-        if let Err(e) = process_score(db, &score).await {
+        if let Err(e) = process_score(deps, &score).await {
             // Leave the row in `scoring`; a later claim retries it (or
             // finalizes it errored once attempts are exhausted).
             warn!(score_id = %score.public_id, error = %e, "Failed to process trace score");
@@ -98,7 +112,8 @@ async fn drain_once(db: &StorageBackend, config: ObserverWorkerConfig) -> anyhow
     Ok(count)
 }
 
-async fn process_score(db: &StorageBackend, score: &TraceScoreRow) -> anyhow::Result<()> {
+async fn process_score(deps: &ObserverWorkerDeps, score: &TraceScoreRow) -> anyhow::Result<()> {
+    let db = &deps.db;
     // Load the observer to recover the scorer config for this key.
     let Some(observer_row) = db.get_observer(score.observer_id).await? else {
         // Observer deleted between enqueue and scoring — skip.
@@ -120,32 +135,62 @@ async fn process_score(db: &StorageBackend, score: &TraceScoreRow) -> anyhow::Re
 
     let final_content = extract_final_assistant_content(&msg_events);
     let tool_calls = extract_tool_calls(&tool_events);
-    let iterations = extract_iterations(&turn_events);
 
-    let result = score_rule(&scorer.rule, &final_content, &tool_calls, iterations);
-    let Some(Score {
-        pass,
-        value,
-        reason,
-    }) = result
-    else {
-        // Rule unsupported for observers (file_contains is rejected at create
-        // time, so this should not happen); mark skipped to avoid retry loops.
-        finalize_skipped(db, score, "scorer rule unsupported for observers").await?;
-        return Ok(());
+    let completion = match scorer.method {
+        ScorerMethod::Rule { rule } => {
+            let iterations = extract_iterations(&turn_events);
+            let Some(Score {
+                pass,
+                value,
+                reason,
+            }) = score_rule(&rule, &final_content, &tool_calls, iterations)
+            else {
+                // file_contains is rejected at create time, so this shouldn't
+                // happen; mark skipped to avoid a retry loop.
+                finalize_skipped(db, score, "scorer rule unsupported for observers").await?;
+                return Ok(());
+            };
+            CompleteTraceScoreRow {
+                status: "completed".to_string(),
+                pass: Some(pass),
+                value: Some(value),
+                reason: Some(reason),
+                ..Default::default()
+            }
+        }
+        ScorerMethod::LlmJudge(judge_config) => {
+            let Some(judge) = deps.judge.clone() else {
+                finalize_skipped(db, score, "llm judge unavailable (no model provider)").await?;
+                return Ok(());
+            };
+            let evidence = TurnEvidence {
+                input_message: extract_input_content(&turn_events),
+                final_answer: final_content,
+                tool_names: tool_calls,
+            };
+            let result = judge
+                .judge(
+                    score.org_id,
+                    judge_config.model_id,
+                    &judge_config.rubric,
+                    &evidence,
+                )
+                .await?;
+            CompleteTraceScoreRow {
+                status: "completed".to_string(),
+                pass: Some(result.value >= judge_config.pass_threshold),
+                value: Some(result.value),
+                label: result.label,
+                reason: Some(result.reasoning),
+                judge_input_tokens: result.input_tokens.map(|t| t as i64),
+                judge_output_tokens: result.output_tokens.map(|t| t as i64),
+                judge_cost_usd: result.cost_usd,
+                error_message: None,
+            }
+        }
     };
 
-    db.complete_trace_score(
-        score.id,
-        CompleteTraceScoreRow {
-            status: "completed".to_string(),
-            pass: Some(pass),
-            value: Some(value),
-            reason: Some(reason),
-            error_message: None,
-        },
-    )
-    .await?;
+    db.complete_trace_score(score.id, completion).await?;
     Ok(())
 }
 
@@ -158,10 +203,8 @@ async fn finalize_skipped(
         score.id,
         CompleteTraceScoreRow {
             status: "skipped".to_string(),
-            pass: None,
-            value: None,
             reason: Some(reason.to_string()),
-            error_message: None,
+            ..Default::default()
         },
     )
     .await?;
@@ -196,17 +239,67 @@ fn extract_iterations(turn_events: &[EventRow]) -> u32 {
         .unwrap_or(1) as u32
 }
 
+/// The user's input text for this turn, carried on `turn.completed`.
+fn extract_input_content(turn_events: &[EventRow]) -> String {
+    turn_events
+        .iter()
+        .rev()
+        .find(|e| e.event_type == "turn.completed")
+        .and_then(|e| e.data.get("input_content"))
+        .and_then(|v| v.as_str())
+        .unwrap_or_default()
+        .to_string()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::domains::observers::judge::{JudgeResult, TurnEvidence};
     use crate::storage::models::{
         CreateEventRow, CreateObserverRow, CreateSessionRow, CreateTraceScoreRow,
     };
-    use everruns_core::observer::{ObserverScope, ObserverScorerConfig};
-    use everruns_core::typed_id::{AgentId, HarnessId, ObserverId, PrincipalId, TraceScoreId};
+    use everruns_core::observer::{
+        LlmJudgeConfig, ObserverScope, ObserverScorerConfig, ScorerMethod,
+    };
+    use everruns_core::typed_id::{
+        AgentId, HarnessId, ModelId, ObserverId, PrincipalId, TraceScoreId,
+    };
     use uuid::Uuid;
 
     const ORG: i64 = 1;
+
+    fn deps(db: &Arc<StorageBackend>) -> ObserverWorkerDeps {
+        ObserverWorkerDeps {
+            db: db.clone(),
+            judge: None,
+        }
+    }
+
+    /// Fake judge returning a fixed grade, for worker dispatch tests.
+    struct FakeJudge {
+        value: f64,
+        label: Option<String>,
+    }
+
+    #[async_trait::async_trait]
+    impl JudgeClient for FakeJudge {
+        async fn judge(
+            &self,
+            _org_id: i64,
+            _model_id: Option<ModelId>,
+            _rubric: &str,
+            _evidence: &TurnEvidence,
+        ) -> anyhow::Result<JudgeResult> {
+            Ok(JudgeResult {
+                value: self.value,
+                label: self.label.clone(),
+                reasoning: "fake".to_string(),
+                input_tokens: Some(42),
+                output_tokens: Some(7),
+                cost_usd: Some(0.001),
+            })
+        }
+    }
 
     fn session_row(agent: AgentId, harness: HarnessId, tags: Vec<String>) -> CreateSessionRow {
         CreateSessionRow {
@@ -269,15 +362,7 @@ mod tests {
         .unwrap();
     }
 
-    fn contains_observer(agent: AgentId, key: &str, text: &str) -> CreateObserverRow {
-        let scorer = ObserverScorerConfig {
-            key: key.to_string(),
-            scope: ObserverScope::Turn,
-            rule: everruns_core::eval::Scorer::Contains {
-                text: text.to_string(),
-                weight: 1.0,
-            },
-        };
+    fn observer_with_scorer(agent: AgentId, scorer: ObserverScorerConfig) -> CreateObserverRow {
         CreateObserverRow {
             public_id: ObserverId::from_uuid(Uuid::now_v7()).to_string(),
             name: "test".to_string(),
@@ -290,6 +375,22 @@ mod tests {
             sampling_rate: 1.0,
             scorers: serde_json::to_value(vec![scorer]).unwrap(),
         }
+    }
+
+    fn contains_observer(agent: AgentId, key: &str, text: &str) -> CreateObserverRow {
+        observer_with_scorer(
+            agent,
+            ObserverScorerConfig {
+                key: key.to_string(),
+                scope: ObserverScope::Turn,
+                method: ScorerMethod::Rule {
+                    rule: everruns_core::eval::Scorer::Contains {
+                        text: text.to_string(),
+                        weight: 1.0,
+                    },
+                },
+            },
+        )
     }
 
     async fn enqueue(
@@ -319,7 +420,7 @@ mod tests {
 
     #[tokio::test]
     async fn drains_and_scores_a_matching_turn() {
-        let db = StorageBackend::in_memory();
+        let db = Arc::new(StorageBackend::in_memory());
         let agent = AgentId::new();
         let harness = HarnessId::new();
         let turn_id = "turn_01933b5a000070008000000000000abc";
@@ -336,7 +437,7 @@ mod tests {
             .unwrap();
         enqueue(&db, observer.id, "greet", session.id, turn_id, agent).await;
 
-        let processed = drain_once(&db, ObserverWorkerConfig::default())
+        let processed = drain_once(&deps(&db), ObserverWorkerConfig::default())
             .await
             .unwrap();
         assert_eq!(processed, 1);
@@ -361,7 +462,7 @@ mod tests {
 
     #[tokio::test]
     async fn scores_failing_rule_as_not_passed() {
-        let db = StorageBackend::in_memory();
+        let db = Arc::new(StorageBackend::in_memory());
         let agent = AgentId::new();
         let harness = HarnessId::new();
         let turn_id = "turn_01933b5a000070008000000000000def";
@@ -378,7 +479,7 @@ mod tests {
             .unwrap();
         enqueue(&db, observer.id, "greet", session.id, turn_id, agent).await;
 
-        drain_once(&db, ObserverWorkerConfig::default())
+        drain_once(&deps(&db), ObserverWorkerConfig::default())
             .await
             .unwrap();
 
@@ -401,7 +502,7 @@ mod tests {
 
     #[tokio::test]
     async fn skips_score_when_scorer_key_removed() {
-        let db = StorageBackend::in_memory();
+        let db = Arc::new(StorageBackend::in_memory());
         let agent = AgentId::new();
         let harness = HarnessId::new();
         let turn_id = "turn_01933b5a000070008000000000000fed";
@@ -429,7 +530,7 @@ mod tests {
         .await
         .unwrap();
 
-        drain_once(&db, ObserverWorkerConfig::default())
+        drain_once(&deps(&db), ObserverWorkerConfig::default())
             .await
             .unwrap();
 
@@ -445,6 +546,91 @@ mod tests {
             )
             .await
             .unwrap();
+        assert_eq!(scores[0].status, "skipped");
+    }
+
+    fn judge_observer(agent: AgentId, key: &str) -> CreateObserverRow {
+        observer_with_scorer(
+            agent,
+            ObserverScorerConfig {
+                key: key.to_string(),
+                scope: ObserverScope::Turn,
+                method: ScorerMethod::LlmJudge(LlmJudgeConfig {
+                    rubric: "Did the agent greet the user?".to_string(),
+                    model_id: None,
+                    pass_threshold: 0.5,
+                }),
+            },
+        )
+    }
+
+    async fn run_judge_observer(judge: Option<Arc<dyn JudgeClient>>) -> Vec<TraceScoreRow> {
+        let db = Arc::new(StorageBackend::in_memory());
+        let agent = AgentId::new();
+        let harness = HarnessId::new();
+        let turn_id = "turn_01933b5a0000700080000000000000aa";
+        let session = db
+            .create_session(session_row(agent, harness, vec![]))
+            .await
+            .unwrap();
+        seed_turn(&db, session.id, turn_id, "hello there").await;
+        let observer = db
+            .create_observer(ORG, judge_observer(agent, "greeted"))
+            .await
+            .unwrap();
+        enqueue(&db, observer.id, "greeted", session.id, turn_id, agent).await;
+
+        let deps = ObserverWorkerDeps {
+            db: db.clone(),
+            judge,
+        };
+        drain_once(&deps, ObserverWorkerConfig::default())
+            .await
+            .unwrap();
+        db.list_trace_scores(
+            ORG,
+            crate::storage::models::ListTraceScoresParams {
+                observer_id: observer.id,
+                session_id: None,
+                limit: 10,
+                offset: 0,
+            },
+        )
+        .await
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn scores_llm_judge_turn_via_judge_client() {
+        let judge = Arc::new(FakeJudge {
+            value: 0.9,
+            label: Some("greeted".to_string()),
+        });
+        let scores = run_judge_observer(Some(judge)).await;
+        assert_eq!(scores.len(), 1);
+        assert_eq!(scores[0].status, "completed");
+        assert_eq!(scores[0].pass, Some(true));
+        assert_eq!(scores[0].value, Some(0.9));
+        assert_eq!(scores[0].label.as_deref(), Some("greeted"));
+        assert_eq!(scores[0].reason.as_deref(), Some("fake"));
+        assert_eq!(scores[0].judge_input_tokens, Some(42));
+        assert_eq!(scores[0].judge_output_tokens, Some(7));
+    }
+
+    #[tokio::test]
+    async fn llm_judge_below_threshold_does_not_pass() {
+        let judge = Arc::new(FakeJudge {
+            value: 0.2,
+            label: None,
+        });
+        let scores = run_judge_observer(Some(judge)).await;
+        assert_eq!(scores[0].status, "completed");
+        assert_eq!(scores[0].pass, Some(false));
+    }
+
+    #[tokio::test]
+    async fn llm_judge_skipped_when_no_judge_client() {
+        let scores = run_judge_observer(None).await;
         assert_eq!(scores[0].status, "skipped");
     }
 }

--- a/crates/server/src/domains/observers/worker.rs
+++ b/crates/server/src/domains/observers/worker.rs
@@ -168,14 +168,20 @@ async fn process_score(deps: &ObserverWorkerDeps, score: &TraceScoreRow) -> anyh
                 final_answer: final_content,
                 tool_names: tool_calls,
             };
-            let result = judge
+            let Some(result) = judge
                 .judge(
                     score.org_id,
                     judge_config.model_id,
                     &judge_config.rubric,
                     &evidence,
                 )
-                .await?;
+                .await?
+            else {
+                // Org has no judge model configured — a permanent config
+                // condition, not a transient failure. Skip without retrying.
+                finalize_skipped(db, score, "no judge model configured for org").await?;
+                return Ok(());
+            };
             CompleteTraceScoreRow {
                 status: "completed".to_string(),
                 pass: Some(result.value >= judge_config.pass_threshold),
@@ -275,10 +281,13 @@ mod tests {
         }
     }
 
-    /// Fake judge returning a fixed grade, for worker dispatch tests.
+    /// Fake judge returning a fixed grade (or `None` for "no model"), for
+    /// worker dispatch tests.
     struct FakeJudge {
         value: f64,
         label: Option<String>,
+        /// When false, simulates "no judge model configured" (`Ok(None)`).
+        has_model: bool,
     }
 
     #[async_trait::async_trait]
@@ -289,15 +298,18 @@ mod tests {
             _model_id: Option<ModelId>,
             _rubric: &str,
             _evidence: &TurnEvidence,
-        ) -> anyhow::Result<JudgeResult> {
-            Ok(JudgeResult {
+        ) -> anyhow::Result<Option<JudgeResult>> {
+            if !self.has_model {
+                return Ok(None);
+            }
+            Ok(Some(JudgeResult {
                 value: self.value,
                 label: self.label.clone(),
                 reasoning: "fake".to_string(),
                 input_tokens: Some(42),
                 output_tokens: Some(7),
                 cost_usd: Some(0.001),
-            })
+            }))
         }
     }
 
@@ -605,6 +617,7 @@ mod tests {
         let judge = Arc::new(FakeJudge {
             value: 0.9,
             label: Some("greeted".to_string()),
+            has_model: true,
         });
         let scores = run_judge_observer(Some(judge)).await;
         assert_eq!(scores.len(), 1);
@@ -622,6 +635,7 @@ mod tests {
         let judge = Arc::new(FakeJudge {
             value: 0.2,
             label: None,
+            has_model: true,
         });
         let scores = run_judge_observer(Some(judge)).await;
         assert_eq!(scores[0].status, "completed");
@@ -632,5 +646,21 @@ mod tests {
     async fn llm_judge_skipped_when_no_judge_client() {
         let scores = run_judge_observer(None).await;
         assert_eq!(scores[0].status, "skipped");
+    }
+
+    #[tokio::test]
+    async fn llm_judge_skipped_when_org_has_no_model() {
+        // Judge client present, but the org has no model configured (Ok(None)).
+        let judge = Arc::new(FakeJudge {
+            value: 0.0,
+            label: None,
+            has_model: false,
+        });
+        let scores = run_judge_observer(Some(judge)).await;
+        assert_eq!(scores[0].status, "skipped");
+        assert_eq!(
+            scores[0].reason.as_deref(),
+            Some("no judge model configured for org")
+        );
     }
 }

--- a/crates/server/src/storage/memory/observers.rs
+++ b/crates/server/src/storage/memory/observers.rs
@@ -182,7 +182,11 @@ impl InMemoryDatabase {
                     attempts: 0,
                     pass: None,
                     value: None,
+                    label: None,
                     reason: None,
+                    judge_input_tokens: None,
+                    judge_output_tokens: None,
+                    judge_cost_usd: None,
                     error_message: None,
                     created_at: now,
                     updated_at: now,
@@ -254,7 +258,11 @@ impl InMemoryDatabase {
         score.status = input.status;
         score.pass = input.pass;
         score.value = input.value;
+        score.label = input.label;
         score.reason = input.reason;
+        score.judge_input_tokens = input.judge_input_tokens;
+        score.judge_output_tokens = input.judge_output_tokens;
+        score.judge_cost_usd = input.judge_cost_usd;
         score.error_message = input.error_message;
         score.updated_at = Self::now();
         Ok(Some(score.clone()))

--- a/crates/server/src/storage/models.rs
+++ b/crates/server/src/storage/models.rs
@@ -2542,7 +2542,11 @@ pub struct TraceScoreRow {
     pub attempts: i32,
     pub pass: Option<bool>,
     pub value: Option<f64>,
+    pub label: Option<String>,
     pub reason: Option<String>,
+    pub judge_input_tokens: Option<i64>,
+    pub judge_output_tokens: Option<i64>,
+    pub judge_cost_usd: Option<f64>,
     pub error_message: Option<String>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
@@ -2562,13 +2566,17 @@ pub struct CreateTraceScoreRow {
 }
 
 /// Terminal result written back by the scoring worker.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct CompleteTraceScoreRow {
     /// `completed`, `errored`, or `skipped`.
     pub status: String,
     pub pass: Option<bool>,
     pub value: Option<f64>,
+    pub label: Option<String>,
     pub reason: Option<String>,
+    pub judge_input_tokens: Option<i64>,
+    pub judge_output_tokens: Option<i64>,
+    pub judge_cost_usd: Option<f64>,
     pub error_message: Option<String>,
 }
 

--- a/crates/server/src/storage/repositories/observers.rs
+++ b/crates/server/src/storage/repositories/observers.rs
@@ -252,7 +252,8 @@ impl Database {
             )
             RETURNING id, org_id, public_id, observer_id, scorer_key, session_id,
                       turn_id, agent_id, agent_version_id, harness_id, status, attempts,
-                      pass, value, reason, error_message, created_at, updated_at
+                      pass, value, label, reason, judge_input_tokens, judge_output_tokens,
+                      judge_cost_usd, error_message, created_at, updated_at
             "#,
         )
         .bind(stale_after_seconds as f64)
@@ -271,18 +272,24 @@ impl Database {
         let row = sqlx::query_as::<_, TraceScoreRow>(
             r#"
             UPDATE trace_scores
-            SET status = $2, pass = $3, value = $4, reason = $5, error_message = $6, updated_at = NOW()
+            SET status = $2, pass = $3, value = $4, label = $5, reason = $6, judge_input_tokens = $7,
+                judge_output_tokens = $8, judge_cost_usd = $9, error_message = $10, updated_at = NOW()
             WHERE id = $1
             RETURNING id, org_id, public_id, observer_id, scorer_key, session_id,
                       turn_id, agent_id, agent_version_id, harness_id, status, attempts,
-                      pass, value, reason, error_message, created_at, updated_at
+                      pass, value, label, reason, judge_input_tokens, judge_output_tokens,
+                      judge_cost_usd, error_message, created_at, updated_at
             "#,
         )
         .bind(id)
         .bind(&input.status)
         .bind(input.pass)
         .bind(input.value)
+        .bind(&input.label)
         .bind(&input.reason)
+        .bind(input.judge_input_tokens)
+        .bind(input.judge_output_tokens)
+        .bind(input.judge_cost_usd)
         .bind(&input.error_message)
         .fetch_optional(&self.pool)
         .await?;
@@ -302,7 +309,8 @@ impl Database {
         let sql = format!(
             r#"SELECT id, org_id, public_id, observer_id, scorer_key, session_id,
                       turn_id, agent_id, agent_version_id, harness_id, status, attempts,
-                      pass, value, reason, error_message, created_at, updated_at
+                      pass, value, label, reason, judge_input_tokens, judge_output_tokens,
+                      judge_cost_usd, error_message, created_at, updated_at
                FROM trace_scores
                WHERE org_id = $1 AND observer_id = $2{session_sql}
                ORDER BY created_at DESC

--- a/crates/server/tests/observers_integration_test.rs
+++ b/crates/server/tests/observers_integration_test.rs
@@ -22,7 +22,7 @@ async fn create_and_get_observer_roundtrip() {
                 "description": "Watch the support agent",
                 "sampling_rate": 0.25,
                 "scorers": [
-                    { "key": "has_greeting", "rule": { "type": "contains", "text": "hello" } }
+                    { "key": "has_greeting", "method": "rule", "rule": { "type": "contains", "text": "hello" } }
                 ]
             }),
         )
@@ -56,7 +56,7 @@ async fn sampling_rate_defaults_to_ten_percent() {
             json!({
                 "name": "Default sampling",
                 "scorers": [
-                    { "key": "k", "rule": { "type": "contains", "text": "x" } }
+                    { "key": "k", "method": "rule", "rule": { "type": "contains", "text": "x" } }
                 ]
             }),
         )
@@ -74,7 +74,7 @@ async fn list_observers_excludes_archived_by_default() {
             "/v1/observers",
             json!({
                 "name": "Temp",
-                "scorers": [{ "key": "k", "rule": { "type": "contains", "text": "x" } }]
+                "scorers": [{ "key": "k", "method": "rule", "rule": { "type": "contains", "text": "x" } }]
             }),
         )
         .await
@@ -118,7 +118,7 @@ async fn update_observer_changes_sampling_and_pause() {
             "/v1/observers",
             json!({
                 "name": "Adjustable",
-                "scorers": [{ "key": "k", "rule": { "type": "contains", "text": "x" } }]
+                "scorers": [{ "key": "k", "method": "rule", "rule": { "type": "contains", "text": "x" } }]
             }),
         )
         .await
@@ -147,7 +147,7 @@ async fn rejects_invalid_sampling_rate() {
             json!({
                 "name": "Bad",
                 "sampling_rate": 1.5,
-                "scorers": [{ "key": "k", "rule": { "type": "contains", "text": "x" } }]
+                "scorers": [{ "key": "k", "method": "rule", "rule": { "type": "contains", "text": "x" } }]
             }),
         )
         .await
@@ -172,8 +172,8 @@ async fn rejects_duplicate_scorer_keys() {
             json!({
                 "name": "Dupe",
                 "scorers": [
-                    { "key": "k", "rule": { "type": "contains", "text": "a" } },
-                    { "key": "k", "rule": { "type": "contains", "text": "b" } }
+                    { "key": "k", "method": "rule", "rule": { "type": "contains", "text": "a" } },
+                    { "key": "k", "method": "rule", "rule": { "type": "contains", "text": "b" } }
                 ]
             }),
         )
@@ -190,8 +190,49 @@ async fn rejects_file_contains_scorer() {
             json!({
                 "name": "File",
                 "scorers": [
-                    { "key": "f", "rule": { "type": "file_contains", "path": "/x", "text": "y" } }
+                    { "key": "f", "method": "rule", "rule": { "type": "file_contains", "path": "/x", "text": "y" } }
                 ]
+            }),
+        )
+        .await
+        .assert_status(StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn creates_llm_judge_scorer() {
+    let server = TestServer::in_memory().await;
+    let created = server
+        .post(
+            "/v1/observers",
+            json!({
+                "name": "Quality",
+                "scorers": [
+                    {
+                        "key": "completeness",
+                        "method": "llm_judge",
+                        "rubric": "Score 1.0 if the answer fully addresses the question.",
+                        "pass_threshold": 0.7
+                    }
+                ]
+            }),
+        )
+        .await
+        .assert_status(StatusCode::CREATED)
+        .json_value();
+    assert_eq!(created["scorers"][0]["method"], "llm_judge");
+    assert_eq!(created["scorers"][0]["pass_threshold"], 0.7);
+    assert_eq!(created["scorers"][0]["key"], "completeness");
+}
+
+#[tokio::test]
+async fn rejects_llm_judge_with_empty_rubric() {
+    let server = TestServer::in_memory().await;
+    server
+        .post(
+            "/v1/observers",
+            json!({
+                "name": "Bad judge",
+                "scorers": [{ "key": "j", "method": "llm_judge", "rubric": "  " }]
             }),
         )
         .await
@@ -206,7 +247,7 @@ async fn scores_endpoint_returns_empty_for_new_observer() {
             "/v1/observers",
             json!({
                 "name": "Fresh",
-                "scorers": [{ "key": "k", "rule": { "type": "contains", "text": "x" } }]
+                "scorers": [{ "key": "k", "method": "rule", "rule": { "type": "contains", "text": "x" } }]
             }),
         )
         .await

--- a/specs/online-evals.md
+++ b/specs/online-evals.md
@@ -1,8 +1,10 @@
 # Online Evals (Observers)
 
-Status: **Phase 1 implemented** (behind the `observers` feature flag) — turn-scope rule scoring of production sessions, with the design options below recording the broader direction. LLM-judge, session/tool scopes, aggregation, and the Phase 2 improvement loop remain proposed.
+Status: **Phase 1 implemented** (behind the `observers` feature flag) — turn-scope rule **and LLM-judge** scoring of production sessions, with the design options below recording the broader direction. Session/tool scopes, aggregation/alerting, judge usage metering into budgets, and the Phase 2 improvement loop remain proposed.
 
-Phase 1 surface: `Observer` entity (org-scoped, embedded match rules + rule scorers), `trace_scores` queue, an `ObserverMatchListener` on `turn.completed` that samples and enqueues, and a dual-mode `spawn_observer_worker` that drains the queue (durable `FOR UPDATE SKIP LOCKED` in full mode, in-process in dev mode). Code: `crates/core/src/observer.rs`, `crates/server/src/domains/observers/`, `crates/server/src/api/observers.rs`, migration `056_observers.sql`. API under `/v1/observers`.
+Phase 1 surface: `Observer` entity (org-scoped, embedded match rules + scorers), `trace_scores` queue, an `ObserverMatchListener` on `turn.completed` that samples and enqueues, and a dual-mode `spawn_observer_worker` that drains the queue (durable `FOR UPDATE SKIP LOCKED` in full mode, in-process in dev mode). Code: `crates/core/src/observer.rs`, `crates/server/src/domains/observers/`, `crates/server/src/api/observers.rs`, migrations `059_observers.sql` + `070_observer_llm_judge.sql`. API under `/v1/observers`.
+
+Each scorer has a `method`: `rule` (the eval scorer vocabulary) or `llm_judge`. An `llm_judge` scorer carries a `rubric`, an optional `model_id` (defaults to the org's default model), and a `pass_threshold`. The judge call (`crates/server/src/domains/observers/judge.rs`) goes through the **org's own configured model/provider** (resolved via `ProviderResolverService`), returns structured `{value, label, reasoning}`, and stores token/cost accounting on the score. Judge usage is recorded on the `trace_score` row; metering into `usage_journal`/budgets is a follow-up.
 
 <!-- Design Decisions (proposed, not yet ratified):
   - Observer is the single user-facing abstraction: create an Observer, configure match rules


### PR DESCRIPTION
## What
Adds an **`llm_judge`** scoring method to Observers (online scoring of production sessions), alongside the existing rule scorers. A judge scorer grades a sampled production turn against a rubric and produces a `0.0–1.0` value, an optional categorical label, and reasoning. This is the highest-value follow-up from `specs/online-evals.md` — rule scorers were the skeleton; the LLM judge is the substance.

New surface:
- `ObserverScorerConfig` now carries a tagged **`method`**: `rule` (the eval scorer vocabulary) or `llm_judge`.
- `LlmJudgeConfig`: `rubric`, optional `model_id` (defaults to the org's default model), `pass_threshold`.
- `judge.rs`: pure `build_judge_messages` + `parse_judge_output` (unit-tested) behind a `JudgeClient` trait; `LlmJudgeClient` calls the **org's own configured model/provider** via `ProviderResolverService` (billed to the org), requesting structured `{value, label, reasoning}`.
- The worker dispatches on `method`; judge scores store `label` + token/cost accounting.
- Migration `070` adds `label`, `judge_input_tokens`, `judge_output_tokens`, `judge_cost_usd` to `trace_scores`.

## Why
Online scoring only becomes useful once it can grade *quality* ("did the answer fully address the question?", "was a source cited?"), not just deterministic rules. The judge's textual reasoning is also the raw material for the Phase 2 improvement loop. Design was settled in `specs/online-evals.md`: judge calls go through the org's own providers (not a platform key), so it works for self-hosted deployments and attributes cost honestly.

## How
- **Testable seams**: prompt construction and JSON parsing are pure functions with unit tests (handles code fences, prose, braces-in-strings, clamps out-of-range values); the LLM call sits behind `JudgeClient` so the worker is tested with a fake. The real call is a thin adapter.
- **Model resolution**: `model_id` resolves via `ProviderResolverService::resolve_model`, or `resolve_default_model` when unset; `provider_type` → `DriverId` → `ProviderConfig` → `create_chat_driver` → `chat_completion`.
- **Graceful degradation**: the worker holds an `Option<Arc<dyn JudgeClient>>`; when no provider is available (e.g. dev without keys), `llm_judge` scores finalize as `skipped` with a clear reason rather than erroring.
- **Wiring**: the matching listener registers early (needs only db+wake); the worker spawn moved to after the driver registry + provider resolver are built, so it can carry the judge client.

## Risk
- **Low.** Entirely within the flag-gated observers subsystem. The scorer-shape change (`rule` → `method`-tagged) is safe: observers shipped recently behind the `observers` flag with no production data; all call sites and tests are updated. No other subsystem is touched except the additive `app_builder` wiring.

## Security
- **Threat categories reviewed:** TM-LLM, TM-TENANT, TM-DOS, TM-API.
- *TM-LLM / TM-TENANT*: judge calls use the org's own resolved credentials (`ProviderResolverService`, fail-closed); no platform key, no cross-tenant leakage. Judge inputs (user message + answer + tool names) are truncated. The judge sees production content — but only for observers the org explicitly created, scoped to that org.
- *TM-DOS*: judge volume is bounded by the existing per-org observer cap, sampling rate, and the worker's batch size / `max_attempts`. Judge inputs are length-truncated.
- *TM-API*: rubric non-empty and `pass_threshold ∈ [0,1]` validated at create time.

## Validation
- `cargo fmt --check` + `cargo clippy --all-targets --all-features` clean (core + server).
- Core lib: 10 `observer` tests pass (incl. `llm_judge` serde). Server lib: 1561 tests pass, incl. 17 observer/judge tests (prompt build/parse, worker dispatch for pass/fail/skip paths, public-id regression).
- Integration: 12 `observers_integration_test` pass, incl. `creates_llm_judge_scorer` and `rejects_llm_judge_with_empty_rubric`.
- **Real PostgreSQL**: applied all 70 migrations to a fresh DB; confirmed the four judge columns exist on `trace_scores`.

## Follow-ups
- **Judge usage metering into `usage_journal`/budgets** — usage is stored on the score row today; wiring it into the org meter so budgets can bound judge spend is the immediate next step.
- **Session + tool scopes** (turn-only today).
- **Default-model selection UX** and a built-in rubric catalog.
- Aggregation/alerting (Quality dashboard, threshold notifications) and the Phase 2 improvement loop, per the spec.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (flag-gated, no prod data; call sites updated)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed

https://claude.ai/code/session_013U9P51Z93bAA6CV3JhXUBQ

---
_Generated by [Claude Code](https://claude.ai/code/session_013U9P51Z93bAA6CV3JhXUBQ)_