### PR TITLE
fix(core): keep base system prompt before capabilities

### DIFF
--- a/crates/core/src/capabilities/mod.rs
+++ b/crates/core/src/capabilities/mod.rs
@@ -372,7 +372,7 @@ impl SystemPromptContext {
 /// Trait for implementing capabilities that extend agent functionality.
 ///
 /// A capability can contribute:
-/// - System prompt additions (prepended to agent's system prompt)
+/// - System prompt additions (appended after the agent's base system prompt)
 /// - Tools (added to agent's available tools)
 ///
 /// # System Prompt Contributions
@@ -578,7 +578,7 @@ pub trait Capability: Send + Sync {
         None
     }
 
-    /// Returns static text to prepend to the agent's system prompt (optional).
+    /// Returns static text to include in the agent's system prompt (optional).
     ///
     /// This is the simple sync path for capabilities with static prompts.
     /// For dynamic content that requires filesystem access, override
@@ -1549,6 +1549,26 @@ impl CollectedCapabilities {
     }
 }
 
+/// Compose the model-visible system prompt from the stable base prompt and
+/// collected capability contributions. Keep the base prompt first so changes in
+/// dynamic capabilities (for example AGENTS.md reads or environment context)
+/// do not invalidate provider prefix caches for the agent's core instructions.
+pub fn compose_system_prompt(base_system_prompt: &str, additions: Option<&str>) -> String {
+    let Some(additions) = additions.filter(|value| !value.is_empty()) else {
+        return base_system_prompt.to_string();
+    };
+
+    if base_system_prompt.is_empty() {
+        return additions.to_string();
+    }
+
+    if base_system_prompt.contains("<system-prompt>") {
+        format!("{base_system_prompt}\n\n{additions}")
+    } else {
+        format!("<system-prompt>\n{base_system_prompt}\n</system-prompt>\n\n{additions}")
+    }
+}
+
 /// Lightweight result containing only message filter providers.
 ///
 /// Used when callers only need message filtering (e.g., message loading in
@@ -2363,7 +2383,7 @@ pub struct AppliedCapabilities {
 ///
 /// This function:
 /// 1. Collects system prompt contributions from capabilities (in order)
-/// 2. Prepends them to the agent's base system prompt
+/// 2. Appends them after the agent's base system prompt
 /// 3. Collects all tools from capabilities
 /// 4. Returns the modified runtime agent and a tool registry
 ///
@@ -2403,14 +2423,11 @@ pub async fn apply_capabilities(
 ) -> AppliedCapabilities {
     let collected = collect_capabilities(capability_ids, registry, ctx).await;
 
-    // Build final system prompt: capability additions + base prompt (wrapped in XML tags)
-    let final_system_prompt = match collected.system_prompt_prefix() {
-        Some(prefix) => format!(
-            "{}\n\n<system-prompt>\n{}\n</system-prompt>",
-            prefix, base_runtime_agent.system_prompt
-        ),
-        None => base_runtime_agent.system_prompt,
-    };
+    // Build final system prompt: base prompt first, then capability additions.
+    let final_system_prompt = compose_system_prompt(
+        &base_runtime_agent.system_prompt,
+        collected.system_prompt_prefix().as_deref(),
+    );
 
     // Build tool registry from collected tools
     let mut tool_registry = ToolRegistry::new();
@@ -3014,6 +3031,7 @@ mod tests {
         .await;
 
         let prompt = &applied.runtime_agent.system_prompt;
+        assert!(prompt.starts_with("<system-prompt>\nYou are helpful.\n</system-prompt>"));
         // Capability wrapped
         assert!(prompt.contains("<capability id=\"stateless_todo_list\">"));
         assert!(prompt.contains("</capability>"));

--- a/crates/core/src/context_report.rs
+++ b/crates/core/src/context_report.rs
@@ -586,7 +586,7 @@ mod tests {
     fn generation_report_attributes_capability_prompt_blocks() {
         let data = LlmGenerationData::success(
             vec![crate::Message::system(
-                "<capability id=\"agent_instructions\">Rules</capability>\n\n<system-prompt>\nBase\n</system-prompt>",
+                "<system-prompt>\nBase\n</system-prompt>\n\n<capability id=\"agent_instructions\">Rules</capability>",
             )],
             vec![],
             Some("ok".into()),

--- a/crates/core/src/runtime_agent.rs
+++ b/crates/core/src/runtime_agent.rs
@@ -16,7 +16,7 @@
 use crate::agent::Agent;
 use crate::capabilities::{
     CapabilityRegistry, SystemPromptContext, ToolDefinitionHook, collect_capabilities_with_configs,
-    resolve_capability_configs,
+    compose_system_prompt, resolve_capability_configs,
 };
 use crate::config_layer::AgentConfigOverlay;
 use crate::driver_registry::{PromptCacheConfig, ToolSearchConfig};
@@ -192,7 +192,7 @@ impl RuntimeAgentBuilder {
 
     /// Apply an Agent's configuration to this builder.
     ///
-    /// Prepends the agent's system prompt and capabilities on top of the
+    /// Applies the agent's system prompt and capabilities on top of the
     /// existing prompt (typically from a harness). Call after `with_harness()`.
     ///
     /// # Example
@@ -230,7 +230,7 @@ impl RuntimeAgentBuilder {
     /// Resolves dependencies, then collects contributions from capabilities:
     /// - Dependencies are automatically included (topologically sorted)
     /// - `system_prompt_contribution(ctx)` called on each (may read from filesystem)
-    /// - System prompt additions are prepended to the current system prompt
+    /// - System prompt additions are appended after the current system prompt
     /// - Tool definitions are added to the tools list
     ///
     /// # Arguments
@@ -269,17 +269,10 @@ impl RuntimeAgentBuilder {
 
         let collected = collect_capabilities_with_configs(&resolved_configs, registry, ctx).await;
 
-        // Apply system prompt additions (prepend to existing, wrap base in XML tags)
+        // Apply system prompt additions after the stable base prompt.
         if let Some(prefix) = collected.system_prompt_prefix() {
-            if !self.runtime_agent.system_prompt.is_empty()
-                && !self.runtime_agent.system_prompt.contains("<system-prompt>")
-            {
-                self.runtime_agent.system_prompt = format!(
-                    "<system-prompt>\n{}\n</system-prompt>",
-                    self.runtime_agent.system_prompt
-                );
-            }
-            self = self.prepend_system_prompt(prefix);
+            self.runtime_agent.system_prompt =
+                compose_system_prompt(&self.runtime_agent.system_prompt, Some(&prefix));
         }
 
         // Apply tool definitions
@@ -318,18 +311,32 @@ impl RuntimeAgentBuilder {
         self
     }
 
-    /// Prepend locale instructions for session-aware localization.
+    /// Append locale instructions for session-aware localization.
     pub fn with_locale(self, locale: Option<&str>) -> Self {
         let Some(locale) = locale.map(str::trim).filter(|value| !value.is_empty()) else {
             return self;
         };
 
-        self.prepend_system_prompt(format!(
+        self.append_system_prompt(format!(
             "<locale preference=\"{locale}\">\n\
              Default locale for this session: {locale}.\n\
              Unless the user explicitly asks otherwise, respond in this locale and use its language, spelling, and regional formatting conventions for dates, times, numbers, and currency.\n\
              </locale>"
         ))
+    }
+
+    /// Append text to the system prompt
+    pub fn append_system_prompt(mut self, suffix: impl Into<String>) -> Self {
+        let suffix = suffix.into();
+        if !suffix.is_empty() {
+            if self.runtime_agent.system_prompt.is_empty() {
+                self.runtime_agent.system_prompt = suffix;
+            } else {
+                self.runtime_agent.system_prompt =
+                    format!("{}\n\n{}", self.runtime_agent.system_prompt, suffix);
+            }
+        }
+        self
     }
 
     /// Set the model
@@ -556,15 +563,16 @@ mod tests {
     }
 
     #[test]
-    fn test_builder_with_locale_prepends_locale_instructions() {
+    fn test_builder_with_locale_appends_locale_instructions() {
         let runtime_agent = RuntimeAgentBuilder::new()
             .system_prompt("Base prompt.")
             .with_locale(Some("uk-UA"))
             .build();
 
+        assert!(runtime_agent.system_prompt.starts_with("Base prompt."));
         assert!(runtime_agent.system_prompt.contains("<locale"));
         assert!(runtime_agent.system_prompt.contains("uk-UA"));
-        assert!(runtime_agent.system_prompt.contains("Base prompt."));
+        assert!(runtime_agent.system_prompt.ends_with("</locale>"));
     }
 
     #[tokio::test]
@@ -601,7 +609,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_builder_with_capabilities_prepends_system_prompt() {
+    async fn test_builder_with_capabilities_keeps_base_prompt_first() {
         let registry = CapabilityRegistry::with_builtins();
         let runtime_agent = RuntimeAgentBuilder::new()
             .system_prompt("Base prompt.")
@@ -615,7 +623,7 @@ mod tests {
         assert!(
             runtime_agent
                 .system_prompt
-                .ends_with("<system-prompt>\nBase prompt.\n</system-prompt>")
+                .starts_with("<system-prompt>\nBase prompt.\n</system-prompt>")
         );
     }
 

--- a/crates/server/src/domains/observers/judge.rs
+++ b/crates/server/src/domains/observers/judge.rs
@@ -13,11 +13,9 @@ use anyhow::{Context, Result};
 use async_trait::async_trait;
 use std::sync::Arc;
 
-use everruns_core::driver_registry::{
-    DriverRegistry, LlmCallConfig, LlmMessage, LlmMessageRole, ProviderConfig,
-};
 use everruns_core::provider::DriverId;
 use everruns_core::typed_id::ModelId;
+use everruns_core::{DriverRegistry, LlmCallConfig, LlmMessage, LlmMessageRole, ProviderConfig};
 
 use crate::services::ProviderResolverService;
 use crate::storage::StorageBackend;

--- a/crates/server/src/services/capability.rs
+++ b/crates/server/src/services/capability.rs
@@ -519,7 +519,7 @@ impl CapabilityService {
     /// Preview the final agent shape by computing the merged system prompt and tools.
     ///
     /// This collects contributions from all specified capabilities and their dependencies:
-    /// - System prompt additions are prepended to the base prompt
+    /// - System prompt additions are appended after the base prompt
     /// - Tool definitions are collected from all capabilities
     /// - Dependencies are automatically resolved (dependencies before dependents)
     ///
@@ -613,15 +613,11 @@ impl CapabilityService {
         // No additional prompt or tool injection needed here.
 
         // Build final system prompt (XML-wrapped when capabilities contribute prompts)
-        let final_system_prompt = if system_prompt_parts.is_empty() {
-            base_system_prompt.to_string()
-        } else {
-            format!(
-                "{}\n\n<system-prompt>\n{}\n</system-prompt>",
-                system_prompt_parts.join("\n\n"),
-                base_system_prompt
-            )
-        };
+        let additions = (!system_prompt_parts.is_empty()).then(|| system_prompt_parts.join("\n\n"));
+        let final_system_prompt = everruns_core::capabilities::compose_system_prompt(
+            base_system_prompt,
+            additions.as_deref(),
+        );
 
         Ok((final_system_prompt, tool_definitions))
     }

--- a/specs/xml-prompt-formatting.md
+++ b/specs/xml-prompt-formatting.md
@@ -2,7 +2,7 @@
 
 ## Abstract
 
-System prompts use XML tags to create clear boundaries between capability instructions, user-provided project instruction files, and the agent's base system prompt. This follows Anthropic's recommendation for multi-component prompts and is the cross-provider consensus for structured prompt formatting.
+System prompts use XML tags to create clear boundaries between the agent's base system prompt, capability instructions, and user-provided project instruction files. This follows Anthropic's recommendation for multi-component prompts and is the cross-provider consensus for structured prompt formatting.
 
 ## Rationale
 
@@ -44,10 +44,9 @@ Three XML tags wrap the three logical sections of the assembled system prompt:
 ### Assembled Prompt Structure
 
 ```xml
-<agent-instructions source="AGENTS.md">
-## Style
-Use snake_case for variables.
-</agent-instructions>
+<system-prompt>
+You are a helpful assistant.
+</system-prompt>
 
 <capability id="session_file_system">
 You have access to file system tools...
@@ -57,18 +56,21 @@ You have access to file system tools...
 You have access to math tools...
 </capability>
 
-<system-prompt>
-You are a helpful assistant.
-</system-prompt>
+<agent-instructions source="AGENTS.md">
+## Style
+Use snake_case for variables.
+</agent-instructions>
 ```
 
 ### Ordering
 
-Top to bottom (matches existing order, unchanged):
+Top to bottom:
 
-1. **Instruction files** — user-provided project instructions (if `agent_instructions` capability enabled and configured files exist)
+1. **Base system prompt** — agent's core behavior prompt
 2. **Capability prompts** — in capability application order (agent caps, then session caps)
-3. **Base system prompt** — agent's core behavior prompt
+3. **Instruction files** — user-provided project instructions, positioned wherever the `agent_instructions` capability appears in that order
+
+The base system prompt is first to maximize provider prefix-cache reuse. Dynamic capability contributions such as `agent_instructions` and environment context should be ordered late by the harness/agent/session configuration when their contents change frequently.
 
 ### Conditional Wrapping
 
@@ -108,30 +110,22 @@ Wraps the base system prompt in `<system-prompt>` tags when capabilities contrib
 
 ```rust
 if let Some(prefix) = collected.system_prompt_prefix() {
-    if !self.runtime_agent.system_prompt.contains("<system-prompt>") {
-        self.runtime_agent.system_prompt = format!(
-            "<system-prompt>\n{}\n</system-prompt>",
-            self.runtime_agent.system_prompt
-        );
-    }
-    self = self.prepend_system_prompt(prefix);
+    self.runtime_agent.system_prompt =
+        compose_system_prompt(&self.runtime_agent.system_prompt, Some(&prefix));
 }
 ```
 
-Double-wrapping is prevented by checking for existing `<system-prompt>` tag (relevant when session capabilities are applied after agent capabilities).
+Double-wrapping is prevented inside `compose_system_prompt` by checking for an existing `<system-prompt>` tag (relevant when session capabilities are applied after agent capabilities).
 
 #### `apply_capabilities()` (mod.rs)
 
 Same wrapping in the standalone `apply_capabilities` path:
 
 ```rust
-let final_system_prompt = match collected.system_prompt_prefix() {
-    Some(prefix) => format!(
-        "{}\n\n<system-prompt>\n{}\n</system-prompt>",
-        prefix, base_runtime_agent.system_prompt
-    ),
-    None => base_runtime_agent.system_prompt,
-};
+let final_system_prompt = compose_system_prompt(
+    &base_runtime_agent.system_prompt,
+    collected.system_prompt_prefix().as_deref(),
+);
 ```
 
 ### UI Impact


### PR DESCRIPTION
## What
Keep the base `<system-prompt>` at the top of assembled prompts, then append capability contributions after it. Locale instructions now append instead of prepending, and the server preview path uses the same shared composer as core runtime assembly.

## Why
Dynamic prompt sections such as project instructions and environment/session context can change frequently. Putting them before the stable base prompt reduces provider prefix-cache reuse when AGENTS.md or other capability prompt content changes.

## How
Added `compose_system_prompt` in core and routed `apply_capabilities`, `RuntimeAgentBuilder`, and server capability preview through it. Updated XML prompt-formatting docs and focused tests/fixtures to assert the base prompt comes first.

## Risk
- Medium
- Prompt ordering changes for agents with capability prompt contributions. Behavior should remain semantically equivalent because XML section boundaries are preserved, but models may weight earlier base instructions slightly more strongly.

## Security
- Threat categories reviewed: No security-relevant code changes; this changes prompt assembly order only.
- Findings and resolutions: No security findings.

## Follow-ups
Yolop should order volatile capabilities such as `agent_instructions` and environment context late in its harness capability list after consuming this core change.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

Validation:
- `cargo fmt --check`
- `cargo test -p everruns-core test_xml_tags_system_prompt_wrapping`
- `cargo test -p everruns-core test_builder_with_capabilities_keeps_base_prompt_first`
- `cargo test -p everruns-core test_builder_with_locale_appends_locale_instructions`
- `cargo test -p everruns-core generation_report_attributes_capability_prompt_blocks`
- Attempted `cargo test -p everruns-server preview`, blocked locally by `No space left on device` while compiling `everruns-server` under `target/debug`.