### PR TITLE
fix(mai): validate OAuth authority URLs

### DIFF
--- a/crates/mai/src/auth.rs
+++ b/crates/mai/src/auth.rs
@@ -21,6 +21,7 @@ use chrono::{DateTime, Duration, Utc};
 use everruns_core::driver_registry::DriverConfig;
 use everruns_core::error::{AgentLoopError, Result};
 use everruns_core::openai_protocol::AuthHeaderProvider;
+use everruns_core::validate_safe_url;
 use serde::Deserialize;
 use tokio::sync::Mutex;
 
@@ -33,6 +34,13 @@ pub const DEFAULT_ENTRA_SCOPE: &str = "https://cognitiveservices.azure.com/.defa
 /// Refresh a cached Entra token this long before it actually expires, so an
 /// in-flight request never races the expiry boundary.
 const TOKEN_REFRESH_SKEW: Duration = Duration::seconds(120);
+
+const ALLOWED_ENTRA_AUTHORITY_HOSTS: &[&str] = &[
+    // Public, US Government, and China cloud Microsoft Entra authorities.
+    "login.microsoftonline.com",
+    "login.microsoftonline.us",
+    "login.chinacloudapi.cn",
+];
 
 /// Authentication strategy for a Microsoft MAI provider.
 ///
@@ -200,14 +208,47 @@ impl EntraOAuthConfig {
             return Ok(None);
         }
 
-        serde_json::from_value::<EntraOAuthConfig>(extra.clone())
-            .map(Some)
-            .map_err(|e| {
-                AgentLoopError::llm(format!(
-                    "Invalid Microsoft Entra ID OAuth config in provider metadata: {e}. \
-                     Required fields: tenant_id, client_id, client_secret."
-                ))
-            })
+        let config = serde_json::from_value::<EntraOAuthConfig>(extra.clone()).map_err(|e| {
+            AgentLoopError::llm(format!(
+                "Invalid Microsoft Entra ID OAuth config in provider metadata: {e}. \
+                 Required fields: tenant_id, client_id, client_secret."
+            ))
+        })?;
+        config.validate_authority()?;
+        Ok(Some(config))
+    }
+
+    fn validate_authority(&self) -> Result<()> {
+        let url = validate_safe_url(&self.authority).map_err(|e| {
+            AgentLoopError::llm(format!(
+                "Invalid Microsoft Entra ID OAuth authority URL: {e}"
+            ))
+        })?;
+
+        if url.scheme() != "https" {
+            return Err(AgentLoopError::llm(
+                "Invalid Microsoft Entra ID OAuth authority URL: authority must use https",
+            ));
+        }
+
+        let host = url.host_str().unwrap_or_default().to_ascii_lowercase();
+        if !ALLOWED_ENTRA_AUTHORITY_HOSTS.contains(&host.as_str()) {
+            return Err(AgentLoopError::llm(format!(
+                "Invalid Microsoft Entra ID OAuth authority URL: unsupported authority host {host}"
+            )));
+        }
+
+        if url.port().is_some()
+            || url.path() != "/"
+            || url.query().is_some()
+            || url.fragment().is_some()
+        {
+            return Err(AgentLoopError::llm(
+                "Invalid Microsoft Entra ID OAuth authority URL: authority must be an https origin without port, path, query, or fragment",
+            ));
+        }
+
+        Ok(())
     }
 
     /// The token endpoint URL for this tenant.
@@ -255,7 +296,10 @@ impl EntraOAuthProvider {
     pub fn new(config: EntraOAuthConfig) -> Self {
         Self {
             config,
-            http: reqwest::Client::new(),
+            http: reqwest::Client::builder()
+                .redirect(reqwest::redirect::Policy::none())
+                .build()
+                .expect("MAI OAuth HTTP client configuration is valid"),
             cache: Mutex::new(None),
         }
     }
@@ -436,6 +480,79 @@ mod tests {
                 );
             }
             other => panic!("expected EntraOAuth, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn oauth_authority_rejects_localhost_and_private_hosts() {
+        for authority in [
+            "http://127.0.0.1:39991",
+            "https://127.0.0.1",
+            "https://localhost",
+            "https://169.254.169.254",
+            "https://10.0.0.5",
+            "https://192.168.1.10",
+        ] {
+            let credential = serde_json::json!({
+                "tenant_id": "tenant",
+                "client_id": "client",
+                "client_secret": "secret",
+                "authority": authority,
+            })
+            .to_string();
+
+            let err = MaiAuth::from_driver_config(&driver_config(Some(&credential), None))
+                .expect_err("unsafe authority must be rejected");
+            assert!(
+                err.to_string().contains("OAuth authority URL"),
+                "{authority}: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn oauth_authority_rejects_non_entra_origins_and_url_components() {
+        for authority in [
+            "https://example.com",
+            "https://login.microsoftonline.com:444",
+            "https://login.microsoftonline.com/path",
+            "https://login.microsoftonline.com?query=1",
+            "https://login.microsoftonline.com#fragment",
+        ] {
+            let extra = serde_json::json!({
+                "tenant_id": "tenant",
+                "client_id": "client",
+                "client_secret": "secret",
+                "authority": authority,
+            });
+
+            let err = MaiAuth::from_driver_config(&driver_config(None, Some(extra)))
+                .expect_err("unsupported authority must be rejected");
+            assert!(
+                err.to_string().contains("OAuth authority URL"),
+                "{authority}: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn oauth_authority_accepts_microsoft_entra_origins() {
+        for authority in [
+            DEFAULT_ENTRA_AUTHORITY,
+            "https://login.microsoftonline.us",
+            "https://login.chinacloudapi.cn",
+        ] {
+            let credential = serde_json::json!({
+                "tenant_id": "tenant",
+                "client_id": "client",
+                "client_secret": "secret",
+                "authority": authority,
+            })
+            .to_string();
+
+            let auth = MaiAuth::from_driver_config(&driver_config(Some(&credential), None))
+                .expect("supported Microsoft authority should be accepted");
+            assert!(matches!(auth, MaiAuth::EntraOAuth(_)));
         }
     }
 

--- a/crates/mai/tests/chat_wire.rs
+++ b/crates/mai/tests/chat_wire.rs
@@ -129,36 +129,15 @@ async fn entra_oauth_mints_token_and_sends_bearer() {
     assert_eq!(drain_text(stream).await, "pong");
 }
 
-/// The full server path: a provider is configured with an Entra OAuth **JSON
-/// document** in its (encrypted) credential field, and the driver is built via
-/// the registry exactly as model resolution / model sync do. This proves OAuth
-/// works end-to-end without any provider-metadata plumbing.
+/// Registry-built providers parse OAuth JSON credentials before any network call.
+/// Unsafe credential authorities must be rejected at build time so server-stored
+/// credentials cannot point token minting at local/internal services.
 #[tokio::test]
-async fn registry_built_driver_uses_oauth_json_credential() {
+async fn registry_built_driver_rejects_unsafe_oauth_json_authority() {
     let server = MockServer::start().await;
 
-    Mock::given(method("POST"))
-        .and(path("/tenant-9/oauth2/v2.0/token"))
-        .and(body_string_contains("grant_type=client_credentials"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-            "token_type": "Bearer",
-            "access_token": "cred-doc-token",
-            "expires_in": 3600,
-        })))
-        .mount(&server)
-        .await;
-
-    Mock::given(method("POST"))
-        .and(path("/openai/v1/chat/completions"))
-        .and(header("authorization", "Bearer cred-doc-token"))
-        .respond_with(
-            ResponseTemplate::new(200).set_body_raw(sse_chat_response(), "text/event-stream"),
-        )
-        .mount(&server)
-        .await;
-
     // OAuth credentials carried as a JSON document in the credential field,
-    // pointing `authority` at the mock token endpoint.
+    // attempting to point `authority` at a local mock token endpoint.
     let credential = serde_json::json!({
         "tenant_id": "tenant-9",
         "client_id": "client-9",
@@ -175,13 +154,15 @@ async fn registry_built_driver_uses_oauth_json_credential() {
                 .with_api_key(credential)
                 .with_base_url(server.uri()),
         )
-        .expect("registry should build a MAI driver from an OAuth JSON credential");
+        .expect("registry should construct the lazy MAI driver");
 
     let messages = vec![LlmMessage::text(LlmMessageRole::User, "ping")];
-    let stream = driver
+    let result = driver
         .chat_completion_stream(messages, &config("mai-code-1-flash"))
-        .await
-        .expect("registry-built MAI driver should authenticate via OAuth");
+        .await;
+    let Err(err) = result else {
+        panic!("unsafe OAuth authority should be rejected before token minting");
+    };
 
-    assert_eq!(drain_text(stream).await, "pong");
+    assert!(err.to_string().contains("OAuth authority URL"), "{err}");
 }


### PR DESCRIPTION
### Motivation
- The MAI provider accepted an unvalidated `authority` from credential JSON and used it to POST for OAuth tokens, creating a server-side request forgery (SSRF) and potential internal response disclosure risk.
- The intent is to validate and restrict credential-supplied OAuth authorities at parse time so stored credentials cannot point at localhost/private/metadata endpoints or arbitrary hosts.

### Description
- Validate Entra OAuth `authority` during parse by reusing the shared safe URL validator and adding `EntraOAuthConfig::validate_authority()` to require `https`, reject ports/paths/queries/fragments, and disallow localhost/private/link-local/metadata hosts. (changes in `crates/mai/src/auth.rs`).
- Restrict accepted authority hosts to Microsoft Entra public/sovereign origins via an allowlist constant `ALLOWED_ENTRA_AUTHORITY_HOSTS` and fail closed for unsupported origins. (`crates/mai/src/auth.rs`).
- Disable HTTP redirects on the OAuth token `reqwest` client with `redirect(Policy::none())` to prevent following redirects to unvalidated endpoints. (`crates/mai/src/auth.rs`).
- Add unit tests for unsafe/allowed authorities and update the registry wire test to assert that OAuth JSON credentials pointing at local authorities are rejected before token minting. (`crates/mai/src/auth.rs` and `crates/mai/tests/chat_wire.rs`).

### Testing
- Ran focused unit tests `cargo test -p everruns-mai oauth_authority -- --nocapture` which passed. 
- Ran the MAI crate full test suite with a localhost proxy bypass `NO_PROXY=127.0.0.1,localhost cargo test -p everruns-mai` and all tests passed. 
- Ran formatting and lint checks with `cargo fmt --check -p everruns-mai` and `cargo clippy -p everruns-mai --all-targets --all-features -- -D warnings`, both of which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30fb6ccfe0832b8cad8fb2cac7b9ab)