### PR TITLE
fix(docs): render GFM tables in .mdx pages

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -1,5 +1,6 @@
 import { defineConfig } from "astro/config";
 import starlight from "@astrojs/starlight";
+import remarkGfm from "remark-gfm";
 import starlightOpenAPI, { openAPISidebarGroups } from "starlight-openapi";
 import starlightSidebarTopics from "starlight-sidebar-topics";
 import apiSidebarFix from "./plugins/api-sidebar-fix.ts";
@@ -13,6 +14,14 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 export default defineConfig({
   site: "https://docs.everruns.com",
   trailingSlash: "always",
+  // Register remark-gfm explicitly so GFM (tables, etc.) applies to `.mdx`
+  // pages too. Starlight auto-adds `@astrojs/mdx` with extendMarkdownConfig,
+  // which inherits `markdown.remarkPlugins` — but Astro's default `gfm: true`
+  // flag alone does not reach the MDX pipeline, so `.mdx` tables silently
+  // render as paragraphs. Listing the plugin here fixes every `.mdx` page.
+  markdown: {
+    remarkPlugins: [remarkGfm],
+  },
   redirects: {
     // virtual_bash capability renamed to bashkit_shell
     "/capabilities/virtual-bash/": "/capabilities/bashkit-shell/",

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -21,6 +21,7 @@
     "astro": "^6.4.6",
     "js-yaml": "^4.2.0",
     "marked": "^18.0.5",
+    "remark-gfm": "^4.0.1",
     "sharp": "^0.34.5",
     "shiki": "^4.2.0",
     "starlight-openapi": "^0.25.3",

--- a/apps/docs/pnpm-lock.yaml
+++ b/apps/docs/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
       marked:
         specifier: ^18.0.5
         version: 18.0.5
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
       sharp:
         specifier: ^0.34.5
         version: 0.34.5


### PR DESCRIPTION
## What
Register `remark-gfm` explicitly as a markdown remark plugin in `apps/docs/astro.config.mjs` so GitHub-Flavored Markdown (tables, etc.) applies to `.mdx` pages.

## Why
Tables in `.mdx` docs pages were silently rendering as plain paragraphs on the live site (e.g. the "Custom backends" table on `/features/runtime/`), while `.md` pages rendered tables correctly.

Root cause: Starlight auto-adds the `@astrojs/mdx` integration with `extendMarkdownConfig` (which inherits `markdown.remarkPlugins`), but Astro's default `gfm: true` *flag* does not propagate into the MDX pipeline. So `.md` got GFM (via the flag) and `.mdx` did not. This affected every `.mdx` page with a table (runtime, sdk, skills, read-tools).

Confirmed not a stale deployment: fetched the live page's raw HTML and found 0 `<table>` elements; the block was emitted as a single `<p>` with literal pipes (inline `code` was processed, the table was not).

## How
- Added `remark-gfm` as a direct dependency of `apps/docs`.
- Added `markdown: { remarkPlugins: [remarkGfm] }` to the Astro config. Because the auto-added MDX integration extends the markdown config's `remarkPlugins`, GFM now reaches `.mdx` too. `.md` pages already had GFM via the flag; re-adding the plugin is idempotent (no double-rendering).

## Validation
Built `apps/docs` before and after the change and counted rendered `<table>` elements in `dist/`:

| Page | Type | Before | After |
| --- | --- | --- | --- |
| features/runtime | .mdx | 0 | 1 |
| features/sdk | .mdx | 0 | 2 |
| features/events | .md | 3 | 3 |
| features/harnesses | .md | 1 | 1 |

Verified the runtime "Custom backends" table is emitted as a proper `<table><thead>…</thead><tbody>…</tbody></table>`.

## Risk
- Low
- Docs build-config only. `.md` rendering is unchanged; only `.mdx` GFM features (tables) are newly applied.

## Security
- No security-relevant code changes. Build-config change to the static docs site only; no runtime, auth, API, or data-handling surface touched.

## Follow-ups
No follow-ups.

## Checklist
- [x] Tests added or updated (N/A — verified via docs build output)
- [x] Backward compatibility considered (.md output unchanged; .mdx gains GFM)
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01L7khuZcFkLdW6TAef1WzUM)_