### PR TITLE
fix(deps): patch dompurify and undici security advisories

### DIFF
--- a/.deepsec/package.json
+++ b/.deepsec/package.json
@@ -6,6 +6,9 @@
   "type": "module",
   "workspaces": [],
   "packageManager": "pnpm@9.15.4",
+  "engines": {
+    "node": ">=20.18.1"
+  },
   "dependencies": {
     "deepsec": "^2.0.12"
   },

--- a/.deepsec/package.json
+++ b/.deepsec/package.json
@@ -13,6 +13,7 @@
     "overrides": {
       "@anthropic-ai/sdk": "^0.91.1",
       "tar": "7.5.16",
+      "undici": "7.28.0",
       "zod": "^3.25.76"
     }
   }

--- a/.deepsec/pnpm-lock.yaml
+++ b/.deepsec/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   '@anthropic-ai/sdk': ^0.91.1
   tar: 7.5.16
+  undici: 7.28.0
   zod: ^3.25.76
 
 importers:
@@ -580,8 +581,8 @@ packages:
     resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
     engines: {node: '>= 18'}
 
-  undici@7.25.0:
-    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   unpipe@1.0.0:
@@ -743,7 +744,7 @@ snapshots:
       ms: 2.1.3
       picocolors: 1.1.1
       tar-stream: 3.1.7
-      undici: 7.25.0
+      undici: 7.28.0
       xdg-app-paths: 5.1.0
       zod: 3.25.76
     transitivePeerDependencies:
@@ -1203,7 +1204,7 @@ snapshots:
       media-typer: 1.1.0
       mime-types: 3.0.2
 
-  undici@7.25.0: {}
+  undici@7.28.0: {}
 
   unpipe@1.0.0: {}
 

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -73,7 +73,7 @@
   "pnpm": {
     "overrides": {
       "@babel/core": "7.29.6",
-      "dompurify": "3.4.9",
+      "dompurify": "3.4.11",
       "js-yaml": "4.2.0",
       "postcss": "8.5.14",
       "prismjs": "1.30.0",

--- a/apps/ui/pnpm-lock.yaml
+++ b/apps/ui/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   '@babel/core': 7.29.6
-  dompurify: 3.4.9
+  dompurify: 3.4.11
   js-yaml: 4.2.0
   postcss: 8.5.14
   prismjs: 1.30.0
@@ -2606,8 +2606,8 @@ packages:
   dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
-  dompurify@3.4.9:
-    resolution: {integrity: sha512-4dPSRMRDqHvs0V4YDFCsaIZo4if5u0xM+llyxiM2fwuZFdKArUBAF3VtI2+n8NKg9P870WMdYk0UhqQNoWXbfQ==}
+  dompurify@3.4.11:
+    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
@@ -6729,7 +6729,7 @@ snapshots:
       '@babel/runtime': 7.29.2
       csstype: 3.2.3
 
-  dompurify@3.4.9:
+  dompurify@3.4.11:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -7814,7 +7814,7 @@ snapshots:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.14
       dayjs: 1.11.20
-      dompurify: 3.4.9
+      dompurify: 3.4.11
       es-toolkit: 1.46.1
       katex: 0.16.47
       khroma: 2.1.0

--- a/apps/ui/pnpm-workspace.yaml
+++ b/apps/ui/pnpm-workspace.yaml
@@ -1,6 +1,8 @@
 packages: []
 minimumReleaseAge: 10080
 minimumReleaseAgeStrict: true
-# Security patches may need to land before the release-age window elapses.
+# Security patches adopted before the maturity window (Dependabot GHSA fixes):
+# dompurify 3.4.11 (Dependabot #114 — ALLOWED_ATTR pollution via setConfig() /
+# IN_PLACE sanitization bypasses).
 minimumReleaseAgeExclude:
   - dompurify

--- a/apps/ui/pnpm-workspace.yaml
+++ b/apps/ui/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
 packages: []
 minimumReleaseAge: 10080
 minimumReleaseAgeStrict: true
+# Security patches may need to land before the release-age window elapses.
+minimumReleaseAgeExclude:
+  - dompurify


### PR DESCRIPTION
## What
Bump `dompurify` to 3.4.11 (apps/ui) and force `undici` to 7.28.0 (.deepsec) to clear the remaining open Dependabot security alerts.

## Why
Three open Dependabot alerts remained after #2303:
- **dompurify <3.4.11** (#114, medium) — `ALLOWED_ATTR` pollution via `setConfig()` / IN_PLACE sanitization bypasses. apps/ui pins dompurify via a pnpm override at 3.4.9.
- **undici <7.28.0** (#113, high) — TLS certificate validation bypass via dropped `requestTls` in the SOCKS5 ProxyAgent.
- **undici <7.28.0** (#112, medium) — cross-user information disclosure via shared cache whitespace bypass. undici is a transitive dep in the `.deepsec` workspace (7.25.0).

## How
- `apps/ui/package.json`: pnpm override `dompurify` 3.4.9 → 3.4.11; lockfile regenerated.
- `apps/ui/pnpm-workspace.yaml`: add a targeted `minimumReleaseAgeExclude: [dompurify]` (with advisory/version rationale in the comment, matching the apps/docs convention) so the security patch can land before the 7-day release-age window elapses (3.4.11 is ~36h old).
- `.deepsec/package.json`: add pnpm override `undici` 7.28.0; declare `engines.node >=20.18.1` so undici's Node floor fails fast; lockfile regenerated.

## Risk
- Low. Patch-level bumps of a sanitizer and an HTTP client; no source changes. dompurify 3.4.x and undici 7.28.x are backward compatible within their majors.

## Security
- Threat categories reviewed: dependency/supply-chain (TM-DEP). These are direct CVE remediations.
- Findings and resolutions: resolves Dependabot alerts #112, #113, #114. The `minimumReleaseAgeExclude` is scoped to a single package to avoid weakening the global supply-chain freshness policy.

## Testing
- `apps/ui` is covered by the **UI Build, Lint & Test** CI job (and Playwright smoke), which exercises the updated dompurify graph.
- `.deepsec` is **not** wired into `.github/workflows` — it is a standalone scanning workspace validated by running `pnpm install` / the deepsec tooling locally. Verified `pnpm install --lockfile-only` resolves the new undici override cleanly here.

## Follow-ups
Once dompurify 3.4.11 ages past the 7-day window, the `minimumReleaseAgeExclude` entry can be removed. No other follow-ups.

## Checklist
- [x] Tests added or updated (n/a — dependency bump; apps/ui covered by UI CI, .deepsec validated locally)
- [x] Backward compatibility considered
- [x] Security review performed against relevant threat model categories
- [x] Final CI ran checks affected by this PR
- [x] All review comments addressed (code change or written reasoning)