### PR TITLE
fix(observers): use renamed driver_registry module in judge

### DIFF
--- a/crates/server/src/domains/observers/judge.rs
+++ b/crates/server/src/domains/observers/judge.rs
@@ -14,7 +14,7 @@ use async_trait::async_trait;
 use std::sync::Arc;
 
 use everruns_core::DriverRegistry;
-use everruns_core::llm_driver_registry::{
+use everruns_core::driver_registry::{
     LlmCallConfig, LlmMessage, LlmMessageRole, ProviderConfig,
 };
 use everruns_core::provider::DriverId;

--- a/crates/server/src/domains/observers/judge.rs
+++ b/crates/server/src/domains/observers/judge.rs
@@ -14,9 +14,7 @@ use async_trait::async_trait;
 use std::sync::Arc;
 
 use everruns_core::DriverRegistry;
-use everruns_core::driver_registry::{
-    LlmCallConfig, LlmMessage, LlmMessageRole, ProviderConfig,
-};
+use everruns_core::driver_registry::{LlmCallConfig, LlmMessage, LlmMessageRole, ProviderConfig};
 use everruns_core::provider::DriverId;
 use everruns_core::typed_id::ModelId;
 


### PR DESCRIPTION
## What
One-line fix: `crates/server/src/domains/observers/judge.rs` imports from `everruns_core::driver_registry` instead of the old `everruns_core::llm_driver_registry`.

## Why
**main is currently broken** (`everruns-server` does not compile). Two PRs merged back-to-back interacted badly:
- **#2263** (LLM-judge, mine) landed `judge.rs`, which imported `everruns_core::llm_driver_registry`.
- **#2262** (`refactor(core): rename llm_driver_registry → driver_registry`) merged right after and renamed that module with no compat alias — but it was in flight concurrently and didn't update my just-landed file.

The result: `judge.rs` is the only file on main still referencing the removed module path, so the server crate fails to compile. Caught while monitoring the post-merge CI of #2263.

## How
Point the import at the renamed module (`driver_registry`). The types (`LlmCallConfig`, `LlmMessage`, `LlmMessageRole`, `ProviderConfig`) are unchanged — only the module path moved.

## Risk
- **Minimal.** Single import-path change to match the completed refactor; no behavior change.

## Validation
- `cargo build -p everruns-server` succeeds (failed before the change).
- `observers::judge` unit tests pass.

## Security
No security-relevant change — import path only.

## Follow-ups
No follow-ups.

https://claude.ai/code/session_013U9P51Z93bAA6CV3JhXUBQ

---
_Generated by [Claude Code](https://claude.ai/code/session_013U9P51Z93bAA6CV3JhXUBQ)_