### PR TITLE
fix: repair judge import and expand docs titles

### DIFF
--- a/crates/server/src/domains/observers/judge.rs
+++ b/crates/server/src/domains/observers/judge.rs
@@ -13,9 +13,8 @@ use anyhow::{Context, Result};
 use async_trait::async_trait;
 use std::sync::Arc;
 
-use everruns_core::DriverRegistry;
-use everruns_core::llm_driver_registry::{
-    LlmCallConfig, LlmMessage, LlmMessageRole, ProviderConfig,
+use everruns_core::driver_registry::{
+    DriverRegistry, LlmCallConfig, LlmMessage, LlmMessageRole, ProviderConfig,
 };
 use everruns_core::provider::DriverId;
 use everruns_core::typed_id::ModelId;

--- a/docs/capabilities/daytona.md
+++ b/docs/capabilities/daytona.md
@@ -1,5 +1,5 @@
 ---
-title: Daytona Sandboxes for Agent Code Execution
+title: Daytona Cloud Sandbox Capability for Agents
 description: Run agent code in isolated Daytona cloud sandboxes with command execution, file access, workspace downloads, lifecycle controls, and session-scoped environments.
 sidebar:
   label: Daytona

--- a/docs/capabilities/fake-crm.md
+++ b/docs/capabilities/fake-crm.md
@@ -1,5 +1,5 @@
 ---
-title: Fake CRM Tools for Agent Workflow Demos
+title: Fake CRM Capability for Support Agent Demos
 description: Test support-agent workflows with a simulated CRM capability for mock customers, tickets, interactions, customer search, and session-persisted demo data.
 sidebar:
   label: Fake CRM

--- a/docs/capabilities/session.md
+++ b/docs/capabilities/session.md
@@ -1,5 +1,5 @@
 ---
-title: Session Metadata Tools for Agents
+title: Session Metadata for Agent Workflow Context
 description: Let agents inspect and update current session metadata, including session IDs, titles, agent names, and context used for logging or conversation organization.
 sidebar:
   label: Session

--- a/docs/features/apps.md
+++ b/docs/features/apps.md
@@ -1,5 +1,5 @@
 ---
-title: Apps
+title: Everruns Apps for Agent Distribution Channels
 description: Apps bind a Harness and Agent to a distribution channel (Slack, webhook, schedule) and expose a publish/unpublish lifecycle.
 sidebar:
   label: Apps

--- a/docs/features/sdk.mdx
+++ b/docs/features/sdk.mdx
@@ -1,5 +1,5 @@
 ---
-title: SDKs
+title: Everruns SDKs for Rust, Python, TypeScript
 description: Official client libraries for Rust, Python, and TypeScript — typed clients, async APIs, SSE streaming with automatic reconnection.
 sidebar:
   label: SDK

--- a/docs/integrations/cursor.md
+++ b/docs/integrations/cursor.md
@@ -1,6 +1,8 @@
 ---
-title: Cursor
+title: Cursor Cloud Agents for Everruns Workflows
 description: Launch and manage Cursor Cloud Agents from Everruns agents.
+sidebar:
+  label: Cursor
 ---
 
 Everruns integrates with [Cursor Cloud Agents](https://docs.cursor.com/en/background-agents) so agents can delegate asynchronous coding work to Cursor. A triage agent can inspect a request, split it into focused tasks, launch Cursor agents against GitHub repositories, send follow-ups, and summarize status or results.

--- a/docs/integrations/daytona.md
+++ b/docs/integrations/daytona.md
@@ -1,6 +1,8 @@
 ---
-title: Daytona
+title: Daytona Integration for Agent Code Sandboxes
 description: Integrate Daytona cloud sandbox environments for secure, isolated code execution. Configure API keys, workspace templates, and session-scoped sandbox lifecycle.
+sidebar:
+  label: Daytona
 ---
 
 ![Daytona Integration](daytona.png)

--- a/docs/integrations/deno.md
+++ b/docs/integrations/deno.md
@@ -1,6 +1,8 @@
 ---
-title: Deno
+title: Deno Deploy Sandboxes for Agent Code Tasks
 description: Integrate Deno cloud sandbox environments for secure, isolated code execution. Configure access tokens, sandbox lifecycle, and session-scoped state.
+sidebar:
+  label: Deno
 ---
 
 Everruns integrates with [Deno Sandboxes](https://docs.deno.com/sandbox/) to provide cloud-based sandbox environments for secure, isolated code execution. Agents can create, manage, and interact with multiple sandboxes per session — each an isolated Linux microVM with network access.

--- a/docs/integrations/sprites.md
+++ b/docs/integrations/sprites.md
@@ -1,6 +1,8 @@
 ---
-title: Sprites
+title: Sprites MicroVM Sandboxes for Everruns Agents
 description: Integrate Sprites persistent Firecracker microVMs for isolated code execution with filesystem persistence, checkpoints, and HTTP services.
+sidebar:
+  label: Sprites
 ---
 
 Everruns integrates with [Sprites](https://sprites.dev/) to provide persistent, hardware-isolated Linux microVMs powered by Firecracker. Unlike ephemeral sandboxes, Sprites maintain their filesystem across idle periods, support instant checkpoint/restore, and expose public HTTP endpoints.


### PR DESCRIPTION
## What
Expand short docs page titles on the SEO-reported docs routes so generated browser title tags are descriptive while sidebar labels stay compact. Also fix a latest-main observer judge import path so the rebased branch builds under clippy.

## Why
Several docs pages had one-word or overly short title tags, which triggered the SEO recommendation for page titles that are too short. After rebasing onto latest `origin/main`, clippy exposed an unrelated observer judge import that referenced a non-existent `everruns_core::llm_driver_registry` module.

## How
Updated frontmatter `title` values for affected docs and integration pages. Added compact `sidebar.label` overrides for autogenerated integration sidebar entries. Left `/vision/` untouched as requested. Corrected the observer judge imports to use `everruns_core::driver_registry`.

## Risk
- Low
- Docs changes affect page headings, browser title tags, search metadata, docs sidebar labels, and docs/OG generation. The server code change is import-only and does not alter judge behavior.

## Security
- Threat categories reviewed: TM-LLM for the observer judge import path; no security-relevant surface for docs frontmatter.
- Findings and resolutions: No findings. The Rust change only points existing LLM driver types at their actual module and does not change model selection, credentials, prompts, requests, responses, logging, or authorization.

## Validation
- `pnpm --dir apps/docs check`
- `pnpm --dir apps/docs build`
- Generated title tag check for all changed routes: 53-56 chars including ` | Everruns`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `bash scripts/lib/check-migration-ordering.sh`
- `just pre-push`
- GitHub CI green on the final commit

Smoke test: skipped because the user-visible change is docs-title/sidebar frontmatter only and the server change is import-only. The docs build verifies the affected static page output end-to-end.

## Follow-ups
No follow-ups.

## Checklist
- [ ] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)