### PR TITLE
feat(agents): show latest health-check run on agent editor mount

### DIFF
--- a/apps/ui/src/__tests__/agent-health-check.test.tsx
+++ b/apps/ui/src/__tests__/agent-health-check.test.tsx
@@ -1,18 +1,64 @@
 import { render, screen } from "@testing-library/react";
 import { AgentHealthCheck } from "@/components/agents/agent-health-check";
-import type { HealthCheckRun } from "@/lib/api/types";
+import type { HealthCheckRun, LatestHealthCheckRun } from "@/lib/api/types";
 
 const mockTrigger = jest.fn(() => ({ mutate: jest.fn(), isPending: false, error: null }));
 let mockRun: HealthCheckRun | undefined;
+let mockLatest: LatestHealthCheckRun | undefined;
 
 jest.mock("@/hooks/use-agents", () => ({
   useTriggerHealthCheck: () => mockTrigger(),
   useHealthCheckRun: () => ({ data: mockRun }),
+  useLatestHealthCheckRun: () => ({ data: mockLatest }),
 }));
+
+const completedRun: HealthCheckRun = {
+  id: "healthcheck_1",
+  config_hash: "abc",
+  status: "completed",
+  created_at: "2026-06-13T00:00:00Z",
+  summary: {
+    total: 2,
+    passed: 1,
+    failed: 1,
+    errored: 0,
+    pass_rate: 0.5,
+    avg_score: 0.7,
+    avg_turns: 1.5,
+    total_input_tokens: 0,
+    total_output_tokens: 0,
+  },
+  results: [
+    {
+      name: "greeting",
+      user_message: "Hi",
+      rubric: "Polite",
+      session_id: "session_1",
+      passed: true,
+      score: 0.9,
+      judge_reason: "Responded politely.",
+      deterministic_reason: "Completed.",
+      turns: 1,
+      latency_ms: 100,
+    },
+    {
+      name: "edge",
+      user_message: "???",
+      rubric: "Clarifies",
+      passed: false,
+      score: 0.4,
+      judge_reason: "Did not clarify.",
+      deterministic_reason: "Completed.",
+      turns: 2,
+      latency_ms: 200,
+    },
+  ],
+};
 
 describe("AgentHealthCheck", () => {
   beforeEach(() => {
     mockRun = undefined;
+    mockLatest = undefined;
   });
 
   it("shows an idle empty state with a run button", () => {
@@ -22,48 +68,7 @@ describe("AgentHealthCheck", () => {
   });
 
   it("renders the score card and per-case results when completed", () => {
-    mockRun = {
-      id: "healthcheck_1",
-      config_hash: "abc",
-      status: "completed",
-      created_at: "2026-06-13T00:00:00Z",
-      summary: {
-        total: 2,
-        passed: 1,
-        failed: 1,
-        errored: 0,
-        pass_rate: 0.5,
-        avg_score: 0.7,
-        avg_turns: 1.5,
-        total_input_tokens: 0,
-        total_output_tokens: 0,
-      },
-      results: [
-        {
-          name: "greeting",
-          user_message: "Hi",
-          rubric: "Polite",
-          session_id: "session_1",
-          passed: true,
-          score: 0.9,
-          judge_reason: "Responded politely.",
-          deterministic_reason: "Completed.",
-          turns: 1,
-          latency_ms: 100,
-        },
-        {
-          name: "edge",
-          user_message: "???",
-          rubric: "Clarifies",
-          passed: false,
-          score: 0.4,
-          judge_reason: "Did not clarify.",
-          deterministic_reason: "Completed.",
-          turns: 2,
-          latency_ms: 200,
-        },
-      ],
-    };
+    mockRun = completedRun;
     render(<AgentHealthCheck agentId="agent_1" />);
     expect(screen.getByText("50%")).toBeInTheDocument();
     expect(screen.getByText("greeting")).toBeInTheDocument();
@@ -81,5 +86,23 @@ describe("AgentHealthCheck", () => {
     };
     render(<AgentHealthCheck agentId="agent_1" />);
     expect(screen.getByText(/utility LLM down/i)).toBeInTheDocument();
+  });
+
+  it("shows the latest persisted run on mount without triggering one", () => {
+    // No freshly triggered run; only the latest run loaded on mount (EVE-588).
+    mockLatest = { run: completedRun, config_changed: false };
+    render(<AgentHealthCheck agentId="agent_1" />);
+    expect(screen.getByText("50%")).toBeInTheDocument();
+    expect(screen.getByText("greeting")).toBeInTheDocument();
+    expect(screen.queryByText(/no health check has been run/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/configuration changed since this run/i)).not.toBeInTheDocument();
+  });
+
+  it("shows a stale-config hint when the latest run predates the current config", () => {
+    mockLatest = { run: completedRun, config_changed: true };
+    render(<AgentHealthCheck agentId="agent_1" />);
+    expect(screen.getByText(/configuration changed since this run/i)).toBeInTheDocument();
+    // The prior run is still rendered alongside the hint.
+    expect(screen.getByText("50%")).toBeInTheDocument();
   });
 });

--- a/apps/ui/src/__tests__/agent-health-check.test.tsx
+++ b/apps/ui/src/__tests__/agent-health-check.test.tsx
@@ -105,4 +105,20 @@ describe("AgentHealthCheck", () => {
     // The prior run is still rendered alongside the hint.
     expect(screen.getByText("50%")).toBeInTheDocument();
   });
+
+  it("keeps the run button disabled while the latest run is still in progress", () => {
+    // A run loaded on mount that is still running must not allow a duplicate
+    // trigger, even though nothing was triggered in this session.
+    mockLatest = {
+      run: {
+        id: "healthcheck_3",
+        config_hash: "abc",
+        status: "running",
+        created_at: "2026-06-13T00:00:00Z",
+      },
+      config_changed: false,
+    };
+    render(<AgentHealthCheck agentId="agent_1" />);
+    expect(screen.getByRole("button", { name: /running/i })).toBeDisabled();
+  });
 });

--- a/apps/ui/src/components/agents/agent-health-check.tsx
+++ b/apps/ui/src/components/agents/agent-health-check.tsx
@@ -2,7 +2,11 @@
 
 import { useState } from "react";
 import Link from "next/link";
-import { useHealthCheckRun, useTriggerHealthCheck } from "@/hooks/use-agents";
+import {
+  useHealthCheckRun,
+  useLatestHealthCheckRun,
+  useTriggerHealthCheck,
+} from "@/hooks/use-agents";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -27,9 +31,20 @@ interface AgentHealthCheckProps {
 export function AgentHealthCheck({ agentId }: AgentHealthCheckProps) {
   const trigger = useTriggerHealthCheck();
   const [runId, setRunId] = useState<string | null>(null);
-  const { data: run } = useHealthCheckRun(agentId, runId);
+  const { data: triggeredRun } = useHealthCheckRun(agentId, runId);
+  const { data: latest } = useLatestHealthCheckRun(agentId);
 
-  const isRunning = trigger.isPending || run?.status === "pending" || run?.status === "running";
+  // Show a freshly triggered run if there is one; otherwise fall back to the
+  // latest persisted run loaded on mount so prior results appear immediately
+  // without triggering a new LLM run (EVE-588).
+  const run = triggeredRun ?? latest?.run;
+  // Only hint staleness for the mounted latest run, not one we just triggered.
+  const configChanged = !runId && !!latest?.run && latest.config_changed;
+
+  const isRunning =
+    trigger.isPending ||
+    triggeredRun?.status === "pending" ||
+    triggeredRun?.status === "running";
 
   return (
     <Card>
@@ -74,6 +89,12 @@ export function AgentHealthCheck({ agentId }: AgentHealthCheckProps) {
         {!run && !trigger.error && (
           <p className="text-sm text-muted-foreground italic">
             No health check has been run for this configuration yet.
+          </p>
+        )}
+        {configChanged && (
+          <p className="text-sm text-amber-600 dark:text-amber-400 flex items-center gap-2 mb-3">
+            <AlertTriangle className="w-4 h-4 shrink-0" />
+            This agent&apos;s configuration changed since this run — re-run to refresh results.
           </p>
         )}
         {run && <HealthCheckResults run={run} />}

--- a/apps/ui/src/components/agents/agent-health-check.tsx
+++ b/apps/ui/src/components/agents/agent-health-check.tsx
@@ -41,8 +41,9 @@ export function AgentHealthCheck({ agentId }: AgentHealthCheckProps) {
   // Only hint staleness for the mounted latest run, not one we just triggered.
   const configChanged = !runId && !!latest?.run && latest.config_changed;
 
-  const isRunning =
-    trigger.isPending || triggeredRun?.status === "pending" || triggeredRun?.status === "running";
+  // Consider the displayed run (triggered or the latest loaded on mount): a run
+  // already in progress keeps the button disabled so we don't start a duplicate.
+  const isRunning = trigger.isPending || run?.status === "pending" || run?.status === "running";
 
   return (
     <Card>

--- a/apps/ui/src/components/agents/agent-health-check.tsx
+++ b/apps/ui/src/components/agents/agent-health-check.tsx
@@ -42,9 +42,7 @@ export function AgentHealthCheck({ agentId }: AgentHealthCheckProps) {
   const configChanged = !runId && !!latest?.run && latest.config_changed;
 
   const isRunning =
-    trigger.isPending ||
-    triggeredRun?.status === "pending" ||
-    triggeredRun?.status === "running";
+    trigger.isPending || triggeredRun?.status === "pending" || triggeredRun?.status === "running";
 
   return (
     <Card>

--- a/apps/ui/src/hooks/use-agents.ts
+++ b/apps/ui/src/hooks/use-agents.ts
@@ -6,6 +6,7 @@ import {
   agentsCrudApi,
   analyzeAgent,
   getHealthCheckRun,
+  getLatestHealthCheckRun,
   triggerHealthCheck,
   copyAgent,
   createAgentVersion,
@@ -138,6 +139,18 @@ export function useAnalyzeAgent() {
 export function useTriggerHealthCheck() {
   return useMutation({
     mutationFn: (agentId: string) => triggerHealthCheck(agentId),
+  });
+}
+
+/**
+ * Latest persisted health-check run for an agent (with a stale-config flag),
+ * loaded on mount so prior results show without triggering a new run (EVE-588).
+ */
+export function useLatestHealthCheckRun(agentId: string | undefined) {
+  return useQuery({
+    queryKey: ["agent", agentId, "health-check", "latest"],
+    queryFn: () => getLatestHealthCheckRun(agentId as string),
+    enabled: !!agentId,
   });
 }
 

--- a/apps/ui/src/lib/api/agents.ts
+++ b/apps/ui/src/lib/api/agents.ts
@@ -10,6 +10,7 @@ import type {
   AgentAnalysisResponse,
   AgentPreviewResponse,
   HealthCheckRun,
+  LatestHealthCheckRun,
   CreateAgentVersionRequest,
   CreateAgentRequest,
   ForkAgentVersionRequest,
@@ -97,6 +98,13 @@ export async function triggerHealthCheck(agentId: string): Promise<HealthCheckRu
 
 export async function getHealthCheckRun(agentId: string, runId: string): Promise<HealthCheckRun> {
   const response = await api.get<HealthCheckRun>(`/v1/agents/${agentId}/health-checks/${runId}`);
+  return response.data;
+}
+
+export async function getLatestHealthCheckRun(agentId: string): Promise<LatestHealthCheckRun> {
+  const response = await api.get<LatestHealthCheckRun>(
+    `/v1/agents/${agentId}/health-checks/latest`,
+  );
   return response.data;
 }
 

--- a/apps/ui/src/lib/api/types/agent-types.ts
+++ b/apps/ui/src/lib/api/types/agent-types.ts
@@ -239,6 +239,14 @@ export interface HealthCheckRun {
   completed_at?: string;
 }
 
+/** Latest health-check run for an agent plus a stale-config flag (EVE-588) */
+export interface LatestHealthCheckRun {
+  /** The latest run, or absent if the agent has never been health-checked */
+  run?: HealthCheckRun;
+  /** True when the run was executed against a different config than current */
+  config_changed: boolean;
+}
+
 /** Response showing the final agent shape after applying capabilities */
 export interface AgentPreviewResponse {
   /** The full system prompt with capability additions prepended */

--- a/crates/server/src/api/agents.rs
+++ b/crates/server/src/api/agents.rs
@@ -300,6 +300,10 @@ pub fn routes(state: AppState) -> Router {
             post(trigger_health_check).get(list_health_checks),
         )
         .route(
+            "/v1/agents/{agent_id}/health-checks/latest",
+            get(get_latest_health_check),
+        )
+        .route(
             "/v1/agents/{agent_id}/health-checks/{run_id}",
             get(get_health_check),
         )
@@ -1477,6 +1481,29 @@ pub async fn get_health_check(
             .run(&state.ctx(&org))
             .await?;
     Ok(Json(run))
+}
+
+/// GET /v1/agents/{agent_id}/health-checks/latest - Latest run + stale flag
+#[utoipa::path(
+    get,
+    path = "/v1/agents/{agent_id}/health-checks/latest",
+    params(("agent_id" = String, Path, description = "Agent ID")),
+    responses(
+        (status = 200, description = "Latest health check run with stale-config flag", body = crate::domains::agents::health_check::types::LatestHealthCheckRun),
+        (status = 404, description = "Agent not found", body = ErrorResponse)
+    ),
+    tag = "agents"
+)]
+pub async fn get_latest_health_check(
+    org: ResolvedOrg,
+    State(state): State<AppState>,
+    Path(agent_id): Path<String>,
+) -> ApiResult<crate::domains::agents::health_check::types::LatestHealthCheckRun> {
+    let result =
+        crate::domains::agents::health_check::commands::GetLatestAgentHealthCheckRun { agent_id }
+            .run(&state.ctx(&org))
+            .await?;
+    Ok(Json(result))
 }
 
 // Regression tests for fix(capabilities): restore high-risk levels for

--- a/crates/server/src/domains/agents/health_check/commands.rs
+++ b/crates/server/src/domains/agents/health_check/commands.rs
@@ -10,7 +10,7 @@ use utoipa::ToSchema;
 use uuid::Uuid;
 
 use super::runner::{HealthCheckRunContext, HealthCheckTarget, spawn_health_check_run};
-use super::types::HealthCheckRun;
+use super::types::{HealthCheckRun, LatestHealthCheckRun};
 use crate::domains::common::*;
 use crate::services::CapabilityService;
 use crate::storage::models::CreateAgentHealthCheckRunRow;
@@ -146,6 +146,58 @@ impl AgentHealthCheckService {
             .map(|row| HealthCheckRun::from_row_at(row, now))
             .collect())
     }
+
+    /// Latest run for the agent (any config), paired with whether the agent's
+    /// current resolved config differs from that run's. Lets the editor show
+    /// prior results on mount and hint when they're stale. Read-only: it never
+    /// triggers a new LLM run.
+    pub async fn latest(
+        &self,
+        caller: &Caller,
+        agent_id: &str,
+    ) -> Result<LatestHealthCheckRun, CommandError> {
+        let org_id = caller.org_id;
+        let agent = crate::domains::agents::queries::resolve(&self.run_ctx.db, org_id, agent_id)
+            .await
+            .map_err(classify_anyhow)?
+            .ok_or_else(|| CommandError::not_found("Agent"))?;
+
+        let rows = self
+            .run_ctx
+            .db
+            .list_agent_health_check_runs(org_id, agent.internal_id, 1)
+            .await
+            .map_err(classify_anyhow)?;
+        let Some(row) = rows.into_iter().next() else {
+            return Ok(LatestHealthCheckRun {
+                run: None,
+                config_changed: false,
+            });
+        };
+
+        // Recompute the current resolved-config hash the same way `trigger`
+        // does; a mismatch means this run predates the agent's current config.
+        let (resolved_prompt, tools) = self
+            .capability_service
+            .preview(org_id, &agent.system_prompt, &agent.capabilities)
+            .await
+            .map_err(classify_anyhow)?;
+        let tool_listing = tools
+            .iter()
+            .map(|t| format!("- {}: {}", t.name(), t.description()))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let model_id = agent.default_model_id.map(|m| m.to_string());
+        let current_hash = config_hash(&resolved_prompt, &tool_listing, model_id.as_deref());
+
+        let config_changed = row.config_hash != current_hash;
+        Ok(LatestHealthCheckRun {
+            // Apply the same staleness guard as get/list so a crashed in-flight
+            // latest run surfaces as failed rather than a perpetual spinner.
+            run: Some(HealthCheckRun::from_row_at(row, chrono::Utc::now())),
+            config_changed,
+        })
+    }
 }
 
 /// Stable hash of the resolved config a run targets.
@@ -268,3 +320,33 @@ impl Command for ListAgentHealthCheckRuns {
 }
 
 inventory::submit! { CommandDescriptor::of::<ListAgentHealthCheckRuns>() }
+
+/// Get the latest health check run for an agent, without triggering a new one.
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct GetLatestAgentHealthCheckRun {
+    pub agent_id: String,
+}
+
+impl Command for GetLatestAgentHealthCheckRun {
+    type Output = LatestHealthCheckRun;
+
+    fn meta() -> CommandMeta {
+        CommandMeta {
+            name: "get_latest_agent_health_check_run",
+            category: "agents",
+            description: "Get the latest health check run for an agent, with a stale-config flag.",
+            method: "GET",
+            path: "/v1/agents/{agent_id}/health-checks/latest",
+        }
+    }
+
+    fn policy() -> Option<&'static everruns_core::Policy> {
+        Some(&crate::domains::agents::AGENT_VIEW)
+    }
+
+    async fn execute(self, ctx: &Ctx) -> Result<LatestHealthCheckRun, CommandError> {
+        service(ctx)?.latest(&ctx.caller, &self.agent_id).await
+    }
+}
+
+inventory::submit! { CommandDescriptor::of::<GetLatestAgentHealthCheckRun>() }

--- a/crates/server/src/domains/agents/health_check/types.rs
+++ b/crates/server/src/domains/agents/health_check/types.rs
@@ -166,6 +166,21 @@ impl HealthCheckRun {
     }
 }
 
+/// The most recent health-check run for an agent, paired with whether the
+/// agent's current resolved config differs from the config that run was
+/// executed against. Returned by the latest-run endpoint so the agent editor
+/// can show prior results on mount without triggering a new run, and surface a
+/// "config changed since last run" hint. See specs/agent-checks.md and EVE-588.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct LatestHealthCheckRun {
+    /// The latest run, or `None` if the agent has never been health-checked.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub run: Option<HealthCheckRun>,
+    /// True when `run` exists but was executed against a different resolved
+    /// config than the agent currently has (UI shows a re-run hint).
+    pub config_changed: bool,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/server/src/openapi.rs
+++ b/crates/server/src/openapi.rs
@@ -186,6 +186,7 @@ use utoipa::OpenApi;
         api::agents::trigger_health_check,
         api::agents::list_health_checks,
         api::agents::get_health_check,
+        api::agents::get_latest_health_check,
         api::agents::upsert_agent,
         api::agents::copy_agent,
         api::agents::list_agent_versions,

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -829,6 +829,48 @@
         }
       }
     },
+    "/v1/agents/{agent_id}/health-checks/latest": {
+      "get": {
+        "tags": [
+          "agents"
+        ],
+        "summary": "GET /v1/agents/{agent_id}/health-checks/latest - Latest run + stale flag",
+        "operationId": "get_latest_health_check",
+        "parameters": [
+          {
+            "name": "agent_id",
+            "in": "path",
+            "description": "Agent ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Latest health check run with stale-config flag",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LatestHealthCheckRun"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Agent not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/agents/{agent_id}/health-checks/{run_id}": {
       "get": {
         "tags": [
@@ -19577,6 +19619,30 @@
             "type": "string",
             "format": "date-time",
             "description": "Timestamp when this resource was last updated (RFC 3339)."
+          }
+        }
+      },
+      "LatestHealthCheckRun": {
+        "type": "object",
+        "description": "The most recent health-check run for an agent, paired with whether the\nagent's current resolved config differs from the config that run was\nexecuted against. Returned by the latest-run endpoint so the agent editor\ncan show prior results on mount without triggering a new run, and surface a\n\"config changed since last run\" hint. See specs/agent-checks.md and EVE-588.",
+        "required": [
+          "config_changed"
+        ],
+        "properties": {
+          "config_changed": {
+            "type": "boolean",
+            "description": "True when `run` exists but was executed against a different resolved\nconfig than the agent currently has (UI shows a re-run hint)."
+          },
+          "run": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/HealthCheckRun",
+                "description": "The latest run, or `None` if the agent has never been health-checked."
+              }
+            ]
           }
         }
       },


### PR DESCRIPTION
## What
Show the latest persisted health-check run in the agent editor on mount, instead of an empty panel that forces a new (LLM-consuming) run.

## Why
The health-check panel only rendered a run after you triggered one, even though the most recent run for the config is already persisted. That wasted an LLM run and hid existing results (EVE-588).

## How
- **Backend:** new read-only `GET /v1/agents/{agent_id}/health-checks/latest` → `LatestHealthCheckRun { run?, config_changed }`. It returns the most recent run for the agent and recomputes the current resolved-config hash (same derivation `trigger` uses) to set `config_changed` when the run predates the agent's current config. No LLM run is triggered. Registered as a static route sibling of `…/health-checks/{run_id}` (axum 0.8 matches the literal `latest` ahead of the param).
- **UI:** `useLatestHealthCheckRun` loads the latest run on mount; the panel renders it (falling back from any freshly triggered run) and shows a subtle "configuration changed since this run — re-run to refresh" hint when `config_changed`.
- Regenerated `docs/api/openapi.json` for the new endpoint + `LatestHealthCheckRun` schema (179 paths).

## Risk
- Low
- Pure read path; no new LLM execution. The new route is authorized by `AGENT_VIEW` (same as get/list) and scoped to the caller's org via the existing agent resolution.

## Security
- Threat categories reviewed: TM-AUTHZ, TM-TENANT
- Findings and resolutions: The endpoint reuses the existing agent resolution (org-scoped) and the `AGENT_VIEW` policy; it exposes only data the caller can already read via get/list. No new write surface or cross-tenant access.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated (N/A — read-only endpoint; covered by existing repo queries + UI typecheck/lint)
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)
