### PR TITLE
feat(local): everruns-local crate for embedded host backends

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2747,6 +2747,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "everruns-local"
+version = "0.14.0"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "everruns-core",
+ "everruns-runtime",
+ "parking_lot",
+ "rusqlite",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "uuid 1.23.3",
+]
+
+[[package]]
 name = "everruns-mai"
 version = "0.14.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "crates/gemini",
     "crates/turbopuffer",
     "crates/internal-protocol",
+    "crates/local",
     "crates/cli",
     "crates/durable",
     "crates/config",

--- a/crates/local/Cargo.toml
+++ b/crates/local/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+name = "everruns-local"
+publish = false
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "Local, SQLite-backed runtime backend stores for embedded in-process Everruns hosts"
+
+[dependencies]
+# SQLite
+rusqlite = { version = "0.39", features = ["bundled"] }
+
+# Everruns crates
+everruns-core = { path = "../core" }
+everruns-runtime = { path = "../runtime" }
+
+# Async
+tokio = { workspace = true, features = ["rt", "time", "sync"] }
+async-trait.workspace = true
+
+# Sync
+parking_lot.workspace = true
+
+# Serialization
+serde_json.workspace = true
+
+# Types
+chrono.workspace = true
+uuid.workspace = true
+
+# Error handling
+thiserror.workspace = true
+
+# Logging
+tracing.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["full", "test-util"] }
+tempfile.workspace = true

--- a/crates/local/src/backends.rs
+++ b/crates/local/src/backends.rs
@@ -1,0 +1,133 @@
+// LocalBackends — composable construction of runtime backends + local stores.
+//
+// Composability requirement (EVE-594): an embedder MUST be able to keep its own
+// event bus and its own `SessionFileSystemFactory`. `LocalBackends` therefore
+// takes the runtime backend bundle (which already carries the caller's event
+// bus) as input, and the file system factory is configured on the embedder's
+// `PlatformDefinition` — never forced here. The individual local stores are
+// exposed so an embedder can wire only the pieces it wants.
+
+use std::sync::Arc;
+
+use everruns_core::error::Result;
+use everruns_core::platform_store::PlatformStore;
+use everruns_core::traits::SessionScheduleStore;
+use everruns_core::typed_id::{PrincipalId, SessionId};
+use everruns_runtime::{PlatformStoreFactory, RuntimeBackends, ScheduleStoreFactory};
+
+use crate::db::SqliteDb;
+use crate::platform_store::{LocalPlatformStore, LocalSessionRunner};
+use crate::profile::LocalProfile;
+use crate::schedule_store::LocalScheduleStore;
+use crate::task_registry::LocalSessionTaskRegistry;
+
+/// The local stores plus a ready-to-use `RuntimeBackends`.
+///
+/// `runtime_backends` carries whatever store set / event bus the caller passed
+/// in, plus the local SQLite-backed task registry and schedule store factory
+/// attached here. The platform store factory is attached separately via
+/// [`LocalBackends::with_platform_runner`] once the embedder supplies a
+/// `LocalSessionRunner` (the runner usually wraps the runtime built from these
+/// backends, hence the two-step wiring).
+pub struct LocalBackends {
+    /// Composable runtime backend bundle (caller bus preserved).
+    pub runtime_backends: RuntimeBackends,
+    /// Shared SQLite handle backing the local stores.
+    pub db: SqliteDb,
+    /// SQLite-backed task registry (also installed on `runtime_backends`).
+    pub task_registry: Arc<LocalSessionTaskRegistry>,
+    /// Profile used to build the stores.
+    pub profile: LocalProfile,
+    org_id: i64,
+}
+
+impl LocalBackends {
+    /// Build local backends from a profile and caller-provided composable
+    /// pieces. The event bus and any custom stores already configured on
+    /// `runtime_backends` are preserved; this only attaches the local task
+    /// registry and schedule store factory.
+    ///
+    /// The SQLite database is opened at `profile.db_path()`; the data directory
+    /// is created if needed.
+    pub fn new(profile: LocalProfile, runtime_backends: RuntimeBackends) -> Result<Self> {
+        profile
+            .ensure_dirs()
+            .map_err(|e| everruns_core::AgentLoopError::config(e.to_string()))?;
+        let db = SqliteDb::open(profile.db_path()).map_err(everruns_core::AgentLoopError::from)?;
+        Self::with_db(profile, runtime_backends, db)
+    }
+
+    /// Build local backends over an already-open SQLite handle (e.g. an
+    /// in-memory DB for tests).
+    pub fn with_db(
+        profile: LocalProfile,
+        runtime_backends: RuntimeBackends,
+        db: SqliteDb,
+    ) -> Result<Self> {
+        let org_id = everruns_runtime::in_process_internal_org_id(&profile.org_public_id);
+        let task_registry = Arc::new(LocalSessionTaskRegistry::new(db.clone())?);
+
+        // Ensure the schedule schema exists once up front (propagating any
+        // error), so the per-(org) factory on the act path stays cheap and
+        // cannot panic. `new` here both creates the schema and validates the DB.
+        LocalScheduleStore::new(db.clone(), org_id, profile.owner_principal_id)?;
+        let schedule_db = db.clone();
+        let owner = profile.owner_principal_id;
+        let schedule_factory: ScheduleStoreFactory = Arc::new(move |org_id: i64| {
+            // One schedule store per org, over the shared DB handle. Schema is
+            // already initialized above, so this is infallible.
+            Arc::new(LocalScheduleStore::scoped(
+                schedule_db.clone(),
+                org_id,
+                owner,
+            )) as Arc<dyn SessionScheduleStore>
+        });
+
+        let runtime_backends = runtime_backends
+            .with_session_task_registry(task_registry.clone())
+            .with_schedule_store_factory(schedule_factory);
+
+        Ok(Self {
+            runtime_backends,
+            db,
+            task_registry,
+            profile,
+            org_id,
+        })
+    }
+
+    /// Build a `LocalScheduleStore` directly (for the embedder that wants the
+    /// concrete type and its additive metadata methods).
+    pub fn schedule_store(&self) -> Result<LocalScheduleStore> {
+        LocalScheduleStore::new(
+            self.db.clone(),
+            self.org_id,
+            self.profile.owner_principal_id,
+        )
+    }
+
+    /// Attach a platform store factory built from a caller-supplied
+    /// `LocalSessionRunner`. Call this after the runtime (and therefore the
+    /// runner) exists. The factory hands out a [`LocalPlatformStore`] per
+    /// (org, session); the runner is the source of truth for local session
+    /// state, so no extra store handles are required.
+    pub fn with_platform_runner(mut self, runner: Arc<dyn LocalSessionRunner>) -> Self {
+        let base_url = self.profile.base_url.clone();
+        let factory: PlatformStoreFactory =
+            Arc::new(move |_org_id: i64, _session_id: SessionId| {
+                Arc::new(LocalPlatformStore::new(runner.clone(), base_url.clone()))
+                    as Arc<dyn PlatformStore>
+            });
+        self.runtime_backends = self.runtime_backends.with_platform_store_factory(factory);
+        self
+    }
+
+    /// Internal org id this backend set is scoped to.
+    pub fn org_id(&self) -> i64 {
+        self.org_id
+    }
+
+    pub fn owner_principal_id(&self) -> PrincipalId {
+        self.profile.owner_principal_id
+    }
+}

--- a/crates/local/src/db.rs
+++ b/crates/local/src/db.rs
@@ -1,0 +1,56 @@
+// Shared SQLite connection handle for the local stores.
+//
+// Decision: a single `parking_lot::Mutex<rusqlite::Connection>` per database
+// file. The local stores are intended for embedded, single-process hosts where
+// throughput is modest and a serialized connection keeps the code simple and
+// correct. Connections are opened with WAL so a freshly-spawned process can
+// reopen the same file (restart-survivability) without losing committed data.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+use rusqlite::Connection;
+
+use crate::error::{LocalError, LocalResult};
+
+/// A shared, serialized SQLite connection. Cloning shares the underlying
+/// connection (the `Arc<Mutex<..>>` is shared), so all stores built from the
+/// same handle write to the same file.
+#[derive(Clone)]
+pub struct SqliteDb {
+    conn: Arc<Mutex<Connection>>,
+}
+
+impl SqliteDb {
+    /// Open (creating if needed) a file-backed database at `path`.
+    pub fn open(path: impl AsRef<Path>) -> LocalResult<Self> {
+        let conn = Connection::open(path.as_ref())?;
+        Self::from_connection(conn)
+    }
+
+    /// Open an in-memory database (for tests). Each call is an independent DB.
+    pub fn open_in_memory() -> LocalResult<Self> {
+        let conn = Connection::open_in_memory()?;
+        Self::from_connection(conn)
+    }
+
+    fn from_connection(conn: Connection) -> LocalResult<Self> {
+        // WAL improves concurrent read/write behavior and survives process
+        // restarts; foreign_keys keeps message rows tied to their task.
+        conn.pragma_update(None, "journal_mode", "WAL")?;
+        conn.pragma_update(None, "foreign_keys", true)?;
+        Ok(Self {
+            conn: Arc::new(Mutex::new(conn)),
+        })
+    }
+
+    /// Run a closure with exclusive access to the connection.
+    pub fn with_conn<T>(
+        &self,
+        f: impl FnOnce(&Connection) -> rusqlite::Result<T>,
+    ) -> LocalResult<T> {
+        let guard = self.conn.lock();
+        f(&guard).map_err(LocalError::from)
+    }
+}

--- a/crates/local/src/error.rs
+++ b/crates/local/src/error.rs
@@ -1,0 +1,30 @@
+// Error type for the local crate. Converts cleanly into the core
+// `AgentLoopError` so trait implementations can return `everruns_core::Result`.
+
+use everruns_core::error::AgentLoopError;
+
+#[derive(Debug, thiserror::Error)]
+pub enum LocalError {
+    #[error("sqlite error: {0}")]
+    Sqlite(#[from] rusqlite::Error),
+
+    #[error("serialization error: {0}")]
+    Serde(#[from] serde_json::Error),
+
+    #[error("configuration error: {0}")]
+    Config(String),
+
+    #[error("{0}")]
+    Other(String),
+}
+
+pub type LocalResult<T> = std::result::Result<T, LocalError>;
+
+impl From<LocalError> for AgentLoopError {
+    fn from(err: LocalError) -> Self {
+        match err {
+            LocalError::Config(msg) => AgentLoopError::config(msg),
+            other => AgentLoopError::store(other.to_string()),
+        }
+    }
+}

--- a/crates/local/src/lib.rs
+++ b/crates/local/src/lib.rs
@@ -1,0 +1,39 @@
+//! Local, SQLite-backed runtime backend stores for embedded Everruns hosts.
+//!
+//! This crate provides restart-survivable, file-backed implementations of the
+//! runtime backend traits used by an in-process host:
+//!
+//! - [`LocalSessionTaskRegistry`] — a [`everruns_core::session_task::SessionTaskRegistry`]
+//!   over SQLite, persisting tasks and their message channel.
+//! - [`LocalScheduleStore`] — a [`everruns_core::traits::SessionScheduleStore`]
+//!   over SQLite, with an additive JSON metadata bag (see its module docs).
+//! - [`LocalPlatformStore`] — a [`everruns_core::platform_store::PlatformStore`]
+//!   implementing the subagent-critical core honestly and returning explicit
+//!   unsupported errors for platform-management-only operations.
+//! - [`LocalProfile`] — named local env config (data dir, workspace, base URL,
+//!   org/principal identity).
+//! - [`LocalBackends`] — composable construction of `RuntimeBackends` + the
+//!   local stores, accepting a caller-provided event bus (via `RuntimeBackends`)
+//!   and file system factory (via the embedder's `PlatformDefinition`).
+//! - [`LocalRuntimeBuilder`] — optional sugar over `InProcessRuntimeBuilder`.
+//!
+//! It is part of the [Everruns](https://everruns.com) ecosystem and is
+//! `publish = false` (local-only).
+
+mod backends;
+mod db;
+mod error;
+mod platform_store;
+mod profile;
+mod runtime_builder;
+mod schedule_store;
+mod task_registry;
+
+pub use backends::LocalBackends;
+pub use db::SqliteDb;
+pub use error::{LocalError, LocalResult};
+pub use platform_store::{LocalPlatformStore, LocalSessionRunner};
+pub use profile::LocalProfile;
+pub use runtime_builder::LocalRuntimeBuilder;
+pub use schedule_store::LocalScheduleStore;
+pub use task_registry::LocalSessionTaskRegistry;

--- a/crates/local/src/platform_store.rs
+++ b/crates/local/src/platform_store.rs
@@ -1,0 +1,293 @@
+// Local PlatformStore.
+//
+// Scope (EVE-594): implement the subagent-critical core honestly, backed by a
+// caller-supplied `LocalSessionRunner` (the embedder wires this to its
+// `InProcessRuntime` so `create_session` / `send_message` / `wait_for_idle`
+// actually create and drive real local sessions, and `get_messages` /
+// `get_session_by_id` / `list_sessions` read real local state). The
+// platform-management-only operations (harness/agent/app CRUD, publish,
+// channels, capability listing, delete/context-report) return an explicit
+// unsupported error rather than half-implementing them — local embedded hosts
+// manage those entities in code, not through this tool surface.
+
+use async_trait::async_trait;
+use everruns_core::agent::Agent;
+use everruns_core::app::{App, AppChannel, ChannelType};
+use everruns_core::capability_dto::CapabilityInfo;
+use everruns_core::error::{AgentLoopError, Result};
+use everruns_core::harness::Harness;
+use everruns_core::platform_store::{PlatformMessage, PlatformStore};
+use everruns_core::session::Session;
+use everruns_core::typed_id::{
+    AgentId, AgentIdentityId, AppChannelId, AppId, HarnessId, SessionId,
+};
+use std::sync::Arc;
+
+/// Drives real local sessions for the platform store. An embedder implements
+/// this over its `InProcessRuntime` (or a thin wrapper) so subagent spawning
+/// can create child sessions, run turns, and read back session state. This is
+/// the seam that keeps the platform store honest without it owning the runtime.
+#[async_trait]
+pub trait LocalSessionRunner: Send + Sync {
+    /// Create a child/local session and persist it in the session catalog.
+    async fn create_session(
+        &self,
+        harness_id: HarnessId,
+        agent_id: Option<AgentId>,
+        title: Option<&str>,
+        locale: Option<&str>,
+        parent_session_id: Option<SessionId>,
+    ) -> Result<Session>;
+
+    /// Deliver a user message and run a turn to completion.
+    async fn send_message(&self, session_id: SessionId, content: &str) -> Result<()>;
+
+    /// List sessions known to the runner. Optionally filtered by agent.
+    async fn list_sessions(
+        &self,
+        limit: Option<usize>,
+        agent_id: Option<AgentId>,
+    ) -> Result<Vec<Session>>;
+
+    /// Look up a single session by id.
+    async fn get_session(&self, session_id: SessionId) -> Result<Option<Session>>;
+
+    /// Read recent messages (most recent first) as platform messages.
+    async fn get_messages(
+        &self,
+        session_id: SessionId,
+        limit: Option<usize>,
+    ) -> Result<Vec<PlatformMessage>>;
+
+    /// Current session status string, or `None` if the session is unknown.
+    async fn get_session_status(&self, session_id: SessionId) -> Result<Option<String>>;
+}
+
+fn unsupported(op: &str) -> AgentLoopError {
+    AgentLoopError::tool(format!(
+        "operation '{op}' is not supported by the local platform store; \
+         manage this entity in embedder code"
+    ))
+}
+
+/// Local platform store for one (org, session) scope, backed by a
+/// [`LocalSessionRunner`].
+#[derive(Clone)]
+pub struct LocalPlatformStore {
+    runner: Arc<dyn LocalSessionRunner>,
+    base_url: String,
+}
+
+impl LocalPlatformStore {
+    pub fn new(runner: Arc<dyn LocalSessionRunner>, base_url: impl Into<String>) -> Self {
+        Self {
+            runner,
+            base_url: base_url.into(),
+        }
+    }
+}
+
+#[async_trait]
+impl PlatformStore for LocalPlatformStore {
+    // ---- Honestly implemented: subagent-critical core -----------------------
+
+    async fn create_session(
+        &self,
+        harness_id: HarnessId,
+        agent_id: Option<AgentId>,
+        title: Option<&str>,
+        locale: Option<&str>,
+        blueprint_id: Option<&str>,
+        _blueprint_config: Option<&serde_json::Value>,
+        parent_session_id: Option<SessionId>,
+    ) -> Result<Session> {
+        if blueprint_id.is_some() {
+            return Err(unsupported("create_session(blueprint)"));
+        }
+        self.runner
+            .create_session(harness_id, agent_id, title, locale, parent_session_id)
+            .await
+    }
+
+    async fn get_session_by_id(&self, id: SessionId) -> Result<Option<Session>> {
+        self.runner.get_session(id).await
+    }
+
+    async fn list_sessions(
+        &self,
+        limit: Option<usize>,
+        agent_id: Option<AgentId>,
+    ) -> Result<Vec<Session>> {
+        self.runner.list_sessions(limit, agent_id).await
+    }
+
+    async fn send_message(&self, session_id: SessionId, content: &str) -> Result<()> {
+        self.runner.send_message(session_id, content).await
+    }
+
+    async fn get_messages(
+        &self,
+        session_id: SessionId,
+        limit: Option<usize>,
+    ) -> Result<Vec<PlatformMessage>> {
+        self.runner.get_messages(session_id, limit).await
+    }
+
+    async fn wait_for_idle(
+        &self,
+        session_id: SessionId,
+        _timeout_secs: Option<u64>,
+    ) -> Result<String> {
+        // `send_message` runs the turn synchronously to completion in the local
+        // host, so by the time a caller polls, the session is already idle.
+        self.runner
+            .get_session_status(session_id)
+            .await?
+            .ok_or_else(|| AgentLoopError::session_not_found(session_id))
+    }
+
+    fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
+    // ---- Platform-management-only: explicit unsupported ---------------------
+
+    async fn list_harnesses(&self) -> Result<Vec<Harness>> {
+        Err(unsupported("list_harnesses"))
+    }
+    async fn get_harness(&self, _id: HarnessId) -> Result<Option<Harness>> {
+        Err(unsupported("get_harness"))
+    }
+    async fn create_harness(
+        &self,
+        _name: &str,
+        _display_name: Option<&str>,
+        _description: Option<&str>,
+        _system_prompt: Option<&str>,
+        _parent_harness_id: Option<HarnessId>,
+        _capabilities: &[String],
+    ) -> Result<Harness> {
+        Err(unsupported("create_harness"))
+    }
+    async fn update_harness(
+        &self,
+        _id: HarnessId,
+        _name: Option<&str>,
+        _display_name: Option<&str>,
+        _description: Option<&str>,
+        _system_prompt: Option<&str>,
+        _parent_harness_id: Option<Option<HarnessId>>,
+    ) -> Result<Harness> {
+        Err(unsupported("update_harness"))
+    }
+    async fn delete_harness(&self, _id: HarnessId) -> Result<()> {
+        Err(unsupported("delete_harness"))
+    }
+    async fn copy_harness(&self, _id: HarnessId, _new_name: Option<&str>) -> Result<Harness> {
+        Err(unsupported("copy_harness"))
+    }
+    async fn list_agents(&self) -> Result<Vec<Agent>> {
+        Err(unsupported("list_agents"))
+    }
+    async fn get_agent_by_id(&self, _id: AgentId) -> Result<Option<Agent>> {
+        Err(unsupported("get_agent_by_id"))
+    }
+    async fn create_agent(
+        &self,
+        _name: &str,
+        _display_name: Option<&str>,
+        _description: Option<&str>,
+        _system_prompt: &str,
+        _capabilities: &[String],
+    ) -> Result<Agent> {
+        Err(unsupported("create_agent"))
+    }
+    async fn update_agent(
+        &self,
+        _id: AgentId,
+        _name: Option<&str>,
+        _display_name: Option<&str>,
+        _description: Option<&str>,
+        _system_prompt: Option<&str>,
+    ) -> Result<Agent> {
+        Err(unsupported("update_agent"))
+    }
+    async fn delete_agent(&self, _id: AgentId) -> Result<()> {
+        Err(unsupported("delete_agent"))
+    }
+    async fn list_apps(&self, _search: Option<&str>, _include_archived: bool) -> Result<Vec<App>> {
+        Err(unsupported("list_apps"))
+    }
+    async fn get_app(&self, _id: AppId) -> Result<Option<App>> {
+        Err(unsupported("get_app"))
+    }
+    async fn create_app(
+        &self,
+        _name: &str,
+        _description: Option<&str>,
+        _harness_id: HarnessId,
+        _agent_id: Option<AgentId>,
+        _agent_identity_id: Option<AgentIdentityId>,
+        _channel_type: Option<ChannelType>,
+        _channel_config: Option<&serde_json::Value>,
+    ) -> Result<App> {
+        Err(unsupported("create_app"))
+    }
+    async fn update_app(
+        &self,
+        _id: AppId,
+        _name: Option<&str>,
+        _description: Option<&str>,
+        _harness_id: Option<HarnessId>,
+        _agent_id: Option<AgentId>,
+        _agent_identity_id: Option<Option<AgentIdentityId>>,
+    ) -> Result<App> {
+        Err(unsupported("update_app"))
+    }
+    async fn delete_app(&self, _id: AppId) -> Result<()> {
+        Err(unsupported("delete_app"))
+    }
+    async fn destroy_app(&self, _id: AppId) -> Result<()> {
+        Err(unsupported("destroy_app"))
+    }
+    async fn publish_app(&self, _id: AppId) -> Result<App> {
+        Err(unsupported("publish_app"))
+    }
+    async fn unpublish_app(&self, _id: AppId) -> Result<App> {
+        Err(unsupported("unpublish_app"))
+    }
+    async fn add_app_channel(
+        &self,
+        _app_id: AppId,
+        _channel_type: ChannelType,
+        _channel_config: Option<&serde_json::Value>,
+        _enabled: Option<bool>,
+    ) -> Result<AppChannel> {
+        Err(unsupported("add_app_channel"))
+    }
+    async fn update_app_channel(
+        &self,
+        _app_id: AppId,
+        _channel_id: AppChannelId,
+        _channel_type: Option<ChannelType>,
+        _channel_config: Option<&serde_json::Value>,
+        _enabled: Option<bool>,
+    ) -> Result<AppChannel> {
+        Err(unsupported("update_app_channel"))
+    }
+    async fn delete_app_channel(&self, _app_id: AppId, _channel_id: AppChannelId) -> Result<()> {
+        Err(unsupported("delete_app_channel"))
+    }
+    async fn get_session_context_report(
+        &self,
+        _id: SessionId,
+    ) -> Result<everruns_core::SessionContextReport> {
+        Err(unsupported("get_session_context_report"))
+    }
+    async fn delete_session(&self, _id: SessionId) -> Result<()> {
+        Err(unsupported("delete_session"))
+    }
+    async fn list_capabilities(&self, _search: Option<&str>) -> Result<Vec<CapabilityInfo>> {
+        Err(unsupported("list_capabilities"))
+    }
+}

--- a/crates/local/src/profile.rs
+++ b/crates/local/src/profile.rs
@@ -1,0 +1,87 @@
+// Named local environment configuration for embedded hosts.
+//
+// A `LocalProfile` bundles the on-disk locations and identity defaults an
+// embedder needs to stand up the local stores: where the SQLite database and
+// workspace files live, the UI base URL used for tool result links, and the
+// local org/principal identity stamped onto created records.
+
+use std::path::{Path, PathBuf};
+
+use everruns_core::typed_id::PrincipalId;
+
+/// Local environment configuration.
+#[derive(Debug, Clone)]
+pub struct LocalProfile {
+    /// Directory holding the local SQLite database(s).
+    pub data_dir: PathBuf,
+    /// Root directory for the session workspace filesystem.
+    pub workspace_root: PathBuf,
+    /// Base URL used to build UI links in tool results.
+    pub base_url: String,
+    /// Public organization id for created records.
+    pub org_public_id: String,
+    /// Owning principal stamped on schedules/sessions created locally.
+    pub owner_principal_id: PrincipalId,
+}
+
+impl Default for LocalProfile {
+    fn default() -> Self {
+        let data_dir = std::env::temp_dir().join("everruns-local");
+        Self {
+            workspace_root: data_dir.join("workspace"),
+            data_dir,
+            base_url: "http://localhost:9300".to_string(),
+            org_public_id: everruns_core::DEFAULT_ORG_PUBLIC_ID.to_string(),
+            owner_principal_id: PrincipalId::from_seed(1),
+        }
+    }
+}
+
+impl LocalProfile {
+    /// Start from defaults rooted at `data_dir`. The workspace defaults to
+    /// `data_dir/workspace`.
+    pub fn new(data_dir: impl Into<PathBuf>) -> Self {
+        let data_dir = data_dir.into();
+        Self {
+            workspace_root: data_dir.join("workspace"),
+            data_dir,
+            ..Self::default()
+        }
+    }
+
+    /// Path to the local stores database file under `data_dir`.
+    pub fn db_path(&self) -> PathBuf {
+        self.data_dir.join("local.db")
+    }
+
+    pub fn with_workspace_root(mut self, root: impl Into<PathBuf>) -> Self {
+        self.workspace_root = root.into();
+        self
+    }
+
+    pub fn with_base_url(mut self, base_url: impl Into<String>) -> Self {
+        self.base_url = base_url.into();
+        self
+    }
+
+    pub fn with_org_public_id(mut self, org_public_id: impl Into<String>) -> Self {
+        self.org_public_id = org_public_id.into();
+        self
+    }
+
+    pub fn with_owner_principal_id(mut self, owner_principal_id: PrincipalId) -> Self {
+        self.owner_principal_id = owner_principal_id;
+        self
+    }
+
+    /// Ensure `data_dir` and `workspace_root` exist on disk.
+    pub fn ensure_dirs(&self) -> std::io::Result<()> {
+        std::fs::create_dir_all(&self.data_dir)?;
+        std::fs::create_dir_all(&self.workspace_root)?;
+        Ok(())
+    }
+
+    pub fn data_dir(&self) -> &Path {
+        &self.data_dir
+    }
+}

--- a/crates/local/src/runtime_builder.rs
+++ b/crates/local/src/runtime_builder.rs
@@ -27,6 +27,10 @@ pub struct LocalRuntimeBuilder {
     profile: LocalProfile,
     inner: InProcessRuntimeBuilder,
     file_system_factory: Option<Arc<dyn SessionFileSystemFactory>>,
+    /// Caller-supplied platform definition override. When `Some`, `build()`
+    /// installs it as-is instead of the default local one; the caller owns the
+    /// session filesystem factory in that case.
+    platform_definition: Option<PlatformDefinition>,
 }
 
 impl LocalRuntimeBuilder {
@@ -37,12 +41,16 @@ impl LocalRuntimeBuilder {
             profile,
             inner: InProcessRuntimeBuilder::new(),
             file_system_factory: None,
+            platform_definition: None,
         }
     }
 
-    /// Replace the platform definition (capabilities, drivers, ...).
+    /// Replace the platform definition (capabilities, drivers, ...). When set,
+    /// `build()` respects this definition instead of constructing the default
+    /// local one, so capability/driver overrides take effect. The caller is
+    /// then responsible for the session filesystem factory on their definition.
     pub fn platform_definition(mut self, platform_definition: PlatformDefinition) -> Self {
-        self.inner = self.inner.platform_definition(platform_definition);
+        self.platform_definition = Some(platform_definition);
         self
     }
 
@@ -105,17 +113,25 @@ impl LocalRuntimeBuilder {
             everruns_runtime::RuntimeBackends::in_memory(),
         )?;
 
-        // Default to a real-disk workspace rooted at the profile workspace.
-        let factory = self.file_system_factory.unwrap_or_else(|| {
-            Arc::new(RealDiskSessionFileSystemFactory::new(
-                self.profile.workspace_root.clone(),
-            ))
-        });
-        let platform_definition = PlatformDefinition::builder()
-            .capability_registry(everruns_core::CapabilityRegistry::with_builtins())
-            .driver_registry(everruns_core::DriverRegistry::new())
-            .session_file_system_factory(factory)
-            .build();
+        // Respect a caller-supplied platform definition; otherwise build the
+        // default local one rooted at the profile workspace. Only install the
+        // default when the caller has not overridden it, so capability/driver
+        // overrides via `platform_definition(...)` are not silently discarded.
+        let platform_definition = match self.platform_definition {
+            Some(pd) => pd,
+            None => {
+                let factory = self.file_system_factory.unwrap_or_else(|| {
+                    Arc::new(RealDiskSessionFileSystemFactory::new(
+                        self.profile.workspace_root.clone(),
+                    ))
+                });
+                PlatformDefinition::builder()
+                    .capability_registry(everruns_core::CapabilityRegistry::with_builtins())
+                    .driver_registry(everruns_core::DriverRegistry::new())
+                    .session_file_system_factory(factory)
+                    .build()
+            }
+        };
 
         let runtime = self
             .inner

--- a/crates/local/src/runtime_builder.rs
+++ b/crates/local/src/runtime_builder.rs
@@ -1,0 +1,130 @@
+// LocalRuntimeBuilder — optional convenience sugar over InProcessRuntimeBuilder.
+//
+// This wires a LocalProfile + LocalBackends (task registry + schedule store)
+// and a real-disk workspace file store into an `InProcessRuntimeBuilder`. It is
+// strictly optional: everything it does can be done by composing the pieces in
+// `LocalBackends` directly. The platform store is intentionally NOT wired here
+// because the local platform store needs a `LocalSessionRunner` that usually
+// wraps the built runtime (a chicken/egg). Attach it after build via
+// `LocalBackends::with_platform_runner` and rebuild, or use the standalone
+// `LocalPlatformStore`.
+
+use std::sync::Arc;
+
+use everruns_core::error::Result;
+use everruns_core::traits::{SessionFileSystemFactory, SessionFileSystemFactoryContext};
+use everruns_core::{PlatformDefinition, ResolvedModel};
+use everruns_runtime::{
+    InProcessRuntime, InProcessRuntimeBuilder, RealDiskSessionFileSystemFactory,
+};
+
+use crate::backends::LocalBackends;
+use crate::profile::LocalProfile;
+
+/// Convenience wrapper around [`InProcessRuntimeBuilder`] that wires a local
+/// profile + SQLite-backed task/schedule stores and a workspace file store.
+pub struct LocalRuntimeBuilder {
+    profile: LocalProfile,
+    inner: InProcessRuntimeBuilder,
+    file_system_factory: Option<Arc<dyn SessionFileSystemFactory>>,
+}
+
+impl LocalRuntimeBuilder {
+    /// Start from a profile. Defaults the platform definition to built-ins via
+    /// `InProcessRuntimeBuilder::new()`.
+    pub fn new(profile: LocalProfile) -> Self {
+        Self {
+            profile,
+            inner: InProcessRuntimeBuilder::new(),
+            file_system_factory: None,
+        }
+    }
+
+    /// Replace the platform definition (capabilities, drivers, ...).
+    pub fn platform_definition(mut self, platform_definition: PlatformDefinition) -> Self {
+        self.inner = self.inner.platform_definition(platform_definition);
+        self
+    }
+
+    /// Register the built-in `llmsim` driver for deterministic local execution.
+    pub fn llm_sim(mut self, config: everruns_core::llmsim_driver::LlmSimConfig) -> Self {
+        self.inner = self.inner.llm_sim(config);
+        self
+    }
+
+    /// Set the runtime default model.
+    pub fn default_model(mut self, model: ResolvedModel) -> Self {
+        self.inner = self.inner.default_model(model);
+        self
+    }
+
+    /// Seed a harness.
+    pub fn harness(mut self, harness: everruns_core::Harness) -> Self {
+        self.inner = self.inner.harness(harness);
+        self
+    }
+
+    /// Seed an agent.
+    pub fn agent(mut self, agent: everruns_core::Agent) -> Self {
+        self.inner = self.inner.agent(agent);
+        self
+    }
+
+    /// Seed a session.
+    pub fn session(mut self, session: everruns_core::Session) -> Self {
+        self.inner = self.inner.session(session);
+        self
+    }
+
+    /// Override the session filesystem factory. By default a real-disk factory
+    /// rooted at `profile.workspace_root` is used.
+    pub fn session_file_system_factory(
+        mut self,
+        factory: Arc<dyn SessionFileSystemFactory>,
+    ) -> Self {
+        self.file_system_factory = Some(factory);
+        self
+    }
+
+    /// Access the underlying `InProcessRuntimeBuilder` for advanced wiring.
+    pub fn inner_mut(&mut self) -> &mut InProcessRuntimeBuilder {
+        &mut self.inner
+    }
+
+    /// Build the runtime and return it along with the constructed
+    /// [`LocalBackends`] so the embedder can attach a platform runner and reuse
+    /// the local stores. The task registry and schedule store factory are
+    /// installed on the runtime; the platform store is left to the embedder.
+    pub async fn build(self) -> Result<(InProcessRuntime, LocalBackends)> {
+        self.profile
+            .ensure_dirs()
+            .map_err(|e| everruns_core::AgentLoopError::config(e.to_string()))?;
+
+        let local = LocalBackends::new(
+            self.profile.clone(),
+            everruns_runtime::RuntimeBackends::in_memory(),
+        )?;
+
+        // Default to a real-disk workspace rooted at the profile workspace.
+        let factory = self.file_system_factory.unwrap_or_else(|| {
+            Arc::new(RealDiskSessionFileSystemFactory::new(
+                self.profile.workspace_root.clone(),
+            ))
+        });
+        let platform_definition = PlatformDefinition::builder()
+            .capability_registry(everruns_core::CapabilityRegistry::with_builtins())
+            .driver_registry(everruns_core::DriverRegistry::new())
+            .session_file_system_factory(factory)
+            .build();
+
+        let runtime = self
+            .inner
+            .platform_definition(platform_definition)
+            .session_file_system_factory_context(SessionFileSystemFactoryContext::new())
+            .backends(local.runtime_backends.clone())
+            .build()
+            .await?;
+
+        Ok((runtime, local))
+    }
+}

--- a/crates/local/src/schedule_store.rs
+++ b/crates/local/src/schedule_store.rs
@@ -1,0 +1,282 @@
+// SQLite-backed SessionScheduleStore, org + session scoped.
+//
+// Metadata round-trip decision (EVE-594 acceptance criterion):
+// The shared core primitive `everruns_core::session_schedule::SessionSchedule`
+// intentionally has NO open metadata bag, and we do not add one — touching the
+// shared data model is out of scope. Instead, the local store carries a JSON
+// `metadata` column in its OWN schema. An embedder that needs to preserve extra
+// fields (name/color/kind/command/model/isolated, etc.) calls the additive
+// `create_schedule_with_metadata` / `get_metadata` methods on this concrete
+// type. The trait-level `SessionScheduleStore` surface is unchanged, so the
+// runtime act path sees the standard schedule store while embedders keep their
+// extensible bag locally.
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use everruns_core::error::{AgentLoopError, Result};
+use everruns_core::session_schedule::SessionSchedule;
+use everruns_core::traits::SessionScheduleStore;
+use everruns_core::typed_id::{PrincipalId, ScheduleId, SessionId};
+use rusqlite::OptionalExtension;
+use serde_json::Value;
+
+use crate::db::SqliteDb;
+use crate::error::LocalError;
+
+/// SQLite-backed schedule store for local embedded hosts.
+#[derive(Clone)]
+pub struct LocalScheduleStore {
+    db: SqliteDb,
+    /// Internal org id this store instance is scoped to.
+    org_id: i64,
+    /// Principal stamped on created schedules.
+    owner_principal_id: PrincipalId,
+}
+
+impl LocalScheduleStore {
+    /// Open (and migrate) a schedule store over `db`, scoped to `org_id`.
+    pub fn new(db: SqliteDb, org_id: i64, owner_principal_id: PrincipalId) -> Result<Self> {
+        Self::ensure_schema(&db)?;
+        Ok(Self::scoped(db, org_id, owner_principal_id))
+    }
+
+    /// Create the `local_schedules` schema if it does not yet exist. Idempotent.
+    /// The schema is org-agnostic (org scoping is a column), so this only needs
+    /// to run once per database file.
+    fn ensure_schema(db: &SqliteDb) -> Result<()> {
+        db.with_conn(|conn| {
+            conn.execute_batch(
+                "CREATE TABLE IF NOT EXISTS local_schedules (
+                    id          TEXT PRIMARY KEY,
+                    org_id      INTEGER NOT NULL,
+                    session_id  TEXT NOT NULL,
+                    enabled     INTEGER NOT NULL,
+                    snapshot    TEXT NOT NULL,
+                    metadata    TEXT NOT NULL DEFAULT '{}'
+                 );
+                 CREATE INDEX IF NOT EXISTS idx_local_schedules_session
+                    ON local_schedules(org_id, session_id);",
+            )
+        })
+        .map_err(AgentLoopError::from)?;
+        Ok(())
+    }
+
+    /// Construct a store scoped to `org_id` without touching the database.
+    /// Callers must have already ensured the schema exists (via [`Self::new`]);
+    /// this keeps the per-(org) factory on the act path cheap and infallible.
+    pub(crate) fn scoped(db: SqliteDb, org_id: i64, owner_principal_id: PrincipalId) -> Self {
+        Self {
+            db,
+            org_id,
+            owner_principal_id,
+        }
+    }
+
+    fn build_schedule(
+        &self,
+        session_id: SessionId,
+        description: String,
+        cron_expression: Option<String>,
+        scheduled_at: Option<DateTime<Utc>>,
+        timezone: String,
+    ) -> SessionSchedule {
+        let now = Utc::now();
+        SessionSchedule {
+            id: ScheduleId::new(),
+            session_id,
+            owner_principal_id: self.owner_principal_id,
+            resolved_owner_user_id: None,
+            owner: None,
+            effective_owner: None,
+            description,
+            cron_expression: cron_expression.clone(),
+            scheduled_at,
+            timezone,
+            enabled: true,
+            schedule_type: SessionSchedule::derive_type(&cron_expression),
+            next_trigger_at: scheduled_at,
+            last_triggered_at: None,
+            trigger_count: 0,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    fn insert(&self, schedule: &SessionSchedule, metadata: &Value) -> Result<()> {
+        let snapshot = serde_json::to_string(schedule)
+            .map_err(|e| AgentLoopError::from(LocalError::from(e)))?;
+        let metadata_json = serde_json::to_string(metadata)
+            .map_err(|e| AgentLoopError::from(LocalError::from(e)))?;
+        let id = schedule.id.to_string();
+        let session = schedule.session_id.to_string();
+        let enabled = schedule.enabled as i64;
+        let org_id = self.org_id;
+        self.db
+            .with_conn(|conn| {
+                conn.execute(
+                    "INSERT INTO local_schedules (id, org_id, session_id, enabled, snapshot, metadata)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+                     ON CONFLICT(id) DO UPDATE SET
+                        enabled = excluded.enabled,
+                        snapshot = excluded.snapshot,
+                        metadata = excluded.metadata",
+                    rusqlite::params![id, org_id, session, enabled, snapshot, metadata_json],
+                )
+            })
+            .map_err(AgentLoopError::from)?;
+        Ok(())
+    }
+
+    fn load(&self, schedule_id: ScheduleId) -> Result<Option<SessionSchedule>> {
+        let id = schedule_id.to_string();
+        let org_id = self.org_id;
+        let snapshot: Option<String> = self
+            .db
+            .with_conn(|conn| {
+                conn.query_row(
+                    "SELECT snapshot FROM local_schedules WHERE id = ?1 AND org_id = ?2",
+                    rusqlite::params![id, org_id],
+                    |row| row.get(0),
+                )
+                .optional()
+            })
+            .map_err(AgentLoopError::from)?;
+        match snapshot {
+            Some(json) => Ok(Some(
+                serde_json::from_str(&json)
+                    .map_err(|e| AgentLoopError::from(LocalError::from(e)))?,
+            )),
+            None => Ok(None),
+        }
+    }
+
+    /// Create a schedule and persist caller-supplied extra fields in the local
+    /// `metadata` column. This is the additive seam that satisfies the
+    /// "extensible metadata bag" criterion without changing the core primitive.
+    pub async fn create_schedule_with_metadata(
+        &self,
+        session_id: SessionId,
+        description: String,
+        cron_expression: Option<String>,
+        scheduled_at: Option<DateTime<Utc>>,
+        timezone: String,
+        metadata: Value,
+    ) -> Result<SessionSchedule> {
+        let schedule = self.build_schedule(
+            session_id,
+            description,
+            cron_expression,
+            scheduled_at,
+            timezone,
+        );
+        self.insert(&schedule, &metadata)?;
+        Ok(schedule)
+    }
+
+    /// Read back the metadata bag previously stored for a schedule. Returns
+    /// `None` when the schedule does not exist in this org scope.
+    pub async fn get_metadata(&self, schedule_id: ScheduleId) -> Result<Option<Value>> {
+        let id = schedule_id.to_string();
+        let org_id = self.org_id;
+        let metadata: Option<String> = self
+            .db
+            .with_conn(|conn| {
+                conn.query_row(
+                    "SELECT metadata FROM local_schedules WHERE id = ?1 AND org_id = ?2",
+                    rusqlite::params![id, org_id],
+                    |row| row.get(0),
+                )
+                .optional()
+            })
+            .map_err(AgentLoopError::from)?;
+        match metadata {
+            Some(json) => Ok(Some(
+                serde_json::from_str(&json)
+                    .map_err(|e| AgentLoopError::from(LocalError::from(e)))?,
+            )),
+            None => Ok(None),
+        }
+    }
+}
+
+#[async_trait]
+impl SessionScheduleStore for LocalScheduleStore {
+    async fn create_schedule(
+        &self,
+        session_id: SessionId,
+        description: String,
+        cron_expression: Option<String>,
+        scheduled_at: Option<DateTime<Utc>>,
+        timezone: String,
+    ) -> Result<SessionSchedule> {
+        // Trait path: empty metadata bag.
+        self.create_schedule_with_metadata(
+            session_id,
+            description,
+            cron_expression,
+            scheduled_at,
+            timezone,
+            Value::Object(Default::default()),
+        )
+        .await
+    }
+
+    async fn cancel_schedule(
+        &self,
+        _session_id: SessionId,
+        schedule_id: ScheduleId,
+    ) -> Result<SessionSchedule> {
+        let mut schedule = self
+            .load(schedule_id)?
+            .ok_or_else(|| AgentLoopError::tool("schedule not found".to_string()))?;
+        schedule.enabled = false;
+        schedule.updated_at = Utc::now();
+        // Preserve existing metadata across the snapshot rewrite.
+        let metadata = self
+            .get_metadata(schedule_id)
+            .await?
+            .unwrap_or_else(|| Value::Object(Default::default()));
+        self.insert(&schedule, &metadata)?;
+        Ok(schedule)
+    }
+
+    async fn list_schedules(&self, session_id: SessionId) -> Result<Vec<SessionSchedule>> {
+        let session = session_id.to_string();
+        let org_id = self.org_id;
+        let snapshots: Vec<String> = self
+            .db
+            .with_conn(|conn| {
+                let mut stmt = conn.prepare(
+                    "SELECT snapshot FROM local_schedules
+                     WHERE org_id = ?1 AND session_id = ?2 ORDER BY rowid ASC",
+                )?;
+                stmt.query_map(rusqlite::params![org_id, session], |row| row.get(0))?
+                    .collect::<rusqlite::Result<Vec<String>>>()
+            })
+            .map_err(AgentLoopError::from)?;
+        snapshots
+            .into_iter()
+            .map(|json| {
+                serde_json::from_str(&json).map_err(|e| AgentLoopError::from(LocalError::from(e)))
+            })
+            .collect()
+    }
+
+    async fn count_active_schedules(&self, session_id: SessionId) -> Result<u32> {
+        let session = session_id.to_string();
+        let org_id = self.org_id;
+        let count: i64 = self
+            .db
+            .with_conn(|conn| {
+                conn.query_row(
+                    "SELECT COUNT(*) FROM local_schedules
+                     WHERE org_id = ?1 AND session_id = ?2 AND enabled = 1",
+                    rusqlite::params![org_id, session],
+                    |row| row.get(0),
+                )
+            })
+            .map_err(AgentLoopError::from)?;
+        Ok(count as u32)
+    }
+}

--- a/crates/local/src/task_registry.rs
+++ b/crates/local/src/task_registry.rs
@@ -1,0 +1,339 @@
+// SQLite-backed SessionTaskRegistry.
+//
+// Persists tasks and their message channel so a freshly-spawned process can
+// reopen the database file and read / continue / inspect tasks
+// (restart-survivability). Lifecycle invariants are NOT reimplemented here:
+// every update routes through `everruns_core::session_task::apply_task_update`,
+// matching the postgres / in-memory backends.
+//
+// Storage shape: one `local_tasks` row per task. The full `SessionTask` is
+// stored as a JSON snapshot for faithful round-tripping; `session_id`, `kind`,
+// and `state` are also stored as plain columns so `SessionTaskFilter` queries
+// hit an index instead of deserializing every row. Messages live in
+// `local_task_messages`, ordered by an autoincrement `seq` to give a stable
+// oldest-first order and a cheap `after_id` cursor.
+
+use async_trait::async_trait;
+use chrono::Utc;
+use everruns_core::error::{AgentLoopError, Result};
+use everruns_core::session_task::{
+    CreateSessionTask, NewTaskMessage, SessionTask, SessionTaskFilter, SessionTaskRegistry,
+    SessionTaskUpdate, TaskMessage, apply_task_update, generate_task_message_id, new_session_task,
+};
+use everruns_core::typed_id::SessionId;
+use rusqlite::OptionalExtension;
+
+use crate::db::SqliteDb;
+use crate::error::LocalError;
+
+/// SQLite-backed task registry for local embedded hosts.
+#[derive(Clone)]
+pub struct LocalSessionTaskRegistry {
+    db: SqliteDb,
+}
+
+impl LocalSessionTaskRegistry {
+    /// Open (and migrate) a registry over the given database handle.
+    pub fn new(db: SqliteDb) -> Result<Self> {
+        db.with_conn(|conn| {
+            conn.execute_batch(
+                "CREATE TABLE IF NOT EXISTS local_tasks (
+                    id          TEXT PRIMARY KEY,
+                    session_id  TEXT NOT NULL,
+                    kind        TEXT NOT NULL,
+                    state       TEXT NOT NULL,
+                    snapshot    TEXT NOT NULL
+                 );
+                 CREATE INDEX IF NOT EXISTS idx_local_tasks_session
+                    ON local_tasks(session_id);
+                 CREATE TABLE IF NOT EXISTS local_task_messages (
+                    seq         INTEGER PRIMARY KEY AUTOINCREMENT,
+                    id          TEXT NOT NULL UNIQUE,
+                    task_id     TEXT NOT NULL,
+                    snapshot    TEXT NOT NULL,
+                    FOREIGN KEY(task_id) REFERENCES local_tasks(id)
+                 );
+                 CREATE INDEX IF NOT EXISTS idx_local_task_messages_task
+                    ON local_task_messages(task_id, seq);",
+            )
+        })
+        .map_err(AgentLoopError::from)?;
+        Ok(Self { db })
+    }
+
+    fn load_task(&self, task_id: &str) -> Result<Option<SessionTask>> {
+        let snapshot: Option<String> = self
+            .db
+            .with_conn(|conn| {
+                conn.query_row(
+                    "SELECT snapshot FROM local_tasks WHERE id = ?1",
+                    [task_id],
+                    |row| row.get(0),
+                )
+                .optional()
+            })
+            .map_err(AgentLoopError::from)?;
+        match snapshot {
+            Some(json) => Ok(Some(
+                serde_json::from_str(&json)
+                    .map_err(|e| AgentLoopError::from(LocalError::from(e)))?,
+            )),
+            None => Ok(None),
+        }
+    }
+
+    fn store_task(&self, task: &SessionTask) -> Result<()> {
+        let snapshot =
+            serde_json::to_string(task).map_err(|e| AgentLoopError::from(LocalError::from(e)))?;
+        let id = task.id.clone();
+        let session_id = task.session_id.to_string();
+        let kind = task.kind.clone();
+        let state = task.state.to_string();
+        self.db
+            .with_conn(|conn| {
+                conn.execute(
+                    "INSERT INTO local_tasks (id, session_id, kind, state, snapshot)
+                     VALUES (?1, ?2, ?3, ?4, ?5)
+                     ON CONFLICT(id) DO UPDATE SET
+                        session_id = excluded.session_id,
+                        kind = excluded.kind,
+                        state = excluded.state,
+                        snapshot = excluded.snapshot",
+                    rusqlite::params![id, session_id, kind, state, snapshot],
+                )
+            })
+            .map_err(AgentLoopError::from)?;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl SessionTaskRegistry for LocalSessionTaskRegistry {
+    async fn create(&self, input: CreateSessionTask) -> Result<SessionTask> {
+        // Idempotent on a caller-supplied id: return the stored task unchanged.
+        if let Some(id) = &input.id
+            && let Some(existing) = self.load_task(id)?
+        {
+            return Ok(existing);
+        }
+        let task = new_session_task(input, Utc::now());
+        self.store_task(&task)?;
+        Ok(task)
+    }
+
+    async fn update(
+        &self,
+        _session_id: SessionId,
+        task_id: &str,
+        update: SessionTaskUpdate,
+    ) -> Result<Option<SessionTask>> {
+        let Some(mut task) = self.load_task(task_id)? else {
+            return Ok(None);
+        };
+        apply_task_update(&mut task, update, Utc::now());
+        self.store_task(&task)?;
+        Ok(Some(task))
+    }
+
+    async fn get(&self, _session_id: SessionId, task_id: &str) -> Result<Option<SessionTask>> {
+        self.load_task(task_id)
+    }
+
+    async fn list(
+        &self,
+        session_id: SessionId,
+        filter: Option<&SessionTaskFilter>,
+    ) -> Result<Vec<SessionTask>> {
+        let session = session_id.to_string();
+        let kind = filter.and_then(|f| f.kind.clone());
+        let state = filter.and_then(|f| f.state.map(|s| s.to_string()));
+        let snapshots: Vec<String> = self
+            .db
+            .with_conn(|conn| {
+                // Build the query with optional kind/state predicates. Bind
+                // params positionally to keep the prepared statement simple.
+                let mut sql =
+                    String::from("SELECT snapshot FROM local_tasks WHERE session_id = ?1");
+                if kind.is_some() {
+                    sql.push_str(" AND kind = ?2");
+                }
+                if state.is_some() {
+                    // ?3 if kind present, else ?2 — rusqlite positional binding
+                    // tolerates gaps, so always use ?3 and bind kind as NULL
+                    // when absent is not possible; instead branch explicitly.
+                    sql.push_str(if kind.is_some() {
+                        " AND state = ?3"
+                    } else {
+                        " AND state = ?2"
+                    });
+                }
+                sql.push_str(" ORDER BY rowid ASC");
+
+                let mut stmt = conn.prepare(&sql)?;
+                let rows = match (&kind, &state) {
+                    (Some(k), Some(s)) => stmt
+                        .query_map(rusqlite::params![session, k, s], |row| row.get(0))?
+                        .collect::<rusqlite::Result<Vec<String>>>()?,
+                    (Some(k), None) => stmt
+                        .query_map(rusqlite::params![session, k], |row| row.get(0))?
+                        .collect::<rusqlite::Result<Vec<String>>>()?,
+                    (None, Some(s)) => stmt
+                        .query_map(rusqlite::params![session, s], |row| row.get(0))?
+                        .collect::<rusqlite::Result<Vec<String>>>()?,
+                    (None, None) => stmt
+                        .query_map(rusqlite::params![session], |row| row.get(0))?
+                        .collect::<rusqlite::Result<Vec<String>>>()?,
+                };
+                Ok(rows)
+            })
+            .map_err(AgentLoopError::from)?;
+        snapshots
+            .into_iter()
+            .map(|json| {
+                serde_json::from_str(&json).map_err(|e| AgentLoopError::from(LocalError::from(e)))
+            })
+            .collect()
+    }
+
+    async fn request_cancel(
+        &self,
+        _session_id: SessionId,
+        task_id: &str,
+    ) -> Result<Option<SessionTask>> {
+        let Some(mut task) = self.load_task(task_id)? else {
+            return Ok(None);
+        };
+        // Cooperative cancel: record intent, do not change state. Idempotent.
+        task.cancel_requested_at.get_or_insert_with(Utc::now);
+        task.updated_at = Utc::now();
+        self.store_task(&task)?;
+        Ok(Some(task))
+    }
+
+    async fn record_message(
+        &self,
+        _session_id: SessionId,
+        task_id: &str,
+        message: NewTaskMessage,
+    ) -> Result<TaskMessage> {
+        // Stale-attempt fence: reject writes from a superseded executor so the
+        // thread cannot grow under a zombie. Mirrors the postgres backend.
+        let mut task = self
+            .load_task(task_id)?
+            .ok_or_else(|| AgentLoopError::tool(format!("no task {task_id}")))?;
+        if let Some(expected) = message.expected_attempt
+            && expected != task.attempt
+        {
+            return Err(AgentLoopError::tool(format!(
+                "stale attempt for task {task_id}: expected {expected}, current {}",
+                task.attempt
+            )));
+        }
+
+        let record = TaskMessage {
+            id: generate_task_message_id(),
+            task_id: task_id.to_string(),
+            direction: message.direction,
+            content: message.content,
+            in_reply_to: message.in_reply_to.clone(),
+            created_at: Utc::now(),
+        };
+        let snapshot = serde_json::to_string(&record)
+            .map_err(|e| AgentLoopError::from(LocalError::from(e)))?;
+        let id = record.id.clone();
+        let tid = task_id.to_string();
+        self.db
+            .with_conn(|conn| {
+                conn.execute(
+                    "INSERT INTO local_task_messages (id, task_id, snapshot)
+                     VALUES (?1, ?2, ?3)",
+                    rusqlite::params![id, tid, snapshot],
+                )
+            })
+            .map_err(AgentLoopError::from)?;
+
+        // Answering messages (in_reply_to set) clear a matching pending input
+        // request and return the task to running, matching the trait contract.
+        if let Some(reply_id) = &message.in_reply_to
+            && task
+                .input_request
+                .as_ref()
+                .is_some_and(|req| &req.id == reply_id)
+        {
+            apply_task_update(
+                &mut task,
+                SessionTaskUpdate {
+                    state: Some(everruns_core::session_task::SessionTaskState::Running),
+                    ..Default::default()
+                },
+                Utc::now(),
+            );
+            self.store_task(&task)?;
+        }
+
+        Ok(record)
+    }
+
+    async fn list_messages(
+        &self,
+        _session_id: SessionId,
+        task_id: &str,
+        limit: Option<u32>,
+        after_id: Option<&str>,
+    ) -> Result<Vec<TaskMessage>> {
+        let tid = task_id.to_string();
+        let after = after_id.map(|s| s.to_string());
+        let limit = limit.map(|l| l as i64);
+        let snapshots: Vec<String> = self
+            .db
+            .with_conn(|conn| {
+                // Resolve the exclusive cursor seq, if any.
+                let after_seq: Option<i64> = match &after {
+                    Some(id) => conn
+                        .query_row(
+                            "SELECT seq FROM local_task_messages WHERE id = ?1",
+                            [id],
+                            |row| row.get(0),
+                        )
+                        .optional()?,
+                    None => None,
+                };
+                let mut sql =
+                    String::from("SELECT snapshot FROM local_task_messages WHERE task_id = ?1");
+                if after_seq.is_some() {
+                    sql.push_str(" AND seq > ?2");
+                }
+                sql.push_str(" ORDER BY seq ASC");
+                if limit.is_some() {
+                    sql.push_str(if after_seq.is_some() {
+                        " LIMIT ?3"
+                    } else {
+                        " LIMIT ?2"
+                    });
+                }
+                let mut stmt = conn.prepare(&sql)?;
+                let rows = match (after_seq, limit) {
+                    (Some(seq), Some(lim)) => stmt
+                        .query_map(rusqlite::params![tid, seq, lim], |row| row.get(0))?
+                        .collect::<rusqlite::Result<Vec<String>>>()?,
+                    (Some(seq), None) => stmt
+                        .query_map(rusqlite::params![tid, seq], |row| row.get(0))?
+                        .collect::<rusqlite::Result<Vec<String>>>()?,
+                    (None, Some(lim)) => stmt
+                        .query_map(rusqlite::params![tid, lim], |row| row.get(0))?
+                        .collect::<rusqlite::Result<Vec<String>>>()?,
+                    (None, None) => stmt
+                        .query_map(rusqlite::params![tid], |row| row.get(0))?
+                        .collect::<rusqlite::Result<Vec<String>>>()?,
+                };
+                Ok(rows)
+            })
+            .map_err(AgentLoopError::from)?;
+        snapshots
+            .into_iter()
+            .map(|json| {
+                serde_json::from_str(&json).map_err(|e| AgentLoopError::from(LocalError::from(e)))
+            })
+            .collect()
+    }
+}

--- a/crates/local/src/task_registry.rs
+++ b/crates/local/src/task_registry.rs
@@ -18,7 +18,8 @@ use chrono::Utc;
 use everruns_core::error::{AgentLoopError, Result};
 use everruns_core::session_task::{
     CreateSessionTask, NewTaskMessage, SessionTask, SessionTaskFilter, SessionTaskRegistry,
-    SessionTaskUpdate, TaskMessage, apply_task_update, generate_task_message_id, new_session_task,
+    SessionTaskState, SessionTaskUpdate, TaskMessage, TaskMessageDirection, apply_task_update,
+    generate_task_message_id, new_session_task,
 };
 use everruns_core::typed_id::SessionId;
 use rusqlite::OptionalExtension;
@@ -110,11 +111,18 @@ impl LocalSessionTaskRegistry {
 #[async_trait]
 impl SessionTaskRegistry for LocalSessionTaskRegistry {
     async fn create(&self, input: CreateSessionTask) -> Result<SessionTask> {
-        // Idempotent on a caller-supplied id: return the stored task unchanged.
+        // Idempotent on a caller-supplied id, but only within the same session.
+        // Reusing an id across sessions is rejected, matching the canonical
+        // DB-backed registry, so a caller cannot alias another session's task.
         if let Some(id) = &input.id
             && let Some(existing) = self.load_task(id)?
         {
-            return Ok(existing);
+            if existing.session_id == input.session_id {
+                return Ok(existing);
+            }
+            return Err(AgentLoopError::store(format!(
+                "task id {id} already exists under a different session"
+            )));
         }
         let task = new_session_task(input, Utc::now());
         self.store_task(&task)?;
@@ -123,20 +131,27 @@ impl SessionTaskRegistry for LocalSessionTaskRegistry {
 
     async fn update(
         &self,
-        _session_id: SessionId,
+        session_id: SessionId,
         task_id: &str,
         update: SessionTaskUpdate,
     ) -> Result<Option<SessionTask>> {
         let Some(mut task) = self.load_task(task_id)? else {
             return Ok(None);
         };
+        // Session-scoped: ignore updates targeting a task in another session.
+        if task.session_id != session_id {
+            return Ok(None);
+        }
         apply_task_update(&mut task, update, Utc::now());
         self.store_task(&task)?;
         Ok(Some(task))
     }
 
-    async fn get(&self, _session_id: SessionId, task_id: &str) -> Result<Option<SessionTask>> {
-        self.load_task(task_id)
+    async fn get(&self, session_id: SessionId, task_id: &str) -> Result<Option<SessionTask>> {
+        // Session-scoped: a task id from another session is not visible here.
+        Ok(self
+            .load_task(task_id)?
+            .filter(|task| task.session_id == session_id))
     }
 
     async fn list(
@@ -197,12 +212,16 @@ impl SessionTaskRegistry for LocalSessionTaskRegistry {
 
     async fn request_cancel(
         &self,
-        _session_id: SessionId,
+        session_id: SessionId,
         task_id: &str,
     ) -> Result<Option<SessionTask>> {
         let Some(mut task) = self.load_task(task_id)? else {
             return Ok(None);
         };
+        // Session-scoped: do not record cancel intent on another session's task.
+        if task.session_id != session_id {
+            return Ok(None);
+        }
         // Cooperative cancel: record intent, do not change state. Idempotent.
         task.cancel_requested_at.get_or_insert_with(Utc::now);
         task.updated_at = Utc::now();
@@ -212,15 +231,18 @@ impl SessionTaskRegistry for LocalSessionTaskRegistry {
 
     async fn record_message(
         &self,
-        _session_id: SessionId,
+        session_id: SessionId,
         task_id: &str,
         message: NewTaskMessage,
     ) -> Result<TaskMessage> {
+        // Session-scoped: a message may only be appended to a task that belongs
+        // to the calling session (mirrors the DB-backed registry).
+        let mut task = self
+            .get(session_id, task_id)
+            .await?
+            .ok_or_else(|| AgentLoopError::tool(format!("no task {task_id}")))?;
         // Stale-attempt fence: reject writes from a superseded executor so the
         // thread cannot grow under a zombie. Mirrors the postgres backend.
-        let mut task = self
-            .load_task(task_id)?
-            .ok_or_else(|| AgentLoopError::tool(format!("no task {task_id}")))?;
         if let Some(expected) = message.expected_attempt
             && expected != task.attempt
         {
@@ -252,9 +274,11 @@ impl SessionTaskRegistry for LocalSessionTaskRegistry {
             })
             .map_err(AgentLoopError::from)?;
 
-        // Answering messages (in_reply_to set) clear a matching pending input
-        // request and return the task to running, matching the trait contract.
-        if let Some(reply_id) = &message.in_reply_to
+        // An inbound answer (in_reply_to set) clears a matching pending input
+        // request and returns the task to running. Only inbound messages resume
+        // the task, matching the DB-backed registry; outbound messages never do.
+        if message.direction == TaskMessageDirection::Inbound
+            && let Some(reply_id) = &message.in_reply_to
             && task
                 .input_request
                 .as_ref()
@@ -263,7 +287,7 @@ impl SessionTaskRegistry for LocalSessionTaskRegistry {
             apply_task_update(
                 &mut task,
                 SessionTaskUpdate {
-                    state: Some(everruns_core::session_task::SessionTaskState::Running),
+                    state: Some(SessionTaskState::Running),
                     ..Default::default()
                 },
                 Utc::now(),
@@ -276,11 +300,16 @@ impl SessionTaskRegistry for LocalSessionTaskRegistry {
 
     async fn list_messages(
         &self,
-        _session_id: SessionId,
+        session_id: SessionId,
         task_id: &str,
         limit: Option<u32>,
         after_id: Option<&str>,
     ) -> Result<Vec<TaskMessage>> {
+        // Session-scoped: do not leak another session's message history even
+        // when the task id is known. Missing/foreign task -> empty list.
+        if self.get(session_id, task_id).await?.is_none() {
+            return Ok(Vec::new());
+        }
         let tid = task_id.to_string();
         let after = after_id.map(|s| s.to_string());
         let limit = limit.map(|l| l as i64);

--- a/crates/local/tests/composability_and_seam_test.rs
+++ b/crates/local/tests/composability_and_seam_test.rs
@@ -1,0 +1,274 @@
+// Composability: caller-supplied event bus + custom SessionFileSystemFactory
+// are used by the runtime. Seam: an InProcessRuntime built from LocalBackends
+// exposes the injected task registry / schedule store through the
+// RuntimeHostAdapter, and a task lifecycle round-trips through the registry.
+//
+// Embedded smoke test: drive a real turn through a runtime wired from
+// LocalBackends with an llmsim + a test math capability, proving the local
+// stores compose into a working in-process runtime.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use async_trait::async_trait;
+use everruns_core::capabilities::TestMathCapability;
+use everruns_core::driver_registry::DriverRegistry;
+use everruns_core::events::{Event, EventRequest};
+use everruns_core::llmsim_driver::LlmSimConfig;
+use everruns_core::session_task::{
+    CreateSessionTask, SessionTaskState, SessionTaskUpdate, TASK_KIND_BACKGROUND_TOOL, TaskLinks,
+    TaskWakePolicy,
+};
+use everruns_core::traits::{
+    EventEmitter, SessionFileSystem, SessionFileSystemFactory, SessionFileSystemFactoryContext,
+};
+use everruns_core::{
+    CapabilityRegistry, DriverId, InputMessage, PlatformDefinition, ResolvedModel, ToolCall,
+};
+use everruns_local::{LocalBackends, LocalProfile, SqliteDb};
+use everruns_runtime::{
+    AgentBuilder, EventBus, HarnessBuilder, InProcessRuntimeBuilder, RealDiskFileStore,
+    RuntimeBackends, RuntimeHostAdapter, SessionBuilder,
+};
+
+// ---- Caller-supplied event bus decorator ----------------------------------
+
+#[derive(Default)]
+struct CountingEventBus {
+    inner: everruns_core::in_memory::InMemoryEventEmitter,
+    count: AtomicUsize,
+}
+
+#[async_trait]
+impl EventEmitter for CountingEventBus {
+    async fn emit(&self, request: EventRequest) -> everruns_core::Result<Event> {
+        self.count.fetch_add(1, Ordering::SeqCst);
+        self.inner.emit(request).await
+    }
+}
+
+#[async_trait]
+impl EventBus for CountingEventBus {
+    async fn collected_events(&self) -> Vec<Event> {
+        self.inner.events().await
+    }
+}
+
+// ---- Custom SessionFileSystemFactory ---------------------------------------
+
+#[derive(Debug)]
+struct FlaggingFactory {
+    root: std::path::PathBuf,
+    used: Arc<std::sync::atomic::AtomicBool>,
+}
+
+#[async_trait]
+impl SessionFileSystemFactory for FlaggingFactory {
+    fn name(&self) -> &'static str {
+        "FlaggingFactory"
+    }
+    async fn create_session_file_system(
+        &self,
+        _context: SessionFileSystemFactoryContext,
+    ) -> everruns_core::Result<Arc<dyn SessionFileSystem>> {
+        self.used.store(true, Ordering::SeqCst);
+        Ok(Arc::new(RealDiskFileStore::new(self.root.clone())?))
+    }
+}
+
+fn ids() -> (
+    everruns_core::HarnessId,
+    everruns_core::AgentId,
+    everruns_core::SessionId,
+) {
+    (
+        "harness_00000000000000000000000000000091".parse().unwrap(),
+        "agent_00000000000000000000000000000091".parse().unwrap(),
+        "session_00000000000000000000000000000091".parse().unwrap(),
+    )
+}
+
+#[tokio::test]
+async fn embedder_bus_and_fs_factory_are_used() {
+    let (harness_id, agent_id, session_id) = ids();
+    let workspace = tempfile::tempdir().unwrap();
+    let data = tempfile::tempdir().unwrap();
+
+    let bus: Arc<dyn EventBus> = Arc::new(CountingEventBus::default());
+    let count_handle = bus.clone();
+    let fs_used = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let factory = Arc::new(FlaggingFactory {
+        root: workspace.path().to_path_buf(),
+        used: fs_used.clone(),
+    });
+
+    // Composable: pass our own bus on the runtime backends, our own FS factory
+    // on the platform definition. LocalBackends only adds the local stores.
+    let runtime_backends = RuntimeBackends::in_memory().with_event_bus(bus.clone());
+    let profile = LocalProfile::new(data.path()).with_workspace_root(workspace.path());
+    let local = LocalBackends::with_db(
+        profile,
+        runtime_backends,
+        SqliteDb::open_in_memory().unwrap(),
+    )
+    .unwrap();
+
+    let mut caps = CapabilityRegistry::new();
+    caps.register(TestMathCapability);
+    let platform = PlatformDefinition::builder()
+        .capability_registry(caps)
+        .driver_registry(DriverRegistry::new())
+        .session_file_system_factory(factory)
+        .build();
+
+    let runtime = InProcessRuntimeBuilder::new()
+        .platform_definition(platform)
+        .backends(local.runtime_backends.clone())
+        .llm_sim(
+            LlmSimConfig::fixed("Let me calculate.").with_tool_call_sequence(vec![
+                vec![ToolCall {
+                    id: "call_mul".into(),
+                    name: "multiply".into(),
+                    arguments: serde_json::json!({"a": 6, "b": 7}),
+                }],
+                vec![],
+            ]),
+        )
+        .harness(
+            HarnessBuilder::new("math", "You are a math assistant.")
+                .id(harness_id)
+                .capability("test_math")
+                .build(),
+        )
+        .agent(
+            AgentBuilder::new("math-agent", "Use tools.")
+                .id(agent_id)
+                .max_iterations(8)
+                .build(),
+        )
+        .session(
+            SessionBuilder::new(harness_id)
+                .id(session_id)
+                .agent(agent_id)
+                .build(),
+        )
+        .build()
+        .await
+        .unwrap();
+
+    // Seam: the adapter returns the injected stores (not None).
+    assert!(
+        runtime.session_task_registry().is_some(),
+        "injected task registry must be visible via the adapter"
+    );
+    assert!(
+        runtime.schedule_store(local.org_id()).is_some(),
+        "injected schedule store must be visible via the adapter"
+    );
+
+    // Embedded smoke test: drive a real turn.
+    let result = runtime
+        .run_turn(session_id, InputMessage::user("What is 6 * 7?"))
+        .await
+        .unwrap();
+    assert!(result.success, "turn should succeed");
+
+    assert!(fs_used.load(Ordering::SeqCst), "custom FS factory was used");
+    // Downcast not needed: collected_events proves our bus saw the turn events.
+    let collected = count_handle.collected_events().await;
+    assert!(!collected.is_empty(), "caller bus collected turn events");
+}
+
+#[tokio::test]
+async fn seam_task_lifecycle_round_trips_through_injected_registry() {
+    // Build the runtime via LocalBackends and exercise the registry returned by
+    // the adapter — proving the same store the act path receives is reachable.
+    let runtime_backends = RuntimeBackends::in_memory();
+    let local = LocalBackends::with_db(
+        LocalProfile::default(),
+        runtime_backends,
+        SqliteDb::open_in_memory().unwrap(),
+    )
+    .unwrap();
+
+    let (harness_id, agent_id, session_id) = ids();
+    let mut caps = CapabilityRegistry::new();
+    caps.register(TestMathCapability);
+    let platform = PlatformDefinition::new(caps, DriverRegistry::new());
+
+    let runtime = InProcessRuntimeBuilder::new()
+        .platform_definition(platform)
+        .backends(local.runtime_backends.clone())
+        .default_model(ResolvedModel {
+            model: "llmsim-model".into(),
+            provider_type: DriverId::LlmSim,
+            api_key: Some("fake-key".into()),
+            base_url: None,
+            provider_metadata: None,
+        })
+        .llm_sim(LlmSimConfig::fixed("ok"))
+        .harness(HarnessBuilder::new("h", "p").id(harness_id).build())
+        .agent(AgentBuilder::new("a", "p").id(agent_id).build())
+        .session(
+            SessionBuilder::new(harness_id)
+                .id(session_id)
+                .agent(agent_id)
+                .build(),
+        )
+        .build()
+        .await
+        .unwrap();
+
+    let registry = runtime.session_task_registry().expect("registry injected");
+
+    let task = registry
+        .create(CreateSessionTask {
+            session_id,
+            id: None,
+            kind: TASK_KIND_BACKGROUND_TOOL.to_string(),
+            display_name: "seam task".to_string(),
+            spec: serde_json::json!({}),
+            state: SessionTaskState::Queued,
+            links: TaskLinks::default(),
+            wake_policy: TaskWakePolicy::Silent,
+        })
+        .await
+        .unwrap();
+
+    let done = registry
+        .update(
+            session_id,
+            &task.id,
+            SessionTaskUpdate {
+                state: Some(SessionTaskState::Succeeded),
+                summary: Some("seam ok".to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(done.state, SessionTaskState::Succeeded);
+
+    // The schedule store from the adapter is the same SQLite-backed store.
+    let schedule_store = runtime
+        .schedule_store(local.org_id())
+        .expect("schedule store");
+    schedule_store
+        .create_schedule(
+            session_id,
+            "seam schedule".to_string(),
+            None,
+            Some(chrono::Utc::now()),
+            "UTC".to_string(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        schedule_store
+            .count_active_schedules(session_id)
+            .await
+            .unwrap(),
+        1
+    );
+}

--- a/crates/local/tests/platform_store_test.rs
+++ b/crates/local/tests/platform_store_test.rs
@@ -1,0 +1,108 @@
+// LocalPlatformStore: honest subagent core vs explicit Unsupported.
+
+use async_trait::async_trait;
+use everruns_core::error::Result;
+use everruns_core::platform_store::{PlatformMessage, PlatformStore};
+use everruns_core::session::Session;
+use everruns_core::typed_id::{AgentId, HarnessId, SessionId};
+use everruns_local::{LocalPlatformStore, LocalSessionRunner};
+use std::sync::Arc;
+use std::sync::Mutex;
+
+#[derive(Default)]
+struct FakeRunner {
+    sent: Mutex<Vec<(SessionId, String)>>,
+}
+
+#[async_trait]
+impl LocalSessionRunner for FakeRunner {
+    async fn create_session(
+        &self,
+        harness_id: HarnessId,
+        agent_id: Option<AgentId>,
+        title: Option<&str>,
+        _locale: Option<&str>,
+        parent_session_id: Option<SessionId>,
+    ) -> Result<Session> {
+        let id = SessionId::new();
+        let mut s = everruns_runtime::SessionBuilder::new(harness_id)
+            .id(id)
+            .title(title.unwrap_or("child"))
+            .build();
+        s.agent_id = agent_id;
+        s.parent_session_id = parent_session_id;
+        Ok(s)
+    }
+
+    async fn send_message(&self, session_id: SessionId, content: &str) -> Result<()> {
+        self.sent
+            .lock()
+            .unwrap()
+            .push((session_id, content.to_string()));
+        Ok(())
+    }
+
+    async fn list_sessions(
+        &self,
+        _limit: Option<usize>,
+        _agent_id: Option<AgentId>,
+    ) -> Result<Vec<Session>> {
+        Ok(vec![])
+    }
+
+    async fn get_session(&self, _session_id: SessionId) -> Result<Option<Session>> {
+        Ok(None)
+    }
+
+    async fn get_messages(
+        &self,
+        _session_id: SessionId,
+        _limit: Option<usize>,
+    ) -> Result<Vec<PlatformMessage>> {
+        Ok(vec![PlatformMessage {
+            role: "agent".into(),
+            content: "hi".into(),
+            created_at: chrono::Utc::now(),
+        }])
+    }
+
+    async fn get_session_status(&self, _session_id: SessionId) -> Result<Option<String>> {
+        Ok(Some("idle".to_string()))
+    }
+}
+
+fn store() -> LocalPlatformStore {
+    LocalPlatformStore::new(Arc::new(FakeRunner::default()), "http://localhost:9300")
+}
+
+#[tokio::test]
+async fn subagent_core_is_honest() {
+    let store = store();
+    let harness_id = HarnessId::new();
+    let child = store
+        .create_session(harness_id, None, Some("child"), None, None, None, None)
+        .await
+        .unwrap();
+    assert_eq!(child.harness_id, harness_id);
+
+    store.send_message(child.id, "go").await.unwrap();
+    assert_eq!(store.wait_for_idle(child.id, None).await.unwrap(), "idle");
+    assert_eq!(store.get_messages(child.id, None).await.unwrap().len(), 1);
+    assert_eq!(store.base_url(), "http://localhost:9300");
+}
+
+#[tokio::test]
+async fn platform_management_ops_are_unsupported() {
+    let store = store();
+    assert!(store.list_harnesses().await.is_err());
+    assert!(store.list_agents().await.is_err());
+    assert!(store.list_apps(None, false).await.is_err());
+    assert!(store.list_capabilities(None).await.is_err());
+    assert!(store.delete_session(SessionId::new()).await.is_err());
+    assert!(
+        store
+            .create_agent("x", None, None, "prompt", &[])
+            .await
+            .is_err()
+    );
+}

--- a/crates/local/tests/schedule_store_test.rs
+++ b/crates/local/tests/schedule_store_test.rs
@@ -1,0 +1,134 @@
+// Schedule store: metadata round-trip, list, cancel, count_active.
+
+use everruns_core::traits::SessionScheduleStore;
+use everruns_core::typed_id::{PrincipalId, SessionId};
+use everruns_local::{LocalScheduleStore, SqliteDb};
+
+fn store() -> LocalScheduleStore {
+    LocalScheduleStore::new(
+        SqliteDb::open_in_memory().unwrap(),
+        1,
+        PrincipalId::from_seed(1),
+    )
+    .unwrap()
+}
+
+#[tokio::test]
+async fn metadata_round_trips_through_local_column() {
+    let store = store();
+    let session_id = SessionId::new();
+    let metadata = serde_json::json!({
+        "name": "Nightly digest",
+        "color": "#3366ff",
+        "kind": "monitor",
+        "command": "/digest",
+        "model": "llmsim-model",
+        "isolated": true
+    });
+
+    let schedule = store
+        .create_schedule_with_metadata(
+            session_id,
+            "summarize the day".to_string(),
+            Some("0 9 * * *".to_string()),
+            None,
+            "UTC".to_string(),
+            metadata.clone(),
+        )
+        .await
+        .unwrap();
+
+    let read_back = store.get_metadata(schedule.id).await.unwrap().unwrap();
+    assert_eq!(read_back, metadata, "extra fields round-trip verbatim");
+
+    // The core schedule primitive is unchanged (no metadata field on it).
+    assert_eq!(schedule.description, "summarize the day");
+    assert!(schedule.enabled);
+}
+
+#[tokio::test]
+async fn list_cancel_and_count_active() {
+    let store = store();
+    let session_id = SessionId::new();
+    let a = store
+        .create_schedule(
+            session_id,
+            "task a".to_string(),
+            None,
+            Some(chrono::Utc::now()),
+            "UTC".to_string(),
+        )
+        .await
+        .unwrap();
+    let _b = store
+        .create_schedule(
+            session_id,
+            "task b".to_string(),
+            Some("* * * * *".to_string()),
+            None,
+            "UTC".to_string(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(store.list_schedules(session_id).await.unwrap().len(), 2);
+    assert_eq!(store.count_active_schedules(session_id).await.unwrap(), 2);
+
+    let canceled = store.cancel_schedule(session_id, a.id).await.unwrap();
+    assert!(!canceled.enabled);
+    assert_eq!(store.count_active_schedules(session_id).await.unwrap(), 1);
+    // Both still listed; one disabled.
+    assert_eq!(store.list_schedules(session_id).await.unwrap().len(), 2);
+}
+
+#[tokio::test]
+async fn cancel_preserves_metadata() {
+    let store = store();
+    let session_id = SessionId::new();
+    let metadata = serde_json::json!({"name": "keep me"});
+    let schedule = store
+        .create_schedule_with_metadata(
+            session_id,
+            "x".to_string(),
+            None,
+            Some(chrono::Utc::now()),
+            "UTC".to_string(),
+            metadata.clone(),
+        )
+        .await
+        .unwrap();
+    store
+        .cancel_schedule(session_id, schedule.id)
+        .await
+        .unwrap();
+    assert_eq!(
+        store.get_metadata(schedule.id).await.unwrap().unwrap(),
+        metadata,
+        "metadata survives cancel"
+    );
+}
+
+#[tokio::test]
+async fn schedules_are_org_scoped() {
+    let db = SqliteDb::open_in_memory().unwrap();
+    let org1 = LocalScheduleStore::new(db.clone(), 1, PrincipalId::from_seed(1)).unwrap();
+    let org2 = LocalScheduleStore::new(db, 2, PrincipalId::from_seed(1)).unwrap();
+    let session_id = SessionId::new();
+
+    org1.create_schedule(
+        session_id,
+        "org1 task".to_string(),
+        None,
+        Some(chrono::Utc::now()),
+        "UTC".to_string(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(org1.list_schedules(session_id).await.unwrap().len(), 1);
+    assert_eq!(
+        org2.list_schedules(session_id).await.unwrap().len(),
+        0,
+        "org2 must not see org1 schedules"
+    );
+}

--- a/crates/local/tests/task_registry_test.rs
+++ b/crates/local/tests/task_registry_test.rs
@@ -50,6 +50,47 @@ async fn create_is_idempotent_on_supplied_id() {
 }
 
 #[tokio::test]
+async fn create_rejects_id_reuse_across_sessions() {
+    let reg = LocalSessionTaskRegistry::new(SqliteDb::open_in_memory().unwrap()).unwrap();
+    let session_a = SessionId::new();
+    let session_b = SessionId::new();
+
+    let mut input_a = create_input(session_a, TASK_KIND_BACKGROUND_TOOL);
+    input_a.id = Some("task_shared_id".to_string());
+    reg.create(input_a).await.unwrap();
+
+    // Reusing the same id under a different session must be rejected, not
+    // silently aliased to session A's task.
+    let mut input_b = create_input(session_b, TASK_KIND_BACKGROUND_TOOL);
+    input_b.id = Some("task_shared_id".to_string());
+    assert!(
+        reg.create(input_b).await.is_err(),
+        "cross-session id reuse must be rejected"
+    );
+
+    // Lookups are session-scoped: the task is invisible from session B and the
+    // foreign session cannot read its message history.
+    assert!(
+        reg.get(session_b, "task_shared_id")
+            .await
+            .unwrap()
+            .is_none()
+    );
+    assert!(
+        reg.get(session_a, "task_shared_id")
+            .await
+            .unwrap()
+            .is_some()
+    );
+    assert!(
+        reg.list_messages(session_b, "task_shared_id", None, None)
+            .await
+            .unwrap()
+            .is_empty()
+    );
+}
+
+#[tokio::test]
 async fn started_at_and_finished_at_invariants() {
     let reg = LocalSessionTaskRegistry::new(SqliteDb::open_in_memory().unwrap()).unwrap();
     let session_id = SessionId::new();

--- a/crates/local/tests/task_registry_test.rs
+++ b/crates/local/tests/task_registry_test.rs
@@ -1,0 +1,355 @@
+// Task registry invariants + restart-survivability over a file-backed DB.
+
+use everruns_core::session_task::{
+    CreateSessionTask, NewTaskMessage, SessionTaskFilter, SessionTaskRegistry, SessionTaskState,
+    SessionTaskUpdate, TASK_KIND_BACKGROUND_TOOL, TASK_KIND_SUBAGENT, TaskInputRequest, TaskLinks,
+    TaskWakePolicy,
+};
+use everruns_core::typed_id::SessionId;
+use everruns_local::{LocalSessionTaskRegistry, SqliteDb};
+
+fn create_input(session_id: SessionId, kind: &str) -> CreateSessionTask {
+    CreateSessionTask {
+        session_id,
+        id: None,
+        kind: kind.to_string(),
+        display_name: "Test Task".to_string(),
+        spec: serde_json::json!({"instructions": "do the thing"}),
+        state: SessionTaskState::Queued,
+        links: TaskLinks::default(),
+        wake_policy: TaskWakePolicy::Silent,
+    }
+}
+
+#[tokio::test]
+async fn create_is_idempotent_on_supplied_id() {
+    let reg = LocalSessionTaskRegistry::new(SqliteDb::open_in_memory().unwrap()).unwrap();
+    let session_id = SessionId::new();
+    let mut input = create_input(session_id, TASK_KIND_BACKGROUND_TOOL);
+    input.id = Some("task_fixed_1".to_string());
+
+    let first = reg.create(input.clone()).await.unwrap();
+    // Mutate state, then re-create the same id: must return the stored task.
+    reg.update(
+        session_id,
+        &first.id,
+        SessionTaskUpdate {
+            state: Some(SessionTaskState::Running),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    let again = reg.create(input).await.unwrap();
+    assert_eq!(again.id, "task_fixed_1");
+    assert_eq!(
+        again.state,
+        SessionTaskState::Running,
+        "create is idempotent"
+    );
+}
+
+#[tokio::test]
+async fn started_at_and_finished_at_invariants() {
+    let reg = LocalSessionTaskRegistry::new(SqliteDb::open_in_memory().unwrap()).unwrap();
+    let session_id = SessionId::new();
+    let task = reg
+        .create(create_input(session_id, TASK_KIND_BACKGROUND_TOOL))
+        .await
+        .unwrap();
+    assert!(task.started_at.is_none());
+
+    let running = reg
+        .update(
+            session_id,
+            &task.id,
+            SessionTaskUpdate {
+                state: Some(SessionTaskState::Running),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(running.started_at.is_some(), "started_at stamped");
+    assert!(running.finished_at.is_none());
+
+    let done = reg
+        .update(
+            session_id,
+            &task.id,
+            SessionTaskUpdate {
+                state: Some(SessionTaskState::Succeeded),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(done.finished_at.is_some(), "finished_at stamped");
+
+    // Terminal state is final: a different state is ignored.
+    let after = reg
+        .update(
+            session_id,
+            &task.id,
+            SessionTaskUpdate {
+                state: Some(SessionTaskState::Failed),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        after.state,
+        SessionTaskState::Succeeded,
+        "terminal is final"
+    );
+}
+
+#[tokio::test]
+async fn input_request_forces_awaiting_input() {
+    let reg = LocalSessionTaskRegistry::new(SqliteDb::open_in_memory().unwrap()).unwrap();
+    let session_id = SessionId::new();
+    let task = reg
+        .create(create_input(session_id, TASK_KIND_SUBAGENT))
+        .await
+        .unwrap();
+
+    let awaiting = reg
+        .update(
+            session_id,
+            &task.id,
+            SessionTaskUpdate {
+                input_request: Some(TaskInputRequest {
+                    id: "req_1".to_string(),
+                    prompt: "Approve?".to_string(),
+                    expected: None,
+                }),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(awaiting.state, SessionTaskState::AwaitingInput);
+    assert!(awaiting.input_request.is_some());
+
+    // Answering message clears the pending request and returns to running.
+    reg.record_message(
+        session_id,
+        &task.id,
+        NewTaskMessage {
+            direction: everruns_core::session_task::TaskMessageDirection::Inbound,
+            content: vec![everruns_core::session_task::TaskMessagePart::text("yes")],
+            in_reply_to: Some("req_1".to_string()),
+            expected_attempt: None,
+        },
+    )
+    .await
+    .unwrap();
+    let resumed = reg.get(session_id, &task.id).await.unwrap().unwrap();
+    assert_eq!(resumed.state, SessionTaskState::Running);
+    assert!(resumed.input_request.is_none());
+}
+
+#[tokio::test]
+async fn request_cancel_records_intent_without_state_change() {
+    let reg = LocalSessionTaskRegistry::new(SqliteDb::open_in_memory().unwrap()).unwrap();
+    let session_id = SessionId::new();
+    let task = reg
+        .create(create_input(session_id, TASK_KIND_BACKGROUND_TOOL))
+        .await
+        .unwrap();
+    let canceled = reg
+        .request_cancel(session_id, &task.id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(canceled.cancel_requested_at.is_some());
+    assert_eq!(canceled.state, SessionTaskState::Queued, "state unchanged");
+}
+
+#[tokio::test]
+async fn list_filters_by_kind_and_state() {
+    let reg = LocalSessionTaskRegistry::new(SqliteDb::open_in_memory().unwrap()).unwrap();
+    let session_id = SessionId::new();
+    let bg = reg
+        .create(create_input(session_id, TASK_KIND_BACKGROUND_TOOL))
+        .await
+        .unwrap();
+    let _sub = reg
+        .create(create_input(session_id, TASK_KIND_SUBAGENT))
+        .await
+        .unwrap();
+    reg.update(
+        session_id,
+        &bg.id,
+        SessionTaskUpdate {
+            state: Some(SessionTaskState::Running),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    let by_kind = reg
+        .list(
+            session_id,
+            Some(&SessionTaskFilter {
+                kind: Some(TASK_KIND_SUBAGENT.to_string()),
+                state: None,
+            }),
+        )
+        .await
+        .unwrap();
+    assert_eq!(by_kind.len(), 1);
+    assert_eq!(by_kind[0].kind, TASK_KIND_SUBAGENT);
+
+    let by_state = reg
+        .list(
+            session_id,
+            Some(&SessionTaskFilter {
+                kind: None,
+                state: Some(SessionTaskState::Running),
+            }),
+        )
+        .await
+        .unwrap();
+    assert_eq!(by_state.len(), 1);
+    assert_eq!(by_state[0].id, bg.id);
+
+    let all = reg.list(session_id, None).await.unwrap();
+    assert_eq!(all.len(), 2);
+}
+
+#[tokio::test]
+async fn messages_persist_and_support_after_cursor() {
+    let reg = LocalSessionTaskRegistry::new(SqliteDb::open_in_memory().unwrap()).unwrap();
+    let session_id = SessionId::new();
+    let task = reg
+        .create(create_input(session_id, TASK_KIND_SUBAGENT))
+        .await
+        .unwrap();
+
+    let m1 = reg
+        .record_message(session_id, &task.id, NewTaskMessage::outbound_text("one"))
+        .await
+        .unwrap();
+    let _m2 = reg
+        .record_message(session_id, &task.id, NewTaskMessage::outbound_text("two"))
+        .await
+        .unwrap();
+
+    let all = reg
+        .list_messages(session_id, &task.id, None, None)
+        .await
+        .unwrap();
+    assert_eq!(all.len(), 2);
+    assert_eq!(
+        everruns_core::session_task::task_message_text(&all[0].content),
+        "one"
+    );
+
+    let after = reg
+        .list_messages(session_id, &task.id, None, Some(&m1.id))
+        .await
+        .unwrap();
+    assert_eq!(after.len(), 1, "after-cursor excludes m1");
+    assert_eq!(
+        everruns_core::session_task::task_message_text(&after[0].content),
+        "two"
+    );
+
+    let limited = reg
+        .list_messages(session_id, &task.id, Some(1), None)
+        .await
+        .unwrap();
+    assert_eq!(limited.len(), 1);
+}
+
+#[tokio::test]
+async fn restart_survivability_reopen_file_backed_db() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("tasks.db");
+    let session_id = SessionId::new();
+    let task_id;
+
+    // First process lifetime: create a task + message, then drop everything.
+    {
+        let reg = LocalSessionTaskRegistry::new(SqliteDb::open(&path).unwrap()).unwrap();
+        let task = reg
+            .create(create_input(session_id, TASK_KIND_SUBAGENT))
+            .await
+            .unwrap();
+        task_id = task.id.clone();
+        reg.update(
+            session_id,
+            &task_id,
+            SessionTaskUpdate {
+                state: Some(SessionTaskState::Running),
+                state_detail: Some("iteration 1".to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        reg.record_message(
+            session_id,
+            &task_id,
+            NewTaskMessage::outbound_text("progress"),
+        )
+        .await
+        .unwrap();
+        // reg + db dropped here.
+    }
+
+    // Second process lifetime: reopen the same file and continue.
+    let reg = LocalSessionTaskRegistry::new(SqliteDb::open(&path).unwrap()).unwrap();
+    let reread = reg.get(session_id, &task_id).await.unwrap().unwrap();
+    assert_eq!(reread.state, SessionTaskState::Running);
+    assert_eq!(reread.state_detail.as_deref(), Some("iteration 1"));
+
+    let messages = reg
+        .list_messages(session_id, &task_id, None, None)
+        .await
+        .unwrap();
+    assert_eq!(messages.len(), 1, "message survived restart");
+
+    // Continue the task to completion after restart.
+    let done = reg
+        .update(
+            session_id,
+            &task_id,
+            SessionTaskUpdate {
+                state: Some(SessionTaskState::Succeeded),
+                summary: Some("done after restart".to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(done.state, SessionTaskState::Succeeded);
+    assert_eq!(done.summary.as_deref(), Some("done after restart"));
+}
+
+#[tokio::test]
+async fn record_message_rejects_stale_attempt() {
+    let reg = LocalSessionTaskRegistry::new(SqliteDb::open_in_memory().unwrap()).unwrap();
+    let session_id = SessionId::new();
+    let task = reg
+        .create(create_input(session_id, TASK_KIND_SUBAGENT))
+        .await
+        .unwrap();
+    // Task attempt is 1; a message fenced on attempt 2 must be rejected.
+    let err = reg
+        .record_message(
+            session_id,
+            &task.id,
+            NewTaskMessage::outbound_text("zombie").with_expected_attempt(2),
+        )
+        .await;
+    assert!(err.is_err(), "stale-attempt message must be rejected");
+}

--- a/crates/runtime/src/backends.rs
+++ b/crates/runtime/src/backends.rs
@@ -16,13 +16,25 @@ use everruns_core::in_memory::{
 };
 use everruns_core::message::Message;
 use everruns_core::message_retriever::{InputMessage, MessageRetriever};
+use everruns_core::platform_store::PlatformStore;
 use everruns_core::session::Session;
+use everruns_core::session_task::SessionTaskRegistry;
 use everruns_core::traits::{
     AgentStore, EventEmitter, HarnessStore, ProviderStore, ResolvedModel, SessionMutator,
-    SessionStorageStore, SessionStore, UserConnectionResolver,
+    SessionScheduleStore, SessionStorageStore, SessionStore, UserConnectionResolver,
 };
 use everruns_core::typed_id::SessionId;
 use std::sync::Arc;
+
+/// Factory producing a per-org [`SessionScheduleStore`]. Embedders that have a
+/// single global store can ignore the `org_id` argument and return the same
+/// `Arc` every time.
+pub type ScheduleStoreFactory = Arc<dyn Fn(i64) -> Arc<dyn SessionScheduleStore> + Send + Sync>;
+
+/// Factory producing a per-(org, session) [`PlatformStore`]. The session id is
+/// supplied because platform stores are scoped to the calling session for
+/// subagent spawning and platform-management tools.
+pub type PlatformStoreFactory = Arc<dyn Fn(i64, SessionId) -> Arc<dyn PlatformStore> + Send + Sync>;
 
 /// Agent store contract for runtime seeding and lookup.
 #[async_trait]
@@ -116,6 +128,17 @@ pub struct RuntimeBackends {
     /// There is no in-memory default because a connection resolver implies a
     /// real credential source the embedder must supply.
     pub connection_resolver: Option<Arc<dyn UserConnectionResolver>>,
+    /// Optional session-task registry injected into the act path so background
+    /// tools, subagents, and monitors persist their lifecycle. `None` (the
+    /// default) leaves `RuntimeHostAdapter::session_task_registry` returning
+    /// `None`, matching prior in-memory behavior.
+    pub session_task_registry: Option<Arc<dyn SessionTaskRegistry>>,
+    /// Optional per-org schedule store factory. `None` (the default) leaves
+    /// `RuntimeHostAdapter::schedule_store` returning `None`.
+    pub schedule_store_factory: Option<ScheduleStoreFactory>,
+    /// Optional per-(org, session) platform store factory. `None` (the
+    /// default) leaves `RuntimeHostAdapter::platform_store` returning `None`.
+    pub platform_store_factory: Option<PlatformStoreFactory>,
 }
 
 impl RuntimeBackends {
@@ -134,6 +157,9 @@ impl RuntimeBackends {
             event_bus,
             storage_store: Arc::new(InMemorySessionStorageStore::new()),
             connection_resolver: None,
+            session_task_registry: None,
+            schedule_store_factory: None,
+            platform_store_factory: None,
         }
     }
 
@@ -178,6 +204,28 @@ impl RuntimeBackends {
     /// capabilities resolve tokens lazily at tool execution time.
     pub fn with_connection_resolver(mut self, resolver: Arc<dyn UserConnectionResolver>) -> Self {
         self.connection_resolver = Some(resolver);
+        self
+    }
+
+    /// Inject a session-task registry so background tools / subagents / monitors
+    /// persist their lifecycle through the act path. Additive: leaving this unset
+    /// keeps the prior behavior (the adapter returns `None`).
+    pub fn with_session_task_registry(mut self, registry: Arc<dyn SessionTaskRegistry>) -> Self {
+        self.session_task_registry = Some(registry);
+        self
+    }
+
+    /// Inject a per-org schedule store factory. The closure is invoked with the
+    /// internal org id each time the act path needs a schedule store.
+    pub fn with_schedule_store_factory(mut self, factory: ScheduleStoreFactory) -> Self {
+        self.schedule_store_factory = Some(factory);
+        self
+    }
+
+    /// Inject a per-(org, session) platform store factory. The closure is
+    /// invoked with the internal org id and the calling session id.
+    pub fn with_platform_store_factory(mut self, factory: PlatformStoreFactory) -> Self {
+        self.platform_store_factory = Some(factory);
         self
     }
 }

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -99,8 +99,8 @@ mod runtime;
 mod turn_strategy;
 
 pub use backends::{
-    EventBus, RuntimeAgentStore, RuntimeBackends, RuntimeHarnessStore, RuntimeMessageStore,
-    RuntimeProviderStore, RuntimeSessionStore,
+    EventBus, PlatformStoreFactory, RuntimeAgentStore, RuntimeBackends, RuntimeHarnessStore,
+    RuntimeMessageStore, RuntimeProviderStore, RuntimeSessionStore, ScheduleStoreFactory,
 };
 pub use builders::{AgentBuilder, HarnessBuilder, SessionBuilder, SingleSessionBuilder};
 pub use everruns_core::AssembledTurnContext;
@@ -116,5 +116,7 @@ pub use in_memory::{
     InMemorySessionStore,
 };
 pub use real_disk::{RealDiskFileStore, RealDiskSessionFileSystemFactory};
-pub use runtime::{InProcessRuntime, InProcessRuntimeBuilder, TurnResult};
+pub use runtime::{
+    InProcessRuntime, InProcessRuntimeBuilder, TurnResult, in_process_internal_org_id,
+};
 pub use turn_strategy::{RuntimeActPlan, RuntimeTurnPlan, RuntimeTurnState, plan_next_host_turn};

--- a/crates/runtime/src/runtime.rs
+++ b/crates/runtime/src/runtime.rs
@@ -62,7 +62,10 @@ const HASH_INPUT_CAP_BYTES: usize = 128;
 /// id unchanged. Other values are mapped into `[2, i64::MAX]` by hashing the
 /// original public id string so runtime namespaces do not fail open to the
 /// shared default org and avoid arithmetic collision gadgets.
-fn in_process_internal_org_id(public_org_id: &str) -> i64 {
+///
+/// Exposed so embedders (e.g. `everruns-local`) can scope per-org stores to the
+/// same internal id the act path resolves a session's org to.
+pub fn in_process_internal_org_id(public_org_id: &str) -> i64 {
     if public_org_id == everruns_core::DEFAULT_ORG_PUBLIC_ID {
         return everruns_core::DEFAULT_ORG_ID;
     }
@@ -262,6 +265,47 @@ impl InProcessRuntimeBuilder {
     /// Supply a custom backend bundle instead of the built-in in-memory stores.
     pub fn backends(mut self, backends: RuntimeBackends) -> Self {
         self.backends = Some(backends);
+        self
+    }
+
+    /// Inject a session-task registry. Convenience over `backends(...)` that
+    /// initializes an in-memory backend bundle on first use, so embedders can
+    /// add the registry without assembling a full `RuntimeBackends`.
+    pub fn with_session_task_registry(
+        mut self,
+        registry: Arc<dyn everruns_core::session_task::SessionTaskRegistry>,
+    ) -> Self {
+        let backends = self
+            .backends
+            .take()
+            .unwrap_or_else(RuntimeBackends::in_memory);
+        self.backends = Some(backends.with_session_task_registry(registry));
+        self
+    }
+
+    /// Inject a per-org schedule store factory (see [`RuntimeBackends`]).
+    pub fn with_schedule_store_factory(
+        mut self,
+        factory: crate::backends::ScheduleStoreFactory,
+    ) -> Self {
+        let backends = self
+            .backends
+            .take()
+            .unwrap_or_else(RuntimeBackends::in_memory);
+        self.backends = Some(backends.with_schedule_store_factory(factory));
+        self
+    }
+
+    /// Inject a per-(org, session) platform store factory (see [`RuntimeBackends`]).
+    pub fn with_platform_store_factory(
+        mut self,
+        factory: crate::backends::PlatformStoreFactory,
+    ) -> Self {
+        let backends = self
+            .backends
+            .take()
+            .unwrap_or_else(RuntimeBackends::in_memory);
+        self.backends = Some(backends.with_platform_store_factory(factory));
         self
     }
 
@@ -483,6 +527,9 @@ impl InProcessRuntimeBuilder {
             file_store,
             storage_store: backends.storage_store,
             connection_resolver: backends.connection_resolver,
+            session_task_registry: backends.session_task_registry,
+            schedule_store_factory: backends.schedule_store_factory,
+            platform_store_factory: backends.platform_store_factory,
             mcp_auth_provider: self
                 .mcp_auth_provider
                 .unwrap_or_else(|| Arc::new(everruns_mcp::NoAuthProvider)),
@@ -525,6 +572,9 @@ pub struct InProcessRuntime {
     file_store: Arc<dyn SessionFileSystem>,
     storage_store: Arc<dyn SessionStorageStore>,
     connection_resolver: Option<Arc<dyn UserConnectionResolver>>,
+    session_task_registry: Option<Arc<dyn everruns_core::session_task::SessionTaskRegistry>>,
+    schedule_store_factory: Option<crate::backends::ScheduleStoreFactory>,
+    platform_store_factory: Option<crate::backends::PlatformStoreFactory>,
     mcp_auth_provider: Arc<dyn everruns_mcp::McpAuthProvider>,
     mcp_discovery_cache: Arc<crate::mcp_cache::McpDiscoveryCache>,
     /// Non-fatal warnings collected during plugin compilation (see
@@ -1010,6 +1060,31 @@ impl RuntimeHostAdapter for InProcessRuntime {
 
     fn connection_resolver(&self) -> Option<Arc<dyn UserConnectionResolver>> {
         self.connection_resolver.clone()
+    }
+
+    fn session_task_registry(
+        &self,
+    ) -> Option<Arc<dyn everruns_core::session_task::SessionTaskRegistry>> {
+        self.session_task_registry.clone()
+    }
+
+    fn schedule_store(
+        &self,
+        org_id: i64,
+    ) -> Option<Arc<dyn everruns_core::traits::SessionScheduleStore>> {
+        self.schedule_store_factory
+            .as_ref()
+            .map(|factory| factory(org_id))
+    }
+
+    fn platform_store(
+        &self,
+        org_id: i64,
+        session_id: SessionId,
+    ) -> Option<Arc<dyn everruns_core::platform_store::PlatformStore>> {
+        self.platform_store_factory
+            .as_ref()
+            .map(|factory| factory(org_id, session_id))
     }
 
     fn utility_llm_service(&self) -> Option<Arc<dyn everruns_core::UtilityLlmService>> {

--- a/specs/runtime.md
+++ b/specs/runtime.md
@@ -235,6 +235,47 @@ backends. `everruns-worker` ships the first-party durable/server-backed host
 adapter (`WorkerRuntimeHost`) that bridges worker storage/adapters into the
 runtime host contract.
 
+### Optional host-backend slots
+
+`RuntimeBackends` carries a uniform set of optional, additive backend slots that
+the host forwards into `ActAtom` when present (see
+`crates/runtime/src/runtime.rs` and `crates/runtime/src/host.rs`):
+
+- `session_task_registry` — persists background-tool / subagent / monitor task
+  lifecycle (`everruns_core::session_task::SessionTaskRegistry`).
+- `schedule_store_factory` — per-org `SessionScheduleStore` for local schedules
+  and monitors.
+- `platform_store_factory` — per-(org, session) `PlatformStore` for local
+  session management and subagent spawning.
+
+Each slot defaults to `None`; leaving it unset preserves the prior in-memory
+behavior (the `RuntimeHostAdapter` method returns `None`). The slots are a
+single, repeatable "optional backend slot" pattern so additional local backends
+can be added without further runtime changes.
+
+## Local Backends (`everruns-local`)
+
+`everruns-local` is the first-party crate that populates the optional
+host-backend slots with local, file-backed implementations for embedded,
+single-process hosts (where Yolop and miy would otherwise each reinvent them).
+The runtime stays generic and owns only the seams; durable local storage choices
+live in this separate opt-in crate.
+
+It provides SQLite-backed, restart-survivable stores —
+`LocalSessionTaskRegistry`, `LocalScheduleStore`, `LocalPlatformStore` — plus a
+`LocalProfile` (data dir / workspace / identity defaults), a composable
+`LocalBackends` (which preserves a caller-supplied event bus and
+`SessionFileSystemFactory`), and an optional `LocalRuntimeBuilder` convenience
+wrapper. Task and message state persists to a SQLite file so a freshly-spawned
+process can read, continue, and inspect tasks an earlier process started.
+
+Schedules keep an extensible per-record metadata bag (name/color/kind/etc.) in a
+local `metadata` JSON column rather than by widening the shared core
+`SessionSchedule` primitive; the trait-level store surface is unchanged. See
+`crates/local/` for the implementation and `crates/local/tests/` for the
+task-lifecycle, restart-survivability, schedule round-trip, composability, and
+embedded-turn coverage.
+
 ## Context and Capabilities
 
 Capabilities continue to live in `everruns-core`.
@@ -293,6 +334,8 @@ test binaries in `crates/runtime/tests/`.
 - `crates/runtime/src/runtime.rs`
 - `crates/runtime/src/host.rs`
 - `crates/runtime/src/in_memory.rs`
+- `crates/runtime/src/backends.rs`
+- `crates/local/` (`everruns-local`: SQLite-backed local host backends)
 - `crates/runtime/examples/in_process_runtime.rs`
 - `crates/runtime/examples/inspect_context.rs`
 - `examples/weekend-concierge-host/src/lib.rs`


### PR DESCRIPTION
## What
Adds a first-party `everruns-local` crate that provides local, SQLite-backed, restart-survivable implementations of the runtime backend traits for embedded, single-process hosts, plus the minimal **additive** runtime seam to inject them. Implements **EVE-594** Phase 1.

## Why
Embedded hosts (Yolop, miy) each re-implement the same local durable backends — background/subagent task registries, schedule stores, a local platform store — because `everruns-runtime` ships the *traits/capabilities* but leaves the *durable backends* empty. When two independent embedders reinvent the same backends, the runtime needs a first-party local backend bundle. Runtime stays generic and owns only the seams; local storage choices live in this opt-in crate.

## How
**Runtime seam (additive, `crates/runtime`):**
- `RuntimeBackends` gains three optional slots — `session_task_registry`, `schedule_store_factory` (per-org), `platform_store_factory` (per-(org, session)) — with `with_*` setters mirrored on `InProcessRuntimeBuilder`. All default to `None`; `RuntimeBackends::in_memory()` and every existing constructor are unchanged, so existing in-memory embedders compile and behave identically.
- `InProcessRuntime`'s `RuntimeHostAdapter` impl returns the injected slots (previously hardcoded `None`); the host already forwards these into `ActAtom`.
- `in_process_internal_org_id` is now `pub` so embedders can scope per-org stores to the same internal id the act path resolves.

**`everruns-local` crate (`crates/local`, `publish = false`):**
- `LocalSessionTaskRegistry` — tasks + message channel in SQLite; all updates route through `everruns_core::session_task::apply_task_update` (no reimplemented invariants); idempotent create on caller-supplied id; stale-attempt fence on messages; answering messages clear a pending input request. Restart-survivable: a freshly-spawned process reopens the file and continues.
- `LocalScheduleStore` — org/session-scoped; carries an **extensible per-record metadata bag** in a local `metadata` JSON column (via additive `create_schedule_with_metadata` / `get_metadata`) rather than widening the shared core `SessionSchedule` primitive. The trait surface is unchanged.
- `LocalPlatformStore` — honestly implements the subagent-critical core (`create_session`/`send_message`/`wait_for_idle`/`get_messages`/`get_session_by_id`/`list_sessions`/`base_url`) over a caller-supplied `LocalSessionRunner`; returns explicit unsupported errors for platform-management-only ops instead of half-implementing them.
- `LocalProfile`, composable `LocalBackends` (preserves a caller-supplied event bus and `SessionFileSystemFactory`), and an optional `LocalRuntimeBuilder` convenience wrapper.

Schema init for the schedule store happens once up front so the per-org factory on the act path is cheap and cannot panic.

## Risk
- **Low–Medium.** New crate; the only change to existing code is additive optional slots on `RuntimeBackends`/`InProcessRuntime` (default `None`). No server, API, OpenAPI, or migration changes. `rusqlite` (bundled) is already a workspace dependency (`session-sqldb`), so no new supply-chain surface.
- What could break: existing runtime embedders — mitigated by defaults and a full `everruns-runtime` + `everruns-core` test pass.

## Security
- **Threat categories reviewed:** TM-SQL, TM-TENANT, TM-FS, TM-DOS.
- **TM-SQL:** All SQLite access is parameterized; the only dynamic SQL appends fixed predicate fragments (`" AND kind = ?2"`) and never interpolates values. No injection surface.
- **TM-TENANT:** `LocalScheduleStore` filters every query by `org_id` (+ `session_id` for list/count). `LocalPlatformStore` is built per (org, session). The task registry keys on globally-unique generated task ids; acceptable for a single-process, single-org embedded host (documented). No cross-tenant query path is introduced into the server.
- **TM-FS:** The SQLite file lives under the host-controlled `LocalProfile` data dir (`ensure_dirs`), not from untrusted input.
- **TM-DOS:** `list_messages` honors `limit`; listings are session-bounded; a single serialized connection is appropriate for the embedded, modest-throughput use case.
- No auth/authz, no new endpoints, no prompt construction, no new network egress. No `THREAT` comments touched; no threat-model entry warranted (local library, no new server trust boundary).

## Validation
Local (`/home/user/eve-594`, rebased on merged `main`):
- `cargo fmt --check` ✅
- `cargo clippy -p everruns-local -p everruns-runtime --all-targets --all-features -- -D warnings` ✅ (no warnings)
- `cargo test -p everruns-local` ✅ — 16 tests: task lifecycle (idempotent create, started/finished stamping + terminal finality, input_request→awaiting_input, cancel intent, kind/state filters, message persistence + after_id cursor + limit, stale-attempt rejection, **restart-survivability** across reopen), schedule metadata round-trip + list/cancel/count + org-scoping, platform-store honest core + unsupported management ops, composability (caller bus + custom FS factory proven used) + adapter-returns-injected-store + an **embedded smoke turn** (llmsim + test capability).
- `cargo test -p everruns-runtime` ✅ and `cargo test -p everruns-core` ✅ — existing suites unchanged.

This is a library crate not yet wired into the server/CLI, so `just start-dev` smoke testing is not applicable; the embedded-runtime test drives a real `run_turn` through a runtime built from `LocalBackends`, which is the equivalent end-to-end proof.

## Follow-ups
Per the issue's Phase-1/follow-up split (same crate, same uniform seam, additive — no further runtime change needed):
- End-to-end `spawn_background` / `spawn_subagent` *tool-driven* smoke test (requires wiring the `background_tools` capability + attaching the platform runner post-build). Phase 1 proves the seam instead: the adapter returns the injected stores and a full task lifecycle + schedule round-trip run through the adapter-returned stores.
- Yolop/miy dogfooding (those repos are out of scope here).
- Local MCP store + OAuth-refreshing `McpAuthProvider`, durable local session-transcript store, `SessionFileSystem` overlay/multi-mount combinator, local provider-credential + image-artifact stores.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (additive `None` defaults; existing runtime/core tests pass)
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [ ] All review comments addressed (code change or written reasoning)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HAaTy59HiBBiQnqM58nj6Z)_