### PR TITLE
fix(drivers): preserve agent system prompt with multiple system messages

### DIFF
--- a/crates/anthropic/src/driver.rs
+++ b/crates/anthropic/src/driver.rs
@@ -28,7 +28,7 @@ use everruns_core::driver_helpers::{
 use everruns_core::driver_registry::{
     BoxedChatDriver, ChatDriver, DiscoveredModel, DriverDescriptor, DriverId, DriverRegistry,
     LlmCallConfig, LlmCompletionMetadata, LlmContentPart, LlmMessage, LlmMessageContent,
-    LlmMessageRole, LlmResponseStream, LlmStreamEvent,
+    LlmMessageRole, LlmResponseStream, LlmStreamEvent, fold_system_messages,
 };
 use everruns_core::error::{AgentLoopError, LlmErrorKind, Result};
 use everruns_core::is_provider_quota_message;
@@ -214,14 +214,18 @@ impl AnthropicChatDriver {
         messages: &[LlmMessage],
         prompt_cache_enabled: bool,
     ) -> (Option<String>, Vec<AnthropicMessage>) {
-        let mut system_prompt = None;
+        // Accumulate all system messages into Anthropic's separate top-level
+        // `system` field. Overwriting on each System message would drop the agent
+        // system prompt whenever a later notice/summary System message is present
+        // (infinity_context / compaction). See `fold_system_messages`.
+        let system_prompt = fold_system_messages(messages);
         let mut converted = Vec::new();
 
         for msg in messages {
             match msg.role {
                 LlmMessageRole::System => {
-                    // Extract system prompt (Anthropic handles it separately)
-                    system_prompt = Some(msg.content.to_text());
+                    // Folded above into the top-level `system` field; never emit a
+                    // System-role entry into the Anthropic `messages` array.
                 }
                 LlmMessageRole::Tool => {
                     // Tool results in Anthropic are user messages with tool_result content blocks.
@@ -2165,6 +2169,25 @@ mod tests {
 
         assert_eq!(system, Some("You are helpful".to_string()));
         assert_eq!(converted.len(), 1); // Only user message
+    }
+
+    #[test]
+    fn test_convert_messages_accumulates_multiple_system_messages() {
+        // The agent system prompt plus a later notice/summary System message
+        // (infinity_context / compaction) must both land in the top-level
+        // `system` field, in order — the later one must not overwrite the agent
+        // system prompt. No System-role entry may leak into `messages`.
+        let messages = vec![
+            LlmMessage::text(LlmMessageRole::System, "A"),
+            LlmMessage::text(LlmMessageRole::User, "hi"),
+            LlmMessage::text(LlmMessageRole::System, "B"),
+        ];
+
+        let (system, converted) = AnthropicChatDriver::convert_messages(&messages, false);
+
+        assert_eq!(system, Some("A\n\nB".to_string()));
+        assert_eq!(converted.len(), 1); // Only the user message
+        assert!(converted.iter().all(|m| m.role == "user"));
     }
 
     #[test]

--- a/crates/bedrock/src/driver.rs
+++ b/crates/bedrock/src/driver.rs
@@ -777,6 +777,31 @@ mod tests {
     }
 
     #[test]
+    fn test_build_messages_accumulates_multiple_system_messages() {
+        // The agent system prompt plus a later notice/summary System message
+        // (infinity_context / compaction) must both survive as system blocks, in
+        // order — the later one must not overwrite the agent system prompt. No
+        // System-role message may leak into the conversation messages.
+        use everruns_core::driver_registry::{LlmMessage, LlmMessageRole};
+        let messages = vec![
+            LlmMessage::text(LlmMessageRole::System, "A"),
+            LlmMessage::text(LlmMessageRole::User, "hi"),
+            LlmMessage::text(LlmMessageRole::System, "B"),
+        ];
+        let (system_blocks, bedrock_msgs) = build_messages(&messages).unwrap();
+        let texts: Vec<&str> = system_blocks
+            .iter()
+            .filter_map(|b| match b {
+                SystemContentBlock::Text(t) => Some(t.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(texts, vec!["A", "B"]);
+        assert_eq!(bedrock_msgs.len(), 1); // Only the user message
+        assert_eq!(bedrock_msgs[0].role, ConversationRole::User);
+    }
+
+    #[test]
     fn test_build_tool_result_block_missing_id_returns_none() {
         use everruns_core::driver_registry::{LlmMessage, LlmMessageContent, LlmMessageRole};
         let msg = LlmMessage {

--- a/crates/core/src/driver_registry.rs
+++ b/crates/core/src/driver_registry.rs
@@ -380,6 +380,30 @@ impl LlmMessage {
     }
 }
 
+/// Fold every `System`-role message into a single string, joined in order with
+/// blank lines.
+///
+/// Multiple system messages legitimately occur in one request: the agent system
+/// prompt plus, e.g., `infinity_context`'s hidden-history notice or
+/// `compaction`'s `[CONVERSATION_SUMMARY]`. Drivers that map the system role into
+/// a dedicated top-level field (Anthropic `system`, Gemini `system_instruction`,
+/// OpenResponses `instructions`) must accumulate rather than overwrite — otherwise
+/// the real agent system prompt is silently dropped and only the last notice
+/// survives. Returns `None` when there are no system messages.
+pub fn fold_system_messages(messages: &[LlmMessage]) -> Option<String> {
+    let mut system: Option<String> = None;
+    for msg in messages {
+        if msg.role == LlmMessageRole::System {
+            let text = msg.content.to_text();
+            system = Some(match system.take() {
+                Some(existing) if !existing.is_empty() => format!("{existing}\n\n{text}"),
+                _ => text,
+            });
+        }
+    }
+    system
+}
+
 /// Message content - either a simple string or array of content parts
 #[derive(Debug, Clone)]
 pub enum LlmMessageContent {
@@ -1851,6 +1875,54 @@ fn truncate_tool_result(text: String) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_fold_system_messages_none_when_absent() {
+        let messages = vec![
+            LlmMessage::text(LlmMessageRole::User, "hi"),
+            LlmMessage::text(LlmMessageRole::Assistant, "ok"),
+        ];
+        assert_eq!(fold_system_messages(&messages), None);
+    }
+
+    #[test]
+    fn test_fold_system_messages_single() {
+        let messages = vec![
+            LlmMessage::text(LlmMessageRole::System, "AGENT-PROMPT"),
+            LlmMessage::text(LlmMessageRole::User, "hi"),
+        ];
+        assert_eq!(
+            fold_system_messages(&messages),
+            Some("AGENT-PROMPT".to_string())
+        );
+    }
+
+    #[test]
+    fn test_fold_system_messages_accumulates_in_order() {
+        // The agent system prompt plus a later notice/summary System message
+        // (infinity_context / compaction) must both survive, in order — the
+        // later one must not overwrite the real agent system prompt.
+        let messages = vec![
+            LlmMessage::text(LlmMessageRole::System, "A"),
+            LlmMessage::text(LlmMessageRole::User, "hi"),
+            LlmMessage::text(LlmMessageRole::Assistant, "ok"),
+            LlmMessage::text(LlmMessageRole::System, "B"),
+        ];
+        assert_eq!(fold_system_messages(&messages), Some("A\n\nB".to_string()));
+    }
+
+    #[test]
+    fn test_fold_system_messages_concatenates_parts() {
+        let messages = vec![LlmMessage::parts(
+            LlmMessageRole::System,
+            vec![
+                LlmContentPart::text("foo"),
+                LlmContentPart::image("data:image/png;base64,xxx"),
+                LlmContentPart::text("bar"),
+            ],
+        )];
+        assert_eq!(fold_system_messages(&messages), Some("foobar".to_string()));
+    }
 
     #[test]
     fn test_llm_call_config_builder_from_runtime_agent() {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -274,6 +274,7 @@ pub use driver_registry::{
     EmbeddingsDriverError, EmbeddingsDriverFactory, LlmCallConfig, LlmCallConfigBuilder,
     LlmCompletionMetadata, LlmContentPart, LlmMessage, LlmMessageContent, LlmMessageRole,
     LlmResponse, LlmResponseStream, LlmStreamEvent, ProviderConfig, ServiceKind,
+    fold_system_messages,
 };
 
 // LLM retry types re-exports

--- a/crates/core/src/openai_protocol.rs
+++ b/crates/core/src/openai_protocol.rs
@@ -1082,6 +1082,32 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_convert_message_preserves_multiple_system_messages() {
+        // OpenAI chat-completions keeps the system role inline, so both the agent
+        // system prompt and a later notice/summary System message (infinity_context
+        // / compaction) pass through as separate `system` entries — neither is
+        // dropped. Lock that in alongside the "separate system field" drivers.
+        let messages = [
+            LlmMessage::text(LlmMessageRole::System, "A"),
+            LlmMessage::text(LlmMessageRole::User, "hi"),
+            LlmMessage::text(LlmMessageRole::System, "B"),
+        ];
+        let converted: Vec<OpenAiMessage> = messages
+            .iter()
+            .map(OpenAIProtocolChatDriver::convert_message)
+            .collect();
+        let system_texts: Vec<String> = converted
+            .iter()
+            .filter(|m| m.role == "system")
+            .filter_map(|m| match &m.content {
+                Some(OpenAiContent::Text(t)) => Some(t.clone()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(system_texts, vec!["A".to_string(), "B".to_string()]);
+    }
+
+    #[test]
     fn test_driver_with_api_key() {
         let driver = OpenAIProtocolChatDriver::new("test-key");
         assert!(format!("{:?}", driver).contains("OpenAIProtocolChatDriver"));

--- a/crates/core/src/openresponses_protocol.rs
+++ b/crates/core/src/openresponses_protocol.rs
@@ -586,8 +586,8 @@ impl OpenResponsesProtocolChatDriver {
 
         for msg in messages {
             if msg.role == LlmMessageRole::System {
-                // Folded above into `instructions`; never emit a System/developer
-                // item into the input array.
+                // Folded above into `instructions`; never emit the System message
+                // as a separate input item.
             } else if msg.role == LlmMessageRole::Assistant {
                 // For assistant messages, emit Reasoning item BEFORE message content if present
                 // This is required for o-series and GPT-5 models with extended thinking

--- a/crates/core/src/openresponses_protocol.rs
+++ b/crates/core/src/openresponses_protocol.rs
@@ -31,7 +31,7 @@ use std::sync::{Arc, Mutex};
 
 use crate::driver_registry::{
     ChatDriver, LlmCallConfig, LlmCompletionMetadata, LlmContentPart, LlmMessage,
-    LlmMessageContent, LlmMessageRole, LlmResponseStream, LlmStreamEvent,
+    LlmMessageContent, LlmMessageRole, LlmResponseStream, LlmStreamEvent, fold_system_messages,
 };
 use crate::error::{AgentLoopError, LlmErrorKind, Result};
 use crate::llm_retry::{
@@ -574,34 +574,20 @@ impl OpenResponsesProtocolChatDriver {
         messages: &[LlmMessage],
         supports_phases: bool,
     ) -> (Option<String>, Vec<ResponsesInputItem>) {
-        let mut instructions: Option<String> = None;
+        // Accumulate all system messages into `instructions`. Multiple system
+        // messages legitimately occur in one request — the agent system prompt
+        // plus, e.g., infinity context's hidden-history notice or compaction's
+        // conversation summary. Overwriting would drop the real system prompt and
+        // keep only the last notice. See `fold_system_messages`.
+        let instructions: Option<String> = fold_system_messages(messages);
         let mut input_items = Vec::new();
         // Counter for generating reasoning item IDs
         let mut reasoning_counter = 0u32;
 
         for msg in messages {
             if msg.role == LlmMessageRole::System {
-                // Accumulate system messages into `instructions`. Multiple system
-                // messages legitimately occur in one request — the agent system
-                // prompt plus, e.g., infinity context's hidden-history notice or
-                // compaction's conversation summary. Overwriting would drop the
-                // real system prompt and keep only the last notice, so join them
-                // in order instead.
-                let text = match &msg.content {
-                    LlmMessageContent::Text(text) => text.clone(),
-                    LlmMessageContent::Parts(parts) => parts
-                        .iter()
-                        .filter_map(|p| match p {
-                            LlmContentPart::Text { text } => Some(text.clone()),
-                            _ => None,
-                        })
-                        .collect::<Vec<_>>()
-                        .join(""),
-                };
-                instructions = Some(match instructions.take() {
-                    Some(existing) if !existing.is_empty() => format!("{existing}\n\n{text}"),
-                    _ => text,
-                });
+                // Folded above into `instructions`; never emit a System/developer
+                // item into the input array.
             } else if msg.role == LlmMessageRole::Assistant {
                 // For assistant messages, emit Reasoning item BEFORE message content if present
                 // This is required for o-series and GPT-5 models with extended thinking

--- a/crates/gemini/src/driver.rs
+++ b/crates/gemini/src/driver.rs
@@ -23,7 +23,7 @@ use everruns_core::driver_helpers::{
 use everruns_core::driver_registry::{
     BoxedChatDriver, ChatDriver, DiscoveredModel, DriverDescriptor, DriverId, DriverRegistry,
     LlmCallConfig, LlmCompletionMetadata, LlmContentPart, LlmMessage, LlmMessageContent,
-    LlmMessageRole, LlmResponseStream, LlmStreamEvent,
+    LlmMessageRole, LlmResponseStream, LlmStreamEvent, fold_system_messages,
 };
 use everruns_core::error::{AgentLoopError, LlmErrorKind, Result};
 use everruns_core::is_provider_quota_message;
@@ -133,19 +133,21 @@ impl GeminiChatDriver {
     }
 
     fn convert_messages(messages: &[LlmMessage]) -> (Option<GeminiContent>, Vec<GeminiContent>) {
-        let mut system_instruction = None;
+        // Accumulate all system messages into Gemini's separate
+        // `system_instruction`. Overwriting on each System message would drop the
+        // agent system prompt whenever a later notice/summary System message is
+        // present (infinity_context / compaction). See `fold_system_messages`.
+        let system_instruction = fold_system_messages(messages).map(|text| GeminiContent {
+            role: None, // system_instruction has no role
+            parts: vec![GeminiPart::Text { text }],
+        });
         let mut contents = Vec::new();
 
         for msg in messages {
             match msg.role {
                 LlmMessageRole::System => {
-                    // Extract system instruction (Gemini handles it separately)
-                    system_instruction = Some(GeminiContent {
-                        role: None, // system_instruction has no role
-                        parts: vec![GeminiPart::Text {
-                            text: msg.content.to_text(),
-                        }],
-                    });
+                    // Folded above into `system_instruction`; never emit
+                    // System-role content into the Gemini `contents` array.
                 }
                 LlmMessageRole::Tool => {
                     // Tool results in Gemini use functionResponse parts
@@ -1112,6 +1114,34 @@ mod tests {
 
         assert!(system.is_some());
         assert_eq!(contents.len(), 1); // Only user message
+    }
+
+    #[test]
+    fn test_convert_messages_accumulates_multiple_system_messages() {
+        // The agent system prompt plus a later notice/summary System message
+        // (infinity_context / compaction) must both land in `system_instruction`,
+        // in order — the later one must not overwrite the agent system prompt.
+        // No System-role content may leak into `contents`.
+        let messages = vec![
+            LlmMessage::text(LlmMessageRole::System, "A"),
+            LlmMessage::text(LlmMessageRole::User, "hi"),
+            LlmMessage::text(LlmMessageRole::System, "B"),
+        ];
+
+        let (system, contents) = GeminiChatDriver::convert_messages(&messages);
+
+        let system = system.expect("system_instruction present");
+        let text = system
+            .parts
+            .iter()
+            .filter_map(|p| match p {
+                GeminiPart::Text { text } => Some(text.as_str()),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join("");
+        assert_eq!(text, "A\n\nB");
+        assert_eq!(contents.len(), 1); // Only the user message
     }
 
     #[test]


### PR DESCRIPTION
## What
Stop the Anthropic and Gemini drivers from dropping the agent system prompt when a request contains more than one `System`-role message, and add cross-driver regression coverage.

Closes #2256. Closes #2257. Closes #2258.

## Why
Anthropic (`convert_messages` → top-level `system`) and Gemini (`convert_messages` → `system_instruction`) **overwrote** their dedicated system field on every `System` message, so the last one won. A normal turn is `[System(agent prompt), …conversation…]`; when `infinity_context` appends a hidden-history notice or `compaction` appends `[CONVERSATION_SUMMARY]` (both `System` messages after the agent prompt), the **real agent system prompt was silently dropped** and only the notice/summary survived — exactly when those long-context capabilities engage. The OpenResponses driver was fixed in #2224 but the parallel drivers were missed, and no test guarded the behavior (#2258).

## How
- Add a shared `fold_system_messages(&[LlmMessage]) -> Option<String>` helper in core that joins all `System` messages in order (blank-line separated).
- Anthropic: fold into the top-level `system` field; combined text stays prompt-cache eligible; no `System`-role entry leaks into `messages`.
- Gemini: fold into a single `system_instruction`; no `System` content leaks into `contents`.
- OpenResponses: refactor `build_input` to reuse the helper, removing the duplicated accumulation that diverged across drivers.
- Regression tests lock the behavior across **every** driver that maps the system role: core helper, Anthropic, Gemini, OpenResponses, OpenAI chat-completions (passthrough), and Bedrock (already accumulates into `system_blocks`).

## Risk
- Low. Pure message-conversion change; output for the single-system-message case is unchanged.
- What can break: system-prompt assembly for the affected providers — covered by new per-driver tests and the shared-helper test.

## Security
- Threat categories reviewed: **TM-LLM**.
- The change only concerns how already-trusted system messages are concatenated into the provider request; it adds no new external input, no logging of prompt contents, and no auth/network surface. Cache-control eligibility on the combined Anthropic system block is preserved.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (single-system-message output unchanged)
- [x] Security review performed against relevant threat model categories
- [ ] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

https://claude.ai/code/session_01RsKWqkbV4gYpTD2PQnQm4s

---
_Generated by [Claude Code](https://claude.ai/code/session_01RsKWqkbV4gYpTD2PQnQm4s)_