### PR TITLE
chore(crates): make published crates discoverable on crates.io

### DIFF
--- a/crates/a2ui/Cargo.toml
+++ b/crates/a2ui/Cargo.toml
@@ -16,8 +16,10 @@ authors.workspace = true
 homepage.workspace = true
 repository.workspace = true
 documentation = "https://docs.rs/everruns-a2ui"
-description = "A2UI component catalog and prompt generator for Everruns"
+description = "A2UI component catalog and prompt generator for Everruns agents"
 readme = "README.md"
+keywords = ["everruns", "a2ui", "agent", "ui", "llm"]
+categories = ["development-tools"]
 
 [dependencies]
 

--- a/crates/anthropic/Cargo.toml
+++ b/crates/anthropic/Cargo.toml
@@ -12,8 +12,10 @@ authors.workspace = true
 homepage.workspace = true
 repository.workspace = true
 documentation = "https://docs.rs/everruns-anthropic"
-description = "Anthropic Claude provider implementation for Everruns"
+description = "Anthropic (Claude) provider for Everruns agents"
 readme = "README.md"
+keywords = ["agent", "llm", "ai", "anthropic", "claude"]
+categories = ["api-bindings", "asynchronous"]
 
 [dependencies]
 # Core dependencies

--- a/crates/bedrock/Cargo.toml
+++ b/crates/bedrock/Cargo.toml
@@ -6,6 +6,8 @@
 [package]
 name = "everruns-bedrock"
 readme = "README.md"
+keywords = ["agent", "llm", "ai", "bedrock", "aws"]
+categories = ["api-bindings", "asynchronous"]
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
@@ -14,7 +16,7 @@ authors.workspace = true
 homepage.workspace = true
 repository.workspace = true
 documentation = "https://docs.rs/everruns-bedrock"
-description = "AWS Bedrock Runtime provider implementation for Everruns"
+description = "AWS Bedrock provider for Everruns agents"
 
 [dependencies]
 # Core dependencies

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -3,9 +3,15 @@ name = "everruns-cli"
 readme = "README.md"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 authors.workspace = true
-description = "Command-line interface for Everruns"
+homepage.workspace = true
+repository.workspace = true
+documentation = "https://docs.rs/everruns-cli"
+description = "Command-line interface for Everruns — run and manage agents from your terminal"
+keywords = ["everruns", "agent", "agentic", "cli", "ai"]
+categories = ["command-line-utilities", "development-tools"]
 
 [[bin]]
 name = "everruns"

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -16,6 +16,8 @@ repository.workspace = true
 documentation = "https://docs.rs/everruns-config"
 description = "Shared configuration loading helpers for Everruns"
 readme = "README.md"
+keywords = ["everruns", "config", "configuration", "agent"]
+categories = ["config", "development-tools"]
 
 [dependencies]
 thiserror.workspace = true

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -17,6 +17,8 @@ repository.workspace = true
 documentation = "https://docs.rs/everruns-core"
 description = "Core agent abstractions for Everruns - agent loop, events, tools, LLM providers"
 readme = "README.md"
+keywords = ["agent", "agentic", "llm", "ai", "framework"]
+categories = ["development-tools", "asynchronous"]
 
 [dependencies]
 # Core dependencies

--- a/crates/gemini/Cargo.toml
+++ b/crates/gemini/Cargo.toml
@@ -5,6 +5,8 @@
 [package]
 name = "everruns-gemini"
 readme = "README.md"
+keywords = ["agent", "llm", "ai", "gemini", "google"]
+categories = ["api-bindings", "asynchronous"]
 version.workspace = true
 rust-version.workspace = true
 homepage.workspace = true
@@ -12,7 +14,7 @@ repository.workspace = true
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
-description = "Google Gemini provider implementation for Everruns"
+description = "Google Gemini provider for Everruns agents"
 documentation = "https://docs.rs/everruns-gemini"
 
 [dependencies]

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -8,8 +8,10 @@ authors.workspace = true
 homepage.workspace = true
 repository.workspace = true
 documentation = "https://docs.rs/everruns-mcp"
-description = "Transport-agnostic MCP (Model Context Protocol) client shared by the Everruns runtime, worker, and server."
+description = "Transport-agnostic MCP (Model Context Protocol) client for connecting tools to Everruns agents"
 readme = "README.md"
+keywords = ["mcp", "agent", "llm", "ai", "tools"]
+categories = ["api-bindings", "asynchronous"]
 
 [features]
 default = []

--- a/crates/openai/Cargo.toml
+++ b/crates/openai/Cargo.toml
@@ -12,8 +12,10 @@ authors.workspace = true
 homepage.workspace = true
 repository.workspace = true
 documentation = "https://docs.rs/everruns-openai"
-description = "OpenAI provider implementation for Everruns"
+description = "OpenAI (GPT) provider for Everruns agents"
 readme = "README.md"
+keywords = ["agent", "llm", "ai", "openai", "gpt"]
+categories = ["api-bindings", "asynchronous"]
 
 [dependencies]
 # Core dependencies

--- a/crates/openrouter/Cargo.toml
+++ b/crates/openrouter/Cargo.toml
@@ -12,8 +12,10 @@ authors.workspace = true
 homepage.workspace = true
 repository.workspace = true
 documentation = "https://docs.rs/everruns-openrouter"
-description = "OpenRouter provider implementation for Everruns"
+description = "OpenRouter provider for Everruns agents"
 readme = "README.md"
+keywords = ["agent", "llm", "ai", "openrouter"]
+categories = ["api-bindings", "asynchronous"]
 
 [dependencies]
 async-trait.workspace = true

--- a/crates/openui/Cargo.toml
+++ b/crates/openui/Cargo.toml
@@ -15,8 +15,10 @@ authors.workspace = true
 homepage.workspace = true
 repository.workspace = true
 documentation = "https://docs.rs/everruns-openui"
-description = "OpenUI component definitions and prompt generator for Everruns"
+description = "OpenUI component definitions and prompt generator for Everruns agents"
 readme = "README.md"
+keywords = ["everruns", "openui", "agent", "ui", "llm"]
+categories = ["development-tools"]
 
 [dependencies]
 

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -12,8 +12,10 @@ authors.workspace = true
 homepage.workspace = true
 repository.workspace = true
 documentation = "https://docs.rs/everruns-runtime"
-description = "Public in-process runtime for embedding Everruns harnesses"
+description = "In-process Rust runtime for building local agentic systems — coding agents, personal agents, and more — by embedding Everruns agent harnesses"
 readme = "README.md"
+keywords = ["agent", "agentic", "coding-agent", "llm", "ai"]
+categories = ["development-tools", "asynchronous"]
 
 [features]
 default = []

--- a/integrations/brave-search/Cargo.toml
+++ b/integrations/brave-search/Cargo.toml
@@ -13,7 +13,9 @@ repository.workspace = true
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
-description = "Brave Search web search integration for Everruns"
+description = "Brave Search web search integration for Everruns agents"
+keywords = ["everruns", "brave", "search", "agents"]
+categories = ["api-bindings", "development-tools"]
 documentation = "https://docs.rs/everruns-integrations-brave-search"
 
 [dependencies]

--- a/integrations/browserless/Cargo.toml
+++ b/integrations/browserless/Cargo.toml
@@ -13,7 +13,9 @@ repository.workspace = true
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
-description = "Browserless browser automation integration for Everruns"
+description = "Browserless browser automation integration for Everruns agents"
+keywords = ["everruns", "browserless", "browser", "agents"]
+categories = ["api-bindings", "development-tools"]
 documentation = "https://docs.rs/everruns-integrations-browserless"
 
 [dependencies]

--- a/integrations/cursor/Cargo.toml
+++ b/integrations/cursor/Cargo.toml
@@ -12,6 +12,8 @@ edition.workspace = true
 license.workspace = true
 authors.workspace = true
 description = "Cursor Cloud Agents integration for Everruns"
+keywords = ["everruns", "cursor", "agents", "ai"]
+categories = ["api-bindings", "development-tools"]
 documentation = "https://docs.rs/everruns-integrations-cursor"
 
 [dependencies]

--- a/integrations/deno/Cargo.toml
+++ b/integrations/deno/Cargo.toml
@@ -11,7 +11,9 @@ repository.workspace = true
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
-description = "Deno Sandbox integration for Everruns"
+description = "Deno Sandbox integration for Everruns agents"
+keywords = ["everruns", "deno", "sandbox", "agents"]
+categories = ["api-bindings", "development-tools"]
 documentation = "https://docs.rs/everruns-integrations-deno"
 
 [dependencies]

--- a/integrations/docker/Cargo.toml
+++ b/integrations/docker/Cargo.toml
@@ -12,7 +12,9 @@ repository.workspace = true
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
-description = "Docker container integration for Everruns"
+description = "Docker container integration for Everruns agents"
+keywords = ["everruns", "docker", "sandbox", "agents"]
+categories = ["api-bindings", "development-tools"]
 documentation = "https://docs.rs/everruns-integrations-docker"
 
 [dependencies]

--- a/integrations/duckduckgo/Cargo.toml
+++ b/integrations/duckduckgo/Cargo.toml
@@ -13,7 +13,9 @@ authors.workspace = true
 homepage.workspace = true
 repository.workspace = true
 documentation = "https://docs.rs/everruns-integrations-duckduckgo"
-description = "DuckDuckGo Instant Answer search integration for Everruns"
+description = "DuckDuckGo Instant Answer search integration for Everruns agents"
+keywords = ["everruns", "duckduckgo", "search", "agents"]
+categories = ["api-bindings", "development-tools"]
 readme = "README.md"
 
 [dependencies]

--- a/integrations/sprites/Cargo.toml
+++ b/integrations/sprites/Cargo.toml
@@ -12,7 +12,9 @@ repository.workspace = true
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
-description = "Sprites cloud sandbox integration for Everruns"
+description = "Sprites cloud sandbox integration for Everruns agents"
+keywords = ["everruns", "sprites", "sandbox", "agents"]
+categories = ["api-bindings", "development-tools"]
 documentation = "https://docs.rs/everruns-integrations-sprites"
 
 [dependencies]


### PR DESCRIPTION
## What
Adds `keywords` and `categories` to every published crate, sharpens crate
descriptions to mention "agent"/"agentic", and completes missing package metadata
(`rust-version`, `homepage`, `repository`, `documentation`) on `everruns-cli`.

Touches all 23 published crates (12 in `crates/`, 11 in `integrations/`).

## Why
A search for "agent" on crates.io did not surface `everruns-runtime` at all.
crates.io ranks search on `name`, `description`, `keywords`, and `categories` —
and the runtime crate (the embeddable entry point for building local agentic
systems: coding agents, personal agents, etc.) had **no keywords, no categories,
and a description that never mentioned "agent"**. So nothing matched. Most other
published crates had the same gap. `everruns-cli` was additionally missing
`homepage`, `repository`, and `documentation`, so its crates.io page had no links
back to the project or docs.

## How
- Library/provider crates (`runtime`, `core`, `openai`, `anthropic`, `gemini`,
  `openrouter`, `bedrock`, `mcp`): added agent-focused `keywords`
  (`agent`, `agentic`, `llm`, `ai`, provider-specific) + `categories`, and
  rewrote descriptions to lead with what they do for agents.
- `a2ui`, `config`, `openui`, `cli`: same treatment; `cli` also gained the
  missing `rust-version`/`homepage`/`repository`/`documentation`.
- Integrations: applied the existing house convention already used by
  `daytona`/`e2b`/`github`/`parallel` —
  `keywords = ["everruns", "<name>", "<purpose>", "agents"]`,
  `categories = ["api-bindings", "development-tools"]` — to the seven that lacked it
  (`brave-search`, `browserless`, `cursor`, `deno`, `docker`, `duckduckgo`, `sprites`).
- `keywords`/`categories`/`description`/`documentation` are kept per-crate (they must
  be unique). A workspace-level `readme` default was explored but dropped: Cargo
  resolves an inherited `readme` path relative to the workspace root, which emits an
  "outside of the package" warning on every crate at publish time, so the per-crate
  `readme = "README.md"` is retained.

Validation:
- `cargo metadata` parses; `cargo fmt --check` clean.
- `cargo package --list` on touched crates: no keyword/category warnings — counts
  ≤5, lengths ≤20, all category slugs valid (`development-tools`, `api-bindings`,
  `asynchronous`, `command-line-utilities`, `config`).
- `cargo check -p everruns-server` builds clean on the rebased base.
- `bash scripts/lib/check-migration-ordering.sh`: sequential (001..070), no migrations touched.

Note: new metadata only takes effect on each crate's **next publish** — crates.io
indexes the uploaded `.crate`, not the repo, so currently-published versions are
unchanged until a release.

## Risk
- Low. Manifest metadata only — no source, dependency, or build-graph changes.
  Worst case is a typo in a keyword/category string, which `cargo package` validates
  (and we verified clean).

## Security
- Threat categories reviewed: **No security-relevant code changes.** The diff is
  limited to `Cargo.toml` package-metadata fields (description, keywords, categories,
  homepage, repository, documentation, rust-version). No runtime code, auth, queries,
  inputs, dependencies, or trust boundaries are affected.
- Findings and resolutions: none.

## Follow-ups
No follow-ups. (Separately worth noting for maintainers, not part of this PR: the
crates.io metadata changes here will need an actual crate release to become visible
in search.)

## Checklist
- [x] Tests added or updated — N/A (metadata-only; covered by `cargo package` validation)
- [x] Backward compatibility considered — no API/behavior change
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)
