### PR TITLE
test(storage): CI coverage for the S3 blob backend offload paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
       docs_notebooks: ${{ steps.core_filter.outputs.docs_notebooks }}
       docker: ${{ steps.core_filter.outputs.docker }}
       postgres_integration: ${{ steps.core_filter.outputs.postgres_integration }}
+      object_storage: ${{ steps.core_filter.outputs.object_storage }}
       brave_search_integration: ${{ steps.core_filter.outputs.brave_search_integration }}
       duckduckgo_integration: ${{ steps.core_filter.outputs.duckduckgo_integration }}
       parallel_integration: ${{ steps.core_filter.outputs.parallel_integration }}
@@ -176,6 +177,24 @@ jobs:
               - 'crates/openai/**'
               - 'crates/anthropic/**'
               - 'crates/gemini/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'rust-toolchain.toml'
+              - '.github/workflows/ci.yml'
+            # S3 blob-backend integration coverage. Narrow on purpose so the
+            # MinIO-backed job only runs when the object-storage offload code,
+            # its sidecar migration, or the harness/workflow that drives it
+            # changes — it should not burn CI on unrelated PRs.
+            object_storage:
+              - 'crates/server/src/storage/blob_store.rs'
+              - 'crates/server/src/storage/repositories/session_files.rs'
+              - 'crates/server/src/storage/repositories/skills.rs'
+              - 'crates/server/src/storage/backend.rs'
+              - 'crates/server/src/storage/repositories/mod.rs'
+              - 'crates/server/migrations/**'
+              - 'crates/server/tests/blob_offload_integration_test.rs'
+              - 'crates/server/tests/test_harness.rs'
+              - 'crates/config/**'
               - 'Cargo.toml'
               - 'Cargo.lock'
               - 'rust-toolchain.toml'
@@ -594,6 +613,14 @@ jobs:
       - name: Run server integration tests (API + repository)
         run: cargo test -p everruns-server --test api_integration_test --test repository_integration_test -- --test-threads=1
 
+      # Blob-offload suite against the in-memory object_store backend (no S3
+      # container). Exercises the same offload code paths the S3 job covers,
+      # giving every PostgreSQL PR coverage of the offload invariants without a
+      # service container. The dedicated `s3-integration-test` job re-runs the
+      # identical suite with STORAGE_BLOB_BACKEND=s3 against MinIO.
+      - name: Run blob offload integration tests (in-memory backend)
+        run: cargo test -p everruns-server --test blob_offload_integration_test -- --test-threads=1
+
       # Domain-focused integration tests that previously only ran manually.
       # Kept split so CI failures surface the offending area fast; each file
       # exercises a cohesive slice (auth, org lifecycle, schedules, git sessions,
@@ -654,6 +681,114 @@ jobs:
         env:
           DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
         run: doppler run --preserve-env="DATABASE_URL" -- cargo test -p everruns-llm-tests --test agent_run_basic --test agent_run_with_thinking --all-features
+
+  # S3 blob-backend integration tests.
+  # The PostgreSQL `integration-test` job above only exercises the inline
+  # (STORAGE_BLOB_BACKEND=db) storage path. This job brings up a real
+  # S3-compatible object store (MinIO) alongside PostgreSQL and runs the
+  # backend-agnostic offload suite with STORAGE_BLOB_BACKEND=s3 so the
+  # object-storage offload code (create/read/update/CAS/move/copy/delete,
+  # materialization, org-scoped image delete guard) is covered against the real
+  # S3 client path — not just the in-memory object_store backend.
+  s3-integration-test:
+    name: Integration Tests (S3 Blob Backend)
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.run_ci == 'true' && needs.changes.outputs.object_storage == 'true' && needs.changes.outputs.skip_slow_rust != 'true' && needs.changes.outputs.skip_postgres_integration != 'true'
+    services:
+      postgres:
+        image: postgres:17-alpine
+        env:
+          POSTGRES_USER: everruns
+          POSTGRES_PASSWORD: everruns
+          POSTGRES_DB: everruns_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      # bitnami/minio starts the S3 server with no extra args (the upstream
+      # minio/minio image needs a `server /data` command, which GH service
+      # containers cannot express) and provisions the bucket at boot via
+      # MINIO_DEFAULT_BUCKETS, so the test never has to create it. Pinned by
+      # digest-bearing tag (not `latest`) for reproducibility.
+      minio:
+        image: bitnami/minio:2025.4.22
+        env:
+          MINIO_ROOT_USER: everruns
+          MINIO_ROOT_PASSWORD: everruns-secret
+          MINIO_DEFAULT_BUCKETS: everruns-test
+        ports:
+          - 9000:9000
+        options: >-
+          --health-cmd "curl -fsS http://localhost:9000/minio/health/live"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      DATABASE_URL: postgres://everruns:everruns@localhost:5432/everruns_test
+      SECRETS_ENCRYPTION_KEY: kek-v1:8B3uCQ4Znx45hl5nB+PKVriRrj/KtEVM+wBZ2VGa9vY=
+      # Drive the offload code path against the real S3 client. The endpoint is
+      # plain HTTP (local container), so ALLOW_HTTP + path-style are required.
+      STORAGE_BLOB_BACKEND: s3
+      STORAGE_S3_BUCKET: everruns-test
+      STORAGE_S3_ENDPOINT: http://localhost:9000
+      STORAGE_S3_REGION: us-east-1
+      STORAGE_S3_ACCESS_KEY_ID: everruns
+      STORAGE_S3_SECRET_ACCESS_KEY: everruns-secret
+      STORAGE_S3_ALLOW_HTTP: "true"
+      STORAGE_S3_FORCE_PATH_STYLE: "true"
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@1.96.0
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "debug"
+
+      - name: Cache cargo binaries
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/cargo-binstall
+            ~/.cargo/bin/sqlx
+          key: ${{ runner.os }}-cargo-bins-sqlx-0.9
+
+      - name: Install sqlx-cli
+        run: |
+          if [ ! -f ~/.cargo/bin/sqlx ]; then
+            if [ ! -f ~/.cargo/bin/cargo-binstall ]; then
+              cargo install cargo-binstall --locked
+            fi
+            cargo binstall sqlx-cli --no-confirm --version '~0.9'
+          fi
+
+      - name: Run migrations
+        run: sqlx migrate run --source crates/server/migrations
+
+      - name: Wait for MinIO S3 endpoint
+        run: |
+          echo "Waiting for MinIO to accept S3 requests..."
+          for i in {1..30}; do
+            if curl -fsS http://localhost:9000/minio/health/live > /dev/null 2>&1; then
+              echo "MinIO is ready!"
+              exit 0
+            fi
+            echo "Attempt $i: MinIO not ready yet..."
+            sleep 2
+          done
+          echo "MinIO failed to become ready"
+          exit 1
+
+      - name: Run blob offload integration tests (S3 backend)
+        run: cargo test -p everruns-server --test blob_offload_integration_test -- --test-threads=1
 
   # Build release binaries and upload as artifacts for E2E jobs and openapi-check
   build-binaries:
@@ -1331,6 +1466,7 @@ jobs:
       - worker-test
       - shell-test
       - integration-test
+      - s3-integration-test
       - build-binaries
       - workflow-test
       - cli-e2e-test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -709,24 +709,9 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
-      # bitnami/minio starts the S3 server with no extra args (the upstream
-      # minio/minio image needs a `server /data` command, which GH service
-      # containers cannot express) and provisions the bucket at boot via
-      # MINIO_DEFAULT_BUCKETS, so the test never has to create it. Pinned by
-      # digest-bearing tag (not `latest`) for reproducibility.
-      minio:
-        image: bitnami/minio:2025.4.22
-        env:
-          MINIO_ROOT_USER: everruns
-          MINIO_ROOT_PASSWORD: everruns-secret
-          MINIO_DEFAULT_BUCKETS: everruns-test
-        ports:
-          - 9000:9000
-        options: >-
-          --health-cmd "curl -fsS http://localhost:9000/minio/health/live"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 10
+      # MinIO is started as a `docker run` step (see "Start MinIO" below) rather
+      # than a service container, because the upstream minio/minio image needs a
+      # `server /data` command and GH service containers cannot express a command.
 
     env:
       DATABASE_URL: postgres://everruns:everruns@localhost:5432/everruns_test
@@ -773,19 +758,34 @@ jobs:
       - name: Run migrations
         run: sqlx migrate run --source crates/server/migrations
 
-      - name: Wait for MinIO S3 endpoint
+      - name: Start MinIO and create the bucket
         run: |
+          # Ephemeral S3-compatible store for this job only. `latest` is used
+          # deliberately: these are throwaway test containers (no production
+          # surface), and it avoids pinning to an unverifiable date-stamped tag.
+          docker run -d --name minio \
+            -p 9000:9000 \
+            -e MINIO_ROOT_USER=everruns \
+            -e MINIO_ROOT_PASSWORD=everruns-secret \
+            minio/minio:latest server /data
           echo "Waiting for MinIO to accept S3 requests..."
+          ready=
           for i in {1..30}; do
             if curl -fsS http://localhost:9000/minio/health/live > /dev/null 2>&1; then
               echo "MinIO is ready!"
-              exit 0
+              ready=1
+              break
             fi
             echo "Attempt $i: MinIO not ready yet..."
             sleep 2
           done
-          echo "MinIO failed to become ready"
-          exit 1
+          if [ -z "$ready" ]; then
+            echo "MinIO failed to become ready"; docker logs minio || true; exit 1
+          fi
+          # Create the test bucket with the MinIO client (idempotent).
+          docker run --rm --network host \
+            -e MC_HOST_local="http://everruns:everruns-secret@localhost:9000" \
+            minio/mc:latest mb --ignore-existing local/everruns-test
 
       - name: Run blob offload integration tests (S3 backend)
         run: cargo test -p everruns-server --test blob_offload_integration_test -- --test-threads=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -615,8 +615,9 @@ jobs:
 
       # Blob-offload suite against the in-memory object_store backend (no S3
       # container). Exercises the same offload code paths the S3 job covers,
-      # giving every PostgreSQL PR coverage of the offload invariants without a
-      # service container. The dedicated `s3-integration-test` job re-runs the
+      # giving every PostgreSQL PR coverage of the offload invariants without an
+      # S3/MinIO container (the PostgreSQL service container is still used). The
+      # dedicated `s3-integration-test` job re-runs the
       # identical suite with STORAGE_BLOB_BACKEND=s3 against MinIO.
       - name: Run blob offload integration tests (in-memory backend)
         run: cargo test -p everruns-server --test blob_offload_integration_test -- --test-threads=1

--- a/crates/server/tests/blob_offload_integration_test.rs
+++ b/crates/server/tests/blob_offload_integration_test.rs
@@ -1,0 +1,608 @@
+//! Backend-agnostic integration coverage for the object-storage blob offload
+//! paths (specs/object-storage.md).
+//!
+//! These tests exercise the *offload* code in
+//! `storage/repositories/{session_files,skills}.rs` end-to-end against a real
+//! PostgreSQL database plus a `BlobStore`. They are written to be **backend
+//! agnostic**: the active blob backend is selected from the environment, so the
+//! identical assertions run against
+//!
+//! - object_store's in-memory backend (the default — `STORAGE_BLOB_BACKEND`
+//!   unset / `db`), which exercises the production offload code path with no
+//!   network dependency, and
+//! - a real S3-compatible service container (`STORAGE_BLOB_BACKEND=s3` +
+//!   `STORAGE_S3_*`), wired up by the dedicated CI job.
+//!
+//! Note: the *default* deployment backend (`STORAGE_BLOB_BACKEND=db`) keeps
+//! bytes inline and never attaches a blob store, so there is nothing to offload
+//! there. To still get coverage of the offload code on every run we attach the
+//! in-memory object_store backend here unless `STORAGE_BLOB_BACKEND=s3` asks for
+//! the real S3 path. Either way these tests assert the *offloaded* invariants
+//! (empty content column, sidecar pointer + hash, byte round-trip), which is
+//! exactly the code that had no automated coverage before.
+//!
+//! Run with: cargo test -p everruns-server --test blob_offload_integration_test -- --test-threads=1
+//!
+//! Requirements:
+//! - PostgreSQL running with DATABASE_URL set
+//! - Migrations applied (run migrations from crates/server/migrations/)
+//! - Optionally STORAGE_BLOB_BACKEND=s3 + STORAGE_S3_* for the real S3 path.
+
+mod test_harness;
+
+use std::sync::Arc;
+
+use serde_json::json;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use everruns_server::storage::blob_store::{
+    BlobStoreConfig, ObjectStoreBlobStore, SharedBlobStore, content_sha256,
+};
+use everruns_server::storage::{
+    CreateAgentRow, CreateImageRow, CreatePrincipalRow, CreateSessionFileRow, CreateSessionRow,
+    Database, StorageBackend, UpdateSessionFile,
+};
+use test_harness::get_database_url;
+
+const TEST_ORG_ID: i64 = 1;
+
+/// Build the blob backend under test from the environment.
+///
+/// `STORAGE_BLOB_BACKEND=s3` selects the real S3-compatible store via the same
+/// `STORAGE_S3_*` config the server reads in production (used by the dedicated
+/// S3 CI job against a MinIO service container). Anything else falls back to
+/// object_store's in-memory backend, which exercises the identical offload code
+/// path with no network dependency. The same test body therefore validates both
+/// backends.
+fn blob_store_under_test() -> SharedBlobStore {
+    let backend = std::env::var("STORAGE_BLOB_BACKEND").unwrap_or_default();
+    if backend == "s3" {
+        let config = BlobStoreConfig::from_env()
+            .expect("STORAGE_BLOB_BACKEND=s3 requires STORAGE_S3_* configuration");
+        let store = ObjectStoreBlobStore::s3_from_config(&config)
+            .expect("failed to build S3 blob store from STORAGE_S3_* configuration");
+        Arc::new(store)
+    } else {
+        Arc::new(ObjectStoreBlobStore::in_memory())
+    }
+}
+
+/// Create a PostgreSQL-backed storage backend with the offload blob store
+/// attached. This is the wiring that triggers the offload code paths.
+async fn create_offload_backend() -> (StorageBackend, PgPool) {
+    let pool = PgPool::connect(&get_database_url())
+        .await
+        .expect("Failed to connect to PostgreSQL");
+    let db = Database::new(pool.clone()).with_blob_store(Some(blob_store_under_test()));
+    (StorageBackend::Postgres(db), pool)
+}
+
+async fn create_test_principal(
+    backend: &StorageBackend,
+    org_id: i64,
+) -> everruns_core::PrincipalId {
+    backend
+        .create_principal(CreatePrincipalRow {
+            id: everruns_core::PrincipalId::new(),
+            org_id,
+            kind: "system".to_string(),
+            subject_id: Some(Uuid::now_v7()),
+            parent_principal_id: None,
+            resolved_user_id: None,
+            metadata: json!({ "source": "blob_offload_integration_test" }),
+        })
+        .await
+        .expect("Failed to create test principal")
+        .id
+}
+
+async fn create_test_session(backend: &StorageBackend) -> everruns_core::SessionId {
+    let agent = backend
+        .create_agent(
+            TEST_ORG_ID,
+            CreateAgentRow {
+                public_id: everruns_core::AgentId::new().to_string(),
+                name: format!("blob-offload-agent-{}", &Uuid::now_v7().to_string()[..8]),
+                display_name: Some("Blob Offload Agent".to_string()),
+                description: None,
+                system_prompt: "Test".to_string(),
+                default_model_id: None,
+                tags: vec![],
+                initial_files: json!([]),
+                tools: json!([]),
+                mcp_servers: json!({}),
+                network_access: None,
+                max_iterations: None,
+            },
+        )
+        .await
+        .expect("Failed to create agent");
+
+    let owner_principal_id = create_test_principal(backend, TEST_ORG_ID).await;
+    backend
+        .create_session(CreateSessionRow {
+            workspace_id: None,
+            org_id: TEST_ORG_ID,
+            app_id: None,
+            harness_id: None,
+            agent_id: Some(agent.id),
+            agent_identity_id: None,
+            owner_principal_id,
+            resolved_owner_user_id: None,
+            title: None,
+            locale: None,
+            tags: vec![],
+            model_id: None,
+            capabilities: json!([]),
+            tools: json!([]),
+            mcp_servers: json!({}),
+            system_prompt: None,
+            initial_files: serde_json::Value::Array(vec![]),
+            hints: None,
+            network_access: None,
+            max_iterations: None,
+            blueprint_id: None,
+            blueprint_config: None,
+            parent_session_id: None,
+        })
+        .await
+        .expect("Failed to create session")
+        .id
+}
+
+/// The raw `content` column for a workspace file (NULL when offloaded).
+async fn raw_file_content(pool: &PgPool, workspace_id: Uuid, path: &str) -> Option<Vec<u8>> {
+    let row: (Option<Vec<u8>>,) =
+        sqlx::query_as("SELECT content FROM workspace_files WHERE workspace_id = $1 AND path = $2")
+            .bind(workspace_id)
+            .bind(path)
+            .fetch_one(pool)
+            .await
+            .expect("file row must exist");
+    row.0
+}
+
+/// The sidecar pointer (blob_key, content_sha256) for a workspace file, if any.
+async fn file_sidecar(pool: &PgPool, workspace_id: Uuid, path: &str) -> Option<(String, String)> {
+    sqlx::query_as::<_, (String, String)>(
+        r#"
+        SELECT b.blob_key, b.content_sha256
+        FROM workspace_file_blobs b
+        JOIN workspace_files f ON f.id = b.file_id
+        WHERE f.workspace_id = $1 AND f.path = $2
+        "#,
+    )
+    .bind(workspace_id)
+    .bind(path)
+    .fetch_optional(pool)
+    .await
+    .expect("sidecar query")
+}
+
+// ============================================================================
+// Workspace file offload
+// ============================================================================
+
+#[tokio::test]
+async fn offloaded_file_empties_content_column_and_records_sidecar() {
+    let (backend, pool) = create_offload_backend().await;
+    let session_id = create_test_session(&backend).await;
+    let workspace_id: Uuid = session_id.into();
+    let body = b"Hello, offloaded world!".to_vec();
+
+    let created = backend
+        .create_session_file(CreateSessionFileRow {
+            session_id,
+            path: "/notes/a.txt".to_string(),
+            is_directory: false,
+            content: Some(body.clone()),
+            is_readonly: false,
+        })
+        .await
+        .expect("create offloaded file");
+
+    // The returned row carries the bytes (materialized for the caller).
+    assert_eq!(created.content.as_deref(), Some(body.as_slice()));
+    assert_eq!(created.size_bytes, body.len() as i64);
+
+    // The DB content column is empty (offloaded), and the sidecar records the
+    // pointer + hash.
+    assert_eq!(
+        raw_file_content(&pool, workspace_id, "/notes/a.txt").await,
+        None,
+        "offloaded file must have NULL content column"
+    );
+    let (key, sha) = file_sidecar(&pool, workspace_id, "/notes/a.txt")
+        .await
+        .expect("sidecar pointer must exist for offloaded file");
+    assert!(
+        key.contains(&workspace_id.to_string()),
+        "key is tenant-scoped"
+    );
+    assert_eq!(sha, content_sha256(&body), "sidecar records content hash");
+
+    // Round-trip on read fetches the bytes from the blob store.
+    let fetched = backend
+        .get_session_file(workspace_id, "/notes/a.txt")
+        .await
+        .expect("get file")
+        .expect("file present");
+    assert_eq!(fetched.content.as_deref(), Some(body.as_slice()));
+
+    backend.delete_session(TEST_ORG_ID, session_id).await.ok();
+}
+
+#[tokio::test]
+async fn offloaded_file_delete_removes_object_and_sidecar() {
+    let (backend, pool) = create_offload_backend().await;
+    let session_id = create_test_session(&backend).await;
+    let workspace_id: Uuid = session_id.into();
+
+    backend
+        .create_session_file(CreateSessionFileRow {
+            session_id,
+            path: "/gone.txt".to_string(),
+            is_directory: false,
+            content: Some(b"delete me".to_vec()),
+            is_readonly: false,
+        })
+        .await
+        .expect("create file");
+
+    // Grab the blob store + key so we can prove the object is gone after delete.
+    let blob = blob_store_under_test();
+    let (key, _) = file_sidecar(&pool, workspace_id, "/gone.txt")
+        .await
+        .expect("sidecar exists");
+    assert!(
+        blob.get(&key).await.expect("blob get").is_some(),
+        "object exists before delete"
+    );
+
+    let deleted = backend
+        .delete_session_file(workspace_id, "/gone.txt")
+        .await
+        .expect("delete file");
+    assert!(deleted);
+
+    // Object gone, and the row (hence cascade sidecar) gone.
+    assert!(
+        blob.get(&key).await.expect("blob get").is_none(),
+        "delete must remove the backing object"
+    );
+    assert!(
+        file_sidecar(&pool, workspace_id, "/gone.txt")
+            .await
+            .is_none(),
+        "sidecar pointer must be gone after delete"
+    );
+
+    backend.delete_session(TEST_ORG_ID, session_id).await.ok();
+}
+
+#[tokio::test]
+async fn offloaded_file_update_overwrites_blob_and_hash() {
+    let (backend, pool) = create_offload_backend().await;
+    let session_id = create_test_session(&backend).await;
+    let workspace_id: Uuid = session_id.into();
+
+    backend
+        .create_session_file(CreateSessionFileRow {
+            session_id,
+            path: "/edit.txt".to_string(),
+            is_directory: false,
+            content: Some(b"v1".to_vec()),
+            is_readonly: false,
+        })
+        .await
+        .expect("create file");
+
+    let new_body = b"v2 longer content".to_vec();
+    let updated = backend
+        .update_session_file(
+            workspace_id,
+            "/edit.txt",
+            UpdateSessionFile {
+                content: Some(new_body.clone()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("update file")
+        .expect("file present");
+    assert_eq!(updated.content.as_deref(), Some(new_body.as_slice()));
+    assert_eq!(updated.size_bytes, new_body.len() as i64);
+
+    // Content column still empty; sidecar hash now reflects the new bytes.
+    assert_eq!(
+        raw_file_content(&pool, workspace_id, "/edit.txt").await,
+        None
+    );
+    let (_, sha) = file_sidecar(&pool, workspace_id, "/edit.txt")
+        .await
+        .expect("sidecar exists");
+    assert_eq!(sha, content_sha256(&new_body));
+
+    // Read returns the new bytes from the blob store.
+    let fetched = backend
+        .get_session_file(workspace_id, "/edit.txt")
+        .await
+        .expect("get file")
+        .expect("file present");
+    assert_eq!(fetched.content.as_deref(), Some(new_body.as_slice()));
+
+    backend.delete_session(TEST_ORG_ID, session_id).await.ok();
+}
+
+#[tokio::test]
+async fn offloaded_file_cas_matches_and_rejects() {
+    let (backend, pool) = create_offload_backend().await;
+    let session_id = create_test_session(&backend).await;
+    let workspace_id: Uuid = session_id.into();
+
+    let original = b"original".to_vec();
+    backend
+        .create_session_file(CreateSessionFileRow {
+            session_id,
+            path: "/cas.txt".to_string(),
+            is_directory: false,
+            content: Some(original.clone()),
+            is_readonly: false,
+        })
+        .await
+        .expect("create file");
+
+    // Stale expected content is rejected (no change).
+    let rejected = backend
+        .update_session_file_if_content_matches(
+            workspace_id,
+            "/cas.txt",
+            b"WRONG".to_vec(),
+            UpdateSessionFile {
+                content: Some(b"should not apply".to_vec()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("cas call");
+    assert!(rejected.is_none(), "CAS must reject a stale expected value");
+    // The blob is unchanged.
+    let fetched = backend
+        .get_session_file(workspace_id, "/cas.txt")
+        .await
+        .expect("get")
+        .expect("present");
+    assert_eq!(fetched.content.as_deref(), Some(original.as_slice()));
+
+    // Correct expected content applies the write.
+    let new_body = b"second revision".to_vec();
+    let applied = backend
+        .update_session_file_if_content_matches(
+            workspace_id,
+            "/cas.txt",
+            original.clone(),
+            UpdateSessionFile {
+                content: Some(new_body.clone()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("cas call")
+        .expect("CAS must apply when expected matches");
+    assert_eq!(applied.content.as_deref(), Some(new_body.as_slice()));
+    assert_eq!(
+        raw_file_content(&pool, workspace_id, "/cas.txt").await,
+        None
+    );
+    let (_, sha) = file_sidecar(&pool, workspace_id, "/cas.txt")
+        .await
+        .expect("sidecar exists");
+    assert_eq!(sha, content_sha256(&new_body));
+
+    backend.delete_session(TEST_ORG_ID, session_id).await.ok();
+}
+
+#[tokio::test]
+async fn offloaded_file_move_keeps_blob_copy_duplicates_it() {
+    let (backend, pool) = create_offload_backend().await;
+    let session_id = create_test_session(&backend).await;
+    let workspace_id: Uuid = session_id.into();
+    let body = b"movable".to_vec();
+
+    backend
+        .create_session_file(CreateSessionFileRow {
+            session_id,
+            path: "/src.txt".to_string(),
+            is_directory: false,
+            content: Some(body.clone()),
+            is_readonly: false,
+        })
+        .await
+        .expect("create file");
+
+    let (src_key, _) = file_sidecar(&pool, workspace_id, "/src.txt")
+        .await
+        .expect("sidecar exists");
+
+    // Copy duplicates the blob under a new object key (independent file id).
+    let copied = backend
+        .copy_session_file(workspace_id, "/src.txt", "/copy.txt")
+        .await
+        .expect("copy")
+        .expect("copy returns row");
+    assert_eq!(copied.content.as_deref(), Some(body.as_slice()));
+    let (copy_key, copy_sha) = file_sidecar(&pool, workspace_id, "/copy.txt")
+        .await
+        .expect("copy sidecar exists");
+    assert_ne!(copy_key, src_key, "copy gets its own object key");
+    assert_eq!(copy_sha, content_sha256(&body));
+
+    // Move only rewrites path metadata: the object/key is untouched, and the
+    // bytes round-trip at the new path.
+    let moved = backend
+        .move_session_file(workspace_id, "/src.txt", "/moved.txt")
+        .await
+        .expect("move")
+        .expect("move returns row");
+    assert_eq!(moved.content.as_deref(), Some(body.as_slice()));
+    let (moved_key, _) = file_sidecar(&pool, workspace_id, "/moved.txt")
+        .await
+        .expect("moved sidecar exists");
+    assert_eq!(moved_key, src_key, "move keeps the same backing object");
+    assert!(
+        file_sidecar(&pool, workspace_id, "/src.txt")
+            .await
+            .is_none(),
+        "old path no longer resolves"
+    );
+
+    backend.delete_session(TEST_ORG_ID, session_id).await.ok();
+}
+
+// ============================================================================
+// Image offload
+// ============================================================================
+
+#[tokio::test]
+async fn offloaded_image_empties_data_column_and_round_trips() {
+    let (backend, pool) = create_offload_backend().await;
+    let data = vec![0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A]; // PNG-ish header
+    let thumb = vec![0x01, 0x02, 0x03];
+
+    let image = backend
+        .create_image(
+            TEST_ORG_ID,
+            CreateImageRow {
+                org_id: TEST_ORG_ID,
+                filename: "offloaded.png".to_string(),
+                content_type: "image/png".to_string(),
+                size_bytes: data.len() as i64,
+                data: data.clone(),
+                thumbnail_data: Some(thumb.clone()),
+                thumbnail_content_type: Some("image/png".to_string()),
+                metadata: json!({}),
+            },
+        )
+        .await
+        .expect("create image");
+
+    // The DB `data` column is empty (offloaded to the object store).
+    let raw: (Vec<u8>, Option<Vec<u8>>) =
+        sqlx::query_as("SELECT data, thumbnail_data FROM images WHERE id = $1")
+            .bind(image.id.uuid())
+            .fetch_one(&pool)
+            .await
+            .expect("image row");
+    assert!(
+        raw.0.is_empty(),
+        "offloaded image data column must be empty"
+    );
+    assert!(
+        raw.1.is_none(),
+        "offloaded image thumbnail column must be empty"
+    );
+
+    // Sidecar pointers exist.
+    let pointers: (String, Option<String>) =
+        sqlx::query_as("SELECT data_key, thumbnail_key FROM image_blobs WHERE image_id = $1")
+            .bind(image.id.uuid())
+            .fetch_one(&pool)
+            .await
+            .expect("image_blobs row");
+    assert!(pointers.0.contains(&format!("org-{TEST_ORG_ID}")));
+    assert!(pointers.1.is_some(), "thumbnail pointer recorded");
+
+    // Read materializes bytes from the blob store.
+    let fetched = backend
+        .get_image(TEST_ORG_ID, image.id.uuid())
+        .await
+        .expect("get image")
+        .expect("image present");
+    assert_eq!(fetched.data, data);
+    assert_eq!(fetched.thumbnail_data.as_deref(), Some(thumb.as_slice()));
+
+    // Delete removes the backing objects.
+    let blob = blob_store_under_test();
+    assert!(blob.get(&pointers.0).await.expect("get").is_some());
+    backend
+        .delete_image(TEST_ORG_ID, image.id.uuid())
+        .await
+        .expect("delete image");
+    assert!(
+        blob.get(&pointers.0).await.expect("get").is_none(),
+        "delete must remove the image data object"
+    );
+}
+
+#[tokio::test]
+async fn offloaded_image_delete_is_org_scoped() {
+    // Cross-tenant guard: a delete issued for the wrong org must not remove the
+    // owning org's objects (the lookup joins images filtered by org_id).
+    let (backend, pool) = create_offload_backend().await;
+
+    // A second org to act as the attacker tenant.
+    let other_org = backend
+        .create_organization(everruns_server::storage::CreateOrganizationRow {
+            public_id: format!("org_{}", Uuid::now_v7().simple()),
+            name: format!("Other Org {}", Uuid::now_v7()),
+            created_by: None,
+        })
+        .await
+        .expect("create other org");
+
+    let data = vec![0xDE, 0xAD, 0xBE, 0xEF];
+    let image = backend
+        .create_image(
+            TEST_ORG_ID,
+            CreateImageRow {
+                org_id: TEST_ORG_ID,
+                filename: "secret.png".to_string(),
+                content_type: "image/png".to_string(),
+                size_bytes: data.len() as i64,
+                data: data.clone(),
+                thumbnail_data: None,
+                thumbnail_content_type: None,
+                metadata: json!({}),
+            },
+        )
+        .await
+        .expect("create image");
+
+    let pointers: (String, Option<String>) =
+        sqlx::query_as("SELECT data_key, thumbnail_key FROM image_blobs WHERE image_id = $1")
+            .bind(image.id.uuid())
+            .fetch_one(&pool)
+            .await
+            .expect("image_blobs row");
+
+    // Attacker org tries to delete the victim org's image id.
+    let deleted = backend
+        .delete_image(other_org.org_id, image.id.uuid())
+        .await
+        .expect("delete call");
+    assert!(
+        !deleted,
+        "cross-org delete must not affect another org's image"
+    );
+
+    // The object and the row are untouched, and the owning org can still read it.
+    let blob = blob_store_under_test();
+    assert!(
+        blob.get(&pointers.0).await.expect("get").is_some(),
+        "victim object must survive a cross-org delete attempt"
+    );
+    let still_there = backend
+        .get_image(TEST_ORG_ID, image.id.uuid())
+        .await
+        .expect("get image")
+        .expect("victim image must still exist");
+    assert_eq!(still_there.data, data);
+
+    // Cleanup.
+    backend
+        .delete_image(TEST_ORG_ID, image.id.uuid())
+        .await
+        .ok();
+    backend.delete_organization(other_org.org_id).await.ok();
+}

--- a/crates/server/tests/blob_offload_integration_test.rs
+++ b/crates/server/tests/blob_offload_integration_test.rs
@@ -30,7 +30,7 @@
 
 mod test_harness;
 
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use serde_json::json;
 use sqlx::PgPool;
@@ -55,17 +55,28 @@ const TEST_ORG_ID: i64 = 1;
 /// object_store's in-memory backend, which exercises the identical offload code
 /// path with no network dependency. The same test body therefore validates both
 /// backends.
+///
+/// The store is built once per test binary and shared: in the in-memory path a
+/// fresh store per call would mean the assertion reads (e.g. "object exists
+/// after write") observe a *different* store than the one attached to the
+/// `Database`, so they would always fail. Tests run serially
+/// (`--test-threads=1`) with unique per-test ids, so sharing one store is safe.
 fn blob_store_under_test() -> SharedBlobStore {
-    let backend = std::env::var("STORAGE_BLOB_BACKEND").unwrap_or_default();
-    if backend == "s3" {
-        let config = BlobStoreConfig::from_env()
-            .expect("STORAGE_BLOB_BACKEND=s3 requires STORAGE_S3_* configuration");
-        let store = ObjectStoreBlobStore::s3_from_config(&config)
-            .expect("failed to build S3 blob store from STORAGE_S3_* configuration");
-        Arc::new(store)
-    } else {
-        Arc::new(ObjectStoreBlobStore::in_memory())
-    }
+    static STORE: OnceLock<SharedBlobStore> = OnceLock::new();
+    STORE
+        .get_or_init(|| {
+            let backend = std::env::var("STORAGE_BLOB_BACKEND").unwrap_or_default();
+            if backend == "s3" {
+                let config = BlobStoreConfig::from_env()
+                    .expect("STORAGE_BLOB_BACKEND=s3 requires STORAGE_S3_* configuration");
+                let store = ObjectStoreBlobStore::s3_from_config(&config)
+                    .expect("failed to build S3 blob store from STORAGE_S3_* configuration");
+                Arc::new(store) as SharedBlobStore
+            } else {
+                Arc::new(ObjectStoreBlobStore::in_memory()) as SharedBlobStore
+            }
+        })
+        .clone()
 }
 
 /// Create a PostgreSQL-backed storage backend with the offload blob store
@@ -103,7 +114,10 @@ async fn create_test_session(backend: &StorageBackend) -> everruns_core::Session
             TEST_ORG_ID,
             CreateAgentRow {
                 public_id: everruns_core::AgentId::new().to_string(),
-                name: format!("blob-offload-agent-{}", &Uuid::now_v7().to_string()[..8]),
+                // Full UUID, not a truncated prefix: the leading chars of a v7
+                // UUID are shared timestamp bits, so a truncated prefix collides
+                // for agents created in the same window (unique (org_id, name)).
+                name: format!("blob-offload-agent-{}", Uuid::now_v7()),
                 display_name: Some("Blob Offload Agent".to_string()),
                 description: None,
                 system_prompt: "Test".to_string(),

--- a/specs/object-storage.md
+++ b/specs/object-storage.md
@@ -261,9 +261,38 @@ unchanged — only the endpoint and credentials differ.
   deleted, orphan-within-grace kept, grace boundary, per-run cap) is unit-tested
   as a pure function, plus an end-to-end list→reconcile→delete sweep against the
   in-memory blob store (no database).
-- End-to-end offload and GC (PostgreSQL + SeaweedFS) are validated manually; the
-  PostgreSQL repository paths and the live-pointer enumeration query are not
-  unit-tested without a database, consistent with the rest of the storage layer.
+
+### CI coverage of the offload paths
+
+The PostgreSQL repository offload paths
+(`crates/server/src/storage/repositories/{session_files,skills}.rs`) are covered
+by a backend-agnostic integration suite,
+`crates/server/tests/blob_offload_integration_test.rs`. It runs the full offload
+lifecycle against a real PostgreSQL database plus a `BlobStore` and asserts the
+offloaded invariants: the inline `content`/`data` column is empty, the sidecar
+pointer and `content_sha256` are recorded, bytes round-trip on read, delete
+removes the backing object (and cascades the sidecar), update/CAS semantics hold,
+move keeps the same object while copy duplicates it, and the cross-tenant
+image-delete guard rejects an out-of-org delete.
+
+The suite selects its blob backend from the environment, so the **same
+assertions** run against both backends:
+
+- **In-memory object_store backend** (default) in the `Integration Tests
+  (PostgreSQL)` CI job — exercises the offload code path on every PostgreSQL PR
+  with no S3/MinIO container (it still uses the PostgreSQL service container).
+- **Real S3-compatible store** in the dedicated `Integration Tests (S3 Blob
+  Backend)` CI job, which starts MinIO via a `docker run` step alongside the
+  PostgreSQL service container, sets `STORAGE_BLOB_BACKEND=s3` + `STORAGE_S3_*`
+  (with `STORAGE_S3_ALLOW_HTTP` and path-style addressing for the local
+  endpoint), and re-runs the identical suite against the AWS S3 client path. The
+  job is gated on a narrow `object_storage` path filter so it only runs when the
+  offload code, its sidecar migration, or its harness changes.
+
+The live-pointer enumeration query and the full GC `spawn_blob_gc_task` path
+require PostgreSQL and are not unit-tested without a database, consistent with
+the rest of the storage layer; end-to-end offload + GC against SeaweedFS remains
+available for local smoke testing (see *Local development*).
 
 ## Non-goals / follow-ups
 


### PR DESCRIPTION
## What
Automated CI coverage for the `STORAGE_BLOB_BACKEND=s3` blob-offload code paths, which previously had none (only a manual SeaweedFS smoke). Implements **EVE-591** (follow-up to #2286).

## Why
CI only exercised the inline `db` backend. The S3 offload paths in `storage/repositories/{session_files,skills}.rs` (create/read/update/CAS/move/copy/delete, materialization, org-scoped delete) were validated only by hand, so the #2286 hardening (transactions, blob-first ordering, SHA-256 CAS, cross-tenant image-delete guard) had no durable regression net.

## How
- **Backend-agnostic integration suite** (`crates/server/tests/blob_offload_integration_test.rs`): selects the blob backend from env, so the *same* assertions run against the in-memory `object_store` (in the existing PostgreSQL job, covering offload logic on every PR) and against real S3 (new job). Covers, for files and images: inline content column empty after offload; sidecar pointer + `content_sha256` present and tenant-scoped; byte round-trip; delete removes the object + cascades the row; update/CAS (accept match, reject stale); move keeps the key / copy duplicates; and the cross-tenant image-delete guard.
- **New `s3-integration-test` CI job**: brings up MinIO (`bitnami/minio`, pinned tag) as a service container with `STORAGE_BLOB_BACKEND=s3` + `STORAGE_S3_*` (path-style addressing, `ALLOW_HTTP`), modeled on the existing PostgreSQL integration job (toolchain, rust-cache, sqlx migrations) plus an explicit MinIO-readiness wait. Gated on a new `object_storage` `changes` path filter and wired into the `ci-success` aggregator.
- `specs/object-storage.md` Testing section documents the new CI coverage.

No production behavior change; no migrations; no new production dependencies.

## Risk
- **Low for production** (test/CI only). The risk is CI-shape: this is infra that can only be validated in CI. The new suite compiles + lints clean locally, but **test execution could not be run locally** (no PostgreSQL/Docker in the sandbox), so first CI runs may need a debug cycle on service-container specifics — see below.

## Security
- **Threat categories reviewed:** none materially affected — test/CI-only change. The new job uses throwaway static MinIO creds for an ephemeral container; no production credentials or behavior. No `THREAT` comments touched.

## Validation
- `cargo fmt -p everruns-server -- --check` ✅
- `cargo test -p everruns-server --test blob_offload_integration_test --no-run` ✅ (compiles + links)
- `cargo clippy -p everruns-server --test blob_offload_integration_test -- -D warnings` ✅
- Workflow YAML structure verified (job present, `object_storage` output wired, in `ci-success` needs, services + env correct).
- **CI-only:** actual test execution (both in-memory-blob mode in the PostgreSQL job and `s3` mode in the new MinIO job) is verified only in CI — no claim it passes locally.

Known first-CI risks (each a one-line fix if hit): the pinned `bitnami/minio` tag must be pullable; the service health-cmd relies on the image's curl + `/minio/health/live` (mitigated by an explicit wait step); `MINIO_DEFAULT_BUCKETS` must provision `everruns-test` at boot (else add a bucket-create step). I'll watch CI and iterate.

## Follow-ups
- The dedicated change-scoped `ard-integration`-style standalone workflow + `integration-live-sweep` inclusion were not added (the issue scoped this to the integration job); can be added if a separate live cadence is wanted.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered (test/CI only; no runtime change)
- [x] Security review performed (test/CI-only; no production surface)
- [ ] Final CI ran checks affected by this PR — **watching; may need a service-container debug cycle**
- [ ] All review comments addressed

---
_Generated by [Claude Code](https://claude.ai/code/session_01HAaTy59HiBBiQnqM58nj6Z)_