### PR TITLE
feat(mai): add Microsoft MAI provider (Azure AI Foundry) with OAuth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2747,6 +2747,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "everruns-mai"
+version = "0.13.0"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "everruns-core",
+ "futures",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "wiremock",
+]
+
+[[package]]
 name = "everruns-mcp"
 version = "0.13.0"
 dependencies = [
@@ -2975,6 +2991,7 @@ dependencies = [
  "everruns-integrations-parallel",
  "everruns-integrations-sprites",
  "everruns-internal-protocol",
+ "everruns-mai",
  "everruns-mcp",
  "everruns-openai",
  "everruns-openrouter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "crates/runtime",
     "crates/openai",
     "crates/openrouter",
+    "crates/mai",
     "crates/anthropic",
     "crates/gemini",
     "crates/internal-protocol",

--- a/apps/ui/src/app/(main)/settings/providers/provider-dialogs.tsx
+++ b/apps/ui/src/app/(main)/settings/providers/provider-dialogs.tsx
@@ -25,6 +25,7 @@ const PROVIDER_TYPES: { value: DriverId; label: string }[] = [
   { value: "anthropic", label: "Anthropic" },
   { value: "gemini", label: "Google Gemini" },
   { value: "bedrock", label: "AWS Bedrock" },
+  { value: "mai", label: "Microsoft MAI" },
 ];
 
 // Get API key placeholder based on provider type
@@ -41,6 +42,8 @@ function getApiKeyPlaceholder(providerType: DriverId): string {
       return "sk-ant-api03-...";
     case "bedrock":
       return '{"access_key_id":"...","secret_access_key":"...","region":"us-east-1"}';
+    case "mai":
+      return "Azure AI Foundry key (or leave blank for Entra ID OAuth)";
     default:
       return "your-api-key";
   }
@@ -60,6 +63,8 @@ function getBaseUrlPlaceholder(providerType: DriverId): string {
       return "https://api.anthropic.com/v1/messages";
     case "gemini":
       return "https://generativelanguage.googleapis.com";
+    case "mai":
+      return "https://your-resource.services.ai.azure.com";
     default:
       return "https://api.example.com";
   }

--- a/apps/ui/src/app/(main)/settings/providers/provider-dialogs.tsx
+++ b/apps/ui/src/app/(main)/settings/providers/provider-dialogs.tsx
@@ -43,7 +43,7 @@ function getApiKeyPlaceholder(providerType: DriverId): string {
     case "bedrock":
       return '{"access_key_id":"...","secret_access_key":"...","region":"us-east-1"}';
     case "mai":
-      return "Azure AI Foundry key (or leave blank for Entra ID OAuth)";
+      return 'Foundry key, or {"tenant_id":"...","client_id":"...","client_secret":"..."}';
     default:
       return "your-api-key";
   }

--- a/apps/ui/src/components/providers/provider-icon.tsx
+++ b/apps/ui/src/components/providers/provider-icon.tsx
@@ -87,6 +87,21 @@ function AwsBedrockIcon({ size }: { size: number }) {
   );
 }
 
+function MicrosoftIcon({ size }: { size: number }) {
+  // Microsoft's four-square mark, rendered monochrome with a gap.
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      width={size}
+      height={size}
+      fill="currentColor"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path d="M2 2h9.2v9.2H2zM12.8 2H22v9.2h-9.2zM2 12.8h9.2V22H2zM12.8 12.8H22V22h-9.2z" />
+    </svg>
+  );
+}
+
 const PROVIDER_ICON_COMPONENTS: Record<DriverId, React.ComponentType<{ size: number }>> = {
   openai: OpenAiIcon,
   openrouter: Server,
@@ -95,6 +110,7 @@ const PROVIDER_ICON_COMPONENTS: Record<DriverId, React.ComponentType<{ size: num
   anthropic: AnthropicIcon,
   gemini: GeminiIcon,
   bedrock: AwsBedrockIcon,
+  mai: MicrosoftIcon,
 };
 
 const PROVIDER_LABELS: Record<DriverId, string> = {
@@ -105,6 +121,7 @@ const PROVIDER_LABELS: Record<DriverId, string> = {
   anthropic: "Anthropic",
   gemini: "Google Gemini",
   bedrock: "AWS Bedrock",
+  mai: "Microsoft MAI",
 };
 
 interface ProviderIconProps {

--- a/apps/ui/src/lib/api/types/provider-types.ts
+++ b/apps/ui/src/lib/api/types/provider-types.ts
@@ -11,7 +11,8 @@ export type DriverId =
   | "openai_completions"
   | "anthropic"
   | "gemini"
-  | "bedrock";
+  | "bedrock"
+  | "mai";
 
 export type ProviderStatus = "active" | "disabled";
 

--- a/crates/core/src/driver_registry.rs
+++ b/crates/core/src/driver_registry.rs
@@ -1604,6 +1604,7 @@ fn default_display_name(id: &DriverId) -> String {
         DriverId::Anthropic => "Anthropic".to_string(),
         DriverId::Gemini => "Google Gemini".to_string(),
         DriverId::Bedrock => "AWS Bedrock".to_string(),
+        DriverId::Mai => "Microsoft MAI".to_string(),
         DriverId::LlmSim => "LLM Simulator".to_string(),
         DriverId::External(id) => id.to_string(),
     }
@@ -1714,10 +1715,11 @@ impl DriverRegistry {
     /// Returns `DriverNotRegistered` error if no driver is registered for the provider type.
     pub fn create_chat_driver(&self, config: &ProviderConfig) -> Result<BoxedChatDriver> {
         // API key is required for real built-in providers, but not for LlmSim
-        // (testing) or External providers (which may use metadata-based auth).
+        // (testing), External providers, or Mai (which may all authenticate via
+        // metadata-based auth — Mai supports Entra ID OAuth without an api_key).
         let requires_api_key = !matches!(
             config.provider_type,
-            DriverId::LlmSim | DriverId::External(_)
+            DriverId::LlmSim | DriverId::External(_) | DriverId::Mai
         );
         if requires_api_key && config.api_key.is_none() {
             return Err(AgentLoopError::llm(

--- a/crates/core/src/model_profiles.rs
+++ b/crates/core/src/model_profiles.rs
@@ -227,6 +227,16 @@ const OPENAI_COMPAT: &[DriverId] = &[
 const ANTHROPIC: &[DriverId] = &[DriverId::Anthropic];
 const GEMINI: &[DriverId] = &[DriverId::Gemini];
 const LLMSIM: &[DriverId] = &[DriverId::LlmSim];
+// Microsoft MAI models are served first-party by the dedicated `Mai` driver
+// (Azure AI Foundry) and are also reachable through OpenAI-compatible gateways
+// (e.g. OpenRouter). They are never offered through the Azure OpenAI driver,
+// which targets OpenAI deployments rather than MAI deployments.
+const MICROSOFT_MAI: &[DriverId] = &[
+    DriverId::Mai,
+    DriverId::OpenAI,
+    DriverId::OpenRouter,
+    DriverId::OpenAICompletions,
+];
 
 static REGISTRY: &[ModelDescriptor] = &[
     // OpenAI
@@ -323,7 +333,12 @@ static REGISTRY: &[ModelDescriptor] = &[
     md(
         &["mai-1-preview", "microsoft/mai-1-preview"],
         ModelVendor::Microsoft,
-        OPENAI_COMPAT,
+        MICROSOFT_MAI,
+    ),
+    md(
+        &["mai-code-1-flash", "microsoft/mai-code-1-flash"],
+        ModelVendor::Microsoft,
+        MICROSOFT_MAI,
     ),
     md(
         &["minimax-m3", "minimax/minimax-m3"],
@@ -1933,6 +1948,39 @@ fn third_party_profile_data(model_id: &str) -> Option<ModelProfile> {
             temperature: true,
             knowledge: None,
             tool_call: false,
+            structured_output: false,
+            open_weights: false,
+            cost: None,
+            limits: None,
+            modalities: Some(ModelModalities {
+                input: vec![Modality::Text],
+                output: vec![Modality::Text],
+            }),
+            reasoning_effort: None,
+            tool_search: false,
+            supported_parameters: Vec::new(),
+            supports_phases: false,
+        }),
+
+        // Microsoft MAI-Code-1-Flash — Microsoft's in-house, latency-optimized
+        // coding model served via Azure AI Foundry (and OpenAI-compatible
+        // gateways). It is a fast, tool-calling code model rather than a graded
+        // reasoning model. Microsoft has not published pricing, context window,
+        // or knowledge cutoff, so cost/limits are left unset rather than guessed
+        // (same policy as MAI-1-preview).
+        "mai-code-1-flash" | "microsoft/mai-code-1-flash" => Some(ModelProfile {
+            name: "MAI-Code-1-Flash".into(),
+            family: "mai-code-1".into(),
+            description: Some(
+                "Microsoft's latency-optimized in-house coding model (Azure AI Foundry).".into(),
+            ),
+            release_date: None,
+            last_updated: None,
+            attachment: false,
+            reasoning: false,
+            temperature: true,
+            knowledge: None,
+            tool_call: true,
             structured_output: false,
             open_weights: false,
             cost: None,

--- a/crates/core/src/openai_protocol.rs
+++ b/crates/core/src/openai_protocol.rs
@@ -47,6 +47,27 @@ pub(crate) fn apply_openai_api_auth(
     }
 }
 
+/// Pluggable authentication-header provider for OpenAI-compatible drivers.
+///
+/// When set on an [`OpenAIProtocolChatDriver`] via
+/// [`OpenAIProtocolChatDriver::with_auth_provider`], the driver calls
+/// [`AuthHeaderProvider::auth_header`] before each request and applies the
+/// returned `(name, value)` header instead of the default `api-key` / bearer
+/// logic keyed on the host.
+///
+/// This lets a driver authenticate with short-lived, refreshable tokens —
+/// e.g. Microsoft Entra ID (OAuth) bearer tokens for Azure AI Foundry — without
+/// the generic protocol driver having to know the auth scheme. The provider is
+/// responsible for caching and refreshing tokens; `auth_header` is awaited once
+/// per HTTP attempt, so it should be cheap on the cached path.
+#[async_trait]
+pub trait AuthHeaderProvider: Send + Sync {
+    /// Return the `(header_name, header_value)` pair to apply for
+    /// authentication, refreshing any cached credential as needed. Returning
+    /// `Err` aborts the request before it is sent.
+    async fn auth_header(&self) -> Result<(String, String)>;
+}
+
 pub fn is_azure_openai_api_url(api_url: &str) -> bool {
     Url::parse(api_url)
         .ok()
@@ -168,6 +189,9 @@ pub struct OpenAIProtocolChatDriver {
     api_url: String,
     /// Retry configuration for rate limit errors
     retry_config: LlmRetryConfig,
+    /// Optional pluggable auth-header provider. When set, it overrides the
+    /// default `api-key` / bearer auth (used for OAuth bearer tokens).
+    auth_provider: Option<Arc<dyn AuthHeaderProvider>>,
 }
 
 impl OpenAIProtocolChatDriver {
@@ -178,6 +202,7 @@ impl OpenAIProtocolChatDriver {
             api_key: api_key.into(),
             api_url: DEFAULT_API_URL.to_string(),
             retry_config: LlmRetryConfig::default(),
+            auth_provider: None,
         }
     }
 
@@ -195,12 +220,20 @@ impl OpenAIProtocolChatDriver {
             api_key: api_key.into(),
             api_url: api_url.into(),
             retry_config: LlmRetryConfig::default(),
+            auth_provider: None,
         }
     }
 
     /// Configure retry behavior for rate limit errors
     pub fn with_retry_config(mut self, config: LlmRetryConfig) -> Self {
         self.retry_config = config;
+        self
+    }
+
+    /// Set a pluggable [`AuthHeaderProvider`] that overrides the default
+    /// `api-key` / bearer auth. Used for OAuth bearer tokens (e.g. Entra ID).
+    pub fn with_auth_provider(mut self, provider: Arc<dyn AuthHeaderProvider>) -> Self {
+        self.auth_provider = Some(provider);
         self
     }
 
@@ -385,16 +418,23 @@ impl ChatDriver for OpenAIProtocolChatDriver {
         let mut last_error: Option<String> = None;
 
         let response = loop {
-            let response = apply_openai_api_auth(
-                self.client.post(&self.api_url),
-                &self.api_url,
-                &self.api_key,
-            )
-            .header("Content-Type", "application/json")
-            .json(&request)
-            .send()
-            .await
-            .map_err(|e| AgentLoopError::llm(format!("Failed to send request: {}", e)))?;
+            // Apply auth: a pluggable provider (e.g. OAuth bearer token) takes
+            // precedence over the default host-keyed `api-key` / bearer logic.
+            let request_builder = self.client.post(&self.api_url);
+            let request_builder = match &self.auth_provider {
+                Some(provider) => {
+                    let (name, value) = provider.auth_header().await?;
+                    request_builder.header(name, value)
+                }
+                None => apply_openai_api_auth(request_builder, &self.api_url, &self.api_key),
+            };
+
+            let response = request_builder
+                .header("Content-Type", "application/json")
+                .json(&request)
+                .send()
+                .await
+                .map_err(|e| AgentLoopError::llm(format!("Failed to send request: {}", e)))?;
 
             let status = response.status();
 

--- a/crates/core/src/provider.rs
+++ b/crates/core/src/provider.rs
@@ -36,6 +36,10 @@ pub enum DriverId {
     LlmSim,
     /// AWS Bedrock Runtime (ConverseStream API)
     Bedrock,
+    /// Microsoft MAI models (e.g. MAI-Code-1-Flash) served via Azure AI Foundry.
+    /// Uses an OpenAI-compatible Chat Completions API and supports either an
+    /// Azure AI Foundry API key or Microsoft Entra ID (OAuth) authentication.
+    Mai,
     /// Embedder-defined provider not compiled into everruns-core. The inner id
     /// is the canonical wire string (e.g. `"openai-codex"`).
     External(std::sync::Arc<str>),
@@ -73,6 +77,7 @@ impl DriverId {
             DriverId::Gemini => "gemini",
             DriverId::LlmSim => "llmsim",
             DriverId::Bedrock => "bedrock",
+            DriverId::Mai => "mai",
             DriverId::External(id) => id.as_ref(),
         }
     }
@@ -95,6 +100,7 @@ impl std::str::FromStr for DriverId {
             "gemini" => DriverId::Gemini,
             "llmsim" => DriverId::LlmSim,
             "bedrock" => DriverId::Bedrock,
+            "mai" => DriverId::Mai,
             _ => DriverId::External(std::sync::Arc::from(lower.as_str())),
         })
     }
@@ -132,7 +138,7 @@ impl utoipa::PartialSchema for DriverId {
             ))
             .description(Some(
                 "LLM provider type. Built-in: openai, openrouter, azure_openai, \
-                 openai_completions, anthropic, gemini, llmsim, bedrock. \
+                 openai_completions, anthropic, gemini, llmsim, bedrock, mai. \
                  Any other string is treated as an embedder-defined external provider.",
             ))
             .build()

--- a/crates/mai/Cargo.toml
+++ b/crates/mai/Cargo.toml
@@ -1,0 +1,47 @@
+# Microsoft MAI Provider Implementation
+# Decision: Microsoft MAI models (e.g. MAI-Code-1-Flash) are served via Azure AI
+# Foundry behind an OpenAI-compatible Chat Completions API. This crate wraps the
+# core Chat Completions protocol driver and adds a pluggable, OAuth-capable auth
+# layer (Azure AI Foundry API key or Microsoft Entra ID client-credentials).
+
+[package]
+name = "everruns-mai"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+documentation = "https://docs.rs/everruns-mai"
+description = "Microsoft MAI (Azure AI Foundry) provider implementation for Everruns"
+readme = "README.md"
+
+[dependencies]
+async-trait.workspace = true
+
+# Async runtime (token cache mutex lives behind tokio::sync)
+tokio = { workspace = true, features = ["sync", "time"] }
+
+# HTTP client (Entra ID token minting)
+reqwest.workspace = true
+
+# Serialization
+serde.workspace = true
+serde_json.workspace = true
+
+# Date/time (OAuth token expiry tracking)
+chrono.workspace = true
+
+# Tracing
+tracing.workspace = true
+
+# Internal dependencies
+everruns-core.workspace = true
+
+[dev-dependencies]
+# tokio powers `#[tokio::test]`; wiremock captures driver/token requests;
+# futures drains the chat stream.
+tokio = { workspace = true, features = ["full", "test-util"] }
+futures.workspace = true
+wiremock = "0.6"

--- a/crates/mai/README.md
+++ b/crates/mai/README.md
@@ -1,0 +1,46 @@
+# everruns-mai
+
+Microsoft MAI provider driver for [Everruns](https://everruns.com).
+
+Microsoft MAI models (e.g. `MAI-Code-1-Flash`) are served via
+[Azure AI Foundry](https://ai.azure.com) behind an OpenAI-compatible Chat
+Completions API. `everruns-mai` implements the `ChatDriver` contract from
+[`everruns-core`](https://crates.io/crates/everruns-core) and registers the
+`mai` driver into a `DriverRegistry`.
+
+## Authentication
+
+Two schemes are supported:
+
+- **Azure AI Foundry API key** — the resource key, sent via the `api-key`
+  header.
+- **Microsoft Entra ID (OAuth)** — a client-credentials service principal
+  (`tenant_id`, `client_id`, `client_secret`), supplied through provider
+  metadata. Bearer tokens are minted with the client-credentials grant and
+  cached, refreshed before expiry.
+
+The auth layer is built on the pluggable `AuthHeaderProvider` hook in
+`everruns-core`, so additional schemes (managed identity, workload identity
+federation, ...) can be added by implementing the trait without changing the
+driver.
+
+## Usage
+
+```rust
+use everruns_core::DriverRegistry;
+use everruns_mai::{register_driver, MaiAuth, MaiChatDriver};
+
+// Register into a driver registry (the usual integration path):
+let mut registry = DriverRegistry::new();
+register_driver(&mut registry);
+
+// Or construct a driver directly:
+let driver = MaiChatDriver::new(
+    MaiAuth::ApiKey("foundry-key".into()),
+    "https://my-resource.services.ai.azure.com",
+);
+```
+
+## License
+
+MIT

--- a/crates/mai/src/auth.rs
+++ b/crates/mai/src/auth.rs
@@ -18,8 +18,8 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use chrono::{DateTime, Duration, Utc};
+use everruns_core::driver_registry::DriverConfig;
 use everruns_core::error::{AgentLoopError, Result};
-use everruns_core::llm_driver_registry::DriverConfig;
 use everruns_core::openai_protocol::AuthHeaderProvider;
 use serde::Deserialize;
 use tokio::sync::Mutex;
@@ -39,7 +39,10 @@ const TOKEN_REFRESH_SKEW: Duration = Duration::seconds(120);
 /// Built from a [`DriverConfig`] via [`MaiAuth::from_driver_config`]: an Entra
 /// OAuth config in `metadata.extra` selects OAuth; otherwise an `api_key`
 /// selects API-key auth.
-#[derive(Clone, Debug)]
+///
+/// `Debug` redacts the key / client secret so credentials never leak via
+/// `{:?}` formatting (logs, error chains).
+#[derive(Clone)]
 pub enum MaiAuth {
     /// Azure AI Foundry API key (`api-key` header).
     ApiKey(String),
@@ -47,14 +50,32 @@ pub enum MaiAuth {
     EntraOAuth(EntraOAuthConfig),
 }
 
+impl std::fmt::Debug for MaiAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            MaiAuth::ApiKey(_) => f.debug_tuple("ApiKey").field(&"[REDACTED]").finish(),
+            MaiAuth::EntraOAuth(config) => f.debug_tuple("EntraOAuth").field(config).finish(),
+        }
+    }
+}
+
 impl MaiAuth {
     /// Resolve the auth strategy from a driver config.
     ///
-    /// Precedence: an Entra OAuth block in `metadata.extra` (an object with at
-    /// least `tenant_id`, `client_id`, and `client_secret`, optionally guarded
-    /// by `"auth": "entra_id"`) wins; otherwise a configured `api_key` is used.
-    /// Returns an error when neither is present so misconfiguration fails with a
-    /// clear message rather than an opaque 401 at call time.
+    /// Precedence:
+    /// 1. An Entra OAuth block in `metadata.extra` (the in-process / embedder
+    ///    path, where credentials arrive as [`ProviderMetadata`]).
+    /// 2. The credential in `api_key`. Server-stored providers carry their
+    ///    secret here (the encrypted credential field): it is either a plain
+    ///    Azure AI Foundry key, or an Entra OAuth **JSON document**
+    ///    (`{tenant_id, client_id, client_secret}`) — mirroring how Bedrock
+    ///    stores its multi-field credential. Carrying OAuth in the credential
+    ///    field means it flows through every existing path (chat execution and
+    ///    model sync) with no provider-metadata plumbing, and keeps the
+    ///    fail-closed contract (a credential is still required).
+    ///
+    /// Returns an error when no credential is present so misconfiguration fails
+    /// with a clear message rather than an opaque 401 at call time.
     pub fn from_driver_config(config: &DriverConfig) -> Result<Self> {
         if let Some(extra) = config.metadata.extra.as_ref()
             && let Some(oauth) = EntraOAuthConfig::from_extra(extra)?
@@ -63,13 +84,29 @@ impl MaiAuth {
         }
 
         match config.api_key.as_deref() {
-            Some(key) if !key.is_empty() => Ok(MaiAuth::ApiKey(key.to_string())),
+            Some(key) if !key.is_empty() => Self::from_credential_str(key),
             _ => Err(AgentLoopError::llm(
                 "Microsoft MAI provider is not authenticated: configure an Azure AI \
                  Foundry API key, or Entra ID OAuth credentials (tenant_id, client_id, \
                  client_secret) in the provider metadata.",
             )),
         }
+    }
+
+    /// Interpret a stored credential string: an Entra OAuth JSON document, or a
+    /// plain Foundry API key. A plain key is not a JSON object, so it falls
+    /// through to [`MaiAuth::ApiKey`]; a JSON object that looks like an Entra
+    /// config but is malformed surfaces a clear error.
+    fn from_credential_str(credential: &str) -> Result<Self> {
+        if let Ok(serde_json::Value::Object(map)) =
+            serde_json::from_str::<serde_json::Value>(credential)
+        {
+            let value = serde_json::Value::Object(map);
+            if let Some(oauth) = EntraOAuthConfig::from_extra(&value)? {
+                return Ok(MaiAuth::EntraOAuth(oauth));
+            }
+        }
+        Ok(MaiAuth::ApiKey(credential.to_string()))
     }
 
     /// Build the [`AuthHeaderProvider`] this strategy resolves to.
@@ -82,9 +119,16 @@ impl MaiAuth {
 }
 
 /// Static Azure AI Foundry API-key auth: always emits the `api-key` header.
-#[derive(Debug)]
 struct ApiKeyAuth {
     key: String,
+}
+
+impl std::fmt::Debug for ApiKeyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKeyAuth")
+            .field("key", &"[REDACTED]")
+            .finish()
+    }
 }
 
 #[async_trait]
@@ -95,7 +139,9 @@ impl AuthHeaderProvider for ApiKeyAuth {
 }
 
 /// Microsoft Entra ID client-credentials configuration.
-#[derive(Clone, Debug, Deserialize)]
+///
+/// `Debug` redacts `client_secret` so it never leaks via `{:?}` formatting.
+#[derive(Clone, Deserialize)]
 pub struct EntraOAuthConfig {
     /// Entra ID (Azure AD) tenant id.
     pub tenant_id: String,
@@ -109,6 +155,18 @@ pub struct EntraOAuthConfig {
     /// Authority host. Defaults to [`DEFAULT_ENTRA_AUTHORITY`].
     #[serde(default = "default_authority")]
     pub authority: String,
+}
+
+impl std::fmt::Debug for EntraOAuthConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EntraOAuthConfig")
+            .field("tenant_id", &self.tenant_id)
+            .field("client_id", &self.client_id)
+            .field("client_secret", &"[REDACTED]")
+            .field("scope", &self.scope)
+            .field("authority", &self.authority)
+            .finish()
+    }
 }
 
 fn default_scope() -> String {
@@ -269,7 +327,7 @@ impl AuthHeaderProvider for EntraOAuthProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use everruns_core::llm_driver_registry::{DriverId, ProviderMetadata};
+    use everruns_core::driver_registry::{DriverId, ProviderMetadata};
 
     fn driver_config(api_key: Option<&str>, extra: Option<serde_json::Value>) -> DriverConfig {
         DriverConfig {
@@ -284,9 +342,79 @@ mod tests {
     }
 
     #[test]
+    fn debug_redacts_secrets() {
+        // Credentials must never surface through `{:?}` (logs, error chains).
+        let api = MaiAuth::ApiKey("super-secret-key".into());
+        let rendered = format!("{api:?}");
+        assert!(!rendered.contains("super-secret-key"), "{rendered}");
+        assert!(rendered.contains("REDACTED"), "{rendered}");
+
+        let oauth = EntraOAuthConfig {
+            tenant_id: "tenant".into(),
+            client_id: "client".into(),
+            client_secret: "super-secret-value".into(),
+            scope: DEFAULT_ENTRA_SCOPE.into(),
+            authority: DEFAULT_ENTRA_AUTHORITY.into(),
+        };
+        let rendered = format!("{:?}", MaiAuth::EntraOAuth(oauth));
+        assert!(!rendered.contains("super-secret-value"), "{rendered}");
+        assert!(rendered.contains("REDACTED"), "{rendered}");
+        // Non-secret fields remain visible for diagnostics.
+        assert!(rendered.contains("tenant"), "{rendered}");
+        assert!(rendered.contains("client"), "{rendered}");
+    }
+
+    #[test]
     fn api_key_selected_when_no_oauth() {
         let auth = MaiAuth::from_driver_config(&driver_config(Some("key-123"), None)).unwrap();
         assert!(matches!(auth, MaiAuth::ApiKey(k) if k == "key-123"));
+    }
+
+    #[test]
+    fn oauth_selected_from_credential_json_document() {
+        // Server-stored providers carry OAuth as a JSON document in the
+        // (encrypted) api_key/credential field, like Bedrock. This is what makes
+        // OAuth work end-to-end for chat and model sync without metadata plumbing.
+        let credential = serde_json::json!({
+            "tenant_id": "tenant",
+            "client_id": "client",
+            "client_secret": "secret",
+            "scope": "https://example/.default",
+        })
+        .to_string();
+        let auth = MaiAuth::from_driver_config(&driver_config(Some(&credential), None)).unwrap();
+        match auth {
+            MaiAuth::EntraOAuth(cfg) => {
+                assert_eq!(cfg.tenant_id, "tenant");
+                assert_eq!(cfg.client_id, "client");
+                assert_eq!(cfg.scope, "https://example/.default");
+            }
+            other => panic!("expected EntraOAuth from credential JSON, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn plain_string_credential_stays_api_key() {
+        // A normal Foundry key is not JSON, so it must remain an api-key.
+        let auth =
+            MaiAuth::from_credential_str("sk-foundry-plain-key").expect("plain key is valid");
+        assert!(matches!(auth, MaiAuth::ApiKey(k) if k == "sk-foundry-plain-key"));
+    }
+
+    #[test]
+    fn malformed_oauth_credential_json_is_a_clear_error() {
+        // Looks like Entra (has tenant_id) but is missing client_secret.
+        let credential = serde_json::json!({ "tenant_id": "t", "client_id": "c" }).to_string();
+        let err = MaiAuth::from_driver_config(&driver_config(Some(&credential), None)).unwrap_err();
+        assert!(err.to_string().contains("Entra ID OAuth config"));
+    }
+
+    #[test]
+    fn non_oauth_json_credential_falls_through_to_api_key() {
+        // A JSON object that is not an Entra config is treated as an opaque key.
+        let credential = r#"{"foo":"bar"}"#;
+        let auth = MaiAuth::from_credential_str(credential).unwrap();
+        assert!(matches!(auth, MaiAuth::ApiKey(k) if k == credential));
     }
 
     #[test]

--- a/crates/mai/src/auth.rs
+++ b/crates/mai/src/auth.rs
@@ -1,0 +1,350 @@
+// Authentication for Microsoft MAI (Azure AI Foundry) providers.
+//
+// MAI deployments on Azure AI Foundry accept two auth schemes:
+//
+//   1. An Azure AI Foundry **API key**, sent via the `api-key` header.
+//   2. A **Microsoft Entra ID** (OAuth 2.0) bearer token, sent via
+//      `Authorization: Bearer <token>`. Tokens are minted with the
+//      client-credentials grant and are short-lived, so they are cached and
+//      refreshed before expiry.
+//
+// Both schemes are exposed through the generic [`AuthHeaderProvider`] hook on
+// the core Chat Completions driver, so the protocol driver never has to know
+// which scheme is in use. New schemes (managed identity, workload identity
+// federation, ...) can be added by implementing [`AuthHeaderProvider`] without
+// touching the driver.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use chrono::{DateTime, Duration, Utc};
+use everruns_core::error::{AgentLoopError, Result};
+use everruns_core::llm_driver_registry::DriverConfig;
+use everruns_core::openai_protocol::AuthHeaderProvider;
+use serde::Deserialize;
+use tokio::sync::Mutex;
+
+/// Default Microsoft Entra ID authority host.
+pub const DEFAULT_ENTRA_AUTHORITY: &str = "https://login.microsoftonline.com";
+
+/// Default OAuth scope for Azure AI Foundry / Azure Cognitive Services.
+pub const DEFAULT_ENTRA_SCOPE: &str = "https://cognitiveservices.azure.com/.default";
+
+/// Refresh a cached Entra token this long before it actually expires, so an
+/// in-flight request never races the expiry boundary.
+const TOKEN_REFRESH_SKEW: Duration = Duration::seconds(120);
+
+/// Authentication strategy for a Microsoft MAI provider.
+///
+/// Built from a [`DriverConfig`] via [`MaiAuth::from_driver_config`]: an Entra
+/// OAuth config in `metadata.extra` selects OAuth; otherwise an `api_key`
+/// selects API-key auth.
+#[derive(Clone, Debug)]
+pub enum MaiAuth {
+    /// Azure AI Foundry API key (`api-key` header).
+    ApiKey(String),
+    /// Microsoft Entra ID OAuth client-credentials flow (bearer token).
+    EntraOAuth(EntraOAuthConfig),
+}
+
+impl MaiAuth {
+    /// Resolve the auth strategy from a driver config.
+    ///
+    /// Precedence: an Entra OAuth block in `metadata.extra` (an object with at
+    /// least `tenant_id`, `client_id`, and `client_secret`, optionally guarded
+    /// by `"auth": "entra_id"`) wins; otherwise a configured `api_key` is used.
+    /// Returns an error when neither is present so misconfiguration fails with a
+    /// clear message rather than an opaque 401 at call time.
+    pub fn from_driver_config(config: &DriverConfig) -> Result<Self> {
+        if let Some(extra) = config.metadata.extra.as_ref()
+            && let Some(oauth) = EntraOAuthConfig::from_extra(extra)?
+        {
+            return Ok(MaiAuth::EntraOAuth(oauth));
+        }
+
+        match config.api_key.as_deref() {
+            Some(key) if !key.is_empty() => Ok(MaiAuth::ApiKey(key.to_string())),
+            _ => Err(AgentLoopError::llm(
+                "Microsoft MAI provider is not authenticated: configure an Azure AI \
+                 Foundry API key, or Entra ID OAuth credentials (tenant_id, client_id, \
+                 client_secret) in the provider metadata.",
+            )),
+        }
+    }
+
+    /// Build the [`AuthHeaderProvider`] this strategy resolves to.
+    pub fn into_provider(self) -> Arc<dyn AuthHeaderProvider> {
+        match self {
+            MaiAuth::ApiKey(key) => Arc::new(ApiKeyAuth { key }),
+            MaiAuth::EntraOAuth(config) => Arc::new(EntraOAuthProvider::new(config)),
+        }
+    }
+}
+
+/// Static Azure AI Foundry API-key auth: always emits the `api-key` header.
+#[derive(Debug)]
+struct ApiKeyAuth {
+    key: String,
+}
+
+#[async_trait]
+impl AuthHeaderProvider for ApiKeyAuth {
+    async fn auth_header(&self) -> Result<(String, String)> {
+        Ok(("api-key".to_string(), self.key.clone()))
+    }
+}
+
+/// Microsoft Entra ID client-credentials configuration.
+#[derive(Clone, Debug, Deserialize)]
+pub struct EntraOAuthConfig {
+    /// Entra ID (Azure AD) tenant id.
+    pub tenant_id: String,
+    /// Application (client) id of the service principal.
+    pub client_id: String,
+    /// Client secret of the service principal.
+    pub client_secret: String,
+    /// OAuth scope. Defaults to [`DEFAULT_ENTRA_SCOPE`].
+    #[serde(default = "default_scope")]
+    pub scope: String,
+    /// Authority host. Defaults to [`DEFAULT_ENTRA_AUTHORITY`].
+    #[serde(default = "default_authority")]
+    pub authority: String,
+}
+
+fn default_scope() -> String {
+    DEFAULT_ENTRA_SCOPE.to_string()
+}
+
+fn default_authority() -> String {
+    DEFAULT_ENTRA_AUTHORITY.to_string()
+}
+
+impl EntraOAuthConfig {
+    /// Parse an Entra OAuth block from provider `metadata.extra`.
+    ///
+    /// Returns `Ok(None)` when the JSON is clearly not an Entra config (no
+    /// OAuth fields present), `Ok(Some(_))` when a full config is present, and
+    /// `Err` when it looks like an Entra config but is missing required fields.
+    fn from_extra(extra: &serde_json::Value) -> Result<Option<Self>> {
+        let Some(obj) = extra.as_object() else {
+            return Ok(None);
+        };
+
+        let tagged_entra = obj
+            .get("auth")
+            .and_then(|v| v.as_str())
+            .is_some_and(|s| matches!(s, "entra" | "entra_id" | "oauth" | "entra_oauth"));
+        let has_oauth_field = obj.contains_key("tenant_id")
+            || obj.contains_key("client_id")
+            || obj.contains_key("client_secret");
+
+        if !tagged_entra && !has_oauth_field {
+            return Ok(None);
+        }
+
+        serde_json::from_value::<EntraOAuthConfig>(extra.clone())
+            .map(Some)
+            .map_err(|e| {
+                AgentLoopError::llm(format!(
+                    "Invalid Microsoft Entra ID OAuth config in provider metadata: {e}. \
+                     Required fields: tenant_id, client_id, client_secret."
+                ))
+            })
+    }
+
+    /// The token endpoint URL for this tenant.
+    fn token_url(&self) -> String {
+        format!(
+            "{}/{}/oauth2/v2.0/token",
+            self.authority.trim_end_matches('/'),
+            self.tenant_id
+        )
+    }
+}
+
+/// A cached Entra bearer token with its expiry instant.
+#[derive(Clone)]
+struct CachedToken {
+    token: String,
+    expires_at: DateTime<Utc>,
+}
+
+impl CachedToken {
+    /// Whether the token is still usable accounting for the refresh skew.
+    fn is_fresh(&self, now: DateTime<Utc>) -> bool {
+        now + TOKEN_REFRESH_SKEW < self.expires_at
+    }
+}
+
+/// Token response from the Entra ID `/oauth2/v2.0/token` endpoint.
+#[derive(Deserialize)]
+struct EntraTokenResponse {
+    access_token: String,
+    /// Token lifetime in seconds.
+    expires_in: i64,
+}
+
+/// [`AuthHeaderProvider`] that mints and caches Entra ID bearer tokens via the
+/// client-credentials grant.
+pub struct EntraOAuthProvider {
+    config: EntraOAuthConfig,
+    http: reqwest::Client,
+    cache: Mutex<Option<CachedToken>>,
+}
+
+impl EntraOAuthProvider {
+    /// Create a new provider with a fresh HTTP client.
+    pub fn new(config: EntraOAuthConfig) -> Self {
+        Self {
+            config,
+            http: reqwest::Client::new(),
+            cache: Mutex::new(None),
+        }
+    }
+
+    /// Return a valid bearer token, minting a new one if the cache is empty or
+    /// near expiry. Serializes concurrent refreshes behind the cache mutex.
+    async fn bearer_token(&self) -> Result<String> {
+        let mut cache = self.cache.lock().await;
+        let now = Utc::now();
+        if let Some(cached) = cache.as_ref()
+            && cached.is_fresh(now)
+        {
+            return Ok(cached.token.clone());
+        }
+
+        let minted = self.mint_token().await?;
+        let token = minted.token.clone();
+        *cache = Some(minted);
+        Ok(token)
+    }
+
+    /// Perform the client-credentials token request against Entra ID.
+    async fn mint_token(&self) -> Result<CachedToken> {
+        let params = [
+            ("grant_type", "client_credentials"),
+            ("client_id", self.config.client_id.as_str()),
+            ("client_secret", self.config.client_secret.as_str()),
+            ("scope", self.config.scope.as_str()),
+        ];
+
+        let response = self
+            .http
+            .post(self.config.token_url())
+            .form(&params)
+            .send()
+            .await
+            .map_err(|e| AgentLoopError::llm(format!("Failed to request Entra ID token: {e}")))?;
+
+        let status = response.status();
+        if !status.is_success() {
+            // Entra error bodies can include client_secret echoes only on
+            // request, never response; the body here is the AADSTS error which
+            // is safe (and useful) to surface for diagnosis.
+            let body = response.text().await.unwrap_or_default();
+            return Err(AgentLoopError::llm(format!(
+                "Entra ID token request failed ({status}): {body}"
+            )));
+        }
+
+        let token: EntraTokenResponse = response.json().await.map_err(|e| {
+            AgentLoopError::llm(format!("Failed to parse Entra ID token response: {e}"))
+        })?;
+
+        Ok(CachedToken {
+            token: token.access_token,
+            expires_at: Utc::now() + Duration::seconds(token.expires_in.max(0)),
+        })
+    }
+}
+
+#[async_trait]
+impl AuthHeaderProvider for EntraOAuthProvider {
+    async fn auth_header(&self) -> Result<(String, String)> {
+        let token = self.bearer_token().await?;
+        Ok(("Authorization".to_string(), format!("Bearer {token}")))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use everruns_core::llm_driver_registry::{DriverId, ProviderMetadata};
+
+    fn driver_config(api_key: Option<&str>, extra: Option<serde_json::Value>) -> DriverConfig {
+        DriverConfig {
+            provider_type: DriverId::Mai,
+            api_key: api_key.map(str::to_string),
+            base_url: Some("https://example.services.ai.azure.com".to_string()),
+            metadata: ProviderMetadata {
+                extra,
+                ..Default::default()
+            },
+        }
+    }
+
+    #[test]
+    fn api_key_selected_when_no_oauth() {
+        let auth = MaiAuth::from_driver_config(&driver_config(Some("key-123"), None)).unwrap();
+        assert!(matches!(auth, MaiAuth::ApiKey(k) if k == "key-123"));
+    }
+
+    #[test]
+    fn oauth_selected_from_metadata_extra() {
+        let extra = serde_json::json!({
+            "tenant_id": "tenant",
+            "client_id": "client",
+            "client_secret": "secret",
+        });
+        let auth = MaiAuth::from_driver_config(&driver_config(Some("key"), Some(extra))).unwrap();
+        match auth {
+            MaiAuth::EntraOAuth(cfg) => {
+                assert_eq!(cfg.tenant_id, "tenant");
+                assert_eq!(cfg.scope, DEFAULT_ENTRA_SCOPE);
+                assert_eq!(cfg.authority, DEFAULT_ENTRA_AUTHORITY);
+                assert_eq!(
+                    cfg.token_url(),
+                    "https://login.microsoftonline.com/tenant/oauth2/v2.0/token"
+                );
+            }
+            other => panic!("expected EntraOAuth, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn missing_auth_is_an_error() {
+        let err = MaiAuth::from_driver_config(&driver_config(None, None)).unwrap_err();
+        assert!(err.to_string().contains("not authenticated"));
+    }
+
+    #[test]
+    fn partial_oauth_block_is_a_clear_error() {
+        // Looks like Entra (has tenant_id) but is missing client_secret.
+        let extra = serde_json::json!({ "tenant_id": "t", "client_id": "c" });
+        let err = MaiAuth::from_driver_config(&driver_config(None, Some(extra))).unwrap_err();
+        assert!(err.to_string().contains("Entra ID OAuth config"));
+    }
+
+    #[tokio::test]
+    async fn api_key_provider_emits_api_key_header() {
+        let provider = MaiAuth::ApiKey("secret-key".to_string()).into_provider();
+        let (name, value) = provider.auth_header().await.unwrap();
+        assert_eq!(name, "api-key");
+        assert_eq!(value, "secret-key");
+    }
+
+    #[test]
+    fn cached_token_freshness_accounts_for_skew() {
+        let now = Utc::now();
+        let almost_expired = CachedToken {
+            token: "t".into(),
+            expires_at: now + Duration::seconds(30),
+        };
+        assert!(!almost_expired.is_fresh(now));
+        let fresh = CachedToken {
+            token: "t".into(),
+            expires_at: now + Duration::seconds(600),
+        };
+        assert!(fresh.is_fresh(now));
+    }
+}

--- a/crates/mai/src/driver.rs
+++ b/crates/mai/src/driver.rs
@@ -16,11 +16,11 @@ use serde::Deserialize;
 
 use everruns_core::OpenAIProtocolChatDriver;
 use everruns_core::credential_schema::{CredentialFormSchema, FieldType, FormField};
-use everruns_core::error::{AgentLoopError, Result};
-use everruns_core::llm_driver_registry::{
+use everruns_core::driver_registry::{
     BoxedChatDriver, ChatDriver, DiscoveredModel, DriverConfig, DriverDescriptor, DriverId,
     DriverRegistry, LlmCallConfig, LlmMessage, LlmResponseStream,
 };
+use everruns_core::error::{AgentLoopError, Result};
 use everruns_core::openai_protocol::{
     AuthHeaderProvider, is_azure_openai_api_url, models_api_status_error, models_url_for_api_url,
 };
@@ -182,9 +182,22 @@ async fn list_foundry_models(
         .await
         .map_err(|e| AgentLoopError::llm(format!("Failed to fetch MAI models: {e}")))?;
 
-    if !response.status().is_success() {
-        let status = response.status();
+    let status = response.status();
+    if !status.is_success() {
         let _ = response.bytes().await; // drain body to allow connection reuse
+        // Project-scoped Azure AI Foundry endpoints expose chat completions but
+        // not a `/models` catalog: such an endpoint returns 404 for
+        // `/openai/v1/models` while `/openai/v1/chat/completions` works. Treat a
+        // missing/unimplemented listing endpoint as "discovery not supported"
+        // (Ok(None)) rather than a hard error, so model sync degrades gracefully
+        // instead of reporting a spurious failure. (Verified live against a
+        // project endpoint.)
+        if matches!(
+            status,
+            reqwest::StatusCode::NOT_FOUND | reqwest::StatusCode::NOT_IMPLEMENTED
+        ) {
+            return Ok(None);
+        }
         return Err(models_api_status_error(status));
     }
 
@@ -266,10 +279,11 @@ fn normalize_mai_url(endpoint: &str) -> String {
     let trimmed = endpoint.trim_end_matches('/');
     if trimmed.ends_with("/chat/completions") {
         trimmed.to_string()
-    } else if trimmed.ends_with("/v1")
-        || trimmed.ends_with("/openai/v1")
-        || trimmed.ends_with("/models")
-    {
+    } else if let Some(base) = trimmed.strip_suffix("/models") {
+        // A models-listing URL was pasted as the endpoint; derive the sibling
+        // chat endpoint by replacing `/models` rather than appending to it.
+        format!("{base}/chat/completions")
+    } else if trimmed.ends_with("/v1") || trimmed.ends_with("/openai/v1") {
         format!("{trimmed}/chat/completions")
     } else {
         format!("{trimmed}/openai/v1/chat/completions")
@@ -284,13 +298,13 @@ fn mai_credential_schema() -> CredentialFormSchema {
         fields: vec![
             FormField {
                 name: "api_key".to_string(),
-                label: "Azure AI Foundry API Key".to_string(),
+                label: "API Key or Entra ID OAuth JSON".to_string(),
                 field_type: FieldType::Password,
-                required: false,
+                required: true,
                 placeholder: None,
                 help_text: Some(
-                    "Leave blank to authenticate with Microsoft Entra ID (OAuth) credentials \
-                     configured in provider metadata."
+                    "An Azure AI Foundry resource key, or a Microsoft Entra ID OAuth JSON \
+                     document: {\"tenant_id\":\"…\",\"client_id\":\"…\",\"client_secret\":\"…\"}."
                         .to_string(),
                 ),
             },
@@ -306,8 +320,8 @@ fn mai_credential_schema() -> CredentialFormSchema {
         instructions_markdown:
             "Configure a Microsoft MAI deployment on [Azure AI Foundry](https://ai.azure.com). \
              Authenticate with the resource API key, or with Microsoft Entra ID OAuth \
-             (client-credentials) by supplying `tenant_id`, `client_id`, and `client_secret` \
-             in the provider metadata."
+             (client-credentials) by entering a JSON document with `tenant_id`, `client_id`, \
+             and `client_secret` in the credential field."
                 .to_string(),
     }
 }
@@ -339,7 +353,7 @@ pub fn register_driver(registry: &mut DriverRegistry) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use everruns_core::llm_driver_registry::{ProviderConfig, ProviderMetadata, ServiceKind};
+    use everruns_core::driver_registry::{ProviderConfig, ProviderMetadata, ServiceKind};
     use wiremock::matchers::{header, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -401,6 +415,29 @@ mod tests {
         assert!(discovered[0].created_at.is_some());
     }
 
+    #[tokio::test]
+    async fn discovery_treats_missing_models_endpoint_as_unsupported() {
+        // Project-scoped Foundry endpoints 404 on /openai/v1/models while chat
+        // works; discovery must degrade to Ok(None), not a hard error, so model
+        // sync does not report a spurious failure. (Mirrors live behavior.)
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/openai/v1/models"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+
+        let auth = MaiAuth::ApiKey("k".into()).into_provider();
+        let models_url = format!("{}/openai/v1/models", server.uri());
+        let result = list_foundry_models(&reqwest::Client::new(), auth.as_ref(), &models_url)
+            .await
+            .expect("404 on /models should not be a hard error");
+        assert!(
+            result.is_none(),
+            "missing /models endpoint should be Ok(None)"
+        );
+    }
+
     #[test]
     fn normalizes_bare_foundry_host() {
         assert_eq!(
@@ -421,6 +458,20 @@ mod tests {
     fn preserves_full_chat_completions_url() {
         let url = "https://res.services.ai.azure.com/openai/v1/chat/completions";
         assert_eq!(normalize_mai_url(url), url);
+    }
+
+    #[test]
+    fn models_url_is_rewritten_to_chat_completions() {
+        // A pasted models-listing URL must derive the sibling chat endpoint,
+        // not append to `/models`.
+        assert_eq!(
+            normalize_mai_url("https://res.services.ai.azure.com/openai/v1/models"),
+            "https://res.services.ai.azure.com/openai/v1/chat/completions"
+        );
+        assert_eq!(
+            normalize_mai_url("https://res.services.ai.azure.com/api/projects/p/openai/v1/models/"),
+            "https://res.services.ai.azure.com/api/projects/p/openai/v1/chat/completions"
+        );
     }
 
     #[test]

--- a/crates/mai/src/driver.rs
+++ b/crates/mai/src/driver.rs
@@ -1,0 +1,339 @@
+// Microsoft MAI Chat Driver
+//
+// Microsoft MAI models (e.g. MAI-Code-1-Flash) are served via Azure AI Foundry
+// behind an OpenAI-compatible Chat Completions API. This driver wraps the core
+// `OpenAIProtocolChatDriver` and supplies a pluggable, OAuth-capable auth layer
+// (see `auth.rs`) through the driver's `AuthHeaderProvider` hook.
+//
+// Because authentication is handled by the auth provider, the underlying
+// protocol driver's own `api_key` field is unused (constructed empty).
+
+use async_trait::async_trait;
+
+use everruns_core::OpenAIProtocolChatDriver;
+use everruns_core::credential_schema::{CredentialFormSchema, FieldType, FormField};
+use everruns_core::error::{AgentLoopError, Result};
+use everruns_core::llm_driver_registry::{
+    BoxedChatDriver, ChatDriver, DiscoveredModel, DriverConfig, DriverDescriptor, DriverId,
+    DriverRegistry, LlmCallConfig, LlmMessage, LlmResponseStream,
+};
+
+use crate::auth::MaiAuth;
+
+/// Microsoft MAI chat driver (Azure AI Foundry, OpenAI-compatible).
+///
+/// Construct directly for programmatic use, or let [`register_driver`] build
+/// instances from a [`DriverConfig`].
+///
+/// # Example
+///
+/// ```
+/// use everruns_mai::{MaiAuth, MaiChatDriver};
+///
+/// let driver = MaiChatDriver::new(
+///     MaiAuth::ApiKey("foundry-key".into()),
+///     "https://my-resource.services.ai.azure.com",
+/// );
+/// assert_eq!(
+///     driver.api_url(),
+///     "https://my-resource.services.ai.azure.com/openai/v1/chat/completions",
+/// );
+/// ```
+pub struct MaiChatDriver {
+    /// Ready driver, or a captured configuration error surfaced at call time.
+    state: DriverState,
+}
+
+enum DriverState {
+    Ready {
+        inner: OpenAIProtocolChatDriver,
+        api_url: String,
+    },
+    Misconfigured(String),
+}
+
+impl MaiChatDriver {
+    /// Create a driver from an explicit auth strategy and Azure AI Foundry
+    /// endpoint. The endpoint is normalized to the chat-completions URL.
+    pub fn new(auth: MaiAuth, endpoint: impl Into<String>) -> Self {
+        let api_url = normalize_mai_url(&endpoint.into());
+        let inner = OpenAIProtocolChatDriver::with_base_url("", &api_url)
+            .with_auth_provider(auth.into_provider());
+        Self {
+            state: DriverState::Ready { inner, api_url },
+        }
+    }
+
+    /// Build a driver from a registry [`DriverConfig`], resolving auth from the
+    /// api key / OAuth metadata and the endpoint from `base_url`.
+    ///
+    /// Configuration errors (no endpoint, no auth) are captured and surfaced
+    /// when the driver is first called, so the infallible factory contract is
+    /// preserved while still producing a clear error.
+    fn from_driver_config(config: &DriverConfig) -> Self {
+        let Some(endpoint) = config.base_url.as_deref().filter(|u| !u.is_empty()) else {
+            return Self {
+                state: DriverState::Misconfigured(
+                    "Microsoft MAI provider requires a base URL: set it to your Azure AI \
+                     Foundry resource endpoint (e.g. https://<resource>.services.ai.azure.com)."
+                        .to_string(),
+                ),
+            };
+        };
+
+        match MaiAuth::from_driver_config(config) {
+            Ok(auth) => Self::new(auth, endpoint),
+            Err(err) => Self {
+                state: DriverState::Misconfigured(err.to_string()),
+            },
+        }
+    }
+
+    /// The resolved chat-completions API URL, or `None` when misconfigured.
+    pub fn api_url(&self) -> &str {
+        match &self.state {
+            DriverState::Ready { api_url, .. } => api_url,
+            DriverState::Misconfigured(_) => "",
+        }
+    }
+
+    fn ready(&self) -> Result<&OpenAIProtocolChatDriver> {
+        match &self.state {
+            DriverState::Ready { inner, .. } => Ok(inner),
+            DriverState::Misconfigured(err) => Err(AgentLoopError::llm(err.clone())),
+        }
+    }
+}
+
+#[async_trait]
+impl ChatDriver for MaiChatDriver {
+    async fn chat_completion_stream(
+        &self,
+        messages: Vec<LlmMessage>,
+        config: &LlmCallConfig,
+    ) -> Result<LlmResponseStream> {
+        self.ready()?.chat_completion_stream(messages, config).await
+    }
+
+    async fn list_models(&self) -> Result<Option<Vec<DiscoveredModel>>> {
+        // MAI deployments on Azure AI Foundry are resource-specific and do not
+        // expose a reliable public `/models` catalog for discovery. Model ids
+        // are well-known and carried by the built-in model profile registry, so
+        // discovery is intentionally skipped.
+        Ok(None)
+    }
+}
+
+impl std::fmt::Debug for MaiChatDriver {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MaiChatDriver")
+            .field("api_url", &self.api_url())
+            .field("api", &"Azure AI Foundry (Chat Completions)")
+            .finish()
+    }
+}
+
+/// Normalize an Azure AI Foundry endpoint to its chat-completions URL.
+///
+/// Accepts a bare resource host, a `/openai/v1` or `/models` base, or a full
+/// `/chat/completions` URL, and always returns a `/chat/completions` endpoint.
+/// A bare host gets Foundry's v1 OpenAI-compatible path appended.
+fn normalize_mai_url(endpoint: &str) -> String {
+    let trimmed = endpoint.trim_end_matches('/');
+    if trimmed.ends_with("/chat/completions") {
+        trimmed.to_string()
+    } else if trimmed.ends_with("/v1")
+        || trimmed.ends_with("/openai/v1")
+        || trimmed.ends_with("/models")
+    {
+        format!("{trimmed}/chat/completions")
+    } else {
+        format!("{trimmed}/openai/v1/chat/completions")
+    }
+}
+
+/// Credential schema for the MAI driver: an Azure AI Foundry API key plus an
+/// optional resource endpoint. Entra ID OAuth is configured through provider
+/// metadata rather than the credential form.
+fn mai_credential_schema() -> CredentialFormSchema {
+    CredentialFormSchema {
+        fields: vec![
+            FormField {
+                name: "api_key".to_string(),
+                label: "Azure AI Foundry API Key".to_string(),
+                field_type: FieldType::Password,
+                required: false,
+                placeholder: None,
+                help_text: Some(
+                    "Leave blank to authenticate with Microsoft Entra ID (OAuth) credentials \
+                     configured in provider metadata."
+                        .to_string(),
+                ),
+            },
+            FormField {
+                name: "base_url".to_string(),
+                label: "Resource Endpoint".to_string(),
+                field_type: FieldType::Url,
+                required: true,
+                placeholder: Some("https://<resource>.services.ai.azure.com".to_string()),
+                help_text: Some("Your Azure AI Foundry resource endpoint.".to_string()),
+            },
+        ],
+        instructions_markdown:
+            "Configure a Microsoft MAI deployment on [Azure AI Foundry](https://ai.azure.com). \
+             Authenticate with the resource API key, or with Microsoft Entra ID OAuth \
+             (client-credentials) by supplying `tenant_id`, `client_id`, and `client_secret` \
+             in the provider metadata."
+                .to_string(),
+    }
+}
+
+/// Register the Microsoft MAI driver with the driver registry.
+///
+/// Registers [`DriverId::Mai`], a chat-only driver backed by Azure AI Foundry's
+/// OpenAI-compatible Chat Completions API.
+///
+/// # Example
+///
+/// ```
+/// use everruns_core::DriverRegistry;
+/// use everruns_mai::register_driver;
+///
+/// let mut registry = DriverRegistry::new();
+/// register_driver(&mut registry);
+/// assert!(registry.has_driver(&everruns_core::DriverId::Mai));
+/// ```
+pub fn register_driver(registry: &mut DriverRegistry) {
+    registry.register_descriptor(DriverDescriptor {
+        credential_schema: mai_credential_schema(),
+        ..DriverDescriptor::chat_only(DriverId::Mai, |config| {
+            Box::new(MaiChatDriver::from_driver_config(config)) as BoxedChatDriver
+        })
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use everruns_core::llm_driver_registry::{ProviderConfig, ProviderMetadata, ServiceKind};
+
+    #[test]
+    fn normalizes_bare_foundry_host() {
+        assert_eq!(
+            normalize_mai_url("https://res.services.ai.azure.com"),
+            "https://res.services.ai.azure.com/openai/v1/chat/completions"
+        );
+    }
+
+    #[test]
+    fn normalizes_trailing_slash_and_v1() {
+        assert_eq!(
+            normalize_mai_url("https://res.services.ai.azure.com/openai/v1/"),
+            "https://res.services.ai.azure.com/openai/v1/chat/completions"
+        );
+    }
+
+    #[test]
+    fn preserves_full_chat_completions_url() {
+        let url = "https://res.services.ai.azure.com/openai/v1/chat/completions";
+        assert_eq!(normalize_mai_url(url), url);
+    }
+
+    #[test]
+    fn ready_driver_exposes_normalized_url() {
+        let driver = MaiChatDriver::new(
+            MaiAuth::ApiKey("k".into()),
+            "https://res.services.ai.azure.com",
+        );
+        assert_eq!(
+            driver.api_url(),
+            "https://res.services.ai.azure.com/openai/v1/chat/completions"
+        );
+    }
+
+    #[tokio::test]
+    async fn misconfigured_without_base_url_errors_at_call_time() {
+        let config = DriverConfig {
+            provider_type: DriverId::Mai,
+            api_key: Some("k".into()),
+            base_url: None,
+            metadata: ProviderMetadata::default(),
+        };
+        let driver = MaiChatDriver::from_driver_config(&config);
+        let err = match driver.chat_completion_stream(vec![], &dummy_config()).await {
+            Ok(_) => panic!("expected configuration error"),
+            Err(e) => e,
+        };
+        assert!(err.to_string().contains("requires a base URL"));
+    }
+
+    #[tokio::test]
+    async fn misconfigured_without_auth_errors_at_call_time() {
+        let config = DriverConfig {
+            provider_type: DriverId::Mai,
+            api_key: None,
+            base_url: Some("https://res.services.ai.azure.com".into()),
+            metadata: ProviderMetadata::default(),
+        };
+        let driver = MaiChatDriver::from_driver_config(&config);
+        let err = match driver.chat_completion_stream(vec![], &dummy_config()).await {
+            Ok(_) => panic!("expected configuration error"),
+            Err(e) => e,
+        };
+        assert!(err.to_string().contains("not authenticated"));
+    }
+
+    #[test]
+    fn register_driver_registers_mai() {
+        let mut registry = DriverRegistry::new();
+        assert!(!registry.has_driver(&DriverId::Mai));
+        register_driver(&mut registry);
+        assert!(registry.has_driver(&DriverId::Mai));
+
+        let descriptor = registry.descriptor(&DriverId::Mai).unwrap();
+        assert_eq!(descriptor.services, vec![ServiceKind::Chat]);
+        assert_eq!(descriptor.display_name, "Microsoft MAI");
+
+        // A provider with an api key and endpoint builds a usable chat driver
+        // (Mai is exempt from the registry's mandatory-api-key check, so OAuth
+        // works too).
+        let config = ProviderConfig::new(DriverId::Mai)
+            .with_api_key("k")
+            .with_base_url("https://res.services.ai.azure.com");
+        assert!(registry.create_chat_driver(&config).is_ok());
+    }
+
+    #[test]
+    fn oauth_provider_builds_without_api_key() {
+        let mut registry = DriverRegistry::new();
+        register_driver(&mut registry);
+
+        let config = ProviderConfig::new(DriverId::Mai)
+            .with_base_url("https://res.services.ai.azure.com")
+            .with_metadata(ProviderMetadata {
+                extra: Some(serde_json::json!({
+                    "tenant_id": "t",
+                    "client_id": "c",
+                    "client_secret": "s",
+                })),
+                ..Default::default()
+            });
+        // No api_key, but OAuth metadata present — must construct successfully.
+        assert!(registry.create_chat_driver(&config).is_ok());
+    }
+
+    fn dummy_config() -> LlmCallConfig {
+        LlmCallConfig {
+            model: "mai-code-1-flash".into(),
+            temperature: None,
+            max_tokens: None,
+            tools: vec![],
+            reasoning_effort: None,
+            metadata: Default::default(),
+            previous_response_id: None,
+            tool_search: None,
+            prompt_cache: None,
+            openrouter_routing: None,
+        }
+    }
+}

--- a/crates/mai/src/driver.rs
+++ b/crates/mai/src/driver.rs
@@ -8,7 +8,11 @@
 // Because authentication is handled by the auth provider, the underlying
 // protocol driver's own `api_key` field is unused (constructed empty).
 
+use std::sync::Arc;
+
 use async_trait::async_trait;
+use chrono::TimeZone;
+use serde::Deserialize;
 
 use everruns_core::OpenAIProtocolChatDriver;
 use everruns_core::credential_schema::{CredentialFormSchema, FieldType, FormField};
@@ -16,6 +20,9 @@ use everruns_core::error::{AgentLoopError, Result};
 use everruns_core::llm_driver_registry::{
     BoxedChatDriver, ChatDriver, DiscoveredModel, DriverConfig, DriverDescriptor, DriverId,
     DriverRegistry, LlmCallConfig, LlmMessage, LlmResponseStream,
+};
+use everruns_core::openai_protocol::{
+    AuthHeaderProvider, is_azure_openai_api_url, models_api_status_error, models_url_for_api_url,
 };
 
 use crate::auth::MaiAuth;
@@ -48,6 +55,9 @@ enum DriverState {
     Ready {
         inner: OpenAIProtocolChatDriver,
         api_url: String,
+        /// Retained so model discovery can authenticate the `/models` request
+        /// with the same scheme (api-key or OAuth bearer) as chat requests.
+        auth: Arc<dyn AuthHeaderProvider>,
     },
     Misconfigured(String),
 }
@@ -57,10 +67,15 @@ impl MaiChatDriver {
     /// endpoint. The endpoint is normalized to the chat-completions URL.
     pub fn new(auth: MaiAuth, endpoint: impl Into<String>) -> Self {
         let api_url = normalize_mai_url(&endpoint.into());
-        let inner = OpenAIProtocolChatDriver::with_base_url("", &api_url)
-            .with_auth_provider(auth.into_provider());
+        let auth = auth.into_provider();
+        let inner =
+            OpenAIProtocolChatDriver::with_base_url("", &api_url).with_auth_provider(auth.clone());
         Self {
-            state: DriverState::Ready { inner, api_url },
+            state: DriverState::Ready {
+                inner,
+                api_url,
+                auth,
+            },
         }
     }
 
@@ -116,11 +131,120 @@ impl ChatDriver for MaiChatDriver {
     }
 
     async fn list_models(&self) -> Result<Option<Vec<DiscoveredModel>>> {
-        // MAI deployments on Azure AI Foundry are resource-specific and do not
-        // expose a reliable public `/models` catalog for discovery. Model ids
-        // are well-known and carried by the built-in model profile registry, so
-        // discovery is intentionally skipped.
-        Ok(None)
+        let DriverState::Ready {
+            inner,
+            api_url,
+            auth,
+        } = &self.state
+        else {
+            // Misconfigured providers have nothing to discover.
+            return Ok(None);
+        };
+
+        // Only run discovery against recognized Azure AI Foundry hosts. Custom
+        // proxy URLs may resolve to private infrastructure, so they are skipped
+        // (mirrors the OpenAI/Azure OpenAI driver gating).
+        if !is_azure_openai_api_url(api_url) {
+            return Ok(None);
+        }
+
+        list_foundry_models(
+            inner.client(),
+            auth.as_ref(),
+            &models_url_for_api_url(api_url),
+        )
+        .await
+    }
+}
+
+/// Fetch the Foundry `/models` catalog and map it to [`DiscoveredModel`]s.
+///
+/// Foundry's OpenAI-compatible `/models` endpoint is *bare* (id/created/owned_by
+/// only — no capabilities, limits, or cost), exactly like OpenAI's. So
+/// discovery returns `discovered_profile: None` and relies on the built-in model
+/// profile registry to supply capabilities by matching the model id at sync
+/// time. (Azure deployment names are operator-chosen; a deployment id that does
+/// not match a known profile falls back to a minimal profile — the same caveat
+/// as Azure OpenAI.)
+///
+/// The request is authenticated with the same `AuthHeaderProvider` used for chat
+/// (`api-key` or an Entra ID OAuth bearer), so discovery works for both schemes.
+async fn list_foundry_models(
+    client: &reqwest::Client,
+    auth: &dyn AuthHeaderProvider,
+    models_url: &str,
+) -> Result<Option<Vec<DiscoveredModel>>> {
+    let (header_name, header_value) = auth.auth_header().await?;
+    let response = client
+        .get(models_url)
+        .header(header_name, header_value)
+        .send()
+        .await
+        .map_err(|e| AgentLoopError::llm(format!("Failed to fetch MAI models: {e}")))?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let _ = response.bytes().await; // drain body to allow connection reuse
+        return Err(models_api_status_error(status));
+    }
+
+    let models: FoundryModelsResponse = response
+        .json()
+        .await
+        .map_err(|e| AgentLoopError::llm(format!("Failed to parse MAI models response: {e}")))?;
+
+    let discovered = models
+        .data
+        .into_iter()
+        .filter(FoundryModelInfo::is_chat_model)
+        .map(|m| DiscoveredModel {
+            created_at: m
+                .created
+                .and_then(|ts| chrono::Utc.timestamp_opt(ts, 0).single()),
+            display_name: None,
+            owned_by: m.owned_by,
+            model_id: m.id,
+            discovered_profile: None,
+        })
+        .collect();
+
+    Ok(Some(discovered))
+}
+
+/// Bare Foundry/OpenAI-compatible `/models` list response.
+#[derive(Debug, Deserialize)]
+struct FoundryModelsResponse {
+    data: Vec<FoundryModelInfo>,
+}
+
+/// One entry from the Foundry `/models` list. `created`/`owned_by` are optional
+/// because Foundry variants do not always populate them.
+#[derive(Debug, Deserialize)]
+struct FoundryModelInfo {
+    id: String,
+    #[serde(default)]
+    created: Option<i64>,
+    #[serde(default)]
+    owned_by: Option<String>,
+}
+
+impl FoundryModelInfo {
+    /// Whether this deployment is a chat/completion model. Foundry serves many
+    /// model families (MAI, Llama, Phi, ...) whose ids do not share a prefix, so
+    /// the filter is exclusion-based: drop obvious non-chat services (embeddings,
+    /// speech, image, rerank) and keep everything else.
+    fn is_chat_model(&self) -> bool {
+        let id = self.id.to_ascii_lowercase();
+        !(id.contains("embed")
+            || id.contains("whisper")
+            || id.starts_with("tts")
+            || id.contains("-tts")
+            || id.contains("text-to-speech")
+            || id.contains("speech")
+            || id.contains("dall-e")
+            || id.contains("-image")
+            || id.contains("image-")
+            || id.contains("rerank"))
     }
 }
 
@@ -216,6 +340,66 @@ pub fn register_driver(registry: &mut DriverRegistry) {
 mod tests {
     use super::*;
     use everruns_core::llm_driver_registry::{ProviderConfig, ProviderMetadata, ServiceKind};
+    use wiremock::matchers::{header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[test]
+    fn chat_model_filter_keeps_chat_excludes_embeddings_and_media() {
+        let chat = |id: &str| FoundryModelInfo {
+            id: id.to_string(),
+            created: None,
+            owned_by: None,
+        };
+        assert!(chat("mai-code-1-flash").is_chat_model());
+        assert!(chat("mai-1-preview").is_chat_model());
+        assert!(chat("Phi-4").is_chat_model());
+        assert!(!chat("text-embedding-3-large").is_chat_model());
+        assert!(!chat("whisper-large").is_chat_model());
+        assert!(!chat("tts-1").is_chat_model());
+        assert!(!chat("dall-e-3").is_chat_model());
+        assert!(!chat("cohere-rerank-v3").is_chat_model());
+    }
+
+    #[tokio::test]
+    async fn list_models_skips_non_azure_hosts() {
+        // A custom/proxy (non-Foundry) host must not be probed for discovery.
+        let driver = MaiChatDriver::new(MaiAuth::ApiKey("k".into()), "https://proxy.example.com");
+        assert!(driver.list_models().await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn discovery_fetch_authenticates_filters_and_maps() {
+        // `list_foundry_models` is exercised directly so the Azure-host gate (which
+        // a wiremock 127.0.0.1 host cannot satisfy) does not block the HTTP path.
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/openai/v1/models"))
+            .and(header("api-key", "foundry-secret"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "object": "list",
+                "data": [
+                    { "id": "mai-code-1-flash", "object": "model", "created": 1_700_000_000, "owned_by": "microsoft" },
+                    { "id": "text-embedding-3-large", "object": "model" },
+                ],
+            })))
+            .mount(&server)
+            .await;
+
+        let auth = MaiAuth::ApiKey("foundry-secret".into()).into_provider();
+        let models_url = format!("{}/openai/v1/models", server.uri());
+        let discovered = list_foundry_models(&reqwest::Client::new(), auth.as_ref(), &models_url)
+            .await
+            .expect("discovery request should succeed")
+            .expect("discovery should return a model list");
+
+        // Embedding model filtered out; chat model retained with bare metadata
+        // (no discovered_profile — profiles come from the registry by id).
+        assert_eq!(discovered.len(), 1);
+        assert_eq!(discovered[0].model_id, "mai-code-1-flash");
+        assert_eq!(discovered[0].owned_by.as_deref(), Some("microsoft"));
+        assert!(discovered[0].discovered_profile.is_none());
+        assert!(discovered[0].created_at.is_some());
+    }
 
     #[test]
     fn normalizes_bare_foundry_host() {

--- a/crates/mai/src/lib.rs
+++ b/crates/mai/src/lib.rs
@@ -1,0 +1,45 @@
+//! Microsoft MAI provider driver for Everruns.
+//!
+//! `everruns-mai` is part of the [Everruns](https://everruns.com) ecosystem. It
+//! implements the [`ChatDriver`] contract from `everruns-core` and registers a
+//! Microsoft MAI provider (e.g. `mai-code-1-flash`) into a [`DriverRegistry`].
+//!
+//! Microsoft MAI models are served via [Azure AI Foundry](https://ai.azure.com)
+//! behind an OpenAI-compatible Chat Completions API, so [`MaiChatDriver`] wraps
+//! `everruns_core::OpenAIProtocolChatDriver` and supplies authentication through
+//! the driver's pluggable [`AuthHeaderProvider`] hook.
+//!
+//! # Authentication
+//!
+//! Two schemes are supported, both selected from the provider configuration:
+//!
+//! - **Azure AI Foundry API key** — the resource key, sent as `api-key`.
+//! - **Microsoft Entra ID (OAuth)** — a client-credentials service principal
+//!   (`tenant_id`, `client_id`, `client_secret`), supplied through provider
+//!   metadata. Bearer tokens are minted and cached, refreshed before expiry.
+//!
+//! Additional schemes (managed identity, workload identity federation, ...) can
+//! be added by implementing [`AuthHeaderProvider`] without changing the driver.
+//!
+//! # Registering the Driver
+//!
+//! ```
+//! use everruns_core::DriverRegistry;
+//! use everruns_mai::register_driver;
+//!
+//! let mut registry = DriverRegistry::new();
+//! register_driver(&mut registry);
+//! ```
+//!
+//! [`AuthHeaderProvider`]: everruns_core::openai_protocol::AuthHeaderProvider
+
+mod auth;
+mod driver;
+
+pub use auth::{
+    DEFAULT_ENTRA_AUTHORITY, DEFAULT_ENTRA_SCOPE, EntraOAuthConfig, EntraOAuthProvider, MaiAuth,
+};
+pub use driver::{MaiChatDriver, register_driver};
+
+// Re-export core types for convenience.
+pub use everruns_core::llm_driver_registry::{ChatDriver, DriverRegistry};

--- a/crates/mai/src/lib.rs
+++ b/crates/mai/src/lib.rs
@@ -42,4 +42,4 @@ pub use auth::{
 pub use driver::{MaiChatDriver, register_driver};
 
 // Re-export core types for convenience.
-pub use everruns_core::llm_driver_registry::{ChatDriver, DriverRegistry};
+pub use everruns_core::driver_registry::{ChatDriver, DriverRegistry};

--- a/crates/mai/tests/chat_wire.rs
+++ b/crates/mai/tests/chat_wire.rs
@@ -11,10 +11,11 @@
 //   2. Microsoft Entra ID OAuth  -> a token is minted from the (mocked) token
 //      endpoint and applied as `Authorization: Bearer <token>`.
 
-use everruns_core::llm_driver_registry::{
-    ChatDriver, LlmCallConfig, LlmMessage, LlmMessageRole, LlmStreamEvent,
+use everruns_core::DriverRegistry;
+use everruns_core::driver_registry::{
+    ChatDriver, DriverId, LlmCallConfig, LlmMessage, LlmMessageRole, LlmStreamEvent, ProviderConfig,
 };
-use everruns_mai::{EntraOAuthConfig, MaiAuth, MaiChatDriver};
+use everruns_mai::{EntraOAuthConfig, MaiAuth, MaiChatDriver, register_driver};
 use futures::StreamExt;
 use wiremock::matchers::{body_string_contains, header, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -48,7 +49,7 @@ fn sse_chat_response() -> String {
     .join("\n")
 }
 
-async fn drain_text(mut stream: everruns_core::llm_driver_registry::LlmResponseStream) -> String {
+async fn drain_text(mut stream: everruns_core::driver_registry::LlmResponseStream) -> String {
     let mut text = String::new();
     while let Some(event) = stream.next().await {
         match event.expect("stream item should not be a transport error") {
@@ -124,6 +125,63 @@ async fn entra_oauth_mints_token_and_sends_bearer() {
         .chat_completion_stream(messages, &config("mai-code-1-flash"))
         .await
         .expect("MAI should accept the OAuth bearer authed request");
+
+    assert_eq!(drain_text(stream).await, "pong");
+}
+
+/// The full server path: a provider is configured with an Entra OAuth **JSON
+/// document** in its (encrypted) credential field, and the driver is built via
+/// the registry exactly as model resolution / model sync do. This proves OAuth
+/// works end-to-end without any provider-metadata plumbing.
+#[tokio::test]
+async fn registry_built_driver_uses_oauth_json_credential() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/tenant-9/oauth2/v2.0/token"))
+        .and(body_string_contains("grant_type=client_credentials"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "token_type": "Bearer",
+            "access_token": "cred-doc-token",
+            "expires_in": 3600,
+        })))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/openai/v1/chat/completions"))
+        .and(header("authorization", "Bearer cred-doc-token"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_raw(sse_chat_response(), "text/event-stream"),
+        )
+        .mount(&server)
+        .await;
+
+    // OAuth credentials carried as a JSON document in the credential field,
+    // pointing `authority` at the mock token endpoint.
+    let credential = serde_json::json!({
+        "tenant_id": "tenant-9",
+        "client_id": "client-9",
+        "client_secret": "secret-9",
+        "authority": server.uri(),
+    })
+    .to_string();
+
+    let mut registry = DriverRegistry::new();
+    register_driver(&mut registry);
+    let driver = registry
+        .create_chat_driver(
+            &ProviderConfig::new(DriverId::Mai)
+                .with_api_key(credential)
+                .with_base_url(server.uri()),
+        )
+        .expect("registry should build a MAI driver from an OAuth JSON credential");
+
+    let messages = vec![LlmMessage::text(LlmMessageRole::User, "ping")];
+    let stream = driver
+        .chat_completion_stream(messages, &config("mai-code-1-flash"))
+        .await
+        .expect("registry-built MAI driver should authenticate via OAuth");
 
     assert_eq!(drain_text(stream).await, "pong");
 }

--- a/crates/mai/tests/chat_wire.rs
+++ b/crates/mai/tests/chat_wire.rs
@@ -1,0 +1,129 @@
+// Wire-level tests for the Microsoft MAI driver.
+//
+// These exercise the full path: `MaiChatDriver` builds an OpenAI-compatible
+// Chat Completions request through the core protocol driver, and its attached
+// auth provider sets the outbound auth header. A wiremock server captures the
+// request so we can assert the auth scheme, and streams back an SSE response so
+// we can confirm parsing.
+//
+// Two auth modes are covered:
+//   1. Azure AI Foundry API key  -> `api-key` header.
+//   2. Microsoft Entra ID OAuth  -> a token is minted from the (mocked) token
+//      endpoint and applied as `Authorization: Bearer <token>`.
+
+use everruns_core::llm_driver_registry::{
+    ChatDriver, LlmCallConfig, LlmMessage, LlmMessageRole, LlmStreamEvent,
+};
+use everruns_mai::{EntraOAuthConfig, MaiAuth, MaiChatDriver};
+use futures::StreamExt;
+use wiremock::matchers::{body_string_contains, header, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn config(model: &str) -> LlmCallConfig {
+    LlmCallConfig {
+        model: model.to_string(),
+        temperature: None,
+        max_tokens: None,
+        tools: vec![],
+        reasoning_effort: None,
+        metadata: std::collections::HashMap::new(),
+        previous_response_id: None,
+        tool_search: None,
+        prompt_cache: None,
+        openrouter_routing: None,
+    }
+}
+
+/// A minimal OpenAI-compatible streamed chat completion response.
+fn sse_chat_response() -> String {
+    [
+        r#"data: {"id":"1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"pong"},"finish_reason":null}]}"#,
+        "",
+        r#"data: {"id":"1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":3,"completion_tokens":1,"total_tokens":4}}"#,
+        "",
+        "data: [DONE]",
+        "",
+        "",
+    ]
+    .join("\n")
+}
+
+async fn drain_text(mut stream: everruns_core::llm_driver_registry::LlmResponseStream) -> String {
+    let mut text = String::new();
+    while let Some(event) = stream.next().await {
+        match event.expect("stream item should not be a transport error") {
+            LlmStreamEvent::TextDelta(delta) => text.push_str(&delta),
+            LlmStreamEvent::Error(e) => panic!("stream returned an error: {e}"),
+            _ => {}
+        }
+    }
+    text
+}
+
+#[tokio::test]
+async fn api_key_auth_sends_api_key_header_and_streams() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/openai/v1/chat/completions"))
+        .and(header("api-key", "foundry-secret"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_raw(sse_chat_response(), "text/event-stream"),
+        )
+        .mount(&server)
+        .await;
+
+    let driver = MaiChatDriver::new(MaiAuth::ApiKey("foundry-secret".into()), server.uri());
+    let messages = vec![LlmMessage::text(LlmMessageRole::User, "ping")];
+    let stream = driver
+        .chat_completion_stream(messages, &config("mai-code-1-flash"))
+        .await
+        .expect("MAI should accept the api-key authed request");
+
+    assert_eq!(drain_text(stream).await, "pong");
+}
+
+#[tokio::test]
+async fn entra_oauth_mints_token_and_sends_bearer() {
+    let server = MockServer::start().await;
+
+    // Token endpoint: client-credentials grant returns a bearer token.
+    Mock::given(method("POST"))
+        .and(path("/tenant-1/oauth2/v2.0/token"))
+        .and(body_string_contains("grant_type=client_credentials"))
+        .and(body_string_contains("client_id=client-1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "token_type": "Bearer",
+            "access_token": "minted-token-xyz",
+            "expires_in": 3600,
+        })))
+        .mount(&server)
+        .await;
+
+    // Chat endpoint: must receive the minted bearer token, not an api-key.
+    Mock::given(method("POST"))
+        .and(path("/openai/v1/chat/completions"))
+        .and(header("authorization", "Bearer minted-token-xyz"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_raw(sse_chat_response(), "text/event-stream"),
+        )
+        .mount(&server)
+        .await;
+
+    let auth = MaiAuth::EntraOAuth(EntraOAuthConfig {
+        tenant_id: "tenant-1".into(),
+        client_id: "client-1".into(),
+        client_secret: "secret-1".into(),
+        scope: "https://cognitiveservices.azure.com/.default".into(),
+        // Point the authority at the mock server so token minting is captured.
+        authority: server.uri(),
+    });
+
+    let driver = MaiChatDriver::new(auth, server.uri());
+    let messages = vec![LlmMessage::text(LlmMessageRole::User, "ping")];
+    let stream = driver
+        .chat_completion_stream(messages, &config("mai-code-1-flash"))
+        .await
+        .expect("MAI should accept the OAuth bearer authed request");
+
+    assert_eq!(drain_text(stream).await, "pong");
+}

--- a/crates/server/src/seed.rs
+++ b/crates/server/src/seed.rs
@@ -43,6 +43,7 @@ mod seed_ids {
     pub const GEMINI_PROVIDER: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000004);
     pub const BEDROCK_PROVIDER: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000005);
     pub const OPENROUTER_PROVIDER: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000006);
+    pub const MAI_PROVIDER: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000007);
 
     // Agents (0x100-0x1FF)
     pub const DAD_JOKES_AGENT: Uuid = Uuid::from_u128(0x01933b5a_0000_7000_8000_000000000101);
@@ -1407,6 +1408,11 @@ const SEED_PROVIDERS: &[SeedProvider] = &[
         id: seed_ids::BEDROCK_PROVIDER,
         name: "AWS Bedrock",
         provider_type: "bedrock",
+    },
+    SeedProvider {
+        id: seed_ids::MAI_PROVIDER,
+        name: "Microsoft MAI",
+        provider_type: "mai",
     },
 ];
 

--- a/crates/server/src/services/model_sync.rs
+++ b/crates/server/src/services/model_sync.rs
@@ -274,6 +274,10 @@ fn supports_sync_with_base_url(provider_type: &DriverId) -> bool {
             | DriverId::OpenRouter
             | DriverId::AzureOpenAI
             | DriverId::OpenAICompletions
+            // MAI providers always carry a base URL (the Azure AI Foundry
+            // resource endpoint); the driver gates discovery to recognized
+            // Foundry hosts internally.
+            | DriverId::Mai
             // External providers are custom by nature: a configured base URL is
             // the embedder's endpoint, so do not skip discovery for them.
             | DriverId::External(_)
@@ -331,6 +335,7 @@ mod tests {
         assert!(supports_sync_with_base_url(&DriverId::OpenAI));
         assert!(supports_sync_with_base_url(&DriverId::OpenRouter));
         assert!(supports_sync_with_base_url(&DriverId::OpenAICompletions));
+        assert!(supports_sync_with_base_url(&DriverId::Mai));
         assert!(!supports_sync_with_base_url(&DriverId::Anthropic));
     }
 

--- a/crates/worker/Cargo.toml
+++ b/crates/worker/Cargo.toml
@@ -36,6 +36,7 @@ everruns-integrations-sprites = { path = "../../integrations/sprites" }
 everruns-container-sandbox = { path = "../container-sandbox" }
 everruns-openai = { path = "../openai" }
 everruns-openrouter = { path = "../openrouter" }
+everruns-mai = { path = "../mai" }
 everruns-anthropic = { path = "../anthropic" }
 everruns-gemini = { path = "../gemini" }
 everruns-bedrock = { path = "../bedrock" }

--- a/crates/worker/src/adapters.rs
+++ b/crates/worker/src/adapters.rs
@@ -11,6 +11,7 @@ use everruns_core::{BoxedChatDriver, DriverId, DriverRegistry, ProviderConfig, R
 /// - OpenAI (Open Responses API - recommended)
 /// - OpenAI Completions (Chat Completions API - backward compatibility)
 /// - OpenRouter (OpenAI-compatible Responses API)
+/// - Microsoft MAI (Azure AI Foundry, OpenAI-compatible Chat Completions)
 /// - Anthropic Claude
 /// - Google Gemini
 /// - LlmSim (for testing)
@@ -18,6 +19,7 @@ pub fn create_driver_registry() -> DriverRegistry {
     let mut registry = DriverRegistry::new();
     everruns_openai::register_driver(&mut registry);
     everruns_openrouter::register_driver(&mut registry);
+    everruns_mai::register_driver(&mut registry);
     everruns_anthropic::register_driver(&mut registry);
     everruns_gemini::register_driver(&mut registry);
     everruns_bedrock::register_driver(&mut registry);

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -16755,7 +16755,7 @@
       },
       "DriverId": {
         "type": "string",
-        "description": "LLM provider type. Built-in: openai, openrouter, azure_openai, openai_completions, anthropic, gemini, llmsim, bedrock. Any other string is treated as an embedder-defined external provider."
+        "description": "LLM provider type. Built-in: openai, openrouter, azure_openai, openai_completions, anthropic, gemini, llmsim, bedrock, mai. Any other string is treated as an embedder-defined external provider."
       },
       "EnqueueTaskOptions": {
         "type": "object",

--- a/specs/llm-drivers.md
+++ b/specs/llm-drivers.md
@@ -317,9 +317,28 @@ behind an OpenAI-compatible Chat Completions API. The `everruns-mai` crate is a
 standalone, crates.io-publishable provider crate that wraps the core
 `OpenAIProtocolChatDriver` and tags it with `DriverId::Mai`. Model ids resolve
 to the Microsoft-vendor profiles in `crates/core/src/model_profiles.rs` (the
-`MICROSOFT_MAI` surface). Model discovery is intentionally `None`: Foundry
-deployments are resource-specific and do not expose a reliable public `/models`
-catalog.
+`MICROSOFT_MAI` surface).
+
+### Model Discovery
+
+Foundry exposes an OpenAI-compatible `/models` endpoint, but it is **bare**
+(`id`/`created`/`owned_by` only — no capabilities, limits, or cost), exactly
+like OpenAI's. So `list_models` syncs model/deployment **ids** with
+`discovered_profile: None` and relies on the built-in profile registry to supply
+capabilities by matching the id at sync time (the OpenAI/Azure OpenAI pattern).
+Rich capability metadata lives only in the separate Foundry model *catalog* API
+(different host/auth, reflects the catalog not the deployment) and cost is never
+provider-reported, so neither is used for profiling. The discovery request is
+authenticated with the same `AuthHeaderProvider` as chat (so it works for both
+api-key and OAuth) and is gated to recognized Foundry hosts
+(`*.services.ai.azure.com` / `*.openai.azure.com`); custom proxy URLs return
+`None`. **Caveat:** Azure deployment names are operator-chosen, so a deployment
+id that does not match a known profile (e.g. `mai-code-1-flash`) falls back to a
+minimal profile — the same limitation Azure OpenAI has.
+
+> OAuth-only MAI providers do not sync today: server `model_sync` still requires
+> a stored api key and does not forward provider OAuth metadata into the
+> discovery driver. API-key MAI providers sync normally.
 
 ### Pluggable Authentication (`AuthHeaderProvider`)
 

--- a/specs/llm-drivers.md
+++ b/specs/llm-drivers.md
@@ -57,7 +57,7 @@ graph TD
 
 2. **Streaming Response**: Drivers return a stream of `LlmStreamEvent` (TextDelta, ToolCalls, ThinkingDelta, ThinkingSignature, Done, Error).
 
-3. **Provider Types**: `OpenAI` (Responses API), `OpenAICompletions` (Chat Completions), `Anthropic`, `Gemini`, `Bedrock` (AWS Bedrock ConverseStream), `LlmSim` (testing).
+3. **Provider Types**: `OpenAI` (Responses API), `OpenAICompletions` (Chat Completions), `Anthropic`, `Gemini`, `Bedrock` (AWS Bedrock ConverseStream), `Mai` (Microsoft MAI via Azure AI Foundry, OpenAI-compatible Chat Completions), `LlmSim` (testing).
 
 ### Error Types (Contract)
 
@@ -284,6 +284,7 @@ sequenceDiagram
 | Anthropic driver | `crates/anthropic/src/driver.rs` |
 | Gemini driver | `crates/gemini/src/driver.rs` |
 | Bedrock driver | `crates/bedrock/src/driver.rs` |
+| Microsoft MAI driver | `crates/mai/src/driver.rs` |
 | Error handling | `crates/core/src/atoms/reason.rs` |
 
 ## OpenAI Driver Variants
@@ -308,6 +309,43 @@ The OpenAI crate provides three driver implementations:
 The Responses drivers share the same base URL handling and can work with
 OpenAI-compatible endpoints while keeping provider-specific request features
 gated by the resolved provider type.
+
+## Microsoft MAI Driver (`everruns-mai`)
+
+Microsoft MAI models (e.g. `mai-code-1-flash`) are served via Azure AI Foundry
+behind an OpenAI-compatible Chat Completions API. The `everruns-mai` crate is a
+standalone, crates.io-publishable provider crate that wraps the core
+`OpenAIProtocolChatDriver` and tags it with `DriverId::Mai`. Model ids resolve
+to the Microsoft-vendor profiles in `crates/core/src/model_profiles.rs` (the
+`MICROSOFT_MAI` surface). Model discovery is intentionally `None`: Foundry
+deployments are resource-specific and do not expose a reliable public `/models`
+catalog.
+
+### Pluggable Authentication (`AuthHeaderProvider`)
+
+Authentication is the reason MAI gets its own crate rather than reusing the
+Azure OpenAI driver: MAI deployments accept either an Azure AI Foundry **API
+key** (`api-key` header) or a Microsoft **Entra ID (OAuth)** bearer token. The
+core Chat Completions driver exposes a generic, async
+`AuthHeaderProvider` hook (`OpenAIProtocolChatDriver::with_auth_provider`); when
+set, it overrides the default host-keyed `api-key`/bearer logic and is awaited
+once per HTTP attempt so providers can refresh short-lived tokens transparently.
+
+The MAI crate ships two providers built on that hook:
+
+- **API key** — emits `("api-key", <key>)`.
+- **Entra ID OAuth** — client-credentials grant against
+  `{authority}/{tenant_id}/oauth2/v2.0/token` (default scope
+  `https://cognitiveservices.azure.com/.default`). Minted bearer tokens are
+  cached and refreshed ~120s before expiry.
+
+`MaiAuth::from_driver_config` selects the scheme: an Entra OAuth block in
+`ProviderMetadata.extra` (`tenant_id`, `client_id`, `client_secret`, optional
+`scope`/`authority`) wins; otherwise the configured `api_key` is used; neither
+present is a fail-closed configuration error. Because OAuth needs no `api_key`,
+`DriverId::Mai` is exempt from the registry's mandatory-api-key check (like
+`External`). New schemes (managed identity, workload identity federation) are
+additive: implement `AuthHeaderProvider` without touching the driver.
 
 ### Model Discovery and Capability Profiles
 

--- a/specs/llm-drivers.md
+++ b/specs/llm-drivers.md
@@ -332,13 +332,26 @@ provider-reported, so neither is used for profiling. The discovery request is
 authenticated with the same `AuthHeaderProvider` as chat (so it works for both
 api-key and OAuth) and is gated to recognized Foundry hosts
 (`*.services.ai.azure.com` / `*.openai.azure.com`); custom proxy URLs return
-`None`. **Caveat:** Azure deployment names are operator-chosen, so a deployment
-id that does not match a known profile (e.g. `mai-code-1-flash`) falls back to a
-minimal profile — the same limitation Azure OpenAI has.
+`None`. Project-scoped Foundry endpoints (`.../api/projects/<project>`) expose
+`/openai/v1/chat/completions` but **not** a `/models` catalog — a 404 (or 501)
+on the listing endpoint is treated as "discovery not supported" (`Ok(None)`),
+not an error, so model sync degrades gracefully. **Caveat:** Azure deployment
+names are operator-chosen, so a deployment id that does not match a known
+profile (e.g. `mai-code-1-flash`) falls back to a minimal profile — the same
+limitation Azure OpenAI has.
 
-> OAuth-only MAI providers do not sync today: server `model_sync` still requires
-> a stored api key and does not forward provider OAuth metadata into the
-> discovery driver. API-key MAI providers sync normally.
+### Authentication storage and end-to-end OAuth
+
+`MaiAuth::from_driver_config` resolves auth in two ways. In-process / embedder
+callers may pass an Entra OAuth block in `ProviderMetadata.extra`. Server-stored
+providers carry their secret in the encrypted credential field (`api_key`),
+which may be **either** a plain Azure AI Foundry key **or** an Entra OAuth JSON
+document (`{tenant_id, client_id, client_secret}`, with optional `scope` /
+`authority`) — mirroring how Bedrock stores its multi-field credential. Because
+the credential always travels through the existing `api_key` field, OAuth works
+end-to-end for **both** chat execution and model sync with no provider-metadata
+forwarding, and the fail-closed key-resolution contract is preserved (a stored
+credential is still required; nothing falls back to env).
 
 ### Pluggable Authentication (`AuthHeaderProvider`)
 

--- a/specs/providers.md
+++ b/specs/providers.md
@@ -49,7 +49,9 @@ Connectors are the user-scoped sibling concept (see "Providers vs Connections" b
 
 ### Driver
 
-A driver is a code unit registered in `DriverRegistry`, keyed by a **driver id** (`openai`, `azure_openai`, `openai_completions`, `openrouter`, `anthropic`, `gemini`, `bedrock`, `llmsim`). Ids are open, not a closed set: built-in drivers are compiled-in enum variants, and embedder-defined drivers register arbitrary ids via `ProviderType::External` (`register_external`, landed in EVE-561) through `PlatformDefinition` — an embedder adds a vendor without patching core. The database stores the id as a plain string; unknown ids parse to `External` rather than erroring.
+A driver is a code unit registered in `DriverRegistry`, keyed by a **driver id** (`openai`, `azure_openai`, `openai_completions`, `openrouter`, `anthropic`, `gemini`, `bedrock`, `mai`, `llmsim`). Ids are open, not a closed set: built-in drivers are compiled-in enum variants, and embedder-defined drivers register arbitrary ids via `ProviderType::External` (`register_external`, landed in EVE-561) through `PlatformDefinition` — an embedder adds a vendor without patching core. The database stores the id as a plain string; unknown ids parse to `External` rather than erroring.
+
+The `mai` driver (`everruns-mai`) is a publishable example of a first-party built-in driver layered on a generic protocol: Microsoft MAI models (e.g. `mai-code-1-flash`) are served via Azure AI Foundry behind an OpenAI-compatible Chat Completions API, so the driver wraps `OpenAIProtocolChatDriver` and supplies authentication through the generic `AuthHeaderProvider` hook (see [llm-drivers.md](llm-drivers.md)). It is the only built-in driver besides `llmsim`/`External` that does not require an `api_key` at the registry layer, because it can authenticate via Microsoft Entra ID (OAuth) credentials carried in `ProviderMetadata`.
 
 Each registered driver declares:
 


### PR DESCRIPTION
## What

Adds a new publishable `everruns-mai` crate implementing a first-party LLM driver/provider for **Microsoft MAI** models (e.g. `mai-code-1-flash`) served via **Azure AI Foundry**, plus the wiring to register, seed, sync, and configure it.

Highlights:
- New built-in `DriverId::Mai`; seeded as a default-org provider and selectable in Settings → Providers (icon, label, placeholders).
- `MaiChatDriver` wraps the core Chat Completions protocol (Foundry exposes an OpenAI-compatible API) and normalizes the resource endpoint to `/openai/v1/chat/completions`.
- **Pluggable auth** via a new generic `AuthHeaderProvider` hook on `OpenAIProtocolChatDriver`: a driver can supply a refreshed auth header instead of the default `api-key`/bearer logic. MAI ships two schemes on it — Azure AI Foundry **API key** and **Microsoft Entra ID (OAuth)** client-credentials with token caching/refresh. New schemes are additive (implement the trait).
- **End-to-end OAuth** with no new resolver/gRPC/storage plumbing: the credential field accepts a plain key **or** an Entra OAuth JSON document `{tenant_id, client_id, client_secret, scope?, authority?}` — mirroring how Bedrock stores its multi-field credential. So OAuth flows through model resolution, chat execution, and model sync unchanged, and the fail-closed contract is preserved (a credential is still required).
- **Model discovery** against Foundry's `/openai/v1/models` (bare list → `discovered_profile: None`; capabilities come from the built-in profile registry by id), authed via the same provider, gated to Foundry hosts. Project-scoped endpoints that 404 the listing endpoint degrade to `Ok(None)`.
- `mai-code-1-flash` model profile under a Microsoft MAI surface.

## Why

The repo had no first-party path to Microsoft MAI / Azure AI Foundry models. Foundry needs either an API key or Entra ID OAuth — neither fit the existing single-`api_key` providers cleanly — and the request was a self-contained, crates.io-publishable driver with OAuth support.

## How

- Core: generic `AuthHeaderProvider` override on the Chat Completions driver; `DriverId::Mai` (exempt from the registry's mandatory-api-key check like `External`, since OAuth needs no key); Microsoft-vendor profile + surface.
- `everruns-mai` crate: `MaiChatDriver` + `MaiAuth` (`ApiKey` / `EntraOAuth`) + `register_driver`. OAuth credentials are detected from `metadata.extra` (in-process) or a JSON document in the credential field (server-stored).
- Server/worker: register in the driver registry; seed a "Microsoft MAI" provider; add `Mai` to model-sync's base-URL discovery allowlist.
- UI: provider type, icon (Microsoft mark), and placeholders.
- Specs: `specs/llm-drivers.md` (MAI driver, pluggable auth, discovery, OAuth storage) and `specs/providers.md`.

## Validation

- `everruns-mai`: 23 unit + 3 wiremock integration + 3 doctests, all green; clippy `-D warnings` clean; fmt clean.
  - Wiremock covers both auth modes end-to-end, the **registry-built** OAuth-via-credential-document path (the server path), discovery fetch/filter/map, and the 404→`Ok(None)` degrade.
- `everruns-core` (2447 tests) and server `seed::`/`model_sync::` tests pass; worker/server build + clippy clean.
- **Live smoke test** against the real Foundry endpoint (Doppler `AZURE_FOUNDRY_*`): `POST {project-endpoint}/openai/v1/chat/completions` with the `api-key` header returns a proper OpenAI-shaped `DeploymentNotFound` — confirming the driver's URL normalization + auth target the right path against a real (project-scoped) endpoint. `/openai/v1/models` returns 404 there, which directly motivated the discovery `Ok(None)` degrade. A real completion couldn't be exercised because `mai-code-1-flash` is not deployed in that dev resource.

## Risk

- **Low.** New, isolated crate behind a new driver id; no behavior change to existing providers. The one shared-core change (`AuthHeaderProvider` hook) is opt-in — the default `api-key`/bearer path is unchanged when no provider is set.

## Security

- **Threat categories reviewed:** TM-LLM (provider credential handling, API keys, OAuth client secrets), TM-TENANT (credential resolution), TM-WEB/SSRF (server-side requests to configured endpoints), TM-API (no new endpoints — UI dropdown + provider CRUD reuse existing paths).
- **Findings and resolutions:**
  - *Secret exposure via `Debug`:* `MaiAuth`, `EntraOAuthConfig` (`client_secret`), and `ApiKeyAuth` (`key`) now have hand-written `Debug` impls that render `[REDACTED]`, matching `OpenAIProtocolChatDriver`. Test asserts secrets never appear in `{:?}`. The crate does no logging of credentials.
  - *Fail-closed resolution preserved:* OAuth rides the existing encrypted credential field; no env fallback is introduced; model sync still requires a stored credential. The `resolve_provider_api_key_env_key_set_does_not_leak` invariant is untouched.
  - *SSRF / outbound:* `base_url` and the optional OAuth `authority` are org-admin-configured (provider management authorization) and subject to the same egress controls as all providers (EVE-69). Model discovery is gated to recognized Foundry hosts (`*.services.ai.azure.com` / `*.openai.azure.com`); custom hosts return `None` (no probe). The `authority` override means `client_id`/`client_secret` are POSTed to the configured authority — defaulting to the real Entra endpoint; kept configurable for sovereign clouds (Azure Government/China), same admin trust model as `base_url`.
  - No new `THREAT[...]` mitigations were removed or required; no threat-model change.

## Follow-ups

- **[EVE-590](https://linear.app/everruns/issue/EVE-590)** — Typed multi-field provider credential schemas (first-class OAuth fields; replace JSON-in-`api_key`). Deferred: the JSON-in-credential approach is correct and fully working today; promoting Bedrock/MAI to declared typed credential fields is a cross-cutting refactor of `CredentialFormSchema` + storage tracked separately.
- Live MAI completion was not exercised because `mai-code-1-flash` is not deployed in the dev Foundry resource (`DeploymentNotFound`); the chat URL/auth contract is validated live and the full streamed flow is covered by wiremock. No code action — provider/model must be deployed to run a real generation.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (new isolated driver; opt-in core hook)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Yaqb7m8hd418dSHKLFkc5d)_