### PR TITLE
fix(server): update judge.rs import after driver_registry rename

### DIFF
--- a/crates/server/src/domains/observers/judge.rs
+++ b/crates/server/src/domains/observers/judge.rs
@@ -14,7 +14,7 @@ use async_trait::async_trait;
 use std::sync::Arc;
 
 use everruns_core::DriverRegistry;
-use everruns_core::llm_driver_registry::{
+use everruns_core::driver_registry::{
     LlmCallConfig, LlmMessage, LlmMessageRole, ProviderConfig,
 };
 use everruns_core::provider::DriverId;


### PR DESCRIPTION
## What
Fix the stale `everruns_core::llm_driver_registry` import in `crates/server/src/domains/observers/judge.rs`.

## Why
The #2262 rename (`llm_driver_registry` → `driver_registry`) missed this file, so `main` fails to compile: `error[E0432]: unresolved import everruns_core::llm_driver_registry` (Integration Tests (PostgreSQL) is red on `main`).

## How
- One-line import path update; symbols unchanged (`LlmCallConfig`, `LlmMessage`, `LlmMessageRole`, `ProviderConfig`).
- Verified `cargo check -p everruns-server --lib` succeeds.

## Risk
- None — rename-only.

## Security
- No security-relevant change.

## Follow-ups
- No follow-ups.

## Checklist
- [x] Tests added or updated (n/a — compile fix)
- [x] Backward compatibility considered
- [x] Security review performed
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed
