### PR TITLE
feat(agents): populate token usage in health-check summary

### DIFF
--- a/apps/ui/src/__tests__/agent-health-check.test.tsx
+++ b/apps/ui/src/__tests__/agent-health-check.test.tsx
@@ -25,8 +25,8 @@ const completedRun: HealthCheckRun = {
     pass_rate: 0.5,
     avg_score: 0.7,
     avg_turns: 1.5,
-    total_input_tokens: 0,
-    total_output_tokens: 0,
+    total_input_tokens: 1500,
+    total_output_tokens: 300,
   },
   results: [
     {
@@ -74,6 +74,9 @@ describe("AgentHealthCheck", () => {
     expect(screen.getByText("greeting")).toBeInTheDocument();
     expect(screen.getByText("Responded politely.")).toBeInTheDocument();
     expect(screen.getByText("Did not clarify.")).toBeInTheDocument();
+    // Token usage from the summary is surfaced.
+    expect(screen.getByText(/1,500 input/)).toBeInTheDocument();
+    expect(screen.getByText(/300 output tokens/)).toBeInTheDocument();
   });
 
   it("shows the failure reason when the run failed", () => {

--- a/apps/ui/src/components/agents/agent-health-check.tsx
+++ b/apps/ui/src/components/agents/agent-health-check.tsx
@@ -130,6 +130,12 @@ function HealthCheckResults({ run }: { run: HealthCheckRun }) {
           <Metric label="Avg turns" value={summary.avg_turns.toFixed(1)} />
         </div>
       )}
+      {summary && (summary.total_input_tokens > 0 || summary.total_output_tokens > 0) && (
+        <p className="text-xs text-muted-foreground">
+          {summary.total_input_tokens.toLocaleString()} input /{" "}
+          {summary.total_output_tokens.toLocaleString()} output tokens
+        </p>
+      )}
       <ul className="space-y-2">
         {(run.results ?? []).map((result, index) => (
           <CaseRow key={result.session_id ?? `${result.name}-${index}`} result={result} />

--- a/apps/ui/src/lib/api/types/agent-types.ts
+++ b/apps/ui/src/lib/api/types/agent-types.ts
@@ -209,6 +209,10 @@ export interface HealthCheckCaseResult {
   deterministic_reason: string;
   turns: number;
   latency_ms: number;
+  /** Input tokens for this case (agent turns + judge). */
+  input_tokens?: number;
+  /** Output tokens for this case (agent turns + judge). */
+  output_tokens?: number;
   error?: string;
 }
 

--- a/crates/server/src/domains/agents/health_check/runner.rs
+++ b/crates/server/src/domains/agents/health_check/runner.rs
@@ -230,10 +230,20 @@ async fn run_case(
     // Deterministic checks.
     let (det_pass, det_reason) = deterministic_score(&final_content, turns);
 
-    // LLM judge.
-    let (judge_pass, score, judge_reason) = judge_case(ctx, &case, &final_content)
-        .await
-        .unwrap_or_else(|e| (false, 0.0, format!("judge unavailable: {e}")));
+    // Agent-turn token usage is accumulated on the session row by the runner.
+    let (agent_input, agent_output) = match ctx.db.get_session(org_id, session.id).await {
+        Ok(Some(row)) => (
+            row.total_input_tokens.max(0) as u32,
+            row.total_output_tokens.max(0) as u32,
+        ),
+        _ => (0, 0),
+    };
+
+    // LLM judge (also reports its own token usage).
+    let (judge_pass, score, judge_reason, judge_input, judge_output) =
+        judge_case(ctx, &case, &final_content)
+            .await
+            .unwrap_or_else(|e| (false, 0.0, format!("judge unavailable: {e}"), 0, 0));
 
     HealthCheckCaseResult {
         name: case.name,
@@ -246,6 +256,8 @@ async fn run_case(
         deterministic_reason: det_reason,
         turns,
         latency_ms,
+        input_tokens: agent_input + judge_input,
+        output_tokens: agent_output + judge_output,
         error: None,
     }
 }
@@ -340,11 +352,14 @@ struct JudgeVerdict {
     reason: String,
 }
 
+/// Judge verdict plus the judge call's token usage (input, output).
+type JudgeOutcome = (bool, f64, String, u32, u32);
+
 async fn judge_case(
     ctx: &HealthCheckRunContext,
     case: &HealthCheckCase,
     final_content: &str,
-) -> Result<(bool, f64, String), String> {
+) -> Result<JudgeOutcome, String> {
     let user = format!(
         "<rubric>\n{}\n</rubric>\n<user-message>\n{}\n</user-message>\n<agent-response>\n{}\n\
          </agent-response>",
@@ -367,10 +382,19 @@ async fn judge_case(
     .map_err(|_| "judge timed out".to_string())?
     .map_err(|e| e.to_string())?;
 
+    let judge_input = response.metadata.prompt_tokens.unwrap_or(0);
+    let judge_output = response.metadata.completion_tokens.unwrap_or(0);
+
     let json = super::strip_code_fences(&response.text);
     let verdict: JudgeVerdict =
         serde_json::from_str(json).map_err(|e| format!("invalid judge output: {e}"))?;
-    Ok((verdict.pass, verdict.score.clamp(0.0, 1.0), verdict.reason))
+    Ok((
+        verdict.pass,
+        verdict.score.clamp(0.0, 1.0),
+        verdict.reason,
+        judge_input,
+        judge_output,
+    ))
 }
 
 fn errored_case(
@@ -390,6 +414,8 @@ fn errored_case(
         deterministic_reason: String::new(),
         turns: 0,
         latency_ms: started.elapsed().as_millis() as u64,
+        input_tokens: 0,
+        output_tokens: 0,
         error: Some(error),
     }
 }
@@ -423,8 +449,9 @@ pub(super) fn summarize(results: &[HealthCheckCaseResult]) -> HealthCheckSummary
         },
         avg_score,
         avg_turns,
-        total_input_tokens: 0,
-        total_output_tokens: 0,
+        // Sum agent + judge usage across all cases (errored cases contribute 0).
+        total_input_tokens: results.iter().map(|r| r.input_tokens as u64).sum(),
+        total_output_tokens: results.iter().map(|r| r.output_tokens as u64).sum(),
     }
 }
 
@@ -471,12 +498,15 @@ mod tests {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn result(
         name: &str,
         passed: bool,
         error: bool,
         score: f64,
         turns: u32,
+        input_tokens: u32,
+        output_tokens: u32,
     ) -> HealthCheckCaseResult {
         HealthCheckCaseResult {
             name: name.to_string(),
@@ -489,6 +519,8 @@ mod tests {
             deterministic_reason: String::new(),
             turns,
             latency_ms: 0,
+            input_tokens,
+            output_tokens,
             error: error.then(|| "boom".to_string()),
         }
     }
@@ -503,9 +535,9 @@ mod tests {
     #[test]
     fn summary_counts_pass_fail_error() {
         let results = vec![
-            result("a", true, false, 1.0, 1),
-            result("b", false, false, 0.2, 3),
-            result("c", false, true, 0.0, 0),
+            result("a", true, false, 1.0, 1, 100, 20),
+            result("b", false, false, 0.2, 3, 50, 10),
+            result("c", false, true, 0.0, 0, 0, 0),
         ];
         let s = summarize(&results);
         assert_eq!((s.total, s.passed, s.failed, s.errored), (3, 1, 1, 1));
@@ -513,6 +545,9 @@ mod tests {
         // avg_score/turns computed over non-errored cases only.
         assert!((s.avg_score - 0.6).abs() < 1e-9);
         assert!((s.avg_turns - 2.0).abs() < 1e-9);
+        // Token usage sums agent + judge across every case.
+        assert_eq!(s.total_input_tokens, 150);
+        assert_eq!(s.total_output_tokens, 30);
     }
 
     #[test]

--- a/crates/server/src/domains/agents/health_check/types.rs
+++ b/crates/server/src/domains/agents/health_check/types.rs
@@ -39,6 +39,12 @@ pub struct HealthCheckCaseResult {
     pub deterministic_reason: String,
     pub turns: u32,
     pub latency_ms: u64,
+    /// Input tokens for this case: the agent session turns plus the judge call.
+    #[serde(default)]
+    pub input_tokens: u32,
+    /// Output tokens for this case: the agent session turns plus the judge call.
+    #[serde(default)]
+    pub output_tokens: u32,
     /// Set when the case errored or timed out instead of completing.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -18887,6 +18887,12 @@
             ],
             "description": "Set when the case errored or timed out instead of completing."
           },
+          "input_tokens": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Input tokens for this case: the agent session turns plus the judge call.",
+            "minimum": 0
+          },
           "judge_reason": {
             "type": "string",
             "description": "LLM judge explanation."
@@ -18898,6 +18904,12 @@
           },
           "name": {
             "type": "string"
+          },
+          "output_tokens": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Output tokens for this case: the agent session turns plus the judge call.",
+            "minimum": 0
           },
           "passed": {
             "type": "boolean",


### PR DESCRIPTION
## What
Populate real token usage in `HealthCheckSummary` instead of the hardcoded `0`s, and surface it in the health-check card.

## Why
The summary's `total_input_tokens`/`total_output_tokens` were placeholder zeros (a flagged follow-up from the phase-3 PR #2205), so the cost dimension of health checks had no grounding from real execution data (EVE-587).

## How
Thread usage through per-case execution in `runner.rs`:
- **Agent turns:** after a case's turn completes, read the case session row's accumulated `total_input_tokens`/`total_output_tokens` (the runner already records them on the session).
- **Judge:** read `prompt_tokens`/`completion_tokens` from the utility-LLM response metadata.

Sum agent + judge per case into new `HealthCheckCaseResult.input_tokens`/`output_tokens`, then aggregate across cases into the summary totals. The summary/results are stored as JSONB, so no migration. The UI card shows `<in> input / <out> output tokens`.

## Risk
- Low
- Pure read/aggregation of usage already produced by execution; errored cases contribute 0. No schema or API-contract change beyond two additive optional JSON fields (OpenAPI regenerated).

## Security
- No security-relevant surface changed: usage figures are derived from the run's own session + judge call, scoped to the same org/agent as the run. No new endpoints, auth, or tenant boundaries.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)
