### PR TITLE
fix(guardrails): prioritize tool output checks

### DIFF
--- a/crates/core/src/atoms/act_hooks.rs
+++ b/crates/core/src/atoms/act_hooks.rs
@@ -98,8 +98,21 @@ pub(super) async fn run_pre_tool_use_hooks(
 ///
 /// Hooks are async because they may perform I/O (VFS writes).
 /// Capability-contributed hooks run first, then final (infrastructure) hooks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum PostToolExecHookPriority {
+    /// Inspect/block output before other hooks can persist or transform it.
+    Guardrail = 0,
+    /// Default post-tool hook ordering for mutating/observability hooks.
+    Normal = 100,
+}
+
 #[async_trait]
 pub trait PostToolExecHook: Send + Sync {
+    /// Ordering within the capability-contributed hook phase.
+    fn priority(&self) -> PostToolExecHookPriority {
+        PostToolExecHookPriority::Normal
+    }
+
     /// Called after a tool returns its result, before ActAtom emits events.
     async fn after_exec(
         &self,

--- a/crates/core/src/atoms/mod.rs
+++ b/crates/core/src/atoms/mod.rs
@@ -32,7 +32,7 @@ pub mod tool_scheduler;
 pub use act::{ActAtom, ActInput, ActResult, ToolCallResult};
 pub use act_hooks::{
     ClientSideToolHook, ConnectionSetupHook, OutputHardLimitHook, PostActAction, PostActHook,
-    PostToolExecHook, PreToolUseDecision, PreToolUseHook,
+    PostToolExecHook, PostToolExecHookPriority, PreToolUseDecision, PreToolUseHook,
 };
 pub use input::{InputAtom, InputAtomInput, InputAtomResult};
 pub use reason::{ReasonAtom, ReasonInput, ReasonResult};

--- a/crates/core/src/capabilities/guardrails.rs
+++ b/crates/core/src/capabilities/guardrails.rs
@@ -12,7 +12,9 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use serde_json::json;
 
-use crate::atoms::{PostToolExecHook, PreToolUseDecision, PreToolUseHook};
+use crate::atoms::{
+    PostToolExecHook, PostToolExecHookPriority, PreToolUseDecision, PreToolUseHook,
+};
 use crate::capabilities::{Capability, CapabilityLocalization};
 use crate::guardrail_checks::{
     CompiledGuardrails, DEFAULT_OUTPUT_REPLACEMENT, DEFAULT_TOOL_OUTPUT_REPLACEMENT,
@@ -704,6 +706,10 @@ struct GuardrailPostToolHook {
 
 #[async_trait]
 impl PostToolExecHook for GuardrailPostToolHook {
+    fn priority(&self) -> PostToolExecHookPriority {
+        PostToolExecHookPriority::Guardrail
+    }
+
     async fn after_exec(
         &self,
         tool_call: &ToolCall,
@@ -721,6 +727,14 @@ impl PostToolExecHook for GuardrailPostToolHook {
         if let Some(error) = &result.error {
             haystack.push('\n');
             haystack.push_str(error);
+        }
+        // Exec-style tools budget the visible `result` JSON but keep the full,
+        // untruncated content in `raw_output`, which is persisted to `/outputs`.
+        // Include it in the haystack so sensitive content that only survives in
+        // `raw_output` is caught before this hook clears it on a block.
+        if let Some(raw_output) = &result.raw_output {
+            haystack.push('\n');
+            haystack.push_str(raw_output);
         }
         if haystack.is_empty() {
             return;
@@ -1203,6 +1217,7 @@ mod tests {
             }]
         }));
         assert_eq!(hooks.len(), 1);
+        assert_eq!(hooks[0].priority(), PostToolExecHookPriority::Guardrail);
         let ctx = ToolContext::new(SessionId::new());
         let mut result = ToolResult {
             tool_call_id: "call_1".to_string(),
@@ -1226,6 +1241,46 @@ mod tests {
             "matched output must be replaced with the notice"
         );
         assert!(result.error.is_none());
+    }
+
+    #[tokio::test]
+    async fn post_tool_hook_scans_raw_output_persistence_surface() {
+        // Exec-style tools keep the full, untruncated content in `raw_output`
+        // (persisted to /outputs) while the visible `result` is budgeted. A
+        // secret that only survives in `raw_output` must still be blocked.
+        let cap = GuardrailsCapability;
+        let hooks = cap.post_tool_exec_hooks_with_config(&json!({
+            "checks": [{
+                "id": "aws_key", "stage": "tool_output", "type": "regex",
+                "patterns": ["AKIA[0-9A-Z]{16}"]
+            }]
+        }));
+        let ctx = ToolContext::new(SessionId::new());
+        let mut result = ToolResult {
+            tool_call_id: "call_1".to_string(),
+            result: Some(json!("(truncated output)")),
+            images: None,
+            error: None,
+            connection_required: None,
+            raw_output: Some("full log: AKIAIOSFODNN7EXAMPLE trailing".to_string()),
+        };
+        hooks[0]
+            .after_exec(
+                &tool_call("bashkit_exec", json!({})),
+                &tool_def(),
+                &mut result,
+                &ctx,
+            )
+            .await;
+        assert_eq!(
+            result.result,
+            Some(json!(DEFAULT_TOOL_OUTPUT_REPLACEMENT)),
+            "a secret only present in raw_output must trigger the block"
+        );
+        assert!(
+            result.raw_output.is_none(),
+            "raw_output must be cleared on a block so it is not persisted"
+        );
     }
 
     #[tokio::test]

--- a/crates/runtime/src/host.rs
+++ b/crates/runtime/src/host.rs
@@ -439,6 +439,9 @@ async fn load_execution_capabilities<A: RuntimeHostAdapter>(
                 .unwrap_or_default()
         })
         .collect();
+    // Tool-output guardrails must inspect the original result before other
+    // capability hooks can persist or compact it into secondary surfaces.
+    post_tool_hooks.sort_by_key(|hook| hook.priority());
 
     // User-hook contributions (see `specs/user-hooks.md`). `finalize_specs_from_configs`
     // gathers specs across every resolved capability — both the user-facing


### PR DESCRIPTION
### Motivation
- Tool-output guardrails could run after capability hooks that persist or compact output, allowing sensitive `raw_output` written to `/outputs` to bypass guardrail checks.
- The runtime collected post-tool hooks in resolved capability order with no priority, and `tool_output_persistence` consumes `raw_output` before guardrails inspect the result.

### Description
- Add a `PostToolExecHookPriority` enum and a default `priority()` method on `PostToolExecHook` in `crates/core/src/atoms/act_hooks.rs` so hooks can declare ordering (`Guardrail` vs `Normal`).
- Re-export the new priority type in `crates/core/src/atoms/mod.rs` for use by capabilities and the runtime.
- Mark the declarative guardrail post-tool hook with `PostToolExecHookPriority::Guardrail` in `crates/core/src/capabilities/guardrails.rs` so it runs before persistence/transform hooks.
- Sort collected capability post-tool hooks by `hook.priority()` in `crates/runtime/src/host.rs` so guardrails inspect original output before other hooks can persist or compact it, and add a regression assertion verifying the guardrail hook priority.

### Testing
- Ran `cargo test -p everruns-core capabilities::guardrails::tests::post_tool_hook_withholds_matching_output`, and the test passed.
- Ran `cargo check -p everruns-runtime`, and the check completed successfully.
- Ran formatting and linting (`cargo fmt --check`, `cargo clippy`) as part of `just pre-push`, which succeeded, but `just pre-push` failed the migration immutability check due to `origin/main` being unavailable in this checkout (external repo fetch required).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a305105b74c832b98074f52c02ce2e2)