### PR TITLE
fix(agents): reap interrupted agent health-check runs

### DIFF
--- a/crates/server/src/app_builder.rs
+++ b/crates/server/src/app_builder.rs
@@ -1871,6 +1871,19 @@ impl ServerAppBuilder {
             });
         }
 
+        // -- Agent health-check reaper (both prod and dev) --
+        // A previous process may have died mid-run, leaving health-check rows
+        // stuck in `running`/`pending` forever (a user-visible perpetual
+        // spinner). A fresh process has no run in flight, so transition every
+        // such orphan to `failed` on boot. See specs/agent-checks.md and EVE-586.
+        match db.reap_running_agent_health_check_runs().await {
+            Ok(0) => {}
+            Ok(count) => tracing::info!(count, "Reaped interrupted agent health-check runs"),
+            Err(e) => {
+                tracing::error!(error = %e, "Failed to reap interrupted agent health-check runs")
+            }
+        }
+
         // -- Durable task scheduler (both prod and dev) --
         if let Some(store) = scheduler_store {
             if let Err(e) =

--- a/crates/server/src/domains/agents/health_check/commands.rs
+++ b/crates/server/src/domains/agents/health_check/commands.rs
@@ -121,7 +121,7 @@ impl AgentHealthCheckService {
             // mismatched URL.
             .filter(|row| row.agent_id == Some(agent.internal_id))
             .ok_or_else(|| CommandError::not_found("Health check run"))?;
-        Ok(HealthCheckRun::from(row))
+        Ok(HealthCheckRun::from_row_at(row, chrono::Utc::now()))
     }
 
     pub async fn list(
@@ -140,7 +140,11 @@ impl AgentHealthCheckService {
             .list_agent_health_check_runs(caller.org_id, agent.internal_id, LIST_LIMIT)
             .await
             .map_err(classify_anyhow)?;
-        Ok(rows.into_iter().map(HealthCheckRun::from).collect())
+        let now = chrono::Utc::now();
+        Ok(rows
+            .into_iter()
+            .map(|row| HealthCheckRun::from_row_at(row, now))
+            .collect())
     }
 }
 

--- a/crates/server/src/domains/agents/health_check/types.rs
+++ b/crates/server/src/domains/agents/health_check/types.rs
@@ -110,6 +110,18 @@ pub struct HealthCheckRun {
     pub completed_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
+/// A non-terminal run untouched for longer than this is treated as `failed`
+/// when read. This is defense-in-depth for a process that crashed without
+/// restarting (the startup reaper covers the restart case). The threshold
+/// comfortably exceeds the runner's worst-case wall-clock budget — `updated_at`
+/// is stamped when the run transitions to `running`, and a run finishes well
+/// inside this window — so an in-flight run is never misreported as failed.
+/// See specs/agent-checks.md (durability) and EVE-586.
+const STALE_AFTER_SECS: i64 = 30 * 60;
+
+const STALE_ERROR_MESSAGE: &str =
+    "Run stalled without completing (no progress past the staleness window).";
+
 impl From<AgentHealthCheckRunRow> for HealthCheckRun {
     fn from(row: AgentHealthCheckRunRow) -> Self {
         use everruns_core::typed_id::AgentId;
@@ -125,5 +137,80 @@ impl From<AgentHealthCheckRunRow> for HealthCheckRun {
             created_at: row.created_at,
             completed_at: row.completed_at,
         }
+    }
+}
+
+impl HealthCheckRun {
+    /// Build the API view, applying the staleness guard relative to `now`.
+    ///
+    /// Read paths (`get`/`list`) use this so a run whose process crashed
+    /// mid-flight surfaces as `failed` instead of a perpetual `running`
+    /// spinner, even when the server has not restarted to run the boot reaper.
+    pub fn from_row_at(row: AgentHealthCheckRunRow, now: chrono::DateTime<chrono::Utc>) -> Self {
+        let last_progress = row.updated_at;
+        let mut run = Self::from(row);
+        // Derive "non-terminal" from the same parsed status the API presents
+        // (rather than the raw DB string) so any unexpected status value is
+        // judged for staleness consistently with how it is displayed.
+        let non_terminal = matches!(
+            run.status,
+            HealthCheckStatus::Pending | HealthCheckStatus::Running
+        );
+        if non_terminal && now - last_progress > chrono::TimeDelta::seconds(STALE_AFTER_SECS) {
+            run.status = HealthCheckStatus::Failed;
+            run.error_message
+                .get_or_insert_with(|| STALE_ERROR_MESSAGE.to_string());
+            run.completed_at.get_or_insert(last_progress);
+        }
+        run
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn row(status: &str, updated_minutes_ago: i64) -> AgentHealthCheckRunRow {
+        let now = chrono::Utc::now();
+        AgentHealthCheckRunRow {
+            id: uuid::Uuid::now_v7(),
+            org_id: 1,
+            public_id: "healthcheck_00000000000000000000000000000001".to_string(),
+            agent_id: None,
+            config_hash: "cfg".to_string(),
+            model_id: None,
+            status: status.to_string(),
+            summary: None,
+            results: None,
+            error_message: None,
+            started_at: None,
+            completed_at: None,
+            created_at: now - chrono::TimeDelta::minutes(updated_minutes_ago),
+            updated_at: now - chrono::TimeDelta::minutes(updated_minutes_ago),
+        }
+    }
+
+    #[test]
+    fn stale_running_run_is_reported_failed() {
+        let now = chrono::Utc::now();
+        let run = HealthCheckRun::from_row_at(row("running", 45), now);
+        assert_eq!(run.status, HealthCheckStatus::Failed);
+        assert!(run.error_message.is_some());
+        assert!(run.completed_at.is_some());
+    }
+
+    #[test]
+    fn fresh_running_run_is_left_running() {
+        let now = chrono::Utc::now();
+        let run = HealthCheckRun::from_row_at(row("running", 2), now);
+        assert_eq!(run.status, HealthCheckStatus::Running);
+        assert!(run.error_message.is_none());
+    }
+
+    #[test]
+    fn terminal_run_is_never_remapped_even_when_old() {
+        let now = chrono::Utc::now();
+        let run = HealthCheckRun::from_row_at(row("completed", 600), now);
+        assert_eq!(run.status, HealthCheckStatus::Completed);
     }
 }

--- a/crates/server/src/storage/backend.rs
+++ b/crates/server/src/storage/backend.rs
@@ -3399,6 +3399,10 @@ impl StorageBackend {
         dispatch!(self, update_agent_health_check_run, id, input)
     }
 
+    pub async fn reap_running_agent_health_check_runs(&self) -> Result<u64> {
+        dispatch!(self, reap_running_agent_health_check_runs)
+    }
+
     // ============================================
     // Agent Check Rules (specs/agent-checks.md, phase 4)
     // ============================================

--- a/crates/server/src/storage/memory/agent_health_checks.rs
+++ b/crates/server/src/storage/memory/agent_health_checks.rs
@@ -83,6 +83,28 @@ impl InMemoryDatabase {
             .cloned())
     }
 
+    /// In-memory parity for the Postgres reaper: mark every non-terminal run
+    /// (`pending`/`running`) as `failed`. See specs/agent-checks.md and EVE-586.
+    pub async fn reap_running_agent_health_check_runs(&self) -> Result<u64> {
+        let now = Self::now();
+        let mut guard = self.agent_health_check_runs.write();
+        let mut count = 0u64;
+        for row in guard.values_mut() {
+            if matches!(row.status.as_str(), "pending" | "running") {
+                row.status = "failed".to_string();
+                if row.error_message.is_none() {
+                    row.error_message = Some("Run interrupted by server restart".to_string());
+                }
+                if row.completed_at.is_none() {
+                    row.completed_at = Some(now);
+                }
+                row.updated_at = now;
+                count += 1;
+            }
+        }
+        Ok(count)
+    }
+
     pub async fn update_agent_health_check_run(
         &self,
         id: Uuid,
@@ -113,5 +135,76 @@ impl InMemoryDatabase {
         }
         row.updated_at = now;
         Ok(Some(row.clone()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn create_input(pid: u128) -> CreateAgentHealthCheckRunRow {
+        CreateAgentHealthCheckRunRow {
+            public_id: format!("healthcheck_{pid:032x}"),
+            agent_id: None,
+            config_hash: "cfg".to_string(),
+            model_id: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn reap_marks_running_failed_and_leaves_terminal_runs() {
+        let db = InMemoryDatabase::new();
+
+        // An orphaned run still marked `running` (simulating a crashed process).
+        let running = db
+            .create_agent_health_check_run(1, create_input(1))
+            .await
+            .unwrap();
+        db.update_agent_health_check_run(
+            running.id,
+            UpdateAgentHealthCheckRunRow {
+                status: Some("running".to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+        // A run that finished normally must be left untouched.
+        let done = db
+            .create_agent_health_check_run(1, create_input(2))
+            .await
+            .unwrap();
+        db.update_agent_health_check_run(
+            done.id,
+            UpdateAgentHealthCheckRunRow {
+                status: Some("completed".to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+        let reaped = db.reap_running_agent_health_check_runs().await.unwrap();
+        assert_eq!(reaped, 1);
+
+        let running_after = db
+            .get_agent_health_check_run(1, &running.public_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(running_after.status, "failed");
+        assert!(running_after.error_message.is_some());
+        assert!(running_after.completed_at.is_some());
+
+        let done_after = db
+            .get_agent_health_check_run(1, &done.public_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(done_after.status, "completed");
+
+        // Idempotent: a second pass finds nothing left to reap.
+        assert_eq!(db.reap_running_agent_health_check_runs().await.unwrap(), 0);
     }
 }

--- a/crates/server/src/storage/repositories/agent_health_checks.rs
+++ b/crates/server/src/storage/repositories/agent_health_checks.rs
@@ -99,6 +99,27 @@ impl Database {
         Ok(row)
     }
 
+    /// Mark every non-terminal run (`pending`/`running`) as `failed`. Called
+    /// once on server boot: a fresh process has no run in flight, so any such
+    /// row is an orphan left by a previous process that died mid-run and would
+    /// otherwise show a perpetual spinner. Returns the number of rows reaped.
+    /// See specs/agent-checks.md (durability) and EVE-586.
+    pub async fn reap_running_agent_health_check_runs(&self) -> Result<u64> {
+        let result = sqlx::query(
+            r#"
+            UPDATE agent_health_check_runs
+            SET status = 'failed',
+                error_message = COALESCE(error_message, 'Run interrupted by server restart'),
+                completed_at = COALESCE(completed_at, NOW()),
+                updated_at = NOW()
+            WHERE status IN ('pending', 'running')
+            "#,
+        )
+        .execute(&self.pool)
+        .await?;
+        Ok(result.rows_affected())
+    }
+
     pub async fn update_agent_health_check_run(
         &self,
         id: Uuid,

--- a/crates/server/tests/repository_integration_test.rs
+++ b/crates/server/tests/repository_integration_test.rs
@@ -21,11 +21,12 @@ use everruns_durable::UpdateField;
 use everruns_server::api::common::Pagination;
 use everruns_server::org_init;
 use everruns_server::storage::{
-    CreateAgentCapabilityRow, CreateAgentRow, CreateAppRow, CreateDeclarativeCapabilityRow,
-    CreateEventRow, CreateHarnessRow, CreateImageRow, CreateMcpServerRow, CreateModelRow,
-    CreateOrganizationRow, CreatePrincipalRow, CreateProviderRow, CreateSessionFileRow,
-    CreateSessionRow, CreateSessionScheduleRow, CreateUserConnectionRow, CreateUserRow, Database,
-    StorageBackend, UpdateAgent, UpdateDeclarativeCapability, UpdateModel, UpdateOrganization,
+    CreateAgentCapabilityRow, CreateAgentHealthCheckRunRow, CreateAgentRow, CreateAppRow,
+    CreateDeclarativeCapabilityRow, CreateEventRow, CreateHarnessRow, CreateImageRow,
+    CreateMcpServerRow, CreateModelRow, CreateOrganizationRow, CreatePrincipalRow,
+    CreateProviderRow, CreateSessionFileRow, CreateSessionRow, CreateSessionScheduleRow,
+    CreateUserConnectionRow, CreateUserRow, Database, StorageBackend, UpdateAgent,
+    UpdateAgentHealthCheckRunRow, UpdateDeclarativeCapability, UpdateModel, UpdateOrganization,
     UpdateOrganizationSettings, UpdateProvider, UpdateSession, UpdateSessionFile,
     UpdateSessionScheduleRow,
 };
@@ -2853,4 +2854,76 @@ async fn list_monitor_tasks_with_inactive_schedules_pg() {
             .all(|(_, tid, _)| tid != &malformed_task_id),
         "malformed-spec task must never appear in results"
     );
+}
+
+/// EVE-586: the boot reaper transitions orphaned `running`/`pending` health
+/// check runs to `failed` while leaving terminal runs untouched. Mirrors the
+/// in-memory unit test so both backends are proven to behave identically.
+#[tokio::test]
+async fn test_reap_running_agent_health_check_runs() {
+    let backend = create_test_backend().await;
+
+    let health_check_input = |pid: u128| CreateAgentHealthCheckRunRow {
+        public_id: format!("healthcheck_{pid:032x}"),
+        agent_id: None,
+        config_hash: "cfg".to_string(),
+        model_id: None,
+    };
+
+    // An orphaned run still marked `running`.
+    let running = backend
+        .create_agent_health_check_run(TEST_ORG_ID, health_check_input(Uuid::now_v7().as_u128()))
+        .await
+        .expect("create running health check run");
+    backend
+        .update_agent_health_check_run(
+            running.id,
+            UpdateAgentHealthCheckRunRow {
+                status: Some("running".to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("mark running");
+
+    // A run that finished normally must be left untouched.
+    let done = backend
+        .create_agent_health_check_run(TEST_ORG_ID, health_check_input(Uuid::now_v7().as_u128()))
+        .await
+        .expect("create completed health check run");
+    backend
+        .update_agent_health_check_run(
+            done.id,
+            UpdateAgentHealthCheckRunRow {
+                status: Some("completed".to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("mark completed");
+
+    let reaped = backend
+        .reap_running_agent_health_check_runs()
+        .await
+        .expect("reap runs");
+    assert!(
+        reaped >= 1,
+        "expected at least the orphaned run to be reaped"
+    );
+
+    let running_after = backend
+        .get_agent_health_check_run(TEST_ORG_ID, &running.public_id)
+        .await
+        .expect("fetch running run")
+        .expect("running run exists");
+    assert_eq!(running_after.status, "failed");
+    assert!(running_after.error_message.is_some());
+    assert!(running_after.completed_at.is_some());
+
+    let done_after = backend
+        .get_agent_health_check_run(TEST_ORG_ID, &done.public_id)
+        .await
+        .expect("fetch completed run")
+        .expect("completed run exists");
+    assert_eq!(done_after.status, "completed");
 }

--- a/specs/agent-checks.md
+++ b/specs/agent-checks.md
@@ -117,6 +117,15 @@ Decided ordering (Option A → C → B from the design review):
    in `agent_health_check_runs` (whole run + results as JSONB on one row;
    health checks are not `Eval` entities). Gated on the utility LLM and the
    org default harness being available.
+
+   The background task is fire-and-forget, so a run is made durable against
+   process death two ways: a **boot reaper** transitions every non-terminal
+   (`pending`/`running`) row to `failed` on server startup (a fresh process has
+   no run in flight, so any such row is an orphan), and a **read-path staleness
+   guard** reports a non-terminal run whose `updated_at` is older than a
+   generous window (well beyond the runner's max wall-clock budget) as `failed`
+   even when the server has not restarted. Together these guarantee a run never
+   shows a perpetual `running` spinner.
 4. **Extensible rules.** Org-level rule registry: per-rule enable/severity
    config for built-ins, plus two custom rule types — declarative
    (keyword/regex/structural, no code) and natural-language rubrics judged by


### PR DESCRIPTION
## What
Make agent health-check runs durable against process death: a boot reaper plus a read-path staleness guard ensure a run never shows a perpetual `running` spinner.

## Why
Health-check runs are launched fire-and-forget with `tokio::spawn`. If the server restarts or the task dies mid-run, the `agent_health_check_runs` row stays in `running` forever — there was no process that ever transitioned it to a terminal state, so the UI shows a perpetual spinner. This is a user-visible correctness/reliability bug (EVE-586).

## How
- **Boot reaper** (`reap_running_agent_health_check_runs`, Postgres + in-memory parity): on server startup, transition every non-terminal (`pending`/`running`) run to `failed` with "Run interrupted by server restart". A fresh process has no run in flight, so any such row is an orphan from a process that died mid-run. Wired unconditionally into the boot path next to the other restart-recovery steps.
- **Read-path staleness guard** (`HealthCheckRun::from_row_at`): `get`/`list` report a non-terminal run whose `updated_at` is older than a generous window (30 min — well beyond the runner's max wall-clock budget) as `failed`, covering a process that crashed without restarting. `updated_at` is stamped on the `running` transition and a run finishes well inside the window, so live runs are never misreported.

## Risk
- Low
- The boot path gains one unconditional `UPDATE`. The staleness threshold sits far above the runner's wall-clock budget, so in-flight runs cannot be falsely failed. The reaper only touches pre-existing non-terminal rows at boot; runs created after boot are untouched.

## Security
- Threat categories reviewed: TM-TENANT, TM-DOS
- Findings and resolutions: The reaper is a global startup sweep with no user input and no new API surface. Read paths preserve existing org/agent scoping — the staleness guard only rewrites the presented status of rows already authorized for return. No credential, auth, or cross-tenant surface changes; the staleness constant bounds nothing user-controllable.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)
