### PR TITLE
feat(providers): org-level default-provider-per-service resolution tier

### DIFF
--- a/apps/ui/src/__tests__/settings-providers.test.tsx
+++ b/apps/ui/src/__tests__/settings-providers.test.tsx
@@ -214,6 +214,18 @@ describe("ProvidersPage", () => {
     );
   });
 
+  it("renders the per-service default provider selectors with provider options", () => {
+    render(<ProvidersPage />, { wrapper });
+
+    expect(screen.getByRole("heading", { name: "Service Defaults" })).toBeInTheDocument();
+    const realtimeSelect = screen.getByLabelText("Default provider for Realtime (voice)");
+    expect(realtimeSelect).toBeInTheDocument();
+    // Each configured provider is an option in the per-service selector.
+    expect(
+      screen.getAllByRole("option", { name: "OpenAI Production" }).length,
+    ).toBeGreaterThan(0);
+  });
+
   it("shows loading skeleton when providers are loading", () => {
     mockUseProviders.mockReturnValue({
       data: [],

--- a/apps/ui/src/__tests__/settings-providers.test.tsx
+++ b/apps/ui/src/__tests__/settings-providers.test.tsx
@@ -223,9 +223,7 @@ describe("ProvidersPage", () => {
     const realtimeSelect = screen.getByLabelText("Default provider for Realtime (voice)");
     expect(realtimeSelect).toBeInTheDocument();
     // Each configured provider is an option in the per-service selector.
-    expect(
-      screen.getAllByRole("option", { name: "OpenAI Production" }).length,
-    ).toBeGreaterThan(0);
+    expect(screen.getAllByRole("option", { name: "OpenAI Production" }).length).toBeGreaterThan(0);
   });
 
   it("shows loading skeleton when providers are loading", () => {

--- a/apps/ui/src/__tests__/settings-providers.test.tsx
+++ b/apps/ui/src/__tests__/settings-providers.test.tsx
@@ -195,8 +195,10 @@ describe("ProvidersPage", () => {
   it("renders provider cards with correct data", () => {
     render(<ProvidersPage />, { wrapper });
 
-    expect(screen.getByText("OpenAI Production")).toBeInTheDocument();
-    expect(screen.getByText("Anthropic Dev")).toBeInTheDocument();
+    // Provider names also appear as <option>s in the Service Defaults selectors,
+    // so assert on the card heading link specifically.
+    expect(screen.getByRole("link", { name: /OpenAI Production/i })).toBeInTheDocument();
+    expect(screen.getAllByText("Anthropic Dev").length).toBeGreaterThan(0);
   });
 
   it("shows provider model counts and links to filtered models", () => {

--- a/apps/ui/src/app/(main)/settings/providers/page.tsx
+++ b/apps/ui/src/app/(main)/settings/providers/page.tsx
@@ -15,6 +15,7 @@ import type { Provider } from "@/lib/api/types";
 
 import { ProviderCard, ProviderCardSkeleton } from "./provider-card";
 import { AddProviderDialog, SetApiKeyDialog } from "./provider-dialogs";
+import { ServiceDefaultsCard } from "./service-defaults-card";
 
 export default function ProvidersPage() {
   usePageTitle("LLM Providers", "Settings");
@@ -152,6 +153,8 @@ export default function ProvidersPage() {
           </div>
         )}
       </section>
+
+      {providers.length > 0 && <ServiceDefaultsCard providers={providers} />}
 
       <AddProviderDialog open={addProviderOpen} onOpenChange={setAddProviderOpen} />
       <SetApiKeyDialog

--- a/apps/ui/src/app/(main)/settings/providers/service-defaults-card.tsx
+++ b/apps/ui/src/app/(main)/settings/providers/service-defaults-card.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { Card } from "@/components/ui/card";
+import { useOrganization, useUpdateOrganization } from "@/hooks/use-organizations";
+import type { Provider } from "@/lib/api/types";
+
+/**
+ * Org-level default provider per service (EVE-569). Tier 2 of service-bound
+ * resolution: after an explicit per-consumer binding and before the
+ * single-active-provider fallback, an org may pin a default provider for a
+ * given service. Chat is intentionally excluded — chat uses `default_model_id`.
+ */
+const SERVICES: { key: string; label: string; description: string }[] = [
+  { key: "realtime", label: "Realtime (voice)", description: "Voice realtime sessions" },
+  { key: "embeddings", label: "Embeddings", description: "Text embeddings" },
+  { key: "images", label: "Images", description: "Image generation" },
+  { key: "rerank", label: "Rerank", description: "Search-result reranking" },
+];
+
+export function ServiceDefaultsCard({ providers }: { providers: Provider[] }) {
+  const { data: org } = useOrganization();
+  const updateOrg = useUpdateOrganization();
+
+  const defaults = org?.default_provider_per_service ?? {};
+
+  const handleChange = async (service: string, providerId: string) => {
+    const next: Record<string, string> = { ...defaults };
+    if (providerId) {
+      next[service] = providerId;
+    } else {
+      delete next[service];
+    }
+    await updateOrg.mutateAsync({ default_provider_per_service: next });
+  };
+
+  return (
+    <section>
+      <div className="mb-4">
+        <h2 className="text-xl font-semibold">Service Defaults</h2>
+        <p className="text-sm text-muted-foreground">
+          Pin a default provider per service. Used when a request does not name a provider
+          explicitly. A provider whose driver does not support the service is rejected when that
+          service runs.
+        </p>
+      </div>
+
+      <Card className="p-6 space-y-4">
+        {SERVICES.map((service) => (
+          <div key={service.key} className="flex items-center justify-between gap-4">
+            <div>
+              <div className="text-sm font-medium">{service.label}</div>
+              <div className="text-xs text-muted-foreground">{service.description}</div>
+            </div>
+            <select
+              aria-label={`Default provider for ${service.label}`}
+              className="border rounded-md px-3 py-2 text-sm bg-background min-w-56"
+              value={defaults[service.key] ?? ""}
+              disabled={updateOrg.isPending}
+              onChange={(event) => handleChange(service.key, event.target.value)}
+            >
+              <option value="">No default</option>
+              {providers.map((provider) => (
+                <option key={provider.id} value={provider.id}>
+                  {provider.name}
+                </option>
+              ))}
+            </select>
+          </div>
+        ))}
+      </Card>
+    </section>
+  );
+}

--- a/apps/ui/src/app/(main)/settings/providers/service-defaults-card.tsx
+++ b/apps/ui/src/app/(main)/settings/providers/service-defaults-card.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { Card } from "@/components/ui/card";
 import { useOrganization, useUpdateOrganization } from "@/hooks/use-organizations";
 import type { Provider } from "@/lib/api/types";
@@ -21,15 +22,27 @@ export function ServiceDefaultsCard({ providers }: { providers: Provider[] }) {
   const { data: org } = useOrganization();
   const updateOrg = useUpdateOrganization();
 
-  const defaults = org?.default_provider_per_service ?? {};
+  // The PATCH API replaces the whole map, and the mutation only invalidates the
+  // org query (no optimistic update). A local draft keeps the latest selections
+  // so rapid edits patch from the freshest state rather than a stale refetch,
+  // then re-syncs when the server response lands.
+  const [draft, setDraft] = useState<Record<string, string>>(
+    () => org?.default_provider_per_service ?? {},
+  );
+  useEffect(() => {
+    if (org?.default_provider_per_service) {
+      setDraft(org.default_provider_per_service);
+    }
+  }, [org?.default_provider_per_service]);
 
   const handleChange = async (service: string, providerId: string) => {
-    const next: Record<string, string> = { ...defaults };
+    const next: Record<string, string> = { ...draft };
     if (providerId) {
       next[service] = providerId;
     } else {
       delete next[service];
     }
+    setDraft(next);
     await updateOrg.mutateAsync({ default_provider_per_service: next });
   };
 
@@ -54,7 +67,7 @@ export function ServiceDefaultsCard({ providers }: { providers: Provider[] }) {
             <select
               aria-label={`Default provider for ${service.label}`}
               className="border rounded-md px-3 py-2 text-sm bg-background min-w-56"
-              value={defaults[service.key] ?? ""}
+              value={draft[service.key] ?? ""}
               disabled={updateOrg.isPending}
               onChange={(event) => handleChange(service.key, event.target.value)}
             >

--- a/apps/ui/src/lib/api/types/auth-types.ts
+++ b/apps/ui/src/lib/api/types/auth-types.ts
@@ -80,8 +80,11 @@ export interface Organization {
   default_model_id: string | null;
   default_harness_id: string | null;
   base_harness_id: string | null;
-  /** Org-level default provider per service (EVE-569): service kind -> provider id. */
-  default_provider_per_service?: Record<string, string>;
+  /**
+   * Org-level default provider per service (EVE-569): service kind -> provider id.
+   * Always present in responses (empty object when no defaults are configured).
+   */
+  default_provider_per_service: Record<string, string>;
   created_at: string;
   updated_at: string;
 }

--- a/apps/ui/src/lib/api/types/auth-types.ts
+++ b/apps/ui/src/lib/api/types/auth-types.ts
@@ -80,6 +80,8 @@ export interface Organization {
   default_model_id: string | null;
   default_harness_id: string | null;
   base_harness_id: string | null;
+  /** Org-level default provider per service (EVE-569): service kind -> provider id. */
+  default_provider_per_service?: Record<string, string>;
   created_at: string;
   updated_at: string;
 }
@@ -95,6 +97,11 @@ export interface UpdateOrganizationRequest {
   default_model_id?: string;
   default_harness_id?: string;
   base_harness_id?: string;
+  /**
+   * Org-level default provider per service (EVE-569): service kind -> provider id.
+   * When present it replaces the whole map.
+   */
+  default_provider_per_service?: Record<string, string>;
 }
 
 export interface UserInfoResponse {

--- a/crates/server/migrations/072_org_default_provider_per_service.sql
+++ b/crates/server/migrations/072_org_default_provider_per_service.sql
@@ -1,0 +1,15 @@
+-- Org-level "default provider per service" resolution tier (EVE-569).
+--
+-- Tier 2 of service-bound provider resolution (specs/providers.md): consulted
+-- after an explicit per-consumer binding and before the single-active-provider
+-- fallback, an org may pin a default provider for a given ServiceKind (e.g.
+-- provider X for `realtime`, provider Y for `embeddings`).
+--
+-- Stored as a JSONB object keyed by snake_case ServiceKind -> provider public id
+-- (e.g. {"realtime": "provider_..."}). An empty object means "no org default";
+-- resolution then falls through to the active-provider scan. A configured
+-- default that is missing, inactive, or whose driver does not declare the
+-- service is fail-closed at resolve time (it errors rather than falling
+-- through). Purely additive; default deployments are unchanged.
+ALTER TABLE organization_settings
+ADD COLUMN default_provider_per_service JSONB NOT NULL DEFAULT '{}'::jsonb;

--- a/crates/server/src/api/organizations.rs
+++ b/crates/server/src/api/organizations.rs
@@ -97,6 +97,15 @@ pub struct UpdateOrganizationRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schema(value_type = Option<String>, example = "harness_01933b5a000070008000000000000601")]
     pub base_harness_id: Option<everruns_core::HarnessId>,
+    /// Org-level default provider per service (EVE-569). Maps a service kind
+    /// (`chat`, `embeddings`, `realtime`, `images`, `rerank`) to the provider id
+    /// used as that service's default, consulted after an explicit binding and
+    /// before the single-active-provider fallback. When present it **replaces**
+    /// the whole map; each referenced provider must exist in the org.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(value_type = Option<std::collections::HashMap<String, String>>)]
+    pub default_provider_per_service:
+        Option<std::collections::HashMap<everruns_core::ServiceKind, everruns_core::ProviderId>>,
 }
 
 /// Response for organization operations
@@ -115,6 +124,11 @@ pub struct OrganizationResponse {
     /// Base harness used when session creation omits harness_id.
     #[schema(value_type = Option<String>)]
     pub base_harness_id: Option<everruns_core::HarnessId>,
+    /// Org-level default provider per service (EVE-569), keyed by service kind.
+    /// Empty when no org defaults are configured.
+    #[schema(value_type = std::collections::HashMap<String, String>)]
+    pub default_provider_per_service:
+        std::collections::HashMap<everruns_core::ServiceKind, everruns_core::ProviderId>,
     /// When the organization was created
     pub created_at: chrono::DateTime<chrono::Utc>,
     /// When the organization was last updated
@@ -382,7 +396,8 @@ pub async fn update_organization(
     let updates_org_settings = req.default_model_id.is_some()
         || req.default_harness_id.is_some()
         || req.default_harness_name.is_some()
-        || req.base_harness_id.is_some();
+        || req.base_harness_id.is_some()
+        || req.default_provider_per_service.is_some();
 
     // Validate format
     if !validate_org_public_id(&org_public_id) {
@@ -438,6 +453,7 @@ pub async fn update_organization(
         mut default_harness_id,
         default_harness_name,
         base_harness_id,
+        default_provider_per_service,
     } = req;
 
     // Resolve default_harness_name to default_harness_id (mutually exclusive)
@@ -492,6 +508,22 @@ pub async fn update_organization(
             .log_internal_error_json("resolve base harness")?
             .ok_or_not_found_json("Harness")?;
     }
+    // Validate every pinned provider exists in the org. Capability (the driver
+    // actually declaring the service) is enforced fail-closed at resolve time in
+    // ProviderResolverService::resolve_service, so we only guard existence here.
+    if let Some(ref defaults) = default_provider_per_service {
+        for provider_id in defaults.values() {
+            state
+                .db
+                .get_provider(org_row.org_id, provider_id.uuid())
+                .await
+                .log_internal_error_json("resolve org default provider")?
+                .ok_or_else(|| {
+                    ErrorResponse::new(format!("Provider {provider_id} not found"))
+                        .into_response(StatusCode::BAD_REQUEST)
+                })?;
+        }
+    }
 
     // Update organization
     let input = UpdateOrganization { name };
@@ -503,7 +535,11 @@ pub async fn update_organization(
         .log_internal_error_json("update organization")?
         .ok_or_not_found_json("Organization")?;
 
-    if default_model_id.is_some() || default_harness_id.is_some() || base_harness_id.is_some() {
+    if default_model_id.is_some()
+        || default_harness_id.is_some()
+        || base_harness_id.is_some()
+        || default_provider_per_service.is_some()
+    {
         state
             .db
             .patch_organization_settings(
@@ -514,6 +550,8 @@ pub async fn update_organization(
                     default_harness_id: default_harness_id
                         .map_or(UpdateField::Unchanged, UpdateField::Set),
                     base_harness_id: base_harness_id
+                        .map_or(UpdateField::Unchanged, UpdateField::Set),
+                    default_provider_per_service: default_provider_per_service
                         .map_or(UpdateField::Unchanged, UpdateField::Set),
                 },
             )
@@ -586,6 +624,10 @@ async fn build_organization_response(
         default_model_id: settings.as_ref().and_then(|s| s.default_model_id),
         default_harness_id: settings.as_ref().and_then(|s| s.default_harness_id),
         base_harness_id: settings.as_ref().and_then(|s| s.base_harness_id),
+        default_provider_per_service: settings
+            .as_ref()
+            .map(|s| s.default_provider_per_service.0.clone())
+            .unwrap_or_default(),
         created_at: org.created_at,
         updated_at: org.updated_at,
     })
@@ -902,6 +944,7 @@ mod tests {
             default_model_id: None,
             default_harness_id: Some("harness_01933b5a000070008000000000000602".parse().unwrap()),
             base_harness_id: Some("harness_01933b5a000070008000000000000601".parse().unwrap()),
+            default_provider_per_service: std::collections::HashMap::new(),
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         };

--- a/crates/server/src/domains/organizations/queries.rs
+++ b/crates/server/src/domains/organizations/queries.rs
@@ -44,6 +44,10 @@ pub async fn build_organization_response(
         default_model_id: settings.as_ref().and_then(|s| s.default_model_id),
         default_harness_id: settings.as_ref().and_then(|s| s.default_harness_id),
         base_harness_id: settings.as_ref().and_then(|s| s.base_harness_id),
+        default_provider_per_service: settings
+            .as_ref()
+            .map(|s| s.default_provider_per_service.0.clone())
+            .unwrap_or_default(),
         created_at: row.created_at,
         updated_at: row.updated_at,
     })

--- a/crates/server/src/services/provider_resolver.rs
+++ b/crates/server/src/services/provider_resolver.rs
@@ -323,7 +323,11 @@ impl ProviderResolverService {
         // silently falling through to the active-provider scan
         // (specs/providers.md, EVE-569).
         if let Some(settings) = self.db.get_organization_settings(org_id).await?
-            && let Some(default_id) = settings.default_provider_per_service.0.get(&service).copied()
+            && let Some(default_id) = settings
+                .default_provider_per_service
+                .0
+                .get(&service)
+                .copied()
         {
             let provider = providers
                 .iter()

--- a/crates/server/src/services/provider_resolver.rs
+++ b/crates/server/src/services/provider_resolver.rs
@@ -317,8 +317,44 @@ impl ProviderResolverService {
             });
         }
 
-        // Tier 2 (org-level default provider per service) is not implemented
-        // yet; no consumer requires it. See specs/providers.md follow-ups.
+        // Tier 2: an org-level default provider pinned for this service. When a
+        // default is configured it is authoritative and fail-closed — a missing,
+        // inactive, or service-incompatible default surfaces an error rather than
+        // silently falling through to the active-provider scan
+        // (specs/providers.md, EVE-569).
+        if let Some(settings) = self.db.get_organization_settings(org_id).await?
+            && let Some(default_id) = settings.default_provider_per_service.0.get(&service).copied()
+        {
+            let provider = providers
+                .iter()
+                .find(|provider| provider.id == default_id)
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "org default provider {default_id} for the {service} service not found"
+                    )
+                })?;
+            if !provider.status.eq_ignore_ascii_case("active") {
+                return Err(anyhow::anyhow!(
+                    "org default provider {default_id} for the {service} service is not active"
+                ));
+            }
+            if !self.driver_supports(&provider.provider_type, service) {
+                return Err(anyhow::anyhow!(
+                    "org default provider {default_id} does not provide the {service} service"
+                ));
+            }
+            let api_key = self.resolve_api_key(provider)?.ok_or_else(|| {
+                anyhow::anyhow!("no credentials configured for org default provider {default_id}")
+            })?;
+            return Ok(ResolvedServiceProvider {
+                provider_type: provider.provider_type.clone(),
+                provider_id: provider.id.to_string(),
+                credentials: ResolvedProviderCredentials {
+                    api_key,
+                    base_url: provider.base_url.clone(),
+                },
+            });
+        }
 
         // Tier 3: the first active provider whose driver declares the service.
         for provider in providers
@@ -1193,5 +1229,138 @@ mod tests {
             .expect("explicit binding resolves");
         assert_eq!(resolved.provider_id, second.to_string());
         assert_ne!(resolved.provider_id, first.to_string());
+    }
+
+    // --- Tier 2: org-level default provider per service (EVE-569) ---
+
+    /// Pin `provider` as the org default for `service`.
+    async fn set_service_default(
+        db: &StorageBackend,
+        service: ServiceKind,
+        provider: everruns_core::ProviderId,
+    ) {
+        let mut defaults = crate::storage::models::ServiceProviderDefaults::new();
+        defaults.insert(service, provider);
+        db.patch_organization_settings(
+            DEFAULT_ORG_ID,
+            crate::storage::models::UpdateOrganizationSettings {
+                default_provider_per_service: everruns_durable::UpdateField::Set(defaults),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    }
+
+    #[test]
+    fn service_provider_defaults_json_round_trips() {
+        // The Postgres path stores this map as JSONB; assert ServiceKind keys
+        // serialize snake_case and ProviderId values round-trip as strings.
+        let mut map = crate::storage::models::ServiceProviderDefaults::new();
+        let pid = everruns_core::ProviderId::new();
+        map.insert(ServiceKind::Realtime, pid);
+        let value = serde_json::to_value(&map).unwrap();
+        assert_eq!(value, serde_json::json!({ "realtime": pid.to_string() }));
+        let back: crate::storage::models::ServiceProviderDefaults =
+            serde_json::from_value(value).unwrap();
+        assert_eq!(back.get(&ServiceKind::Realtime), Some(&pid));
+    }
+
+    #[tokio::test]
+    async fn resolve_service_uses_org_default_before_active_fallback() {
+        // Two realtime-capable providers; the org default (tier 2) must win over
+        // the first-active scan (tier 3).
+        let db = Arc::new(StorageBackend::in_memory());
+        let encryption = test_encryption();
+        let _first = seed_active_provider(&db, &encryption, "openai").await;
+        let second = seed_active_provider(&db, &encryption, "openai").await;
+        set_service_default(&db, ServiceKind::Realtime, second).await;
+        let resolver = service_resolver(db, Some(encryption));
+
+        let resolved = resolver
+            .resolve_service(DEFAULT_ORG_ID, ServiceKind::Realtime, None)
+            .await
+            .expect("org default resolves");
+        assert_eq!(resolved.provider_id, second.to_string());
+    }
+
+    #[tokio::test]
+    async fn resolve_service_binding_overrides_org_default() {
+        // Precedence: explicit binding (tier 1) wins over the org default (tier 2).
+        let db = Arc::new(StorageBackend::in_memory());
+        let encryption = test_encryption();
+        let bound = seed_active_provider(&db, &encryption, "openai").await;
+        let default = seed_active_provider(&db, &encryption, "openai").await;
+        set_service_default(&db, ServiceKind::Realtime, default).await;
+        let resolver = service_resolver(db, Some(encryption));
+
+        let resolved = resolver
+            .resolve_service(
+                DEFAULT_ORG_ID,
+                ServiceKind::Realtime,
+                Some(&bound.to_string()),
+            )
+            .await
+            .expect("binding resolves");
+        assert_eq!(resolved.provider_id, bound.to_string());
+        assert_ne!(resolved.provider_id, default.to_string());
+    }
+
+    #[tokio::test]
+    async fn resolve_service_org_default_fails_closed_when_missing() {
+        // A default that points at a non-existent provider must error, not
+        // silently fall through to an otherwise-usable active provider.
+        let db = Arc::new(StorageBackend::in_memory());
+        let encryption = test_encryption();
+        seed_active_provider(&db, &encryption, "openai").await;
+        set_service_default(&db, ServiceKind::Realtime, everruns_core::ProviderId::new()).await;
+        let resolver = service_resolver(db, Some(encryption));
+
+        let err = resolver
+            .resolve_service(DEFAULT_ORG_ID, ServiceKind::Realtime, None)
+            .await
+            .expect_err("missing org default fails closed");
+        assert!(err.to_string().contains("not found"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn resolve_service_org_default_fails_closed_when_inactive() {
+        let db = Arc::new(StorageBackend::in_memory());
+        let encryption = test_encryption();
+        let provider = seed_active_provider(&db, &encryption, "openai").await;
+        set_service_default(&db, ServiceKind::Realtime, provider).await;
+        db.update_provider(
+            DEFAULT_ORG_ID,
+            provider.uuid(),
+            crate::storage::models::UpdateProvider {
+                status: Some("inactive".to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        let resolver = service_resolver(db, Some(encryption));
+
+        let err = resolver
+            .resolve_service(DEFAULT_ORG_ID, ServiceKind::Realtime, None)
+            .await
+            .expect_err("inactive org default fails closed");
+        assert!(err.to_string().contains("not active"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn resolve_service_org_default_fails_closed_when_service_unsupported() {
+        // openrouter is chat-only; pinning it as the Realtime default is invalid.
+        let db = Arc::new(StorageBackend::in_memory());
+        let encryption = test_encryption();
+        let provider = seed_active_provider(&db, &encryption, "openrouter").await;
+        set_service_default(&db, ServiceKind::Realtime, provider).await;
+        let resolver = service_resolver(db, Some(encryption));
+
+        let err = resolver
+            .resolve_service(DEFAULT_ORG_ID, ServiceKind::Realtime, None)
+            .await
+            .expect_err("incompatible org default fails closed");
+        assert!(err.to_string().contains("does not provide"), "got: {err}");
     }
 }

--- a/crates/server/src/storage/memory/organizations.rs
+++ b/crates/server/src/storage/memory/organizations.rs
@@ -32,6 +32,7 @@ impl InMemoryDatabase {
                 default_model_id: None,
                 default_harness_id: None,
                 base_harness_id: None,
+                default_provider_per_service: sqlx::types::Json(ServiceProviderDefaults::new()),
                 created_at: now,
                 updated_at: now,
             });
@@ -54,6 +55,7 @@ impl InMemoryDatabase {
                 default_model_id: None,
                 default_harness_id: None,
                 base_harness_id: None,
+                default_provider_per_service: sqlx::types::Json(ServiceProviderDefaults::new()),
                 created_at: now,
                 updated_at: now,
             });
@@ -61,6 +63,16 @@ impl InMemoryDatabase {
         input.default_model_id.apply(&mut row.default_model_id);
         input.default_harness_id.apply(&mut row.default_harness_id);
         input.base_harness_id.apply(&mut row.base_harness_id);
+        // The per-service default map is replaced wholesale (mirrors the SQL path).
+        match input.default_provider_per_service {
+            everruns_durable::UpdateField::Unchanged => {}
+            everruns_durable::UpdateField::Clear => {
+                row.default_provider_per_service = sqlx::types::Json(ServiceProviderDefaults::new());
+            }
+            everruns_durable::UpdateField::Set(map) => {
+                row.default_provider_per_service = sqlx::types::Json(map);
+            }
+        }
 
         row.updated_at = now;
         Ok(row.clone())

--- a/crates/server/src/storage/memory/organizations.rs
+++ b/crates/server/src/storage/memory/organizations.rs
@@ -67,7 +67,8 @@ impl InMemoryDatabase {
         match input.default_provider_per_service {
             everruns_durable::UpdateField::Unchanged => {}
             everruns_durable::UpdateField::Clear => {
-                row.default_provider_per_service = sqlx::types::Json(ServiceProviderDefaults::new());
+                row.default_provider_per_service =
+                    sqlx::types::Json(ServiceProviderDefaults::new());
             }
             everruns_durable::UpdateField::Set(map) => {
                 row.default_provider_per_service = sqlx::types::Json(map);

--- a/crates/server/src/storage/models.rs
+++ b/crates/server/src/storage/models.rs
@@ -3,7 +3,8 @@
 use chrono::{DateTime, Utc};
 use everruns_core::{
     AgentId, AgentIdentityId, EventId, HarnessId, ImageId, LeasedResourceId, McpServerId,
-    MessageId, ModelId, NotificationId, PrincipalId, ProviderId, ScheduleId, SessionId, SkillId,
+    MessageId, ModelId, NotificationId, PrincipalId, ProviderId, ScheduleId, ServiceKind,
+    SessionId, SkillId,
 };
 use everruns_durable::UpdateField;
 use sqlx::FromRow;
@@ -72,6 +73,12 @@ pub struct UpdateOrganization {
     pub name: Option<String>,
 }
 
+/// Org-level "default provider per service" map (EVE-569): tier-2 service
+/// resolution defaults keyed by [`ServiceKind`]. Empty when no defaults are
+/// configured. Persisted as a JSONB object (snake_case service kind -> provider
+/// public id).
+pub type ServiceProviderDefaults = std::collections::HashMap<ServiceKind, ProviderId>;
+
 /// Organization settings row from database
 #[derive(Debug, Clone, FromRow)]
 pub struct OrganizationSettingsRow {
@@ -79,6 +86,9 @@ pub struct OrganizationSettingsRow {
     pub default_model_id: Option<ModelId>,
     pub default_harness_id: Option<HarnessId>,
     pub base_harness_id: Option<HarnessId>,
+    /// Org-level default provider per service (EVE-569). Always present;
+    /// an empty map means no org defaults are configured.
+    pub default_provider_per_service: sqlx::types::Json<ServiceProviderDefaults>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -88,6 +98,9 @@ pub struct UpdateOrganizationSettings {
     pub default_model_id: UpdateField<ModelId>,
     pub default_harness_id: UpdateField<HarnessId>,
     pub base_harness_id: UpdateField<HarnessId>,
+    /// Replaces the whole per-service default map. `Set` overwrites,
+    /// `Clear` resets to empty, `Unchanged` leaves it as-is.
+    pub default_provider_per_service: UpdateField<ServiceProviderDefaults>,
 }
 
 /// Organization task webhook row from database

--- a/crates/server/src/storage/models.rs
+++ b/crates/server/src/storage/models.rs
@@ -972,7 +972,7 @@ pub struct CreateProviderRow {
     pub settings: Option<serde_json::Value>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct UpdateProvider {
     pub name: Option<String>,
     pub provider_type: Option<String>,

--- a/crates/server/src/storage/repositories/organizations.rs
+++ b/crates/server/src/storage/repositories/organizations.rs
@@ -56,11 +56,11 @@ impl Database {
         // `Clear` resets to `{}`, `Unchanged` keeps the stored value. A NULL bind
         // (Unchanged/Clear) collapses to `{}` only when the CASE selects it.
         let default_providers_changed = input.default_provider_per_service.is_changed();
-        let default_providers_json: Option<serde_json::Value> = input
-            .default_provider_per_service
-            .clone()
-            .into_value()
-            .map(|map| serde_json::to_value(map).unwrap_or_else(|_| serde_json::json!({})));
+        let default_providers_json: Option<serde_json::Value> =
+            match input.default_provider_per_service.clone().into_value() {
+                Some(map) => Some(serde_json::to_value(map)?),
+                None => None,
+            };
 
         let row = sqlx::query_as::<_, OrganizationSettingsRow>(
             r#"

--- a/crates/server/src/storage/repositories/organizations.rs
+++ b/crates/server/src/storage/repositories/organizations.rs
@@ -16,7 +16,7 @@ impl Database {
         org_id: i64,
     ) -> Result<Option<OrganizationSettingsRow>> {
         let row = sqlx::query_as::<_, OrganizationSettingsRow>(
-            "SELECT org_id, default_model_id, default_harness_id, base_harness_id, created_at, updated_at FROM organization_settings WHERE org_id = $1",
+            "SELECT org_id, default_model_id, default_harness_id, base_harness_id, default_provider_per_service, created_at, updated_at FROM organization_settings WHERE org_id = $1",
         )
         .bind(org_id)
         .fetch_optional(&self.pool)
@@ -37,7 +37,7 @@ impl Database {
             ON CONFLICT (org_id) DO UPDATE SET
                 default_model_id = EXCLUDED.default_model_id,
                 updated_at = NOW()
-            RETURNING org_id, default_model_id, default_harness_id, base_harness_id, created_at, updated_at
+            RETURNING org_id, default_model_id, default_harness_id, base_harness_id, default_provider_per_service, created_at, updated_at
             "#,
         )
         .bind(org_id)
@@ -52,10 +52,20 @@ impl Database {
         org_id: i64,
         input: UpdateOrganizationSettings,
     ) -> Result<OrganizationSettingsRow> {
+        // The per-service default map is replaced wholesale: `Set` overwrites,
+        // `Clear` resets to `{}`, `Unchanged` keeps the stored value. A NULL bind
+        // (Unchanged/Clear) collapses to `{}` only when the CASE selects it.
+        let default_providers_changed = input.default_provider_per_service.is_changed();
+        let default_providers_json: Option<serde_json::Value> = input
+            .default_provider_per_service
+            .clone()
+            .into_value()
+            .map(|map| serde_json::to_value(map).unwrap_or_else(|_| serde_json::json!({})));
+
         let row = sqlx::query_as::<_, OrganizationSettingsRow>(
             r#"
-            INSERT INTO organization_settings (org_id, default_model_id, default_harness_id, base_harness_id)
-            VALUES ($1, $2, $4, $6)
+            INSERT INTO organization_settings (org_id, default_model_id, default_harness_id, base_harness_id, default_provider_per_service)
+            VALUES ($1, $2, $4, $6, COALESCE($9, '{}'::jsonb))
             ON CONFLICT (org_id) DO UPDATE SET
                 default_model_id = CASE
                     WHEN $3 THEN $2
@@ -69,8 +79,12 @@ impl Database {
                     WHEN $7 THEN $6
                     ELSE organization_settings.base_harness_id
                 END,
+                default_provider_per_service = CASE
+                    WHEN $8 THEN COALESCE($9, '{}'::jsonb)
+                    ELSE organization_settings.default_provider_per_service
+                END,
                 updated_at = NOW()
-            RETURNING org_id, default_model_id, default_harness_id, base_harness_id, created_at, updated_at
+            RETURNING org_id, default_model_id, default_harness_id, base_harness_id, default_provider_per_service, created_at, updated_at
             "#,
         )
         .bind(org_id)
@@ -80,6 +94,8 @@ impl Database {
         .bind(input.default_harness_id.is_changed())
         .bind(input.base_harness_id.clone().into_value().map(|id| id.uuid()))
         .bind(input.base_harness_id.is_changed())
+        .bind(default_providers_changed)
+        .bind(default_providers_json)
         .fetch_one(&self.pool)
         .await?;
         Ok(row)

--- a/crates/server/tests/api_integration_test.rs
+++ b/crates/server/tests/api_integration_test.rs
@@ -3857,6 +3857,7 @@ async fn test_delete_org_default_harness_returns_conflict() {
                 default_model_id: UpdateField::Unchanged,
                 default_harness_id: UpdateField::Set(harness.id),
                 base_harness_id: UpdateField::Unchanged,
+                ..Default::default()
             },
         )
         .await

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -21289,6 +21289,7 @@
               "required": [
                 "id",
                 "name",
+                "default_provider_per_service",
                 "created_at",
                 "updated_at"
               ],
@@ -21318,6 +21319,16 @@
                     "null"
                   ],
                   "description": "Default LLM model for the organization."
+                },
+                "default_provider_per_service": {
+                  "type": "object",
+                  "description": "Org-level default provider per service (EVE-569), keyed by service kind.\nEmpty when no org defaults are configured.",
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "propertyNames": {
+                    "type": "string"
+                  }
                 },
                 "id": {
                   "type": "string",
@@ -24767,6 +24778,7 @@
         "required": [
           "id",
           "name",
+          "default_provider_per_service",
           "created_at",
           "updated_at"
         ],
@@ -24796,6 +24808,16 @@
               "null"
             ],
             "description": "Default LLM model for the organization."
+          },
+          "default_provider_per_service": {
+            "type": "object",
+            "description": "Org-level default provider per service (EVE-569), keyed by service kind.\nEmpty when no org defaults are configured.",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "propertyNames": {
+              "type": "string"
+            }
           },
           "id": {
             "type": "string",
@@ -31558,6 +31580,19 @@
             ],
             "description": "Default LLM model for this organization. Must be an enabled model.",
             "example": "model_01933b5a00007000800000000000001"
+          },
+          "default_provider_per_service": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "description": "Org-level default provider per service (EVE-569). Maps a service kind\n(`chat`, `embeddings`, `realtime`, `images`, `rerank`) to the provider id\nused as that service's default, consulted after an explicit binding and\nbefore the single-active-provider fallback. When present it **replaces**\nthe whole map; each referenced provider must exist in the org.",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "propertyNames": {
+              "type": "string"
+            }
           },
           "name": {
             "type": [

--- a/specs/providers.md
+++ b/specs/providers.md
@@ -130,7 +130,7 @@ resolve_service(org, ServiceKind, binding) -> (ProviderConnection, service clien
 
 Selection: explicit `provider_id` on the consumer's binding (e.g. the voice connection's `provider_id` field) wins; otherwise an org-level default provider per service; otherwise the single active provider whose driver declares the service. "First active provider matching a type string" — the old voice behavior — is removed. Resolution failures surface structured "no provider configured for {service}" errors, fail-closed.
 
-Implemented today: the explicit-binding tier (validated against the driver's declared services) and the active-provider-declaring-service tier. The org-default-per-service tier is not built yet (no consumer needs it). Voice realtime currently calls `resolve_service(org, Realtime, None)` — a per-connection provider binding is not plumbed, so it resolves the single realtime-capable provider; the binding parameter exists for when that selection lands.
+All three tiers are implemented. The org-default-per-service tier reads an org-settings map (`organization_settings.default_provider_per_service`, `ServiceKind` → provider id) set via `PATCH /v1/orgs/{org}` (`default_provider_per_service`). It is consulted only when no explicit binding is supplied, and it is fail-closed: a configured default that is missing, inactive, or whose driver does not declare the service errors rather than falling through to the active-provider scan. An unset default for a service falls through to that scan as before. Voice realtime currently calls `resolve_service(org, Realtime, None)` — a per-connection provider binding is not plumbed, so it relies on the org default (or the single realtime-capable provider); the binding parameter exists for when that selection lands.
 
 Consumers and their paths:
 
@@ -212,7 +212,7 @@ PR-sized slices, each leaving the tree green and self-consistent (code + specs +
 1. **Core domain types and registry** — `ServiceKind`, driver descriptor with credential schema and service factories (building on `DriverConfig`/`External` from EVE-561), `ChatDriver` rename, profile keys. No DB change.
 2. **DB + storage rename** — migrations, storage traits, repositories, seeds, resolver rename, `profile_key` backfill.
 3. **API + UI rename** — routes, OpenAPI, UI pages/hooks/clients, profile catalog endpoint, picker grouping.
-4. ✅ **Service resolution** — `resolve_service(org, ServiceKind, binding)` (explicit-binding and active-provider-declaring-service tiers), voice realtime rerouted through it (`ServiceKind::Realtime`, fail-closed). The org-level default-provider-per-service tier is deferred — no consumer requires it yet (chat already has `default_model_id`; voice resolves the single realtime-capable provider).
+4. ✅ **Service resolution** — `resolve_service(org, ServiceKind, binding)` (all three tiers: explicit binding, org-level default-provider-per-service, and active-provider-declaring-service), voice realtime rerouted through it (`ServiceKind::Realtime`, fail-closed). The org default-per-service tier (EVE-569) is stored on `organization_settings.default_provider_per_service` and editable via the org PATCH API + Settings → Providers.
 5. **Connector alignment** — shared credential primitives, `ConnectorPlugin` rename.
 6. ✅ **First new service** — `EmbeddingsDriver` + knowledge-base hybrid retrieval configuration (closes the open question in `specs/knowledge-bases.md`).
 


### PR DESCRIPTION
## What
Implements tier 2 of service-bound provider resolution (`specs/providers.md`): an org can pin a **default provider per `ServiceKind`** (e.g. provider X for `realtime`, provider Y for `embeddings`). It is consulted after an explicit per-consumer binding (tier 1) and before the single-active-provider fallback (tier 3). Closes EVE-569.

## Why
Phase 4 of the providers refactor (PR #2210) shipped tiers 1 and 3 and explicitly deferred the org-default tier — no consumer needed it and it required an org-settings schema addition. This fills that gap so multi-provider orgs can choose which provider powers a given non-chat service without a per-request binding.

## How
- **Migration `072`**: additive `organization_settings.default_provider_per_service JSONB NOT NULL DEFAULT '{}'` (snake_case `ServiceKind` → provider public id).
- **Storage**: typed `ServiceProviderDefaults = HashMap<ServiceKind, ProviderId>` on `OrganizationSettingsRow`/`UpdateOrganizationSettings`; wired through the Postgres repo (get/upsert/patch, whole-map replace) and the in-memory backend.
- **Resolver**: `resolve_service` tier-2 lookup between binding and the active-provider scan. **Fail-closed**: a configured default that is missing, inactive, or whose driver doesn't declare the service errors rather than falling through. An *unset* default falls through to the scan as before.
- **API**: `PATCH /v1/orgs/{org}` gains `default_provider_per_service` (admin-gated like other org settings; replaces the whole map; validates each provider exists in the org). `OrganizationResponse` surfaces it (always present). OpenAPI regenerated.
- **UI**: a "Service Defaults" card on Settings → Providers with a per-service provider selector (local draft state so rapid edits don't patch from a stale base).
- **Spec**: `specs/providers.md` updated — all three tiers now implemented.

## Validation
- `cargo clippy --all-targets --all-features -D warnings` clean; `cargo fmt`/oxfmt clean.
- Resolver unit tests (31 pass) including 6 new: tier-2 selection beats tier-3, binding overrides org default, and fail-closed on missing / inactive / service-incompatible defaults; plus a JSONB round-trip test proving `ServiceKind` keys serialize snake_case and `ProviderId` values round-trip (the Postgres path's contract).
- UI: typecheck + lint clean; `settings-providers` jest suite 11/11 (incl. a new test for the per-service selectors).
- End-to-end smoke (in-memory `start-dev`): `GET /v1/orgs/{org}` surfaces `default_provider_per_service: {}`; `PATCH` set→`200` and persists/round-trips; bogus provider id → `400 "Provider … not found"`; invalid service-kind key → `422`; clear (`{}`) → `200`.
- Migration ordering check passes (001..072); spec freshness regenerated.

## Risk
- **Low.** Additive migration and an additive, default-`{}` setting. Existing resolution is unchanged when no org default is configured (falls through to the prior tier-3 behavior). The new API field is admin-gated and bounded to the 5 valid `ServiceKind`s.

## Security
- Threat categories reviewed: **TM-API**, **TM-AUTHZ**, **TM-TENANT**, **TM-LLM**, **TM-DOS**.
  - TM-AUTHZ: new field is part of `updates_org_settings`, so the existing org-admin gate applies.
  - TM-TENANT: provider-existence validation and resolver enumeration are scoped to the path org's `org_id`; the map is stored per-org. No cross-tenant path.
  - TM-API/TM-DOS: input is a typed `HashMap<ServiceKind, ProviderId>` — unknown service keys are rejected by serde (`422`), so the map is bounded to ≤5 entries; SQL is parameterized and the map is bound as a JSONB value (no injection).
  - TM-LLM: same credential-resolution path as before; fail-closed on unusable defaults.
- No new threat surface; no `specs/threat-model.md` changes warranted (same trust boundary as the existing `default_model_id` org setting).

## Follow-ups
- **API-side capability validation (deferred):** the PATCH handler validates provider *existence* but not that the driver declares the service, because the organizations route's `AppState` has no driver registry. Capability is enforced fail-closed at resolve time (and tested). A nicer UX would reject an incompatible pin at config time — small follow-up once a registry is threaded into that route.
- **UI capability filtering (deferred):** the per-service selector lists all providers; it doesn't filter by which drivers declare the service (that capability data isn't exposed to the UI yet). Safe because the backend fail-closes; worth tightening when driver capabilities are surfaced to the client.
- **`resolve_service` settings-read caching (deferred):** tier-2 adds one PK-indexed `get_organization_settings` lookup on binding-less resolutions. The only live consumer today is voice realtime (per-session setup, not a per-token hot path), so it's left uncached; when embeddings/rerank become live hot consumers, fold the read into the existing resolver cache (with invalidation on org PATCH) or fetch it alongside `list_providers`.

https://claude.ai/code/session_01S31nkCLvxTiSMYCp4rsrtY