### PR TITLE
fix(llm): drop orphan tool results for stateless providers

### DIFF
--- a/crates/anthropic/src/driver.rs
+++ b/crates/anthropic/src/driver.rs
@@ -18,6 +18,7 @@ use futures::StreamExt;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
+use std::collections::HashSet;
 use std::sync::{Arc, Mutex};
 
 use everruns_core::credential_schema::CredentialFormSchema;
@@ -220,6 +221,7 @@ impl AnthropicChatDriver {
         // (infinity_context / compaction). See `fold_system_messages`.
         let system_prompt = fold_system_messages(messages);
         let mut converted = Vec::new();
+        let visible_tool_use_ids = visible_tool_call_ids(messages);
 
         for msg in messages {
             match msg.role {
@@ -231,6 +233,12 @@ impl AnthropicChatDriver {
                     // Tool results in Anthropic are user messages with tool_result content blocks.
                     // When the message contains images, we use the array form with content blocks.
                     if let Some(tool_call_id) = &msg.tool_call_id {
+                        // Anthropic rejects tool_result blocks unless the matching tool_use
+                        // is present in the visible request after context trimming.
+                        if !visible_tool_use_ids.contains(tool_call_id.as_str()) {
+                            continue;
+                        }
+
                         let has_images = match &msg.content {
                             LlmMessageContent::Parts(parts) => parts
                                 .iter()
@@ -1079,6 +1087,15 @@ fn is_anthropic_model_not_found(status: reqwest::StatusCode, error_text: &str) -
         }
     }
     false
+}
+
+fn visible_tool_call_ids(messages: &[LlmMessage]) -> HashSet<&str> {
+    messages
+        .iter()
+        .filter(|msg| msg.role == LlmMessageRole::Assistant)
+        .flat_map(|msg| msg.tool_calls.iter().flatten())
+        .map(|tool_call| tool_call.id.as_str())
+        .collect()
 }
 
 fn is_anthropic_request_too_large(status: reqwest::StatusCode, error_text: &str) -> bool {
@@ -2193,22 +2210,37 @@ mod tests {
     #[test]
     fn test_convert_messages_tool_result() {
         // Tool result should be converted to user message with tool_result block
-        let messages = vec![LlmMessage {
-            role: LlmMessageRole::Tool,
-            content: LlmMessageContent::Text("{\"temp\": 20}".to_string()),
-            tool_calls: None,
-            tool_call_id: Some("call_123".to_string()),
-            phase: None,
-            thinking: None,
-            thinking_signature: None,
-        }];
+        let messages = vec![
+            LlmMessage {
+                role: LlmMessageRole::Assistant,
+                content: LlmMessageContent::Text(String::new()),
+                tool_calls: Some(vec![ToolCall {
+                    id: "call_123".to_string(),
+                    name: "get_weather".to_string(),
+                    arguments: json!({"city": "London"}),
+                }]),
+                tool_call_id: None,
+                phase: None,
+                thinking: None,
+                thinking_signature: None,
+            },
+            LlmMessage {
+                role: LlmMessageRole::Tool,
+                content: LlmMessageContent::Text("{\"temp\": 20}".to_string()),
+                tool_calls: None,
+                tool_call_id: Some("call_123".to_string()),
+                phase: None,
+                thinking: None,
+                thinking_signature: None,
+            },
+        ];
 
         let (_, converted) = AnthropicChatDriver::convert_messages(&messages, false);
 
-        assert_eq!(converted.len(), 1);
-        assert_eq!(converted[0].role, "user");
-        assert_eq!(converted[0].content.len(), 1);
-        match &converted[0].content[0] {
+        assert_eq!(converted.len(), 2);
+        assert_eq!(converted[1].role, "user");
+        assert_eq!(converted[1].content.len(), 1);
+        match &converted[1].content[0] {
             AnthropicContentBlock::ToolResult {
                 tool_use_id,
                 content,
@@ -2224,6 +2256,23 @@ mod tests {
             }
             _ => panic!("Expected ToolResult block"),
         }
+    }
+
+    #[test]
+    fn test_convert_messages_drops_orphan_tool_result() {
+        let messages = vec![LlmMessage {
+            role: LlmMessageRole::Tool,
+            content: LlmMessageContent::Text("orphan result".to_string()),
+            tool_calls: None,
+            tool_call_id: Some("trimmed_call".to_string()),
+            phase: None,
+            thinking: None,
+            thinking_signature: None,
+        }];
+
+        let (_, converted) = AnthropicChatDriver::convert_messages(&messages, false);
+
+        assert!(converted.is_empty());
     }
 
     #[test]
@@ -2246,13 +2295,26 @@ mod tests {
             thinking_signature: None,
         };
 
-        let (_, converted) = AnthropicChatDriver::convert_messages(&[msg], false);
+        let assistant = LlmMessage {
+            role: LlmMessageRole::Assistant,
+            content: LlmMessageContent::Text(String::new()),
+            tool_calls: Some(vec![ToolCall {
+                id: "call_img".to_string(),
+                name: "capture".to_string(),
+                arguments: json!({}),
+            }]),
+            tool_call_id: None,
+            phase: None,
+            thinking: None,
+            thinking_signature: None,
+        };
+        let (_, converted) = AnthropicChatDriver::convert_messages(&[assistant, msg], false);
 
-        assert_eq!(converted.len(), 1);
-        assert_eq!(converted[0].role, "user");
-        assert_eq!(converted[0].content.len(), 1);
+        assert_eq!(converted.len(), 2);
+        assert_eq!(converted[1].role, "user");
+        assert_eq!(converted[1].content.len(), 1);
 
-        match &converted[0].content[0] {
+        match &converted[1].content[0] {
             AnthropicContentBlock::ToolResult {
                 tool_use_id,
                 content,
@@ -2299,9 +2361,22 @@ mod tests {
             thinking_signature: None,
         };
 
-        let (_, converted) = AnthropicChatDriver::convert_messages(&[msg], false);
+        let assistant = LlmMessage {
+            role: LlmMessageRole::Assistant,
+            content: LlmMessageContent::Text(String::new()),
+            tool_calls: Some(vec![ToolCall {
+                id: "call_txt".to_string(),
+                name: "read".to_string(),
+                arguments: json!({}),
+            }]),
+            tool_call_id: None,
+            phase: None,
+            thinking: None,
+            thinking_signature: None,
+        };
+        let (_, converted) = AnthropicChatDriver::convert_messages(&[assistant, msg], false);
 
-        match &converted[0].content[0] {
+        match &converted[1].content[0] {
             AnthropicContentBlock::ToolResult { content, .. } => match content {
                 AnthropicToolResultContent::Text(text) => {
                     assert_eq!(text, "result text");

--- a/crates/gemini/src/driver.rs
+++ b/crates/gemini/src/driver.rs
@@ -13,6 +13,7 @@ use futures::StreamExt;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
+use std::collections::HashSet;
 use std::sync::{Arc, Mutex};
 
 use everruns_core::credential_schema::CredentialFormSchema;
@@ -142,6 +143,7 @@ impl GeminiChatDriver {
             parts: vec![GeminiPart::Text { text }],
         });
         let mut contents = Vec::new();
+        let visible_function_call_ids = visible_tool_call_ids(messages);
 
         for msg in messages {
             match msg.role {
@@ -152,6 +154,12 @@ impl GeminiChatDriver {
                 LlmMessageRole::Tool => {
                     // Tool results in Gemini use functionResponse parts
                     if let Some(tool_call_id) = &msg.tool_call_id {
+                        // Gemini rejects functionResponse parts unless the matching
+                        // functionCall is present in the visible request after trimming.
+                        if !visible_function_call_ids.contains(tool_call_id.as_str()) {
+                            continue;
+                        }
+
                         // Try to parse as JSON, fall back to wrapping in object
                         let response_value = serde_json::from_str::<Value>(&msg.content.to_text())
                             .unwrap_or_else(|_| json!({"result": msg.content.to_text()}));
@@ -854,6 +862,15 @@ pub fn register_driver(registry: &mut DriverRegistry) {
 // SSE Parsing
 // ============================================================================
 
+fn visible_tool_call_ids(messages: &[LlmMessage]) -> HashSet<&str> {
+    messages
+        .iter()
+        .filter(|msg| msg.role == LlmMessageRole::Assistant)
+        .flat_map(|msg| msg.tool_calls.iter().flatten())
+        .map(|tool_call| tool_call.id.as_str())
+        .collect()
+}
+
 /// Extract a complete SSE event from the buffer, returning the data payload
 fn extract_sse_event(buffer: &mut String) -> Option<String> {
     // Look for "data: " followed by a complete JSON object or "[DONE]"
@@ -1401,6 +1418,39 @@ mod tests {
 
     #[test]
     fn test_convert_messages_tool_result() {
+        let messages = vec![
+            LlmMessage {
+                role: LlmMessageRole::Assistant,
+                content: LlmMessageContent::Text(String::new()),
+                tool_calls: Some(vec![ToolCall {
+                    id: "get_weather".to_string(),
+                    name: "get_weather".to_string(),
+                    arguments: json!({"city": "London"}),
+                }]),
+                tool_call_id: None,
+                phase: None,
+                thinking: None,
+                thinking_signature: None,
+            },
+            LlmMessage {
+                role: LlmMessageRole::Tool,
+                content: LlmMessageContent::Text("{\"temp\": 20}".to_string()),
+                tool_calls: None,
+                tool_call_id: Some("get_weather".to_string()),
+                phase: None,
+                thinking: None,
+                thinking_signature: None,
+            },
+        ];
+
+        let (_, contents) = GeminiChatDriver::convert_messages(&messages);
+
+        assert_eq!(contents.len(), 2);
+        assert_eq!(contents[1].role.as_deref(), Some("user"));
+    }
+
+    #[test]
+    fn test_convert_messages_drops_orphan_tool_result() {
         let messages = vec![LlmMessage {
             role: LlmMessageRole::Tool,
             content: LlmMessageContent::Text("{\"temp\": 20}".to_string()),
@@ -1413,8 +1463,7 @@ mod tests {
 
         let (_, contents) = GeminiChatDriver::convert_messages(&messages);
 
-        assert_eq!(contents.len(), 1);
-        assert_eq!(contents[0].role.as_deref(), Some("user"));
+        assert!(contents.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- InfinityContext trimming could leave a `ToolResult` message whose matching assistant `ToolCall` was removed, causing stateless providers to receive orphaned tool-result/function-response items that some providers reject. 
- The change aims to prevent malformed provider requests and restore reliable agent runs for Anthropic and Gemini without reintroducing provider-agnostic behavior that would re-enable the original stateful preservation logic.

### Description
- Added a `visible_tool_call_ids` helper and provider-local filtering in `crates/anthropic/src/driver.rs` to skip Anthropic `tool_result` blocks whose `tool_call_id` is not present among visible assistant tool calls. 
- Added the same visible-call-id check in `crates/gemini/src/driver.rs` to skip `functionResponse` parts that reference trimmed/absent function calls. 
- Updated and extended unit tests in both provider crates so valid tool-result cases include the matching assistant `ToolCall` and added explicit tests that orphaned tool results are dropped.

### Testing
- Ran focused provider tests with `cargo test -p everruns-anthropic convert_messages --all-features` and `cargo test -p everruns-gemini convert_messages --all-features`, and the updated tests passed (Anthropic: 5 passed; Gemini: 3 passed). 
- Ran formatting and lint checks with `cargo fmt --check` and `cargo clippy -p everruns-anthropic -p everruns-gemini --all-targets --all-features -- -D warnings`, both succeeding. 
- Verified no whitespace/diff issues with `git diff --check` and inspected the resulting diffs for the two modified provider files under `crates/anthropic/src/driver.rs` and `crates/gemini/src/driver.rs`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b67a3be14832bbf6890c8b03d7521)