### PR TITLE
docs: fix post-providers-refactor drift (DriverId/ResolvedModel)

### DIFF
--- a/crates/openai/README.md
+++ b/crates/openai/README.md
@@ -37,7 +37,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .platform_definition(platform)
         .default_model(ResolvedModel {
             model: "gpt-5.4-mini".into(),
-            provider_type: DriverId::Openai,
+            provider_type: DriverId::OpenAI,
             api_key: Some(std::env::var("OPENAI_API_KEY")?),
             base_url: None,
             provider_metadata: None,

--- a/crates/openai/README.md
+++ b/crates/openai/README.md
@@ -23,7 +23,7 @@ models, or run with no key at all using the built-in LLM simulator in
 
 ```rust,no_run
 use everruns_core::{
-    CapabilityRegistry, DriverRegistry, LlmProviderType, ModelWithProvider, PlatformDefinition,
+    CapabilityRegistry, DriverId, DriverRegistry, PlatformDefinition, ResolvedModel,
 };
 use everruns_runtime::InProcessRuntimeBuilder;
 
@@ -35,11 +35,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let platform = PlatformDefinition::new(CapabilityRegistry::new(), drivers);
     let runtime = InProcessRuntimeBuilder::new()
         .platform_definition(platform)
-        .default_model(ModelWithProvider {
+        .default_model(ResolvedModel {
             model: "gpt-5.4-mini".into(),
-            provider_type: LlmProviderType::Openai,
+            provider_type: DriverId::Openai,
             api_key: Some(std::env::var("OPENAI_API_KEY")?),
             base_url: None,
+            provider_metadata: None,
         })
         .single_session(|s| {
             s.harness("assistant", "You are a helpful assistant.")

--- a/crates/runtime/README.md
+++ b/crates/runtime/README.md
@@ -24,7 +24,7 @@ with provider crates such as
 
 ```rust
 use everruns_core::{
-    CapabilityRegistry, DriverRegistry, LlmProviderType, ModelWithProvider, PlatformDefinition,
+    CapabilityRegistry, DriverId, DriverRegistry, PlatformDefinition, ResolvedModel,
 };
 use everruns_core::capabilities::TestMathCapability;
 use everruns_runtime::InProcessRuntimeBuilder;
@@ -37,11 +37,12 @@ let platform = PlatformDefinition::new(capabilities, DriverRegistry::new());
 let runtime = InProcessRuntimeBuilder::new()
     .platform_definition(platform)
     .llm_sim(everruns_core::llmsim_driver::LlmSimConfig::fixed("4"))
-    .default_model(ModelWithProvider {
+    .default_model(ResolvedModel {
         model: "llmsim-model".into(),
-        provider_type: LlmProviderType::LlmSim,
+        provider_type: DriverId::LlmSim,
         api_key: Some("fake-key".into()),
         base_url: None,
+        provider_metadata: None,
     })
     .single_session(|s| {
         s.harness("math", "You are a calculator.")

--- a/docs/advanced/embedding-everruns.md
+++ b/docs/advanced/embedding-everruns.md
@@ -167,12 +167,12 @@ Reference the provider from a model by its id, passing any non-API-key auth
 through `provider_metadata`:
 
 ```rust
-use everruns_core::{LlmProviderType, ModelWithProvider};
+use everruns_core::{DriverId, ResolvedModel};
 use everruns_core::driver_registry::ProviderMetadata;
 
-let model = ModelWithProvider {
+let model = ResolvedModel {
     model: "gpt-5-codex".into(),
-    provider_type: LlmProviderType::External("openai-codex".into()),
+    provider_type: DriverId::External("openai-codex".into()),
     api_key: None, // external providers may use metadata-based auth instead
     base_url: None,
     provider_metadata: Some(ProviderMetadata {
@@ -226,7 +226,7 @@ This path is for applications that want to:
 
 ```rust
 use everruns_core::{
-    CapabilityRegistry, DriverRegistry, LlmProviderType, ModelWithProvider, PlatformDefinition,
+    CapabilityRegistry, DriverId, DriverRegistry, PlatformDefinition, ResolvedModel,
 };
 use everruns_core::llmsim_driver::LlmSimConfig;
 use everruns_runtime::InProcessRuntimeBuilder;
@@ -236,9 +236,9 @@ let platform = PlatformDefinition::new(CapabilityRegistry::new(), DriverRegistry
 let runtime = InProcessRuntimeBuilder::new()
     .platform_definition(platform)
     .llm_sim(LlmSimConfig::fixed("hello from everruns-runtime"))
-    .default_model(ModelWithProvider {
+    .default_model(ResolvedModel {
         model: "llmsim-model".into(),
-        provider_type: LlmProviderType::LlmSim,
+        provider_type: DriverId::LlmSim,
         api_key: Some("fake-key".into()),
         base_url: None,
         provider_metadata: None,

--- a/docs/features/runtime.mdx
+++ b/docs/features/runtime.mdx
@@ -38,7 +38,7 @@ Build an in-process runtime with an in-memory backend and a simulated LLM, then 
 
 ```rust
 use everruns_core::{
-    CapabilityRegistry, DriverRegistry, LlmProviderType, ModelWithProvider, PlatformDefinition,
+    CapabilityRegistry, DriverId, DriverRegistry, PlatformDefinition, ResolvedModel,
 };
 use everruns_core::llmsim_driver::LlmSimConfig;
 use everruns_runtime::InProcessRuntimeBuilder;
@@ -48,11 +48,12 @@ let platform = PlatformDefinition::new(CapabilityRegistry::new(), DriverRegistry
 let runtime = InProcessRuntimeBuilder::new()
     .platform_definition(platform)
     .llm_sim(LlmSimConfig::fixed("hello from everruns-runtime"))
-    .default_model(ModelWithProvider {
+    .default_model(ResolvedModel {
         model: "llmsim-model".into(),
-        provider_type: LlmProviderType::LlmSim,
+        provider_type: DriverId::LlmSim,
         api_key: Some("fake-key".into()),
         base_url: None,
+        provider_metadata: None,
     })
     // .capability(...)
     // .backends(...)

--- a/specs/architecture.md
+++ b/specs/architecture.md
@@ -451,7 +451,7 @@ a vendor-neutral, open-source API standard for multi-provider LLM interfaces.
 
 For integration testing without real API keys, Everruns uses [llmsim](https://github.com/chaliy/llmsim) - a simulated LLM driver:
 
-1. **Provider Type**: `llmsim` - registered as `LlmProviderType::LlmSim`
+1. **Provider Type**: `llmsim` - registered as `DriverId::LlmSim`
 2. **No API Keys Required**: Tests can run without external dependencies
 3. **Configurable Responses**: Supports fixed responses, echo mode, lorem ipsum generation, and tool call simulation
 4. **Latency Simulation**: Optional latency profiles for realistic timing

--- a/specs/providers.md
+++ b/specs/providers.md
@@ -232,14 +232,16 @@ PR-sized slices, each leaving the tree green and self-consistent (code + specs +
 
 ## Source Index
 
-Until the refactor lands, current implementations live at:
+The refactor has landed; current implementations live at:
 
-- `crates/core/src/llm_models.rs` — entity types (to become `Provider`/`Model`/`ModelProfile`)
-- `crates/core/src/driver_registry.rs` — `ChatDriver` trait + `DriverRegistry`
-- `crates/core/src/llm_model_profiles.rs` — built-in profile data
-- `crates/server/src/services/llm_resolver.rs` — fail-closed resolution
+- `crates/core/src/provider.rs` — `Provider` entity + `DriverId`
+- `crates/core/src/model.rs` — `Model` / `ModelWithProvider` entity types
+- `crates/core/src/model_profiles.rs` — built-in profile data
+- `crates/core/src/driver_registry.rs` — `ChatDriver` trait + `DriverRegistry` (string-keyed driver ids, credential schema + service factories)
+- `crates/core/src/traits.rs` — `ProviderStore` + `ResolvedModel`
+- `crates/server/src/services/provider_resolver.rs` — fail-closed resolution (`resolve_service`)
 - `crates/server/src/services/model_sync.rs` — model discovery
-- `crates/server/src/api/llm_providers.rs`, `crates/server/src/api/llm_models.rs` — REST API
-- `crates/server/src/api/voice.rs` — realtime credential resolution (to be rerouted)
+- `crates/server/src/api/providers.rs`, `crates/server/src/api/models.rs` — REST API
+- `crates/server/src/api/voice.rs` — realtime credential resolution (routed through `resolve_service`)
 - `crates/core/src/connector.rs` — connector plugin trait
 - `apps/ui/src/app/(main)/settings/providers/` — provider settings UI


### PR DESCRIPTION
## What
Fix documentation/spec drift left over from the providers refactor: stale `LlmProviderType` / `ModelWithProvider` snippets and the outdated `specs/providers.md` "Source Index".

## Why
The refactor renamed the runtime model-config type `ModelWithProvider` → `ResolvedModel` and the provider enum `LlmProviderType` → `DriverId`. Several doc/spec code snippets still referenced the old names, so they no longer matched the real `InProcessRuntimeBuilder::default_model(ResolvedModel)` API and would mislead embedders. The `providers.md` Source Index was still prefaced "Until the refactor lands" and pointed at files that have since been renamed.

## How
- `docs/advanced/embedding-everruns.md`, `docs/features/runtime.mdx`, `crates/openai/README.md`, `crates/runtime/README.md`: construct `ResolvedModel` with `provider_type: DriverId::…` and the `provider_metadata` field, mirroring the compiled `crates/runtime/examples/*` and the `everruns_core` exports (`DriverId`, `ResolvedModel`).
- `specs/architecture.md`: replace the stale `LlmProviderType::LlmSim` reference with `DriverId::LlmSim`.
- `specs/providers.md`: refresh the Source Index to the post-refactor files (`provider.rs`/`model.rs`, `model_profiles.rs`, `traits.rs` `ResolvedModel`/`ProviderStore`, `provider_resolver.rs`, `api/providers.rs`/`api/models.rs`).

Verified every referenced path exists on `main` and that no `LlmProviderType` references remain in the repo.

## Risk
- Low
- Docs/spec-only. Snippets are inside fenced code blocks (not compiled doctests); the affected runtime snippets now match the compiled `examples/`.

## Security
- No security-relevant code changes (documentation and spec text only).

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated (N/A — docs only)
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)
