### PR TITLE
fix(openrouter): honor provider rate limit reset

### DIFF
--- a/crates/core/src/llm_retry.rs
+++ b/crates/core/src/llm_retry.rs
@@ -206,7 +206,7 @@ impl RateLimitInfo {
         info
     }
 
-    /// Parse rate limit info from OpenAI response headers
+    /// Parse rate limit info from OpenAI-compatible response headers.
     pub fn from_openai_headers(headers: &reqwest::header::HeaderMap) -> Self {
         let mut info = Self::default();
 

--- a/crates/core/src/openresponses_protocol.rs
+++ b/crates/core/src/openresponses_protocol.rs
@@ -91,6 +91,15 @@ pub trait OpenResponsesRequestExtension: Send + Sync {
     fn decorate_headers(&self, _headers: &mut HeaderMap, _config: &LlmCallConfig) -> Result<()> {
         Ok(())
     }
+
+    /// Refine retry metadata from provider-specific rate limit response fields.
+    fn update_rate_limit_info(
+        &self,
+        _info: &mut RateLimitInfo,
+        _headers: &HeaderMap,
+        _error_body: &str,
+    ) {
+    }
 }
 
 #[derive(Clone)]
@@ -469,13 +478,19 @@ impl OpenResponsesProtocolChatDriver {
             // Check if this is a retryable error
             if is_transient_error(status) && retry_metadata.attempts < self.retry_config.max_retries
             {
-                let rate_limit_info = if is_rate_limit_status(status) {
-                    Some(RateLimitInfo::from_openai_headers(response.headers()))
+                let response_headers = response.headers().clone();
+                let mut rate_limit_info = if is_rate_limit_status(status) {
+                    Some(RateLimitInfo::from_openai_headers(&response_headers))
                 } else {
                     None
                 };
 
                 let error_text = response.text().await.unwrap_or_default();
+                if let (Some(extension), Some(info)) =
+                    (self.request_extension.as_ref(), rate_limit_info.as_mut())
+                {
+                    extension.update_rate_limit_info(info, &response_headers, &error_text);
+                }
 
                 let wait_duration = rate_limit_info
                     .as_ref()
@@ -887,13 +902,19 @@ impl ChatDriver for OpenResponsesProtocolChatDriver {
             if is_transient_error(status) && retry_metadata.attempts < self.retry_config.max_retries
             {
                 // Parse rate limit info from headers before consuming response body
-                let rate_limit_info = if is_rate_limit_status(status) {
-                    Some(RateLimitInfo::from_openai_headers(response.headers()))
+                let response_headers = response.headers().clone();
+                let mut rate_limit_info = if is_rate_limit_status(status) {
+                    Some(RateLimitInfo::from_openai_headers(&response_headers))
                 } else {
                     None
                 };
 
                 let error_text = response.text().await.unwrap_or_default();
+                if let (Some(extension), Some(info)) =
+                    (self.request_extension.as_ref(), rate_limit_info.as_mut())
+                {
+                    extension.update_rate_limit_info(info, &response_headers, &error_text);
+                }
 
                 // Exhausted billing quota is surfaced as a 429 but is not
                 // transient — fail fast instead of burning retries.

--- a/crates/openrouter/src/request_ext.rs
+++ b/crates/openrouter/src/request_ext.rs
@@ -141,7 +141,11 @@ fn apply_rate_limit_values(info: &mut RateLimitInfo, remaining: Option<&str>, re
 }
 
 fn header_str<'a>(headers: &'a HeaderMap, name: &HeaderName) -> Option<&'a str> {
-    headers.get(name).and_then(|value| value.to_str().ok())
+    headers
+        .get(name)
+        .and_then(|value| value.to_str().ok())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
 }
 
 fn json_header_value<'a>(
@@ -152,6 +156,7 @@ fn json_header_value<'a>(
         .iter()
         .find(|(key, _)| key.eq_ignore_ascii_case(wanted))
         .and_then(|(_, value)| value.as_str())
+        .map(str::trim)
         .filter(|value| !value.is_empty())
 }
 
@@ -390,6 +395,21 @@ mod tests {
         let retry_after = info.retry_after_secs.expect("retry wait");
         assert!((44..=45).contains(&retry_after));
         assert_eq!(info.limit_type, Some(RateLimitType::Requests));
+    }
+
+    #[test]
+    fn update_rate_limit_info_ignores_blank_openrouter_headers() {
+        let mut headers = HeaderMap::new();
+        headers.insert(X_RATE_LIMIT_REMAINING_HEADER, HeaderValue::from_static(" "));
+        headers.insert(X_RATE_LIMIT_RESET_HEADER, HeaderValue::from_static("\t"));
+        let mut info = RateLimitInfo::default();
+
+        OpenRouterRequestExtension.update_rate_limit_info(&mut info, &headers, "");
+
+        assert_eq!(info.requests_remaining, None);
+        assert_eq!(info.requests_reset, None);
+        assert_eq!(info.retry_after_secs, None);
+        assert_eq!(info.limit_type, None);
     }
 
     #[test]

--- a/crates/openrouter/src/request_ext.rs
+++ b/crates/openrouter/src/request_ext.rs
@@ -11,6 +11,7 @@
 //   - `HTTP-Referer` / `X-Title` — app attribution headers
 
 use std::borrow::Cow;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use everruns_core::OpenResponsesRequestExtension;
 use everruns_core::driver_registry::{
@@ -18,11 +19,14 @@ use everruns_core::driver_registry::{
     OpenRouterCapacityStrategy, OpenRouterPluginConfig, OpenRouterRoutingConfig,
 };
 use everruns_core::error::{AgentLoopError, Result};
+use everruns_core::llm_retry::{RateLimitInfo, RateLimitType};
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use serde_json::{Value, json};
 
 const HTTP_REFERER_HEADER: HeaderName = HeaderName::from_static("http-referer");
 const X_TITLE_HEADER: HeaderName = HeaderName::from_static("x-title");
+const X_RATE_LIMIT_REMAINING_HEADER: HeaderName = HeaderName::from_static("x-ratelimit-remaining");
+const X_RATE_LIMIT_RESET_HEADER: HeaderName = HeaderName::from_static("x-ratelimit-reset");
 
 /// Layers OpenRouter-specific fields onto an Open Responses request body.
 #[derive(Debug, Default, Clone)]
@@ -92,6 +96,87 @@ impl OpenResponsesRequestExtension for OpenRouterRequestExtension {
 
         Ok(())
     }
+
+    fn update_rate_limit_info(
+        &self,
+        info: &mut RateLimitInfo,
+        headers: &HeaderMap,
+        error_body: &str,
+    ) {
+        let body = serde_json::from_str::<Value>(error_body).ok();
+        let body_headers = body
+            .as_ref()
+            .and_then(|value| value.get("error"))
+            .and_then(|error| error.get("metadata"))
+            .and_then(|metadata| metadata.get("headers"))
+            .and_then(Value::as_object);
+
+        let remaining = header_str(headers, &X_RATE_LIMIT_REMAINING_HEADER).or_else(|| {
+            body_headers.and_then(|headers| json_header_value(headers, "x-ratelimit-remaining"))
+        });
+        let reset = header_str(headers, &X_RATE_LIMIT_RESET_HEADER).or_else(|| {
+            body_headers.and_then(|headers| json_header_value(headers, "x-ratelimit-reset"))
+        });
+
+        apply_rate_limit_values(info, remaining, reset);
+    }
+}
+
+fn apply_rate_limit_values(info: &mut RateLimitInfo, remaining: Option<&str>, reset: Option<&str>) {
+    if let Some(remaining) = remaining
+        && let Ok(parsed) = remaining.parse::<u32>()
+    {
+        info.requests_remaining = Some(parsed);
+        if parsed == 0 {
+            info.limit_type = Some(RateLimitType::Requests);
+        }
+    }
+
+    if let Some(reset) = reset {
+        info.requests_reset = Some(reset.to_string());
+        if info.retry_after_secs.is_none() {
+            info.retry_after_secs = parse_reset(reset);
+        }
+    }
+}
+
+fn header_str<'a>(headers: &'a HeaderMap, name: &HeaderName) -> Option<&'a str> {
+    headers.get(name).and_then(|value| value.to_str().ok())
+}
+
+fn json_header_value<'a>(
+    headers: &'a serde_json::Map<String, Value>,
+    wanted: &str,
+) -> Option<&'a str> {
+    headers
+        .iter()
+        .find(|(key, _)| key.eq_ignore_ascii_case(wanted))
+        .and_then(|(_, value)| value.as_str())
+        .filter(|value| !value.is_empty())
+}
+
+fn parse_reset(value: &str) -> Option<u64> {
+    let reset = value.trim().parse::<u64>().ok()?;
+    let now = unix_epoch_secs()?;
+    reset_wait_secs(reset, now)
+}
+
+fn unix_epoch_secs() -> Option<u64> {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .ok()
+        .map(|duration| duration.as_secs())
+}
+
+fn reset_wait_secs(reset: u64, now_secs: u64) -> Option<u64> {
+    let reset_secs = if reset >= 1_000_000_000_000 {
+        reset.div_ceil(1000)
+    } else {
+        reset
+    };
+    reset_secs
+        .checked_sub(now_secs)
+        .filter(|seconds| *seconds > 0)
 }
 
 fn remove_attribution_metadata(obj: &mut serde_json::Map<String, Value>) {
@@ -280,5 +365,58 @@ mod tests {
                 json!({ "id": "file" })
             ]
         );
+    }
+
+    #[test]
+    fn reset_wait_secs_accepts_openrouter_epoch_millis() {
+        assert_eq!(reset_wait_secs(1_781_650_680_000, 1_781_650_620), Some(60));
+    }
+
+    #[test]
+    fn update_rate_limit_info_uses_openrouter_headers() {
+        let reset = unix_epoch_secs().expect("system clock") + 45;
+        let mut headers = HeaderMap::new();
+        headers.insert(X_RATE_LIMIT_REMAINING_HEADER, HeaderValue::from_static("0"));
+        headers.insert(
+            X_RATE_LIMIT_RESET_HEADER,
+            HeaderValue::from_str(&reset.to_string()).expect("valid header"),
+        );
+        let mut info = RateLimitInfo::default();
+
+        OpenRouterRequestExtension.update_rate_limit_info(&mut info, &headers, "");
+
+        assert_eq!(info.requests_remaining, Some(0));
+        assert_eq!(info.requests_reset, Some(reset.to_string()));
+        let retry_after = info.retry_after_secs.expect("retry wait");
+        assert!((44..=45).contains(&retry_after));
+        assert_eq!(info.limit_type, Some(RateLimitType::Requests));
+    }
+
+    #[test]
+    fn update_rate_limit_info_uses_openrouter_error_body_headers() {
+        let reset_ms = (unix_epoch_secs().expect("system clock") + 45) * 1000;
+        let body = format!(
+            r#"{{
+                "error": {{
+                    "message": "Rate limit exceeded: free-models-per-min.",
+                    "metadata": {{
+                        "headers": {{
+                            "X-RateLimit-Limit": "16",
+                            "X-RateLimit-Remaining": "0",
+                            "X-RateLimit-Reset": "{reset_ms}"
+                        }}
+                    }}
+                }}
+            }}"#
+        );
+        let mut info = RateLimitInfo::default();
+
+        OpenRouterRequestExtension.update_rate_limit_info(&mut info, &HeaderMap::new(), &body);
+
+        assert_eq!(info.requests_remaining, Some(0));
+        assert_eq!(info.requests_reset, Some(reset_ms.to_string()));
+        let retry_after = info.retry_after_secs.expect("retry wait");
+        assert!((44..=45).contains(&retry_after));
+        assert_eq!(info.limit_type, Some(RateLimitType::Requests));
     }
 }

--- a/crates/openrouter/tests/request_wire.rs
+++ b/crates/openrouter/tests/request_wire.rs
@@ -257,6 +257,81 @@ async fn sends_reasoning_none_to_disable_openrouter_reasoning() {
 }
 
 #[tokio::test]
+async fn retries_after_openrouter_rate_limit_reset() {
+    use futures::StreamExt;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    let reset_ms = (SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock")
+        .as_secs()
+        + 1)
+        * 1000;
+    let rate_limit_body = json!({
+        "error": {
+            "message": "Rate limit exceeded: free-models-per-min.",
+            "code": 429,
+            "metadata": {
+                "headers": {
+                    "X-RateLimit-Limit": "16",
+                    "X-RateLimit-Remaining": "0",
+                    "X-RateLimit-Reset": reset_ms.to_string()
+                }
+            }
+        }
+    });
+    let success_body =
+        "data: {\"type\":\"response.output_text.delta\",\"delta\":\"ok\"}\n\ndata: [DONE]\n\n";
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(429).set_body_json(rate_limit_body))
+        .up_to_n_times(1)
+        .expect(1)
+        .named("OpenRouter first rate-limit response")
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_body_string(success_body),
+        )
+        .expect(1)
+        .named("OpenRouter retry success response")
+        .mount(&server)
+        .await;
+
+    let api_url = format!("{}/v1/responses", server.uri());
+    let driver = OpenRouterChatDriver::with_base_url("test-key", api_url);
+    let messages = vec![LlmMessage::text(LlmMessageRole::User, "hello")];
+    let mut stream = driver
+        .chat_completion_stream(messages, &base_config("openai/gpt-4o-mini"))
+        .await
+        .expect("OpenRouter driver should retry after reset and start the stream");
+
+    let mut text = String::new();
+    while let Some(event) = stream.next().await {
+        match event.expect("stream item") {
+            everruns_core::driver_registry::LlmStreamEvent::TextDelta(delta) => {
+                text.push_str(&delta)
+            }
+            everruns_core::driver_registry::LlmStreamEvent::Error(error) => {
+                panic!("retry success stream should not emit an error: {error}")
+            }
+            _ => {}
+        }
+    }
+
+    assert_eq!(text, "ok");
+    let requests = server
+        .received_requests()
+        .await
+        .expect("mock server recorded requests");
+    assert_eq!(requests.len(), 2, "rate-limited request should be retried");
+}
+
+#[tokio::test]
 async fn rejects_invalid_routing_before_dispatch() {
     let server = MockServer::start().await;
     Mock::given(method("POST"))


### PR DESCRIPTION
## What
Teach the OpenRouter chat driver to honor OpenRouter rate-limit reset metadata when retrying 429 responses.

## Why
OpenRouter can return `X-RateLimit-Remaining` / `X-RateLimit-Reset` values inside the HTTP headers or inside the JSON error body's `error.metadata.headers`. The generic Open Responses retry loop did not expose the response body to provider-specific retry parsing, so these reset hints were ignored.

## How
Added a generic `OpenResponsesRequestExtension::update_rate_limit_info` hook in core, called from both Open Responses retry loops after reading retryable error bodies. Implemented OpenRouter-specific parsing in `everruns-openrouter`, including epoch seconds and epoch milliseconds reset values. Added direct parser tests and a wiremock smoke test that returns an OpenRouter-style 429, then succeeds on retry through the real OpenRouter driver wrapper.

## Risk
- Low
- Touches retry wait calculation for OpenRouter 429 responses. The existing `MAX_RETRY_AFTER_SECS` cap and retry fallback behavior remain in core, so very large reset values still fall back instead of causing long sleeps.

## Security
- Threat categories reviewed: TM-LLM, TM-DOS
- Findings and resolutions: No credential, auth, tenant, or public API surface changes. Provider error-body parsing reads only rate-limit metadata and does not log or expose provider secrets. Resource-exhaustion risk is bounded by the existing retry count and max retry-after cap in core.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)
