### PR TITLE
feat(infinity-context): load head+tail so task anchor survives long histories

### DIFF
--- a/crates/core/src/capabilities/infinity_context.rs
+++ b/crates/core/src/capabilities/infinity_context.rs
@@ -95,7 +95,7 @@ impl Capability for InfinityContextCapability {
                 "keep_first_messages": {
                     "type": "integer",
                     "title": "Anchored first messages",
-                    "description": "Leading messages always kept as an anchor (the original task), even under a tight budget. Additional to the maximum recent messages.",
+                    "description": "Leading messages always kept as an anchor (the original task), even under a tight budget. Additional to the maximum recent messages. The anchor is fetched as a head+tail load, so it is guaranteed even for histories far longer than the candidate load window — any value is meaningful, independent of max_recent_messages.",
                     "minimum": 0,
                     "default": default_keep_first_messages()
                 }

--- a/crates/core/src/capabilities/infinity_context.rs
+++ b/crates/core/src/capabilities/infinity_context.rs
@@ -95,7 +95,7 @@ impl Capability for InfinityContextCapability {
                 "keep_first_messages": {
                     "type": "integer",
                     "title": "Anchored first messages",
-                    "description": "Leading messages always kept as an anchor (the original task), even under a tight budget. Additional to the maximum recent messages. The anchor is fetched as a head+tail load, so it is guaranteed even for histories far longer than the candidate load window — any value is meaningful, independent of max_recent_messages.",
+                    "description": "Leading messages always kept as an anchor (the original task), even under a tight budget. Additional to the maximum recent messages. The anchor is fetched as a head+tail load, so it is guaranteed even for histories far longer than the candidate load window — any value is honored, independent of max_recent_messages. Larger values are not free: every load fetches keep_first_messages extra rows and includes them in the prompt, so keep it small (the default 1 anchors the original task) and raise it only when more leading context is genuinely needed.",
                     "minimum": 0,
                     "default": default_keep_first_messages()
                 }

--- a/crates/core/src/capabilities/infinity_context.rs
+++ b/crates/core/src/capabilities/infinity_context.rs
@@ -240,6 +240,13 @@ impl MessageFilterProvider for InfinityContextFilterProvider {
             serde_json::from_value(config.clone()).unwrap_or_default();
 
         query.limit = Some(resolve_candidate_load_limit(&config) as i64);
+        // Always fetch the first `keep_first_messages` alongside the latest-N tail
+        // so the task/goal anchor survives even when the history is far longer than
+        // the candidate load window (the tail-only LIMIT would otherwise never
+        // fetch the genuine first message).
+        if config.keep_first_messages > 0 {
+            query.keep_head = Some(config.keep_first_messages);
+        }
         query.prepend_transform = Some(Arc::new(ExcludedNoticeTransform::infinity_context()));
     }
 
@@ -775,6 +782,31 @@ mod tests {
 
         assert_eq!(query.limit, Some(16));
         assert!(query.prepend_transform.is_some());
+        // Default keep_first_messages (1) is loaded as a head anchor so the task
+        // goal survives even for histories longer than the candidate window.
+        assert_eq!(query.keep_head, Some(1));
+    }
+
+    #[test]
+    fn test_filter_provider_sets_keep_head_from_keep_first_messages() {
+        let mut query = MessageQuery::new(SessionId::new());
+        let provider = InfinityContextFilterProvider;
+        provider.apply_filters(
+            &mut query,
+            &json!({"context_budget_tokens": 1_000, "keep_first_messages": 3}),
+        );
+        assert_eq!(query.keep_head, Some(3));
+    }
+
+    #[test]
+    fn test_filter_provider_omits_keep_head_when_zero() {
+        let mut query = MessageQuery::new(SessionId::new());
+        let provider = InfinityContextFilterProvider;
+        provider.apply_filters(
+            &mut query,
+            &json!({"context_budget_tokens": 1_000, "keep_first_messages": 0}),
+        );
+        assert_eq!(query.keep_head, None);
     }
 
     #[test]

--- a/crates/core/src/message_filter.rs
+++ b/crates/core/src/message_filter.rs
@@ -263,6 +263,17 @@ pub struct MessageQuery {
     /// Number of messages to skip
     pub offset: Option<i64>,
 
+    /// Number of leading (oldest) messages to always retain as a head anchor,
+    /// in addition to the latest `limit` tail.
+    ///
+    /// `limit` alone fetches a tail-only window (latest N), so for histories
+    /// longer than that window the genuine first message is never loaded and any
+    /// head anchor silently degrades to the oldest *loaded* message. When
+    /// `keep_head` is set, the head and tail are fetched together (de-duplicated
+    /// on overlap), so the original task/goal survives no matter how long the
+    /// history grows. Used by `infinity_context`'s `keep_first_messages`.
+    pub keep_head: Option<usize>,
+
     /// Optional transform to prepend a message based on filter results.
     /// Applied after filtering, receives context about excluded messages.
     pub prepend_transform: Option<Arc<dyn PrependTransform>>,
@@ -276,6 +287,7 @@ impl Default for MessageQuery {
             injections: Vec::new(),
             limit: None,
             offset: None,
+            keep_head: None,
             prepend_transform: None,
         }
     }
@@ -289,6 +301,7 @@ impl std::fmt::Debug for MessageQuery {
             .field("injections", &self.injections)
             .field("limit", &self.limit)
             .field("offset", &self.offset)
+            .field("keep_head", &self.keep_head)
             .field("prepend_transform", &self.prepend_transform.is_some())
             .finish()
     }
@@ -303,6 +316,7 @@ impl MessageQuery {
             injections: Vec::new(),
             limit: None,
             offset: None,
+            keep_head: None,
             prepend_transform: None,
         }
     }
@@ -352,6 +366,13 @@ impl MessageQuery {
     /// Set the number of messages to skip
     pub fn with_offset(mut self, offset: i64) -> Self {
         self.offset = Some(offset);
+        self
+    }
+
+    /// Set the head-anchor size: always retain the first `keep_head` messages in
+    /// addition to the latest `limit` tail. See [`MessageQuery::keep_head`].
+    pub fn with_keep_head(mut self, keep_head: usize) -> Self {
+        self.keep_head = Some(keep_head);
         self
     }
 
@@ -424,6 +445,12 @@ impl MessageQuery {
     /// `limit` means "keep the latest N messages" while preserving chronological
     /// order in the returned slice. This is the prompt-window behavior expected
     /// by long-context capabilities such as `infinity_context`.
+    ///
+    /// When `keep_head` is set, the first `keep_head` messages are additionally
+    /// retained as an anchor: the kept set is `[first keep_head] + [latest limit]`
+    /// with the middle dropped, de-duplicated when the two windows overlap. This
+    /// mirrors the head+tail load performed by the storage backends so the
+    /// original task/goal survives in histories longer than the tail window.
     pub fn apply_window_bounds(&self, messages: &mut Vec<Message>) {
         if let Some(offset) = self.offset {
             let offset = offset.max(0) as usize;
@@ -436,9 +463,13 @@ impl MessageQuery {
 
         if let Some(limit) = self.limit {
             let limit = limit.max(0) as usize;
-            if messages.len() > limit {
-                let skip_count = messages.len() - limit;
-                messages.drain(0..skip_count);
+            let keep_head = self.keep_head.unwrap_or(0).min(messages.len());
+            // Drop the middle `[keep_head, len - limit)`, keeping the head anchor
+            // and the latest `limit`. When the windows overlap (keep_head + limit
+            // >= len) nothing is dropped and no message is duplicated.
+            if messages.len() > keep_head + limit {
+                let drain_end = messages.len() - limit;
+                messages.drain(keep_head..drain_end);
             }
         }
     }
@@ -700,6 +731,71 @@ mod tests {
         assert_eq!(messages.len(), 2);
         assert_eq!(messages[0].text(), Some("middle"));
         assert_eq!(messages[1].text(), Some("newest"));
+    }
+
+    #[test]
+    fn test_apply_window_bounds_keep_head_anchors_first_messages() {
+        let session_id: SessionId = Uuid::now_v7().into();
+        let query = MessageQuery::new(session_id)
+            .with_limit(2)
+            .with_keep_head(1);
+        let mut messages = vec![
+            Message::user("goal"),
+            Message::user("m1"),
+            Message::user("m2"),
+            Message::user("m3"),
+            Message::user("m4"),
+        ];
+
+        query.apply_window_bounds(&mut messages);
+
+        // First (anchor) + latest 2; the middle is dropped.
+        let texts: Vec<_> = messages.iter().filter_map(|m| m.text()).collect();
+        assert_eq!(texts, vec!["goal", "m3", "m4"]);
+    }
+
+    #[test]
+    fn test_apply_window_bounds_keep_head_no_duplicate_on_overlap() {
+        let session_id: SessionId = Uuid::now_v7().into();
+        // keep_head + limit >= len -> nothing dropped, no duplication.
+        let query = MessageQuery::new(session_id)
+            .with_limit(3)
+            .with_keep_head(2);
+        let mut messages = vec![Message::user("a"), Message::user("b"), Message::user("c")];
+
+        query.apply_window_bounds(&mut messages);
+
+        let texts: Vec<_> = messages.iter().filter_map(|m| m.text()).collect();
+        assert_eq!(texts, vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn test_apply_window_bounds_keep_head_zero_matches_tail_only() {
+        let session_id: SessionId = Uuid::now_v7().into();
+        let query = MessageQuery::new(session_id)
+            .with_limit(2)
+            .with_keep_head(0);
+        let mut messages = vec![Message::user("a"), Message::user("b"), Message::user("c")];
+
+        query.apply_window_bounds(&mut messages);
+
+        let texts: Vec<_> = messages.iter().filter_map(|m| m.text()).collect();
+        assert_eq!(texts, vec!["b", "c"]);
+    }
+
+    #[test]
+    fn test_apply_window_bounds_keep_head_exceeds_total() {
+        let session_id: SessionId = Uuid::now_v7().into();
+        // keep_head larger than the list -> keep everything, no panic/duplication.
+        let query = MessageQuery::new(session_id)
+            .with_limit(1)
+            .with_keep_head(10);
+        let mut messages = vec![Message::user("a"), Message::user("b")];
+
+        query.apply_window_bounds(&mut messages);
+
+        let texts: Vec<_> = messages.iter().filter_map(|m| m.text()).collect();
+        assert_eq!(texts, vec!["a", "b"]);
     }
 
     #[test]

--- a/crates/server/src/storage/memory/events.rs
+++ b/crates/server/src/storage/memory/events.rs
@@ -528,9 +528,13 @@ impl InMemoryDatabase {
         }
         if let Some(limit) = query.limit {
             let limit = limit.max(0) as usize;
-            if result.len() > limit {
-                let skip_count = result.len() - limit;
-                result.drain(0..skip_count);
+            // Head+tail window: keep the first `keep_head` (the task anchor) plus
+            // the latest `limit`, dropping the middle. De-dups on overlap. Mirrors
+            // the Postgres backend so both honor `MessageQuery::keep_head`.
+            let keep_head = query.keep_head.unwrap_or(0).min(result.len());
+            if result.len() > keep_head + limit {
+                let drain_end = result.len() - limit;
+                result.drain(keep_head..drain_end);
             }
         }
 

--- a/crates/server/src/storage/memory/tests.rs
+++ b/crates/server/src/storage/memory/tests.rs
@@ -443,6 +443,102 @@ async fn test_events_sequence() {
 }
 
 #[tokio::test]
+async fn test_list_message_events_filtered_keep_head_loads_head_and_tail() {
+    use chrono::Utc;
+
+    let db = InMemoryDatabase::new();
+
+    let agent = db
+        .create_agent(
+            DEFAULT_ORG_ID,
+            CreateAgentRow {
+                public_id: AgentId::new().to_string(),
+                name: "test-agent".to_string(),
+                display_name: Some("Test Agent".to_string()),
+                description: None,
+                system_prompt: String::new(),
+                default_model_id: None,
+                tags: vec![],
+                initial_files: serde_json::json!([]),
+                tools: serde_json::json!([]),
+                mcp_servers: serde_json::json!({}),
+                network_access: None,
+                max_iterations: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    let session = db
+        .create_session(CreateSessionRow {
+            workspace_id: None,
+            org_id: DEFAULT_ORG_ID,
+            app_id: None,
+            harness_id: None,
+            agent_id: Some(agent.id),
+            agent_identity_id: None,
+            owner_principal_id: everruns_core::PrincipalId::from_seed(1),
+            resolved_owner_user_id: None,
+            title: None,
+            locale: None,
+            tags: vec![],
+            model_id: None,
+            capabilities: serde_json::json!([]),
+            tools: serde_json::json!([]),
+            mcp_servers: serde_json::json!({}),
+            system_prompt: None,
+            initial_files: serde_json::Value::Array(vec![]),
+            hints: None,
+            network_access: None,
+            max_iterations: None,
+            blueprint_id: None,
+            blueprint_config: None,
+            parent_session_id: None,
+        })
+        .await
+        .unwrap();
+
+    // Six messages, far more than the tail window.
+    for i in 0..6 {
+        db.create_event(CreateEventRow {
+            session_id: session.id,
+            event_type: "input.message".to_string(),
+            ts: Utc::now(),
+            context: serde_json::json!({}),
+            data: serde_json::json!({"content": format!("Message {}", i)}),
+            metadata: None,
+            tags: None,
+        })
+        .await
+        .unwrap();
+    }
+
+    // limit=2 (tail) + keep_head=1 (anchor): expect sequences [1, 5, 6].
+    let query = MessageQuery::new(session.id)
+        .with_limit(2)
+        .with_keep_head(1);
+    let events = db.list_message_events_filtered(&query).await.unwrap();
+    let seqs: Vec<i32> = events.iter().map(|e| e.sequence).collect();
+    assert_eq!(seqs, vec![1, 5, 6]);
+
+    // keep_head=0 stays tail-only: latest 2.
+    let tail_only = MessageQuery::new(session.id)
+        .with_limit(2)
+        .with_keep_head(0);
+    let events = db.list_message_events_filtered(&tail_only).await.unwrap();
+    let seqs: Vec<i32> = events.iter().map(|e| e.sequence).collect();
+    assert_eq!(seqs, vec![5, 6]);
+
+    // Overlapping windows must not duplicate: keep_head + limit >= total.
+    let overlap = MessageQuery::new(session.id)
+        .with_limit(5)
+        .with_keep_head(3);
+    let events = db.list_message_events_filtered(&overlap).await.unwrap();
+    let seqs: Vec<i32> = events.iter().map(|e| e.sequence).collect();
+    assert_eq!(seqs, vec![1, 2, 3, 4, 5, 6]);
+}
+
+#[tokio::test]
 async fn test_session_connection_resolution_uses_resolved_owner_user() {
     let db = InMemoryDatabase::new();
 

--- a/crates/server/src/storage/repositories/events.rs
+++ b/crates/server/src/storage/repositories/events.rs
@@ -659,16 +659,26 @@ impl Database {
             (None, Some(limit)) if keep_head > 0 => {
                 // Head+tail load: keep the first `keep_head` (the task anchor) plus
                 // the latest `limit` tail, de-duplicated when the windows overlap.
-                // ROW_NUMBER over both orderings selects each end without a UNION
-                // (avoids equality on jsonb columns), already in chronological order.
+                //
+                // Select each end with an index-friendly `ORDER BY sequence … LIMIT`
+                // over the (session_id, sequence) index — early-terminating after
+                // keep_head / limit rows — then UNION on `id` (avoids equality on
+                // jsonb columns) and fetch the full rows by primary key. This keeps
+                // the common candidate load at O(keep_head + limit), not
+                // O(total_history): infinity_context sets keep_head > 0 on every
+                // load, so a full-history window sort here would scale with the
+                // entire conversation. The base query is inlined into each end
+                // (rather than a multiply-referenced CTE, which Postgres would
+                // materialize and full-scan) so both ends keep the index. Bound
+                // parameters are referenced by number, so repeating the SQL text
+                // reuses the same bindings.
                 sql = format!(
-                    "WITH base AS ({sql}), ranked AS (\
-                       SELECT *, \
-                         ROW_NUMBER() OVER (ORDER BY sequence ASC)  AS er_rn_asc, \
-                         ROW_NUMBER() OVER (ORDER BY sequence DESC) AS er_rn_desc \
-                       FROM base) \
-                     SELECT id, session_id, sequence, event_type, ts, context, data, metadata, tags, created_at \
-                     FROM ranked WHERE er_rn_asc <= {} OR er_rn_desc <= {} ORDER BY sequence ASC",
+                    "SELECT id, session_id, sequence, event_type, ts, context, data, metadata, tags, created_at \
+                     FROM events WHERE id IN (\
+                       (SELECT id FROM ({sql}) head_q ORDER BY sequence ASC LIMIT {}) \
+                       UNION \
+                       (SELECT id FROM ({sql}) tail_q ORDER BY sequence DESC LIMIT {})\
+                     ) ORDER BY sequence ASC",
                     keep_head as i64,
                     limit.max(0)
                 );

--- a/crates/server/src/storage/repositories/events.rs
+++ b/crates/server/src/storage/repositories/events.rs
@@ -640,7 +640,10 @@ impl Database {
             }
         }
 
-        let latest_window = query.limit.is_some();
+        let keep_head = query.keep_head.unwrap_or(0);
+        // Whether the final SQL emits rows newest-first (needs reversing back to
+        // chronological order after fetch).
+        let mut needs_reverse = false;
         match (query.offset, query.limit) {
             (Some(offset), Some(limit)) => {
                 sql = format!(
@@ -648,12 +651,31 @@ impl Database {
                     offset.max(0),
                     limit.max(0)
                 );
+                needs_reverse = true;
             }
             (Some(offset), None) => {
                 sql.push_str(&format!(" ORDER BY sequence ASC OFFSET {}", offset.max(0)));
             }
+            (None, Some(limit)) if keep_head > 0 => {
+                // Head+tail load: keep the first `keep_head` (the task anchor) plus
+                // the latest `limit` tail, de-duplicated when the windows overlap.
+                // ROW_NUMBER over both orderings selects each end without a UNION
+                // (avoids equality on jsonb columns), already in chronological order.
+                sql = format!(
+                    "WITH base AS ({sql}), ranked AS (\
+                       SELECT *, \
+                         ROW_NUMBER() OVER (ORDER BY sequence ASC)  AS er_rn_asc, \
+                         ROW_NUMBER() OVER (ORDER BY sequence DESC) AS er_rn_desc \
+                       FROM base) \
+                     SELECT id, session_id, sequence, event_type, ts, context, data, metadata, tags, created_at \
+                     FROM ranked WHERE er_rn_asc <= {} OR er_rn_desc <= {} ORDER BY sequence ASC",
+                    keep_head as i64,
+                    limit.max(0)
+                );
+            }
             (None, Some(limit)) => {
                 sql.push_str(&format!(" ORDER BY sequence DESC LIMIT {}", limit.max(0)));
+                needs_reverse = true;
             }
             (None, None) => {
                 sql.push_str(" ORDER BY sequence ASC");
@@ -687,7 +709,7 @@ impl Database {
             db_query = db_query.bind(include_ids);
         }
         let mut rows = db_query.fetch_all(&self.pool).await?;
-        if latest_window {
+        if needs_reverse {
             rows.reverse();
         }
 

--- a/crates/server/tests/repository_integration_test.rs
+++ b/crates/server/tests/repository_integration_test.rs
@@ -1066,6 +1066,117 @@ async fn test_message_events_filtered_offset_and_latest_limit() {
 }
 
 #[tokio::test]
+async fn test_message_events_filtered_keep_head_loads_head_and_tail() {
+    let backend = create_test_backend().await;
+
+    let agent = backend
+        .create_agent(
+            TEST_ORG_ID,
+            CreateAgentRow {
+                public_id: everruns_core::AgentId::new().to_string(),
+                name: format!("event-anchor-agent-{}", &Uuid::now_v7().to_string()[..8]),
+                display_name: Some("Event Anchor Test Agent".to_string()),
+                description: None,
+                system_prompt: "Test".to_string(),
+                default_model_id: None,
+                tags: vec![],
+                initial_files: serde_json::json!([]),
+                tools: serde_json::json!([]),
+                mcp_servers: serde_json::json!({}),
+                network_access: None,
+                max_iterations: None,
+            },
+        )
+        .await
+        .expect("Failed to create agent");
+
+    let owner_principal_id = create_test_principal(&backend, TEST_ORG_ID).await;
+    let session = backend
+        .create_session(CreateSessionRow {
+            workspace_id: None,
+            org_id: TEST_ORG_ID,
+            app_id: None,
+            harness_id: None,
+            agent_id: Some(agent.id),
+            agent_identity_id: None,
+            owner_principal_id,
+            resolved_owner_user_id: None,
+            title: None,
+            locale: None,
+            tags: vec![],
+            model_id: None,
+            capabilities: serde_json::json!([]),
+            tools: serde_json::json!([]),
+            mcp_servers: serde_json::json!({}),
+            system_prompt: None,
+            initial_files: serde_json::Value::Array(vec![]),
+            hints: None,
+            network_access: None,
+            max_iterations: None,
+            blueprint_id: None,
+            blueprint_config: None,
+            parent_session_id: None,
+        })
+        .await
+        .expect("Failed to create session");
+
+    for text in ["m1", "m2", "m3", "m4", "m5", "m6"] {
+        backend
+            .create_event(CreateEventRow {
+                session_id: session.id,
+                event_type: "input.message".to_string(),
+                ts: Utc::now(),
+                context: json!({"role": "user"}),
+                data: json!({
+                    "message": {
+                        "role": "user",
+                        "content": [{"type": "text", "text": text}]
+                    }
+                }),
+                metadata: None,
+                tags: None,
+            })
+            .await
+            .expect("Failed to create event");
+    }
+
+    let texts = |events: &[everruns_server::storage::EventRow]| -> Vec<String> {
+        events
+            .iter()
+            .map(|event| {
+                event
+                    .data
+                    .pointer("/message/content/0/text")
+                    .and_then(|value| value.as_str())
+                    .expect("message text")
+                    .to_string()
+            })
+            .collect()
+    };
+
+    // limit=2 tail + keep_head=1 anchor: the genuine first message survives even
+    // though it sits far outside the tail window.
+    let query = MessageQuery::new(session.id)
+        .with_limit(2)
+        .with_keep_head(1);
+    let events = backend
+        .list_message_events_filtered(&query)
+        .await
+        .expect("Failed to list filtered message events");
+    assert_eq!(texts(&events), vec!["m1", "m5", "m6"]);
+
+    // Overlapping windows must not duplicate rows.
+    let overlap = MessageQuery::new(session.id)
+        .with_limit(5)
+        .with_keep_head(3);
+    let events = backend
+        .list_message_events_filtered(&overlap)
+        .await
+        .expect("Failed to list filtered message events");
+    assert_eq!(texts(&events), vec!["m1", "m2", "m3", "m4", "m5", "m6"]);
+}
+
+#[tokio::test]
 async fn test_event_filter_types() {
     let backend = create_test_backend().await;
 

--- a/specs/infinity-context.md
+++ b/specs/infinity-context.md
@@ -169,12 +169,17 @@ support chat; it bounds only the recent tail (the head anchor is additional).
 Message limits always mean the latest N messages, returned in chronological
 order; older excluded messages remain available through `query_history`.
 
-**Known limitation:** the anchor is guaranteed only within the candidate load
-window (`resolve_candidate_load_limit`). For conversations longer than that
-window — or when `max_recent_messages` is set very low — the DB loads only the
-latest N messages, so the true first message is never fetched and the anchor
-degrades to the oldest loaded message. Guaranteeing the head for arbitrarily
-long histories needs a head+tail DB fetch (tracked as a follow-up).
+**Head+tail load.** The candidate set is fetched as a head+tail window, not a
+tail-only "latest N". `apply_filters` sets `MessageQuery::keep_head =
+keep_first_messages` alongside the candidate `limit`, and every storage backend
+honors it: the first `keep_head` messages (the task anchor) are loaded **in
+addition to** the latest `limit` tail, de-duplicated when the windows overlap
+and returned in chronological order. So the genuine first message is always
+fetched, and the anchor never silently degrades to a mid-conversation message —
+even for conversations far longer than the candidate window or when
+`max_recent_messages` is set very low. `keep_first_messages` is therefore
+meaningful at any size relative to the candidate window; it does not need to be
+clamped to it.
 
 ### History Notice Format
 


### PR DESCRIPTION
## What
Make `infinity_context`'s task anchor (`keep_first_messages`) durable for conversations of any length by loading a **head + tail** candidate window instead of a tail-only "latest N".

Closes #2259. Closes #2260.

## Why
The candidate set was loaded "latest N" via a tail-only SQL `LIMIT` (`resolve_candidate_load_limit` → `ORDER BY sequence DESC LIMIT n`). For conversations longer than that window the genuine first message was **never fetched**, so the head anchor silently degraded to the oldest *loaded* message — defeating the anchor in exactly the "infinite context" case it exists for. #2260 was the related concern that `keep_first_messages` had no meaningful relationship to the load window; with head+tail it does, so no clamp is needed.

## How
- Add `MessageQuery::keep_head: Option<usize>` (+ `with_keep_head` builder).
- `apply_window_bounds` (in-memory retriever path): keep the first `keep_head` plus the latest `limit`, dropping the middle and de-duplicating on overlap.
- Postgres `list_message_events_filtered`: when `keep_head > 0` with a limit, select `ROW_NUMBER() OVER (ORDER BY sequence ASC) <= keep_head OR ROW_NUMBER() OVER (ORDER BY sequence DESC) <= limit` in one pass — already chronological, naturally de-duped, and avoids a `UNION` over jsonb columns.
- In-memory backend `list_message_events_filtered`: mirrors the same head+tail selection.
- `infinity_context::apply_filters` sets `keep_head = keep_first_messages` (when > 0).
- Spec + config-schema description updated: the anchor is now guaranteed at any history length, so `keep_first_messages` need not be clamped to the window (resolves #2260's decision).

## Risk
- Medium. Touches message loading across both storage backends (Postgres SQL + in-memory) and the shared windowing helper.
- What can break: the candidate window shape. Mitigated by keeping `keep_head = 0` behavior byte-identical to the previous tail-only path, and by cross-backend tests covering head+tail, overlap de-dup, `keep_head = 0`, and `keep_head > total`.

## Security
- Threat categories reviewed: **TM-SQL**, **TM-DOS**.
- TM-SQL: the new SQL interpolates only integers (`keep_head as i64`, `limit`) via the same `format!` + `AssertSqlSafe` pattern already used for `LIMIT`/`OFFSET`; no user-controlled strings enter the query. WHERE-clause user values remain parameter-bound.
- TM-DOS: head+tail loads at most `keep_head` extra rows beyond the existing candidate cap (`keep_first_messages` default 1); negligible and bounded.
- No auth/authz/tenant surface touched; queries remain scoped by `session_id` as before.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (`keep_head = 0` preserves prior behavior)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

https://claude.ai/code/session_01RsKWqkbV4gYpTD2PQnQm4s

---
_Generated by [Claude Code](https://claude.ai/code/session_01RsKWqkbV4gYpTD2PQnQm4s)_