### PR TITLE
fix(core): avoid completing idle subagents

### DIFF
--- a/crates/core/src/capabilities/subagents.rs
+++ b/crates/core/src/capabilities/subagents.rs
@@ -82,7 +82,10 @@ const SUBAGENT_SYSTEM_PROMPT: &str = "Spawn subagents only for independent works
 
 fn terminal_subagent_status(wait_status: &str) -> Option<crate::session::SubagentStatus> {
     match wait_status {
-        "idle" | "completed" => Some(crate::session::SubagentStatus::Completed),
+        // Plain `idle` only means the worker is ready for another turn — failed
+        // turns also leave the session idle — so only explicit terminal
+        // outcomes may settle the spawn handle and persist terminal metadata.
+        "completed" => Some(crate::session::SubagentStatus::Completed),
         "error" | "failed" => Some(crate::session::SubagentStatus::Failed),
         "cancelled" => Some(crate::session::SubagentStatus::Cancelled),
         "max_iterations_reached" => Some(crate::session::SubagentStatus::MaxIterationsReached),
@@ -809,8 +812,11 @@ mod tests {
 
     #[test]
     fn terminal_subagent_status_maps_only_terminal_wait_states() {
+        // `idle` is not terminal: a failed turn also idles the worker, so it
+        // must not settle the subagent as completed.
+        assert_eq!(terminal_subagent_status("idle"), None);
         assert_eq!(
-            terminal_subagent_status("idle"),
+            terminal_subagent_status("completed"),
             Some(crate::session::SubagentStatus::Completed)
         );
         assert_eq!(


### PR DESCRIPTION
### Motivation

- Foreground `spawn_subagent` persisted `SubagentStatus::Completed` whenever `wait_for_idle` returned `"idle"`, but worker lifecycle sets sessions to `idle` even after failed turns, causing failed child work to be durably recorded as completed.

### Description

- Stop treating plain `idle` as a terminal success in the subagent terminal-status mapping by requiring explicit `completed` for success.
- Preserve existing mappings for `completed`, `failed`/`error`, `cancelled`, and `max_iterations_reached` to their respective `SessionResourceStatus` and `SubagentStatus` values.
- Update the focused unit test to assert that `terminal_subagent_status("idle") == None` and that `completed` still maps to success.
- File changed: `crates/core/src/capabilities/subagents.rs` (status mapping and test update).

### Testing

- Ran the focused unit test: `cargo test -p everruns-core terminal_subagent_status_maps_only_terminal_wait_states -- --nocapture` and it passed.
- Ran repository pre-push checks via `just pre-push` (formatting, clippy, migration ordering, specs coverage, author checks); the checks passed in this environment after using the current HEAD as the migration immutability base.
- Verified `cargo fmt` and `clippy` were successful as part of the pre-push checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b67a2b684832bb546dcd3a9b148b5)