### PR TITLE
fix(core): detect repeated read range loops

### DIFF
--- a/crates/core/src/capabilities/loop_detection.rs
+++ b/crates/core/src/capabilities/loop_detection.rs
@@ -6,7 +6,7 @@
 // tool-call signature, a system warning is appended telling the model to
 // change its approach.
 
-use std::collections::hash_map::DefaultHasher;
+use std::collections::{HashMap, hash_map::DefaultHasher};
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
@@ -15,7 +15,7 @@ use crate::message::{Message, MessageRole, ToolCallContentPart};
 use crate::message_filter::{MessageFilterProvider, MessageQuery};
 use crate::tool_fingerprint::tool_call_parts_fingerprint;
 
-/// Default threshold: 3 consecutive identical tool call batches triggers warning.
+/// Default threshold: 3 repeated attempts triggers warning.
 const DEFAULT_THRESHOLD: usize = 3;
 
 pub const LOOP_DETECTION_CAPABILITY_ID: &str = "loop_detection";
@@ -48,7 +48,7 @@ impl Capability for LoopDetectionCapability {
                 "threshold": {
                     "type": "integer",
                     "title": "Repetition threshold",
-                    "description": "Number of consecutive identical tool-call batches that triggers the loop warning.",
+                    "description": "Number of repeated identical tool-call batches, tool results, or read ranges that triggers the loop warning.",
                     "minimum": 1,
                     "default": DEFAULT_THRESHOLD
                 }
@@ -83,7 +83,7 @@ impl Capability for LoopDetectionCapability {
                 name: None,
                 description: None,
                 config_description: Some(
-                    "Controls how many consecutive identical tool-call batches count as a loop.",
+                    "Controls how many repeated identical tool-call batches, tool results, or read ranges count as a loop.",
                 ),
                 config_overlay: None,
             },
@@ -101,7 +101,7 @@ impl Capability for LoopDetectionCapability {
                     "properties": {
                         "threshold": {
                             "title": "Поріг повторень",
-                            "description": "Кількість послідовних однакових пакетів викликів інструментів, після якої додається попередження про цикл."
+                            "description": "Кількість повторюваних однакових викликів інструментів, результатів або діапазонів читання, після якої додається попередження про цикл."
                         }
                     }
                 })),
@@ -139,6 +139,23 @@ impl MessageFilterProvider for LoopDetectionFilter {
                 "Loop detected: the same tool call produced the same result repeatedly. \
                  The approach is not making progress. Try different arguments, inspect a \
                  new source of context, change state before retrying, or report the blocker.",
+            ));
+            return;
+        }
+
+        if let Some(repetition) = repeated_read_range_count(messages, threshold) {
+            tracing::warn!(
+                tool_name = repetition.tool_name,
+                path = repetition.path,
+                repeated_range_count = repetition.repeated_range_count,
+                total_recent_reads = repetition.total_recent_reads,
+                threshold,
+                "Loop detected: read tool repeatedly requested the same range"
+            );
+            messages.push(Message::system(
+                "Loop detected: you are repeatedly reading the same file or output range. \
+                 Use the content already returned, read a different range once, change approach, \
+                 or report the blocker.",
             ));
             return;
         }
@@ -221,6 +238,105 @@ fn tool_result_signature(msg: &Message) -> Option<String> {
     let call = metadata.get("tool_call_fingerprint")?.as_str()?;
     let result = metadata.get("tool_result_fingerprint")?.as_str()?;
     Some(format!("{call}:{result}"))
+}
+
+#[derive(Debug)]
+struct RepeatedReadRange {
+    tool_name: String,
+    path: String,
+    repeated_range_count: usize,
+    total_recent_reads: usize,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct ReadResourceKey {
+    tool_name: String,
+    path: String,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct ReadRangeKey {
+    offset: Option<String>,
+}
+
+fn repeated_read_range_count(messages: &[Message], threshold: usize) -> Option<RepeatedReadRange> {
+    let mut target_resource: Option<ReadResourceKey> = None;
+    let mut range_counts: HashMap<ReadRangeKey, usize> = HashMap::new();
+    let mut total_recent_reads = 0;
+    let mut max_repeated_range_count = 0;
+
+    for msg in messages.iter().rev() {
+        match msg.role {
+            MessageRole::User | MessageRole::System => break,
+            MessageRole::Agent => {
+                let tool_calls = msg.tool_calls();
+                if tool_calls.is_empty() {
+                    break;
+                }
+
+                let mut read_calls = Vec::new();
+                for tool_call in tool_calls {
+                    let read_call = read_call_key(tool_call)?;
+                    read_calls.push(read_call);
+                }
+
+                for read_call in read_calls {
+                    match &target_resource {
+                        Some(target) if target == &read_call.resource => {}
+                        Some(_) => return None,
+                        None => target_resource = Some(read_call.resource.clone()),
+                    }
+
+                    total_recent_reads += 1;
+                    let repeated_range_count = range_counts.entry(read_call.range).or_insert(0);
+                    *repeated_range_count += 1;
+                    max_repeated_range_count = max_repeated_range_count.max(*repeated_range_count);
+                }
+            }
+            _ => continue,
+        }
+    }
+
+    let target_resource = target_resource?;
+    (max_repeated_range_count >= threshold && total_recent_reads > max_repeated_range_count)
+        .then_some(RepeatedReadRange {
+            tool_name: target_resource.tool_name,
+            path: target_resource.path,
+            repeated_range_count: max_repeated_range_count,
+            total_recent_reads,
+        })
+}
+
+#[derive(Clone, Debug)]
+struct ReadCallKey {
+    resource: ReadResourceKey,
+    range: ReadRangeKey,
+}
+
+fn read_call_key(tool_call: &ToolCallContentPart) -> Option<ReadCallKey> {
+    if !is_read_file_tool_name(&tool_call.name) {
+        return None;
+    }
+
+    let path = tool_call.arguments.get("path")?.as_str()?.to_string();
+    let offset = match tool_call.arguments.get("offset") {
+        Some(serde_json::Value::Number(number)) => Some(number.to_string()),
+        Some(serde_json::Value::String(value)) => Some(value.clone()),
+        Some(value) => Some(value.to_string()),
+        None => None,
+    };
+
+    Some(ReadCallKey {
+        resource: ReadResourceKey {
+            tool_name: tool_call.name.clone(),
+            path,
+        },
+        range: ReadRangeKey { offset },
+    })
+}
+
+fn is_read_file_tool_name(name: &str) -> bool {
+    name == "read_file" || name.ends_with("__read_file")
 }
 
 #[cfg(test)]
@@ -328,6 +444,71 @@ mod tests {
         let last = messages.last().unwrap();
         assert_eq!(last.role, MessageRole::System);
         assert!(last.text().unwrap().contains("same tool call produced"));
+    }
+
+    #[test]
+    fn test_loop_detected_repeated_read_range_with_alternating_offsets() {
+        let filter = LoopDetectionFilter;
+        let mut messages = vec![
+            Message::user("inspect saved output"),
+            agent_msg_with_calls(vec![(
+                "read_file",
+                serde_json::json!({"path": "/workspace/outputs/call_123.stdout", "offset": 0, "limit": 100}),
+            )]),
+            agent_msg_with_calls(vec![(
+                "read_file",
+                serde_json::json!({"path": "/workspace/outputs/call_123.stdout", "offset": 100, "limit": 100}),
+            )]),
+            agent_msg_with_calls(vec![(
+                "read_file",
+                serde_json::json!({"path": "/workspace/outputs/call_123.stdout", "offset": 0, "limit": 105}),
+            )]),
+            agent_msg_with_calls(vec![(
+                "read_file",
+                serde_json::json!({"path": "/workspace/outputs/call_123.stdout", "offset": 100, "limit": 105}),
+            )]),
+            agent_msg_with_calls(vec![(
+                "read_file",
+                serde_json::json!({"path": "/workspace/outputs/call_123.stdout", "offset": 0, "limit": 110}),
+            )]),
+        ];
+        let original_len = messages.len();
+
+        filter.post_load(&mut messages, &default_config());
+
+        assert_eq!(messages.len(), original_len + 1);
+        let last = messages.last().unwrap();
+        assert_eq!(last.role, MessageRole::System);
+        assert!(last.text().unwrap().contains("same file or output range"));
+    }
+
+    #[test]
+    fn test_sequential_read_ranges_are_not_a_loop() {
+        let filter = LoopDetectionFilter;
+        let mut messages = vec![
+            Message::user("inspect saved output"),
+            agent_msg_with_calls(vec![(
+                "read_file",
+                serde_json::json!({"path": "/workspace/outputs/call_123.stdout", "offset": 0, "limit": 100}),
+            )]),
+            agent_msg_with_calls(vec![(
+                "read_file",
+                serde_json::json!({"path": "/workspace/outputs/call_123.stdout", "offset": 100, "limit": 100}),
+            )]),
+            agent_msg_with_calls(vec![(
+                "read_file",
+                serde_json::json!({"path": "/workspace/outputs/call_123.stdout", "offset": 200, "limit": 100}),
+            )]),
+            agent_msg_with_calls(vec![(
+                "read_file",
+                serde_json::json!({"path": "/workspace/outputs/call_123.stdout", "offset": 300, "limit": 100}),
+            )]),
+        ];
+        let original_len = messages.len();
+
+        filter.post_load(&mut messages, &default_config());
+
+        assert_eq!(messages.len(), original_len);
     }
 
     #[test]

--- a/crates/core/src/capabilities/loop_detection.rs
+++ b/crates/core/src/capabilities/loop_detection.rs
@@ -32,7 +32,7 @@ impl Capability for LoopDetectionCapability {
     }
 
     fn description(&self) -> &str {
-        "Detects repeated identical tool calls and injects a warning to break the loop."
+        "Detects repeated tool loops and injects a warning to break the loop."
     }
 
     fn message_filter_provider(&self) -> Option<Arc<dyn MessageFilterProvider>> {
@@ -95,7 +95,8 @@ impl Capability for LoopDetectionCapability {
                      щоб розірвати цикл.",
                 ),
                 config_description: Some(
-                    "Визначає, скільки однакових послідовних викликів інструментів вважається циклом.",
+                    "Визначає, скільки повторюваних однакових викликів, результатів або \
+                     діапазонів читання вважається циклом.",
                 ),
                 config_overlay: Some(serde_json::json!({
                     "properties": {
@@ -265,7 +266,7 @@ fn repeated_read_range_count(messages: &[Message], threshold: usize) -> Option<R
     let mut total_recent_reads = 0;
     let mut max_repeated_range_count = 0;
 
-    for msg in messages.iter().rev() {
+    'scan: for msg in messages.iter().rev() {
         match msg.role {
             MessageRole::User | MessageRole::System => break,
             MessageRole::Agent => {
@@ -274,16 +275,16 @@ fn repeated_read_range_count(messages: &[Message], threshold: usize) -> Option<R
                     break;
                 }
 
-                let mut read_calls = Vec::new();
                 for tool_call in tool_calls {
-                    let read_call = read_call_key(tool_call)?;
-                    read_calls.push(read_call);
-                }
-
-                for read_call in read_calls {
+                    let Some(read_call) = read_call_key(tool_call) else {
+                        if target_resource.is_some() {
+                            break 'scan;
+                        }
+                        return None;
+                    };
                     match &target_resource {
                         Some(target) if target == &read_call.resource => {}
-                        Some(_) => return None,
+                        Some(_) => break 'scan,
                         None => target_resource = Some(read_call.resource.clone()),
                     }
 
@@ -323,7 +324,7 @@ fn read_call_key(tool_call: &ToolCallContentPart) -> Option<ReadCallKey> {
         Some(serde_json::Value::Number(number)) => Some(number.to_string()),
         Some(serde_json::Value::String(value)) => Some(value.clone()),
         Some(value) => Some(value.to_string()),
-        None => None,
+        None => Some("0".to_string()),
     };
 
     Some(ReadCallKey {
@@ -480,6 +481,89 @@ mod tests {
         let last = messages.last().unwrap();
         assert_eq!(last.role, MessageRole::System);
         assert!(last.text().unwrap().contains("same file or output range"));
+    }
+
+    #[test]
+    fn test_loop_detected_when_zero_offset_is_omitted() {
+        let filter = LoopDetectionFilter;
+        let mut messages = vec![
+            Message::user("inspect saved output"),
+            agent_msg_with_calls(vec![(
+                "read_file",
+                serde_json::json!({"path": "/workspace/outputs/call_123.stdout", "limit": 100}),
+            )]),
+            agent_msg_with_calls(vec![(
+                "read_file",
+                serde_json::json!({"path": "/workspace/outputs/call_123.stdout", "offset": 100, "limit": 100}),
+            )]),
+            agent_msg_with_calls(vec![(
+                "read_file",
+                serde_json::json!({"path": "/workspace/outputs/call_123.stdout", "offset": 0, "limit": 105}),
+            )]),
+            agent_msg_with_calls(vec![(
+                "read_file",
+                serde_json::json!({"path": "/workspace/outputs/call_123.stdout", "offset": 100, "limit": 105}),
+            )]),
+            agent_msg_with_calls(vec![(
+                "read_file",
+                serde_json::json!({"path": "/workspace/outputs/call_123.stdout", "limit": 110}),
+            )]),
+        ];
+        let original_len = messages.len();
+
+        filter.post_load(&mut messages, &default_config());
+
+        assert_eq!(messages.len(), original_len + 1);
+        assert!(
+            messages
+                .last()
+                .unwrap()
+                .text()
+                .unwrap()
+                .contains("same file or output range")
+        );
+    }
+
+    #[test]
+    fn test_read_range_loop_stops_at_older_non_read_boundary() {
+        let filter = LoopDetectionFilter;
+        let mut messages = vec![
+            Message::user("inspect saved output"),
+            agent_msg_with_calls(vec![("write_file", serde_json::json!({"path": "/notes"}))]),
+            agent_msg_with_calls(vec![(
+                "read_file",
+                serde_json::json!({"path": "/workspace/outputs/call_123.stdout", "offset": 0, "limit": 100}),
+            )]),
+            agent_msg_with_calls(vec![(
+                "read_file",
+                serde_json::json!({"path": "/workspace/outputs/call_123.stdout", "offset": 100, "limit": 100}),
+            )]),
+            agent_msg_with_calls(vec![(
+                "read_file",
+                serde_json::json!({"path": "/workspace/outputs/call_123.stdout", "offset": 0, "limit": 105}),
+            )]),
+            agent_msg_with_calls(vec![(
+                "read_file",
+                serde_json::json!({"path": "/workspace/outputs/call_123.stdout", "offset": 100, "limit": 105}),
+            )]),
+            agent_msg_with_calls(vec![(
+                "read_file",
+                serde_json::json!({"path": "/workspace/outputs/call_123.stdout", "offset": 0, "limit": 110}),
+            )]),
+        ];
+        let original_len = messages.len();
+
+        filter.post_load(&mut messages, &default_config());
+
+        assert_eq!(messages.len(), original_len + 1);
+        assert!(
+            messages
+                .last()
+                .unwrap()
+                .text()
+                .unwrap()
+                .contains("same file or output range")
+        );
     }
 
     #[test]

--- a/specs/capabilities.md
+++ b/specs/capabilities.md
@@ -720,9 +720,9 @@ Following the agentskills.io specification:
 #### LoopDetection
 
 - **ID**: `loop_detection`
-- **Purpose**: Detects repeated identical tool calls and injects a warning to break the loop
+- **Purpose**: Detects repeated tool loops and injects a warning to break the loop
 - **Tools**: None (uses `MessageFilterProvider::post_load` only)
-- **Config**: `{"threshold": N}` — number of consecutive identical tool-call batches before warning (default 3)
+- **Config**: `{"threshold": N}` — number of repeated identical results, identical tool-call batches, or read ranges before warning (default 3)
 - **Source**: `crates/core/src/capabilities/loop_detection.rs`
 
 #### MessageMetadata

--- a/specs/tool-execution.md
+++ b/specs/tool-execution.md
@@ -290,18 +290,18 @@ Current final hooks (always-on, cannot be removed):
 
 ### Loop Detection (EVE-227)
 
-The `loop_detection` capability detects repeated identical tool calls and injects a system warning to break the loop. It uses `MessageFilterProvider::post_load` to scan loaded messages.
+The `loop_detection` capability detects repeated tool loops and injects a system warning to break the loop. It uses `MessageFilterProvider::post_load` to scan loaded messages.
 
 **Mechanism:** `ActAtom` emits stable fingerprints on tool events:
 
 - `tool_call_fingerprint` on `tool.started` and `tool.completed`: `sha256:` over the tool name plus normalized arguments. UI-only fields such as `human_intent` and verbosity-only `output` are excluded.
 - `tool_result_fingerprint` on `tool.completed`: `sha256:` over the tool name plus normalized result/error. Common volatile fields such as durations and timestamps are excluded.
 
-After messages are loaded, the filter scans the recent available window in reverse. If `threshold` (default 3) consecutive tool results have identical call+result fingerprints, a system message is appended warning the model to change approach. If result fingerprints are unavailable, it falls back to recent agent messages and detects consecutive identical tool-call batches by normalized name+arguments.
+After messages are loaded, the filter scans the recent available window in reverse. If `threshold` (default 3) consecutive tool results have identical call+result fingerprints, a system message is appended warning the model to change approach. It also detects repeated `read_file` ranges for the same path within the current read cluster, so alternating between the same saved-output ranges is treated as a loop while sequential paging is allowed. If result fingerprints are unavailable, it falls back to recent agent messages and detects consecutive identical tool-call batches by normalized name+arguments.
 
 This is intentionally a rolling-window detector: hosts are not required to read all historical events. Durable hosts can rehydrate from the last relevant events; embedded hosts such as ercode can use their in-memory/logged message history. If the visible window is too short to prove a cycle, the detector continues without blocking.
 
-**Configuration:** `{"threshold": 5}` to change the default repeat count.
+**Configuration:** `{"threshold": 5}` to change the default repeat count for identical results, identical call batches, and repeated read ranges.
 
 See `crates/core/src/capabilities/loop_detection.rs`.
 


### PR DESCRIPTION
## What
Extends `loop_detection` so it catches repeated `read_file` ranges for the same path, including alternating offset cycles over persisted output files.

## Why
The Yolop loop session repeatedly alternated between the same saved-output ranges, so the existing consecutive-identical-call detector never fired. The model kept rereading offset 0 after adjacent ranges because the behavior was a cycle, not a single identical call streak.

## How
- Track recent uninterrupted `read_file` calls by tool name and path.
- Count repeated offsets within that same-resource read cluster.
- Warn when one range repeats at the configured threshold while allowing monotonic sequential paging.
- Keep existing identical tool-result and identical tool-call batch detection intact.
- Update the loop-detection specs to cover repeated read ranges.

## Risk
- Low / Medium
- Could warn earlier for agents rereading the same file range intentionally, but it only triggers inside the current same-resource read cluster and requires a repeated range plus another read in the cluster.

## Security
No new external input surface, persistence, secrets handling, or network behavior. The pushed-branch Dependabot notice reflects existing default-branch vulnerabilities, not this patch.

## Validation
- `cargo fmt --check`
- `cargo test -p everruns-core capabilities::loop_detection::tests`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `just pre-push`

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
